### PR TITLE
web(copy): tighten substrate language

### DIFF
--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -174,13 +174,13 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       </p>
       <p>
         The second is <strong>early collaboration</strong>: working with the project in depth,
-        with real engineering involvement, as a cooperative or federation willing to be part of how the substrate gets shaped.
+        with real engineering involvement, as a cooperative or federation willing to be part of how the infrastructure gets shaped.
         This is the right relationship for institutions that have the capacity and the interest,
         and who understand they are helping build the thing, not buying it finished.
       </p>
       <p>
         The third is <strong>contribution of expertise</strong>: bringing the institutional knowledge
-        of how real cooperatives actually run into the design of the substrate.
+        of how real cooperatives actually run into the design of the system.
         ICN needs to be informed by the institutions it is meant to serve.
       </p>
       <p>
@@ -195,7 +195,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       </p>
       <ol>
         <li><strong>Evaluate first.</strong> Read <a href="/whats-real-now">What's Real Now</a> and confirm that the current maturity is compatible with your timing.</li>
-        <li><strong>Bring a concrete institutional case.</strong> Open a <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">GitHub Discussion</a> that describes the governance, accounting, coordination, or federation problem your current stack does not carry well. There is no formal pilot program or managed onboarding track yet — institutions engaging in depth are helping shape the substrate directly.</li>
+        <li><strong>Bring a concrete institutional case.</strong> Open a <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">GitHub Discussion</a> that describes the governance, accounting, coordination, or federation problem your current stack does not carry well. There is no formal pilot program or managed onboarding track yet — institutions engaging in depth are helping shape the infrastructure directly.</li>
         <li><strong>If you only want to support the work without implying a vendor relationship,</strong> use the GitHub Sponsors rail on <a href="/get-involved#support">Get Involved</a>.</li>
       </ol>
 

--- a/website/src/pages/get-involved.astro
+++ b/website/src/pages/get-involved.astro
@@ -158,7 +158,7 @@ cargo test --workspace --lib</code></pre>
           <span class="badge badge-amber">Contribute</span>
           <h2>Writers, designers, researchers, organizers.</h2>
           <p class="path-header-lede">
-            ICN is not only a Rust project. The substrate has to be described, designed, stress-tested, and
+            ICN is not only a Rust project. The system has to be described, designed, stress-tested, and
             translated into something cooperatives can actually use. The work below is real and needed.
           </p>
         </div>
@@ -182,7 +182,7 @@ cargo test --workspace --lib</code></pre>
         <article class="contribution-card">
           <h3>Design and member-facing UX</h3>
           <p>
-            The member-facing experience is the part of the system most visibly trailing the substrate underneath.
+            The member-facing experience is the part of the system most visibly trailing the capabilities underneath.
             Design work on how identity, standing, governance, and receipts cohere into something a person can use
             is wanted and has room.
           </p>
@@ -267,7 +267,7 @@ cargo test --workspace --lib</code></pre>
           <h2>Cooperatives, federations, aligned institutions.</h2>
           <p class="path-header-lede">
             If your cooperative, network, or aligned project is thinking about ICN as institutional infrastructure,
-            the honest frame is not "vendor selection." It is early collaboration on a substrate that is still being built.
+            the honest frame is not "vendor selection." It is early collaboration on infrastructure that is still being built.
           </p>
         </div>
       </div>
@@ -288,7 +288,7 @@ cargo test --workspace --lib</code></pre>
           <h3>Bring how your institution actually runs</h3>
           <p>
             Governance patterns that work, accounting rules that don't fit generic tools, federation relationships
-            that current software can't carry — this knowledge shapes the substrate. You don't need to write code to do this.
+            that current software can't carry — this knowledge shapes the infrastructure. You don't need to write code to do this.
             Open a <a href="https://github.com/InterCooperative-Network/icn/discussions" target="_blank" rel="noopener">Discussion</a>
             describing what your institution does and where the current stack fails.
           </p>
@@ -299,7 +299,7 @@ cargo test --workspace --lib</code></pre>
           <h3>Work in depth, with engineering capacity</h3>
           <p>
             If your institution has the capacity and the interest, working with the project directly as a cooperative
-            or federation willing to shape how the substrate gets built is an option. This is engineering-heavy.
+            or federation willing to shape how the infrastructure gets built is an option. This is engineering-heavy.
             You are helping build it, not buying it finished.
           </p>
           <p>
@@ -334,7 +334,7 @@ cargo test --workspace --lib</code></pre>
           <h2>Sponsor the work financially.</h2>
           <p class="path-header-lede">
             ICN is open infrastructure. Financial support goes to sustaining engineering capacity on the
-            substrate — not to a commercial product with an investor ladder behind it.
+            infrastructure — not to a commercial product with an investor ladder behind it.
           </p>
         </div>
       </div>
@@ -375,7 +375,7 @@ cargo test --workspace --lib</code></pre>
           </li>
           <li>
             <strong>We are not issuing tokens, equity, or governance rights in exchange for funding.</strong>
-            ICN's governance lives in the cooperative substrate it builds, not in a funding tier.
+            ICN's governance lives in the cooperative infrastructure it builds, not in a funding tier.
           </li>
           <li>
             <strong>For institutional funding conversations</strong> — grants, fiscal sponsorship, aligned-foundation

--- a/website/src/pages/how-it-works.astro
+++ b/website/src/pages/how-it-works.astro
@@ -83,7 +83,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <p>
         ICN models cooperatives, communities, and federations as <strong>scopes</strong>:
         real institutional entities with their own rules, their own members, their own history, and their own boundaries.
-        A scope is not a tenant on someone else's platform. It is a distinct institution the substrate knows about directly.
+        A scope is not a tenant on someone else's platform. It is a distinct institution the system knows about directly.
       </p>
       <p>
         Scopes are <em>contexts of action</em>, not levels of hierarchy.
@@ -147,14 +147,14 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <h2><span class="station-number">08</span>Receipts, provenance, and auditability <MaturityBadge band="strong" /></h2>
       <p>
         When something happens in ICN — a proposal accepted, a rule applied, an obligation settled,
-        an action taken under authorization — the substrate produces a durable record of it.
+        an action taken under authorization — the system produces a durable record of it.
         Those records are receipts in the strict sense: evidence that a specific thing happened
         under specific rules with specific standing.
       </p>
       <p>
         Provenance is the chain those receipts form. You can follow a particular outcome back to the decision
         that authorized it, to the rule that shaped it, to the members who had standing in the decision.
-        This is where the substrate is strongest, and it is the anchor the rest of the system is built around.
+        This is where ICN is strongest, and it is the anchor the rest of the system is built around.
       </p>
 
       <ProvenanceTrail title="How the chain is built" />
@@ -183,7 +183,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         Some things institutions need to do cannot be held by a single organization.
         Shared resources — compute capacity, storage, coordinated work, infrastructure — need
         to be held in common across members of a network, with rules that are accountable to all of them.
-        <strong>Commons and compute</strong> is the name ICN uses for this part of the substrate:
+        <strong>Commons and compute</strong> is the name ICN uses for this part of the system:
         shared infrastructure participating in the same institutional loop as governance and accounting.
       </p>
       <p>
@@ -204,7 +204,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         receipts, and federation come together into something a person can see and use.
       </p>
       <p>
-        This is an area where the substrate is ahead of the surface.
+        This is an area where the system is ahead of the surface.
         The capabilities underneath are real and in many places strong.
         The interface through which ordinary members interact with those capabilities is still being built out.
       </p>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -279,7 +279,7 @@ import MaturityCard from '../components/MaturityCard.astro';
           <p>Federation and commons/compute have serious implementation behind them — treaties, attestations, cross-institutional clearing, shared resource governance. These subsystems are real and advancing.</p>
         </MaturityCard>
         <MaturityCard band="behind">
-          <p>The member-facing experience — where identity, standing, governance, accounting, and receipts converge into something a person can actually see and use — is the part most visibly trailing the substrate underneath.</p>
+          <p>The member-facing experience — where identity, standing, governance, accounting, and receipts converge into something a person can actually see and use — is the part most visibly trailing the capabilities underneath.</p>
         </MaturityCard>
       </MaturityGrid>
 

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -22,7 +22,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       <div class="truth-grid truth-grid-2">
         <div class="truth-note truth-note-teal">
           <span class="truth-note-label">Practical proposition</span>
-          <h3>A shared substrate for governance, records, and coordination</h3>
+          <h3>A shared foundation for governance, records, and coordination</h3>
           <p>
             ICN gives democratic organizations a technical foundation for identity,
             governance, rules, records, and inter-organizational coordination.


### PR DESCRIPTION
## Summary

Targeted vocabulary pass on the word **\"substrate\"** across the public site. Before: 24 uses across six public pages; the word started reading like internal architecture vocabulary instead of confident civic-infrastructure copy. After: 7 retained uses, each carrying single-instance technical-thesis weight.

## PR #1807 status before this work

✅ **Merged** at \`a2aae376\` (squash). State before merge: CLEAN / MERGEABLE, all 18 checks green, Copilot review with no comments requested. Local \`main\` synced before branching.

## Pages inspected

- **Primary:** \`how-it-works.astro\` (7 uses → 2 retained), \`get-involved.astro\` (7 uses → 0 retained).
- **Secondary:** \`what-is-icn.astro\` (3 → 2 retained), \`for-cooperatives.astro\` (5 → 2 retained), \`index.astro\` (2 → 1 retained), \`whats-real-now.astro\` (0 → 0).

## Substrate usage summary

**Retained (technical thesis, single-instance per page):**
- \`how-it-works.astro:11\` (meta description)
- \`how-it-works.astro:59\` — \`<em>one coherent substrate</em>\` (the page's italicized technical thesis)
- \`what-is-icn.astro:8\` (meta description)
- \`what-is-icn.astro:111\` — single contrast in the \"Not a DAO framework\" bullet
- \`index.astro:247\` — homepage's single use, station-by-station framing
- \`for-cooperatives.astro:58\` — \"the digital substrate for membership, decisions, action…\" (definition)
- \`for-cooperatives.astro:97\` — \"its own institutional substrate\" (page's defining claim)

**Changed (17 sentence-level substitutions):**

| Page | Line | Before | After |
|---|---|---|---|
| how-it-works | 86 | the substrate knows about directly | the system knows about directly |
| how-it-works | 150 | the substrate produces a durable record | the system produces a durable record |
| how-it-works | 157 | where the substrate is strongest, and it is the anchor the rest of the system… | where ICN is strongest, and it is the anchor the rest of the system… *(removes substrate/system collision)* |
| how-it-works | 186 | this part of the substrate | this part of the system |
| how-it-works | 207 | the substrate is ahead of the surface | the system is ahead of the surface |
| for-cooperatives | 177 | how the substrate gets shaped | how the infrastructure gets shaped |
| for-cooperatives | 183 | into the design of the substrate | into the design of the system |
| for-cooperatives | 198 | shape the substrate directly | shape the infrastructure directly |
| what-is-icn | 25 (h3) | A shared substrate for governance, records, and coordination | A shared foundation for governance, records, and coordination *(parallels body word \"foundation\")* |
| get-involved | 161 | The substrate has to be described, designed, stress-tested | The system has to be described, designed, stress-tested |
| get-involved | 185 | trailing the substrate underneath *(with \"system\" earlier in the same sentence)* | trailing the capabilities underneath |
| get-involved | 270 | on a substrate that is still being built | on infrastructure that is still being built |
| get-involved | 291 | this knowledge shapes the substrate | this knowledge shapes the infrastructure |
| get-involved | 302 | shape how the substrate gets built | shape how the infrastructure gets built |
| get-involved | 337 | engineering capacity on the substrate | engineering capacity on the infrastructure |
| get-involved | 378 | the cooperative substrate it builds | the cooperative infrastructure it builds |
| index | 282 | trailing the substrate underneath | trailing the capabilities underneath |

Net change: **+17 / -17 across 5 files** (each edit is a 1:1 sentence-level substitution; no paragraph rewrites).

## What was intentionally left alone

- All 7 retained \`substrate\` uses, each single-instance per page with technical-thesis weight.
- Maturity caveats — none removed; replacements preserve meaning.
- Visual components — untouched.
- Format / whitespace — no broad \`npm run format\` run; pre-existing format debt left intact.
- Adjacent copy concerns — sharper headings on secondary pages, \"current stack\" vs. \"current tools\" consistency, broader rhythm work — deferred.

## Validation

| Gate | Result |
|---|---|
| \`npm run lint\` (astro check) | ✅ 0 errors, 0 warnings, 0 hints |
| \`npm run build\` | ✅ 830 pages built, no regressions |
| \`ops/scripts/drift-check.sh\` | ✅ PASS (0 errors, 0 warnings) |
| Docs control check | ⏭️ not run — no docs files changed |
| Broad \`npm run format\` | ⏭️ deliberately not run |

## What this PR is NOT

- ❌ No generated images.
- ❌ No new visual explainers.
- ❌ No VE-002 / VE-003 source-asset builds.
- ❌ No PNG / JPG visual assets.
- ❌ No runtime / backend changes.
- ❌ No NYCN / Summit / package-specific content added.
- ❌ No production-readiness, live-federation, formal-pilot, or complete-member-app claims added.
- ❌ No broad \`npm run format\` run.
- ❌ No whole-page rewrites.
- ❌ No paragraph-level rewrites — only sentence-level word substitutions.
- ❌ No maturity caveats removed.

## Invariants

- adversarial-by-default — N/A (presentation)
- determinism — N/A
- canonical-encodings — N/A
- no-panics — N/A
- kernel/app-boundaries — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)