### PR TITLE
demo(pilot-ui): align ?mode=demo shell with organizing-committee path

### DIFF
--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -29,15 +29,24 @@ const DEMO_MODE = (() => {
     }
 })();
 const DEMO_MODE_MESSAGES = {
-    demo:    'UI is in DEMO mode — labeling convention; not authoritative gateway state. Gateway-side fixture/demo mode arrives in PR 5.',
+    demo:    'Local organizer/member demo. Standing and action cards are fixture-backed; governance, receipts, ledger, members, trust, and federation are not fixture-backed yet.',
     fixture: 'UI is in FIXTURE mode — committed test data only; not real participant state.',
     devnet:  'UI is in DEVNET mode — local 3-node Docker cluster; not production.',
     local:   'UI is in LOCAL mode — single-node local gateway.',
     live:    'UI is in LIVE mode — reading real gateway state. LIVE does not mean production; ICN is not production-deployed.',
 };
 
+// In ?mode=demo only, retitle the visible app and de-emphasize timebank
+// surfaces in nav so the first impression matches the organizing-committee
+// demo, not "ICN Timebank with extra tabs." Non-demo paths are unchanged.
+const DEMO_TITLE = 'ICN Organizing Committee Demo';
+const DEMO_SUBTITLE = 'Cooperative Civic Coordination — Local Demo';
+
 // Render the demo-mode banner and unhide the Demo Guide nav button.
-// Idempotent. Safe to call multiple times. No-op when DEMO_MODE is null.
+// In ?mode=demo only: also swap the visible app title away from "ICN
+// Timebank" and hide timebank-oriented nav buttons that aren't part of
+// the organizing-committee story. Idempotent. Safe to call multiple
+// times. No-op when DEMO_MODE is null.
 function applyDemoMode() {
     if (!DEMO_MODE) return;
     const banner = document.getElementById('demo-mode-banner');
@@ -53,6 +62,30 @@ function applyDemoMode() {
     if (navBtn) navBtn.classList.remove('hidden');
     const modeEl = document.getElementById('demo-guide-mode');
     if (modeEl) modeEl.textContent = DEMO_MODE.toUpperCase();
+
+    // ?mode=demo specifically (not fixture/devnet/local/live): retitle
+    // the app to the organizing-committee framing and hide timebank
+    // nav surfaces that aren't part of this demo's story. Only the
+    // visible UI changes; the underlying tabs remain in the DOM so a
+    // direct hash-link still works for adjacent tools.
+    if (DEMO_MODE === 'demo') {
+        try { document.title = DEMO_TITLE; } catch (_) { /* noop */ }
+        const headerTitle = document.getElementById('app-title-header');
+        if (headerTitle) headerTitle.textContent = DEMO_TITLE;
+        const loginTitle = document.getElementById('app-title-login');
+        if (loginTitle) loginTitle.textContent = DEMO_TITLE;
+        const loginSubtitle = document.getElementById('app-subtitle-login');
+        if (loginSubtitle) loginSubtitle.textContent = DEMO_SUBTITLE;
+
+        document.querySelectorAll('[data-demo-irrelevant="true"]').forEach((el) => {
+            el.classList.add('hidden');
+            // Strip the default "active" highlight so the demo-guide
+            // tab is the unambiguous starting point. switchTab() will
+            // handle the actual active-state once it runs.
+            el.classList.remove('active');
+            el.removeAttribute('aria-current');
+        });
+    }
 }
 
 // Update the per-session fields in the Demo Guide ("Where you are")

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -637,7 +637,7 @@
 
             <!-- Navigation -->
             <nav role="navigation" aria-label="Main navigation">
-                <button class="nav-btn hidden" data-tab="demo-guide" id="demo-guide-nav-btn">
+                <button class="nav-btn hidden" data-tab="demo-guide" id="demo-guide-nav-btn" aria-controls="demo-guide">
                     <span aria-label="Demo guide and orientation">Demo Guide</span>
                 </button>
                 <button class="nav-btn active" data-tab="dashboard" data-demo-irrelevant="true" aria-current="page">
@@ -678,7 +678,7 @@
             <!-- Dashboard Tab -->
             <main id="main-content" class="tab-container">
                 <!-- Demo Guide Tab (PR 2 — guided demo landing; reads existing app state only, no new endpoint consumers) -->
-                <div id="demo-guide" class="tab-content" role="tabpanel" aria-labelledby="tab-demo-guide">
+                <div id="demo-guide" class="tab-content" role="tabpanel" aria-labelledby="demo-guide-nav-btn">
                     <section class="demo-guide-section" aria-labelledby="demo-guide-heading">
                         <h2 id="demo-guide-heading">ICN Organizing Committee Demo</h2>
                         <p class="demo-guide-intro">

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -32,8 +32,8 @@
         <div id="login-screen" class="screen">
             <main id="login-main" aria-label="Sign in to ICN">
             <div class="card login-card">
-                <h1>ICN Timebank</h1>
-                <p class="subtitle">Community Time Exchange</p>
+                <h1 id="app-title-login">ICN Timebank</h1>
+                <p class="subtitle" id="app-subtitle-login">Community Time Exchange</p>
 
                 <form id="login-form" aria-label="Sign in to your cooperative">
                     <div class="form-group">
@@ -512,7 +512,7 @@
             <!-- Header -->
             <header role="banner">
                 <div class="header-left">
-                    <h1>ICN Timebank</h1>
+                    <h1 id="app-title-header">ICN Timebank</h1>
                     <span id="coop-name" class="coop-badge" aria-label="Current cooperative"></span>
                 </div>
                 <div class="header-right">
@@ -640,22 +640,22 @@
                 <button class="nav-btn hidden" data-tab="demo-guide" id="demo-guide-nav-btn">
                     <span aria-label="Demo guide and orientation">Demo Guide</span>
                 </button>
-                <button class="nav-btn active" data-tab="dashboard" aria-current="page">
+                <button class="nav-btn active" data-tab="dashboard" data-demo-irrelevant="true" aria-current="page">
                     <span aria-label="Dashboard">Dashboard</span>
                 </button>
-                <button class="nav-btn" data-tab="log-hours">
+                <button class="nav-btn" data-tab="log-hours" data-demo-irrelevant="true">
                     <span aria-label="Log service hours">Log Hours</span>
                 </button>
-                <button class="nav-btn" data-tab="history">
+                <button class="nav-btn" data-tab="history" data-demo-irrelevant="true">
                     <span aria-label="Transaction history">History</span>
                 </button>
-                <button class="nav-btn" data-tab="members">
+                <button class="nav-btn" data-tab="members" data-demo-irrelevant="true">
                     <span aria-label="Member directory">Members</span>
                 </button>
                 <button class="nav-btn hidden" data-tab="service-board">
                     <span aria-label="Service marketplace">Services</span>
                 </button>
-                <button class="nav-btn" data-tab="member-profile">
+                <button class="nav-btn" data-tab="member-profile" data-demo-irrelevant="true">
                     <span aria-label="Your profile">Profile</span>
                 </button>
                 <button class="nav-btn" data-tab="my-standing" id="tab-my-standing">
@@ -680,9 +680,9 @@
                 <!-- Demo Guide Tab (PR 2 — guided demo landing; reads existing app state only, no new endpoint consumers) -->
                 <div id="demo-guide" class="tab-content" role="tabpanel" aria-labelledby="tab-demo-guide">
                     <section class="demo-guide-section" aria-labelledby="demo-guide-heading">
-                        <h2 id="demo-guide-heading">ICN Local Demo — Guided Path</h2>
+                        <h2 id="demo-guide-heading">ICN Organizing Committee Demo</h2>
                         <p class="demo-guide-intro">
-                            You are running ICN's pilot UI as a guided demo. This page tells you where you are, what is real runtime behavior, what is fixture/local/demo-only, and what is not implemented yet. The §3 Guided workflow narrative in <code>docs/pilots/no-cli-organizer-member-rehearsal-workflow.md</code> walks: <strong>standing → action cards → governance → receipts → provenance/evidence</strong>. Today's pilot-ui covers parts of this; the labels below tell you exactly which parts.
+                            You are running ICN's pilot UI as a local organizing-committee demo. ICN is a substrate for cooperative civic coordination, not a timebank app. The <strong>§3 Guided workflow</strong> narrative in <code>docs/pilots/no-cli-organizer-member-rehearsal-workflow.md</code> walks: <strong>standing → action cards → governance → receipts → provenance/evidence</strong>. This page labels exactly what is fixture-backed today, what is still gateway-backed, and what is not implemented in this demo.
                         </p>
 
                         <h3>Where you are</h3>
@@ -692,44 +692,60 @@
                             <dt>Mode</dt><dd id="demo-guide-mode">—</dd>
                             <dt>Logged-in DID</dt><dd id="demo-guide-did" class="did-display">— (sign in to populate)</dd>
                         </dl>
-                        <p class="demo-guide-note">
-                            The "Logged-in DID" line above comes from your sign-in (auth-known DID), not from a standing read-model fetch. The member standing read-model surface arrives in PR 3.
-                        </p>
 
-                        <h3>Available now in pilot-ui</h3>
+                        <h3>Available now in this local demo</h3>
                         <ul class="demo-guide-list demo-guide-available">
-                            <li><a href="#governance" data-demo-target="governance">Governance — proposals / votes</a> <span class="demo-status">live</span></li>
-                            <li><a href="#governance" data-demo-target="governance">Action items</a> <span class="demo-status">live</span> <span class="demo-note">per-domain ledger via <code>/gov/domains/{d}/action-items</code> — different endpoint and concept from per-member action cards</span></li>
-                            <li><a href="#history" data-demo-target="history">Ledger / transaction history</a> <span class="demo-status">live</span></li>
-                            <li><a href="#dashboard" data-demo-target="dashboard">Trust score</a> <span class="demo-status">live</span></li>
-                            <li><a href="#receipts" data-demo-target="receipts">Receipt chain view</a> <span class="demo-status">live</span> <span class="demo-note">via <code>receipts.js</code>; plain-language framing arrives in PR 4</span></li>
+                            <li>No-gateway demo bootstrap <span class="demo-status">live</span></li>
+                            <li>Demo / local mode banner <span class="demo-status">live</span></li>
+                            <li><a href="#my-standing" data-demo-target="my-standing">My Standing surface</a> <span class="demo-status">live</span></li>
+                            <li><a href="#my-standing" data-demo-target="my-standing">Action Cards surface</a> <span class="demo-status">live</span></li>
+                            <li>Standing fixture <span class="demo-status">fixture</span> <span class="demo-note">committed under <code>web/pilot-ui/fixtures/icn-organizer-demo/standing.json</code></span></li>
+                            <li>Action-card fixture <span class="demo-status">fixture</span> <span class="demo-note">committed under <code>web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json</code></span></li>
+                            <li>Plain-language receipt summary shell <span class="demo-status">live</span> <span class="demo-note">render path via <code>receipts.js</code>; needs gateway data to populate</span></li>
                         </ul>
 
-                        <h3>Coming next in this demo tranche — Not yet wired</h3>
-                        <ul class="demo-guide-list demo-guide-coming">
-                            <li>Member standing read-model surface <span class="demo-status">PR 3</span></li>
-                            <li>Per-member action cards surface <span class="demo-status">PR 3</span> <span class="demo-note">distinct from the existing Action Items tab; uses <code>/v1/gov/me/action-cards</code></span></li>
-                            <li>Plain-language receipt / provenance framing <span class="demo-status">PR 4</span> <span class="demo-note">extends existing <code>receipts.js</code> with a plain-language summary above the existing chain render</span></li>
-                            <li>Fixture-backed local demo mode (gateway-side) <span class="demo-status">PR 5</span></li>
+                        <h3>Fixture-backed today</h3>
+                        <ul class="demo-guide-list demo-guide-fixture">
+                            <li>Standing</li>
+                            <li>Action cards</li>
                         </ul>
 
-                        <h3>Not implemented in demo</h3>
+                        <h3>Visible but still gateway-backed / not fixture-backed</h3>
+                        <ul class="demo-guide-list demo-guide-gateway-backed">
+                            <li>Governance proposals / votes</li>
+                            <li>Receipt-chain data</li>
+                            <li>Ledger / history</li>
+                            <li>Members</li>
+                            <li>Trust</li>
+                            <li>Federation</li>
+                        </ul>
+
+                        <h3>Not implemented in this demo</h3>
                         <ul class="demo-guide-list demo-guide-not-implemented">
-                            <li>Federation topology — no first-class topology surface; node-dashboard's "peer count" is a proxy from <code>/v1/trust/edges</code></li>
-                            <li>Holder-label DID activation — substrate spec only; partner-package policy required</li>
-                            <li>Allocation / settlement at scale</li>
+                            <li>Backend <code>--demo-mode</code></li>
+                            <li>Full fixture-backed runtime mode</li>
+                            <li>Live federation</li>
+                            <li>Cloud sync</li>
                             <li>Private-overlay activation</li>
-                            <li>Cross-cooperative federation flows</li>
-                            <li>Cloud sync (Drive / Sheets / Groups / Calendar / mail)</li>
-                            <li>K3s / DNS / Forgejo / production deployment mutation</li>
+                            <li>Real holder-label activation</li>
+                            <li>Production deployment</li>
+                            <li>Formal NYCN pilot</li>
+                        </ul>
+
+                        <h3>Future narrow slices</h3>
+                        <ul class="demo-guide-list demo-guide-future">
+                            <li>Governance proposal / vote fixture slice</li>
+                            <li>Receipt / provenance fixture slice</li>
+                            <li>Ledger / federation only if needed</li>
+                            <li>Backend <code>--demo-mode</code> as a separate broader design pass</li>
                         </ul>
 
                         <h3>Non-claims</h3>
                         <ul class="demo-guide-non-claims">
-                            <li>Demo mode is a UI labeling convention until PR 5 adds gateway-side fixture/demo mode.</li>
-                            <li><strong>LIVE</strong> does not mean production — it means the page is reading real gateway state. ICN is not production-deployed.</li>
-                            <li>"Not yet wired" means upcoming in this tranche (PRs 3, 4, 5).</li>
-                            <li>"Not implemented in demo" means out of scope for this entire tranche.</li>
+                            <li>Demo mode is a UI labeling convention.</li>
+                            <li>Standing and action cards are fictional fixtures, not real participant state.</li>
+                            <li><strong>LIVE</strong> does not mean production — ICN is not production-deployed.</li>
+                            <li>"Not implemented in this demo" means out of scope for this slice.</li>
                         </ul>
                     </section>
                 </div>

--- a/web/pilot-ui/tests/e2e/demo-mode.spec.js
+++ b/web/pilot-ui/tests/e2e/demo-mode.spec.js
@@ -65,11 +65,13 @@ test.describe('Demo Mode (PR 2)', () => {
         await page.waitForLoadState('networkidle');
 
         const guide = page.locator('#demo-guide');
-        await expect(guide).toContainText('ICN Local Demo — Guided Path');
+        await expect(guide).toContainText('ICN Organizing Committee Demo');
         await expect(guide).toContainText('Where you are');
-        await expect(guide).toContainText('Available now in pilot-ui');
-        await expect(guide).toContainText('Coming next in this demo tranche');
-        await expect(guide).toContainText('Not implemented in demo');
+        await expect(guide).toContainText('Available now in this local demo');
+        await expect(guide).toContainText('Fixture-backed today');
+        await expect(guide).toContainText('Visible but still gateway-backed');
+        await expect(guide).toContainText('Not implemented in this demo');
+        await expect(guide).toContainText('Future narrow slices');
         await expect(guide).toContainText('Non-claims');
 
         // Mode echo
@@ -103,20 +105,38 @@ test.describe('Demo Mode (PR 2)', () => {
         const nonClaims = page.locator('.demo-guide-non-claims');
         await expect(nonClaims).toContainText('UI labeling convention');
         await expect(nonClaims).toContainText('LIVE');
-        await expect(nonClaims).toContainText('Not yet wired');
-        await expect(nonClaims).toContainText('Not implemented in demo');
+        await expect(nonClaims).toContainText('fictional fixtures');
+        await expect(nonClaims).toContainText('Not implemented in this demo');
     });
 
-    test('Demo Guide labels Action Items as distinct from Action Cards', async ({ page }) => {
+    test('Demo Guide says standing and action cards are fixture-backed (not coming-next)', async ({ page }) => {
         await page.goto('/?mode=demo');
         await page.waitForLoadState('networkidle');
 
         const guide = page.locator('#demo-guide');
-        // Action Items live now, action-cards is PR 3
-        await expect(guide).toContainText('Action items');
-        await expect(guide).toContainText('different endpoint and concept from per-member action cards');
-        await expect(guide).toContainText('Per-member action cards surface');
-        await expect(guide).toContainText('PR 3');
+        // After #1771–#1774, standing + action cards are live + fixture-backed.
+        // Old "PR 3 / Not yet wired" framing must be gone.
+        await expect(guide).toContainText('My Standing surface');
+        await expect(guide).toContainText('Action Cards surface');
+        await expect(guide).toContainText('Fixture-backed today');
+
+        // Stale tranche labels must NOT appear.
+        await expect(guide).not.toContainText('Coming next in this demo tranche');
+        await expect(guide).not.toContainText('Not yet wired');
+        await expect(guide).not.toContainText('arrives in PR');
+    });
+
+    test('Demo Guide says governance and receipt-chain data are not fixture-backed yet', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        const gatewayBacked = page.locator('.demo-guide-gateway-backed');
+        await expect(gatewayBacked).toContainText('Governance proposals / votes');
+        await expect(gatewayBacked).toContainText('Receipt-chain data');
+        await expect(gatewayBacked).toContainText('Ledger / history');
+        await expect(gatewayBacked).toContainText('Members');
+        await expect(gatewayBacked).toContainText('Trust');
+        await expect(gatewayBacked).toContainText('Federation');
     });
 
     test('?mode=demo auto-bootstraps the main screen without a running gateway', async ({ page }) => {
@@ -156,5 +176,75 @@ test.describe('Demo Mode (PR 2)', () => {
         const mainScreen = page.locator('#main-screen');
         await expect(loginScreen).not.toHaveClass(/hidden/);
         await expect(mainScreen).toHaveClass(/hidden/);
+    });
+
+    test('?mode=demo retitles the app away from "ICN Timebank"', async ({ page }) => {
+        // Demo shell must read as an organizing-committee demo on first
+        // glance, not as a timebank app. Document title (browser tab),
+        // header title, and login-screen title must all be retitled.
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        await expect(page).toHaveTitle('ICN Organizing Committee Demo');
+
+        const headerTitle = page.locator('#app-title-header');
+        await expect(headerTitle).toHaveText('ICN Organizing Committee Demo');
+        await expect(headerTitle).not.toHaveText('ICN Timebank');
+
+        const loginTitle = page.locator('#app-title-login');
+        await expect(loginTitle).toHaveText('ICN Organizing Committee Demo');
+    });
+
+    test('non-demo path keeps "ICN Timebank" title', async ({ page }) => {
+        // Discovery did not show the non-demo shell to be obsolete, so
+        // the existing live/timebank surface stays as-is until the
+        // user explicitly asks for a global rename.
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        await expect(page).toHaveTitle('ICN Timebank');
+        const loginTitle = page.locator('#app-title-login');
+        await expect(loginTitle).toHaveText('ICN Timebank');
+    });
+
+    test('?mode=demo hides timebank-oriented nav buttons (Dashboard/Log Hours/History/Members/Profile)', async ({ page }) => {
+        // The organizing-committee demo's preferred nav is:
+        //   Demo Guide • My Standing & Action Cards • Governance • Receipts (• Federation, optional)
+        // Timebank-oriented surfaces are hidden in demo mode (only — they
+        // remain in the DOM and remain visible in non-demo mode).
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        for (const tab of ['dashboard', 'log-hours', 'history', 'members', 'member-profile']) {
+            const btn = page.locator(`[data-tab="${tab}"]`);
+            await expect(btn).toHaveClass(/hidden/);
+        }
+
+        // Organizing-path nav remains visible (no hidden class).
+        for (const tab of ['demo-guide', 'my-standing', 'governance', 'receipts']) {
+            const btn = page.locator(`[data-tab="${tab}"]`);
+            await expect(btn).not.toHaveClass(/hidden/);
+        }
+    });
+
+    test('non-demo path keeps timebank-oriented nav buttons visible', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        for (const tab of ['dashboard', 'log-hours', 'history', 'members', 'member-profile']) {
+            const btn = page.locator(`[data-tab="${tab}"]`);
+            await expect(btn).not.toHaveClass(/hidden/);
+        }
+    });
+
+    test('?mode=demo banner copy is current (no stale "PR 5" claim)', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        const message = page.locator('#demo-mode-message');
+        await expect(message).toContainText('Local organizer/member demo');
+        await expect(message).toContainText('fixture-backed');
+        await expect(message).not.toContainText('PR 5');
+        await expect(message).not.toContainText('arrives in');
     });
 });


### PR DESCRIPTION
## Why

Manual inspection of `http://localhost:8765/?mode=demo` after #1774 merged showed the visual shell still framed the demo as **ICN Timebank**:

- Browser tab and in-app header read **ICN Timebank**.
- First-class nav showed **Dashboard / Log Hours / History / Members / Profile** above-the-fold.
- The Demo Guide still listed standing, action cards, and plain-language receipts as **Coming next in this demo tranche — Not yet wired (PR 3 / PR 4 / PR 5)**.

After #1771–#1774, those PR-tranche labels are stale. Standing, action cards, and the receipt-summary shell shipped. The demo is the ICN organizing-committee / civic coordination demo, not a timebank demo with extras bolted on. The visual shell needs to match.

## What changed (demo mode only — non-demo unchanged)

- **Retitle** the visible app to `ICN Organizing Committee Demo` — `document.title` (browser tab), in-app header `<h1>`, and login-screen `<h1>`. `applyDemoMode()` does the swap at script-eval time. The static HTML defaults stay `ICN Timebank` so the non-demo / live timebank surface keeps its existing identity until a global rename is explicitly requested.

- **De-emphasize timebank nav** in demo mode: `Dashboard`, `Log Hours`, `History`, `Members`, `Profile` carry `data-demo-irrelevant="true"` and are hidden via the existing `.hidden` class when `?mode=demo`. Preferred demo-mode nav becomes:
  - `Demo Guide`
  - `My Standing & Action Cards`
  - `Governance`
  - `Receipts`
  - `Federation` (kept; honestly labeled in the Demo Guide as gateway-backed, not fixture-backed)
  
  The tab DOM is untouched, so anchor / programmatic `switchTab()` into any tab still works for adjacent tools.

- **Banner copy**: drop the stale "Gateway-side fixture/demo mode arrives in PR 5." line. New copy reads:
  > Local organizer/member demo. Standing and action cards are fixture-backed; governance, receipts, ledger, members, trust, and federation are not fixture-backed yet.

- **Demo Guide rewrite**: replace the old "Coming next" / PR3/PR4/PR5 block with truth-current sections matching the §3 Guided workflow narrative:
  - Available now in this local demo
  - **Fixture-backed today** (standing, action cards)
  - **Visible but still gateway-backed / not fixture-backed** (governance, receipt-chain, ledger, members, trust, federation)
  - **Not implemented in this demo** (backend `--demo-mode`, full fixture runtime, live federation, cloud sync, private-overlay activation, real holder-label activation, production deployment, formal NYCN pilot)
  - **Future narrow slices** (governance fixture slice, receipt/provenance fixture slice, ledger/federation only if needed, backend `--demo-mode` as a separate broader design pass)

- **Tests**: add coverage for the title swap (demo + non-demo paths), nav hiding (demo + non-demo paths), the new banner copy, the new Demo Guide sections, and the absence of stale tranche labels (`Coming next in this demo tranche`, `Not yet wired`, `arrives in PR`). Existing `demo-fixture-preload.spec.js` is untouched.

## What did not change

- **Non-demo / live shell.** `<title>ICN Timebank</title>`, the login-screen and header `<h1>`, and the full timebank nav (`Dashboard / Log Hours / History / Members / Profile`) all behave exactly as they did before. Discovery did not show the live shell to be obsolete — global rename is out of scope and was not requested.
- **Tab content / endpoints.** No tab is removed from the DOM. No new endpoint consumer. No backend change. No fixture change.
- **Existing fixture slice (#1773).** `loadDemoFixture` short-circuits and the `web/pilot-ui/fixtures/icn-organizer-demo/` files are untouched.

## Non-claims

- This PR does not introduce backend `--demo-mode` (ICN #1727 remains open).
- This PR does not introduce a full fixture-backed runtime mode.
- This PR does not introduce a live federation, cloud sync, private-overlay activation, real holder-label DID activation, production deployment, or any formal NYCN pilot.
- "Production", "K3s", "DNS", "Forgejo", "live federation", "cloud sync", and "formal NYCN pilot" appear only in explicit non-claim / out-of-scope contexts.
- No real participant data, no real DIDs, no contact information anywhere in the diff.
- The tool-library demo remains dev scaffolding, not the ICN demo.

## Validation

- `git diff --check` clean
- `node --check web/pilot-ui/app.js` ok
- `node --check web/pilot-ui/tests/e2e/demo-mode.spec.js` ok
- `node --check web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js` ok (unchanged)
- `python3 -m json.tool` on both fixture JSON files ok (unchanged)
- `git diff --name-only | grep -E '\.rs$|Cargo\.toml$|Cargo\.lock$'` empty — no Rust touched
- Leak/overclaim grep: only legitimate non-claim / out-of-scope contexts hit; no real participant data

## Local inspection

```
cd /home/matt/projects/icn/web/pilot-ui
python3 -m http.server 8765
# Open: http://localhost:8765/?mode=demo
```

Above-the-fold expectation:
- Browser tab title: **ICN Organizing Committee Demo**
- Header: **ICN Organizing Committee Demo** + `demo.coop.organizing` badge + `Demo organizer (fictional)`
- DEMO banner: "Local organizer/member demo. Standing and action cards are fixture-backed; governance, receipts, ledger, members, trust, and federation are not fixture-backed yet."
- Nav (left to right): Demo Guide • My Standing & Action Cards • Governance • Federation • Receipts
- Demo Guide tab is the auto-active landing.

## Recommended next

Pause and let Matt visually confirm before adding the governance fixture slice.