### PR TITLE
test(governance): clean up TrustThreshold follow-up assertions and docs

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -53,11 +53,14 @@ use super::handlers;
 /// the bootstrap-vs-production distinction legible at startup. The
 /// `TrustThreshold` direct-membership-mutation fail-open that issue #1870
 /// tracked is now closed in the add/remove member handlers (see
-/// `handlers::resolve_caller_membership`): `TrustThreshold` callers are
-/// resolved through `membership_resolver`, unresolved standing is rejected
-/// rather than treated as standing, and an unconfigured resolver rejects
-/// outright in `Production`. Other production hardening (full checker
-/// wiring, operational posture) still applies before claiming readiness.
+/// `handlers::resolve_caller_membership`): when a `membership_resolver` is
+/// configured, `TrustThreshold` callers are resolved through it and
+/// unresolved standing is rejected rather than treated as standing; an
+/// unconfigured resolver rejects outright in `Production`, while
+/// `Bootstrap`/`Test` posture without a resolver stays permissive
+/// (preserving dev/devnet behavior). Other production hardening (full
+/// checker wiring, operational posture) still applies before claiming
+/// readiness.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum GovernanceContextBuildMode {
     /// Permissive mode for dev, devnet, and bootstrap contexts.

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -6468,10 +6468,11 @@ mod tests {
             !body_str.contains("unresolved_standing"),
             "confirmed standing must not be reported as unresolved; got: {body_str}"
         );
-        assert_eq!(
-            status, 500,
-            "request must reach the manager (which rejects TrustThreshold mutation), proving \
-             authorization was granted; got body: {body_str}"
+        assert!(
+            body_str.contains("trust-based membership domain"),
+            "request must reach the manager's TrustThreshold safety net (proving the membership \
+             gate granted authorization), not be blocked at the gate; got status {status}, \
+             body: {body_str}"
         );
     }
 
@@ -6660,10 +6661,10 @@ mod tests {
             "Bootstrap posture without a resolver must remain permissive (no behavior change); \
              got body: {body_str}"
         );
-        assert_eq!(
-            status, 500,
+        assert!(
+            body_str.contains("trust-based membership domain"),
             "permissive gate must let the request reach the manager's TrustThreshold safety net; \
-             got body: {body_str}"
+             got status {status}, body: {body_str}"
         );
     }
 


### PR DESCRIPTION
## Summary

Smallest-safe follow-up cleanup after PR #1911 / PR #1916. Test + rustdoc only — no behavior change.

**#1914 — harden TrustThreshold membership-mutation authz assertions** (`http/handlers.rs`)
- The Copilot review on #1911 flagged that the "allowed" membership-mutation test coupled its
  authorization assertion to an internal `500`. The `500` is an orthogonal, pre-existing manager
  safety net (the in-memory `GovernanceManager` rejects direct member-list mutation of a
  `TrustThreshold` domain), not the #1870 authz path — so a future remap of that rejection to a
  more appropriate status would break the authz test for the wrong reason.
- Both `status == 500`-coupled tests (`add_member_trust_threshold_resolved_standing_allows` and its
  Bootstrap permissive twin `add_member_trust_threshold_bootstrap_without_resolver_still_permissive`)
  now keep the direct `assert_ne!(status, 403, …)` authz assertion and replace the brittle
  `assert_eq!(status, 500, …)` with the durable manager-path marker
  `body.contains("trust-based membership domain")` (the manager's stable rejection message, surfaced
  verbatim by `ApiError::Internal`). Same brittle pattern, same module, same authz intent — fixed
  together.

**#1915 — clarify TrustThreshold rejection wording** (`http/configure.rs`)
- The `GovernanceContextBuildMode` rustdoc stated unresolved standing is "rejected rather than
  treated as standing" unconditionally, which overstated behavior: in `Bootstrap`/`Test` posture
  with no resolver the caller is still admitted (preserved dev/devnet behavior).
- Tightened to: rejection occurs when a `membership_resolver` is configured and fails to resolve
  standing, or in `Production` posture with no resolver; `Bootstrap`/`Test` without a resolver stays
  permissive. Matches the actual three-way logic in `resolve_caller_membership`.

## Validation

Run from `icn/` (Rust workspace root); drift-check from monorepo root.

| Check | Command | Result |
|-------|---------|--------|
| fmt | `cargo fmt -p icn-governance-actor --check` | pass (exit 0) |
| clippy | `cargo clippy -p icn-governance-actor --all-targets -- -D warnings` | pass (no warnings) |
| unit tests | `cargo test -p icn-governance-actor --lib` | 246 passed, 0 failed |
| TrustThreshold suite | `cargo test -p icn-governance-actor --lib trust_threshold` | 13 passed, 0 failed |
| drift | `bash ops/scripts/drift-check.sh` | PASS (0 errors, 0 warnings) |
| whitespace | `git diff --check` | clean |

## Scope notes

- Test + rustdoc cleanup only; **no behavior change**.
- No kernel-side change.
- No `MembershipSource` enum change.
- No #1868 governance-scope migration.
- No dependency or lockfile changes.
- PR #1907 untouched.
- Launchpad untouched.

Closes #1914
Closes #1915

🤖 Generated with [Claude Code](https://claude.com/claude-code)