### PR TITLE
visuals(web): opt public placements into truth-label chips

### DIFF
--- a/website/src/pages/for-cooperatives.astro
+++ b/website/src/pages/for-cooperatives.astro
@@ -117,7 +117,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         It changes what the work is resting on.
       </p>
 
-      <ScopeModel title="The contexts your members would actually act inside" />
+      <ScopeModel title="The contexts your members would actually act inside" showTruthLabelChip />
 
       <h2>What is real today</h2>
       <p>

--- a/website/src/pages/for-developers.astro
+++ b/website/src/pages/for-developers.astro
@@ -108,7 +108,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         <li><strong>Commons and compute.</strong> Shared infrastructure with trust-aware placement, checkpointing, cross-participant clearing, and dispute resolution — participating in the same institutional loop as governance and accounting.</li>
       </ul>
 
-      <ClosureLoop variant="full" title="The institutional loop you'll be reading code against" showReturn={false} />
+      <ClosureLoop variant="full" title="The institutional loop you'll be reading code against" showReturn={false} showTruthLabelChip />
 
       <h2>Subsystems that exist but are not yet publicly described</h2>
       <p>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -248,7 +248,7 @@ import MaturityCard from '../components/MaturityCard.astro';
         </p>
       </div>
 
-      <ClosureLoop variant="compact" title="The institutional closure" />
+      <ClosureLoop variant="compact" title="The institutional closure" showTruthLabelChip />
 
       <p class="closure-footnote">
         <a href="/what-is-icn">What is ICN</a> walks through each station in plain language.

--- a/website/src/pages/what-is-icn.astro
+++ b/website/src/pages/what-is-icn.astro
@@ -87,7 +87,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         They are the primitives of the system.
       </p>
 
-      <ScopeModel title="The five scopes of institutional action" />
+      <ScopeModel title="The five scopes of institutional action" showTruthLabelChip />
 
       <h2>Closing the institutional loop</h2>
       <p>
@@ -96,7 +96,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         to carry every station of it. Read the nine stations in order:
       </p>
 
-      <ClosureLoop variant="full" title="The nine-station closure" />
+      <ClosureLoop variant="full" title="The nine-station closure" showTruthLabelChip />
 
       <p class="after-loop">
         That is the loop. ICN exists to close it.

--- a/website/src/pages/why-icn.astro
+++ b/website/src/pages/why-icn.astro
@@ -141,7 +141,7 @@ import ReadingLadder from '../components/ReadingLadder.astro';
         and the whole history remains legible to the people who live inside it.
       </p>
 
-      <ClosureLoop variant="compact" title="The chain ICN is built to keep intact" showReturn={false} />
+      <ClosureLoop variant="compact" title="The chain ICN is built to keep intact" showReturn={false} showTruthLabelChip />
 
       <p>
         That is not a small claim, and ICN does not pretend the work is done.


### PR DESCRIPTION
## Summary

Editorial follow-up to #1810. Now that \`ClosureLoop\`, \`ScopeModel\`, and \`ProvenanceTrail\` support an optional \`showTruthLabelChip\` prop, this PR opts six high-visibility public-facing placements into the visible chip so the bible-§3 truth label is rendered on the asset itself, not only in assistive-tech / source. The chip is the strongest pattern because it survives screenshots and reuse in decks.

## PR #1810 status before this work

✅ **Merged** at \`df63156a\` via standard \`--squash --delete-branch\`. CLEAN / MERGEABLE; all 18 required checks green; the two bot reviews (Copilot + Codex P2) on the prior commit \`53f772b7\` were both resolved in the fix commit \`0027ab05\` (Copilot's spacing concern via the \`.trail-wrap\` div; Codex's concern via flipping the MemberSurface default to \`showTruthLabelChip = true\` per VE-004 brief §2).

## Placement audit

10 primitive placements total across the public site. Decision per placement:

| Placement | Variant | Decision |
|---|---|---|
| \`index.astro:251\` ClosureLoop | compact | **Opt in** |
| \`what-is-icn.astro:90\` ScopeModel | — | **Opt in** |
| \`what-is-icn.astro:99\` ClosureLoop | full | **Opt in** |
| \`why-icn.astro:144\` ClosureLoop | compact | **Opt in** |
| \`for-developers.astro:111\` ClosureLoop | full | **Opt in** |
| \`for-cooperatives.astro:120\` ScopeModel | — | **Opt in** (sibling consistency with same page's already-chipped ProvenanceTrail) |
| \`how-it-works.astro:94\` ScopeModel | — | Skip — downstream of HowIcnWorksExplainer's own chip; over-labels |
| \`how-it-works.astro:160\` ProvenanceTrail | — | Skip — same reasoning |
| \`how-it-works.astro:212\` MemberSurface | — | Already chipped (VE-004 default, wired in #1810) |
| \`for-cooperatives.astro:132\` ProvenanceTrail | — | Already chipped (opted in by #1810) |

## Net diff

\`\`\`
website/src/pages/index.astro            | +1 / -1
website/src/pages/what-is-icn.astro      | +2 / -2
website/src/pages/why-icn.astro          | +1 / -1
website/src/pages/for-developers.astro   | +1 / -1
website/src/pages/for-cooperatives.astro | +1 / -1
─────────────────────────────────────────────────
                                          +6 / -6
\`\`\`

Each edit is a single-token \`showTruthLabelChip\` prop addition to an existing \`<ClosureLoop />\` / \`<ScopeModel />\` invocation. No copy changes, no layout changes, no markup beyond the prop.

## Truth labels

All chips render \"Truth label: \`repo-grounded public explainer\`\" sourced from each component's \`truthLabel\` const wired in #1810, which itself was sourced from the asset register VE-001 / VE-002 / VE-003 rows. **No labels invented in this PR.**

## Validation

| Gate | Result |
|---|---|
| \`npm run lint\` (astro check) | ✅ 0 errors, 0 warnings, 0 hints |
| \`npm run build\` | ✅ 830 pages built, no regressions |
| \`ops/scripts/drift-check.sh\` | ✅ PASS (0 errors, 0 warnings) |
| Docs control check | ⏭️ not run — no docs files changed |
| Broad \`npm run format\` | ⏭️ deliberately not run |

## What this PR is NOT

- ❌ No generated images.
- ❌ No PNG / JPG visual assets.
- ❌ No new visual explainers.
- ❌ No VE source-asset builds.
- ❌ No runtime / backend changes.
- ❌ No new dependencies.
- ❌ No new pages.
- ❌ No invented truth labels — only labels already established by the Visual Explainer Bible / asset register.
- ❌ No changes to asset-register row data.
- ❌ No NYCN / Summit / package-specific content added.
- ❌ No production-readiness, live-federation, formal-pilot, or complete-member-app claims added.
- ❌ No paragraph or section rewrites — only single-token prop additions.
- ❌ No broad \`npm run format\` run.
- ❌ No copy changes.

## Invariants

- adversarial-by-default — N/A (presentation)
- determinism — ✅ chip text is sourced from a deterministic \`const\` per component, not computed at runtime
- canonical-encodings — N/A
- no-panics — N/A
- kernel/app-boundaries — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)