### PR TITLE
feat(governance): add MandateGate context guard (#1868)

### DIFF
--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -20,6 +20,7 @@ use tracing::warn;
 
 use crate::events::GovernanceEventEmitter;
 use crate::manager::GovernanceManager;
+use crate::mandate_gate::MandateGate;
 
 use super::handlers;
 
@@ -144,10 +145,11 @@ impl std::fmt::Display for GovernanceContextValidationError {
         write!(
             f,
             "governance context built in {:?} mode is missing required \
-             standing/resolver dependencies: {}. \
+             standing/resolver/authority dependencies: {}. \
              Production deployments must wire MemberStandingChecker, \
-             SuspensionChecker, and a MembershipResolver — unresolved \
-             standing must not be treated as standing in production.",
+             SuspensionChecker, a MembershipResolver, and a MandateGate — \
+             unresolved standing must not be treated as standing, and \
+             capability scope is not a mandate.",
             self.mode,
             self.missing.join(", ")
         )
@@ -402,6 +404,25 @@ pub struct GovernanceContext<E> {
     /// system (`SystemEvent::ProposalAccepted` → `KernelGovernanceExecutor` → `SdisService`).
     /// Setting this in tests provides a synchronous wiring path without an actor runtime.
     pub sdis_service: Option<Arc<dyn icn_kernel_api::SdisService>>,
+    /// Optional app-side, act-time authority resolver.
+    ///
+    /// When wired, governance handlers that perform high/medium-blast
+    /// institutional acts (charter activation, federation lifecycle, steward
+    /// appointment, etc.) will resolve a `MandateGrant` via this gate before
+    /// proceeding. The gate sits beside capability scope checks and member
+    /// standing — never replacing them — preserving the design's
+    /// separate/composable-checks intent (see
+    /// `docs/design/governance/mandate-gate-design.md`).
+    ///
+    /// `None` means no act-time mandate gating. Production deployments must
+    /// wire this; [`Self::validate`] rejects a `Production` context with
+    /// `mandate_gate: None`. Bootstrap/Test contexts may leave it unset and
+    /// receive a startup warning. The field is **not** consumed by any
+    /// handler in this PR — wiring `require()` into handlers is a separate,
+    /// follow-up slice (#1868 step 7) so the act-time semantics can be
+    /// reviewed independently of the startup-guard infrastructure landed
+    /// here.
+    pub mandate_gate: Option<Arc<dyn MandateGate + Send + Sync>>,
     /// Deployment posture for this governance HTTP context.
     ///
     /// Controls how missing optional standing checkers and the membership
@@ -434,6 +455,9 @@ impl<E> GovernanceContext<E> {
         }
         if self.membership_resolver.is_none() {
             missing.push("membership_resolver");
+        }
+        if self.mandate_gate.is_none() {
+            missing.push("mandate_gate");
         }
         missing
     }
@@ -500,6 +524,13 @@ impl<E> GovernanceContext<E> {
                     "governance: membership_resolver is not wired; \
                      TrustThreshold domains will close with excluded_delegators=None \
                      (fail-open — delegations from suspended members may flow)"
+                ),
+                "mandate_gate" => warn!(
+                    "governance: MandateGate is not wired; act-time institutional \
+                     authority will not be checked when handlers begin requiring it. \
+                     Production mode would reject this configuration. \
+                     Capability scope is not a mandate — unresolved mandate \
+                     authority must not be treated as authority in production."
                 ),
                 _ => {}
             }
@@ -829,6 +860,7 @@ mod build_mode_tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: mode,
         }
     }
@@ -843,6 +875,27 @@ mod build_mode_tests {
 
     fn dummy_resolver() -> Arc<dyn MembershipResolver> {
         Arc::new(icn_governance::StaticMembershipResolver::new())
+    }
+
+    /// A test-only `MandateGate` stub that always rejects every request.
+    /// Used by validate()-passes tests where only `Option::is_some()` matters;
+    /// no test in this module exercises `require()` against this stub.
+    struct DummyMandateGate;
+
+    impl crate::mandate_gate::MandateGate for DummyMandateGate {
+        fn require(
+            &self,
+            _req: &crate::mandate_gate::MandateRequest,
+        ) -> Result<crate::mandate_gate::MandateGrant, crate::mandate_gate::MandateGateError>
+        {
+            Err(crate::mandate_gate::MandateGateError::Rejected(
+                crate::mandate_gate::MandateRejection::NoMandate,
+            ))
+        }
+    }
+
+    fn dummy_mandate_gate() -> Arc<dyn crate::mandate_gate::MandateGate + Send + Sync> {
+        Arc::new(DummyMandateGate)
     }
 
     #[test]
@@ -864,14 +917,18 @@ mod build_mode_tests {
 
     #[test]
     fn missing_production_dependencies_lists_unset_optional_fields() {
-        // Empty context → all three deps missing, in stable order.
+        // Empty context → every required dep missing, in stable order. The
+        // order matches the field-declaration order on `GovernanceContext`
+        // and is part of this method's stable contract — operators reading
+        // a startup error and tooling parsing the message both rely on it.
         let ctx = ctx_with_mode(GovernanceContextBuildMode::Bootstrap);
         assert_eq!(
             ctx.missing_production_dependencies(),
             vec![
                 "member_checker",
                 "suspension_checker",
-                "membership_resolver"
+                "membership_resolver",
+                "mandate_gate",
             ]
         );
     }
@@ -882,7 +939,7 @@ mod build_mode_tests {
         ctx.member_checker = Some(dummy_member_checker());
         assert_eq!(
             ctx.missing_production_dependencies(),
-            vec!["suspension_checker", "membership_resolver"]
+            vec!["suspension_checker", "membership_resolver", "mandate_gate",]
         );
     }
 
@@ -892,6 +949,7 @@ mod build_mode_tests {
         ctx.member_checker = Some(dummy_member_checker());
         ctx.suspension_checker = Some(dummy_suspension_checker());
         ctx.membership_resolver = Some(dummy_resolver());
+        ctx.mandate_gate = Some(dummy_mandate_gate());
         assert!(ctx.missing_production_dependencies().is_empty());
     }
 
@@ -909,7 +967,8 @@ mod build_mode_tests {
             vec![
                 "member_checker",
                 "suspension_checker",
-                "membership_resolver"
+                "membership_resolver",
+                "mandate_gate",
             ]
         );
 
@@ -930,6 +989,10 @@ mod build_mode_tests {
             msg.contains("membership_resolver"),
             "error must name membership_resolver: {msg}"
         );
+        assert!(
+            msg.contains("mandate_gate"),
+            "error must name mandate_gate: {msg}"
+        );
     }
 
     #[test]
@@ -937,6 +1000,7 @@ mod build_mode_tests {
         let mut ctx = ctx_with_mode(GovernanceContextBuildMode::Production);
         ctx.member_checker = Some(dummy_member_checker());
         ctx.suspension_checker = Some(dummy_suspension_checker());
+        ctx.mandate_gate = Some(dummy_mandate_gate());
         // membership_resolver still missing
         let result = ctx.validate();
         let Err(err) = result else {
@@ -953,6 +1017,10 @@ mod build_mode_tests {
             !msg.contains("member_checker,"),
             "must not falsely name wired dep: {msg}"
         );
+        assert!(
+            !msg.contains("mandate_gate,") && !msg.ends_with("mandate_gate."),
+            "must not falsely name wired dep: {msg}"
+        );
     }
 
     #[test]
@@ -961,7 +1029,70 @@ mod build_mode_tests {
         ctx.member_checker = Some(dummy_member_checker());
         ctx.suspension_checker = Some(dummy_suspension_checker());
         ctx.membership_resolver = Some(dummy_resolver());
+        ctx.mandate_gate = Some(dummy_mandate_gate());
         assert!(ctx.validate().is_ok());
+    }
+
+    #[test]
+    fn production_without_mandate_gate_rejects() {
+        // All three standing/resolver deps wired; only `mandate_gate` is
+        // missing. Production must fail closed and the missing-list must
+        // name `mandate_gate` alone — proving the new dep is fully
+        // integrated into the production guard (not merely listed).
+        let mut ctx = ctx_with_mode(GovernanceContextBuildMode::Production);
+        ctx.member_checker = Some(dummy_member_checker());
+        ctx.suspension_checker = Some(dummy_suspension_checker());
+        ctx.membership_resolver = Some(dummy_resolver());
+        // mandate_gate intentionally left None
+
+        let Err(err) = ctx.validate() else {
+            panic!("Production without mandate_gate must reject; got Ok");
+        };
+        assert_eq!(err.missing, vec!["mandate_gate"]);
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("mandate_gate"),
+            "error must name mandate_gate: {msg}"
+        );
+        assert!(
+            msg.contains("MandateGate"),
+            "error message must reference MandateGate by name: {msg}"
+        );
+        assert!(
+            msg.contains("capability scope is not a mandate"),
+            "error message must explain the doctrine — capability is not a mandate: {msg}"
+        );
+    }
+
+    #[test]
+    fn bootstrap_without_mandate_gate_does_not_reject() {
+        // Bootstrap is the legacy/dev posture. Missing mandate_gate emits
+        // a warning but does not fail validation, preserving dev/devnet
+        // behavior.
+        let mut ctx = ctx_with_mode(GovernanceContextBuildMode::Bootstrap);
+        ctx.member_checker = Some(dummy_member_checker());
+        ctx.suspension_checker = Some(dummy_suspension_checker());
+        ctx.membership_resolver = Some(dummy_resolver());
+        // mandate_gate intentionally left None
+        assert!(
+            ctx.validate().is_ok(),
+            "Bootstrap mode must not reject startup on missing mandate_gate"
+        );
+    }
+
+    #[test]
+    fn test_mode_without_mandate_gate_does_not_reject() {
+        // Test mode is permissive, identical to Bootstrap for missing deps.
+        let mut ctx = ctx_with_mode(GovernanceContextBuildMode::Test);
+        ctx.member_checker = Some(dummy_member_checker());
+        ctx.suspension_checker = Some(dummy_suspension_checker());
+        ctx.membership_resolver = Some(dummy_resolver());
+        // mandate_gate intentionally left None
+        assert!(
+            ctx.validate().is_ok(),
+            "Test mode must not reject startup on missing mandate_gate"
+        );
     }
 
     #[test]

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -1017,8 +1017,15 @@ mod build_mode_tests {
             !msg.contains("member_checker,"),
             "must not falsely name wired dep: {msg}"
         );
+        // `err.missing == ["membership_resolver"]` above is already the strong
+        // assertion that `mandate_gate` is not falsely listed. The string-level
+        // check below is a belt-and-suspenders sanity guard: the snake_case
+        // identifier `mandate_gate` can only enter the rendered message via
+        // `missing.join(", ")`, since the doctrine sentence uses the CamelCase
+        // `MandateGate`. So any `mandate_gate` substring is a falsehood
+        // regardless of its position in the list (mid or trailing).
         assert!(
-            !msg.contains("mandate_gate,") && !msg.ends_with("mandate_gate."),
+            !msg.contains("mandate_gate"),
             "must not falsely name wired dep: {msg}"
         );
     }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -5764,6 +5764,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -5888,6 +5889,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -6015,6 +6017,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -6139,6 +6142,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -6260,6 +6264,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -6327,6 +6332,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -6450,6 +6456,7 @@ mod tests {
             suspension_checker: Some(suspension_checker),
             membership_resolver: Some(resolver),
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -6536,6 +6543,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver,
             sdis_service: None,
+            mandate_gate: None,
             build_mode,
         }
     }
@@ -7071,6 +7079,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -7123,6 +7132,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -7156,6 +7166,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -7214,6 +7225,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         };
 
@@ -7250,6 +7262,7 @@ mod tests {
                 suspension_checker: None,
                 membership_resolver: None,
                 sdis_service: None,
+                mandate_gate: None,
                 build_mode: GovernanceContextBuildMode::Test,
             };
             me_test_app!(ctx, $caller)
@@ -7763,6 +7776,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         }
     }
@@ -8817,6 +8831,7 @@ mod tests {
             suspension_checker: None,
             membership_resolver: None,
             sdis_service: None,
+            mandate_gate: None,
             build_mode: GovernanceContextBuildMode::Test,
         }
     }

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -57,6 +57,10 @@ pub use manager::{
     SledMilestoneEventLog, SledMilestoneStore, SledProgramEventLog, SledProgramStore,
     SledStructureStore, UpcomingMeetingDigest,
 };
+pub use mandate_gate::{
+    DefaultMandateGate, MandateAct, MandateGate, MandateGateError, MandateGrant, MandateRejection,
+    MandateRequest, MandateTarget,
+};
 pub use receipt_backend::GovernanceReceiptBackend;
 pub use state_store::{GovernanceStateStore, SledGovernanceStateStore};
 

--- a/icn/apps/governance/tests/activity_scope_migration.rs
+++ b/icn/apps/governance/tests/activity_scope_migration.rs
@@ -56,6 +56,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }

--- a/icn/apps/governance/tests/assign_role_authority_scope.rs
+++ b/icn/apps/governance/tests/assign_role_authority_scope.rs
@@ -39,6 +39,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }

--- a/icn/apps/governance/tests/charter_activation.rs
+++ b/icn/apps/governance/tests/charter_activation.rs
@@ -88,6 +88,7 @@ fn make_ctx_with_capture() -> (GovernanceContext<NoopEventEmitter>, CapturedHook
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
@@ -456,6 +457,7 @@ async fn activate_charter_returns_500_when_charter_hook_not_wired() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
     let app = charter_test_app!(ctx, Some("governance:write"));
@@ -499,6 +501,7 @@ async fn activate_charter_returns_500_when_proposal_hook_not_wired() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
     let app = charter_test_app!(ctx, Some("governance:write"));

--- a/icn/apps/governance/tests/charter_scope_migration.rs
+++ b/icn/apps/governance/tests/charter_scope_migration.rs
@@ -66,6 +66,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }

--- a/icn/apps/governance/tests/comment_scope_migration.rs
+++ b/icn/apps/governance/tests/comment_scope_migration.rs
@@ -55,6 +55,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }

--- a/icn/apps/governance/tests/federation_scope_migration.rs
+++ b/icn/apps/governance/tests/federation_scope_migration.rs
@@ -67,6 +67,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }

--- a/icn/apps/governance/tests/me_action_card_receipt_chain.rs
+++ b/icn/apps/governance/tests/me_action_card_receipt_chain.rs
@@ -171,6 +171,7 @@ fn make_harness() -> Harness {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
     Harness { ctx, receipts }

--- a/icn/apps/governance/tests/me_action_cards.rs
+++ b/icn/apps/governance/tests/me_action_cards.rs
@@ -52,6 +52,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }

--- a/icn/apps/governance/tests/me_action_item_receipt_chain.rs
+++ b/icn/apps/governance/tests/me_action_item_receipt_chain.rs
@@ -254,6 +254,7 @@ fn make_harness() -> Harness {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
     Harness { ctx, receipts }

--- a/icn/apps/governance/tests/me_standing.rs
+++ b/icn/apps/governance/tests/me_standing.rs
@@ -55,6 +55,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }

--- a/icn/apps/governance/tests/meeting_scope_migration.rs
+++ b/icn/apps/governance/tests/meeting_scope_migration.rs
@@ -51,6 +51,7 @@ fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     }
 }

--- a/icn/apps/governance/tests/steward_scope_migration.rs
+++ b/icn/apps/governance/tests/steward_scope_migration.rs
@@ -85,6 +85,7 @@ fn ctx_with_structure() -> (GovernanceContext<NoopEventEmitter>, String) {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
     (ctx, structure_id)

--- a/icn/bins/icnctl/src/institution_bootstrap.rs
+++ b/icn/bins/icnctl/src/institution_bootstrap.rs
@@ -1745,6 +1745,7 @@ mod tests {
                 suspension_checker: None,
                 membership_resolver: None,
                 sdis_service: None,
+                mandate_gate: None,
                 build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
             };
 

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1416,7 +1416,18 @@ impl GatewayServer {
             // Daemon mode: SDIS execution goes through the actor event system
             // (KernelGovernanceExecutor → SdisServiceImpl). HTTP path leaves this None.
             sdis_service: None,
-            mandate_gate: None,
+            // Wire the app-side, act-time authority resolver over the gateway's
+            // existing `receipt_store`, which already implements
+            // `GovernanceReceiptBackend`. `DefaultMandateGate` introduces no new
+            // persistence — it reuses the gateway's mandate/grant indexes.
+            //
+            // No handler calls `require()` yet (handler wiring is #1868 step 7);
+            // populating this field now is necessary so the Production startup
+            // guard does not fail closed on the gateway path. Bootstrap/Test
+            // contexts may still leave this `None` and receive a warning.
+            mandate_gate: Some(Arc::new(icn_governance_actor::DefaultMandateGate::new(
+                receipt_store.clone(),
+            ))),
             // Deployment posture for the governance HTTP context.
             //
             // Resolved from the `ICN_GOVERNANCE_BUILD_MODE` environment variable

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -1416,6 +1416,7 @@ impl GatewayServer {
             // Daemon mode: SDIS execution goes through the actor event system
             // (KernelGovernanceExecutor → SdisServiceImpl). HTTP path leaves this None.
             sdis_service: None,
+            mandate_gate: None,
             // Deployment posture for the governance HTTP context.
             //
             // Resolved from the `ICN_GOVERNANCE_BUILD_MODE` environment variable

--- a/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
+++ b/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
@@ -226,6 +226,7 @@ async fn build_app_with_proposal(
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
@@ -272,6 +272,7 @@ async fn test_suspended_member_cannot_create_delegation() {
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
@@ -506,6 +507,7 @@ async fn test_suspended_member_cannot_create_blanket_delegation() {
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -312,6 +312,7 @@ async fn test_e2e_freeze_member_suspends_commons_affiliation() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
@@ -570,6 +571,7 @@ async fn test_e2e_unfreeze_member_reinstates_commons_affiliation() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
@@ -920,6 +922,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: Some(sdis_svc),
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
@@ -228,6 +228,7 @@ async fn test_freeze_member_blocks_ledger_entries_after_governance_acceptance() 
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
@@ -138,6 +138,7 @@ async fn build_app(
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
@@ -213,6 +213,7 @@ async fn test_suspended_member_cannot_open_proposal() {
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
@@ -247,6 +247,7 @@ async fn test_suspended_member_cannot_submit_proposals() {
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
@@ -138,6 +138,7 @@ async fn build_app(
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs
@@ -180,6 +180,7 @@ async fn build_app_with_trust_resolver(
         // Live production resolver — NOT a TrackingResolver mock
         membership_resolver: Some(resolver),
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
@@ -161,6 +161,7 @@ async fn build_app_with_open_proposal(
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
@@ -414,6 +415,7 @@ async fn build_app_with_suspension_checker(
         suspension_checker: Some(suspension_checker),
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/governance_proof.rs
+++ b/icn/crates/icn-gateway/tests/governance_proof.rs
@@ -78,6 +78,7 @@ async fn test_governance_proposal_full_lifecycle_with_real_auth() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 
@@ -397,6 +398,7 @@ async fn test_governance_endpoints_require_auth() {
         suspension_checker: None,
         membership_resolver: None,
         sdis_service: None,
+        mandate_gate: None,
         build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
     };
 

--- a/icn/crates/icn-gateway/tests/mandate_gate_production_wiring.rs
+++ b/icn/crates/icn-gateway/tests/mandate_gate_production_wiring.rs
@@ -1,0 +1,119 @@
+//! Regression test for PR #1927 / #1868 startup-guard wiring.
+//!
+//! Proves the gateway's daemon-backed production path can construct a real
+//! `DefaultMandateGate` over the existing `ReceiptStore` and that the resulting
+//! `GovernanceContext::validate()` accepts Production mode. Companion assertion
+//! shows the guard still fails closed when `mandate_gate` is `None` — so this
+//! test catches both regressions: forgetting to wire the gate, and silently
+//! weakening the guard.
+//!
+//! The validate() pathway never calls `MandateGate::require()`; handler wiring
+//! is out of scope for this PR (#1868 step 7). The point here is purely that
+//! the field is populated with a real backend-backed gate, exactly as
+//! `server.rs` does in the daemon-backed path.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use icn_gateway::ReceiptStore;
+use icn_governance::{MembershipResolver, StaticMembershipResolver};
+use icn_governance_actor::events::NoopEventEmitter;
+use icn_governance_actor::http::{
+    configure::{
+        GovernanceContext, MemberStandingChecker, StewardStandingChecker, SuspensionChecker,
+    },
+    GovernanceContextBuildMode,
+};
+use icn_governance_actor::{DefaultMandateGate, GovernanceManager, MandateGate};
+
+fn temp_db() -> sled::Db {
+    sled::Config::new()
+        .temporary(true)
+        .open()
+        .expect("sled temp open")
+}
+
+fn dummy_member_checker() -> MemberStandingChecker {
+    Arc::new(|_did, _domain| Box::pin(async { true }))
+}
+
+fn dummy_steward_checker() -> StewardStandingChecker {
+    Arc::new(|_did| Box::pin(async { true }))
+}
+
+fn dummy_suspension_checker() -> SuspensionChecker {
+    Arc::new(|_did, _domain| Box::pin(async { false }))
+}
+
+fn dummy_membership_resolver() -> Arc<dyn MembershipResolver> {
+    Arc::new(StaticMembershipResolver::new())
+}
+
+/// Build a `GovernanceContext` that mirrors the shape `server.rs` constructs
+/// on the daemon-backed path: all standing/resolver deps wired, and the
+/// `mandate_gate` derived from the gateway's real `ReceiptStore`.
+fn production_like_ctx(
+    receipt_store: Arc<ReceiptStore>,
+    mandate_gate: Option<Arc<dyn MandateGate + Send + Sync>>,
+) -> GovernanceContext<NoopEventEmitter> {
+    // Touch `receipt_store` so the test fails to compile if the gateway ever
+    // moves the field off the context shape this test depends on.
+    let _: &ReceiptStore = &receipt_store;
+
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: Some(dummy_member_checker()),
+        steward_checker: Some(dummy_steward_checker()),
+        suspension_checker: Some(dummy_suspension_checker()),
+        membership_resolver: Some(dummy_membership_resolver()),
+        sdis_service: None,
+        mandate_gate,
+        build_mode: GovernanceContextBuildMode::Production,
+    }
+}
+
+#[test]
+fn production_gateway_context_validates_when_mandate_gate_wired_from_receipt_store() {
+    // Mirror the daemon-backed path in `server.rs`: build the `ReceiptStore`
+    // first, then construct a `DefaultMandateGate` over it. The `Arc<ReceiptStore>`
+    // coerces to `Arc<dyn GovernanceReceiptBackend>` at the call site because
+    // `ReceiptStore` implements `GovernanceReceiptBackend`.
+    let db = temp_db();
+    let receipt_store = Arc::new(ReceiptStore::new(db));
+
+    let mandate_gate: Arc<dyn MandateGate + Send + Sync> =
+        Arc::new(DefaultMandateGate::new(receipt_store.clone()));
+
+    let ctx = production_like_ctx(receipt_store, Some(mandate_gate));
+    ctx.validate()
+        .expect("Production gateway context with a real DefaultMandateGate must validate");
+}
+
+#[test]
+fn production_gateway_context_still_rejects_when_mandate_gate_missing() {
+    // The companion direction: even when every other production dep is wired,
+    // a missing `mandate_gate` must fail closed. This is the guard the
+    // PR-#1927 fix preserves; weakening validate() to make the wiring test
+    // pass would silently retire this rejection. Keep both assertions in the
+    // same file so any future weakening shows up as a test diff here.
+    let db = temp_db();
+    let receipt_store = Arc::new(ReceiptStore::new(db));
+
+    let ctx = production_like_ctx(receipt_store, None);
+    let err = ctx
+        .validate()
+        .expect_err("Production gateway context without mandate_gate must reject");
+    assert_eq!(err.missing, vec!["mandate_gate"]);
+    assert_eq!(err.mode, GovernanceContextBuildMode::Production);
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("mandate_gate"),
+        "error message must name the missing dep: {msg}"
+    );
+}


### PR DESCRIPTION
## Update (post-review, 2026-05-28)

Codex P1 on `server.rs` was correct: extending
`missing_production_dependencies()` to include `mandate_gate` made
`GovernanceContext::validate()` reject Production startup
unconditionally on the gateway path, because the daemon-backed
construction left the field `None`. Fixed in 5a02775.

The gateway's daemon-backed path now wires a real `DefaultMandateGate`
from the existing `receipt_store` (which already implements
`GovernanceReceiptBackend`). No new persistence; no stub gates in
production code. Bootstrap/Test construction sites elsewhere remain
`None` to exercise the warn-only fall-open posture.

Regression test added at
`icn/crates/icn-gateway/tests/mandate_gate_production_wiring.rs`:

- `production_gateway_context_validates_when_mandate_gate_wired_from_receipt_store`
  — gateway-shaped Production context with a real `DefaultMandateGate`
  over `ReceiptStore` passes `validate()`.
- `production_gateway_context_still_rejects_when_mandate_gate_missing`
  — same shape with `mandate_gate: None` still fails closed, naming
  `mandate_gate` in `err.missing`. Both assertions live in one file so
  any future weakening of the guard shows up as a test diff here.

Also addressed a Copilot review nit on the build_mode test's negative
assertion (a31c7f3) — replaced an ends_with check that could never
fire with a tighter contains check on the snake_case identifier.

Non-claims preserved:

- No handler calls `MandateGate::require()` yet (#1868 step 7 is still
  out of scope).
- No receipt-body schema migration.
- No `governance:write` retirement.
- No kernel meaning-firewall widening — the gateway construction site
  spells the trait, never the act-time semantics.
- No production-readiness, live-federation, or demo-ready claim. The
  Production startup guard is enabled and satisfiable on the gateway
  path; nothing here makes the broader system ready to deploy.

---

## What

Adds `mandate_gate: Option<Arc<dyn MandateGate + Send + Sync>>` to
`GovernanceContext<E>` in `icn/apps/governance/src/http/configure.rs`
and integrates it into the existing
`missing_production_dependencies()` / `validate()` machinery, mirroring
the established pattern for `member_checker`, `suspension_checker`,
and `membership_resolver`.

Behavior matrix:

| Build mode  | `mandate_gate: None`         | `mandate_gate: Some(_)` |
|-------------|------------------------------|-------------------------|
| Production  | `validate()` **fails closed**, naming `mandate_gate` in the error | `validate()` returns `Ok(())` |
| Bootstrap   | warning, `validate()` returns `Ok(())` | `validate()` returns `Ok(())` |
| Test        | warning, `validate()` returns `Ok(())` | `validate()` returns `Ok(())` |

Construction-site changes are mechanical: 48 `GovernanceContext { … }`
literals across the workspace receive `mandate_gate: None,`. No
handler behavior change.

## Why this is the next #1868 slice

PR #1926 merged the step-6 `MandateGate` resolver primitives as a
purely additive module — its own docs state "Nothing calls this gate
in step 6." `docs/design/governance/mandate-gate-design.md` §9 names
two follow-up directions:

1. **Step 7 — handler wiring**: wire `require()` into the charter and
   federation handlers, recording a `MandateGrant` hash in receipts
   (depends on the step-2 receipt schema).
2. **Startup guard (with #1871)**: extend `GovernanceContext::validate()`
   so Production refuses to start without a wired gate.

This PR is the **Startup guard** slice. It is intentionally narrower
than step 7 so the act-time mandate semantics can be reviewed
independently of the infrastructure plumbing.

There are 49 `GovernanceContext` construction sites in the workspace.
Combining the field addition with handler behavior change for
`activate_charter` would push the diff past the small/reviewable
boundary; the design doc also recommends wiring charter and federation
together in step 7, not `activate_charter` alone.

## Tests

Added in `build_mode_tests` in `configure.rs`:

- `production_without_mandate_gate_rejects` — all three
  standing/resolver deps wired, `mandate_gate: None` → `validate()`
  returns `Err(...)` and `missing` contains exactly `"mandate_gate"`;
  the rendered message references MandateGate and the doctrine
  ("capability scope is not a mandate").
- `bootstrap_without_mandate_gate_does_not_reject`,
  `test_mode_without_mandate_gate_does_not_reject` — Bootstrap/Test
  stay permissive.
- Existing tests
  (`missing_production_dependencies_lists_unset_optional_fields`,
   `missing_production_dependencies_excludes_wired_fields`,
   `missing_production_dependencies_empty_when_all_wired`,
   `production_all_missing_returns_error_naming_all`,
   `production_single_missing_dep_names_only_that_dep`,
   `production_all_wired_validates_ok`) extended to include
  `mandate_gate` in their assertions, preserving the stable-ordering
  contract on the missing-deps list.

A test-only `DummyMandateGate` lives inside `#[cfg(test)]` and always
returns `Err(Rejected(NoMandate))`. It is not exported; nothing in
production code can construct it.

## Invariants preserved

- **Meaning firewall.** `MandateGate`, `MandateAct`, `MandateTarget`
  stay in `apps/governance`. The kernel sees nothing new. The field
  stored in `GovernanceContext` is an app-side handle.
- **Composability.** `mandate_gate` is a sibling of `member_checker` /
  `suspension_checker` / `membership_resolver`, not a wrapper. No
  god-auth function. The async `suspension_checker` stays
  handler-composed (the gate is synchronous by design).
- **Trait surface untouched.** Using `Arc<dyn MandateGate + Send + Sync>`
  at the field type adds the marker bounds at the coercion point only.
  The `MandateGate` trait keeps its current definition.
- **Behavior-neutral for Bootstrap/Test.** Every existing construction
  site gets `mandate_gate: None`. `validate()` in Bootstrap/Test
  continues to return `Ok(())`. No handler calls the gate.

## Validation run

All commands from `icn/icn/` unless noted:

- `cargo fmt --all -- --check` — pass
- `cargo check --workspace --all-targets` — pass
- `cargo clippy -p icn-governance-actor --all-targets -- -D warnings` — pass
- `cargo test -p icn-governance-actor` — pass (270 lib unit, plus all integration suites)
- `cargo test -p icn-gateway --tests` — pass (35 test groups, all green)
- `python3 .github/scripts/compliance_linter.py` (from repo root) — pass (107 files scanned, no violations)
- `git diff --check` — clean

## Out of scope / non-claims

- Does **not** wire any handler. `activate_charter` and all other
  handlers are untouched. Step 7 will wire charter and federation
  handlers together in a follow-up PR.
- Does **not** change receipt-body schema (no `MandateGrantRef`, no
  `capability_scope_presented`, no receipt v2).
- Does **not** retire `governance:write`.
- Does **not** move mandate semantics into kernel crates. The meaning
  firewall is unchanged.
- Does **not** change public surfaces, demos, the website, K3s
  manifests, or partner/NYCN activation paths.
- Does **not** claim production readiness, live-federation readiness,
  or any deployment milestone. This slice only proves the startup
  guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
