### PR TITLE
chore(ci): make Claude review advisory and reliable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,19 +39,27 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          ALL_CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)
+          # Use the merge base, not the base branch tip, so a PR that is merely
+          # behind main does not get credited with every upstream commit since
+          # divergence. Falls back to the base SHA if no common ancestor exists
+          # (shouldn't happen for a normal PR).
+          MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "$BASE_SHA")
+          ALL_CHANGED=$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA" 2>/dev/null || true)
           # Truncate to 60 paths for domain-hint matching; track the real total separately.
           CHANGED=$(printf '%s' "$ALL_CHANGED" | head -60)
-          TOTAL=$(printf '%s' "$ALL_CHANGED" | grep -c . || echo 0)
+          # `grep -c` always prints a number and exits 1 on zero matches. Use
+          # `|| true` (not `|| echo 0`) so we don't get duplicate "0\n0" output
+          # that would break the numeric tests below.
+          TOTAL=$(printf '%s' "$ALL_CHANGED" | grep -c . || true)
 
           # Identify low-signal paths (generated, lockfiles, archived docs, binary fixtures).
           # SIGNAL_FILES = total minus those — used to decide whether the diff is purely noise.
           SIGNAL_FILES=$(printf '%s' "$ALL_CHANGED" \
             | grep -vE '(^|/)Cargo\.lock$|(^|/)package-lock\.json$|(^|/)yarn\.lock$|(^|/)pnpm-lock\.yaml$|/generated/|/api-types\.ts$|\.wasm$|^docs/archive/' \
-            | grep -c . || echo 0)
+            | grep -c . || true)
 
           # Approximate total diff size (added + removed lines). Used only for the skip threshold.
-          DIFF_LOC=$(git diff --shortstat "$BASE_SHA" "$HEAD_SHA" 2>/dev/null \
+          DIFF_LOC=$(git diff --shortstat "$MERGE_BASE" "$HEAD_SHA" 2>/dev/null \
             | awk '{
                 ins = 0; del = 0;
                 for (i = 1; i <= NF; i++) {
@@ -151,9 +159,14 @@ jobs:
             DOMAIN_HINTS="No specific domain detected. Apply general ICN review: check 5 invariants."
           fi
 
-          # Write outputs (escape newlines for GitHub Actions).
-          HINTS_ESCAPED="${DOMAIN_HINTS//$'\n'/%0A}"
-          echo "domain_hints=$HINTS_ESCAPED" >> "$GITHUB_OUTPUT"
+          # Write outputs. domain_hints is multiline, so use the file-mode
+          # heredoc syntax — the older `%0A` escape was for the deprecated
+          # `::set-output` command and is NOT decoded by $GITHUB_OUTPUT.
+          {
+            echo "domain_hints<<DOMAIN_HINTS_EOF"
+            printf '%s\n' "$DOMAIN_HINTS"
+            echo "DOMAIN_HINTS_EOF"
+          } >> "$GITHUB_OUTPUT"
           echo "changed_files=${TOTAL}" >> "$GITHUB_OUTPUT"
           echo "signal_files=${SIGNAL_FILES}" >> "$GITHUB_OUTPUT"
           echo "diff_loc=${DIFF_LOC}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,13 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Advisory only — never blocks merge
+    # Advisory layer — never blocks merge.
+    # Job-level continue-on-error is defense for runner-death scenarios.
+    # The per-step continue-on-error on the review action below is the
+    # primary mechanism that keeps the JOB conclusion (= PR check status)
+    # green when the SDK fails for auth, rate-limit, plugin, or model
+    # availability reasons. Without step-level continue-on-error, a failing
+    # SDK call produces a red "claude-review" check on every PR.
     continue-on-error: true
     permissions:
       contents: read
@@ -27,15 +33,51 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect change scope
+      - name: Detect change scope and skip thresholds
         id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
-          ALL_CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || true)
+          ALL_CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)
           # Truncate to 60 paths for domain-hint matching; track the real total separately.
           CHANGED=$(printf '%s' "$ALL_CHANGED" | head -60)
           TOTAL=$(printf '%s' "$ALL_CHANGED" | grep -c . || echo 0)
+
+          # Identify low-signal paths (generated, lockfiles, archived docs, binary fixtures).
+          # SIGNAL_FILES = total minus those — used to decide whether the diff is purely noise.
+          SIGNAL_FILES=$(printf '%s' "$ALL_CHANGED" \
+            | grep -vE '(^|/)Cargo\.lock$|(^|/)package-lock\.json$|(^|/)yarn\.lock$|(^|/)pnpm-lock\.yaml$|/generated/|/api-types\.ts$|\.wasm$|^docs/archive/' \
+            | grep -c . || echo 0)
+
+          # Approximate total diff size (added + removed lines). Used only for the skip threshold.
+          DIFF_LOC=$(git diff --shortstat "$BASE_SHA" "$HEAD_SHA" 2>/dev/null \
+            | awk '{
+                ins = 0; del = 0;
+                for (i = 1; i <= NF; i++) {
+                  if ($i ~ /^[0-9]+$/) {
+                    if ($(i+1) ~ /^insertion/) ins = $i;
+                    else if ($(i+1) ~ /^deletion/) del = $i;
+                  }
+                }
+                print ins + del
+              }')
+          DIFF_LOC=${DIFF_LOC:-0}
+
+          # Advisory skip thresholds. Required CI gates are unaffected.
+          # These cap the prompt/diff size we hand to the SDK so the review
+          # stays within rate-limit/token budget and finishes well under the
+          # 20-minute job timeout.
+          SKIP_REASON=""
+          if [ "$TOTAL" -eq 0 ]; then
+            SKIP_REASON="diff is empty"
+          elif [ "$TOTAL" -gt 500 ]; then
+            SKIP_REASON="changed file count ($TOTAL) exceeds advisory threshold (500)"
+          elif [ "$DIFF_LOC" -gt 20000 ]; then
+            SKIP_REASON="diff size (${DIFF_LOC} added+removed lines) exceeds advisory threshold (20000)"
+          elif [ "$SIGNAL_FILES" -eq 0 ]; then
+            SKIP_REASON="diff consists exclusively of generated files / lockfiles / archived docs"
+          fi
 
           DOMAIN_HINTS=""
 
@@ -109,13 +151,43 @@ jobs:
             DOMAIN_HINTS="No specific domain detected. Apply general ICN review: check 5 invariants."
           fi
 
-          # Write to output (escape newlines for GitHub Actions)
+          # Write outputs (escape newlines for GitHub Actions).
           HINTS_ESCAPED="${DOMAIN_HINTS//$'\n'/%0A}"
           echo "domain_hints=$HINTS_ESCAPED" >> "$GITHUB_OUTPUT"
           echo "changed_files=${TOTAL}" >> "$GITHUB_OUTPUT"
+          echo "signal_files=${SIGNAL_FILES}" >> "$GITHUB_OUTPUT"
+          echo "diff_loc=${DIFF_LOC}" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=${SKIP_REASON}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip notice (advisory review skipped)
+        if: steps.scope.outputs.skip_reason != ''
+        env:
+          SKIP_REASON: ${{ steps.scope.outputs.skip_reason }}
+          TOTAL_FILES: ${{ steps.scope.outputs.changed_files }}
+          SIGNAL_FILES: ${{ steps.scope.outputs.signal_files }}
+          DIFF_LOC: ${{ steps.scope.outputs.diff_loc }}
+        run: |
+          {
+            echo "## Claude review skipped (advisory)"
+            echo ""
+            echo "**Reason:** ${SKIP_REASON}"
+            echo ""
+            echo "Claude code review is an advisory layer. It is skipped on diffs that exceed advisory thresholds or consist entirely of generated content."
+            echo ""
+            echo "- Total files changed: ${TOTAL_FILES}"
+            echo "- Signal files (non-generated, non-lockfile): ${SIGNAL_FILES}"
+            echo "- Diff size (added+removed lines): ${DIFF_LOC}"
+            echo ""
+            echo "This is not a failure. Required CI gates are unaffected."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Claude Code Review
         id: claude-review
+        if: steps.scope.outputs.skip_reason == ''
+        # Step-level continue-on-error keeps the JOB conclusion (= the PR
+        # check status) green when the SDK fails. Without this, every
+        # auth / rate-limit / plugin error produces a red advisory check.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -136,3 +208,43 @@ jobs:
 
             High signal-to-noise: only surface issues that genuinely matter (bugs, security, invariant violations).
             Skip style nits. Skip issues already caught by clippy.
+
+      - name: Summarize review outcome
+        if: always() && steps.scope.outputs.skip_reason == ''
+        env:
+          REVIEW_OUTCOME: ${{ steps.claude-review.outcome }}
+        run: |
+          case "$REVIEW_OUTCOME" in
+            success)
+              {
+                echo "## Claude review completed"
+                echo ""
+                echo "Advisory review ran. See PR conversation for any inline comments."
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            failure)
+              {
+                echo "## Claude review unavailable (advisory)"
+                echo ""
+                echo "The advisory review step did not complete. This repo uses Claude **subscription** OAuth auth via the \`CLAUDE_CODE_OAUTH_TOKEN\` Actions secret — not direct Anthropic API billing. Common causes, in order of likelihood:"
+                echo ""
+                echo "- **Subscription OAuth token stale, expired, or generated under the wrong account/org context.** Fix: regenerate the token locally with \`claude setup-token\` while authenticated as the intended Claude subscription account, then update the GitHub Actions secret \`CLAUDE_CODE_OAUTH_TOKEN\` (repo or org level)."
+                echo "- **Organization-managed subscription disables Claude Code access for this workspace/account.** Fix: confirm Claude Code subscription access is enabled for the org/workspace/account whose token is in use."
+                echo "- Rate limit or transient SDK error."
+                echo "- Plugin marketplace or model availability issue."
+                echo ""
+                echo "Switching to \`anthropic_api_key\` / \`ANTHROPIC_API_KEY\` is an alternate path **only** if we intentionally decide to bill through direct API access instead of subscription. Do not flip to it as a quick fix — subscription auth is the intended default for this repo."
+                echo ""
+                echo "This is not a failure of the PR. Required CI gates are unaffected. A red \`claude-review\` check now indicates workflow/config breakage worth investigating, not a normal timeout."
+              } >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            cancelled)
+              echo "## Claude review cancelled (advisory)" >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            skipped)
+              echo "## Claude review skipped (advisory)" >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              echo "## Claude review outcome: ${REVIEW_OUTCOME} (advisory)" >> "$GITHUB_STEP_SUMMARY"
+              ;;
+          esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,7 +440,7 @@ Common CI failures and their minimal fixes:
 | **non-exhaustive patterns** | Enum variant added in shared crate | Add match arm in consumer crate, map to closest existing semantics |
 | **Clippy** | Lint regression in changed code | Fix the warning — never suppress with `#[allow]` unless pre-existing |
 | **Compare Against Base** | Benchmark compare flaky | If not required: ignore. If required: `gh run rerun <run-id> --failed` once before touching code |
-| **claude-review** | 15-min job timeout (infra flake) | Never blocks merge |
+| **claude-review** | Advisory review using Claude **subscription** OAuth via the `CLAUDE_CODE_OAUTH_TOKEN` Actions secret (not direct API billing). Step-level `continue-on-error` keeps the check green on SDK errors, and oversized diffs (>500 files or >20k LOC) skip cleanly. A red `claude-review` now means workflow/config breakage worth investigating — see the run's job summary. If the failure is "organization has disabled Claude subscription access," regenerate the token with `claude setup-token` from the intended Claude subscription account and update the GitHub secret `CLAUDE_CODE_OAUTH_TOKEN`; if org-managed, confirm Claude Code subscription access is enabled for that workspace. Never blocks merge regardless. |
 
 **Full drift chain**: shared crate change → gateway/API match updates → OpenAPI regen → TS type regen → CI passes. Don't skip the second half.
 
@@ -815,7 +815,7 @@ Specialized agents in `.claude/agents/` auto-activate based on crate scope. Invo
 - Use `--admin` sparingly (prefer fixing flake sources rather than normalizing bypass).
 - `gh pr checks` exits code 8 on mixed results — always capture with `|| true`.
 - `gh pr checks` output is tab-separated; multi-word check names (e.g. "Test Coverage") need `awk -F'\t' '{print $2}'`, not `awk '{print $2}'`.
-- `claude-review` failure = 15-min job timeout (infra flake). Never blocks merge.
+- `claude-review` is advisory and never blocks merge. The workflow authenticates via Claude **subscription** OAuth using the `CLAUDE_CODE_OAUTH_TOKEN` Actions secret (not direct Anthropic API billing). Step-level `continue-on-error` keeps the check green on SDK errors; oversized diffs are skipped cleanly with a job summary. A red check now means workflow/config breakage — most commonly a stale/wrong-account `CLAUDE_CODE_OAUTH_TOKEN` (regenerate with `claude setup-token` from the correct subscription account and update the secret) or an org-managed subscription that has disabled Claude Code access for the workspace. Flipping to `ANTHROPIC_API_KEY` is an alternate path only if we intentionally choose direct API billing — not a default fix.
 - "Test Coverage" at `pending / 0s` = queue-stalled, not running. Safe to `--admin` merge when all other required gates are green.
 - When merging multiple PRs in dependency order, expect compilation errors from struct field changes across crates — fix forward, don't over-investigate.
 - Prefer merge strategy over rebase for subtree commits (subtree squash commits do not rebase cleanly).


### PR DESCRIPTION
## What
Make the `claude-review` GitHub Actions check behave like the advisory review layer it is.

This PR:
- keeps Claude SDK/auth/rate-limit/plugin failures from turning into red PR checks
- skips Claude review cleanly for oversized, empty, or generated/lockfile/archive-only diffs
- writes the review outcome and remediation path into `$GITHUB_STEP_SUMMARY`
- corrects stale `CLAUDE.md` guidance that incorrectly described the recurring failure as a 15-minute timeout
- documents that this repo uses Claude subscription OAuth via `CLAUDE_CODE_OAUTH_TOKEN`, not direct Anthropic API billing

## Why
The recurring `claude-review` failure was not a timeout.

Recent runs failed in about 30 seconds with:

> Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access

The workflow already had job-level `continue-on-error: true`, which made the overall workflow run look successful, but the job/check shown on PRs still appeared red. That meant a non-required advisory review layer kept poisoning PR confidence.

This PR fixes the broken-window behavior without changing any required gates.

## How
- Adds step-level `continue-on-error: true` to the Claude action step.
- Adds preflight diff sizing and low-signal diff detection.
- Skips Claude review cleanly for:
  - >500 files
  - >20k added+removed LOC
  - generated/lockfile/archive-only diffs
  - empty diffs
- Adds an always-run summary step explaining whether review completed, skipped, or was unavailable.
- Threads GitHub event values through `env:` instead of inline shell interpolation.
- Updates `CLAUDE.md` so future agents stop misdiagnosing this as a timeout.

## Subscription-auth note
This repo intentionally uses Claude subscription OAuth via the `CLAUDE_CODE_OAUTH_TOKEN` Actions secret.

The correct remediation for the current auth failure is:

1. Run `claude setup-token` while authenticated as the intended Claude subscription account.
2. Update the GitHub Actions secret named `CLAUDE_CODE_OAUTH_TOKEN`.
3. If the subscription is org-managed, verify Claude Code subscription access is enabled for the workspace/account used to generate the token.

Do not switch to `ANTHROPIC_API_KEY` / direct API billing unless we intentionally choose that auth model later.

## Risk
Low.

Required CI gates are untouched. Security/correctness gates are untouched. This does not weaken merge protection. It only makes the advisory Claude review layer stop producing red checks for known advisory-layer failures.

The underlying Claude subscription auth problem still needs a manual secret/account fix; this PR makes that failure visible in the job summary instead of red on every PR.

## Test plan
- [x] YAML parsed successfully with Python
- [x] diff-size parser smoke-tested against real `git diff --shortstat` output
- [x] worktree clean after amended commit
- [ ] PR CI confirms workflow syntax
- [ ] After manual secret refresh: small PR shows `Claude review completed`
- [ ] Large/generated-only PR shows `Claude review skipped (advisory)`