### PR TITLE
feat(governance): add production guard for standing checker configuration

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -16,11 +16,138 @@ use std::sync::Arc;
 use actix_web::web;
 use icn_governance::MembershipResolver;
 use icn_identity::Did;
+use tracing::warn;
 
 use crate::events::GovernanceEventEmitter;
 use crate::manager::GovernanceManager;
 
 use super::handlers;
+
+/// Deployment posture that determines how missing optional standing
+/// checkers and the membership resolver are treated at HTTP context build
+/// time.
+///
+/// The governance HTTP context exposes three optional dependencies:
+/// `member_checker`, `suspension_checker`, and `membership_resolver`. When
+/// any of them is `None`, governance handlers fall through to permissive
+/// behavior (e.g. `TrustThreshold` domains build with
+/// `excluded_delegators = None`). That is acceptable for development,
+/// devnet, and bootstrap contexts; it is unsafe for production and
+/// partner-bound deployments where unresolved member standing must not
+/// implicitly count as standing.
+///
+/// `GovernanceContextBuildMode` makes that distinction legible:
+///
+/// * [`Bootstrap`](Self::Bootstrap) — current dev/devnet behavior.
+///   Missing checkers/resolver emit explicit `tracing::warn!` warnings
+///   at context-validation time. Startup is not rejected.
+/// * [`Production`](Self::Production) — partner/production deployments.
+///   Missing checkers/resolver are a hard configuration error: validation
+///   returns a [`GovernanceContextValidationError`] naming every missing
+///   dependency so the daemon fails fast before serving traffic.
+/// * [`Test`](Self::Test) — explicit test-only mode. Identical permissive
+///   semantics to `Bootstrap`, but distinguishable in logs so test runs
+///   are not mistaken for a production misconfiguration.
+///
+/// **This type does not make governance production-ready.** It only makes
+/// the bootstrap-vs-production distinction legible at startup. The
+/// `TrustThreshold` direct-membership-mutation fail-open path tracked in
+/// issue #1870 remains open and must be resolved before claiming
+/// production readiness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GovernanceContextBuildMode {
+    /// Permissive mode for dev, devnet, and bootstrap contexts.
+    ///
+    /// Missing standing checkers or membership resolver emit explicit
+    /// warnings via `tracing::warn!` but do not reject startup. This is
+    /// the default for backward compatibility with existing constructors
+    /// that do not yet wire the mode explicitly.
+    #[default]
+    Bootstrap,
+
+    /// Strict mode for partner/production deployments.
+    ///
+    /// Missing `MemberStandingChecker`, `SuspensionChecker`, or
+    /// `membership_resolver` cause [`GovernanceContext::validate`] to
+    /// return [`GovernanceContextValidationError`] naming every missing
+    /// dependency. The daemon should fail to start in this case.
+    Production,
+
+    /// Explicit test mode.
+    ///
+    /// Functionally identical to [`Bootstrap`](Self::Bootstrap) — missing
+    /// dependencies do not reject startup — but distinguishable in logs
+    /// so test runs are not confused with production misconfiguration.
+    Test,
+}
+
+impl GovernanceContextBuildMode {
+    /// Resolve a build mode from the `ICN_GOVERNANCE_BUILD_MODE`
+    /// environment variable, falling back to `Bootstrap` when unset or
+    /// unrecognized. The gateway uses this to pick the mode at runtime;
+    /// callers that wire a mode explicitly should use the variants
+    /// directly rather than this helper.
+    ///
+    /// Recognized values (case-insensitive): `bootstrap`, `production`,
+    /// `test`. Unrecognized values fall back to `Bootstrap` to preserve
+    /// existing behavior; the gateway logs the unrecognized value.
+    pub fn from_env() -> Self {
+        match std::env::var("ICN_GOVERNANCE_BUILD_MODE") {
+            Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+                "bootstrap" | "" => Self::Bootstrap,
+                "production" => Self::Production,
+                "test" => Self::Test,
+                other => {
+                    warn!(
+                        mode = %other,
+                        "ICN_GOVERNANCE_BUILD_MODE is set to an unrecognized value; falling back to Bootstrap"
+                    );
+                    Self::Bootstrap
+                }
+            },
+            Err(_) => Self::Bootstrap,
+        }
+    }
+
+    /// Returns `true` if this mode rejects governance contexts that are
+    /// missing optional standing checkers or the membership resolver.
+    pub fn rejects_unresolved_standing(self) -> bool {
+        matches!(self, Self::Production)
+    }
+}
+
+/// Configuration error returned by [`GovernanceContext::validate`] when
+/// the context is built in [`GovernanceContextBuildMode::Production`] but
+/// is missing one or more optional standing dependencies that production
+/// requires.
+///
+/// The error names every missing dependency (not just the first) so the
+/// operator can fix the full configuration in a single pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GovernanceContextValidationError {
+    /// Mode the context was built in.
+    pub mode: GovernanceContextBuildMode,
+    /// Names of the missing optional dependencies. Stable strings,
+    /// matching the field names on [`GovernanceContext`].
+    pub missing: Vec<&'static str>,
+}
+
+impl std::fmt::Display for GovernanceContextValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "governance context built in {:?} mode is missing required \
+             standing/resolver dependencies: {}. \
+             Production deployments must wire MemberStandingChecker, \
+             SuspensionChecker, and a MembershipResolver — unresolved \
+             standing must not be treated as standing in production.",
+            self.mode,
+            self.missing.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for GovernanceContextValidationError {}
 
 /// Callback invoked when a `Charter` proposal is accepted.
 ///
@@ -268,6 +395,109 @@ pub struct GovernanceContext<E> {
     /// system (`SystemEvent::ProposalAccepted` → `KernelGovernanceExecutor` → `SdisService`).
     /// Setting this in tests provides a synchronous wiring path without an actor runtime.
     pub sdis_service: Option<Arc<dyn icn_kernel_api::SdisService>>,
+    /// Deployment posture for this governance HTTP context.
+    ///
+    /// Controls how missing optional standing checkers and the membership
+    /// resolver are treated by [`Self::validate`]: warned about in
+    /// `Bootstrap`/`Test`, hard-rejected in `Production`. See
+    /// [`GovernanceContextBuildMode`] for the full contract.
+    ///
+    /// Defaults to [`GovernanceContextBuildMode::Bootstrap`] so existing
+    /// dev/devnet/test constructors continue to compile and behave
+    /// identically without code changes.
+    pub build_mode: GovernanceContextBuildMode,
+}
+
+impl<E> GovernanceContext<E> {
+    /// Return the names of optional standing/resolver dependencies that
+    /// are unset on this context and that production deployments must
+    /// wire. The strings are stable identifiers (matching field names)
+    /// suitable for inclusion in operator-visible error messages and
+    /// log output. Returns an empty vec if everything required is wired.
+    ///
+    /// This is purely an inspection of the field set — it does not
+    /// consult [`Self::build_mode`].
+    pub fn missing_production_dependencies(&self) -> Vec<&'static str> {
+        let mut missing = Vec::new();
+        if self.member_checker.is_none() {
+            missing.push("member_checker");
+        }
+        if self.suspension_checker.is_none() {
+            missing.push("suspension_checker");
+        }
+        if self.membership_resolver.is_none() {
+            missing.push("membership_resolver");
+        }
+        missing
+    }
+
+    /// Validate this governance context against its declared build mode.
+    ///
+    /// In [`GovernanceContextBuildMode::Production`] every missing
+    /// dependency listed by [`Self::missing_production_dependencies`] is
+    /// a hard configuration error and this returns
+    /// [`GovernanceContextValidationError`] naming all of them.
+    ///
+    /// In [`GovernanceContextBuildMode::Bootstrap`] and
+    /// [`GovernanceContextBuildMode::Test`] this emits a `tracing::warn!`
+    /// for each missing dependency (so operators can see the fall-open
+    /// state in logs) but returns `Ok(())`.
+    ///
+    /// Callers should invoke this at daemon/gateway startup before
+    /// routes are registered, not lazily inside a handler.
+    pub fn validate(&self) -> Result<(), GovernanceContextValidationError> {
+        let missing = self.missing_production_dependencies();
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        match self.build_mode {
+            GovernanceContextBuildMode::Production => Err(GovernanceContextValidationError {
+                mode: self.build_mode,
+                missing,
+            }),
+            mode @ (GovernanceContextBuildMode::Bootstrap | GovernanceContextBuildMode::Test) => {
+                self.warn_missing_dependencies(mode, &missing);
+                Ok(())
+            }
+        }
+    }
+
+    fn warn_missing_dependencies(
+        &self,
+        mode: GovernanceContextBuildMode,
+        missing: &[&'static str],
+    ) {
+        warn!(
+            mode = ?mode,
+            missing = ?missing,
+            "governance context is running in {:?} mode without required \
+             production standing wiring; missing: {}. \
+             Production mode would reject this configuration. \
+             Unresolved standing must not be treated as standing in production.",
+            mode,
+            missing.join(", ")
+        );
+        for dep in missing {
+            match *dep {
+                "member_checker" => warn!(
+                    "governance: MemberStandingChecker is not wired; \
+                     create_proposal will not enforce active Member standing"
+                ),
+                "suspension_checker" => warn!(
+                    "governance: SuspensionChecker is not wired; \
+                     cast_vote will not block suspended members and \
+                     close_proposal will not exclude suspended delegators"
+                ),
+                "membership_resolver" => warn!(
+                    "governance: membership_resolver is not wired; \
+                     TrustThreshold domains will close with excluded_delegators=None \
+                     (fail-open — delegations from suspended members may flow)"
+                ),
+                _ => {}
+            }
+        }
+    }
 }
 
 /// Register all governance routes on `cfg`.
@@ -278,6 +508,15 @@ pub fn configure<E>(cfg: &mut web::ServiceConfig, ctx: GovernanceContext<E>)
 where
     E: GovernanceEventEmitter + Clone + 'static,
 {
+    // Validate before route registration so missing production dependencies
+    // surface at startup rather than at first request. Callers in production
+    // (daemon/gateway) are expected to call `ctx.validate()` themselves and
+    // propagate the error up — reaching here in Production with missing
+    // dependencies is a programmer bug, so we fail fast and loud.
+    if let Err(err) = ctx.validate() {
+        panic!("{}", err);
+    }
+
     let data = web::Data::new(ctx);
 
     cfg.app_data(data.clone())
@@ -545,4 +784,252 @@ where
             web::resource("/me/action-cards")
                 .route(web::get().to(handlers::get_my_action_cards::<E>)),
         );
+}
+
+#[cfg(test)]
+mod build_mode_tests {
+    //! Unit tests for `GovernanceContextBuildMode` and the
+    //! production-guard logic on `GovernanceContext::validate`.
+    //!
+    //! These tests construct a minimal context without exercising any
+    //! HTTP/actor wiring, so they can be run in isolation under
+    //! `cargo test -p icn-governance-actor`.
+
+    use super::*;
+    use crate::events::NoopEventEmitter;
+    use crate::manager::GovernanceManager;
+
+    fn ctx_with_mode(mode: GovernanceContextBuildMode) -> GovernanceContext<NoopEventEmitter> {
+        GovernanceContext {
+            manager: Arc::new(GovernanceManager::new()),
+            emitter: NoopEventEmitter,
+            on_charter_accepted: None,
+            on_proposal_accepted: None,
+            on_proposal_accepted_with_evidence: None,
+            member_checker: None,
+            steward_checker: None,
+            suspension_checker: None,
+            membership_resolver: None,
+            sdis_service: None,
+            build_mode: mode,
+        }
+    }
+
+    fn dummy_member_checker() -> MemberStandingChecker {
+        Arc::new(|_did, _domain| Box::pin(async { true }))
+    }
+
+    fn dummy_suspension_checker() -> SuspensionChecker {
+        Arc::new(|_did, _domain| Box::pin(async { false }))
+    }
+
+    fn dummy_resolver() -> Arc<dyn MembershipResolver> {
+        Arc::new(icn_governance::StaticMembershipResolver::new())
+    }
+
+    #[test]
+    fn default_mode_is_bootstrap() {
+        // Backward-compatibility guard: existing call sites that do not
+        // set `build_mode` should land on Bootstrap, not Production. If
+        // this assertion ever needs to change, every downstream caller
+        // must opt in to Production explicitly first.
+        let mode: GovernanceContextBuildMode = Default::default();
+        assert_eq!(mode, GovernanceContextBuildMode::Bootstrap);
+    }
+
+    #[test]
+    fn production_only_mode_rejects_unresolved_standing() {
+        assert!(GovernanceContextBuildMode::Production.rejects_unresolved_standing());
+        assert!(!GovernanceContextBuildMode::Bootstrap.rejects_unresolved_standing());
+        assert!(!GovernanceContextBuildMode::Test.rejects_unresolved_standing());
+    }
+
+    #[test]
+    fn missing_production_dependencies_lists_unset_optional_fields() {
+        // Empty context → all three deps missing, in stable order.
+        let ctx = ctx_with_mode(GovernanceContextBuildMode::Bootstrap);
+        assert_eq!(
+            ctx.missing_production_dependencies(),
+            vec![
+                "member_checker",
+                "suspension_checker",
+                "membership_resolver"
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_production_dependencies_excludes_wired_fields() {
+        let mut ctx = ctx_with_mode(GovernanceContextBuildMode::Bootstrap);
+        ctx.member_checker = Some(dummy_member_checker());
+        assert_eq!(
+            ctx.missing_production_dependencies(),
+            vec!["suspension_checker", "membership_resolver"]
+        );
+    }
+
+    #[test]
+    fn missing_production_dependencies_empty_when_all_wired() {
+        let mut ctx = ctx_with_mode(GovernanceContextBuildMode::Production);
+        ctx.member_checker = Some(dummy_member_checker());
+        ctx.suspension_checker = Some(dummy_suspension_checker());
+        ctx.membership_resolver = Some(dummy_resolver());
+        assert!(ctx.missing_production_dependencies().is_empty());
+    }
+
+    #[test]
+    fn production_all_missing_returns_error_naming_all() {
+        let ctx = ctx_with_mode(GovernanceContextBuildMode::Production);
+        let result = ctx.validate();
+        let Err(err) = result else {
+            panic!("Production with all deps missing must reject; got Ok");
+        };
+
+        assert_eq!(err.mode, GovernanceContextBuildMode::Production);
+        assert_eq!(
+            err.missing,
+            vec![
+                "member_checker",
+                "suspension_checker",
+                "membership_resolver"
+            ]
+        );
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Production"),
+            "error must name the mode: {msg}"
+        );
+        assert!(
+            msg.contains("member_checker"),
+            "error must name member_checker: {msg}"
+        );
+        assert!(
+            msg.contains("suspension_checker"),
+            "error must name suspension_checker: {msg}"
+        );
+        assert!(
+            msg.contains("membership_resolver"),
+            "error must name membership_resolver: {msg}"
+        );
+    }
+
+    #[test]
+    fn production_single_missing_dep_names_only_that_dep() {
+        let mut ctx = ctx_with_mode(GovernanceContextBuildMode::Production);
+        ctx.member_checker = Some(dummy_member_checker());
+        ctx.suspension_checker = Some(dummy_suspension_checker());
+        // membership_resolver still missing
+        let result = ctx.validate();
+        let Err(err) = result else {
+            panic!("Production with one dep missing must reject; got Ok");
+        };
+
+        assert_eq!(err.missing, vec!["membership_resolver"]);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("membership_resolver"),
+            "error must name the missing dep: {msg}"
+        );
+        assert!(
+            !msg.contains("member_checker,"),
+            "must not falsely name wired dep: {msg}"
+        );
+    }
+
+    #[test]
+    fn production_all_wired_validates_ok() {
+        let mut ctx = ctx_with_mode(GovernanceContextBuildMode::Production);
+        ctx.member_checker = Some(dummy_member_checker());
+        ctx.suspension_checker = Some(dummy_suspension_checker());
+        ctx.membership_resolver = Some(dummy_resolver());
+        assert!(ctx.validate().is_ok());
+    }
+
+    #[test]
+    fn bootstrap_with_missing_deps_does_not_reject() {
+        // Bootstrap is the legacy/dev posture. Missing deps emit warnings
+        // (tracing::warn!) but do not fail validation.
+        let ctx = ctx_with_mode(GovernanceContextBuildMode::Bootstrap);
+        assert!(
+            ctx.validate().is_ok(),
+            "Bootstrap mode must not reject startup on missing deps"
+        );
+    }
+
+    #[test]
+    fn test_mode_with_missing_deps_does_not_reject() {
+        // Test mode is functionally identical to Bootstrap — permissive,
+        // but distinguishable in logs.
+        let ctx = ctx_with_mode(GovernanceContextBuildMode::Test);
+        assert!(
+            ctx.validate().is_ok(),
+            "Test mode must not reject startup on missing deps"
+        );
+    }
+
+    #[test]
+    fn validation_error_is_std_error() {
+        // The error must implement `std::error::Error` so callers can
+        // bubble it through `?` and into gateway-level error types.
+        fn assert_is_error<T: std::error::Error>(_: &T) {}
+        let err = GovernanceContextValidationError {
+            mode: GovernanceContextBuildMode::Production,
+            missing: vec!["member_checker"],
+        };
+        assert_is_error(&err);
+    }
+
+    #[test]
+    fn from_env_falls_back_to_bootstrap_when_unset() {
+        // Save and restore env to avoid cross-test contamination. This
+        // also defends against the env var being set by the harness.
+        let prev = std::env::var("ICN_GOVERNANCE_BUILD_MODE").ok();
+        // SAFETY: unit tests are single-threaded for env access; the
+        // assertion only inspects this single var.
+        std::env::remove_var("ICN_GOVERNANCE_BUILD_MODE");
+
+        assert_eq!(
+            GovernanceContextBuildMode::from_env(),
+            GovernanceContextBuildMode::Bootstrap
+        );
+
+        if let Some(v) = prev {
+            std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", v);
+        }
+    }
+
+    #[test]
+    fn from_env_parses_production() {
+        let prev = std::env::var("ICN_GOVERNANCE_BUILD_MODE").ok();
+        std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", "production");
+        assert_eq!(
+            GovernanceContextBuildMode::from_env(),
+            GovernanceContextBuildMode::Production
+        );
+        std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", "PRODUCTION");
+        assert_eq!(
+            GovernanceContextBuildMode::from_env(),
+            GovernanceContextBuildMode::Production
+        );
+
+        match prev {
+            Some(v) => std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", v),
+            None => std::env::remove_var("ICN_GOVERNANCE_BUILD_MODE"),
+        }
+    }
+
+    #[test]
+    fn from_env_falls_back_on_unknown_value() {
+        let prev = std::env::var("ICN_GOVERNANCE_BUILD_MODE").ok();
+        std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", "garbage");
+        assert_eq!(
+            GovernanceContextBuildMode::from_env(),
+            GovernanceContextBuildMode::Bootstrap
+        );
+        match prev {
+            Some(v) => std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", v),
+            None => std::env::remove_var("ICN_GOVERNANCE_BUILD_MODE"),
+        }
+    }
 }

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -508,13 +508,24 @@ pub fn configure<E>(cfg: &mut web::ServiceConfig, ctx: GovernanceContext<E>)
 where
     E: GovernanceEventEmitter + Clone + 'static,
 {
-    // Validate before route registration so missing production dependencies
-    // surface at startup rather than at first request. Callers in production
-    // (daemon/gateway) are expected to call `ctx.validate()` themselves and
-    // propagate the error up — reaching here in Production with missing
-    // dependencies is a programmer bug, so we fail fast and loud.
-    if let Err(err) = ctx.validate() {
-        panic!("{}", err);
+    // Defensive Production-only check: callers (daemon/gateway) are expected
+    // to call `ctx.validate()` themselves and propagate the error up before
+    // reaching this point, so reaching here in `Production` with missing
+    // standing/resolver deps means a programmer skipped that step. We do NOT
+    // call `validate()` here because that would duplicate the Bootstrap/Test
+    // warning logs already emitted by the caller. We only enforce the
+    // Production invariant.
+    if ctx.build_mode == GovernanceContextBuildMode::Production {
+        let missing = ctx.missing_production_dependencies();
+        if !missing.is_empty() {
+            panic!(
+                "{}",
+                GovernanceContextValidationError {
+                    mode: ctx.build_mode,
+                    missing,
+                }
+            );
+        }
     }
 
     let data = web::Data::new(ctx);
@@ -980,28 +991,58 @@ mod build_mode_tests {
         assert_is_error(&err);
     }
 
-    #[test]
-    fn from_env_falls_back_to_bootstrap_when_unset() {
-        // Save and restore env to avoid cross-test contamination. This
-        // also defends against the env var being set by the harness.
-        let prev = std::env::var("ICN_GOVERNANCE_BUILD_MODE").ok();
-        // SAFETY: unit tests are single-threaded for env access; the
-        // assertion only inspects this single var.
-        std::env::remove_var("ICN_GOVERNANCE_BUILD_MODE");
+    /// Serialize the `from_env_*` tests against each other.
+    ///
+    /// Rust's test harness runs unit tests in parallel by default and these
+    /// three tests mutate `ICN_GOVERNANCE_BUILD_MODE` via `set_var` /
+    /// `remove_var` — without serialization they race on process-wide state
+    /// and assertions become flaky depending on scheduling. A single static
+    /// `Mutex` makes the env-mutating section single-threaded across the
+    /// crate's lib-test process. We poison-tolerate (via `.unwrap_or_else`)
+    /// so a panic in one test does not cascade into the others.
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-        assert_eq!(
-            GovernanceContextBuildMode::from_env(),
-            GovernanceContextBuildMode::Bootstrap
-        );
+    /// Acquire the env-test lock and restore the previous value of
+    /// `ICN_GOVERNANCE_BUILD_MODE` when the guard drops. This keeps
+    /// each test hermetic regardless of order or external env state.
+    struct EnvGuard {
+        prev: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
 
-        if let Some(v) = prev {
-            std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", v);
+    impl EnvGuard {
+        fn acquire() -> Self {
+            let lock = ENV_TEST_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let prev = std::env::var("ICN_GOVERNANCE_BUILD_MODE").ok();
+            std::env::remove_var("ICN_GOVERNANCE_BUILD_MODE");
+            EnvGuard { prev, _lock: lock }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", v),
+                None => std::env::remove_var("ICN_GOVERNANCE_BUILD_MODE"),
+            }
         }
     }
 
     #[test]
+    fn from_env_falls_back_to_bootstrap_when_unset() {
+        let _g = EnvGuard::acquire();
+        // EnvGuard already removed the var; assert the unset path.
+        assert_eq!(
+            GovernanceContextBuildMode::from_env(),
+            GovernanceContextBuildMode::Bootstrap
+        );
+    }
+
+    #[test]
     fn from_env_parses_production() {
-        let prev = std::env::var("ICN_GOVERNANCE_BUILD_MODE").ok();
+        let _g = EnvGuard::acquire();
         std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", "production");
         assert_eq!(
             GovernanceContextBuildMode::from_env(),
@@ -1012,24 +1053,15 @@ mod build_mode_tests {
             GovernanceContextBuildMode::from_env(),
             GovernanceContextBuildMode::Production
         );
-
-        match prev {
-            Some(v) => std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", v),
-            None => std::env::remove_var("ICN_GOVERNANCE_BUILD_MODE"),
-        }
     }
 
     #[test]
     fn from_env_falls_back_on_unknown_value() {
-        let prev = std::env::var("ICN_GOVERNANCE_BUILD_MODE").ok();
+        let _g = EnvGuard::acquire();
         std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", "garbage");
         assert_eq!(
             GovernanceContextBuildMode::from_env(),
             GovernanceContextBuildMode::Bootstrap
         );
-        match prev {
-            Some(v) => std::env::set_var("ICN_GOVERNANCE_BUILD_MODE", v),
-            None => std::env::remove_var("ICN_GOVERNANCE_BUILD_MODE"),
-        }
     }
 }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -5314,7 +5314,8 @@ mod tests {
     use super::*;
     use crate::events::NoopEventEmitter;
     use crate::http::configure::{
-        GovernanceContext, GovernanceEffect, ProposalAcceptedHook, SuspensionChecker,
+        GovernanceContext, GovernanceContextBuildMode, GovernanceEffect, ProposalAcceptedHook,
+        SuspensionChecker,
     };
     use crate::manager::{GovernanceManager, InMemoryMilestoneEventLog};
 
@@ -5577,6 +5578,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = test_app!(ctx, member_did);
@@ -5700,6 +5702,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = test_app!(ctx, member_did);
@@ -5826,6 +5829,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = test_app!(ctx, steward_did);
@@ -5949,6 +5953,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = test_app!(ctx, steward_did);
@@ -6069,6 +6074,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = test_app!(ctx, steward_did);
@@ -6135,6 +6141,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = test_app!(ctx, member_did);
@@ -6257,6 +6264,7 @@ mod tests {
             suspension_checker: Some(suspension_checker),
             membership_resolver: Some(resolver),
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = test_app!(ctx, alice_did);
@@ -6321,6 +6329,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = me_test_app!(ctx, caller);
@@ -6372,6 +6381,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = me_test_app!(ctx, caller.clone());
@@ -6404,6 +6414,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = me_test_app!(ctx, caller);
@@ -6461,6 +6472,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         };
 
         let app = me_test_app!(ctx, caller.clone());
@@ -6496,6 +6508,7 @@ mod tests {
                 suspension_checker: None,
                 membership_resolver: None,
                 sdis_service: None,
+                build_mode: GovernanceContextBuildMode::Test,
             };
             me_test_app!(ctx, $caller)
         }};
@@ -7008,6 +7021,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         }
     }
 
@@ -8061,6 +8075,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            build_mode: GovernanceContextBuildMode::Test,
         }
     }
 

--- a/icn/apps/governance/src/http/mod.rs
+++ b/icn/apps/governance/src/http/mod.rs
@@ -10,4 +10,6 @@ pub mod handlers;
 pub mod models;
 pub mod validation;
 
-pub use configure::{configure, GovernanceContext};
+pub use configure::{
+    configure, GovernanceContext, GovernanceContextBuildMode, GovernanceContextValidationError,
+};

--- a/icn/apps/governance/tests/assign_role_authority_scope.rs
+++ b/icn/apps/governance/tests/assign_role_authority_scope.rs
@@ -39,6 +39,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }
 

--- a/icn/apps/governance/tests/charter_activation.rs
+++ b/icn/apps/governance/tests/charter_activation.rs
@@ -84,6 +84,7 @@ fn make_ctx_with_capture() -> (GovernanceContext<NoopEventEmitter>, CapturedHook
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     (
@@ -392,6 +393,7 @@ async fn activate_charter_returns_500_when_charter_hook_not_wired() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
     let app = charter_test_app!(ctx, Some("governance:write"));
 
@@ -434,6 +436,7 @@ async fn activate_charter_returns_500_when_proposal_hook_not_wired() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
     let app = charter_test_app!(ctx, Some("governance:write"));
 

--- a/icn/apps/governance/tests/me_action_card_receipt_chain.rs
+++ b/icn/apps/governance/tests/me_action_card_receipt_chain.rs
@@ -171,6 +171,7 @@ fn make_harness() -> Harness {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
     Harness { ctx, receipts }
 }

--- a/icn/apps/governance/tests/me_action_cards.rs
+++ b/icn/apps/governance/tests/me_action_cards.rs
@@ -52,6 +52,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }
 

--- a/icn/apps/governance/tests/me_action_item_receipt_chain.rs
+++ b/icn/apps/governance/tests/me_action_item_receipt_chain.rs
@@ -254,6 +254,7 @@ fn make_harness() -> Harness {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
     Harness { ctx, receipts }
 }

--- a/icn/apps/governance/tests/me_standing.rs
+++ b/icn/apps/governance/tests/me_standing.rs
@@ -55,6 +55,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }
 

--- a/icn/bins/icnctl/src/institution_bootstrap.rs
+++ b/icn/bins/icnctl/src/institution_bootstrap.rs
@@ -1745,6 +1745,7 @@ mod tests {
                 suspension_checker: None,
                 membership_resolver: None,
                 sdis_service: None,
+                build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
             };
 
             let auth_mgr2 = auth_mgr.clone();

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1416,7 +1416,27 @@ impl GatewayServer {
             // Daemon mode: SDIS execution goes through the actor event system
             // (KernelGovernanceExecutor → SdisServiceImpl). HTTP path leaves this None.
             sdis_service: None,
+            // Deployment posture for the governance HTTP context.
+            //
+            // Resolved from the `ICN_GOVERNANCE_BUILD_MODE` environment variable
+            // (matching the existing `ICN_DEV_MODE` convention). When set to
+            // `production`, missing standing checkers/membership resolver below
+            // become a hard configuration error that prevents the gateway from
+            // starting — see `GovernanceContext::validate`. When unset, defaults
+            // to `Bootstrap` so existing dev/devnet behavior is preserved.
+            //
+            // A daemon-level config field is the obvious next step; see PR body
+            // for follow-up notes.
+            build_mode: icn_governance_actor::http::GovernanceContextBuildMode::from_env(),
         };
+
+        // Fail fast at startup if the governance context is missing required
+        // production dependencies in `Production` mode. Bootstrap/Test mode
+        // logs warnings via `tracing::warn!` but does not reject startup,
+        // preserving current dev/devnet behavior.
+        if let Err(err) = gov_ctx.validate() {
+            return Err(GatewayError::InternalError(err.to_string()));
+        }
 
         // Create rate limiter with configured or default config
         let rate_limit_config = self.rate_limit_config.unwrap_or_default();

--- a/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
+++ b/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
@@ -226,6 +226,7 @@ async fn build_app_with_proposal(
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
@@ -272,6 +272,7 @@ async fn test_suspended_member_cannot_create_delegation() {
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -505,6 +506,7 @@ async fn test_suspended_member_cannot_create_blanket_delegation() {
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -312,6 +312,7 @@ async fn test_e2e_freeze_member_suspends_commons_affiliation() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -569,6 +570,7 @@ async fn test_e2e_unfreeze_member_reinstates_commons_affiliation() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -918,6 +920,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: Some(sdis_svc),
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
@@ -228,6 +228,7 @@ async fn test_freeze_member_blocks_ledger_entries_after_governance_acceptance() 
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
@@ -138,6 +138,7 @@ async fn build_app(
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
@@ -213,6 +213,7 @@ async fn test_suspended_member_cannot_open_proposal() {
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
@@ -247,6 +247,7 @@ async fn test_suspended_member_cannot_submit_proposals() {
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
@@ -138,6 +138,7 @@ async fn build_app(
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs
@@ -180,6 +180,7 @@ async fn build_app_with_trust_resolver(
         // Live production resolver — NOT a TrackingResolver mock
         membership_resolver: Some(resolver),
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = actix_web_httpauth::middleware::HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
@@ -161,6 +161,7 @@ async fn build_app_with_open_proposal(
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
@@ -413,6 +414,7 @@ async fn build_app_with_suspension_checker(
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);

--- a/icn/crates/icn-gateway/tests/governance_proof.rs
+++ b/icn/crates/icn-gateway/tests/governance_proof.rs
@@ -78,6 +78,7 @@ async fn test_governance_proposal_full_lifecycle_with_real_auth() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     // Build test app — mirrors the governance-relevant subset of server.rs:
@@ -396,6 +397,7 @@ async fn test_governance_endpoints_require_auth() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);


### PR DESCRIPTION
## What

Adds `GovernanceContextBuildMode { Bootstrap, Production, Test }` to
`icn-governance-actor` and wires it through the gateway so the bootstrap
vs production posture of the governance HTTP context is **legible at
startup**.

- New types in `apps/governance/src/http/configure.rs`:
  `GovernanceContextBuildMode`, `GovernanceContextValidationError`.
- New `GovernanceContext::validate()` + `missing_production_dependencies()`.
- New `GovernanceContextBuildMode::from_env()` reading
  `ICN_GOVERNANCE_BUILD_MODE` (case-insensitive `bootstrap` / `production`
  / `test`), falling back to `Bootstrap` on unset or unrecognized value.
- Gateway `server.rs::run()` picks the mode from env and calls
  `gov_ctx.validate()?` before route registration — `Production` with
  missing deps now returns a `GatewayError::InternalError` and the
  daemon fails to start rather than serving traffic with unresolved
  standing.
- `configure()` defensively re-validates and panics on
  Production-with-missing-deps (programmer-bug at this point).

Default for all existing construction sites is `Bootstrap` (production
wiring) or `Test` (every test, including the icnctl bootstrap test
server and ~24 gateway/governance integration tests). No behavior
change for dev/devnet by default.

## Why this closes #1871

`apps/governance/src/http/configure.rs` previously documented that
`MemberStandingChecker`, `SuspensionChecker`, and `membership_resolver`
fall open when `None`. That was reasonable for bootstrap but invisible
in production. With this change:

- a partner/production deployment can set
  `ICN_GOVERNANCE_BUILD_MODE=production` and the daemon will refuse to
  start with an operator-visible error naming every missing dependency,
- a bootstrap deployment will see explicit warnings via `tracing::warn!`
  identifying which dependency is missing and which fall-through
  behavior is active.

Issue #1871 acceptance criteria:

- [x] Mode discriminator with at least `Bootstrap` and `Production`
      (and an explicit `Test` variant)
- [x] Defaults preserve existing dev/devnet behavior (default is
      `Bootstrap`, not `Production`)
- [x] `Production` rejects missing `MemberStandingChecker`,
      `SuspensionChecker`, `membership_resolver`; error names every
      missing dep
- [x] `Bootstrap`/`Test` emits a per-dep warning naming the exact
      fall-through behavior
- [x] Daemon selects mode explicitly via existing env-var convention
- [x] Tests: production+all-missing, production+single-missing,
      bootstrap+missing-ok, test+missing-ok, structured error type
- [x] Does not alter `MembershipSource`
- [x] Does not change kernel capability semantics
- [x] Does not broaden the meaning firewall
- [x] Does not claim production readiness

## Behavior by mode

| Mode | Missing standing/resolver | Startup |
|------|---------------------------|---------|
| `Bootstrap` (default) | per-dep `tracing::warn!` | continues |
| `Test` | per-dep `tracing::warn!` (labeled "Test") | continues |
| `Production` | `GovernanceContextValidationError` naming every missing dep | **rejected** |

Warning messages explicitly say *"Production mode would reject this
configuration"* and *"Unresolved standing must not be treated as
standing in production"* so the operator sees both the current state
and the production contract in the same log line.

## What this does NOT do

- Does not fix #1870 (TrustThreshold direct membership mutation
  resolution / rejecting unresolved standing in production)
- Does not add `MandateGate`
- Does not migrate governance handlers from `governance:write` to
  class-level capability scopes
- Does not claim production readiness — only makes the bootstrap vs
  production distinction legible
- Does not change kernel meaning-firewall semantics; no domain types
  leak into kernel crates

## Tests added

14 unit tests in `apps/governance/src/http/configure.rs` under
`build_mode_tests`:

- `default_mode_is_bootstrap`
- `production_only_mode_rejects_unresolved_standing`
- `missing_production_dependencies_lists_unset_optional_fields`
- `missing_production_dependencies_excludes_wired_fields`
- `missing_production_dependencies_empty_when_all_wired`
- `production_all_missing_returns_error_naming_all`
- `production_single_missing_dep_names_only_that_dep`
- `production_all_wired_validates_ok`
- `bootstrap_with_missing_deps_does_not_reject`
- `test_mode_with_missing_deps_does_not_reject`
- `validation_error_is_std_error`
- `from_env_falls_back_to_bootstrap_when_unset`
- `from_env_parses_production` (case-insensitive)
- `from_env_falls_back_on_unknown_value`

## Validation

```
cargo fmt --all -- --check                                           ok
cargo clippy -p icn-governance-actor --all-targets -- -D warnings    ok
cargo clippy -p icn-gateway --all-targets -- -D warnings             ok
cargo check  -p icnctl --all-targets                                 ok
cargo test   -p icn-governance-actor                                 ok (all 7 suites green; 14 new tests pass)
python3 .github/scripts/compliance_linter.py                         No violations
bash    ops/scripts/drift-check.sh                                   PASS (0 errors, 0 warnings)
git diff --check                                                     clean
```

Targeted lib-test summary:

```
running 14 tests
test http::configure::build_mode_tests::default_mode_is_bootstrap ... ok
test http::configure::build_mode_tests::bootstrap_with_missing_deps_does_not_reject ... ok
test http::configure::build_mode_tests::test_mode_with_missing_deps_does_not_reject ... ok
test http::configure::build_mode_tests::production_only_mode_rejects_unresolved_standing ... ok
test http::configure::build_mode_tests::missing_production_dependencies_lists_unset_optional_fields ... ok
test http::configure::build_mode_tests::missing_production_dependencies_excludes_wired_fields ... ok
test http::configure::build_mode_tests::missing_production_dependencies_empty_when_all_wired ... ok
test http::configure::build_mode_tests::production_all_missing_returns_error_naming_all ... ok
test http::configure::build_mode_tests::production_single_missing_dep_names_only_that_dep ... ok
test http::configure::build_mode_tests::production_all_wired_validates_ok ... ok
test http::configure::build_mode_tests::validation_error_is_std_error ... ok
test http::configure::build_mode_tests::from_env_falls_back_to_bootstrap_when_unset ... ok
test http::configure::build_mode_tests::from_env_parses_production ... ok
test http::configure::build_mode_tests::from_env_falls_back_on_unknown_value ... ok

test result: ok. 14 passed; 0 failed
```

## Risk

- All existing construction sites set the field explicitly. New code
  that builds a `GovernanceContext` without the field will not compile;
  this is intentional (no silent default to `Production`).
- The gateway's `run()` now returns an error on Production+missing,
  surfacing as `GatewayError::InternalError`. The daemon will fail
  fast — desired behavior.
- Bootstrap path (the existing default) is functionally unchanged.
  Warnings are additive logging.

## Follow-up

The recommended next session is issue **#1870** — resolve
`TrustThreshold` direct membership mutation through the configured
resolver and reject unresolved standing in production. The
`build_mode` discriminator added here is the natural place for #1870
to plug into; once #1870 lands, `Production` mode will hard-reject
both the dependency wiring (this PR) **and** runtime unresolved
standing.

A daemon-level config field (replacing or complementing the env-var
toggle) is the obvious follow-on for the next sprint; the issue
explicitly allowed deferring CLI/config wiring if it would sprawl, so
the env-var matches the existing `ICN_DEV_MODE` convention as the
minimal correct slice.

## Invariants checklist

- [x] No new domain imports in kernel crates
- [x] Determinism preserved (no new sources of nondeterminism)
- [x] No new panics on protocol paths (panic is only at startup-time
      configuration validation, guarding a programmer bug)
- [x] No wire-format changes
- [x] Regulatory-safe vocabulary preserved (no payment / wallet /
      balance / currency language introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)