### PR TITLE
docs(contracts): publish ActionCard contract for institution packages

### DIFF
--- a/docs/contracts/institution-package/README.md
+++ b/docs/contracts/institution-package/README.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-05-04
+Last Reviewed: 2026-05-07
 ---
 
 # Institution package — ActionCard contract notes
@@ -11,10 +11,14 @@ Last Reviewed: 2026-05-04
 | File | Purpose |
 |------|---------|
 | [`action-card.schema.json`](action-card.schema.json) | JSON Schema for one element of the `cards` array on `GET /v1/gov/me/action-cards`. |
+| [`action-card.example.json`](action-card.example.json) | Fictional sample card object. Validates against the schema. Demonstrates the `proposal` / `vote` shape with all required fields plus optional `deadline` and `domain_id`. |
+| [`../../scripts/validate-action-card.py`](../../scripts/validate-action-card.py) | Tiny validator — given a card-object path, checks it against the schema. Used by contributors and partner-package CI before committing example cards or rendering generic templates that will be checked into a public repository. |
 
 ## Stability
 
-The schema sets `"x-icn-status": "rfc"`. Treat the shape as **versioned contract surface**, not frozen public API. **OpenAPI export and generated TypeScript types** are what CI drift checks guard today (`icnctl api export-openapi`, `sdk/typescript` regen) — those checks protect the **generated** API contract, not this hand-maintained JSON file. **`action-card.schema.json` is edited by hand** alongside contract work; changes to `ActionCard` / `ActionCardsResponse` in `icn/apps/governance/src/http/models.rs` should update this schema in the **same PR** as the API/OpenAPI change. **Mechanical** drift detection for this schema (for example CI comparing schema to serde shapes) is **future work** unless and until it is implemented. Publication and stabilization work is tracked in [#1713](https://github.com/InterCooperative-Network/icn/issues/1713).
+The schema sets `"x-icn-status": "rfc"`. Treat the shape as **versioned contract surface**, not frozen public API. The `rfc` marker is honest: the runtime ships the surface for three currently-emitted source/action pairs, but the contract is still subject to amendment (see [ADR-0027 § Card kind taxonomy](../../adr/ADR-0027-action-card-contract.md), which records that the closed taxonomy is "growable by ADR amendment"). **OpenAPI export and generated TypeScript types** are what CI drift checks guard today (`icnctl api export-openapi`, `sdk/typescript` regen) — those checks protect the **generated** API contract, not this hand-maintained JSON file. **`action-card.schema.json` is edited by hand** alongside contract work; changes to `ActionCard` / `ActionCardsResponse` in `icn/apps/governance/src/http/models.rs` should update this schema in the **same PR** as the API/OpenAPI change. **Mechanical** drift detection for this schema (for example CI comparing schema to serde shapes) is **future work** unless and until it is implemented. Publication and stabilization work is tracked in [icn#1713](https://github.com/InterCooperative-Network/icn/issues/1713).
+
+The schema's `$id` is currently DNS-backed (`https://intercooperative.network/contracts/institution-package/action-card.schema.json`). Per [`../schema-id-audit.md`](../schema-id-audit.md), that identifier is **retained temporarily and reviewed by 2026-06-30**. Migration to a non-DNS URN of the form `urn:icn:contract:action-card:v<N>` will be a separate single-schema PR under the audit's §5 migration safety rules; this README and the audit table will be updated in the same PR as that migration.
 
 ## Emitted pairs (runtime today)
 
@@ -43,8 +47,30 @@ Enum values exist for forward compatibility; the runtime does **not** return car
 
 1. Validate each planned card object against `action-card.schema.json` **only** for keys you intend to align with ICN runtime; package-local extensions belong outside the validated object or in a separate schema owned by the package.
 2. Do **not** add institution-specific **nouns** to this schema; bind local meaning in package docs or mappings.
-3. Respect **emitted vs gated** `source_kind` values documented in the schema (`x-icn-emitted-source-kinds`, `x-icn-emitted-source-action-pairs`, and `x-icn-rfc-gated-source-kinds`).
-4. Prefer regulatory-safe vocabulary in human docs: **settlement**, **obligation**, **allocation**, **receipt**, **provenance** — not payment/wallet/balance framing for the substrate.
+3. Respect **emitted vs gated** `source_kind` values documented in the schema (`x-icn-emitted-source-kinds`, `x-icn-emitted-source-action-pairs`, and `x-icn-rfc-gated-source-kinds`). Today only `proposal`/`vote`, `meeting`/`attend`, and `action_item`/`complete` are emitted by the runtime; `signal_rule` and `obligation_lifecycle` are reserved for forward compatibility, gated on icn#1631 / icn#1711 and icn#1634 / icn#1712 respectively.
+4. Prefer regulatory-safe vocabulary in human docs: **obligation**, **allocation**, **settlement**, **unit**, **position**, **receipt**, **provenance**, **evidence** — not payment/wallet/balance/currency framing for the substrate.
+5. Institution-specific semantics belong in **institution packages**, not in ICN core. ICN core knows the generic primitives in this schema; packages translate their local templates (for example NYCN action-card templates) into these generic kinds and validate them against `action-card.schema.json` before committing or rendering.
+
+### Command — validate a single card object
+
+The bundled validator works as a draft-2020-12 JSON Schema validator with a stable CLI. Use it from the repo root, or from any partner package vendoring a copy:
+
+```bash
+# Validate the bundled fictional example.
+python3 docs/scripts/validate-action-card.py
+
+# Validate a partner-side card object.
+python3 docs/scripts/validate-action-card.py path/to/card.json
+
+# Validate against an alternate (pinned-version) schema.
+python3 docs/scripts/validate-action-card.py --schema custom.schema.json card.json
+```
+
+Exit code 0 means the card validates; exit code 1 means the card or schema failed. The validator prints `OK: <path> validates against <$id>` on success and a per-error path/message report on failure.
+
+Partner packages MAY vendor a copy of `action-card.schema.json` and either vendor or invoke `validate-action-card.py` from their own CI. Vendored copies should track this repo's version and update in the same change set as any contract amendment.
+
+The validator validates a **single card object** (one element of the `cards` array on `GET /v1/gov/me/action-cards`). The HTTP wrapper (`{ did, cards, generated_at }`) is OpenAPI-documented in the gateway and is not described by this hand-maintained schema; if a partner needs to validate a wrapper, they should validate each element of `cards` against this schema and check the wrapper fields separately.
 
 ## Runtime source of truth
 

--- a/docs/contracts/institution-package/action-card.example.json
+++ b/docs/contracts/institution-package/action-card.example.json
@@ -1,0 +1,18 @@
+{
+  "id": "card-proposal-prop-example-2026-05-07-001-vote",
+  "source_kind": "proposal",
+  "action_kind": "vote",
+  "scope": "entity",
+  "title": "Vote on proposal: EXAMPLE — Adopt fictional sample charter amendment",
+  "summary": "An open proposal awaits your vote in a domain where you have voting standing.",
+  "authority_basis": "domain_membership",
+  "required_authority_scope": [
+    "vote_in:domain-example-fictional-cooperative"
+  ],
+  "deadline": 1778544000,
+  "risk_level": "normal",
+  "accessibility_hint": "Plain-language proposal summary available; alternate formats on request.",
+  "receipt_expected": true,
+  "source_id": "prop-example-2026-05-07-001",
+  "domain_id": "domain-example-fictional-cooperative"
+}

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -3212,8 +3212,8 @@ last_reviewed = "2026-05-04"
 category = "reference"
 status = "living"
 title = "Institution Package ActionCard Contract Notes"
-description = "Validation guidance for institution packages using action-card.schema.json; emitted vs RFC-gated source kinds; pointers to runtime models and issue icn#1713."
-last_updated = "2026-05-04"
+description = "Validation guidance for institution packages using action-card.schema.json; emitted vs RFC-gated source kinds; pointers to runtime models, ADR-0027, and issue icn#1713. JSON schema and fictional example live alongside; tiny validator at docs/scripts/validate-action-card.py. Schema $id retained temporarily per docs/contracts/schema-id-audit.md (review by 2026-06-30)."
+last_updated = "2026-05-07"
 owner = "matt"
 audiences = ["contributors", "organizers"]
 truth_class = "descriptive"
@@ -3222,7 +3222,7 @@ canonical = "no"
 freshness = "current"
 domain_tags = ["contracts", "governance", "action-cards"]
 recommended_action = "keep"
-last_reviewed = "2026-05-04"
+last_reviewed = "2026-05-07"
 
 [docs."docs/contracts/rehearsal-evidence-export.md"]
 category = "reference"

--- a/docs/scripts/validate-action-card.py
+++ b/docs/scripts/validate-action-card.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Validate an ActionCard object against the institution-package
+JSON Schema at docs/contracts/institution-package/action-card.schema.json.
+
+The schema describes one element of the `cards` array on
+`GET /v1/gov/me/action-cards`. The HTTP wrapper
+(`{ did, cards, generated_at }`) is OpenAPI-documented in the
+gateway and is not described by this hand-maintained schema; this
+validator works against single card objects, which is what
+institution packages produce when planning or rendering templates.
+
+The schema's `$id` is currently DNS-backed (HTTPS). Per
+docs/contracts/schema-id-audit.md, that identifier is retained
+temporarily and reviewed by 2026-06-30; a future single-schema PR
+may migrate it to a non-DNS URN under the §5 migration rules.
+This validator works regardless of the `$id` form, since it loads
+the schema by file path.
+
+Usage:
+    python3 docs/scripts/validate-action-card.py
+        # Validates the bundled example card by default.
+
+    python3 docs/scripts/validate-action-card.py path/to/card.json
+        # Validates an arbitrary single-card object.
+
+    python3 docs/scripts/validate-action-card.py --schema custom.schema.json card.json
+        # Validates against an alternate schema (rarely needed; intended
+        # for partner repositories that pin a different version).
+
+Exit codes:
+    0: card validates
+    1: card fails validation, or input file / schema is invalid
+
+Requires: Python 3.11+ and the `jsonschema` library.
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA = (
+    REPO_ROOT
+    / "docs"
+    / "contracts"
+    / "institution-package"
+    / "action-card.schema.json"
+)
+DEFAULT_PACKET = (
+    REPO_ROOT
+    / "docs"
+    / "contracts"
+    / "institution-package"
+    / "action-card.example.json"
+)
+
+
+def load_json(path: Path, label: str) -> dict:
+    if not path.exists():
+        print(f"ERROR: {label} not found at {path}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: {label} at {path} is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def build_format_checker(FormatChecker):
+    """
+    Return a FormatChecker that enforces RFC 3339 `date-time` and basic `uri`
+    using only stdlib. The action-card schema does not currently use either
+    `format` annotation; the registrations are kept symmetric with the other
+    contract validators (`validate-preview-review.py`,
+    `validate-rehearsal-evidence.py`) so a future field that adds either
+    format is enforced without touching this file.
+    """
+    checker = FormatChecker()
+
+    @checker.checks("date-time", raises=ValueError)
+    def _check_datetime(value: object) -> bool:
+        if not isinstance(value, str):
+            return False
+        normalised = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        datetime.fromisoformat(normalised)
+        return True
+
+    @checker.checks("uri", raises=ValueError)
+    def _check_uri(value: object) -> bool:
+        if not isinstance(value, str):
+            return False
+        parsed = urlparse(value)
+        if not parsed.scheme:
+            raise ValueError("uri missing scheme")
+        if not (parsed.netloc or parsed.path):
+            raise ValueError("uri missing netloc or path")
+        return True
+
+    return checker
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "packet",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_PACKET,
+        help="Card JSON file to validate (defaults to the bundled example).",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=DEFAULT_SCHEMA,
+        help="Schema JSON file to validate against (defaults to the bundled schema).",
+    )
+    args = parser.parse_args()
+
+    try:
+        from jsonschema import Draft202012Validator, FormatChecker, SchemaError
+    except ImportError:
+        print(
+            "ERROR: the `jsonschema` Python package is required (pip install jsonschema).",
+            file=sys.stderr,
+        )
+        return 1
+
+    schema = load_json(args.schema, "schema")
+
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError as exc:
+        print(f"ERROR: schema at {args.schema} is invalid: {exc.message}", file=sys.stderr)
+        return 1
+
+    format_checker = build_format_checker(FormatChecker)
+    validator = Draft202012Validator(schema, format_checker=format_checker)
+
+    packet = load_json(args.packet, "packet")
+
+    try:
+        errors = sorted(validator.iter_errors(packet), key=lambda e: list(e.path))
+    except Exception as exc:  # safety net; iter_errors normally returns, not raises
+        print(
+            f"ERROR: validator raised unexpectedly while validating {args.packet}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not errors:
+        contract = schema.get("$id", "<unknown>")
+        rel = (
+            args.packet.relative_to(REPO_ROOT)
+            if args.packet.is_relative_to(REPO_ROOT)
+            else args.packet
+        )
+        print(f"OK: {rel} validates against {contract}")
+        return 0
+
+    print(
+        f"FAIL: {args.packet} did not validate against {schema.get('$id', '<unknown>')}",
+        file=sys.stderr,
+    )
+    for err in errors:
+        loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        print(f"  at {loc}: {err.message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/scripts/validate-action-card.py
+++ b/docs/scripts/validate-action-card.py
@@ -50,7 +50,7 @@ DEFAULT_SCHEMA = (
     / "institution-package"
     / "action-card.schema.json"
 )
-DEFAULT_PACKET = (
+DEFAULT_CARD = (
     REPO_ROOT
     / "docs"
     / "contracts"
@@ -109,10 +109,10 @@ def main() -> int:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "packet",
+        "card",
         nargs="?",
         type=Path,
-        default=DEFAULT_PACKET,
+        default=DEFAULT_CARD,
         help="Card JSON file to validate (defaults to the bundled example).",
     )
     parser.add_argument(
@@ -143,13 +143,13 @@ def main() -> int:
     format_checker = build_format_checker(FormatChecker)
     validator = Draft202012Validator(schema, format_checker=format_checker)
 
-    packet = load_json(args.packet, "packet")
+    card = load_json(args.card, "card")
 
     try:
-        errors = sorted(validator.iter_errors(packet), key=lambda e: list(e.path))
+        errors = sorted(validator.iter_errors(card), key=lambda e: list(e.path))
     except Exception as exc:  # safety net; iter_errors normally returns, not raises
         print(
-            f"ERROR: validator raised unexpectedly while validating {args.packet}: {exc}",
+            f"ERROR: validator raised unexpectedly while validating {args.card}: {exc}",
             file=sys.stderr,
         )
         return 1
@@ -157,15 +157,15 @@ def main() -> int:
     if not errors:
         contract = schema.get("$id", "<unknown>")
         rel = (
-            args.packet.relative_to(REPO_ROOT)
-            if args.packet.is_relative_to(REPO_ROOT)
-            else args.packet
+            args.card.relative_to(REPO_ROOT)
+            if args.card.is_relative_to(REPO_ROOT)
+            else args.card
         )
         print(f"OK: {rel} validates against {contract}")
         return 0
 
     print(
-        f"FAIL: {args.packet} did not validate against {schema.get('$id', '<unknown>')}",
+        f"FAIL: {args.card} did not validate against {schema.get('$id', '<unknown>')}",
         file=sys.stderr,
     )
     for err in errors:


### PR DESCRIPTION
## Summary

Closes the publication/stabilization gap on **icn#1713** by giving the existing institution-package `ActionCard` JSON Schema the same convention the other two `docs/contracts/` schemas already have: a fictional bundled example and a draft-2020-12 validator script. Adds the explicit validation command to the institution-package README, cross-links ADR-0027 and the schema-id audit, and records the schema's current `rfc` stability marker honestly. No schema fields change. No `\$id` migration. No new source paths. No runtime/code changes.

## What changed

| File | Change |
|---|---|
| `docs/contracts/institution-package/action-card.example.json` | **New.** Fictional sample card object demonstrating the `proposal`/`vote` shape with all required fields plus optional `deadline` and `domain_id`. Uses fictional ids (`prop-example-2026-05-07-001`, `domain-example-fictional-cooperative`); contains no NYCN-specific nouns. |
| `docs/scripts/validate-action-card.py` | **New.** Tiny draft-2020-12 JSON Schema validator. Mirrors `validate-preview-review.py` and `validate-rehearsal-evidence.py` exactly, swapping schema/example default paths. Defaults to validating the bundled example; accepts a partner-side card path; supports `--schema` for pinned-version validation. Stdlib-only `format: date-time` and `format: uri` checkers registered for symmetry with the other contract validators (the action-card schema does not currently use either format; future format additions will be enforced without touching this file). |
| `docs/contracts/institution-package/README.md` | Added Files table entries for the new example and validator. Expanded Stability section to cite ADR-0027 § Card kind taxonomy ("growable by ADR amendment") explaining why `rfc` is honest. Added a Stability subsection documenting that the schema's current DNS-backed `\$id` is retained temporarily per [`../schema-id-audit.md`](../schema-id-audit.md) (review by 2026-06-30) and that a future migration to `urn:icn:contract:action-card:v<N>` will be a separate single-schema PR under the audit's §5 rules. Expanded Validation guidance with explicit emitted-vs-gated source kind enumeration, the regulatory-safe vocabulary list (obligation, allocation, settlement, unit, position, receipt, provenance, evidence — explicitly not payment/wallet/balance/currency), and a new "Command — validate a single card object" subsection with the exact CLI invocations. Added explicit "institution-specific semantics belong in institution packages, not in ICN core" guidance. Bumped Last Reviewed: 2026-05-04 → 2026-05-07. |
| `docs/registry.toml` | Bumped `last_updated` and `last_reviewed` for the institution-package README entry to 2026-05-07. Refreshed `description` to mention the new example and validator and the schema-id-audit retention decision. |

## Why this matters

NYCN already has package-local action-card templates and needs a generic ICN contract to validate against (per icn#1713 background and ADR-0027). The schema and ADR landed earlier (icn#1646 vertical slice + ADR-0027), but the `docs/contracts/` directory had a clear convention — `validate-preview-review.py` + `preview-review.example.json` for one schema, `validate-rehearsal-evidence.py` + `rehearsal-evidence-export.example.json` for another — and the action-card schema had neither. Without an example and a tiny validator, partner packages had to trust prose rather than run a command before committing or rendering generic templates that reference ICN's contract surface. This PR closes that gap by mirroring the existing convention precisely.

## Relationship to icn#1713 / NYCN package validation / ADR-0027

icn#1713 acceptance criteria, item-by-item:

- [x] **Generic ActionCard schema exists and matches current runtime fields** — schema at `docs/contracts/institution-package/action-card.schema.json` matches the `ActionCard` struct in `icn/apps/governance/src/http/models.rs:235` field-for-field (12 always-emitted required fields; 2 `\#[serde(skip_serializing_if = "Option::is_none")]` optional fields; four enums with matching `\#[serde(rename_all = "snake_case")]` values).
- [x] **Schema has honest stability/status marker** — `"x-icn-status": "rfc"` in the schema; the README's Stability section now cites ADR-0027's "growable by ADR amendment" stance to explain *why* `rfc` is honest.
- [x] **Source kinds distinguish shipped vs gated variants** — schema's `x-icn-emitted-source-kinds`, `x-icn-emitted-source-action-pairs`, and `x-icn-rfc-gated-source-kinds` extension keys, and the README's Emitted-pairs and Gated-source-kinds tables (each gated kind cites its tracking issues: `signal_rule` → icn#1631 / icn#1711; `obligation_lifecycle` → icn#1634 / icn#1712).
- [x] **NYCN-specific nouns are absent from generic schema** — schema and example use only generic primitives (`proposal`, `meeting`, `action_item`, `vote`, `attend`, `complete`, `entity`, `structure`, `individual`, `low`/`normal`/`elevated`); the example uses fictional ids and no NYCN-specific labels. README mentions NYCN only as an example consumer.
- [x] **Regulatory-safe vocabulary preserved** — README's Validation guidance now lists the regulatory-safe set explicitly: obligation, allocation, settlement, unit, position, receipt, provenance, evidence — and explicitly names the avoided framing (payment, wallet, balance, currency). Compliance linter passes with zero violations on the touched files.
- [x] **Package validation path documented for NYCN and future institution packages** — bundled validator + worked CLI examples + vendor-or-invoke-from-CI guidance in the README.

ADR-0027 implementation_status is left unchanged; the ADR's status is partial-implementation tracking for the runtime work (icn#1646), not the contract publication path. The README cross-link to ADR-0027 § Card kind taxonomy is sufficient.

icn#1737 / `docs/contracts/schema-id-audit.md` is honored: the schema's `\$id` is unchanged; this PR only adds the README pointer to that audit. Per the audit's §5, any future `\$id` migration to a non-DNS URN ships in its own single-schema PR.

## Stability marker explanation

`"x-icn-status": "rfc"` is the honest marker for this contract today. The runtime ships three currently-emitted source/action pairs (`proposal`/`vote`, `meeting`/`attend`, `action_item`/`complete`) with their proof loops verified end-to-end (per ADR-0027 implementation_status block: `icn/apps/governance/tests/me_action_card_receipt_chain.rs`, `me_action_item_receipt_chain.rs`, `me_meeting_attendance_receipt_chain.rs`). The closed taxonomy reserves `signal_rule` and `obligation_lifecycle` for forward compatibility, gated on icn#1631 / icn#1634 respectively, and ADR-0027 explicitly states the taxonomy is "growable by ADR amendment." `rfc` rather than `stable` is therefore not an admission of doubt about the runtime — it is a contract on contract amendment: any breaking shape change goes through ADR amendment, regen of OpenAPI / TypeScript types in the same PR, and re-validation of partner-side example cards.

## Explicit non-claims

- Not a new action-card source path. The runtime is unchanged. `signal_rule` and `obligation_lifecycle` remain RFC-gated on icn#1631 / icn#1634.
- Not an obligation/signal runtime change.
- Not an NYCN template implementation. NYCN action-card templates are out of scope here.
- Not an ADR addition. ADR-0027 already exists and stands.
- Not an RFC.
- Not a new contract URN. The schema's `\$id` is unchanged; migration is deferred per the schema-id audit (review by 2026-06-30).
- Not a website source change.
- Not a K3s / DNS / Forgejo mutation.
- Not private-data handling. Example uses fictional ids only.
- Not a Phase 2 completion claim.
- Not a formal NYCN pilot claim.
- Not a production-readiness claim.
- Not a live federation claim.
- Not a `ProcessSession` storage change.
- Not a new `ProcessTransitionReceipt` class. The opaque cascade landed in icn#1755 / #1757 / #1758 / #1759 is unchanged.
- Not a DAP runtime dogfood.
- Not a Stage 1.5 / Stage 2 / Stage 3 / Stage 4 / Stage 5 process-substrate move.

## Validation

```text
git diff --check                                                           → clean
python3 .github/scripts/compliance_linter.py                               → 0 violations (107 files scanned)
python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict
                                                                           → OK; 36 enforcement warnings (baseline; no new warnings; corpus 777 unchanged because no new .md files added)
bash ops/scripts/drift-check.sh                                            → STATUS: PASS (0 errors, 0 warnings)
python3 docs/scripts/validate-action-card.py                               → OK: docs/contracts/institution-package/action-card.example.json validates against https://intercooperative.network/contracts/institution-package/action-card.schema.json
```

No Rust changes; Rust gates (`cargo fmt`, `cargo clippy`, `cargo test`) intentionally not run — no `.rs` file touched.

`docs/DOCUMENT_REGISTRY.md` regen is intentionally not in scope: this PR adds two non-`.md` files (`*.json`, `*.py`) and modifies one already-tracked `.md` file (`README.md`). Doc-control's corpus count (777) is unchanged.

## Follow-ups

- **Schema `\$id` migration to `urn:icn:contract:action-card:v1`** — separate single-schema PR per `docs/contracts/schema-id-audit.md` §5; review by 2026-06-30.
- **Mechanical drift detection** — comparing the hand-maintained schema to the serde-derived shapes in `icn/apps/governance/src/http/models.rs`. The README explicitly names this as future work.
- **icn#1711 / icn#1712** — when the `signal_rule` / `obligation_lifecycle` source paths land (each gated on icn#1631 / icn#1634), the schema's `x-icn-emitted-*` arrays move those values from RFC-gated to emitted in the same PR as the runtime change.
- **Partner repo vendor pattern** — partner packages (NYCN today; future institution packages) may vendor a copy of `action-card.schema.json` and either vendor or invoke `validate-action-card.py` from their own CI. Each vendoring repo decides whether to track this repo's version mechanically or via release pin.

## Refs

- icn#1713 (this PR closes the publication/stabilization gap)
- icn#1646 (action-card runtime vertical slice; partial implementation tracker)
- icn#1608 (original `GET /me/action-cards` runtime issue)
- icn#1711 / icn#1712 (RFC-gated source paths)
- icn#1631 / icn#1634 (signals / obligation primitives gating the RFC-gated source paths)
- icn#1737 / `docs/contracts/schema-id-audit.md` (schema `\$id` audit; defers migration past 2026-06-30)
- icn#1744 (substantive AI review findings are merge-gating)
- ADR-0020 (Bootstrap Activation and Standing Read Model — promised the surface)
- ADR-0027 (Action Card Contract — names the contract this PR publishes)
- ADR-0028 (Accessibility Baseline for Member Interfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)