### PR TITLE
feat(governance): migrate meeting/activity/comment to class scopes (#1868 steps 9-11)

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2289,7 +2289,10 @@ pub async fn add_comment<E: GovernanceEventEmitter + Clone + 'static>(
     proposal_id: web::Path<String>,
     req: web::Json<AddCommentRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:comment:write", "governance:write"],
+    )?;
     let author = parse_did(&claims.sub, "Invalid DID in token")?;
 
     if req.content.trim().is_empty() {
@@ -2368,7 +2371,10 @@ pub async fn edit_comment<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<(String, String)>,
     req: web::Json<EditCommentRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:comment:write", "governance:write"],
+    )?;
     let editor = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (_proposal_id, comment_id_str) = path.into_inner();
@@ -2399,7 +2405,10 @@ pub async fn delete_comment<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     path: web::Path<(String, String)>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:comment:write", "governance:write"],
+    )?;
     let deleter = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (_proposal_id, comment_id_str) = path.into_inner();
@@ -2420,7 +2429,10 @@ pub async fn add_reaction<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<(String, String)>,
     req: web::Json<AddReactionRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:comment:write", "governance:write"],
+    )?;
     let reactor = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (_proposal_id, comment_id_str) = path.into_inner();
@@ -2445,7 +2457,10 @@ pub async fn remove_reaction<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<(String, String)>,
     req: web::Json<RemoveReactionRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:comment:write", "governance:write"],
+    )?;
     let reactor = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (_proposal_id, comment_id_str) = path.into_inner();
@@ -2634,7 +2649,10 @@ pub async fn create_action_item<E: GovernanceEventEmitter + Clone + 'static>(
     domain_id: web::Path<String>,
     req: web::Json<CreateActionItemRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let creator_did = parse_did(&claims.sub, "Invalid DID in token")?;
     let domain = GovernanceDomainId(domain_id.into_inner());
 
@@ -2723,7 +2741,10 @@ pub async fn update_action_item<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<(String, String)>,
     req: web::Json<UpdateActionItemRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let user_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, item_id) = path.into_inner();
@@ -2816,7 +2837,10 @@ pub async fn delete_action_item<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     path: web::Path<(String, String)>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let user_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, item_id) = path.into_inner();
@@ -2851,7 +2875,10 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
     path: web::Path<(String, String)>,
     req: web::Json<StatusUpdateRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let user_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, item_id) = path.into_inner();
@@ -2890,7 +2917,10 @@ pub async fn add_action_item_note<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<(String, String)>,
     req: web::Json<AddActionItemNoteRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let author_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, item_id) = path.into_inner();
@@ -3499,7 +3529,10 @@ pub async fn create_structure<E: GovernanceEventEmitter + Clone + 'static>(
     entity_id: web::Path<String>,
     req: web::Json<CreateStructureRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:activity:write", "governance:write"],
+    )?;
     let entity = entity_id.into_inner();
     let kind = parse_structure_kind(&req.kind)?;
 
@@ -3599,7 +3632,10 @@ pub async fn create_activity<E: GovernanceEventEmitter + Clone + 'static>(
     entity_id: web::Path<String>,
     req: web::Json<CreateActivityRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:activity:write", "governance:write"],
+    )?;
     let entity = entity_id.into_inner();
     let kind = parse_activity_kind(&req.kind)?;
 
@@ -3766,7 +3802,10 @@ pub async fn create_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     domain_id: web::Path<String>,
     req: web::Json<CreateMeetingRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let domain = GovernanceDomainId(domain_id.into_inner());
 
     check_domain_membership(
@@ -3844,7 +3883,10 @@ pub async fn start_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     meeting_id: web::Path<String>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let id = MeetingId(meeting_id.into_inner());
 
     let mut m = ctx
@@ -3894,7 +3936,10 @@ pub async fn end_meeting<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     meeting_id: web::Path<String>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let id = MeetingId(meeting_id.into_inner());
 
     let mut m = ctx
@@ -3936,7 +3981,10 @@ pub async fn add_attendee<E: GovernanceEventEmitter + Clone + 'static>(
     meeting_id: web::Path<String>,
     req: web::Json<AddAttendeeRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let id = MeetingId(meeting_id.into_inner());
     let role = parse_meeting_role(&req.meeting_role)?;
 
@@ -3992,7 +4040,10 @@ pub async fn mark_attendance<E: GovernanceEventEmitter + Clone + 'static>(
     meeting_id: web::Path<String>,
     req: web::Json<MarkAttendanceRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let id = MeetingId(meeting_id.into_inner());
     let status = parse_attendance_status(&req.status)?;
     let recorded_by = parse_did(&claims.sub, "Invalid DID in token")?;
@@ -4033,7 +4084,10 @@ pub async fn add_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
     meeting_id: web::Path<String>,
     req: web::Json<AddAgendaItemRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let id = MeetingId(meeting_id.into_inner());
 
     let mut m = ctx
@@ -4074,7 +4128,10 @@ pub async fn update_agenda_item<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<(String, String)>,
     req: web::Json<UpdateAgendaItemRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )?;
     let (meeting_id_str, item_id_str) = path.into_inner();
     let meeting_id = MeetingId(meeting_id_str);
     let item_uuid = item_id_str
@@ -4218,7 +4275,10 @@ pub async fn create_program<E: GovernanceEventEmitter + Clone + 'static>(
     domain_id: web::Path<String>,
     req: web::Json<CreateProgramRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:activity:write", "governance:write"],
+    )?;
     let domain = GovernanceDomainId(domain_id.into_inner());
 
     check_domain_membership(
@@ -4300,7 +4360,10 @@ pub async fn create_milestone<E: GovernanceEventEmitter + Clone + 'static>(
     program_id: web::Path<String>,
     req: web::Json<CreateMilestoneRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:activity:write", "governance:write"],
+    )?;
     let pid = ProgramId(program_id.into_inner());
 
     if req.name.trim().is_empty() {
@@ -4381,7 +4444,10 @@ pub async fn update_milestone_status<E: GovernanceEventEmitter + Clone + 'static
     milestone_id: web::Path<String>,
     req: web::Json<UpdateMilestoneStatusRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:activity:write", "governance:write"],
+    )?;
     let id = MilestoneId(milestone_id.into_inner());
     let status = parse_milestone_status(&req.status)?;
     let actor = parse_did(&claims.sub, "Invalid DID in token")?;
@@ -4422,7 +4488,10 @@ pub async fn link_activity_to_program<E: GovernanceEventEmitter + Clone + 'stati
     http_req: HttpRequest,
     path: web::Path<(String, String)>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:activity:write", "governance:write"],
+    )?;
     let (program_id_str, activity_id_str) = path.into_inner();
     let pid = ProgramId(program_id_str);
     let aid = ActivityId(activity_id_str);
@@ -4462,7 +4531,10 @@ pub async fn unlink_activity_from_program<E: GovernanceEventEmitter + Clone + 's
     http_req: HttpRequest,
     path: web::Path<(String, String)>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:activity:write", "governance:write"],
+    )?;
     let (program_id_str, activity_id_str) = path.into_inner();
     let pid = ProgramId(program_id_str);
     let aid = ActivityId(activity_id_str);
@@ -5007,7 +5079,10 @@ pub async fn update_program_status<E: GovernanceEventEmitter + Clone + 'static>(
     program_id: web::Path<String>,
     req: web::Json<UpdateProgramStatusRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:activity:write", "governance:write"],
+    )?;
     let pid = ProgramId(program_id.into_inner());
     let status = parse_program_status(&req.status)?;
     let actor = parse_did(&claims.sub, "Invalid DID in token")?;

--- a/icn/apps/governance/tests/activity_scope_migration.rs
+++ b/icn/apps/governance/tests/activity_scope_migration.rs
@@ -1,0 +1,187 @@
+//! Activity handler-family capability migration (#1868 step 10).
+//!
+//! Migrates the eight activity / program / structure / milestone mutation
+//! handlers (`create_activity`, `create_program`, `create_structure`,
+//! `create_milestone`, `link_activity_to_program`, `unlink_activity_from_program`,
+//! `update_milestone_status`, `update_program_status`) from the broad
+//! `governance:write` gate to `governance:activity:write` with the legacy broad
+//! scope as an accepted-also fallback. No shared helper — each is an independent
+//! one-line gate.
+//!
+//! Note: `update_milestone_status` and `update_program_status` are status
+//! transitions flagged in the decomposition design (§6) as medium-blast and
+//! will require the mandate gate in a later step. This PR only narrows the
+//! technical capability scope; the mandate-check is a separate future layer.
+//!
+//! Assertion semantics (authorization test): acceptance is "not 401 and not 403"
+//! (the request passes the gate and continues into the handler; its eventual
+//! status depends on entity/program state, not under test here); rejection is
+//! exactly 403 at the gate, before any handler logic.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use serde_json::{json, Value};
+
+const ACTIVITY_CLASS: &str = "governance:activity:write";
+const LEGACY_BROAD: &str = "governance:write";
+const UNRELATED_READ: &str = "governance:read";
+const SIBLING_CLASS: &str = "governance:charter:write";
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
+    }
+}
+
+macro_rules! gov_app {
+    ($ctx:expr, $caller_did:expr, $scope:expr) => {{
+        let scope: &'static str = $scope;
+        let caller = $caller_did.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some(scope.to_string()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+/// (method, path, deserializable body) for each activity-family route.
+/// CreateProgram/CreateMilestone/UpdateMilestoneStatus/UpdateProgramStatus use
+/// `#[serde(deny_unknown_fields)]`, so their bodies carry only known fields.
+fn activity_routes() -> Vec<(&'static str, &'static str, Value)> {
+    vec![
+        (
+            "POST",
+            "/entities/test-entity/activities",
+            json!({ "kind": "event", "name": "scope test" }),
+        ),
+        (
+            "POST",
+            "/domains/test-domain/programs",
+            json!({ "parent_entity_id": "test-entity", "kind": "cycle", "name": "scope test" }),
+        ),
+        (
+            "POST",
+            "/entities/test-entity/structures",
+            json!({ "kind": "committee", "name": "scope test" }),
+        ),
+        (
+            "POST",
+            "/programs/test-program/milestones",
+            json!({ "name": "scope test" }),
+        ),
+        (
+            "PUT",
+            "/programs/test-program/activities/test-activity",
+            json!({}),
+        ),
+        (
+            "DELETE",
+            "/programs/test-program/activities/test-activity",
+            json!({}),
+        ),
+        (
+            "PATCH",
+            "/milestones/test-milestone",
+            json!({ "status": "in_progress" }),
+        ),
+        (
+            "PATCH",
+            "/programs/test-program/status",
+            json!({ "status": "active_planning" }),
+        ),
+    ]
+}
+
+async fn status_for(method: &str, path: &str, body: &Value, scope: &'static str) -> StatusCode {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let app = gov_app!(ctx, &caller, scope);
+    let builder = match method {
+        "POST" => test::TestRequest::post(),
+        "PUT" => test::TestRequest::put(),
+        "PATCH" => test::TestRequest::patch(),
+        "DELETE" => test::TestRequest::delete(),
+        other => panic!("unsupported method {other}"),
+    };
+    let req = builder.uri(path).set_json(body).to_request();
+    test::call_service(&app, req).await.status()
+}
+
+fn assert_auth_accepted(status: StatusCode, scope: &str, route: &str) {
+    assert!(
+        status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
+        "{scope} must be accepted at {route} (auth passes; {status} is the downstream \
+         outcome, not an auth rejection)"
+    );
+}
+
+#[actix_web::test]
+async fn create_activity_accepts_activity_class_scope() {
+    let (m, p, b) = &activity_routes()[0];
+    assert_auth_accepted(status_for(m, p, b, ACTIVITY_CLASS).await, ACTIVITY_CLASS, p);
+}
+
+#[actix_web::test]
+async fn create_activity_accepts_legacy_broad_scope() {
+    let (m, p, b) = &activity_routes()[0];
+    assert_auth_accepted(status_for(m, p, b, LEGACY_BROAD).await, LEGACY_BROAD, p);
+}
+
+#[actix_web::test]
+async fn all_activity_routes_reject_unrelated_read_scope() {
+    for (m, p, b) in activity_routes() {
+        let status = status_for(m, p, &b, UNRELATED_READ).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "governance:read must be rejected at {m} {p}, got {status}"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn all_activity_routes_reject_sibling_write_class_scope() {
+    for (m, p, b) in activity_routes() {
+        let status = status_for(m, p, &b, SIBLING_CLASS).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "sibling class {SIBLING_CLASS} must be rejected at {m} {p}, got {status}"
+        );
+    }
+}

--- a/icn/apps/governance/tests/comment_scope_migration.rs
+++ b/icn/apps/governance/tests/comment_scope_migration.rs
@@ -1,0 +1,175 @@
+//! Comment handler-family capability migration (#1868 step 11).
+//!
+//! Migrates the five comment/reaction mutation handlers (`add_comment`,
+//! `edit_comment`, `delete_comment`, `add_reaction`, `remove_reaction`) from the
+//! broad `governance:write` gate to `governance:comment:write` with the legacy
+//! broad scope as an accepted-also fallback. No shared helper — each handler is
+//! an independent one-line gate.
+//!
+//! Assertion semantics (authorization test): acceptance is "not 401 and not
+//! 403" (the request passes the gate and continues into the handler; its
+//! eventual status depends on proposal/comment state, not under test here);
+//! rejection is exactly 403 at the gate, before any handler logic.
+//!
+//! `edit_comment` / `delete_comment` enforce an author-only app-level check
+//! *after* the gate, so an accepted non-author still gets 403 there. We
+//! therefore prove ACCEPTANCE on `add_comment` (no author check) and prove
+//! REJECTION (unrelated scope -> 403, which fires at the gate, before the
+//! author check) across all five routes.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use serde_json::{json, Value};
+
+const COMMENT_CLASS: &str = "governance:comment:write";
+const LEGACY_BROAD: &str = "governance:write";
+const UNRELATED_READ: &str = "governance:read";
+const SIBLING_CLASS: &str = "governance:charter:write";
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
+    }
+}
+
+macro_rules! gov_app {
+    ($ctx:expr, $caller_did:expr, $scope:expr) => {{
+        let scope: &'static str = $scope;
+        let caller = $caller_did.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some(scope.to_string()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+/// (method, path, deserializable body) for each comment-family route. All five
+/// share the migrated gate; bodies deserialize so the request reaches it.
+fn comment_routes() -> Vec<(&'static str, &'static str, Value)> {
+    vec![
+        (
+            "POST",
+            "/proposals/test-proposal/discussion/comments",
+            json!({ "content": "scope test" }),
+        ),
+        (
+            "PUT",
+            "/proposals/test-proposal/discussion/comments/test-comment",
+            json!({ "content": "scope test edit" }),
+        ),
+        (
+            "DELETE",
+            "/proposals/test-proposal/discussion/comments/test-comment",
+            json!({}),
+        ),
+        (
+            "POST",
+            "/proposals/test-proposal/discussion/comments/test-comment/reactions",
+            json!({ "emoji": "thumbsup" }),
+        ),
+        (
+            "DELETE",
+            "/proposals/test-proposal/discussion/comments/test-comment/reactions",
+            json!({ "emoji": "thumbsup" }),
+        ),
+    ]
+}
+
+async fn status_for(method: &str, path: &str, body: &Value, scope: &'static str) -> StatusCode {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let app = gov_app!(ctx, &caller, scope);
+    let builder = match method {
+        "POST" => test::TestRequest::post(),
+        "PUT" => test::TestRequest::put(),
+        "PATCH" => test::TestRequest::patch(),
+        "DELETE" => test::TestRequest::delete(),
+        other => panic!("unsupported method {other}"),
+    };
+    let req = builder.uri(path).set_json(body).to_request();
+    test::call_service(&app, req).await.status()
+}
+
+fn assert_auth_accepted(status: StatusCode, scope: &str, route: &str) {
+    assert!(
+        status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
+        "{scope} must be accepted at {route} (auth passes; {status} is the downstream \
+         outcome, not an auth rejection)"
+    );
+}
+
+#[actix_web::test]
+async fn add_comment_accepts_comment_class_scope() {
+    // add_comment has no author check, so a scope-accepted request reaches the
+    // handler body (not 401/403).
+    let (m, p, b) = &comment_routes()[0];
+    assert_auth_accepted(status_for(m, p, b, COMMENT_CLASS).await, COMMENT_CLASS, p);
+}
+
+#[actix_web::test]
+async fn add_comment_accepts_legacy_broad_scope() {
+    let (m, p, b) = &comment_routes()[0];
+    assert_auth_accepted(status_for(m, p, b, LEGACY_BROAD).await, LEGACY_BROAD, p);
+}
+
+#[actix_web::test]
+async fn all_comment_routes_reject_unrelated_read_scope() {
+    // Rejection fires at the gate, before the edit/delete author check, so it
+    // holds for all five routes.
+    for (m, p, b) in comment_routes() {
+        let status = status_for(m, p, &b, UNRELATED_READ).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "governance:read must be rejected at {m} {p}, got {status}"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn all_comment_routes_reject_sibling_write_class_scope() {
+    // Class isolation: a sibling write class never satisfies comment:write.
+    for (m, p, b) in comment_routes() {
+        let status = status_for(m, p, &b, SIBLING_CLASS).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "sibling class {SIBLING_CLASS} must be rejected at {m} {p}, got {status}"
+        );
+    }
+}

--- a/icn/apps/governance/tests/meeting_scope_migration.rs
+++ b/icn/apps/governance/tests/meeting_scope_migration.rs
@@ -1,0 +1,188 @@
+//! Meeting handler-family capability migration (#1868 step 9).
+//!
+//! Migrates the twelve meeting / action-item mutation handlers (`create_meeting`,
+//! `start_meeting`, `end_meeting`, `add_agenda_item`, `update_agenda_item`,
+//! `add_attendee`, `mark_attendance`, `create_action_item`, `update_action_item`,
+//! `update_action_item_status`, `delete_action_item`, `add_action_item_note`)
+//! from the broad `governance:write` gate to `governance:meeting:write` with the
+//! legacy broad scope as an accepted-also fallback. No shared helper — each is an
+//! independent one-line gate.
+//!
+//! Assertion semantics (authorization test): acceptance is "not 401 and not 403"
+//! (the request passes the gate and continues into the handler; its eventual
+//! status depends on meeting/domain state, not under test here); rejection is
+//! exactly 403 at the gate, before any handler logic.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use serde_json::{json, Value};
+
+const MEETING_CLASS: &str = "governance:meeting:write";
+const LEGACY_BROAD: &str = "governance:write";
+const UNRELATED_READ: &str = "governance:read";
+const SIBLING_CLASS: &str = "governance:charter:write";
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
+    }
+}
+
+macro_rules! gov_app {
+    ($ctx:expr, $caller_did:expr, $scope:expr) => {{
+        let scope: &'static str = $scope;
+        let caller = $caller_did.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some(scope.to_string()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+/// (method, path, deserializable body) for each meeting-family route.
+fn meeting_routes() -> Vec<(&'static str, &'static str, Value)> {
+    vec![
+        (
+            "POST",
+            "/domains/test-domain/meetings",
+            json!({ "title": "scope test" }),
+        ),
+        ("POST", "/meetings/test-meeting/start", json!({})),
+        ("POST", "/meetings/test-meeting/end", json!({})),
+        (
+            "POST",
+            "/meetings/test-meeting/attendees",
+            json!({ "did": "did:icn:test" }),
+        ),
+        (
+            "PUT",
+            "/meetings/test-meeting/attendance",
+            json!({ "did": "did:icn:test", "status": "present" }),
+        ),
+        (
+            "POST",
+            "/meetings/test-meeting/agenda",
+            json!({ "title": "scope test" }),
+        ),
+        ("PUT", "/meetings/test-meeting/agenda/test-item", json!({})),
+        (
+            "POST",
+            "/domains/test-domain/action-items",
+            json!({ "title": "scope test" }),
+        ),
+        (
+            "PUT",
+            "/domains/test-domain/action-items/test-item",
+            json!({}),
+        ),
+        (
+            "PUT",
+            "/domains/test-domain/action-items/test-item/status",
+            json!({ "status": "in_progress" }),
+        ),
+        (
+            "DELETE",
+            "/domains/test-domain/action-items/test-item",
+            json!({}),
+        ),
+        (
+            "POST",
+            "/domains/test-domain/action-items/test-item/notes",
+            json!({ "content": "scope test note" }),
+        ),
+    ]
+}
+
+async fn status_for(method: &str, path: &str, body: &Value, scope: &'static str) -> StatusCode {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let app = gov_app!(ctx, &caller, scope);
+    let builder = match method {
+        "POST" => test::TestRequest::post(),
+        "PUT" => test::TestRequest::put(),
+        "PATCH" => test::TestRequest::patch(),
+        "DELETE" => test::TestRequest::delete(),
+        other => panic!("unsupported method {other}"),
+    };
+    let req = builder.uri(path).set_json(body).to_request();
+    test::call_service(&app, req).await.status()
+}
+
+fn assert_auth_accepted(status: StatusCode, scope: &str, route: &str) {
+    assert!(
+        status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
+        "{scope} must be accepted at {route} (auth passes; {status} is the downstream \
+         outcome, not an auth rejection)"
+    );
+}
+
+#[actix_web::test]
+async fn create_meeting_accepts_meeting_class_scope() {
+    let (m, p, b) = &meeting_routes()[0];
+    assert_auth_accepted(status_for(m, p, b, MEETING_CLASS).await, MEETING_CLASS, p);
+}
+
+#[actix_web::test]
+async fn create_meeting_accepts_legacy_broad_scope() {
+    let (m, p, b) = &meeting_routes()[0];
+    assert_auth_accepted(status_for(m, p, b, LEGACY_BROAD).await, LEGACY_BROAD, p);
+}
+
+#[actix_web::test]
+async fn all_meeting_routes_reject_unrelated_read_scope() {
+    for (m, p, b) in meeting_routes() {
+        let status = status_for(m, p, &b, UNRELATED_READ).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "governance:read must be rejected at {m} {p}, got {status}"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn all_meeting_routes_reject_sibling_write_class_scope() {
+    for (m, p, b) in meeting_routes() {
+        let status = status_for(m, p, &b, SIBLING_CLASS).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "sibling class {SIBLING_CLASS} must be rejected at {m} {p}, got {status}"
+        );
+    }
+}


### PR DESCRIPTION
## What
Steps 9-11 of the `governance:write` decomposition ladder (`docs/design/governance/governance-write-decomposition.md` §10). Migrates the three **no-mandate-check** class families from the broad `governance:write` gate to their class scopes, keeping the broad scope as an **accepted-also fallback** (non-breaking).

**25 handler gates** migrated `require_scope("governance:write")` → `require_any_scope(["governance:<class>:write", "governance:write"])`, preserving the existing claims-binding form:
- **meeting:write (12):** create_meeting, start_meeting, end_meeting, add_agenda_item, update_agenda_item, add_attendee, mark_attendance, create_action_item, update_action_item, update_action_item_status, delete_action_item, add_action_item_note
- **activity:write (8):** create_activity, create_program, create_structure, create_milestone, link_activity_to_program, unlink_activity_from_program, update_milestone_status, update_program_status
- **comment:write (5):** add_comment, edit_comment, delete_comment, add_reaction, remove_reaction

These handlers share **no** auth helper (unlike the federation family), so each is an independent one-line gate. The **proposal:write** family (8 handlers) is deliberately untouched — it is mandate-sensitive and pairs with MandateGate (steps 6-8).

- 3 new integration files (`meeting_/activity_/comment_scope_migration.rs`).

## Why
Doctrine §4.1 / §7 (`docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md`): a capability token is not a mandate, and a single broad write scope removes per-action distinction from the kernel layer. Continues the cadence of charter (#1918), steward (#1922), federation (#1923). **This PR only narrows the technical capability gate with a legacy fallback** — it changes no institutional semantics and adds no mandate logic.

## Test plan
From `icn/icn/`; package `icn-governance-actor`:
- `cargo fmt --all -- --check` → pass
- `cargo clippy -p icn-governance-actor --all-targets -- -D warnings` → pass
- `cargo test -p icn-governance-actor --test meeting_scope_migration --test activity_scope_migration --test comment_scope_migration` → pass (12/12)
- `python3 .github/scripts/compliance_linter.py` → 0 violations
- `git diff --name-only` → `handlers.rs` + 3 new test files; no generated/OpenAPI/SDK/lockfile changes.

### Assertions
Authorization tests: acceptance = "not 401/403" (the request passes the gate and continues; downstream status isn't under test — robust per the #1922 lesson); rejection = exactly 403 at the gate. Per class: class scope accepted + legacy accepted on a representative route, plus **loop tests over every route** asserting an unrelated read scope and a sibling write class are both rejected (403) — proving each family is uniformly migrated.

**comment edit/delete** enforce an author-only check *after* the gate, so acceptance is proven on `add_comment` (no author check) and rejection (unrelated scope → 403, fired at the gate before the author check) is proven on all five routes.

## Scope
No gateway/auth/SDK change: the three class scopes were minted in `icn-rpc::auth` and allowlisted in `icn-gateway` in step 1.

## Future semantic / MandateGate concerns (out of scope here)
- activity status transitions (`update_milestone_status`, `update_program_status`) are §6 medium-blast and will require the mandate gate later.
- comment `edit_comment`/`delete_comment` author checks are app-level, unchanged.
- No MandateGate (steps 6-8); no `proposal:write` migration; no receipt-body scope recording (step 2); no `governance:write` retirement (step 13).
- No production/pilot/live-federation/NYCN readiness claim; no regulatory-vocabulary change.

Part of #1868

🤖 Generated with [Claude Code](https://claude.com/claude-code)