### PR TITLE
fix(react-native): restore local validation against current SDK types

### DIFF
--- a/sdk/react-native/src/client.ts
+++ b/sdk/react-native/src/client.ts
@@ -186,7 +186,7 @@ export class ICNMobileClient extends ICNClient {
    * Basic network monitoring using periodic checks
    */
   private startBasicNetworkMonitoring(): void {
-    setInterval(async () => {
+    const intervalId = setInterval(async () => {
       try {
         const baseUrl = (this as unknown as { baseUrl: string }).baseUrl;
         const controller = new AbortController();
@@ -195,7 +195,7 @@ export class ICNMobileClient extends ICNClient {
         await fetch(`${baseUrl}/v1/health`, {
           signal: controller.signal,
         });
-        
+
         clearTimeout(timeout);
 
         if (this._networkState !== 'online') {
@@ -210,6 +210,11 @@ export class ICNMobileClient extends ICNClient {
         }
       }
     }, 30000); // Check every 30 seconds
+
+    // The heartbeat must not keep a host process alive on its own. `unref` exists
+    // on Node timers (so Jest/Node can exit cleanly); on React Native the timer id
+    // is a number and this optional call is a safe no-op.
+    (intervalId as { unref?: () => void }).unref?.();
   }
 
   /**
@@ -221,9 +226,9 @@ export class ICNMobileClient extends ICNClient {
     await this.queueManager.processQueue(async (op) => {
       switch (op.type) {
         case 'payment':
-          // Re-execute payment
+          // Re-execute settlement
           const paymentData = op.data as any;
-          await this.pay(paymentData.coopId, paymentData.request);
+          await this.settle(paymentData.coopId, paymentData.request);
           break;
         case 'vote':
           // Re-execute vote
@@ -1480,7 +1485,7 @@ export class ICNMobileClient extends ICNClient {
    * @param amendmentId - Amendment ID (hex)
    * @returns Vote record or null if not voted
    */
-  async getMyAmendmentVote(amendmentId: string): Promise<import('./constitutional-hooks').AmendmentVote> {
+  async getMyAmendmentVote(amendmentId: string): Promise<import('@icn/client').MyAmendmentVoteResponse> {
     const baseUrl = (this as unknown as { baseUrl: string }).baseUrl;
     const response = await fetch(`${baseUrl}/v1/constitutional/amendments/${amendmentId}/my-vote`, {
       method: 'GET',
@@ -1503,7 +1508,7 @@ export class ICNMobileClient extends ICNClient {
    * @param amendmentId - Amendment ID (hex)
    * @returns Voting results with counts and quorum status
    */
-  async getAmendmentResults(amendmentId: string): Promise<import('./constitutional-hooks').AmendmentResults> {
+  async getAmendmentResults(amendmentId: string): Promise<import('@icn/client').AmendmentVoteResults> {
     const baseUrl = (this as unknown as { baseUrl: string }).baseUrl;
     const response = await fetch(`${baseUrl}/v1/constitutional/amendments/${amendmentId}/results`, {
       method: 'GET',

--- a/sdk/react-native/src/client.ts
+++ b/sdk/react-native/src/client.ts
@@ -187,16 +187,17 @@ export class ICNMobileClient extends ICNClient {
    */
   private startBasicNetworkMonitoring(): void {
     const intervalId = setInterval(async () => {
-      try {
-        const baseUrl = (this as unknown as { baseUrl: string }).baseUrl;
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 5000);
+      const baseUrl = (this as unknown as { baseUrl: string }).baseUrl;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5000);
+      // Like the heartbeat interval, this abort timer must never keep a host
+      // process alive on its own; `unref` is a safe no-op on the RN numeric id.
+      (timeout as { unref?: () => void }).unref?.();
 
+      try {
         await fetch(`${baseUrl}/v1/health`, {
           signal: controller.signal,
         });
-
-        clearTimeout(timeout);
 
         if (this._networkState !== 'online') {
           this._networkState = 'online';
@@ -208,6 +209,10 @@ export class ICNMobileClient extends ICNClient {
           this._networkState = 'offline';
           this.notifyNetworkListeners();
         }
+      } finally {
+        // Always clear the abort timer, including on fetch errors, so a failed
+        // probe never leaves a 5s timer scheduled on every interval tick.
+        clearTimeout(timeout);
       }
     }, 30000); // Check every 30 seconds
 

--- a/sdk/react-native/src/constitutional-hooks.ts
+++ b/sdk/react-native/src/constitutional-hooks.ts
@@ -5,6 +5,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import type { MyAmendmentVoteResponse, AmendmentVoteResults } from '@icn/client';
 import { ICNMobileClient } from './client';
 import {
   Amendment,
@@ -766,7 +767,9 @@ export interface AmendmentResults {
  * ```
  */
 export function useAmendmentVoting(client: ICNMobileClient, amendmentId: string) {
-  const [myVote, setMyVote] = useState<AmendmentVote | null>(null);
+  // Holds either the fetched "my vote" status (getMyAmendmentVote) or the
+  // record returned when casting a vote (voteOnAmendment) — two distinct shapes.
+  const [myVote, setMyVote] = useState<MyAmendmentVoteResponse | AmendmentVote | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -846,7 +849,7 @@ export function useAmendmentVoting(client: ICNMobileClient, amendmentId: string)
  * ```
  */
 export function useAmendmentResults(client: ICNMobileClient, amendmentId: string) {
-  const [results, setResults] = useState<AmendmentResults | null>(null);
+  const [results, setResults] = useState<AmendmentVoteResults | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/sdk/react-native/src/constitutional-hooks.ts
+++ b/sdk/react-native/src/constitutional-hooks.ts
@@ -745,8 +745,10 @@ export interface AmendmentResults {
  * function AmendmentVoting({ amendmentId }: { amendmentId: string }) {
  *   const { vote, loading, myVote, error } = useAmendmentVoting(client, amendmentId);
  *
- *   if (myVote) {
- *     return <Text>You voted: {myVote.vote}</Text>;
+ *   // `myVote` is a union: the on-mount fetch returns a status object
+ *   // (`MyAmendmentVoteResponse`) whose `vote` field is the nested record.
+ *   if (myVote && 'has_voted' in myVote && myVote.has_voted) {
+ *     return <Text>You voted: {myVote.vote?.vote}</Text>;
  *   }
  *
  *   return (
@@ -839,9 +841,9 @@ export function useAmendmentVoting(client: ICNMobileClient, amendmentId: string)
  *       <Text>Status: {results.status}</Text>
  *       <Text>Approve: {results.approve_count}</Text>
  *       <Text>Reject: {results.reject_count}</Text>
- *       <Text>Quorum: {results.has_quorum ? 'Met' : 'Not Met'}</Text>
+ *       <Text>Quorum: {results.quorum_achieved ? 'Met' : 'Not Met'}</Text>
  *       <ProgressBar
- *         progress={results.total_votes / results.eligible_voters}
+ *         progress={results.approval_percentage / 100}
  *       />
  *     </View>
  *   );

--- a/sdk/react-native/src/constitutional-types.ts
+++ b/sdk/react-native/src/constitutional-types.ts
@@ -2,65 +2,74 @@
  * Constitutional Governance Types for ICN React Native SDK
  *
  * Types for amendments and appeals within the ICN commons.
+ *
+ * The canonical definitions live in `@icn/client` (the core TypeScript SDK).
+ * The React Native client extends `ICNClient`, so its overridden amendment /
+ * appeal methods must use the same types as the base class. We re-export the
+ * canonical types here so existing imports of `./constitutional-types` keep
+ * resolving to the single source of truth, and add the small set of
+ * RN-specific aliases/types that the core SDK does not expose.
  */
 
 // ============================================================================
-// Amendment Types
+// Canonical types (re-exported from the core SDK)
+// ============================================================================
+
+export type {
+  // Amendments
+  AmendmentType,
+  AmendmentScopeType,
+  AmendmentStatus,
+  ChangeTarget,
+  ChangeType,
+  AmendmentChange,
+  Amendment,
+  CreateAmendmentRequest,
+  AddAmendmentChangeRequest,
+  RatifyAmendmentRequest,
+  AmendmentListResponse,
+  // Appeals
+  AppealStatus,
+  AppealOutcome,
+  AppealTypeCategory,
+  AppealScopeType,
+  AppealGroundsType,
+  AppealRemedyType,
+  EvidenceType,
+  ResponseType,
+  AppealTypeRequest,
+  AppealGroundsRequest,
+  FileAppealRequest,
+  AddEvidenceRequest,
+  AddResponseRequest,
+  ResolveAppealRequest,
+  Appeal,
+  AppealListResponse,
+} from '@icn/client';
+
+import type {
+  AmendmentType,
+  AmendmentStatus,
+  AddAmendmentChangeRequest,
+  RatifyAmendmentRequest,
+} from '@icn/client';
+
+// ============================================================================
+// RN-specific aliases (core SDK uses longer canonical names)
+// ============================================================================
+
+/** Request to add a change to a draft amendment (alias of the canonical type) */
+export type AddChangeRequest = AddAmendmentChangeRequest;
+
+/** Request to ratify an amendment (alias of the canonical type) */
+export type RatifyRequest = RatifyAmendmentRequest;
+
+// ============================================================================
+// RN-specific types (not exposed by the core SDK)
 // ============================================================================
 
 /**
- * Amendment type
- */
-export type AmendmentType = 'charter' | 'constitutional' | 'policy' | 'economic' | 'governance';
-
-/**
- * Amendment scope type
- */
-export type AmendmentScopeType = 'jurisdiction' | 'federation' | 'network';
-
-/**
- * Amendment status
- */
-export type AmendmentStatus =
-  | 'draft'
-  | 'under_review'
-  | 'voting'
-  | 'ratifying'
-  | 'adopted'
-  | 'rejected'
-  | 'withdrawn';
-
-/**
- * Change target
- */
-export type ChangeTarget =
-  | 'governance_rules'
-  | 'membership_policy'
-  | 'economic_policy'
-  | 'dispute_policy'
-  | 'commons_rights'
-  | 'steward_requirements'
-  | 'network_parameters'
-  | string; // For custom targets
-
-/**
- * Change type
- */
-export type ChangeType = 'add' | 'modify' | 'remove' | 'replace';
-
-/**
- * Amendment change
- */
-export interface AmendmentChange {
-  target: ChangeTarget;
-  change_type: ChangeType;
-  description: string;
-  old_value?: string;
-  new_value: string;
-}
-
-/**
- * Amendment summary
+ * Amendment summary (lightweight list projection used by mobile screens)
  */
 export interface AmendmentSummary {
   id: string;
@@ -73,234 +82,14 @@ export interface AmendmentSummary {
 }
 
 /**
- * Amendment detail
+ * Raw amendment change as returned by the gateway, where `change_type` is an
+ * unvalidated string. Retained for backwards compatibility with mobile code
+ * that reads responses without narrowing to {@link ChangeType}.
  */
-export interface Amendment {
-  id: string;
-  amendment_type: string;
-  scope: string;
-  status: string;
-  title: string;
-  description: string;
-  proposer: string;
-  sponsors: string[];
-  changes: AmendmentChangeResponse[];
-  ratifications_count: number;
-  approvals_count: number;
-  created_at: number;
-  updated_at: number;
-}
-
 export interface AmendmentChangeResponse {
   target: string;
   change_type: string;
   description: string;
   old_value?: string;
   new_value: string;
-}
-
-/**
- * Create amendment request
- */
-export interface CreateAmendmentRequest {
-  amendment_type: AmendmentType;
-  scope_type: AmendmentScopeType;
-  scope_id?: string;
-  title: string;
-  description: string;
-  charter_id?: string;
-  changes: AmendmentChange[];
-}
-
-/**
- * Add change request
- */
-export interface AddChangeRequest {
-  target: ChangeTarget;
-  change_type: ChangeType;
-  description: string;
-  old_value?: string;
-  new_value: string;
-}
-
-/**
- * Ratify amendment request
- */
-export interface RatifyRequest {
-  ratifier_id: string;
-  ratifier_type: 'commons_holder' | 'jurisdiction' | 'federation';
-  approved: boolean;
-  comment?: string;
-  signature: string;
-}
-
-/**
- * Amendment list response
- */
-export interface AmendmentListResponse {
-  amendments: Amendment[];
-  count: number;
-}
-
-// ============================================================================
-// Appeal Types
-// ============================================================================
-
-/**
- * Appeal status
- */
-export type AppealStatus =
-  | 'filed'
-  | 'under_review'
-  | 'awaiting_response'
-  | 'in_hearing'
-  | 'resolved'
-  | 'withdrawn';
-
-/**
- * Appeal outcome
- */
-export type AppealOutcome = 'upheld' | 'denied' | 'partially_upheld' | 'remanded';
-
-/**
- * Appeal type category
- */
-export type AppealTypeCategory =
-  | 'revocation'
-  | 'suspension'
-  | 'governance_decision'
-  | 'dispute_resolution'
-  | 'membership_denial'
-  | 'steward_action'
-  | 'other';
-
-/**
- * Appeal scope type
- */
-export type AppealScopeType = 'jurisdiction' | 'federation' | 'network';
-
-/**
- * Appeal grounds type
- */
-export type AppealGroundsType =
-  | 'procedural_error'
-  | 'new_evidence'
-  | 'exceeded_authority'
-  | 'rights_violation'
-  | 'factual_error'
-  | 'bias'
-  | 'disproportionate_penalty'
-  | 'other';
-
-/**
- * Appeal remedy type
- */
-export type AppealRemedyType = 'reverse' | 'reinstate' | 'modify' | 'compensation' | 'custom' | 'none';
-
-/**
- * Evidence type
- */
-export type EvidenceType =
-  | 'document'
-  | 'transaction'
-  | 'communication'
-  | 'witness_statement'
-  | 'expert_opinion'
-  | 'technical'
-  | 'other';
-
-/**
- * Response type
- */
-export type ResponseType = 'initial_response' | 'reply' | 'comment' | 'question' | 'clarification';
-
-/**
- * Appeal type request
- */
-export interface AppealTypeRequest {
-  category: AppealTypeCategory;
-  revocation_id?: string;
-  target_id?: string;
-  proposal_id?: string;
-  dispute_id?: string;
-  steward_did?: string;
-  details?: string;
-}
-
-/**
- * Appeal grounds request
- */
-export interface AppealGroundsRequest {
-  ground_type: AppealGroundsType;
-  description: string;
-}
-
-/**
- * File appeal request
- */
-export interface FileAppealRequest {
-  appeal_type: AppealTypeRequest;
-  scope_type: AppealScopeType;
-  scope_id?: string;
-  grounds: AppealGroundsRequest[];
-  statement: string;
-  requested_remedy: AppealRemedyType;
-  remedy_details?: string;
-  respondent_did?: string;
-  original_decision_ref?: string;
-}
-
-/**
- * Add evidence request
- */
-export interface AddEvidenceRequest {
-  evidence_type: EvidenceType;
-  description: string;
-  content_hash?: string;
-  uri?: string;
-}
-
-/**
- * Add response request
- */
-export interface AddResponseRequest {
-  response_type: ResponseType;
-  content: string;
-}
-
-/**
- * Resolve appeal request
- */
-export interface ResolveAppealRequest {
-  outcome: AppealOutcome;
-  reason: string;
-  remedy?: AppealRemedyType;
-  remedy_details?: string;
-}
-
-/**
- * Appeal summary
- */
-export interface Appeal {
-  id: string;
-  appeal_type: string;
-  scope: string;
-  status: string;
-  appellant: string;
-  respondent?: string;
-  grounds: string[];
-  statement: string;
-  requested_remedy: string;
-  evidence_count: number;
-  responses_count: number;
-  created_at: number;
-  updated_at: number;
-}
-
-/**
- * Appeal list response
- */
-export interface AppealListResponse {
-  appeals: Appeal[];
-  count: number;
 }

--- a/sdk/react-native/src/hooks.ts
+++ b/sdk/react-native/src/hooks.ts
@@ -9,7 +9,7 @@ import { ICNMobileClient } from './client';
 import {
   AuthState,
   WebSocketState,
-  Balance,
+  Position,
   WsMessage,
   Cooperative,
   Member,
@@ -187,7 +187,7 @@ export function useEvent(
  *
  *   return (
  *     <View>
- *       <Text>Balance: {balance?.balance} hours</Text>
+ *       <Text>Balance: {balance?.position} {balance?.unit}</Text>
  *       <Button onPress={refresh} title="Refresh" />
  *     </View>
  *   );
@@ -195,7 +195,7 @@ export function useEvent(
  * ```
  */
 export function useBalance(client: ICNMobileClient, coopId: string, did: string) {
-  const [balance, setBalance] = useState<Balance | null>(null);
+  const [balance, setBalance] = useState<Position | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -203,7 +203,7 @@ export function useBalance(client: ICNMobileClient, coopId: string, did: string)
     setIsLoading(true);
     setError(null);
     try {
-      const result = await client.getBalance(coopId, did);
+      const result = await client.getPosition(coopId, did);
       setBalance(result);
     } catch (err) {
       setError((err as Error).message);
@@ -529,15 +529,15 @@ export function usePayment(client: ICNMobileClient, coopId: string, defaultCurre
         if (!senderDid) {
           throw new Error('Not authenticated - no DID available');
         }
-        // Build full payment request with required fields
+        // Build full settlement request with required fields
         const fullRequest = {
           from: senderDid,
           to: request.to,
           amount: request.amount,
-          currency: request.currency || defaultCurrency,
+          unit: request.currency || defaultCurrency,
           memo: request.memo,
         };
-        const result = await client.pay(coopId, fullRequest);
+        const result = await client.settle(coopId, fullRequest);
         return result;
       } catch (err) {
         setError((err as Error).message);

--- a/sdk/react-native/src/index.ts
+++ b/sdk/react-native/src/index.ts
@@ -165,7 +165,14 @@ export {
 } from './steward-hooks';
 
 // Membership Types
-export * from './membership-types';
+// Canonical membership types flow through `./types` (re-exported from @icn/client);
+// only re-export the RN-specific additions here to avoid duplicate-export ambiguity.
+export type {
+  BanMemberRequest,
+  MemberResponse,
+  RevokeMembershipRequest,
+  RoleRequest,
+} from './membership-types';
 
 // Membership React Hooks
 export {
@@ -177,7 +184,9 @@ export {
 } from './membership-hooks';
 
 // Charter Types
-export * from './charter-types';
+// Canonical charter types flow through `./types` (re-exported from @icn/client);
+// only re-export the RN-specific additions here to avoid duplicate-export ambiguity.
+export type { UpdateCharterStatusRequest } from './charter-types';
 
 // Charter React Hooks
 export {
@@ -189,7 +198,14 @@ export {
 } from './charter-hooks';
 
 // Constitutional Governance Types (Amendments & Appeals)
-export * from './constitutional-types';
+// Canonical amendment/appeal types flow through `./types` (re-exported from
+// @icn/client); only re-export the RN-specific aliases/additions here.
+export type {
+  AddChangeRequest,
+  RatifyRequest,
+  AmendmentSummary,
+  AmendmentChangeResponse,
+} from './constitutional-types';
 
 // Constitutional Governance React Hooks
 export {

--- a/sdk/react-native/tsconfig.json
+++ b/sdk/react-native/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2020", "DOM"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

- Restores local `sdk/react-native` build/test validation against the current `@icn/client` (core TS SDK) type surfaces.
- Addresses TypeScript 6 validation drift without broad dependency cleanup.
- Aligns the React Native client/hooks/tests with current public API/types (payment→settlement migration + amendment/charter/membership type consolidation into the core SDK).
- Does not touch runtime/security/governance surfaces outside `sdk/react-native`.

## What changed (and why)

The core TS SDK (`@icn/client`, symlinked from `sdk/typescript`) drifted underneath the RN SDK: `pay`/`getBalance`/`Balance` were removed (→ `settle`/`getPosition`/`Position`), and amendment/charter/membership/appeal types were consolidated into the core SDK. RN's local duplicates then collided and its overridden methods no longer matched the base class. TypeScript 6 also turned `moduleResolution=node10` into a hard error (TS5107).

| File | Change |
|------|--------|
| `tsconfig.json` | Add `ignoreDeprecations: "6.0"` — a **compatibility bridge** for the TS6 `moduleResolution=node10` deprecation (TS5107). Preserves existing resolution behavior; not a modernization. |
| `src/constitutional-types.ts` | Re-export canonical amendment/appeal types from `@icn/client` (single source of truth); keep only RN-specific additions (`AmendmentSummary`, `AmendmentChangeResponse`) and aliases (`AddChangeRequest`, `RatifyRequest`). Fixes 10× TS2416 override conflicts. |
| `src/client.ts` | Align two overridden methods to canonical return types (`MyAmendmentVoteResponse`, `AmendmentVoteResults`); replace removed `pay` with `settle` in offline-queue replay; `unref()` the network-monitor heartbeat. |
| `src/hooks.ts` | `Balance`→`Position`, `getBalance`→`getPosition`, and `currency`/`pay`→`unit`/`settle` (`SettlementRequest`). |
| `src/constitutional-hooks.ts` | Widen amendment-vote/result hook state to the canonical response types. |
| `src/index.ts` | Re-export RN-specific type additions explicitly instead of `export *`, removing duplicate-export ambiguity (42× TS2308) with `@icn/client` (which flows through `./types`). |

### Open-handle fix
Once `client.test.ts` compiles again it actually runs and constructs `ICNMobileClient` instances, each of which started a 30s `setInterval` heartbeat that was never `unref`'d — so Jest's event loop never drained and `npm test` hung indefinitely (Phase 3B never hit this because the suite failed to compile and never ran). The heartbeat is now `unref()`'d so Node/Jest exit cleanly; on React Native the timer id is a number and the optional call is a safe no-op. No assertions weakened, no `--forceExit` mask.

## Validation (local, from `sdk/react-native`)

| Command | Result |
|---------|--------|
| `npm ci` | ✅ pass (574 packages) |
| `npm audit --audit-level=critical` | ✅ pass (0 critical) |
| `npm run build` | ✅ pass (exit 0; was 56 TS errors) |
| `npm test -- --runInBand` | ✅ pass — 7 suites, 202 tests (was 1 failed suite / 6 passed / 181 tests) |
| `git diff --check` | ✅ clean |

## Audit readback

`npm audit --audit-level=high` still reports the same non-target alerts (unchanged — no dependency/lockfile changes here), **intentionally left for later**:

- `@babel/plugin-transform-modules-systemjs` — high — GHSA-fv7c-fp4j-7gwp
- `picomatch` — high — GHSA-3v7f-55p6-f55p, GHSA-c2c7-rcm5-vvqj
- `diff` — low — GHSA-73rr-hh4g-fpgx

## Scope notes

- This PR does **not** claim to reduce the Dependabot alert count.
- This PR does **not** start the broad vulnerability burn-down.
- No dependency or lockfile changes (`package.json` / `package-lock.json` untouched).
- PR #1907 (dev-portal) remains review-only and untouched.
- All changes are confined to `sdk/react-native/`.

## Risk

Low. Type-level alignment + a behavior-preserving timer `unref()`. Runtime request/response shapes are unchanged (the gateway already returns the canonical settlement/position/amendment shapes). No CI workflow currently exercises `sdk/react-native`, so this is local-validation hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)