### PR TITLE
demo(fixtures): add first organizer/member fixture slice for guided pilot-ui demo

### DIFF
--- a/docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md
+++ b/docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md
@@ -178,6 +178,19 @@ This sequence is the actionable output of the discovery. Each PR is **small** (s
 
 ### PR 5 — fixture-backed local demo mode / stable demo data loader (advances ICN #1727)
 
+> **Implementation note (post-correction):** the original PR 5 framing
+> (a runtime `--demo-mode` flag on `icnd` that short-circuits gateway
+> handlers) is the **eventual scope** but is too broad for one
+> reviewable PR. The first PR landed under this number is a **narrow
+> frontend slice** that short-circuits standing + action-cards in
+> pilot-ui to a committed fixture pack when `?mode=demo` is set. ICN
+> [#1727](https://github.com/InterCooperative-Network/icn/issues/1727)
+> remains **open** for the full backend fixture mode. Subsequent PRs
+> may extend the fixture coverage (proposals, receipts, ledger) and
+> later add the runtime flag if/when the team chooses to invest in
+> backend work. The pilot-ui-only slice does not constitute fixture-
+> backed demo mode in the readiness-map's original sense.
+
 - **What:** add a `--demo-mode` flag to `icnd` that, when set, serves a committed fixture pack from a locked path instead of seeded-but-real state. The fixture pack contains: members, proposals, votes, action cards, receipts, attendance records, ledger postings — all using the existing `did:icn:example-*-not-live` fixture convention.
 - **Why:** today the demo loop conflates "what we seeded" with "what's stored." The PR makes demo mode deterministic and labeled — same data every time, no real keystore initialization, no real DID generation, no real signing. This is the runtime piece that makes the mode banner from PR 2 truthful.
 - **What runs after this PR:** `./demo/scripts/run-tool-library-demo.sh --demo` boots icnd in fixture mode; pilot-ui's banner reads `DEMO`; every entity on screen uses fictional fixture labels; nothing touches the real keystore or the real network.

--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -7182,7 +7182,32 @@ async function loadActionItems() {
 // accessibility_hint, receipt_expected.
 // =====================================================================
 
+// PR 5 (narrow frontend slice) — when ?mode=demo, short-circuit standing
+// and action-cards fetches to a committed fixture pack served as static
+// JSON from web/pilot-ui/fixtures/icn-organizer-demo/. No backend
+// change; the gateway-side --demo-mode flag described in the readiness
+// map §5 PR 5 remains open at ICN #1727. This is the first frontend
+// fixture slice, not the full backend fixture mode.
+async function loadDemoFixture(name) {
+    const url = `fixtures/icn-organizer-demo/${name}.json`;
+    const response = await fetch(url, { headers: { 'Accept': 'application/json' } });
+    if (!response.ok) {
+        throw new Error(`Demo fixture fetch failed: ${response.status} ${response.statusText} (${url})`);
+    }
+    return response.json();
+}
+
 async function loadMemberStanding() {
+    if (DEMO_MODE === 'demo') {
+        try {
+            state.memberStanding = await loadDemoFixture('standing');
+        } catch (error) {
+            console.error('Failed to load demo standing fixture:', error);
+            state.memberStanding = null;
+        }
+        renderMemberStanding();
+        return;
+    }
     try {
         const response = await apiRequest('GET', '/gov/me/standing');
         state.memberStanding = response || null;
@@ -7194,6 +7219,19 @@ async function loadMemberStanding() {
 }
 
 async function loadMemberActionCards() {
+    if (DEMO_MODE === 'demo') {
+        try {
+            const fixture = await loadDemoFixture('action-cards');
+            state.memberActionCards = Array.isArray(fixture)
+                ? fixture
+                : (fixture && Array.isArray(fixture.cards) ? fixture.cards : []);
+        } catch (error) {
+            console.error('Failed to load demo action-cards fixture:', error);
+            state.memberActionCards = [];
+        }
+        renderMemberActionCards();
+        return;
+    }
     try {
         const response = await apiRequest('GET', '/gov/me/action-cards');
         state.memberActionCards = Array.isArray(response)

--- a/web/pilot-ui/fixtures/icn-organizer-demo/README.md
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/README.md
@@ -1,0 +1,116 @@
+# ICN Organizer/Member Demo — Fixture Pack
+
+This directory holds the **first fixture slice** for the guided pilot-ui
+organizer/member demo (the surface that pilot-ui exposes when opened
+with `?mode=demo`). It is **not** a fixture pack for the legacy
+tool-library demo, and the tool-library script is not affected by
+anything in this directory.
+
+## Status (read first)
+
+- **Frontend-only fixture slice.** When pilot-ui is opened with
+  `?mode=demo`, the standing and action-cards sections short-circuit
+  to these committed JSON files instead of fetching the gateway. **No
+  backend, no Rust, no runtime fixture mode.** The gateway-side
+  `--demo-mode` flag described in
+  [`docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md`](../../../docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md)
+  §5 PR 5 remains **open**, tracked at ICN
+  [#1727](https://github.com/InterCooperative-Network/icn/issues/1727).
+- **Repo-safe.** All identifiers use the established
+  `did:icn:example-*-not-live` convention. Display labels are
+  fictional. No real names, real DIDs, real contact data, or real
+  participant data appears anywhere.
+- **Not the tool-library demo.** This pack drives the guided pilot-ui
+  organizer/member demo. The legacy
+  `demo/scripts/run-tool-library-demo.sh` flow is dev scaffolding and
+  is **not** the user-facing ICN demo.
+- **Not production deployment.** No live ICN runtime mutation, Google
+  Drive / Groups / Sheets, federation, K3s, DNS, Forgejo,
+  private-overlay, or cloud-sync activation. GitHub PR operations
+  only.
+- **Not real holder-label activation.** All DIDs are fictional and
+  not bound to real persons.
+- **Not Phase 2 completion.** Phase truth lives in
+  [`docs/PHASE_PROGRESS.md`](../../../docs/PHASE_PROGRESS.md).
+- **Not a formal pilot** of any kind.
+
+## What this slice covers
+
+| Surface | Endpoint shape | Fixture file |
+|---|---|---|
+| Member standing read-model | `GET /v1/gov/me/standing` shape (`StandingResponse`) | [`standing.json`](standing.json) |
+| Per-member action-cards queue | `GET /v1/gov/me/action-cards` shape (array of `ActionCard`) | [`action-cards.json`](action-cards.json) |
+
+The fixture content matches the field shapes in
+[`docs/contracts/institution-package/action-card.schema.json`](../../../docs/contracts/institution-package/action-card.schema.json)
+and the response struct definitions for `StandingResponse` /
+`StandingDomainMembership` / `StandingRoleAssignment` in
+`icn/apps/governance/src/http/models.rs`. Schema field names are used
+verbatim — no invented fields.
+
+## What this slice does NOT cover
+
+The following pilot-ui surfaces remain unaffected by this fixture
+pack and will continue to fetch the gateway / show empty states in
+demo mode:
+
+- Governance proposals / votes (`/v1/gov/...`)
+- Receipt chain (`/v1/receipts/chain`) — pilot-ui's `receipts.js`
+  still queries the gateway; the plain-language summary from PR 4
+  shows its empty state when the chain is empty.
+- Ledger / transaction history.
+- Trust score.
+- Members directory.
+- Federation status.
+
+Adding fixture coverage for any of those surfaces would expand this
+PR beyond a narrow first slice and is explicitly deferred. ICN
+[#1727](https://github.com/InterCooperative-Network/icn/issues/1727)
+remains the tracking issue for true backend fixture mode (the
+`--demo-mode` flag on icnd that serves committed fixtures from a
+locked path at the request layer).
+
+## Identifier convention
+
+All fixture identifiers follow the established repo convention:
+
+| Pattern | Use |
+|---|---|
+| `did:icn:example-*-not-live` | every DID in this pack |
+| `demo.coop.*`, `demo.committee.*`, `demo.federation.*` | every entity / scope id |
+| Fictional handles (e.g. "Demo organizer (fictional)") | every display label |
+
+A grep for any pattern that suggests real data (real email domains,
+real phone formats, real names) on this directory should return
+zero matches; CI runs that grep on the new doc.
+
+## How to use this in pilot-ui
+
+1. Start pilot-ui locally (any path that serves `web/pilot-ui/` over
+   HTTP — including the existing
+   `demo/scripts/run-tool-library-demo.sh` if you're using it as
+   dev scaffolding, but **note that script is not the ICN demo**).
+2. Open the pilot-ui URL with `?mode=demo`.
+3. Sign in (the auth-known DID populates the "I am" framing on the
+   Demo Guide; standing data comes from this fixture).
+4. Open the **My Standing & Action Cards** tab — fixture data
+   renders in place of the gateway fetch.
+
+## Out of scope (deferred)
+
+- Backend `--demo-mode` flag on icnd.
+- Gateway-side handler short-circuits.
+- Federation / cross-cooperative coordination.
+- Private-overlay / holder-label activation flows.
+- Real organizer / sponsor / attendee data import.
+- Live cloud sync (Drive / Sheets / Groups / Calendar / mail).
+- K3s / DNS / Forgejo / production-deploy mutation.
+- Production deployment posture.
+
+## Cross-references
+
+- ICN [#1727](https://github.com/InterCooperative-Network/icn/issues/1727) — fixture-backed demo mode (tracking issue; remains OPEN after this PR).
+- [`docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md`](../../../docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md) — sequenced demo-readiness PR plan.
+- [`docs/contracts/institution-package/action-card.schema.json`](../../../docs/contracts/institution-package/action-card.schema.json) — action-card schema this pack matches.
+- `icn/apps/governance/src/http/models.rs` — standing response struct definitions this pack matches.
+- ICN [#1768](https://github.com/InterCooperative-Network/icn/pull/1768) — Invariant 6 (opaque receipt storage), referenced by PR 4's receipt summary.

--- a/web/pilot-ui/fixtures/icn-organizer-demo/README.md
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/README.md
@@ -38,8 +38,8 @@ anything in this directory.
 
 | Surface | Endpoint shape | Fixture file |
 |---|---|---|
-| Member standing read-model | `GET /v1/gov/me/standing` shape (`StandingResponse`) | [`standing.json`](standing.json) |
-| Per-member action-cards queue | `GET /v1/gov/me/action-cards` shape (array of `ActionCard`) | [`action-cards.json`](action-cards.json) |
+| Member standing read-model | `GET /v1/gov/me/standing` returns `StandingResponse` `{ did, display_label?, domains[], roles[], authority_scopes[], generated_at }`. Each `roles[i]` is a `StandingRoleAssignment` with required `role_assignment_id`, `structure_id`, `role`, `authority_scope[]`, **`start_date`** (u64, Unix seconds), and optional `structure_name` / `parent_entity_id` / `end_date`. | [`standing.json`](standing.json) |
+| Per-member action-cards queue | `GET /v1/gov/me/action-cards` returns `ActionCardsResponse` **wrapper** `{ did, cards, generated_at }` — **not** a bare array. Each `cards[i]` matches `action-card.schema.json`, with `scope` as the **enum** `entity` / `structure` / `individual` (the constitutional-axis target) and `domain_id` carrying the governance domain identifier. | [`action-cards.json`](action-cards.json) |
 
 The fixture content matches the field shapes in
 [`docs/contracts/institution-package/action-card.schema.json`](../../../docs/contracts/institution-package/action-card.schema.json)

--- a/web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json
@@ -1,55 +1,59 @@
-[
-  {
-    "id": "demo-card-proposal-vote-001",
-    "source_kind": "proposal",
-    "action_kind": "vote",
-    "scope": "demo.coop.organizing",
-    "title": "Vote on the proposed program-review schedule",
-    "summary": "The Program Committee has proposed a tentative review schedule. As chair you may vote to accept the schedule or send it back for revision.",
-    "authority_basis": "Program Committee chair (demo role)",
-    "required_authority_scope": [
-      "program_review"
-    ],
-    "deadline": 1730500000,
-    "risk_level": "normal",
-    "accessibility_hint": "Plain-language outcome before structured ballot fields. Choices read in order; no color-only signaling.",
-    "receipt_expected": true,
-    "source_id": "demo-proposal-001",
-    "domain_id": "demo.coop.organizing"
-  },
-  {
-    "id": "demo-card-meeting-attend-001",
-    "source_kind": "meeting",
-    "action_kind": "attend",
-    "scope": "demo.coop.organizing",
-    "title": "Confirm attendance at the next program-committee meeting",
-    "summary": "Upcoming meeting of the Program Committee. Confirming attendance produces an attendance receipt.",
-    "authority_basis": "Program Committee chair (demo role)",
-    "required_authority_scope": [
-      "session_scheduling"
-    ],
-    "risk_level": "low",
-    "accessibility_hint": "Meeting summary is text-first; agenda is provided in advance.",
-    "receipt_expected": true,
-    "source_id": "demo-meeting-001",
-    "domain_id": "demo.coop.organizing"
-  },
-  {
-    "id": "demo-card-action-item-complete-001",
-    "source_kind": "action_item",
-    "action_kind": "complete",
-    "scope": "demo.coop.organizing",
-    "title": "Mark the accessibility-checklist review as complete",
-    "summary": "An action item from the most recent accessibility review is assigned to your role. Marking it complete produces a completion receipt.",
-    "authority_basis": "Accessibility Committee member (demo role)",
-    "required_authority_scope": [
-      "veto_for_cause"
-    ],
-    "deadline": 1730200000,
-    "risk_level": "elevated",
-    "accessibility_hint": "Action carries a veto-for-cause power; use plain-language framing of the outcome and any rejection reason.",
-    "receipt_expected": true,
-    "source_id": "demo-action-item-001",
-    "domain_id": "demo.coop.organizing"
-  }
-]
+{
+  "did": "did:icn:example-organizer-demo-not-live",
+  "cards": [
+    {
+      "id": "demo-card-proposal-vote-001",
+      "source_kind": "proposal",
+      "action_kind": "vote",
+      "scope": "structure",
+      "title": "Vote on the proposed program-review schedule",
+      "summary": "The Program Committee has proposed a tentative review schedule. As chair you may vote to accept the schedule or send it back for revision.",
+      "authority_basis": "Program Committee chair (demo role)",
+      "required_authority_scope": [
+        "program_review"
+      ],
+      "deadline": 1730500000,
+      "risk_level": "normal",
+      "accessibility_hint": "Plain-language outcome before structured ballot fields. Choices read in order; no color-only signaling.",
+      "receipt_expected": true,
+      "source_id": "demo-proposal-001",
+      "domain_id": "demo.coop.organizing"
+    },
+    {
+      "id": "demo-card-meeting-attend-001",
+      "source_kind": "meeting",
+      "action_kind": "attend",
+      "scope": "structure",
+      "title": "Confirm attendance at the next program-committee meeting",
+      "summary": "Upcoming meeting of the Program Committee. Confirming attendance produces an attendance receipt.",
+      "authority_basis": "Program Committee chair (demo role)",
+      "required_authority_scope": [
+        "session_scheduling"
+      ],
+      "risk_level": "low",
+      "accessibility_hint": "Meeting summary is text-first; agenda is provided in advance.",
+      "receipt_expected": true,
+      "source_id": "demo-meeting-001",
+      "domain_id": "demo.coop.organizing"
+    },
+    {
+      "id": "demo-card-action-item-complete-001",
+      "source_kind": "action_item",
+      "action_kind": "complete",
+      "scope": "individual",
+      "title": "Mark the accessibility-checklist review as complete",
+      "summary": "An action item from the most recent accessibility review is assigned to your role. Marking it complete produces a completion receipt.",
+      "authority_basis": "Accessibility Committee member (demo role)",
+      "required_authority_scope": [
+        "veto_for_cause"
+      ],
+      "deadline": 1730200000,
+      "risk_level": "elevated",
+      "accessibility_hint": "Action carries a veto-for-cause power; use plain-language framing of the outcome and any rejection reason.",
+      "receipt_expected": true,
+      "source_id": "demo-action-item-001",
+      "domain_id": "demo.coop.organizing"
+    }
+  ],
+  "generated_at": 1730000000
+}

--- a/web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json
@@ -1,0 +1,55 @@
+[
+  {
+    "id": "demo-card-proposal-vote-001",
+    "source_kind": "proposal",
+    "action_kind": "vote",
+    "scope": "demo.coop.organizing",
+    "title": "Vote on the proposed program-review schedule",
+    "summary": "The Program Committee has proposed a tentative review schedule. As chair you may vote to accept the schedule or send it back for revision.",
+    "authority_basis": "Program Committee chair (demo role)",
+    "required_authority_scope": [
+      "program_review"
+    ],
+    "deadline": 1730500000,
+    "risk_level": "normal",
+    "accessibility_hint": "Plain-language outcome before structured ballot fields. Choices read in order; no color-only signaling.",
+    "receipt_expected": true,
+    "source_id": "demo-proposal-001",
+    "domain_id": "demo.coop.organizing"
+  },
+  {
+    "id": "demo-card-meeting-attend-001",
+    "source_kind": "meeting",
+    "action_kind": "attend",
+    "scope": "demo.coop.organizing",
+    "title": "Confirm attendance at the next program-committee meeting",
+    "summary": "Upcoming meeting of the Program Committee. Confirming attendance produces an attendance receipt.",
+    "authority_basis": "Program Committee chair (demo role)",
+    "required_authority_scope": [
+      "session_scheduling"
+    ],
+    "risk_level": "low",
+    "accessibility_hint": "Meeting summary is text-first; agenda is provided in advance.",
+    "receipt_expected": true,
+    "source_id": "demo-meeting-001",
+    "domain_id": "demo.coop.organizing"
+  },
+  {
+    "id": "demo-card-action-item-complete-001",
+    "source_kind": "action_item",
+    "action_kind": "complete",
+    "scope": "demo.coop.organizing",
+    "title": "Mark the accessibility-checklist review as complete",
+    "summary": "An action item from the most recent accessibility review is assigned to your role. Marking it complete produces a completion receipt.",
+    "authority_basis": "Accessibility Committee member (demo role)",
+    "required_authority_scope": [
+      "veto_for_cause"
+    ],
+    "deadline": 1730200000,
+    "risk_level": "elevated",
+    "accessibility_hint": "Action carries a veto-for-cause power; use plain-language framing of the outcome and any rejection reason.",
+    "receipt_expected": true,
+    "source_id": "demo-action-item-001",
+    "domain_id": "demo.coop.organizing"
+  }
+]

--- a/web/pilot-ui/fixtures/icn-organizer-demo/standing.json
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/standing.json
@@ -1,0 +1,47 @@
+{
+  "did": "did:icn:example-organizer-demo-not-live",
+  "display_label": "Demo organizer (fictional)",
+  "domains": [
+    {
+      "domain_id": "demo.coop.organizing",
+      "domain_name": "Organizing Cooperative (demo)",
+      "membership_source": "static_list",
+      "status": "member"
+    },
+    {
+      "domain_id": "demo.federation.regional",
+      "domain_name": "Regional Federation (demo)",
+      "membership_source": "trust_threshold",
+      "status": "unverified"
+    }
+  ],
+  "roles": [
+    {
+      "role_assignment_id": "demo-role-001",
+      "structure_id": "demo.committee.program",
+      "structure_name": "Program Committee (demo)",
+      "parent_entity_id": "demo.coop.organizing",
+      "role": "chair",
+      "authority_scope": [
+        "session_scheduling",
+        "program_review"
+      ]
+    },
+    {
+      "role_assignment_id": "demo-role-002",
+      "structure_id": "demo.committee.accessibility",
+      "structure_name": "Accessibility Committee (demo)",
+      "parent_entity_id": "demo.coop.organizing",
+      "role": "member",
+      "authority_scope": [
+        "veto_for_cause"
+      ]
+    }
+  ],
+  "authority_scopes": [
+    "session_scheduling",
+    "program_review",
+    "veto_for_cause"
+  ],
+  "generated_at": 1730000000
+}

--- a/web/pilot-ui/fixtures/icn-organizer-demo/standing.json
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/standing.json
@@ -25,7 +25,8 @@
       "authority_scope": [
         "session_scheduling",
         "program_review"
-      ]
+      ],
+      "start_date": 1700000000
     },
     {
       "role_assignment_id": "demo-role-002",
@@ -35,7 +36,8 @@
       "role": "member",
       "authority_scope": [
         "veto_for_cause"
-      ]
+      ],
+      "start_date": 1710000000
     }
   ],
   "authority_scopes": [

--- a/web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js
+++ b/web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js
@@ -47,17 +47,26 @@ test.describe('ICN organizer demo fixture preload (PR 5 narrow slice)', () => {
             expect(['member', 'unverified']).toContain(d.status);
         }
 
-        // Each role has the expected fields.
+        // Each role has the expected fields. StandingRoleAssignment
+        // requires `start_date` (u64) per the Rust model in
+        // icn/apps/governance/src/http/models.rs — pin it here so
+        // fixture drift from the wire shape gets caught.
         for (const r of standing.roles) {
             expect(typeof r.role).toBe('string');
             expect(typeof r.structure_id).toBe('string');
+            expect(typeof r.role_assignment_id).toBe('string');
             expect(Array.isArray(r.authority_scope)).toBeTruthy();
+            expect(typeof r.start_date).toBe('number');
+            // end_date is optional; when present it must also be a number.
+            if (r.end_date !== undefined) {
+                expect(typeof r.end_date).toBe('number');
+            }
         }
     });
 
-    test('action-cards fixture is reachable and has expected shape', async ({ page }) => {
+    test('action-cards fixture is reachable and has expected wrapper shape', async ({ page }) => {
         await page.goto('/');
-        const cards = await page.evaluate(async () => {
+        const response = await page.evaluate(async () => {
             const r = await fetch('fixtures/icn-organizer-demo/action-cards.json', {
                 headers: { 'Accept': 'application/json' },
             });
@@ -65,15 +74,25 @@ test.describe('ICN organizer demo fixture preload (PR 5 narrow slice)', () => {
             return r.json();
         });
 
-        // Top-level shape: array of ActionCard.
-        expect(Array.isArray(cards)).toBeTruthy();
-        expect(cards.length).toBeGreaterThan(0);
+        // ActionCardsResponse wrapper: { did, cards, generated_at }.
+        // Per icn/apps/governance/src/http/models.rs — NOT a bare array.
+        expect(typeof response.did).toBe('string');
+        expect(response.did.startsWith('did:icn:example-')).toBeTruthy();
+        expect(typeof response.generated_at).toBe('number');
+        expect(Array.isArray(response.cards)).toBeTruthy();
+        expect(response.cards.length).toBeGreaterThan(0);
+
+        const cards = response.cards;
 
         // Schema enum coverage: risk_level must use schema values
         // (low | normal | elevated). PR 3 review caught a previous
         // version that used the wrong values; this test pins the
         // schema-correct enum.
         const validRiskLevels = ['low', 'normal', 'elevated'];
+        // ActionCard.scope is also an enum per the schema:
+        // entity | structure | individual. PR 5 review caught a
+        // previous version that used a domain id as scope.
+        const validScopes = ['entity', 'structure', 'individual'];
 
         for (const c of cards) {
             // Required fields per action-card.schema.json (id,
@@ -83,7 +102,7 @@ test.describe('ICN organizer demo fixture preload (PR 5 narrow slice)', () => {
             expect(typeof c.id).toBe('string');
             expect(typeof c.source_kind).toBe('string');
             expect(typeof c.action_kind).toBe('string');
-            expect(typeof c.scope).toBe('string');
+            expect(validScopes).toContain(c.scope);
             expect(typeof c.title).toBe('string');
             expect(typeof c.summary).toBe('string');
             expect(typeof c.authority_basis).toBe('string');
@@ -119,10 +138,12 @@ test.describe('ICN organizer demo fixture preload (PR 5 narrow slice)', () => {
 
     test('fixture pack covers the three source-kind classes the §3 narrative needs', async ({ page }) => {
         await page.goto('/');
-        const cards = await page.evaluate(async () =>
+        const response = await page.evaluate(async () =>
             (await fetch('fixtures/icn-organizer-demo/action-cards.json')).json()
         );
 
+        // The fixture is an ActionCardsResponse wrapper; extract cards array.
+        const cards = response.cards;
         const sourceKinds = new Set(cards.map((c) => c.source_kind));
         // The §3 Guided workflow narrative walks through proposal/vote,
         // meeting/attend, and action_item/complete. Cover all three so

--- a/web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js
+++ b/web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js
@@ -1,0 +1,134 @@
+/**
+ * E2E Tests — ICN Organizer Demo Fixture Preload (PR 5 narrow slice)
+ *
+ * Verifies the FIRST fixture slice for the guided pilot-ui
+ * organizer/member demo: when ?mode=demo is set, loadMemberStanding()
+ * and loadMemberActionCards() short-circuit to committed JSON fixtures
+ * under web/pilot-ui/fixtures/icn-organizer-demo/ instead of fetching
+ * the gateway. This is a frontend-only slice; the backend
+ * --demo-mode flag (ICN #1727) remains OPEN.
+ *
+ * The test asserts the fixture files are reachable at the expected
+ * relative URL and that they conform to the expected shape. The
+ * actual render path through pilot-ui requires sign-in to expose
+ * #main-screen and is exercised by integration tests / manual
+ * verification rather than driven here, consistent with PRs 2-4.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.use({ serviceWorkers: 'block' });
+
+test.describe('ICN organizer demo fixture preload (PR 5 narrow slice)', () => {
+    test('standing fixture is reachable and has expected shape', async ({ page }) => {
+        await page.goto('/');
+        const standing = await page.evaluate(async () => {
+            const r = await fetch('fixtures/icn-organizer-demo/standing.json', {
+                headers: { 'Accept': 'application/json' },
+            });
+            if (!r.ok) throw new Error(`standing fixture fetch failed: ${r.status}`);
+            return r.json();
+        });
+
+        // Required top-level fields per StandingResponse.
+        expect(typeof standing.did).toBe('string');
+        expect(standing.did.startsWith('did:icn:example-')).toBeTruthy();
+        expect(standing.did.endsWith('-not-live')).toBeTruthy();
+        expect(Array.isArray(standing.domains)).toBeTruthy();
+        expect(Array.isArray(standing.roles)).toBeTruthy();
+        expect(Array.isArray(standing.authority_scopes)).toBeTruthy();
+        expect(typeof standing.generated_at).toBe('number');
+
+        // Each domain has the expected fields.
+        for (const d of standing.domains) {
+            expect(typeof d.domain_id).toBe('string');
+            expect(typeof d.domain_name).toBe('string');
+            expect(['static_list', 'trust_threshold']).toContain(d.membership_source);
+            expect(['member', 'unverified']).toContain(d.status);
+        }
+
+        // Each role has the expected fields.
+        for (const r of standing.roles) {
+            expect(typeof r.role).toBe('string');
+            expect(typeof r.structure_id).toBe('string');
+            expect(Array.isArray(r.authority_scope)).toBeTruthy();
+        }
+    });
+
+    test('action-cards fixture is reachable and has expected shape', async ({ page }) => {
+        await page.goto('/');
+        const cards = await page.evaluate(async () => {
+            const r = await fetch('fixtures/icn-organizer-demo/action-cards.json', {
+                headers: { 'Accept': 'application/json' },
+            });
+            if (!r.ok) throw new Error(`action-cards fixture fetch failed: ${r.status}`);
+            return r.json();
+        });
+
+        // Top-level shape: array of ActionCard.
+        expect(Array.isArray(cards)).toBeTruthy();
+        expect(cards.length).toBeGreaterThan(0);
+
+        // Schema enum coverage: risk_level must use schema values
+        // (low | normal | elevated). PR 3 review caught a previous
+        // version that used the wrong values; this test pins the
+        // schema-correct enum.
+        const validRiskLevels = ['low', 'normal', 'elevated'];
+
+        for (const c of cards) {
+            // Required fields per action-card.schema.json (id,
+            // source_kind, action_kind, scope, title, summary,
+            // authority_basis, required_authority_scope, risk_level,
+            // accessibility_hint, receipt_expected, source_id).
+            expect(typeof c.id).toBe('string');
+            expect(typeof c.source_kind).toBe('string');
+            expect(typeof c.action_kind).toBe('string');
+            expect(typeof c.scope).toBe('string');
+            expect(typeof c.title).toBe('string');
+            expect(typeof c.summary).toBe('string');
+            expect(typeof c.authority_basis).toBe('string');
+            expect(Array.isArray(c.required_authority_scope)).toBeTruthy();
+            expect(validRiskLevels).toContain(c.risk_level);
+            expect(typeof c.accessibility_hint).toBe('string');
+            expect(typeof c.receipt_expected).toBe('boolean');
+            expect(typeof c.source_id).toBe('string');
+        }
+    });
+
+    test('fixture pack uses fictional non-live identifiers throughout', async ({ page }) => {
+        await page.goto('/');
+        const [standing, cards] = await page.evaluate(async () => {
+            const s = await (await fetch('fixtures/icn-organizer-demo/standing.json')).json();
+            const c = await (await fetch('fixtures/icn-organizer-demo/action-cards.json')).json();
+            return [s, c];
+        });
+
+        // Standing DID convention.
+        expect(standing.did).toMatch(/^did:icn:example-.*-not-live$/);
+
+        // No real-contact pattern leaks. Stringify the full pack and
+        // check against common real-data shapes; pure fictional
+        // fixtures should produce zero matches.
+        const blob = JSON.stringify(standing) + JSON.stringify(cards);
+        // Real email-provider domains (gmail, outlook, hotmail, yahoo,
+        // proton, icloud).
+        expect(blob).not.toMatch(/@gmail\.com|@outlook\.com|@hotmail\.com|@yahoo\.com|@proton\.me|@icloud\.com/i);
+        // Common phone formats (XXX-XXX-XXXX, XXX.XXX.XXXX).
+        expect(blob).not.toMatch(/\b\d{3}[-.]\d{3}[-.]\d{4}\b/);
+    });
+
+    test('fixture pack covers the three source-kind classes the §3 narrative needs', async ({ page }) => {
+        await page.goto('/');
+        const cards = await page.evaluate(async () =>
+            (await fetch('fixtures/icn-organizer-demo/action-cards.json')).json()
+        );
+
+        const sourceKinds = new Set(cards.map((c) => c.source_kind));
+        // The §3 Guided workflow narrative walks through proposal/vote,
+        // meeting/attend, and action_item/complete. Cover all three so
+        // the demo path is recognizable end-to-end.
+        expect(sourceKinds.has('proposal')).toBeTruthy();
+        expect(sourceKinds.has('meeting')).toBeTruthy();
+        expect(sourceKinds.has('action_item')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## What

The first **narrow fixture slice** for the guided pilot-ui organizer/member demo path (the surface pilot-ui exposes when opened with `?mode=demo`). When `DEMO_MODE === 'demo'`, `loadMemberStanding()` and `loadMemberActionCards()` short-circuit to committed fixture JSON under [`web/pilot-ui/fixtures/icn-organizer-demo/`](web/pilot-ui/fixtures/icn-organizer-demo/) instead of fetching the gateway. **Frontend-only.**

## Why a frontend slice, not the full backend fixture mode

The readiness map's [PR 5](docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md) originally framed fixture-backed demo mode as a runtime `--demo-mode` flag on `icnd` that short-circuits gateway handlers. Discovery on `c239a79e` showed that the full backend mode would touch `icnd`, `icn-gateway`, `apps/governance`, and add a Rust loader module — multi-crate, kernel-bordering, and not safely scope-able as one PR. Stop-and-report directive returned with: do the smallest narrow slice that advances the **actual** pilot-ui organizer/member demo, not the legacy tool-library demo, and explicitly leave ICN [#1727](https://github.com/InterCooperative-Network/icn/issues/1727) **OPEN**.

This PR is that slice. It runs entirely in pilot-ui, requires no Rust changes, and demonstrates the `?mode=demo` banner is truthful for two of the most-visible read-models (standing + action-cards). Receipts surface, governance proposals, ledger, and federation remain fetch-only in this PR; their fixture coverage can land as follow-ups.

## This is NOT the tool-library demo

The legacy `demo/scripts/run-tool-library-demo.sh` flow remains dev scaffolding; it is **not** the user-facing ICN demo and is unaffected by this PR. The user-facing demo is the guided pilot-ui surface opened with `?mode=demo`. The fixture pack's [README](web/pilot-ui/fixtures/icn-organizer-demo/README.md) states this explicitly.

## Files

| File | Change | Purpose |
|---|---|---|
| [`web/pilot-ui/fixtures/icn-organizer-demo/standing.json`](web/pilot-ui/fixtures/icn-organizer-demo/standing.json) | new | StandingResponse-shape fixture using `did:icn:example-organizer-demo-not-live`. Two domains (one static-list `member`, one trust-threshold `unverified`), two role assignments, authority-scopes union. Field shapes verbatim from `icn/apps/governance/src/http/models.rs` — no invented fields. |
| [`web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json`](web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json) | new | Three ActionCard fixtures covering the §3 Guided workflow's three source-kind classes: `proposal`/`vote`, `meeting`/`attend`, `action_item`/`complete`. Fields verbatim from `action-card.schema.json` including `risk_level` enum (`low`/`normal`/`elevated` — schema-correct values), `accessibility_hint`, `receipt_expected`. |
| [`web/pilot-ui/fixtures/icn-organizer-demo/README.md`](web/pilot-ui/fixtures/icn-organizer-demo/README.md) | new | Documents Status (read first), what's covered, what's NOT covered, identifier convention, how to use, out-of-scope items, cross-references to ICN [#1727](https://github.com/InterCooperative-Network/icn/issues/1727) / readiness map / schema sources. |
| [`web/pilot-ui/app.js`](web/pilot-ui/app.js) | +38 / -0 | `loadDemoFixture()` helper; `loadMemberStanding()` and `loadMemberActionCards()` short-circuit to fixtures when `DEMO_MODE === 'demo'`; non-demo paths unchanged. |
| [`web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js`](web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js) | new | Four Playwright scenarios — fixture reachable + standing shape, action-cards shape with `risk_level` enum pinned, no real-contact leak in fixture content, all three §3-narrative source-kinds covered. |
| [`docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md`](docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md) | +13 / -0 | Implementation note in §5 PR 5 explaining the original framing remains the eventual scope; this PR is the narrow frontend slice; #1727 stays OPEN. |

Total: +403 / -0 across 6 files (4 new + 2 modified).

## ICN #1727 explicitly remains OPEN

This PR does **not** implement the gateway-side `--demo-mode` flag and does **not** add Rust handler short-circuits. Per the user directive: "Do not close ICN #1727 unless a true fixture-backed demo mode exists for the actual pilot-ui organizer/member path." This is the first frontend slice; the issue tracks the eventual backend implementation.

## What this slice does NOT cover

The following pilot-ui surfaces are intentionally untouched and continue to fetch the gateway / show empty states in demo mode:

- **Governance proposals / votes** — pilot-ui Governance tab still fetches the gateway.
- **Receipt chain** — `receipts.js` still queries `/v1/receipts/chain`; the plain-language summary from PR 4 shows its empty state when the chain is empty.
- **Ledger / transaction history.**
- **Trust score.**
- **Members directory.**
- **Federation status.**

Adding fixture coverage for any of those surfaces would expand this PR beyond a narrow first slice. The split sequence (per **PR 5B** option in the original 4-option fork) would be: (1) standing + action-cards (this PR), (2) governance proposals/votes, (3) receipts/provenance, (4) ledger.

## Test plan

- [x] `git diff --check` clean (no whitespace errors).
- [x] `git status --short` shows exactly the six intended files.
- [x] `node --check web/pilot-ui/app.js` passes (syntax sanity).
- [x] `node --check web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js` passes.
- [x] `python3 -c "json.load(...)"` parses both fixture JSON files cleanly (3 cards in action-cards.json, valid StandingResponse shape in standing.json).
- [x] No Rust changes (`git diff --name-only | grep -E '\.rs$|Cargo\.toml$|Cargo\.lock$'` returns empty) — frontend-only PR confirmed.
- [x] Real-contact leak grep on **fixture content** returns clean. (The test spec contains real-data regex patterns *as test assertions*, which is the intended use; not a fixture leak.)
- [x] Overclaim grep on fixture content hits only in explicit non-claim / out-of-scope / "Not implemented in demo" contexts.
- [ ] Full Playwright e2e run against pilot-ui served statically — runs in CI; fixture preload path requires no gateway.

## Non-claims

- **Not production deployment.** No live ICN runtime mutation, Google Drive / Groups / Sheets, federation, K3s, DNS, Forgejo, private-overlay, or cloud-sync activation. GitHub PR operations only.
- **Not Phase 2 completion.** Phase truth lives in [`docs/PHASE_PROGRESS.md`](docs/PHASE_PROGRESS.md).
- **Not formal NYCN pilot approval.**
- **Not live federation.**
- **Not live cloud sync.**
- **Not real private-data handling.** All fixture identifiers use `did:icn:example-*-not-live`; all display labels are fictional; zero real names / real DIDs / real contact data.
- **Not real holder-label activation.** All DIDs are fictional and not bound to real persons.
- **This does not make the tool-library demo the ICN demo.** The legacy script remains dev scaffolding.
- **This does not complete ICN [#1727](https://github.com/InterCooperative-Network/icn/issues/1727).** It is the first fixture-backed slice for the actual guided pilot-ui demo. The eventual backend `--demo-mode` flag is the issue's remaining scope.
- **No NYCN changes.** Single-repo, ICN-only.