### PR TITLE
docs(appliance): reconcile README with landed scaffold + real build/smoke

### DIFF
--- a/deploy/appliance/README.md
+++ b/deploy/appliance/README.md
@@ -17,10 +17,13 @@ boots.
 
 This directory establishes the **vocabulary, layout, and honest
 non-claims** for that work. The scaffold (PR #1865) and the real local QCOW2
-build + one-VM boot smoke (PR #1866) have both landed. The scripts exist;
-no real QCOW2 has been produced in the current verified session. Running
-the real path still requires an operator-staged Debian base image and
-explicit authorization — see "Real local build + boot smoke" below.
+build + one-VM boot smoke (PR #1866) have both landed. The repo does not
+ship a prebuilt QCOW2 artifact; the operator must stage a Debian base
+image and invoke `build-image.sh --real` to produce one. The script does
+not download the base image, but the `--real` path's in-image
+`virt-customize --update --install` step does fetch Debian apt packages
+from the base image's configured repos — so the real path is not
+network-free. See "Real local build + boot smoke" below.
 
 For the full design including lifecycle stages, node states, role-profile
 vocabulary, and runtime-provider roadmap, see
@@ -144,11 +147,13 @@ hosted-service installation, smoke fixtures) is layered on after.
 The scripts for **Bootable dev image** (real build) and the one-VM boot
 smoke that verifies `/v1/health` on 8080 are present and landed via PR
 #1866. Whether a given clone has produced an actual QCOW2 artifact depends
-on operator action: the build does not run automatically, downloads
-nothing, and requires an operator-staged base image plus explicit
-invocation with `--real`. See the suggested follow-on stages at the bottom
-of `DEBIAN_APPLIANCE_MODEL.md` and the next-step list at the bottom of
-this README.
+on operator action: the build does not run automatically and requires an
+operator-staged base image plus explicit invocation with `--real`. The
+build script itself does not download the base image; the `--real` path's
+in-image `virt-customize --update --install` step does fetch apt packages
+from the base image's configured repos. See the suggested follow-on
+stages at the bottom of `DEBIAN_APPLIANCE_MODEL.md` and the next-step list
+at the bottom of this README.
 
 ## Layout
 
@@ -346,12 +351,16 @@ What has landed:
    built image and verifies `icnd` is alive and `/v1/health` responds on
    8080 (PR #1866).
 
-What has *not* been verified in the current session:
+Caveats on the real path:
 
-- No real QCOW2 artifact has been produced by this clone in the current
-  verified session. The scripts are present but the operator must
-  explicitly stage a Debian base image and invoke `--real` to actually
-  build or smoke. The build downloads nothing on its own.
+- The repo does not ship a prebuilt QCOW2 artifact. The scripts are
+  present, but producing one requires the operator to stage a Debian
+  base image and invoke `--real` explicitly.
+- The build script does not download the base image. The `--real` path's
+  in-image `virt-customize --update --install` step does fetch apt
+  packages from the base image's configured repos, so the real path is
+  not network-free even though the script never downloads the base
+  image itself.
 
 What is still ahead:
 

--- a/deploy/appliance/README.md
+++ b/deploy/appliance/README.md
@@ -15,9 +15,12 @@ role-profiled into a member node, witness, domain host, or future service
 host. The same image is used everywhere; the role is applied after the image
 boots.
 
-Today this directory establishes the **vocabulary, layout, and honest
-non-claims** for that work so that the next slice — a real local QCOW2 build
-and a one-VM boot smoke — can drop into a settled structure.
+This directory establishes the **vocabulary, layout, and honest
+non-claims** for that work. The scaffold (PR #1865) and the real local QCOW2
+build + one-VM boot smoke (PR #1866) have both landed. The scripts exist;
+no real QCOW2 has been produced in the current verified session. Running
+the real path still requires an operator-staged Debian base image and
+explicit authorization — see "Real local build + boot smoke" below.
 
 For the full design including lifecycle stages, node states, role-profile
 vocabulary, and runtime-provider roadmap, see
@@ -131,16 +134,21 @@ hosted-service installation, smoke fixtures) is layered on after.
 
 | Stage | What the appliance is |
 |---|---|
-| **Unbuilt scaffold** (today) | Docs, templates, scripts, no image artifact. |
-| **Bootable dev image** | Local QCOW2 image that boots, runs `icnd`, passes health. |
+| **Unbuilt scaffold** | Docs, templates, scripts, no image artifact. |
+| **Bootable dev image** (today, for operators who stage a base image) | Local QCOW2 image that boots, runs `icnd`, passes health. |
 | **Claimed devnet node** | The image after a devnet operator runs first-boot and joins a local devnet. |
 | **Role-profiled node** | Same image, declared role applied via the appliance manifest. |
 | **Governed service host** | A `RuntimeProvider` hosts services under `GovernedServiceBinding`. |
 | **Production-signed appliance** | Signed updates, immutable rootfs, A-B updates, measured boot. |
 
-Today is **Unbuilt scaffold**. Next slice is **Bootable dev image** plus a
-boot smoke that verifies `/v1/health` on 8080. See the suggested next slice
-at the bottom of `DEBIAN_APPLIANCE_MODEL.md`.
+The scripts for **Bootable dev image** (real build) and the one-VM boot
+smoke that verifies `/v1/health` on 8080 are present and landed via PR
+#1866. Whether a given clone has produced an actual QCOW2 artifact depends
+on operator action: the build does not run automatically, downloads
+nothing, and requires an operator-staged base image plus explicit
+invocation with `--real`. See the suggested follow-on stages at the bottom
+of `DEBIAN_APPLIANCE_MODEL.md` and the next-step list at the bottom of
+this README.
 
 ## Layout
 
@@ -148,7 +156,8 @@ at the bottom of `DEBIAN_APPLIANCE_MODEL.md`.
 deploy/appliance/
 ├── README.md                                   # this file
 ├── appliance.manifest.example.yaml             # declarative manifest template
-├── build-image.sh                              # dry-run build scaffold (no real build yet)
+├── build-image.sh                              # dry-run by default; `--real` builds a QCOW2 from an operator-staged base image
+├── check.sh                                    # script + manifest sanity check
 ├── roles/
 │   ├── genesis.example.yaml
 │   ├── witness-archive.example.yaml
@@ -159,7 +168,8 @@ deploy/appliance/
 │   └── icn-appliance-firstboot.sh              # POSIX bash, idempotent, no secrets
 ├── smoke/
 │   ├── README.md
-│   └── smoke-local.sh                          # dry-run scaffold for next PR
+│   ├── cloud-init/                             # example user-data / meta-data for the smoke VM (placeholders only)
+│   └── smoke-local.sh                          # dry-run by default; `--real` boots the built QCOW2 and checks `/v1/health`
 └── systemd/
     └── icn-appliance-firstboot.service         # oneshot unit, runs before icnd.service
 ```
@@ -324,16 +334,35 @@ the same directory), then reboot or rerun firstboot.
   measured boot, attested federation enrollment. This image is a local
   dev-VM artifact, not a partner-distributable appliance.
 
-## Next implementation slice
+## What has landed and what is still ahead
 
-After this scaffold lands:
+What has landed:
 
-1. Turn `build-image.sh` into a real local QCOW2 build path using Debian
-   cloud-image customization (`virt-customize` or equivalent).
-2. Add a one-VM boot smoke under `smoke/` that boots the image and verifies
-   `icnd` is alive and `/v1/health` responds on 8080.
-3. Decide on Packer vs debos vs live-build as the longer-term backend after
-   the first qcow2 path is working.
+1. The scaffold — docs, manifest template, role examples, firstboot script,
+   systemd unit, dry-run check (PR #1865).
+2. A real local QCOW2 build path implemented in `build-image.sh --real`
+   using Debian cloud-image customization via `virt-customize` (PR #1866).
+3. A one-VM boot smoke under `smoke/smoke-local.sh --real` that boots the
+   built image and verifies `icnd` is alive and `/v1/health` responds on
+   8080 (PR #1866).
+
+What has *not* been verified in the current session:
+
+- No real QCOW2 artifact has been produced by this clone in the current
+  verified session. The scripts are present but the operator must
+  explicitly stage a Debian base image and invoke `--real` to actually
+  build or smoke. The build downloads nothing on its own.
+
+What is still ahead:
+
+1. Decide on Packer vs debos vs live-build as the longer-term backend now
+   that the first qcow2 path is working.
+2. Signed releases, A-B updates, immutable rootfs, TPM-backed keys,
+   measured boot, attested federation enrollment — see the future-work
+   list in `DEBIAN_APPLIANCE_MODEL.md`. These are not implemented here.
+3. Convergence between appliance and devnet behavior; the appliance does
+   not yet replace `deploy/install.sh` + `deploy/icnd.service` or
+   `deploy/devnet/`.
 
 ## Cross-references
 


### PR DESCRIPTION
## What

Reconcile `deploy/appliance/README.md` with the current state of the appliance work. The README still described the real local QCOW2 build and the one-VM boot smoke as "the next slice" and "for next PR", even though both landed via PR #1866 on top of the scaffold from PR #1865.

## Why

Operators reading the README would conclude that the real build path does not yet exist — when in fact it does. The handoff merged in PR #1876 already records the verified host toolchain inventory and the base-image staging gap; this PR keeps the public-facing README consistent with that handoff and with what is actually in `deploy/appliance/`.

## How

README-only. No script changes. No real build or smoke is run.

| Change | Where | Effect |
|---|---|---|
| Intro paragraph | L18–23 | States scaffold (#1865) and real build/smoke (#1866) have landed; scripts exist; no real QCOW2 produced in current verified session; `--real` still requires operator-staged Debian base image + explicit invocation |
| Lifecycle table | L137 | `(today)` moves from "Unbuilt scaffold" to "Bootable dev image (today, for operators who stage a base image)" |
| Stale "Today is" line | L144–151 | Replaced with an honest description that the scripts are present, that artifact production depends on operator action, and that the build downloads nothing on its own |
| Layout block | L155–172 | Updated `build-image.sh` and `smoke-local.sh` comments to reflect `--real` behavior; added missing `check.sh` and `smoke/cloud-init/` entries |
| Bottom section | L337+ | Renamed "Next implementation slice" to "What has landed and what is still ahead" with three subsections: landed (#1865, #1866), not verified in current session (no real QCOW2 produced here), and still ahead (Packer vs debos decision; signed / A-B / TPM future work; devnet convergence) |

## Non-claims (preserved)

- No claim of production readiness.
- No claim of live federation readiness.
- No claim of NYCN / partner activation.
- No claim that a real QCOW2 has been built or smoke-tested in this session — the README now states this explicitly.
- No new schema, ADR, RFC, or contract URN.
- No script behavior changes.

## Validation

| Check | Result |
|---|---|
| `git diff --check` | clean |
| `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml --strict` | OK (827 docs; 55 pre-existing yaml-mismatch warnings unrelated to this edit) |
| `PYTHONIOENCODING=utf-8 python3 .github/scripts/compliance_linter.py` | No compliance violations |
| `ops/scripts/drift-check.sh` | STATUS: PASS |

## Invariants

- Adversarial-by-default: no change.
- Determinism: no change.
- Canonical encodings: no change.
- No-panics: no change.
- Kernel/app boundary: no change (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)