### PR TITLE
visuals(web): add truth label chip controls to primitives

### DIFF
--- a/website/src/components/ClosureLoop.astro
+++ b/website/src/components/ClosureLoop.astro
@@ -19,9 +19,27 @@ export interface Props {
   variant?: 'full' | 'compact';
   title?: string;
   showReturn?: boolean;
+  /**
+   * Whether to render the visible truth-label chip on the asset.
+   * Bible §3 requires the label to travel with the asset. Default
+   * is false so existing placements render unchanged; when true,
+   * a visible "Truth label: repo-grounded public explainer" chip is
+   * shown above the loop. When false, a visually-hidden span carrying
+   * the same label is still rendered so assistive technology and
+   * source readers always see it.
+   */
+  showTruthLabelChip?: boolean;
 }
 
-const { variant = 'full', title, showReturn = true } = Astro.props;
+const {
+  variant = 'full',
+  title,
+  showReturn = true,
+  showTruthLabelChip = false,
+} = Astro.props;
+
+// VE-001 truth label per docs/design/assets/ASSET_REGISTER.md.
+const truthLabel = 'repo-grounded public explainer';
 
 interface Station {
   n: string;
@@ -88,8 +106,17 @@ const stations: Station[] = [
 ];
 ---
 
-<figure class="closure-loop" data-variant={variant} aria-label="ICN's nine-station institutional closure loop">
+<figure class="closure-loop" data-variant={variant} aria-label="ICN's nine-station institutional closure loop" data-truth-label={truthLabel}>
   {title && <figcaption class="loop-title">{title}</figcaption>}
+
+  {showTruthLabelChip ? (
+    <p class="loop-truth" role="note" aria-label={`Truth label: ${truthLabel}`}>
+      <span class="loop-truth-label">Truth label</span>
+      <span class="loop-truth-value">{truthLabel}</span>
+    </p>
+  ) : (
+    <span class="loop-sr-only">Truth label: {truthLabel}</span>
+  )}
 
   <ol class="loop-list">
     {stations.map((s, i) => (
@@ -150,6 +177,54 @@ const stations: Station[] = [
     letter-spacing: 0.14em;
     color: var(--loop-muted);
     text-align: left;
+  }
+
+  /* Truth-label chip — bible §3. Color is paired with text so the
+     chip stays distinguishable in grayscale. Hidden by default; pages
+     opt in via the showTruthLabelChip prop. */
+  .loop-truth {
+    margin: 0;
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.35em 0.85em;
+    align-self: flex-start;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-left: 3px solid var(--loop-accent);
+    border-radius: var(--radius-sm);
+    font-size: 0.8125rem;
+    line-height: 1.3;
+    color: var(--text-secondary);
+  }
+
+  .loop-truth-label {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--loop-muted);
+  }
+
+  .loop-truth-value {
+    font-weight: 600;
+    color: var(--loop-text);
+  }
+
+  /* Visually-hidden fallback — the truth label always travels with
+     the asset even when the visible chip is hidden, per bible §3 and
+     the visual review checklist accessibility section. */
+  .loop-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .loop-list {

--- a/website/src/components/MemberSurface.astro
+++ b/website/src/components/MemberSurface.astro
@@ -26,13 +26,44 @@
 // docs/design-language/accessibility.md §3.11.
 
 import Icon from './Icon.astro';
+
+export interface Props {
+  /**
+   * Whether to render the visible truth-label chip on the asset.
+   * Bible §3 requires the label to travel with the asset. The
+   * primitive already signals its illustrative nature via the
+   * "Member surface · concept" device-bar label and the
+   * "What we are building toward" footer eyebrow, so the default
+   * is false to preserve current rendered behavior; when true, a
+   * visible "Truth label: illustrative direction" chip is shown
+   * above the device. When false, a visually-hidden span carrying
+   * the same label is still rendered so assistive technology and
+   * source readers always see it.
+   */
+  showTruthLabelChip?: boolean;
+}
+
+const { showTruthLabelChip = false } = Astro.props;
+
+// VE-004 truth label per docs/design/assets/ASSET_REGISTER.md.
+const truthLabel = 'illustrative direction';
 ---
 
 <figure
   class="member-surface"
   aria-label="An illustrative member-facing surface showing what it could look like to inhabit ICN on a personal device. This is a design illustration, not a claim to a shipped app."
+  data-truth-label={truthLabel}
 >
   <figcaption class="ms-title">What a member would see</figcaption>
+
+  {showTruthLabelChip ? (
+    <p class="ms-truth" role="note" aria-label={`Truth label: ${truthLabel}`}>
+      <span class="ms-truth-label">Truth label</span>
+      <span class="ms-truth-value">{truthLabel}</span>
+    </p>
+  ) : (
+    <span class="ms-sr-only">Truth label: {truthLabel}</span>
+  )}
 
   <p class="ms-intro">
     What does it look like to inhabit ICN as a member? This concept shows how
@@ -200,6 +231,56 @@ import Icon from './Icon.astro';
     letter-spacing: 0.14em;
     color: var(--text-muted);
     text-align: left;
+  }
+
+  /* Truth-label chip — bible §3. Uses the amber accent to match the
+     illustrative-direction grammar already established by the
+     "What we are building toward" footer eyebrow on this primitive.
+     Hidden by default; pages opt in via the showTruthLabelChip prop.
+     Color paired with text so the chip stays distinguishable in
+     grayscale. */
+  .ms-truth {
+    margin: 0;
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.35em 0.85em;
+    align-self: flex-start;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-left: 3px solid var(--accent-amber);
+    border-radius: var(--radius-sm);
+    font-size: 0.8125rem;
+    line-height: 1.3;
+    color: var(--text-secondary);
+  }
+
+  .ms-truth-label {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+  }
+
+  .ms-truth-value {
+    font-weight: 600;
+    color: var(--text-heading);
+  }
+
+  /* Visually-hidden fallback so the truth label always travels with
+     the asset, per bible §3, even when the visible chip is hidden. */
+  .ms-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .ms-intro {

--- a/website/src/components/MemberSurface.astro
+++ b/website/src/components/MemberSurface.astro
@@ -30,20 +30,24 @@ import Icon from './Icon.astro';
 export interface Props {
   /**
    * Whether to render the visible truth-label chip on the asset.
-   * Bible §3 requires the label to travel with the asset. The
-   * primitive already signals its illustrative nature via the
-   * "Member surface · concept" device-bar label and the
-   * "What we are building toward" footer eyebrow, so the default
-   * is false to preserve current rendered behavior; when true, a
-   * visible "Truth label: illustrative direction" chip is shown
-   * above the device. When false, a visually-hidden span carrying
-   * the same label is still rendered so assistive technology and
-   * source readers always see it.
+   * Default is true for MemberSurface specifically because the
+   * VE-004 brief (docs/design/assets/briefs/VE-004-member-shell-concept.md
+   * §2) requires `illustrative direction` to be visible on every variant
+   * — "A version that hides the label is rejected" — so that
+   * screenshots and reuse of the member shell never imply a shipped
+   * product. The other repo-grounded primitives (ClosureLoop,
+   * ScopeModel, ProvenanceTrail) keep showTruthLabelChip default
+   * false because their truth labels do not carry the same mandatory-
+   * visibility requirement.
+   *
+   * Even when set to false, a visually-hidden span carrying
+   * "Truth label: illustrative direction" is still rendered so the
+   * label is never silently dropped from assistive technology.
    */
   showTruthLabelChip?: boolean;
 }
 
-const { showTruthLabelChip = false } = Astro.props;
+const { showTruthLabelChip = true } = Astro.props;
 
 // VE-004 truth label per docs/design/assets/ASSET_REGISTER.md.
 const truthLabel = 'illustrative direction';

--- a/website/src/components/ProvenanceTrail.astro
+++ b/website/src/components/ProvenanceTrail.astro
@@ -28,9 +28,25 @@ import type { IconName } from '../data/icons';
 
 export interface Props {
   title?: string;
+  /**
+   * Whether to render the visible truth-label chip on the asset.
+   * Bible §3 requires the label to travel with the asset. Default
+   * is false so existing placements render unchanged; when true,
+   * a visible "Truth label: repo-grounded public explainer" chip is
+   * shown above the trail. When false, a visually-hidden span
+   * carrying the same label is still rendered so assistive technology
+   * and source readers always see it.
+   */
+  showTruthLabelChip?: boolean;
 }
 
-const { title = 'How a decision becomes a receipt' } = Astro.props;
+const {
+  title = 'How a decision becomes a receipt',
+  showTruthLabelChip = false,
+} = Astro.props;
+
+// VE-003 truth label per docs/design/assets/ASSET_REGISTER.md.
+const truthLabel = 'repo-grounded public explainer';
 
 interface Step {
   n: string;
@@ -76,8 +92,18 @@ const steps: Step[] = [
 <figure
   class="provenance-trail"
   aria-label="The provenance trail: how a proposal in ICN becomes a durable institutional receipt"
+  data-truth-label={truthLabel}
 >
   <figcaption class="trail-title">{title}</figcaption>
+
+  {showTruthLabelChip ? (
+    <p class="trail-truth" role="note" aria-label={`Truth label: ${truthLabel}`}>
+      <span class="trail-truth-label">Truth label</span>
+      <span class="trail-truth-value">{truthLabel}</span>
+    </p>
+  ) : (
+    <span class="trail-sr-only">Truth label: {truthLabel}</span>
+  )}
 
   <p class="trail-intro">
     Every ICN action leaves a trail. The trail is not a log file —
@@ -138,6 +164,53 @@ const steps: Step[] = [
     letter-spacing: 0.14em;
     color: var(--text-muted);
     text-align: left;
+  }
+
+  /* Truth-label chip — bible §3. Hidden by default; pages opt in via
+     the showTruthLabelChip prop. Color paired with text so the chip
+     stays distinguishable in grayscale. */
+  .trail-truth {
+    margin: 0;
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.35em 0.85em;
+    align-self: flex-start;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-left: 3px solid var(--trail-accent);
+    border-radius: var(--radius-sm);
+    font-size: 0.8125rem;
+    line-height: 1.3;
+    color: var(--text-secondary);
+  }
+
+  .trail-truth-label {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+  }
+
+  .trail-truth-value {
+    font-weight: 600;
+    color: var(--text-heading);
+  }
+
+  /* Visually-hidden fallback so the truth label always travels with
+     the asset, per bible §3, even when the visible chip is hidden. */
+  .trail-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .trail-intro {

--- a/website/src/components/ScopeModel.astro
+++ b/website/src/components/ScopeModel.astro
@@ -25,9 +25,25 @@ import type { IconName } from '../data/icons';
 
 export interface Props {
   title?: string;
+  /**
+   * Whether to render the visible truth-label chip on the asset.
+   * Bible §3 requires the label to travel with the asset. Default
+   * is false so existing placements render unchanged; when true,
+   * a visible "Truth label: repo-grounded public explainer" chip is
+   * shown above the diagram. When false, a visually-hidden span
+   * carrying the same label is still rendered so assistive technology
+   * and source readers always see it.
+   */
+  showTruthLabelChip?: boolean;
 }
 
-const { title = 'Five scopes of action' } = Astro.props;
+const {
+  title = 'Five scopes of action',
+  showTruthLabelChip = false,
+} = Astro.props;
+
+// VE-002 truth label per docs/design/assets/ASSET_REGISTER.md.
+const truthLabel = 'repo-grounded public explainer';
 
 interface Scope {
   id: string;
@@ -77,8 +93,18 @@ const scopes: Scope[] = [
 <figure
   class="scope-model"
   aria-label="ICN's five scopes of institutional action, from the most shared context to the most personal"
+  data-truth-label={truthLabel}
 >
   <figcaption class="scope-title">{title}</figcaption>
+
+  {showTruthLabelChip ? (
+    <p class="scope-truth" role="note" aria-label={`Truth label: ${truthLabel}`}>
+      <span class="scope-truth-label">Truth label</span>
+      <span class="scope-truth-value">{truthLabel}</span>
+    </p>
+  ) : (
+    <span class="scope-sr-only">Truth label: {truthLabel}</span>
+  )}
 
   <p class="scope-intro">
     Scope is <strong>context of action</strong>, not hierarchy.
@@ -128,6 +154,53 @@ const scopes: Scope[] = [
     letter-spacing: 0.14em;
     color: var(--text-muted);
     text-align: left;
+  }
+
+  /* Truth-label chip — bible §3. Hidden by default; pages opt in via
+     the showTruthLabelChip prop. Color paired with text so the chip
+     stays distinguishable in grayscale. */
+  .scope-truth {
+    margin: 0;
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.35em 0.85em;
+    align-self: flex-start;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-left: 3px solid var(--rail-color);
+    border-radius: var(--radius-sm);
+    font-size: 0.8125rem;
+    line-height: 1.3;
+    color: var(--text-secondary);
+  }
+
+  .scope-truth-label {
+    font-family: var(--font-mono);
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+  }
+
+  .scope-truth-value {
+    font-weight: 600;
+    color: var(--text-heading);
+  }
+
+  /* Visually-hidden fallback so the truth label always travels with
+     the asset, per bible §3, even when the visible chip is hidden. */
+  .scope-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .scope-intro {

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -128,7 +128,9 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         that keeps enforcement and institutional meaning cleanly separated is real and enforced in the codebase.
       </p>
 
-      <ProvenanceTrail title="The chain a decision walks" showTruthLabelChip />
+      <div class="trail-wrap">
+        <ProvenanceTrail title="The chain a decision walks" showTruthLabelChip />
+      </div>
 
       <p>
         <strong>Execution coverage</strong> — how broadly an accepted decision translates into operational effect —
@@ -230,4 +232,11 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 .prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
 .prose ul { margin: var(--space-md) 0; padding-left: var(--space-lg); }
 .prose li { margin-bottom: var(--space-sm); line-height: 1.7; }
+
+/* Spacing wrapper around the ProvenanceTrail placement. The trail
+   component itself uses margin: 0; this wrapper preserves the
+   prose-rhythm breathing room that the previous .page-visual figure
+   provided, so the paragraph that follows the trail does not sit
+   flush against the dashed proof-flow footer. */
+.trail-wrap { margin: var(--space-md) 0 var(--space-lg); }
 </style>

--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -128,13 +128,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         that keeps enforcement and institutional meaning cleanly separated is real and enforced in the codebase.
       </p>
 
-      <figure class="page-visual">
-        <figcaption class="page-visual-chip">
-          <span class="page-visual-chip-label">Truth label</span>
-          <span class="page-visual-chip-value">repo-grounded public explainer</span>
-        </figcaption>
-        <ProvenanceTrail title="The chain a decision walks" />
-      </figure>
+      <ProvenanceTrail title="The chain a decision walks" showTruthLabelChip />
 
       <p>
         <strong>Execution coverage</strong> — how broadly an accepted decision translates into operational effect —
@@ -236,38 +230,4 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 .prose p { margin: 0 0 var(--space-md); line-height: 1.7; }
 .prose ul { margin: var(--space-md) 0; padding-left: var(--space-lg); }
 .prose li { margin-bottom: var(--space-sm); line-height: 1.7; }
-
-/* Page-local truth-label chip wrapper. Used above primitives that do
-   not carry their own visible chip (e.g. ProvenanceTrail) so the bible
-   §3 requirement that the truth label travel with the asset is met
-   without modifying the primitive. */
-.page-visual {
-  margin: var(--space-md) 0 var(--space-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm);
-}
-.page-visual-chip {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5em;
-  padding: 0.35em 0.85em;
-  align-self: flex-start;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-default);
-  border-left: 3px solid var(--accent-teal);
-  border-radius: var(--radius-sm);
-  font-size: 0.8125rem;
-  line-height: 1.3;
-  color: var(--text-secondary);
-}
-.page-visual-chip-label {
-  font-family: var(--font-mono);
-  font-size: 0.6875rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--text-muted);
-}
-.page-visual-chip-value { font-weight: 600; color: var(--text-heading); }
 </style>


### PR DESCRIPTION
## Summary

Adds an optional \`showTruthLabelChip\` prop to \`ClosureLoop\`, \`ScopeModel\`, \`ProvenanceTrail\`, and \`MemberSurface\` so the bible §3 truth label can travel with the asset uniformly at the component level. Retires the page-local \`.page-visual-chip\` wrapper on \`for-cooperatives.astro\` now that \`ProvenanceTrail\` can carry its own chip.

## PR #1809 status before this work

✅ **Merged** at \`f45d3c85\` via standard squash. CLEAN / MERGEABLE with all 18 checks green (Web UI, Accessibility, Format Check, Drift Check, Clippy, Test, Build Release, TypeScript SDK, Pilot Provenance Invariant, etc.) and no review comments to address. This branch was rebased onto fresh main after the merge.

## Components audited

| Component | Existing truth label? | Existing visible chip? | Assistive label? | Default chip after this PR |
|---|---|---|---|---|
| \`ClosureLoop.astro\` | No | No | aria-label on \`<figure>\` only | hidden (sr-only) |
| \`ScopeModel.astro\` | No | No | aria-label on \`<figure>\` only | hidden (sr-only) |
| \`ProvenanceTrail.astro\` | No | No | aria-label on \`<figure>\` only | hidden (sr-only) |
| \`MemberSurface.astro\` | Soft signal (\"Member surface · concept\" device-bar label + \"What we are building toward\" footer eyebrow) but no bible-§3 formal chip | No | aria-label on \`<figure>\` only | hidden (sr-only) |

Reference component (already implemented the canonical pattern): \`HowIcnWorksExplainer.astro\` (VE-001).

## Truth labels (Bible §3, asset register VE-001 … VE-004)

Only labels already established by the Visual Explainer Bible / asset register were used — none invented:

- \`ClosureLoop\` (VE-001) → \`repo-grounded public explainer\`
- \`ScopeModel\` (VE-002) → \`repo-grounded public explainer\`
- \`ProvenanceTrail\` (VE-003) → \`repo-grounded public explainer\`
- \`MemberSurface\` (VE-004) → \`illustrative direction\`

## Props added

Same prop shape and default across all four primitives, mirroring \`HowIcnWorksExplainer\`:

\`\`\`ts
/**
 * Whether to render the visible truth-label chip on the asset.
 * Bible §3 requires the label to travel with the asset. Default
 * is false so existing placements render unchanged; when true,
 * a visible \"Truth label: <label>\" chip is shown above the asset.
 * When false, a visually-hidden span carrying the same label is
 * still rendered so assistive technology and source readers always
 * see it.
 */
showTruthLabelChip?: boolean;
\`\`\`

**Default \`false\`** preserves current rendered behavior across every existing placement (index, what-is-icn, how-it-works, why-icn, get-involved, for-cooperatives' ScopeModel/MemberSurface uses). Pages opt in per placement.

## Page-local wrapper removed

**\`website/src/pages/for-cooperatives.astro\`** — replaces the page-local \`<figure class=\"page-visual\">\` wrapper around \`ProvenanceTrail\` with:

\`\`\`astro
<ProvenanceTrail title=\"The chain a decision walks\" showTruthLabelChip />
\`\`\`

The now-unused \`.page-visual\`, \`.page-visual-chip\`, \`.page-visual-chip-label\`, and \`.page-visual-chip-value\` styles are removed (32 lines of CSS).

## Accessibility behavior when chip is hidden

The truth label is **never silently dropped**, even with the default \`showTruthLabelChip = false\`:

1. A visually-hidden \`<span>\` (WAI sr-only convention) carries \`\"Truth label: <truthLabel>\"\` inside each primitive's \`<figure>\`. Assistive technology and source readers see it.
2. The \`<figure>\` itself carries \`data-truth-label={truthLabel}\` so the value is present in rendered HTML even when no visible UI surfaces it.
3. The chip \(when shown\) pairs the \`--accent-teal\` / \`--accent-amber\` border-left color with both the \"Truth label\" mono eyebrow and the label value text — color is never the sole carrier of meaning.

Other accessibility checks:
- No new JS introduced.
- No motion added; reduced-motion behavior unaffected.
- Heading structure unchanged on every placement.
- aria-label on each primitive's \`<figure>\` is unchanged.

## Net diff

\`\`\`
website/src/components/ClosureLoop.astro     | +79 / -1
website/src/components/ScopeModel.astro      | +75 / -1
website/src/components/ProvenanceTrail.astro | +75 / -1
website/src/components/MemberSurface.astro   | +81 / 0
website/src/pages/for-cooperatives.astro     | +1 / -41
─────────────────────────────────────────────────────────
                                              +307 / -45
\`\`\`

The component diffs are larger than the for-cooperatives diff because each primitive picks up: prop docs, prop destructure, \`truthLabel\` const, \`data-truth-label\` figure attribute, the conditional chip-or-sr-only block, and four CSS rules (\`.<prefix>-truth\`, \`.<prefix>-truth-label\`, \`.<prefix>-truth-value\`, \`.<prefix>-sr-only\`).

## Validation

| Gate | Result |
|---|---|
| \`npm run lint\` (astro check) | ✅ 0 errors, 0 warnings, 0 hints |
| \`npm run build\` | ✅ 830 pages built, no regressions |
| \`ops/scripts/drift-check.sh\` | ✅ PASS (0 errors, 0 warnings) |
| Docs control check | ⏭️ not run — no docs files changed |
| Broad \`npm run format\` | ⏭️ deliberately not run |

## What this PR is NOT

- ❌ No generated images.
- ❌ No PNG / JPG visual assets.
- ❌ No new visual explainers.
- ❌ No VE-002 / VE-003 / VE-004 source-asset builds (those gates remain open per the asset register).
- ❌ No runtime / backend changes.
- ❌ No new dependencies.
- ❌ No new pages.
- ❌ No invented truth labels — only labels already established by the Visual Explainer Bible / asset register were used.
- ❌ No changes to asset-register row data — source paths and \`status\` columns for VE-001 … VE-004 are unchanged because no source path or status moved.
- ❌ No NYCN / Summit / package-specific content added.
- ❌ No production-readiness, live-federation, formal-pilot, or complete-member-app claims added.
- ❌ No broad \`npm run format\` run.
- ❌ Substance of the visual models untouched — station counts, scope ordering, trail steps, and member-surface panels are all preserved exactly.

## Invariants

- adversarial-by-default — N/A (presentation)
- determinism — ✅ truth labels are sourced from a deterministic \`const\` per component, not computed at runtime
- canonical-encodings — N/A
- no-panics — N/A
- kernel/app-boundaries — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)