### PR TITLE
docs(pilot): pointer to NYCN REHEARSAL-0002 gate prep

### DIFF
--- a/docs/INDEX.generated.md
+++ b/docs/INDEX.generated.md
@@ -1711,7 +1711,7 @@ Planning artifact only. Component-by-component licensing/autonomy matrix and opt
 
 Organizer-safe control-plane gate for moving from Phase 2 machinery exists to formal NYCN pilot rehearsal: organizer presentation, pilot formalization, first operator rehearsal. Descriptive planning only; not production readiness or Phase 2 completion.
 
-**For:** `maintainers`, `organizers`, `operators` | **Updated:** 2026-05-02
+**For:** `maintainers`, `organizers`, `operators` | **Updated:** 2026-05-03
 
 ### 📋 **Draft** [ICN Compliance Architecture](/docs/strategy/grants/compliance-architecture.md)
 

--- a/docs/pilots/nycn-organizer-user-readiness.md
+++ b/docs/pilots/nycn-organizer-user-readiness.md
@@ -57,3 +57,5 @@ Tracking: [#1713](https://github.com/InterCooperative-Network/icn/issues/1713). 
 
 - [STATE.md](../STATE.md), [PHASE_PROGRESS.md](../PHASE_PROGRESS.md)
 - [NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md](../strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md)
+- NYCN facilitator prep (checklists only, not a decision record):
+  [REHEARSAL-0002 — Organizer gate prep](https://github.com/InterCooperative-Network/nycn/blob/main/docs/rehearsals/REHEARSAL-0002-organizer-gate-prep.md)

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -1320,7 +1320,7 @@ category = "strategy"
 status = "draft"
 title = "NYCN Phase 2 pilot rehearsal gate"
 description = "Organizer-safe control-plane gate for moving from Phase 2 machinery exists to formal NYCN pilot rehearsal: organizer presentation, pilot formalization, first operator rehearsal. Descriptive planning only; not production readiness or Phase 2 completion."
-last_updated = "2026-05-02"
+last_updated = "2026-05-03"
 owner = "matt"
 audiences = ["maintainers", "organizers", "operators"]
 truth_class = "descriptive"
@@ -1329,7 +1329,7 @@ canonical = "no"
 freshness = "current"
 domain_tags = ["strategy", "nycn", "pilot", "phase-2"]
 recommended_action = "keep"
-last_reviewed = "2026-05-02"
+last_reviewed = "2026-05-03"
 
 [docs."docs/strategy/LICENSING_STRATEGY_MATRIX.md"]
 category = "strategy"

--- a/docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md
+++ b/docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md
@@ -23,9 +23,6 @@ declare production readiness, or authorize live infrastructure mutation.
 
 Required inputs:
 
-- Optional facilitator prep (NYCN repo, checklist only — does **not** record
-  that the presentation occurred):
-  [REHEARSAL-0002 — Organizer gate prep](https://github.com/InterCooperative-Network/nycn/blob/main/docs/rehearsals/REHEARSAL-0002-organizer-gate-prep.md).
 - Drive-ingest `START_HERE`, organizer briefing, and simple summit demo.
 - Plain-language explanation of the ICN proof loop: organizer material becomes
   reviewable action items, operator decisions produce receipts, and provenance
@@ -34,6 +31,11 @@ Required inputs:
   Google Groups synchronization, no K3s mutation, and no NYCN private data in
   the public ICN repository.
 - A clear statement of what organizers are being asked to decide.
+
+Optional prep (NYCN repo, checklist only — does **not** record that the
+presentation occurred):
+
+- [REHEARSAL-0002 — Organizer gate prep](https://github.com/InterCooperative-Network/nycn/blob/main/docs/rehearsals/REHEARSAL-0002-organizer-gate-prep.md).
 
 Required organizer decision:
 

--- a/docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md
+++ b/docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-05-02
+Last Reviewed: 2026-05-03
 ---
 
 # NYCN Phase 2 Pilot Rehearsal Gate
@@ -23,6 +23,9 @@ declare production readiness, or authorize live infrastructure mutation.
 
 Required inputs:
 
+- Optional facilitator prep (NYCN repo, checklist only — does **not** record
+  that the presentation occurred):
+  [REHEARSAL-0002 — Organizer gate prep](https://github.com/InterCooperative-Network/nycn/blob/main/docs/rehearsals/REHEARSAL-0002-organizer-gate-prep.md).
 - Drive-ingest `START_HERE`, organizer briefing, and simple summit demo.
 - Plain-language explanation of the ICN proof loop: organizer material becomes
   reviewable action items, operator decisions produce receipts, and provenance


### PR DESCRIPTION
## What changed
- `docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md` and `docs/pilots/nycn-organizer-user-readiness.md`: narrow links to NYCN `REHEARSAL-0002-organizer-gate-prep.md` (facilitator/steward execution prep).
- Gate 1 structure: **Required inputs** lists only items needed for the organizer presentation; **Optional prep** holds the REHEARSAL-0002 checklist link (addresses review feedback: optional material must not sit under a "required" heading).
- `docs/registry.toml` + `docs/INDEX.generated.md`: freshness sync for the strategy doc.

## Why (May ~15, 2026 organizer introduction)
ICN maintainers and facilitators landing on the Phase 2 human-gate doc get a direct path to NYCN-side prep checklists without repo spelunking, with honest required vs optional labeling so rehearsal expectations stay legible under time pressure.

## What did **not** happen / non-claims
- No Phase 2 completion, formal NYCN pilot commitment, production readiness, live sync/federation/infra authorization, or claim that the organizer meeting occurred.
- REHEARSAL-0002 remains checklist-only; it does not record that a presentation happened.

## Privacy boundaries
- Link targets are repo-safe prep text only (no private overlays, Drive/Groups URLs, credentials, or subscriber data in this PR).

## Validation
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict` — **passed** (pre-existing `explicit-registry` / `yaml-mismatch` warnings unchanged)
- `python3 .github/scripts/compliance_linter.py` — **no violations**
- `git diff --check` — **ok**
- `cargo fmt --all -- --check` (from `icn/`) — **ok** (no Rust changes on branch; gate sanity)

## Related
- InterCooperative-Network/nycn#41
- InterCooperative-Network/icn#1703

**Merge note:** Prefer merging NYCN first so the `main` URL in the new bullets resolves; ICN can follow.

Made with [Cursor](https://cursor.com)