### PR TITLE
docs(claude-md): correct branch-deletion policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -822,4 +822,4 @@ Specialized agents in `.claude/agents/` auto-activate based on crate scope. Invo
 - **Stacked PRs**: Before merging a PR that is the base branch of another open PR, retarget the stacked PR first:
   `gh pr edit <stacked-pr-number> --base main`
   If you forget, GitHub leaves the stacked PR open but its base is gone — it shows as open with a stale diff. Verify with `gh pr view <pr> --json baseRefName`.
-- **Branch cleanup**: `delete_branch_on_merge` is not enabled in repo settings (GitHub UI: Settings → General → Pull Requests). Until enabled, merged branches must be deleted manually or by Dependabot. Run `git fetch --prune` periodically to clean local refs.
+- **Branch cleanup**: `delete_branch_on_merge` is enabled — remote branches are auto-deleted when a PR merges. No manual remote cleanup needed. Local refs still go stale, so run `git fetch --prune` periodically and delete local branches with `git branch -d <name>` after pulling the squash commit into `main`.


### PR DESCRIPTION
## What
One-line correction in `CLAUDE.md`: the repo actually has `delete_branch_on_merge: true` set; remote branches are auto-deleted on merge.

## Why
The previous note said the setting was disabled and merged branches needed manual remote cleanup. Verified via:

```
gh api repos/InterCooperative-Network/icn --jq '.delete_branch_on_merge'
→ true
```

Observed during PR #1800 cleanup: `git push origin --delete <branch>` always errored with `remote ref does not exist` because GitHub had already deleted the remote ref on merge. Also seen via `git fetch --prune` showing 30+ already-deleted remote branches in one pass.

The stale note misled agents into doing redundant manual cleanup that always failed.

## How
Replace the bullet with accurate guidance: remote cleanup is automatic; local refs still go stale and need periodic `git fetch --prune` + `git branch -d`.

## Risk
None — text-only correction in `CLAUDE.md`. No code, no workflow, no required gates touched.

## Test plan
- [x] `gh api ... --jq .delete_branch_on_merge` returns `true`
- [x] PR #1800's branch was auto-deleted on merge (the trigger for this fix)