### PR TITLE
docs(project-index): add drift-control maps

### DIFF
--- a/docs/reference/project-index/pilot-ui-current-state-map.md
+++ b/docs/reference/project-index/pilot-ui-current-state-map.md
@@ -1,0 +1,136 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-09
+---
+
+# Pilot UI Current State Map
+
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), [`runtime-surface-map.md`](runtime-surface-map.md), and [`source-of-truth-map.md`](source-of-truth-map.md). This map routes the current pilot UI surface; it is not a production-readiness claim.
+
+## Purpose
+
+The pilot UI is the current human-facing organizer/member demo surface. It has moved faster than some older docs, so this map records the current boundary between fixture-backed, gateway-backed, partial, and not-yet surfaces.
+
+## Source paths
+
+| Area | Path |
+|---|---|
+| Pilot UI | `web/pilot-ui/` |
+| Demo fixtures | `web/pilot-ui/fixtures/icn-organizer-demo/` |
+| Runtime surface map | `docs/reference/project-index/runtime-surface-map.md` |
+| Demo readiness map | `docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md` |
+| ActionCard contract | `docs/contracts/institution-package/action-card.schema.json` |
+| Governance HTTP models | `icn/apps/governance/src/http/` |
+
+## Current status
+
+| Surface | Current posture | Notes |
+|---|---|---|
+| Static UI shell | implemented | Vanilla HTML/CSS/JS PWA-style surface. |
+| Gateway-backed mode | implemented but partial | Depends on running gateway and auth/session setup. |
+| `?mode=demo` entry | implemented | Demo mode is a bounded UI mode, not full backend demo mode. |
+| Member standing | implemented and fixture-backed | Fixture-backed in guided demo mode. |
+| Action cards | implemented and fixture-backed | Fixture-backed in guided demo mode. |
+| Governance | gateway-backed / not fully fixture-backed | Next intended fixture slice is proposal/vote. |
+| Receipts/provenance | implemented but not fully fixture-backed | Plain-language framing exists; demo fixture coverage remains incomplete. |
+| Action items | gateway-backed | Distinct from Action Cards. |
+| Ledger/economics | partial / not current demo center | Avoid old product framing. |
+| Members/trust/federation | partial / not fixture-backed | Do not present as complete local demo. |
+| Accessibility | active requirement | Must be verified through tests/gates, not asserted by copy alone. |
+
+## Demo boundary
+
+Current local demo path:
+
+```text
+Standing -> Action Cards
+```
+
+Desired next demo path:
+
+```text
+Standing -> Action Cards -> Governance proposal/vote fixture
+```
+
+Later demo path:
+
+```text
+Standing -> Action Cards -> Governance proposal/vote -> Receipt/provenance fixture
+```
+
+Do not describe the current demo as full fixture-backed ICN. It is a first narrow slice of the organizer/member path.
+
+## Action Cards vs Action Items
+
+Action Cards are the per-member queue:
+
+```text
+GET /v1/gov/me/action-cards
+```
+
+Action Items are domain records. They are related, but they are not the same surface.
+
+A good demo should help a member move:
+
+```text
+personal action card -> underlying domain action/governance object -> receipt/provenance
+```
+
+## Fixture rules
+
+Demo fixtures must:
+
+- use fictional identifiers;
+- avoid real names, contact data, private organizer details, and real DIDs;
+- match actual Rust/API/schema shapes;
+- document which surfaces are covered;
+- document which surfaces are not covered;
+- preserve the difference between frontend fixture mode and a future backend demo mode.
+
+## Current proof-bearing source paths
+
+| Source/action | Receipt | Status |
+|---|---|---|
+| `proposal` / `vote` | `GovernanceDecisionReceipt` | implemented proof loop |
+| `action_item` / `complete` | `ActionItemCompletionReceipt` | implemented proof loop |
+| `meeting` / `attend` | `MeetingAttendanceReceipt` | implemented proof loop |
+
+Other source paths must not be presented as complete unless current runtime evidence changes.
+
+## Public/demo claims to avoid
+
+Avoid claiming:
+
+- production readiness;
+- formal NYCN pilot status;
+- live federation;
+- full backend demo mode;
+- all surfaces are fixture-backed;
+- complete mobile/member UX;
+- service hosting or Tool Commons runtime;
+- old product framing as the current pilot UI identity.
+
+## Local verification
+
+When local tooling is available, relevant checks include:
+
+```bash
+cd web/pilot-ui
+npm ci
+npm run test
+npm run test:e2e
+npm run test:a11y
+```
+
+If gateway/API shapes change, also run the relevant OpenAPI/SDK drift checks described in `AGENTS.md` and `runtime-surface-map.md`.
+
+## Related items
+
+| Item | Purpose |
+|---|---|
+| #1779 | Public/demo-facing truth sync. |
+| #1777 | Next governance proposal/vote fixture slice. |
+| #1727 | Broader fixture-backed demo mode tracking; do not close without true backend/full demo mode. |
+| `runtime-surface-map.md` | Current gateway/member-facing runtime surfaces. |
+| `show-readiness-map.md` | What is safe to show externally. |

--- a/docs/reference/project-index/stale-and-archived-map.md
+++ b/docs/reference/project-index/stale-and-archived-map.md
@@ -1,0 +1,111 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-09
+---
+
+# Stale and Archived Map
+
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), and [`source-of-truth-map.md`](source-of-truth-map.md). This map identifies drift-prone document classes and how to handle them. It does not make archived material current.
+
+## Purpose
+
+ICN has a large history of plans, architecture sketches, demo tracks, website mirrors, old README material, and implementation notes. Some of that material is valuable archaeology. Some of it is dangerous if treated as current truth.
+
+This map exists to prevent old confidence from outranking current evidence.
+
+## Core rule
+
+```text
+Historical detail is not current truth.
+Current truth comes from code/tests, STATE.md, PHASE_PROGRESS.md, accepted ADR/RFCs, current contracts, and recent merged evidence.
+```
+
+## Drift classes
+
+| Drift class | Examples | Risk | Action |
+|---|---|---|---|
+| Old implementation counts | crate counts, LOC, app topology, old status numbers | medium | replace with current state docs or generated stats |
+| Old product framing | outdated demo/product descriptions | high | update or mark historical |
+| Unsafe economic vocabulary | older public/demo text using deprecated framing | high | replace in public surfaces; allow only in explicit historical/avoid-list contexts |
+| Old demo universe | legacy scripts or old demo names presented as main demo | high | clarify actual pilot-ui guided demo path |
+| NYCN overclaim | NYCN described as formal pilot or live federation member | high | rewrite as intended first partner / active track |
+| Live federation overclaim | peer networking or primitives described as production federation | high | distinguish transport, gossip, federation |
+| Service/tool overclaim | service hosting or Tool Commons described as implemented runtime | high | classify as design-direction unless evidence exists |
+| Security/autonomy overclaim | PQ/ZKP/steward/privacy primitives described as production posture | high | require specific source/runtime evidence |
+| Root/docs mirror duplication | website or mirror docs copying stale README material | medium-high | convert mirrors to routing/truth-boundary pages |
+| Archived planning docs | historical architecture maps, old phase plans, session docs | medium | annotate as historical; mine for context only |
+
+## Known high-risk surfaces
+
+| Surface | Risk | Current handling |
+|---|---|---|
+| `website/src/content/docs/README.md` | can become stale second README | should route to canonical docs, not duplicate them |
+| `web/pilot-ui/README.md` | old demo/product framing can persist | should describe current organizer/member demo only |
+| `website/src/pages/whats-real-now.astro` | public freshness anchor can lag runtime progress | must be checked against STATE/PHASE docs before date bump |
+| historical architecture maps | detailed but sometimes old | use as archaeology only |
+| old demo docs/scripts | can imply wrong demo path | distinguish legacy dev scaffolding from guided pilot UI demo |
+| archived session/handoff docs | useful but time-bound | cite only with date/status context |
+
+## Required labels for stale material
+
+When a doc is retained but not current, use explicit language such as:
+
+- historical;
+- archived;
+- superseded;
+- design-direction;
+- package-local;
+- fixture-only;
+- not current runtime truth;
+- useful archaeology, not source of truth.
+
+## Public-surface handling
+
+Public surfaces should not make readers perform archaeology.
+
+If a public page contains stale material, prefer one of these actions:
+
+1. replace it with current truth;
+2. replace it with a short routing note to canonical truth;
+3. move it to an archive if it must be preserved;
+4. clearly label it historical.
+
+Do not leave stale public copy in place because it used to be true.
+
+## Non-claims guardrail
+
+Stale material must not be allowed to reintroduce claims that ICN currently has:
+
+- Phase 2 completion;
+- formal NYCN pilot status;
+- production readiness;
+- live federation;
+- complete mobile/member UX;
+- implemented service hosting;
+- live Tool Commons;
+- full fixture-backed demo mode;
+- production SDIS/ZKP/PQ deployment posture.
+
+## Suggested future checks
+
+A future drift check should flag or classify:
+
+- old repo paths and app topology;
+- stale port claims;
+- stale demo names;
+- old implementation counts;
+- public website references to NYCN/Summit unless intentionally allowlisted;
+- unsafe vocabulary in public/demo surfaces;
+- project-index docs without `Last Reviewed`;
+- maps that claim implemented status without source/state anchors.
+
+## Related maps
+
+| Map | Relationship |
+|---|---|
+| `source-of-truth-map.md` | Defines the ranking this map enforces. |
+| `project-coverage-matrix.md` | Tracks where stale/archive risk remains. |
+| `website-truth-map.md` | Applies these rules to the public site. |
+| `pilot-ui-current-state-map.md` | Applies these rules to the current demo surface. |
+| `show-readiness-map.md` | Defines external-facing non-claims. |

--- a/docs/reference/project-index/website-truth-map.md
+++ b/docs/reference/project-index/website-truth-map.md
@@ -1,0 +1,120 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-05-09
+---
+
+# Website Truth Map
+
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), ADR-0032, and [`source-of-truth-map.md`](source-of-truth-map.md). This map routes public website truth discipline; it does not make the website canonical over the repo.
+
+## Purpose
+
+The public website is the front door to ICN. It must be clear, readable, and honest. It should summarize current truth without becoming a second source of truth.
+
+This map exists to prevent public copy from drifting ahead of implementation or lagging behind current runtime evidence.
+
+## Core rule
+
+```text
+The website summarizes current truth.
+It does not create current truth.
+```
+
+When the website and repo disagree, defer to the source-of-truth hierarchy, then fix the website.
+
+## Source paths
+
+| Area | Path |
+|---|---|
+| Website source | `website/` |
+| Main public pages | `website/src/pages/` |
+| Website docs mirror/content | `website/src/content/docs/` |
+| Website truth boundary ADR | `docs/adr/ADR-0032-website-truth-boundary.md` |
+| Show-readiness rules | `docs/reference/project-index/show-readiness-map.md` |
+| Current truth | `docs/STATE.md`, `docs/PHASE_PROGRESS.md`, `docs/reference/project-index/current-truth-map.md` |
+
+## Important website surfaces
+
+| Surface | Role | Drift risk |
+|---|---|---|
+| `index.astro` | Public landing page. | medium: can over-simplify into product pitch. |
+| `whats-real-now.astro` | Public maturity anchor. | high: freshness anchor can lag current state. |
+| `for-cooperatives.astro` | Adoption framing. | high: can imply readiness or formal pilots. |
+| `for-developers.astro` | Contributor/developer framing. | medium: can point to stale commands or surfaces. |
+| `get-involved.astro` | Participation path. | medium: can overpromise. |
+| `src/content/docs/` | Website docs mirror/content. | high: can become stale duplicate documentation. |
+
+## Public claim checklist
+
+Before publishing or updating a public page, check:
+
+- Does it preserve Phase 2 as in progress, not complete?
+- Does it avoid describing NYCN as a formal pilot?
+- Does it avoid claiming live federation?
+- Does it avoid production-readiness claims?
+- Does it distinguish implemented, partial, fixture-backed, design-direction, and future work?
+- Does it avoid implying service hosting or Tool Commons are implemented runtime ecosystems?
+- Does it avoid broad security/autonomy claims without current evidence?
+- Does it keep public ICN copy free of private/package-local NYCN specifics unless intentionally reviewed?
+- Does it use current ICN vocabulary and avoid deprecated product framing?
+
+## Current safe website framing
+
+Safe short framing:
+
+```text
+ICN is institutional infrastructure for democratic organizations: cooperatives, communities, and federations.
+It is a constraint engine: apps translate institutional meaning into constraints, and the kernel enforces constraints without understanding that meaning.
+```
+
+Safe current status framing:
+
+```text
+Phase 0 and Phase 1 are complete. Phase 2 is in progress and not complete.
+NYCN is the intended first cooperative partner and active partnership track, not yet a formal pilot.
+Member standing and action cards exist. The pilot UI has a bounded demo slice for standing and action cards.
+```
+
+## What the website must not imply
+
+The website must not imply:
+
+- ICN is a finished product;
+- ICN is production deployed as a multi-cooperative network;
+- NYCN is a signed/formal pilot;
+- federation is live in production;
+- Tool Commons is a live app ecosystem;
+- service hosting is implemented as a complete runtime feature;
+- the mobile/member shell is complete;
+- all privacy, ZKP, steward, or post-quantum paths are production-ready;
+- old demo/product framing is the current ICN identity.
+
+## Docs mirror rule
+
+Website docs mirrors should be routing surfaces, not duplicate root READMEs.
+
+If a website docs file contains copied status numbers, old crate counts, old app topology, or stale commands, prefer replacing it with a short truth-boundary note that points to canonical docs.
+
+## Review cadence
+
+Review `whats-real-now` whenever any of these change:
+
+- Phase status;
+- member standing/action-card surface status;
+- demo fixture status;
+- NYCN pilot status;
+- federation status;
+- service/tool runtime status;
+- public-safe vocabulary rules.
+
+Only bump the reviewed date after checking claims against current anchors.
+
+## Related issues and PRs
+
+| Item | Purpose |
+|---|---|
+| #1779 | Tracks public website and pilot-ui truth sync. |
+| ADR-0032 | Defines website truth-boundary doctrine. |
+| `show-readiness-map.md` | Defines external non-claims and demo-safe framing. |
+| `stale-and-archived-map.md` | Defines stale public-surface handling. |


### PR DESCRIPTION
## Summary

Adds three project-index maps for drift control:

- `docs/reference/project-index/stale-and-archived-map.md`
- `docs/reference/project-index/website-truth-map.md`
- `docs/reference/project-index/pilot-ui-current-state-map.md`

These maps turn the recent truth-sync work into repeatable guidance for stale docs, public website claims, and pilot-ui/demo boundaries.

## Why

Recent review found that ICN's biggest risk is not lack of architecture, but truth fragmentation across current state docs, project-index maps, website pages, pilot-ui docs, demos, archives, and NYCN/package material.

These maps make that drift visible and classifiable.

## Key boundaries preserved

- Historical detail is not current truth.
- The website summarizes current truth; it does not create current truth.
- The pilot UI currently fixture-backs standing and action cards, not the whole system.
- Governance, receipts, ledger, members, trust, and federation are not fully fixture-backed in the current local demo path.
- NYCN is the intended first cooperative partner / active track, not a formal pilot.
- Live federation and production readiness are not claimed.

## Non-goals

- No runtime changes.
- No schema changes.
- No generated docs changes.
- No new contract URNs.
- No claim that Phase 2 is complete.
- No claim of formal NYCN pilot status.
- No claim of live federation, production readiness, implemented service hosting, live Tool Commons, or full fixture-backed demo mode.

## Verification

Not run locally from this environment.

Recommended when available:

```bash
python3 docs/scripts/doc_control_check.py --strict
git diff --check
```

## Related

Advances #1689 and supports #1779 / #1777.