### PR TITLE
fix(react-native): replace TypeScript moduleResolution deprecation bridge

### DIFF
--- a/sdk/react-native/tsconfig.json
+++ b/sdk/react-native/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

- Replaces the temporary TypeScript 6 deprecation bridge (`ignoreDeprecations: "6.0"`) left in `sdk/react-native/tsconfig.json` by #1909.
- Switches `moduleResolution` from the deprecated `"node"` (TS6 normalizes it to `node10`, removed in TS7) to the supported `"bundler"` mode.
- Keeps `module: "ESNext"`, so the emitted module format is unchanged (ESM, not CommonJS).
- Scoped to React Native SDK TypeScript configuration. This is a moduleResolution follow-up, **not** a dependency or vulnerability burn-down.

## Why `bundler`

Reproduced the bridge and tested each candidate:

| Candidate | Result |
|-----------|--------|
| `node` (current) with no `ignoreDeprecations` | `error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0` |
| `node10` | Same TS5107 — `node`/`node10` are aliases; both removed in TS7 |
| `nodenext` / `node16` | Builds, but flips emit to **CommonJS** (no `"type":"module"` in package.json) — changes module semantics |
| **`bundler`** ✅ | Clean build, ESM emit preserved, models how Metro resolves a RN library, `@icn/client` (`dist` `main`/`types`) resolves correctly |

`bundler` is the smallest behavior-preserving change that removes the deprecation without any `ignoreDeprecations` escape hatch.

## Validation

From `sdk/react-native` (TypeScript 6.0.3, node_modules already present):

- `npm run build` → exit 0
- `npm test -- --runInBand` → 7 suites / 202 tests passed, jest exit 0
- `git diff --check` → clean
- Emit verified ESM (`export { ... } from './client'`, no `"use strict"` CJS header)
- 27 `.d.ts` declaration files emitted

## Scope Notes

- No Rust/governance/runtime/dev-portal changes
- No dependency or lockfile changes (single file: `sdk/react-native/tsconfig.json`, net 1 insertion / 2 deletions)
- No broad dependency cleanup; no Dependabot reduction claimed
- PR #1907 remains untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)