### PR TITLE
demo(pilot-ui): improve local demo guide visual hierarchy

### DIFF
--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -29,7 +29,7 @@ const DEMO_MODE = (() => {
     }
 })();
 const DEMO_MODE_MESSAGES = {
-    demo:    'Local organizer/member demo. Standing and action cards are fixture-backed; governance, receipts, ledger, members, trust, and federation are not fixture-backed yet.',
+    demo:    'Local organizer/member demo. Only Standing and Action Cards are fixture-backed today.',
     fixture: 'UI is in FIXTURE mode — committed test data only; not real participant state.',
     devnet:  'UI is in DEVNET mode — local 3-node Docker cluster; not production.',
     local:   'UI is in LOCAL mode — single-node local gateway.',
@@ -70,6 +70,10 @@ function applyDemoMode() {
     // direct hash-link still works for adjacent tools.
     if (DEMO_MODE === 'demo') {
         try { document.title = DEMO_TITLE; } catch (_) { /* noop */ }
+        // Mark body so demo-mode-only CSS (wider main, action-cards
+        // grid, etc.) can target the right scope without leaking
+        // into non-demo pages.
+        if (document.body) document.body.setAttribute('data-demo-mode', 'true');
         const headerTitle = document.getElementById('app-title-header');
         if (headerTitle) headerTitle.textContent = DEMO_TITLE;
         const loginTitle = document.getElementById('app-title-login');
@@ -86,6 +90,79 @@ function applyDemoMode() {
             el.removeAttribute('aria-current');
         });
     }
+}
+
+// Build a "this surface is gateway-backed and not fixture-backed in this
+// demo" placeholder for tabs whose default UI (Loading… spinners, sign-in
+// hints, hash-query forms) is honest only when a real gateway is present.
+// Demo mode hides those default chunks and shows this card instead so the
+// page reads as intentional rather than broken.
+function makeDemoTabPlaceholder(displayName) {
+    const wrapper = document.createElement('section');
+    wrapper.className = 'demo-tab-placeholder';
+    wrapper.setAttribute('aria-label', `Demo placeholder for ${displayName}`);
+
+    const card = document.createElement('div');
+    card.className = 'demo-tab-placeholder-card';
+
+    const eyebrow = document.createElement('p');
+    eyebrow.className = 'demo-tab-placeholder-eyebrow';
+    eyebrow.textContent = 'Demo mode · Gateway-backed';
+
+    const heading = document.createElement('h2');
+    heading.textContent = displayName;
+
+    const lead = document.createElement('p');
+    lead.className = 'demo-tab-placeholder-lead';
+    lead.textContent = `${displayName} is visible in pilot-ui but is not fixture-backed in this demo.`;
+
+    const body = document.createElement('p');
+    body.textContent = `With a running gateway and the right token, this surface would render real ${displayName.toLowerCase()} state. The committed local-demo fixtures cover Standing and Action Cards only.`;
+
+    const note = document.createElement('p');
+    note.className = 'demo-tab-placeholder-note';
+    note.appendChild(document.createTextNode('See the '));
+    const a = document.createElement('a');
+    a.href = '#';
+    a.dataset.demoTarget = 'demo-guide';
+    a.textContent = 'Demo Guide';
+    note.appendChild(a);
+    note.appendChild(document.createTextNode(' for the full label of what is and is not fixture-backed today.'));
+
+    card.appendChild(eyebrow);
+    card.appendChild(heading);
+    card.appendChild(lead);
+    card.appendChild(body);
+    card.appendChild(note);
+    wrapper.appendChild(card);
+    return wrapper;
+}
+
+function injectDemoTabPlaceholders() {
+    if (DEMO_MODE !== 'demo') return;
+    const targets = [
+        ['governance', 'Governance'],
+        ['federation', 'Federation'],
+        ['receipts',   'Receipts'],
+    ];
+    for (const [tabId, displayName] of targets) {
+        const tab = document.getElementById(tabId);
+        if (!tab) continue;
+        if (tab.dataset.demoPlaceholderInjected === 'true') continue;
+        // Hide every existing child of the tab so default content
+        // (sub-tab navigation, Loading spinners, sign-in hints, hash
+        // query forms) does not render in demo mode.
+        Array.from(tab.children).forEach((child) => { child.style.display = 'none'; });
+        tab.appendChild(makeDemoTabPlaceholder(displayName));
+        tab.dataset.demoPlaceholderInjected = 'true';
+    }
+    // Wire the "Demo Guide" anchors inside the placeholders to switchTab.
+    document.querySelectorAll('.demo-tab-placeholder a[data-demo-target="demo-guide"]').forEach((a) => {
+        a.addEventListener('click', (e) => {
+            e.preventDefault();
+            if (typeof switchTab === 'function') switchTab('demo-guide');
+        });
+    });
 }
 
 // Update the per-session fields in the Demo Guide ("Where you are")
@@ -3215,6 +3292,7 @@ function bootstrapDemoMode() {
     if (typeof switchTab === 'function') {
         switchTab('demo-guide');
     }
+    injectDemoTabPlaceholders();
 }
 bootstrapDemoMode();
 

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -11,7 +11,7 @@
     <meta name="apple-mobile-web-app-title" content="ICN Timebank">
     <meta name="mobile-web-app-capable" content="yes">
     <title>ICN Timebank</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=2026050802">
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="/icons/icon-192x192.png">
     <!-- QR Code library for wallet login -->
@@ -680,73 +680,115 @@
                 <!-- Demo Guide Tab (PR 2 — guided demo landing; reads existing app state only, no new endpoint consumers) -->
                 <div id="demo-guide" class="tab-content" role="tabpanel" aria-labelledby="demo-guide-nav-btn">
                     <section class="demo-guide-section" aria-labelledby="demo-guide-heading">
-                        <h2 id="demo-guide-heading">ICN Organizing Committee Demo</h2>
-                        <p class="demo-guide-intro">
-                            You are running ICN's pilot UI as a local organizing-committee demo. ICN is a substrate for cooperative civic coordination, not a timebank app. The <strong>§3 Guided workflow</strong> narrative in <code>docs/pilots/no-cli-organizer-member-rehearsal-workflow.md</code> walks: <strong>standing → action cards → governance → receipts → provenance/evidence</strong>. This page labels exactly what is fixture-backed today, what is still gateway-backed, and what is not implemented in this demo.
-                        </p>
+                        <div class="demo-guide-hero">
+                            <p class="demo-guide-eyebrow">Local demo · Civic coordination substrate</p>
+                            <h2 id="demo-guide-heading">ICN Organizing Committee Demo</h2>
+                            <p class="demo-guide-intro">
+                                You are running ICN's pilot UI as a local organizing-committee demo. ICN is a substrate for cooperative civic coordination, not a timebank app. The <strong>§3 Guided workflow</strong> narrative walks: <strong>standing → action cards → governance → receipts → provenance/evidence</strong>. The cards below label what is fixture-backed today, what is still gateway-backed, and what is not implemented in this demo.
+                            </p>
+                        </div>
 
-                        <h3>Where you are</h3>
-                        <dl class="demo-guide-where">
-                            <dt>Surface</dt><dd>pilot-ui (browser PWA)</dd>
-                            <dt>Gateway</dt><dd id="demo-guide-gateway">— (sign in to populate)</dd>
-                            <dt>Mode</dt><dd id="demo-guide-mode">—</dd>
-                            <dt>Logged-in DID</dt><dd id="demo-guide-did" class="did-display">— (sign in to populate)</dd>
-                        </dl>
+                        <section class="demo-guide-card demo-guide-where-card" data-section="context" aria-labelledby="demo-guide-where-heading">
+                            <div class="demo-guide-card-header">
+                                <h3 id="demo-guide-where-heading">Where you are</h3>
+                                <span class="demo-guide-card-badge">Context</span>
+                            </div>
+                            <dl class="demo-guide-where">
+                                <dt>Surface</dt><dd>pilot-ui (browser PWA)</dd>
+                                <dt>Gateway</dt><dd id="demo-guide-gateway">— (sign in to populate)</dd>
+                                <dt>Mode</dt><dd id="demo-guide-mode">—</dd>
+                                <dt>Logged-in DID</dt><dd id="demo-guide-did" class="did-display">— (sign in to populate)</dd>
+                            </dl>
+                        </section>
 
-                        <h3>Available now in this local demo</h3>
-                        <ul class="demo-guide-list demo-guide-available">
-                            <li>No-gateway demo bootstrap <span class="demo-status">live</span></li>
-                            <li>Demo / local mode banner <span class="demo-status">live</span></li>
-                            <li><a href="#my-standing" data-demo-target="my-standing">My Standing surface</a> <span class="demo-status">live</span></li>
-                            <li><a href="#my-standing" data-demo-target="my-standing">Action Cards surface</a> <span class="demo-status">live</span></li>
-                            <li>Standing fixture <span class="demo-status">fixture</span> <span class="demo-note">committed under <code>web/pilot-ui/fixtures/icn-organizer-demo/standing.json</code></span></li>
-                            <li>Action-card fixture <span class="demo-status">fixture</span> <span class="demo-note">committed under <code>web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json</code></span></li>
-                            <li>Plain-language receipt summary shell <span class="demo-status">live</span> <span class="demo-note">render path via <code>receipts.js</code>; needs gateway data to populate</span></li>
-                        </ul>
+                        <div class="demo-guide-grid">
+                            <section class="demo-guide-card" data-section="available" aria-labelledby="demo-guide-available-heading">
+                                <div class="demo-guide-card-header">
+                                    <h3 id="demo-guide-available-heading">Available now in this local demo</h3>
+                                    <span class="demo-guide-card-badge">Live</span>
+                                </div>
+                                <ul class="demo-guide-list demo-guide-available">
+                                    <li>No-gateway demo bootstrap <span class="demo-status demo-status--live">live</span></li>
+                                    <li>Demo / local mode banner <span class="demo-status demo-status--live">live</span></li>
+                                    <li><a href="#my-standing" data-demo-target="my-standing">My Standing surface</a> <span class="demo-status demo-status--live">live</span></li>
+                                    <li><a href="#my-standing" data-demo-target="my-standing">Action Cards surface</a> <span class="demo-status demo-status--live">live</span></li>
+                                    <li>Standing fixture <span class="demo-status demo-status--fixture">fixture</span> <span class="demo-note">committed under <code>web/pilot-ui/fixtures/icn-organizer-demo/standing.json</code></span></li>
+                                    <li>Action-card fixture <span class="demo-status demo-status--fixture">fixture</span> <span class="demo-note">committed under <code>web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json</code></span></li>
+                                    <li>Plain-language receipt summary shell <span class="demo-status demo-status--live">live</span> <span class="demo-note">render path via <code>receipts.js</code>; needs gateway data to populate</span></li>
+                                </ul>
+                            </section>
 
-                        <h3>Fixture-backed today</h3>
-                        <ul class="demo-guide-list demo-guide-fixture">
-                            <li>Standing</li>
-                            <li>Action cards</li>
-                        </ul>
+                            <section class="demo-guide-card" data-section="fixture" aria-labelledby="demo-guide-fixture-heading">
+                                <div class="demo-guide-card-header">
+                                    <h3 id="demo-guide-fixture-heading">Fixture-backed today</h3>
+                                    <span class="demo-guide-card-badge">Fixture</span>
+                                </div>
+                                <ul class="demo-guide-list demo-guide-fixture">
+                                    <li>Standing</li>
+                                    <li>Action cards</li>
+                                </ul>
+                                <p class="demo-guide-card-note">These two surfaces render committed fictional fixtures and require no running gateway.</p>
+                            </section>
 
-                        <h3>Visible but still gateway-backed / not fixture-backed</h3>
-                        <ul class="demo-guide-list demo-guide-gateway-backed">
-                            <li>Governance proposals / votes</li>
-                            <li>Receipt-chain data</li>
-                            <li>Ledger / history</li>
-                            <li>Members</li>
-                            <li>Trust</li>
-                            <li>Federation</li>
-                        </ul>
+                            <section class="demo-guide-card" data-section="gateway-backed" aria-labelledby="demo-guide-gateway-heading">
+                                <div class="demo-guide-card-header">
+                                    <h3 id="demo-guide-gateway-heading">Visible but still gateway-backed / not fixture-backed</h3>
+                                    <span class="demo-guide-card-badge">Gateway-backed</span>
+                                </div>
+                                <ul class="demo-guide-list demo-guide-gateway-backed">
+                                    <li>Governance proposals / votes</li>
+                                    <li>Receipt-chain data</li>
+                                    <li>Ledger / history</li>
+                                    <li>Members</li>
+                                    <li>Trust</li>
+                                    <li>Federation</li>
+                                </ul>
+                                <p class="demo-guide-card-note">These tabs exist in the UI; without a running gateway they render their existing empty state.</p>
+                            </section>
 
-                        <h3>Not implemented in this demo</h3>
-                        <ul class="demo-guide-list demo-guide-not-implemented">
-                            <li>Backend <code>--demo-mode</code></li>
-                            <li>Full fixture-backed runtime mode</li>
-                            <li>Live federation</li>
-                            <li>Cloud sync</li>
-                            <li>Private-overlay activation</li>
-                            <li>Real holder-label activation</li>
-                            <li>Production deployment</li>
-                            <li>Formal NYCN pilot</li>
-                        </ul>
+                            <section class="demo-guide-card" data-section="not-implemented" aria-labelledby="demo-guide-not-implemented-heading">
+                                <div class="demo-guide-card-header">
+                                    <h3 id="demo-guide-not-implemented-heading">Not implemented in this demo</h3>
+                                    <span class="demo-guide-card-badge">Out of scope</span>
+                                </div>
+                                <ul class="demo-guide-list demo-guide-not-implemented">
+                                    <li>Backend <code>--demo-mode</code></li>
+                                    <li>Full fixture-backed runtime mode</li>
+                                    <li>Live federation</li>
+                                    <li>Cloud sync</li>
+                                    <li>Private-overlay activation</li>
+                                    <li>Real holder-label activation</li>
+                                    <li>Production deployment</li>
+                                    <li>Formal NYCN pilot</li>
+                                </ul>
+                            </section>
 
-                        <h3>Future narrow slices</h3>
-                        <ul class="demo-guide-list demo-guide-future">
-                            <li>Governance proposal / vote fixture slice</li>
-                            <li>Receipt / provenance fixture slice</li>
-                            <li>Ledger / federation only if needed</li>
-                            <li>Backend <code>--demo-mode</code> as a separate broader design pass</li>
-                        </ul>
+                            <section class="demo-guide-card" data-section="future" aria-labelledby="demo-guide-future-heading">
+                                <div class="demo-guide-card-header">
+                                    <h3 id="demo-guide-future-heading">Future narrow slices</h3>
+                                    <span class="demo-guide-card-badge">Planned</span>
+                                </div>
+                                <ul class="demo-guide-list demo-guide-future">
+                                    <li>Governance proposal / vote fixture slice</li>
+                                    <li>Receipt / provenance fixture slice</li>
+                                    <li>Ledger / federation only if needed</li>
+                                    <li>Backend <code>--demo-mode</code> as a separate broader design pass</li>
+                                </ul>
+                            </section>
 
-                        <h3>Non-claims</h3>
-                        <ul class="demo-guide-non-claims">
-                            <li>Demo mode is a UI labeling convention.</li>
-                            <li>Standing and action cards are fictional fixtures, not real participant state.</li>
-                            <li><strong>LIVE</strong> does not mean production — ICN is not production-deployed.</li>
-                            <li>"Not implemented in this demo" means out of scope for this slice.</li>
-                        </ul>
+                            <section class="demo-guide-card" data-section="non-claims" aria-labelledby="demo-guide-non-claims-heading">
+                                <div class="demo-guide-card-header">
+                                    <h3 id="demo-guide-non-claims-heading">Non-claims</h3>
+                                    <span class="demo-guide-card-badge">Read carefully</span>
+                                </div>
+                                <ul class="demo-guide-non-claims">
+                                    <li>Demo mode is a UI labeling convention.</li>
+                                    <li>Standing and action cards are fictional fixtures, not real participant state.</li>
+                                    <li><strong>LIVE</strong> does not mean production — ICN is not production-deployed.</li>
+                                    <li>"Not implemented in this demo" means out of scope for this slice.</li>
+                                </ul>
+                            </section>
+                        </div>
                     </section>
                 </div>
 

--- a/web/pilot-ui/style.css
+++ b/web/pilot-ui/style.css
@@ -5980,6 +5980,138 @@ footer .sync-status.error {
 }
 
 /* ============================================================
+ * Demo mode typography
+ *
+ * The default app uses a system font stack on body but native
+ * <button>/<input> elements fall back to Arial — visible mismatch
+ * across the nav. Force inheritance globally so every interactive
+ * element matches the body. Then establish a clean 5-step type
+ * scale for the demo surfaces (12 / 14 / 16 / 18 / 24 / 28 px) so
+ * titles, body text, badges, and metadata read as a hierarchy
+ * instead of as ten near-equal sizes.
+ * ============================================================ */
+
+button,
+input,
+select,
+textarea {
+    font-family: inherit;
+}
+
+body[data-demo-mode="true"] {
+    font-feature-settings: "kern" 1, "ss01" 0, "ss02" 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+/* App title in the main shell — a touch larger so the hero h2
+   below doesn't dwarf it, but still smaller than a page title. */
+body[data-demo-mode="true"] #app-title-header {
+    font-size: 1.125rem;     /* 18px */
+    line-height: 1.4;
+    font-weight: 700;
+    letter-spacing: -0.005em;
+}
+
+/* Banner message: 14px; the badge to its left is uppercase 12px
+   tracked, so the sentence beside it reads as supporting copy. */
+body[data-demo-mode="true"] #demo-mode-message {
+    font-size: 0.875rem;     /* 14px */
+    line-height: 1.5;
+}
+
+/* Nav: 14px, slightly increased weight when active so the
+   selected tab doesn't fight the body text for attention. */
+body[data-demo-mode="true"] .nav-btn {
+    font-size: 0.875rem;     /* 14px */
+    font-weight: 500;
+    letter-spacing: 0;
+}
+body[data-demo-mode="true"] .nav-btn.active {
+    font-weight: 600;
+}
+
+/* Hero h2: a real page title (28px), tightened line-height. */
+body[data-demo-mode="true"] #demo-guide-heading {
+    font-size: 1.75rem;      /* 28px */
+    line-height: 1.2;
+    letter-spacing: -0.015em;
+    font-weight: 700;
+}
+
+/* Card titles: 18px so they read as titles, not body. */
+body[data-demo-mode="true"] .demo-guide-card-header h3,
+body[data-demo-mode="true"] .demo-tab-placeholder-card h2 {
+    font-size: 1.125rem;     /* 18px */
+    line-height: 1.35;
+    font-weight: 600;
+    letter-spacing: -0.005em;
+}
+
+body[data-demo-mode="true"] .demo-tab-placeholder-card h2 {
+    font-size: 1.5rem;       /* 24px — placeholder is the only thing on the page */
+    line-height: 1.25;
+}
+
+/* Eyebrow + section badge: align both to 12px tracked uppercase
+   so they read as the same visual category instead of two
+   different small-caps treatments. */
+body[data-demo-mode="true"] .demo-guide-eyebrow,
+body[data-demo-mode="true"] .demo-tab-placeholder-eyebrow {
+    font-size: 0.75rem;      /* 12px */
+    line-height: 1.4;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+}
+
+body[data-demo-mode="true"] .demo-guide-card-badge {
+    font-size: 0.75rem;      /* 12px — was 0.7rem */
+    line-height: 1.3;
+    letter-spacing: 0.06em;
+    font-weight: 700;
+    padding: 0.25rem 0.6rem;
+}
+
+/* Status pills on list items: also 12px, distinct via color */
+body[data-demo-mode="true"] .demo-status {
+    font-size: 0.7rem;       /* 11.2px — slightly smaller because they sit inline with body */
+    letter-spacing: 0.05em;
+    font-weight: 700;
+}
+
+/* Body text inside cards: 16px / 1.5 — readable, no surprises */
+body[data-demo-mode="true"] .demo-guide-intro,
+body[data-demo-mode="true"] .demo-tab-placeholder-card p,
+body[data-demo-mode="true"] .demo-guide-card .demo-guide-list li,
+body[data-demo-mode="true"] .demo-guide-card .demo-guide-non-claims li {
+    font-size: 1rem;         /* 16px */
+    line-height: 1.55;
+}
+
+/* Lead paragraph on placeholder cards: 18px, slightly larger than
+   the secondary explanatory paragraph below. */
+body[data-demo-mode="true"] .demo-tab-placeholder-lead {
+    font-size: 1.125rem;     /* 18px */
+    line-height: 1.5;
+}
+
+/* Notes + metadata: 14px, muted — clear secondary tier */
+body[data-demo-mode="true"] .demo-guide-list .demo-note,
+body[data-demo-mode="true"] .demo-guide-card-note,
+body[data-demo-mode="true"] .demo-tab-placeholder-note,
+body[data-demo-mode="true"] .demo-guide-where dt,
+body[data-demo-mode="true"] .demo-guide-where dd {
+    font-size: 0.875rem;     /* 14px */
+    line-height: 1.5;
+}
+
+/* "Where you are" values stay monospace but at the consistent
+   14px size rather than 14.4. */
+body[data-demo-mode="true"] .demo-guide-where dd {
+    font-family: var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+}
+
+/* ============================================================
  * Demo mode global layout
  *
  * The default `main { max-width: 800px }` is too narrow for the

--- a/web/pilot-ui/style.css
+++ b/web/pilot-ui/style.css
@@ -6129,34 +6129,442 @@ body[data-demo-mode="true"] main#main-content {
     max-width: 1200px;
 }
 
-/* Demo-only: let the standing + action-cards sections use the full
-   widened main width instead of the default 80ch reading column. */
+/* ============================================================
+ * Demo-mode My Standing & Action Cards layout redesign
+ *
+ * The default rendering put DID/label in a dl, memberships in a
+ * single line each ("name (id) MEMBER via static_list"), and
+ * action cards as a flex column with title and 3 badges fighting
+ * inside one header row. Result: dense, mushy, low scannability.
+ *
+ * Redesigned (demo-only) so each piece has its own visual region:
+ *  - Standing → identity hero + memberships table + roles cards +
+ *    authority chip cloud
+ *  - Action cards → grid of cards with hierarchy:
+ *      kind & scope (eyebrow)  ·  risk (right pill)
+ *      Title (prominent)
+ *      Summary (body)
+ *      Metadata row (Authority / Scope / Deadline as 3 cells)
+ *      Accessibility callout
+ *      Receipt-expected footer
+ * ============================================================ */
+
+/* Let the section escape the 80ch reading clamp */
 body[data-demo-mode="true"] .member-standing-section,
 body[data-demo-mode="true"] .member-action-cards-section {
     max-width: none;
 }
 
-/* Demo-only: render the action-cards list as a responsive grid so
-   each card has room to breathe and the section doesn't read as a
-   single tall column floating in empty page. */
-body[data-demo-mode="true"] .member-action-cards-list {
+/* Section headings ("My Standing", "Action Cards") become real
+   page titles instead of small h2 mixed with body text. */
+body[data-demo-mode="true"] .member-standing-section > h2,
+body[data-demo-mode="true"] .member-action-cards-section > h2 {
+    font-size: 1.5rem;          /* 24px */
+    line-height: 1.25;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 0.4rem 0;
+}
+
+body[data-demo-mode="true"] .member-standing-intro,
+body[data-demo-mode="true"] .member-action-cards-intro {
+    max-width: 65ch;
+    font-size: 0.9375rem;       /* 15px */
+    line-height: 1.55;
+    color: var(--text-secondary);
+    margin: 0 0 1.25rem 0;
+}
+
+/* === Standing identity hero === */
+body[data-demo-mode="true"] .standing-id-block {
+    display: block;
+    background: linear-gradient(135deg,
+        rgba(37, 99, 235, 0.07) 0%,
+        rgba(37, 99, 235, 0.02) 100%);
+    border: 1px solid var(--border-color);
+    border-left: 4px solid var(--primary);
+    border-radius: 10px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.25rem;
+}
+
+body[data-demo-mode="true"] .standing-id-block dt {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--primary-dark);
+    margin-top: 0.6rem;
+}
+
+body[data-demo-mode="true"] .standing-id-block dt:first-of-type {
+    margin-top: 0;
+}
+
+body[data-demo-mode="true"] .standing-id-block dd {
+    display: block;
+    margin: 0.15rem 0 0 0;
+    font-size: 1rem;
+    line-height: 1.4;
+    color: var(--text-primary);
+}
+
+body[data-demo-mode="true"] .standing-id-block dd.did-display {
+    font-family: var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    word-break: break-all;
+}
+
+/* === Section group heading inside standing ("Domain memberships",
+       "Role assignments", "Authority scopes (union)") === */
+body[data-demo-mode="true"] .member-standing-content > h3 {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    margin: 1.25rem 0 0.6rem 0;
+    padding: 0;
+    border: none;
+}
+
+/* === Domain memberships: tabular row layout === */
+body[data-demo-mode="true"] .standing-domain-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+}
+
+body[data-demo-mode="true"] .standing-domain {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+        "name   status"
+        "id     source";
+    gap: 0.15rem 1rem;
+    padding: 0.85rem 1.15rem;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    line-height: 1.4;
+}
+
+body[data-demo-mode="true"] .standing-domain + .standing-domain {
+    border-top: 1px solid var(--border-color);
+}
+
+body[data-demo-mode="true"] .standing-domain > strong {
+    grid-area: name;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+body[data-demo-mode="true"] .standing-domain-id {
+    grid-area: id;
+    margin-left: 0;
+    font-family: var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+    font-size: 0.8rem;
+    color: var(--text-tertiary);
+}
+
+body[data-demo-mode="true"] .standing-domain .standing-status {
+    grid-area: status;
+    align-self: center;
+    margin-left: 0;
+    padding: 0.22rem 0.6rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+}
+
+body[data-demo-mode="true"] .standing-status-member {
+    background: rgba(22, 163, 74, 0.12);
+    color: #15803d;
+    border-color: rgba(22, 163, 74, 0.30);
+}
+
+body[data-demo-mode="true"] .standing-status-unverified {
+    background: rgba(245, 158, 11, 0.12);
+    color: #b45309;
+    border-color: rgba(245, 158, 11, 0.30);
+}
+
+body[data-demo-mode="true"] .standing-domain .standing-source {
+    grid-area: source;
+    margin-left: 0;
+    text-align: right;
+    font-size: 0.8rem;
+    color: var(--text-tertiary);
+    font-style: italic;
+}
+
+/* === Role assignments: card grid === */
+body[data-demo-mode="true"] .standing-role-list {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    gap: 0.75rem;
+}
+
+body[data-demo-mode="true"] .standing-role {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-left: 3px solid var(--primary);
+    border-radius: 10px;
+    padding: 1rem 1.15rem;
+    box-shadow: var(--shadow-sm);
+    line-height: 1.5;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+body[data-demo-mode="true"] .standing-role > strong {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--primary-dark);
+}
+
+body[data-demo-mode="true"] .standing-role-structure {
+    margin-left: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    /* Strip the leading " in " prefix the renderer adds */
+    color: var(--text-primary);
+}
+
+body[data-demo-mode="true"] .standing-role-scope {
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    align-items: center;
+}
+
+body[data-demo-mode="true"] .standing-role-scope-label {
+    color: var(--text-tertiary);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-right: 0.15rem;
+}
+
+/* === Authority chip styling (used in roles + union) === */
+body[data-demo-mode="true"] .standing-scope-badge {
+    display: inline-flex;
+    align-items: center;
+    margin: 0;
+    padding: 0.18rem 0.55rem;
+    background: rgba(37, 99, 235, 0.10);
+    color: #1d4ed8;
+    border: 1px solid rgba(37, 99, 235, 0.25);
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-family: var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+}
+
+/* Authority union: chip cloud */
+body[data-demo-mode="true"] .standing-scope-union {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.85rem 1rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+}
+
+/* === Action cards: redesigned card layout === */
+body[data-demo-mode="true"] .member-action-cards-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(22rem, 1fr));
     gap: 1rem;
+    align-items: stretch;
 }
 
 body[data-demo-mode="true"] .member-action-card {
     background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.25rem 1.4rem 1.4rem 1.4rem;
     box-shadow: var(--shadow-sm);
-    border-radius: 10px;
-    padding: 1.1rem 1.25rem;
+    line-height: 1.55;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    border-top: 4px solid var(--card-accent, var(--gray-300));
 }
 
-/* Tighten the standing description so it doesn't read as a wall
-   of dense text running edge-to-edge. */
-body[data-demo-mode="true"] .member-standing-intro {
-    max-width: 70ch;
-    line-height: 1.6;
+/* Per-card accent on the top stripe — driven by risk level by default,
+   set on the article via a CSS attribute selector */
+body[data-demo-mode="true"] .member-action-card:has(.badge-risk-low) {
+    --card-accent: #16a34a;
+}
+body[data-demo-mode="true"] .member-action-card:has(.badge-risk-normal) {
+    --card-accent: #2563eb;
+}
+body[data-demo-mode="true"] .member-action-card:has(.badge-risk-elevated) {
+    --card-accent: #dc2626;
+}
+
+/* Header: kind/scope eyebrow on left, risk pill on right */
+body[data-demo-mode="true"] .member-action-card-header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem 1rem;
+    align-items: start;
+    margin: 0;
+}
+
+body[data-demo-mode="true"] .member-action-card-header h4 {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    margin: 0;
+    font-size: 1.0625rem;        /* 17px — prominent title */
+    line-height: 1.35;
+    font-weight: 600;
+    letter-spacing: -0.005em;
+    color: var(--text-primary);
+}
+
+body[data-demo-mode="true"] .member-action-card-badges {
+    grid-row: 1;
+    grid-column: 1 / -1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+    justify-content: flex-start;
+}
+
+/* Kind / source = small-caps eyebrow, no background; risk = colored
+   pill, on the right of the row. */
+body[data-demo-mode="true"] .member-action-card .badge {
+    padding: 0.18rem 0.55rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    border-radius: 999px;
+    border: 1px solid transparent;
+}
+
+body[data-demo-mode="true"] .member-action-card .badge-source,
+body[data-demo-mode="true"] .member-action-card .badge-action {
+    background: transparent;
+    border-color: var(--border-color);
+    color: var(--text-secondary);
+}
+
+body[data-demo-mode="true"] .member-action-card .badge-risk-low {
+    background: rgba(22, 163, 74, 0.12);
+    color: #15803d;
+    border-color: rgba(22, 163, 74, 0.30);
+    margin-left: auto;
+}
+body[data-demo-mode="true"] .member-action-card .badge-risk-normal {
+    background: rgba(37, 99, 235, 0.12);
+    color: #1d4ed8;
+    border-color: rgba(37, 99, 235, 0.30);
+    margin-left: auto;
+}
+body[data-demo-mode="true"] .member-action-card .badge-risk-elevated {
+    background: rgba(220, 38, 38, 0.12);
+    color: #b91c1c;
+    border-color: rgba(220, 38, 38, 0.30);
+    margin-left: auto;
+}
+
+body[data-demo-mode="true"] .member-action-card-summary {
+    margin: 0;
+    font-size: 0.9375rem;        /* 15px — body slightly smaller than title */
+    color: var(--text-secondary);
+    line-height: 1.55;
+}
+
+/* Authority metadata: 3-cell row instead of dl pairs */
+body[data-demo-mode="true"] .member-action-card-authority {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    gap: 0.65rem 1rem;
+    margin: 0;
+    padding: 0.85rem 0;
+    background: transparent;
+    border-top: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
+    font-size: 0.85rem;
+}
+
+body[data-demo-mode="true"] .member-action-card-authority dt {
+    margin: 0;
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+}
+
+body[data-demo-mode="true"] .member-action-card-authority dd {
+    margin: 0.2rem 0 0 0;
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    line-height: 1.4;
+}
+
+/* Accessibility callout: distinct quote-like block */
+body[data-demo-mode="true"] .member-action-card-accessibility {
+    margin: 0;
+    padding: 0.65rem 0.85rem;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+}
+
+body[data-demo-mode="true"] .member-action-card-accessibility strong {
+    color: var(--text-primary);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+/* Receipt-expected footer: full-width subtle pill */
+body[data-demo-mode="true"] .member-action-card-receipt-expected {
+    margin: 0;
+    padding: 0.6rem 0.85rem;
+    background: rgba(22, 163, 74, 0.08);
+    border: 1px solid rgba(22, 163, 74, 0.25);
+    border-left-width: 3px;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    color: #15803d;
+    font-weight: 500;
+}
+
+/* Dark-theme adjustments for the redesigned standing/action layouts */
+[data-theme="dark"] body[data-demo-mode="true"] .standing-id-block {
+    background: linear-gradient(135deg,
+        rgba(59, 130, 246, 0.12) 0%,
+        rgba(59, 130, 246, 0.04) 100%);
+}
+[data-theme="dark"] body[data-demo-mode="true"] .standing-domain-list,
+[data-theme="dark"] body[data-demo-mode="true"] .standing-role,
+[data-theme="dark"] body[data-demo-mode="true"] .member-action-card {
+    background: var(--bg-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
 /* Demo-only "this surface is gateway-backed and not fixture-backed"

--- a/web/pilot-ui/style.css
+++ b/web/pilot-ui/style.css
@@ -5675,6 +5675,9 @@ footer .sync-status.error {
     padding: 0.5rem;
     background: var(--background);
     border-radius: 4px;
+}
+
+/* ============================================================================
    Inline Receipt Chain (Proposal Detail Sidebar) — P0-T11
    ============================================================================ */
 
@@ -5976,135 +5979,369 @@ footer .sync-status.error {
     min-width: 0;
 }
 
-/* Demo Guide tab content */
+/* ============================================================
+ * Demo Guide visual hierarchy
+ *
+ * Card-based layout for ?mode=demo's organizing-committee landing.
+ * Each section is a self-contained card with a colored accent and a
+ * section badge so the eye can scan: Live / Fixture / Gateway-backed /
+ * Out of scope / Planned / Read-carefully. Light + dark theme aware
+ * via the existing CSS variables.
+ * ============================================================ */
+
 .demo-guide-section {
-    max-width: 80ch;
-    padding: 1rem 0;
+    max-width: 76rem;
+    margin: 0 auto;
+    padding: 1.25rem 1rem 2.5rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
 }
 
-.demo-guide-section h2 {
-    margin: 0 0 0.5rem 0;
+/* Hero block */
+.demo-guide-hero {
+    background: linear-gradient(135deg,
+        rgba(37, 99, 235, 0.07) 0%,
+        rgba(37, 99, 235, 0.02) 100%);
+    border: 1px solid var(--border-color);
+    border-left: 4px solid var(--primary);
+    border-radius: 10px;
+    padding: 1.5rem 1.75rem;
 }
 
-.demo-guide-section h3 {
-    margin-top: 1.5rem;
-    margin-bottom: 0.75rem;
-    border-bottom: 1px solid var(--border-color, #e5e7eb);
-    padding-bottom: 0.25rem;
+.demo-guide-eyebrow {
+    margin: 0 0 0.4rem 0;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--primary);
+}
+
+.demo-guide-section h2#demo-guide-heading {
+    margin: 0 0 0.6rem 0;
+    font-size: 1.65rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    line-height: 1.2;
 }
 
 .demo-guide-intro {
-    font-size: 1.05rem;
-    line-height: 1.6;
-    margin-bottom: 1rem;
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.65;
+    color: var(--text-secondary);
+    max-width: 75ch;
 }
 
+/* Section card — shared shell */
+.demo-guide-card {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1.25rem 1.5rem;
+    box-shadow: var(--shadow-sm);
+    --section-accent: var(--gray-400);
+    border-left: 4px solid var(--section-accent);
+}
+
+.demo-guide-card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0 0 0.85rem 0;
+    flex-wrap: wrap;
+}
+
+.demo-guide-card-header h3 {
+    margin: 0;
+    padding: 0;
+    border: none;
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: 1.3;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.demo-guide-card-badge {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    background: var(--section-accent-bg, var(--bg-tertiary));
+    color: var(--section-accent-text, var(--text-secondary));
+    border: 1px solid var(--section-accent-border, var(--border-color));
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+.demo-guide-card-note {
+    margin: 0.85rem 0 0 0;
+    font-size: 0.85rem;
+    color: var(--text-tertiary);
+    line-height: 1.5;
+    font-style: italic;
+}
+
+/* Per-section accents */
+.demo-guide-card[data-section="context"] {
+    --section-accent: var(--primary);
+    --section-accent-bg: rgba(37, 99, 235, 0.10);
+    --section-accent-text: var(--primary-dark);
+    --section-accent-border: rgba(37, 99, 235, 0.25);
+}
+
+.demo-guide-card[data-section="available"] {
+    --section-accent: #16a34a;
+    --section-accent-bg: rgba(22, 163, 74, 0.10);
+    --section-accent-text: #15803d;
+    --section-accent-border: rgba(22, 163, 74, 0.30);
+}
+
+.demo-guide-card[data-section="fixture"] {
+    --section-accent: #7c3aed;
+    --section-accent-bg: rgba(124, 58, 237, 0.10);
+    --section-accent-text: #6d28d9;
+    --section-accent-border: rgba(124, 58, 237, 0.30);
+}
+
+.demo-guide-card[data-section="gateway-backed"] {
+    --section-accent: #f59e0b;
+    --section-accent-bg: rgba(245, 158, 11, 0.10);
+    --section-accent-text: #b45309;
+    --section-accent-border: rgba(245, 158, 11, 0.30);
+}
+
+.demo-guide-card[data-section="not-implemented"] {
+    --section-accent: var(--gray-400);
+    --section-accent-bg: var(--gray-100);
+    --section-accent-text: var(--text-tertiary);
+    --section-accent-border: var(--border-color);
+    background: var(--bg-secondary);
+}
+
+.demo-guide-card[data-section="future"] {
+    --section-accent: #0891b2;
+    --section-accent-bg: rgba(8, 145, 178, 0.10);
+    --section-accent-text: #0e7490;
+    --section-accent-border: rgba(8, 145, 178, 0.30);
+}
+
+.demo-guide-card[data-section="non-claims"] {
+    --section-accent: var(--gray-500);
+    --section-accent-bg: var(--gray-100);
+    --section-accent-text: var(--text-secondary);
+    --section-accent-border: var(--border-color);
+    background: var(--bg-secondary);
+}
+
+/* Where-you-are panel: 2-col definition list inside the context card */
 .demo-guide-where {
     display: grid;
     grid-template-columns: max-content 1fr;
-    gap: 0.5rem 1rem;
-    margin: 0.75rem 0;
-    padding: 0.75rem 1rem;
-    background: var(--bg-secondary, #f9fafb);
-    border-radius: 6px;
-    border: 1px solid var(--border-color, #e5e7eb);
+    gap: 0.5rem 1.25rem;
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    border: none;
 }
 
 .demo-guide-where dt {
     font-weight: 600;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
 }
 
 .demo-guide-where dd {
     margin: 0;
     font-family: var(--mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
     font-size: 0.9rem;
+    color: var(--text-primary);
 }
 
 .demo-guide-where .did-display {
     word-break: break-all;
 }
 
-.demo-guide-note {
-    font-size: 0.9rem;
-    color: var(--text-secondary, #6b7280);
-    font-style: italic;
+/* Two-column responsive grid for the section cards */
+.demo-guide-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(22rem, 1fr));
+    gap: 1rem;
+    align-items: stretch;
 }
 
-.demo-guide-list {
-    padding-left: 0;
+.demo-guide-grid > .demo-guide-card {
+    display: flex;
+    flex-direction: column;
+}
+
+.demo-guide-grid > .demo-guide-card > ul {
+    flex: 1 0 auto;
+}
+
+/* Lists inside the cards: clean separators, no dashed borders */
+.demo-guide-card .demo-guide-list,
+.demo-guide-card .demo-guide-non-claims {
+    margin: 0;
+    padding: 0;
     list-style: none;
-    margin: 0.5rem 0;
 }
 
-.demo-guide-list li {
-    padding: 0.4rem 0;
-    border-bottom: 1px dashed var(--border-color, #e5e7eb);
-    line-height: 1.5;
+.demo-guide-card .demo-guide-list li,
+.demo-guide-card .demo-guide-non-claims li {
+    padding: 0.45rem 0;
+    line-height: 1.55;
+    color: var(--text-primary);
+    border: none;
+    margin: 0;
 }
 
-.demo-guide-list li:last-child {
-    border-bottom: none;
+.demo-guide-card .demo-guide-list li + li,
+.demo-guide-card .demo-guide-non-claims li + li {
+    border-top: 1px solid var(--border-color);
 }
 
-.demo-guide-list a {
-    color: var(--link-color, #2563eb);
-    text-decoration: underline;
+.demo-guide-card .demo-guide-list a {
+    color: var(--primary);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--primary);
 }
 
-.demo-guide-available .demo-status,
-.demo-guide-coming .demo-status {
+.demo-guide-card .demo-guide-list a:hover,
+.demo-guide-card .demo-guide-list a:focus {
+    border-bottom-style: solid;
+    color: var(--primary-dark);
+}
+
+/* Status pills on individual list items */
+.demo-status {
     display: inline-block;
     margin-left: 0.4rem;
-    padding: 0.1rem 0.5rem;
-    border-radius: 3px;
-    font-size: 0.78rem;
-    font-weight: 600;
+    padding: 0.12rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.05em;
+    line-height: 1.4;
+    vertical-align: 0.05em;
+    border: 1px solid transparent;
+    white-space: nowrap;
 }
 
-.demo-guide-available .demo-status {
+.demo-status--live {
     background: rgba(22, 163, 74, 0.14);
     color: #15803d;
+    border-color: rgba(22, 163, 74, 0.25);
 }
 
-.demo-guide-coming .demo-status {
-    background: rgba(245, 158, 11, 0.14);
-    color: #b45309;
+.demo-status--fixture {
+    background: rgba(124, 58, 237, 0.14);
+    color: #6d28d9;
+    border-color: rgba(124, 58, 237, 0.25);
 }
 
-.demo-guide-not-implemented {
-    color: var(--text-secondary, #6b7280);
-}
-
-.demo-guide-not-implemented li::before {
-    content: "✕ ";
-    color: #9ca3af;
-    margin-right: 0.25rem;
-    font-weight: 700;
-}
-
+/* Inline note below an item */
 .demo-guide-list .demo-note {
     display: block;
     font-size: 0.85rem;
-    color: var(--text-secondary, #6b7280);
-    margin-top: 0.15rem;
+    color: var(--text-tertiary);
+    margin-top: 0.2rem;
+    line-height: 1.5;
 }
 
+/* "Not implemented" items — quieter without being illegible */
+.demo-guide-not-implemented li {
+    color: var(--text-secondary);
+}
+
+.demo-guide-not-implemented li::before {
+    content: "—  ";
+    color: var(--gray-400);
+    font-weight: 600;
+}
+
+/* Non-claims list: keep disc bullets but inside the card */
 .demo-guide-non-claims {
-    background: var(--bg-secondary, #f9fafb);
-    border-left: 3px solid var(--demo-banner-color, #2563eb);
-    padding: 0.75rem 1rem 0.75rem 1.25rem;
-    margin-top: 1rem;
-    list-style: disc;
+    list-style: none;
+    padding: 0;
+    margin: 0;
 }
 
 .demo-guide-non-claims li {
-    margin-bottom: 0.5rem;
+    position: relative;
+    padding-left: 1.25rem;
 }
 
-.demo-guide-non-claims li:last-child {
-    margin-bottom: 0;
+.demo-guide-non-claims li::before {
+    content: "•";
+    position: absolute;
+    left: 0.25rem;
+    top: 0.45rem;
+    color: var(--gray-500);
+    font-weight: 700;
+}
+
+/* Inline code inside the demo guide */
+.demo-guide-section code {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    padding: 0.05rem 0.35rem;
+    border-radius: 3px;
+    font-size: 0.85em;
+    color: var(--text-primary);
+}
+
+/* Dark mode tweaks: lift the card backgrounds away from the page bg */
+[data-theme="dark"] .demo-guide-card {
+    background: var(--bg-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .demo-guide-card[data-section="not-implemented"],
+[data-theme="dark"] .demo-guide-card[data-section="non-claims"] {
+    background: var(--bg-secondary);
+}
+
+[data-theme="dark"] .demo-guide-hero {
+    background: linear-gradient(135deg,
+        rgba(59, 130, 246, 0.10) 0%,
+        rgba(59, 130, 246, 0.03) 100%);
+}
+
+/* Narrow-screen tightening */
+@media (max-width: 720px) {
+    .demo-guide-section {
+        padding: 1rem 0.75rem 2rem 0.75rem;
+        gap: 1rem;
+    }
+    .demo-guide-hero {
+        padding: 1.25rem 1rem;
+    }
+    .demo-guide-section h2#demo-guide-heading {
+        font-size: 1.35rem;
+    }
+    .demo-guide-card {
+        padding: 1rem 1.1rem;
+    }
+    .demo-guide-grid {
+        grid-template-columns: 1fr;
+    }
+    .demo-guide-where {
+        grid-template-columns: 1fr;
+        gap: 0.15rem 0;
+    }
+    .demo-guide-where dt {
+        margin-top: 0.4rem;
+    }
 }
 
 /* ============================================================

--- a/web/pilot-ui/style.css
+++ b/web/pilot-ui/style.css
@@ -5980,6 +5980,129 @@ footer .sync-status.error {
 }
 
 /* ============================================================
+ * Demo mode global layout
+ *
+ * The default `main { max-width: 800px }` is too narrow for the
+ * Demo Guide's 2-col card grid and for the action-cards surface.
+ * Widen main only when ?mode=demo flagged the body, so non-demo
+ * pages stay at their original 800px reading width.
+ * ============================================================ */
+
+body[data-demo-mode="true"] main {
+    max-width: 1200px;
+    padding: 1.5rem 1.75rem;
+}
+
+body[data-demo-mode="true"] main#main-content {
+    max-width: 1200px;
+}
+
+/* Demo-only: let the standing + action-cards sections use the full
+   widened main width instead of the default 80ch reading column. */
+body[data-demo-mode="true"] .member-standing-section,
+body[data-demo-mode="true"] .member-action-cards-section {
+    max-width: none;
+}
+
+/* Demo-only: render the action-cards list as a responsive grid so
+   each card has room to breathe and the section doesn't read as a
+   single tall column floating in empty page. */
+body[data-demo-mode="true"] .member-action-cards-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    gap: 1rem;
+}
+
+body[data-demo-mode="true"] .member-action-card {
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-sm);
+    border-radius: 10px;
+    padding: 1.1rem 1.25rem;
+}
+
+/* Tighten the standing description so it doesn't read as a wall
+   of dense text running edge-to-edge. */
+body[data-demo-mode="true"] .member-standing-intro {
+    max-width: 70ch;
+    line-height: 1.6;
+}
+
+/* Demo-only "this surface is gateway-backed and not fixture-backed"
+   placeholder used in Governance, Federation, and Receipts tabs.
+   Same visual language as the Demo Guide's gateway-backed card so
+   the page reads as deliberately scoped, not broken. */
+.demo-tab-placeholder {
+    max-width: 64rem;
+    margin: 1.5rem auto;
+    padding: 0 0.5rem;
+}
+
+.demo-tab-placeholder-card {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-left: 4px solid #f59e0b;
+    border-radius: 10px;
+    padding: 2rem 2.25rem 2.25rem 2.25rem;
+    box-shadow: var(--shadow-sm);
+}
+
+.demo-tab-placeholder-eyebrow {
+    margin: 0 0 0.4rem 0;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #b45309;
+}
+
+.demo-tab-placeholder-card h2 {
+    margin: 0 0 1rem 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    line-height: 1.25;
+}
+
+.demo-tab-placeholder-lead {
+    margin: 0 0 0.85rem 0;
+    font-size: 1.05rem;
+    color: var(--text-primary);
+    line-height: 1.5;
+}
+
+.demo-tab-placeholder-card p {
+    line-height: 1.65;
+    color: var(--text-secondary);
+    max-width: 62ch;
+    margin: 0 0 0.85rem 0;
+}
+
+.demo-tab-placeholder-note {
+    margin: 1.25rem 0 0 0 !important;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+    font-size: 0.9rem;
+    color: var(--text-tertiary);
+}
+
+.demo-tab-placeholder-note a {
+    color: var(--primary);
+    font-weight: 600;
+    text-decoration: none;
+    border-bottom: 1px dotted var(--primary);
+}
+
+.demo-tab-placeholder-note a:hover,
+.demo-tab-placeholder-note a:focus {
+    border-bottom-style: solid;
+    color: var(--primary-dark);
+}
+
+[data-theme="dark"] .demo-tab-placeholder-card {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+
+/* ============================================================
  * Demo Guide visual hierarchy
  *
  * Card-based layout for ?mode=demo's organizing-committee landing.

--- a/web/pilot-ui/sw.js
+++ b/web/pilot-ui/sw.js
@@ -7,7 +7,7 @@
 // changes meaningfully so existing installs reliably pick up the new bundle.
 // The activate event purges any cache whose name doesn't match the current
 // CACHE_VERSION, which forces clients off the old asset set.
-const CACHE_VERSION = 'icn-timebank-v1.1';
+const CACHE_VERSION = 'icn-timebank-v1.2';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const API_CACHE = `${CACHE_VERSION}-api`;
@@ -17,6 +17,7 @@ const STATIC_ASSETS = [
     '/',
     '/index.html',
     '/style.css',
+    '/style.css?v=2026050802',
     '/app.js',
     '/offline-storage.js',
     '/manifest.json',

--- a/web/pilot-ui/sw.js
+++ b/web/pilot-ui/sw.js
@@ -3,7 +3,11 @@
  * Provides offline support, caching, and background sync
  */
 
-const CACHE_VERSION = 'icn-timebank-v1.0';
+// Bump CACHE_VERSION whenever a static asset (style.css, app.js, index.html)
+// changes meaningfully so existing installs reliably pick up the new bundle.
+// The activate event purges any cache whose name doesn't match the current
+// CACHE_VERSION, which forces clients off the old asset set.
+const CACHE_VERSION = 'icn-timebank-v1.1';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const API_CACHE = `${CACHE_VERSION}-api`;


### PR DESCRIPTION
## Why

Manual visual inspection of `http://localhost:8765/?mode=demo` after #1775 merged showed the Demo Guide rendered as a wall of unstyled text. The page-source/server side was correct (cards, sections, copy) but nothing was actually styled.

**Root cause:** a pre-existing CSS parse error in `style.css` at line 5670 — the `#wizard-did-display` rule was missing its closing `}` and the comment that followed was missing its `/*` opener. The browser CSS parser silently dropped every rule after that point, including the demo-guide selectors landed in #1770 / #1771 / #1775.

```css
#wizard-did-display {
    ...
    border-radius: 4px;
   Inline Receipt Chain (Proposal Detail Sidebar) — P0-T11   /* never closed */
   ============================================================================ */
```

Verified via the browser CSS Object Model: stylesheet parsed **704 rules** before the fix, **835 rules** after.

## What changed (in `?mode=demo` only)

### Pre-existing parse-error fix
Closed `#wizard-did-display { … }` properly and reopened the next section comment with `/*`. This is the root cause; without it, no demo-guide CSS would apply.

### Demo Guide visual hierarchy
- Hero block with eyebrow (`Local demo · Civic coordination substrate`), gradient background, primary-color left accent.
- Each existing section becomes a `.demo-guide-card` with a `data-section` attribute that drives a per-section accent color and badge:

| Section | Accent | Badge |
|--|--|--|
| Where you are | primary blue | `Context` |
| Available now in this local demo | green | `Live` |
| Fixture-backed today | purple | `Fixture` |
| Visible but still gateway-backed | amber | `Gateway-backed` |
| Not implemented in this demo | gray (dimmed) | `Out of scope` |
| Future narrow slices | cyan | `Planned` |
| Non-claims | neutral (dimmed) | `Read carefully` |

- Responsive `auto-fit, minmax(22rem, 1fr)` grid: two columns on wide viewports, one on narrow.
- Status pills on individual list items: `.demo-status--live` (green) and `.demo-status--fixture` (purple).
- "Not implemented" items get a quiet em-dash marker instead of an alarming `✕`; muted text so the section reads as out-of-scope rather than failure.
- Narrow-screen tightening at `≤720px`: single column, tighter hero, where-you-are collapses to one column.
- Light + dark theme support via existing CSS variables.

### Tag fixes
- `.demo-guide-hero` and `.demo-guide-card-header` were originally `<header>`. The global `header { display: flex; justify-content: space-between; … }` rule (line 625) hijacked them and split children across the row. Switched to `<div>`.
- Added `?v=2026050802` to the `<link rel=\"stylesheet\">` so the PWA service worker stops serving the old CSS to existing users.

## What did not change

- **No new fixtures, no backend, no runtime mode, no issue edits, no Rust touched.**
- Demo-mode shell behavior from #1775 (title swap, nav hiding, banner copy, no-gateway bootstrap) is unchanged.
- Demo Guide copy is unchanged in meaning (only one tiny wording tweak: removed the now-redundant \"Logged-in DID\" note since the hero already implies it).
- Non-demo path is unchanged.

## Validation

- `node --check` on `app.js` and both e2e specs — clean
- `python3 -m json.tool` on both fixture JSON files — clean (unchanged)
- No Rust / Cargo files in diff
- Leak / overclaim grep — only legitimate non-claim contexts hit
- `git diff --check` — clean
- Fresh-load Playwright smoke test on `http://localhost:8765/?mode=demo` — 6 styled cards rendered, distinct accents, working status pills, no broken hero
- CSS parser sanity — **835 rules parsed (up from 704)** confirms the parse-error fix landed

Existing test selectors (`.demo-guide-non-claims`, `.demo-guide-gateway-backed`, `.demo-guide-fixture`, `.demo-guide-future`, `#demo-guide-mode`, `#demo-guide-heading`, `aria-labelledby=\"demo-guide-nav-btn\"`) remain valid; classes/ids are preserved on the existing list/heading elements that are now wrapped in cards.

## Local inspection

```bash
cd /home/matt/projects/icn/web/pilot-ui
python3 -m http.server 8765
# http://localhost:8765/?mode=demo
```

If you have an old session running, hard-reload (Ctrl+Shift+R) — the `?v=2026050802` query on the new stylesheet link bypasses the service-worker cache.

## Recommended next

Pause here and let Matt visually inspect again before starting the governance proposal/vote fixture slice.

The tool-library demo remains dev scaffolding, not the ICN demo.