### PR TITLE
web: add scoped website format check

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,8 @@
     "astro": "astro",
     "deploy": "astro build && npx gh-pages -d dist",
     "lint": "astro check",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "format:check:changed": "bash scripts/format-check-changed.sh"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.6",

--- a/website/scripts/format-check-changed.sh
+++ b/website/scripts/format-check-changed.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Non-destructive Prettier check restricted to website files changed vs a base ref.
+#
+# Default base ref: origin/main. Override with BASE_REF env or first positional arg.
+#
+# Usage:
+#   bash scripts/format-check-changed.sh
+#   bash scripts/format-check-changed.sh origin/some-branch
+#   BASE_REF=HEAD~1 bash scripts/format-check-changed.sh
+#
+# Exits 0 when no website files changed under the configured extensions
+# (so it is safe to call unconditionally from CI or pre-push hooks).
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root/website"
+
+base_ref="${1:-${BASE_REF:-origin/main}}"
+
+if ! git rev-parse --verify --quiet "$base_ref" >/dev/null; then
+  if [ "$base_ref" = "origin/main" ] && git rev-parse --verify --quiet main >/dev/null; then
+    base_ref="main"
+  else
+    echo "format-check-changed: base ref '$base_ref' not found; skipping (no-op)."
+    exit 0
+  fi
+fi
+
+# Prettier-handled extensions present under website/. Keep narrow on purpose —
+# anything else falls through to a deliberate follow-up rather than silently
+# expanding the script's surface area.
+allowed_re='\.(astro|css|ts|tsx|js|jsx|mjs|cjs|json|md|yml|yaml)$'
+
+changed_files="$(git diff --name-only --diff-filter=d "${base_ref}"...HEAD -- 'website/' \
+  | sed 's#^website/##' \
+  | grep -E "$allowed_re" || true)"
+
+if [ -z "$changed_files" ]; then
+  echo "format-check-changed: no website files to check (base: $base_ref)."
+  exit 0
+fi
+
+file_count="$(printf '%s\n' "$changed_files" | wc -l | tr -d ' ')"
+echo "format-check-changed: checking ${file_count} file(s) against base '${base_ref}'..."
+
+printf '%s\n' "$changed_files" \
+  | xargs npx prettier --check --plugin=prettier-plugin-astro

--- a/website/scripts/format-check-changed.sh
+++ b/website/scripts/format-check-changed.sh
@@ -32,7 +32,7 @@ fi
 # expanding the script's surface area.
 allowed_re='\.(astro|css|ts|tsx|js|jsx|mjs|cjs|json|md|yml|yaml)$'
 
-changed_files="$(git diff --name-only --diff-filter=d "${base_ref}"...HEAD -- 'website/' \
+changed_files="$(git -C "$repo_root" diff --name-only --diff-filter=d "${base_ref}"...HEAD -- 'website/' \
   | sed 's#^website/##' \
   | grep -E "$allowed_re" || true)"
 

--- a/website/scripts/format-check-changed.sh
+++ b/website/scripts/format-check-changed.sh
@@ -45,4 +45,4 @@ file_count="$(printf '%s\n' "$changed_files" | wc -l | tr -d ' ')"
 echo "format-check-changed: checking ${file_count} file(s) against base '${base_ref}'..."
 
 printf '%s\n' "$changed_files" \
-  | xargs npx prettier --check --plugin=prettier-plugin-astro
+  | xargs -d '\n' npx prettier --check --plugin=prettier-plugin-astro


### PR DESCRIPTION
## Summary
Adds `format:check:changed` — a non-destructive Prettier helper restricted to website files changed vs a base ref. Existing `npm run format` rewrites the entire website tree and has repeatedly leaked unrelated reformatting into copy and visual PRs.

## What
- New: `website/scripts/format-check-changed.sh` — bash helper anchored at repo root for stable path resolution
- Edit: `website/package.json` — adds one script entry: `"format:check:changed": "bash scripts/format-check-changed.sh"`

## Why
- `npm run format` is `prettier --write .` — destructive across the whole website tree, no `--check` variant exists
- There is no website-specific Prettier coverage in CI today: `Format Check` is Rust-only (`cargo fmt --all --check` in `./icn`), and `Web UI` targets `./web/pilot-ui`, not `./website`
- Copy and visual reviewers need a way to verify their PR's files are formatted without rewriting unrelated files
- This recurring failure mode is documented in memory (`feedback_schema_discipline_in_fixtures`) and visible across PRs #1769–#1810

## How
- Helper diffs vs base ref: positional arg > `BASE_REF` env > `origin/main` default, with fallback to `main` if `origin/main` does not resolve
- Filters `git diff --name-only --diff-filter=d` to `website/`-prefixed paths matching a narrow extension allowlist: `.astro`, `.css`, `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.json`, `.md`, `.yml`, `.yaml`
- `--diff-filter=d` excludes deleted files (avoids confusing "no such file" failures)
- No-ops cleanly when the base ref does not resolve or no matching files exist (safe to call unconditionally)
- Always invokes `prettier --check` — never `--write`
- Anchors `git diff` at the repo root via `git -C "$repo_root"` so the `-- 'website/'` pathspec resolves correctly even when the script's cwd is inside `website/`

## Risk
Low. No existing files reformatted. No new dependencies — `prettier@^3` and `prettier-plugin-astro@^0.12` are already in `devDependencies`. No CI gate wired, so running this script blocks nothing. The script is opt-in via an explicit npm command; it does not run on `npm install`, `npm run build`, or any existing path.

## Test plan
- [x] `BASE_REF=HEAD bash scripts/format-check-changed.sh` → "no website files to check" (empty-diff case)
- [x] `bash scripts/format-check-changed.sh nonexistent-ref` → "base ref not found; skipping" (missing-ref case)
- [x] `npm run format:check:changed --prefix website` against `origin/main` → checks the single eligible file (`website/package.json`) and reports clean
- [x] `cd website && npm run lint` → 0 errors, 0 warnings, 0 hints across 43 files
- [x] `cd website && npm run build` → 830 pages built in 6.84s, complete
- [x] `bash ops/scripts/drift-check.sh` → PASS (0 errors, 0 warnings)

## Context
PR #1811 (`visuals(web): opt public placements into truth-label chips`) merged at 2026-05-14T05:54:15Z, completing the visual-explainer truth-label opt-in series (#1803–#1811). Local main synced at `c66cc771`.

## Intentionally left alone
- Existing files are **not** reformatted. Pre-existing Prettier-rule drift across the website tree remains; a one-time baseline-format PR is a deferred follow-up.
- No `format:check` whole-tree variant — that would fail today on baseline drift and produce a misleading script.
- No CI gate is wired. CI integration is deferred until baseline drift is cleared.
- `website/CLAUDE.md` is not edited — the new command is self-documenting via its header comments; keeping the patch minimal.
- No new dependencies. No lockfile changes.

## What this PR is not
- Not a visual change. No public site copy or component touched.
- Not a runtime, backend, or protocol change. No Rust files, no API, no kernel/app boundaries.
- No generated images, no PNG/JPG assets, no truth-label semantics changed.
- No production-readiness, live-federation, pilot, or wallet/token/payment claims.

## Follow-up recommendations (not for this PR)
1. `docs(freshness): review stale canonical sections` — recurring freshness reports flagged identity/cryptography, state ledger, contract execution, governance, and federation
2. `visuals(web): build VE-002 source asset` — once tooling is stable and docs-freshness posture is understood
3. `visuals(web): build VE-003 source asset` — same constraint
4. Dependabot PR triage for #1790/#1791 — when main is quiet and CI is healthy