### PR TITLE
feat(governance): emit v2 meeting attendance receipts (#1868)

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -15,7 +15,7 @@ use icn_governance::{
     ProposalPayload, ProposalScope, StructureId, StructureKind, StructureStatus, VoteChoice,
 };
 use icn_http_kit::{
-    auth::{require_any_scope, require_scope, BasicClaims},
+    auth::{require_any_scope, require_any_scope_matched, require_scope, BasicClaims},
     error::ApiError,
     pagination::{ListPagination, ListQuery, ListResponse},
 };
@@ -4040,7 +4040,10 @@ pub async fn mark_attendance<E: GovernanceEventEmitter + Clone + 'static>(
     meeting_id: web::Path<String>,
     req: web::Json<MarkAttendanceRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_any_scope::<BasicClaims>(
+    // Record the scope that actually authorized the request (evidence): the
+    // narrowed class scope when present, else the legacy broad scope during the
+    // compatibility period. Listed narrowest-first so it is preferred.
+    let (claims, presented_scope) = require_any_scope_matched::<BasicClaims>(
         &http_req,
         &["governance:meeting:write", "governance:write"],
     )?;
@@ -4072,7 +4075,7 @@ pub async fn mark_attendance<E: GovernanceEventEmitter + Clone + 'static>(
 
     let updated = ctx
         .manager
-        .update_meeting_attendance(&id, &req.did, status, &recorded_by)
+        .update_meeting_attendance(&id, &req.did, status, &recorded_by, &presented_scope)
         .map_err(anyhow_to_api)?;
     Ok(HttpResponse::Ok().json(meeting_to_response(&updated)))
 }

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -5484,12 +5484,20 @@ impl GovernanceManager {
     /// `recorded_by` is the authenticated caller. It can differ from
     /// `attendee_did` (steward-recorded attendance) and is bound into the
     /// receipt's canonical hash.
+    ///
+    /// `capability_scope` is the capability scope that actually authorized the
+    /// request (e.g. `"governance:meeting:write"`, or the legacy
+    /// `"governance:write"` during the compatibility period). It is recorded
+    /// verbatim into the emitted [`MeetingAttendanceReceiptV2`]'s
+    /// `capability_scope_presented` field — it is evidence, so callers must
+    /// pass the accepted scope, not a canonical preferred one.
     pub fn update_meeting_attendance(
         &self,
         meeting_id: &MeetingId,
         attendee_did: &str,
         status: AttendanceStatus,
         recorded_by: &Did,
+        capability_scope: &str,
     ) -> Result<Meeting> {
         let mut m = self
             .meeting_store
@@ -5539,6 +5547,39 @@ impl GovernanceManager {
                 store.put_meeting_attendance(&receipt).map_err(|e| {
                     anyhow::anyhow!(
                         "Failed to persist meeting attendance receipt for ({}, {}): {e}",
+                        m.id.0,
+                        attendee_did
+                    )
+                })?;
+
+                // #1868: emit the v2 receipt alongside v1. Meeting attendance
+                // is a membership-standing-only act (decomposition §6 / §10
+                // step 9), so the attestation is the explicit
+                // `NoMandateRequired { MembershipStandingOnly }` discriminator —
+                // no MandateGate call, no grant. `capability_scope` is recorded
+                // verbatim as the scope that authorized this request.
+                let receipt_v2 = icn_governance::MeetingAttendanceReceiptV2::new(
+                    m.id.0.clone(),
+                    m.domain_id.clone(),
+                    attendee_did.to_string(),
+                    recorded_by.to_string(),
+                    transition,
+                    now,
+                    capability_scope.to_string(),
+                    icn_governance::ReceiptMandateAttestation::NoMandateRequired {
+                        reason: icn_governance::NoMandateReason::MembershipStandingOnly,
+                    },
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Invalid v2 meeting attendance receipt for ({}, {}): {e}",
+                        m.id.0,
+                        attendee_did
+                    )
+                })?;
+                store.put_meeting_attendance_v2(&receipt_v2).map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to persist v2 meeting attendance receipt for ({}, {}): {e}",
                         m.id.0,
                         attendee_did
                     )

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -3,8 +3,8 @@
 
 use icn_governance::{
     ActionItemCompletionReceipt, AuthorityGrant, AuthorityGrantId, GovernanceDecisionReceipt,
-    Grantee, Mandate, MeetingAttendanceReceipt, ProcessGateKind, ProcessGateResultReceipt,
-    Timestamp,
+    Grantee, Mandate, MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, ProcessGateKind,
+    ProcessGateResultReceipt, Timestamp,
 };
 use icn_kernel_api::{AllocationReceipt, Hash};
 
@@ -410,6 +410,25 @@ pub trait GovernanceReceiptBackend: Send + Sync {
     /// [`ReceiptStore`](icn_gateway::receipt_store::ReceiptStore)
     /// override.
     fn put_meeting_attendance(&self, _receipt: &MeetingAttendanceReceipt) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Persist a [`MeetingAttendanceReceiptV2`] — the #1868 v2 form carrying
+    /// `capability_scope_presented` and an explicit
+    /// [`ReceiptMandateAttestation`](icn_governance::ReceiptMandateAttestation).
+    /// Emitted **alongside** the v1 receipt by migrated handlers (the v1
+    /// emission and its consumers are unchanged this slice).
+    ///
+    /// Append-only and idempotent on `record_hash`, same discipline as
+    /// [`Self::put_meeting_attendance`].
+    ///
+    /// Default impl is a no-op so backends that do not yet durably persist v2
+    /// receipts inherit a truthful "v2 attendance receipt not persisted"
+    /// behavior; storage-backed implementations override.
+    fn put_meeting_attendance_v2(
+        &self,
+        _receipt: &MeetingAttendanceReceiptV2,
+    ) -> Result<(), String> {
         Ok(())
     }
 

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -15,6 +15,11 @@ use crate::institutional_effect::InstitutionalEffectRecord;
 /// in the apps layer so the gateway never sees the typed name.
 const PROCESS_GATE_RESULT_CLASS: &str = "process_gate_result";
 
+/// Class string for `MeetingAttendanceReceiptV2` opaque storage (#1868).
+/// Chosen in the apps layer so the gateway persists v2 attendance evidence
+/// without importing the typed name (preserves the meaning firewall).
+const MEETING_ATTENDANCE_V2_CLASS: &str = "meeting_attendance_v2";
+
 /// Stable string mapping for `ProcessGateKind` used as the
 /// opaque-storage `key2`. Distinct from serde wire form so the
 /// storage key is unambiguous and free of any future enum-rename
@@ -422,14 +427,33 @@ pub trait GovernanceReceiptBackend: Send + Sync {
     /// Append-only and idempotent on `record_hash`, same discipline as
     /// [`Self::put_meeting_attendance`].
     ///
-    /// Default impl is a no-op so backends that do not yet durably persist v2
-    /// receipts inherit a truthful "v2 attendance receipt not persisted"
-    /// behavior; storage-backed implementations override.
+    /// **Default routes through opaque storage** (same pattern as
+    /// [`Self::put_process_gate_result`]): the typed receipt is serialised to
+    /// JSON and delegated to [`Self::put_opaque`] under class
+    /// `"meeting_attendance_v2"` with `key1 = receipt.meeting_id`,
+    /// `key2 = Some(receipt.attendee_did)`. The production gateway-backed
+    /// `ReceiptStore` overrides `put_opaque` (Stage 1b), so it gets durable
+    /// persistence here **without** the gateway importing
+    /// `MeetingAttendanceReceiptV2` — the meaning firewall stays put. A
+    /// backend that does not implement opaque storage hits the
+    /// `put_opaque` fail-closed default (`opaque_storage_not_implemented`)
+    /// rather than silently dropping the v2 evidence. Backends wanting custom
+    /// typed persistence (e.g. an in-memory test store) may still override
+    /// this method directly.
     fn put_meeting_attendance_v2(
         &self,
-        _receipt: &MeetingAttendanceReceiptV2,
+        receipt: &MeetingAttendanceReceiptV2,
     ) -> Result<(), String> {
-        Ok(())
+        let payload = serde_json::to_vec(receipt)
+            .map_err(|e| format!("serialize MeetingAttendanceReceiptV2: {e}"))?;
+        self.put_opaque(
+            MEETING_ATTENDANCE_V2_CLASS,
+            &receipt.meeting_id,
+            Some(receipt.attendee_did.as_str()),
+            receipt.recorded_at,
+            receipt.record_hash,
+            &payload,
+        )
     }
 
     /// Retrieve the latest [`MeetingAttendanceReceipt`] for a

--- a/icn/apps/governance/tests/me_meeting_attendance_receipt_chain.rs
+++ b/icn/apps/governance/tests/me_meeting_attendance_receipt_chain.rs
@@ -210,6 +210,63 @@ impl GovernanceReceiptBackend for FailingAttendanceStore {
     }
 }
 
+/// One captured opaque-storage write: `(class, key1, key2, payload)`.
+type CapturedOpaque = (String, String, Option<String>, Vec<u8>);
+
+/// A backend that overrides **only** the opaque storage primitive (like the
+/// production gateway-backed `ReceiptStore`, which overrides `put_opaque` but
+/// has no typed `put_meeting_attendance_v2`). Proves the v2 typed default
+/// routes through `put_opaque` so production persists the evidence rather than
+/// silently dropping it.
+#[derive(Default)]
+struct OpaqueCapturingStore {
+    opaque: Mutex<Vec<CapturedOpaque>>,
+}
+
+impl GovernanceReceiptBackend for OpaqueCapturingStore {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    // Note: no `put_meeting_attendance_v2` override — exercises the typed
+    // default's opaque-routing path. v1 `put_meeting_attendance` inherits the
+    // trait no-op default (v1 persistence is not under test here).
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        _recorded_at: u64,
+        _record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        self.opaque.lock().unwrap().push((
+            class.to_string(),
+            key1.to_string(),
+            key2.map(str::to_string),
+            payload.to_vec(),
+        ));
+        Ok(())
+    }
+}
+
 // ============================================================================
 // Scaffolding
 // ============================================================================
@@ -761,5 +818,79 @@ async fn meeting_attendance_emits_v2_recording_the_accepted_scope() {
             .unwrap()
             .is_some(),
         "v1 receipt still present for the legacy-scope attendee"
+    );
+}
+
+/// #1868: a backend that overrides only `put_opaque` (like the production
+/// gateway-backed `ReceiptStore`, which has no typed `put_meeting_attendance_v2`)
+/// must still durably receive the v2 receipt via the typed default's
+/// opaque-routing path — proving the evidence is persisted in production, not
+/// silently dropped.
+#[tokio::test]
+async fn meeting_attendance_v2_default_routes_through_opaque_storage() {
+    let receipts = Arc::new(OpaqueCapturingStore::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(receipts.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let attendee = fresh_did();
+    let recorder = fresh_did();
+    let domain = seed_domain_with_member(&mgr, &recorder, "test-coop").await;
+
+    let now_secs = icn_time::current_timestamp_secs();
+    let meeting = mgr
+        .create_meeting(
+            domain.0.clone(),
+            "V2 opaque-routing meeting (fictional)".to_string(),
+            None,
+            Some(now_secs + 3_600),
+            recorder.as_str().to_string(),
+        )
+        .expect("create_meeting");
+    invite_to_meeting(&mgr, &meeting.id, &attendee);
+
+    mgr.update_meeting_attendance(
+        &meeting.id,
+        attendee.as_str(),
+        AttendanceStatus::Present,
+        &recorder,
+        "governance:meeting:write",
+    )
+    .expect("Present");
+
+    // The typed default serialised the v2 receipt and routed it through
+    // `put_opaque` under the meeting-attendance-v2 class — exactly what the
+    // production gateway persists.
+    let captured = receipts.opaque.lock().unwrap().clone();
+    let v2: Vec<_> = captured
+        .iter()
+        .filter(|(class, _, _, _)| class == "meeting_attendance_v2")
+        .collect();
+    assert_eq!(
+        v2.len(),
+        1,
+        "exactly one v2 receipt must route through opaque storage (not be dropped)"
+    );
+    let (_class, key1, key2, payload) = v2[0];
+    assert_eq!(key1, &meeting.id.0, "opaque key1 must be the meeting id");
+    assert_eq!(
+        key2.as_deref(),
+        Some(attendee.to_string().as_str()),
+        "opaque key2 must be the attendee did"
+    );
+    let receipt: MeetingAttendanceReceiptV2 =
+        serde_json::from_slice(payload).expect("opaque payload deserializes to v2 receipt");
+    assert!(
+        receipt.verify(),
+        "routed v2 receipt must verify its own hash"
+    );
+    assert_eq!(
+        receipt.capability_scope_presented,
+        "governance:meeting:write"
+    );
+    assert_eq!(
+        receipt.mandate_attestation,
+        ReceiptMandateAttestation::NoMandateRequired {
+            reason: NoMandateReason::MembershipStandingOnly,
+        }
     );
 }

--- a/icn/apps/governance/tests/me_meeting_attendance_receipt_chain.rs
+++ b/icn/apps/governance/tests/me_meeting_attendance_receipt_chain.rs
@@ -44,8 +44,9 @@ use std::sync::{Arc, Mutex};
 
 use icn_governance::{
     AttendanceStatus, AuthorityGrant, GovernanceDecisionReceipt, GovernanceDomainId,
-    GovernanceParams, MeetingAttendanceReceipt, MeetingAttendanceTransition, MeetingAttendee,
-    MeetingRole, MembershipConfig, MembershipSource,
+    GovernanceParams, MeetingAttendanceReceipt, MeetingAttendanceReceiptV2,
+    MeetingAttendanceTransition, MeetingAttendee, MeetingRole, MembershipConfig, MembershipSource,
+    NoMandateReason, ReceiptMandateAttestation,
 };
 use icn_governance_actor::{
     dispatch_evidence::EffectDispatchEvidence, institutional_effect::InstitutionalEffectRecord,
@@ -61,6 +62,7 @@ use icn_kernel_api::{AllocationReceipt, Hash};
 #[derive(Default)]
 struct TestReceiptStore {
     attendance: Mutex<Vec<MeetingAttendanceReceipt>>,
+    attendance_v2: Mutex<Vec<MeetingAttendanceReceiptV2>>,
 }
 
 impl GovernanceReceiptBackend for TestReceiptStore {
@@ -115,6 +117,14 @@ impl GovernanceReceiptBackend for TestReceiptStore {
         Ok(())
     }
 
+    fn put_meeting_attendance_v2(
+        &self,
+        receipt: &MeetingAttendanceReceiptV2,
+    ) -> Result<(), String> {
+        self.attendance_v2.lock().unwrap().push(receipt.clone());
+        Ok(())
+    }
+
     fn get_meeting_attendance(
         &self,
         meeting_id: &str,
@@ -154,6 +164,17 @@ impl TestReceiptStore {
             .iter()
             .filter(|r| r.meeting_id == meeting_id && r.attendee_did == attendee_did)
             .count()
+    }
+
+    /// All v2 receipts captured for a `(meeting_id, attendee_did)` pair.
+    fn v2_for_pair(&self, meeting_id: &str, attendee_did: &str) -> Vec<MeetingAttendanceReceiptV2> {
+        self.attendance_v2
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.meeting_id == meeting_id && r.attendee_did == attendee_did)
+            .cloned()
+            .collect()
     }
 }
 
@@ -272,6 +293,7 @@ async fn meeting_attendance_receipt_chain_end_to_end() {
             attendee.as_str(),
             AttendanceStatus::Present,
             &recorder,
+            "governance:meeting:write",
         )
         .expect("update_meeting_attendance -> Present");
     let updated_attendee = updated
@@ -347,6 +369,7 @@ async fn another_did_does_not_see_first_did_attendance_receipt() {
         alice.as_str(),
         AttendanceStatus::Present,
         &recorder,
+        "governance:meeting:write",
     )
     .expect("alice -> Present");
 
@@ -397,6 +420,7 @@ async fn re_marking_present_is_idempotent_no_duplicate_receipt() {
         attendee.as_str(),
         AttendanceStatus::Present,
         &recorder,
+        "governance:meeting:write",
     )
     .expect("first Present");
 
@@ -406,6 +430,7 @@ async fn re_marking_present_is_idempotent_no_duplicate_receipt() {
         attendee.as_str(),
         AttendanceStatus::Present,
         &recorder,
+        "governance:meeting:write",
     )
     .expect("re-Present");
 
@@ -443,6 +468,7 @@ async fn present_to_remote_appends_new_transition_receipt() {
         attendee.as_str(),
         AttendanceStatus::Present,
         &recorder,
+        "governance:meeting:write",
     )
     .expect("Present");
     let first = receipts
@@ -460,6 +486,7 @@ async fn present_to_remote_appends_new_transition_receipt() {
         attendee.as_str(),
         AttendanceStatus::Remote,
         &recorder,
+        "governance:meeting:write",
     )
     .expect("Remote");
     let chain = receipts
@@ -514,6 +541,7 @@ async fn absent_does_not_emit_attendance_receipt() {
             attendee.as_str(),
             AttendanceStatus::Absent,
             &recorder,
+            "governance:meeting:write",
         )
         .expect("Absent write must succeed");
     let row = updated
@@ -560,6 +588,7 @@ async fn receipt_backend_failure_prevents_attendance_status_commit() {
             attendee.as_str(),
             AttendanceStatus::Present,
             &recorder,
+            "governance:meeting:write",
         )
         .expect_err("receipt backend failure must propagate");
     let msg = err.to_string();
@@ -609,6 +638,7 @@ async fn attendance_receipt_uses_regulatory_safe_vocabulary() {
         attendee.as_str(),
         AttendanceStatus::Present,
         &recorder,
+        "governance:meeting:write",
     )
     .expect("Present");
 
@@ -628,4 +658,108 @@ async fn attendance_receipt_uses_regulatory_safe_vocabulary() {
              found `{forbidden}` in: {json}"
         );
     }
+}
+
+/// #1868: a meeting-attendance transition emits a `MeetingAttendanceReceiptV2`
+/// alongside the v1 receipt, recording the capability scope that **actually**
+/// authorized the request and the explicit
+/// `NoMandateRequired { MembershipStandingOnly }` attestation (meeting
+/// attendance is a membership-standing-only act — no MandateGate, no grant).
+#[tokio::test]
+async fn meeting_attendance_emits_v2_recording_the_accepted_scope() {
+    let receipts = Arc::new(TestReceiptStore::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(receipts.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let narrow_attendee = fresh_did();
+    let legacy_attendee = fresh_did();
+    let recorder = fresh_did();
+    let domain = seed_domain_with_member(&mgr, &recorder, "test-coop").await;
+
+    let now_secs = icn_time::current_timestamp_secs();
+    let meeting = mgr
+        .create_meeting(
+            domain.0.clone(),
+            "V2 emission meeting (fictional)".to_string(),
+            None,
+            Some(now_secs + 3_600),
+            recorder.as_str().to_string(),
+        )
+        .expect("create_meeting");
+    invite_to_meeting(&mgr, &meeting.id, &narrow_attendee);
+    invite_to_meeting(&mgr, &meeting.id, &legacy_attendee);
+
+    // Accepted via the narrowed class scope.
+    mgr.update_meeting_attendance(
+        &meeting.id,
+        narrow_attendee.as_str(),
+        AttendanceStatus::Present,
+        &recorder,
+        "governance:meeting:write",
+    )
+    .expect("Present (meeting:write)");
+
+    // Accepted via the legacy broad scope during the compatibility period.
+    mgr.update_meeting_attendance(
+        &meeting.id,
+        legacy_attendee.as_str(),
+        AttendanceStatus::Present,
+        &recorder,
+        "governance:write",
+    )
+    .expect("Present (legacy write)");
+
+    // ── v2 emitted, recording the accepted scope verbatim + the explicit
+    //    no-mandate attestation.
+    let narrow_v2 = receipts.v2_for_pair(meeting.id.0.as_str(), narrow_attendee.as_str());
+    assert_eq!(
+        narrow_v2.len(),
+        1,
+        "exactly one v2 receipt for the narrow-scope attendee"
+    );
+    let narrow = &narrow_v2[0];
+    assert_eq!(
+        narrow.capability_scope_presented,
+        "governance:meeting:write"
+    );
+    assert_eq!(
+        narrow.mandate_attestation,
+        ReceiptMandateAttestation::NoMandateRequired {
+            reason: NoMandateReason::MembershipStandingOnly,
+        },
+        "meeting attendance is membership-standing-only — no mandate grant"
+    );
+    assert!(
+        narrow.verify(),
+        "emitted v2 receipt must verify its own canonical hash"
+    );
+    assert_eq!(narrow.meeting_id, meeting.id.0);
+    assert_eq!(narrow.attendee_did, narrow_attendee.to_string());
+    assert_eq!(narrow.recorded_by, recorder.to_string());
+    assert_eq!(narrow.transition, MeetingAttendanceTransition::Present);
+
+    // ── Legacy-scope acceptance must record "governance:write", NOT the
+    //    preferred class scope: the field is evidence of what authorized
+    //    the request.
+    let legacy_v2 = receipts.v2_for_pair(meeting.id.0.as_str(), legacy_attendee.as_str());
+    assert_eq!(legacy_v2.len(), 1);
+    assert_eq!(
+        legacy_v2[0].capability_scope_presented, "governance:write",
+        "a request accepted via the legacy broad scope must not claim the narrowed class scope"
+    );
+    assert!(legacy_v2[0].verify());
+
+    // ── v1 still emitted alongside (no consumer regression).
+    assert_eq!(
+        receipts.count_for_pair(meeting.id.0.as_str(), narrow_attendee.as_str()),
+        1,
+        "v1 receipt must still be emitted alongside v2"
+    );
+    assert!(
+        receipts
+            .get_meeting_attendance(meeting.id.0.as_str(), legacy_attendee.as_str())
+            .unwrap()
+            .is_some(),
+        "v1 receipt still present for the legacy-scope attendee"
+    );
 }

--- a/icn/crates/icn-http-kit/src/auth.rs
+++ b/icn/crates/icn-http-kit/src/auth.rs
@@ -100,6 +100,47 @@ pub fn require_any_scope<C: ClaimsLike>(
     Ok(claims)
 }
 
+/// Like [`require_any_scope`], but also returns **which** candidate scope
+/// authorized the request.
+///
+/// The returned scope is the first entry of `required_scopes` (in listed
+/// preference order) that the claims actually grant. Callers that record the
+/// accepted scope as evidence — e.g. a receipt's `capability_scope_presented`
+/// — must use this rather than assuming the preferred class scope: during a
+/// capability-decomposition migration a request may be accepted via a legacy
+/// broad scope, and the evidence must say so truthfully. List the narrowed
+/// class scope first so it is preferred when both are present.
+///
+/// Rejection behavior mirrors [`require_any_scope`] / [`require_scope`]: an
+/// empty `required_scopes` is a programmer error (`ApiError::Internal`), and a
+/// caller with none of the scopes gets the canonical rejection keyed on the
+/// preferred (first) scope.
+pub fn require_any_scope_matched<C: ClaimsLike>(
+    req: &HttpRequest,
+    required_scopes: &[&str],
+) -> Result<(C, String), ApiError> {
+    let Some((&preferred, _)) = required_scopes.split_first() else {
+        return Err(ApiError::Internal(
+            "require_any_scope_matched called with no candidate scopes".to_string(),
+        ));
+    };
+    let claims = get_claims::<C>(req).ok_or(ApiError::Unauthenticated)?;
+    for &scope in required_scopes {
+        if check_scope(&claims, scope).is_ok() {
+            return Ok((claims, scope.to_string()));
+        }
+    }
+    // No candidate matched. Defer to the preferred scope's own check, which
+    // returns the canonical Forbidden/Unauthenticated error. `preferred` is
+    // among the candidates just tried, so this always returns Err and `?`
+    // propagates; the trailing Err is unreachable but keeps the function
+    // total without an unwrap/expect/panic.
+    check_scope(&claims, preferred)?;
+    Err(ApiError::Internal(
+        "require_any_scope_matched: candidate rejected but no error produced".to_string(),
+    ))
+}
+
 /// Centralized scope checking. Split and normalize once, not in every handler.
 fn check_scope<C: ClaimsLike>(claims: &C, required: &str) -> Result<(), ApiError> {
     let Some(raw) = claims.raw_scope() else {
@@ -198,5 +239,46 @@ mod tests {
         // `governance:write:admin` satisfies the broad `governance:write` candidate.
         let req = req_with_scope(Some("governance:write:admin"));
         assert!(require_any_scope::<BasicClaims>(&req, &[CHARTER, BROAD]).is_ok());
+    }
+
+    #[test]
+    fn require_any_scope_matched_returns_narrow_class_scope() {
+        let req = req_with_scope(Some(CHARTER));
+        let (_claims, matched) =
+            require_any_scope_matched::<BasicClaims>(&req, &[CHARTER, BROAD]).unwrap();
+        assert_eq!(matched, CHARTER);
+    }
+
+    #[test]
+    fn require_any_scope_matched_returns_legacy_broad_scope_when_only_that_is_present() {
+        // Evidence integrity: a request accepted via the legacy broad scope must
+        // report `governance:write`, not the preferred narrowed class scope.
+        let req = req_with_scope(Some(BROAD));
+        let (_claims, matched) =
+            require_any_scope_matched::<BasicClaims>(&req, &[CHARTER, BROAD]).unwrap();
+        assert_eq!(matched, BROAD);
+    }
+
+    #[test]
+    fn require_any_scope_matched_prefers_first_listed_when_both_present() {
+        // Both scopes granted → the first-listed (narrowed) candidate wins.
+        let req = req_with_scope(Some(&format!("{CHARTER} {BROAD}")));
+        let (_claims, matched) =
+            require_any_scope_matched::<BasicClaims>(&req, &[CHARTER, BROAD]).unwrap();
+        assert_eq!(matched, CHARTER);
+    }
+
+    #[test]
+    fn require_any_scope_matched_rejects_unrelated_scope() {
+        let req = req_with_scope(Some("ledger:write"));
+        let err = require_any_scope_matched::<BasicClaims>(&req, &[CHARTER, BROAD]).unwrap_err();
+        assert!(matches!(err, ApiError::Forbidden(_)));
+    }
+
+    #[test]
+    fn require_any_scope_matched_empty_candidates_is_internal_error() {
+        let req = req_with_scope(Some(CHARTER));
+        let err = require_any_scope_matched::<BasicClaims>(&req, &[]).unwrap_err();
+        assert!(matches!(err, ApiError::Internal(_)));
     }
 }


### PR DESCRIPTION
## What

Puts the #1868 V2 receipt schema (#1929/#1930/#1931) into production for the first time. Emits `MeetingAttendanceReceiptV2` in the meeting-attendance path, recording the **actual accepted/presented capability scope** and an explicit `NoMandateRequired { MembershipStandingOnly }` attestation.

## Why

The V2 receipt types existed but were **dormant** — no production code constructed any of them. Meeting attendance is the cleanest first emission: it is a membership-standing-only act (decomposition §6 / §10 step 9), so it needs no mandate grant and no `MandateGate` call. This delivers §7's "low-blast → explicit `no_mandate_required` discriminator" evidence **without creating always-reject MandateGate handler theater** (no proposal currently mints an Execution-class grant the gate could validate, so wiring `require()` would reject everything).

## How

- V2 emitted **alongside** v1 (additive); v1 emission and its consumers are unchanged.
- `capability_scope_presented` records the scope that **actually** authorized the request. During the compatibility period that may be either `governance:meeting:write` or the legacy `governance:write` — the field is evidence, so it reports what was accepted, not the preferred class scope. A narrow `require_any_scope_matched` helper (icn-http-kit) returns the matched scope (narrowest-first preferred when several are granted); the scope-matching rule stays centralized.

### Changed files
- `icn-http-kit/src/auth.rs` — `require_any_scope_matched` + 5 unit tests.
- `apps/governance/src/receipt_backend.rs` — `put_meeting_attendance_v2` whose default routes through the fail-closed `put_opaque` primitive (durable in production via the gateway's Stage-1b `put_opaque` override; no new typed import in the kernel gateway). Mirrors `put_process_gate_result`.
- `apps/governance/src/manager.rs` — `update_meeting_attendance` takes `capability_scope: &str`; emits v2 alongside v1 (fail-closed).
- `apps/governance/src/http/handlers.rs` — `mark_attendance` threads the accepted scope.
- `tests/me_meeting_attendance_receipt_chain.rs` — backend captures v2; new test covers both scope cases + attestation + verify + v1-still-emitted.

## Risk

Low. Additive — v1 is untouched, and the manager change is a fail-closed supplement. The v2 persistence default routes through the fail-closed `put_opaque` primitive (durable in production; explicit error rather than silent drop if a backend lacks opaque storage). No handler enforcement behavior changes.

## Review

Codex P1 (the typed v2 default was a no-op, so the production gateway would silently drop v2 evidence) addressed in `e9f020eb`: the default now routes through `put_opaque` (firewall-clean, fail-closed), with a test proving a `put_opaque`-only backend (gateway-shaped) durably receives the receipt. Thread resolved.

## Test plan

From `icn/icn/`: `cargo fmt --check`; `cargo check --workspace --all-targets`; `cargo clippy -p icn-http-kit / icn-governance / icn-governance-actor --all-targets -- -D warnings`; `cargo test` for all three (icn-http-kit 18, icn-governance 571+42+4+7, icn-governance-actor 274 + all integration) — clean. Compliance linter: no violations. `git diff --check`: clean.

New tests prove: v2 emitted recording the accepted scope verbatim (`governance:meeting:write` **and** legacy `governance:write`), `NoMandateRequired { MembershipStandingOnly }`, `.verify()`, v1 still emitted; plus the `require_any_scope_matched` selection logic (narrow-only, legacy-only, both→prefer-narrow, unrelated→reject, empty→internal).

## Notes / non-claims

- V2 meeting-attendance receipts now record the **actual** accepted/presented capability scope.
- During compatibility, that may be either `governance:meeting:write` or legacy `governance:write`.
- **No** `MandateGate::require()` handler wiring.
- **No** grant-minting expansion.
- **No** `TypedScope` federation/role binding.
- **No** `governance:write` retirement.
- **No** `ActionItemCompletionReceipt` or `GovernanceDecisionReceipt` emission migration.
- **No** production-readiness / live-federation / demo-ready claim.

Part of #1868.

