### PR TITLE
docs(contracts): ActionCard emitted pairs and gated-path clarity

### DIFF
--- a/docs/INDEX.generated.md
+++ b/docs/INDEX.generated.md
@@ -1210,7 +1210,7 @@ CI gates, ratchet phases, required checks, and failure index
 
 Validation guidance for institution packages using action-card.schema.json; emitted vs RFC-gated source kinds; pointers to runtime models and issue icn#1713.
 
-**For:** `contributors`, `organizers` | **Updated:** 2026-05-03
+**For:** `contributors`, `organizers` | **Updated:** 2026-05-04
 
 ### 📝 **Living** [Demo System Documentation](/docs/demo/README.md)
 
@@ -1372,7 +1372,7 @@ Bounded set of questions to ask NYCN organizers — workflow validation, source/
 
 ICN-side pilot readiness: /me/standing, /me/action-cards, completion-receipt retrieval, proof loops, generic vs package-local material, gated paths, and accessible participation. Links to STATE, phase progress, runtime map, member standing, and NYCN Phase 2 rehearsal gate.
 
-**For:** `team`, `organizers` | **Updated:** 2026-05-03
+**For:** `team`, `organizers` | **Updated:** 2026-05-04
 
 ### 📋 **Draft** [Agent Knowledge Architecture](/docs/planning/agent-knowledge-architecture.md)
 

--- a/docs/contracts/institution-package/README.md
+++ b/docs/contracts/institution-package/README.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-05-03
+Last Reviewed: 2026-05-04
 ---
 
 # Institution package — ActionCard contract notes
@@ -16,11 +16,34 @@ Last Reviewed: 2026-05-03
 
 The schema sets `"x-icn-status": "rfc"`. Treat the shape as **versioned contract surface**, not frozen public API. **OpenAPI export and generated TypeScript types** are what CI drift checks guard today (`icnctl api export-openapi`, `sdk/typescript` regen) — those checks protect the **generated** API contract, not this hand-maintained JSON file. **`action-card.schema.json` is edited by hand** alongside contract work; changes to `ActionCard` / `ActionCardsResponse` in `icn/apps/governance/src/http/models.rs` should update this schema in the **same PR** as the API/OpenAPI change. **Mechanical** drift detection for this schema (for example CI comparing schema to serde shapes) is **future work** unless and until it is implemented. Publication and stabilization work is tracked in [#1713](https://github.com/InterCooperative-Network/icn/issues/1713).
 
+## Emitted pairs (runtime today)
+
+These `(source_kind, action_kind)` combinations are what `icn/apps/governance` may place on `GET /v1/gov/me/action-cards` when matching governance objects exist. They are also listed in the schema extension `x-icn-emitted-source-action-pairs`.
+
+| source_kind | action_kind | Plain-language ask |
+|-------------|---------------|-------------------|
+| `proposal` | `vote` | Cast or delegate a vote on an open proposal. |
+| `meeting` | `attend` | Confirm or adjust attendance for a scheduled meeting. |
+| `action_item` | `complete` | Close an assigned action item via its governance endpoints. |
+
+## Gated source kinds (schema reserved; not emitted)
+
+Enum values exist for forward compatibility; the runtime does **not** return cards for these until their source paths land.
+
+| source_kind | Tracking (implementation + contract) |
+|-------------|----------------------------------------|
+| `signal_rule` | [#1631](https://github.com/InterCooperative-Network/icn/issues/1631), [#1711](https://github.com/InterCooperative-Network/icn/issues/1711), [#1646](https://github.com/InterCooperative-Network/icn/issues/1646) |
+| `obligation_lifecycle` | [#1634](https://github.com/InterCooperative-Network/icn/issues/1634), [#1712](https://github.com/InterCooperative-Network/icn/issues/1712), [#1646](https://github.com/InterCooperative-Network/icn/issues/1646) |
+
+## Organizer-facing chain (how to explain the demo)
+
+**Standing → action cards → authorized action on native endpoints → receipt → provenance/evidence.** Standing (`GET /v1/gov/me/standing`) says who the caller is and what scopes apply. Action cards (`GET /v1/gov/me/action-cards`) list pending work as generic derived rows only. Completing work uses the normal proposal, meeting, or action-item HTTP surfaces for that object type; cards do not define a separate mutation API. Receipts close the proof loop where documented (see runtime maps and ADR-0027).
+
 ## Validation guidance for package repos
 
 1. Validate each planned card object against `action-card.schema.json` **only** for keys you intend to align with ICN runtime; package-local extensions belong outside the validated object or in a separate schema owned by the package.
 2. Do **not** add institution-specific **nouns** to this schema; bind local meaning in package docs or mappings.
-3. Respect **emitted vs gated** `source_kind` values documented in the schema (`x-icn-emitted-source-kinds` vs `x-icn-rfc-gated-source-kinds`).
+3. Respect **emitted vs gated** `source_kind` values documented in the schema (`x-icn-emitted-source-kinds`, `x-icn-emitted-source-action-pairs`, and `x-icn-rfc-gated-source-kinds`).
 4. Prefer regulatory-safe vocabulary in human docs: **settlement**, **obligation**, **allocation**, **receipt**, **provenance** — not payment/wallet/balance framing for the substrate.
 
 ## Runtime source of truth

--- a/docs/contracts/institution-package/action-card.schema.json
+++ b/docs/contracts/institution-package/action-card.schema.json
@@ -5,6 +5,11 @@
   "description": "A single pending action card for a member, returned by GET /v1/gov/me/action-cards. Cards are derived views — computed at request time from the holder's standing plus open governance state — and are never stored entities. See ADR-0027. The companion HTTP wrapper `{ did, cards, generated_at }` is OpenAPI-documented in the gateway; institution packages validating exports should validate each element of `cards` against this schema.",
   "x-icn-status": "rfc",
   "x-icn-emitted-source-kinds": ["proposal", "meeting", "action_item"],
+  "x-icn-emitted-source-action-pairs": [
+    { "source_kind": "proposal", "action_kind": "vote" },
+    { "source_kind": "meeting", "action_kind": "attend" },
+    { "source_kind": "action_item", "action_kind": "complete" }
+  ],
   "x-icn-rfc-gated-source-kinds": ["signal_rule", "obligation_lifecycle"],
   "x-icn-references": [
     "ADR-0020",
@@ -12,7 +17,11 @@
     "ADR-0028",
     "GitHub icn#1646",
     "GitHub icn#1608",
-    "GitHub icn#1713"
+    "GitHub icn#1713",
+    "GitHub icn#1631",
+    "GitHub icn#1634",
+    "GitHub icn#1711",
+    "GitHub icn#1712"
   ],
   "type": "object",
   "required": [
@@ -37,7 +46,7 @@
       "minLength": 1
     },
     "source_kind": {
-      "description": "Where this card was derived from. Closed taxonomy. Values in x-icn-emitted-source-kinds are returned today when matching governance objects exist. Values in x-icn-rfc-gated-source-kinds appear in this schema for forward compatibility only; they are not emitted until their source paths land (icn#1646, icn#1631, icn#1634).",
+      "description": "Where this card was derived from. Closed taxonomy. Values in x-icn-emitted-source-kinds are returned today when matching governance objects exist, paired with action_kind as listed in x-icn-emitted-source-action-pairs (proposal→vote, meeting→attend, action_item→complete). Values in x-icn-rfc-gated-source-kinds appear for forward compatibility only: signal_rule is tracked with icn#1631 / icn#1711; obligation_lifecycle with icn#1634 / icn#1712; neither is emitted until those paths land (see also icn#1646).",
       "type": "string",
       "enum": [
         "proposal",

--- a/docs/pilots/nycn-organizer-user-readiness.md
+++ b/docs/pilots/nycn-organizer-user-readiness.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-05-03
+Last Reviewed: 2026-05-04
 ---
 
 # NYCN organizer and user readiness (ICN side)
@@ -48,7 +48,7 @@ Non-technical members should only need a **shell** (web, mobile, or assisted kio
 
 Institution packages should validate card-shaped JSON against:
 
-- `docs/contracts/institution-package/action-card.schema.json` (**experimental / RFC** — see `x-icn-status` in file)
+- `docs/contracts/institution-package/action-card.schema.json` (**RFC** — see `x-icn-status`; emitted `(source_kind, action_kind)` pairs are listed under `x-icn-emitted-source-action-pairs`, with `signal_rule` / `obligation_lifecycle` reserved-not-emitted)
 - Package validation notes: `docs/contracts/institution-package/README.md`
 
 Tracking: [#1713](https://github.com/InterCooperative-Network/icn/issues/1713). Organizer gate: [#1703](https://github.com/InterCooperative-Network/icn/issues/1703).

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -3149,7 +3149,7 @@ category = "reference"
 status = "living"
 title = "NYCN Organizer User Readiness (ICN side)"
 description = "ICN-side pilot readiness: /me/standing, /me/action-cards, completion-receipt retrieval, proof loops, generic vs package-local material, gated paths, and accessible participation. Links to STATE, phase progress, runtime map, member standing, and NYCN Phase 2 rehearsal gate."
-last_updated = "2026-05-03"
+last_updated = "2026-05-04"
 owner = "matt"
 audiences = ["team", "organizers"]
 truth_class = "descriptive"
@@ -3158,14 +3158,14 @@ canonical = "no"
 freshness = "current"
 domain_tags = ["pilot", "nycn", "communications", "action-cards"]
 recommended_action = "keep"
-last_reviewed = "2026-05-03"
+last_reviewed = "2026-05-04"
 
 [docs."docs/contracts/institution-package/README.md"]
 category = "reference"
 status = "living"
 title = "Institution Package ActionCard Contract Notes"
 description = "Validation guidance for institution packages using action-card.schema.json; emitted vs RFC-gated source kinds; pointers to runtime models and issue icn#1713."
-last_updated = "2026-05-03"
+last_updated = "2026-05-04"
 owner = "matt"
 audiences = ["contributors", "organizers"]
 truth_class = "descriptive"
@@ -3174,7 +3174,7 @@ canonical = "no"
 freshness = "current"
 domain_tags = ["contracts", "governance", "action-cards"]
 recommended_action = "keep"
-last_reviewed = "2026-05-03"
+last_reviewed = "2026-05-04"
 
 # ============================================================================
 # PLANNING AND STRATEGY (Additional)


### PR DESCRIPTION
## What changed
- `docs/contracts/institution-package/action-card.schema.json`: added `x-icn-emitted-source-action-pairs` (proposal→vote, meeting→attend, action_item→complete); expanded `source_kind` description with explicit pair semantics and gated-path tracking (#1631/#1711, #1634/#1712); extended `x-icn-references`.
- `docs/contracts/institution-package/README.md`: tables for emitted pairs and gated kinds; short organizer-facing chain (standing → cards → native endpoints → receipt → evidence).
- `docs/pilots/nycn-organizer-user-readiness.md`: pointer to the new schema extensions.
- `docs/registry.toml` + `docs/INDEX.generated.md`: freshness sync.

## Why (May ~15 organizer introduction)
Gives a single, honest place to explain which action cards exist today versus which enum values are reserved for future work, without institution-specific nouns in the generic contract.

## What did not happen / non-claims
- No new runtime `source_kind` or `action_kind` values; no `signal_rule` / `obligation_lifecycle` emission; no Phase 2 completion, pilot approval, production readiness, live federation, or live Google sync claims; no organizer meeting-held claim.

## Privacy boundaries
- Documentation and schema metadata only; no member or organizer private data.

## Validation run
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict` — pass (pre-existing registry warnings unchanged)
- `python3 .github/scripts/compliance_linter.py` — pass
- `git diff --check` — pass
- `python3 docs/scripts/generate-index.py --registry docs/registry.toml` → updated `docs/INDEX.generated.md`

## Related issues/PRs
- InterCooperative-Network/icn#1713
- InterCooperative-Network/nycn#43 (companion package alignment PR)

Made with [Cursor](https://cursor.com)