### PR TITLE
web: polish visual explainer presentation

### DIFF
--- a/website/src/lib/markdown.ts
+++ b/website/src/lib/markdown.ts
@@ -5,12 +5,32 @@ import { marked } from "marked";
 import { resolveRepoDocsRoot } from "./paths";
 
 /**
+ * Strip a leading YAML frontmatter block from a markdown source.
+ *
+ * Many ICN docs carry doc-control frontmatter (Status, Canonical,
+ * Last Reviewed, Owner, Purpose) consumed by docs/scripts/doc_control_check.py.
+ * Without stripping, the marked renderer treats the second `---` as a setext
+ * underline and renders the YAML keys as body text on the public docs
+ * explorer (e.g. /docs/design/ICN_VISUAL_EXPLAINER_BIBLE previously leaked
+ * "Status: draft", "Canonical: no", "Owner: Matt Faherty", etc. as the first
+ * thing a visitor saw).
+ *
+ * The regex anchors at the very start of the source (`^`) and only matches a
+ * paired delimiter on its own line, so `---` inside body content (e.g. a
+ * thematic break or a code fence) is unaffected.
+ */
+function stripFrontmatter(content: string): string {
+  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+}
+
+/**
  * Render markdown to HTML with link rewriting.
  * Relative .md links are resolved to /docs/ paths on this site,
  * or fall back to GitHub links for files we don't sync.
  */
 export function renderMarkdown(content: string): string {
   const docsRoot = resolveRepoDocsRoot();
+  const body = stripFrontmatter(content);
 
   // Build slug inventory
   const allSlugs = new Set<string>();
@@ -71,5 +91,5 @@ export function renderMarkdown(content: string): string {
     return `<a href="${cleanHref}${anchor}"${titleAttr}>${text}</a>`;
   };
 
-  return marked(content, { gfm: true, breaks: false, renderer }) as string;
+  return marked(body, { gfm: true, breaks: false, renderer }) as string;
 }


### PR DESCRIPTION
## Summary

Single-fix polish PR after the recent visual-explainer stack:
- #1803 — visual-explainer bible / control plane (merged).
- #1804 — VE-001 `HowIcnWorksExplainer` source asset (merged).
- #1805 — applied explainers to `how-it-works.astro` + `for-cooperatives.astro` (merged earlier in this session, after a targeted review-fix landed the truth-label-chip wrapper around the `ProvenanceTrail` placement and corrected the *"one station at a time"* walkthrough wording).

This PR fixes one visible rendering bug surfaced by auditing the live public pages.

## PR #1805 status before this work

✅ **Merged** via squash earlier in this session. Two Copilot review comments were resolved before merge via commit `8e07bd57`:
- added a visible `Truth label: repo-grounded public explainer` chip around the `ProvenanceTrail` placement on `for-cooperatives.astro` (the primitive does not yet render its own chip);
- rewrote the bridging paragraph on `how-it-works.astro` so it stops promising a station-by-station walk that the page does not actually deliver.

CI cleared 18 pass / 5 skipping / 0 fail on the new HEAD before merge.

## Pages inspected (audit)

`index.astro`, `what-is-icn.astro`, `how-it-works.astro` (post-#1805), `for-cooperatives.astro` (post-#1805), `whats-real-now.astro`, `docs/[...slug].astro`, `lib/markdown.ts`.

## Visible issues found

| # | Severity | Issue | Root cause | Resolution |
|---|---|---|---|---|
| **1** | **High** | `/docs/design/ICN_VISUAL_EXPLAINER_BIBLE`, `/docs/design/assets/ASSET_REGISTER`, the VE-001 brief page, and every other docs-explorer page with YAML frontmatter rendered the raw doc-control keys (`Status: draft`, `Canonical: no`, `Owner: Matt Faherty`, `Last Reviewed: …`, `Purpose: …`) as the first body text. Verified by greppping the built `dist/`. | `website/src/lib/markdown.ts:74` called `marked(content, …)` without stripping the leading YAML frontmatter block. `marked`'s default parse treats the second `---` as a setext H2 underline, so the keys ended up as page content. | **Fixed in this PR.** Added a `stripFrontmatter(content)` helper anchored at byte zero (3-line regex). After the fix, all three sampled doc pages render 0 frontmatter-key hits (they previously had 5+). |
| 2 | Doctrine consistency | `ClosureLoop` placements on `index.astro` and `what-is-icn.astro`, and `ScopeModel` / `MemberSurface` placements on `how-it-works.astro` and `what-is-icn.astro`, do not carry the truth-label chip the bible §3 requires. | Primitives don't yet expose a chip prop; only the `HowIcnWorksExplainer` composer and the inline `for-cooperatives` page wrapper carry one. | **Deferred.** Right fix is an optional `showTruthLabelChip` prop on each primitive — bigger than polish, merits a dedicated PR. |
| 3 | Format debt | `how-it-works.astro` and `for-cooperatives.astro` carry pre-existing prettier warnings on `main`. | Project `npm run format` is broad/destructive (rewrites unrelated files). | **Deferred.** Recommended PR: `web: add scoped website format check`. |
| 4 | Cosmetic | Unused `.section-explainer` class on `how-it-works.astro` | Future CSS hook | Skipped — harmless, no visible difference. |

## What was fixed

- **`website/src/lib/markdown.ts`** — added `stripFrontmatter()` and called it before `marked()`. The regex (`/^---\r?\n[\s\S]*?\r?\n---\r?\n?/`) anchors at the start of the source and requires a paired delimiter line, so `---` inside a body code fence or thematic break is unaffected.

```ts
function stripFrontmatter(content: string): string {
  return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
}

export function renderMarkdown(content: string): string {
  // ...
  const body = stripFrontmatter(content);
  // ...
  return marked(body, { gfm: true, breaks: false, renderer }) as string;
}
```

The title extraction in `docs/[...slug].astro` was already correct (it uses `/^#\s+(.+)$/m` which doesn't match YAML keys), so no change needed there.

## What was deferred

- Truth-label-chip primitive gap (issue #2) — dedicated PR with a `showTruthLabelChip` prop pattern across `ClosureLoop`, `ScopeModel`, `ProvenanceTrail`, `MemberSurface`.
- Scoped website format check (issue #3) — separate `web: add scoped website format check` PR.
- Pre-existing prettier warnings on touched-pages — same dedicated PR as above.

## What this PR is NOT

- No generated images.
- No new visual explainers from scratch.
- No VE-002 / VE-003 source-asset builds.
- No whole-page rewrites.
- No runtime / backend changes.
- No NYCN / Summit / institution-package content added.
- No production-readiness, live-federation, formal-pilot, or complete-member-app claims.
- No broad `npm run format` run — deliberately avoided.

## Validation

| Gate | Result |
|---|---|
| `npm run lint` (Astro check) | ✅ 0 errors, 0 warnings, 0 hints |
| `npm run build` | ✅ 830 pages built, no regressions |
| Rendered-HTML verification (grep on `dist/`) | ✅ all three sampled doc pages (`ICN_VISUAL_EXPLAINER_BIBLE`, `assets/ASSET_REGISTER`, `assets/briefs/VE-001-how-icn-works-closure-loop`) now show **0** frontmatter-key hits (were 5+ before). Article body intact (page now opens with the real H1 and one-sentence summary). |
| docs control check | ⏭️ not run — no docs files changed |

## Risk

Very low. One file, one function, one regex. The strip pattern is anchored at byte zero and requires a paired delimiter line, so non-frontmatter `---` content (thematic breaks, code fences) is untouched. Body of every doc page is intact post-build.

## Invariants

- adversarial-by-default — N/A (presentation)
- determinism — ✅ regex is pure; output is stable across builds
- canonical-encodings — N/A
- no-panics — N/A
- kernel/app-boundaries — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)