### PR TITLE
feat(governance): label direct charter activation as bootstrap path (#1869)

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -808,6 +808,12 @@ pub async fn activate_charter<E: GovernanceEventEmitter + Clone + 'static>(
         charter_id: req.charter_id.clone(),
         status: "active".to_string(),
         activated_at: current_time_secs(),
+        // Direct activation is a bootstrap / direct-administrative path, not a
+        // ratified/mandate activation. Surface that lineage at the API boundary
+        // so clients cannot mistake it for ordinary ratified authority. The
+        // artifact-level marker (the synthetic direct-activation provenance
+        // string on the emitted effect) is unchanged.
+        activation_path: ActivationPath::Bootstrap,
     }))
 }
 

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -68,6 +68,30 @@ pub struct ActivateCharterRequest {
     pub charter_yaml: String,
 }
 
+/// How a charter became active — the authority lineage of the activation.
+///
+/// Bootstrap activation is **not** ratified/mandate activation. The substrate
+/// has to be bootstrappable (the first charter comes from outside the
+/// governance loop, which is administrative by definition), but a charter that
+/// bypasses governance must never be mistaken by clients or surfaces for one
+/// ratified through a proposal. This discriminator marks the direct path
+/// explicitly so it cannot be rendered as ordinary ratified authority.
+///
+/// Single variant for now; the ratified-path counterpart is intentionally not
+/// modeled here (it travels a different response type). A future administrative
+/// receipt may subsume this signal — see the bootstrap-activation receipt-class
+/// question in the abuse-case hardening doctrine (§4.4, §15).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivationPath {
+    /// Direct, bootstrap / direct-administrative activation: registered an
+    /// already-decided charter without a proposal or recorded decision. The
+    /// artifact-level marker for this path is the synthetic
+    /// `direct-activation:<charter_id>` provenance string carried on the
+    /// emitted effect, which this discriminator surfaces at the API boundary.
+    Bootstrap,
+}
+
 /// Response returned after a successful charter activation.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ActivateCharterResponse {
@@ -76,6 +100,10 @@ pub struct ActivateCharterResponse {
     pub status: String,
     /// Unix epoch seconds when activation was recorded.
     pub activated_at: u64,
+    /// Authority lineage of this activation. Direct activation is always
+    /// [`ActivationPath::Bootstrap`]: it is a bootstrap / direct-administrative
+    /// path, not a ratified/mandate activation.
+    pub activation_path: ActivationPath,
 }
 
 // ============================================================================

--- a/icn/apps/governance/tests/charter_activation.rs
+++ b/icn/apps/governance/tests/charter_activation.rs
@@ -20,6 +20,10 @@
 //!    rather than silently succeeding with commons unaware of the domain.
 //! 9. Response payload uses regulatory-safe vocabulary
 //!    (no "payment", "currency", or "balance" terms).
+//! 10. The response marks the direct path as a bootstrap path
+//!     (`activation_path: "bootstrap"`) while the emitted effect preserves the
+//!     artifact-level `direct-activation:` provenance marker, so the path
+//!     cannot be mistaken for a ratified/mandate activation.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -147,6 +151,13 @@ async fn activate_charter_returns_201_and_fires_hook() {
         parsed["activated_at"].as_u64().is_some(),
         "activated_at must be a unix epoch seconds u64"
     );
+    // Direct activation is a bootstrap / direct-administrative path. The
+    // response must mark it as such so it cannot be mistaken for a
+    // ratified/mandate activation.
+    assert_eq!(
+        parsed["activation_path"], "bootstrap",
+        "direct activation response must mark the bootstrap path"
+    );
 
     // Regulatory-safe vocabulary: response must not leak economic-payment terms.
     let raw = String::from_utf8(body_bytes.to_vec()).unwrap();
@@ -180,6 +191,58 @@ async fn activate_charter_returns_201_and_fires_hook() {
             assert!(
                 proposal_id.starts_with("direct-activation:"),
                 "synthetic proposal_id must mark the direct-activation origin, got {proposal_id}"
+            );
+        }
+        other => panic!("expected GovernanceEffect::DeployCharter, got {other:?}"),
+    }
+}
+
+#[actix_web::test]
+async fn activate_charter_marks_bootstrap_path_under_charter_scope() {
+    // Under the charter-class scope, the direct path must still be labeled a
+    // bootstrap path: the response carries the `bootstrap` discriminator and the
+    // emitted effect preserves the artifact-level `direct-activation:` provenance
+    // marker. This is the handler → emitted artifact → response round-trip.
+    let (ctx, captured) = make_ctx_with_capture();
+    let app = charter_test_app!(ctx, Some("governance:charter:write"));
+
+    let body = json!({
+        "charter_id": "nycn-bootstrap",
+        "charter_yaml": VALID_CHARTER_YAML,
+    });
+    let req = test::TestRequest::post()
+        .uri("/charters")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let body_bytes = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "charter-scope holder must activate, body: {}",
+        String::from_utf8_lossy(&body_bytes)
+    );
+
+    // Response boundary: bootstrap discriminator present.
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(
+        parsed["activation_path"], "bootstrap",
+        "direct activation under charter scope must mark the bootstrap path"
+    );
+
+    // Artifact boundary: synthetic `direct-activation:` provenance preserved.
+    let effects = captured.effect_calls.lock().unwrap();
+    assert_eq!(effects.len(), 1, "proposal-accepted hook must fire once");
+    match &effects[0] {
+        GovernanceEffect::DeployCharter {
+            charter_id,
+            proposal_id,
+        } => {
+            assert_eq!(charter_id, "nycn-bootstrap");
+            assert!(
+                proposal_id.starts_with("direct-activation:"),
+                "direct-activation provenance marker must be preserved, got {proposal_id}"
             );
         }
         other => panic!("expected GovernanceEffect::DeployCharter, got {other:?}"),


### PR DESCRIPTION
## What
- Direct charter activation now carries an explicit bootstrap/direct-administrative path discriminator: `ActivateCharterResponse.activation_path = "bootstrap"` (single-variant `ActivationPath` enum), set only by the direct `activate_charter` handler.
- Existing `direct-activation:{charter_id}` provenance string on the emitted `GovernanceEffect::DeployCharter` is preserved unchanged — it remains the artifact-level marker.
- Tests cover the discriminator and provenance round-trip (handler → emitted effect → response), including under the `governance:charter:write` scope.

## Why
- Bootstrap is not democracy.
- Direct activation is a convenience/bootstrap path and must not be rendered as ordinary ratified authority. The response lacked an explicit discriminator, so clients/surfaces could not distinguish it from a ratified/mandate activation.
- Aligns with `docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md` §2.6 / §4.4 / §7 (Stage B item 3). Authorization is untouched (charter-class scope with the existing accepted-also fallback landed in #1918).
- This closes #1869 and follows the charter-scope migration landed in #1918.

## Test plan
Run from `icn/icn/`; package `icn-governance-actor`; compliance linter from repo root.
- `cargo fmt --all -- --check` → pass
- `cargo clippy -p icn-governance-actor --all-targets -- -D warnings` → pass
- `cargo test -p icn-governance-actor` → pass (charter_activation: 10/10, incl. new `activate_charter_marks_bootstrap_path_under_charter_scope` and extended `activate_charter_returns_201_and_fires_hook`)
- `python3 .github/scripts/compliance_linter.py` → 0 violations
- `git diff --name-only` → only the 3 governance files; no generated/OpenAPI/SDK/lockfile changes (`ActivateCharterResponse` is not part of the gateway-built `docs/api/openapi.generated.yaml`).

## Out of scope
- No MandateGate.
- No receipt-body scope recording / #1868 step 2.
- No #1872 atomicity tests.
- No steward/federation/proposal/membership scope migrations.
- No `governance:write` retirement; no change to the `governance:charter:write` / `governance:write` fallback.
- No TrustThreshold/member-standing fail-closed changes.
- No production/pilot/live-federation/NYCN readiness claim. The `BootstrapCharterActivationReceipt` vs discriminator decision (doctrine §15) stays open.

Closes #1869

🤖 Generated with [Claude Code](https://claude.com/claude-code)