### PR TITLE
docs(project-index): add identity and network subsystem maps

### DIFF
--- a/docs/reference/project-index/identity-crypto-map.md
+++ b/docs/reference/project-index/identity-crypto-map.md
@@ -1,0 +1,96 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-09
+---
+
+# Identity and Cryptography Map
+
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md), and [`source-of-truth-map.md`](source-of-truth-map.md). This map is a routing layer, not a security audit.
+
+## Purpose
+
+Identity and cryptography are substrate concerns in ICN. They connect members, devices, nodes, services, institutions, actions, receipts, and recovery paths.
+
+This map exists to prevent three mistakes:
+
+1. treating identity as only a DID string;
+2. turning source-level primitives into broad production claims;
+3. collapsing person, device, node, service, and institution identity into one concept.
+
+## Identity layers
+
+| Layer | Meaning | Current posture |
+|---|---|---|
+| Person / member identity | A human participant or holder. | Real primitives exist; user-facing claims need precision. |
+| Device identity | A device acting for a member or operator. | Source-level support exists; UX maturity needs verification. |
+| Node identity | Infrastructure node identity. | Used by network/runtime paths; not the same as a person. |
+| Service identity | A service actor under institutional control. | Mostly tied to service-hosting design direction. |
+| Institution identity | Cooperative, community, federation, or other entity identity. | Represented through entity/governance/federation layers. |
+
+## Source paths
+
+| Area | Path |
+|---|---|
+| Identity, DID, keystore, recovery, revocation, membership | `icn/crates/icn-identity/` |
+| General cryptography facade | `icn/crates/icn-crypto/` |
+| Hybrid post-quantum primitives | `icn/crates/icn-crypto-pq/` |
+| Zero-knowledge proof support | `icn/crates/icn-zkp/` |
+| Steward / SDIS / VUI services | `icn/crates/icn-steward/` |
+| Authorization and capabilities | `icn/crates/icn-authz/` |
+| Network identity binding | `icn/crates/icn-net/` |
+| Member-facing standing | `icn/apps/governance/`, `icn/crates/icn-gateway/` |
+| Architecture docs | `docs/ARCHITECTURE.md`, `docs/architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md` |
+
+## Status bands
+
+| Subsystem | Status | Public/demo visibility | Drift risk |
+|---|---|---|---|
+| DID identity and DID documents | implemented but partial | visible indirectly through member standing/session flows | medium |
+| Keystore and backup paths | implemented but partial | developer/operator-facing | medium |
+| Multi-device identity support | implemented but partial | not current demo center | high |
+| Recovery and revocation | implemented but partial | not current demo center | high |
+| Steward / SDIS / VUI machinery | implemented but partial | not current demo center | high |
+| General signing/encryption primitives | implemented | mostly infrastructure | low-medium |
+| Hybrid post-quantum primitives | feature-gated / partial | not current demo center | high |
+| Zero-knowledge proof support | feature-gated / partial | not current demo center | high |
+| Hardware-backed key paths | feature-gated / needs verification | not current demo center | high |
+| Member standing read model | implemented | visible in pilot UI and demo fixtures | low-medium |
+
+## Safe claims
+
+Safe, current claims:
+
+- ICN uses self-held identities and signed actions as substrate primitives.
+- Member standing exists as a member-facing read model.
+- Identity, roles, domains, and authority scopes are part of the current institutional runtime story.
+- The repo includes dedicated crates for identity, cryptography, post-quantum primitives, zero-knowledge proof support, and steward-related machinery.
+- Deeper autonomy or production-security claims require evidence for the specific runtime path being described.
+
+## Claims to avoid
+
+Avoid broad public claims that ICN already has:
+
+- complete mobile identity UX;
+- production steward-network deployment;
+- fully deployed post-quantum runtime posture;
+- production zero-knowledge credential deployment;
+- fully audited cryptographic stack;
+- default hardware-backed identity deployment;
+- implemented service identity as part of live service hosting.
+
+## Related maps
+
+| Map | Relationship |
+|---|---|
+| `runtime-surface-map.md` | Shows where identity becomes member-facing standing and action cards. |
+| `network-gossip-map.md` | Covers node identity, transport binding, signed envelopes, and network trust. |
+| `service-hosting-map.md` | Should cover service identity when service hosting moves beyond design direction. |
+| `tool-commons-map.md` | Should cover tool identity and capability grants. |
+| `stale-and-archived-map.md` | Should catch old or overbroad security/autonomy claims. |
+
+## Follow-ups
+
+- Verify which identity, PQ, ZKP, and hardware-backed paths are enabled by default versus optional.
+- Add a deeper security/autonomy map if cryptographic autonomy becomes a public narrative focus.
+- Keep person, device, node, service, and institution identity separate in future docs.

--- a/docs/reference/project-index/network-gossip-map.md
+++ b/docs/reference/project-index/network-gossip-map.md
@@ -1,0 +1,179 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-09
+---
+
+# Network and Gossip Map
+
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md), and [`source-of-truth-map.md`](source-of-truth-map.md). This map routes the distributed-systems substrate; it is not a production-readiness claim.
+
+## Purpose
+
+ICN's distributed substrate has several layers that are easy to collapse by accident. This map keeps them separate.
+
+Core distinction:
+
+```text
+transport = connection
+gossip = state propagation
+federation = institutional relationship
+```
+
+A node connection is not a federation. A gossip topic is not a governance agreement. A federation is a governed institutional relationship that may use transport and gossip underneath it.
+
+## Source paths
+
+| Area | Path |
+|---|---|
+| Transport, peer sessions, discovery, topology, NAT/relay support | `icn/crates/icn-net/` |
+| Topic gossip, anti-entropy, partition handling, storage messages | `icn/crates/icn-gossip/` |
+| Time / clock / replay-adjacent support | `icn/crates/icn-time/` |
+| Store, replicas, proof-of-storage related state | `icn/crates/icn-store/` |
+| Snapshot and distributed snapshot support | `icn/crates/icn-snapshot/` |
+| Observability | `icn/crates/icn-obs/`, `monitoring/` |
+| Deployment and ports | `deploy/`, `docs/reference/project-index/ci-ops-deploy-map.md` |
+| Federation layer | `icn/crates/icn-federation/`, governance/entity docs |
+
+## Layer model
+
+| Layer | Question answered | Status | Drift risk |
+|---|---|---|---|
+| Transport | Can this node connect to that peer? | implemented but partial | medium |
+| Peer discovery | How are peers found? | implemented but partial | medium |
+| Identity-bound transport | Is a peer connection bound to node identity? | implemented but needs precise claims | medium |
+| Topology / fanout | Which peers should this node prioritize? | implemented but partial | medium |
+| NAT / relay support | Can peers connect across difficult networks? | implemented but partial | high if described as production-reliable |
+| Gossip topics | What state classes are exchanged? | implemented but partial | medium |
+| Anti-entropy sync | How does state converge after missed messages? | implemented but partial | medium |
+| Partition detection/healing | What happens after network splits? | implemented but partial | high |
+| Replica/storage messages | How does storage durability propagate? | implemented but partial | medium-high |
+| Observability | How do operators see network/gossip health? | implemented but partial | medium |
+| Federation | What institutional relationships authorize exchange? | implemented but partial; not live production | high |
+
+## Transport map
+
+The transport layer belongs primarily to `icn-net`.
+
+It includes or routes toward:
+
+- peer sessions;
+- discovery and bootstrap paths;
+- identity-bound connection semantics;
+- signed or authenticated message envelopes;
+- replay protection and sequencing concerns;
+- rate limiting;
+- topology-aware neighbor selection;
+- NAT traversal and relay-related support;
+- version/capability negotiation;
+- blob location support.
+
+Public claim boundary:
+
+- Safe: ICN has a real peer-networking substrate.
+- Unsafe without more evidence: ICN is production-ready across arbitrary real-world networks.
+
+## Gossip map
+
+The gossip layer belongs primarily to `icn-gossip`.
+
+It includes or routes toward:
+
+- topic-based state propagation;
+- topic access controls;
+- causal/version tracking;
+- Bloom-filter and digest-style sync;
+- push/pull exchange;
+- anti-entropy repair;
+- partition detection and healing;
+- storage and replica status messages;
+- service-discovery and key-rotation related topics.
+
+Public claim boundary:
+
+- Safe: ICN has a real gossip/synchronization substrate.
+- Unsafe without more evidence: all distributed conflict cases are solved automatically.
+
+## Federation is higher than networking
+
+Federation should not be described as the same thing as peer connectivity.
+
+Correct model:
+
+```text
+secure transport
+  -> gossip/sync
+  -> institutional relationship
+  -> governance/agreements/receipts
+```
+
+A live federation claim requires more than working network and gossip code. It requires a governed inter-institutional relationship and evidence that the relationship is active in the claimed context.
+
+Current public boundary:
+
+- Federation primitives exist.
+- Live production federation should not be claimed.
+- NYCN should not be described as a live federation member or formal pilot.
+
+## Storage and durability connection
+
+Network and gossip intersect with storage through:
+
+- blob announcement and retrieval;
+- replica status and requests;
+- storage challenges and proofs;
+- snapshot and recovery paths;
+- maintenance and health checks.
+
+These are substrate capabilities. They do not by themselves prove production durability for a public deployment.
+
+## Observability connection
+
+Operators need visibility into:
+
+- peer count and session health;
+- gossip throughput and lag;
+- partition events;
+- retry/backoff behavior;
+- replica health;
+- storage amplification;
+- metrics and alerts.
+
+The observability layer exists, but specific dashboard/alert coverage should be checked before making operational-readiness claims.
+
+## Safe claims
+
+Safe, current claims:
+
+- ICN has a real peer-networking crate and a real gossip/synchronization crate.
+- Transport, gossip, federation, and governance are separate layers.
+- Network and gossip primitives are substantial but are not the current organizer/member demo proof.
+- The current demo proves member/institutional proof-loop concepts, not production network readiness.
+
+## Claims to avoid
+
+Avoid claiming:
+
+- production-ready networking across arbitrary environments;
+- live federation deployment;
+- NYCN as a live federation member;
+- automatic resolution of all distributed conflicts;
+- complete durability guarantees without storage/replica evidence;
+- that peer connectivity alone equals institutional federation.
+
+## Related maps
+
+| Map | Relationship |
+|---|---|
+| `identity-crypto-map.md` | Node identity, signed messages, and network trust depend on identity/crypto. |
+| `runtime-surface-map.md` | Runtime surfaces sit above networking/gossip. |
+| `pilot-and-nycn-map.md` | NYCN rehearsal currently avoids live federation mutation. |
+| `ci-ops-deploy-map.md` | Ports, deploy paths, K3s/devnet, and monitoring live there. |
+| `show-readiness-map.md` | Defines what can and cannot be claimed externally. |
+
+## Follow-ups
+
+- Verify current production posture of NAT/relay paths before any public reliability claim.
+- Review monitoring dashboards/alerts for network and gossip health.
+- Add a storage/durability map if proof-of-storage and replica operations become public-facing.
+- Keep federation described as an institutional relationship, not as network adjacency.


### PR DESCRIPTION
## Summary

Adds two project-index subsystem maps:

- `docs/reference/project-index/identity-crypto-map.md`
- `docs/reference/project-index/network-gossip-map.md`

These maps cover two substrate layers that were underweighted in earlier repo overviews: identity/crypto/SDIS/ZKP/steward surfaces, and networking/gossip/topology/federation distinctions.

## Why

The project coverage review identified a recurring failure mode: high-level summaries drift toward governance/demo/UI and miss the distributed substrate underneath. These maps make those layers explicit while preserving status bands and non-claims.

## Key boundaries preserved

- Person, device, node, service, and institution identity are distinct.
- Source-level crypto/PQ/ZKP primitives do not automatically equal production autonomy guarantees.
- Transport, gossip, and federation are different layers.
- Peer connectivity does not equal institutional federation.
- Live production federation is not claimed.
- NYCN is not described as a formal pilot or live federation member.

## Non-goals

- No runtime changes.
- No security audit.
- No schema changes.
- No new contract URNs.
- No production-readiness claim.
- No claim of fully deployed post-quantum, ZKP, steward-network, service-identity, or live-federation posture.

## Verification

Not run locally from this environment.

Recommended when available:

```bash
python3 docs/scripts/doc_control_check.py --strict
git diff --check
```

## Related

Advances #1689 and complements #1782.