### PR TITLE
docs(web,pilot-ui): sync public surfaces with current Phase 2 truth

### DIFF
--- a/web/pilot-ui/README.md
+++ b/web/pilot-ui/README.md
@@ -1,375 +1,151 @@
-# ICN Pilot Web UI
+# ICN Pilot UI
 
-A user-friendly web interface for ICN pilot communities to manage their timebank or mutual credit system.
+The ICN Pilot UI is the current organizer/member demo surface for ICN. It is a static HTML/CSS/JS application used to inspect member standing, action cards, governance activity, action items, receipts, and provenance through the ICN gateway or through bounded demo fixtures.
 
-## 🚀 Quick Start
+This is a pilot-stage interface for showing how ICN turns institutional standing and democratic decisions into action cards and receipt-backed evidence. It is not a production product.
 
-**New to ICN?** Choose your path:
+## Current status
 
-- **🎯 I want to test locally (5 minutes)**: [Getting Started Guide](GETTING-STARTED.md)
-- **🏢 I want to deploy for my cooperative**: [Production Deployment](PRODUCTION-DEPLOY.md)
-- **📋 I'm deploying to production**: [Deployment Checklist](DEPLOYMENT-CHECKLIST.md)
-- **📚 I want to learn everything**: [Complete Summary](SUMMARY.md)
+As of the current Phase 2 framing:
 
-**Deployment Scripts**:
-- `./deploy-ui.sh` - Simple UI deployment (Python/Node/Docker)
-- `./seed-demo-data.sh` - Populate with sample data for testing
-- `../../deploy/quickstart.sh` - Complete ICN + UI setup with Docker
+- Phase 0 is complete.
+- Phase 1 is complete.
+- Phase 2 is in progress and not complete.
+- NYCN is the intended first cooperative partner and active partnership track, not a formal pilot.
+- Member standing is a real gateway read model.
+- Action cards are a real gateway read model.
+- `?mode=demo` can render fixture-backed member standing and action cards without requiring a live gateway login.
+- Governance, receipts, ledger, members, trust, and federation are not yet fully fixture-backed in demo mode.
 
-**User Documentation**:
-- [Quick Start for Members](QUICK-START.md) - 5-minute onboarding
-- [Treasurer's Guide](TREASURER-GUIDE.md) - Financial management
-- [Admin Guide](ADMIN-GUIDE.md) - System administration
-- [FAQ](FAQ.md) - Common questions answered
+Use the current truth anchors before making capability claims:
 
----
+- `docs/STATE.md`
+- `docs/PHASE_PROGRESS.md`
+- `docs/reference/project-index/current-truth-map.md`
+- `docs/reference/project-index/runtime-surface-map.md`
+- `docs/reference/project-index/show-readiness-map.md`
+- `docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md`
 
-## Features
+## What this UI is for
 
-- **Dashboard**: View balance, member count, and recent activity
-- **Log Hours**: Record service hours provided to other members
-- **History**: View all transactions
-- **Members**: See community member list
-- **Governance**: Vote on proposals and view community decisions
-- **Real-time Updates**: WebSocket notifications for instant updates
-- **User-Friendly Errors**: Clear, helpful error messages instead of technical jargon
-- **Token Management**: Visual token expiration warnings
-- **Auth Help**: Step-by-step guide to getting authentication tokens
-- **Toast Notifications**: Non-intrusive success/error messages
+The Pilot UI helps answer a member or organizer's first practical questions:
 
-## Recent Improvements (Phase 1 Enhancements)
+- Who am I in this institution?
+- What domains, roles, and authority scopes are attached to my standing?
+- What action cards require my attention?
+- Which governance decisions or action items are connected to those cards?
+- Which receipts and provenance records prove what happened?
 
-### 1. Better Authentication Experience
-- **"How do I get a token?" button** - Opens modal with step-by-step instructions
-- **Copy-to-clipboard** functionality for auth commands
-- **Token expiration tracking** - Shows countdown in header
-- **Auto-expiration warnings** - Alerts at 15, 10, and 5 minutes before expiry
-- **Expired token detection** - Prevents login with expired tokens
+The strongest current story is:
 
-### 2. User-Friendly Error Messages
-All technical errors are now translated to helpful messages:
-- ❌ `401 Unauthorized` → ✅ "Your session has expired. Please sign in again."
-- ❌ `403 Forbidden` → ✅ "You don't have permission to do that. Check with your administrator."
-- ❌ `429 Too Many Requests` → ✅ "Too many requests. Please wait a moment and try again."
-- ❌ `NetworkError` → ✅ "Cannot connect to the server. Please check your internet connection."
+```text
+standing -> action cards -> governance action -> receipt -> provenance
+```
 
-### 3. Toast Notification System
-Modern, non-blocking notifications for:
-- ✅ Successful actions (green border)
-- ❌ Errors (red border)
-- ⚠️ Warnings (yellow border)
-- ℹ️ Info messages (blue border)
+The demo path currently proves only the first part of that story locally through fixtures:
 
-Auto-dismiss after 5 seconds with manual close option.
+```text
+standing -> action cards
+```
 
-### 4. Session Management
-- **Automatic logout** on token expiration
-- **Persistent sessions** with localStorage
-- **Visual token countdown** in header (changes color based on time remaining)
-- **Graceful expiration handling** - warns before kicking user out
+The next intended fixture slice is governance proposal/vote coverage, followed by receipt/provenance fixture coverage.
 
-### 5. Governance UI (Already Existed, Now Documented)
-- View active proposals
-- Cast votes (For/Against/Abstain)
-- See vote tallies in real-time
-- View closed proposals with outcomes
-- WebSocket updates for live vote counts
+## Running locally
 
-## Phase 2 Enhancements (Polish & Mobile Support)
-
-### 1. Comprehensive Responsive Design
-- **Mobile-optimized** (≤768px): Vertical layouts, touch-friendly buttons
-- **Small mobile** (≤375px): Optimized for iPhone SE and small Android devices
-- **Tablet landscape** (769-1024px): Efficient use of screen space
-- **iOS auto-zoom prevention**: 16px font size on inputs
-- **Touch-friendly scrolling**: Hidden scrollbars, smooth navigation
-
-### 2. Member Directory Search
-- **Real-time search** by DID
-- **Case-insensitive** filtering
-- **Instant results** - no delays
-- Useful for large cooperatives with many members
-
-### 3. Transaction History Filtering
-- **5 time periods**: Today, This Week, This Month, This Year, All Time
-- **Default**: This Month (most common use case)
-- **Instant filtering** - no page reload
-- Helps treasurers focus on recent activity
-
-### 4. CSV Export for Transactions
-- **One-click export** to Excel/Google Sheets
-- **Respects current filter** - export only what you see
-- **Proper formatting**: Quoted fields, escaped special characters
-- **All fields included**: Date, Time, From, To, Amount, Currency, Memo
-- Perfect for treasurer reports and analysis
-
-### 5. Card Header System
-- Flexible header layout with actions
-- Professional UI with filters/search integrated
-- Wraps gracefully on mobile
-
-### 6. Loading Skeleton Animation
-- CSS-only shimmer effect
-- Better perceived performance
-- Ready for future loading states
-
-## Phase 3 Enhancements (Advanced Features & Documentation)
-
-### 1. Quick Wins (Productivity Features)
-- **⌨️ Keyboard Shortcuts**: Navigate tabs with Ctrl+1-5 (Cmd on Mac)
-- **📋 Copy DID Button**: One-click copy button next to member DIDs
-- **🔄 Transaction Sorting**: Sort by newest/oldest/highest/lowest amount
-- **📈 Balance Trend Indicator**: Visual arrow showing if balance is ↑ up, ↓ down, or → stable
-- **⏰ Proposal Deadlines**: Color-coded countdown showing urgency (gray → yellow → red)
-
-### 2. Dashboard Enhancements
-- **📊 Balance Chart**: Canvas-based line chart showing balance over last 30 days
-- **🗳️ Pending Proposals Widget**: Quick access to open proposals requiring votes
-- **🏆 Top Contributors**: Leaderboard showing top 5 most active givers with emoji medals
-
-### 3. Comprehensive Documentation
-- **📖 [Quick Start Guide](QUICK-START.md)**: 5-minute onboarding for new users (467 lines)
-- **💰 [Treasurer's Guide](TREASURER-GUIDE.md)**: Financial management and reporting (584 lines)
-- **⚙️ [Admin Guide](ADMIN-GUIDE.md)**: Complete system administration reference (738 lines)
-- **❓ [FAQ](FAQ.md)**: 60+ questions covering all user scenarios (560 lines)
-
-**Total Documentation**: 2,349 lines of professional guides!
-
-### 4. Keyboard Shortcuts Reference
-- **Ctrl+1**: Dashboard
-- **Ctrl+2**: Log Hours
-- **Ctrl+3**: History
-- **Ctrl+4**: Members
-- **Ctrl+5**: Governance
-
-## Quick Start
-
-### 1. Serve the UI
-
-The UI is static HTML/CSS/JS, so you can serve it with any web server:
+The UI is static. Serve it with any local web server:
 
 ```bash
-# Python 3
 cd web/pilot-ui
 python -m http.server 3000
-
-# Node.js
-npx serve -s . -l 3000
-
-# Or just open index.html directly in your browser
 ```
 
-### 2. Start the ICN Gateway
+Then open:
 
-Make sure the ICN daemon is running with the gateway enabled:
+```text
+http://localhost:3000
+```
+
+To use the guided fixture-backed demo slice, open:
+
+```text
+http://localhost:3000?mode=demo
+```
+
+Demo mode currently uses committed fixture JSON under:
+
+```text
+web/pilot-ui/fixtures/icn-organizer-demo/
+```
+
+Those fixtures are fictional and must not contain real names, real DIDs, real contact data, or private organizer/member material.
+
+## Gateway-backed mode
+
+For live gateway-backed development, run an ICN daemon with the gateway enabled and connect the UI to the gateway URL.
+
+Typical development gateway port:
+
+```text
+http://localhost:8080
+```
+
+The gateway port is 8080, not 8000.
+
+Authentication and exact gateway startup commands depend on the current daemon configuration and should be checked against the current developer docs and `AGENTS.md` before use.
+
+## Main surfaces
+
+| Surface | Purpose |
+|---|---|
+| Profile / connection state | Shows the current local connection/session context. |
+| My Standing & Action Cards | Member-facing standing plus the action-card queue. |
+| Governance | Proposals and voting surfaces when gateway-backed. |
+| Action Items | Domain action-item lists and completion flows. Distinct from Action Cards. |
+| Receipts | Receipt/provenance viewing and plain-language explanation. |
+| Members / domains | Supporting views for institutional context. |
+
+## Action Cards vs Action Items
+
+Action Cards are the per-member queue:
+
+```text
+GET /v1/gov/me/action-cards
+```
+
+They answer: what needs this member's attention?
+
+Action Items are domain records. They answer: what work exists in this domain, and what is its status?
+
+A good UI should help members move from a personal action card into the underlying domain action or governance object, then back to the receipt/provenance that proves completion.
+
+## Proof-bearing source paths
+
+The currently exercised action-card source paths are:
+
+| Source/action | Receipt |
+|---|---|
+| `proposal` / `vote` | `GovernanceDecisionReceipt` |
+| `action_item` / `complete` | `ActionItemCompletionReceipt` |
+| `meeting` / `attend` | `MeetingAttendanceReceipt` |
+
+Other source paths are not complete and must not be presented as finished.
+
+## Tests
+
+Useful local checks:
 
 ```bash
-icnd --gateway-enable --gateway-bind 127.0.0.1:8080 --gateway-jwt-secret "your-secret"
+cd web/pilot-ui
+npm ci
+npm run test
+npm run test:e2e
+npm run test:a11y
 ```
 
-### 3. Get a JWT Token
+When gateway or API shapes change, also check the relevant gateway/OpenAPI/SDK instructions in `AGENTS.md` and the project-index maps.
 
-Use icnctl to get an authentication token:
+## Non-claims
 
-```bash
-# Get challenge
-icnctl auth challenge --did did:icn:your-did
+This UI does not prove production readiness, formal NYCN pilot status, live federation, full fixture-backed demo mode, implemented service hosting, or complete mobile/member UX.
 
-# Sign and verify (you'll need to implement signing)
-# For testing, you can use the gateway's test token if available
-```
-
-### 4. Connect
-
-1. Open the UI in your browser (http://localhost:3000)
-2. Enter the gateway URL (default: http://localhost:8080)
-3. Enter your cooperative ID
-4. Enter your DID
-5. Paste your JWT token
-6. Click "Connect"
-
-## Usage
-
-### Logging Hours
-
-1. Click "Log Hours" tab
-2. Select the member you provided service to
-3. Enter the number of hours
-4. Add a description of the service
-5. Click "Log Hours"
-
-The other member will see their balance decrease (they owe you) and yours will increase.
-
-### Viewing Balance
-
-Your current balance is shown on the Dashboard.
-- **Positive** (green): You have credit - others owe you hours
-- **Negative** (red): You owe hours to others
-
-### Understanding Transactions
-
-In a timebank:
-- When you help someone, they owe you (their balance decreases, yours increases)
-- When someone helps you, you owe them (your balance decreases, theirs increases)
-
-All transactions are visible in the History tab.
-
-## Development
-
-### Customization
-
-The UI is intentionally simple vanilla HTML/CSS/JS for easy customization:
-
-- **style.css**: All styling, easy to adjust colors and layout
-- **app.js**: Application logic, API calls
-- **index.html**: Page structure
-
-### Adding Features
-
-Common additions for pilots:
-
-1. **Offers/Requests Board**: Add a new tab to display member offers
-2. **Profile Page**: Show member details and contact info
-3. **Export**: Add CSV export for treasurer reports
-4. **Notifications**: Show alerts for new transactions
-
-### API Integration
-
-The UI uses the ICN Gateway REST API. See [docs/api/openapi.yaml](../../docs/api/openapi.yaml) for the full API spec.
-
-Key endpoints used:
-- `GET /v1/health` - Check gateway status
-- `GET /v1/ledger/{coop}/balance/{did}` - Get member balance
-- `GET /v1/ledger/{coop}/history` - Get transactions
-- `POST /v1/ledger/{coop}/payment` - Create transaction
-- `GET /v1/coops/{coop}/members` - List members
-
-## Deployment
-
-For production pilots:
-
-1. **Serve over HTTPS**: Use a reverse proxy (nginx, caddy) with TLS
-2. **Restrict CORS**: Configure gateway to only accept requests from your domain
-3. **Token Management**: Implement proper token refresh (tokens expire after 24h)
-
-### Example nginx config
-
-```nginx
-server {
-    listen 443 ssl;
-    server_name timebank.example.com;
-
-    ssl_certificate /path/to/cert.pem;
-    ssl_certificate_key /path/to/key.pem;
-
-    # Serve static UI
-    location / {
-        root /var/www/icn-pilot-ui;
-        try_files $uri /index.html;
-    }
-
-    # Proxy API requests
-    location /v1 {
-        proxy_pass http://localhost:8080;
-        proxy_set_header Host $host;
-    }
-}
-```
-
-## Browser Support
-
-Tested on:
-- Chrome 90+
-- Firefox 88+
-- Safari 14+
-- Edge 90+
-
-Requires modern JavaScript features (fetch, async/await, template literals).
-
-## User Guide
-
-### Getting Your First Token
-
-1. Click **"How do I get a token?"** on the login screen
-2. Follow the 3-step wizard:
-   - Open terminal
-   - Run the provided command (click Copy button)
-   - Paste the token back into the login form
-3. Click **Connect**
-
-The token is valid for 24 hours. You'll see a countdown timer in the header showing when it expires.
-
-### Token Expiration
-
-Watch for these indicators:
-- **Green badge** (>1 hour): Token is fine
-- **Yellow badge** (<1 hour): Token expiring soon
-- **Red badge** (<15 minutes): Get a new token soon!
-
-You'll receive automatic warnings at 15, 10, and 5 minutes before expiration.
-
-### Understanding Notifications
-
-The app uses toast notifications (top-right corner):
-- **Green checkmark (✓)**: Success - action completed
-- **Red X (✕)**: Error - something went wrong
-- **Yellow warning (⚠)**: Warning - attention needed
-- **Blue info (ℹ)**: Info - general notification
-
-Click the **×** to dismiss, or they auto-dismiss after 5 seconds.
-
-## Troubleshooting
-
-### Error Messages Explained
-
-The app now shows helpful error messages. Here's what they mean:
-
-**"Cannot connect to the server. Please check your internet connection."**
-- Gateway is not running or unreachable
-- Check gateway URL (default: `http://localhost:8080`)
-- Verify gateway is enabled: `icnd --gateway-enable`
-
-**"Your session has expired. Please sign in again."**
-- Your 24-hour token has expired
-- Get a new token by clicking "How do I get a token?"
-- Run: `icnctl auth login --gateway http://localhost:8080 --coop your-coop-id`
-
-**"You don't have permission to do that."**
-- Your token doesn't have the required scope
-- Contact your cooperative administrator
-- You may need admin privileges for this action
-
-**"Too many requests. Please wait a moment and try again."**
-- You're being rate-limited (100 requests per burst)
-- Wait 10-30 seconds and try again
-- This is a security feature to prevent abuse
-
-**"The requested resource was not found."**
-- Check your cooperative ID spelling
-- Verify the cooperative exists
-- Ask your admin for the correct ID
-
-### No members showing
-- Verify you're using the correct cooperative ID
-- Check that members have been added via `icnctl coops member add`
-- Refresh the page
-
-### Transactions not appearing
-- Transactions appear in real-time via WebSocket
-- If disconnected, refresh the page
-- Check the History tab (dashboard shows last 5 only)
-
-### WebSocket Disconnected
-- Check the footer status indicator
-- Red dot = disconnected (will auto-reconnect in 5 seconds)
-- Green dot = connected
-- Refresh page if reconnection fails
-
-### Token Expired During Session
-- You'll see a red "Token expired" badge in header
-- A persistent warning toast will appear
-- Sign out and get a new token
-
-## License
-
-MIT OR Apache-2.0
+It is a pilot-stage human surface for inspecting and demonstrating the institutional proof loop as it becomes legible.

--- a/web/pilot-ui/package.json
+++ b/web/pilot-ui/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "icn-timebank-pilot-ui",
+  "name": "icn-pilot-ui",
   "version": "1.0.0",
-  "description": "ICN Timebank Pilot UI - Progressive Web App for cooperative time banking",
+  "description": "ICN Pilot UI - organizer/member demo surface for standing, action cards, governance, receipts, and provenance",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
@@ -15,9 +15,10 @@
     "test:a11y:ci": "playwright test tests/e2e/accessibility.spec.js --project=chromium"
   },
   "keywords": [
-    "timebank",
     "cooperative",
-    "mutual-credit",
+    "governance",
+    "receipts",
+    "provenance",
     "pwa"
   ],
   "author": "ICN Project",

--- a/website/src/content/docs/README.md
+++ b/website/src/content/docs/README.md
@@ -1,200 +1,70 @@
-# ICN - InterCooperative Network
+# ICN Website Docs Mirror
 
-[![CI](https://github.com/InterCooperative-Network/icn/actions/workflows/ci.yml/badge.svg)](https://github.com/InterCooperative-Network/icn/actions/workflows/ci.yml)
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
+This directory is a website content surface, not the source of project truth.
 
-A substrate daemon for the cooperative internet.
+Do not treat this file as a second root README. Current ICN truth lives in the main repo docs and project-index maps.
 
-**[intercooperative.network](https://intercooperative.network)**
+## Current truth anchors
 
-ICN is a P2P coordination layer for cooperatives, communities, and federations. It is not a blockchain or federation server — it's a constraint engine where apps translate cooperative governance into generic constraints, and the kernel enforces them without understanding their meaning.
+Use these files first:
 
----
+- `docs/STATE.md`
+- `docs/PHASE_PROGRESS.md`
+- `docs/ARCHITECTURE.md`
+- `docs/INDEX.md`
+- `docs/reference/project-index/source-of-truth-map.md`
+- `docs/reference/project-index/current-truth-map.md`
+- `docs/reference/project-index/runtime-surface-map.md`
+- `docs/reference/project-index/show-readiness-map.md`
+- `docs/reference/project-index/source-tree-map.md`
+- `docs/reference/project-index/rust-workspace-map.md`
 
-## What ICN Provides
+## Public website rule
 
-- **Decentralized Identity** — DIDs with Ed25519 cryptography and Age-encrypted keystores
-- **Trust Graph** — Web-of-participation trust computation with signed attestations
-- **Mutual Credit Ledger** — Double-entry accounting with Merkle-DAG integrity
-- **Cooperative Contracts** — CCL (Cooperative Contract Language) for expressing bylaws, agreements, and governance
-- **P2P Networking** — QUIC/TLS sessions with mDNS discovery and gossip replication
-- **Democratic Governance** — Proposals, voting, and parameter management
-- **Distributed Compute** — Trust-gated task execution with receipt settlement
+The public website should summarize current truth. It should not create current truth.
 
-## Architecture
+If the website and repo docs disagree, defer to the source-of-truth hierarchy in `docs/reference/project-index/source-of-truth-map.md`, then update or remove the stale website copy.
 
-ICN implements a **constraint enforcement architecture**:
+## Current short framing
 
-```
-CCL Document (constitution / bylaws / treaty)
-         |
-App / Policy Oracle (governance, trust, ledger)
-         |
-ConstraintSet (rate limits, credit ceilings, voting weights)
-         |
-Kernel enforces constraints mechanically
-```
+ICN is institutional infrastructure for democratic organizations: cooperatives, communities, and federations. It is a constraint engine. Apps translate institutional meaning into constraints; the kernel enforces constraints without understanding that meaning.
 
-The kernel never sees "trust scores" or "governance rules" — only generic constraints. This is the **Meaning Firewall**: domain semantics stay in apps, the kernel stays predictable.
+Current phase framing:
 
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full architecture documentation.
+- Phase 0 is complete.
+- Phase 1 is complete.
+- Phase 2 is in progress and not complete.
+- NYCN is the intended first cooperative partner and active partnership track, not yet a formal pilot.
+- Member standing and action cards exist as member-facing read models.
+- The pilot UI has a bounded fixture-backed demo slice for standing and action cards.
+- Production readiness, live federation, formal NYCN pilot status, implemented service hosting, and complete mobile/member UX must not be claimed.
 
-## Quick Start
+## Safe vocabulary
 
-```bash
-# Build
-cd icn && cargo build --release
+Prefer ICN's current institutional vocabulary:
 
-# Start node alpha (terminal 1)
-./target/release/icnd --config ../config/icn-alpha.toml
+- settlement
+- unit
+- position
+- obligation
+- allocation
+- receipt
+- provenance
+- evidence
+- identity
+- standing
+- action card
 
-# Start node beta (terminal 2)
-./target/release/icnd --config ../config/icn-beta.toml
+When old docs or older examples use deprecated product framing, update the public surface or clearly mark the material as historical.
 
-# Check status (terminal 3)
-./target/release/icnctl network status
-./target/release/icnctl network peers
-# Nodes discover each other via mDNS within seconds
-```
+## Where to edit public copy
 
-### Identity Management
+Important website entry points include:
 
-```bash
-icnctl id init          # Create identity (DID + keystore)
-icnctl id show          # Show current DID
-icnctl id rotate        # Rotate keys
-icnctl id export b.age  # Export encrypted backup
-```
+- `website/src/pages/index.astro`
+- `website/src/pages/whats-real-now.astro`
+- `website/src/pages/for-cooperatives.astro`
+- `website/src/pages/for-developers.astro`
+- `website/src/pages/get-involved.astro`
 
-### Trust & Networking
-
-```bash
-icnctl trust add did:icn:z6Mk... --score 0.8 --label partner
-icnctl trust list
-icnctl network peers
-icnctl network stats
-```
-
-### Ports
-
-| Service | Port | Protocol | Purpose |
-|---------|------|----------|---------|
-| Peer Transport | 7777 | QUIC/UDP | P2P communication |
-| RPC API | 5601 | HTTP | CLI control (icnctl) |
-| Metrics | 9100 | HTTP | Prometheus exporter |
-| Health | 8080 | HTTP | Health checks |
-
-## Project Structure
-
-**28 crates** in `icn/crates/`, **4 app crates** in `apps/`, **3 binaries** in `icn/bins/`.
-
-### Kernel (domain-agnostic)
-
-| Crate | Purpose |
-|-------|---------|
-| `icn-kernel-api` | Trait definitions (PolicyOracle, State, Compute, Comms) |
-| `icn-core` | Tokio runtime, supervisor, actor lifecycle |
-| `icn-net` | QUIC/TLS sessions, mDNS discovery |
-| `icn-gossip` | Topic-based replication with causal ordering |
-| `icn-gateway` | REST + WebSocket API |
-| `icn-rpc` | gRPC API server |
-| `icn-store` | Persistent KV storage (sled) |
-| `icn-obs` | Prometheus metrics, tracing |
-| `icn-identity` | DIDs, Ed25519 keypairs, encrypted keystore |
-| `icn-encoding` | Serialization utilities |
-| `icn-time` | Clock synchronization |
-| `icn-snapshot` | State snapshots for graceful restarts |
-| `icn-api` | Shared validation and error handling |
-| `icn-testkit` | Test utilities |
-
-### Apps (domain-specific, Policy Oracles)
-
-| Crate | Purpose |
-|-------|---------|
-| `apps/trust` | Trust graph → PolicyOracle (rate limits, credit multipliers) |
-| `apps/governance` | GovernanceActor, proposal execution |
-| `apps/ledger` | Ledger reduction and settlement |
-| `apps/echo` | Example app for testing |
-
-### Domain Crates
-
-| Crate | Purpose |
-|-------|---------|
-| `icn-trust` | Trust graph storage and computation |
-| `icn-governance` | Governance primitives (proposals, voting, parameters) |
-| `icn-ledger` | Double-entry mutual credit with Merkle-DAG |
-| `icn-ccl` | Contract language AST, interpreter, fuel metering |
-| `icn-compute` | Distributed compute with trust-gated execution |
-| `icn-federation` | Inter-cooperative coordination |
-| `icn-entity` | Unified entity model |
-| `icn-coop` | Cooperative management |
-| `icn-community` | Community structures |
-| `icn-security` | Byzantine fault detection |
-| `icn-privacy` | Privacy primitives |
-| `icn-crypto-pq` | Post-quantum hybrid cryptography |
-| `icn-steward` | SDIS steward network |
-| `icn-zkp` | Zero-knowledge proofs |
-
-### Binaries
-
-| Binary | Purpose |
-|--------|---------|
-| `icnd` | The ICN daemon |
-| `icnctl` | CLI management tool |
-| `icn-console` | Interactive TUI |
-
-## Development
-
-```bash
-cd icn
-
-# Build
-cargo build
-
-# Test
-cargo test --all-features
-
-# Lint
-cargo fmt --check
-cargo clippy --all-targets --all-features -- -D warnings
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for architectural guardrails and the git workflow.
-
-## Security
-
-ICN implements three-layer security:
-
-1. **Transport** — QUIC/TLS with DID-TLS certificate binding
-2. **Message** — Ed25519 signed envelopes with replay protection
-3. **Application** — E2E encryption with X25519-ChaCha20-Poly1305
-
-Trust-gated rate limiting enforces per-actor throughput bounds based on trust class. See [docs/production-hardening.md](docs/production-hardening.md).
-
-## Documentation
-
-- **[Architecture](docs/ARCHITECTURE.md)** — Constraint engine model, kernel/app separation, Policy Oracle pattern
-- **[Getting Started](docs/GETTING_STARTED.md)** — Installation and first steps
-- **[FAQ](docs/FAQ.md)** — Common questions
-- **[Contributing](CONTRIBUTING.md)** — Development workflow and architectural guardrails
-- **[Architecture Index](docs/architecture/)** — Visual diagrams, kernel/app separation details
-- **[Onboarding Modules](docs/onboarding/)** — Deep-dive learning modules
-- **[Production Hardening](docs/production-hardening.md)** — Security and deployment
-- **[Roadmap](docs/dev-journal/ROADMAP.md)** — Current and planned phases
-- **[Phase History](docs/PHASE_HISTORY.md)** — Completed development phases
-
-## Status
-
-~362K lines of Rust across 28 crates and 4 app crates. Deployed on a K3s cluster since December 2025.
-
-Active work is tracked in [6 epics](https://github.com/InterCooperative-Network/icn/issues/856):
-- **Kernel/App Separation** — Extracting domain logic from kernel (governance ratchet: 83 → 43)
-- **Architecture Invariants** — Formalizing the constraint engine boundary
-- **Trust Hardening** — Attestation signing, revocations, replay protection
-- **Service Discovery** — Gossip-based endpoint propagation
-- **Commons/Compute** — Resource pool and credit accounting
-- **Kernel Performance** — StateSnapshot COW, rate limiting
-
-## License
-
-[AGPL-3.0](LICENSE)
+Before publishing website changes, check the current anchors above and preserve the non-claim boundaries.

--- a/website/src/pages/whats-real-now.astro
+++ b/website/src/pages/whats-real-now.astro
@@ -2,12 +2,10 @@
 import Layout from '../layouts/Layout.astro';
 import MaturityGrid from '../components/MaturityGrid.astro';
 import MaturityCard from '../components/MaturityCard.astro';
-import ProvenanceTrail from '../components/ProvenanceTrail.astro';
-import ScopeModel from '../components/ScopeModel.astro';
 import ReadingLadder from '../components/ReadingLadder.astro';
 ---
 
-<Layout title="What's Real Now" activeNav="whats-real-now" description="An honest account of which parts of ICN are strongest today, which are advancing, which are still maturing, and which are not yet built.">
+<Layout title="What's Real Now" activeNav="whats-real-now" description="An honest account of which parts of ICN are strongest today, which are advancing, which are still maturing, and which are not yet complete.">
 
   <section class="section" style="padding-top: calc(64px + var(--space-3xl));">
     <div class="container narrow">
@@ -15,21 +13,20 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <span class="badge badge-amber">Maturity Anchor</span>
         <h1>What's Real Now</h1>
         <p class="lead">
-          ICN has uneven maturity across its subsystems.
-          This page states what is proven, what is advancing, and what is not yet complete.
-          Every other page on this site should be readable against what is here without contradiction.
+          ICN has uneven maturity across its subsystems. This page states what is proven,
+          what is advancing, and what is not yet complete. Every other page on this site
+          should be readable against what is here without contradiction.
         </p>
       </div>
 
       <div class="status-anchor">
-        <span class="status-anchor-label">Reviewed 2026-04-26</span>
+        <span class="status-anchor-label">Reviewed 2026-05-09</span>
         <p>
-          As of April 26, 2026, the institutional activation chain — live charter activation, role binding with typed authority scope,
-          a person-directory overlay for binding real members to package definitions, and a member-facing
-          standing read model — has landed. Federation provenance now persists across restart.
-          Provenance and institutional memory are still the strongest parts of the system.
-          The member-facing surface, broader execution coverage, and full governance-to-economics integration
-          are still being built.
+          ICN is in Phase 2 — Pilot Launch — and Phase 2 is not complete. Phase 0 and Phase 1 are complete.
+          NYCN is the intended first cooperative partner and active partnership track, not yet a formally committed pilot.
+          The strongest current path is institutional coordination: member standing, action cards, governance actions,
+          receipts, and retrievable provenance. The member-facing demo surface is real enough to show the shape of the system,
+          but it is still maturing and must not be presented as a finished product.
         </p>
       </div>
     </div>
@@ -40,8 +37,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <h2>How to read this page</h2>
       <p>
         ICN is large, and different parts of the system are at different levels of maturity.
-        We describe maturity in four bands. Every capability claim on this site
-        is placed in one of them.
+        We describe maturity in four bands. Every capability claim on this site belongs in one of them.
       </p>
 
       <MaturityGrid>
@@ -49,10 +45,10 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           <p>Implemented, integrated, and load-bearing. These are capabilities we are prepared to stand behind in public.</p>
         </MaturityCard>
         <MaturityCard band="advancing">
-          <p>Actively under development with visible progress. Not yet something to rely on, but moving.</p>
+          <p>Actively under development with visible progress. Not finished, but moving.</p>
         </MaturityCard>
         <MaturityCard band="maturing">
-          <p>Serious implementation exists. Surfaces and integrations are still being finished. Implementation is often ahead of the public-facing story.</p>
+          <p>Serious implementation exists. Surfaces and integrations are still being finished.</p>
         </MaturityCard>
         <MaturityCard band="notyet">
           <p>Scoped, but not where work is concentrated right now. We would rather say that directly than imply a schedule.</p>
@@ -66,125 +62,102 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <h2>Strong today</h2>
       <p>
         <strong>Provenance and institutional memory.</strong>
-        The deepest mature part of ICN is the chain that carries an outcome back through the rule that shaped it,
-        the decision that authorized it, and the members who held standing. Proposals, votes, receipts,
-        and the decision-to-outcome chain are the most mature path in the current system.
+        The strongest mature part of ICN is the chain that carries an outcome back through the rule that shaped it,
+        the decision that authorized it, and the member standing that made action legitimate.
       </p>
       <p>
-        <strong>Auditable coordination.</strong>
-        The paths that carry a decision into a recorded outcome are where the most implementation effort and
-        the most hardening have gone. These are the capabilities we are most willing to stand behind today.
+        <strong>Member standing.</strong>
+        A member-facing read model can answer the basic institutional question: who am I here, what domains do I belong to,
+        what roles do I hold, and what authority scopes are currently available to me?
+      </p>
+      <p>
+        <strong>Action cards.</strong>
+        Action cards now exist as a member-facing read model and have begun appearing in the pilot UI demo path.
+        The currently exercised source paths are proposal/vote, action_item/complete, and meeting/attend.
+        Other source paths remain gated and should not be presented as complete.
       </p>
       <p>
         <strong>Institutional activation.</strong>
-        An institution package — a manifest of entities, structures, activities, and roles — can be applied to a node,
-        a charter can be activated against that node, real members can be bound to package definitions through a private overlay,
-        and a member can ask the substrate "what am I currently authorized to do?" and get a typed, auditable answer.
-        This activation chain landed in April 2026.
-      </p>
-      <p>
-        <strong>Cryptographic identity and membership primitives.</strong>
-        Self-held identity for members and institutions is in place, and is the foundation the rest of the system builds on.
+        An institution package can describe entities, structures, activities, and roles; a charter can be activated against a node;
+        members can be bound to package definitions through a private overlay; and member standing can be surfaced through the gateway.
       </p>
       <p>
         <strong>Structural discipline.</strong>
-        The separation between the enforcement layer (which enforces constraints without understanding
-        their domain meaning) and the application layer (which interprets institutional concepts)
-        is enforced in the codebase architecture. This is how the system stays coherent as it grows.
+        The enforcement layer handles generic constraints while the application layer interprets institutional meaning.
+        This meaning firewall is one of the core design lines that keeps the system coherent as it grows.
       </p>
-
-      <ProvenanceTrail title="What 'strongest today' means, concretely" />
 
       <h2>Advancing now</h2>
       <p>
-        <strong>Execution coverage.</strong>
-        The mechanism that carries accepted decisions into operational effect already exists.
-        Expanding the range of decision types it handles — so that more of what an institution
-        decides actually becomes operationally real — is where active development is concentrated.
+        <strong>The guided organizer/member demo.</strong>
+        The pilot UI can open a guided demo mode and render fixture-backed member standing and action cards without requiring
+        a live gateway login. That is not full demo mode for the entire system. It is the first narrow slice of the human-facing path.
       </p>
       <p>
-        <strong>Policy binding practice.</strong>
-        The mechanisms that let shared rules bind what happens, rather than just describe what is supposed to happen,
-        are advancing alongside execution coverage. This is one of the most consequential active fronts in the project.
+        <strong>Governance fixture coverage.</strong>
+        The next useful demo slice is a governance proposal/vote fixture so the local story can move from standing to action cards
+        to a visible governance action. Receipt/provenance fixtures should follow after that.
+      </p>
+      <p>
+        <strong>Receipt storage and retrieval.</strong>
+        ICN is hardening the path by which app-level receipt records can be stored and retrieved while preserving the boundary between
+        generic infrastructure and institution-specific meaning.
+      </p>
+      <p>
+        <strong>NYCN rehearsal path.</strong>
+        NYCN is the intended first cooperative partner and active rehearsal track. The next human gate is organizer presentation,
+        then pilot formalization, then first operator rehearsal. That sequence has not completed.
       </p>
 
       <h2>Real but maturing</h2>
       <p>
         <strong>Federation.</strong>
-        Inter-institutional coordination is a serious, active subsystem with real implementation behind it:
-        formal agreements, attestations, typed inter-institutional channels, and cross-scope clearing.
-        It is not yet at the level where its public-facing story is complete, and some integrations remain partial.
-        We would rather say that directly than paper over it.
+        Inter-institutional coordination is a serious subsystem with real implementation behind it, but no two cooperatives are
+        federating in production over ICN today. Federation must not be confused with peer connectivity or local demo fixtures.
       </p>
       <p>
         <strong>Commons and compute.</strong>
-        Shared infrastructure participating in the same institutional loop as governance and accounting.
-        Implementation includes trust-aware task placement, cross-participant clearing, checkpointing, and dispute resolution.
-        This is one of the areas where the implementation is ahead of what the documentation
-        and public surfaces currently convey.
+        Shared infrastructure participates in the same institutional loop as governance and accounting. Compute can produce evidence
+        and support deliberation, but it does not decide governance outcomes.
       </p>
       <p>
         <strong>Economic semantics.</strong>
-        Obligations, treasury with budgets and approvals, patronage settlement, mutual-credit positions,
-        progressive credit limits, and usage-rights accounting all have implementation behind them.
-        The governed-social-accounting framing is real; the cross-scope integration story is still being completed.
+        ICN uses settlement, unit, position, obligation, allocation, receipt, and provenance language. The governed-social-accounting
+        framing is real; the cross-scope integration story is still being completed.
       </p>
       <p>
         <strong>Member-facing experience.</strong>
-        Identity, participation, and institutional interaction are converging toward a coherent member surface,
-        but that surface is not yet where the underlying system is. This is the gap a cooperative adopting ICN today
-        will feel most directly.
+        Identity, participation, standing, action cards, and receipts are converging toward a coherent member surface.
+        The surface exists, but it still needs more demo coverage, accessibility verification, and organizer rehearsal.
       </p>
 
       <h2>Not yet, or not yet publicly surfaced</h2>
       <p>
-        Some parts of the system are real but not yet worth highlighting to outsiders because their
-        public-facing story is thin. <strong>Privacy primitives</strong> and <strong>zero-knowledge proof components</strong>
-        exist as dedicated subsystems, and a <strong>steward network</strong> for trust distribution is implemented —
-        but none of them are ready to be described in public without risking overclaim. We would rather wait
-        than paint pictures we cannot yet stand behind.
+        ICN is not a finished production network, NYCN is not yet a formal pilot, and there is no live federation deployment.
+        The current demo mode has fixture-backed standing and action cards, but governance, receipts, ledger, members, trust,
+        and federation are not yet fully fixture-backed.
       </p>
       <p>
-        <strong>Action cards</strong> — the member-facing nervous system that surfaces what a holder needs to attend to —
-        are designed and named, with a contract written down, but not yet implemented. The standing read model
-        they will derive from is in place; the cards themselves are the next surface to ship.
+        ICN has design direction for governed services, service identities, tool manifests, tool bindings, and institution-owned tool state.
+        That is not the same thing as implemented service hosting or a live tool ecosystem.
       </p>
       <p>
-        <strong>Conflict resolution</strong> beyond compute is a first-class architectural goal but
-        not yet a complete runtime surface. ICN distinguishes conflicts about effects, conflicts about decisions,
-        and relational conflicts between members; runtime support today covers compute disputes only,
-        with institutional resolution paths still in the design layer.
+        Privacy, zero-knowledge proofs, steward networks, and post-quantum cryptography exist as dedicated subsystems or source-level primitives.
+        They should not be turned into broad public claims until their runtime integration, user-facing role, and production posture are verified
+        for the specific claim being made.
       </p>
       <p>
-        <strong>Accessibility</strong> is treated as a participation floor, not a feature.
-        The layered model — sensory, cognitive, linguistic, economic, temporal — is recognized at the architectural level;
-        the runtime contract that ties every member-facing surface to a measurable floor is still being built,
-        with the glossary endpoint and locale-aware standing among the named pieces in flight.
-      </p>
-      <p>
-        Other parts of the system are scoped but not where active work is concentrated right now.
-        When outsiders ask "does ICN do X," the honest answer is sometimes <em>not yet, and we are not pretending otherwise</em>.
+        Accessibility is a participation floor, not a feature. The design doctrine is clear; the runtime and demo acceptance gates still need
+        continued enforcement across real member-facing surfaces.
       </p>
 
       <h2>What this page commits to</h2>
       <p>
         Every capability claim on this site is grounded in the maturity bands above.
-        If something is described as "strong today," it is implemented and in use.
-        If something is described as "advancing," it is under active development but not finished.
-        If you find a claim elsewhere on this site that contradicts what is here, please let us know.
+        If something is described as strong today, it is implemented and in use.
+        If something is described as advancing, it is under active development but not finished.
+        If something is described as maturing, serious implementation exists but surfaces, integrations, or public story remain incomplete.
       </p>
-
-      <h2>The scopes the bands above apply across</h2>
-      <p>
-        The maturity bands above describe <em>capabilities</em>. ICN runs those capabilities
-        across five distinct contexts of action — five scopes. The substrate is at <strong>different
-        levels of maturity inside each scope</strong>. Provenance and identity are strongest at the
-        cooperative scope today; federation and commons are real but maturing; the
-        member-facing surface trails the substrate underneath. The scopes diagram below is the
-        map the bands apply across — not a claim that ICN is uniformly strong everywhere on it.
-      </p>
-
-      <ScopeModel title="The contexts the maturity bands apply across" />
 
       <h2>Where to look directly</h2>
       <ul>
@@ -232,12 +205,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
   line-height: 1.7;
   color: var(--text-secondary);
 }
-
 .prose h2 { margin-top: var(--space-2xl); margin-bottom: var(--space-md); }
 .prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
 .prose ul { margin: var(--space-md) 0; padding-left: var(--space-lg); }
 .prose li { margin-bottom: var(--space-xs); line-height: 1.6; }
-
-/* Band grid styles moved to MaturityGrid/MaturityCard components. */
-/* Bottom CTA styles moved to ReadingLadder component. */
 </style>


### PR DESCRIPTION
## Summary

Advances #1779 by aligning public/demo-facing copy with current Phase 2 truth.

Changes:

- refreshes `website/src/pages/whats-real-now.astro` around current Phase 2 framing;
- replaces the stale website docs mirror README with a truth-boundary/routing note;
- updates `web/pilot-ui/package.json` metadata away from old product framing;
- replaces the stale `web/pilot-ui/README.md` with current organizer/member demo documentation.

## Current truth preserved

- Phase 0 complete.
- Phase 1 complete.
- Phase 2 in progress, not complete.
- NYCN is the intended first cooperative partner / active partnership track, not a formal pilot.
- Member standing exists.
- Action cards exist.
- `?mode=demo` currently fixture-backs standing + action cards only.
- Governance, receipts, ledger, members, trust, and federation are not yet fully fixture-backed.

## Non-goals

- No runtime behavior changes.
- No schema changes.
- No generated OpenAPI/SDK changes.
- No claim that Phase 2 is complete.
- No claim that NYCN is a formal pilot.
- No live federation or production-readiness claim.
- No service-hosting or Tool Commons implementation claim.

## Verification

Not run locally from this environment.

Recommended when available:

```bash
python3 docs/scripts/doc_control_check.py --strict
cd website && npm ci && npm run build
cd web/pilot-ui && npm ci && npm run test && npm run test:e2e && npm run test:a11y
git diff --check
```

## Notes

The website page rewrite intentionally reduces older stale detail rather than trying to keep another exhaustive current-state ledger. Current truth should continue to live in `docs/STATE.md`, `docs/PHASE_PROGRESS.md`, and the project-index maps.