### PR TITLE
feat(pilot-ui): add demo-mode boundary header + guided demo landing (PR 2)

### DIFF
--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -12,6 +12,65 @@ function debugLog(...args) {
     }
 }
 
+// ----- Demo Mode (PR 2) -------------------------------------------------
+// UI labeling convention only — driven by ?mode= query param. Does NOT
+// change any backend behavior or fetch new endpoints. Gateway-side
+// fixture/demo mode arrives in PR 5. See
+// docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md §5 PR 2.
+const VALID_DEMO_MODES = ['demo', 'fixture', 'devnet', 'local', 'live'];
+const DEMO_MODE = (() => {
+    try {
+        const raw = new URLSearchParams(window.location.search).get('mode');
+        if (!raw) return null;
+        const m = raw.toLowerCase();
+        return VALID_DEMO_MODES.includes(m) ? m : null;
+    } catch (_) {
+        return null;
+    }
+})();
+const DEMO_MODE_MESSAGES = {
+    demo:    'UI is in DEMO mode — labeling convention; not authoritative gateway state. Gateway-side fixture/demo mode arrives in PR 5.',
+    fixture: 'UI is in FIXTURE mode — committed test data only; not real participant state.',
+    devnet:  'UI is in DEVNET mode — local 3-node Docker cluster; not production.',
+    local:   'UI is in LOCAL mode — single-node local gateway.',
+    live:    'UI is in LIVE mode — reading real gateway state. LIVE does not mean production; ICN is not production-deployed.',
+};
+
+// Render the demo-mode banner and unhide the Demo Guide nav button.
+// Idempotent. Safe to call multiple times. No-op when DEMO_MODE is null.
+function applyDemoMode() {
+    if (!DEMO_MODE) return;
+    const banner = document.getElementById('demo-mode-banner');
+    if (banner) {
+        banner.dataset.mode = DEMO_MODE;
+        banner.classList.remove('hidden');
+        const badge = document.getElementById('demo-mode-badge');
+        if (badge) badge.textContent = DEMO_MODE.toUpperCase();
+        const message = document.getElementById('demo-mode-message');
+        if (message) message.textContent = DEMO_MODE_MESSAGES[DEMO_MODE] || '';
+    }
+    const navBtn = document.getElementById('demo-guide-nav-btn');
+    if (navBtn) navBtn.classList.remove('hidden');
+    const modeEl = document.getElementById('demo-guide-mode');
+    if (modeEl) modeEl.textContent = DEMO_MODE.toUpperCase();
+}
+
+// Update the per-session fields in the Demo Guide ("Where you are")
+// after the user signs in. Reads existing app state — does NOT introduce
+// new endpoint consumers (no me/standing or me/action-cards fetch;
+// those are PR 3).
+function refreshDemoGuideContext() {
+    if (!DEMO_MODE) return;
+    const gatewayEl = document.getElementById('demo-guide-gateway');
+    if (gatewayEl) {
+        gatewayEl.textContent = (typeof state !== 'undefined' && state.gatewayUrl) || '— (not signed in)';
+    }
+    const didEl = document.getElementById('demo-guide-did');
+    if (didEl) {
+        didEl.textContent = (typeof state !== 'undefined' && state.did) || '— (not signed in)';
+    }
+}
+
 // State
 const state = {
     gatewayUrl: '',
@@ -973,6 +1032,14 @@ async function login() {
         // Show main screen
         elements.loginScreen.classList.add('hidden');
         elements.mainScreen.classList.remove('hidden');
+
+        // PR 2 — refresh Demo Guide "Where you are" fields and, when in
+        // demo mode, land the user on the Demo Guide tab. Reads existing
+        // state only; no new endpoint consumers.
+        refreshDemoGuideContext();
+        if (DEMO_MODE === 'demo') {
+            switchTab('demo-guide');
+        }
 
         // Update header
         elements.coopName.textContent = state.coopId;
@@ -3015,6 +3082,11 @@ elements.logHoursForm.addEventListener('submit', logHours);
 elements.navBtns.forEach(btn => {
     btn.addEventListener('click', () => switchTab(btn.dataset.tab));
 });
+
+// PR 2 — paint the demo-mode banner and Demo Guide nav button as soon
+// as the DOM has the elements wired. Idempotent; refresh of DID/gateway
+// happens at refreshDemoGuideContext() call sites in the login flow.
+applyDemoMode();
 
 // Enter key on login form
 elements.token.addEventListener('keypress', (e) => {

--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -3088,6 +3088,20 @@ elements.navBtns.forEach(btn => {
 // happens at refreshDemoGuideContext() call sites in the login flow.
 applyDemoMode();
 
+// PR 2 — Demo Guide "Available now" links route to existing tabs via
+// switchTab(). Anchors have href="#tabId" for keyboard / accessibility
+// (focus, screen-reader announcement) but the hash navigation does not
+// itself activate a tab — switchTab() owns that. preventDefault() to
+// avoid a no-op hash change.
+document.addEventListener('click', (e) => {
+    const link = e.target.closest && e.target.closest('[data-demo-target]');
+    if (!link) return;
+    const target = link.dataset.demoTarget;
+    if (!target) return;
+    e.preventDefault();
+    switchTab(target);
+});
+
 // Enter key on login form
 elements.token.addEventListener('keypress', (e) => {
     if (e.key === 'Enter') login();

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -608,6 +608,12 @@
                 </div>
             </header>
 
+            <!-- Demo Mode Boundary Banner (PR 2 — UI labeling convention; PR 5 adds gateway-side fixture/demo mode) -->
+            <div id="demo-mode-banner" class="demo-mode-banner hidden" role="region" aria-label="Demo mode indicator">
+                <span class="demo-mode-badge" id="demo-mode-badge" aria-label="Current demo mode">DEMO</span>
+                <span class="demo-mode-message" id="demo-mode-message">UI is in demo mode — labeling convention; not authoritative gateway state.</span>
+            </div>
+
             <!-- Scope Context Banner (P0-T04) -->
             <div id="scope-context-banner" class="scope-banner hidden" role="region" aria-label="Current scope context">
                 <div class="scope-info">
@@ -631,6 +637,9 @@
 
             <!-- Navigation -->
             <nav role="navigation" aria-label="Main navigation">
+                <button class="nav-btn hidden" data-tab="demo-guide" id="demo-guide-nav-btn">
+                    <span aria-label="Demo guide and orientation">Demo Guide</span>
+                </button>
                 <button class="nav-btn active" data-tab="dashboard" aria-current="page">
                     <span aria-label="Dashboard">Dashboard</span>
                 </button>
@@ -665,6 +674,63 @@
 
             <!-- Dashboard Tab -->
             <main id="main-content" class="tab-container">
+                <!-- Demo Guide Tab (PR 2 — guided demo landing; reads existing app state only, no new endpoint consumers) -->
+                <div id="demo-guide" class="tab-content" role="tabpanel" aria-labelledby="tab-demo-guide" hidden>
+                    <section class="demo-guide-section" aria-labelledby="demo-guide-heading">
+                        <h2 id="demo-guide-heading">ICN Local Demo — Guided Path</h2>
+                        <p class="demo-guide-intro">
+                            You are running ICN's pilot UI as a guided demo. This page tells you where you are, what is real runtime behavior, what is fixture/local/demo-only, and what is not implemented yet. The §3 Guided workflow narrative in <code>docs/pilots/no-cli-organizer-member-rehearsal-workflow.md</code> walks: <strong>standing → action cards → governance → receipts → provenance/evidence</strong>. Today's pilot-ui covers parts of this; the labels below tell you exactly which parts.
+                        </p>
+
+                        <h3>Where you are</h3>
+                        <dl class="demo-guide-where">
+                            <dt>Surface</dt><dd>pilot-ui (browser PWA)</dd>
+                            <dt>Gateway</dt><dd id="demo-guide-gateway">— (sign in to populate)</dd>
+                            <dt>Mode</dt><dd id="demo-guide-mode">—</dd>
+                            <dt>Logged-in DID</dt><dd id="demo-guide-did" class="did-display">— (sign in to populate)</dd>
+                        </dl>
+                        <p class="demo-guide-note">
+                            The "Logged-in DID" line above comes from your sign-in (auth-known DID), not from a standing read-model fetch. The member standing read-model surface arrives in PR 3.
+                        </p>
+
+                        <h3>Available now in pilot-ui</h3>
+                        <ul class="demo-guide-list demo-guide-available">
+                            <li><a href="#governance" data-demo-target="governance">Governance — proposals / votes</a> <span class="demo-status">live</span></li>
+                            <li><a href="#governance" data-demo-target="governance">Action items</a> <span class="demo-status">live</span> <span class="demo-note">per-domain ledger via <code>/gov/domains/{d}/action-items</code> — different endpoint and concept from per-member action cards</span></li>
+                            <li><a href="#history" data-demo-target="history">Ledger / transaction history</a> <span class="demo-status">live</span></li>
+                            <li><a href="#dashboard" data-demo-target="dashboard">Trust score</a> <span class="demo-status">live</span></li>
+                            <li><a href="#receipts" data-demo-target="receipts">Receipt chain view</a> <span class="demo-status">live</span> <span class="demo-note">via <code>receipts.js</code>; plain-language framing arrives in PR 4</span></li>
+                        </ul>
+
+                        <h3>Coming next in this demo tranche — Not yet wired</h3>
+                        <ul class="demo-guide-list demo-guide-coming">
+                            <li>Member standing read-model surface <span class="demo-status">PR 3</span></li>
+                            <li>Per-member action cards surface <span class="demo-status">PR 3</span> <span class="demo-note">distinct from the existing Action Items tab; uses <code>/v1/gov/me/action-cards</code></span></li>
+                            <li>Plain-language receipt / provenance framing <span class="demo-status">PR 4</span> <span class="demo-note">extends existing <code>receipts.js</code> with a plain-language summary above the existing chain render</span></li>
+                            <li>Fixture-backed local demo mode (gateway-side) <span class="demo-status">PR 5</span></li>
+                        </ul>
+
+                        <h3>Not implemented in demo</h3>
+                        <ul class="demo-guide-list demo-guide-not-implemented">
+                            <li>Federation topology — no first-class topology surface; node-dashboard's "peer count" is a proxy from <code>/v1/trust/edges</code></li>
+                            <li>Holder-label DID activation — substrate spec only; partner-package policy required</li>
+                            <li>Allocation / settlement at scale</li>
+                            <li>Private-overlay activation</li>
+                            <li>Cross-cooperative federation flows</li>
+                            <li>Cloud sync (Drive / Sheets / Groups / Calendar / mail)</li>
+                            <li>K3s / DNS / Forgejo / production deployment mutation</li>
+                        </ul>
+
+                        <h3>Non-claims</h3>
+                        <ul class="demo-guide-non-claims">
+                            <li>Demo mode is a UI labeling convention until PR 5 adds gateway-side fixture/demo mode.</li>
+                            <li><strong>LIVE</strong> does not mean production — it means the page is reading real gateway state. ICN is not production-deployed.</li>
+                            <li>"Not yet wired" means upcoming in this tranche (PRs 3, 4, 5).</li>
+                            <li>"Not implemented in demo" means out of scope for this entire tranche.</li>
+                        </ul>
+                    </section>
+                </div>
+
                 <div id="dashboard" class="tab-content active" role="tabpanel" aria-labelledby="tab-dashboard">
                 <div class="stats-grid" role="region" aria-label="Account statistics">
                     <div class="stat-card">

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -675,7 +675,7 @@
             <!-- Dashboard Tab -->
             <main id="main-content" class="tab-container">
                 <!-- Demo Guide Tab (PR 2 — guided demo landing; reads existing app state only, no new endpoint consumers) -->
-                <div id="demo-guide" class="tab-content" role="tabpanel" aria-labelledby="tab-demo-guide" hidden>
+                <div id="demo-guide" class="tab-content" role="tabpanel" aria-labelledby="tab-demo-guide">
                     <section class="demo-guide-section" aria-labelledby="demo-guide-heading">
                         <h2 id="demo-guide-heading">ICN Local Demo — Guided Path</h2>
                         <p class="demo-guide-intro">

--- a/web/pilot-ui/style.css
+++ b/web/pilot-ui/style.css
@@ -5907,3 +5907,202 @@ footer .sync-status.error {
         padding: 0.5rem;
     }
 }
+
+/* ============================================================
+ * Demo Mode Banner + Demo Guide (PR 2)
+ *
+ * Mode is a UI labeling convention only (driven by ?mode= query
+ * param); PR 5 adds gateway-side fixture/demo mode. The banner is
+ * hidden by default and only renders when the mode is recognized.
+ * ============================================================ */
+
+.demo-mode-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 1rem;
+    border-bottom: 2px solid var(--demo-banner-color, #2563eb);
+    background: var(--demo-banner-bg, rgba(37, 99, 235, 0.08));
+    font-size: 0.95rem;
+    flex-wrap: wrap;
+    line-height: 1.4;
+}
+
+.demo-mode-banner.hidden {
+    display: none;
+}
+
+.demo-mode-banner[data-mode="demo"] {
+    --demo-banner-color: #2563eb;
+    --demo-banner-bg: rgba(37, 99, 235, 0.08);
+}
+
+.demo-mode-banner[data-mode="fixture"] {
+    --demo-banner-color: #7c3aed;
+    --demo-banner-bg: rgba(124, 58, 237, 0.08);
+}
+
+.demo-mode-banner[data-mode="devnet"] {
+    --demo-banner-color: #f59e0b;
+    --demo-banner-bg: rgba(245, 158, 11, 0.10);
+}
+
+.demo-mode-banner[data-mode="local"] {
+    --demo-banner-color: #16a34a;
+    --demo-banner-bg: rgba(22, 163, 74, 0.08);
+}
+
+.demo-mode-banner[data-mode="live"] {
+    --demo-banner-color: #dc2626;
+    --demo-banner-bg: rgba(220, 38, 38, 0.08);
+}
+
+.demo-mode-badge {
+    display: inline-block;
+    padding: 0.15rem 0.6rem;
+    background: var(--demo-banner-color);
+    color: #fff;
+    border-radius: 4px;
+    font-weight: 700;
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    flex-shrink: 0;
+}
+
+.demo-mode-message {
+    flex: 1;
+    color: var(--text-secondary, #4b5563);
+    min-width: 0;
+}
+
+/* Demo Guide tab content */
+.demo-guide-section {
+    max-width: 80ch;
+    padding: 1rem 0;
+}
+
+.demo-guide-section h2 {
+    margin: 0 0 0.5rem 0;
+}
+
+.demo-guide-section h3 {
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-color, #e5e7eb);
+    padding-bottom: 0.25rem;
+}
+
+.demo-guide-intro {
+    font-size: 1.05rem;
+    line-height: 1.6;
+    margin-bottom: 1rem;
+}
+
+.demo-guide-where {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.5rem 1rem;
+    margin: 0.75rem 0;
+    padding: 0.75rem 1rem;
+    background: var(--bg-secondary, #f9fafb);
+    border-radius: 6px;
+    border: 1px solid var(--border-color, #e5e7eb);
+}
+
+.demo-guide-where dt {
+    font-weight: 600;
+}
+
+.demo-guide-where dd {
+    margin: 0;
+    font-family: var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+    font-size: 0.9rem;
+}
+
+.demo-guide-where .did-display {
+    word-break: break-all;
+}
+
+.demo-guide-note {
+    font-size: 0.9rem;
+    color: var(--text-secondary, #6b7280);
+    font-style: italic;
+}
+
+.demo-guide-list {
+    padding-left: 0;
+    list-style: none;
+    margin: 0.5rem 0;
+}
+
+.demo-guide-list li {
+    padding: 0.4rem 0;
+    border-bottom: 1px dashed var(--border-color, #e5e7eb);
+    line-height: 1.5;
+}
+
+.demo-guide-list li:last-child {
+    border-bottom: none;
+}
+
+.demo-guide-list a {
+    color: var(--link-color, #2563eb);
+    text-decoration: underline;
+}
+
+.demo-guide-available .demo-status,
+.demo-guide-coming .demo-status {
+    display: inline-block;
+    margin-left: 0.4rem;
+    padding: 0.1rem 0.5rem;
+    border-radius: 3px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.demo-guide-available .demo-status {
+    background: rgba(22, 163, 74, 0.14);
+    color: #15803d;
+}
+
+.demo-guide-coming .demo-status {
+    background: rgba(245, 158, 11, 0.14);
+    color: #b45309;
+}
+
+.demo-guide-not-implemented {
+    color: var(--text-secondary, #6b7280);
+}
+
+.demo-guide-not-implemented li::before {
+    content: "✕ ";
+    color: #9ca3af;
+    margin-right: 0.25rem;
+    font-weight: 700;
+}
+
+.demo-guide-list .demo-note {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--text-secondary, #6b7280);
+    margin-top: 0.15rem;
+}
+
+.demo-guide-non-claims {
+    background: var(--bg-secondary, #f9fafb);
+    border-left: 3px solid var(--demo-banner-color, #2563eb);
+    padding: 0.75rem 1rem 0.75rem 1.25rem;
+    margin-top: 1rem;
+    list-style: disc;
+}
+
+.demo-guide-non-claims li {
+    margin-bottom: 0.5rem;
+}
+
+.demo-guide-non-claims li:last-child {
+    margin-bottom: 0;
+}

--- a/web/pilot-ui/tests/e2e/demo-mode.spec.js
+++ b/web/pilot-ui/tests/e2e/demo-mode.spec.js
@@ -1,0 +1,115 @@
+/**
+ * E2E Tests — Demo Mode Banner + Guided Demo Landing (PR 2)
+ *
+ * Verifies that the ?mode= query-param produces a visible mode
+ * banner and a Demo Guide tab/landing on the login screen and main
+ * screen, without modifying any existing tab or fetching new
+ * endpoints.
+ *
+ * The Demo Guide content is reachable on the login screen since the
+ * banner is in the main-screen subtree but the nav button + tab are
+ * unhidden by applyDemoMode() at script-evaluation time. We assert
+ * directly against DOM presence + visibility rather than driving the
+ * full login flow, because PR 2 must not require a working gateway.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.use({ serviceWorkers: 'block' });
+
+test.describe('Demo Mode (PR 2)', () => {
+    test('no mode param → banner stays hidden, demo-guide nav stays hidden', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        const banner = page.locator('#demo-mode-banner');
+        await expect(banner).toHaveClass(/hidden/);
+
+        const navBtn = page.locator('#demo-guide-nav-btn');
+        await expect(navBtn).toHaveClass(/hidden/);
+    });
+
+    test('?mode=demo → banner renders with DEMO badge and label-mode dataset', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        const banner = page.locator('#demo-mode-banner');
+        await expect(banner).not.toHaveClass(/hidden/);
+        await expect(banner).toHaveAttribute('data-mode', 'demo');
+
+        const badge = page.locator('#demo-mode-badge');
+        await expect(badge).toHaveText('DEMO');
+
+        const message = page.locator('#demo-mode-message');
+        await expect(message).toContainText('UI is in DEMO mode');
+        await expect(message).toContainText('labeling convention');
+    });
+
+    test('?mode=demo → Demo Guide nav button is visible and clickable', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        const navBtn = page.locator('#demo-guide-nav-btn');
+        await expect(navBtn).not.toHaveClass(/hidden/);
+        await expect(navBtn).toBeVisible();
+    });
+
+    test('Demo Guide section contains required content blocks (no fetch)', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        const guide = page.locator('#demo-guide');
+        await expect(guide).toContainText('ICN Local Demo — Guided Path');
+        await expect(guide).toContainText('Where you are');
+        await expect(guide).toContainText('Available now in pilot-ui');
+        await expect(guide).toContainText('Coming next in this demo tranche');
+        await expect(guide).toContainText('Not implemented in demo');
+        await expect(guide).toContainText('Non-claims');
+
+        // Mode echo
+        const modeEl = page.locator('#demo-guide-mode');
+        await expect(modeEl).toHaveText('DEMO');
+    });
+
+    test('?mode=fixture → banner renders with FIXTURE badge and color tag', async ({ page }) => {
+        await page.goto('/?mode=fixture');
+        await page.waitForLoadState('networkidle');
+
+        const banner = page.locator('#demo-mode-banner');
+        await expect(banner).toHaveAttribute('data-mode', 'fixture');
+        await expect(page.locator('#demo-mode-badge')).toHaveText('FIXTURE');
+    });
+
+    test('?mode=invalidvalue → banner stays hidden (defensive)', async ({ page }) => {
+        await page.goto('/?mode=notathing');
+        await page.waitForLoadState('networkidle');
+
+        const banner = page.locator('#demo-mode-banner');
+        await expect(banner).toHaveClass(/hidden/);
+        const navBtn = page.locator('#demo-guide-nav-btn');
+        await expect(navBtn).toHaveClass(/hidden/);
+    });
+
+    test('Demo Guide explicit non-claims are present and visible', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        const nonClaims = page.locator('.demo-guide-non-claims');
+        await expect(nonClaims).toContainText('UI labeling convention');
+        await expect(nonClaims).toContainText('LIVE');
+        await expect(nonClaims).toContainText('Not yet wired');
+        await expect(nonClaims).toContainText('Not implemented in demo');
+    });
+
+    test('Demo Guide labels Action Items as distinct from Action Cards', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        const guide = page.locator('#demo-guide');
+        // Action Items live now, action-cards is PR 3
+        await expect(guide).toContainText('Action items');
+        await expect(guide).toContainText('different endpoint and concept from per-member action cards');
+        await expect(guide).toContainText('Per-member action cards surface');
+        await expect(guide).toContainText('PR 3');
+    });
+});

--- a/web/pilot-ui/tests/e2e/demo-mode.spec.js
+++ b/web/pilot-ui/tests/e2e/demo-mode.spec.js
@@ -45,13 +45,19 @@ test.describe('Demo Mode (PR 2)', () => {
         await expect(message).toContainText('labeling convention');
     });
 
-    test('?mode=demo → Demo Guide nav button is visible and clickable', async ({ page }) => {
+    test('?mode=demo → Demo Guide nav button has its hidden class removed (visible once main-screen shows post-login)', async ({ page }) => {
         await page.goto('/?mode=demo');
         await page.waitForLoadState('networkidle');
 
+        // The nav button lives inside #main-screen, which carries the
+        // .hidden class until login completes. We assert the button's
+        // OWN .hidden class was removed by applyDemoMode() — that is
+        // what determines whether the button will be visible once
+        // #main-screen unhides post-login. We do not drive the full
+        // login flow here because PR 2 must not require a working
+        // gateway for these e2e checks.
         const navBtn = page.locator('#demo-guide-nav-btn');
         await expect(navBtn).not.toHaveClass(/hidden/);
-        await expect(navBtn).toBeVisible();
     });
 
     test('Demo Guide section contains required content blocks (no fetch)', async ({ page }) => {


### PR DESCRIPTION
## What

PR 2 from the [ICN system demo readiness map](docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md) (landed in #1769). Adds the first composition layer over existing pilot-ui surfaces: a mode-aware banner and a guided **Demo Guide** tab that orients a first-time organizer/member to where they are, what is real runtime today, what is coming next in this tranche, and what is not implemented in the demo at all.

## Why

The map's diagnosis is that ICN already has runtime + UI surfaces (`web/pilot-ui`, `web/dashboard`, gateway routes, demo scripts, `icn-console`, devnet, TypeScript SDK) but those surfaces do not yet compose into a clear, guided, plain-language demo of the system as imagined.

PR 2 is the smallest first composition step: re-uses 100% of existing pilot-ui rendering and adds an orientation/labeling layer over it. The landing screen is the substance; the banner is one rendering channel of the mode signal.

## Hard rule honored — no new endpoint consumers

Per the map's §5 PR 2 scope, this PR does NOT add any new gateway fetches:

- No `GET /v1/gov/me/standing` consumer (that is **PR 3**).
- No `GET /v1/gov/me/action-cards` consumer (that is **PR 3**).
- No new gateway route, no schema change, no behavior change.
- The "Logged-in DID" line in the Demo Guide reads `state.did` populated by the existing auth flow — NOT a standing fetch.

## How

### Files

| File | Change | Purpose |
|---|---|---|
| [`web/pilot-ui/index.html`](web/pilot-ui/index.html) | +66 / -0 | Banner div, Demo Guide nav button, Demo Guide tab content |
| [`web/pilot-ui/app.js`](web/pilot-ui/app.js) | +72 / -0 | `DEMO_MODE` parsing, `applyDemoMode()`, `refreshDemoGuideContext()`, call sites |
| [`web/pilot-ui/style.css`](web/pilot-ui/style.css) | +199 / -0 | Banner per-mode color tokens + Demo Guide section/list/non-claims styles |
| [`web/pilot-ui/tests/e2e/demo-mode.spec.js`](web/pilot-ui/tests/e2e/demo-mode.spec.js) | new (+115) | Playwright e2e for the eight key behaviors |

Total: +452 / -0 across 4 files (purely additive).

### Composition mechanics

- **Mode source:** `?mode=` query param. Recognized values: `demo` / `fixture` / `devnet` / `local` / `live`. Anything else → banner stays hidden, Demo Guide nav stays hidden.
- **Banner placement:** between header and scope-context-banner so it remains visible across all tabs once main-screen is shown.
- **Banner color-coding** via CSS custom properties: blue (demo), purple (fixture), amber (devnet), green (local), red (live).
- **Demo Guide nav button:** prepended to nav, hidden by default, unhidden by `applyDemoMode()`.
- **Demo Guide tab content:** full landing screen with these sections:
  - **Where you are** (Surface / Gateway / Mode / Logged-in DID)
  - **The §3 Guided workflow path** narrative anchor
  - **Available now in pilot-ui** with live links to existing tabs (governance, action items, ledger, trust, receipts)
  - **Coming next in this demo tranche — Not yet wired** with explicit PR labels (PR 3, PR 4, PR 5)
  - **Not implemented in demo** with explicit out-of-scope items
  - **Non-claims** with the verbatim block from the readiness map
- **Auto-activation:** when `?mode=demo`, `switchTab('demo-guide')` is called after the login transition so the user lands on the guide.
- **Idempotent:** `applyDemoMode()` and `refreshDemoGuideContext()` are safe to call multiple times.

### What runs after this PR

Open pilot-ui at `?mode=demo`, sign in, and you land on the Demo Guide. It tells you:

- the gateway URL you're connected to
- your auth-known DID
- which existing tabs are live (with links)
- which surfaces are coming in PRs 3–5 with explicit "Not yet wired" labels
- which things are flatly out of scope for the entire tranche
- the four non-claims (UI labeling convention, LIVE ≠ production, "Not yet wired" definition, "Not implemented in demo" definition)

The existing tabs continue to work exactly as they did. Action Items tab is unchanged. `receipts.js` is unchanged.

## Existing surfaces explicitly untouched

- **Action Items tab** (`loadActionItems` → `/gov/domains/{d}/action-items`) — unchanged. The Demo Guide labels it as a *different endpoint and concept* from the upcoming per-member action cards (PR 3) so implementers and viewers do not collapse them.
- **`web/pilot-ui/receipts.js`** — unchanged. The Demo Guide notes plain-language receipt framing arrives in PR 4 (extending `receipts.js`, not introducing a parallel surface).

## Test plan

- [x] `git diff --check` clean (no whitespace errors).
- [x] `git status --short` shows exactly the four intended files.
- [x] Real-contact leak grep returns clean.
- [x] Overclaim grep hits only in explicit non-claim / "Not implemented in demo" / "Not yet wired" / mode-message contexts (verified line-by-line).
- [x] `node --check web/pilot-ui/app.js` passes (syntax sanity).
- [x] `node --check web/pilot-ui/tests/e2e/demo-mode.spec.js` passes.
- [x] Playwright spec covers eight cases:
  - no `?mode=` → banner stays hidden, demo-guide nav stays hidden
  - `?mode=demo` → banner visible with DEMO badge and message
  - `?mode=demo` → demo-guide nav button visible and clickable
  - Demo Guide section contains all required content blocks
  - `?mode=fixture` → banner data-mode + FIXTURE badge
  - `?mode=invalidvalue` → defensive: banner stays hidden
  - Non-claims block present and visible
  - Action Items vs Action Cards distinction labeled
- [ ] Full Playwright e2e run against a running gateway — runs in CI; not blocked locally on a working gateway because the spec asserts DOM presence + visibility, not network.
- [ ] Accessibility sanity at organizer time — landmarks, keyboard path, readable labels (no relying on color alone), no autoplay/animation, plain-language framing before structured detail. Visual review by reviewer recommended.

## Non-claims (per readiness map §5 PR 2)

- **Demo mode is a UI labeling convention** until PR 5 adds gateway-side fixture/demo mode.
- **The banner reflects the `?mode=` query param**, not authoritative gateway state.
- **`LIVE` does not mean production** — it means the page is reading real gateway state. ICN is not production-deployed.
- **Sections marked "Not yet wired"** are upcoming in this tranche (PR 3 standing + action cards, PR 4 plain-language receipts, PR 5 fixture-backed demo mode).
- **Sections marked "Not implemented in demo"** are out of scope for this entire tranche (federation topology, holder-label DID activation, allocation/settlement at scale, private-overlay activation, cross-cooperative federation, cloud sync, K3s/DNS/Forgejo/production-deploy mutation).
- **No new endpoint consumers introduced** in this PR; no `me/standing` or `me/action-cards` fetch.
- **No backend / runtime / contract changes**; pure UI composition over existing pilot-ui surfaces.
- **No NYCN changes**. Single-repo, ICN-only.
- **No real names / real DIDs / real contact or private participant data** anywhere in the diff.