### PR TITLE
web: polish visual explainer copy and presentation

### DIFF
--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -195,15 +195,9 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       </p>
       <ol>
         <li><strong>Evaluate first.</strong> Read <a href="/whats-real-now">What's Real Now</a> and confirm that the current maturity is compatible with your timing.</li>
-        <li><strong>Bring a concrete institutional case.</strong> Open a <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">GitHub Discussion</a> that describes the governance, accounting, coordination, or federation problem your current stack does not carry well.</li>
+        <li><strong>Bring a concrete institutional case.</strong> Open a <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">GitHub Discussion</a> that describes the governance, accounting, coordination, or federation problem your current stack does not carry well. There is no formal pilot program or managed onboarding track yet — institutions engaging in depth are helping shape the substrate directly.</li>
         <li><strong>If you only want to support the work without implying a vendor relationship,</strong> use the GitHub Sponsors rail on <a href="/get-involved#support">Get Involved</a>.</li>
       </ol>
-      <ul>
-        <li><strong>Track the work before you commit institutional energy.</strong> Start with <a href="/whats-real-now">What's Real Now</a>, then use <a href="/community">Community</a> to follow the repository and discussions.</li>
-        <li><strong>Bring institutional patterns, not just product requests.</strong> If your cooperative, federation, or aligned project has a real governance, accounting, or coordination problem that the current stack cannot carry cleanly, use <a href="/get-involved">Get Involved</a> for the current collaboration path.</li>
-        <li><strong>Assume early collaboration is engineering-heavy.</strong> There is no formal pilot program or managed onboarding track yet. Institutions engaging in depth are helping shape the substrate directly.</li>
-        <li><strong>If you want to support the work financially without implying a vendor relationship,</strong> the live path today is the GitHub Sponsors rail surfaced on <a href="/get-involved#support">Get Involved</a>.</li>
-      </ul>
 
       <h2>This is about enhancing human institutions, not automating them away</h2>
       <p>

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -61,10 +61,11 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         rather than as seven disconnected systems that staff have to reconcile by hand.
       </p>
       <p>
-        The explainer above is the model. The rest of this page walks the same loop in more depth —
-        grouping stations where it helps and adding the cross-cutting pieces (scope, federation,
-        commons and compute) where they belong — so you can see what each piece actually does,
-        where the substrate is strongest today, and where work is still concentrated.
+        Each station answers a different question: who is acting, under what authority,
+        by which rule, and with what proof afterward. Scope, federation, and commons and compute
+        cross every station and sit alongside the loop rather than inside any one stop.
+        Each station carries a maturity marker, so the strong parts and the parts still being filled
+        in are visible in place.
       </p>
 
       <h2><span class="station-number">01 · 02</span>Identity and membership <MaturityBadge band="strong" /></h2>


### PR DESCRIPTION
## Summary

Two small public-copy fixes after the visual-explainer stack landed.

## State recovery / context

- **#1803** (visual explainer bible + asset register) — ✅ merged.
- **#1804** (VE-001 `HowIcnWorksExplainer` source asset) — ✅ merged.
- **#1805** (apply explainers to `how-it-works.astro` + `for-cooperatives.astro`) — ✅ merged.
- **#1806** (`stripFrontmatter` fix in `website/src/lib/markdown.ts`) — ✅ merged at the start of this session via squash (`63e62d59`). Was CLEAN/MERGEABLE with all 18 checks green and no requested review changes. Its scope was the markdown rendering bug; this PR is the separate copy-tone pass.

## Pages audited

`index.astro`, `what-is-icn.astro`, `how-it-works.astro`, `for-cooperatives.astro`, `whats-real-now.astro`.

## Visual issues found

None large. Rhythm around `HowIcnWorksExplainer` (how-it-works) and `ProvenanceTrail` (for-cooperatives) reads cleanly. Truth-label-chip primitive gap remains (carried forward from #1806's deferral list).

## Copy issues found

| # | Severity | Page | Issue |
|---|---|---|---|
| 1 | **High** | `how-it-works.astro` lines 63-68 | Textbook meta-commentary under the `HowIcnWorksExplainer` placement: *\"The explainer above is the model. The rest of this page walks the same loop in more depth — grouping stations where it helps and adding the cross-cutting pieces (scope, federation, commons and compute) where they belong — so you can see what each piece actually does, where the substrate is strongest today, and where work is still concentrated.\"* This is the exact \"LLM describing what the page should be\" pattern called out in the audit brief. |
| 2 | **High** | `for-cooperatives.astro` lines 196-206 | Duplicate engagement guidance: a numbered `<ol>` (\"How to engage right now,\" 3 steps) is immediately followed by a `<ul>` (4 bullets) covering nearly the same advice. The `<ul>` reads like an earlier draft that should have been removed when the `<ol>` was added. Only the no-formal-pilot / engineering-heavy caveat is non-duplicative. |
| 3 | Low | `what-is-icn.astro` line 96 | \"Read the nine stations in order:\" is mild reader-direction but reads as honest framing for the `ClosureLoop` placement below it. Left alone. |

## Fixes made

**`how-it-works.astro`** — replaced the meta-commentary bridge paragraph with confident standalone copy. The page no longer narrates itself; the new paragraph frames what each station answers, places scope / federation / commons-and-compute as cross-cutting, and signals the per-station maturity markers without referring back to the explainer or to \"the rest of this page.\"

Before:
> The explainer above is the model. The rest of this page walks the same loop in more depth — grouping stations where it helps and adding the cross-cutting pieces (scope, federation, commons and compute) where they belong — so you can see what each piece actually does, where the substrate is strongest today, and where work is still concentrated.

After:
> Each station answers a different question: who is acting, under what authority, by which rule, and with what proof afterward. Scope, federation, and commons and compute cross every station and sit alongside the loop rather than inside any one stop. Each station carries a maturity marker, so the strong parts and the parts still being filled in are visible in place.

**`for-cooperatives.astro`** — removed the duplicate `<ul>` immediately following the \"How to engage right now\" `<ol>`. The only non-duplicative content from the `<ul>` (the no-formal-pilot / engineering-heavy caveat) is folded into item 2 of the `<ol>` so the substantive guidance is preserved.

Net diff: **+6 / -11 across 2 files.**

## Validation

| Gate | Result |
|---|---|
| `npm run lint` (astro check) | ✅ 0 errors, 0 warnings, 0 hints |
| `npm run build` | ✅ 830 pages built, no regressions |
| Drift check (`ops/scripts/drift-check.sh`) | ✅ PASS (0 errors, 0 warnings) |
| Docs control check | ⏭️ not run — no docs files changed |
| Broad `npm run format` | ⏭️ deliberately not run (rewrites unrelated website files; pre-existing format debt left intact) |

## Deferred (separate PRs)

- Truth-label-chip primitive prop gap for `ClosureLoop` / `ScopeModel` / `MemberSurface` placements on `index.astro` and `what-is-icn.astro` (carried over from #1806's deferral list).
- Scoped website format check that avoids the destructive broad `npm run format` (carried over from #1806).
- Heavier copy tightening — `substrate` repetition pass across `how-it-works.astro` (8×) and `get-involved.astro` (7×) — out of scope for this polish PR; left for a dedicated copy-tightening pass.

## What this PR is NOT

- ❌ No generated images.
- ❌ No new visual explainers from scratch.
- ❌ No VE-002 / VE-003 source-asset builds.
- ❌ No PNG / JPG visual assets.
- ❌ No runtime / backend changes.
- ❌ No NYCN / Summit / package-specific content added.
- ❌ No production-readiness, live-federation, formal-pilot, or complete-member-app claims added.
- ❌ No broad `npm run format` run.
- ❌ No whole-page rewrites.

## Invariants

- adversarial-by-default — N/A (presentation)
- determinism — N/A
- canonical-encodings — N/A
- no-panics — N/A
- kernel/app-boundaries — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)