### PR TITLE
chore(ci): tighten benchmark regression detection

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -143,11 +143,9 @@ jobs:
             exit 1
           fi
 
-          # Extract regressions - Criterion outputs various indicators:
-          # - "Performance has regressed" (explicit message)
-          # - "regressed" in change analysis
-          # - Positive percentage changes like "change: +15.234%"
-          REGRESSION_COUNT=$(grep -ciE "(Performance has regressed|regressed|change:.*\+[0-9]+\.[0-9]+%)" bench_output.txt || echo "0")
+          # Count only Criterion's explicit regression verdict. Do not match confidence-interval
+          # lines like `change: [-0.5% -0.2% +0.03%]` — the positive upper bound is not a regression.
+          REGRESSION_COUNT=$(grep -ciF "Performance has regressed" bench_output.txt || echo "0")
 
           if [ "$REGRESSION_COUNT" -gt 0 ]; then
             echo "has_regressions=true" >> $GITHUB_OUTPUT
@@ -163,7 +161,7 @@ jobs:
               echo "<summary>Regression Details</summary>"
               echo ""
               echo '```'
-              REGRESSION_OUTPUT=$(grep -B3 -A1 -iE "(Performance has regressed|regressed|change:.*\+[0-9]+\.[0-9]+%)" bench_output.txt)
+              REGRESSION_OUTPUT=$(grep -B3 -A1 -iF "Performance has regressed" bench_output.txt)
               REGRESSION_LINES=$(echo "$REGRESSION_OUTPUT" | wc -l)
               echo "$REGRESSION_OUTPUT" | head -100
               if [ "$REGRESSION_LINES" -gt 100 ]; then


### PR DESCRIPTION
## What

The Benchmarks `Compare Against Base` job counted lines matching a broad regex that also matched Criterion confidence intervals such as `change: [-0.5% -0.2% +0.03%]`, producing large false-positive regression counts.

## Change

- Count only lines containing Criterion's explicit verdict: `Performance has regressed` (case-insensitive `-iF`).
- Regression comment excerpt uses the same filter.

## Risk

If Criterion ever emitted a regression without that exact phrase, the job could miss it. Criterion's documented output for regressions includes this line; interval-only matches were the bug.

## After merge

Re-run or refresh PR #1787 checks so Benchmarks can go green without `perf-regression-ok` if the prior failure was entirely from this grep.

Made with [Cursor](https://cursor.com)