### PR TITLE
docs(pilot): add NYCN organizer readiness and ActionCard contract alignment

### DIFF
--- a/docs/INDEX.generated.md
+++ b/docs/INDEX.generated.md
@@ -1206,6 +1206,12 @@ CI gates, ratchet phases, required checks, and failure index
 
 **For:** `developers` | **Updated:** 2026-03-10
 
+### 📝 **Living** [Institution Package ActionCard Contract Notes](/docs/contracts/institution-package/README.md)
+
+Validation guidance for institution packages using action-card.schema.json; emitted vs RFC-gated source kinds; pointers to runtime models and issue icn#1713.
+
+**For:** `contributors`, `organizers` | **Updated:** 2026-05-03
+
 ### 📝 **Living** [Demo System Documentation](/docs/demo/README.md)
 
 Documentation for ICN demonstration system
@@ -1361,6 +1367,12 @@ Step-by-step organizer-facing demo flow against a localhost ICN gateway: action 
 Bounded set of questions to ask NYCN organizers — workflow validation, source/data validation, pilot-readiness — without assuming any partnership commitment. Includes explicit non-asks.
 
 **For:** `team`, `organizers` | **Updated:** 2026-04-29
+
+### 📝 **Living** [NYCN Organizer User Readiness (ICN side)](/docs/pilots/nycn-organizer-user-readiness.md)
+
+ICN-side pilot readiness: /me/standing, /me/action-cards, completion-receipt retrieval, proof loops, generic vs package-local material, gated paths, and accessible participation. Links to STATE, phase progress, runtime map, member standing, and NYCN Phase 2 rehearsal gate.
+
+**For:** `team`, `organizers` | **Updated:** 2026-05-03
 
 ### 📋 **Draft** [Agent Knowledge Architecture](/docs/planning/agent-knowledge-architecture.md)
 
@@ -1736,9 +1748,9 @@ Assessment of pilot readiness and gaps
 
 ## Summary
 
-**Total documents:** 282
+**Total documents:** 284
 
 **By status:**
 - Canonical: 39
 - Draft: 57
-- Living: 186
+- Living: 188

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -357,6 +357,7 @@ Organizer-facing pilot materials. Honest scope-of-now framing; not pitch decks. 
 - [nycn-boundary-brief.md](pilots/nycn-boundary-brief.md) - What ICN can demonstrate now, what it cannot honestly claim yet, what NYCN organizers would need to validate, what is explicitly not being asked
 - [nycn-demo-script.md](pilots/nycn-demo-script.md) - Step-by-step organizer-facing demo flow against a localhost ICN gateway
 - [nycn-organizer-asks.md](pilots/nycn-organizer-asks.md) - Bounded set of validation questions for NYCN organizers; includes explicit non-asks
+- [nycn-organizer-user-readiness.md](pilots/nycn-organizer-user-readiness.md) - ICN-side organizer/member readiness: standing, action cards, receipts, gated paths; links NYCN rehearsal gate
 - [pilot-proposal-template.md](pilots/pilot-proposal-template.md) - Template for approaching potential pilot communities
 - [hosted-approach.md](pilots/hosted-approach.md) - Approach for hosted cooperative pilot deployments
 - [decision_registry_treasury_vote.md](pilots/decision_registry_treasury_vote.md) - Economic receipt chain implementation in pilot

--- a/docs/contracts/institution-package/README.md
+++ b/docs/contracts/institution-package/README.md
@@ -1,0 +1,28 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-03
+---
+
+# Institution package — ActionCard contract notes
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| [`action-card.schema.json`](action-card.schema.json) | JSON Schema for one element of the `cards` array on `GET /v1/gov/me/action-cards`. |
+
+## Stability
+
+The schema sets `"x-icn-status": "rfc"`. Treat the shape as **versioned contract surface**, not frozen public API — gateway field additions go through OpenAPI regeneration and CI drift checks. Publication and stabilization work is tracked in [#1713](https://github.com/InterCooperative-Network/icn/issues/1713).
+
+## Validation guidance for package repos
+
+1. Validate each planned card object against `action-card.schema.json` **only** for keys you intend to align with ICN runtime; package-local extensions belong outside the validated object or in a separate schema owned by the package.
+2. Do **not** add institution-specific **nouns** to this schema; bind local meaning in package docs or mappings.
+3. Respect **emitted vs gated** `source_kind` values documented in the schema (`x-icn-emitted-source-kinds` vs `x-icn-rfc-gated-source-kinds`).
+4. Prefer regulatory-safe vocabulary in human docs: **settlement**, **obligation**, **allocation**, **receipt**, **provenance** — not payment/wallet/balance framing for the substrate.
+
+## Runtime source of truth
+
+Rust structs and serde names live in `icn/apps/governance/src/http/models.rs` (`ActionCard`, `ActionCardsResponse`). If they diverge from this schema, update the schema in the same change set as the API change and regenerate OpenAPI / TypeScript types per `AGENTS.md`.

--- a/docs/contracts/institution-package/README.md
+++ b/docs/contracts/institution-package/README.md
@@ -14,7 +14,7 @@ Last Reviewed: 2026-05-03
 
 ## Stability
 
-The schema sets `"x-icn-status": "rfc"`. Treat the shape as **versioned contract surface**, not frozen public API — gateway field additions go through OpenAPI regeneration and CI drift checks. Publication and stabilization work is tracked in [#1713](https://github.com/InterCooperative-Network/icn/issues/1713).
+The schema sets `"x-icn-status": "rfc"`. Treat the shape as **versioned contract surface**, not frozen public API. **OpenAPI export and generated TypeScript types** are what CI drift checks guard today (`icnctl api export-openapi`, `sdk/typescript` regen) — those checks protect the **generated** API contract, not this hand-maintained JSON file. **`action-card.schema.json` is edited by hand** alongside contract work; changes to `ActionCard` / `ActionCardsResponse` in `icn/apps/governance/src/http/models.rs` should update this schema in the **same PR** as the API/OpenAPI change. **Mechanical** drift detection for this schema (for example CI comparing schema to serde shapes) is **future work** unless and until it is implemented. Publication and stabilization work is tracked in [#1713](https://github.com/InterCooperative-Network/icn/issues/1713).
 
 ## Validation guidance for package repos
 

--- a/docs/contracts/institution-package/action-card.schema.json
+++ b/docs/contracts/institution-package/action-card.schema.json
@@ -2,14 +2,17 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://intercooperative.network/contracts/institution-package/action-card.schema.json",
   "title": "ActionCard",
-  "description": "A single pending action card for a member, returned by GET /v1/gov/me/action-cards. Cards are derived views — computed at request time from the holder's standing plus open governance state — and are never stored entities. See ADR-0027.",
+  "description": "A single pending action card for a member, returned by GET /v1/gov/me/action-cards. Cards are derived views — computed at request time from the holder's standing plus open governance state — and are never stored entities. See ADR-0027. The companion HTTP wrapper `{ did, cards, generated_at }` is OpenAPI-documented in the gateway; institution packages validating exports should validate each element of `cards` against this schema.",
   "x-icn-status": "rfc",
+  "x-icn-emitted-source-kinds": ["proposal", "meeting", "action_item"],
+  "x-icn-rfc-gated-source-kinds": ["signal_rule", "obligation_lifecycle"],
   "x-icn-references": [
     "ADR-0020",
     "ADR-0027",
     "ADR-0028",
     "GitHub icn#1646",
-    "GitHub icn#1608"
+    "GitHub icn#1608",
+    "GitHub icn#1713"
   ],
   "type": "object",
   "required": [
@@ -30,11 +33,11 @@
   "properties": {
     "id": {
       "type": "string",
-      "description": "Stable, deterministic id of the card. Format: card-<source_kind>-<source_id>(-<action_kind>). Two requests at the same moment from the same DID return identical card ids.",
+      "description": "Stable, deterministic id of the card. Runtime format today: card-<source_kind_snake>-<source_id>-<action_kind_snake> (examples: card-proposal-<proposal_id>-vote, card-meeting-<meeting_id>-attend, card-action_item-<item_id>-complete). Two requests at the same moment from the same DID return identical card ids.",
       "minLength": 1
     },
     "source_kind": {
-      "description": "Where this card was derived from. Closed taxonomy. Variants 'signal_rule' and 'obligation_lifecycle' are reserved by issue icn#1646 and not emitted by the runtime today; they will land alongside their source-path implementation.",
+      "description": "Where this card was derived from. Closed taxonomy. Values in x-icn-emitted-source-kinds are returned today when matching governance objects exist. Values in x-icn-rfc-gated-source-kinds appear in this schema for forward compatibility only; they are not emitted until their source paths land (icn#1646, icn#1631, icn#1634).",
       "type": "string",
       "enum": [
         "proposal",

--- a/docs/pilots/nycn-organizer-user-readiness.md
+++ b/docs/pilots/nycn-organizer-user-readiness.md
@@ -1,0 +1,56 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-03
+---
+
+# NYCN organizer and user readiness (ICN side)
+
+ICN-side orientation for **NYCN organizers**, **stewards**, and anyone explaining **member-legible** surfaces. It does not duplicate the NYCN package repo; use [NYCN `docs/ORGANIZER-USER-READINESS.md`](https://github.com/fahertym/nycn/blob/main/docs/ORGANIZER-USER-READINESS.md) for ladder commands and fixture policy there.
+
+**Non-claims:** Phase 2 is **not** marked complete here. NYCN is the **intended** first cooperative partner, not a formally committed pilot unless a repo-safe organizer record says so. No production-readiness, live federation, or hosted multi-tenant guarantee.
+
+## What ICN runtime surfaces matter for organizers now
+
+| Surface | HTTP (gateway) | Role |
+|---------|----------------|------|
+| Standing | `GET /v1/gov/me/standing` | Who the caller is, memberships, roles, capabilities, selected scope — the join point for accessible shells. |
+| Action cards | `GET /v1/gov/me/action-cards` | Pending **vote**, **attend**, **complete** work items derived from governance state (see ADR-0027). |
+| Action-item completion receipt | `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | Read-side closure of the action-item proof loop (`governance:read` + domain membership). |
+
+Routing and vocabulary: [runtime-surface-map.md](../reference/project-index/runtime-surface-map.md). Honest demo boundaries: [show-readiness-map.md](../reference/project-index/show-readiness-map.md).
+
+## Path for a future member (standing → cards → receipts → evidence)
+
+1. **Standing** — one coherent view of participatory position (contract: [MEMBER_STANDING.md](../architecture/MEMBER_STANDING.md)); implementation exists per [STATE.md](../STATE.md).
+2. **Action cards** — a deterministic, derived list of what needs attention **now**; completing an item uses the normal governance endpoints for that object type, not a separate “card API.”
+3. **Receipts** — append-only records (governance decision, meeting attendance, action-item completion) retrievable over HTTP for audit and provenance.
+4. **Evidence** — for pilot rehearsals, evidence is **human procedure + repo-safe artifacts** (see [NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md](../strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md) and NYCN evidence docs), not private data in the ICN tree.
+
+## Generic substrate vs NYCN package material
+
+- **ICN** ships closed enums, receipt types, and gateway routes that any institution package can use without baking in partner-specific nouns.
+- **NYCN** (separate repo) holds charter instances, summit fixtures, drive-ingest ladders, and **package-local** template prose. NYCN maps to ICN primitives in its own docs and `institution/mappings/` — not the other way around in core.
+
+## What remains gated
+
+- Action-card source paths **`signal_rule`** and **`obligation_lifecycle`** are **reserved** in the contract; the runtime does **not** emit them yet ([#1646](https://github.com/InterCooperative-Network/icn/issues/1646), [#1631](https://github.com/InterCooperative-Network/icn/issues/1631), [#1634](https://github.com/InterCooperative-Network/icn/issues/1634)).
+- Broader federation, hosted operator defaults, and mobile productization remain phased work — see [PHASE_PROGRESS.md](../PHASE_PROGRESS.md).
+
+## Accessible participation
+
+Non-technical members should only need a **shell** (web, mobile, or assisted kiosk) that reads standing and action cards, guides one action at a time, and surfaces receipts in plain language. ICN keeps policy and meaning in apps and charters; the kernel enforces **constraints**, not social doctrine ([KERNEL_APP_SEPARATION.md](../architecture/KERNEL_APP_SEPARATION.md)).
+
+## ActionCard package contract
+
+Institution packages should validate card-shaped JSON against:
+
+- `docs/contracts/institution-package/action-card.schema.json` (**experimental / RFC** — see `x-icn-status` in file)
+- Package validation notes: `docs/contracts/institution-package/README.md`
+
+Tracking: [#1713](https://github.com/InterCooperative-Network/icn/issues/1713). Organizer gate: [#1703](https://github.com/InterCooperative-Network/icn/issues/1703).
+
+## Source of truth
+
+- [STATE.md](../STATE.md), [PHASE_PROGRESS.md](../PHASE_PROGRESS.md)
+- [NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md](../strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md)

--- a/docs/pilots/nycn-organizer-user-readiness.md
+++ b/docs/pilots/nycn-organizer-user-readiness.md
@@ -6,7 +6,7 @@ Last Reviewed: 2026-05-03
 
 # NYCN organizer and user readiness (ICN side)
 
-ICN-side orientation for **NYCN organizers**, **stewards**, and anyone explaining **member-legible** surfaces. It does not duplicate the NYCN package repo; use [NYCN `docs/ORGANIZER-USER-READINESS.md`](https://github.com/fahertym/nycn/blob/main/docs/ORGANIZER-USER-READINESS.md) for ladder commands and fixture policy there.
+ICN-side orientation for **NYCN organizers**, **stewards**, and anyone explaining **member-legible** surfaces. It does not duplicate the NYCN package repo; use [NYCN `docs/ORGANIZER-USER-READINESS.md`](https://github.com/InterCooperative-Network/nycn/blob/main/docs/ORGANIZER-USER-READINESS.md) for ladder commands and fixture policy there.
 
 **Non-claims:** Phase 2 is **not** marked complete here. NYCN is the **intended** first cooperative partner, not a formally committed pilot unless a repo-safe organizer record says so. No production-readiness, live federation, or hosted multi-tenant guarantee.
 
@@ -24,7 +24,10 @@ Routing and vocabulary: [runtime-surface-map.md](../reference/project-index/runt
 
 1. **Standing** — one coherent view of participatory position (contract: [MEMBER_STANDING.md](../architecture/MEMBER_STANDING.md)); implementation exists per [STATE.md](../STATE.md).
 2. **Action cards** — a deterministic, derived list of what needs attention **now**; completing an item uses the normal governance endpoints for that object type, not a separate “card API.”
-3. **Receipts** — append-only records (governance decision, meeting attendance, action-item completion) retrievable over HTTP for audit and provenance.
+3. **Receipts** — append-only records close the proof loop, but **HTTP retrieval today is not uniform across kinds**:
+   - **Action-item completion:** `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` returns the completion receipt when permitted (see the table above and [runtime-surface-map.md](../reference/project-index/runtime-surface-map.md)).
+   - **Proposal / vote:** governance decision receipts and proof-style reads are exercised through the proposal/vote flow and related surfaces documented in runtime maps and tests — not the same URL shape as the action-item completion-receipt route.
+   - **Meeting / attend:** marking attendance (`PUT` on the meeting attendance surface) is part of the loop that **produces** `MeetingAttendanceReceipt` records in governance storage; this doc does **not** claim a dedicated public `GET …/attendance-receipt`-style HTTP mirror analogous to the action-item completion-receipt path unless one is listed in the gateway route map.
 4. **Evidence** — for pilot rehearsals, evidence is **human procedure + repo-safe artifacts** (see [NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md](../strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md) and NYCN evidence docs), not private data in the ICN tree.
 
 ## Generic substrate vs NYCN package material

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -10,7 +10,7 @@
 [control]
 schema_version = 1
 allowlisted_docs_subdirs = [
-  "adr", "ai", "api", "architecture", "archive", "ci", "crate-manifests", "demo", "deployment",
+  "adr", "ai", "api", "architecture", "archive", "ci", "contracts", "crate-manifests", "demo", "deployment",
   "design", "design-language", "dev", "development", "examples", "features", "guides", "internal",
   "maintenance", "manual", "migration-guides", "mobile", "observability", "onboarding", "operations",
   "ops", "performance", "phases", "pilots", "planning", "plans", "reference", "rfcs", "scripts", "sdis",
@@ -3143,6 +3143,38 @@ freshness = "current"
 domain_tags = ["pilot", "nycn", "discovery", "communications"]
 recommended_action = "keep"
 last_reviewed = "2026-04-29"
+
+[docs."docs/pilots/nycn-organizer-user-readiness.md"]
+category = "reference"
+status = "living"
+title = "NYCN Organizer User Readiness (ICN side)"
+description = "ICN-side pilot readiness: /me/standing, /me/action-cards, completion-receipt retrieval, proof loops, generic vs package-local material, gated paths, and accessible participation. Links to STATE, phase progress, runtime map, member standing, and NYCN Phase 2 rehearsal gate."
+last_updated = "2026-05-03"
+owner = "matt"
+audiences = ["team", "organizers"]
+truth_class = "descriptive"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["pilot", "nycn", "communications", "action-cards"]
+recommended_action = "keep"
+last_reviewed = "2026-05-03"
+
+[docs."docs/contracts/institution-package/README.md"]
+category = "reference"
+status = "living"
+title = "Institution Package ActionCard Contract Notes"
+description = "Validation guidance for institution packages using action-card.schema.json; emitted vs RFC-gated source kinds; pointers to runtime models and issue icn#1713."
+last_updated = "2026-05-03"
+owner = "matt"
+audiences = ["contributors", "organizers"]
+truth_class = "descriptive"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["contracts", "governance", "action-cards"]
+recommended_action = "keep"
+last_reviewed = "2026-05-03"
 
 # ============================================================================
 # PLANNING AND STRATEGY (Additional)

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -233,8 +233,10 @@ pub enum ActionCardRiskLevel {
 /// does not learn package-specific nouns from this surface.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ActionCard {
-    /// Stable, deterministic id of the card. Format:
-    /// `card-<source_kind>-<source_id>` so the same underlying object yields
+    /// Stable, deterministic id of the card. Runtime format:
+    /// `card-<source_kind_snake>-<source_id>-<action_kind_snake>` (for example
+    /// `card-proposal-<id>-vote`, `card-meeting-<id>-attend`,
+    /// `card-action_item-<id>-complete`) so the same underlying object yields
     /// the same card id across requests.
     pub id: String,
     pub source_kind: ActionCardSourceKind,


### PR DESCRIPTION
## Summary

Adds an ICN-side NYCN organizer/user readiness bridge and aligns the generic ActionCard package contract with the current runtime surface.

## What changed

- Added `docs/pilots/nycn-organizer-user-readiness.md`
- Updated `docs/contracts/institution-package/action-card.schema.json`
- Added `docs/contracts/institution-package/README.md`
- Updated `ActionCard` id documentation in `icn/apps/governance/src/http/models.rs`
- Registered new docs and regenerated docs index

## Why

This gives organizers and package authors a clearer bridge from ICN runtime surfaces to the NYCN rehearsal path:

standing → action cards → receipts → evidence

It also distinguishes currently emitted ActionCard source kinds from RFC-gated ones.

## What did not change

- No runtime behavior change
- No OpenAPI or TypeScript type change
- No Phase 2 completion claim
- No formal NYCN pilot claim
- No production readiness claim
- No live federation claim
- No K3s/DNS/GitHub/Forgejo mutation
- No licensing decision

## Privacy

No private NYCN data, private URLs, organizer/member/sponsor/attendee details, credentials, or private overlays were added.

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict`
- `python3 .github/scripts/compliance_linter.py`
- `cargo fmt --check`
- `cargo check -p icn-governance-actor`
- `git diff --check`

## Related

- #1703
- #1713
- #1711
- #1712
