### PR TITLE
docs(project-index): add middle-layer subsystem maps

### DIFF
--- a/docs/reference/project-index/ccl-map.md
+++ b/docs/reference/project-index/ccl-map.md
@@ -1,0 +1,121 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-09
+---
+
+# CCL Map
+
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md), accepted ADRs, and [`source-of-truth-map.md`](source-of-truth-map.md). This map routes CCL's current and future roles; it is not a language specification.
+
+## Purpose
+
+CCL is the Cooperative Contract Language. It is the rule/expression layer that lets institutional meaning be compiled into bounded, deterministic forms that ICN can enforce or execute safely.
+
+This map prevents three mistakes:
+
+1. treating CCL as a general-purpose programming language;
+2. treating future process-language ambitions as current implementation;
+3. blurring CCL's role with the kernel's role.
+
+## Boundary rule
+
+```text
+CCL expresses bounded rules.
+Apps and hosts interpret institutional meaning.
+Policy oracles compile meaning into constraints.
+The kernel enforces generic constraints.
+```
+
+The kernel should not become a domain-meaning interpreter. CCL helps institutions express rules, but the meaning firewall still matters.
+
+## Source paths
+
+| Area | Path |
+|---|---|
+| CCL crate | `icn/crates/icn-ccl/` |
+| Charter runtime | `icn/apps/charter/` |
+| Governance integration | `icn/apps/governance/`, `icn/crates/icn-governance/` |
+| Contract templates | `contracts/templates/` |
+| ADR: CCL determinism/fuel/capability safety | `docs/adr/ADR-0021-ccl-determinism-fuel-and-capability-safety.md` |
+| ADR: schema bridge / ConstraintSet compilation | `docs/adr/ADR-0022-ccl-schema-bridge-and-constraintset-compilation.md` |
+| Architecture | `docs/ARCHITECTURE.md`, `docs/architecture/KERNEL_APP_SEPARATION.md` |
+
+## Status bands
+
+| Role | Status | Public/demo visibility | Drift risk |
+|---|---|---|---|
+| Deterministic contract/rule language | implemented | architecture/developer docs | medium |
+| Fuel/capability bounded execution | implemented | developer docs | medium |
+| Charter rule expression | implemented | public architecture narrative | low-medium |
+| Schema bridge / constraint compilation | implemented but should be verified per path | developer docs | medium |
+| Compute task packaging | implemented but not public-demo central | mostly internal/developer | medium |
+| Institutional process language | design-direction / future | not public capability claim | high |
+| Signals/escalation/indicator rules | design-direction / future | not public capability claim | high |
+| Obligation/allocation lifecycle rules | design-direction / RFC-gated depending path | not complete | high |
+
+## Current safe claims
+
+Safe, current claims:
+
+- ICN has a dedicated CCL crate.
+- CCL is deterministic and bounded by design.
+- CCL participates in charter/rule expression and constraint compilation.
+- CCL is not the kernel; it is part of the expression/translation layer above mechanical enforcement.
+- Future institutional process-language roles should be described as future or design-direction unless runtime evidence exists.
+
+## Claims to avoid
+
+Avoid claiming:
+
+- CCL is a general-purpose application language;
+- every institutional process can already be expressed in CCL;
+- CCL directly performs unrestricted side effects;
+- CCL replaces governance, legal judgment, facilitation, or institutional care;
+- signal rules, obligation lifecycle rules, or full process sessions are complete unless the relevant RFC/runtime evidence exists.
+
+## Relationship to charters
+
+Charters are the clearest current CCL-adjacent path:
+
+```text
+institutional rule text / template
+  -> CCL or schema bridge
+  -> ConstraintSet / policy shape
+  -> kernel enforcement
+```
+
+This is one of the strongest examples of the meaning firewall working: institutional meaning stays in app/policy layers; the kernel receives enforceable constraints.
+
+## Relationship to compute
+
+CCL can participate in bounded compute packaging and rule execution, but compute is not governance authority.
+
+Correct frame:
+
+```text
+compute executes bounded work
+CCL constrains/expresses rules
+receipts record outcomes
+governance authorizes power
+```
+
+## Relationship to future process primitives
+
+Future or design-direction uses include:
+
+- signal rules;
+- escalation policies;
+- indicators;
+- temporary authority grants;
+- obligation/allocation lifecycle rules;
+- support/care process rules;
+- institutional process sessions.
+
+These should not be described as complete runtime capabilities unless backed by current code, tests, and state docs.
+
+## Follow-ups
+
+- Add a deeper CCL implementation map if CCL changes become a near-term workstream.
+- Link each CCL-related future primitive to its RFC/issue before making public claims.
+- Keep CCL claims tied to accepted ADRs and current code, not long-arc strategy docs.

--- a/docs/reference/project-index/service-hosting-map.md
+++ b/docs/reference/project-index/service-hosting-map.md
@@ -1,0 +1,109 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-09
+---
+
+# Service Hosting Map
+
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md), and [`source-of-truth-map.md`](source-of-truth-map.md). This map routes the service-hosting design layer; it is not an implementation claim.
+
+## Purpose
+
+Service hosting is the layer where externally useful services become institutionally legible. A service being reachable is not enough. ICN's design direction is that services should be governed, scoped, auditable, exportable, and accountable to the institution using them.
+
+This map prevents three mistakes:
+
+1. treating a hosted service as automatically ICN-native;
+2. treating service-hosting design docs as runtime implementation proof;
+3. treating service operators as the source of institutional authority.
+
+## Lifecycle model
+
+| Stage | Meaning | Current posture |
+|---|---|---|
+| Hosted service | A service runs somewhere and may be useful. | Operational concept; not automatically ICN-native. |
+| Governed service | Access, custody, upgrades, backups, restore, routes, failures, and operator powers are institutionally legible. | Design direction unless tied to specific runtime evidence. |
+| ICN-native service | The service has service identity, scoped capabilities, receipt-emitting transitions, event streams, and binding/install lifecycle. | Future/design-direction unless specific evidence exists. |
+
+## Source paths
+
+| Area | Path |
+|---|---|
+| Service hosting doctrine | `docs/architecture/SERVICE_HOSTING_MODEL.md` |
+| Domain infrastructure | `docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md` |
+| Tool install infrastructure | `docs/rfcs/RFC-0017-tool-install-infrastructure.md` |
+| Ops/deploy surfaces | `deploy/`, `ops/`, `monitoring/` |
+| Identity/capability dependencies | `icn/crates/icn-identity/`, `icn/crates/icn-authz/` |
+| Runtime/API dependencies | `icn/crates/icn-gateway/`, `icn/apps/` |
+
+## Service questions
+
+A service-hosting plan should answer:
+
+| Question | Why it matters |
+|---|---|
+| Who operates the service? | Operator power must be visible. |
+| Which institution authorizes it? | Services do not create authority by existing. |
+| Which scope grants access? | Access must be constrained. |
+| What data is canonical? | Prevents SaaS-style institutional memory capture. |
+| What data is mirrored? | Clarifies recoverability and export. |
+| Which actions require receipts? | Makes service transitions auditable. |
+| How are backups created and tested? | Prevents operational hostage-taking. |
+| What is the restore path? | Institutions need continuity. |
+| What is the exit path? | Institutions must be able to leave. |
+| Which event streams exist? | Services should produce evidence, not just state. |
+
+## Candidate service classes
+
+| Service class | Purpose | Status band |
+|---|---|---|
+| Forge/code hosting | Institution-controlled code collaboration. | design-direction / ops-adjacent |
+| Identity/auth bridge | Web access bridge for identity/session handling. | design-direction |
+| Status page | Public service health and incidents. | design-direction / ops-adjacent |
+| Metrics/monitoring | Operator observability. | implemented but partial in ops context |
+| Artifact/registry service | Releases, receipts, packages, or artifacts. | design-direction |
+| Docs/publishing service | Institution-controlled documentation/publication. | design-direction |
+| Tool services | Services behind Tool Commons tools. | design-direction |
+
+## Safe claims
+
+Safe, current claims:
+
+- ICN has a service-hosting design model.
+- The design model distinguishes hosted, governed, and ICN-native services.
+- ICN-native service hosting requires identity, capabilities, receipts, event streams, and lifecycle/binding concepts.
+- Current service-hosting docs should not be read as proof that those services are live.
+
+## Claims to avoid
+
+Avoid claiming:
+
+- service hosting is implemented as a complete runtime feature;
+- ICN already provides a live service marketplace;
+- a hosted service is ICN-native merely because it runs near ICN;
+- operator custody equals institutional authority;
+- service identity is fully implemented across live services;
+- institutions have proven exit/export guarantees for every service class.
+
+## Relationship to Tool Commons
+
+Tool Commons depends on the service-hosting layer, but it is not the same thing.
+
+```text
+service hosting = how services are governed and operated
+tool commons = how reusable tools bind to institution-owned state
+```
+
+A future tool may use a service. That service still needs service identity, scoped authority, receipts, event visibility, backup/restore posture, and exit rights.
+
+## Relationship to domains
+
+Service hosting should be scoped through institutional domains. A DNS route or web URL does not create institutional authority. Authority comes from governance, standing, roles, scopes, and agreements.
+
+## Follow-ups
+
+- Add concrete service rows only when source evidence exists.
+- Tie future service maps to `ToolManifest`, `ToolBinding`, service identity, and receipt classes.
+- Keep public website copy from implying implemented service hosting.
+- Add service-hosting checks to a future stale/public-surface drift pass.

--- a/docs/reference/project-index/tool-commons-map.md
+++ b/docs/reference/project-index/tool-commons-map.md
@@ -1,0 +1,136 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-09
+---
+
+# Tool Commons Map
+
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), accepted RFCs, and [`source-of-truth-map.md`](source-of-truth-map.md). This map routes the Tool Commons design layer; it is not an implementation claim.
+
+## Purpose
+
+Tool Commons is the design direction for reusable, institution-controlled tools over institution-owned state.
+
+This map prevents three mistakes:
+
+1. treating Tool Commons as a live app store;
+2. treating tools as the source of institutional truth;
+3. treating package-local NYCN tool shapes as generic ICN runtime implementation.
+
+## Core rule
+
+```text
+tools do not own institutional truth
+the institution/domain/node owns institutional truth
+```
+
+A tool may render, edit, summarize, import, publish, search, or assist. It should not become the sovereign database of the institution.
+
+## Source paths
+
+| Area | Path |
+|---|---|
+| Tool Commons architecture | `docs/architecture/COOPERATIVE_TOOL_COMMONS.md` |
+| Domain infrastructure dependency | `docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md` |
+| Tool install RFC | `docs/rfcs/RFC-0017-tool-install-infrastructure.md` |
+| Service hosting dependency | `docs/architecture/SERVICE_HOSTING_MODEL.md` |
+| NYCN package-side examples | external `InterCooperative-Network/nycn`, in-repo `institutions/nycn/` |
+| Runtime/API dependencies | `icn-gateway`, governance, identity, authz, receipt/provenance paths |
+
+## Tool lifecycle concepts
+
+| Concept | Meaning | Current posture |
+|---|---|---|
+| ToolManifest | Declares what a tool is and what it needs. | RFC/design-direction unless implemented in a current path. |
+| ToolInstallRequest | Request to install/bind a tool for a domain. | RFC/design-direction. |
+| ToolBinding | Specific tool version bound into a specific institutional domain. | RFC/design-direction. |
+| CapabilityRegistryEntry | Records what scopes a tool actually holds. | RFC/design-direction. |
+| ServiceIdentityAuditEntry | Audits service/tool actions through evidence. | RFC/design-direction. |
+
+## Candidate tool families
+
+| Tool | Role | Status band |
+|---|---|---|
+| `icn-domain-admin` | Manage institutional domain configuration and boundaries. | design-direction |
+| `icn-member-directory` | Member/role/standing directory. | design-direction / overlaps with current standing surfaces |
+| `icn-governance` | Proposals, votes, decisions, governance records. | partially grounded in current governance runtime |
+| `icn-meetings` | Agendas, attendance, minutes, meeting receipts. | partially grounded in current meeting/attendance paths |
+| `icn-action-cards` | Member action queue and completion paths. | partially grounded in current action-card runtime |
+| `icn-drive` / artifact vault | Institution-owned artifact storage and imports. | package-local/design-direction |
+| `icn-docs` | Collaborative docs over institution-owned state. | design-direction |
+| `icn-tables` | Structured records and operating tables. | design-direction |
+| `icn-forms` | Intake/review forms. | design-direction |
+| `icn-calendar` | Events, meetings, deadlines. | design-direction |
+| `icn-publish` | Public publishing from governed artifacts. | design-direction |
+| `icn-search` | Permission-aware search. | design-direction |
+| `icn-agreements` | Membership/service/data/compute/resource agreements. | design-direction |
+| `icn-budget` | Resource/treasury/budget views using safe vocabulary. | design-direction / economics-dependent |
+| `icn-signals` | Institutional feedback and escalation signals. | design-direction |
+| `icn-compute-jobs` | Bounded compute workload submission and evidence. | compute-dependent/design-direction |
+| `icn-directory` | Public/community/institution directory. | design-direction |
+
+## Status rule
+
+A tool family can be described as runtime-backed only if there is current evidence for:
+
+- source paths;
+- API or app surface;
+- identity/capability boundary;
+- data ownership boundary;
+- receipt/provenance behavior;
+- tests or runbook evidence;
+- current state-doc support.
+
+Otherwise, describe it as design-direction, package-local, or future work.
+
+## Relationship to NYCN
+
+NYCN may contain package-local tool shapes, fixtures, templates, or workflow artifacts. Those are useful proof-of-shape materials, but they do not automatically mean the generic ICN Tool Commons runtime exists.
+
+Correct frame:
+
+```text
+NYCN package tools = first institution-package rehearsal shapes
+Tool Commons = reusable generic tool layer still being designed/built
+```
+
+## Relationship to service hosting
+
+Tools may depend on services. Services still need their own governance model:
+
+- service identity;
+- scoped authority;
+- backups and restore;
+- event streams;
+- receipt-producing transitions;
+- exit/export path.
+
+A tool UI without those boundaries is not enough.
+
+## Safe claims
+
+Safe, current claims:
+
+- ICN has a Tool Commons design direction.
+- Some current runtime surfaces already support future tools: governance, meetings, action cards, standing, receipts.
+- NYCN provides package-local examples and rehearsal shapes.
+- The generic install/binding lifecycle is not something to claim as complete unless runtime evidence exists.
+
+## Claims to avoid
+
+Avoid claiming:
+
+- ICN has a live app store;
+- Tool Commons is implemented as a complete ecosystem;
+- NYCN package-local tools are generic ICN runtime tools;
+- tools own institutional truth;
+- service hosting is automatically solved by Tool Commons;
+- tools replace governance, facilitation, care, legal judgment, or institutional accountability.
+
+## Follow-ups
+
+- Add concrete rows when `ToolManifest`, `ToolBinding`, or tool install lifecycle code lands.
+- Map each candidate tool to existing runtime primitives before implementation.
+- Keep public website copy from implying a live tool ecosystem.
+- Cross-link future NYCN package maps to this file without duplicating NYCN-specific details here.


### PR DESCRIPTION
## Summary

Adds three project-index maps for ICN's middle layers:

- `docs/reference/project-index/service-hosting-map.md`
- `docs/reference/project-index/ccl-map.md`
- `docs/reference/project-index/tool-commons-map.md`

These maps cover the layer between low-level substrate/runtime primitives and user-facing institution tools.

## Why

The project review found that high-level ICN summaries often jump from substrate/governance directly to pilot UI/NYCN. These maps make the missing middle explicit:

- governed services are not just hosted services;
- CCL is a bounded rule/expression layer, not a general-purpose app language;
- Tool Commons is design-direction unless backed by specific runtime evidence.

## Key boundaries preserved

- Service hosting is design-direction unless tied to current runtime evidence.
- A hosted service is not automatically ICN-native.
- CCL expresses bounded rules; the kernel enforces generic constraints.
- Future process-language uses of CCL are not claimed as complete.
- Tool Commons is not a live app store.
- Tools do not own institutional truth.
- NYCN package-local tool shapes do not automatically equal generic ICN runtime tools.

## Non-goals

- No runtime changes.
- No schema changes.
- No new contract URNs.
- No service-hosting implementation claim.
- No Tool Commons implementation claim.
- No claim that every future CCL/process primitive is implemented.

## Verification

Not run locally from this environment.

Recommended when available:

```bash
python3 docs/scripts/doc_control_check.py --strict
git diff --check
```

## Related

Advances #1689 and complements #1782 / #1783.