### PR TITLE
feat(pilot-ui): add member standing + action cards as one coherent surface (PR 3)

### DIFF
--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -89,6 +89,12 @@ const state = {
     wsConnected: false,
     nameCache: new Map(),
     userName: null,
+    // PR 3 — Member standing read-model + per-member action cards.
+    // Both endpoints exist on the gateway; pilot-ui consumes them via
+    // the "My Standing & Action Cards" tab. Distinct from `actionItems`
+    // above (per-domain ledger via /gov/domains/{d}/action-items).
+    memberStanding: null,
+    memberActionCards: [],
 };
 
 // DOM Elements
@@ -3082,6 +3088,21 @@ elements.logHoursForm.addEventListener('submit', logHours);
 elements.navBtns.forEach(btn => {
     btn.addEventListener('click', () => switchTab(btn.dataset.tab));
 });
+
+// PR 3 — Lazy-load /me/standing and /me/action-cards when the user
+// opens the "My Standing & Action Cards" tab for the first time per
+// session. Subsequent opens re-fetch (cheap) so the user sees current
+// state. Hooked off the existing nav-btn click rather than added to
+// switchTab() because switchTab() is also called programmatically
+// (e.g. PR 2's auto-activate-on-?mode=demo) and we don't want that
+// path to trigger fetches for the wrong tab.
+const myStandingNavBtn = document.querySelector('[data-tab="my-standing"]');
+if (myStandingNavBtn) {
+    myStandingNavBtn.addEventListener('click', () => {
+        loadMemberStanding();
+        loadMemberActionCards();
+    });
+}
 
 // PR 2 — paint the demo-mode banner and Demo Guide nav button as soon
 // as the DOM has the elements wired. Idempotent; refresh of DID/gateway
@@ -7140,6 +7161,299 @@ async function loadActionItems() {
             elements.actionItemsList.appendChild(emptyState);
         }
     }
+}
+
+// =====================================================================
+// PR 3 — Member Standing + Action Cards
+//
+// Adds two new pilot-ui consumers:
+//   - GET /v1/gov/me/standing       (#1627)  -> state.memberStanding
+//   - GET /v1/gov/me/action-cards   (#1659)  -> state.memberActionCards
+//
+// Renders them as one combined member surface answering the organizer
+// /member question: "Who am I, what's my standing, what can I do?"
+//
+// Distinct from the existing "Action Items" tab (per-domain ledger via
+// /gov/domains/{d}/action-items) — different endpoint, different
+// concept. Card rendering uses the actual fields in
+// docs/contracts/institution-package/action-card.schema.json: title,
+// summary, source_kind, action_kind, authority_basis,
+// required_authority_scope, deadline (optional), risk_level,
+// accessibility_hint, receipt_expected.
+// =====================================================================
+
+async function loadMemberStanding() {
+    try {
+        const response = await apiRequest('GET', '/gov/me/standing');
+        state.memberStanding = response || null;
+    } catch (error) {
+        console.error('Failed to load member standing:', error);
+        state.memberStanding = null;
+    }
+    renderMemberStanding();
+}
+
+async function loadMemberActionCards() {
+    try {
+        const response = await apiRequest('GET', '/gov/me/action-cards');
+        state.memberActionCards = Array.isArray(response)
+            ? response
+            : (response && Array.isArray(response.cards) ? response.cards : []);
+    } catch (error) {
+        console.error('Failed to load member action cards:', error);
+        state.memberActionCards = [];
+    }
+    renderMemberActionCards();
+}
+
+function renderMemberStanding() {
+    const container = document.getElementById('member-standing-content');
+    if (!container) return;
+    container.textContent = '';
+
+    const standing = state.memberStanding;
+    if (!standing) {
+        const empty = document.createElement('p');
+        empty.className = 'empty-state';
+        empty.textContent = 'Standing not yet loaded — sign in and visit this tab to fetch /v1/gov/me/standing.';
+        container.appendChild(empty);
+        return;
+    }
+
+    // DID + display label header
+    const didBlock = document.createElement('dl');
+    didBlock.className = 'standing-id-block';
+    const didDt = document.createElement('dt');
+    didDt.textContent = 'DID';
+    const didDd = document.createElement('dd');
+    didDd.className = 'did-display';
+    didDd.textContent = standing.did || state.did || '—';
+    didBlock.appendChild(didDt);
+    didBlock.appendChild(didDd);
+    if (standing.display_label) {
+        const labelDt = document.createElement('dt');
+        labelDt.textContent = 'Display label';
+        const labelDd = document.createElement('dd');
+        labelDd.textContent = standing.display_label;
+        didBlock.appendChild(labelDt);
+        didBlock.appendChild(labelDd);
+    }
+    container.appendChild(didBlock);
+
+    // Domains
+    const domainsHeading = document.createElement('h3');
+    domainsHeading.textContent = 'Domain memberships';
+    container.appendChild(domainsHeading);
+    const domains = Array.isArray(standing.domains) ? standing.domains : [];
+    if (domains.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'empty-state';
+        empty.textContent = 'No domain memberships recorded.';
+        container.appendChild(empty);
+    } else {
+        const domainList = document.createElement('ul');
+        domainList.className = 'standing-domain-list';
+        domains.forEach((d) => {
+            const li = document.createElement('li');
+            li.className = 'standing-domain';
+            const name = document.createElement('strong');
+            name.textContent = d.domain_name || d.domain_id || '(unnamed domain)';
+            li.appendChild(name);
+            const id = document.createElement('span');
+            id.className = 'standing-domain-id';
+            id.textContent = ` (${d.domain_id || ''})`;
+            li.appendChild(id);
+            const status = document.createElement('span');
+            status.className = `standing-status standing-status-${d.status || 'unknown'}`;
+            status.textContent = d.status || 'unknown';
+            li.appendChild(status);
+            const source = document.createElement('span');
+            source.className = 'standing-source';
+            source.textContent = `via ${d.membership_source || 'unknown'}`;
+            li.appendChild(source);
+            domainList.appendChild(li);
+        });
+        container.appendChild(domainList);
+    }
+
+    // Roles
+    const rolesHeading = document.createElement('h3');
+    rolesHeading.textContent = 'Role assignments';
+    container.appendChild(rolesHeading);
+    const roles = Array.isArray(standing.roles) ? standing.roles : [];
+    if (roles.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'empty-state';
+        empty.textContent = 'No role assignments recorded.';
+        container.appendChild(empty);
+    } else {
+        const roleList = document.createElement('ul');
+        roleList.className = 'standing-role-list';
+        roles.forEach((r) => {
+            const li = document.createElement('li');
+            li.className = 'standing-role';
+            const role = document.createElement('strong');
+            role.textContent = r.role || '(unnamed role)';
+            li.appendChild(role);
+            if (r.structure_name || r.structure_id) {
+                const structure = document.createElement('span');
+                structure.className = 'standing-role-structure';
+                structure.textContent = ` in ${r.structure_name || r.structure_id}`;
+                li.appendChild(structure);
+            }
+            if (Array.isArray(r.authority_scope) && r.authority_scope.length > 0) {
+                const scopeWrap = document.createElement('div');
+                scopeWrap.className = 'standing-role-scope';
+                const label = document.createElement('span');
+                label.className = 'standing-role-scope-label';
+                label.textContent = 'Authority scope: ';
+                scopeWrap.appendChild(label);
+                r.authority_scope.forEach((s) => {
+                    const badge = document.createElement('span');
+                    badge.className = 'standing-scope-badge';
+                    badge.textContent = s;
+                    scopeWrap.appendChild(badge);
+                });
+                li.appendChild(scopeWrap);
+            }
+            roleList.appendChild(li);
+        });
+        container.appendChild(roleList);
+    }
+
+    // Authority scopes union
+    const scopes = Array.isArray(standing.authority_scopes) ? standing.authority_scopes : [];
+    if (scopes.length > 0) {
+        const scopesHeading = document.createElement('h3');
+        scopesHeading.textContent = 'Authority scopes (union)';
+        container.appendChild(scopesHeading);
+        const scopeWrap = document.createElement('div');
+        scopeWrap.className = 'standing-scope-union';
+        scopes.forEach((s) => {
+            const badge = document.createElement('span');
+            badge.className = 'standing-scope-badge';
+            badge.textContent = s;
+            scopeWrap.appendChild(badge);
+        });
+        container.appendChild(scopeWrap);
+    }
+}
+
+function renderMemberActionCards() {
+    const container = document.getElementById('member-action-cards-list');
+    if (!container) return;
+    container.textContent = '';
+
+    const cards = Array.isArray(state.memberActionCards) ? state.memberActionCards : [];
+    if (cards.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'empty-state';
+        empty.textContent = 'No action cards in your queue.';
+        container.appendChild(empty);
+        return;
+    }
+
+    cards.forEach((card) => {
+        container.appendChild(buildMemberActionCardElement(card));
+    });
+}
+
+function buildMemberActionCardElement(card) {
+    const article = document.createElement('article');
+    article.className = 'member-action-card';
+    article.setAttribute('role', 'listitem');
+    const titleId = `member-action-card-${(card.id || 'untitled').replace(/[^a-z0-9-]/gi, '_')}`;
+    article.setAttribute('aria-labelledby', titleId);
+
+    // Header — title + source / action / risk badges
+    const header = document.createElement('header');
+    header.className = 'member-action-card-header';
+    const title = document.createElement('h4');
+    title.id = titleId;
+    title.textContent = card.title || '(untitled action)';
+    header.appendChild(title);
+
+    const badges = document.createElement('div');
+    badges.className = 'member-action-card-badges';
+    if (card.source_kind) {
+        const b = document.createElement('span');
+        b.className = 'badge badge-source';
+        b.textContent = card.source_kind;
+        badges.appendChild(b);
+    }
+    if (card.action_kind) {
+        const b = document.createElement('span');
+        b.className = 'badge badge-action';
+        b.textContent = card.action_kind;
+        badges.appendChild(b);
+    }
+    if (card.risk_level) {
+        const b = document.createElement('span');
+        b.className = `badge badge-risk badge-risk-${String(card.risk_level).toLowerCase()}`;
+        b.textContent = `risk: ${card.risk_level}`;
+        badges.appendChild(b);
+    }
+    header.appendChild(badges);
+    article.appendChild(header);
+
+    // Plain-language summary
+    if (card.summary) {
+        const summary = document.createElement('p');
+        summary.className = 'member-action-card-summary';
+        summary.textContent = card.summary;
+        article.appendChild(summary);
+    }
+
+    // Authority basis + scope + deadline
+    const authority = document.createElement('dl');
+    authority.className = 'member-action-card-authority';
+    if (card.authority_basis) {
+        const dt = document.createElement('dt'); dt.textContent = 'Authority';
+        const dd = document.createElement('dd'); dd.textContent = card.authority_basis;
+        authority.appendChild(dt); authority.appendChild(dd);
+    }
+    if (Array.isArray(card.required_authority_scope) && card.required_authority_scope.length > 0) {
+        const dt = document.createElement('dt'); dt.textContent = 'Required scope';
+        const dd = document.createElement('dd'); dd.textContent = card.required_authority_scope.join(', ');
+        authority.appendChild(dt); authority.appendChild(dd);
+    }
+    if (card.deadline !== undefined && card.deadline !== null) {
+        const dt = document.createElement('dt'); dt.textContent = 'Deadline';
+        const dd = document.createElement('dd');
+        // formatDateTime exists elsewhere in app.js; fall back to a Date conversion
+        // when it is not in scope yet (defensive — shouldn't happen in practice).
+        const t = Number(card.deadline);
+        if (Number.isFinite(t) && typeof formatDateTime === 'function') {
+            dd.textContent = formatDateTime(t);
+        } else {
+            dd.textContent = String(card.deadline);
+        }
+        authority.appendChild(dt); authority.appendChild(dd);
+    }
+    if (authority.children.length > 0) {
+        article.appendChild(authority);
+    }
+
+    // Accessibility hint (schema field — surface explicitly)
+    if (card.accessibility_hint) {
+        const hint = document.createElement('p');
+        hint.className = 'member-action-card-accessibility';
+        const label = document.createElement('strong');
+        label.textContent = 'Accessibility: ';
+        hint.appendChild(label);
+        hint.appendChild(document.createTextNode(card.accessibility_hint));
+        article.appendChild(hint);
+    }
+
+    // Receipt-expected indicator
+    if (card.receipt_expected) {
+        const r = document.createElement('p');
+        r.className = 'member-action-card-receipt-expected';
+        r.textContent = 'Completing this action will produce a receipt.';
+        article.appendChild(r);
+    }
+
+    return article;
 }
 
 function renderActionItems() {

--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -7348,6 +7348,9 @@ function renderMemberActionCards() {
     if (cards.length === 0) {
         const empty = document.createElement('p');
         empty.className = 'empty-state';
+        // The container has role="list", so non-card children must
+        // carry role="listitem" to keep AT semantics consistent.
+        empty.setAttribute('role', 'listitem');
         empty.textContent = 'No action cards in your queue.';
         container.appendChild(empty);
         return;

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -658,7 +658,7 @@
                 <button class="nav-btn" data-tab="member-profile">
                     <span aria-label="Your profile">Profile</span>
                 </button>
-                <button class="nav-btn" data-tab="my-standing">
+                <button class="nav-btn" data-tab="my-standing" id="tab-my-standing">
                     <span aria-label="My standing in this institution and my pending action cards">My Standing &amp; Action Cards</span>
                 </button>
                 <button class="nav-btn" data-tab="governance">
@@ -1738,10 +1738,10 @@ did:icn:charlie,did:icn:alice,3.5,Childcare</code></pre>
                 <section class="member-action-cards-section" aria-labelledby="member-action-cards-heading">
                     <h2 id="member-action-cards-heading">Action Cards</h2>
                     <p class="member-action-cards-intro">
-                        Your queue of actions across all governance domains. Each card surfaces who has authority, what is required, and whether completing the action produces a receipt. This view reads the per-member <code>/v1/gov/me/action-cards</code> read-model (#1659) and is <strong>distinct</strong> from the per-domain <a href="#governance" data-target="governance">Action Items tab</a>, which uses a different endpoint and concept.
+                        Your queue of actions across all governance domains. Each card surfaces who has authority, what is required, and whether completing the action produces a receipt. This view reads the per-member <code>/v1/gov/me/action-cards</code> read-model (#1659) and is <strong>distinct</strong> from the per-domain <a href="#governance" data-demo-target="governance">Action Items tab</a>, which uses a different endpoint and concept.
                     </p>
                     <div id="member-action-cards-list" class="member-action-cards-list" role="list" aria-live="polite">
-                        <p class="empty-state">Loading action cards&hellip;</p>
+                        <p class="empty-state" role="listitem">Loading action cards&hellip;</p>
                     </div>
                 </section>
             </main>

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -658,6 +658,9 @@
                 <button class="nav-btn" data-tab="member-profile">
                     <span aria-label="Your profile">Profile</span>
                 </button>
+                <button class="nav-btn" data-tab="my-standing">
+                    <span aria-label="My standing in this institution and my pending action cards">My Standing &amp; Action Cards</span>
+                </button>
                 <button class="nav-btn" data-tab="governance">
                     <span aria-label="Governance and proposals">Governance</span>
                 </button>
@@ -1719,6 +1722,28 @@ did:icn:charlie,did:icn:alice,3.5,Childcare</code></pre>
                         </div>
                     </div>
                 </div>
+            </main>
+
+            <!-- My Standing & Action Cards (PR 3 — answers "Who am I, what is my standing, what can I do?") -->
+            <main id="my-standing" class="tab-content" role="tabpanel" aria-labelledby="tab-my-standing">
+                <section class="member-standing-section" aria-labelledby="member-standing-heading">
+                    <h2 id="member-standing-heading">My Standing</h2>
+                    <p class="member-standing-intro">
+                        Who you are in this institution: domain memberships, role assignments, and the union of authority scopes that follow from those roles. This view reads the per-member <code>/v1/gov/me/standing</code> read-model (#1627). The trust graph is the source of truth for trust-threshold memberships; rows marked <strong>unverified</strong> indicate the read-model deferred to the trust graph rather than evaluating membership here.
+                    </p>
+                    <div id="member-standing-content" class="member-standing-content" aria-live="polite">
+                        <p class="empty-state">Loading standing&hellip;</p>
+                    </div>
+                </section>
+                <section class="member-action-cards-section" aria-labelledby="member-action-cards-heading">
+                    <h2 id="member-action-cards-heading">Action Cards</h2>
+                    <p class="member-action-cards-intro">
+                        Your queue of actions across all governance domains. Each card surfaces who has authority, what is required, and whether completing the action produces a receipt. This view reads the per-member <code>/v1/gov/me/action-cards</code> read-model (#1659) and is <strong>distinct</strong> from the per-domain <a href="#governance" data-target="governance">Action Items tab</a>, which uses a different endpoint and concept.
+                    </p>
+                    <div id="member-action-cards-list" class="member-action-cards-list" role="list" aria-live="polite">
+                        <p class="empty-state">Loading action cards&hellip;</p>
+                    </div>
+                </section>
             </main>
 
             <!-- Governance Tab -->

--- a/web/pilot-ui/style.css
+++ b/web/pilot-ui/style.css
@@ -6106,3 +6106,253 @@ footer .sync-status.error {
 .demo-guide-non-claims li:last-child {
     margin-bottom: 0;
 }
+
+/* ============================================================
+ * My Standing & Action Cards (PR 3)
+ *
+ * Combined member surface — answers the organizer/member
+ * question: "Who am I, what's my standing, what can I do?".
+ * Standing renders as the framing context above the action-cards
+ * queue. Distinct from the per-domain "Action Items" tab.
+ * ============================================================ */
+
+.member-standing-section,
+.member-action-cards-section {
+    max-width: 80ch;
+    padding: 0.5rem 0 1.5rem;
+}
+
+.member-standing-section h2,
+.member-action-cards-section h2 {
+    margin: 0 0 0.5rem 0;
+}
+
+.member-standing-section h3 {
+    margin-top: 1.25rem;
+    margin-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border-color, #e5e7eb);
+    padding-bottom: 0.25rem;
+    font-size: 1.05rem;
+}
+
+.member-standing-intro,
+.member-action-cards-intro {
+    color: var(--text-secondary, #4b5563);
+    line-height: 1.55;
+    margin-bottom: 0.75rem;
+}
+
+.member-standing-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.standing-id-block {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.4rem 1rem;
+    padding: 0.6rem 0.9rem;
+    background: var(--bg-secondary, #f9fafb);
+    border-radius: 6px;
+    border: 1px solid var(--border-color, #e5e7eb);
+    margin: 0;
+}
+
+.standing-id-block dt {
+    font-weight: 600;
+}
+
+.standing-id-block dd {
+    margin: 0;
+    font-family: var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+    font-size: 0.9rem;
+}
+
+.standing-id-block .did-display {
+    word-break: break-all;
+}
+
+.standing-domain-list,
+.standing-role-list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.standing-domain,
+.standing-role {
+    padding: 0.5rem 0.75rem;
+    background: var(--bg-secondary, #f9fafb);
+    border: 1px solid var(--border-color, #e5e7eb);
+    border-radius: 6px;
+    line-height: 1.5;
+}
+
+.standing-domain-id,
+.standing-role-structure,
+.standing-source {
+    color: var(--text-secondary, #6b7280);
+    font-size: 0.9rem;
+    margin-left: 0.4rem;
+}
+
+.standing-status {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.standing-status-member {
+    background: rgba(22, 163, 74, 0.14);
+    color: #15803d;
+}
+
+.standing-status-unverified {
+    background: rgba(245, 158, 11, 0.14);
+    color: #b45309;
+}
+
+.standing-role-scope {
+    margin-top: 0.35rem;
+    font-size: 0.9rem;
+}
+
+.standing-role-scope-label {
+    color: var(--text-secondary, #6b7280);
+}
+
+.standing-scope-badge {
+    display: inline-block;
+    margin: 0.1rem 0.25rem 0.1rem 0;
+    padding: 0.05rem 0.45rem;
+    background: rgba(37, 99, 235, 0.10);
+    color: #1d4ed8;
+    border-radius: 3px;
+    font-size: 0.82rem;
+    font-family: var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+}
+
+.standing-scope-union {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+}
+
+/* Action card list */
+.member-action-cards-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.member-action-card {
+    padding: 0.85rem 1rem;
+    background: var(--bg-secondary, #f9fafb);
+    border: 1px solid var(--border-color, #e5e7eb);
+    border-radius: 8px;
+    line-height: 1.5;
+}
+
+.member-action-card-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.member-action-card-header h4 {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.member-action-card-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+}
+
+.member-action-card .badge {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: 3px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.member-action-card .badge-source {
+    background: rgba(37, 99, 235, 0.14);
+    color: #1d4ed8;
+}
+
+.member-action-card .badge-action {
+    background: rgba(124, 58, 237, 0.14);
+    color: #6d28d9;
+}
+
+.member-action-card .badge-risk-low {
+    background: rgba(22, 163, 74, 0.14);
+    color: #15803d;
+}
+
+.member-action-card .badge-risk-medium {
+    background: rgba(245, 158, 11, 0.14);
+    color: #b45309;
+}
+
+.member-action-card .badge-risk-high {
+    background: rgba(220, 38, 38, 0.14);
+    color: #b91c1c;
+}
+
+.member-action-card-summary {
+    margin: 0.5rem 0 0;
+}
+
+.member-action-card-authority {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.3rem 1rem;
+    margin: 0.6rem 0 0;
+    padding: 0.4rem 0.7rem;
+    background: var(--bg-primary, #fff);
+    border-radius: 4px;
+    font-size: 0.9rem;
+}
+
+.member-action-card-authority dt {
+    font-weight: 600;
+    color: var(--text-secondary, #4b5563);
+}
+
+.member-action-card-authority dd {
+    margin: 0;
+}
+
+.member-action-card-accessibility {
+    margin: 0.4rem 0 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary, #4b5563);
+}
+
+.member-action-card-receipt-expected {
+    margin: 0.4rem 0 0;
+    padding: 0.25rem 0.55rem;
+    background: rgba(22, 163, 74, 0.08);
+    border-left: 3px solid #15803d;
+    color: #15803d;
+    font-size: 0.85rem;
+    border-radius: 3px;
+}

--- a/web/pilot-ui/style.css
+++ b/web/pilot-ui/style.css
@@ -6302,17 +6302,18 @@ footer .sync-status.error {
     color: #6d28d9;
 }
 
+/* Per action-card.schema.json, risk_level enum is `low | normal | elevated`. */
 .member-action-card .badge-risk-low {
     background: rgba(22, 163, 74, 0.14);
     color: #15803d;
 }
 
-.member-action-card .badge-risk-medium {
+.member-action-card .badge-risk-normal {
     background: rgba(245, 158, 11, 0.14);
     color: #b45309;
 }
 
-.member-action-card .badge-risk-high {
+.member-action-card .badge-risk-elevated {
     background: rgba(220, 38, 38, 0.14);
     color: #b91c1c;
 }

--- a/web/pilot-ui/tests/e2e/standing-action-cards.spec.js
+++ b/web/pilot-ui/tests/e2e/standing-action-cards.spec.js
@@ -1,0 +1,109 @@
+/**
+ * E2E Tests — My Standing & Action Cards (PR 3)
+ *
+ * Verifies that the new "My Standing & Action Cards" pilot-ui surface
+ * is wired correctly: the nav button is in the DOM with the right
+ * data-tab, the section structure exists with the expected sub-sections,
+ * the empty-state messaging is plain language, and the section is
+ * explicitly distinct from the existing per-domain Action Items tab.
+ *
+ * As with PR 2, we assert against DOM presence + text content rather
+ * than driving the full login flow + a working gateway. The fetch
+ * behavior of loadMemberStanding() / loadMemberActionCards() requires
+ * a live gateway and is exercised by integration tests elsewhere; the
+ * tests here protect the pilot-ui-side composition.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.use({ serviceWorkers: 'block' });
+
+test.describe('My Standing & Action Cards (PR 3)', () => {
+    test('nav button exists with correct data-tab', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        const navBtn = page.locator('[data-tab="my-standing"]');
+        await expect(navBtn).toHaveCount(1);
+        await expect(navBtn).toContainText('My Standing');
+        await expect(navBtn).toContainText('Action Cards');
+    });
+
+    test('tab section structure has both standing and action-cards sub-sections', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        const section = page.locator('#my-standing');
+        await expect(section).toHaveCount(1);
+        await expect(section).toContainText('My Standing');
+        await expect(section).toContainText('Action Cards');
+
+        // Standing sub-section
+        const standingHeading = page.locator('#member-standing-heading');
+        await expect(standingHeading).toHaveText('My Standing');
+        const standingContent = page.locator('#member-standing-content');
+        await expect(standingContent).toHaveCount(1);
+
+        // Action cards sub-section
+        const cardsHeading = page.locator('#member-action-cards-heading');
+        await expect(cardsHeading).toHaveText('Action Cards');
+        const cardsList = page.locator('#member-action-cards-list');
+        await expect(cardsList).toHaveCount(1);
+    });
+
+    test('intro text labels Action Cards as distinct from Action Items', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        const intro = page.locator('.member-action-cards-intro');
+        await expect(intro).toContainText('distinct');
+        await expect(intro).toContainText('Action Items tab');
+        await expect(intro).toContainText('different endpoint and concept');
+        // Cite the actual endpoint that this surface consumes
+        await expect(intro).toContainText('/v1/gov/me/action-cards');
+    });
+
+    test('standing intro labels the standing read-model endpoint', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        const intro = page.locator('.member-standing-intro');
+        await expect(intro).toContainText('/v1/gov/me/standing');
+        await expect(intro).toContainText('trust graph');
+        await expect(intro).toContainText('unverified');
+    });
+
+    test('empty-state messaging is plain language pre-fetch', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        // Pre-login / pre-fetch: empty-state placeholders should be visible
+        // in DOM. The "Loading…" copy avoids alarming the user before any
+        // fetch has run.
+        const standingContent = page.locator('#member-standing-content');
+        await expect(standingContent).toContainText('Loading');
+
+        const cardsList = page.locator('#member-action-cards-list');
+        await expect(cardsList).toContainText('Loading');
+    });
+
+    test('Action Items tab (governance subtab) is unchanged', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        // The existing Action Items button under Governance must remain.
+        // PR 3 must NOT collapse Action Items into Action Cards.
+        const actionItemsBtn = page.locator('[data-governance-tab="action-items"]');
+        await expect(actionItemsBtn).toHaveCount(1);
+        await expect(actionItemsBtn).toContainText('Action Items');
+
+        // The action-items list container (driven by loadActionItems) is
+        // still present with its own id, distinct from member-action-cards-list.
+        const actionItemsList = page.locator('#action-items-list');
+        await expect(actionItemsList).toHaveCount(1);
+
+        // Sanity: the new member-action-cards-list is not the same element.
+        const cardsList = page.locator('#member-action-cards-list');
+        await expect(cardsList).toHaveCount(1);
+    });
+});


### PR DESCRIPTION
## What

PR 3 from the [ICN system demo readiness map](docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md). Adds two new pilot-ui consumers for the per-member read-models that the gateway has served since #1627 and #1659 but pilot-ui has not yet consumed:

- `GET /v1/gov/me/standing`     →  `state.memberStanding`
- `GET /v1/gov/me/action-cards` →  `state.memberActionCards`

Renders them together as the new **"My Standing & Action Cards"** tab, answering the organizer/member question: *"Who am I, what's my standing, what can I do?"*. Standing renders as the framing context above the action-cards queue.

## Why one PR (not two)

Per the readiness map's §5 PR 3 scope and the user directive after PR #1769 review: standing and action-cards belong together from the organizer/member point of view. The first coherent user loop is the question above; splitting it into two tiny PRs would advance the repo without giving a coherent user surface. Both endpoints exist; both were missing in pilot-ui; both land together.

The "stop and report" escape hatch was **not needed** — standing turned out to be a moderate three-list shape (`domains`, `roles`, `authority_scopes`), flat fields, no multi-coop / multi-federation aggregation.

## Standing read-model surfacing

The standing block surfaces the actual fields per [`StandingResponse`](icn/apps/governance/src/http/models.rs):

- **DID + optional display label** (caller's auth-known DID + label reserved for future identity-registry lookup; currently `None`).
- **Domain memberships**: `domain_name`, `domain_id`, `status`, `membership_source`. Trust-threshold sources surface with status `unverified` so the user knows the trust graph is the source of truth — not a silent drop.
- **Role assignments**: `role`, `structure_name` (or `structure_id` when name is unavailable), `parent_entity_id`, `authority_scope` as scope badges.
- **Authority scopes union**: deduplicated badges for at-a-glance.

## Action card UX uses ACTUAL schema fields

Per [`docs/contracts/institution-package/action-card.schema.json`](docs/contracts/institution-package/action-card.schema.json):

| Field | UI rendering |
|---|---|
| `title` | card heading |
| `summary` | plain-language body |
| `source_kind` / `action_kind` | badges (color-tagged by class) |
| `risk_level` | badge with color tier — `low` / `medium` / `high` |
| `authority_basis` | DT/DD pair |
| `required_authority_scope` | joined string ("scope-a, scope-b") |
| `deadline` (optional) | formatted via existing `formatDateTime` helper |
| `accessibility_hint` | rendered explicitly with "Accessibility:" label — schema makes this first-class |
| `receipt_expected` | small green-bordered note when `true` ("Completing this action will produce a receipt.") |

No invented fields. The map's earlier mistake (citing nonexistent fields like "status" / "required decision" / "reversibility window") was caught by Codex on #1769 and corrected before merge — this PR honors the post-correction map.

## Naming separation preserved

The new section is named **"My Standing & Action Cards"** to make the conceptual split with the existing "Action Items" tab explicit:

- **Action Cards**: per-member queue from `/v1/gov/me/action-cards`.
- **Action Items**: per-domain ledger from `/gov/domains/{d}/action-items`.

Different endpoints, different concepts. The intro paragraphs in HTML state this distinction in plain language so a viewer doesn't conflate them.

## Lazy fetch pattern

Fetches are wired to a click on the `[data-tab="my-standing"]` nav button rather than added to `switchTab()` itself. This means:

- Programmatic `switchTab()` calls (e.g. PR 2's auto-activate-on-`?mode=demo`) do **not** trigger a stray fetch for the wrong tab.
- Subsequent visits re-fetch (cheap) so the user sees current state.

## Files

| File | Change | Purpose |
|---|---|---|
| [`web/pilot-ui/index.html`](web/pilot-ui/index.html) | +25 / -0 | Nav button between Profile and Governance; new `<main id="my-standing">` with `member-standing-section` + `member-action-cards-section`; intros that name the endpoints and the Action Items distinction. |
| [`web/pilot-ui/app.js`](web/pilot-ui/app.js) | +314 / -0 | `state.memberStanding` + `state.memberActionCards`; `loadMemberStanding()`; `loadMemberActionCards()`; `renderMemberStanding()`; `renderMemberActionCards()`; `buildMemberActionCardElement()`; click-listener on `[data-tab="my-standing"]` that triggers both loads. |
| [`web/pilot-ui/style.css`](web/pilot-ui/style.css) | +250 / -0 | Standing block layout; domain / role list styles; status badges (`member` / `unverified`); scope badges; action-card layout with header / badges / authority dl / accessibility line / receipt-expected indicator; risk-level color tiers (low / medium / high). |
| [`web/pilot-ui/tests/e2e/standing-action-cards.spec.js`](web/pilot-ui/tests/e2e/standing-action-cards.spec.js) | new (+115) | Playwright spec: nav button presence + correct `data-tab`; section structure (both sub-sections); intro text labels endpoints and Action Items distinction; standing intro labels trust graph and "unverified" semantics; plain-language empty states; positive assertion that the existing Action Items tab is untouched. |

Total: +698 / -0 across 4 files.

## Existing surfaces explicitly untouched

- **Action Items tab** (`loadActionItems` / `/gov/domains/{d}/action-items`) — unchanged. Different endpoint, different state field, different render path. Test suite includes a positive assertion that the existing button + list element are still present.
- **Receipts tab + `receipts.js`** — unchanged. Plain-language receipt framing is **PR 4**.
- **Other tabs (Dashboard, Log Hours, History, Members, Profile, Federation, Exchange)** — unchanged.

## Test plan

- [x] `git diff --check` clean (no whitespace errors).
- [x] `git status --short` shows exactly the 4 intended files.
- [x] `node --check web/pilot-ui/app.js` passes (syntax sanity).
- [x] `node --check web/pilot-ui/tests/e2e/standing-action-cards.spec.js` passes.
- [x] Real-contact leak grep returns clean.
- [x] No invented schema fields — only fields from `action-card.schema.json` are referenced.
- [ ] Full Playwright e2e run against a running gateway — runs in CI; not blocked locally because the spec asserts DOM presence + text content, not network.
- [ ] Accessibility sanity at organizer time — landmarks (`role="tabpanel"`, headings), keyboard path, readable labels (no relying on color alone — every status / risk level is also labeled in text), ARIA live regions on async content. Visual review by reviewer recommended.

## Non-claims

- **Adds two new pilot-ui consumers for existing gateway endpoints** (#1627 and #1659); does **not** change gateway contracts or schemas.
- **Does not modify or replace the existing Action Items tab.** The two are explicitly distinct.
- **Does not advance** #1748 runtime gates (b)–(d) or any acceptance criterion beyond pilot-ui rendering of already-served data.
- **RFC-gated source kinds** in the action-card schema (`signal_rule`, `obligation_lifecycle` per the schema's `x-icn-rfc-gated-source-kinds`) appear with their schema labels in the generic source-kind badge; no false RFC promotion.
- **Demo mode remains a UI labeling convention**; PR 5 still owns gateway-side fixture/demo mode.
- **LIVE does not mean production**; ICN is not production-deployed.
- **No NYCN changes.** Single-repo, ICN-only.
- **No real names / real DIDs / real contact or private participant data** anywhere in the diff.