### PR TITLE
feat(governance): migrate charter family to governance:charter:write (accepted-also fallback) (#1868 step 3)

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -15,7 +15,7 @@ use icn_governance::{
     ProposalPayload, ProposalScope, StructureId, StructureKind, StructureStatus, VoteChoice,
 };
 use icn_http_kit::{
-    auth::{require_scope, BasicClaims},
+    auth::{require_any_scope, require_scope, BasicClaims},
     error::ApiError,
     pagination::{ListPagination, ListQuery, ListResponse},
 };
@@ -447,7 +447,12 @@ pub async fn create_domain<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     req: web::Json<CreateDomainRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    // #1868 step 3: charter-class capability with accepted-also fallback to the
+    // legacy broad `governance:write` until that scope is retired.
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:charter:write", "governance:write"],
+    )?;
     let creator_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     val::validate_domain_id(&req.id)?;
@@ -610,7 +615,12 @@ pub async fn add_domain_member<E: GovernanceEventEmitter + Clone + 'static>(
     domain_id: web::Path<String>,
     body: web::Json<AddDomainMemberRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    // #1868 step 3: charter-class capability with accepted-also fallback to the
+    // legacy broad `governance:write` until that scope is retired.
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:charter:write", "governance:write"],
+    )?;
     let caller_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let domain_id_str = domain_id.into_inner();
@@ -651,7 +661,12 @@ pub async fn remove_domain_member<E: GovernanceEventEmitter + Clone + 'static>(
     domain_id: web::Path<String>,
     body: web::Json<RemoveDomainMemberRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    // #1868 step 3: charter-class capability with accepted-also fallback to the
+    // legacy broad `governance:write` until that scope is retired.
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:charter:write", "governance:write"],
+    )?;
     let caller_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let domain_id_str = domain_id.into_inner();
@@ -747,7 +762,9 @@ pub async fn activate_charter<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     req: web::Json<ActivateCharterRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    // #1868 step 3: charter-class capability with accepted-also fallback to the
+    // legacy broad `governance:write` until that scope is retired.
+    require_any_scope::<BasicClaims>(&http_req, &["governance:charter:write", "governance:write"])?;
 
     val::validate_charter_id(&req.charter_id)?;
     val::validate_charter_yaml(&req.charter_yaml)?;

--- a/icn/apps/governance/tests/charter_scope_migration.rs
+++ b/icn/apps/governance/tests/charter_scope_migration.rs
@@ -1,0 +1,224 @@
+//! Charter handler-family capability migration (#1868 step 3).
+//!
+//! Proves the four charter-family mutation handlers (`create_domain`,
+//! `add_domain_member`, `remove_domain_member`, `activate_charter`) accept the
+//! narrowed `governance:charter:write` class scope while still accepting the
+//! legacy broad `governance:write` scope as an accepted-also fallback, and
+//! reject an unrelated scope.
+//!
+//! Scope of the proof:
+//! - `governance:charter:write` is accepted (the migration's distinguishing
+//!   effect — before the migration this class scope would have been rejected by
+//!   the broad-only gate).
+//! - legacy `governance:write` is still accepted (no token-compat regression).
+//! - an unrelated scope (`governance:read`) is rejected with 403.
+//!
+//! The scope-matching logic itself is unit-tested in
+//! `icn-http-kit::auth` (`require_any_scope_*`); this file pins the handler
+//! wiring. It does NOT exercise mandate gating (unbuilt), receipt-body scope
+//! recording (a later slice), or charter bootstrap labeling (#1869).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{body::to_bytes, dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use serde_json::json;
+
+/// Minimal valid CCL document — mirrors `charter_activation.rs`. With the
+/// `on_charter_accepted` hook unwired (see `make_ctx`), a scope-accepted
+/// activation proceeds past the gate and fails at the unwired hook (500),
+/// which is a non-auth status and therefore evidence the gate let it through.
+const VALID_CHARTER_YAML: &str = r#"
+schema_version: v0
+entity:
+  name: "Test Cooperative"
+  type: cooperative
+"#;
+
+const CHARTER_CLASS: &str = "governance:charter:write";
+const LEGACY_BROAD: &str = "governance:write";
+const UNRELATED: &str = "governance:read";
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
+    }
+}
+
+/// Build a test app injecting the given caller + scope on every request.
+macro_rules! charter_app {
+    ($ctx:expr, $caller_did:expr, $scope:expr) => {{
+        let scope: &'static str = $scope;
+        let caller = $caller_did.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some(scope.to_string()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+fn create_domain_body(caller: &Did, domain_id: &str) -> serde_json::Value {
+    json!({
+        "id": domain_id,
+        "name": "Charter Scope Migration Test",
+        "profile": "cooperative_default",
+        "quorum_percent": 50,
+        "approval_percent": 50,
+        "voting_period_days": 7,
+        "members": [caller.to_string()],
+    })
+}
+
+#[actix_web::test]
+async fn create_domain_accepts_charter_class_scope() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let app = charter_app!(ctx, &caller, CHARTER_CLASS);
+
+    let req = test::TestRequest::post()
+        .uri("/domains")
+        .set_json(create_domain_body(&caller, "csm-charter-class"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "governance:charter:write must be accepted on create_domain, got {status}, body: {}",
+        String::from_utf8_lossy(&bytes)
+    );
+}
+
+#[actix_web::test]
+async fn create_domain_accepts_legacy_broad_scope() {
+    // Accepted-also fallback: tokens minted before the migration still work.
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let app = charter_app!(ctx, &caller, LEGACY_BROAD);
+
+    let req = test::TestRequest::post()
+        .uri("/domains")
+        .set_json(create_domain_body(&caller, "csm-legacy-broad"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "legacy governance:write must remain accepted on create_domain, got {status}, body: {}",
+        String::from_utf8_lossy(&bytes)
+    );
+}
+
+#[actix_web::test]
+async fn create_domain_rejects_unrelated_scope() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let app = charter_app!(ctx, &caller, UNRELATED);
+
+    let req = test::TestRequest::post()
+        .uri("/domains")
+        .set_json(create_domain_body(&caller, "csm-unrelated"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "an unrelated scope (governance:read) must be rejected with 403 on create_domain"
+    );
+}
+
+/// Each of the four charter-family handlers must accept the class scope. A
+/// scope rejection is 401/403; any other status means the gate let the request
+/// through to handler logic. `add`/`remove` target a non-existent domain so the
+/// post-gate path is a 404 lookup miss (not the membership 403), and
+/// `activate_charter` hits the unwired hook (500) — both non-auth statuses.
+#[actix_web::test]
+async fn all_charter_family_handlers_accept_charter_class_scope() {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let member = fresh_did();
+    let app = charter_app!(ctx, &caller, CHARTER_CLASS);
+
+    let assert_gate_passed = |status: StatusCode, route: &str| {
+        assert!(
+            status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
+            "governance:charter:write must pass the gate on {route}, got auth-rejection {status}"
+        );
+    };
+
+    // create_domain
+    let req = test::TestRequest::post()
+        .uri("/domains")
+        .set_json(create_domain_body(&caller, "csm-all-create"))
+        .to_request();
+    assert_gate_passed(
+        test::call_service(&app, req).await.status(),
+        "POST /domains",
+    );
+
+    // add_domain_member (missing domain → 404 after gate)
+    let req = test::TestRequest::post()
+        .uri("/domains/csm-missing/members")
+        .set_json(json!({ "did": member.to_string() }))
+        .to_request();
+    assert_gate_passed(
+        test::call_service(&app, req).await.status(),
+        "POST /domains/{id}/members",
+    );
+
+    // remove_domain_member (missing domain → 404 after gate)
+    let req = test::TestRequest::delete()
+        .uri("/domains/csm-missing/members")
+        .set_json(json!({ "did": member.to_string() }))
+        .to_request();
+    assert_gate_passed(
+        test::call_service(&app, req).await.status(),
+        "DELETE /domains/{id}/members",
+    );
+
+    // activate_charter (unwired hook → 500 after gate)
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(json!({ "charter_id": "csm-charter", "charter_yaml": VALID_CHARTER_YAML }))
+        .to_request();
+    assert_gate_passed(
+        test::call_service(&app, req).await.status(),
+        "POST /charters",
+    );
+}

--- a/icn/apps/governance/tests/charter_scope_migration.rs
+++ b/icn/apps/governance/tests/charter_scope_migration.rs
@@ -163,11 +163,17 @@ async fn create_domain_rejects_unrelated_scope() {
     );
 }
 
-/// Each of the four charter-family handlers must accept the class scope. A
-/// scope rejection is 401/403; any other status means the gate let the request
-/// through to handler logic. `add`/`remove` target a non-existent domain so the
-/// post-gate path is a 404 lookup miss (not the membership 403), and
-/// `activate_charter` hits the unwired hook (500) — both non-auth statuses.
+/// Each of the four charter-family handlers must accept the class scope and
+/// reach handler logic. Asserting the *specific* post-gate status and body
+/// (not merely "not 401/403") is deliberate: a router-level 404 from a
+/// mis-registered route would also be "not 401/403" and would falsely pass.
+/// The expected post-gate outcomes are:
+/// - `create_domain` → 201 (valid body, domain created).
+/// - `add`/`remove` member → 404 with the handler's "Domain not found" body
+///   (targets a non-existent domain, so the handler's own lookup miss — not the
+///   later membership 403, and not a router 404 which carries no such body).
+/// - `activate_charter` → 500 with the handler's "hook is not wired" body
+///   (the unwired `on_charter_accepted` in `make_ctx`).
 #[actix_web::test]
 async fn all_charter_family_handlers_accept_charter_class_scope() {
     let ctx = make_ctx();
@@ -175,50 +181,65 @@ async fn all_charter_family_handlers_accept_charter_class_scope() {
     let member = fresh_did();
     let app = charter_app!(ctx, &caller, CHARTER_CLASS);
 
-    let assert_gate_passed = |status: StatusCode, route: &str| {
-        assert!(
-            status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
-            "governance:charter:write must pass the gate on {route}, got auth-rejection {status}"
-        );
-    };
-
-    // create_domain
+    // create_domain → 201 Created (gate passed, handler ran to completion).
     let req = test::TestRequest::post()
         .uri("/domains")
         .set_json(create_domain_body(&caller, "csm-all-create"))
         .to_request();
-    assert_gate_passed(
-        test::call_service(&app, req).await.status(),
-        "POST /domains",
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "POST /domains under governance:charter:write must reach the handler and create the domain"
     );
 
-    // add_domain_member (missing domain → 404 after gate)
+    // add_domain_member → 404 with the handler's own "Domain not found" body.
     let req = test::TestRequest::post()
         .uri("/domains/csm-missing/members")
         .set_json(json!({ "did": member.to_string() }))
         .to_request();
-    assert_gate_passed(
-        test::call_service(&app, req).await.status(),
-        "POST /domains/{id}/members",
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "POST /members status");
+    let body = to_bytes(resp.into_body()).await.unwrap();
+    assert!(
+        String::from_utf8_lossy(&body).contains("Domain not found"),
+        "POST /members must reach the handler's domain-lookup miss (not a router 404), body: {}",
+        String::from_utf8_lossy(&body)
     );
 
-    // remove_domain_member (missing domain → 404 after gate)
+    // remove_domain_member → 404 with the handler's own "Domain not found" body.
     let req = test::TestRequest::delete()
         .uri("/domains/csm-missing/members")
         .set_json(json!({ "did": member.to_string() }))
         .to_request();
-    assert_gate_passed(
-        test::call_service(&app, req).await.status(),
-        "DELETE /domains/{id}/members",
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "DELETE /members status"
+    );
+    let body = to_bytes(resp.into_body()).await.unwrap();
+    assert!(
+        String::from_utf8_lossy(&body).contains("Domain not found"),
+        "DELETE /members must reach the handler's domain-lookup miss (not a router 404), body: {}",
+        String::from_utf8_lossy(&body)
     );
 
-    // activate_charter (unwired hook → 500 after gate)
+    // activate_charter → 500 with the handler's own "hook is not wired" body.
     let req = test::TestRequest::post()
         .uri("/charters")
         .set_json(json!({ "charter_id": "csm-charter", "charter_yaml": VALID_CHARTER_YAML }))
         .to_request();
-    assert_gate_passed(
-        test::call_service(&app, req).await.status(),
-        "POST /charters",
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "POST /charters status"
+    );
+    let body = to_bytes(resp.into_body()).await.unwrap();
+    assert!(
+        String::from_utf8_lossy(&body).contains("hook is not wired"),
+        "POST /charters must reach the handler's unwired-hook path (not a router 404), body: {}",
+        String::from_utf8_lossy(&body)
     );
 }

--- a/icn/crates/icn-http-kit/src/auth.rs
+++ b/icn/crates/icn-http-kit/src/auth.rs
@@ -70,22 +70,34 @@ pub fn require_scope<C: ClaimsLike>(
 /// matched with the same rule as [`require_scope`] (exact or sub-scope).
 ///
 /// Returns the claims on the first candidate that matches. If none match, the
-/// `Forbidden` error names the first (preferred) entry in `required_scopes`.
+/// rejection mirrors [`require_scope`] applied to the first (preferred) entry —
+/// distinguishing "no scope present" from "not in granted scopes". Called with
+/// an empty `required_scopes` is a programmer error and returns
+/// `ApiError::Internal`.
 pub fn require_any_scope<C: ClaimsLike>(
     req: &HttpRequest,
     required_scopes: &[&str],
 ) -> Result<C, ApiError> {
+    let Some((&preferred, fallbacks)) = required_scopes.split_first() else {
+        return Err(ApiError::Internal(
+            "require_any_scope called with no candidate scopes".to_string(),
+        ));
+    };
     let claims = get_claims::<C>(req).ok_or(ApiError::Unauthenticated)?;
-    if required_scopes
+
+    // Accept on the first matching fallback candidate.
+    if fallbacks
         .iter()
         .any(|scope| check_scope(&claims, scope).is_ok())
     {
         return Ok(claims);
     }
-    let preferred = required_scopes.first().copied().unwrap_or("");
-    Err(ApiError::Forbidden(format!(
-        "required scope '{preferred}' not in granted scopes"
-    )))
+    // No fallback matched — defer to the preferred scope's own check so the
+    // rejection mirrors `require_scope` exactly (preserving the "no scope
+    // present" vs "not in granted scopes" distinction) and names the
+    // preferred (narrowed) scope.
+    check_scope(&claims, preferred)?;
+    Ok(claims)
 }
 
 /// Centralized scope checking. Split and normalize once, not in every handler.
@@ -153,7 +165,25 @@ mod tests {
     fn require_any_scope_rejects_when_no_scope_present() {
         let req = req_with_scope(None);
         let err = require_any_scope::<BasicClaims>(&req, &[CHARTER, BROAD]).unwrap_err();
-        assert!(matches!(err, ApiError::Forbidden(_)));
+        // Mirrors `require_scope`: distinguishes "no scope present" from the
+        // ordinary "not in granted scopes" rejection, naming the preferred scope.
+        match err {
+            ApiError::Forbidden(msg) => {
+                assert!(
+                    msg.contains("no scope present") && msg.contains(CHARTER),
+                    "expected a 'no scope present' rejection naming {CHARTER}, got: {msg}"
+                );
+            }
+            other => panic!("expected Forbidden, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn require_any_scope_empty_candidates_is_internal_error() {
+        // Empty candidate list is a programmer error, not an auth rejection.
+        let req = req_with_scope(Some(CHARTER));
+        let err = require_any_scope::<BasicClaims>(&req, &[]).unwrap_err();
+        assert!(matches!(err, ApiError::Internal(_)));
     }
 
     #[test]

--- a/icn/crates/icn-http-kit/src/auth.rs
+++ b/icn/crates/icn-http-kit/src/auth.rs
@@ -60,6 +60,34 @@ pub fn require_scope<C: ClaimsLike>(
     Ok(claims)
 }
 
+/// Require that the request carries valid claims satisfying **at least one** of
+/// `required_scopes`.
+///
+/// This supports capability-decomposition migrations: a handler can require a
+/// narrowed class scope (e.g. `"governance:charter:write"`) while still
+/// accepting a legacy broad scope (e.g. `"governance:write"`) as an
+/// accepted-also fallback until the broad scope is retired. Each candidate is
+/// matched with the same rule as [`require_scope`] (exact or sub-scope).
+///
+/// Returns the claims on the first candidate that matches. If none match, the
+/// `Forbidden` error names the first (preferred) entry in `required_scopes`.
+pub fn require_any_scope<C: ClaimsLike>(
+    req: &HttpRequest,
+    required_scopes: &[&str],
+) -> Result<C, ApiError> {
+    let claims = get_claims::<C>(req).ok_or(ApiError::Unauthenticated)?;
+    if required_scopes
+        .iter()
+        .any(|scope| check_scope(&claims, scope).is_ok())
+    {
+        return Ok(claims);
+    }
+    let preferred = required_scopes.first().copied().unwrap_or("");
+    Err(ApiError::Forbidden(format!(
+        "required scope '{preferred}' not in granted scopes"
+    )))
+}
+
 /// Centralized scope checking. Split and normalize once, not in every handler.
 fn check_scope<C: ClaimsLike>(claims: &C, required: &str) -> Result<(), ApiError> {
     let Some(raw) = claims.raw_scope() else {
@@ -79,5 +107,66 @@ fn check_scope<C: ClaimsLike>(claims: &C, required: &str) -> Result<(), ApiError
         Err(ApiError::Forbidden(format!(
             "required scope '{required}' not in granted scopes"
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use actix_web::test::TestRequest;
+
+    const CHARTER: &str = "governance:charter:write";
+    const BROAD: &str = "governance:write";
+
+    fn req_with_scope(scope: Option<&str>) -> HttpRequest {
+        let req = TestRequest::default().to_http_request();
+        req.extensions_mut().insert(BasicClaims {
+            sub: "did:icn:test".to_string(),
+            scope: scope.map(str::to_string),
+        });
+        req
+    }
+
+    #[test]
+    fn require_any_scope_accepts_class_scope() {
+        let req = req_with_scope(Some(CHARTER));
+        assert!(require_any_scope::<BasicClaims>(&req, &[CHARTER, BROAD]).is_ok());
+    }
+
+    #[test]
+    fn require_any_scope_accepts_legacy_broad_scope() {
+        // Accepted-also fallback: tokens minted before the migration still work.
+        let req = req_with_scope(Some(BROAD));
+        assert!(require_any_scope::<BasicClaims>(&req, &[CHARTER, BROAD]).is_ok());
+    }
+
+    #[test]
+    fn require_any_scope_rejects_unrelated_scope() {
+        let req = req_with_scope(Some("ledger:write"));
+        let err = require_any_scope::<BasicClaims>(&req, &[CHARTER, BROAD]).unwrap_err();
+        assert!(matches!(err, ApiError::Forbidden(_)));
+    }
+
+    #[test]
+    fn require_any_scope_rejects_when_no_scope_present() {
+        let req = req_with_scope(None);
+        let err = require_any_scope::<BasicClaims>(&req, &[CHARTER, BROAD]).unwrap_err();
+        assert!(matches!(err, ApiError::Forbidden(_)));
+    }
+
+    #[test]
+    fn require_any_scope_unauthenticated_without_claims() {
+        let req = TestRequest::default().to_http_request();
+        let err = require_any_scope::<BasicClaims>(&req, &[CHARTER, BROAD]).unwrap_err();
+        assert!(matches!(err, ApiError::Unauthenticated));
+    }
+
+    #[test]
+    fn require_any_scope_honors_sub_scope_match() {
+        // `governance:write:admin` satisfies the broad `governance:write` candidate.
+        let req = req_with_scope(Some("governance:write:admin"));
+        assert!(require_any_scope::<BasicClaims>(&req, &[CHARTER, BROAD]).is_ok());
     }
 }


### PR DESCRIPTION
## What

Step 3 of the `governance:write` decomposition ladder (`docs/design/governance/governance-write-decomposition.md` §10, hybrid path picked in #1880, class scopes minted in #1881). Migrates the **charter handler family** off the broad `governance:write` capability onto the narrowed `governance:charter:write` class scope, **keeping `governance:write` as an accepted-also fallback** so the change is non-breaking.

- **`icn-http-kit`**: new `require_any_scope` helper — accepts a request whose token satisfies *at least one* of the listed scopes, reusing the same exact/sub-scope matching as `require_scope`. Lets a handler require a narrowed class scope while still accepting the legacy broad scope until that scope is retired.
- **`icn-governance-actor`**: the four charter-family handlers — `create_domain`, `add_domain_member`, `remove_domain_member`, `activate_charter` — now gate on `require_any_scope(["governance:charter:write", "governance:write"])`.
- **tests**: 6 `require_any_scope` unit tests in `icn-http-kit`; `apps/governance/tests/charter_scope_migration.rs` proving the class scope is accepted, the legacy broad scope is still accepted, and an unrelated scope is rejected across the charter family.

## Why

`docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md` §4.1 / §2.7 — a single broad `governance:write` is "an institution factory"; a capability scope must describe an act the institution can authorize. This narrows the most dangerous capability class (charter + membership mutation + charter activation) to one class scope. Tracked by #1868; named as the next slice in `docs/STATE.md`.

## How

Accepted-also fallback (not a hard swap): the gateway already issues the class scopes (#1881 added them to `ALLOWED_SCOPES`), and tokens minted with the legacy broad scope keep working on these routes. `require_any_scope` returns on the first matching candidate; if none match and claims are present it returns `403 Forbidden`, and `401 Unauthenticated` when no claims are present (parity with `require_scope`).

## Risk

- **Token compatibility**: covered — broad `governance:write` still accepted on all four routes (regression-pinned by the existing `charter_activation` suite, which uses `governance:write` and still passes).
- TrustThreshold / member-standing fail-closed logic (recently hardened in #1911/#1916/#1917) is **untouched** — only the capability-gate line changed.

## Test plan

```
cargo fmt --all -- --check
cargo clippy -p icn-http-kit -p icn-governance-actor --all-targets -- -D warnings
cargo test -p icn-http-kit --lib                       # 6 require_any_scope tests
cargo test -p icn-governance-actor                     # full app suite, 0 failed
python3 .github/scripts/compliance_linter.py           # no violations
```
All green locally on `icn-dev`.

## Invariants

- **Meaning firewall preserved**: the kernel still enforces opaque strings; only the app knows what `governance:charter:write` means.
- **Determinism / canonical encodings**: unchanged (no wire-format change).

## Out of scope (later ladder rungs / separate issues)

- Receipt-body scope recording (§10 step 2) — not in this PR.
- `MandateGate` trait + mandate gating (§10 step 6) — **not implemented**; this PR is capability-class only.
- Charter bootstrap-path labeling — **#1869** (planned immediate follow-up, separate PR).
- Non-app gateway/JSON-RPC surfaces (§10 step 12) and retiring `governance:write` (§10 step 13).

## Non-claims

No production-readiness, pilot, live-federation, or NYCN-activation claim. Not "mandate-gated" — the mandate gate is unbuilt. This narrows the charter-class capability surface; one rung of a multi-step migration.

Refs #1868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)