### PR TITLE
feat(governance): expose opaque storage on GovernanceReceiptBackend trait

### DIFF
--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -519,4 +519,91 @@ pub trait GovernanceReceiptBackend: Send + Sync {
     ) -> Result<Vec<ProcessGateResultReceipt>, String> {
         Ok(vec![])
     }
+
+    // ========================================================================
+    // Opaque storage primitive (Stage 1b of architecture orchestration plan)
+    //
+    // The gateway-side ReceiptStore exposes a meaning-blind storage shape:
+    // store payloads under (class, key1, key2_opt) keyed by record_hash and
+    // ordered by recorded_at. The runtime layer (this crate) owns the typed
+    // envelope and the serde adapter; the gateway sees only opaque bytes.
+    //
+    // These trait methods exist so a `GovernanceReceiptBackend` can be
+    // routed through opaque storage WITHOUT adding new typed receipt types
+    // to the gateway's existing imports — the meaning-firewall ratchet
+    // stays where it is.
+    //
+    // Stage 1c will rewire the typed default impls above to delegate
+    // through these opaque methods, so adding a new receipt class becomes
+    // a one-file change in apps with no gateway touch. Stage 1d will then
+    // flip ProcessGateResultReceipt's fail-closed default to a routing
+    // default that uses opaque storage.
+    //
+    // Default impls below are FAIL-CLOSED. A backend that does not opt
+    // in to opaque storage surfaces the gap as an explicit error (stable
+    // sentinel `opaque_storage_not_implemented`) rather than as a silent
+    // commit-without-persistence. Same discipline as the existing
+    // `put_process_gate_result` default landed in #1755.
+    // ========================================================================
+
+    /// Persist an opaque receipt payload under a `(class, key1, key2_opt)`
+    /// key, tagged with the receipt's canonical `record_hash` and
+    /// ordered by `recorded_at`. See the gateway-side
+    /// `ReceiptStore::put_opaque` docstring for the layout contract;
+    /// this trait method is the indirection so the runtime layer can
+    /// call into the gateway storage without typing the receipt at the
+    /// boundary.
+    ///
+    /// **Fail-closed default.** A backend that has not opted in to
+    /// opaque storage returns `Err` with stable sentinel
+    /// `opaque_storage_not_implemented`. Callers must either handle
+    /// the error or wire a backend that overrides this method.
+    fn put_opaque(
+        &self,
+        _class: &str,
+        _key1: &str,
+        _key2: Option<&str>,
+        _recorded_at: u64,
+        _record_hash: [u8; 32],
+        _payload: &[u8],
+    ) -> Result<(), String> {
+        Err("opaque_storage_not_implemented: \
+             this backend inherits the fail-closed default for \
+             put_opaque. Override the method to opt in to durable \
+             opaque storage, or handle this error at the caller."
+            .to_string())
+    }
+
+    /// Retrieve the latest opaque payload for a
+    /// `(class, key1, key2_opt)` triple — the entry with the largest
+    /// `recorded_at`. Returns `Ok(None)` when the backend supports
+    /// opaque storage but has no entry for the triple. Returns
+    /// `Err(opaque_storage_not_implemented)` from the default impl
+    /// for backends that have not opted in.
+    fn get_latest_opaque(
+        &self,
+        _class: &str,
+        _key1: &str,
+        _key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        Err("opaque_storage_not_implemented: \
+             this backend inherits the fail-closed default for \
+             get_latest_opaque. Override the method to opt in to \
+             durable opaque storage, or handle this error at the \
+             caller."
+            .to_string())
+    }
+
+    /// List all opaque payloads under a given `(class, key1)`
+    /// regardless of `key2`, oldest-first by `recorded_at`. Returns
+    /// `Err(opaque_storage_not_implemented)` from the default impl
+    /// for backends that have not opted in.
+    fn list_opaque_for(&self, _class: &str, _key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        Err("opaque_storage_not_implemented: \
+             this backend inherits the fail-closed default for \
+             list_opaque_for. Override the method to opt in to \
+             durable opaque storage, or handle this error at the \
+             caller."
+            .to_string())
+    }
 }

--- a/icn/crates/icn-gateway/src/receipt_store.rs
+++ b/icn/crates/icn-gateway/src/receipt_store.rs
@@ -2197,6 +2197,43 @@ impl GovernanceReceiptBackend for ReceiptStore {
         }
         Ok(out)
     }
+
+    // ------------------------------------------------------------------------
+    // Opaque storage primitive overrides (Stage 1b)
+    //
+    // Delegate to the inherent `put_opaque`/`get_latest_opaque`/
+    // `list_opaque_for` methods on `ReceiptStore` (Stage 1a). The trait
+    // method signatures intentionally match the inherent signatures so
+    // these overrides are pure pass-through. The runtime layer in
+    // apps/governance can now route typed receipts through opaque
+    // storage on the production gateway-backed `ReceiptStore` without
+    // adding new typed governance imports here.
+    // ------------------------------------------------------------------------
+
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        ReceiptStore::put_opaque(self, class, key1, key2, recorded_at, record_hash, payload)
+    }
+
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        ReceiptStore::get_latest_opaque(self, class, key1, key2)
+    }
+
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        ReceiptStore::list_opaque_for(self, class, key1)
+    }
 }
 
 #[cfg(test)]
@@ -4167,5 +4204,50 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(latest, b"v3");
+    }
+
+    // ========================================================================
+    // Opaque trait dispatch test (Stage 1b)
+    //
+    // Confirms the gateway's `impl GovernanceReceiptBackend for ReceiptStore`
+    // overrides for the opaque methods route correctly to the inherent
+    // implementations from Stage 1a. This is the integration point that
+    // unblocks the apps/governance adapter (Stage 1c+) — without this
+    // dispatch working the whole opaque indirection is dead weight.
+    // ========================================================================
+
+    #[test]
+    fn opaque_trait_dispatch_round_trip() {
+        // Box as `Box<dyn GovernanceReceiptBackend>` so the call site
+        // exercises the dynamic-dispatch path that the runtime layer
+        // (apps/governance) actually uses, not the inherent method
+        // directly.
+        let store: Box<dyn GovernanceReceiptBackend> = Box::new(ReceiptStore::new(temp_db()));
+
+        let h = fake_hash(42);
+        store
+            .put_opaque(
+                "trait_dispatch_class",
+                "key-alpha",
+                Some("key-beta"),
+                123,
+                h,
+                b"trait-routed payload",
+            )
+            .unwrap();
+
+        let latest = store
+            .get_latest_opaque("trait_dispatch_class", "key-alpha", Some("key-beta"))
+            .unwrap()
+            .expect("trait dispatch must surface the persisted payload");
+        assert_eq!(latest, b"trait-routed payload");
+
+        // list_opaque_for through the trait must also span every key2
+        // under the (class, key1).
+        let chain = store
+            .list_opaque_for("trait_dispatch_class", "key-alpha")
+            .unwrap();
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0], b"trait-routed payload");
     }
 }


### PR DESCRIPTION
## Summary

**Stage 1b** of the architecture orchestration plan. Stacked on top of #1757 (Stage 1a). Adds the opaque storage primitive to the runtime-layer trait so apps can route receipts through opaque storage without adding new typed governance imports to the gateway.

## What this PR ships

### Three new methods on \`GovernanceReceiptBackend\`

- \`put_opaque(class, key1, key2_opt, recorded_at, record_hash, payload) -> Result<(), String>\`
- \`get_latest_opaque(class, key1, key2_opt) -> Result<Option<Vec<u8>>, String>\`
- \`list_opaque_for(class, key1) -> Result<Vec<Vec<u8>>, String>\`

Each ships with a **fail-closed default** returning the stable sentinel error \`opaque_storage_not_implemented\`. Discipline matches the existing \`put_process_gate_result\` default landed in #1755.

### Override impls on gateway's \`ReceiptStore\`

Pass-through to the Stage 1a inherent methods. The trait-impl block at the bottom of \`crates/icn-gateway/src/receipt_store.rs\` gains 3 new methods.

### Test

- New \`opaque_trait_dispatch_round_trip\` test exercises the dynamic-dispatch path (\`Box<dyn GovernanceReceiptBackend>\`) to confirm the gateway-side overrides actually wire through to the inherent methods. This is the integration point that unblocks the apps/governance adapter in Stage 1c+.

## Compatibility

Zero existing test backends are broken. The 3 new trait methods have **fail-closed defaults**, so backends that haven't opted in surface the gap as an explicit error if (and only if) anyone calls opaque methods on them. No current caller does. The next stages will route typed defaults through opaque, which is when fail-closed becomes meaningful.

## Firewall posture

**ZERO new kernel/domain crossings.** Verified:

- \`firewall_denylist.py\`: 0 new violations; 10 baseline preserved.
- \`check-meaning-firewall.sh\`: 3 baseline \`icn_trust\` imports preserved.
- \`apps/governance/src/receipt_backend.rs\` is an app crate (not kernel).
- \`crates/icn-gateway/src/receipt_store.rs\` already imports \`icn_governance\` at the baseline; this PR adds no new types to that import.

## What this PR does NOT do

- Does not rewire typed default impls through opaque (Stage 1c).
- Does not flip ProcessGateResultReceipt's fail-closed default (Stage 1d).
- Does not change firewall ratchet (no new imports).
- Does not touch docs.

## Validation

\`\`\`
cargo fmt --check -p icn-gateway -p icn-governance-actor   # clean
cargo clippy -p icn-gateway -p icn-governance-actor --all-targets --all-features -- -D warnings  # clean
cargo test -p icn-gateway --lib                            # 538 passed (537 baseline + 1 new), 0 failed
cargo test -p icn-governance-actor                         # all integration suites pass
python3 .github/scripts/firewall_denylist.py               # 0 new; baseline 10
bash scripts/check-meaning-firewall.sh                     # 3 baseline preserved
\`\`\`

## Test plan

- [x] All 538 gateway lib tests pass (including new trait-dispatch test)
- [x] All icn-governance-actor integration suites pass
- [x] cargo fmt --check is clean
- [x] cargo clippy --all-targets --all-features -- -D warnings is clean
- [x] firewall_denylist.py reports 0 new violations
- [x] check-meaning-firewall.sh shows 3 baseline preserved
- [x] Stacked on #1757; merge after #1757 lands or rebase to main when #1757 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)