### PR TITLE
chore(ci): guard ci-runner disk headroom and bound Docker build cache

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -215,15 +215,26 @@ jobs:
         run: |
           # Runs even on failure. Bound the build cache (the silent accumulator
           # the weekly image-only cleanup never touched) while keeping recent
-          # layers for fast incremental rebuilds. Then drop dangling layers and
-          # reap old icn:<sha> images (one piles up per merge), keeping the 3
-          # most recent. The runner's Docker images are never used by K3s
-          # (K3s uses its own containerd), so removing them here is safe.
-          docker builder prune -f --keep-storage 20GB || true
-          docker image prune -f || true
-          old_icn=$(docker images icn --format '{{.ID}}' | awk '!seen[$0]++' | awk 'NR>3')
+          # layers for fast incremental rebuilds. Then prune dangling images
+          # and reap old icn:<sha> images (one piles up per merge), keeping the
+          # 3 most recently created. The runner's Docker images are never used
+          # by K3s (K3s uses its own containerd), so removing them here is safe.
+          # Cleanup must not fail the (already-succeeded) deploy, but a failed
+          # prune is surfaced as a warning so cache-bounding regressions to disk
+          # exhaustion don't go silent.
+          docker builder prune -f --keep-storage 20GB \
+            || echo "::warning::docker builder prune failed on ci-runner — build cache not bounded this run; check Docker/BuildKit"
+          docker image prune -f \
+            || echo "::warning::docker image prune (dangling) failed on ci-runner"
+          # Sort icn images newest-first by creation time before keeping the 3
+          # newest — `docker images` default ordering is not a stable contract,
+          # so sorting explicitly avoids reaping newer images by accident.
+          old_icn=$(docker images icn --format '{{.CreatedAt}}|{{.ID}}' \
+            | sort -r \
+            | awk -F'|' '!seen[$2]++ {print $2}' \
+            | awk 'NR>3')
           if [ -n "$old_icn" ]; then
-            echo "Reaping old icn images (keeping 3 most recent):"
+            echo "Reaping old icn images (keeping 3 most recently created):"
             echo "$old_icn"
             echo "$old_icn" | xargs -r docker rmi -f 2>/dev/null || true
           fi

--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -75,6 +75,32 @@ jobs:
             exit 1
           }
 
+      - name: Ensure disk headroom
+        run: |
+          # The self-hosted ci-runner accumulates Docker images (one icn:<sha>
+          # per merge) and build cache on its small root disk. A full-workspace
+          # `docker build` needs ~10-15G of headroom; without a guard the build
+          # starts blind on a near-full disk and crashes mid-layer-write with
+          # "No space left on device". Reclaim proactively when free space is
+          # low, and fail with an actionable message if reclaim is not enough.
+          THRESHOLD_GB=20
+          free_gb() { df -BG --output=avail / | tail -1 | tr -dc '0-9'; }
+          avail=$(free_gb)
+          echo "Free space on /: ${avail:-0}G (threshold ${THRESHOLD_GB}G)"
+          if [ "${avail:-0}" -lt "$THRESHOLD_GB" ]; then
+            echo "::warning::ci-runner low on disk (${avail:-0}G < ${THRESHOLD_GB}G) — reclaiming Docker space before build"
+            docker system prune -af || true
+            docker builder prune -af || true
+            avail=$(free_gb)
+            echo "Free space after reclaim: ${avail:-0}G"
+            if [ "${avail:-0}" -lt "$THRESHOLD_GB" ]; then
+              echo "::error::Disk still below ${THRESHOLD_GB}G after reclaim (${avail:-0}G free)."
+              echo "Manual cleanup or a larger ci-runner root disk is required."
+              df -h /
+              exit 1
+            fi
+          fi
+
       - name: Build Docker image
         run: |
           echo "Building image ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
@@ -184,6 +210,26 @@ jobs:
           ssh -o BatchMode=yes ubuntu@${K3S_CONTROL} "sudo kubectl get pods -A | grep icn" >> $GITHUB_STEP_SUMMARY || echo "No pods found" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
+      - name: Bound Docker disk usage
+        if: always()
+        run: |
+          # Runs even on failure. Bound the build cache (the silent accumulator
+          # the weekly image-only cleanup never touched) while keeping recent
+          # layers for fast incremental rebuilds. Then drop dangling layers and
+          # reap old icn:<sha> images (one piles up per merge), keeping the 3
+          # most recent. The runner's Docker images are never used by K3s
+          # (K3s uses its own containerd), so removing them here is safe.
+          docker builder prune -f --keep-storage 20GB || true
+          docker image prune -f || true
+          old_icn=$(docker images icn --format '{{.ID}}' | awk '!seen[$0]++' | awk 'NR>3')
+          if [ -n "$old_icn" ]; then
+            echo "Reaping old icn images (keeping 3 most recent):"
+            echo "$old_icn"
+            echo "$old_icn" | xargs -r docker rmi -f 2>/dev/null || true
+          fi
+          echo "=== ci-runner disk after build ==="
+          df -h /
+
   # Cleanup old images (runs weekly)
   cleanup:
     name: Cleanup Old Images
@@ -202,6 +248,13 @@ jobs:
             ssh -o BatchMode=yes ubuntu@$NODE "sudo k3s ctr images ls | grep 'docker.io/library/icn:' | sort -r | tail -n +6 | awk '{print \$1}' | xargs -r sudo k3s ctr images rm" 2>/dev/null || true
           done
 
-          # Cleanup local docker on ci-runner
-          docker image prune -f
+          # Cleanup local docker on ci-runner: dangling layers, unused images
+          # older than a week, and the full build cache (regenerated on the
+          # next build). This is the deep weekly reclaim; the per-build
+          # "Bound Docker disk usage" step keeps growth bounded between runs.
+          docker image prune -f || true
+          docker image prune -af --filter "until=168h" || true
+          docker builder prune -af || true
+          echo "=== ci-runner disk after weekly cleanup ==="
+          df -h /
           echo "✓ Cleanup complete"


### PR DESCRIPTION
## What

Durable fix for the recurring self-hosted **`ci-runner` disk exhaustion** that breaks the post-merge `Build and Deploy to K3s` workflow. Three changes to `.github/workflows/docker-build-deploy.yml`:

1. **Ensure disk headroom** — new preflight step before `Build Docker image`. Reclaims Docker space when free space on `/` is `< 20G`, and fails with an actionable error if reclaim isn't enough (instead of crashing mid-layer-write).
2. **Bound Docker disk usage** — new `if: always()` post-build step. `docker builder prune --keep-storage 20GB` bounds the build cache while keeping recent layers for fast rebuilds, prunes dangling layers, and reaps old `icn:<sha>` images keeping the 3 most recent.
3. **Weekly cleanup extended** — the scheduled `cleanup` job now also clears the runner's build cache and unused images older than 7 days (previously dangling-images only).

## Why

The `Build and Deploy to K3s` job runs on the self-hosted `ci-runner` (10.8.30.46, ~77G root disk). It failed with `No space left on device` on **three consecutive merges (#1929, #1930, #1931)**. Root cause: each merge's `docker build` adds ~8G (image + build cache), and the only existing cleanup was a weekly cron that prunes images (keeping 6) but **never the build cache** — the silent ~26G accumulator. Disk crept to 100% and the runner crashed mid-build.

This is a **deploy-lane infrastructure failure, not an ICN source-code issue** — the required CI gates on `ubuntu-latest` passed on all three PRs. The immediate disk-full condition was already relieved manually (99% → 23% used); this PR makes the workflow self-defending so it doesn't recur.

## How

- The preflight guard only reclaims when genuinely low (≥20G free → no-op), so normal builds keep their cache for speed.
- The per-build bound keeps growth in check between weekly runs; the weekly job does the deep clear.
- Removing the runner's Docker images is safe: K3s pulls into its **own** containerd (`k3s ctr`), not the runner's Docker daemon, so runner-local images are never used by running pods.

## Risk

Low. Workflow-only change; no application code, K3s manifests, or other workflows touched. Worst case if a threshold/prune misbehaves is a slower (cold-cache) build or an explicit, readable failure — not a silent crash. The guard's failure path is strictly more informative than today's behavior.

## Test plan

- `python3 -c "yaml.safe_load(...)"` — workflow YAML parses.
- `shellcheck` on both new `run:` blocks — clean.
- `df -BG --output=avail /` parsing validated against the **live ci-runner** (`56G` free → integer compare correct → no reclaim).
- Full end-to-end exercise of the workflow happens on the next push to `main` that touches `icn/**` (this PR's merge will itself run the new path).

## Out of scope / follow-ups (not in this PR)

- **Resize the `ci-runner` root disk** (VM446 on node-4) — a host/infra change, not a workflow change. Recommended so the guard rarely has to reclaim.
- **`icn-infra/runbooks/ci-runner/README.md`** — add the disk-pressure recovery procedure (separate repo, separate PR).
- Possible larger refactor: split image build from deploy to reduce full-workspace rebuilds.

## Non-claims

- Not an ICN source-code fix. No production-readiness / live-federation / demo-ready claim. This bounds runner disk growth and guards the build; it does not by itself guarantee permanent remediation without the host-level disk resize.
