### PR TITLE
feat(governance): emit v2 action-item receipts (#1868)

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2741,7 +2741,10 @@ pub async fn update_action_item<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<(String, String)>,
     req: web::Json<UpdateActionItemRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_any_scope::<BasicClaims>(
+    // Record the scope that actually authorized the request (evidence) — used
+    // when this update transitions the item into Completed. Narrowest-first so
+    // the narrow class scope is preferred when both are present.
+    let (claims, presented_scope) = require_any_scope_matched::<BasicClaims>(
         &http_req,
         &["governance:meeting:write", "governance:write"],
     )?;
@@ -2819,7 +2822,7 @@ pub async fn update_action_item<E: GovernanceEventEmitter + Clone + 'static>(
     let final_item = if let Some(new_status) = requested_status {
         if new_status != prior_status {
             ctx.manager
-                .update_action_item_status(&domain, &id, new_status, &user_did)
+                .update_action_item_status(&domain, &id, new_status, &user_did, &presented_scope)
                 .map_err(anyhow_to_api)?
         } else {
             item
@@ -2875,7 +2878,10 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
     path: web::Path<(String, String)>,
     req: web::Json<StatusUpdateRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_any_scope::<BasicClaims>(
+    // Record the scope that actually authorized the request (evidence): the
+    // narrowed class scope when present, else the legacy broad scope during
+    // the compatibility period. Listed narrowest-first so it is preferred.
+    let (claims, presented_scope) = require_any_scope_matched::<BasicClaims>(
         &http_req,
         &["governance:meeting:write", "governance:write"],
     )?;
@@ -2904,7 +2910,7 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
     let new_status = parse_status(&req.status)?;
     let item = ctx
         .manager
-        .update_action_item_status(&domain, &id, new_status, &user_did)
+        .update_action_item_status(&domain, &id, new_status, &user_did, &presented_scope)
         .map_err(anyhow_to_api)?;
 
     Ok(HttpResponse::Ok().json(action_item_to_response(&item)))

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -4894,13 +4894,21 @@ impl GovernanceManager {
         Ok(item)
     }
 
-    /// Update the status of an action item
+    /// Update the status of an action item.
+    ///
+    /// `capability_scope` is the capability scope that actually authorized the
+    /// request (e.g. `"governance:meeting:write"`, or the legacy
+    /// `"governance:write"` during the compatibility period). It is recorded
+    /// verbatim into the emitted [`ActionItemCompletionReceiptV2`]'s
+    /// `capability_scope_presented` field — it is evidence, so callers must
+    /// pass the accepted scope, not a canonical preferred one.
     pub fn update_action_item_status(
         &self,
         domain_id: &GovernanceDomainId,
         id: &ActionItemId,
         status: ActionItemStatus,
         actor: &icn_identity::Did,
+        capability_scope: &str,
     ) -> Result<ActionItem> {
         let mut item = self
             .action_items
@@ -4934,6 +4942,36 @@ impl GovernanceManager {
                         "Failed to persist action item completion receipt for {id}: {e}"
                     )
                 })?;
+
+                // #1868: emit the v2 receipt alongside v1. Action-item
+                // completion is a membership-standing-only act (decomposition
+                // §6 — governance:meeting:write, "no mandate beyond
+                // membership-in-good-standing"), so the attestation is the
+                // explicit `NoMandateRequired { MembershipStandingOnly }`
+                // discriminator — no MandateGate call, no grant.
+                // `capability_scope` is recorded verbatim as the scope that
+                // authorized this request.
+                let receipt_v2 = icn_governance::ActionItemCompletionReceiptV2::new(
+                    item.id.to_string(),
+                    item.domain_id.0.clone(),
+                    actor.to_string(),
+                    icn_governance::ActionItemTransition::Completed,
+                    now,
+                    capability_scope.to_string(),
+                    icn_governance::ReceiptMandateAttestation::NoMandateRequired {
+                        reason: icn_governance::NoMandateReason::MembershipStandingOnly,
+                    },
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!("Invalid v2 action item completion receipt for {id}: {e}")
+                })?;
+                store
+                    .put_action_item_completion_v2(&receipt_v2)
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Failed to persist v2 action item completion receipt for {id}: {e}"
+                        )
+                    })?;
             }
         }
 

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -2,9 +2,9 @@
 //! in this crate without a circular dependency on icn-gateway.
 
 use icn_governance::{
-    ActionItemCompletionReceipt, AuthorityGrant, AuthorityGrantId, GovernanceDecisionReceipt,
-    Grantee, Mandate, MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, ProcessGateKind,
-    ProcessGateResultReceipt, Timestamp,
+    ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, AuthorityGrant, AuthorityGrantId,
+    GovernanceDecisionReceipt, Grantee, Mandate, MeetingAttendanceReceipt,
+    MeetingAttendanceReceiptV2, ProcessGateKind, ProcessGateResultReceipt, Timestamp,
 };
 use icn_kernel_api::{AllocationReceipt, Hash};
 
@@ -19,6 +19,11 @@ const PROCESS_GATE_RESULT_CLASS: &str = "process_gate_result";
 /// Chosen in the apps layer so the gateway persists v2 attendance evidence
 /// without importing the typed name (preserves the meaning firewall).
 const MEETING_ATTENDANCE_V2_CLASS: &str = "meeting_attendance_v2";
+
+/// Class string for `ActionItemCompletionReceiptV2` opaque storage (#1868).
+/// Chosen in the apps layer so the gateway persists v2 completion evidence
+/// without importing the typed name (preserves the meaning firewall).
+const ACTION_ITEM_COMPLETION_V2_CLASS: &str = "action_item_completion_v2";
 
 /// Stable string mapping for `ProcessGateKind` used as the
 /// opaque-storage `key2`. Distinct from serde wire form so the
@@ -360,6 +365,44 @@ pub trait GovernanceReceiptBackend: Send + Sync {
         _receipt: &ActionItemCompletionReceipt,
     ) -> Result<(), String> {
         Ok(())
+    }
+
+    /// Persist an [`ActionItemCompletionReceiptV2`] — the #1868 v2 form
+    /// carrying `capability_scope_presented` and an explicit
+    /// [`ReceiptMandateAttestation`](icn_governance::ReceiptMandateAttestation).
+    /// Emitted **alongside** the v1 receipt by the migrated
+    /// `update_action_item_status` path (v1 emission + consumers unchanged).
+    ///
+    /// Append-only and idempotent on `record_hash`, same discipline as
+    /// [`Self::put_action_item_completion`].
+    ///
+    /// **Default routes through opaque storage** (same pattern as
+    /// [`Self::put_meeting_attendance_v2`] / [`Self::put_process_gate_result`]):
+    /// the typed receipt is serialised to JSON and delegated to
+    /// [`Self::put_opaque`] under class `"action_item_completion_v2"` with
+    /// `key1 = receipt.item_id`, `key2 = None` (mirrors the v1 by-item index).
+    /// The production gateway-backed `ReceiptStore` overrides `put_opaque`
+    /// (Stage 1b), so it gets durable persistence here **without** importing
+    /// `ActionItemCompletionReceiptV2` — the meaning firewall stays put. A
+    /// backend that does not implement opaque storage hits the `put_opaque`
+    /// fail-closed default (`opaque_storage_not_implemented`) rather than
+    /// silently dropping the v2 evidence. Backends wanting custom typed
+    /// persistence (e.g. an in-memory test store) may still override this
+    /// method directly.
+    fn put_action_item_completion_v2(
+        &self,
+        receipt: &ActionItemCompletionReceiptV2,
+    ) -> Result<(), String> {
+        let payload = serde_json::to_vec(receipt)
+            .map_err(|e| format!("serialize ActionItemCompletionReceiptV2: {e}"))?;
+        self.put_opaque(
+            ACTION_ITEM_COMPLETION_V2_CLASS,
+            &receipt.item_id,
+            None,
+            receipt.completed_at,
+            receipt.record_hash,
+            &payload,
+        )
     }
 
     /// Retrieve the latest [`ActionItemCompletionReceipt`] for an action

--- a/icn/apps/governance/tests/me_action_item_receipt_chain.rs
+++ b/icn/apps/governance/tests/me_action_item_receipt_chain.rs
@@ -47,9 +47,10 @@ use std::sync::{Arc, Mutex};
 
 use actix_web::{body::to_bytes, dev::Service as _, http::StatusCode, test, App, HttpMessage};
 use icn_governance::{
-    ActionItemCompletionReceipt, ActionItemPriority, ActionItemStatus, ActionItemTransition,
-    AuthorityGrant, GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams,
-    MembershipConfig, MembershipSource,
+    ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActionItemPriority,
+    ActionItemStatus, ActionItemTransition, AuthorityGrant, GovernanceDecisionReceipt,
+    GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource, NoMandateReason,
+    ReceiptMandateAttestation,
 };
 use icn_governance_actor::{
     dispatch_evidence::EffectDispatchEvidence,
@@ -72,6 +73,7 @@ use serde_json::Value;
 struct TestReceiptStore {
     governance: Mutex<Vec<GovernanceDecisionReceipt>>,
     action_item_completions: Mutex<Vec<ActionItemCompletionReceipt>>,
+    action_item_completions_v2: Mutex<Vec<ActionItemCompletionReceiptV2>>,
 }
 
 impl GovernanceReceiptBackend for TestReceiptStore {
@@ -149,6 +151,17 @@ impl GovernanceReceiptBackend for TestReceiptStore {
         Ok(())
     }
 
+    fn put_action_item_completion_v2(
+        &self,
+        receipt: &ActionItemCompletionReceiptV2,
+    ) -> Result<(), String> {
+        self.action_item_completions_v2
+            .lock()
+            .unwrap()
+            .push(receipt.clone());
+        Ok(())
+    }
+
     fn get_action_item_completion_by_item(
         &self,
         item_id: &str,
@@ -186,6 +199,17 @@ impl TestReceiptStore {
             .filter(|r| r.item_id == item_id)
             .count()
     }
+
+    /// All v2 completion receipts captured for an item id.
+    fn v2_for_item(&self, item_id: &str) -> Vec<ActionItemCompletionReceiptV2> {
+        self.action_item_completions_v2
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.item_id == item_id)
+            .cloned()
+            .collect()
+    }
 }
 
 /// A backend whose `put_action_item_completion` always rejects, used to
@@ -220,6 +244,63 @@ impl GovernanceReceiptBackend for FailingCompletionStore {
         _receipt: &ActionItemCompletionReceipt,
     ) -> Result<(), String> {
         Err("simulated receipt backend failure".to_string())
+    }
+}
+
+/// One captured opaque-storage write: `(class, key1, key2, payload)`.
+type CapturedOpaque = (String, String, Option<String>, Vec<u8>);
+
+/// A backend that overrides **only** the opaque storage primitive (like the
+/// production gateway-backed `ReceiptStore`, which overrides `put_opaque` but
+/// has no typed `put_action_item_completion_v2`). Proves the v2 typed default
+/// routes through `put_opaque` so production persists the evidence rather than
+/// silently dropping it.
+#[derive(Default)]
+struct OpaqueCapturingStore {
+    opaque: Mutex<Vec<CapturedOpaque>>,
+}
+
+impl GovernanceReceiptBackend for OpaqueCapturingStore {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    // Note: no `put_action_item_completion_v2` override — exercises the typed
+    // default's opaque-routing path. v1 `put_action_item_completion` inherits
+    // the trait no-op default (v1 persistence is not under test here).
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        _recorded_at: u64,
+        _record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        self.opaque.lock().unwrap().push((
+            class.to_string(),
+            key1.to_string(),
+            key2.map(str::to_string),
+            payload.to_vec(),
+        ));
+        Ok(())
     }
 }
 
@@ -363,7 +444,13 @@ async fn action_item_completion_receipt_chain_end_to_end() {
     let updated = h
         .ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::Completed,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("update_action_item_status -> Completed");
     assert_eq!(updated.status, ActionItemStatus::Completed);
 
@@ -403,7 +490,13 @@ async fn action_item_completion_receipt_chain_end_to_end() {
     let _ = h
         .ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::Completed,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("idempotent re-complete");
     assert_eq!(
         h.receipts.completion_count_for(&item_id_str),
@@ -440,7 +533,13 @@ async fn another_did_does_not_see_first_did_completion_via_action_cards() {
 
     h.ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &alice)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::Completed,
+            &alice,
+            "governance:meeting:write",
+        )
         .expect("alice complete");
 
     // Bob: not a member, never assigned. Must not see a card pointing at
@@ -486,7 +585,13 @@ async fn completion_receipt_uses_regulatory_safe_vocabulary() {
 
     h.ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::Completed,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("complete");
 
     let receipt = h
@@ -631,8 +736,13 @@ async fn receipt_backend_failure_prevents_completed_status_commit() {
         .expect("create_action_item");
     let prior_status = item.status;
 
-    let result =
-        manager.update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller);
+    let result = manager.update_action_item_status(
+        &domain,
+        &item.id,
+        ActionItemStatus::Completed,
+        &caller,
+        "governance:meeting:write",
+    );
     assert!(
         result.is_err(),
         "completion must fail when the receipt backend rejects the receipt"
@@ -680,7 +790,13 @@ async fn reopen_and_recomplete_preserves_completion_history() {
     // First completion.
     h.ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::Completed,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("first complete");
     let first_receipt = h
         .receipts
@@ -699,13 +815,25 @@ async fn reopen_and_recomplete_preserves_completion_history() {
     // Reopen.
     h.ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::InProgress, &caller)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::InProgress,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("reopen via InProgress");
 
     // Second completion.
     h.ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::Completed,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("second complete");
 
     let chain = h
@@ -795,7 +923,13 @@ async fn completion_receipt_endpoint_returns_persisted_receipt() {
     let updated = h
         .ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::Completed,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("update_action_item_status -> Completed");
 
     // GET the new endpoint as the same caller (governance:read). The
@@ -894,7 +1028,13 @@ async fn completion_receipt_endpoint_does_not_leak_across_domains() {
         .expect("create_action_item");
     h.ctx
         .manager
-        .update_action_item_status(&dom_a, &item.id, ActionItemStatus::Completed, &caller)
+        .update_action_item_status(
+            &dom_a,
+            &item.id,
+            ActionItemStatus::Completed,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("complete in dom_a");
     let item_id = item.id.to_string();
 
@@ -948,7 +1088,13 @@ async fn completion_receipt_endpoint_response_uses_regulatory_safe_vocabulary() 
         .expect("create_action_item");
     h.ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::Completed,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("complete");
 
     let app = gov_app_with_scope!(h.ctx.clone(), &caller, "governance:read");
@@ -1004,7 +1150,13 @@ async fn completion_receipt_endpoint_canonicalizes_non_canonical_uuids() {
         .expect("create_action_item");
     h.ctx
         .manager
-        .update_action_item_status(&domain, &item.id, ActionItemStatus::Completed, &caller)
+        .update_action_item_status(
+            &domain,
+            &item.id,
+            ActionItemStatus::Completed,
+            &caller,
+            "governance:meeting:write",
+        )
         .expect("complete");
 
     let item_id_lower = item.id.to_string();
@@ -1038,4 +1190,186 @@ async fn completion_receipt_endpoint_canonicalizes_non_canonical_uuids() {
             "response item_id must be the canonical lowercase form regardless of input casing"
         );
     }
+}
+
+// ============================================================================
+// #1868: v2 action-item completion receipt emission
+// ============================================================================
+
+/// A completion transition emits an `ActionItemCompletionReceiptV2` alongside
+/// the v1 receipt, recording the capability scope that **actually** authorized
+/// the request and the explicit `NoMandateRequired { MembershipStandingOnly }`
+/// attestation (action-item completion is membership-standing-only — no
+/// MandateGate, no grant).
+#[actix_web::test]
+async fn action_item_completion_emits_v2_recording_accepted_scope() {
+    let receipts = Arc::new(TestReceiptStore::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(receipts.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&mgr, &caller, "test-coop").await;
+
+    let mk_item = |title: &str| {
+        mgr.create_action_item(
+            domain.clone(),
+            title.to_string(),
+            None,
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec!["fictional".to_string()],
+        )
+        .expect("create_action_item")
+    };
+
+    // Accepted via the narrowed class scope.
+    let item_narrow = mk_item("Narrow-scope completion (fictional)");
+    mgr.update_action_item_status(
+        &domain,
+        &item_narrow.id,
+        ActionItemStatus::Completed,
+        &caller,
+        "governance:meeting:write",
+    )
+    .expect("complete (meeting:write)");
+
+    // Accepted only via the legacy broad scope during the compatibility period.
+    let item_legacy = mk_item("Legacy-scope completion (fictional)");
+    mgr.update_action_item_status(
+        &domain,
+        &item_legacy.id,
+        ActionItemStatus::Completed,
+        &caller,
+        "governance:write",
+    )
+    .expect("complete (legacy write)");
+
+    // ── v2 emitted, recording the accepted scope verbatim + the explicit
+    //    no-mandate attestation.
+    let narrow_v2 = receipts.v2_for_item(&item_narrow.id.to_string());
+    assert_eq!(
+        narrow_v2.len(),
+        1,
+        "exactly one v2 receipt for the narrow item"
+    );
+    let narrow = &narrow_v2[0];
+    assert_eq!(
+        narrow.capability_scope_presented,
+        "governance:meeting:write"
+    );
+    assert_eq!(
+        narrow.mandate_attestation,
+        ReceiptMandateAttestation::NoMandateRequired {
+            reason: NoMandateReason::MembershipStandingOnly,
+        },
+        "action-item completion is membership-standing-only — no mandate grant"
+    );
+    assert!(
+        narrow.verify(),
+        "emitted v2 receipt must verify its own hash"
+    );
+    assert_eq!(narrow.actor_did, caller.to_string());
+    assert_eq!(narrow.transition, ActionItemTransition::Completed);
+
+    // ── Legacy-scope acceptance must record "governance:write", NOT the
+    //    preferred class scope: the field is evidence of what authorized
+    //    the request.
+    let legacy_v2 = receipts.v2_for_item(&item_legacy.id.to_string());
+    assert_eq!(legacy_v2.len(), 1);
+    assert_eq!(
+        legacy_v2[0].capability_scope_presented, "governance:write",
+        "a request accepted via the legacy broad scope must not claim the narrowed class scope"
+    );
+    assert!(legacy_v2[0].verify());
+
+    // ── v1 still emitted alongside (no consumer regression).
+    assert_eq!(
+        receipts.completion_count_for(&item_narrow.id.to_string()),
+        1,
+        "v1 receipt must still be emitted alongside v2"
+    );
+}
+
+/// A backend that overrides only `put_opaque` (like the production
+/// gateway-backed `ReceiptStore`, which has no typed
+/// `put_action_item_completion_v2`) must still durably receive the v2 receipt
+/// via the typed default's opaque-routing path — proving the evidence is
+/// persisted in production, not silently dropped.
+#[actix_web::test]
+async fn action_item_completion_v2_default_routes_through_opaque_storage() {
+    let receipts = Arc::new(OpaqueCapturingStore::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(receipts.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&mgr, &caller, "test-coop").await;
+
+    let item = mgr
+        .create_action_item(
+            domain.clone(),
+            "Opaque-routing completion (fictional)".to_string(),
+            None,
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec!["fictional".to_string()],
+        )
+        .expect("create_action_item");
+
+    mgr.update_action_item_status(
+        &domain,
+        &item.id,
+        ActionItemStatus::Completed,
+        &caller,
+        "governance:meeting:write",
+    )
+    .expect("complete");
+
+    // The typed default serialised the v2 receipt and routed it through
+    // `put_opaque` under the action-item-completion-v2 class — exactly what the
+    // production gateway persists.
+    let captured = receipts.opaque.lock().unwrap().clone();
+    let v2: Vec<_> = captured
+        .iter()
+        .filter(|(class, _, _, _)| class == "action_item_completion_v2")
+        .collect();
+    assert_eq!(
+        v2.len(),
+        1,
+        "exactly one v2 receipt must route through opaque storage (not be dropped)"
+    );
+    let (_class, key1, key2, payload) = v2[0];
+    assert_eq!(
+        key1,
+        &item.id.to_string(),
+        "opaque key1 must be the item id"
+    );
+    assert_eq!(
+        key2.as_deref(),
+        None,
+        "opaque key2 mirrors the v1 by-item index (none)"
+    );
+    let receipt: ActionItemCompletionReceiptV2 =
+        serde_json::from_slice(payload).expect("opaque payload deserializes to v2 receipt");
+    assert!(
+        receipt.verify(),
+        "routed v2 receipt must verify its own hash"
+    );
+    assert_eq!(
+        receipt.capability_scope_presented,
+        "governance:meeting:write"
+    );
+    assert_eq!(
+        receipt.mandate_attestation,
+        ReceiptMandateAttestation::NoMandateRequired {
+            reason: NoMandateReason::MembershipStandingOnly,
+        }
+    );
 }


### PR DESCRIPTION
## What

Puts `ActionItemCompletionReceiptV2` into production — the sibling of #1934 (meeting attendance). Emits the v2 receipt **alongside** the v1 receipt on the first transition into `Completed`, recording the **actual accepted/presented capability scope** and an explicit `NoMandateRequired { MembershipStandingOnly }` attestation.

## Why

Action-item completion is documented and implemented as routine meeting record-keeping under membership-standing authority — **decomposition §6** lists `update_action_item_status` under `governance:meeting:write` with *"no mandate beyond membership-in-good-standing"*, and the runtime auth is domain membership + creator-or-assignee. It does **not** need `MandateGate::require()` and has no grant-backed authority, so `NoMandateRequired { MembershipStandingOnly }` is the honest attestation.

## How

- Emits `ActionItemCompletionReceiptV2` **alongside** v1 (additive; v1 emission + consumers unchanged).
- Records the scope that **actually** authorized the request: `governance:meeting:write` if accepted by the narrow scope, or legacy `governance:write` if accepted only by the broad fallback; **prefers the narrow scope when both are present**. Reuses `require_any_scope_matched` (from #1934) at both call paths (`update_action_item_status` and the status-changing `update_action_item`). It is evidence, so it reports what was accepted — never a preferred constant.
- `manager.rs::update_action_item_status` takes `capability_scope: &str`; the v2 put is fail-closed (persist-before-commit).
- `put_action_item_completion_v2` (backend trait) default **routes through the fail-closed `put_opaque` primitive** (class `action_item_completion_v2`, key1=item_id, key2=None — mirrors the v1 by-item index). The production gateway-backed `ReceiptStore` persists it durably via its existing Stage-1b `put_opaque` override — **no new typed import in the kernel gateway** (firewall preserved), **no silent no-op default**. Built correctly from the start per the #1934 fix; mirrors `put_process_gate_result`.

### Changed files
- `apps/governance/src/receipt_backend.rs` — class const + `put_action_item_completion_v2` opaque-routing default.
- `apps/governance/src/manager.rs` — `capability_scope` param + v2 emission alongside v1.
- `apps/governance/src/http/handlers.rs` — both action-item callers use `require_any_scope_matched` + thread the accepted scope.
- `tests/me_action_item_receipt_chain.rs` — v2 capture in the backend; new tests for scope cases + attestation + verify + v1-alongside + opaque routing.

## Risk

Low. Additive — v1 untouched; the manager change is a fail-closed supplement; the v2 default fails closed (explicit error, never silent drop) if a backend lacks opaque storage. No handler enforcement behavior changes. No gateway code touched.

## Test plan

From `icn/icn/`: `cargo fmt --check`; `cargo check --workspace --all-targets`; `cargo clippy -p icn-governance-actor --all-targets -- -D warnings`; `cargo test -p icn-governance-actor` (25 result-groups, 0 failures, incl. the two new tests). Compliance linter: no violations. `git diff --check`: clean.

New tests prove: v2 emitted alongside v1 recording the accepted scope verbatim (`governance:meeting:write` **and** legacy `governance:write`), `NoMandateRequired { MembershipStandingOnly }`, `.verify()`, v1 still emitted; and that the default routes through `put_opaque` on a gateway-shaped backend (no silent drop). The narrow-vs-legacy preference is unit-tested on `require_any_scope_matched` in icn-http-kit (#1934).

## Notes / non-claims

- Emits `ActionItemCompletionReceiptV2` for completion transitions, **alongside** v1.
- Records the actual accepted/presented capability scope; supports both `governance:meeting:write` and legacy `governance:write`; prefers narrow when both present.
- Records `NoMandateRequired { MembershipStandingOnly }`.
- Persists v2 through the **fail-closed `put_opaque` default** — no silent no-op backend default.
- **No** `MandateGate::require()` handler wiring.
- **No** grant-minting expansion.
- **No** `TypedScope` federation/role binding.
- **No** `governance:write` retirement.
- **No** `GovernanceDecisionReceipt` emission migration.
- No production-readiness / live-federation / demo-ready claim.

Part of #1868.
