### PR TITLE
docs(design): add candidate icon family review package

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -78,6 +78,7 @@ Governance scaffold for taking Claude Design seed artifacts into the canonical r
 - **[design/claude-design-seed/README.md](design/claude-design-seed/README.md)** — seed directory workflow; what canonical truth is and how it is preserved
 - **[design/claude-design-seed/CHANGELOG.md](design/claude-design-seed/CHANGELOG.md)** — imported seed versions, one entry per seed
 - **[design/claude-design-seed/REVIEW_NOTES.md](design/claude-design-seed/REVIEW_NOTES.md)** — human-readable per-seed review summary
+- **[design/icons/CANDIDATES.md](design/icons/CANDIDATES.md)** — 14 candidate icons proposed for promotion into the production icon set; companion contact sheet at [`design/icons/contact-sheet.svg`](design/icons/contact-sheet.svg)
 
 ---
 

--- a/docs/design/ICN_DESIGN_SYSTEM.md
+++ b/docs/design/ICN_DESIGN_SYSTEM.md
@@ -55,6 +55,7 @@ Living docs that make up the system. Read in order on first pass:
 | 12 | [docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md](CLAUDE_DESIGN_HANDOFF_TEMPLATE.md) | Seed-level handoff template (seed → Claude Code) — fill one copy per seed before any promotion work |
 | 13 | [docs/design/MUST_NOT_SHIP.md](MUST_NOT_SHIP.md) | Hard rejection floor — twelve patterns and artifacts that disqualify a surface from production |
 | 14 | [docs/design/claude-design-seed/README.md](claude-design-seed/README.md) | Seed directory workflow — what a seed is, where canonical truth lives, how seeds are reviewed and promoted (companions: `CHANGELOG.md`, `REVIEW_NOTES.md`) |
+| 15 | [docs/design/icons/CANDIDATES.md](icons/CANDIDATES.md) | Candidate icon family review package — 14 candidate icons proposed for promotion into `website/src/data/icons.ts`, with per-icon rationale, ARIA usage, distinct-silhouette test, and "do not ship until" checklist (companion: `contact-sheet.svg`) |
 
 ADRs that bind this work:
 

--- a/docs/design/icons/CANDIDATES.md
+++ b/docs/design/icons/CANDIDATES.md
@@ -1,0 +1,279 @@
+---
+Status: operational
+Canonical: no
+Owner: Matt Faherty
+Last Reviewed: 2026-05-19
+Last Updated: 2026-05-19
+Purpose: Candidate icon family review package — 14 candidate icons proposed for promotion into `website/src/data/icons.ts`. Each carries a documented rationale, distinct-silhouette test, ARIA usage, and explicit do/don't notes. Promotion blocked on designer sign-off + 16px on-device pass.
+---
+
+# Candidate Icon Family · Review Package
+
+> **One sentence.** Fourteen candidate icons proposed for promotion into ICN's production icon set, each anchored to a canonical concept id and held to the icon-style rules in [`docs/design-language/brief-v0.md §7a`](../../design-language/brief-v0.md).
+
+This document is the review package. It lives in the canonical repo so the icon family is reviewable in-place, without re-opening the Claude Design seed. The contact sheet is in [`contact-sheet.svg`](contact-sheet.svg).
+
+**Status:** candidate icons · review required · not production canonical.
+
+**Promotion gate:** the seven review gates in [`../CLAUDE_DESIGN_REVIEW_PROTOCOL.md`](../CLAUDE_DESIGN_REVIEW_PROTOCOL.md) §3, with the truth-label, accessibility, and source-doc drift gates load-bearing for icons. Each icon needs a designer sign-off and a 16px silhouette pass before it lands in production.
+
+**Production destination (when promoted):** [`website/src/data/icons.ts`](../../../website/src/data/icons.ts).
+
+**Contact sheet:** [`contact-sheet.svg`](contact-sheet.svg) — all 25 icons (11 production + 14 candidates) at a glance. Candidates are amber-marked.
+
+**Source:** the v0.1+v0.2 Claude Design seed (the seed's `assets/icons.js` and the seed's `ICON_CANDIDATES.md`). See [`../claude-design-seed/CHANGELOG.md`](../claude-design-seed/CHANGELOG.md) for seed identity.
+
+---
+
+## Style obligations (apply to every candidate)
+
+- 24×24 viewBox
+- 1.5px stroke, `currentColor`, no fills
+- `stroke-linecap: round`, `stroke-linejoin: round`
+- No baked-in color, no gradients, no decorative flourish
+- Silhouette distinct from every other icon at 16px
+- No literal handshake / coin / wallet / globe / scroll-with-ribbon
+- No emoji equivalent; no Material / Heroicons substitution
+- Decorative use → `aria-hidden="true"`; standalone use → `aria-label`
+- Paired with a visible text label on first use
+
+These rules are enforced by [`website/src/components/Icon.astro`](../../../website/src/components/Icon.astro) for any icon that lands in production.
+
+---
+
+## Per-icon rationale
+
+### 1 · `membership`
+
+| Field | Value |
+|-------|-------|
+| Concept | Recognized participation in a scope |
+| Silhouette | Horizontal member card · avatar dot + two text lines |
+| Distinct from | `policy` (vertical doc, corner-fold), `identity` (just person), `member_experience` (frame around person) |
+| Public label | "Membership" |
+| ARIA standalone | `aria-label="Membership in this scope"` |
+| Do | Use beside the scope name; use in scope-switcher and membership cards |
+| Don't | Use for identity-in-general; don't replace with a generic person glyph |
+| Status | candidate · review required |
+
+### 2 · `attestation`
+
+| Field | Value |
+|-------|-------|
+| Concept | A signed statement another party can rely on |
+| Silhouette | A declared horizontal line with a verifying check below |
+| Distinct from | `standing` (shield + check inside), `provenance` (linked records) |
+| Public label | "Attestation" or "Verified by" |
+| ARIA standalone | `aria-label="Signed attestation"` |
+| Do | Use on signed witness statements, endorsements, social-trust evidence |
+| Don't | Use for cryptographic proof generally (use `provenance`); don't use for stamps of authority (use `authority`) |
+| Status | candidate · review required |
+
+### 3 · `role`
+
+| Field | Value |
+|-------|-------|
+| Concept | A named bundle of authority and responsibility |
+| Silhouette | Two stacked chevrons — institutional rank insignia |
+| Distinct from | `identity` (person), `authority` (sealed stamp), `role_grant` (seal + arrow + person) |
+| Public label | "Role" |
+| ARIA standalone | `aria-label="Role in this scope"` |
+| Do | Pair with the role name ("Role · Member", "Role · Steward") |
+| Don't | Use the role icon as a status badge without naming the role |
+| Status | candidate · review required |
+
+### 4 · `agreement`
+
+| Field | Value |
+|-------|-------|
+| Concept | Recorded understanding between two parties |
+| Silhouette | Two small boxes connected by two horizontal lines |
+| Distinct from | `federation` (three circles, not two boxes), `obligation` (one bound rectangle) |
+| Public label | "Agreement" |
+| ARIA standalone | `aria-label="Two-party agreement"` |
+| Do | Use for mutual contracts, MOUs, charter side-agreements |
+| Don't | Use literal handshake imagery; don't use for single-party obligations |
+| Status | candidate · review required |
+
+### 5 · `resource`
+
+| Field | Value |
+|-------|-------|
+| Concept | Something shared, used, or governed |
+| Silhouette | Three stacked horizontal slabs |
+| Distinct from | `commons` (3×3 grid), `accounting` (balance scale) |
+| Public label | "Resource" |
+| ARIA standalone | `aria-label="Tracked resource"` |
+| Do | Use for material or computational stock the institution holds |
+| Don't | Use for member-owned positions (use `position` / `accounting`); don't use stacked-coin imagery |
+| Status | candidate · review required |
+
+### 6 · `allocation`
+
+| Field | Value |
+|-------|-------|
+| Concept | A decision to direct resources or authority |
+| Silhouette | Circle with a vertical bisector + diagonal slice line |
+| Distinct from | `governance` (three-node deliberation), `settlement` (arrow into target) |
+| Public label | "Allocation" |
+| ARIA standalone | `aria-label="Allocation decision"` |
+| Do | Use on budget approvals, capacity assignments, patronage allocations |
+| Don't | Use as a generic "split" icon for unrelated UI; don't use for income / revenue |
+| Status | candidate · review required |
+
+### 7 · `obligation`
+
+| Field | Value |
+|-------|-------|
+| Concept | A structured claim one party has on another |
+| Silhouette | A rectangle bound by a vertical cinch band |
+| Distinct from | `agreement` (two separate boxes), `commitment-to-self` (no icon — not a concept) |
+| Public label | "Obligation" |
+| ARIA standalone | `aria-label="Open obligation"` |
+| Do | Pair with the obligation's state ("Open obligation", "Settled obligation") |
+| Don't | Use the word "debt" with this icon — vocabulary contract forbids it |
+| Status | candidate · review required |
+
+### 8 · `settlement`
+
+| Field | Value |
+|-------|-------|
+| Concept | Closing an obligation per its terms |
+| Silhouette | Directed arrow arriving into a target circle that carries the verifying tick |
+| Distinct from | `attestation` (no arrow), `execution` (gate + arrow through) |
+| Public label | "Settlement" |
+| ARIA standalone | `aria-label="Settled obligation"` |
+| Do | Use on receipts that close an obligation; pair with the receipt id |
+| Don't | Use the word "payment" with this icon — vocabulary contract forbids it |
+| Status | candidate · review required |
+
+### 9 · `dispute`
+
+| Field | Value |
+|-------|-------|
+| Concept | A structured challenge or appeal path |
+| Silhouette | Two opposing horizontal arrows |
+| Distinct from | `agreement` (parallel lines bound), `execution` (single arrow through gate) |
+| Public label | "Dispute" or "Challenge" |
+| ARIA standalone | `aria-label="Dispute path"` |
+| Do | Use on the "Challenge" affordance of the challenge / review / exit pattern; pair with the dispute window |
+| Don't | Use literal scales-of-justice imagery (that conflicts with `accounting`) |
+| Status | candidate · review required |
+
+### 10 · `unit`
+
+| Field | Value |
+|-------|-------|
+| Concept | Generic accounting unit (never currency, never coin) |
+| Silhouette | A single hexagon |
+| Distinct from | `commons` (square grid), `policy` (document) — only hex in the family |
+| Public label | "Unit" |
+| ARIA standalone | `aria-label="Accounting unit"` |
+| Do | Pair with the unit's name ("Brightworks hour", "NYCN credit"); show the count alongside |
+| Don't | Use for currency, token, coin, or any monetary metaphor |
+| Status | candidate · review required |
+
+### 11 · `charter`
+
+| Field | Value |
+|-------|-------|
+| Concept | The founding rules of an institution |
+| Silhouette | Tall document with rule-lines + a circular seal near the bottom |
+| Distinct from | `policy` (doc + corner-fold + rule-lines, no seal) |
+| Public label | "Charter" |
+| ARIA standalone | `aria-label="Institution charter"` |
+| Do | Use beside the institution name; link to the canonical charter record |
+| Don't | Use heraldic seal imagery — the seal here is a mark of "sealed", not "official" |
+| Status | candidate · review required |
+
+### 12 · `commons_credit`
+
+| Field | Value |
+|-------|-------|
+| Concept | A credit drawn against a commons it does not own |
+| Silhouette | The commons grid with the center cell emphasized as a marker |
+| Distinct from | `commons` (grid only), `unit` (hexagon) |
+| Public label | "Commons credit" |
+| ARIA standalone | `aria-label="Commons credit position"` |
+| Do | Pair with the commons name and the credit count |
+| Don't | Use the word "balance" — vocabulary contract forbids it |
+| Status | candidate · review required |
+
+### 13 · `role_grant`
+
+| Field | Value |
+|-------|-------|
+| Concept | The act of granting a role to a member |
+| Silhouette | A small institutional seal with an arrow descending into a member figure |
+| Distinct from | `role` (two chevrons, no arrow, no person), `authority` (single sealed stamp) |
+| Public label | "Role grant" |
+| ARIA standalone | `aria-label="Role granted to member"` |
+| Do | Use on the receipt of a role-grant action; pair with the role name and the mandate that authorized it |
+| Don't | Use as a generic "promote" icon |
+| Status | candidate · review required |
+
+### 14 · `language`
+
+| Field | Value |
+|-------|-------|
+| Concept | A language used by a member-facing surface |
+| Silhouette | Speech container with two horizontal text lines and a tail |
+| Distinct from | Anything else — the only speech-shaped icon in the family |
+| Public label | "Language" |
+| ARIA standalone | `aria-label="Interface language"` |
+| Do | Use on the explicit language selector; do not auto-detect from IP |
+| Don't | Use a globe (that triggers the "glowing network globe" reject pattern in [`../MUST_NOT_SHIP.md`](../MUST_NOT_SHIP.md) item 9) |
+| Status | candidate · review required |
+
+---
+
+## Icon review checklist
+
+For each candidate, the reviewer confirms:
+
+- [ ] Renders cleanly at 16px, 20px, 24px, 32px, 48px
+- [ ] Silhouette distinct from every other icon in the family (compare at 16px on the contact sheet)
+- [ ] Reads in light, dark, hc-dark, hc-light, and grayscale
+- [ ] No baked-in color; renders correctly with `color: currentColor`
+- [ ] No literal handshake / coin / wallet / globe / faux-government seal
+- [ ] No English idiom dependence
+- [ ] Pairs with the canonical concept id in [`docs/design-language/concept-map.md`](../../design-language/concept-map.md)
+- [ ] Has a documented `aria-label` for standalone use
+- [ ] Has a documented public label for paired use
+- [ ] Vocabulary contract for the concept is preserved in the icon's "Do" / "Don't" notes
+
+---
+
+## "Do not ship until" checklist
+
+The 14 candidates do not ship into production until every box below closes green. This is the production-adoption gate; it is separate from this review-package PR.
+
+- [ ] Designer signs off on each silhouette
+- [ ] 16px render checked on real devices (not in-iframe)
+- [ ] All 25 icons rendered side-by-side and confirmed silhouette-distinct (the contact sheet is the artifact for this check)
+- [ ] Each candidate has a matching public-label string in the localization corpus
+- [ ] [`website/src/data/icons.ts`](../../../website/src/data/icons.ts) is updated through a docs-only candidate-review PR (this one) first, then a production-adoption PR — never both in a single PR
+- [ ] No icon ships before its referenced canonical concept is stable in [`docs/design-language/concept-map.md`](../../design-language/concept-map.md) (every candidate's concept id already exists upstream)
+
+The production-adoption PR is out of scope here. It runs after sign-off.
+
+---
+
+## Open questions for the reviewer
+
+- The seed adds `role_grant` and `commons_credit` as joined-word concept ids. [`docs/design-language/concept-map.md`](../../design-language/concept-map.md) uses spaced "Commons credit" / "Role grant" in some places and hyphenated `role-grant` / `commons-credit` in others. Decide canonical hyphenation before the production-adoption PR.
+- `attestation` could be split into `social_attestation` (witness) vs `cryptographic_attestation` (signed proof) if the kernel grows distinct types. Single icon stands today.
+- `unit` is deliberately abstract (hexagon). If the kernel introduces a distinguished "Commons-credit unit" vs "Time-credit unit" vs "External settlement unit", the unit icon may need a small marker overlay. Track as a v0.3 concern.
+
+---
+
+## See also
+
+- [`contact-sheet.svg`](contact-sheet.svg) — all 25 icons (11 production + 14 candidates), at a glance, in a single SVG
+- [`../CLAUDE_DESIGN_REVIEW_PROTOCOL.md`](../CLAUDE_DESIGN_REVIEW_PROTOCOL.md) — review gates the candidates must clear before promotion
+- [`../MUST_NOT_SHIP.md`](../MUST_NOT_SHIP.md) — hard rejection floor (item 9: glowing-globe / central-hub maps)
+- [`../../design-language/concept-map.md`](../../design-language/concept-map.md) — canonical concept ids the icons anchor to
+- [`../../design-language/brief-v0.md`](../../design-language/brief-v0.md) §7a — canonical icon style rules
+- [`../../../website/src/data/icons.ts`](../../../website/src/data/icons.ts) — current 11 production icons (the destination, when candidates are promoted)
+- [`../../../website/src/components/Icon.astro`](../../../website/src/components/Icon.astro) — production Icon component enforcing focus / `aria-hidden` / `currentColor`
+- [`../claude-design-seed/CHANGELOG.md`](../claude-design-seed/CHANGELOG.md) — seed identity and provenance

--- a/docs/design/icons/contact-sheet.svg
+++ b/docs/design/icons/contact-sheet.svg
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660 710" width="660" height="710" role="img" aria-label="ICN Commons icon family contact sheet — 25 icons (11 production + 14 candidates).">
+  <title>ICN Commons icon family contact sheet</title>
+  <desc>Five concept families across 25 icons. 11 production icons and 14 v0.2 candidates (amber-marked). Stroke-only, currentColor, 24×24 viewBox per icon. Source: seed/ICON_CANDIDATES.md.</desc>
+  <rect x="0" y="0" width="660" height="710" fill="transparent"/>
+  <text x="30" y="32" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="12" letter-spacing="1.4" fill="currentColor" font-weight="600">ICN COMMONS · ICON FAMILY · 25 ICONS · 11 PRODUCTION + 14 CANDIDATE (V0.2)</text>
+  <text x="30" y="48" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="10" fill="currentColor" opacity="0.55">Candidates marked with amber dot. Renders correctly with color:currentColor.</text>
+  <g transform="translate(30,60)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 3.75a3.25 3.25 0 1 0 0 6.5 3.25 3.25 0 0 0 0-6.5Z"/><path d="M5.5 20.25c0-3.25 2.9-5.75 6.5-5.75s6.5 2.5 6.5 5.75"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Identity</text>
+  </g>
+  <g transform="translate(150,60)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 3.25 5.5 6v5.5c0 4.25 2.75 7.75 6.5 9.25 3.75-1.5 6.5-5 6.5-9.25V6L12 3.25Z"/><path d="m9 11.75 2.25 2.25L15.25 10"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Standing</text>
+  </g>
+  <g transform="translate(270,60)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M5 7.5A2.5 2.5 0 0 1 7.5 5h9A2.5 2.5 0 0 1 19 7.5v9a2.5 2.5 0 0 1-2.5 2.5h-9A2.5 2.5 0 0 1 5 16.5v-9Z"/><path d="M12 9.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z"/><path d="M8 19.25h8"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Authority</text>
+  </g>
+  <g transform="translate(390,60)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 6.5h18v11H3z"/><path d="M7.5 11.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M11 9.75h7"/><path d="M11 13h5"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Membership</text>
+  </g>
+  <g transform="translate(510,60)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M5 10l7-4 7 4"/><path d="M5 15l7-4 7 4"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Role</text>
+  </g>
+  <g transform="translate(30,170)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 4h5v5H3z"/><path d="M4 6.5h3"/><path d="M8 8 14 14"/><path d="M12 13h2v2"/><path d="M18 12a1.75 1.75 0 1 0 0-3.5 1.75 1.75 0 0 0 0 3.5Z"/><path d="M14.5 18c0-2 1.5-3.25 3.5-3.25s3.5 1.25 3.5 3.25"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Role grant</text>
+  </g>
+  <g transform="translate(150,170)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 4.5a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"/><path d="M5.5 15a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"/><path d="M18.5 15a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"/><path d="M12 8.5 12 11.5"/><path d="m7 14.5 4-2"/><path d="m17 14.5-4-2"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Governance</text>
+  </g>
+  <g transform="translate(270,170)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M6.75 4.25h8.5l3 3v11.5a1.5 1.5 0 0 1-1.5 1.5H6.75a1.5 1.5 0 0 1-1.5-1.5V5.75a1.5 1.5 0 0 1 1.5-1.5Z"/><path d="M15.25 4.25v3h3"/><path d="M8.5 12h7"/><path d="M8.5 15h7"/><path d="M8.5 9.5h3.5"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Policy</text>
+  </g>
+  <g transform="translate(390,170)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M6 4h12v16H6z"/><path d="M7.5 7h9"/><path d="M7.5 10h9"/><path d="M7.5 13h6"/><path d="M12 17.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Charter</text>
+  </g>
+  <g transform="translate(510,170)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 9h5v6H3z"/><path d="M16 9h5v6h-5z"/><path d="M8 11h8"/><path d="M8 14h8"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Agreement</text>
+  </g>
+  <g transform="translate(30,280)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 8h16"/><path d="M6 13l3 3 9-9"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Attestation</text>
+  </g>
+  <g transform="translate(150,280)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 9h11"/><path d="M12 6.5 15.5 9 12 11.5"/><path d="M20 15H9"/><path d="M12 12.5 8.5 15 12 17.5"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Dispute</text>
+  </g>
+  <g transform="translate(270,280)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 4.25v15.5"/><path d="M5.25 8.25h13.5"/><path d="M5.25 8.25 3 13.5h4.5L5.25 8.25Z"/><path d="M18.75 8.25 16.5 13.5H21l-2.25-5.25Z"/><path d="M8.5 19.75h7"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Accounting</text>
+  </g>
+  <g transform="translate(390,280)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 4a8 8 0 1 0 0 16 8 8 0 0 0 0-16Z"/><path d="M12 4v8"/><path d="M12 12l7 4"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Allocation</text>
+  </g>
+  <g transform="translate(510,280)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 8h16v8H4z"/><path d="M10 6h4v12h-4z"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Obligation</text>
+  </g>
+  <g transform="translate(30,390)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 12h11"/><path d="M11 9.5 13.5 12 11 14.5"/><path d="M19 12a3 3 0 1 0 0 0Z"/><path d="M17.5 12l1.5 1.5 2-2"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Settlement</text>
+  </g>
+  <g transform="translate(150,390)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 4 19 8v8l-7 4-7-4V8z"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Unit</text>
+  </g>
+  <g transform="translate(270,390)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 4h16v16H4z"/><path d="M4 9h16"/><path d="M4 15h16"/><path d="M9 4v16"/><path d="M15 4v16"/><path d="M11 11h2v2h-2z"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Commons credit</text>
+  </g>
+  <g transform="translate(390,390)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 7h16v3H4z"/><path d="M4 11h16v3H4z"/><path d="M4 15h16v3H4z"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Resource</text>
+  </g>
+  <g transform="translate(510,390)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M5.25 8.5v7"/><path d="M18.75 8.5v7"/><path d="M5.25 12h13.5"/><path d="m15 8.5 3.75 3.5L15 15.5"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Execution</text>
+  </g>
+  <g transform="translate(30,500)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3.25 7.75h5v8.5h-5z"/><path d="M9.5 7.75h5v8.5h-5z"/><path d="M15.75 7.75h5v8.5h-5z"/><path d="M8.25 12h1.25"/><path d="M14.5 12h1.25"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Provenance</text>
+  </g>
+  <g transform="translate(150,500)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 3.25a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z"/><path d="M5.5 14.25a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z"/><path d="M18.5 14.25a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5Z"/><path d="M10.5 7 7 13"/><path d="M13.5 7 17 13"/><path d="M8 16.75h8"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Federation</text>
+  </g>
+  <g transform="translate(270,500)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4.25 4.25h15.5v15.5H4.25z"/><path d="M4.25 9.5h15.5"/><path d="M4.25 14.5h15.5"/><path d="M9.5 4.25v15.5"/><path d="M14.5 4.25v15.5"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Commons</text>
+  </g>
+  <g transform="translate(390,500)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="1"/>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M5.25 5A2.25 2.25 0 0 1 7.5 2.75h9A2.25 2.25 0 0 1 18.75 5v14A2.25 2.25 0 0 1 16.5 21.25h-9A2.25 2.25 0 0 1 5.25 19V5Z"/><path d="M12 8.25a1.75 1.75 0 1 0 0 3.5 1.75 1.75 0 0 0 0-3.5Z"/><path d="M8.75 17.25c0-1.75 1.45-3 3.25-3s3.25 1.25 3.25 3"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Member exp.</text>
+  </g>
+  <g transform="translate(510,500)">
+    <rect x="0" y="0" width="112" height="102" rx="6" fill="none" stroke="currentColor" stroke-opacity="0.45" stroke-width="1"/>
+    <circle cx="102" cy="14" r="4" fill="#fb923c"/>
+    <text x="94" y="18" text-anchor="end" font-family="ui-monospace, SF Mono, Menlo, monospace" font-size="8" fill="#fb923c" letter-spacing="0.5">V0.2</text>
+    <g transform="translate(28.0,22) scale(2.3333333333333335)" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 5h16v11H4z"/><path d="M11 16l-3 4v-4"/><path d="M7 9h10"/><path d="M7 12h6"/>
+    </g>
+    <text x="56.0" y="92" text-anchor="middle" font-family="ui-sans-serif, system-ui, -apple-system, sans-serif" font-size="11" fill="currentColor">Language</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Adds the 14-candidate icon review package staged in the v0.2 Claude Design seed bundle. Each candidate carries a documented rationale, distinct-silhouette test against the existing 11-icon production set, ARIA standalone label, public label, and explicit do/don't notes. A companion `contact-sheet.svg` shows all 25 icons (11 production + 14 candidate) at a glance, with amber markers on candidates for at-a-glance distinction.

Per [`seed/FOLLOW_UP_PRS.md` PR-A](https://github.com/InterCooperative-Network/icn/blob/main/docs/design/claude-design-seed/CHANGELOG.md) (first of four docs-only follow-ups from v0.1+v0.2 of the seed). Docs-only. Each candidate stays a candidate until designer sign-off and a 16px on-device pass.

## Files

- `docs/design/icons/CANDIDATES.md` — review package (per-icon rationale, ARIA, do/don't, review checklist, "do not ship until" checklist, open questions)
- `docs/design/icons/contact-sheet.svg` — single SVG combining all 25 silhouettes (extracted from seed `preview/iconography-v2.html`)
- `docs/design/ICN_DESIGN_SYSTEM.md` — constituent-docs table, new row 15
- `docs/INDEX.md` — Claude Design seed review subsection entry

## Scope

Docs/protocol only.

## Non-goals

- No change to `website/src/data/icons.ts` — production adoption is a separate downstream PR
- No candidate icon rendered in any production component
- No candidate icon shipped on the public website
- No icon promoted as canonical until designer sign-off
- No vocabulary additions to `concept-map.md`

## Verification

- [x] `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — pass
- [x] No forbidden paths touched (`website/`, `web/`, `sdk/`, `apps/`, `crates/`, `bins/`, `docs/adr/`, `docs/registry.toml`)
- [x] SVG parses (xml.etree round-trip)

## Human decision blocking the production-adoption follow-up

- Designer sign-off on each of the 14 silhouettes
- 16px on-device render check (not in-iframe)
- Confirm silhouette-distinct at 16px across all 25
- Canonical hyphenation for `role_grant` / `commons_credit` in `concept-map.md`

These are explicit gates in the "Do not ship until" checklist inside `CANDIDATES.md`. They block the production-adoption PR; this review-package PR does not need them resolved.

## Notes

The contact sheet is review material, not a brand asset. It renders the 25 silhouettes at scale with `currentColor` so a reviewer can do the at-a-glance distinct-silhouette check against the upstream production icon set.