### PR TITLE
authz(gateway): allow decomposed governance write scopes via canonical constants (#1868 step 2)

### DIFF
--- a/icn/crates/icn-gateway/src/validation.rs
+++ b/icn/crates/icn-gateway/src/validation.rs
@@ -6,6 +6,11 @@
 //! - Invalid formats
 
 use crate::error::{GatewayError, Result};
+use icn_rpc::auth::scopes::{
+    GOVERNANCE_ACTIVITY_WRITE, GOVERNANCE_CHARTER_WRITE, GOVERNANCE_COMMENT_WRITE,
+    GOVERNANCE_FEDERATION_WRITE, GOVERNANCE_MEETING_WRITE, GOVERNANCE_PROPOSAL_WRITE,
+    GOVERNANCE_STEWARD_WRITE,
+};
 
 /// Maximum length for cooperative ID
 pub const MAX_COOP_ID_LEN: usize = 64;
@@ -54,16 +59,20 @@ pub const ALLOWED_SCOPES: &[&str] = &[
     "governance:write",
     // Governance class-level write scopes (subdivisions of `governance:write`).
     // Minted by §10 step 1 of `docs/design/governance/governance-write-decomposition.md`.
-    // No handler in `apps/governance/src/http/handlers.rs` references these
-    // yet; handler migration happens in later steps. The broad
-    // `governance:write` remains in the allowlist during the migration.
-    "governance:charter:write",
-    "governance:proposal:write",
-    "governance:steward:write",
-    "governance:federation:write",
-    "governance:meeting:write",
-    "governance:activity:write",
-    "governance:comment:write",
+    // Wire strings are sourced from `icn_rpc::auth::scopes` so the gateway
+    // allowlist and the RPC scope constants cannot drift; the test
+    // `test_allowed_scopes_contains_governance_class_write` locks that
+    // invariant. No handler in `apps/governance/src/http/handlers.rs`
+    // references these yet; handler migration happens in later steps. The
+    // broad `governance:write` remains in the allowlist during the
+    // migration.
+    GOVERNANCE_CHARTER_WRITE,
+    GOVERNANCE_PROPOSAL_WRITE,
+    GOVERNANCE_STEWARD_WRITE,
+    GOVERNANCE_FEDERATION_WRITE,
+    GOVERNANCE_MEETING_WRITE,
+    GOVERNANCE_ACTIVITY_WRITE,
+    GOVERNANCE_COMMENT_WRITE,
     // Settlement operations
     "settlements:read",
     "settlements:write",
@@ -856,6 +865,44 @@ mod tests {
         assert!(validate_scopes(&["governance:nonexistent:write".to_string()]).is_err());
         assert!(validate_scopes(&["governance:charter".to_string()]).is_err());
         assert!(validate_scopes(&["governance:charter:admin".to_string()]).is_err());
+    }
+
+    /// Cross-crate invariant: every class-level governance write scope
+    /// minted in `icn_rpc::auth::scopes::GOVERNANCE_CLASS_WRITE` must be
+    /// accepted by the gateway scope allowlist. Without this lock, a
+    /// future PR could add a new class scope on the icn-rpc side without
+    /// extending the gateway allowlist, leaving any handler migrated to
+    /// that scope unreachable because the gateway auth endpoint at
+    /// `icn/crates/icn-gateway/src/api/auth.rs:87-94` would refuse to
+    /// issue a capability containing the new string.
+    ///
+    /// This test asserts membership both at the constant-list level
+    /// (`ALLOWED_SCOPES`) and at the public-API level (`validate_scopes`).
+    #[test]
+    fn test_allowed_scopes_contains_governance_class_write() {
+        use icn_rpc::auth::scopes::GOVERNANCE_CLASS_WRITE;
+
+        for scope in GOVERNANCE_CLASS_WRITE {
+            assert!(
+                ALLOWED_SCOPES.contains(scope),
+                "icn-rpc canonical scope {scope:?} must be in the gateway ALLOWED_SCOPES"
+            );
+            assert!(
+                validate_scopes(&[(*scope).to_string()]).is_ok(),
+                "icn-rpc canonical scope {scope:?} must pass validate_scopes"
+            );
+        }
+        // Also assert the full slice is acceptable as a bundled token request,
+        // matching how a migrated client would request a single capability
+        // covering multiple class-level acts.
+        let bundled: Vec<String> = GOVERNANCE_CLASS_WRITE
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(
+            validate_scopes(&bundled).is_ok(),
+            "all of GOVERNANCE_CLASS_WRITE must be acceptable in a single request"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Wires the seven class-level governance write-scope constants minted in PR #1881 (#1868 step 1) through `icn-gateway::validation::ALLOWED_SCOPES` as **references to the canonical icn-rpc constants** instead of duplicated string literals, and locks the cross-crate invariant with a new test.

## Why

PR #1881 added the seven strings to `ALLOWED_SCOPES` as hard-coded literals duplicated from §6 of `docs/design/governance/governance-write-decomposition.md`. That left two parallel sources of truth (`icn_rpc::auth::scopes` and the gateway allowlist) which could drift if a future PR extends one without touching the other. After this PR, `icn_rpc::auth::scopes` is canonical and the gateway allowlist references it directly.

## How

- `icn/crates/icn-gateway/src/validation.rs`:
  - Imports `GOVERNANCE_CHARTER_WRITE`, `GOVERNANCE_PROPOSAL_WRITE`, `GOVERNANCE_STEWARD_WRITE`, `GOVERNANCE_FEDERATION_WRITE`, `GOVERNANCE_MEETING_WRITE`, `GOVERNANCE_ACTIVITY_WRITE`, `GOVERNANCE_COMMENT_WRITE` from `icn_rpc::auth::scopes`.
  - Replaces the seven duplicated string literals in `ALLOWED_SCOPES` with references to those constants.
  - Updates the comment block above the seven entries to point to the new invariant test.
- New test `test_allowed_scopes_contains_governance_class_write` imports `GOVERNANCE_CLASS_WRITE` at test-module scope, then iterates it and asserts every entry is both (a) present in `ALLOWED_SCOPES` and (b) accepted by `validate_scopes` — individually and bundled.

## What this PR does **not** do

- Does **not** migrate any handler. Every governance handler in `apps/governance/src/http/handlers.rs` still gates on the broad `governance:write` exactly as before.
- Does **not** retire `governance:write`. The broad constant stays in `ALLOWED_SCOPES` for the duration of the migration (§10 step 13 of the design doc).
- Does **not** introduce `MandateGate` (§10 step 6).
- Does **not** change receipts, reconciliation, standing checkers, or any governance runtime semantics.
- Does **not** broaden privilege. The same seven scope strings remain accepted at the boundary; only the source of truth changes.
- Does **not** rebind any JSON-RPC method to a new scope. `required_scope_for_method` still maps governance methods to `GOVERNANCE_WRITE` (§10 step 12).

## Risk

Low. Zero functional change to scope recognition — `ALLOWED_SCOPES` still contains the same nine governance strings (broad read, broad write, seven class scopes). The diff is a one-file change of +57/-10. If the constants in `icn-rpc` ever change wire string, the existing icn-rpc snapshot test `test_governance_class_scope_constants` catches it before the gateway side notices, and the new invariant test catches divergence in the other direction.

## Test plan

Local validation on icn-dev (1.95.0 toolchain):

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p icn-gateway --all-targets -- -D warnings` — clean
- `cargo test -p icn-gateway --lib` — 544 passed (1 new)
- `cargo test -p icn-gateway --lib test_allowed_scopes_contains_governance_class_write` — passed
- `bash ops/scripts/drift-check.sh` — STATUS: PASS
- `python3 .github/scripts/compliance_linter.py` — no violations

## Next slice after this PR

Per §10 of `docs/design/governance/governance-write-decomposition.md`, the natural follow-up depends on whether the design's §10 step 2 (extend governance receipt types to carry `capability_scope_presented` + `mandate_grant`) is wanted before any handler migration, or whether step 3 (migrate `governance:charter:write` — `create_domain`, `activate_charter`, `add_domain_member`, `remove_domain_member`) ships first. The two are independently mergeable per §10's note that the step order is recommendation, not constraint.

## Invariants checklist

- [x] No new domain imports into kernel crates
- [x] `governance:write` still in `ALLOWED_SCOPES`
- [x] No handler authorization requirement changed
- [x] No `MandateGate` introduced
- [x] No receipt schema change
- [x] No regulatory vocabulary drift (`compliance_linter.py` clean)
- [x] No production-readiness or live-federation claim
- [x] Adversarial-by-default preserved (same strings accepted)

Refs: #1868