### PR TITLE
docs(state): sync no-CLI and website cleanup tranche

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,10 +1,44 @@
 ---
 Status: descriptive
 Canonical: yes
-Last Reviewed: 2026-05-02
+Last Reviewed: 2026-05-04
 ---
 
 # ICN State (living doc)
+
+<!-- [sync edit] 2026-05-04 (post-#1725 / NYCN-#53 / #1732):
+     Documentation and public-surface truth-sync. ICN #1725
+     landed the generic no-CLI organizer/member rehearsal
+     workflow spec at docs/pilots/no-cli-organizer-member-
+     rehearsal-workflow.md — review-first, mutation-last,
+     three roles distinguished (organizer / steward-operator /
+     future member), accessibility baseline release-blocking
+     for any user-facing shell, evidence export repo-safe by
+     default. NYCN #53 landed the NYCN companion at
+     docs/NO-CLI-ORGANIZER-REHEARSAL-WORKFLOW.md (in
+     fahertym/nycn). ICN #1732 landed the website README
+     civic design truth-sync, replacing stale Lexend / hex
+     palette / "modern design system" / Tailwind framing
+     with pointers to docs/design-language/ and
+     website/src/styles/global.css as the single token
+     surface. These are documentation and presentation-
+     readiness changes only. No Phase 2 status change. NYCN
+     remains the intended first cooperative partner, not a
+     formally committed pilot. Implementation follow-ups
+     remain open: ICN #1726-#1731 plus #1713 (organizer
+     rehearsal shell, fixture-backed demo mode, generic
+     preview/review read-model contract, repo-safe evidence
+     export schema, private-overlay/DID-binding activation
+     flow, accessibility review gate, ActionCard schema
+     stabilization); NYCN #54-#58 (presentation wireframe
+     deck, fixture demo packet, evidence packet example,
+     holder-label/DID activation policy, accessibility/
+     privacy checklist). Next substantive implementation
+     path remains ICN #1729 (repo-safe evidence export
+     schema). Do not read this sync as production readiness,
+     live federation integration, implemented service
+     hosting, K3s/DNS/Forgejo mutation, NYCN private-data
+     handling, or resolved licensing. -->
 
 <!-- [sync edit] 2026-05-02 (post-#1695/#1696/#1697/#1698/#1699/#1700/#1701):
      Follow-up May-cycle queue is now merged on main: Dependabot

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -650,7 +650,7 @@ category = "status"
 status = "living"
 title = "ICN State (living doc)"
 description = "Living snapshot of repo layout, decisions, constraints, and current engineering status"
-last_updated = "2026-05-02"
+last_updated = "2026-05-04"
 owner = "matt"
 audiences = ["developers", "agents"]
 truth_class = "descriptive"
@@ -659,7 +659,7 @@ canonical = "yes"
 freshness = "current"
 domain_tags = ["status", "project"]
 recommended_action = "keep"
-last_reviewed = "2026-05-02"
+last_reviewed = "2026-05-04"
 
 [docs."docs/DOCUMENTATION_CONTROL_SYSTEM.md"]
 category = "reference"


### PR DESCRIPTION
## What changed

Two files, 37 insertions / 3 deletions.

**`docs/STATE.md`** — appends a 2026-05-04 sync edit at the top in the existing HTML-comment style, recording:

- ICN #1725 — generic no-CLI organizer/member rehearsal workflow spec at `docs/pilots/no-cli-organizer-member-rehearsal-workflow.md` (review-first, mutation-last, three roles distinguished, accessibility baseline release-blocking, evidence export repo-safe by default)
- NYCN #53 — companion no-CLI organizer rehearsal workflow at `docs/NO-CLI-ORGANIZER-REHEARSAL-WORKFLOW.md` in `fahertym/nycn`
- ICN #1732 — website README civic design truth-sync (replaced stale Lexend / hex palette / "modern design system" / Tailwind framing with pointers to `docs/design-language/` and `website/src/styles/global.css` as the single token surface)

The sync edit also enumerates the open implementation tranche (ICN #1726–#1731 plus #1713; NYCN #54–#58) and names ICN #1729 (repo-safe evidence export schema) as the next substantive implementation path. Closing paragraph repeats the standing non-claims verbatim.

YAML front-matter `Last Reviewed` bumped from 2026-05-02 to 2026-05-04 to reflect the edit.

**`docs/registry.toml`** — bumps `last_updated` and `last_reviewed` for the `docs/STATE.md` entry from 2026-05-02 to 2026-05-04 to keep the `doc_control_check.py --strict` `yaml-mismatch` warning surface clean. No other registry entries touched.

## Why this matters

`docs/STATE.md` is the canonical living truth surface for current ICN engineering state. Three relevant changes (#1725 / NYCN #53 / #1732) landed since the last sync edit (2026-05-02). Without an entry, the next agent or contributor reading STATE.md would not see the no-CLI documentation tranche or the website README correction reflected, and may calibrate expectations off stale text — exactly the drift pattern the prior README cleanup was meant to interrupt.

This is documentation truth-sync only. It does not change phase status, runtime claims, partnership status, or any other governing fact about ICN.

## What did not change

- No phase status change (Phase 2 remains in progress).
- No partnership status change (NYCN remains the **intended first cooperative partner**, not a formally committed pilot).
- No runtime, API, gateway, ledger, governance, or kernel code touched.
- No website file touched (`#1732` already landed that PR; this PR does not re-edit the README).
- No NYCN repo edit.
- No CI workflow, lockfile, package.json, or generated-doc churn.
- No registry entries other than the `docs/STATE.md` row.
- No NYCN/Summit/reference-federation/first-institution-package language added to public website surfaces (this PR does not touch the website).
- No closure of any open implementation issue. ICN #1724 / NYCN #52 remain umbrella issues; ICN #1726–#1731 + #1713 and NYCN #54–#58 remain open.

## Validation

- `git diff --check` — clean
- `python3 .github/scripts/compliance_linter.py` — `✅ No compliance violations detected (107 files scanned)`
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict` — `OK: doc control check passed (768 docs markdown files); 36 enforcement warnings` (same pre-existing warnings as before this PR; no new STATE.md-specific warnings introduced; the `yaml-mismatch` for STATE.md was avoided by bumping the registry entry alongside the YAML)
- `git diff --stat` — confirms only `docs/STATE.md` (+34/-1) and `docs/registry.toml` (+2/-2) modified

Heavyweight Rust / SDK / website checks were not run because this PR touches no Rust, SDK, or website code. The `Documentation Maintenance` and `Regulatory Compliance Linter` CI jobs are the relevant gates and run automatically.

## Explicit non-claims preserved

- No production deployment, no Phase 2 completion, no formal NYCN pilot.
- NYCN remains the **intended first cooperative partner**, not a committed pilot.
- No live federation, no live Google Drive / Groups / Sheets sync, no K3s / DNS / Forgejo mutation, no implemented service hosting.
- No private partner data introduced; no licensing decision.
- Vocabulary held to **obligation / allocation / settlement / unit / position / receipt / provenance / evidence**; ICN-native **payment / currency / balance / wallet** framing avoided.
- ICN public site stays generic; partner-specific nouns confined to NYCN repo (this PR adds none).

## Next step

After this PR lands, the next substantive implementation step is **ICN #1729** (repo-safe evidence export schema) per the prior audit. That work belongs in a separate PR scoped to `docs/contracts/` or `docs/spec/` and should not be bundled with documentation truth-sync.

## Push note

The CLAUDE.md "always use `/push`" rule was not invoked because `/push` is a slash command the human operator types, not one this assistant can call. Branch was pushed via `git push -u origin docs/state-sync-post-no-cli-website-cleanup` so the PR could be opened. If a `/push` re-run is desired before merge, that's a quick local re-run on this branch.