### PR TITLE
feat(governance): add mandate attestation to action-item receipts (#1868)

### DIFF
--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -136,12 +136,12 @@ pub use membership::{MembershipConfig, MembershipSource};
 pub use message::{GovernanceMessage, ProposalOutcome, TallySnapshot};
 pub use profile::{DecisionOutcome, GovernanceProfile, GovernanceProfileId, GovernanceRule};
 pub use proof::{
-    ActionItemCompletionReceipt, ActionItemTransition, GovernanceDecisionAttestation,
-    GovernanceDecisionReceipt, GovernanceDecisionReceiptV2, GovernanceDecisionReceiptV2Error,
-    GovernanceProof, GovernanceProofV2, MandateGrantRef, MandateGrantRefError,
-    MandateGrantRefTarget, MeetingAttendanceReceipt, MeetingAttendanceTransition, NoMandateReason,
-    ProcessGateKind, ProcessGateResult, ProcessGateResultReceipt, ProofOutcome,
-    ReceiptMandateAttestation,
+    ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActionItemCompletionReceiptV2Error,
+    ActionItemTransition, GovernanceDecisionAttestation, GovernanceDecisionReceipt,
+    GovernanceDecisionReceiptV2, GovernanceDecisionReceiptV2Error, GovernanceProof,
+    GovernanceProofV2, MandateGrantRef, MandateGrantRefError, MandateGrantRefTarget,
+    MeetingAttendanceReceipt, MeetingAttendanceTransition, NoMandateReason, ProcessGateKind,
+    ProcessGateResult, ProcessGateResultReceipt, ProofOutcome, ReceiptMandateAttestation,
 };
 pub use proposal::{
     AllocationOption, DataSharingLevel, DisputeResolutionMethod, DisputeResolutionOutcome,

--- a/icn/crates/icn-governance/src/proof.rs
+++ b/icn/crates/icn-governance/src/proof.rs
@@ -953,22 +953,320 @@ impl ActionItemCompletionReceipt {
     ) -> Hash {
         let mut hasher = blake3::Hasher::new();
         hasher.update(Self::DOMAIN_TAG);
-        // Use u64 length prefixes to match the canonical encoding used by
-        // `GovernanceProof::compute_proof_hash` and `compute_vote_hash`
-        // elsewhere in this module — keeps the hash binding consistent
-        // across receipt types and avoids any risk of u32 truncation.
-        for field in [item_id, domain_id, actor_did] {
-            hasher.update(&(field.len() as u64).to_le_bytes());
-            hasher.update(field.as_bytes());
-        }
-        let transition_byte: u8 = match transition {
-            ActionItemTransition::Completed => 0,
-        };
-        hasher.update(&[transition_byte]);
-        hasher.update(&completed_at.to_le_bytes());
+        absorb_action_item_base_field_bytes(
+            &mut hasher,
+            item_id,
+            domain_id,
+            actor_did,
+            transition,
+            completed_at,
+        );
         let mut out = [0u8; 32];
         out.copy_from_slice(hasher.finalize().as_bytes());
         out
+    }
+}
+
+/// Absorb the canonical base-field byte sequence shared by every versioned
+/// [`ActionItemCompletionReceipt`] family member.
+///
+/// Writes only `item_id`, `domain_id`, `actor_did`, `transition`, and
+/// `completed_at` into the hasher — **not** a domain-separation tag.
+/// Each versioned receipt's `compute_record_hash` writes its **own**
+/// [`Self::DOMAIN_TAG`] first and then calls this helper, so the two
+/// version namespaces (`icn:gov:action_item_completion:v1`,
+/// `icn:gov:action_item_completion:v2`, …) remain fully separate even
+/// though they share the same base-field encoding.
+///
+/// The encoding mirrors the original v1
+/// [`ActionItemCompletionReceipt::compute_record_hash`] body
+/// byte-for-byte so v1 hashes remain stable after extraction. u64
+/// length prefixes are used (matching the convention elsewhere in this
+/// module) and the transition ordinal comes from
+/// [`action_item_transition_ordinal`].
+fn absorb_action_item_base_field_bytes(
+    hasher: &mut blake3::Hasher,
+    item_id: &str,
+    domain_id: &str,
+    actor_did: &str,
+    transition: ActionItemTransition,
+    completed_at: u64,
+) {
+    for field in [item_id, domain_id, actor_did] {
+        hasher.update(&(field.len() as u64).to_le_bytes());
+        hasher.update(field.as_bytes());
+    }
+    hasher.update(&[action_item_transition_ordinal(transition)]);
+    hasher.update(&completed_at.to_le_bytes());
+}
+
+/// Map [`ActionItemTransition`] to a deterministic ordinal for canonical
+/// hashing. Ordinals are fixed at v1 of the receipt's wire format; adding
+/// a variant after `Completed` requires a new domain-separation tag on
+/// every receipt that consumes this helper.
+fn action_item_transition_ordinal(transition: ActionItemTransition) -> u8 {
+    match transition {
+        ActionItemTransition::Completed => 0,
+    }
+}
+
+// ============================================================================
+// Action item completion receipt v2 — mandate-attestation fork (#1868 step 2)
+// ============================================================================
+
+/// Errors returned by [`ActionItemCompletionReceiptV2::new`] (and by the
+/// `try_from` shadow that routes `Deserialize` through the same checks).
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ActionItemCompletionReceiptV2Error {
+    /// The `capability_scope_presented` field was empty or whitespace-
+    /// only. Rejected at the constructor and at the wire boundary so the
+    /// receipt cannot record an unattributed scope. Mirrors the
+    /// [`GovernanceDecisionReceiptV2Error::EmptyCapabilityScope`]
+    /// contract.
+    #[error("capability_scope_presented must be a non-empty, non-whitespace string")]
+    EmptyCapabilityScope,
+}
+
+/// Cross-node deterministic completion receipt for a governance action
+/// item — **v2** of the canonical wire form, embedding the mandate-
+/// attestation discriminator and the capability scope a caller presented
+/// at completion time.
+///
+/// # Relationship to existing types
+///
+/// - [`ActionItemCompletionReceipt`] (this module, above) is the v1
+///   receipt and is **byte-stable** — its `DOMAIN_TAG`
+///   (`icn:gov:action_item_completion:v1`), canonical hash, and call
+///   sites are unchanged. v2 is purely additive; no v1 caller is forced
+///   to migrate.
+/// - [`GovernanceDecisionReceiptV2`] is the parallel v2 fork on the
+///   proposal-decision side (#1868 step 2). The two v2 receipts share the
+///   same [`ReceiptMandateAttestation`] / [`NoMandateReason`] primitives
+///   and the same wire-boundary discipline (checked constructor + serde
+///   `try_from` shadow), differing only in their base-field set and
+///   their domain-separation tag namespace.
+///
+/// # Wire / canonical contract
+///
+/// - `DOMAIN_TAG = b"icn:gov:action_item_completion:v2"`. Fully separate
+///   from the v1 namespace; the two cannot collide. Also distinct from
+///   the proposal-decision and meeting-attendance tags so records can
+///   never collide across receipt families.
+/// - Canonical encoding: v2 tag, then the same base-field byte sequence
+///   v1 binds (via the shared [`absorb_action_item_base_field_bytes`]
+///   helper), then the v2-only fields. The v2 hash is a fresh `blake3`
+///   over that byte stream — **never** derived from v1's
+///   `record_hash`, v1's tag, or any serialized form of either.
+/// - `Deserialize` is routed through a private
+///   `ActionItemCompletionReceiptV2Raw` shadow + `#[serde(try_from =
+///   ...)]` so empty-scope rejection runs on every deserialized
+///   payload (mirrors the #1928 / #1929 boundary pattern).
+/// - Equality is anchored to `record_hash` (matches the v1 convention).
+///
+/// # Out of scope for this PR
+///
+/// - No handler emits a v2 action-item receipt yet.
+/// - No `MeetingAttendanceReceipt` fork.
+/// - No grant-minting expansion; no `TypedScope` federation/role binding;
+///   no `governance:write` retirement; no kernel meaning-firewall
+///   widening; no production-readiness/live-federation/demo claim.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(try_from = "ActionItemCompletionReceiptV2Raw")]
+pub struct ActionItemCompletionReceiptV2 {
+    /// Action item id (string form of `ActionItemId`).
+    pub item_id: String,
+    /// Governance domain the action item lives under.
+    pub domain_id: String,
+    /// DID of the actor whose authorized completion call produced this
+    /// receipt.
+    pub actor_did: String,
+    /// Transition this receipt records. Closed enum; see
+    /// [`ActionItemTransition`].
+    pub transition: ActionItemTransition,
+    /// Unix-seconds the transition was recorded.
+    pub completed_at: u64,
+    /// The capability scope string the caller presented at completion
+    /// time (e.g. `"governance:meeting:write"`, `"governance:write"`).
+    /// Bound into the canonical hash so the receipt records *which kind
+    /// of write happened* alongside the transition. Rejected
+    /// empty/whitespace by the constructor and the serde boundary.
+    pub capability_scope_presented: String,
+    /// Explicit mandate-attestation discriminator: either a
+    /// [`ReceiptMandateAttestation::Grant`] carrying a wire-form
+    /// [`MandateGrantRef`] or a
+    /// [`ReceiptMandateAttestation::NoMandateRequired`] carrying a
+    /// closed-taxonomy [`NoMandateReason`]. Never `Option` — absence
+    /// must never be interpretable as "no mandate."
+    pub mandate_attestation: ReceiptMandateAttestation,
+    /// blake3 canonical record hash from receipt fields under the v2
+    /// domain-separation tag.
+    pub record_hash: Hash,
+}
+
+impl PartialEq for ActionItemCompletionReceiptV2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.record_hash == other.record_hash
+    }
+}
+
+impl Eq for ActionItemCompletionReceiptV2 {}
+
+impl ActionItemCompletionReceiptV2 {
+    /// Domain separation tag for v2 canonical action-item completion
+    /// record hashes. Distinct from
+    /// [`ActionItemCompletionReceipt::DOMAIN_TAG`] so the v1 and v2
+    /// namespaces remain fully separate.
+    pub const DOMAIN_TAG: &[u8] = b"icn:gov:action_item_completion:v2";
+
+    /// Build a new v2 receipt and compute its canonical `record_hash`.
+    /// Rejects empty/whitespace `capability_scope_presented`.
+    pub fn new(
+        item_id: String,
+        domain_id: String,
+        actor_did: String,
+        transition: ActionItemTransition,
+        completed_at: u64,
+        capability_scope_presented: String,
+        mandate_attestation: ReceiptMandateAttestation,
+    ) -> Result<Self, ActionItemCompletionReceiptV2Error> {
+        if capability_scope_presented.trim().is_empty() {
+            return Err(ActionItemCompletionReceiptV2Error::EmptyCapabilityScope);
+        }
+        let record_hash = Self::compute_record_hash(
+            &item_id,
+            &domain_id,
+            &actor_did,
+            transition,
+            completed_at,
+            &capability_scope_presented,
+            &mandate_attestation,
+        );
+        Ok(Self {
+            item_id,
+            domain_id,
+            actor_did,
+            transition,
+            completed_at,
+            capability_scope_presented,
+            mandate_attestation,
+            record_hash,
+        })
+    }
+
+    /// Compute the canonical v2 `record_hash` from receipt fields.
+    ///
+    /// The byte stream is: v2 [`Self::DOMAIN_TAG`], then the v1 base
+    /// fields via [`absorb_action_item_base_field_bytes`] (length-
+    /// prefixed strings, single-byte transition ordinal, u64 LE
+    /// `completed_at`, identical order to v1), then the v2-only
+    /// additions: length-prefixed `capability_scope_presented`, a single
+    /// ordinal byte for the [`ReceiptMandateAttestation`] variant
+    /// (`NoMandateRequired` = 0, `Grant` = 1), then the per-variant
+    /// payload:
+    ///
+    /// - `NoMandateRequired { reason }`: a single
+    ///   [`no_mandate_reason_ordinal`] byte.
+    /// - `Grant { grant_ref }`: the 32-byte
+    ///   [`MandateGrantRef::ref_hash`] (fixed-length; no length prefix).
+    ///   Binding via `ref_hash` propagates the grant ref's per-component
+    ///   canonical encoding (#1928) without re-deriving the field layout
+    ///   here.
+    pub fn compute_record_hash(
+        item_id: &str,
+        domain_id: &str,
+        actor_did: &str,
+        transition: ActionItemTransition,
+        completed_at: u64,
+        capability_scope_presented: &str,
+        mandate_attestation: &ReceiptMandateAttestation,
+    ) -> Hash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(Self::DOMAIN_TAG);
+        absorb_action_item_base_field_bytes(
+            &mut hasher,
+            item_id,
+            domain_id,
+            actor_did,
+            transition,
+            completed_at,
+        );
+        hasher.update(&(capability_scope_presented.len() as u64).to_le_bytes());
+        hasher.update(capability_scope_presented.as_bytes());
+        hasher.update(&[attestation_kind_ordinal(mandate_attestation)]);
+        match mandate_attestation {
+            ReceiptMandateAttestation::NoMandateRequired { reason } => {
+                hasher.update(&[no_mandate_reason_ordinal(*reason)]);
+            }
+            ReceiptMandateAttestation::Grant { grant_ref } => {
+                // Bind via the grant ref's canonical hash (#1928). Fixed
+                // length (32 bytes), no length prefix.
+                hasher.update(&grant_ref.ref_hash());
+            }
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hasher.finalize().as_bytes());
+        out
+    }
+
+    /// Verify the stored `record_hash` against canonical v2 receipt
+    /// fields.
+    pub fn verify(&self) -> bool {
+        let recomputed = Self::compute_record_hash(
+            &self.item_id,
+            &self.domain_id,
+            &self.actor_did,
+            self.transition,
+            self.completed_at,
+            &self.capability_scope_presented,
+            &self.mandate_attestation,
+        );
+        self.record_hash == recomputed
+    }
+}
+
+/// Raw deserialization shadow for [`ActionItemCompletionReceiptV2`].
+///
+/// `ActionItemCompletionReceiptV2` is a wire/persisted primitive, so
+/// `Deserialize` is an input boundary that must apply the same checks as
+/// the constructor. Routing deserialization through this shadow +
+/// `try_from` keeps the wire surface symmetric with `new` — a payload
+/// with an empty `capability_scope_presented` fails closed at the
+/// deserialization boundary, not only via `new`. Mirrors the pattern
+/// established by `MandateGrantRefRaw` (#1928) and
+/// `GovernanceDecisionReceiptV2Raw` (#1929).
+#[derive(Deserialize)]
+struct ActionItemCompletionReceiptV2Raw {
+    item_id: String,
+    domain_id: String,
+    actor_did: String,
+    transition: ActionItemTransition,
+    completed_at: u64,
+    capability_scope_presented: String,
+    mandate_attestation: ReceiptMandateAttestation,
+    record_hash: Hash,
+}
+
+impl TryFrom<ActionItemCompletionReceiptV2Raw> for ActionItemCompletionReceiptV2 {
+    type Error = ActionItemCompletionReceiptV2Error;
+
+    fn try_from(raw: ActionItemCompletionReceiptV2Raw) -> Result<Self, Self::Error> {
+        if raw.capability_scope_presented.trim().is_empty() {
+            return Err(ActionItemCompletionReceiptV2Error::EmptyCapabilityScope);
+        }
+        // Matches v1 behavior: `Deserialize` accepts whatever
+        // `record_hash` value the wire carries; callers verify integrity
+        // via `verify()` separately. Keeps the deserialization surface a
+        // pure structural check.
+        Ok(Self {
+            item_id: raw.item_id,
+            domain_id: raw.domain_id,
+            actor_did: raw.actor_did,
+            transition: raw.transition,
+            completed_at: raw.completed_at,
+            capability_scope_presented: raw.capability_scope_presented,
+            mandate_attestation: raw.mandate_attestation,
+            record_hash: raw.record_hash,
+        })
     }
 }
 
@@ -2997,6 +3295,342 @@ mod tests {
                 assert!(
                     !lower.contains(forbidden),
                     "GovernanceDecisionReceiptV2 JSON must not contain \
+                     regulated-finance vocabulary; found `{forbidden}` in: {json}"
+                );
+            }
+        }
+    }
+
+    // ============================================================================
+    // ActionItemCompletionReceiptV2 — mandate-attestation fork (#1868 step 2)
+    // ============================================================================
+
+    /// Deterministic v2 action-item receipt around the given attestation.
+    /// Uses fixed values for every base field so per-test mutation is
+    /// localized to the field under assertion.
+    fn sample_action_item_v2_receipt(
+        att: ReceiptMandateAttestation,
+    ) -> ActionItemCompletionReceiptV2 {
+        ActionItemCompletionReceiptV2::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_000,
+            "governance:meeting:write".to_string(),
+            att,
+        )
+        .expect("sample v2 action-item receipt must construct cleanly")
+    }
+
+    #[test]
+    fn action_item_v1_record_hash_remains_stable_after_v2_introduction() {
+        // Explicit byte-stream fixture: a v1 receipt over known inputs
+        // must hash to the same bytes the v1 canonical encoding
+        // produces. Mirrors v1's length-prefix layout by hand so any
+        // drift in v1 encoding (including from the shared-helper
+        // refactor in this PR) makes this test fail loudly with a
+        // visible byte diff.
+        let mut expected_bytes = Vec::new();
+        expected_bytes.extend_from_slice(ActionItemCompletionReceipt::DOMAIN_TAG);
+        for field in [b"item-1".as_slice(), b"coop:test", b"did:icn:actor"] {
+            expected_bytes.extend_from_slice(&(field.len() as u64).to_le_bytes());
+            expected_bytes.extend_from_slice(field);
+        }
+        expected_bytes.push(0); // transition ordinal: Completed = 0
+        expected_bytes.extend_from_slice(&1_700_000_000u64.to_le_bytes());
+        let expected: Hash = *blake3::hash(&expected_bytes).as_bytes();
+
+        let actual = ActionItemCompletionReceipt::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_000,
+        )
+        .record_hash;
+
+        assert_eq!(
+            actual, expected,
+            "v1 action-item canonical encoding must remain byte-stable after v2 introduction"
+        );
+    }
+
+    #[test]
+    fn action_item_v2_hash_is_deterministic_across_calls() {
+        let r1 = sample_action_item_v2_receipt(sample_no_mandate_attestation());
+        let r2 = sample_action_item_v2_receipt(sample_no_mandate_attestation());
+        assert_eq!(r1.record_hash, r2.record_hash);
+        assert!(
+            r1.verify(),
+            "v2 action-item receipt must verify its own hash"
+        );
+    }
+
+    #[test]
+    fn action_item_v2_hash_distinct_from_v1_for_same_logical_fields() {
+        // Domain-separation tags must keep v1 and v2 hash namespaces
+        // disjoint. A v1 receipt and a v2 receipt over identical base
+        // fields must hash to different values even when the v2
+        // additions are trivially fixed.
+        let v1 = ActionItemCompletionReceipt::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_000,
+        );
+        let v2 = ActionItemCompletionReceiptV2::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_000,
+            "governance:meeting:write".to_string(),
+            sample_no_mandate_attestation(),
+        )
+        .unwrap();
+        assert_ne!(
+            v1.record_hash, v2.record_hash,
+            "v1 and v2 action-item hashes must be domain-separated"
+        );
+    }
+
+    #[test]
+    fn action_item_v1_and_v2_hashes_namespace_separate() {
+        // Required cross-namespace test (mirror of the decision-receipt
+        // analogue). Builds v1 + v2 with identical base fields, asserts
+        // hashes differ; mutates one base field (`completed_at`) on
+        // both and asserts each hash changes within its own namespace
+        // while the two new hashes still differ.
+        let v1_a = ActionItemCompletionReceipt::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_000,
+        );
+        let v2_a = ActionItemCompletionReceiptV2::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_000,
+            "governance:meeting:write".to_string(),
+            sample_no_mandate_attestation(),
+        )
+        .unwrap();
+        assert_ne!(
+            v1_a.record_hash, v2_a.record_hash,
+            "v1/v2 hashes must differ for identical base fields (domain separation)"
+        );
+
+        // Mutate completed_at on both; everything else stays identical.
+        let v1_b = ActionItemCompletionReceipt::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_001,
+        );
+        let v2_b = ActionItemCompletionReceiptV2::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_001,
+            "governance:meeting:write".to_string(),
+            sample_no_mandate_attestation(),
+        )
+        .unwrap();
+
+        assert_ne!(
+            v1_a.record_hash, v1_b.record_hash,
+            "v1 hash must change when base fields change"
+        );
+        assert_ne!(
+            v2_a.record_hash, v2_b.record_hash,
+            "v2 hash must change when base fields change"
+        );
+        assert_ne!(
+            v1_b.record_hash, v2_b.record_hash,
+            "v1/v2 namespaces must remain disjoint after base mutation"
+        );
+    }
+
+    #[test]
+    fn action_item_v2_hash_binds_capability_scope_presented() {
+        let r_meeting = ActionItemCompletionReceiptV2::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_000,
+            "governance:meeting:write".to_string(),
+            sample_no_mandate_attestation(),
+        )
+        .unwrap();
+        let r_activity = ActionItemCompletionReceiptV2::new(
+            "item-1".to_string(),
+            "coop:test".to_string(),
+            "did:icn:actor".to_string(),
+            ActionItemTransition::Completed,
+            1_700_000_000,
+            "governance:activity:write".to_string(),
+            sample_no_mandate_attestation(),
+        )
+        .unwrap();
+        assert_ne!(
+            r_meeting.record_hash, r_activity.record_hash,
+            "different capability scopes must hash differently"
+        );
+    }
+
+    #[test]
+    fn action_item_v2_hash_binds_attestation_kind() {
+        let no_mandate = sample_action_item_v2_receipt(sample_no_mandate_attestation());
+        let with_grant = sample_action_item_v2_receipt(sample_grant_attestation());
+        assert_ne!(
+            no_mandate.record_hash, with_grant.record_hash,
+            "NoMandateRequired vs Grant must produce distinct hashes"
+        );
+    }
+
+    #[test]
+    fn action_item_v2_hash_binds_no_mandate_reason() {
+        let r_membership =
+            sample_action_item_v2_receipt(ReceiptMandateAttestation::NoMandateRequired {
+                reason: NoMandateReason::MembershipStandingOnly,
+            });
+        let r_bootstrap =
+            sample_action_item_v2_receipt(ReceiptMandateAttestation::NoMandateRequired {
+                reason: NoMandateReason::Bootstrap,
+            });
+        assert_ne!(
+            r_membership.record_hash, r_bootstrap.record_hash,
+            "distinct NoMandateReason variants must hash differently"
+        );
+    }
+
+    #[test]
+    fn action_item_v2_hash_binds_grant_ref() {
+        // Mutating any field of the embedded MandateGrantRef changes the
+        // receipt hash via ref_hash propagation. Exercise the target
+        // identifier as a representative field.
+        let r_coop_a = sample_action_item_v2_receipt(ReceiptMandateAttestation::Grant {
+            grant_ref: sample_ref(MandateGrantRefTarget::Domain {
+                domain_id: "coop-a".to_string(),
+            }),
+        });
+        let r_coop_b = sample_action_item_v2_receipt(ReceiptMandateAttestation::Grant {
+            grant_ref: sample_ref(MandateGrantRefTarget::Domain {
+                domain_id: "coop-b".to_string(),
+            }),
+        });
+        assert_ne!(
+            r_coop_a.record_hash, r_coop_b.record_hash,
+            "different grant_ref content must propagate into receipt hash"
+        );
+    }
+
+    #[test]
+    fn action_item_v2_constructor_rejects_empty_capability_scope() {
+        for bad in ["", "   ", "\t\n"] {
+            let err = ActionItemCompletionReceiptV2::new(
+                "item-1".to_string(),
+                "coop:test".to_string(),
+                "did:icn:actor".to_string(),
+                ActionItemTransition::Completed,
+                1_700_000_000,
+                bad.to_string(),
+                sample_no_mandate_attestation(),
+            )
+            .unwrap_err();
+            assert_eq!(
+                err,
+                ActionItemCompletionReceiptV2Error::EmptyCapabilityScope,
+                "input {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn action_item_v2_deserialize_rejects_empty_capability_scope() {
+        // Wire boundary symmetric with the constructor. A payload with
+        // an empty `capability_scope_presented` must fail at the serde
+        // path, not silently round-trip.
+        let valid = sample_action_item_v2_receipt(sample_no_mandate_attestation());
+        let mut value: serde_json::Value =
+            serde_json::to_value(&valid).expect("serialize valid v2 action-item receipt");
+        value["capability_scope_presented"] = serde_json::Value::String(String::new());
+        let err = serde_json::from_value::<ActionItemCompletionReceiptV2>(value).unwrap_err();
+        assert!(
+            err.to_string().contains("capability_scope_presented"),
+            "expected EmptyCapabilityScope surfaced through serde, got: {err}"
+        );
+    }
+
+    #[test]
+    fn action_item_v2_serde_roundtrip_preserves_hash() {
+        for att in [sample_no_mandate_attestation(), sample_grant_attestation()] {
+            let original = sample_action_item_v2_receipt(att.clone());
+            let json = serde_json::to_string(&original).expect("serialize");
+            let recovered: ActionItemCompletionReceiptV2 =
+                serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(
+                original.record_hash, recovered.record_hash,
+                "round-trip must preserve record_hash for attestation {att:?}"
+            );
+            assert!(
+                recovered.verify(),
+                "round-tripped v2 action-item receipt must verify; attestation {att:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn action_item_v2_attestation_serde_uses_snake_case_tags() {
+        let no_mandate = sample_action_item_v2_receipt(sample_no_mandate_attestation());
+        let json = serde_json::to_string(&no_mandate).expect("serialize");
+        assert!(
+            json.contains("\"kind\":\"no_mandate_required\""),
+            "expected snake_case attestation tag in JSON: {json}"
+        );
+        assert!(
+            json.contains("\"reason\":\"membership_standing_only\""),
+            "expected snake_case reason in JSON: {json}"
+        );
+        // transition snake_case sanity check (carries over from v1's
+        // serde rename_all = "snake_case" on ActionItemTransition).
+        assert!(
+            json.contains("\"transition\":\"completed\""),
+            "expected snake_case transition in JSON: {json}"
+        );
+
+        let grant = sample_action_item_v2_receipt(sample_grant_attestation());
+        let json = serde_json::to_string(&grant).expect("serialize");
+        assert!(
+            json.contains("\"kind\":\"grant\""),
+            "expected grant tag in JSON: {json}"
+        );
+    }
+
+    #[test]
+    fn action_item_v2_no_regulated_finance_vocabulary() {
+        // Mirror the receipt-family vocabulary discipline: the v2
+        // action-item receipt is an institutional-authority record, not
+        // an economic one. Its serialized form must not echo
+        // regulated-finance terms.
+        for att in [sample_no_mandate_attestation(), sample_grant_attestation()] {
+            let r = sample_action_item_v2_receipt(att);
+            let json = serde_json::to_string(&r).expect("serialize");
+            let lower = json.to_lowercase();
+            for forbidden in [
+                "wallet", "balance", "currency", "payment", "token", "withdraw", "deposit",
+            ] {
+                assert!(
+                    !lower.contains(forbidden),
+                    "ActionItemCompletionReceiptV2 JSON must not contain \
                      regulated-finance vocabulary; found `{forbidden}` in: {json}"
                 );
             }


### PR DESCRIPTION
## What

Adds the v2 action-item completion receipt — the next #1868 slice after
#1929's \`GovernanceDecisionReceiptV2\`. Purely additive: the v1
\`ActionItemCompletionReceipt\` and its call sites stay byte-stable.

**\`icn-governance/src/proof.rs\`:**

- Refactor v1's \`compute_record_hash\` to route base-field absorption
  through a new private helper \`absorb_action_item_base_field_bytes\`
  (matching v1's existing \`&mut blake3::Hasher\` idiom) plus a free
  \`action_item_transition_ordinal\` helper. v1 hash is byte-stable —
  the new
  \`action_item_v1_record_hash_remains_stable_after_v2_introduction\`
  fixture test asserts the exact byte stream against an inline
  reconstruction.
- Add \`ActionItemCompletionReceiptV2\` carrying all v1 base fields plus
  \`capability_scope_presented: String\` and
  \`mandate_attestation: ReceiptMandateAttestation\`, under its own
  \`DOMAIN_TAG = b"icn:gov:action_item_completion:v2"\`.
- Add \`ActionItemCompletionReceiptV2Error::EmptyCapabilityScope\` for
  the checked-constructor failure surface.
- Add \`ActionItemCompletionReceiptV2Raw\` private shadow + serde
  \`try_from\` so empty-scope rejection runs on every deserialized
  payload (mirrors the #1928 / #1929 boundary pattern).

**v2 hash contract — strict:**

- Fresh \`blake3\` over \`v2 DOMAIN_TAG || shared base bytes || v2 additions\`.
- Never derived from v1's \`record_hash\`, v1's \`DOMAIN_TAG\`, JSON, or
  \`Debug\`. Domain-tag separation is the only namespace boundary.
- Base fields absorbed by the new shared helper; v1 also routes
  through it after writing its own tag. v1 byte-stability asserted by
  the fixture test.
- \`Grant { grant_ref }\` binds via the 32-byte
  \`MandateGrantRef::ref_hash()\`; \`NoMandateRequired { reason }\`
  binds the \`NoMandateReason\` ordinal byte.

**\`icn-governance/src/lib.rs\`:** re-exports
\`ActionItemCompletionReceiptV2\` and
\`ActionItemCompletionReceiptV2Error\`. \`ReceiptMandateAttestation\` /
\`NoMandateReason\` / \`MandateGrantRef\` are reused unchanged from
#1928 / #1929.

## Why this is the next #1868 slice

#1929 forked \`GovernanceDecisionReceipt\` to v2 with the same wire
discipline. This PR applies the same fork to
\`ActionItemCompletionReceipt\`, sharing the
\`ReceiptMandateAttestation\` / \`NoMandateReason\` primitives and the
\`try_from\` boundary pattern. \`MeetingAttendanceReceipt\` gets the
parallel fork as a follow-up slice.

Handler wiring remains blocked on grant-minting expansion and a
\`TypedScope\` federation/role binding surface — both out of scope
here.

## Tests (13 new in \`proof.rs\`)

- \`action_item_v1_record_hash_remains_stable_after_v2_introduction\`
  — explicit byte-stream fixture for v1 canonical encoding; catches
  any drift from the shared-helper refactor.
- \`action_item_v2_hash_is_deterministic_across_calls\`
- \`action_item_v2_hash_distinct_from_v1_for_same_logical_fields\` —
  proves domain-separation tags do their job.
- \`action_item_v1_and_v2_hashes_namespace_separate\` — required
  cross-namespace test; mutates \`completed_at\` on both versions and
  asserts each hash changes within its own namespace and the
  namespaces remain disjoint.
- \`action_item_v2_hash_binds_capability_scope_presented\`
- \`action_item_v2_hash_binds_attestation_kind\`
- \`action_item_v2_hash_binds_no_mandate_reason\`
- \`action_item_v2_hash_binds_grant_ref\` — propagates grant-ref
  mutations into the receipt hash.
- \`action_item_v2_constructor_rejects_empty_capability_scope\`
  (\`""\`, \`"   "\`, \`"\\t\\n"\`)
- \`action_item_v2_deserialize_rejects_empty_capability_scope\` —
  symmetric wire boundary.
- \`action_item_v2_serde_roundtrip_preserves_hash\` — both \`Grant\`
  and \`NoMandateRequired\` variants.
- \`action_item_v2_attestation_serde_uses_snake_case_tags\` — checks
  JSON contains \`"kind":"no_mandate_required"\`,
  \`"reason":"membership_standing_only"\`,
  \`"transition":"completed"\`, \`"kind":"grant"\`.
- \`action_item_v2_no_regulated_finance_vocabulary\` — vocabulary
  discipline mirror.

## Validation run

All commands from \`icn/icn/\`:

- \`cargo fmt --all -- --check\` — clean
- \`cargo check --workspace --all-targets\` — clean
- \`cargo clippy -p icn-governance --all-targets -- -D warnings\` — clean
- \`cargo test -p icn-governance\` — 558 lib + 42 integration + 4
  sub-integration + 7 doc tests pass; 0 failures
- \`python3 .github/scripts/compliance_linter.py\` (from repo root) —
  ✅ no violations (107 files scanned)
- \`git diff --check\` — clean

## Out of scope / non-claims

- No \`GovernanceDecisionReceipt\` migration changes beyond what
  already landed in #1929.
- No \`MeetingAttendanceReceipt\` migration yet.
- No handler wiring.
- No grant-minting expansion.
- No \`TypedScope\` federation/role binding surface.
- No \`governance:write\` retirement.
- No kernel meaning-firewall widening — the new types live in the
  existing app-facing \`icn-governance\` primitives crate; the kernel
  still sees nothing.
- No production-readiness claim.
- No live-federation claim.
- No demo-ready claim.

Part of #1868.