### PR TITLE
test(devnet): retrofit Slice A repair fixtures to consume public RepairReceipt

### DIFF
--- a/icn/crates/icn-kernel-api/tests/member_shell_read_only_render_slice_a.rs
+++ b/icn/crates/icn-kernel-api/tests/member_shell_read_only_render_slice_a.rs
@@ -6,7 +6,8 @@
 //! #1843 (`AntiEntropyProbe` + `StateDigest`),
 //! #1844 (`DivergenceEvidence` + `RepairPlan`),
 //! #1845 (receipt-index anti-entropy Slice A fixture),
-//! and #1846 (steward cockpit divergence-render Slice A fixture).
+//! #1846 (steward cockpit divergence-render Slice A fixture),
+//! and #1850 (`RepairReceipt` wire-stable schema, issue #1849).
 //!
 //! # What this is
 //!
@@ -50,11 +51,13 @@
 //!   existence + scope + access path only. There is no body, content,
 //!   payload, raw bytes, or secret field on the rendering type by
 //!   construction.
-//! * Not a public `RepairReceipt` schema. That identifier remains
-//!   design-level after #1845 and #1846; the resolved view shows the
-//!   plain-language "Receipt available" sync status without claiming a
-//!   wire-stable receipt has landed.
-//! * Not a public `PeerSyncReport` schema. Also still design-level.
+//! * Not a member-facing surface for the wire-stable receipt. The
+//!   public `RepairReceipt` (#1849) now anchors the resolved card's
+//!   opaque `receipt_ref_hash` so an auditor can chase the chain back
+//!   to the resolved repair evidence. No member-facing string surfaces
+//!   the receipt's internal field set; the closed plain-language
+//!   vocabulary stays intact.
+//! * Not a public `PeerSyncReport` schema. Still design-level.
 //! * Not a steward cockpit surface. That fixture (#1840 / PR #1846)
 //!   renders the operator-facing technical detail; this fixture renders
 //!   the member-facing plain-language projection of the same proof rail.
@@ -66,8 +69,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use icn_gossip::{to_bloom_projection, BloomFilter};
 use icn_kernel_api::{
     AuthorityBasis, BoundaryRuleRef, BoundaryRuleSet, Did, DigestMismatch, DivergenceClass,
-    DivergenceEvidence, ExpectedRepairReceiptClass, Hash, PeerSet, PolicyClauseRef, ProbeScope,
-    RepairAction, RepairPlan, StateClass, StateDigest,
+    DivergenceEvidence, EffectOutcome, ExpectedRepairReceiptClass, Hash, PeerSet, PolicyClauseRef,
+    ProbeScope, RepairAction, RepairPlan, RepairReceipt, RepairReceiptClass, StateClass,
+    StateDigest,
 };
 
 // ===========================================================================
@@ -160,6 +164,48 @@ fn build_slice_a_repair_plan(evidence: &DivergenceEvidence) -> RepairPlan {
         1_715_000_032,
         [0xCC; 32],
     )
+}
+
+/// Build the public `RepairReceipt` (#1849) the resolved member-shell
+/// view anchors on.
+///
+/// Constructs the wire-stable receipt with `EffectOutcome::Applied`,
+/// cross-linked to `evidence` and `plan` by hash, over a deterministic
+/// fixture after-state digest. The resulting `receipt_hash` is what the
+/// resolved card's opaque `receipt_ref_hash` points at — the member
+/// never reads it, but an auditor can chase the chain back to the
+/// resolved repair evidence.
+///
+/// Kernel-level only: no live network, no live repair. The receipt
+/// records what a fixture peer would have produced had the bounded
+/// `FetchMissing` action run against real peers.
+fn build_slice_a_repair_receipt(evidence: &DivergenceEvidence, plan: &RepairPlan) -> RepairReceipt {
+    let r1 = fixture_receipt_hash("r1", 0x01);
+    let r2 = fixture_receipt_hash("r2", 0x02);
+    let r3 = fixture_receipt_hash("r3", 0x03);
+    let after = fixture_bloom_digest(&[r1.receipt_hash, r2.receipt_hash, r3.receipt_hash]);
+    RepairReceipt::new(
+        RepairReceiptClass::FetchMissingReceipt,
+        EffectOutcome::Applied,
+        evidence.evidence_hash,
+        plan.plan_hash,
+        StateClass::ReceiptIndex,
+        fixture_scope(),
+        "did:icn:fixture:repair-actor".to_string(),
+        AuthorityBasis::DomainPolicyClause(fixture_policy_clause()),
+        BoundaryRuleSet::from_rules(vec![
+            BoundaryRuleRef::NoRepairBeyondAuthority,
+            BoundaryRuleRef::NoLocalityOrDisclosureWidening,
+        ]),
+        None,
+        Some(after),
+        1_715_000_040,
+        1_715_000_070,
+        false,
+        None,
+        [0xDD; 32],
+    )
+    .expect("Slice A member-shell receipt is structurally consistent")
 }
 
 // ===========================================================================
@@ -1054,7 +1100,15 @@ fn render_open_view() -> FixtureMemberShellView {
 /// Render the resolved view: the Slice A repair has landed; the paused
 /// card and the surface rollup transition to `Receipt available`. The
 /// member-facing strings stay in the closed vocabulary.
-fn render_resolved_view(open_view: &FixtureMemberShellView) -> FixtureMemberShellView {
+///
+/// `receipt` is the public, wire-stable `RepairReceipt` (#1849) whose
+/// `receipt_hash` anchors the resolved card's opaque
+/// `receipt_ref_hash`. The member never reads this hash — it is the
+/// auditor-facing cross-link to the resolved repair evidence.
+fn render_resolved_view(
+    open_view: &FixtureMemberShellView,
+    receipt: &RepairReceipt,
+) -> FixtureMemberShellView {
     let mut resolved = open_view.clone();
     for card in resolved.action_cards.iter_mut() {
         if matches!(card.state, FixtureActionLifecycle::OpenButPaused) {
@@ -1065,15 +1119,16 @@ fn render_resolved_view(open_view: &FixtureMemberShellView) -> FixtureMemberShel
                 "This card has been recorded as completed. The plain receipt summary is shown.";
             // Receipt has landed — the pre-receipt expected-receipt
             // label is no longer applicable; the receipt_summary below
-            // is the rendered post-confirm artifact.
+            // is the rendered post-confirm artifact, anchored on the
+            // public RepairReceipt binding hash.
             card.expected_receipt_label = None;
             card.receipt_summary = Some(FixtureReceiptSummary {
                 plain_summary:
                     "Your action item was completed for the example fixture action item.",
                 receipt_class_label: FixtureReceiptClassLabel::ActionCompleted,
                 scope_label: "Example Local Domain",
-                applied_at: 1_715_000_040,
-                receipt_ref_hash: [0xEE; 32],
+                applied_at: receipt.applied_at,
+                receipt_ref_hash: receipt.receipt_hash,
             });
         }
     }
@@ -1263,7 +1318,20 @@ fn member_shell_slice_a_renders_read_only_surface_and_action_cards() {
     assert_eq!(categories.len(), 12);
 
     // ---- Resolved transition: paused → Receipt available ----
-    let resolved_view = render_resolved_view(&open_view);
+    // Construct the public RepairReceipt (#1849) and anchor the
+    // resolved card's opaque receipt_ref_hash on it. The receipt's
+    // verify_binding() proves the artifact has not been tampered
+    // with; the resolved view's audit-facing cross-link points back
+    // to it. No member-facing string surfaces the receipt's internal
+    // field set.
+    let evidence = build_slice_a_divergence();
+    let plan = build_slice_a_repair_plan(&evidence);
+    let receipt = build_slice_a_repair_receipt(&evidence, &plan);
+    assert!(receipt.verify_binding());
+    assert_eq!(receipt.effect_outcome, EffectOutcome::Applied);
+    assert_eq!(receipt.divergence_evidence_hash, evidence.evidence_hash);
+    assert_eq!(receipt.repair_plan_hash, plan.plan_hash);
+    let resolved_view = render_resolved_view(&open_view, &receipt);
     assert_eq!(
         resolved_view.surface_sync_status.label(),
         "Receipt available"
@@ -1277,6 +1345,14 @@ fn member_shell_slice_a_renders_read_only_surface_and_action_cards() {
         was_paused_now_confirmed.state,
         FixtureActionLifecycle::Confirmed
     ));
+    // The opaque audit-facing receipt_ref_hash on the resolved card
+    // anchors on the public RepairReceipt binding hash.
+    let resolved_summary = was_paused_now_confirmed
+        .receipt_summary
+        .as_ref()
+        .expect("resolved card carries a receipt summary");
+    assert_eq!(resolved_summary.receipt_ref_hash, receipt.receipt_hash);
+    assert_eq!(resolved_summary.applied_at, receipt.applied_at);
     assert_eq!(
         was_paused_now_confirmed.sync_status.label(),
         "Receipt available"
@@ -1474,7 +1550,10 @@ fn member_facing_strings_contain_no_protocol_jargon() {
     // table calls v0 violation on "raw scheduler, runtime, or cockpit
     // jargon." This test locks the bar.
     let open_view = render_open_view();
-    let resolved_view = render_resolved_view(&open_view);
+    let evidence = build_slice_a_divergence();
+    let plan = build_slice_a_repair_plan(&evidence);
+    let receipt = build_slice_a_repair_receipt(&evidence, &plan);
+    let resolved_view = render_resolved_view(&open_view, &receipt);
 
     for (label, view) in [("open", &open_view), ("resolved", &resolved_view)] {
         for s in view.all_member_facing_strings() {
@@ -1731,7 +1810,10 @@ fn slice_a_resolved_view_surface_status_is_receipt_available() {
     // Slice A's decisive resolved string is "Receipt available." Lock
     // it.
     let open_view = render_open_view();
-    let resolved_view = render_resolved_view(&open_view);
+    let evidence = build_slice_a_divergence();
+    let plan = build_slice_a_repair_plan(&evidence);
+    let receipt = build_slice_a_repair_receipt(&evidence, &plan);
+    let resolved_view = render_resolved_view(&open_view, &receipt);
     assert_eq!(
         resolved_view.surface_sync_status,
         FixtureSyncStatus::ReceiptAvailable
@@ -1764,28 +1846,38 @@ fn four_owning_entity_classes_match_the_merged_taxonomy() {
 }
 
 #[test]
-fn proof_rail_records_remain_design_level_in_the_member_view() {
-    // The fixture builds the same `DivergenceEvidence` / `RepairPlan`
-    // that the cockpit fixture (#1846) renders. The member shell must
-    // *not* surface any of those records' typed fields. Slice A asserts
-    // that the `DivergenceEvidence::evidence_hash` and
-    // `RepairPlan::plan_hash` are NOT embedded as visible strings in
-    // the rendered view, and that no `RepairReceipt` schema is
-    // claimed.
+fn proof_rail_records_stay_off_member_facing_strings() {
+    // The fixture builds the same `DivergenceEvidence` / `RepairPlan` /
+    // `RepairReceipt` chain that the cockpit fixture (#1846) and
+    // receipt-index fixture (#1845) render against. The member shell
+    // anchors the resolved card's opaque `receipt_ref_hash` on the
+    // receipt's binding hash so an auditor can chase the chain — but
+    // none of those records' typed fields appear as member-facing
+    // strings. Slice A asserts that none of the binding hashes leak
+    // through as visible text on either view.
     let divergence = build_slice_a_divergence();
     let plan = build_slice_a_repair_plan(&divergence);
+    let receipt = build_slice_a_repair_receipt(&divergence, &plan);
     let evidence_hex = hex::encode(divergence.evidence_hash);
     let plan_hex = hex::encode(plan.plan_hash);
-    let view = render_open_view();
-    for s in view.all_member_facing_strings() {
-        assert!(
-            !s.contains(&evidence_hex),
-            "member-facing string leaks evidence_hash: `{s}`"
-        );
-        assert!(
-            !s.contains(&plan_hex),
-            "member-facing string leaks plan_hash: `{s}`"
-        );
+    let receipt_hex = hex::encode(receipt.receipt_hash);
+    let open_view = render_open_view();
+    let resolved_view = render_resolved_view(&open_view, &receipt);
+    for (label, view) in [("open", &open_view), ("resolved", &resolved_view)] {
+        for s in view.all_member_facing_strings() {
+            assert!(
+                !s.contains(&evidence_hex),
+                "{label} member-facing string leaks evidence_hash: `{s}`"
+            );
+            assert!(
+                !s.contains(&plan_hex),
+                "{label} member-facing string leaks plan_hash: `{s}`"
+            );
+            assert!(
+                !s.contains(&receipt_hex),
+                "{label} member-facing string leaks receipt_hash: `{s}`"
+            );
+        }
     }
     // The plan still carries its expected receipt class, but that
     // identifier is the cockpit's surface, not the member's. The
@@ -1793,5 +1885,10 @@ fn proof_rail_records_remain_design_level_in_the_member_view() {
     assert_eq!(
         plan.expected_repair_receipt_class,
         ExpectedRepairReceiptClass::FetchMissingReceipt
+    );
+    // The receipt's class maps 1:1 back to the plan's expected class.
+    assert_eq!(
+        ExpectedRepairReceiptClass::from(receipt.repair_receipt_class),
+        plan.expected_repair_receipt_class
     );
 }

--- a/icn/crates/icn-kernel-api/tests/member_shell_read_only_render_slice_a.rs
+++ b/icn/crates/icn-kernel-api/tests/member_shell_read_only_render_slice_a.rs
@@ -169,12 +169,15 @@ fn build_slice_a_repair_plan(evidence: &DivergenceEvidence) -> RepairPlan {
 /// Build the public `RepairReceipt` (#1849) the resolved member-shell
 /// view anchors on.
 ///
-/// Constructs the wire-stable receipt with `EffectOutcome::Applied`,
-/// cross-linked to `evidence` and `plan` by hash, over a deterministic
-/// fixture after-state digest. The resulting `receipt_hash` is what the
-/// resolved card's opaque `receipt_ref_hash` points at — the member
-/// never reads it, but an auditor can chase the chain back to the
-/// resolved repair evidence.
+/// Constructs the wire-stable receipt with `EffectOutcome::Applied`
+/// over a deterministic fixture after-state digest. The
+/// `affected_state_class` is sourced from `evidence`; `scope`,
+/// `authority_basis`, and `boundary_rules` are sourced from `plan` so
+/// any drift in the evidence/plan→receipt chain would diverge the
+/// binding hash. The resulting `receipt_hash` is what the resolved
+/// card's opaque `receipt_ref_hash` points at — the member never
+/// reads it, but an auditor can chase the chain back to the resolved
+/// repair evidence.
 ///
 /// Kernel-level only: no live network, no live repair. The receipt
 /// records what a fixture peer would have produced had the bounded
@@ -185,23 +188,20 @@ fn build_slice_a_repair_receipt(evidence: &DivergenceEvidence, plan: &RepairPlan
     let r3 = fixture_receipt_hash("r3", 0x03);
     let after = fixture_bloom_digest(&[r1.receipt_hash, r2.receipt_hash, r3.receipt_hash]);
     RepairReceipt::new(
-        RepairReceiptClass::FetchMissingReceipt,
+        RepairReceiptClass::from(plan.expected_repair_receipt_class),
         EffectOutcome::Applied,
         evidence.evidence_hash,
         plan.plan_hash,
-        StateClass::ReceiptIndex,
-        fixture_scope(),
+        evidence.affected_state_class,
+        plan.scope.clone(),
         "did:icn:fixture:repair-actor".to_string(),
-        AuthorityBasis::DomainPolicyClause(fixture_policy_clause()),
-        BoundaryRuleSet::from_rules(vec![
-            BoundaryRuleRef::NoRepairBeyondAuthority,
-            BoundaryRuleRef::NoLocalityOrDisclosureWidening,
-        ]),
+        plan.authority_basis.clone(),
+        plan.boundary_rules.clone(),
         None,
         Some(after),
         1_715_000_040,
         1_715_000_070,
-        false,
+        evidence.private_content_implication,
         None,
         [0xDD; 32],
     )

--- a/icn/crates/icn-kernel-api/tests/receipt_index_anti_entropy_slice_a.rs
+++ b/icn/crates/icn-kernel-api/tests/receipt_index_anti_entropy_slice_a.rs
@@ -21,6 +21,9 @@
 //! Fixture plan produces RepairPlan { action: FetchMissing }.
 //! Fixture apply copies only public fixture receipt r3 into B's index.
 //! After-state matches.
+//! Public RepairReceipt (#1849) with EffectOutcome::Applied is constructed
+//! over the after-state digest; verify_binding() passes; the cross-link
+//! hashes resolve back to the evidence and plan.
 //! Cockpit / member-shell surfaces move from open / "sync delayed" to
 //! resolved / "receipt available".
 //! ```
@@ -41,19 +44,20 @@
 //!   that ICN-native anti-entropy operates today against real peers.
 //! * Not a `PeerSyncReport` implementation. That identifier remains
 //!   design-level per spec §"Proof artifacts"; the fixture uses a
-//!   private `FixtureSyncOutcome` enum scoped to this file.
-//! * Not a `RepairReceipt` implementation. That identifier also remains
-//!   design-level. After-state is asserted directly against the fixture
-//!   peer indexes.
+//!   private `FixtureSyncOutcome` enum scoped to this file for the
+//!   compare-phase result, distinct from the resolved repair artifact.
+//! * Not a live repair. The `RepairReceipt` constructed at phase 7 is
+//!   evidence of what a fixture peer would have produced; no real
+//!   `FetchMissing` ran against a real peer.
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use icn_gossip::{to_bloom_projection, BloomFilter};
 use icn_kernel_api::{
     AntiEntropyProbe, AuthorityBasis, BoundaryRuleRef, BoundaryRuleSet, Did, DigestMismatch,
-    DivergenceClass, DivergenceEvidence, ExpectedRepairReceiptClass, Hash, PeerSet,
-    PolicyClauseRef, ProbeScope, ReceiptDigest, RepairAction, RepairPlan, RequestedResponseClass,
-    StateClass, StateDigest, TriggerSource,
+    DivergenceClass, DivergenceEvidence, EffectOutcome, ExpectedRepairReceiptClass, Hash, PeerSet,
+    PolicyClauseRef, ProbeScope, ReceiptDigest, RepairAction, RepairPlan, RepairReceipt,
+    RepairReceiptClass, RequestedResponseClass, StateClass, StateDigest, TriggerSource,
 };
 
 // ---------------------------------------------------------------------------
@@ -211,6 +215,9 @@ struct FixtureCockpitView {
     repair_action: RepairAction,
     evidence_hash: Hash,
     plan_hash: Hash,
+    /// Present only on the resolved view. The public `RepairReceipt`
+    /// (#1849) binding hash that resolves the open divergence.
+    repair_receipt_hash: Option<Hash>,
 }
 
 /// Fixture renderer for the member shell. **Private to this test file.**
@@ -404,6 +411,7 @@ fn slice_a_receipt_index_probe_classify_plan_apply_surface() {
         repair_action: plan.action,
         evidence_hash: evidence.evidence_hash,
         plan_hash: plan.plan_hash,
+        repair_receipt_hash: None,
     };
     assert!(cockpit_open.open);
     assert_eq!(
@@ -411,6 +419,7 @@ fn slice_a_receipt_index_probe_classify_plan_apply_surface() {
         DivergenceClass::MissingReceipt
     );
     assert_eq!(cockpit_open.repair_action, RepairAction::FetchMissing);
+    assert!(cockpit_open.repair_receipt_hash.is_none());
 
     let member_shell_open = FixtureMemberShellState::SyncDelayed;
     assert_eq!(member_shell_open.as_str(), "sync delayed");
@@ -422,7 +431,7 @@ fn slice_a_receipt_index_probe_classify_plan_apply_surface() {
     // no network, no gossip, no runtime mutation.
     peer_b.fixture_apply_fetch_missing(&peer_a, &missing);
 
-    // ---- 7. Evidence (after-state) ----
+    // ---- 7. Evidence (after-state + RepairReceipt) ----
     assert_eq!(
         peer_b.receipt_index.len(),
         3,
@@ -450,16 +459,71 @@ fn slice_a_receipt_index_probe_classify_plan_apply_surface() {
     // hash-keyed BTreeMap iterates in sorted order.
     assert_eq!(peer_a.state_digest(), peer_b.state_digest());
 
+    // Public RepairReceipt (#1849) — the wire-stable evidence artifact
+    // for the resolved repair. The fixture builds the receipt over
+    // peer B's now-converged state digest, cross-linked back to the
+    // evidence and the plan; verify_binding() proves the receipt has
+    // not been tampered with. No live network, no live repair: the
+    // receipt records what a fixture peer would have produced had the
+    // bounded FetchMissing action run against real peers.
+    let repair_receipt = RepairReceipt::new(
+        RepairReceiptClass::FetchMissingReceipt,
+        EffectOutcome::Applied,
+        evidence.evidence_hash,
+        plan.plan_hash,
+        StateClass::ReceiptIndex,
+        scope.clone(),
+        "did:icn:fixture:repair-actor".to_string(),
+        AuthorityBasis::DomainPolicyClause(policy.clone()),
+        BoundaryRuleSet::from_rules(vec![
+            BoundaryRuleRef::NoRepairBeyondAuthority,
+            BoundaryRuleRef::NoLocalityOrDisclosureWidening,
+        ]),
+        None,
+        Some(peer_b.state_digest()),
+        1_715_000_003,
+        1_715_000_033,
+        false,
+        None,
+        [0xEE; 32],
+    )
+    .expect("Slice A receipt is structurally consistent");
+    assert!(repair_receipt.verify_binding());
+    assert_eq!(repair_receipt.effect_outcome, EffectOutcome::Applied);
+    assert_eq!(
+        repair_receipt.repair_receipt_class,
+        RepairReceiptClass::FetchMissingReceipt
+    );
+    assert_eq!(
+        repair_receipt.divergence_evidence_hash,
+        evidence.evidence_hash
+    );
+    assert_eq!(repair_receipt.repair_plan_hash, plan.plan_hash);
+    assert!(repair_receipt.failure_reason.is_none());
+    assert!(repair_receipt.after_state_digest.is_some());
+    // The receipt's class matches the plan's expected receipt class
+    // (1:1 from ExpectedRepairReceiptClass per #1849).
+    assert_eq!(
+        ExpectedRepairReceiptClass::from(repair_receipt.repair_receipt_class),
+        plan.expected_repair_receipt_class
+    );
+
     // ---- 8. Surface (resolved) ----
     let cockpit_resolved = FixtureCockpitView {
         open: false,
+        repair_receipt_hash: Some(repair_receipt.receipt_hash),
         ..cockpit_open.clone()
     };
     assert!(!cockpit_resolved.open);
-    // The cross-link to evidence / plan persists in the resolved view;
-    // only the open flag flips.
+    // The cross-link to evidence / plan / receipt persists in the
+    // resolved view; only the open flag flips and the receipt link
+    // populates.
     assert_eq!(cockpit_resolved.evidence_hash, evidence.evidence_hash);
     assert_eq!(cockpit_resolved.plan_hash, plan.plan_hash);
+    assert_eq!(
+        cockpit_resolved.repair_receipt_hash,
+        Some(repair_receipt.receipt_hash)
+    );
 
     let member_shell_resolved = FixtureMemberShellState::ReceiptAvailable;
     assert_eq!(member_shell_resolved.as_str(), "receipt available");

--- a/icn/crates/icn-kernel-api/tests/receipt_index_anti_entropy_slice_a.rs
+++ b/icn/crates/icn-kernel-api/tests/receipt_index_anti_entropy_slice_a.rs
@@ -463,27 +463,28 @@ fn slice_a_receipt_index_probe_classify_plan_apply_surface() {
     // for the resolved repair. The fixture builds the receipt over
     // peer B's now-converged state digest, cross-linked back to the
     // evidence and the plan; verify_binding() proves the receipt has
-    // not been tampered with. No live network, no live repair: the
-    // receipt records what a fixture peer would have produced had the
-    // bounded FetchMissing action run against real peers.
+    // not been tampered with. The receipt's `affected_state_class`,
+    // `scope`, `authority_basis`, and `boundary_rules` are sourced
+    // directly from `evidence` and `plan` so any drift in the plan→
+    // receipt chain would diverge the binding hash. No live network,
+    // no live repair: the receipt records what a fixture peer would
+    // have produced had the bounded FetchMissing action run against
+    // real peers.
     let repair_receipt = RepairReceipt::new(
-        RepairReceiptClass::FetchMissingReceipt,
+        RepairReceiptClass::from(plan.expected_repair_receipt_class),
         EffectOutcome::Applied,
         evidence.evidence_hash,
         plan.plan_hash,
-        StateClass::ReceiptIndex,
-        scope.clone(),
+        evidence.affected_state_class,
+        plan.scope.clone(),
         "did:icn:fixture:repair-actor".to_string(),
-        AuthorityBasis::DomainPolicyClause(policy.clone()),
-        BoundaryRuleSet::from_rules(vec![
-            BoundaryRuleRef::NoRepairBeyondAuthority,
-            BoundaryRuleRef::NoLocalityOrDisclosureWidening,
-        ]),
+        plan.authority_basis.clone(),
+        plan.boundary_rules.clone(),
         None,
         Some(peer_b.state_digest()),
         1_715_000_003,
         1_715_000_033,
-        false,
+        evidence.private_content_implication,
         None,
         [0xEE; 32],
     )

--- a/icn/crates/icn-kernel-api/tests/steward_cockpit_divergence_render_slice_a.rs
+++ b/icn/crates/icn-kernel-api/tests/steward_cockpit_divergence_render_slice_a.rs
@@ -5,7 +5,8 @@
 //! the cockpit rendering surface over the proof rail landed by
 //! #1843 (`AntiEntropyProbe` + `StateDigest`),
 //! #1844 (`DivergenceEvidence` + `RepairPlan`),
-//! and #1845 (receipt-index anti-entropy Slice A fixture).
+//! #1845 (receipt-index anti-entropy Slice A fixture),
+//! and #1850 (`RepairReceipt` wire-stable schema, issue #1849).
 //!
 //! # What this is
 //!
@@ -18,8 +19,8 @@
 //! One open DivergenceEvidence (class: MissingReceipt) over the
 //! receipt-index state class, surfaced as a Bloom-filter set-difference.
 //! One RepairPlan (action: FetchMissing) linked to the evidence by hash.
-//! One fixture RepairOutcome (EffectOutcome::Applied) recorded as a
-//! test-private stand-in for the spec's still-design-level RepairReceipt.
+//! One public RepairReceipt (#1849) with EffectOutcome::Applied,
+//! verify_binding() passing, cross-linked to evidence + plan by hash.
 //! Cockpit view renders all NINE required fields per spec §"Network /
 //! Federation surface". Member-impact summary attached, exact strings.
 //! Twelve-category accessibility gate evaluated and passing.
@@ -43,20 +44,23 @@
 //! * Not a member shell implementation (`#1839`). The fixture attaches
 //!   the member-impact summary string verbatim from the spec's mapping
 //!   but does not render the member-shell surface itself.
-//! * Not a public `RepairReceipt` schema. That identifier remains
-//!   design-level after #1845; the fixture uses a private
-//!   `FixtureRepairOutcome` and documents the substitution.
+//! * Not a public `PeerSyncReport` schema. That identifier remains
+//!   design-level; the fixture compares peer indexes directly rather
+//!   than constructing a wire-stable `PeerSyncReport`.
 //! * Not a production-readiness claim, live-federation claim, or NYCN
-//!   pilot claim.
+//!   pilot claim. The repair did not run against a live network; the
+//!   `RepairReceipt` records what a fixture peer would have produced
+//!   had the bounded `FetchMissing` action been executed against
+//!   real peers.
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use icn_gossip::{to_bloom_projection, BloomFilter};
 use icn_kernel_api::{
     AntiEntropyProbe, AuthorityBasis, BoundaryRuleRef, BoundaryRuleSet, Did, DigestMismatch,
-    DivergenceClass, DivergenceEvidence, ExpectedRepairReceiptClass, Hash, PeerSet,
-    PolicyClauseRef, ProbeScope, RepairAction, RepairPlan, RequestedResponseClass, StateClass,
-    StateDigest, TriggerSource,
+    DivergenceClass, DivergenceEvidence, EffectOutcome, ExpectedRepairReceiptClass, Hash, PeerSet,
+    PolicyClauseRef, ProbeScope, RepairAction, RepairPlan, RepairReceipt, RepairReceiptClass,
+    RequestedResponseClass, StateClass, StateDigest, TriggerSource,
 };
 
 // ===========================================================================
@@ -209,25 +213,49 @@ enum FixtureEscalationStatus {
     EscalatedToGovernanceReview,
 }
 
-/// Test-private stand-in for the spec's still-design-level
-/// `RepairReceipt`. After #1845, `RepairReceipt` remains forward work;
-/// this fixture asserts after-state plus a linked outcome hash instead
-/// of producing a wire-stable receipt.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct FixtureRepairOutcome {
-    /// `EffectOutcome::Applied` style label. Test-private.
-    effect_outcome: &'static str,
-    /// `evidence_hash` of the `DivergenceEvidence` this outcome resolves.
-    divergence_evidence_hash: Hash,
-    /// `plan_hash` of the `RepairPlan` that produced this outcome.
-    repair_plan_hash: Hash,
-    /// State-class digest after the fixture apply (for a future
-    /// `verify_convergence` step).
-    after_state_digest: StateDigest,
-    /// Fixture timestamp; deterministic.
+/// Build the public `RepairReceipt` (#1849) the cockpit view links to.
+///
+/// Constructs the wire-stable receipt with `EffectOutcome::Applied`,
+/// the cross-link hashes from `evidence` and `plan`, the fixture
+/// after-state digest from `peer_b`, and the fixture actor DID. The
+/// resulting receipt is the canonical evidence artifact the cockpit
+/// row renders against — replacing the test-private stand-in this
+/// fixture used to carry before #1850 landed.
+fn build_repair_receipt(
+    evidence: &DivergenceEvidence,
+    plan: &RepairPlan,
+    peer_b: &FixturePeer,
+    actor_did: &str,
     applied_at: u64,
-    /// Fixture actor — the steward who recorded the outcome.
-    actor_did: Did,
+) -> RepairReceipt {
+    RepairReceipt::new(
+        RepairReceiptClass::FetchMissingReceipt,
+        EffectOutcome::Applied,
+        evidence.evidence_hash,
+        plan.plan_hash,
+        StateClass::ReceiptIndex,
+        fixture_scope(),
+        actor_did.to_string(),
+        AuthorityBasis::DomainPolicyClause(fixture_policy_clause()),
+        BoundaryRuleSet::from_rules(vec![
+            BoundaryRuleRef::NoRepairBeyondAuthority,
+            BoundaryRuleRef::NoLocalityOrDisclosureWidening,
+        ]),
+        // Slice A's "before" digest is implied (peer A's index); the
+        // fixture's decisive evidence is the after-state digest. The
+        // public RepairReceipt accepts an optional before; we omit it
+        // here because the before-state digest the spec describes is
+        // the divergent peer's index *before* fetch-missing, and the
+        // fixture does not retain that snapshot.
+        None,
+        Some(peer_b.state_digest()),
+        applied_at,
+        applied_at + 30,
+        false,
+        None,
+        [0xEF; 32],
+    )
+    .expect("Slice A repair receipt is structurally consistent")
 }
 
 /// Steward cockpit rendering of a single open divergence row.
@@ -328,10 +356,16 @@ struct FixtureEvidenceLinks {
     evidence_hash: Hash,
     /// `RepairPlan::plan_hash`.
     plan_hash: Hash,
-    /// `FixtureRepairOutcome` reference, present only on the resolved
-    /// view. Production-direction `RepairReceipt` will replace this
-    /// field with a wire-stable hash; until then the cockpit fixture
-    /// renders the fixture-local outcome's identity directly.
+    /// Cross-link to the public `RepairReceipt` (#1849), present only
+    /// on the resolved view. Records the receipt's binding hash and
+    /// actor DID so the cockpit row can chase the chain back to the
+    /// resolved repair evidence without surfacing the receipt's
+    /// internal field set.
+    repair_receipt_hash: Option<Hash>,
+    /// Actor DID recorded on the resolved view alongside the receipt
+    /// hash. Spec §"Network / Federation surface" field 8 lists this
+    /// alongside the evidence and plan hashes; the kernel does not
+    /// validate it against any real registry.
     repair_outcome_actor: Option<Did>,
 }
 
@@ -705,6 +739,7 @@ fn render_cockpit_open(
         receipts_and_evidence: FixtureEvidenceLinks {
             evidence_hash: evidence.evidence_hash,
             plan_hash: plan.plan_hash,
+            repair_receipt_hash: None,
             repair_outcome_actor: None,
         },
         escalation_status: FixtureEscalationStatus::NotEscalated,
@@ -716,7 +751,7 @@ fn render_cockpit_open(
 
 fn render_cockpit_resolved(
     open_view: &FixtureStewardCockpitView,
-    outcome: &FixtureRepairOutcome,
+    receipt: &RepairReceipt,
 ) -> FixtureStewardCockpitView {
     let state = FixtureOperatorState::RepairApplied;
     FixtureStewardCockpitView {
@@ -726,7 +761,8 @@ fn render_cockpit_resolved(
         receipts_and_evidence: FixtureEvidenceLinks {
             evidence_hash: open_view.receipts_and_evidence.evidence_hash,
             plan_hash: open_view.receipts_and_evidence.plan_hash,
-            repair_outcome_actor: Some(outcome.actor_did.clone()),
+            repair_receipt_hash: Some(receipt.receipt_hash),
+            repair_outcome_actor: Some(receipt.actor_did.clone()),
         },
         ..open_view.clone()
     }
@@ -843,23 +879,27 @@ fn cockpit_slice_a_renders_all_nine_fields_and_passes_accessibility_gate() {
     assert_eq!(peer_b.receipt_index.len(), 3);
     assert_eq!(peer_a.receipt_hash_set(), peer_b.receipt_hash_set());
 
-    // ---- Fixture repair outcome (test-private stand-in for the
-    // design-level RepairReceipt; cockpit links to it via the evidence
-    // hash + plan hash + actor DID) ----
-    let outcome = FixtureRepairOutcome {
-        effect_outcome: "Applied",
-        divergence_evidence_hash: evidence.evidence_hash,
-        repair_plan_hash: plan.plan_hash,
-        after_state_digest: peer_b.state_digest(),
-        applied_at: 1_715_000_003,
-        actor_did: "did:icn:fixture:c".to_string(),
-    };
-    assert_eq!(outcome.effect_outcome, "Applied");
-    assert_eq!(outcome.divergence_evidence_hash, evidence.evidence_hash);
-    assert_eq!(outcome.repair_plan_hash, plan.plan_hash);
+    // ---- Public RepairReceipt (#1849) for the applied repair ----
+    let receipt = build_repair_receipt(
+        &evidence,
+        &plan,
+        &peer_b,
+        "did:icn:fixture:c",
+        1_715_000_003,
+    );
+    assert!(receipt.verify_binding(), "fresh receipt verifies");
+    assert_eq!(receipt.effect_outcome, EffectOutcome::Applied);
+    assert_eq!(receipt.divergence_evidence_hash, evidence.evidence_hash);
+    assert_eq!(receipt.repair_plan_hash, plan.plan_hash);
+    assert_eq!(
+        receipt.repair_receipt_class,
+        RepairReceiptClass::FetchMissingReceipt
+    );
+    assert!(receipt.failure_reason.is_none());
+    assert!(receipt.after_state_digest.is_some());
 
     // ---- Render resolved cockpit view ----
-    let resolved_view = render_cockpit_resolved(&open_view, &outcome);
+    let resolved_view = render_cockpit_resolved(&open_view, &receipt);
     assert!(!resolved_view.open);
     assert_eq!(
         resolved_view.operator_state,
@@ -869,7 +909,8 @@ fn cockpit_slice_a_renders_all_nine_fields_and_passes_accessibility_gate() {
         resolved_view.member_impact_summary,
         "Members see: Receipt available."
     );
-    // The cross-link chain persists across the transition.
+    // The cross-link chain persists across the transition and now
+    // anchors on the public RepairReceipt binding hash.
     assert_eq!(
         resolved_view.receipts_and_evidence.evidence_hash,
         evidence.evidence_hash
@@ -877,6 +918,10 @@ fn cockpit_slice_a_renders_all_nine_fields_and_passes_accessibility_gate() {
     assert_eq!(
         resolved_view.receipts_and_evidence.plan_hash,
         plan.plan_hash
+    );
+    assert_eq!(
+        resolved_view.receipts_and_evidence.repair_receipt_hash,
+        Some(receipt.receipt_hash)
     );
     assert_eq!(
         resolved_view.receipts_and_evidence.repair_outcome_actor,
@@ -1051,10 +1096,11 @@ fn missing_receipt_with_named_authority_does_not_escalate() {
 }
 
 #[test]
-fn fixture_repair_outcome_links_evidence_and_plan_by_hash() {
-    // FixtureRepairOutcome is the test-private stand-in for the still
-    // design-level RepairReceipt. It must carry the cross-link hashes
-    // so an auditor can chase the chain back to the open divergence.
+fn repair_receipt_links_evidence_and_plan_by_hash() {
+    // The public RepairReceipt (#1849) replaces the prior test-private
+    // FixtureRepairOutcome stand-in. It carries the cross-link hashes so
+    // an auditor can chase the chain back to the open divergence, and
+    // verify_binding() proves the binding has not been tampered with.
     let (peer_a, mut peer_b, peer_c) = build_three_peer_slice_a();
     let evidence = build_divergence_evidence(&peer_a, &peer_b, &peer_c);
     let plan = build_repair_plan(&evidence);
@@ -1064,16 +1110,16 @@ fn fixture_repair_outcome_links_evidence_and_plan_by_hash() {
         .copied()
         .collect();
     peer_b.fixture_apply_fetch_missing(&peer_a, &missing);
-    let outcome = FixtureRepairOutcome {
-        effect_outcome: "Applied",
-        divergence_evidence_hash: evidence.evidence_hash,
-        repair_plan_hash: plan.plan_hash,
-        after_state_digest: peer_b.state_digest(),
-        applied_at: 1_715_000_003,
-        actor_did: "did:icn:fixture:c".to_string(),
-    };
-    assert_eq!(outcome.divergence_evidence_hash, evidence.evidence_hash);
-    assert_eq!(outcome.repair_plan_hash, plan.plan_hash);
+    let receipt = build_repair_receipt(
+        &evidence,
+        &plan,
+        &peer_b,
+        "did:icn:fixture:c",
+        1_715_000_003,
+    );
+    assert!(receipt.verify_binding());
+    assert_eq!(receipt.divergence_evidence_hash, evidence.evidence_hash);
+    assert_eq!(receipt.repair_plan_hash, plan.plan_hash);
     // If the evidence is rebuilt with a different nonce, the link breaks.
     let rebuilt_evidence = DivergenceEvidence::new(
         evidence.divergence_class,
@@ -1088,7 +1134,7 @@ fn fixture_repair_outcome_links_evidence_and_plan_by_hash() {
         [0xEE; 32], // different nonce
     );
     assert_ne!(
-        outcome.divergence_evidence_hash,
+        receipt.divergence_evidence_hash,
         rebuilt_evidence.evidence_hash
     );
 }
@@ -1103,7 +1149,6 @@ fn fixture_view_has_no_runtime_state_fields() {
         std::mem::size_of::<FixtureStewardCockpitView>() < 1024,
         "FixtureStewardCockpitView must remain a plain data struct"
     );
-    assert!(std::mem::size_of::<FixtureRepairOutcome>() < 512);
     assert!(std::mem::size_of::<FixtureAccessibilityCheck>() < 256);
 }
 

--- a/icn/crates/icn-kernel-api/tests/steward_cockpit_divergence_render_slice_a.rs
+++ b/icn/crates/icn-kernel-api/tests/steward_cockpit_divergence_render_slice_a.rs
@@ -215,12 +215,14 @@ enum FixtureEscalationStatus {
 
 /// Build the public `RepairReceipt` (#1849) the cockpit view links to.
 ///
-/// Constructs the wire-stable receipt with `EffectOutcome::Applied`,
-/// the cross-link hashes from `evidence` and `plan`, the fixture
-/// after-state digest from `peer_b`, and the fixture actor DID. The
-/// resulting receipt is the canonical evidence artifact the cockpit
-/// row renders against — replacing the test-private stand-in this
-/// fixture used to carry before #1850 landed.
+/// Constructs the wire-stable receipt with `EffectOutcome::Applied`
+/// and the fixture's after-state digest. `scope`, `authority_basis`,
+/// and `boundary_rules` are sourced directly from `plan` so a
+/// drift between plan and receipt cannot pass verify_binding(); the
+/// affected state class is sourced from `evidence`. The receipt is
+/// the canonical evidence artifact the cockpit row renders against —
+/// replacing the test-private stand-in this fixture used to carry
+/// before #1850 landed.
 fn build_repair_receipt(
     evidence: &DivergenceEvidence,
     plan: &RepairPlan,
@@ -229,18 +231,15 @@ fn build_repair_receipt(
     applied_at: u64,
 ) -> RepairReceipt {
     RepairReceipt::new(
-        RepairReceiptClass::FetchMissingReceipt,
+        RepairReceiptClass::from(plan.expected_repair_receipt_class),
         EffectOutcome::Applied,
         evidence.evidence_hash,
         plan.plan_hash,
-        StateClass::ReceiptIndex,
-        fixture_scope(),
+        evidence.affected_state_class,
+        plan.scope.clone(),
         actor_did.to_string(),
-        AuthorityBasis::DomainPolicyClause(fixture_policy_clause()),
-        BoundaryRuleSet::from_rules(vec![
-            BoundaryRuleRef::NoRepairBeyondAuthority,
-            BoundaryRuleRef::NoLocalityOrDisclosureWidening,
-        ]),
+        plan.authority_basis.clone(),
+        plan.boundary_rules.clone(),
         // Slice A's "before" digest is implied (peer A's index); the
         // fixture's decisive evidence is the after-state digest. The
         // public RepairReceipt accepts an optional before; we omit it
@@ -251,7 +250,7 @@ fn build_repair_receipt(
         Some(peer_b.state_digest()),
         applied_at,
         applied_at + 30,
-        false,
+        evidence.private_content_implication,
         None,
         [0xEF; 32],
     )
@@ -577,9 +576,9 @@ impl FixtureAccessibilityChecklist {
             // 3.10 Privacy-preserving accommodation path — the row never
             // surfaces private artifact bodies. For Slice A the
             // `private_content_implication` flag is false anyway, but
-            // the structural absence of body fields on
-            // `FixtureRepairOutcome` and `FixtureDigestMismatchSummary`
-            // satisfies the doc's process-boundary requirement.
+            // the structural absence of body fields on `RepairReceipt`
+            // and `FixtureDigestMismatchSummary` satisfies the doc's
+            // process-boundary requirement.
             item(Cat::PrivacyPreservingAccommodationPath, Pass),
             // 3.11 Receipts / provenance / evidence access — the row
             // carries `evidence_hash` and `plan_hash` so an auditor can
@@ -1097,9 +1096,9 @@ fn missing_receipt_with_named_authority_does_not_escalate() {
 
 #[test]
 fn repair_receipt_links_evidence_and_plan_by_hash() {
-    // The public RepairReceipt (#1849) replaces the prior test-private
-    // FixtureRepairOutcome stand-in. It carries the cross-link hashes so
-    // an auditor can chase the chain back to the open divergence, and
+    // The public RepairReceipt (#1849) is the cockpit row's resolved
+    // evidence artifact. It carries the cross-link hashes so an auditor
+    // can chase the chain back to the open divergence, and
     // verify_binding() proves the binding has not been tampered with.
     let (peer_a, mut peer_b, peer_c) = build_three_peer_slice_a();
     let evidence = build_divergence_evidence(&peer_a, &peer_b, &peer_c);


### PR DESCRIPTION
> Stacked on top of #1850. Retarget to \`main\` before merging #1850.

## Summary

Wires the three Slice A fixtures (#1845 / #1846 / #1848) onto the public
\`RepairReceipt\` schema landed by #1849 / #1850, replacing fixture-local
outcome stand-ins with the wire-stable artifact.

After this PR, the proof rail consumes the public schema end-to-end at
fixture level:

\`\`\`
AntiEntropyProbe + StateDigest      (#1843, wire-stable)
→ DivergenceEvidence + RepairPlan   (#1844, wire-stable)
→ RepairReceipt                     (#1849 / #1850, wire-stable, consumed here)
\`\`\`

## Why this follows #1843 / #1844 / #1845 / #1846 / #1848 / #1850

The three Slice A fixtures landed before \`RepairReceipt\` was
wire-stable. Each one acknowledged that gap and carried a local
stand-in:

- #1845 (receipt-index): asserted after-state directly against fixture
  peer indexes, no resolved repair artifact.
- #1846 (steward cockpit): used a test-private \`FixtureRepairOutcome\`
  struct with a string-typed \`effect_outcome\` field.
- #1848 (member shell): rendered \`"Receipt available"\` with a
  hardcoded opaque \`receipt_ref_hash: [0xEE; 32]\`.

#1850 closed the schema gap. This PR wires each fixture onto the public
type.

## What changed

### \`receipt_index_anti_entropy_slice_a.rs\` (#1845)

- Adds a \`RepairReceipt\` construction step after the fixture-apply
  phase, using \`peer_b\`'s now-converged Bloom digest as the
  \`after_state_digest\`.
- Asserts \`verify_binding()\`, \`EffectOutcome::Applied\`, cross-link
  hashes back to evidence + plan, no failure_reason, after-digest
  present.
- Asserts the 1:1 mapping: \`ExpectedRepairReceiptClass::from(receipt.repair_receipt_class) == plan.expected_repair_receipt_class\`.
- \`FixtureCockpitView\` gains \`repair_receipt_hash: Option<Hash>\`;
  the resolved view populates it.
- \`FixtureSyncOutcome\` is kept — it is the compare-phase result (the
  spec's still-design-level \`PeerSyncReport\`), not the repair outcome.

### \`steward_cockpit_divergence_render_slice_a.rs\` (#1846)

- Removes the test-private \`FixtureRepairOutcome\` struct.
- New helper \`build_repair_receipt()\` constructs the public
  \`RepairReceipt\` over the same evidence + plan the open view already
  carries.
- \`FixtureEvidenceLinks\` gains \`repair_receipt_hash: Option<Hash>\`
  alongside \`repair_outcome_actor\`. \`render_cockpit_resolved\` now
  takes \`&RepairReceipt\` and populates both.
- Existing test \`fixture_repair_outcome_links_evidence_and_plan_by_hash\`
  renamed to \`repair_receipt_links_evidence_and_plan_by_hash\`; uses
  the public type, asserts \`verify_binding()\`.
- The size tripwire test loses its \`FixtureRepairOutcome\` size check.

### \`member_shell_read_only_render_slice_a.rs\` (#1848)

- New helper \`build_slice_a_repair_receipt()\` over the same evidence
  + plan the no-jargon proof-rail test already constructs.
- \`render_resolved_view\` now takes \`&RepairReceipt\` and anchors the
  resolved action card's opaque \`receipt_ref_hash\` and \`applied_at\`
  on the wire-stable receipt's binding hash.
- Existing \`proof_rail_records_remain_design_level_in_the_member_view\`
  renamed to \`proof_rail_records_stay_off_member_facing_strings\` and
  extended to assert the receipt's hash also stays off member-facing
  strings.
- Closed plain-language vocabulary unchanged. No new member-facing
  strings. \`"RepairReceipt"\` remains on the forbidden-substring list.

## Mapping to acceptance criteria

- ✅ #1845 receipt-index fixture: replaced fixture-local after-state /
  outcome assertions with assertions over public \`RepairReceipt\`
  (the after-state assertion is kept as the input to the receipt;
  the receipt is the resolved evidence artifact).
- ✅ #1846 steward cockpit fixture: replaced test-private
  \`FixtureRepairOutcome\` with the public \`RepairReceipt\`. Kept as
  fixture / proof rendering only; no cockpit UI.
- ✅ #1848 member shell fixture: anchored \`"Receipt available"\` on a
  real public \`RepairReceipt\` reference. Read-only rendering proof
  only; no member shell UI.
- ✅ Public \`RepairReceipt\` is the common proof artifact across all
  three fixtures.
- ✅ Receipts cross-link evidence + plan + class + outcome + actor +
  authority + boundary rules + after-state digest; \`verify_binding()\`
  passes on all three fixtures.
- ✅ Privacy: no body bytes, no private content surfaced; the receipt
  carries digests / refs only.
- ✅ No member-facing string surfaces protocol vocabulary; closed
  member-shell label set is unchanged.
- ✅ No parallel fixture-only repair-outcome type remains.

## Validation

- \`cargo fmt -p icn-kernel-api -- --check\` ✓
- \`cargo clippy -p icn-kernel-api --all-targets --all-features -- -D warnings\` ✓
- \`cargo test -p icn-kernel-api\` ✓
  - lib: 442 pass
  - receipt-index Slice A: 8 pass
  - steward cockpit Slice A: 10 pass
  - member shell Slice A: 21 pass
  - doctests: 9 pass

## Non-claims

- ❌ No automatic repair.
- ❌ No live network.
- ❌ No real federation.
- ❌ No runtime mutation.
- ❌ No gossip protocol mutation.
- ❌ No cockpit UI.
- ❌ No member shell UI.
- ❌ No platform choice.
- ❌ No partner skin.
- ❌ No NYCN / Summit-specific framing.
- ❌ No production-readiness claim.
- ❌ No new ADR-0026 top-level receipt class — the \`RepairReceipt\`
  this fixture set now consumes was added by #1849 as an
  evidence-artifact identifier traveling inside an existing Stage 5
  \`EffectDispatchEvidence\` per \`docs/spec/effect-dispatch-contract.md\`,
  not as a new top-level layer.
- ❌ No public \`PeerSyncReport\` schema.

## Follow-up path

Forward work that remains design-level:

- \`PeerSyncReport\` (compare-phase wire-stable record).
- \`SyncDegradedStatus\`.
- \`QuorumSyncCheck\`.
- \`FederationSyncWindow\`.
- \`RoutingProof\`, \`RedundancyProof\`.

None of these are in scope for this PR.

Refs: #1849 #1850 #1845 #1846 #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)