### PR TITLE
docs(pilots): no-CLI organizer/member rehearsal workflow

### DIFF
--- a/docs/pilots/no-cli-organizer-member-rehearsal-workflow.md
+++ b/docs/pilots/no-cli-organizer-member-rehearsal-workflow.md
@@ -1,0 +1,98 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-04
+---
+
+# No-CLI organizer and member rehearsal workflow (generic ICN)
+
+This document specifies the **guided, browser- or mobile-first** rehearsal story that institution packages should present to **organizers**, **members**, and **committee participants** — without treating a terminal or local script ladder as the default user journey.
+
+It complements operator runbooks and ladder checkers: those remain **steward/operator** and **verifier** tooling. It does **not** replace package-local ingest pipelines; it defines the **human-facing** steps and boundaries those pipelines must respect.
+
+**Non-claims:** No production readiness, no Phase 2 completion, no formal pilot for any partner, no live Google Drive/Groups/Sheets sync, no K3s/DNS/Forgejo mutation, no commitment that every step is implemented in product UI today. No private partner data belongs in the ICN repository.
+
+**Privacy:** ICN docs and examples stay **generic** and **repo-safe**. Partner-specific nouns, fixtures, and overlay policy live only in partner repositories.
+
+**Vocabulary:** Prefer **obligation**, **allocation**, **settlement**, **unit**, **position**, **receipt**, **provenance**, and **evidence** in substrate-facing copy. Do not describe ICN-native primitives as payment, currency, balance, or wallet surfaces.
+
+**Tracking:** [ICN#1724](https://github.com/InterCooperative-Network/icn/issues/1724), [NYCN#52](https://github.com/InterCooperative-Network/nycn/issues/52), gate context [ICN#1703](https://github.com/InterCooperative-Network/icn/issues/1703), [NYCN#41](https://github.com/InterCooperative-Network/nycn/issues/41).
+
+## 1. Three paths (must stay distinct)
+
+| Path | Primary actor | Default surface | Role of CLI / scripts |
+|------|----------------|-----------------|------------------------|
+| **Organizer** | Coordinating body, facilitator | Guided shell (web/mobile); slides or scripted demo acceptable for May presentations | Invisible in the **default** story; may appear only as “what stewards run later” |
+| **Steward / operator** | Trusted technical runner | Runbooks, localhost gateway, fenced execute modes | **Expected** — validation, smoke, ingest stages, proof checks |
+| **Future member** | Participant acting on assigned work | Standing → action cards → native completion flows → receipt visibility | None for day-to-day participation; optional developer tools |
+
+## 2. Mapped ICN primitives (substrate)
+
+| Workflow step (plain language) | ICN primitive (generic) | Notes |
+|--------------------------------|-------------------------|--------|
+| Who am I; where may I act? | **Standing** — `GET /v1/gov/me/standing` | Join point for accessible shells; see [MEMBER_STANDING.md](../architecture/MEMBER_STANDING.md) |
+| What needs my attention now? | **Action cards** — `GET /v1/gov/me/action-cards` | Derived rows only; cards do not define a separate mutation API ([ADR-0027](../adr/ADR-0027-action-card-contract.md)); contract [action-card.schema.json](../contracts/institution-package/action-card.schema.json) |
+| Governed work units from decisions | **Action items** | Created and updated through governance HTTP surfaces for the domain |
+| Completing an action item | **Action item** status change + **ActionItemCompletionReceipt** | Proof loop; read-side retrieval where documented ([nycn-organizer-user-readiness.md](nycn-organizer-user-readiness.md), runtime maps) |
+| Votes and meetings | **Proposals**, **meetings**, linked **receipts** | Emitted action-card pairs include `proposal`/`vote`, `meeting`/`attend`, `action_item`/`complete` |
+| Durable attestations | **Receipts** (governance, attendance, completion, per path) | Append-only records; HTTP retrieval is **not** uniform across every receipt kind today — shells must not over-promise |
+| Audit narrative | **Provenance** / **evidence** | Human procedure + **repo-safe** artifacts; not private spreadsheets in the ICN tree |
+
+Institution packages map local labels to these primitives in **package** docs and mappings — not by extending ICN core vocabulary.
+
+## 3. Guided workflow (organizer-visible)
+
+The organizer path is **review-first** and **mutation-last**. Numbers are the logical order for UX and training; implementation may batch steps where safe.
+
+1. **Start rehearsal** — From a browser-friendly shell (or facilitator-led demo), open a “rehearsal” mode that is clearly labeled **not live production** and **not** a pilot commitment.
+2. **Select material** — Choose **committed fixture / example** content prepared for the rehearsal, or upload **reviewed** organizer material per package policy. No silent import from live cloud drives on behalf of organizers.
+3. **Preview parsed proposals** — Show **plain-language** summaries of proposed **action items** (and other governed objects if applicable) **before** any publish or assign step.
+4. **Approve, reject, or edit** — Organizers record decisions in human-readable form; the system reflects edits in the preview. This mirrors the package’s human-review artifact boundaries (e.g. review → decisions files in partner tooling).
+5. **Assign by human name / role / label** — Assignment UX uses **labels** organizers understand first. **DID binding** and directory overlay steps are a **separate**, guided **activation / private-overlay** flow (package-local policy; not replicated into ICN core docs).
+6. **Preview before mutation** — Show exactly what will be created or changed (counts, titles, domains, assignee labels, mode flags). No mutation without an explicit second screen.
+7. **Confirm with warnings** — Require explicit acknowledgement of **privacy** (what leaves the device, what enters git, what stays in overlay) and **mutation** (that the rehearsal may write to a **non-production** gateway when operators enable it).
+8. **After confirmation** — Surface **action cards** (for holders who can authenticate), **completion status**, **receipts** where retrievable, **proof** or validation status in plain language, and a short **provenance / evidence** summary suitable for organizers.
+9. **Export evidence packet** — Produce a **repo-safe** rehearsal packet (basenames, categories, redacted summaries) suitable for version control or public issue comments — **no** private fields by default.
+
+## 4. Hard boundaries (all paths)
+
+- **Preview / review boundary before mutation** — Organizers never “skip ahead” into publish without a visible diff or summary equivalent.
+- **CLI as backend layer** — Scripts and modules remain for stewards, CI, and mechanical verification; they are not the organizer default story.
+- **Privacy-safe evidence by default** — Evidence exports list commands, modes, artifact basenames, and outcome categories — not private contact or accommodation data.
+- **No private partner data in ICN** — Partner repos hold package fixtures and overlay rules.
+- **No production pilot claim** from running tooling or demos.
+- **No live Google sync** from rehearsal tooling.
+- **No K3s/DNS/Forgejo mutation** from package rehearsal defaults.
+
+## 5. Accessibility (release-blocking for the user-facing path)
+
+When a product shell implements this workflow, it must be **mobile-first**, **plain-language**, **keyboard** and **screen-reader** usable, with **large touch targets**, and **no terminal assumption**. Until that shell exists, facilitators should use **reduced-motion**, high-contrast materials and avoid requiring attendees to read raw JSON or stack traces in meeting rooms.
+
+## 6. Implementation status and smallest presentation storyboard
+
+**Today:** ICN exposes the **HTTP** surfaces above; institution packages own ingest and review file formats. The ICN `web/pilot-ui` tree is oriented to **pilot community** flows (governance, timebank-style demos) and **steward enrollment** (`steward-dashboard`); it does **not** yet implement the full ingest → review → assign → preview → confirm ladder as a single guided organizer shell.
+
+**Smallest presentation-grade approach for May (recommended):**
+
+1. **Facilitator storyboard** — Walk through §3 using printed or slide **wireframes** (one screen per step). Use generic labels (“governing body,” “action item,” “holder”) — partner deck copy lives in the partner repo ([NYCN companion doc](https://github.com/InterCooperative-Network/nycn/blob/main/docs/NO-CLI-ORGANIZER-REHEARSAL-WORKFLOW.md)).
+2. **Optional live substrate peek (steward-only)** — On a **non-production** gateway, demonstrate **standing** and **action cards** JSON in a tool the room consents to (e.g. REST client), **after** stating privacy boundaries — not as the organizer default.
+3. **Defer product build** — A thin PWA that implements §3 end-to-end is **multi-sprint** work; track as follow-ups below rather than shipping a half-baked UI under presentation pressure.
+
+## 7. Follow-up work (issues / contracts)
+
+Track as discrete work items (GitHub issues welcome; not all may exist yet):
+
+- **UI prototype** — Single guided shell (organizer mode) with the §3 screen list.
+- **Fixture-backed demo** — Deterministic fixture load with no network by default.
+- **Generic preview/review API contract** — Stable read models for “pending publish” summaries (package-agnostic shapes).
+- **Evidence export contract** — Machine-readable **repo-safe** evidence summary schema shared with partners.
+- **Private-overlay / DID binding activation flow** — Documented UX for label → directory → DID without leaking overlay into public repos.
+- **Accessibility review** — WCAG-oriented pass on any new shell before calling it organizer-ready.
+- **Package validation** — Mechanical checks that package outputs align with [action-card.schema.json](../contracts/institution-package/action-card.schema.json) where applicable ([ICN#1713](https://github.com/InterCooperative-Network/icn/issues/1713), partner validation issues).
+
+## 8. See also
+
+- [nycn-organizer-user-readiness.md](nycn-organizer-user-readiness.md) — ICN runtime surfaces for organizers (NYCN-oriented bridge)
+- [NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md](../strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md) — Human gate: presentation → formalization → rehearsal
+- [Institution package ActionCard notes](../contracts/institution-package/README.md)
+- [STATE.md](../STATE.md), [PHASE_PROGRESS.md](../PHASE_PROGRESS.md)

--- a/docs/pilots/nycn-organizer-user-readiness.md
+++ b/docs/pilots/nycn-organizer-user-readiness.md
@@ -8,6 +8,8 @@ Last Reviewed: 2026-05-04
 
 ICN-side orientation for **NYCN organizers**, **stewards**, and anyone explaining **member-legible** surfaces. It does not duplicate the NYCN package repo; use [NYCN `docs/ORGANIZER-USER-READINESS.md`](https://github.com/InterCooperative-Network/nycn/blob/main/docs/ORGANIZER-USER-READINESS.md) for ladder commands and fixture policy there.
 
+For the **presentation-first, no-terminal default story** (organizer vs steward vs future member), read the generic workflow spec: [no-cli-organizer-member-rehearsal-workflow.md](no-cli-organizer-member-rehearsal-workflow.md). NYCN copy and meeting-room wireframes: [NO-CLI-ORGANIZER-REHEARSAL-WORKFLOW.md on NYCN](https://github.com/InterCooperative-Network/nycn/blob/main/docs/NO-CLI-ORGANIZER-REHEARSAL-WORKFLOW.md).
+
 **Non-claims:** Phase 2 is **not** marked complete here. NYCN is the **intended** first cooperative partner, not a formally committed pilot unless a repo-safe organizer record says so. No production-readiness, live federation, or hosted multi-tenant guarantee.
 
 ## What ICN runtime surfaces matter for organizers now
@@ -51,10 +53,11 @@ Institution packages should validate card-shaped JSON against:
 - `docs/contracts/institution-package/action-card.schema.json` (**RFC** — see `x-icn-status`; emitted `(source_kind, action_kind)` pairs are listed under `x-icn-emitted-source-action-pairs`, with `signal_rule` / `obligation_lifecycle` reserved-not-emitted)
 - Package validation notes: `docs/contracts/institution-package/README.md`
 
-Tracking: [#1713](https://github.com/InterCooperative-Network/icn/issues/1713). Organizer gate: [#1703](https://github.com/InterCooperative-Network/icn/issues/1703).
+Tracking: [#1713](https://github.com/InterCooperative-Network/icn/issues/1713). Organizer gate: [#1703](https://github.com/InterCooperative-Network/icn/issues/1703). No-CLI rehearsal narrative: [#1724](https://github.com/InterCooperative-Network/icn/issues/1724).
 
 ## Source of truth
 
+- [no-cli-organizer-member-rehearsal-workflow.md](no-cli-organizer-member-rehearsal-workflow.md) — generic guided workflow; CLI remains steward/operator layer
 - [STATE.md](../STATE.md), [PHASE_PROGRESS.md](../PHASE_PROGRESS.md)
 - [NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md](../strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md)
 - NYCN facilitator prep (checklists only, not a decision record):

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -3160,6 +3160,22 @@ domain_tags = ["pilot", "nycn", "communications", "action-cards"]
 recommended_action = "keep"
 last_reviewed = "2026-05-04"
 
+[docs."docs/pilots/no-cli-organizer-member-rehearsal-workflow.md"]
+category = "reference"
+status = "living"
+title = "No-CLI organizer and member rehearsal workflow (generic ICN)"
+description = "Guided browser/mobile-first rehearsal story: standing, action cards, action items, receipts, provenance, repo-safe evidence; organizer vs steward vs member paths; preview-before-mutation; CLI as operator layer only; follow-ups for UI/API/evidence contracts. Partner companion doc lives in NYCN repo."
+last_updated = "2026-05-04"
+owner = "matt"
+audiences = ["team", "organizers"]
+truth_class = "descriptive"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["pilot", "nycn", "communications", "action-cards", "accessibility"]
+recommended_action = "keep"
+last_reviewed = "2026-05-04"
+
 [docs."docs/contracts/institution-package/README.md"]
 category = "reference"
 status = "living"

--- a/docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md
+++ b/docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md
@@ -36,6 +36,8 @@ Optional prep (NYCN repo, checklist only — does **not** record that the
 presentation occurred):
 
 - [REHEARSAL-0002 — Organizer gate prep](https://github.com/InterCooperative-Network/nycn/blob/main/docs/rehearsals/REHEARSAL-0002-organizer-gate-prep.md).
+- Guided **no-CLI** organizer/member narrative (generic ICN): [`docs/pilots/no-cli-organizer-member-rehearsal-workflow.md`](../pilots/no-cli-organizer-member-rehearsal-workflow.md).
+- NYCN companion (package language, wireframe order): [`NO-CLI-ORGANIZER-REHEARSAL-WORKFLOW.md` on NYCN](https://github.com/InterCooperative-Network/nycn/blob/main/docs/NO-CLI-ORGANIZER-REHEARSAL-WORKFLOW.md).
 
 Required organizer decision:
 


### PR DESCRIPTION
## What changed

- Added `docs/pilots/no-cli-organizer-member-rehearsal-workflow.md`: generic guided workflow (browser/mobile-first) for organizers vs stewards vs future members, mapped to standing, action cards, action items, receipts, provenance, and repo-safe evidence export.
- Registered the doc in `docs/registry.toml`.
- Cross-linked from `docs/pilots/nycn-organizer-user-readiness.md` and `docs/strategy/NYCN_PHASE_2_PILOT_REHEARSAL_GATE.md`.
- Documents smallest May presentation path (facilitator storyboard + optional steward-only substrate peek); defers integrated UI to follow-up issues listed in the spec.

## Why this matters for the May organizer presentation

Organizers should meet a **plain-language, non-terminal** narrative first. The existing operator ladder stays valid for stewards and verifiers but must not read as the default democratic user story.

## Non-claims

- No production readiness, Phase 2 completion, or formal NYCN pilot.
- No live Google sync, K3s/DNS/Forgejo mutation, or private NYCN data in ICN.
- No claim that a full ingest UI exists in-repo today (`web/pilot-ui` is pilot-community / steward-enrollment oriented, not the full ingest shell).

## Privacy boundaries

- ICN doc stays generic; partner nouns and fixtures live in the NYCN repo only.
- Evidence by default is repo-safe summaries, not private overlays.

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict`
- `python3 .github/scripts/compliance_linter.py`
- `git diff --check`

## Related issues

- InterCooperative-Network/icn#1724
- InterCooperative-Network/nycn#52
- InterCooperative-Network/icn#1703
- InterCooperative-Network/nycn#41


Made with [Cursor](https://cursor.com)