### PR TITLE
docs(design): add Claude Design seed review and handoff protocol

### DIFF
--- a/.claude/skills/icn-commons-design/SKILL.md
+++ b/.claude/skills/icn-commons-design/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: icn-commons-design
+description: >
+  ICN Commons design review and seed-promotion companion. Use when reviewing Claude Design
+  seeds, drafting docs-only promotion PRs, auditing member-facing surfaces against ICN
+  doctrine, or enforcing the canonical-vs-generated boundary. Provides review-gate routing
+  (truth-label, accessibility, vocabulary, implementation-status, language/RTL,
+  low-bandwidth/reduced-motion/large-text, source-doc drift), the must-not-ship floor,
+  and a doctrine-bound critique pattern for action cards, receipts, standing views, and
+  the member shell. Triggers on: "Claude Design seed", "design review", "member shell",
+  "action card", "receipt strip", "standing view", "truth label", "accessibility audit",
+  "vocabulary review", "design handoff", "promotion candidate", "canonical-vs-generated",
+  "must not ship", "design system", "icn-commons", "design language", "design tokens".
+version: 0.1.0
+truth_contract:
+  canonical_sources:
+    - docs/design/ICN_DESIGN_SYSTEM.md             # design system entry point
+    - docs/design/CLAUDE_DESIGN_CONTEXT.md         # paste briefing for external Claude Design
+    - docs/design/CLAUDE_DESIGN_SETUP.md           # external + local mode workflow
+    - docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md # seven review gates, canonical-vs-generated boundary
+    - docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md # seed → Claude Code handoff template
+    - docs/design/MUST_NOT_SHIP.md                 # twelve-item rejection floor
+    - docs/design/ACCESSIBILITY_BASELINE.md        # per-surface accessibility floor
+    - docs/design/CONTENT_STYLE_GUIDE.md           # regulatory-safe vocabulary, dangerous-action copy
+    - docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md    # truth labels, source hierarchy, rejected-patterns appendix
+    - docs/design-language/brief-v0.md             # canonical design language brief
+    - docs/design-language/concept-map.md          # canonical → public label mapping
+    - docs/design-language/accessibility.md        # component-level accessibility rules
+    - docs/mobile/icn-mobile-ux-spec-v1.md         # mobile member UX spec
+    - docs/spec/member-shell-v0.md                 # member shell spec
+    - docs/design/claude-design-seed/README.md     # seed workflow
+    - docs/design/claude-design-seed/CHANGELOG.md  # imported seed versions
+    - docs/design/claude-design-seed/REVIEW_NOTES.md # per-seed human review summary
+  live_load_required:
+    - "git branch --show-current"
+    - "git status --short"
+  examples_only: []
+  never_hardcode:
+    - seed version (always read from claude-design-seed/CHANGELOG.md)
+    - canonical doc paths (always read from docs/INDEX.md and docs/registry.toml)
+    - production code paths (website/src/, web/pilot-ui/, sdk/ — never imported from a seed)
+    - logo decisions (placeholder marks remain rejected until logo direction is taken)
+---
+
+# ICN Commons Design Skill
+
+Routing and review layer for ICN design work, including Claude Design seed review, member-surface critique, and promotion of seed artifacts to canonical repo paths.
+
+This skill points at **canonical repo paths** only. Anything under `docs/design/claude-design-seed/` is governance trail, not source of truth. The seed bundle, when present, lives outside the repo (typically under a job scratch directory); it is consulted for review but not imported.
+
+## What this skill helps with
+
+- **Claude Design seed review.** Walking [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](../../../docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3 gates against a freshly-arrived seed. Filling in a fresh copy of [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](../../../docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md). Recording findings in [REVIEW_NOTES.md](../../../docs/design/claude-design-seed/REVIEW_NOTES.md) and the [CHANGELOG.md](../../../docs/design/claude-design-seed/CHANGELOG.md).
+- **Accessibility review.** Against [ACCESSIBILITY_BASELINE.md](../../../docs/design/ACCESSIBILITY_BASELINE.md) (per-surface floor) and [docs/design-language/accessibility.md](../../../docs/design-language/accessibility.md) (component-level rules). WCAG 2.2 AA, high-contrast light/dark, `prefers-reduced-motion`, 200% zoom, low-bandwidth, screen-reader semantics, color-not-alone, translated-label headroom, RTL readiness, glossary access.
+- **Vocabulary review.** Against [CONTENT_STYLE_GUIDE.md](../../../docs/design/CONTENT_STYLE_GUIDE.md) §"Regulatory-safe vocabulary" and [docs/design-language/concept-map.md](../../../docs/design-language/concept-map.md). Enforce **member / standing / mandate / obligation / allocation / settlement / unit / position / receipt / provenance**; reject fintech and SaaS habits.
+- **Truth-label review.** Against [ICN_VISUAL_EXPLAINER_BIBLE.md](../../../docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md) and [ADR-0033](../../../docs/adr/ADR-0033-public-maturity-claims-and-evidence-links.md). One of: `implemented / current UI`, `repo-grounded public explainer`, `repo-grounded architecture explainer`, `illustrative direction`, `future-state / roadmap`, `historical`, `do not use`.
+- **Design handoff review.** Verifying a filled [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](../../../docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) is complete before any promotion PR opens.
+- **Member-shell / action-card / receipt critique.** Against [docs/spec/member-shell-v0.md](../../../docs/spec/member-shell-v0.md), [docs/mobile/icn-mobile-ux-spec-v1.md](../../../docs/mobile/icn-mobile-ux-spec-v1.md), and [ADR-0027 (Action Card Contract)](../../../docs/adr/ADR-0027-action-card-contract.md). Every action card declares mandate · reversibility · receipt before confirm. Every receipt is first-class UI.
+- **Canonical-vs-generated boundary enforcement.** Refuses to treat seed artifacts as canonical, regardless of polish. Routes promotion candidates through scope-locked PRs against canonical paths — never bulk imports.
+
+## Non-negotiables (do not break)
+
+These are the rules a seed review or promotion PR must satisfy. They are reproduced here so the skill carries them; full statements live in the canonical docs above.
+
+0. **A seed is not canonical.** Default status of every seed artifact is `generated seed`. Promotion requires the review gates in [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](../../../docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3 to close green.
+1. **WCAG 2.2 Level AA is the floor.** Both themes must pass independently, in default + large-text modes. Contrast, keyboard, screen-reader, 44×44 tap targets, reduced motion, 200% zoom.
+2. **Color never carries meaning alone.** Pair every color cue with text + icon. Grayscale-render the surface; if state distinction collapses, the surface fails.
+3. **No payment / wallet / balance / currency / debt / user / dashboard / admin-panel** vocabulary on ICN-native primitives. See [CONTENT_STYLE_GUIDE.md](../../../docs/design/CONTENT_STYLE_GUIDE.md) §"Regulatory-safe vocabulary".
+4. **Member-first.** The DID is the anchor; institutions are the changing context.
+5. **Cooperatives, communities, federations are co-equal.** Never depicted as a hierarchy or a ladder.
+6. **Receipts are first-class UI.** Every consequential action declares mandate · reversibility · receipt before confirm ([ADR-0027](../../../docs/adr/ADR-0027-action-card-contract.md)).
+7. **Every visual asset carries a truth label.** Member-shell screenshots without an `illustrative direction` chip are rejected.
+8. **No fake futurism.** No glassmorphism, no neon, no "AI sheen", no glowing-globe network maps, no central-hub diagrams, no faux-foundation seals, no SaaS dashboard chrome.
+9. **Mobile-first, low-bandwidth.** Design target is a five-year-old phone on a 2 Mbps link, in a language the member chose.
+10. **All motion gated by `prefers-reduced-motion`.** Motion never carries meaning.
+11. **Placeholder logo stays placeholder.** Not for production, not for institution packages, not for marketing. Until logo direction is taken.
+12. **No production UI / production CSS / SDK / prototype migration** from a seed without an explicit, separately-scoped follow-up PR. Docs-only promotion PRs are the first move.
+
+Full rejection floor: [MUST_NOT_SHIP.md](../../../docs/design/MUST_NOT_SHIP.md).
+
+## Operating loop for a new seed
+
+When a Claude Design seed arrives:
+
+1. **Read live state first** — `git branch --show-current`, `git status --short`. Confirm working in a docs-PR-appropriate branch (typically `docs/claude-design-seed-review-protocol` for the first seed, scope-specific for follow-ups).
+2. **Read the bundle's authoritative handoff docs in order:** `seed/CLAUDE_CODE_BUNDLE.md`, `seed/INVENTORY.md`, `seed/PROMOTION_MAP.md`, `seed/DRIFT_REPORT.md`, `seed/PRODUCTION_READINESS.md`, `seed/MUST_NOT_SHIP.md`. Open preview HTML last, not first.
+3. **Fill in [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](../../../docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md)** for this seed. Enumerate allowed paths, forbidden paths, non-goals, promotion candidates, drift findings, unresolved decisions.
+4. **Walk the review gates in [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](../../../docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3.** Record findings in [REVIEW_NOTES.md](../../../docs/design/claude-design-seed/REVIEW_NOTES.md).
+5. **Append a row to [CHANGELOG.md](../../../docs/design/claude-design-seed/CHANGELOG.md).** Bundle URL, status, summary, promotion candidates, held items, drift, production-readiness caveats, human decisions.
+6. **Open scope-locked promotion PRs** for each `candidate doctrine` row. One promotion per PR (or one tight cluster). First seed-promotion PR is the protocol/handoff/must-not-ship scaffold itself.
+
+## Promotion routing
+
+When a piece of seed content is a promotion candidate, route it to the right canonical path:
+
+| Seed artifact type | Canonical destination |
+|---|---|
+| Review protocol / handoff template / rejection floor | `docs/design/` (this skill's anchors) |
+| Token additions (modes, HC themes) | `website/src/styles/global.css` — **separate PR**, needs CSS review |
+| Accessibility obligations (theme × mode coverage) | `docs/design/ACCESSIBILITY_BASELINE.md` — needs design owner |
+| Vocabulary additions / pattern names | `docs/design-language/concept-map.md` — needs design-language owner |
+| Truth-label scheme refinements | `docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md` — needs design owner |
+| Member-shell pattern refinements | `docs/spec/member-shell-v0.md` and/or `docs/mobile/icn-mobile-ux-spec-v1.md` — needs mobile/spec owner |
+| UI component implementations | `website/src/components/` (Astro) or `sdk/react-native/...` (RN) — **separate PR**, needs full member-surface checklist, never from seed kit recreations as-is |
+
+A row in the seed's `PROMOTION_MAP.md` is a proposal. The decision to open a promotion PR is the reviewer's.
+
+## What this skill will not do
+
+- Recreate generated prototypes pixel-perfectly. The seed's preview HTML and UI kits are illustrative; production code is Astro / React Native, not React/JSX recreations.
+- Migrate React prototype code into `website/src/` or `web/pilot-ui/`.
+- Adopt the placeholder logo, wordmark, or icon assets from a seed.
+- Generate production CSS from seed tokens in the seed-promotion PR.
+- Claim a seed is canonical.
+- Imply a member-facing surface is shipped when the seed depicts it as illustrative.
+
+For a request that asks for production-UI implementation against a promoted candidate, that is a separate PR with its own scope and approval — surface the constraint and ask the user to confirm before proceeding.
+
+## If invoked without other guidance
+
+Ask the user:
+
+1. **Mode** — seed review, accessibility audit, vocabulary review, truth-label audit, design handoff check, member-surface critique, or canonical-vs-generated boundary enforcement?
+2. **Artifact** — bundle URL, file path, paste, or repo path?
+3. **Truth state** — is the target shipped (`implemented / current UI`), grounded but not member-final (`repo-grounded public/architecture explainer`), illustrative (`illustrative direction`), or aspirational (`future-state / roadmap`)?
+4. **PR scope** — docs-only seed promotion, member-surface implementation (separate track), or in-flight review?
+5. **Allowed paths** — confirm before any write.
+
+Then route to the relevant canonical docs above and apply the corresponding review gates.
+
+## See also
+
+- Specialist agent: [icn-design-advisor](../../agents/icn-design-advisor.md)
+- Mobile specialist: [icn-mobile-advisor](../../agents/icn-mobile-advisor.md)
+- Design rule auto-load: [`.claude/rules/design.md`](../../rules/design.md)
+- Per-surface accessibility gate: [docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md](../../../docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -68,6 +68,17 @@ Control plane for ICN's visual explainer system — the doctrine, asset register
 - **[design/assets/VISUAL_REVIEW_CHECKLIST.md](design/assets/VISUAL_REVIEW_CHECKLIST.md)** — the gate every visual explainer clears before shipping
 - **[design/assets/briefs/](design/assets/briefs/)** — per-asset briefs (closure loop, scope model, decision-to-receipt, member shell concept, kernel/app separation)
 
+### Claude Design — seed review and handoff
+
+Governance scaffold for taking Claude Design seed artifacts into the canonical repo without confusing generated output with repo truth. Default: a seed is a proposal, not a design system:
+
+- **[design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md](design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md)** — seven review gates (truth-label, accessibility, vocabulary, implementation-status, language/RTL, low-bandwidth/reduced-motion/large-text, source-doc drift); holds the canonical-vs-generated boundary
+- **[design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md)** — seed-level handoff template for passing a Claude Design seed to Claude Code (one filled copy per seed)
+- **[design/MUST_NOT_SHIP.md](design/MUST_NOT_SHIP.md)** — twelve-item hard rejection floor for design artifacts
+- **[design/claude-design-seed/README.md](design/claude-design-seed/README.md)** — seed directory workflow; what canonical truth is and how it is preserved
+- **[design/claude-design-seed/CHANGELOG.md](design/claude-design-seed/CHANGELOG.md)** — imported seed versions, one entry per seed
+- **[design/claude-design-seed/REVIEW_NOTES.md](design/claude-design-seed/REVIEW_NOTES.md)** — human-readable per-seed review summary
+
 ---
 
 ## 📚 Core Documentation

--- a/docs/design-language/accessibility.md
+++ b/docs/design-language/accessibility.md
@@ -98,9 +98,9 @@ This document defines the rules every public surface must meet.
 
 **WCAG:** 2.4.7 Focus Visible (Level AA), 2.4.11 Focus Not Obscured (Level AA)
 
-**Current state:** the site has no `:focus-visible` rules. Keyboard users cannot see where they are as they tab through.
+**Current state:** implemented. [`website/src/styles/global.css`](../../website/src/styles/global.css) §"Accessibility foundations" defines a global `*:focus-visible` ring (2px `var(--accent-teal)` outline, 3px offset, `var(--radius-sm)` corner radius), plus per-element selectors for `a`, `button`, `[role="button"]`, `input`, `textarea`, `select`, `summary`, and a dedicated skip-link / `#main-content` focus treatment.
 
-**Required fix:** add a global `:focus-visible` rule with a visible ring (outline or box-shadow), applied to links, buttons, form controls, and interactive cards.
+**Ongoing obligation:** every new interactive element inherits the global rule; new component styles must not override it without providing an equivalent ring. Verify on PRs that touch new interactive controls.
 
 ### 3.4 Motion respects user preferences
 
@@ -225,7 +225,7 @@ See `docs/design-language/brief-v0.md §7a` for the full icon system rules.
 
 These are the accessibility failures identified in the latest assessment. Each should be addressed in the accessibility foundation pass.
 
-1. **No `:focus-visible` styles anywhere.** Keyboard users cannot see where they are. Fails 2.4.7.
+1. ~~No `:focus-visible` styles anywhere.~~ **Resolved.** A global `:focus-visible` ring and per-element selectors now live in [`website/src/styles/global.css`](../../website/src/styles/global.css) §"Accessibility foundations". Carry-forward: new interactive components inherit the ring; do not override it without an equivalent treatment.
 2. **No skip-to-main-content link.** Screen reader users tab through the full nav on every page load. Fails 2.4.1.
 3. **Hamburger menu lacks `aria-expanded`.** Screen reader users cannot tell if the menu is open. Fails 4.1.2.
 4. **No `prefers-reduced-motion` handling.** The `.reveal` animation and theme toggle ignore user preferences. Fails 2.3.3.

--- a/docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md
+++ b/docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md
@@ -1,0 +1,240 @@
+---
+Status: operational
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-05-19
+Last Updated: 2026-05-19
+Purpose: Standard template for passing a Claude Design seed to Claude Code. Fill in one copy per seed before any promotion work begins.
+---
+
+# Claude Design Handoff Template
+
+> **One sentence.** When Claude Design produces a seed, this template is the contract that hands it to Claude Code without losing the truth boundary.
+
+This is not the per-PR member-surface checklist (that lives separately and travels with each member-facing PR). This is the seed-level handoff: it records what the seed contains, what may be promoted, what must remain seed-only, and which paths Claude Code is allowed to touch.
+
+**Use it like this.** Copy this file into `docs/design/claude-design-seed/handoff-<seed-version>.md` (or its equivalent in the seed's review directory), fill every field, and link it from [`docs/design/claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md). A seed without a filled handoff template is not ready for promotion work.
+
+---
+
+## 1. Seed identity
+
+- **Design bundle URL:** `_______________________`
+- **Seed name / version:** _______________________ (e.g. "ICN Commons Design System — Claude Design Seed v0.1")
+- **Seed produced on:** YYYY-MM-DD
+- **Handoff prepared on:** YYYY-MM-DD
+- **Bundle author / Claude Design session lead:** _______________________
+- **Handoff reviewer (this template's author):** _______________________
+
+## 2. Source docs the bundle was produced against
+
+List every ICN repo doc the seed was given as input. The seed almost certainly bundled imported copies of these; record the version it bundled vs the live repo version.
+
+| Repo doc | Seed-bundled version (commit / last reviewed) | Live repo version (commit / last reviewed) | Drift? |
+|---|---|---|---|
+| `docs/design/ICN_DESIGN_SYSTEM.md` | | | |
+| `docs/design/CLAUDE_DESIGN_CONTEXT.md` | | | |
+| `docs/design/CLAUDE_DESIGN_SETUP.md` | | | |
+| `docs/design/ACCESSIBILITY_BASELINE.md` | | | |
+| `docs/design/CONTENT_STYLE_GUIDE.md` | | | |
+| `docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md` | | | |
+| `docs/design-language/brief-v0.md` | | | |
+| `docs/design-language/concept-map.md` | | | |
+| `docs/design-language/accessibility.md` | | | |
+| `docs/mobile/icn-mobile-ux-spec-v1.md` | | | |
+| `docs/spec/member-shell-v0.md` | | | |
+| _other_ | | | |
+
+If any row shows drift, file it under §10 "Drift report summary" and treat the live repo version as authoritative.
+
+## 3. Generated files in the seed
+
+What the seed produced. Classify every file as **generated seed**, **UI kit / illustrative mock**, **preview card / showcase**, **generated asset**, or **screenshot**. Default status is seed-only.
+
+| Path inside the bundle | What it is | Status | Notes |
+|---|---|---|---|
+| | | | |
+
+(Add rows as needed. If the bundle ships an `INVENTORY.md`, this section can summarize that file rather than duplicate it.)
+
+## 4. Imported references
+
+Files the seed copied verbatim from the upstream repo for offline reference. Imported ≠ fresh. Use the live repo for authoritative reads.
+
+| Path inside the bundle | Upstream path | Bundled freshness | Action |
+|---|---|---|---|
+| | | | |
+
+## 5. Proposed upstream promotions
+
+For each piece of generated seed content the reviewer believes could become canonical, name the proposed upstream path and the gate(s) that still need to close. **Default status is `candidate doctrine` — not promoted.**
+
+| Seed artifact | Proposed upstream path | Gates outstanding (from REVIEW_PROTOCOL.md §3) | Reviewer notes |
+|---|---|---|---|
+| | | | |
+
+A row in this table is a proposal, not an authorization. Promotion only happens after the review gates close green and a separate, scope-locked PR lands.
+
+## 6. Explicit non-goals for this handoff
+
+State every thing this handoff is *not* asking Claude Code to do. Be specific. Generic non-goals do not protect the truth boundary.
+
+- Do not recreate generated prototypes pixel-perfectly. **Claude Code should not recreate generated prototypes pixel-perfectly unless a later task specifically asks for production UI implementation.**
+- Do not migrate seed React / JSX recreations into `website/src/` or `web/pilot-ui/`.
+- Do not adopt placeholder logo, wordmark, or icon assets from the seed.
+- Do not create production CSS from seed tokens in this PR.
+- Do not adopt seed pattern names as canonical concept ids without a separate `concept-map.md` PR.
+- Do not claim the seed is canonical.
+- Do not claim member surfaces are shipped if the seed depicts them as illustrative.
+- _add seed-specific non-goals here_
+
+## 7. Truth labels in scope
+
+Every artifact this handoff names carries one of the labels from [ICN_VISUAL_EXPLAINER_BIBLE.md](ICN_VISUAL_EXPLAINER_BIBLE.md) and [ADR-0033](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md):
+
+- [ ] `implemented / current UI`
+- [ ] `repo-grounded public explainer`
+- [ ] `repo-grounded architecture explainer`
+- [ ] `illustrative direction`
+- [ ] `future-state / roadmap`
+- [ ] `historical`
+- [ ] `do not use`
+
+For each artifact named in §3 or §5, declare the label here. Member-shell mocks default to `illustrative direction`.
+
+## 8. Accessibility obligations to plan for
+
+Claude Code must plan for, even on a docs-only PR:
+
+- [ ] WCAG 2.2 Level AA minimum (contrast, target size, keyboard, semantics)
+- [ ] High-contrast light and dark themes (not just default dark)
+- [ ] `prefers-reduced-motion` honored — motion never carries meaning
+- [ ] Large-text / 200% zoom reflow without horizontal scroll or content loss
+- [ ] Low-bandwidth mode (no autoplay video, no heavy hero animation, no required JS for first paint)
+- [ ] Visible keyboard focus on every interactive element
+- [ ] Screen-reader semantics (landmarks, headings, `aria-*` where required)
+- [ ] Color is not the only carrier of meaning
+- [ ] Room for translated labels (~1.5× English length is the planning floor)
+- [ ] Right-to-left readiness (flow direction, label wrapping, mirrored chrome)
+- [ ] Language selector path is named, even if not wired
+- [ ] Glossary access from member-facing terminology
+- [ ] Three vocabulary layers preserved where relevant: canonical term, public label, local institutional vocabulary
+
+Floor doc: [ACCESSIBILITY_BASELINE.md](ACCESSIBILITY_BASELINE.md). Component-level rules: [docs/design-language/accessibility.md](../design-language/accessibility.md).
+
+## 9. Vocabulary scan result
+
+Run a vocabulary scan against the seed's member-facing strings. Reference: [CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md) §"Regulatory-safe vocabulary" and [docs/design-language/concept-map.md](../design-language/concept-map.md).
+
+- [ ] No `wallet / balance / currency / crypto / token / payment / payout / debt / user / account holder / dashboard / admin panel` in member-facing copy (Reject-pattern examples exempt and labeled)
+- [ ] Canonical terms used consistently: **member, standing, mandate / authority, obligation, allocation, settlement, unit, position, receipt, provenance**
+- [ ] Every first-use of a canonical term shows the public label or links the glossary
+- [ ] No invented canonical term (new concepts route through `concept-map.md` first)
+- [ ] Three vocabulary layers preserved where applicable: canonical / public / local-institutional
+
+Findings: _______________________
+
+## 10. Drift report summary
+
+Summarize the seed's `DRIFT_REPORT.md` (if present) and any additional drift found against the live repo.
+
+| Finding | Severity | Live repo source of truth | Action |
+|---|---|---|---|
+| | | | |
+
+For each finding: state the drift, name the live repo source that wins, and route the correction to a separate docs PR if needed.
+
+## 11. Unresolved human decisions
+
+Decisions that block follow-up PRs until resolved. The seed's own `CLAUDE_CODE_BUNDLE.md` typically enumerates these; list them here so they cannot be silently absorbed by a subsequent agent.
+
+| Decision | Owner | Why blocking | Status |
+|---|---|---|---|
+| | | | |
+
+## 12. Allowed paths Claude Code may touch in this handoff
+
+Default is **none**. List every path explicitly. Anything not on this list is forbidden.
+
+Examples for a docs-only seed-promotion PR:
+
+- `docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md` — create or update
+- `docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md` — create or update
+- `docs/design/MUST_NOT_SHIP.md` — create or update
+- `docs/design/CLAUDE_DESIGN_SETUP.md` — append section
+- `docs/design/ICN_DESIGN_SYSTEM.md` — add references
+- `docs/design/claude-design-seed/README.md` — create
+- `docs/design/claude-design-seed/CHANGELOG.md` — append entry
+- `docs/design/claude-design-seed/REVIEW_NOTES.md` — create or append
+- `docs/design-language/accessibility.md` — targeted correction(s) only
+- `docs/INDEX.md` — slot new entries under design section
+- `.claude/skills/icn-commons-design/SKILL.md` — create or update
+
+## 13. Forbidden paths
+
+Hard non-goals. Any change to these paths inside this PR is out of scope and must be removed before merge.
+
+- `website/src/**`
+- `website/public/**`
+- `web/pilot-ui/**`
+- `sdk/**`
+- `apps/**`
+- `crates/**`
+- `bins/**`
+- `docs/adr/**` (ADRs are architectural decisions, not seed promotions)
+- any other production code or production CSS
+
+## 14. Verification commands
+
+Run before opening the PR. For a docs-only handoff, the minimum set is:
+
+```bash
+# Doc structure / canon / supersession check
+python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml
+
+# Diff is docs-only
+git status --short
+git diff --stat origin/main...HEAD
+```
+
+If the PR touches a member-facing surface (it should not, for a seed-promotion handoff), additionally use the per-PR member-surface checklist that lives alongside the design system. That checklist enumerates `pnpm test`, `pnpm typecheck`, vocabulary linter, axe-core, and visual diff against preview cards.
+
+## 15. PR title and branch guidance
+
+- **Branch:** `docs/claude-design-seed-review-protocol` (or seed-specific equivalent for a follow-up)
+- **PR title:** `docs(design): add Claude Design seed review and handoff protocol` (or scope-specific equivalent)
+- **Commit style:** ICN's `<type>(<scope>): <summary>` convention. Use `docs(design)` for seed-promotion PRs.
+- **Co-author:** add the Claude Design session author if attribution is desired; otherwise omit.
+
+## 16. Sign-off
+
+- **Handoff prepared by:** _______________________ on YYYY-MM-DD
+- **Truth-label / accessibility / vocabulary review by:** _______________________ on YYYY-MM-DD
+- **Decision to proceed with promotion PR:** yes / no / hold
+
+If no or hold, record the reason and the unresolved decision in [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md). Do not proceed silently.
+
+---
+
+## Operating note for Claude Code
+
+When Claude Code reads a handoff filled out using this template:
+
+- Treat §6 (non-goals), §12 (allowed paths), and §13 (forbidden paths) as load-bearing constraints. They override any inferred scope from the seed's preview HTML or visual finish.
+- **Do not recreate generated prototypes pixel-perfectly** unless a later, separate task explicitly asks for production UI implementation.
+- The seed's polish does not relax the truth boundary. A preview card depicts a pattern; it is not the pattern's implementation.
+- Promotion of any artifact requires the gates in [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3 to close green. A "candidate doctrine" row in §5 of this template is a proposal, not authorization.
+- Surface findings, drift, and unresolved decisions in the PR description, not silently in commits.
+
+---
+
+## See also
+
+- [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) — review gates this handoff feeds
+- [MUST_NOT_SHIP.md](MUST_NOT_SHIP.md) — hard rejection floor
+- [claude-design-seed/README.md](claude-design-seed/README.md) — what the seed directory is and how it is organized
+- [claude-design-seed/CHANGELOG.md](claude-design-seed/CHANGELOG.md) — imported seed versions
+- [claude-design-seed/REVIEW_NOTES.md](claude-design-seed/REVIEW_NOTES.md) — per-seed human review summary
+- [CLAUDE_DESIGN_CONTEXT.md](CLAUDE_DESIGN_CONTEXT.md) — paste briefing for external Claude Design sessions
+- [CLAUDE_DESIGN_SETUP.md](CLAUDE_DESIGN_SETUP.md) — workflow, external and local modes
+- [ICN_DESIGN_SYSTEM.md](ICN_DESIGN_SYSTEM.md) — design system entry point

--- a/docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md
+++ b/docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md
@@ -1,0 +1,234 @@
+---
+Status: operational
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-05-19
+Last Updated: 2026-05-19
+Purpose: Define how Claude Design seed artifacts are reviewed before any piece of them is promoted into the ICN repo as canonical truth. Holds the canonical-vs-generated boundary.
+---
+
+# Claude Design Review Protocol
+
+> **One sentence.** Claude Design generates seeds; the repo decides what becomes canonical, and most of a seed never does.
+
+This protocol governs what happens between "Claude Design produced something" and "this is now ICN truth." It exists because polished output is the most dangerous shape of misinformation in a design system: a seed that looks like a final product invites everyone — including future agents — to treat it as one.
+
+The handoff template ([CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md)) is the shape of every review request. The hard rejection list ([MUST_NOT_SHIP.md](MUST_NOT_SHIP.md)) is the floor every artifact clears. This document is the process that connects them.
+
+---
+
+## 1. Seed status definitions
+
+Every artifact from a Claude Design session falls into exactly one of these states. The status is declared by the human reviewer in [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md), not by the artifact itself.
+
+| Status | What it is | What it is not |
+|---|---|---|
+| **generated seed** | Output of a Claude Design session — markdown, HTML, CSS, screenshots, prose, illustrations. Default state of everything coming out of a seed bundle. | Canonical. Implementation evidence. Brand. |
+| **imported reference** | A copy of an existing ICN repo doc that the seed bundled for context. May be stale relative to the live repo. | Authoritative. The repo is. |
+| **UI kit / illustrative mock** | A visual composition meant to communicate direction or tone. May depict capability that doesn't exist. | Production UI. A shipped surface. A promise. |
+| **screenshot** | A rendered image of something — a prototype, an illustrative mock, an existing site. | Evidence the depicted thing is implemented, accessible, or live. |
+| **candidate doctrine** | A piece of generated seed content that a reviewer has marked as worth promoting to canonical, pending the review gates in §3. | Promoted. Still seed-only until the gates close green. |
+| **production implementation** | Code, content, or design that has been merged into the canonical repo paths after passing every gate. | Anything that exists only inside a seed bundle. |
+
+**Default status of any artifact inside a seed: generated seed.** Promotion is an explicit, reviewed step.
+
+---
+
+## 2. Canonical-vs-generated boundary
+
+The boundary is asymmetric and unconditional.
+
+- **Canonical truth lives in the upstream ICN repo.** Specifically: anything declared canonical in [`docs/registry.toml`](../registry.toml) `[control].canonical_doc_paths`, plus the `Canonical: yes` rows in [`docs/INDEX.md`](../INDEX.md). Generated artifacts are never automatically canonical.
+- **Generated Claude Design files are not canonical by default.** A polished seed produces files that look load-bearing. They are not.
+- **Imported repo docs inside a seed may become stale** between the moment the seed was produced and the moment it is reviewed. Always re-read the live repo version before citing a doc the seed bundled.
+- **Screenshots are not implementation evidence.** A screenshot can depict a future state, an illustrative mock, an existing site, or a hallucination, and the image will look the same regardless. Implementation is verified against code, not pixels.
+- **UI kits are illustrative unless explicitly promoted.** A component shown in a kit is not a component shipped in the repo. Promotion requires a code change in the appropriate canonical path (`website/src/`, `sdk/`, or `web/`), not an import of the kit.
+- **Polish is not evidence.** Visual finish, brand consistency, and prose quality of a seed say nothing about whether the content matches ICN doctrine, accessibility floor, vocabulary, or kernel truth.
+
+**Rule of thumb:** if a reviewer has not signed off on a specific artifact via [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md), the artifact is seed-only.
+
+---
+
+## 3. Required review gates
+
+A piece of generated seed content can only become canonical after passing every gate below. Gates are sequential; a failure at any gate sends the artifact back to seed-only status (or to discard).
+
+### 3.1 Truth-label review
+
+Each artifact must carry one of the truth labels from [ICN_VISUAL_EXPLAINER_BIBLE.md](ICN_VISUAL_EXPLAINER_BIBLE.md) and [ADR-0033](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md):
+
+- `implemented / current UI` — exists in the canonical repo paths today
+- `repo-grounded public explainer` — describes implemented or imminent behavior with linked evidence
+- `repo-grounded architecture explainer` — describes the architecture, with kernel/app boundary respected
+- `illustrative direction` — concept art; explicitly not implementation
+- `future-state / roadmap` — depicts a target; tied to an issue or ADR
+- `historical` — past state, kept for record
+- `do not use` — flagged as unfit; remains for archive only
+
+An artifact missing a truth label is not reviewable. Send it back.
+
+### 3.2 Accessibility review
+
+Against [ACCESSIBILITY_BASELINE.md](ACCESSIBILITY_BASELINE.md) and [docs/design-language/accessibility.md](../design-language/accessibility.md). The artifact must plan for:
+
+- WCAG 2.2 Level AA minimum
+- high-contrast light and dark themes (not just dark)
+- `prefers-reduced-motion` honored
+- large text / 200% zoom without horizontal scroll or content loss
+- low-bandwidth mode (no autoplay, no heavy hero media, no decorative video)
+- visible keyboard focus on every interactive element
+- screen-reader semantics (landmarks, headings, `aria-*` where required)
+- color is not the only carrier of meaning
+- room for long translated labels without truncation
+- right-to-left readiness
+- a language selector path (even if not yet wired)
+- glossary access from member-facing terminology
+
+A seed that displays only dark-mode aesthetic perfection passes none of these by default. Verify each.
+
+### 3.3 Vocabulary review
+
+Against the regulatory-safe vocabulary in [CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md) §"Regulatory-safe vocabulary" and the canonical → public mapping in [docs/design-language/concept-map.md](../design-language/concept-map.md). Required swaps:
+
+- **member**, not user / account holder
+- **standing**, not reputation / rank / account level
+- **mandate / authority**, not permission / admin power
+- **obligation**, not debt / IOU / balance owed
+- **allocation**, not payment plan / payout
+- **settlement**, not payment / transfer / payout / transaction
+- **unit**, not currency / token / coin
+- **position**, not balance / wallet / account
+- **receipt**, not confirmation / transaction record
+- **provenance**, not log / audit log (when member-facing)
+
+Any seed string using the right-hand vocabulary fails the gate. Generated seeds tend to import fintech and SaaS habits silently — search for them.
+
+### 3.4 Implementation-status review
+
+For every claim or depiction in the artifact, the reviewer answers: *does the ICN repo actually do this today?* If the answer is "no" or "not yet," the artifact must be relabeled as `illustrative direction` or `future-state / roadmap`. The artifact may not be promoted as `implemented / current UI` without a code citation.
+
+This is where most seed content fails. Generated UI kits depict signed actions, live federation, real receipts, working compute pools — none of which the repo has shipped end-to-end in the surfaces shown.
+
+### 3.5 Language / RTL readiness review
+
+The artifact must:
+
+- not be fixed-width English-only
+- not assume Latin character widths in label sizing
+- leave room for translated labels (40% expansion is a safe planning floor)
+- not assume left-to-right reading order in flow direction
+- support a glossary path for institutional terminology
+- expose the three vocabulary layers when relevant: canonical term, public label, local institutional vocabulary
+
+A seed that ships in one language with no translation seams is illustrative at best.
+
+### 3.6 Low-bandwidth / reduced-motion / large-text review
+
+- low-bandwidth: no autoplay video, no heavy hero animation, no required JavaScript for first paint of critical content
+- reduced-motion: every motion behavior gated by `prefers-reduced-motion`
+- large-text: layout reflows at 200% without content loss, no horizontal scroll on standard breakpoints
+
+If the seed depends on motion for meaning, it fails this gate even if it would otherwise pass §3.2.
+
+### 3.7 Source-doc drift review
+
+Any seed-internal copy of an ICN repo doc is suspect by default. For each `imported reference` in the seed:
+
+- diff the seed copy against the live repo version
+- list every drift point in [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md) §"Known drift findings"
+- treat the live repo version as authoritative
+- if the seed introduces a change worth keeping, propose it as an upstream PR against the canonical path — do not promote the seed's drifted copy
+
+Drift in the seed is normal. Promoting the drifted copy is the failure mode.
+
+---
+
+## 4. Promotion rule
+
+> **No Claude Design artifact becomes canonical merely because it looks polished.**
+
+A piece of generated seed content can be promoted only when:
+
+1. It is labeled `candidate doctrine` in [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md).
+2. Every applicable gate in §3 closes green.
+3. A reviewer with design ownership signs off in writing.
+4. The change is opened as a normal repo PR against the appropriate canonical path — not committed silently from inside the seed directory.
+5. The PR cites this protocol, the seed version, and the truth label.
+
+Promotion of a UI artifact (component, page, asset) additionally requires a code change in `website/src/`, `sdk/`, or `web/` — not just a docs reference. Importing a seed file into a canonical path is not promotion; it is a future-self trap.
+
+---
+
+## 5. Rejection rule
+
+Any artifact that violates ICN truth boundaries, accessibility floor, vocabulary, or member-rights requirements remains seed-only or is discarded outright. There is no "we'll fix it later" path that ends in canonical promotion.
+
+Specific rejection triggers (non-exhaustive — full list lives in [MUST_NOT_SHIP.md](MUST_NOT_SHIP.md)):
+
+- placeholder logo presented as final brand
+- member-app screenshots without an `illustrative direction` truth label
+- action card without mandate / reversibility / receipt declared before confirm
+- status conveyed by color alone
+- English-only fixed-width UI
+- crypto / wallet / token / balance / payment framing applied to ICN-native primitives
+- generic SaaS dashboard patterns
+- AI sheen / glassmorphism / glowing-globe network maps
+- faux-government seals or fake-foundation marks
+- screenshots cited as evidence the surface is implemented
+- generated seed artifacts presented as canonical
+
+A rejected artifact may remain in the seed directory for archive and learning. It may not be cited as ICN truth, used in member-facing material, or imported into canonical paths.
+
+---
+
+## 6. Reviewer's loop
+
+When a new seed arrives:
+
+1. Read the bundle's `seed/CLAUDE_CODE_BUNDLE.md`, `seed/INVENTORY.md`, `seed/PROMOTION_MAP.md`, `seed/DRIFT_REPORT.md`, `seed/PRODUCTION_READINESS.md`, and `seed/MUST_NOT_SHIP.md` before opening any prototype HTML or screenshot.
+2. Open [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) and fill in a fresh copy for this seed.
+3. Walk the gates in §3 against each named artifact. Record findings in [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md).
+4. Update [`claude-design-seed/CHANGELOG.md`](claude-design-seed/CHANGELOG.md) with the seed version, key findings, and final status counts (how many `candidate doctrine`, how many `illustrative direction`, how many `do not use`).
+5. For each `candidate doctrine`, open a small, scope-locked repo PR against the canonical path.
+6. Leave the rest of the seed where it is: under `docs/design/claude-design-seed/` as `generated seed`, labeled and archived.
+
+---
+
+## 7. What Claude Code is and is not asked to do
+
+Claude Code working from a Claude Design seed is asked to:
+
+- read the bundle's authoritative handoff docs
+- apply this protocol to the seed's content
+- promote `candidate doctrine` pieces via docs-only or scope-limited PRs
+- update the changelog and review notes for the seed
+- enforce the rejection rule and the hard list in [MUST_NOT_SHIP.md](MUST_NOT_SHIP.md)
+
+Claude Code is **not** asked to:
+
+- recreate generated prototypes pixel-perfectly
+- migrate React prototype code into `website/src/` or `web/pilot-ui/`
+- adopt placeholder logo, brand, or icon assets from a seed
+- generate production CSS from seed tokens
+- claim production readiness on member-facing surfaces depicted in a seed
+- treat a polished seed as canonical truth
+
+If a later task explicitly asks for production UI implementation against a promoted candidate, that is a separate PR with its own scope, its own review, and its own non-goals.
+
+---
+
+## 8. See also
+
+- [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) — shape of every review request
+- [MUST_NOT_SHIP.md](MUST_NOT_SHIP.md) — hard rejection floor
+- [claude-design-seed/README.md](claude-design-seed/README.md) — what the seed directory is for and how it is organized
+- [claude-design-seed/CHANGELOG.md](claude-design-seed/CHANGELOG.md) — imported seed versions
+- [claude-design-seed/REVIEW_NOTES.md](claude-design-seed/REVIEW_NOTES.md) — per-seed human review summary
+- [CLAUDE_DESIGN_CONTEXT.md](CLAUDE_DESIGN_CONTEXT.md) — paste briefing for external Claude Design sessions
+- [CLAUDE_DESIGN_SETUP.md](CLAUDE_DESIGN_SETUP.md) — workflow, external and local modes
+- [ICN_DESIGN_SYSTEM.md](ICN_DESIGN_SYSTEM.md) — design system entry point
+- [ICN_VISUAL_EXPLAINER_BIBLE.md](ICN_VISUAL_EXPLAINER_BIBLE.md) — truth labels and source hierarchy for visual material
+- [ACCESSIBILITY_BASELINE.md](ACCESSIBILITY_BASELINE.md) — per-surface accessibility floor
+- [CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md) — regulatory-safe vocabulary, dangerous-action copy
+- [docs/design-language/concept-map.md](../design-language/concept-map.md) — canonical → public label mapping
+- [docs/design-language/accessibility.md](../design-language/accessibility.md) — component-level accessibility rules

--- a/docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md
+++ b/docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md
@@ -190,7 +190,7 @@ When a new seed arrives:
 3. Walk the gates in §3 against each named artifact. Record findings in [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md).
 4. Update [`claude-design-seed/CHANGELOG.md`](claude-design-seed/CHANGELOG.md) with the seed version, key findings, and final status counts (how many `candidate doctrine`, how many `illustrative direction`, how many `do not use`).
 5. For each `candidate doctrine`, open a small, scope-locked repo PR against the canonical path.
-6. Leave the rest of the seed where it is: under `docs/design/claude-design-seed/` as `generated seed`, labeled and archived.
+6. Leave the rest of the seed in its external bundle location (typically `$CLAUDE_JOB_DIR` or a separate scratch directory) — do **not** copy preview HTML, UI kits, generated assets, screenshots, or imported references into the repo. Only the governance trail — the seed's entry in [`claude-design-seed/CHANGELOG.md`](claude-design-seed/CHANGELOG.md) and its section in [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md) — lives in the canonical repo. The bundle URL plus the review trail is sufficient record.
 
 ---
 

--- a/docs/design/CLAUDE_DESIGN_SETUP.md
+++ b/docs/design/CLAUDE_DESIGN_SETUP.md
@@ -287,7 +287,84 @@ without an NYCN or Summit logo on it, it's ICN-substrate work, and CONTEXT.md ap
 
 ---
 
-## 6. Maintenance
+## 6. Seed import, review, and promotion workflow
+
+Claude Design now produces **seeds** — packaged bundles that include generated docs, HTML preview cards, CSS token files, UI kit recreations, illustrative screenshots, and the bundle's own governance trail. A seed is a *proposal* for ICN design, not a design system in itself. Canonical truth still lives in the upstream repo paths; the seed waits for review.
+
+This section covers the workflow for handing a seed off to Claude Code without contaminating canonical truth with generated polish.
+
+### 6.1 What a seed is, what it is not
+
+- **A seed is:** the output of an external Claude Design session — markdown, HTML, CSS, screenshots, prose, illustrations, plus a self-describing governance bundle (the seed's own `INVENTORY.md`, `PROMOTION_MAP.md`, `DRIFT_REPORT.md`, `PRODUCTION_READINESS.md`, `MUST_NOT_SHIP.md`, and a `CLAUDE_CODE_BUNDLE.md` handoff).
+- **A seed is not:** canonical truth, brand decision, implementation evidence, sanctioned source of CSS / components / assets for production paths, or a place from which to import code into `website/src/`, `web/pilot-ui/`, or `sdk/`.
+
+Default status of every seed artifact is `generated seed`. Promotion is an explicit, gated step — see §6.4 below.
+
+### 6.2 Generated-vs-canonical boundary
+
+This boundary is asymmetric and unconditional:
+
+- Canonical truth lives in the upstream ICN repo paths declared in [`docs/registry.toml`](../registry.toml) `[control].canonical_doc_paths` and the `Canonical: yes` rows in [`docs/INDEX.md`](../INDEX.md).
+- Generated Claude Design files are not canonical by default.
+- Imported repo docs inside a seed may be stale; trust the live repo.
+- Screenshots are not implementation evidence.
+- UI kits are illustrative unless explicitly promoted.
+- Polish is not evidence.
+
+The full version of this boundary, with the rule-of-thumb, lives in [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §2. The hard rejection floor lives in [MUST_NOT_SHIP.md](MUST_NOT_SHIP.md).
+
+### 6.3 Docs / protocol-first handoff
+
+The first PR for any new seed is **docs-only**. It establishes the protocol scaffold (or extends it), records the seed's drift findings, and updates `claude-design-seed/CHANGELOG.md` + `REVIEW_NOTES.md`. It does not touch production UI, CSS, SDK, or assets.
+
+The shape of the handoff is [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md). Fill in a fresh copy per seed; the template's §6 (non-goals), §12 (allowed paths), and §13 (forbidden paths) are load-bearing — they override any inferred scope the seed's preview HTML might suggest.
+
+### 6.4 When Claude Code should implement docs only
+
+Default. Every new seed lands as docs-only first. Specifically:
+
+- Adopting the protocol / handoff template / rejection floor / skill scaffold ← **first PR, docs-only**
+- Fixing seed-identified drift in canonical docs (e.g., the seed's `DRIFT_REPORT.md` entries) ← **docs-only, scope-locked**
+- Adding seed workflow files under `docs/design/claude-design-seed/` ← **docs-only**
+
+Claude Code in docs-only mode does **not** recreate generated prototypes pixel-perfectly, does **not** migrate React / JSX recreations from a seed, does **not** adopt placeholder logo or icon assets, and does **not** create production CSS from seed tokens.
+
+### 6.5 When production UI implementation is allowed
+
+Only after:
+
+1. The relevant promotion candidate has been reviewed via [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3.
+2. The human decisions in [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md) §"What requires human decision" are resolved.
+3. A separate, scope-locked PR is opened against the appropriate canonical path (`website/src/`, `sdk/`, etc.).
+4. That PR carries the full per-PR member-surface checklist (the seed's `HANDOFF.md` shape, retained here as the per-PR template) — accessibility obligations, vocabulary scan, truth-label requirements, member-rights affordances, sync-state honesty, verification commands.
+
+A production-UI PR is not a continuation of the seed-promotion PR. It is a downstream artifact with its own scope, review, and approval.
+
+### 6.6 How to use the handoff template
+
+1. Copy [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) into a scratch location (typically `$CLAUDE_JOB_DIR/handoff-<seed-version>.md` or a worktree).
+2. Fill every section: seed identity, source docs the bundle was produced against, generated files, imported references, proposed upstream promotions, explicit non-goals, truth labels, accessibility obligations, vocabulary scan result, drift report summary, unresolved human decisions, allowed paths, forbidden paths, verification commands, PR title / branch guidance, sign-off.
+3. Link the filled handoff from [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md). A seed without a filled handoff is not ready for promotion work.
+4. Update [`claude-design-seed/CHANGELOG.md`](claude-design-seed/CHANGELOG.md) once review closes.
+
+### 6.7 How to use the review protocol
+
+The protocol enumerates seven required review gates: truth-label, accessibility, vocabulary, implementation-status, language/RTL readiness, low-bandwidth / reduced-motion / large-text, and source-doc drift. A piece of generated seed content can only be promoted after every applicable gate closes green.
+
+The reviewer's loop:
+
+1. Read the bundle's authoritative handoff docs in order: `CLAUDE_CODE_BUNDLE.md`, `INVENTORY.md`, `PROMOTION_MAP.md`, `DRIFT_REPORT.md`, `PRODUCTION_READINESS.md`, `MUST_NOT_SHIP.md` from the seed. Open preview HTML last.
+2. Open [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) and fill in a fresh copy.
+3. Walk the gates in [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3 against each named artifact.
+4. Record findings in [`claude-design-seed/REVIEW_NOTES.md`](claude-design-seed/REVIEW_NOTES.md).
+5. Append a row to [`claude-design-seed/CHANGELOG.md`](claude-design-seed/CHANGELOG.md).
+6. Open scope-locked promotion PRs.
+
+Full protocol detail in [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md). Rejection floor in [MUST_NOT_SHIP.md](MUST_NOT_SHIP.md). Workflow narrative in [`claude-design-seed/README.md`](claude-design-seed/README.md).
+
+---
+
+## 7. Maintenance
 
 Keep this doc and `CLAUDE_DESIGN_CONTEXT.md` in sync with:
 
@@ -300,9 +377,15 @@ Re-review on: any of the above changing, or quarterly, whichever is sooner.
 
 ---
 
-## 7. See also
+## 8. See also
 
 - [CLAUDE_DESIGN_CONTEXT.md](CLAUDE_DESIGN_CONTEXT.md) — the paste briefing
+- [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) — seed → canonical review gates
+- [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) — seed-level handoff template
+- [MUST_NOT_SHIP.md](MUST_NOT_SHIP.md) — hard rejection floor
+- [claude-design-seed/README.md](claude-design-seed/README.md) — seed directory workflow
+- [claude-design-seed/CHANGELOG.md](claude-design-seed/CHANGELOG.md) — imported seed versions
+- [claude-design-seed/REVIEW_NOTES.md](claude-design-seed/REVIEW_NOTES.md) — per-seed human review summary
 - [ICN_DESIGN_SYSTEM.md](ICN_DESIGN_SYSTEM.md) — design system entry point
 - [../DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md) — kernel-side counterpart
 - [ICN_VISUAL_EXPLAINER_BIBLE.md](ICN_VISUAL_EXPLAINER_BIBLE.md) — for diagrams and infographics specifically

--- a/docs/design/ICN_DESIGN_SYSTEM.md
+++ b/docs/design/ICN_DESIGN_SYSTEM.md
@@ -51,6 +51,10 @@ Living docs that make up the system. Read in order on first pass:
 | 8 | [docs/design/assets/ASSET_REGISTER.md](assets/ASSET_REGISTER.md) | Live register of planned and tracked visual assets (one row per asset, briefs in `assets/briefs/`) |
 | 9 | [docs/design/CLAUDE_DESIGN_CONTEXT.md](CLAUDE_DESIGN_CONTEXT.md) | Self-contained briefing for paste into Claude Design or any external collaborator — brand, tokens, vocabulary, surface inventory, kernel binding |
 | 10 | [docs/design/CLAUDE_DESIGN_SETUP.md](CLAUDE_DESIGN_SETUP.md) | How to use Claude Design — external paste flow, local `icn-design-advisor` agent (repo-shipped), optional `design` plugin pack, mixed-mode workflow, job-card templates |
+| 11 | [docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) | Seven-gate review protocol for promoting Claude Design seed artifacts to canonical — holds the canonical-vs-generated boundary |
+| 12 | [docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) | Seed-level handoff template (seed → Claude Code) — fill one copy per seed before any promotion work |
+| 13 | [docs/design/MUST_NOT_SHIP.md](MUST_NOT_SHIP.md) | Hard rejection floor — twelve patterns and artifacts that disqualify a surface from production |
+| 14 | [docs/design/claude-design-seed/README.md](claude-design-seed/README.md) | Seed directory workflow — what a seed is, where canonical truth lives, how seeds are reviewed and promoted (companions: `CHANGELOG.md`, `REVIEW_NOTES.md`) |
 
 ADRs that bind this work:
 

--- a/docs/design/MUST_NOT_SHIP.md
+++ b/docs/design/MUST_NOT_SHIP.md
@@ -1,0 +1,181 @@
+---
+Status: operational
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-05-19
+Last Updated: 2026-05-19
+Purpose: Hard-stop list of design patterns and artifacts that must not ship in any production ICN surface. Each item is here because it has appeared or could plausibly appear in or near a Claude Design seed, and every recurrence in the future would be a regression.
+---
+
+# What Must Not Ship
+
+> **One sentence.** Polish is not approval; these are the patterns and artifacts that disqualify a surface from production no matter how finished it looks.
+
+This document is a floor, not a ceiling. The full design doctrine lives across [ICN_DESIGN_SYSTEM.md](ICN_DESIGN_SYSTEM.md), [ACCESSIBILITY_BASELINE.md](ACCESSIBILITY_BASELINE.md), [CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md), [ICN_VISUAL_EXPLAINER_BIBLE.md](ICN_VISUAL_EXPLAINER_BIBLE.md), [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md), and the design-language docs under [`docs/design-language/`](../design-language/). This file is the short, hard rejection list every promotion has to clear before any other doctrine applies.
+
+Adopted from the Claude Design seed's `seed/MUST_NOT_SHIP.md` (v0.1) and extended for repo-side promotion review. The seed's items are integrated, not preserved verbatim — the canonical repo wins on phrasing.
+
+---
+
+## 1 · The placeholder logo as final brand
+
+The current "ICN Commons" three-circle wordmark — wherever it appears, in any seed, preview, screenshot, or imported asset — is a **placeholder**. It must not ship as the final brand mark, and it must not appear in any institution package (NYCN, Summit, future federations) as if it were settled identity.
+
+**How to detect:** the mark appears anywhere without a visible "placeholder mark · not final" caption nearby. If the caption is missing, the mark is being asserted as final.
+
+**What to do instead:** finish the logo exploration described in [ICN_DESIGN_SYSTEM.md](ICN_DESIGN_SYSTEM.md) and the seed's README ("federated ring · interlocking civic forms · transit-map relation mark · receipt/provenance mark · cooperative weave · modular institutional glyph"), pick a direction, and replace the placeholder atomically across all surfaces. Until that decision is taken, the placeholder is rejected from any production surface.
+
+---
+
+## 2 · Member-app screenshots without an illustrative truth label
+
+Member-shell screenshots are **illustrative direction** unless the underlying surface is implemented end-to-end in the canonical repo (`website/src/`, `sdk/`, or `web/pilot-ui/`). Every screenshot, exported PNG, or embedded mock of a member surface must carry a visible truth-label chip ([ADR-0033](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md), [ICN_VISUAL_EXPLAINER_BIBLE.md](ICN_VISUAL_EXPLAINER_BIBLE.md)).
+
+**How to detect:** any image of a phone or browser running the ICN member shell that does not show the truth-label strip near the top of the device viewport. Marketing material that crops the strip out is the most common offender.
+
+**What to do instead:** export with the strip intact. If the strip is too visually heavy for a marketing context, the answer is to use a different asset — not to remove the label. The `MemberSurface` component upstream enforces this rule by design (`showTruthLabelChip=true`); do not silently override.
+
+---
+
+## 3 · Any action card without mandate, reversibility, and receipt
+
+Per [ADR-0027 (Action Card Contract)](../adr/ADR-0027-action-card-contract.md): every action that produces a receipt must declare, before the confirm step, **the mandate that authorizes it**, **its reversibility**, and **the receipt it will produce**. A confirm button without these three is a regulatory and institutional liability — the surface is asserting authority the kernel cannot prove.
+
+**How to detect:** any Confirm / Submit / Send / Vote button that does not sit below a labeled "Mandate" / "Reversibility" / "Produces" row.
+
+**What to do instead:** use the action-card pattern documented in the design system. If a flow truly has no mandate, no reversibility statement, or no receipt — it is not an ICN action, it is a preference setting. Use a different pattern.
+
+---
+
+## 4 · Any status conveyed by color alone
+
+Color reinforces; it never carries. Every color-coded state must pair with a text or icon companion that names the state. Grayscale-rendered, the surface must remain fully legible.
+
+**How to detect:** open the surface, drop saturation to 0%, and check whether every state remains distinguishable. If state distinction collapses, the surface is failing this rule.
+
+**Common offenders:** "your standing is green" without text · red-rimmed cards that don't say "rejected" · accent-only sync states without "saved" / "sent" / "confirmed" labels · maturity bands distinguished only by accent bar color.
+
+**What to do instead:** every accent pairs with a text label and a concept icon. Reference: [docs/design-language/accessibility.md](../design-language/accessibility.md) §3.1.
+
+---
+
+## 5 · English-only fixed-width UI
+
+ICN is global infrastructure. A surface that only renders English, that breaks at long-string locales (German, Finnish), or that fixed-pixels its containers so non-English content gets clipped, is not member-ready.
+
+**How to detect:** switch the surface to Spanish and German; switch to Arabic with `dir="rtl"`; verify every label fits, every chip wraps, every action card holds its layout. If any of these fails, the surface is English-only by construction.
+
+**What to do instead:**
+
+- Every text container is flexible-width with `min-width: 0` and `text-wrap` appropriate to the content.
+- Every label is authored with the longest plausible localized form in mind (~1.5× English string length as the planning floor).
+- The language selector is explicit and member-chosen, never IP-detected.
+- Formal records always carry the canonical original alongside any translation.
+- Flow direction respects `dir="rtl"` end-to-end (chrome, controls, icons).
+
+---
+
+## 6 · Crypto, wallet, token, balance, or payment framing on ICN-native primitives
+
+ICN-native primitives are obligations, allocations, settlements, units, positions, and receipts. Importing fintech or crypto vocabulary onto them is a regulatory liability and a category error.
+
+**How to detect:** grep member-facing strings for `wallet | balance | currency | crypto | token | coin | payment | payout | transfer | transaction fee | debt | IOU`. Any match outside an explicit "Reject" example is a violation.
+
+**What to do instead:** use the canonical vocabulary in [CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md) §"Regulatory-safe vocabulary" and [docs/design-language/concept-map.md](../design-language/concept-map.md):
+
+- **member**, not user / account holder
+- **standing**, not reputation / rank / account level
+- **mandate / authority**, not permission / admin power
+- **obligation**, not debt / IOU / balance owed
+- **allocation**, not payment plan / payout
+- **settlement**, not payment / transfer / payout / transaction
+- **unit**, not currency / token / coin
+- **position**, not balance / wallet / account
+- **receipt**, not confirmation / transaction record
+- **provenance**, not log / audit log (when member-facing)
+
+---
+
+## 7 · Generic SaaS dashboard / admin-console patterns
+
+ICN does not have a dashboard. The member shell is not a dashboard, the operator surface is not a dashboard, the federation view is not a dashboard. "Dashboard" implies metrics-over-meaning, optimization-over-accountability, and platform-over-institution.
+
+**How to detect:** the word "dashboard" or "admin panel" anywhere in member-facing copy. Stacked metric tiles for their own sake. A "stats" view that exists without answering a specific institutional question. KPI tiles, gauge widgets, and analytics chrome borrowed from product-analytics SaaS.
+
+**What to do instead:** name surfaces by what they do. **Standing view** — "who you are, where you are recognized." **Action queue** — "what needs you now." **Activity** — "what happened, with proof." **Position** — "what you have contributed and what you can draw on."
+
+---
+
+## 8 · "AI sheen" / glassmorphism
+
+No glowing borders, no shimmer effects, no `✨` decorations, no gradient text on copy that isn't the brand name, no animated particles, no "powered by AI" chrome, no frosted-glass cards layered over neon gradients, no chromatic-aberration accents.
+
+**How to detect:** any surface that asserts intelligence (smartness, magic, power) through visual treatment rather than through what it tells the member.
+
+**What to do instead:** the institution is not "smart" — the member is. Surface copy that helps the member decide. Skip the chrome. ICN looks like public infrastructure, not a startup deck.
+
+---
+
+## 9 · Glowing-globe / central-hub network maps
+
+A glowing globe with arcs is not a network diagram; it is a venture-pitch motif. A central hub with spokes is not federation; it is hub-and-spoke architecture. Both encode the wrong story about ICN.
+
+**How to detect:** any diagram that uses a sphere, a globe, or a single central node radiating to peripheral nodes. Animated arcs traveling along great-circle routes. World maps with pulsing dots.
+
+**What to do instead:** depict ICN's actual topology — peers in named scopes, federations of co-equal entities, provenance threads between participants. The "persistent member across institutional contexts" motif from the design language is the right primitive. Reference: [ICN_VISUAL_EXPLAINER_BIBLE.md](ICN_VISUAL_EXPLAINER_BIBLE.md).
+
+---
+
+## 10 · Faux-government / faux-foundation seals
+
+No round seals with laurel branches, no eagles, no shield motifs, no "Department of ___" chrome, no fake watermarks asserting officialdom. ICN is institutional, not governmental.
+
+**How to detect:** circular emblems flanked by laurels, classical-seal compositions, embossed-foundation marks, fake watermarks on member-facing documents.
+
+**What to do instead:** the institution package's own brand mark (NYCN, Summit, the cooperative federation that issued the receipt) is what carries authority on a document, not borrowed state iconography. ICN substrate is unbranded by default.
+
+---
+
+## 11 · Screenshots cited as implementation evidence
+
+A screenshot proves nothing about what is implemented. It depicts what was rendered into pixels at some moment — possibly from a live deploy, possibly from a mock, possibly hallucinated.
+
+**How to detect:** a PR description, marketing page, or roadmap doc that links a screenshot as the proof a feature is shipped. A "current state" claim backed by an image and no code link.
+
+**What to do instead:** cite the code path, the test, the ADR, the commit. If a screenshot accompanies the citation, it is an illustration, not the evidence. Per [ADR-0033](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md), public maturity claims require linked evidence — and an image is not evidence.
+
+---
+
+## 12 · Generated seed artifacts presented as canonical
+
+A Claude Design seed produces polished output. Polished output is not canonical truth. Anything under `docs/design/claude-design-seed/` is seed-only by default; anything inside a delivered bundle is seed-only by default; anything that looks like a final design system but has not been promoted via [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3 is seed-only.
+
+**How to detect:** a seed artifact (HTML preview card, UI kit composition, generated CSS, imported screenshot) cited or referenced from a canonical doc, an ADR, a press surface, or a member-facing page. A seed file linked as if it were the source of a doctrine.
+
+**What to do instead:** promote the underlying *idea* through a normal repo PR against the appropriate canonical path. The seed file stays where it is — under `docs/design/claude-design-seed/` — as record. Citations point at the promoted canonical doc, not back at the seed.
+
+---
+
+## How to enforce this list
+
+- **At review time:** [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3 includes the truth-label, accessibility, vocabulary, implementation-status, language/RTL, low-bandwidth/reduced-motion/large-text, and source-doc drift gates. This file is the rejection floor those gates default to.
+- **At PR time:** the design rule in [`.claude/rules/design.md`](../../.claude/rules/design.md) auto-loads doctrine when design paths are touched. Reviewers cite item numbers from this file when blocking a PR.
+- **At marketing/comms time:** anyone preparing a public asset of ICN against this list before publish. The seed's `MUST_NOT_SHIP.md` was originally a self-check for the seed author; the repo-side version is a self-check for every contributor.
+
+A surface that violates any of the twelve items is not shipped. There is no "we'll fix it later" path that ends in canonical promotion of a violating surface.
+
+---
+
+## See also
+
+- [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) — gates that run before promotion
+- [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) — handoff shape for seed → Claude Code
+- [ICN_DESIGN_SYSTEM.md](ICN_DESIGN_SYSTEM.md) — design system entry point
+- [ICN_VISUAL_EXPLAINER_BIBLE.md](ICN_VISUAL_EXPLAINER_BIBLE.md) — truth-label scheme, source hierarchy, rejected-patterns appendix
+- [ACCESSIBILITY_BASELINE.md](ACCESSIBILITY_BASELINE.md) — per-surface accessibility floor
+- [CONTENT_STYLE_GUIDE.md](CONTENT_STYLE_GUIDE.md) — regulatory-safe vocabulary, dangerous-action copy
+- [docs/design-language/concept-map.md](../design-language/concept-map.md) — canonical → public label mapping
+- [docs/design-language/accessibility.md](../design-language/accessibility.md) — component-level accessibility rules
+- [ADR-0027 — Action Card Contract](../adr/ADR-0027-action-card-contract.md)
+- [ADR-0032 — Website Truth Boundary](../adr/ADR-0032-website-truth-boundary.md)
+- [ADR-0033 — Public Maturity Claims and Evidence Links](../adr/ADR-0033-public-maturity-claims-and-evidence-links.md)

--- a/docs/design/MUST_NOT_SHIP.md
+++ b/docs/design/MUST_NOT_SHIP.md
@@ -160,7 +160,7 @@ A Claude Design seed produces polished output. Polished output is not canonical 
 
 - **At review time:** [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3 includes the truth-label, accessibility, vocabulary, implementation-status, language/RTL, low-bandwidth/reduced-motion/large-text, and source-doc drift gates. This file is the rejection floor those gates default to.
 - **At PR time:** the design rule in [`.claude/rules/design.md`](../../.claude/rules/design.md) auto-loads doctrine when design paths are touched. Reviewers cite item numbers from this file when blocking a PR.
-- **At marketing/comms time:** anyone preparing a public asset of ICN against this list before publish. The seed's `MUST_NOT_SHIP.md` was originally a self-check for the seed author; the repo-side version is a self-check for every contributor.
+- **At marketing/comms time:** anyone preparing a public asset of ICN checks it against this list before publishing. The seed's `MUST_NOT_SHIP.md` was originally a self-check for the seed author; the repo-side version is a self-check for every contributor.
 
 A surface that violates any of the twelve items is not shipped. There is no "we'll fix it later" path that ends in canonical promotion of a violating surface.
 

--- a/docs/design/claude-design-seed/CHANGELOG.md
+++ b/docs/design/claude-design-seed/CHANGELOG.md
@@ -1,0 +1,84 @@
+---
+Status: operational
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-05-19
+Last Updated: 2026-05-19
+Purpose: Track imported Claude Design seed versions and their review outcomes. One entry per seed produced for ICN. Newest first.
+---
+
+# Claude Design Seed Changelog
+
+> **One sentence.** A seed gets one row when it arrives, one update when its review closes, and no edits to its row after that.
+
+This is the governance trail for Claude Design seeds. It records what was produced, what was promoted, what was held, and what was rejected — without copying seed contents into the repo. The full review summary for each seed lives in [REVIEW_NOTES.md](REVIEW_NOTES.md).
+
+Entry format:
+
+```
+## <YYYY-MM-DD> — <Seed name and version>
+- Bundle URL: <url or path>
+- Status: <review required · in review · promoted (partial) · promoted (full) · rejected · archived>
+- Summary of contents:
+- Promotion candidates (linked to PRs once opened):
+- Held / rejected items:
+- Drift findings:
+- Production-readiness caveats:
+- Human decisions still required:
+- See also: REVIEW_NOTES.md §<seed slug>
+```
+
+---
+
+## 2026-05-19 — ICN Commons Design System — Claude Design Seed v0.1
+
+- **Bundle URL:** Claude Design handoff bundle (local extract under job scratch dir; not committed to repo)
+- **Status:** review required · not production canonical
+- **Summary of contents:**
+  - Generated seed governance: `seed/SEED_v0.1.md`, `seed/REVIEW_PROTOCOL.md`, `seed/HANDOFF.md`, `seed/MUST_NOT_SHIP.md`, `seed/REVIEW_PROMPTS.md`, `seed/AUDIT_PASS_2.md`, `seed/INVENTORY.md`, `seed/PROMOTION_MAP.md`, `seed/DRIFT_REPORT.md`, `seed/PRODUCTION_READINESS.md`, `seed/CLAUDE_CODE_BUNDLE.md`
+  - Generated tokens: `colors_and_type.css` (three-layer raw / theme / element, with seed-extended `hc-dark`, `hc-light`, and `data-mode~="large-text"` / `data-mode~="low-bandwidth"`)
+  - Generated UI kits: `ui_kits/website/` (Astro component recreations as inline React/JSX) and `ui_kits/member-shell/` (illustrative direction for the unbuilt member shell)
+  - Generated preview cards: 45 self-contained HTML cards across Brand, Colors, Type, Spacing, Components groups, plus the `canonical-vs-generated.html` boundary card
+  - Generated assets: placeholder logo mark and wordmark (SVG with stamped "PLACEHOLDER · NOT FINAL" caption), 11-icon institutional set
+  - Imported upstream docs (for offline reference, may be stale): the ICN design doctrine docs and a snapshot of `website/src/`
+  - Screenshots: 23 PNGs from the session (debug iterations to be discarded; the keep-set is illustrative)
+- **Promotion candidates landed in this PR (seed → upstream):**
+  - `seed/REVIEW_PROTOCOL.md` → [`docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md`](../CLAUDE_DESIGN_REVIEW_PROTOCOL.md) (canonical-vs-generated boundary, review gates, promotion/rejection rules)
+  - `seed/HANDOFF.md` + user-spec extensions → [`docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md`](../CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) (seed-level handoff template, not the per-PR member-surface checklist)
+  - `seed/MUST_NOT_SHIP.md` (seven items) plus user-spec additions → [`docs/design/MUST_NOT_SHIP.md`](../MUST_NOT_SHIP.md) (12-item rejection floor)
+  - `SKILL.md` (seed) → [`.claude/skills/icn-commons-design/SKILL.md`](../../../.claude/skills/icn-commons-design/SKILL.md) (skill scaffold, edited to point at canonical repo paths rather than seed paths)
+  - Seed workflow documentation → [`docs/design/claude-design-seed/README.md`](README.md), this changelog, and [`REVIEW_NOTES.md`](REVIEW_NOTES.md)
+- **Promotion candidates held (separate review track required):**
+  - Seed token extensions in `colors_and_type.css` (`hc-dark`, `hc-light`, `data-mode~="large-text"`, `data-mode~="low-bandwidth"`) — additive proposal; needs human decision on whether HC themes are a v1.0 obligation or a v1.x stretch goal
+  - `data-mode` mechanism for member preferences — needs architecture review (CSS-only opt-in vs gateway-plumbed member preference)
+  - Seed pattern names ("scope frame", "mandate line", "challenge / review / exit", "sync state", seven-state truth-label enumeration) — needs design-language owner sign-off before promotion into [`docs/design-language/concept-map.md`](../../design-language/concept-map.md)
+  - Seven-state truth-label enumeration → potential appendix in [`docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md`](../ICN_VISUAL_EXPLAINER_BIBLE.md) (separate PR)
+  - Rejected-patterns appendix → potential appendix in [`docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md`](../ICN_VISUAL_EXPLAINER_BIBLE.md) (separate PR)
+- **Held / rejected (seed-only or discard):**
+  - Placeholder logo mark and wordmark — remains rejected for production until logo direction is taken
+  - All UI kit React/JSX recreations — production stays Astro for the website and React Native for mobile; recreations would create a dual codebase
+  - All preview HTML cards — showcase only, never source
+  - All screenshots — artifacts only, never source
+  - All bundled imports of upstream docs — trust the live repo; the seed's copies may be stale
+- **Drift findings (from seed `DRIFT_REPORT.md`):**
+  - **D-01 (HIGH, actively misleading):** [`docs/design-language/accessibility.md`](../../design-language/accessibility.md) claimed at multiple points that the site had no `:focus-visible` rules. Upstream [`website/src/styles/global.css`](../../../website/src/styles/global.css) has had a global `:focus-visible` ring (2px teal outline, 3px offset, per-element selectors for `a`, `button`, `[role="button"]`, `input`, `textarea`, `select`, `summary`, plus a skip link) since well before the seed was produced. **Fixed in this PR** — language updated to reflect current repo reality at the two affected locations (§3.3 and §5 known failures #1).
+  - **D-02 (MEDIUM, additive):** seed CSS extends upstream tokens with `hc-dark`, `hc-light`, `data-mode~="large-text"`, and `data-mode~="low-bandwidth"`. Not a contradiction — these are proposed extensions for a separate review track.
+  - **D-03 (LOW, by design):** seed `colors_and_type.css` is token-only; upstream `global.css` is token + components. No conflict; the seed would add token rows, not replace.
+  - **D-04 (LOW, minor gaps):** member-shell mock vs [`docs/mobile/icn-mobile-ux-spec-v1.md`](../../mobile/icn-mobile-ux-spec-v1.md) — explicit threshold display, deadline timestamp, proof affordance on closed proposals, sync-state chip per action — track as v0.2 follow-up.
+  - **D-05 (LOW, by design):** seed introduces pattern names ("scope frame", "mandate line", etc.) not in concept-map. Design-system patterns, not kernel concepts. Promotion requires authorization.
+  - **D-06 (MEDIUM, bounded ~3 days):** imported doc `Last Reviewed:` dates predate the seed by up to ~3 days. Consumers should re-read the live repo for changes after the relevant `Last Reviewed:` date on each doc.
+- **Production-readiness caveats (from seed `PRODUCTION_READINESS.md`):**
+  - Theme coverage: 4 themes defined; HC themes shown only in `global-readiness.html`, not threaded through the UI kits
+  - Accessibility: pattern correct; no axe-core, no NVDA/VoiceOver pass, no device verification, no 200% browser-zoom test
+  - Vocabulary: clean per the seed's audit
+  - Truth-label discipline: strong — persistent strip on the member shell, on-SVG caption on the logo, rule documented
+  - Language / RTL: English-only first pass; RTL demonstrated in one stress card; not threaded through UI kits
+  - Mobile readiness: concept-strong, hardware-verification absent
+  - **Verdict:** ready for review, not for production
+- **Human decisions still required:**
+  - HC themes (`hc-dark` / `hc-light`) — v1.0 obligation or v1.x stretch? (owner: Matt Faherty)
+  - `data-mode` mechanism — CSS-only opt-in, or member preference plumbed through the gateway? (owner: architecture review)
+  - Seed pattern names — promote into [`docs/design-language/concept-map.md`](../../design-language/concept-map.md) as canonical concept ids, or keep as design-system pattern names only? (owner: design + design-language owners)
+  - Logo exploration — when does it start, who drives it? (owner: Matt Faherty)
+  - Spanish first-pass — against this seed, against the live upstream website, or both in parallel? (owner: localization owner)
+- **See also:** [REVIEW_NOTES.md §icn-commons-design-system-v0.1](REVIEW_NOTES.md#icn-commons-design-system--claude-design-seed-v01-2026-05-19)

--- a/docs/design/claude-design-seed/README.md
+++ b/docs/design/claude-design-seed/README.md
@@ -1,0 +1,119 @@
+---
+Status: operational
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-05-19
+Last Updated: 2026-05-19
+Purpose: Repository-facing explanation of the Claude Design seed workflow. Records what a seed is, what canonical truth is, and how the two relate without contaminating each other.
+---
+
+# Claude Design Seed — Repository Workflow
+
+> **One sentence.** A seed is a generated proposal for ICN design; canonical truth lives in the upstream repo; this directory is where seeds wait while review decides which pieces of them, if any, are promoted.
+
+This README is the entry point for anyone — human or agent — encountering the `docs/design/claude-design-seed/` directory for the first time. It explains the workflow, the boundaries, and what changes when a new seed arrives.
+
+---
+
+## 1. What a seed is
+
+A **Claude Design seed** is the output of a Claude Design session: a packaged bundle that typically contains generated markdown, HTML preview cards, CSS token files, UI kit recreations, illustrative screenshots, governance docs (the seed's own `INVENTORY.md`, `PROMOTION_MAP.md`, `DRIFT_REPORT.md`, `PRODUCTION_READINESS.md`, `MUST_NOT_SHIP.md`, and a `CLAUDE_CODE_BUNDLE.md` handoff), and sometimes imported copies of upstream ICN repo docs for offline reference.
+
+Each seed has a version (e.g. `v0.1`) and a status banner ("review required · not production canonical" by default). The seed's own README sets the framing; this directory sets the rules for what the repo does with it.
+
+## 2. What a seed is not
+
+A seed is **not**:
+
+- the canonical design system
+- a brand decision
+- an implementation
+- evidence that any depicted capability is shipped
+- a sanctioned source of CSS, components, or assets for production paths
+- a place from which to import code into `website/src/`, `web/pilot-ui/`, or `sdk/`
+
+A seed may *contain* candidate doctrine that, after review, becomes canonical via a separate PR. But until that review closes, the seed is seed-only.
+
+## 3. Where canonical truth lives
+
+Canonical ICN design truth is the union of:
+
+- `Canonical: yes` rows in [`docs/INDEX.md`](../../INDEX.md)
+- `canonical_doc_paths` in [`docs/registry.toml`](../../registry.toml) (the doc control plane)
+- the design subsystems entry point [ICN_DESIGN_SYSTEM.md](../ICN_DESIGN_SYSTEM.md)
+- the doctrine docs it indexes ([ACCESSIBILITY_BASELINE.md](../ACCESSIBILITY_BASELINE.md), [CONTENT_STYLE_GUIDE.md](../CONTENT_STYLE_GUIDE.md), [ICN_VISUAL_SYSTEM.md](../ICN_VISUAL_SYSTEM.md), [ICN_VISUAL_EXPLAINER_BIBLE.md](../ICN_VISUAL_EXPLAINER_BIBLE.md), the design-language docs under [`docs/design-language/`](../../design-language/), the mobile UX spec at [`docs/mobile/icn-mobile-ux-spec-v1.md`](../../mobile/icn-mobile-ux-spec-v1.md), the member-shell spec at [`docs/spec/member-shell-v0.md`](../../spec/member-shell-v0.md))
+- the ADRs that bind design (currently 0026, 0027, 0028, 0032, 0033)
+- the production code in `website/src/`, `web/pilot-ui/`, and `sdk/` — for anything that has actually shipped
+
+The seed directory is not on this list and never automatically joins it.
+
+## 4. How to review a seed
+
+The protocol is [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](../CLAUDE_DESIGN_REVIEW_PROTOCOL.md). The shape of the handoff is [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](../CLAUDE_DESIGN_HANDOFF_TEMPLATE.md). The rejection floor is [MUST_NOT_SHIP.md](../MUST_NOT_SHIP.md).
+
+Workflow:
+
+1. **Receive the bundle.** Download or unpack it locally. Do not commit the raw bundle into the repo.
+2. **Read the bundle's authoritative handoff docs first.** In order: `seed/CLAUDE_CODE_BUNDLE.md`, `seed/INVENTORY.md`, `seed/PROMOTION_MAP.md`, `seed/DRIFT_REPORT.md`, `seed/PRODUCTION_READINESS.md`, `seed/MUST_NOT_SHIP.md`. Open preview HTML last, not first — polish is the distortion field.
+3. **Fill in a handoff template** from [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](../CLAUDE_DESIGN_HANDOFF_TEMPLATE.md). Record every promotion candidate, every non-goal, every allowed/forbidden path.
+4. **Walk the review gates** in [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](../CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3 against each named artifact. Record findings in [REVIEW_NOTES.md](REVIEW_NOTES.md).
+5. **Append a row** to [CHANGELOG.md](CHANGELOG.md) summarizing the seed version, the artifacts, the gate outcomes, and the human decisions still required.
+6. **Open scope-locked promotion PRs.** Each `candidate doctrine` row becomes its own small PR against the canonical path — never a bulk import.
+
+## 5. How to promote pieces of a seed
+
+Promotion is always:
+
+1. Done by a normal repo PR against the appropriate canonical path. **Never** by adding files under `claude-design-seed/` and citing them as authoritative.
+2. Scope-locked: one promotion per PR, or one tightly-related cluster. The first seed-promotion PR (this one) is the protocol/handoff/must-not-ship scaffold itself — every subsequent promotion is its own PR.
+3. Reviewed against the [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](../CLAUDE_DESIGN_REVIEW_PROTOCOL.md) gates with findings recorded in [REVIEW_NOTES.md](REVIEW_NOTES.md).
+4. Documented with the truth label the artifact carries forward.
+
+What gets promoted is the *idea or pattern*, not the seed file itself. The seed file remains at its original path; the canonical path gets the cleaned, repo-style version.
+
+## 6. What must stay seed-only
+
+By default, the following stay seed-only forever:
+
+- placeholder logo, wordmark, and brand marks
+- React / JSX recreations of Astro components (production stays Astro for the website, React Native for mobile)
+- preview HTML cards (they are showcase, not source)
+- screenshots (they are artifacts, not source)
+- seed-internal governance docs (`SEED_v*.md`, `AUDIT_PASS_*.md`, `REVIEW_PROMPTS.md`, the seed's own `INVENTORY.md` / `PROMOTION_MAP.md` / `DRIFT_REPORT.md` / `PRODUCTION_READINESS.md` / `CLAUDE_CODE_BUNDLE.md`)
+- bundled imports of upstream docs (they go stale; trust the live repo)
+
+A seed-only artifact may be referenced from [REVIEW_NOTES.md](REVIEW_NOTES.md) for context. It may not be cited from canonical docs.
+
+## 7. How Claude Design and Claude Code work together
+
+| Role | Where | Job |
+|---|---|---|
+| **Claude Design (external)** | claude.ai or any Claude Design session | Produce seeds — visual artifacts, governance docs, illustrative direction. Output is generated seed by default. |
+| **Human reviewer** | this repo | Walk gates, fill handoff template, write review notes, decide what is promoted. |
+| **Claude Code** | this repo, via the [icn-commons-design](../../../.claude/skills/icn-commons-design/SKILL.md) skill and the [icn-design-advisor](../../../.claude/agents/icn-design-advisor.md) agent | Apply review protocol to the seed, draft docs-only promotion PRs, enforce the rejection floor. Does **not** recreate generated prototypes pixel-perfectly without explicit later instruction. |
+
+The pattern is: Claude Design generates → human reviews → Claude Code drafts the docs-only promotion PR → human merges. UI implementation is a separate, later track with its own scope and approval.
+
+## 8. Directory layout
+
+```
+docs/design/claude-design-seed/
+├── README.md            # this file
+├── CHANGELOG.md         # imported seed versions, one entry per seed
+└── REVIEW_NOTES.md      # human review summary per seed
+```
+
+The bundle's preview HTML, UI kits, screenshots, and assets are **not** copied into this directory. They live wherever the bundle was extracted (typically outside the repo, under a job/scratch directory). What lives here is the *governance trail*: the changelog of seeds and the review notes that explain why each piece was promoted or held.
+
+When a seed *is* archived for record (rare — only when its review notes need to cite seed-internal paths), it goes under `docs/design/claude-design-seed/archive/<seed-version>/` and is treated as `historical`. Default behavior is not to archive — the bundle URL and the review notes are sufficient record.
+
+## 9. See also
+
+- [CLAUDE_DESIGN_REVIEW_PROTOCOL.md](../CLAUDE_DESIGN_REVIEW_PROTOCOL.md) — gates
+- [CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](../CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) — handoff shape
+- [MUST_NOT_SHIP.md](../MUST_NOT_SHIP.md) — hard rejection floor
+- [CLAUDE_DESIGN_CONTEXT.md](../CLAUDE_DESIGN_CONTEXT.md) — paste briefing for external Claude Design sessions
+- [CLAUDE_DESIGN_SETUP.md](../CLAUDE_DESIGN_SETUP.md) — external vs local mode workflow
+- [ICN_DESIGN_SYSTEM.md](../ICN_DESIGN_SYSTEM.md) — canonical design system entry point
+- [CHANGELOG.md](CHANGELOG.md) — imported seed versions
+- [REVIEW_NOTES.md](REVIEW_NOTES.md) — human review summary per seed

--- a/docs/design/claude-design-seed/REVIEW_NOTES.md
+++ b/docs/design/claude-design-seed/REVIEW_NOTES.md
@@ -1,0 +1,122 @@
+---
+Status: operational
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-05-19
+Last Updated: 2026-05-19
+Purpose: Human-readable review summary for each Claude Design seed. One section per seed. Newest first. Reviewers update their own section; once a seed is promoted or retired, its section is frozen.
+---
+
+# Claude Design Seed — Review Notes
+
+> **One sentence.** This is the file a reviewer fills out while walking the gates; the changelog records what *happened*, this file records what was *seen*.
+
+Each seed gets one section. Section format:
+
+```
+## <Seed name and version> (<YYYY-MM-DD>)
+### What is strong
+### What is not canonical
+### What should be proposed upstream
+### What should remain seed-only
+### What should be discarded
+### What requires human decision
+### Known drift findings
+### Production-readiness caveats
+### Reviewer
+```
+
+---
+
+## ICN Commons Design System — Claude Design Seed v0.1 (2026-05-19)
+
+> **Status banner from the bundle:** "review required · not production canonical"
+
+### What is strong
+
+- **Token discipline.** The three-layer raw / theme / element token system in `colors_and_type.css` is internally consistent and matches the live `website/src/styles/global.css` palette exactly. The seed CSS is intentionally narrower (token-only, no component classes) — a clean subset, not a competing definition.
+- **Truth-label discipline.** The seed's persistent on-screen truth-label strip across the member shell, on-SVG caption stamped into both placeholder logo files, and the explicit "hidden chip is rejected" rule in the seed's own `MUST_NOT_SHIP.md` are well-drawn. The seven-state enumeration (`strong today`, `advancing now`, `real but maturing`, `illustrative direction`, `behind the system`, `not yet`, plus the `do not use` archive bucket) is a sharper instrument than the prior loose labeling.
+- **Vocabulary fidelity.** The seed's `AUDIT_PASS_2.md` shows a clean grep against `wallet / balance / currency / crypto / token / payment / payout / debt / user / account holder / dashboard`. UI-kit copy uses **obligation / mandate / receipt / standing / settlement / position / unit / scope / allocation** consistently. The three-vocabulary-layer pattern (canonical / public / local-institutional) is demonstrated in `language-patterns.html`.
+- **Member-shell mock alignment with the mobile UX spec.** Five-tab navigation in the right order, persistent acting-as/scope context, action-card contract substantially present. Gaps are bounded and named (see drift D-04).
+- **Self-aware governance.** The seed ships its own `INVENTORY.md`, `PROMOTION_MAP.md`, `DRIFT_REPORT.md`, `PRODUCTION_READINESS.md`, `MUST_NOT_SHIP.md`, and `CLAUDE_CODE_BUNDLE.md`. The bundle treats itself as a proposal under review, not a finished system — that posture is exactly what makes promotion possible.
+
+### What is not canonical
+
+- The entire bundle is `generated seed` by default. Nothing inside it becomes canonical merely by being read into the repo. This includes every preview HTML card, every UI kit, every screenshot, every imported reference, and the seed's own governance docs.
+- The placeholder logo and wordmark are explicitly marked as not-final inside the SVG itself. They remain rejected for any production surface.
+- All UI kit React/JSX files are recreations of upstream Astro components. They are illustrative; production stays Astro on the website and React Native on mobile.
+- Imported copies of upstream docs (`docs/design/...`, `docs/design-language/...`, `docs/mobile/...`) are reference snapshots, not authoritative. The live repo is authoritative.
+
+### What should be proposed upstream
+
+Landed in this PR (docs-only):
+
+- `seed/REVIEW_PROTOCOL.md` → `docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md` (extended to cover the seven review gates the user requested)
+- `seed/HANDOFF.md` + user-spec extensions → `docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md` (the seed-level handoff template; the seed's original HANDOFF.md remains useful as the *per-PR* member-surface checklist for any future production-UI PR)
+- `seed/MUST_NOT_SHIP.md` (7 items) + user-spec extensions → `docs/design/MUST_NOT_SHIP.md` (12-item floor)
+- `SKILL.md` (seed) → `.claude/skills/icn-commons-design/SKILL.md` (edited to reference canonical repo paths, not seed paths)
+- `docs/design/claude-design-seed/{README,CHANGELOG,REVIEW_NOTES}.md` — new directory, this trail
+
+Held for separate review tracks (do not land in this PR):
+
+- Token extensions in `colors_and_type.css` → `website/src/styles/global.css` (modes section). Decision blocker: are HC themes v1.0 or v1.x?
+- Theme × mode coverage requirement → `docs/design/ACCESSIBILITY_BASELINE.md` (new section). Depends on the modes decision above.
+- Rejected-patterns concept → `docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md` (appendix). Visual content; needs design owner pass.
+- Seven-state truth-label band → `docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md` (existing truth-label section). Decision blocker: promote, simplify, or hold?
+- Seed pattern names (`scope frame`, `mandate line`, `challenge / review / exit`, `sync state`) → `docs/design-language/concept-map.md`. Decision blocker: pattern names or canonical concepts?
+
+### What should remain seed-only
+
+- Every preview HTML card (`preview/*.html`) — they are showcase, not source. Pattern reference, not patterns.
+- Every UI kit file (`ui_kits/website/*`, `ui_kits/member-shell/*`) — recreations, not production code. Migrating them would create a dual codebase.
+- The seed's own governance docs (`seed/SEED_v0.1.md`, `seed/AUDIT_PASS_2.md`, `seed/REVIEW_PROMPTS.md`, `seed/INVENTORY.md`, `seed/PROMOTION_MAP.md`, `seed/DRIFT_REPORT.md`, `seed/PRODUCTION_READINESS.md`, `seed/CLAUDE_CODE_BUNDLE.md`) — they exist to support this seed's review workflow; the repo doesn't need them after this PR lands.
+- `fonts/README.md` (offline-safe three-tier font plan) — strategy doc; once self-hosted, the strategy lives in the deployment, not the design system.
+
+### What should be discarded
+
+- `assets/logo-mark.svg`, `assets/logo-wordmark.svg` — placeholder marks; not for shipping anywhere.
+- The faux-foundation seal example in `preview/rejected-patterns.html` — already a "reject" example; do not migrate the visual itself, only the documented rule (which is now item #10 in [MUST_NOT_SHIP.md](../MUST_NOT_SHIP.md)).
+- All debug-iteration screenshots (`01-website-debug2.png`, `02-website-debug2.png`, `01-rejected-patterns-v2.png` / `v3.png`, `01-rejected-v4.png`, `website-dark.png` early iteration, `01–04-website-scroll.png`, `member-shell-1.png` / `2.png`, `website-debug.png`).
+
+### What requires human decision
+
+| Decision | Owner | Why blocking |
+|---|---|---|
+| Should HC themes (`hc-dark`, `hc-light`) be a v1.0 obligation or a v1.x stretch goal? | Matt Faherty | Determines whether the second seed-promotion PR adds CSS or just docs. |
+| Should `data-mode~="large-text"` / `low-bandwidth"` ship as member preferences plumbed through the gateway, or as CSS-only opt-ins? | Architecture review | Determines API surface for the future member shell. |
+| Should the seed's pattern names (`scope frame`, `mandate line`, `challenge / review / exit`, `sync state`) be promoted into [`docs/design-language/concept-map.md`](../../design-language/concept-map.md) as canonical concepts? | Design + design-language owners | Determines whether they become kernel-bound terms or stay as design-system patterns only. |
+| Logo exploration — when does it start and who drives it? | Matt Faherty | Until decided, the placeholder remains rejected for production. |
+| Spanish first-pass — does it run against this seed, against the live upstream website, or both in parallel? | Localization owner | Determines where translation work lands. |
+| Should the seven-state truth-label enumeration be promoted into [`docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md`](../ICN_VISUAL_EXPLAINER_BIBLE.md)? | Design owner | Determines whether the bible's truth-label scheme gains the additional granularity. |
+
+### Known drift findings
+
+(Summarized; full table in [CHANGELOG.md](CHANGELOG.md).)
+
+- **D-01 (HIGH, fixed in this PR):** [`docs/design-language/accessibility.md`](../../design-language/accessibility.md) claimed the site has no `:focus-visible` rules. It does — global ring + per-element selectors in [`website/src/styles/global.css`](../../../website/src/styles/global.css). Fixed at §3.3 and §5 known failures #1; `Last Reviewed:` bumped to 2026-05-19.
+- **D-02 (MEDIUM, additive proposal):** seed adds `hc-dark`, `hc-light`, `data-mode~="large-text"`, `data-mode~="low-bandwidth"`. Not contradictory; not in this PR.
+- **D-03 (LOW, by design):** seed CSS narrower than upstream `global.css`. No conflict.
+- **D-04 (LOW, minor gaps):** member-shell mock vs [`docs/mobile/icn-mobile-ux-spec-v1.md`](../../mobile/icn-mobile-ux-spec-v1.md). Track for v0.2 — missing explicit threshold display, deadline timestamp, proof affordance, per-action sync-state chip.
+- **D-05 (LOW, by design):** seed introduces pattern names not in [`concept-map.md`](../../design-language/concept-map.md). Design-system layer, not kernel layer.
+- **D-06 (MEDIUM, bounded):** imported doc `Last Reviewed:` dates predate the seed by up to ~3 days. Consumers should re-check live repo for changes since each doc's `Last Reviewed:`.
+
+### Production-readiness caveats
+
+This seed is **ready for review**. It is **not ready for production**. Specifically:
+
+- No axe-core run against the cards or kits
+- No NVDA / VoiceOver screen-reader pass
+- No on-device tap target measurement
+- No 200% browser-zoom test on the kits
+- HC themes defined in tokens but not threaded through the UI kits' theme toggles
+- RTL demonstrated in one stress card but not threaded through chrome (nav, footer)
+- Spanish first-pass not started
+- No real-device test on a five-year-old phone
+
+These are *seed* gaps. They are not blockers for the docs-only promotion PR that landed (this one). They are blockers for any future promotion of seed UI patterns into production.
+
+### Reviewer
+
+- **This review:** prepared 2026-05-19 by Matt Faherty (via Claude Code seed-promotion session)
+- **Sign-off on docs-only promotion PR:** yes — the protocol, handoff template, must-not-ship floor, skill scaffold, seed-workflow docs, and the targeted D-01 accessibility doc correction are scope-appropriate for a docs-only first PR.
+- **Sign-off on token / UI / icon / brand promotions:** deferred — each requires its own scope-locked PR and the human decisions enumerated above.


### PR DESCRIPTION
## Summary
Adds the docs/protocol layer for reviewing Claude Design seed artifacts before anything generated is promoted into canonical ICN design docs or implementation.

This PR adds:
- Claude Design seed review protocol
- Claude Design handoff template
- must-not-ship design rejection floor
- seed workflow README, changelog, and review notes
- reusable ICN design skill scaffold
- navigation references in the design system and docs index
- targeted correction to stale focus-visible accessibility language

## Scope
Docs/protocol only.

## Non-goals
- No production UI changes
- No website/src changes
- No SDK changes
- No production CSS/token changes
- No placeholder logo adoption
- No React prototype migration
- No final brand identity
- No production-readiness claim
- No member-shell shipped claim

## Verification
- [ ] python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml

## Notes
The Claude Design seed remains review material, not canonical truth. Canonical truth remains the upstream ICN repo. Generated artifacts require review before promotion.