### PR TITLE
docs(contracts): define rehearsal evidence export schema

### DIFF
--- a/docs/contracts/rehearsal-evidence-export.example.json
+++ b/docs/contracts/rehearsal-evidence-export.example.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "0.1.0",
+  "recorded_at": "2026-05-04T22:31:16Z",
+  "rehearsal_label": "Fictional fixture-only organizer rehearsal — sample committee",
+  "rehearsal_mode": "fixture-only",
+  "audience_categories": ["organizer", "facilitator", "reviewer"],
+  "source_material": [
+    {
+      "kind": "committed-fixture",
+      "basename": "sample-committee-meeting-notes.fixture.md",
+      "summary": "Fictional sample committee meeting notes used to walk the parser preview step. No real people, no real organization."
+    },
+    {
+      "kind": "example-snippet",
+      "basename": "sample-action-item.snippet.md",
+      "summary": "One fictional action item in plain language: example committee to draft a sample agenda for a sample meeting."
+    }
+  ],
+  "workflow_steps_completed": [
+    "start",
+    "select-material",
+    "preview",
+    "decide",
+    "assign-by-label",
+    "preview-mutation",
+    "export-evidence"
+  ],
+  "decision_outcomes": [
+    {
+      "category": "approved",
+      "plain_summary": "Sample committee approved drafting a sample agenda for a fictional follow-up meeting; assigned to the example agenda role-label."
+    },
+    {
+      "category": "deferred",
+      "plain_summary": "Sample committee deferred a fictional sponsorship inquiry to a later rehearsal so the privacy boundary could be re-walked first."
+    }
+  ],
+  "preview_review_boundary": {
+    "enforced": true,
+    "notes": "Preview was shown and acknowledged before any assign-by-label or preview-mutation step. No mutation was attempted in this rehearsal."
+  },
+  "mutation_boundary": {
+    "executed": false,
+    "target": "none",
+    "notes": "Fixture-only rehearsal; no gateway contacted, no write attempted, no network egress."
+  },
+  "proof_loop_references": [
+    {
+      "kind": "action-item-completion-receipt",
+      "status": "not-attempted"
+    },
+    {
+      "kind": "validator-output-category",
+      "public_id_or_category": "fixture-validate-pass",
+      "status": "closed"
+    }
+  ],
+  "warnings": [
+    "Holder-label to DID binding remained a label-only step; activation flow was not exercised.",
+    "Live cloud sync surfaces were not part of this rehearsal and must not be inferred from this packet."
+  ],
+  "follow_ups": [
+    {
+      "title": "Walk the holder-label to DID activation flow in a separate rehearsal",
+      "url": "https://github.com/InterCooperative-Network/icn/issues/1730"
+    },
+    {
+      "title": "Cross-reference this schema from a partner package's evidence checklist",
+      "url": "https://github.com/InterCooperative-Network/nycn/issues/56"
+    }
+  ],
+  "privacy_review": {
+    "reviewer_role": "facilitator",
+    "status": "reviewed-clean",
+    "notes": "All material in this packet is fictional; no real names, contacts, or partner data were present at any point."
+  },
+  "accessibility_review": {
+    "reviewer_role": "facilitator",
+    "status": "reviewed-clean",
+    "notes": "Walkthrough materials were available in plain language and at large enough font for the room; no terminal use was required of any organizer."
+  },
+  "export_safety_classification": "repo-safe",
+  "non_claims": [
+    "Not a production deployment.",
+    "Not a formally committed cooperative pilot.",
+    "Not a live federation, live Google Drive / Groups / Sheets sync, or any K3s / DNS / Forgejo mutation.",
+    "Not private-data handling; all material is fictional and repo-safe by construction."
+  ]
+}

--- a/docs/contracts/rehearsal-evidence-export.md
+++ b/docs/contracts/rehearsal-evidence-export.md
@@ -1,0 +1,132 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-04
+---
+
+# Rehearsal evidence export — contract notes
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| [`rehearsal-evidence-export.schema.json`](rehearsal-evidence-export.schema.json) | JSON Schema (draft 2020-12) for a single repo-safe rehearsal evidence packet. |
+| [`rehearsal-evidence-export.example.json`](rehearsal-evidence-export.example.json) | Fictional sample packet. Validates against the schema. Demonstrates the field shape a rehearsal walk should produce. |
+| [`../scripts/validate-rehearsal-evidence.py`](../scripts/validate-rehearsal-evidence.py) | Tiny validator — given a packet path, checks it against the schema. Used by CI / contributors before committing example or partner-side packets that will live in a public repository. |
+
+## Purpose
+
+This schema defines the shape of the **repo-safe rehearsal evidence packet** described by [`docs/pilots/no-cli-organizer-member-rehearsal-workflow.md`](../pilots/no-cli-organizer-member-rehearsal-workflow.md) §3 step 9 and §4 ("Privacy-safe evidence by default"). It is the substrate-level contract that every institution package's evidence checklist binds to. Packages do not extend this schema with partner-specific nouns; they bind their local meaning in package docs and produce packets that conform.
+
+The packet enumerates what a rehearsal did, in plain language, with categories and basenames only.
+
+## Identity — non-DNS contract identifier
+
+The schema `$id` is a non-DNS URN:
+
+```
+urn:icn:contract:rehearsal-evidence-export:v1
+```
+
+Contract identity for ICN must not depend on centralized DNS, ICANN registrars, registrar renewal, or capitalist hosting/payment structures. Schema `$id` values are machine-facing identifiers — validators and `$ref` consumers read them — but "machine-facing" does not mean "DNS should be authoritative." HTTP URIs like `https://intercooperative.network/contracts/...` quietly make contract identity depend on a single domain registration and a single hosting decision. ICN should not put its contract identity behind a centralized naming choke point.
+
+The companion field `x-icn-contract-name` (`icn.contract.rehearsal_evidence_export.v1`) gives a human-readable handle for the same identity, useful in logs and discovery. It is not a substitute for the URN; the URN is canonical.
+
+The companion field `x-icn-distribution-hints` lists repo-relative paths where copies of the schema and its companion artifacts can be found. **Distribution hints are not authority.** They tell a consumer where to look for a copy. The contract identity remains the URN.
+
+DNS-backed URLs (`intercooperative.network`, `icn.zone`, future mirrors) may be used as **discovery, routing, mirror, or human-facing surfaces** for these documents. They must not become the canonical identifier.
+
+Verifiability of a packet's claim to conform to this contract comes from:
+
+- the URN identity, which is stable across hosts and registrars
+- the repository path that holds this schema (`docs/contracts/rehearsal-evidence-export.schema.json`)
+- the git history of that path
+- future receipt and provenance mechanisms when those land
+
+If a future ICN-side mechanism (for example a content-addressed contract registry) supersedes the URN approach, that is a deliberate contract-identity migration. It is not driven by DNS availability.
+
+## Stability
+
+The schema sets `"x-icn-status": "rfc"`. Treat the shape as **versioned contract surface**, not frozen public API. The version is encoded in the URN (`...:v1`); the next breaking shape requires a new URN (`...:v2`) and an explicit migration note. Non-breaking additions (new optional fields, new enum members at the end of a closed taxonomy) may land at the same URN, with a `schema_version` bump in the packet field.
+
+Producers should pin to the URN, not to a file path or a DNS URL.
+
+## Field shape
+
+The schema is the source of truth; this section is an at-a-glance summary. See `rehearsal-evidence-export.schema.json` for required-vs-optional, types, and closed-enum membership.
+
+| Field | Closed taxonomy? | Notes |
+|-------|------------------|-------|
+| `schema_version` | — | Semver-style; bumped per shape change at this URN. |
+| `recorded_at` | — | RFC 3339 timestamp; the moment of human review-and-export. |
+| `rehearsal_label` | — | Short, plain-language title; generic labels only. |
+| `rehearsal_mode` | yes | `fixture-only` / `local-dry-run` / `local-execute` / `non-production-gateway`. Production gateways are never a valid value. |
+| `audience_categories` | yes | Generic role labels only — never names, emails, or counts that could de-anonymize a small group. |
+| `source_material[]` | partial | `kind` is closed (`committed-fixture` / `example-snippet` / `repo-safe-paste`); basename + summary are free text. **No raw external paths.** |
+| `workflow_steps_completed[]` | yes | Mirrors §3 of the no-CLI workflow doc. |
+| `decision_outcomes[]` | partial | `category` closed; `plain_summary` free text but repo-safe. |
+| `preview_review_boundary` | — | `enforced` boolean; document why if not enforced. |
+| `mutation_boundary` | partial | `target` closed; `executed` and `target` together describe whether and how mutation happened. |
+| `proof_loop_references[]` | yes | `kind` closed; only public ids or category labels. **No private DIDs or holder identifiers.** |
+| `warnings[]` | — | Plain-language; not stack traces. |
+| `follow_ups[]` | — | URLs only to public issues / PRs. |
+| `privacy_review` | partial | Generic role label + closed status enum. |
+| `accessibility_review` | partial | Same shape as `privacy_review`; status enum is its own. |
+| `export_safety_classification` | yes | `repo-safe` is the only value packets in this repository should carry. |
+| `non_claims[]` | — | Free text; must include the standing four (no production deployment, no formal pilot, no live federation/cloud-sync, no private-data handling). |
+
+## What this schema MUST NOT carry
+
+The schema declares `additionalProperties: false` so unknown fields are rejected at validation time. The following content is **forbidden** by the schema's design and the project's privacy posture, regardless of whether a field could technically hold it:
+
+- real personal names (unless explicitly fictional / example-only)
+- real email addresses
+- real phone numbers
+- sponsor contact details
+- accommodation or access needs tied to an identifiable person
+- raw attendee or member rolls
+- API tokens, secrets, signed URLs, or session credentials
+- private Drive / Groups / Sheets paths or content
+- private overlay contents
+- live partner operational details
+- any field that implies formal pilot approval or production deployment
+- DIDs of unconsented participants
+
+This list is also captured in the schema's `x-icn-must-not-include` extension so machine consumers (linters, partner CI) can read it without parsing this prose.
+
+## Validation guidance for package repos
+
+1. Validate every example or evidence packet that will live in a **public repository** against `rehearsal-evidence-export.schema.json` before committing. Use the bundled validator (`docs/scripts/validate-rehearsal-evidence.py`) or any draft-2020-12 JSON Schema validator. Pin to the URN.
+2. Do **not** add partner-specific nouns to this schema. Bind local meaning in package docs.
+3. **Partner-internal overlays do not validate against this schema and must not be committed.** This schema is for the repo-safe export path only.
+4. Prefer regulatory-safe vocabulary in human-language fields: **obligation**, **allocation**, **settlement**, **unit**, **position**, **receipt**, **provenance**, **evidence** — not payment / wallet / balance / currency framing for substrate flows.
+5. Keep the standing non-claims in every packet. Producers may **add** packet-specific non-claims; producers MUST NOT **remove** the standing four.
+
+## Producing a packet
+
+A rehearsal facilitator (or a future organizer shell) walks the §3 ladder of the no-CLI workflow doc and records what happened. Producing the packet is the final step (`workflow_steps_completed: export-evidence`). The producer should:
+
+1. Use a generic label for the rehearsal — no partner / organization / person names unless they are fictional examples.
+2. Categorize source material by `committed-fixture` / `example-snippet` / `repo-safe-paste`. Do not paste in raw cloud-drive paths or private content.
+3. Record decisions in plain language with the closed `category` taxonomy.
+4. Honor the **review-first / mutation-last** boundary. If `preview_review_boundary.enforced` was false, document why in `notes` so the failure is visible.
+5. Run the privacy review (even on a fictional packet) and record the result with a generic `reviewer_role`.
+6. Run the accessibility review of the rehearsal itself; record the result.
+7. Validate the packet against the schema before committing or pasting it into a public issue comment.
+
+## Out of scope
+
+- Mutation API for emitting evidence packets (no runtime / gateway code is implied here).
+- Partner overlay format — partner-internal data lives in private overlays, outside this schema.
+- Federation export protocol.
+- UI rendering of evidence packets (organizer / member shell work tracked under [#1726](https://github.com/InterCooperative-Network/icn/issues/1726) / [#1727](https://github.com/InterCooperative-Network/icn/issues/1727)).
+- Migration of existing contract schemas (e.g. `action-card.schema.json`) to non-DNS `$id` — that is a deliberate follow-up evaluation, not part of this PR.
+
+## See also
+
+- [`../pilots/no-cli-organizer-member-rehearsal-workflow.md`](../pilots/no-cli-organizer-member-rehearsal-workflow.md) — generic ICN no-CLI organizer / member rehearsal workflow (§3, §4)
+- [`./institution-package/README.md`](institution-package/README.md) — institution-package contract notes (existing schema follows the older HTTP `$id` pattern; migration is a separate evaluation)
+- [`../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md`](../rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md) — surface-architecture context for `intercooperative.network` vs `icn.zone` (DNS-backed surfaces are discovery / routing / human-facing, not contract authority)
+- ICN [#1729](https://github.com/InterCooperative-Network/icn/issues/1729) — tracking issue for this contract
+- ICN [#1724](https://github.com/InterCooperative-Network/icn/issues/1724) — umbrella issue for the no-CLI organizer / member rehearsal UX
+- NYCN [#56](https://github.com/InterCooperative-Network/nycn/issues/56) — partner-side example packet to follow once this contract lands

--- a/docs/contracts/rehearsal-evidence-export.schema.json
+++ b/docs/contracts/rehearsal-evidence-export.schema.json
@@ -1,0 +1,305 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:icn:contract:rehearsal-evidence-export:v1",
+  "title": "RehearsalEvidenceExport",
+  "description": "A repo-safe rehearsal evidence packet emitted at the end of an organizer or steward rehearsal walk, as described by docs/pilots/no-cli-organizer-member-rehearsal-workflow.md (§3 step 9, §4 'Privacy-safe evidence by default'). The packet is the substrate-level shape every institution package's evidence checklist binds to. It enumerates what a rehearsal did, in plain language, with categories and basenames only — never private contact data, raw attendee rolls, tokens, sponsor information, accommodation needs, real Drive paths, or any field that would imply formal pilot approval or production deployment. Partner-internal overlays are not in this schema; they live in package private overlays and never enter the ICN repository tree. Packets validating against this schema are repo-safe by construction (export_safety_classification = 'repo-safe'); the partner-internal classification exists only to mark a packet that should NOT be checked into ICN, and is never produced from this repo. The schema $id is a non-DNS URN so contract identity does not depend on centralized DNS or registrar infrastructure; see docs/contracts/rehearsal-evidence-export.md for the rationale.",
+  "x-icn-status": "rfc",
+  "x-icn-contract-name": "icn.contract.rehearsal_evidence_export.v1",
+  "x-icn-distribution-hints": [
+    "docs/contracts/rehearsal-evidence-export.schema.json",
+    "docs/contracts/rehearsal-evidence-export.md",
+    "docs/contracts/rehearsal-evidence-export.example.json"
+  ],
+  "x-icn-references": [
+    "GitHub icn#1729",
+    "GitHub icn#1724",
+    "GitHub icn#1725",
+    "GitHub icn#1732",
+    "GitHub icn#1733",
+    "GitHub nycn#52",
+    "GitHub nycn#53",
+    "GitHub nycn#56"
+  ],
+  "x-icn-must-not-include": [
+    "real personal names (unless explicitly fictional / example-only)",
+    "real email addresses",
+    "real phone numbers",
+    "sponsor contact details",
+    "accommodation or access needs tied to an identifiable person",
+    "raw attendee or member rolls",
+    "API tokens, secrets, signed URLs, or session credentials",
+    "private Drive / Groups / Sheets paths or content",
+    "private overlay contents",
+    "live partner operational details",
+    "any field that implies formal pilot approval or production deployment",
+    "DIDs of unconsented participants"
+  ],
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "recorded_at",
+    "rehearsal_label",
+    "rehearsal_mode",
+    "audience_categories",
+    "source_material",
+    "workflow_steps_completed",
+    "decision_outcomes",
+    "preview_review_boundary",
+    "mutation_boundary",
+    "privacy_review",
+    "export_safety_classification",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Semver-style version of this schema the packet was authored against. Accepts 'MAJOR.MINOR.PATCH' or 'MAJOR.MINOR'. Bumped only when the schema's required fields or closed enums change.",
+      "pattern": "^[0-9]+\\.[0-9]+(?:\\.[0-9]+)?$"
+    },
+    "recorded_at": {
+      "type": "string",
+      "description": "Wall-clock timestamp when the packet was finalized for export. RFC 3339 'date-time' (e.g. 2026-05-04T22:31:16Z). The producer is responsible for ensuring this is the moment of human review-and-export, not an arbitrary build time.",
+      "format": "date-time"
+    },
+    "rehearsal_label": {
+      "type": "string",
+      "description": "Short, plain-language title for the rehearsal suitable for an issue comment or evidence index row. Generic labels only; no partner / organization / person names unless they are explicitly fictional examples.",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "rehearsal_mode": {
+      "description": "Closed taxonomy describing how mutation was treated during the rehearsal. 'fixture-only' = no mutation, no network. 'local-dry-run' = preview-only against a local gateway. 'local-execute' = explicit execution against a local non-production gateway. 'non-production-gateway' = an explicitly-labeled non-production gateway elsewhere. Production gateways are never a valid value here; this schema does not describe production runs.",
+      "type": "string",
+      "enum": [
+        "fixture-only",
+        "local-dry-run",
+        "local-execute",
+        "non-production-gateway"
+      ]
+    },
+    "audience_categories": {
+      "description": "Closed taxonomy of generic audience role labels present at the rehearsal. Categories only — never names, emails, or counts that could de-anonymize a small group. If no audience was present (solo dry-run), use an empty array.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "organizer",
+          "steward",
+          "operator",
+          "member",
+          "committee",
+          "facilitator",
+          "observer",
+          "reviewer"
+        ]
+      }
+    },
+    "source_material": {
+      "description": "Inputs the rehearsal walked through. Each entry is described by safe basename and category — never by raw external path. 'committed-fixture' = file already in the repository. 'example-snippet' = inline fictional content authored for the rehearsal. 'repo-safe-paste' = content reviewed and confirmed to contain no private fields before being pasted into the rehearsal surface. 'sha256' is optional and only meaningful for committed fixtures or otherwise public content.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "basename", "summary"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["committed-fixture", "example-snippet", "repo-safe-paste"]
+          },
+          "basename": {
+            "type": "string",
+            "description": "File or snippet basename only — no directory paths, no Drive URLs, no external links to private content.",
+            "minLength": 1
+          },
+          "sha256": {
+            "type": "string",
+            "description": "Optional content hash; include only when the underlying content is itself repo-safe (committed fixture or fictional example).",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "summary": {
+            "type": "string",
+            "description": "One-sentence plain-language description of what this material is. Generic enough to publish in a public issue comment.",
+            "minLength": 1,
+            "maxLength": 400
+          }
+        }
+      }
+    },
+    "workflow_steps_completed": {
+      "description": "Closed taxonomy mirroring §3 of docs/pilots/no-cli-organizer-member-rehearsal-workflow.md. Lists which steps the rehearsal actually completed in human-visible form. Steps that were skipped are simply omitted; this is not a checklist of intent.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "start",
+          "select-material",
+          "preview",
+          "decide",
+          "assign-by-label",
+          "preview-mutation",
+          "confirm",
+          "surface-result",
+          "export-evidence"
+        ]
+      }
+    },
+    "decision_outcomes": {
+      "description": "Plain-language record of how proposed action items / decisions were resolved during the rehearsal. Categories are closed; the plain summary is free text but must remain repo-safe (no private rolls, no contact details).",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["category", "plain_summary"],
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "approved",
+              "rejected",
+              "deferred",
+              "edit-and-resubmit",
+              "out-of-scope",
+              "withdrawn"
+            ]
+          },
+          "plain_summary": {
+            "type": "string",
+            "description": "One- or two-sentence plain-language description of the decision. Generic phrasing; no private fields.",
+            "minLength": 1,
+            "maxLength": 600
+          }
+        }
+      }
+    },
+    "preview_review_boundary": {
+      "description": "Whether the review-first / mutation-last boundary defined in the no-CLI workflow §3 was honored in this rehearsal. 'enforced' must be true for any rehearsal that intends to be reusable as evidence; if it was false, document why in 'notes' so the failure is visible rather than silent.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enforced"],
+      "properties": {
+        "enforced": { "type": "boolean" },
+        "notes": { "type": "string", "minLength": 1, "maxLength": 600 }
+      }
+    },
+    "mutation_boundary": {
+      "description": "Whether the rehearsal performed any mutation, and if so, against what target. 'target' is the specific surface that received writes. 'none' is the only acceptable value when 'executed' is false; anything else implies executed = true.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["executed", "target"],
+      "properties": {
+        "executed": { "type": "boolean" },
+        "target": {
+          "type": "string",
+          "enum": [
+            "none",
+            "fixture-only",
+            "local-dry-run",
+            "local-gateway",
+            "non-production-gateway"
+          ]
+        },
+        "notes": { "type": "string", "minLength": 1, "maxLength": 600 }
+      }
+    },
+    "proof_loop_references": {
+      "description": "Pointers to the proof-loop categories the rehearsal exercised. References are by category (and optionally a public id, e.g. an opaque receipt id from a non-production run that is already public). Never include private DIDs, holder identifiers, or partner-internal correlation ids. 'status' captures whether the loop closed in this rehearsal.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "status"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "governance-decision-receipt",
+              "action-item-completion-receipt",
+              "meeting-attendance-receipt",
+              "provenance-summary",
+              "validator-output-category"
+            ]
+          },
+          "public_id_or_category": {
+            "type": "string",
+            "description": "Optional opaque public id (already public — receipt id from a non-production run) or category label. Omit if the rehearsal did not generate a citable id."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["closed", "partial", "not-attempted", "skipped"]
+          }
+        }
+      }
+    },
+    "warnings": {
+      "description": "Plain-language warnings the rehearsal surfaced. These are repo-safe phrasings of what would have gone wrong if a step were skipped or misapplied; not stack traces, not raw error payloads.",
+      "type": "array",
+      "items": { "type": "string", "minLength": 1, "maxLength": 400 }
+    },
+    "follow_ups": {
+      "description": "Open follow-up items the rehearsal recorded. URLs, when present, must point to public issues or PRs only — never to private partner trackers, Drive paths, or internal links.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title"],
+        "properties": {
+          "title": { "type": "string", "minLength": 1, "maxLength": 200 },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Optional public issue or PR URL. Omit for follow-ups that do not yet have a public tracker entry."
+          },
+          "notes": { "type": "string", "minLength": 1, "maxLength": 600 }
+        }
+      }
+    },
+    "privacy_review": {
+      "description": "Privacy review status of this packet. 'reviewer_role' is a generic role label — never a person name. 'status' captures whether the packet was reviewed and whether redactions were applied before export. 'not-reviewed' is permitted but should be uncommon; downstream consumers may treat it as a red flag.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reviewer_role", "status"],
+      "properties": {
+        "reviewer_role": {
+          "type": "string",
+          "enum": ["organizer", "steward", "facilitator", "reviewer", "operator"]
+        },
+        "status": {
+          "type": "string",
+          "enum": ["reviewed-clean", "redactions-applied", "not-reviewed"]
+        },
+        "notes": { "type": "string", "minLength": 1, "maxLength": 600 }
+      }
+    },
+    "accessibility_review": {
+      "description": "Accessibility review status of the rehearsal itself (not of this packet). Mirrors the privacy review shape. 'reviewer_role' is generic; 'status' is closed taxonomy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reviewer_role", "status"],
+      "properties": {
+        "reviewer_role": {
+          "type": "string",
+          "enum": ["organizer", "steward", "facilitator", "reviewer", "operator"]
+        },
+        "status": {
+          "type": "string",
+          "enum": ["reviewed-clean", "adjustments-applied", "not-reviewed"]
+        },
+        "notes": { "type": "string", "minLength": 1, "maxLength": 600 }
+      }
+    },
+    "export_safety_classification": {
+      "description": "Whether the packet is safe to commit to a public repository or share in a public issue comment. 'repo-safe' is the only classification produced from packets that validate against this schema in normal use; 'partner-internal-only' is reserved as a contractual marker that the producing system itself decided NOT to export through the repo-safe path. The latter MUST NOT appear in any packet checked into the ICN repository.",
+      "type": "string",
+      "enum": ["repo-safe", "partner-internal-only"]
+    },
+    "non_claims": {
+      "description": "Required free-text array enumerating the standing non-claims this packet preserves. At minimum: not production deployment, not a formal pilot, not a live federation or cloud-sync run, not private-data handling. Producers may add packet-specific non-claims; producers MUST NOT remove the standing four.",
+      "type": "array",
+      "minItems": 4,
+      "items": { "type": "string", "minLength": 1, "maxLength": 400 }
+    }
+  }
+}

--- a/docs/pilots/no-cli-organizer-member-rehearsal-workflow.md
+++ b/docs/pilots/no-cli-organizer-member-rehearsal-workflow.md
@@ -85,7 +85,7 @@ Track as discrete work items (GitHub issues welcome; not all may exist yet):
 - **UI prototype** — Single guided shell (organizer mode) with the §3 screen list.
 - **Fixture-backed demo** — Deterministic fixture load with no network by default.
 - **Generic preview/review API contract** — Stable read models for “pending publish” summaries (package-agnostic shapes).
-- **Evidence export contract** — Machine-readable **repo-safe** evidence summary schema shared with partners.
+- **Evidence export contract** — Machine-readable **repo-safe** evidence summary schema shared with partners. Substrate contract: [`rehearsal-evidence-export.schema.json`](../contracts/rehearsal-evidence-export.schema.json) with companion notes at [`rehearsal-evidence-export.md`](../contracts/rehearsal-evidence-export.md). `$id` is the non-DNS URN `urn:icn:contract:rehearsal-evidence-export:v1` ([ICN#1729](https://github.com/InterCooperative-Network/icn/issues/1729)).
 - **Private-overlay / DID binding activation flow** — Documented UX for label → directory → DID without leaking overlay into public repos.
 - **Accessibility review** — WCAG-oriented pass on any new shell before calling it organizer-ready.
 - **Package validation** — Mechanical checks that package outputs align with [action-card.schema.json](../contracts/institution-package/action-card.schema.json) where applicable ([ICN#1713](https://github.com/InterCooperative-Network/icn/issues/1713), partner validation issues).

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -3192,6 +3192,22 @@ domain_tags = ["contracts", "governance", "action-cards"]
 recommended_action = "keep"
 last_reviewed = "2026-05-04"
 
+[docs."docs/contracts/rehearsal-evidence-export.md"]
+category = "reference"
+status = "living"
+title = "Rehearsal evidence export — contract notes"
+description = "Companion notes for the substrate-level repo-safe rehearsal evidence export schema (urn:icn:contract:rehearsal-evidence-export:v1). Defines field shape, must-not-include list, validation guidance, stability, and the non-DNS contract-identity decision. JSON schema and fictional example live alongside; tiny validator at docs/scripts/validate-rehearsal-evidence.py."
+last_updated = "2026-05-04"
+owner = "matt"
+audiences = ["contributors", "organizers"]
+truth_class = "descriptive"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["contracts", "pilots", "evidence", "accessibility", "privacy"]
+recommended_action = "keep"
+last_reviewed = "2026-05-04"
+
 # ============================================================================
 # PLANNING AND STRATEGY (Additional)
 # ============================================================================

--- a/docs/scripts/validate-rehearsal-evidence.py
+++ b/docs/scripts/validate-rehearsal-evidence.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Validate a rehearsal evidence export packet against the substrate-level
+JSON Schema at docs/contracts/rehearsal-evidence-export.schema.json.
+
+The schema is identified by a non-DNS URN ($id =
+urn:icn:contract:rehearsal-evidence-export:v1). The repo-relative path
+is a distribution hint, not authority. See
+docs/contracts/rehearsal-evidence-export.md for the rationale.
+
+Usage:
+    python3 docs/scripts/validate-rehearsal-evidence.py
+        # Validates the bundled example packet by default.
+
+    python3 docs/scripts/validate-rehearsal-evidence.py path/to/packet.json
+        # Validates an arbitrary packet.
+
+    python3 docs/scripts/validate-rehearsal-evidence.py --schema custom.schema.json packet.json
+        # Validates against an alternate schema (rarely needed; intended
+        # for partner repositories that pin a different version URN).
+
+Exit codes:
+    0: packet validates
+    1: packet fails validation (or input file is missing/invalid)
+
+Requires: Python 3.11+ and the `jsonschema` library.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA = REPO_ROOT / "docs" / "contracts" / "rehearsal-evidence-export.schema.json"
+DEFAULT_PACKET = REPO_ROOT / "docs" / "contracts" / "rehearsal-evidence-export.example.json"
+
+
+def load_json(path: Path, label: str) -> dict:
+    if not path.exists():
+        print(f"ERROR: {label} not found at {path}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: {label} at {path} is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("packet", nargs="?", type=Path, default=DEFAULT_PACKET, help="Packet JSON file to validate (defaults to the bundled example).")
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA, help="Schema JSON file to validate against (defaults to the bundled schema).")
+    args = parser.parse_args()
+
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        print("ERROR: the `jsonschema` Python package is required (pip install jsonschema).", file=sys.stderr)
+        return 1
+
+    schema = load_json(args.schema, "schema")
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    packet = load_json(args.packet, "packet")
+    errors = sorted(validator.iter_errors(packet), key=lambda e: list(e.path))
+
+    if not errors:
+        contract = schema.get("$id", "<unknown>")
+        print(f"OK: {args.packet.relative_to(REPO_ROOT) if args.packet.is_relative_to(REPO_ROOT) else args.packet} validates against {contract}")
+        return 0
+
+    print(f"FAIL: {args.packet} did not validate against {schema.get('$id', '<unknown>')}", file=sys.stderr)
+    for err in errors:
+        loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        print(f"  at {loc}: {err.message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the spec deliverable for ICN #1729.

## What changed

Six files. 626 insertions, 1 deletion. Net new substrate-level contract:

| File | Purpose |
|------|---------|
| `docs/contracts/rehearsal-evidence-export.schema.json` | JSON Schema (draft 2020-12) for one repo-safe rehearsal evidence packet. `additionalProperties: false`. Closed enums for every taxonomy field. |
| `docs/contracts/rehearsal-evidence-export.example.json` | Fictional sample packet (sample committee / fictional action item / no real people / no partner data). Validates against the schema. |
| `docs/contracts/rehearsal-evidence-export.md` | Companion notes — identity rationale, stability, field shape summary, must-not-include enumeration, validation guidance, producing a packet, out-of-scope, see-also. |
| `docs/scripts/validate-rehearsal-evidence.py` | Tiny draft-2020-12 validator wrapper around the system `jsonschema` package. Defaults to validating the bundled example. No new repo dependencies. |
| `docs/registry.toml` | One new `[docs."docs/contracts/rehearsal-evidence-export.md"]` entry, matching the convention used for `action-card.schema.json` (only the `.md` companion is registered; `.schema.json` and `.example.json` are not). |
| `docs/pilots/no-cli-organizer-member-rehearsal-workflow.md` | One-line edit to §7 — the existing "Evidence export contract" follow-up bullet now points at the schema, companion notes, and the URN. |

## Why this matters

ICN #1729 is the substrate prerequisite for NYCN #56 and for any partner-side evidence checklist. Without a substrate-level schema, every package would invent its own evidence shape and either over-share private data or under-record what a rehearsal actually did. This PR defines one shape, declares what it must not carry, and ships a deterministic validator.

## DNS / non-DNS contract identity decision

The schema `$id` is a **non-DNS URN**:

```
urn:icn:contract:rehearsal-evidence-export:v1
```

Schema `$id` values are machine-facing identifiers — validators read them, schema authors paste them into `$ref` declarations — but "machine-facing" must not mean "DNS should be authoritative." HTTP URIs like `https://intercooperative.network/contracts/...` quietly make contract identity depend on a single registrar, a single hosting decision, and ICANN. ICN's contract identity should not sit behind a centralized naming choke point.

The URN encodes the version (`...:v1`); breaking shape changes require a new URN (`...:v2`). Companion fields:

- `x-icn-contract-name = "icn.contract.rehearsal_evidence_export.v1"` — human-readable handle for the same identity.
- `x-icn-distribution-hints = [...]` — repo-relative paths to copies of the schema and companions. **Distribution hints are not authority.**

DNS-backed surfaces (`intercooperative.network`, `icn.zone`, future mirrors) remain valid for **discovery, routing, mirror, or human-facing surfaces** — they are not contract authority.

The companion `.md` documents the rationale in full so future maintainers and partner repositories can see the reasoning, not just the result.

## Privacy / repo-safety boundary

Packets validating against this schema are **repo-safe by construction**. Two enforcement layers:

- `additionalProperties: false` on the schema and every nested object. Unknown fields are rejected at validation time.
- An explicit `x-icn-must-not-include` enumeration on the schema (and a parallel enumeration in the companion `.md`) lists what the schema's design forbids regardless of where a field could technically hold it: real personal names (unless explicitly fictional), real email addresses, real phone numbers, sponsor contacts, accommodation/access needs tied to a person, raw attendee/member rolls, API tokens / secrets / signed URLs, private Drive/Groups/Sheets paths or content, private overlay contents, live partner operational details, anything implying formal pilot approval or production deployment, DIDs of unconsented participants.

`export_safety_classification` is an enum with two values. Only `repo-safe` should appear in any packet committed to this repository. The `partner-internal-only` value exists as a contractual marker so producing systems can declare a packet is **not** to be checked in; it must never appear in the ICN tree.

## Validation

- `git diff --check` — clean
- `python3 .github/scripts/compliance_linter.py` — `✅ No compliance violations detected (107 files scanned)` (regulatory vocabulary intact)
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict` — `OK: doc control check passed (769 docs markdown files); 36 enforcement warnings` (same pre-existing warnings as before; no new contracts/-specific warnings; `docs/scripts/` already has a prefix default so the new validator script does not need a per-file row)
- `python3 docs/scripts/validate-rehearsal-evidence.py` — `OK: docs/contracts/rehearsal-evidence-export.example.json validates against urn:icn:contract:rehearsal-evidence-export:v1`

`jsonschema` 4.26.0 is already on the system; no new repo dependencies were added. Heavyweight Rust / SDK / website checks were not run because this PR touches no Rust, SDK, or website code.

## What did not change

- No runtime, gateway, ledger, governance, or kernel code touched.
- No NYCN repo edit. NYCN #56 follows separately once this contract lands.
- No UI work. Organizer / member shell work remains under #1726 / #1727.
- **`docs/contracts/institution-package/action-card.schema.json` is not modified.** It still uses an HTTP `$id`. Migrating it is a deliberate evaluation, not part of this PR (see follow-up below).
- No CI workflow or lockfile change.
- No registry entries other than the new `.md` row.
- ICN #1724 / #1729 remain open; this PR satisfies the spec deliverable but the linter / partner-side example acceptance criteria require the bundled validator to land + NYCN-side cross-reference under #56.

## Explicit non-claims preserved

- No production deployment, no Phase 2 completion, no formal NYCN pilot.
- NYCN remains the **intended first cooperative partner**, not a committed pilot.
- No live federation, no live Google Drive / Groups / Sheets sync, no K3s / DNS / Forgejo mutation, no private-data handling, no licensing decision.
- Vocabulary held to **obligation / allocation / settlement / unit / position / receipt / provenance / evidence**; ICN-native **payment / currency / balance / wallet** framing avoided.
- ICN substrate stays generic; no NYCN-specific nouns added.

## Follow-ups

- **`action-card.schema.json` `$id` migration evaluation.** That schema still uses `https://intercooperative.network/contracts/institution-package/action-card.schema.json`. The non-DNS rationale in this PR's companion doc applies to it too, and a separate deliberate evaluation should decide whether and how to migrate it. Tracking suggestion: a short follow-up issue under the `epic:contracts` line.
- **NYCN #56 — partner-side example packet.** Once this PR lands, the NYCN companion can ship a fictional NYCN-shaped packet (still no real partner data) that validates against `urn:icn:contract:rehearsal-evidence-export:v1` and is referenced from `docs/NO-CLI-ORGANIZER-REHEARSAL-WORKFLOW.md` §5.
- **Partner-CI integration**: partner repositories that want pre-commit guards for their evidence packets can vendor or reimplement the bundled validator; the URN is stable across vendoring.

## Push note

The CLAUDE.md "always use `/push`" rule was not invoked because `/push` is a slash command the human operator types, not one this assistant can call. Branch was pushed via `git push -u origin docs/rehearsal-evidence-export-schema` so the PR could open. If a `/push` re-run is desired before merge, that's a quick local re-run on this branch.