### PR TITLE
docs(spec): clarify member-shell action card sync and threshold rendering

### DIFF
--- a/docs/design/CONTENT_STYLE_GUIDE.md
+++ b/docs/design/CONTENT_STYLE_GUIDE.md
@@ -53,7 +53,11 @@ Any action that creates an obligation, casts a vote, dispatches a mandate, settl
 2. The mandate or authority that backs it (named, linked).
 3. A reversibility statement: reversible / appealable / final.
 4. The receipt that will be produced, named in advance.
-5. A confirm step that requires explicit user input (not a default-yes button).
+5. **(v0.2)** The action's current sync state, named — one of `drafted`, `saved on device`, `sent to network`, `confirmed`, `offline queued`, `rejected with reason`. No silent failure; no spinner without a label.
+6. **(v0.2, governance actions only)** The decision threshold required and the current tally — rendered above the confirm step, not hidden under "details."
+7. A confirm step that requires explicit member input (not a default-yes button).
+
+Fields 5 and 6 were added per the v0.2 Claude Design seed and the [`docs/spec/member-shell-v0.md`](../spec/member-shell-v0.md) "v0.2 rendering refinements" section. They elaborate [ADR-0027 (Action Card Contract)](../adr/ADR-0027-action-card-contract.md) at the copy layer.
 
 Example pattern:
 

--- a/docs/mobile/icn-mobile-ux-spec-v1.md
+++ b/docs/mobile/icn-mobile-ux-spec-v1.md
@@ -111,10 +111,12 @@ Every mobile view renders projections of real ICN types. Cards are rendering pri
 | Status | `proposal.status` | `Draft`, `Open`, `Accepted`, `Rejected`, `NoQuorum` |
 | Summary | `proposal.description` (truncated) | First 2-3 sentences |
 | Impact line | Derived from payload type | Budget: "Allocate X units to Y". Membership: "Add/remove Z". Config: "Change K to V" |
-| Threshold info | From governance domain | "Requires 2/3 approval, 5 of 7 quorum" (charter-derived) |
+| Threshold info | From governance domain | "Requires 2/3 approval, 5 of 7 quorum" (charter-derived); rendered above the confirm step, not hidden under details (v0.2) |
 | Deadline | `proposal.voting_period_days` + created timestamp | "Closes in 3 days" |
 | Primary action | Based on status + member role | `Vote` (if Open + eligible), `Review` (if Draft + author), `View Result` (if closed) |
 | Proof affordance | Link to `/v1/gov/proposals/{id}/proof` | "View proof" button on closed proposals |
+| Sync-state chip (v0.2) | Local sync queue + gateway WS | "Vote sent · awaiting confirmation"; one of drafted / saved on device / sent / confirmed / offline queued / rejected with reason — text + icon, never color-only |
+| Stale-confirmation row (v0.2) | Gateway timestamp | "Last confirmed 7 minutes ago" when > 5 min; pair with a degraded-scope banner if the gateway reports degraded consensus |
 
 **Appears in:** Home (if vote needed), Participate (always in active scope)
 
@@ -127,11 +129,15 @@ Every mobile view renders projections of real ICN types. Cards are rendering pri
 | Title | Obligation summary | Derived from originating proposal/allocation |
 | Type badge | `obligation` | |
 | Scope chip | Entity context | |
-| Status | Obligation state | Color-coded: Issued (blue), Accepted (green), Disputed (red) |
+| Status | Obligation state | Color-coded **and** text-labeled: Issued (blue + "Issued"), Accepted (green + "Accepted"), Disputed (red + "Disputed"). Color reinforces; text label is load-bearing. |
 | Provenance link | `ProvenanceRef` on originating `JournalEntry` | "Authorized by Proposal #X" |
 | Primary action | Based on state | `Accept` (if Issued to me), `Confirm Settlement` (if Accepted), `Dispute` (if concerned) |
+| Sync-state chip (v0.2) | Local sync queue + gateway WS | "Acceptance sent · awaiting confirmation"; one of drafted / saved on device / sent / confirmed / offline queued / rejected with reason — text + icon, never color-only |
+| Stale-confirmation row (v0.2) | Gateway timestamp | "Last confirmed 7 minutes ago" when > 5 min; pair with a degraded-scope banner if the gateway reports degraded consensus |
 
 **Appears in:** Home (if action needed), Participate (in active scope)
+
+> **v0.2 refinement.** Sync-state chip and stale-confirmation row apply to **every** ActionCard the shell renders, not just proposals and obligations. See [`docs/spec/member-shell-v0.md`](../spec/member-shell-v0.md) §"v0.2 rendering refinements" for the contract. Promoted from the v0.2 Claude Design seed per [`docs/design/claude-design-seed/CHANGELOG.md`](../design/claude-design-seed/CHANGELOG.md).
 
 ### 3.3 GovernanceProof → Detail Panel (Participate + Activity)
 

--- a/docs/spec/member-shell-v0.md
+++ b/docs/spec/member-shell-v0.md
@@ -161,6 +161,51 @@ ADR-0027 defines the canonical ActionCard schema with fourteen fields. The spec 
 
 Per ADR-0027 the closed `source_kind` taxonomy reserves `signal_rule` and `obligation_lifecycle` against `#1631` and `#1634`. The shell **must not** render either source path as live until the corresponding implementation lands. Until then, those values are inert at the rendering layer.
 
+### v0.2 rendering refinements
+
+> Promoted from the v0.2 Claude Design seed (`seed/MEMBER_SHELL_v0.2_PATCH.md`) per [`docs/design/claude-design-seed/CHANGELOG.md`](../design/claude-design-seed/CHANGELOG.md). Refinements only — the 14-field ADR-0027 schema stays canonical. This section tightens the contract on how the shell **renders** uncertain network state, gated cards, and the decision-threshold preamble.
+
+#### Sync-state chip (every card)
+
+Every ActionCard carries a **sync-state chip** that names the action's current state in the local-sync queue and the gateway. Six named states; no silent failure; no spinner without a label:
+
+- **drafted** — the member started the action; nothing left the device
+- **saved on device** — the action is durable locally but not yet sent
+- **sent to network** — the action left the device; awaiting confirmation
+- **confirmed** — the gateway accepted the action and emitted the expected receipt
+- **offline queued** — the device is offline; the action will replay when network returns
+- **rejected with reason** — the gateway rejected the action; the reason is named on the card
+
+The chip is text + icon. Color reinforces; the named state is load-bearing. A grayscale render must still distinguish the six states.
+
+#### Stale, sync-in-flight, degraded scope (network honesty)
+
+When the gateway state is uncertain, every affected card surfaces it explicitly:
+
+- **Stale** — last gateway confirmation > 5 minutes ago. The card renders a "last confirmed" timestamp below the sync-state chip.
+- **Sync in flight** — the action has been sent but not confirmed. The sync-state chip reads "Sent · awaiting confirmation" with a sub-line counting elapsed time.
+- **Degraded scope** — the gateway reports degraded mode for the scope (reduced consensus, partition-tolerant). A scope-level banner above the affected cards reads "This scope is operating in degraded mode. Decisions may delay." Dismissible per session; reappears on every relevant card until the gateway clears the flag.
+
+Each state has a text companion; no color-only signaling, no motion-only signaling.
+
+#### "Unavailable" — gated cards never hide, they explain
+
+When an action is gated and the member cannot perform it, the card renders in an explicit unavailable state that **names the missing condition**:
+
+- "Action unavailable. Mandate `Charter §4.2` requires `recognized-member` standing. Your standing in `Brightworks Collective` is `applicant`."
+- "Action unavailable. Quorum not reached. 4 of 7 votes recorded."
+- "Action unavailable. Offline. Action will queue until network reconnects."
+
+The card never silently disables the action. It always names why. This refines the existing "Closed: insufficient authority" state by requiring the missing-condition text be plain language and member-actionable.
+
+#### Threshold + tally above confirm (governance actions)
+
+For governance ActionCards, the **decision threshold** required (quorum, supermajority, simple majority) and the **current tally** are rendered above the confirm step — not hidden under "details." Source: the governance domain's charter-derived rule (already shown in [`docs/mobile/icn-mobile-ux-spec-v1.md`](../mobile/icn-mobile-ux-spec-v1.md) §3.1 as the `Threshold info` row). The refinement is placement: the member sees the decision rule before casting a vote, not after.
+
+#### Cross-reference
+
+These v0.2 refinements elaborate [ADR-0027 (Action Card Contract)](../adr/ADR-0027-action-card-contract.md) at the rendering layer. ADR-0027 remains the canonical schema; this section is the rendering contract's v0.2 update. See also [`docs/design/CONTENT_STYLE_GUIDE.md`](../design/CONTENT_STYLE_GUIDE.md) "Dangerous-action copy" template, which has been updated to require sync state and threshold + tally before the confirm step.
+
 ## Standing surface
 
 The Standing surface renders `/me/standing` (per ADR-0020) at v0. The shell must surface:


### PR DESCRIPTION
## Summary

Promotes the v0.2 ActionCard rendering refinements from the Claude Design seed bundle. [ADR-0027](https://github.com/InterCooperative-Network/icn/blob/main/docs/adr/ADR-0027-action-card-contract.md) defines the canonical 14-field schema; this PR stays inside that schema and clarifies how the shell **renders** uncertain network state, gated cards, and the decision-threshold preamble.

Per [`seed/FOLLOW_UP_PRS.md` PR-C](https://github.com/InterCooperative-Network/icn/blob/main/docs/design/claude-design-seed/CHANGELOG.md) (third of four docs-only follow-ups). Docs-only.

## Files

- `docs/spec/member-shell-v0.md` — new "v0.2 rendering refinements" subsection inside the ActionCard rendering contract:
  - Sync-state chip: every card carries one (drafted / saved on device / sent / confirmed / offline queued / rejected with reason); text + icon, never color-only
  - Stale / sync-in-flight / degraded scope: three explicit rendering rules for uncertain network state, including a dismissible scope-level degraded banner
  - "Unavailable" explicit rendering: gated cards never silently disable — they always name the missing condition (e.g., "Mandate `Charter §4.2` requires `recognized-member` standing")
  - Threshold + tally above confirm: refinement of placement for governance ActionCards
- `docs/mobile/icn-mobile-ux-spec-v1.md` — two new rows in each of §3.1 (Proposal → Action Card) and §3.2 (Obligation → Action Card): sync-state chip + stale-confirmation row. Existing obligation status row tightened to require text label alongside color (no-color-only rule, per [`docs/design/MUST_NOT_SHIP.md`](https://github.com/InterCooperative-Network/icn/blob/main/docs/design/MUST_NOT_SHIP.md) item 4)
- `docs/design/CONTENT_STYLE_GUIDE.md` — "Dangerous-action copy" template grows from 5 items to 7. New field 5 (sync state) and field 6 (governance threshold + tally) inserted; existing "confirm step" item renumbered to 7

## Scope

Docs/spec only.

## Non-goals

- No mobile app implementation
- No change to `sdk/react-native/`
- No claim that the member shell is shipped (status remains illustrative direction for the unified surface)
- No new vocabulary outside the canonical set (member / standing / mandate / obligation / allocation / settlement / unit / position / receipt / provenance)
- No change to ADR-0027 itself; this PR is the v0.2 elaboration of the rendering contract, not a schema change
- No new endpoint consumers; sync state derives from the existing local sync queue + gateway WS surfaces

## Verification

- [x] `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — pass (844 docs, 62 warnings, no new warnings)
- [x] No forbidden paths touched (`website/`, `web/`, `sdk/`, `apps/`, `crates/`, `bins/`, `docs/adr/`, `docs/registry.toml`)
- [x] Cross-references resolve (ADR-0027, spec ↔ mobile spec, style guide ↔ spec)
- [x] Vocabulary: only canonical terms used in the new copy

## Human decision blocking downstream follow-up

- Designer sign-off on the rendering of the unavailable-state and stale/degraded scope banner (currently specified in prose only)

This refinement PR does not require the designer sign-off resolved; the production rendering of the new states is a separate downstream PR with its own gates.