### PR TITLE
feat(governance): migrate assign_role to governance:steward:write (#1868 step 4)

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3547,7 +3547,11 @@ pub async fn assign_role<E: GovernanceEventEmitter + Clone + 'static>(
     structure_id: web::Path<String>,
     req: web::Json<AssignRoleRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    // #1868 step 4: steward-class capability with accepted-also fallback to the
+    // legacy broad `governance:write` until that scope is retired. Direct role
+    // assignment grants steward authority, so it carries its own narrow scope;
+    // steward *proposals* stay under the proposal-write family (a later rung).
+    require_any_scope::<BasicClaims>(&http_req, &["governance:steward:write", "governance:write"])?;
     let sid = StructureId(structure_id.into_inner());
     let person_did = parse_did(&req.did, "Invalid DID in request")?;
 

--- a/icn/apps/governance/tests/steward_scope_migration.rs
+++ b/icn/apps/governance/tests/steward_scope_migration.rs
@@ -1,0 +1,165 @@
+//! Steward handler capability migration (#1868 step 4).
+//!
+//! Proves the single direct-mutation steward act (`assign_role`) accepts the
+//! narrowed `governance:steward:write` class scope while still accepting the
+//! legacy broad `governance:write` scope as an accepted-also fallback, and
+//! rejects scopes outside that set.
+//!
+//! `assign_role` is the only steward act in this rung: it directly grants
+//! steward authority, so it carries its own narrow scope. Steward *proposals*
+//! (`create_appoint_steward_proposal`, `create_remove_steward_proposal`) stay
+//! under the proposal-write family — they create a proposal that still must
+//! pass voting before authority is granted — and are migrated in a later rung.
+//!
+//! Scope of the proof:
+//! - `governance:steward:write` is accepted (the migration's distinguishing
+//!   effect — before the migration this class scope would have been rejected by
+//!   the broad-only gate).
+//! - legacy `governance:write` is still accepted (no token-compat regression).
+//! - an unrelated read scope (`governance:read`) is rejected with 403.
+//! - a sibling write class (`governance:charter:write`) is rejected with 403 —
+//!   the point of decomposition is that one class scope does not satisfy
+//!   another.
+//!
+//! With no structure created, a scope-accepted request reaches the handler and
+//! fails downstream with 500 (Structure not found via `anyhow_to_api` →
+//! `Internal`) — a non-auth status, and therefore evidence the gate let it
+//! through. A scope-rejected request is blocked at the gate with 403 before any
+//! manager logic runs.
+//!
+//! The scope-matching logic itself is unit-tested in `icn-http-kit::auth`
+//! (`require_any_scope_*`); this file pins the handler wiring. It does NOT
+//! exercise mandate gating (unbuilt) or receipt-body scope recording (a later
+//! slice).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{body::to_bytes, dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use serde_json::json;
+
+const STEWARD_CLASS: &str = "governance:steward:write";
+const LEGACY_BROAD: &str = "governance:write";
+const UNRELATED_READ: &str = "governance:read";
+const SIBLING_CLASS: &str = "governance:charter:write";
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
+    }
+}
+
+/// Build a test app injecting the given caller + scope on every request.
+macro_rules! roles_app {
+    ($ctx:expr, $caller_did:expr, $scope:expr) => {{
+        let scope: &'static str = $scope;
+        let caller = $caller_did.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some(scope.to_string()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+/// POST a role assignment to a (non-existent) structure under `scope`, and
+/// return the resulting HTTP status. The structure does not exist, so a
+/// scope-accepted request reaches the manager and fails with 500; a
+/// scope-rejected request is blocked at the auth gate with 403.
+async fn assign_role_status(scope: &'static str) -> StatusCode {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let target = fresh_did();
+    let app = roles_app!(ctx, &caller, scope);
+
+    let body = json!({
+        "did": target.to_string(),
+        "role": "coordinator",
+        "authority_scope": [],
+    });
+    let req = test::TestRequest::post()
+        .uri("/structures/test-structure/roles")
+        .set_json(&body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    // Drain the body so a failed assertion can surface it via the caller.
+    let _ = to_bytes(resp.into_body()).await;
+    status
+}
+
+#[actix_web::test]
+async fn assign_role_accepts_steward_class_scope() {
+    let status = assign_role_status(STEWARD_CLASS).await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "governance:steward:write must be accepted on assign_role (reaches the \
+         handler; 500 = structure-not-found downstream, a non-auth status), got {status}"
+    );
+}
+
+#[actix_web::test]
+async fn assign_role_accepts_legacy_broad_scope() {
+    let status = assign_role_status(LEGACY_BROAD).await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "legacy governance:write must remain accepted on assign_role, got {status}"
+    );
+}
+
+#[actix_web::test]
+async fn assign_role_rejects_unrelated_read_scope() {
+    let status = assign_role_status(UNRELATED_READ).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "governance:read must be rejected on assign_role, got {status}"
+    );
+}
+
+#[actix_web::test]
+async fn assign_role_rejects_sibling_write_class_scope() {
+    // Class isolation: a different governance write class must not satisfy
+    // steward:write — this is the whole point of the decomposition.
+    let status = assign_role_status(SIBLING_CLASS).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a sibling class scope (governance:charter:write) must not satisfy \
+         steward:write on assign_role, got {status}"
+    );
+}

--- a/icn/apps/governance/tests/steward_scope_migration.rs
+++ b/icn/apps/governance/tests/steward_scope_migration.rs
@@ -21,11 +21,12 @@
 //!   the point of decomposition is that one class scope does not satisfy
 //!   another.
 //!
-//! With no structure created, a scope-accepted request reaches the handler and
-//! fails downstream with 500 (Structure not found via `anyhow_to_api` →
-//! `Internal`) — a non-auth status, and therefore evidence the gate let it
-//! through. A scope-rejected request is blocked at the gate with 403 before any
-//! manager logic runs.
+//! Each test creates a minimal structure via `manager.create_structure`, so a
+//! scope-accepted request reaches the handler and returns a stable
+//! `201 Created` (the role is assigned), while a scope-rejected request is
+//! blocked at the gate with `403` before any manager logic runs. Asserting on
+//! the handler-level success status avoids coupling to downstream error
+//! mappings.
 //!
 //! The scope-matching logic itself is unit-tested in `icn-http-kit::auth`
 //! (`require_any_scope_*`); this file pins the handler wiring. It does NOT
@@ -37,6 +38,7 @@
 use std::sync::Arc;
 
 use actix_web::{body::to_bytes, dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance::StructureKind;
 use icn_governance_actor::{
     http::{self, GovernanceContext},
     manager::GovernanceManager,
@@ -58,9 +60,22 @@ fn fresh_did() -> Did {
         .clone()
 }
 
-fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
-    GovernanceContext {
-        manager: Arc::new(GovernanceManager::new()),
+/// Build a context with one pre-created structure, returning the context and
+/// that structure's id (so the `assign_role` route can target a structure that
+/// actually exists and a scope-accepted request can succeed with `201`).
+fn ctx_with_structure() -> (GovernanceContext<NoopEventEmitter>, String) {
+    let manager = Arc::new(GovernanceManager::new());
+    let structure = manager
+        .create_structure(
+            "coop:test".to_string(),
+            StructureKind::Committee,
+            "Steward Scope Migration Test".to_string(),
+            None,
+        )
+        .expect("create_structure");
+    let structure_id = structure.id.to_string();
+    let ctx = GovernanceContext {
+        manager,
         emitter: NoopEventEmitter,
         on_charter_accepted: None,
         on_proposal_accepted: None,
@@ -71,7 +86,8 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         membership_resolver: None,
         sdis_service: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
-    }
+    };
+    (ctx, structure_id)
 }
 
 /// Build a test app injecting the given caller + scope on every request.
@@ -94,12 +110,11 @@ macro_rules! roles_app {
     }};
 }
 
-/// POST a role assignment to a (non-existent) structure under `scope`, and
-/// return the resulting HTTP status. The structure does not exist, so a
-/// scope-accepted request reaches the manager and fails with 500; a
-/// scope-rejected request is blocked at the auth gate with 403.
+/// POST a role assignment to an existing structure under `scope`, returning the
+/// resulting HTTP status. A scope-accepted request assigns the role and returns
+/// `201`; a scope-rejected request is blocked at the auth gate with `403`.
 async fn assign_role_status(scope: &'static str) -> StatusCode {
-    let ctx = make_ctx();
+    let (ctx, structure_id) = ctx_with_structure();
     let caller = fresh_did();
     let target = fresh_did();
     let app = roles_app!(ctx, &caller, scope);
@@ -110,12 +125,12 @@ async fn assign_role_status(scope: &'static str) -> StatusCode {
         "authority_scope": [],
     });
     let req = test::TestRequest::post()
-        .uri("/structures/test-structure/roles")
+        .uri(&format!("/structures/{structure_id}/roles"))
         .set_json(&body)
         .to_request();
     let resp = test::call_service(&app, req).await;
     let status = resp.status();
-    // Drain the body so a failed assertion can surface it via the caller.
+    // Drain the body so the response is fully consumed.
     let _ = to_bytes(resp.into_body()).await;
     status
 }
@@ -125,9 +140,8 @@ async fn assign_role_accepts_steward_class_scope() {
     let status = assign_role_status(STEWARD_CLASS).await;
     assert_eq!(
         status,
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "governance:steward:write must be accepted on assign_role (reaches the \
-         handler; 500 = structure-not-found downstream, a non-auth status), got {status}"
+        StatusCode::CREATED,
+        "governance:steward:write must be accepted on assign_role and assign the role, got {status}"
     );
 }
 
@@ -136,7 +150,7 @@ async fn assign_role_accepts_legacy_broad_scope() {
     let status = assign_role_status(LEGACY_BROAD).await;
     assert_eq!(
         status,
-        StatusCode::INTERNAL_SERVER_ERROR,
+        StatusCode::CREATED,
         "legacy governance:write must remain accepted on assign_role, got {status}"
     );
 }


### PR DESCRIPTION
## What
Step 4 of the `governance:write` decomposition ladder (`docs/design/governance/governance-write-decomposition.md` §10). Migrates the single direct-mutation steward act, `assign_role` (`POST /gov/structures/{structure_id}/roles`), from the broad `governance:write` gate to `require_any_scope(["governance:steward:write", "governance:write"])` — narrowing the steward-class capability surface while keeping the broad scope as an **accepted-also fallback** (non-breaking).

- `handlers.rs`: `assign_role` now requires the steward-class scope, accepting the legacy broad scope until it is retired (step 13).
- `tests/steward_scope_migration.rs` (new): proves the steward class scope is accepted, the legacy broad scope is still accepted, and that **both** an unrelated read scope and a **sibling write class** (`governance:charter:write`) are rejected — pinning class isolation.

`assign_role` is the only steward act in this rung: it directly grants steward authority, so it carries its own narrow scope. Steward *proposals* (`create_appoint_steward_proposal`, `create_remove_steward_proposal`) create a proposal that must still pass voting before authority is granted, and stay under the `governance:proposal:write` family (a later rung).

## Why
Doctrine §4.1 / §7 (`docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md`): a capability token is not a mandate, and a single broad write scope removes per-action distinction from the kernel layer. This narrows the highest-blast-radius steward act to its own scope. Follows the charter-family migration in #1918 (step 3).

## Test plan
From `icn/icn/`; package `icn-governance-actor`:
- `cargo fmt --all -- --check` → pass
- `cargo clippy -p icn-governance-actor --all-targets -- -D warnings` → pass
- `cargo test -p icn-governance-actor --test steward_scope_migration` → pass (4/4: steward-class accepted, legacy broad accepted, read scope rejected, sibling charter:write rejected)
- `python3 .github/scripts/compliance_linter.py` → 0 violations
- `git diff --name-only` → `handlers.rs` + new `steward_scope_migration.rs`; no generated/OpenAPI/SDK/lockfile changes.

## Scope
No gateway/schema change needed: `governance:steward:write` was already minted in `icn-rpc::auth` and added to the gateway `ALLOWED_SCOPES` in step 1 (covered by existing `icn-gateway` validation tests).

## Out of scope (later ladder rungs / separate issues)
- Steward *proposal* / other scope families (`proposal:write`, `federation:write`, `meeting:write`, …).
- MandateGate (step 6); receipt-body scope recording (step 2); retiring `governance:write` (step 13).
- No mandate gating; the kernel still enforces opaque strings (meaning firewall unchanged).
- No production/pilot/live-federation/NYCN readiness claim; no regulatory-vocabulary change.

Part of #1868

🤖 Generated with [Claude Code](https://claude.com/claude-code)