### PR TITLE
feat(governance): emit v3 governance decision receipts (#1868)

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -194,6 +194,16 @@ pub enum GovernanceCommand {
         /// preventing indirect governance influence after a FreezeMember proposal.
         /// When `None`, all non-voter members may have delegation applied (default).
         excluded_delegators: Option<std::collections::HashSet<Did>>,
+        /// Capability scope the caller actually presented at close time, when
+        /// the close was driven by an authenticated request (#1868). `Some`
+        /// only for the HTTP close path, which presents `governance:write`;
+        /// `None` for scheduler/timer auto-close (no capability presented).
+        ///
+        /// This is **evidence**: it records what was actually presented, never
+        /// a canonical constant. The actor emits a process-authorized
+        /// `GovernanceDecisionReceiptV3` only when this is `Some`; the timer
+        /// path emits no v3 because no scope was presented.
+        capability_scope: Option<String>,
     },
     /// Emergency veto - marks a proposal as vetoed
     VetoProposal {
@@ -353,25 +363,6 @@ impl GovernanceHandle {
         self.submit(GovernanceCommand::RevokeDelegation {
             id: id.clone(),
             revoked_at,
-        })
-        .await
-    }
-
-    /// Close a proposal with standing revalidation and suspension-based delegation exclusion.
-    ///
-    /// Members in `excluded_delegators` are excluded from the close-time delegation
-    /// expansion: their vote weight will not flow via any active delegation.
-    /// Pass `eligible_voters: None` and `excluded_delegators: None` for standard close behavior.
-    pub async fn close_proposal_with_suspension(
-        &self,
-        proposal_id: ProposalId,
-        eligible_voters: Option<std::collections::HashSet<Did>>,
-        excluded_delegators: Option<std::collections::HashSet<Did>>,
-    ) -> Result<()> {
-        self.submit(GovernanceCommand::CloseProposal {
-            proposal_id,
-            eligible_voters,
-            excluded_delegators,
         })
         .await
     }
@@ -1080,6 +1071,9 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
             proposal_id,
             eligible_voters: None,
             excluded_delegators: None,
+            // GovernanceOps trait close: no authenticated request scope flows
+            // through this entry point — emit no v3 (see CloseProposal docs).
+            capability_scope: None,
         })
         .await
     }
@@ -1093,6 +1087,38 @@ impl icn_governance::GovernanceOps for GovernanceHandle {
             proposal_id,
             eligible_voters: Some(eligible_voters.clone()),
             excluded_delegators: None,
+            // GovernanceOps trait close: no authenticated request scope flows
+            // through this entry point — emit no v3 (see CloseProposal docs).
+            capability_scope: None,
+        })
+        .await
+    }
+
+    /// Override the trait default so a scoped HTTP close can carry the
+    /// presented capability scope into the actor, enabling a process-authorized
+    /// `GovernanceDecisionReceiptV3` (#1868).
+    ///
+    /// Behavior note: like the trait default, this does **not** wire
+    /// `excluded_delegators` into the command (the actor's delegation-exclusion
+    /// path is unchanged by this slice — it is submitted as `None`, exactly as
+    /// the default's delegation to `close_proposal_filtered`/`close_proposal`
+    /// produced). The only added behavior is threading `capability_scope`.
+    async fn close_proposal_with_suspension(
+        &self,
+        proposal_id: ProposalId,
+        eligible_voters: Option<std::collections::HashSet<Did>>,
+        excluded_delegators: Option<std::collections::HashSet<Did>>,
+        capability_scope: Option<String>,
+    ) -> Result<()> {
+        // Unchanged from the trait default: excluded_delegators is not wired
+        // into the actor command in this slice. Carrying the presented scope is
+        // the only added behavior.
+        let _ = excluded_delegators;
+        self.submit(GovernanceCommand::CloseProposal {
+            proposal_id,
+            eligible_voters,
+            excluded_delegators: None,
+            capability_scope,
         })
         .await
     }
@@ -1336,6 +1362,9 @@ impl GovernanceActor {
                                         proposal_id: proposal_id.clone(),
                                         eligible_voters: None,
                                         excluded_delegators: None,
+                                        // Scheduler/timer auto-close: no capability scope
+                                        // was presented, so emit no process-authorized v3.
+                                        capability_scope: None,
                                     }).await {
                                         // May fail if proposal was manually closed (race condition - expected)
                                         warn!("Scheduled close for proposal {} skipped: {}", proposal_id.0, e);
@@ -1772,6 +1801,7 @@ impl GovernanceActor {
                 proposal_id,
                 eligible_voters,
                 excluded_delegators,
+                capability_scope,
             } => {
                 info!("Closing proposal: {}", proposal_id.0);
 
@@ -2055,6 +2085,59 @@ impl GovernanceActor {
                     );
                     None
                 };
+
+                // #1868: emit a process-authorized GovernanceDecisionReceiptV3
+                // alongside the v1 receipt / GovernanceProofV2, but ONLY when the
+                // close was driven by an authenticated request that actually
+                // presented a capability scope. A normal democratic close is
+                // authorized by the governance process itself (eligible voters,
+                // period, quorum/threshold, tally) — not membership standing, not
+                // a personal grant — so the attestation is `ProcessAuthorized`.
+                //
+                // `capability_scope` is `None` for scheduler/timer auto-close
+                // (nothing was presented), so no v3 is emitted there: the field is
+                // evidence and must record what was actually presented, never a
+                // constant. Forced-accept (Bootstrap) is a separate path and is
+                // intentionally not emitted in this slice.
+                //
+                // Persisted before the terminal `proposal.close`/`save_proposal`
+                // so a persistence failure fails closed (the proposal stays open)
+                // rather than committing a close without its decision evidence.
+                // Routes through the fail-closed `put_governance_decision_v3` →
+                // `put_opaque` seam; the gateway never imports the v3 type.
+                if let Some(scope) = capability_scope.as_deref() {
+                    if let Some(ref store) = self.receipt_store {
+                        use icn_governance::proof::ProofOutcome;
+                        let v3_outcome = match outcome_result {
+                            DecisionOutcome::Accepted => ProofOutcome::Accepted,
+                            DecisionOutcome::Rejected => ProofOutcome::Rejected,
+                            DecisionOutcome::NoQuorum => ProofOutcome::NoQuorum,
+                        };
+                        let receipt_v3 = icn_governance::GovernanceDecisionReceiptV3::new(
+                            proposal_id.0.clone(),
+                            proposal.domain_id.0.clone(),
+                            v3_outcome,
+                            tally.clone(),
+                            &votes,
+                            scope.to_string(),
+                            icn_governance::ReceiptMandateAttestation::ProcessAuthorized,
+                        )
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "Invalid v3 decision receipt for proposal {}: {e}",
+                                proposal_id.0
+                            )
+                        })?;
+                        store
+                            .put_governance_decision_v3(&receipt_v3, now)
+                            .map_err(|e| {
+                                anyhow::anyhow!(
+                                    "Failed to persist v3 decision receipt for proposal {}: {e}",
+                                    proposal_id.0
+                                )
+                            })?;
+                    }
+                }
 
                 // Update proposal
                 proposal.close(new_state)?;

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -2033,12 +2033,67 @@ impl GovernanceActor {
                     None
                 };
 
-                // Generate + persist GovernanceProofV2 BEFORE terminal proposal
-                // save. If proof persistence fails, the proposal must not be
-                // persisted as closed — otherwise the API returns Err while the
-                // store disagrees. Non-Accepted outcomes still emit a proof
-                // (useful for audit of rejection / no-quorum signals) but they
-                // bypass the Invariant 7 gate above.
+                // #1868: persist a process-authorized GovernanceDecisionReceiptV3
+                // as a PREFLIGHT — before the GovernanceProofV2 below and before
+                // the terminal `proposal.close`/`save_proposal` — but ONLY when the
+                // close was driven by an authenticated request that actually
+                // presented a capability scope. A normal democratic close is
+                // authorized by the governance process itself (eligible voters,
+                // period, quorum/threshold, tally) — not membership standing, not
+                // a personal grant — so the attestation is `ProcessAuthorized`.
+                //
+                // `capability_scope` is `None` for scheduler/timer auto-close
+                // (nothing was presented), so no v3 is emitted there: the field is
+                // evidence and must record what was actually presented, never a
+                // constant. Forced-accept (Bootstrap) is a separate path and is
+                // intentionally not emitted in this slice.
+                //
+                // Ordering matters: this runs BEFORE proof persistence (and the
+                // terminal close) so a v3 persistence failure fails closed without
+                // leaving a durable closed-outcome proof — or any other decision
+                // artifact — behind for a still-Open proposal. Routes through the
+                // fail-closed `put_governance_decision_v3` → `put_opaque` seam; the
+                // gateway never imports the v3 type.
+                if let Some(scope) = capability_scope.as_deref() {
+                    if let Some(ref store) = self.receipt_store {
+                        use icn_governance::proof::ProofOutcome;
+                        let v3_outcome = match outcome_result {
+                            DecisionOutcome::Accepted => ProofOutcome::Accepted,
+                            DecisionOutcome::Rejected => ProofOutcome::Rejected,
+                            DecisionOutcome::NoQuorum => ProofOutcome::NoQuorum,
+                        };
+                        let receipt_v3 = icn_governance::GovernanceDecisionReceiptV3::new(
+                            proposal_id.0.clone(),
+                            proposal.domain_id.0.clone(),
+                            v3_outcome,
+                            tally.clone(),
+                            &votes,
+                            scope.to_string(),
+                            icn_governance::ReceiptMandateAttestation::ProcessAuthorized,
+                        )
+                        .map_err(|e| {
+                            anyhow::anyhow!(
+                                "Invalid v3 decision receipt for proposal {}: {e}",
+                                proposal_id.0
+                            )
+                        })?;
+                        store
+                            .put_governance_decision_v3(&receipt_v3, now)
+                            .map_err(|e| {
+                                anyhow::anyhow!(
+                                    "Failed to persist v3 decision receipt for proposal {}: {e}",
+                                    proposal_id.0
+                                )
+                            })?;
+                    }
+                }
+
+                // Generate + persist GovernanceProofV2 after the v3 preflight and
+                // BEFORE terminal proposal save. If proof persistence fails, the
+                // proposal must not be persisted as closed — otherwise the API
+                // returns Err while the store disagrees. Non-Accepted outcomes
+                // still emit a proof (useful for audit of rejection / no-quorum
+                // signals) but they bypass the Invariant 7 gate above.
                 let proof_bytes = if let Some(ref signing_key) = self.signing_key {
                     use icn_governance::ProofOutcome;
 
@@ -2085,59 +2140,6 @@ impl GovernanceActor {
                     );
                     None
                 };
-
-                // #1868: emit a process-authorized GovernanceDecisionReceiptV3
-                // alongside the v1 receipt / GovernanceProofV2, but ONLY when the
-                // close was driven by an authenticated request that actually
-                // presented a capability scope. A normal democratic close is
-                // authorized by the governance process itself (eligible voters,
-                // period, quorum/threshold, tally) — not membership standing, not
-                // a personal grant — so the attestation is `ProcessAuthorized`.
-                //
-                // `capability_scope` is `None` for scheduler/timer auto-close
-                // (nothing was presented), so no v3 is emitted there: the field is
-                // evidence and must record what was actually presented, never a
-                // constant. Forced-accept (Bootstrap) is a separate path and is
-                // intentionally not emitted in this slice.
-                //
-                // Persisted before the terminal `proposal.close`/`save_proposal`
-                // so a persistence failure fails closed (the proposal stays open)
-                // rather than committing a close without its decision evidence.
-                // Routes through the fail-closed `put_governance_decision_v3` →
-                // `put_opaque` seam; the gateway never imports the v3 type.
-                if let Some(scope) = capability_scope.as_deref() {
-                    if let Some(ref store) = self.receipt_store {
-                        use icn_governance::proof::ProofOutcome;
-                        let v3_outcome = match outcome_result {
-                            DecisionOutcome::Accepted => ProofOutcome::Accepted,
-                            DecisionOutcome::Rejected => ProofOutcome::Rejected,
-                            DecisionOutcome::NoQuorum => ProofOutcome::NoQuorum,
-                        };
-                        let receipt_v3 = icn_governance::GovernanceDecisionReceiptV3::new(
-                            proposal_id.0.clone(),
-                            proposal.domain_id.0.clone(),
-                            v3_outcome,
-                            tally.clone(),
-                            &votes,
-                            scope.to_string(),
-                            icn_governance::ReceiptMandateAttestation::ProcessAuthorized,
-                        )
-                        .map_err(|e| {
-                            anyhow::anyhow!(
-                                "Invalid v3 decision receipt for proposal {}: {e}",
-                                proposal_id.0
-                            )
-                        })?;
-                        store
-                            .put_governance_decision_v3(&receipt_v3, now)
-                            .map_err(|e| {
-                                anyhow::anyhow!(
-                                    "Failed to persist v3 decision receipt for proposal {}: {e}",
-                                    proposal_id.0
-                                )
-                            })?;
-                    }
-                }
 
                 // Update proposal
                 proposal.close(new_state)?;

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1260,7 +1260,13 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     proposal_id: web::Path<String>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    // #1868: capture the scope class that actually authorized this close so the
+    // process-authorized v3 receipt records evidence derived from the auth
+    // decision rather than a hardcoded constant. With a single candidate this is
+    // `governance:write` today; listing decomposed close scope(s) first here
+    // when they land will make the receipt record the narrowest matched class.
+    let (claims, presented_scope) =
+        require_any_scope_matched::<BasicClaims>(&http_req, &["governance:write"])?;
     let requester_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let proposal_id = ProposalId(proposal_id.into_inner());
@@ -1379,11 +1385,11 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
             proposal_id.clone(),
             eligible_voters,
             excluded_delegators,
-            // #1868: this authenticated close presented `governance:write`
-            // (the scope `require_scope` accepted above). Recorded verbatim as
-            // the v3 receipt's `capability_scope_presented` — it is evidence of
-            // what was actually presented, not a canonical preference.
-            Some("governance:write".to_string()),
+            // #1868: record the scope class that actually authorized this close
+            // (from `require_any_scope_matched` above) as the v3 receipt's
+            // `capability_scope_presented` — evidence derived from the auth
+            // decision, not a hardcoded constant.
+            Some(presented_scope),
         )
         .await
         .map_err(anyhow_to_api)?;

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -1375,7 +1375,16 @@ pub async fn close_proposal<E: GovernanceEventEmitter + Clone + 'static>(
         };
 
     ctx.manager
-        .close_proposal_with_suspension(proposal_id.clone(), eligible_voters, excluded_delegators)
+        .close_proposal_with_suspension(
+            proposal_id.clone(),
+            eligible_voters,
+            excluded_delegators,
+            // #1868: this authenticated close presented `governance:write`
+            // (the scope `require_scope` accepted above). Recorded verbatim as
+            // the v3 receipt's `capability_scope_presented` — it is evidence of
+            // what was actually presented, not a canonical preference.
+            Some("governance:write".to_string()),
+        )
         .await
         .map_err(anyhow_to_api)?;
 
@@ -5539,6 +5548,22 @@ mod tests {
             _decision_hash: &icn_kernel_api::Hash,
         ) -> Result<Vec<icn_kernel_api::AllocationReceipt>, String> {
             Ok(vec![])
+        }
+        // Support the opaque seam so a scoped normal close can persist its
+        // process-authorized v3 decision receipt (#1868). The production
+        // gateway `ReceiptStore` overrides this; these handler tests don't
+        // assert on v3 content, so accepting the write is sufficient to keep
+        // the close from fail-closing on the v3 emission.
+        fn put_opaque(
+            &self,
+            _class: &str,
+            _key1: &str,
+            _key2: Option<&str>,
+            _recorded_at: u64,
+            _record_hash: [u8; 32],
+            _payload: &[u8],
+        ) -> Result<(), String> {
+            Ok(())
         }
         fn put_institutional_effect(
             &self,

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -3561,43 +3561,27 @@ impl GovernanceManager {
             }
 
             if let Some(ref store) = self.receipt_store {
-                let receipt = GovernanceDecisionReceipt::new(
-                    proposal_id.0.clone(),
-                    proposal.domain_id.0.clone(),
-                    outcome,
-                    tally.clone(),
-                    &proposal_votes,
-                );
-                if let Err(e) = store.put_governance(&receipt) {
-                    tracing::error!(
-                        proposal_id = %proposal_id.0,
-                        error = %e,
-                        "Failed to store governance decision receipt — provenance chain broken"
-                    );
-                    // Escalated from warn to error: receipt store failure means
-                    // the governance→economics provenance chain is broken (PS-3).
-                    if requires_execution_closure {
-                        anyhow::bail!(
-                            "Proposal '{}' requires execution closure but governance receipt persistence failed: {e}",
-                            proposal_id.0
-                        );
-                    }
-                }
-
-                // #1868: emit a process-authorized GovernanceDecisionReceiptV3
-                // alongside v1 — ONLY when a capability scope was actually
-                // presented (the scoped HTTP close path). `capability_scope` is
-                // `None` for unscoped/timer entry points, which emit no v3
+                // #1868: persist a process-authorized GovernanceDecisionReceiptV3
+                // as a PREFLIGHT — before the v1 receipt below and before the
+                // terminal `proposal.close(...)` — ONLY when a capability scope was
+                // actually presented (the scoped HTTP close path). `capability_scope`
+                // is `None` for unscoped/timer entry points, which emit no v3
                 // because nothing was presented (the field is evidence, never a
                 // constant). Mirrors the actor close path so the in-memory and
-                // actor backends produce the same v3 evidence. Routes through the
-                // fail-closed `put_governance_decision_v3` → `put_opaque` seam.
+                // actor backends produce the same v3 evidence.
+                //
+                // Ordering matters: persisting v3 first means a v3 persistence
+                // failure fails closed (bail below) before any durable v1 decision
+                // receipt is written, so a still-Open proposal never has a
+                // contradictory committed receipt exposed via `get_chain`. Routes
+                // through the fail-closed `put_governance_decision_v3` →
+                // `put_opaque` seam.
                 if let Some(scope) = capability_scope {
                     let receipt_v3 = icn_governance::GovernanceDecisionReceiptV3::new(
                         proposal_id.0.clone(),
                         proposal.domain_id.0.clone(),
                         outcome,
-                        tally,
+                        tally.clone(),
                         &proposal_votes,
                         scope.to_string(),
                         icn_governance::ReceiptMandateAttestation::ProcessAuthorized,
@@ -3616,14 +3600,42 @@ impl GovernanceManager {
                         );
                         // Fail closed, unconditionally. A scoped close emits the
                         // v3 receipt as required decision evidence; this runs
-                        // before the terminal `proposal.close(...)` below, so
-                        // bailing leaves the proposal Open rather than committing
-                        // a close without its evidence. Matches the actor path and
-                        // the fail-closed opaque-storage contract — not guarded by
-                        // `requires_execution_closure` (which only gates the v1
-                        // provenance-chain bail above).
+                        // before the v1 receipt write and the terminal
+                        // `proposal.close(...)` below, so bailing leaves the
+                        // proposal Open with NO durable decision artifact rather
+                        // than half-persisting a close (a durable v1 receipt for an
+                        // Open proposal). Not guarded by `requires_execution_closure`
+                        // (which only gates the v1 provenance-chain bail below).
                         anyhow::bail!(
                             "Proposal '{}' close aborted: v3 decision receipt persistence failed: {e}",
+                            proposal_id.0
+                        );
+                    }
+                }
+
+                // v1 GovernanceDecisionReceipt, emitted after the v3 preflight
+                // above. For a scoped close the v3 evidence is already durable by
+                // this point; an unscoped close has no v3 and this v1 receipt is
+                // the decision record. A put_governance failure here is fatal only
+                // when execution closure is required (PS-3 provenance chain).
+                let receipt = GovernanceDecisionReceipt::new(
+                    proposal_id.0.clone(),
+                    proposal.domain_id.0.clone(),
+                    outcome,
+                    tally.clone(),
+                    &proposal_votes,
+                );
+                if let Err(e) = store.put_governance(&receipt) {
+                    tracing::error!(
+                        proposal_id = %proposal_id.0,
+                        error = %e,
+                        "Failed to store governance decision receipt — provenance chain broken"
+                    );
+                    // Escalated from warn to error: receipt store failure means
+                    // the governance→economics provenance chain is broken (PS-3).
+                    if requires_execution_closure {
+                        anyhow::bail!(
+                            "Proposal '{}' requires execution closure but governance receipt persistence failed: {e}",
                             proposal_id.0
                         );
                     }

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -3383,7 +3383,9 @@ impl GovernanceManager {
         if let Some(ref handle) = self.governance_handle {
             return handle.close_proposal(proposal_id).await;
         }
-        self.close_proposal_inner(proposal_id, None)
+        // No authenticated request scope flows through this entry point —
+        // emit no process-authorized v3 (#1868).
+        self.close_proposal_inner(proposal_id, None, None)
     }
 
     /// Close a proposal counting only votes from currently-eligible members.
@@ -3409,7 +3411,9 @@ impl GovernanceManager {
                 .close_proposal_filtered(proposal_id, eligible_voters)
                 .await;
         }
-        self.close_proposal_inner(proposal_id, Some(eligible_voters))
+        // No authenticated request scope flows through this entry point —
+        // emit no process-authorized v3 (#1868).
+        self.close_proposal_inner(proposal_id, Some(eligible_voters), None)
     }
 
     /// Close a proposal with both standing revalidation and suspension-based
@@ -3421,17 +3425,26 @@ impl GovernanceManager {
         proposal_id: ProposalId,
         eligible_voters: Option<HashSet<Did>>,
         excluded_delegators: Option<HashSet<Did>>,
+        capability_scope: Option<String>,
     ) -> Result<()> {
         if let Some(ref handle) = self.governance_handle {
             return handle
-                .close_proposal_with_suspension(proposal_id, eligible_voters, excluded_delegators)
+                .close_proposal_with_suspension(
+                    proposal_id,
+                    eligible_voters,
+                    excluded_delegators,
+                    capability_scope,
+                )
                 .await;
         }
         // In-memory path: no delegation expansion, so suspension exclusion is a no-op.
-        // Just apply the eligible_voters filter if present.
+        // Just apply the eligible_voters filter if present. The presented scope
+        // (if any) flows through so the in-memory path emits the same
+        // process-authorized v3 as the actor path (#1868).
+        let scope = capability_scope.as_deref();
         match eligible_voters.as_ref() {
-            Some(eligible) => self.close_proposal_inner(proposal_id, Some(eligible)),
-            None => self.close_proposal_inner(proposal_id, None),
+            Some(eligible) => self.close_proposal_inner(proposal_id, Some(eligible), scope),
+            None => self.close_proposal_inner(proposal_id, None, scope),
         }
     }
 
@@ -3439,6 +3452,11 @@ impl GovernanceManager {
         &self,
         proposal_id: ProposalId,
         eligible_voters: Option<&HashSet<Did>>,
+        // Capability scope the caller presented at close time, when the close
+        // was driven by an authenticated request (#1868). `Some` only for the
+        // scoped HTTP close path; `None` for unscoped entry points. Drives the
+        // process-authorized v3 emission (evidence — never a constant).
+        capability_scope: Option<&str>,
     ) -> Result<()> {
         let mut proposals = self.proposals.write().map_err(|e| {
             anyhow::anyhow!("Proposals storage lock poisoned (concurrent panic?): {e}")
@@ -3547,7 +3565,7 @@ impl GovernanceManager {
                     proposal_id.0.clone(),
                     proposal.domain_id.0.clone(),
                     outcome,
-                    tally,
+                    tally.clone(),
                     &proposal_votes,
                 );
                 if let Err(e) = store.put_governance(&receipt) {
@@ -3563,6 +3581,45 @@ impl GovernanceManager {
                             "Proposal '{}' requires execution closure but governance receipt persistence failed: {e}",
                             proposal_id.0
                         );
+                    }
+                }
+
+                // #1868: emit a process-authorized GovernanceDecisionReceiptV3
+                // alongside v1 — ONLY when a capability scope was actually
+                // presented (the scoped HTTP close path). `capability_scope` is
+                // `None` for unscoped/timer entry points, which emit no v3
+                // because nothing was presented (the field is evidence, never a
+                // constant). Mirrors the actor close path so the in-memory and
+                // actor backends produce the same v3 evidence. Routes through the
+                // fail-closed `put_governance_decision_v3` → `put_opaque` seam.
+                if let Some(scope) = capability_scope {
+                    let receipt_v3 = icn_governance::GovernanceDecisionReceiptV3::new(
+                        proposal_id.0.clone(),
+                        proposal.domain_id.0.clone(),
+                        outcome,
+                        tally,
+                        &proposal_votes,
+                        scope.to_string(),
+                        icn_governance::ReceiptMandateAttestation::ProcessAuthorized,
+                    )
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Invalid v3 decision receipt for proposal {}: {e}",
+                            proposal_id.0
+                        )
+                    })?;
+                    if let Err(e) = store.put_governance_decision_v3(&receipt_v3, now) {
+                        tracing::error!(
+                            proposal_id = %proposal_id.0,
+                            error = %e,
+                            "Failed to store v3 decision receipt — process-authority evidence not persisted"
+                        );
+                        if requires_execution_closure {
+                            anyhow::bail!(
+                                "Proposal '{}' requires execution closure but v3 decision receipt persistence failed: {e}",
+                                proposal_id.0
+                            );
+                        }
                     }
                 }
 

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -3614,12 +3614,18 @@ impl GovernanceManager {
                             error = %e,
                             "Failed to store v3 decision receipt — process-authority evidence not persisted"
                         );
-                        if requires_execution_closure {
-                            anyhow::bail!(
-                                "Proposal '{}' requires execution closure but v3 decision receipt persistence failed: {e}",
-                                proposal_id.0
-                            );
-                        }
+                        // Fail closed, unconditionally. A scoped close emits the
+                        // v3 receipt as required decision evidence; this runs
+                        // before the terminal `proposal.close(...)` below, so
+                        // bailing leaves the proposal Open rather than committing
+                        // a close without its evidence. Matches the actor path and
+                        // the fail-closed opaque-storage contract — not guarded by
+                        // `requires_execution_closure` (which only gates the v1
+                        // provenance-chain bail above).
+                        anyhow::bail!(
+                            "Proposal '{}' close aborted: v3 decision receipt persistence failed: {e}",
+                            proposal_id.0
+                        );
                     }
                 }
 

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -3,8 +3,9 @@
 
 use icn_governance::{
     ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, AuthorityGrant, AuthorityGrantId,
-    GovernanceDecisionReceipt, Grantee, Mandate, MeetingAttendanceReceipt,
-    MeetingAttendanceReceiptV2, ProcessGateKind, ProcessGateResultReceipt, Timestamp,
+    GovernanceDecisionReceipt, GovernanceDecisionReceiptV3, Grantee, Mandate,
+    MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, ProcessGateKind,
+    ProcessGateResultReceipt, Timestamp,
 };
 use icn_kernel_api::{AllocationReceipt, Hash};
 
@@ -24,6 +25,12 @@ const MEETING_ATTENDANCE_V2_CLASS: &str = "meeting_attendance_v2";
 /// Chosen in the apps layer so the gateway persists v2 completion evidence
 /// without importing the typed name (preserves the meaning firewall).
 const ACTION_ITEM_COMPLETION_V2_CLASS: &str = "action_item_completion_v2";
+
+/// Class string for `GovernanceDecisionReceiptV3` opaque storage (#1868).
+/// Chosen in the apps layer so the gateway persists v3 process-authorized
+/// decision evidence without importing the typed name (preserves the meaning
+/// firewall).
+const GOVERNANCE_DECISION_V3_CLASS: &str = "governance_decision_v3";
 
 /// Stable string mapping for `ProcessGateKind` used as the
 /// opaque-storage `key2`. Distinct from serde wire form so the
@@ -74,6 +81,47 @@ pub trait GovernanceReceiptBackend: Send + Sync {
         &self,
         decision_hash: &Hash,
     ) -> Result<Vec<AllocationReceipt>, String>;
+
+    /// Persist a [`GovernanceDecisionReceiptV3`] — the #1868 process-authorized
+    /// decision receipt carrying `capability_scope_presented` and an explicit
+    /// [`ReceiptMandateAttestation`](icn_governance::ReceiptMandateAttestation).
+    /// Emitted **alongside** the existing v1 receipt / `GovernanceProofV2` by
+    /// the migrated normal-close path (v1 emission and its consumers are
+    /// unchanged this slice).
+    ///
+    /// Unlike the meeting/action-item v2 receipts, a decision receipt carries
+    /// no timestamp field, so `recorded_at` (the proposal close time) is
+    /// passed explicitly — it only orders the opaque entry, it is not part of
+    /// the canonical `decision_hash`.
+    ///
+    /// **Default routes through opaque storage** (same pattern as
+    /// [`Self::put_meeting_attendance_v2`] / [`Self::put_action_item_completion_v2`]):
+    /// the typed receipt is serialised to JSON and delegated to
+    /// [`Self::put_opaque`] under class `"governance_decision_v3"` with
+    /// `key1 = receipt.proposal_id`, `key2 = None` (mirrors the v1 by-proposal
+    /// index). The production gateway-backed `ReceiptStore` overrides
+    /// `put_opaque`, so it gets durable persistence here **without** importing
+    /// `GovernanceDecisionReceiptV3` — the meaning firewall stays put. A backend
+    /// that does not implement opaque storage hits the `put_opaque` fail-closed
+    /// default (`opaque_storage_not_implemented`) rather than silently dropping
+    /// the v3 evidence. Backends wanting custom typed persistence (e.g. an
+    /// in-memory test store) may still override this method directly.
+    fn put_governance_decision_v3(
+        &self,
+        receipt: &GovernanceDecisionReceiptV3,
+        recorded_at: u64,
+    ) -> Result<(), String> {
+        let payload = serde_json::to_vec(receipt)
+            .map_err(|e| format!("serialize GovernanceDecisionReceiptV3: {e}"))?;
+        self.put_opaque(
+            GOVERNANCE_DECISION_V3_CLASS,
+            &receipt.proposal_id,
+            None,
+            recorded_at,
+            receipt.decision_hash,
+            &payload,
+        )
+    }
 
     /// Persist an institutional effect record emitted at proposal acceptance.
     ///

--- a/icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs
+++ b/icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs
@@ -282,6 +282,7 @@ async fn normal_close_execution_required_emits_exactly_once() {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await
         .expect("CloseProposal submit");
@@ -471,6 +472,7 @@ async fn normal_close_preflight_failure_leaves_proposal_open() {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await;
     assert!(result.is_err(), "preflight failure must surface as Err");

--- a/icn/apps/governance/tests/actor_close_proposal_accept_parity.rs
+++ b/icn/apps/governance/tests/actor_close_proposal_accept_parity.rs
@@ -234,6 +234,7 @@ async fn actor_close_proposal_accept_emits_appoint_steward_effect() {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await
         .expect("CloseProposal submit");
@@ -330,6 +331,7 @@ async fn actor_close_proposal_accept_without_receipt_store_is_rejected() {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await;
     assert!(

--- a/icn/apps/governance/tests/actor_close_proposal_mandate_parity.rs
+++ b/icn/apps/governance/tests/actor_close_proposal_mandate_parity.rs
@@ -280,6 +280,7 @@ async fn actor_close_proposal_accept_mints_mandate_and_grant() {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await
         .expect("CloseProposal submit");
@@ -398,6 +399,7 @@ async fn actor_close_proposal_accept_text_mints_mandate_without_grants() {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await
         .expect("CloseProposal submit");
@@ -499,6 +501,7 @@ async fn actor_close_proposal_mandate_mint_is_idempotent() {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await
         .expect("first CloseProposal submit");

--- a/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
+++ b/icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs
@@ -295,6 +295,7 @@ async fn sink_records_dispatch_evidence_after_actor_accept() {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await
         .expect("CloseProposal submit");

--- a/icn/apps/governance/tests/governance_decision_receipt_v3_emission.rs
+++ b/icn/apps/governance/tests/governance_decision_receipt_v3_emission.rs
@@ -260,6 +260,29 @@ async fn in_memory_unscoped_close_emits_v1_only_no_v3() {
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn in_memory_scoped_close_v3_persistence_failure_is_fail_closed() {
+    // In-memory path parity with the actor: a scoped close on a backend without
+    // opaque storage must fail closed, not log-and-commit. The proposal must
+    // remain un-closed (Open) so the decision is never committed without its v3.
+    let backend = Arc::new(NoOpaqueBackend);
+    let (mgr, _domain, proposal_id, _did) =
+        seeded_in_memory_manager(backend as Arc<dyn GovernanceReceiptBackend>).await;
+
+    let result = mgr
+        .close_proposal_with_suspension(
+            proposal_id.clone(),
+            None,
+            None,
+            Some("governance:write".to_string()),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "standalone v3 persistence failure must fail the close closed, not drop evidence"
+    );
+}
+
 // ============================================================================
 // Actor path (production): manager → dyn GovernanceOps → CloseProposal.
 // ============================================================================

--- a/icn/apps/governance/tests/governance_decision_receipt_v3_emission.rs
+++ b/icn/apps/governance/tests/governance_decision_receipt_v3_emission.rs
@@ -28,7 +28,7 @@ use icn_gossip::{AccessControl, GossipActor, Topic};
 use icn_governance::{
     ForcedOutcome, GovernanceDecisionReceipt, GovernanceDecisionReceiptV3, GovernanceDomainId,
     GovernanceOps, GovernanceParams, MembershipConfig, ProofOutcome, ProposalId, ProposalPayload,
-    ProposalScope, ReceiptMandateAttestation, StaticMembershipResolver, VoteChoice,
+    ProposalScope, ProposalState, ReceiptMandateAttestation, StaticMembershipResolver, VoteChoice,
 };
 use icn_governance_actor::{
     actor::GovernanceActor, manager::GovernanceManager, receipt_backend::GovernanceReceiptBackend,
@@ -124,10 +124,22 @@ impl GovernanceReceiptBackend for CapturingBackend {
 // fail-closed `put_opaque` default (`opaque_storage_not_implemented`), so a v3
 // emission through it must error rather than drop silently.
 #[derive(Default)]
-struct NoOpaqueBackend;
+struct NoOpaqueBackend {
+    // Records every v1 receipt write so a test can prove the v3 preflight bails
+    // BEFORE any durable v1 decision receipt is written when opaque storage is
+    // unavailable.
+    v1: Mutex<Vec<GovernanceDecisionReceipt>>,
+}
+
+impl NoOpaqueBackend {
+    fn v1_count(&self) -> usize {
+        self.v1.lock().unwrap().len()
+    }
+}
 
 impl GovernanceReceiptBackend for NoOpaqueBackend {
-    fn put_governance(&self, _: &GovernanceDecisionReceipt) -> Result<(), String> {
+    fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
+        self.v1.lock().unwrap().push(receipt.clone());
         Ok(())
     }
     fn get_governance_by_proposal(
@@ -265,9 +277,9 @@ async fn in_memory_scoped_close_v3_persistence_failure_is_fail_closed() {
     // In-memory path parity with the actor: a scoped close on a backend without
     // opaque storage must fail closed, not log-and-commit. The proposal must
     // remain un-closed (Open) so the decision is never committed without its v3.
-    let backend = Arc::new(NoOpaqueBackend);
+    let backend = Arc::new(NoOpaqueBackend::default());
     let (mgr, _domain, proposal_id, _did) =
-        seeded_in_memory_manager(backend as Arc<dyn GovernanceReceiptBackend>).await;
+        seeded_in_memory_manager(backend.clone() as Arc<dyn GovernanceReceiptBackend>).await;
 
     let result = mgr
         .close_proposal_with_suspension(
@@ -280,6 +292,28 @@ async fn in_memory_scoped_close_v3_persistence_failure_is_fail_closed() {
     assert!(
         result.is_err(),
         "standalone v3 persistence failure must fail the close closed, not drop evidence"
+    );
+
+    // Preflight guarantee: the v3 write runs BEFORE the v1 put_governance, so a
+    // v3 failure must leave NO durable v1 decision receipt behind — otherwise
+    // `get_chain` could expose a committed receipt for a proposal that never
+    // closed.
+    assert_eq!(
+        backend.v1_count(),
+        0,
+        "v3 preflight must bail before any durable v1 receipt is written"
+    );
+
+    // And the proposal itself must remain Open (the close never committed).
+    let proposal = mgr
+        .get_proposal(&proposal_id)
+        .await
+        .expect("get_proposal")
+        .expect("proposal exists");
+    assert!(
+        matches!(proposal.state, ProposalState::Open { .. }),
+        "proposal must remain Open after a fail-closed v3 persistence, got {:?}",
+        proposal.state
     );
 }
 
@@ -313,10 +347,23 @@ async fn seeded_actor(
     let gossip = gossip_with_governance_topic(did.clone()).await;
     let resolver = Arc::new(StaticMembershipResolver::new());
 
-    let actor_handle =
-        GovernanceActor::spawn(did.clone(), store.clone(), gossip, resolver, None, None)
-            .await
-            .expect("spawn actor");
+    // Install a signing key so the close path also generates + persists a
+    // GovernanceProofV2. This makes the v3-preflight ordering observable: the
+    // fail-closed test asserts a v3 persistence failure leaves no proof behind.
+    let signing_key = Arc::new(ed25519_dalek::SigningKey::from_bytes(
+        &bundle.keypair().expect("keypair").to_signing_key_bytes(),
+    ));
+
+    let actor_handle = GovernanceActor::spawn(
+        did.clone(),
+        store.clone(),
+        gossip,
+        resolver,
+        None,
+        Some(signing_key),
+    )
+    .await
+    .expect("spawn actor");
     let manager = GovernanceManager::with_handle(
         Arc::new(actor_handle.clone()) as Arc<dyn GovernanceOps + Send + Sync>
     );
@@ -365,7 +412,7 @@ async fn seeded_actor(
 #[tokio::test(flavor = "current_thread")]
 async fn actor_scoped_close_emits_process_authorized_v3() {
     let backend = Arc::new(CapturingBackend::default());
-    let (manager, _handle, proposal_id) =
+    let (manager, handle, proposal_id) =
         seeded_actor(backend.clone() as Arc<dyn GovernanceReceiptBackend>).await;
 
     manager
@@ -389,6 +436,18 @@ async fn actor_scoped_close_emits_process_authorized_v3() {
         ReceiptMandateAttestation::ProcessAuthorized
     ));
     assert!(v3.verify(), "emitted v3 receipt must verify");
+
+    // Existing proof behavior preserved after the v3 preflight: a signing key is
+    // configured in `seeded_actor`, so a successful scoped close still persists a
+    // GovernanceProofV2 alongside the v3 decision receipt.
+    assert!(
+        handle
+            .get_proof(&proposal_id)
+            .await
+            .expect("get_proof query")
+            .is_some(),
+        "successful scoped close must still persist a GovernanceProofV2 alongside v3"
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -443,15 +502,16 @@ async fn actor_force_accept_emits_no_decision_v2_or_v3() {
 #[tokio::test(flavor = "current_thread")]
 async fn actor_scoped_close_v3_persistence_failure_is_fail_closed() {
     // Backend without opaque storage → the v3 emission hits the fail-closed
-    // `put_opaque` default. The actor persists v3 before the terminal close, so
-    // the whole close must fail rather than commit without its decision evidence.
-    let backend = Arc::new(NoOpaqueBackend);
-    let (manager, _handle, proposal_id) =
+    // `put_opaque` default. The actor persists v3 as a PREFLIGHT (before the
+    // GovernanceProofV2 and the terminal close), so the whole close must fail
+    // AND leave no durable closed-outcome proof behind.
+    let backend = Arc::new(NoOpaqueBackend::default());
+    let (manager, handle, proposal_id) =
         seeded_actor(backend as Arc<dyn GovernanceReceiptBackend>).await;
 
     let result = manager
         .close_proposal_with_suspension(
-            proposal_id,
+            proposal_id.clone(),
             None,
             None,
             Some("governance:write".to_string()),
@@ -461,5 +521,30 @@ async fn actor_scoped_close_v3_persistence_failure_is_fail_closed() {
     assert!(
         result.is_err(),
         "a v3 persistence failure must fail the close closed, not drop the evidence silently"
+    );
+
+    // Preflight guarantee: v3 runs before proof persistence, so no
+    // closed-outcome GovernanceProofV2 may be served for a proposal whose close
+    // was aborted. The signing key IS configured in `seeded_actor`, so a proof
+    // WOULD have been written had the v3 preflight not bailed first.
+    assert!(
+        handle
+            .get_proof(&proposal_id)
+            .await
+            .expect("get_proof query")
+            .is_none(),
+        "v3 preflight failure must leave no durable closed-outcome proof"
+    );
+
+    // And the proposal must remain Open — the close never committed.
+    let proposal = handle
+        .get_proposal(&proposal_id)
+        .await
+        .expect("get_proposal")
+        .expect("proposal exists");
+    assert!(
+        matches!(proposal.state, ProposalState::Open { .. }),
+        "proposal must remain Open after a fail-closed v3 persistence, got {:?}",
+        proposal.state
     );
 }

--- a/icn/apps/governance/tests/governance_decision_receipt_v3_emission.rs
+++ b/icn/apps/governance/tests/governance_decision_receipt_v3_emission.rs
@@ -1,0 +1,442 @@
+//! #1868 — process-authorized `GovernanceDecisionReceiptV3` production emission.
+//!
+//! Pins the honest emission slice decided in
+//! `docs/design/governance/decision-receipt-authority-and-grant-minting.md` §5/§7:
+//!
+//! - A **scoped** normal democratic close (an authenticated HTTP close that
+//!   actually presented a capability scope) emits a `GovernanceDecisionReceiptV3`
+//!   carrying `ReceiptMandateAttestation::ProcessAuthorized` and the actual
+//!   presented scope — **alongside** the existing v1 receipt / proof.
+//! - An **unscoped** close (scheduler/timer auto-close, which presents no
+//!   capability) emits **no** v3 — `capability_scope_presented` is evidence and
+//!   must never be fabricated.
+//! - The v3 receipt is persisted through the fail-closed `put_opaque` seam (the
+//!   gateway never imports the typed v3 receipt); a backend without opaque
+//!   storage surfaces the gap as an error rather than silently dropping it.
+//! - **Forced-accept** (Bootstrap administrative override) emits **no** decision
+//!   v2/v3 in this slice — it has no honest `capability_scope_presented` source.
+//!
+//! Two layers are exercised: the in-memory `GovernanceManager` close path
+//! (`close_proposal_inner`, which emits v1 + v3 together) and the actor close
+//! path (the production path: `manager → dyn GovernanceOps → CloseProposal`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex};
+
+use icn_gossip::{AccessControl, GossipActor, Topic};
+use icn_governance::{
+    ForcedOutcome, GovernanceDecisionReceipt, GovernanceDecisionReceiptV3, GovernanceDomainId,
+    GovernanceOps, GovernanceParams, MembershipConfig, ProofOutcome, ProposalId, ProposalPayload,
+    ProposalScope, ReceiptMandateAttestation, StaticMembershipResolver, VoteChoice,
+};
+use icn_governance_actor::{
+    actor::GovernanceActor, manager::GovernanceManager, receipt_backend::GovernanceReceiptBackend,
+    GovernanceCommand,
+};
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+use icn_store::SledStore;
+
+const DECISION_V3_CLASS: &str = "governance_decision_v3";
+const DECISION_V2_CLASS: &str = "governance_decision_v2";
+
+// ============================================================================
+// Capturing backend: records v1 receipts and every opaque payload (which is
+// how v3 is persisted — the default `put_governance_decision_v3` routes through
+// `put_opaque`, so capturing here also proves the opaque-seam routing).
+// ============================================================================
+
+#[derive(Default)]
+struct CapturingBackend {
+    v1: Mutex<Vec<GovernanceDecisionReceipt>>,
+    opaque: Mutex<Vec<(String, String, Vec<u8>)>>, // (class, key1, payload)
+}
+
+impl CapturingBackend {
+    fn v1_count(&self) -> usize {
+        self.v1.lock().unwrap().len()
+    }
+
+    fn opaque_classes(&self) -> Vec<String> {
+        self.opaque
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(c, _, _)| c.clone())
+            .collect()
+    }
+
+    fn v3_receipts(&self) -> Vec<GovernanceDecisionReceiptV3> {
+        self.opaque
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(class, _, _)| class == DECISION_V3_CLASS)
+            .map(|(_, _, payload)| {
+                serde_json::from_slice(payload).expect("opaque v3 payload deserializes")
+            })
+            .collect()
+    }
+}
+
+impl GovernanceReceiptBackend for CapturingBackend {
+    fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
+        self.v1.lock().unwrap().push(receipt.clone());
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        _key2: Option<&str>,
+        _recorded_at: u64,
+        _record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        self.opaque
+            .lock()
+            .unwrap()
+            .push((class.to_string(), key1.to_string(), payload.to_vec()));
+        Ok(())
+    }
+}
+
+// A backend that does NOT implement opaque storage. It inherits the
+// fail-closed `put_opaque` default (`opaque_storage_not_implemented`), so a v3
+// emission through it must error rather than drop silently.
+#[derive(Default)]
+struct NoOpaqueBackend;
+
+impl GovernanceReceiptBackend for NoOpaqueBackend {
+    fn put_governance(&self, _: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    // `put_opaque` intentionally NOT overridden → fail-closed default.
+}
+
+// ============================================================================
+// In-memory `GovernanceManager` path (close_proposal_inner emits v1 + v3).
+// ============================================================================
+
+async fn seeded_in_memory_manager(
+    backend: Arc<dyn GovernanceReceiptBackend>,
+) -> (GovernanceManager, GovernanceDomainId, ProposalId, Did) {
+    let bundle = IdentityBundle::generate().expect("identity");
+    let did = bundle.did().clone();
+    let mgr = GovernanceManager::new().with_receipt_store(backend);
+    let domain = GovernanceDomainId("v3-emit-inmem".to_string());
+    mgr.create_domain(
+        domain.clone(),
+        "V3 Emit (in-memory)".to_string(),
+        "cooperative_default".to_string(),
+        GovernanceParams::new(50, 50, 3600),
+        MembershipConfig::static_list(vec![did.clone()]),
+    )
+    .await
+    .expect("create_domain");
+
+    let proposal_id = ProposalId("v3-inmem-prop".to_string());
+    mgr.create_proposal(
+        proposal_id.clone(),
+        domain.clone(),
+        did.clone(),
+        "Endorse a fictional statement".to_string(),
+        "A declarative text proposal — no execution closure.".to_string(),
+        ProposalPayload::Text {
+            body: "We endorse this fictional statement.".to_string(),
+        },
+        ProposalScope::Local,
+    )
+    .await
+    .expect("create_proposal");
+    mgr.open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+    mgr.cast_vote(proposal_id.clone(), did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+    (mgr, domain, proposal_id, did)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn in_memory_scoped_close_emits_v1_and_process_authorized_v3() {
+    let backend = Arc::new(CapturingBackend::default());
+    let (mgr, _domain, proposal_id, _did) =
+        seeded_in_memory_manager(backend.clone() as Arc<dyn GovernanceReceiptBackend>).await;
+
+    mgr.close_proposal_with_suspension(
+        proposal_id.clone(),
+        None,
+        None,
+        Some("governance:write".to_string()),
+    )
+    .await
+    .expect("scoped close");
+
+    // v1 receipt still emitted (behavior preserved).
+    assert_eq!(
+        backend.v1_count(),
+        1,
+        "v1 GovernanceDecisionReceipt must still be emitted alongside v3"
+    );
+
+    // Exactly one v3, persisted through the opaque seam.
+    let v3s = backend.v3_receipts();
+    assert_eq!(v3s.len(), 1, "expected exactly one v3 decision receipt");
+    let v3 = &v3s[0];
+    assert_eq!(v3.proposal_id, proposal_id.0);
+    assert_eq!(
+        v3.outcome,
+        ProofOutcome::Accepted,
+        "single-member For vote crosses 50/50 thresholds"
+    );
+    assert_eq!(
+        v3.capability_scope_presented, "governance:write",
+        "v3 must record the actual presented scope, not a constant"
+    );
+    assert!(
+        matches!(
+            v3.mandate_attestation,
+            ReceiptMandateAttestation::ProcessAuthorized
+        ),
+        "a normal democratic close is process-authorized, got {:?}",
+        v3.mandate_attestation
+    );
+    assert!(v3.verify(), "emitted v3 receipt must verify");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn in_memory_unscoped_close_emits_v1_only_no_v3() {
+    let backend = Arc::new(CapturingBackend::default());
+    let (mgr, _domain, proposal_id, _did) =
+        seeded_in_memory_manager(backend.clone() as Arc<dyn GovernanceReceiptBackend>).await;
+
+    // No capability scope presented (unscoped entry point).
+    mgr.close_proposal_with_suspension(proposal_id.clone(), None, None, None)
+        .await
+        .expect("unscoped close");
+
+    assert_eq!(backend.v1_count(), 1, "v1 receipt still emitted");
+    assert!(
+        backend.v3_receipts().is_empty(),
+        "no v3 may be emitted when no capability scope was presented"
+    );
+}
+
+// ============================================================================
+// Actor path (production): manager → dyn GovernanceOps → CloseProposal.
+// ============================================================================
+
+async fn gossip_with_governance_topic(did: Did) -> Arc<tokio::sync::RwLock<GossipActor>> {
+    let gossip = GossipActor::spawn(did, None);
+    gossip.write().await.create_topic(Topic::new(
+        "governance:proposal".to_string(),
+        AccessControl::Public,
+    ));
+    gossip
+}
+
+/// Spawn an actor + single-member domain with one open, For-voted Text
+/// proposal, with `backend` installed. Returns the manager (handle-backed),
+/// the actor handle, and the proposal id.
+async fn seeded_actor(
+    backend: Arc<dyn GovernanceReceiptBackend>,
+) -> (
+    GovernanceManager,
+    icn_governance_actor::actor::GovernanceHandle,
+    ProposalId,
+) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bundle = IdentityBundle::generate().expect("identity");
+    let did = bundle.did().clone();
+    let store = Arc::new(SledStore::open(tmp.path()).expect("sled"));
+    let gossip = gossip_with_governance_topic(did.clone()).await;
+    let resolver = Arc::new(StaticMembershipResolver::new());
+
+    let actor_handle =
+        GovernanceActor::spawn(did.clone(), store.clone(), gossip, resolver, None, None)
+            .await
+            .expect("spawn actor");
+    let manager = GovernanceManager::with_handle(
+        Arc::new(actor_handle.clone()) as Arc<dyn GovernanceOps + Send + Sync>
+    );
+
+    let domain = GovernanceDomainId("v3-emit-actor".to_string());
+    manager
+        .create_domain(
+            domain.clone(),
+            "V3 Emit (actor)".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![did.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    // The actor assigns its own proposal id; use the returned value, not the
+    // placeholder we pass in (mirrors the accept-parity test pattern).
+    let proposal_id = manager
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain,
+            did.clone(),
+            "Endorse a fictional statement".to_string(),
+            "A declarative text proposal — no execution closure.".to_string(),
+            ProposalPayload::Text {
+                body: "We endorse this fictional statement.".to_string(),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+    manager
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+    manager
+        .cast_vote(proposal_id.clone(), did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+
+    actor_handle.install_receipt_store(backend).await;
+    (manager, actor_handle, proposal_id)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn actor_scoped_close_emits_process_authorized_v3() {
+    let backend = Arc::new(CapturingBackend::default());
+    let (manager, _handle, proposal_id) =
+        seeded_actor(backend.clone() as Arc<dyn GovernanceReceiptBackend>).await;
+
+    manager
+        .close_proposal_with_suspension(
+            proposal_id.clone(),
+            None,
+            None,
+            Some("governance:write".to_string()),
+        )
+        .await
+        .expect("scoped close via production actor path");
+
+    let v3s = backend.v3_receipts();
+    assert_eq!(v3s.len(), 1, "actor path must emit exactly one v3");
+    let v3 = &v3s[0];
+    assert_eq!(v3.proposal_id, proposal_id.0);
+    assert_eq!(v3.outcome, ProofOutcome::Accepted);
+    assert_eq!(v3.capability_scope_presented, "governance:write");
+    assert!(matches!(
+        v3.mandate_attestation,
+        ReceiptMandateAttestation::ProcessAuthorized
+    ));
+    assert!(v3.verify(), "emitted v3 receipt must verify");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn actor_unscoped_close_emits_no_v3() {
+    let backend = Arc::new(CapturingBackend::default());
+    let (_manager, handle, proposal_id) =
+        seeded_actor(backend.clone() as Arc<dyn GovernanceReceiptBackend>).await;
+
+    // The exact command the scheduler/timer auto-close submits: no scope.
+    handle
+        .submit(GovernanceCommand::CloseProposal {
+            proposal_id,
+            eligible_voters: None,
+            excluded_delegators: None,
+            capability_scope: None,
+        })
+        .await
+        .expect("timer-shaped close");
+
+    assert!(
+        backend.v3_receipts().is_empty(),
+        "scheduler/timer auto-close presents no scope → no v3"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn actor_force_accept_emits_no_decision_v2_or_v3() {
+    let backend = Arc::new(CapturingBackend::default());
+    let (_manager, handle, proposal_id) =
+        seeded_actor(backend.clone() as Arc<dyn GovernanceReceiptBackend>).await;
+
+    handle
+        .submit(GovernanceCommand::ForceCloseProposal {
+            proposal_id,
+            forced_outcome: ForcedOutcome::Accept,
+            reason: "admin override".to_string(),
+        })
+        .await
+        .expect("force close");
+
+    let classes = backend.opaque_classes();
+    assert!(
+        !classes.iter().any(|c| c == DECISION_V3_CLASS),
+        "forced-accept must emit no decision v3 in this slice; classes: {classes:?}"
+    );
+    assert!(
+        !classes.iter().any(|c| c == DECISION_V2_CLASS),
+        "forced-accept must emit no decision v2 Bootstrap in this slice; classes: {classes:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn actor_scoped_close_v3_persistence_failure_is_fail_closed() {
+    // Backend without opaque storage → the v3 emission hits the fail-closed
+    // `put_opaque` default. The actor persists v3 before the terminal close, so
+    // the whole close must fail rather than commit without its decision evidence.
+    let backend = Arc::new(NoOpaqueBackend);
+    let (manager, _handle, proposal_id) =
+        seeded_actor(backend as Arc<dyn GovernanceReceiptBackend>).await;
+
+    let result = manager
+        .close_proposal_with_suspension(
+            proposal_id,
+            None,
+            None,
+            Some("governance:write".to_string()),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a v3 persistence failure must fail the close closed, not drop the evidence silently"
+    );
+}

--- a/icn/crates/icn-core/tests/delegation_tally_integration.rs
+++ b/icn/crates/icn-core/tests/delegation_tally_integration.rs
@@ -143,6 +143,7 @@ async fn lifecycle_proposal(
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await?;
 
@@ -352,6 +353,7 @@ async fn test_lost_standing_member_delegation_blocked() -> Result<()> {
             proposal_id: proposal_id.clone(),
             eligible_voters: Some(eligible),
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await?;
 
@@ -451,6 +453,7 @@ async fn test_suspended_delegator_weight_excluded_at_close_time() -> Result<()> 
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: Some(excluded),
+            capability_scope: None,
         })
         .await?;
 
@@ -525,6 +528,7 @@ async fn test_suspended_delegator_weight_excluded_at_close_time() -> Result<()> 
             proposal_id: proposal_id2.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await?;
 

--- a/icn/crates/icn-core/tests/execution_receipt_gate_integration.rs
+++ b/icn/crates/icn-core/tests/execution_receipt_gate_integration.rs
@@ -139,6 +139,7 @@ async fn run_proposal(
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await?;
 

--- a/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
+++ b/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
@@ -233,6 +233,7 @@ async fn test_allocation_receipt_chain_end_to_end() -> Result<()> {
             proposal_id: proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await?;
 

--- a/icn/crates/icn-core/tests/vertical_slice_integration.rs
+++ b/icn/crates/icn-core/tests/vertical_slice_integration.rs
@@ -453,6 +453,7 @@ async fn test_tool_library_cooperative_vertical_slice() -> Result<()> {
             proposal_id: membership_proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await?;
 
@@ -547,6 +548,7 @@ async fn test_tool_library_cooperative_vertical_slice() -> Result<()> {
             proposal_id: budget_proposal_id.clone(),
             eligible_voters: None,
             excluded_delegators: None,
+            capability_scope: None,
         })
         .await?;
 

--- a/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
@@ -122,6 +122,23 @@ impl GovernanceReceiptBackend for TestReceiptBackend {
             .cloned()
             .unwrap_or_default())
     }
+
+    // Support the opaque seam so a scoped normal close can persist its
+    // process-authorized v3 decision receipt (#1868). The production gateway
+    // `ReceiptStore` overrides this; these e2e tests don't assert on v3
+    // content, so accepting the write keeps the scoped close from
+    // fail-closing on the v3 emission.
+    fn put_opaque(
+        &self,
+        _class: &str,
+        _key1: &str,
+        _key2: Option<&str>,
+        _recorded_at: u64,
+        _record_hash: [u8; 32],
+        _payload: &[u8],
+    ) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 /// Auth helper: challenge → sign → JWT.

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -61,6 +61,20 @@ struct TestReceiptBackend {
 }
 
 impl GovernanceReceiptBackend for TestReceiptBackend {
+    // #1868: accept the opaque v3 decision-receipt write so a scoped normal
+    // close does not fail closed in this test (the production gateway
+    // `ReceiptStore` overrides `put_opaque`; this stand-in doesn't assert on v3).
+    fn put_opaque(
+        &self,
+        _class: &str,
+        _key1: &str,
+        _key2: Option<&str>,
+        _recorded_at: u64,
+        _record_hash: [u8; 32],
+        _payload: &[u8],
+    ) -> Result<(), String> {
+        Ok(())
+    }
     fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
         self.governance_by_proposal
             .lock()

--- a/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
@@ -61,6 +61,20 @@ struct TestReceiptBackend {
 }
 
 impl GovernanceReceiptBackend for TestReceiptBackend {
+    // #1868: accept the opaque v3 decision-receipt write so a scoped normal
+    // close does not fail closed in this test (the production gateway
+    // `ReceiptStore` overrides `put_opaque`; this stand-in doesn't assert on v3).
+    fn put_opaque(
+        &self,
+        _class: &str,
+        _key1: &str,
+        _key2: Option<&str>,
+        _recorded_at: u64,
+        _record_hash: [u8; 32],
+        _payload: &[u8],
+    ) -> Result<(), String> {
+        Ok(())
+    }
     fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
         self.governance_by_proposal
             .lock()

--- a/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
@@ -63,6 +63,20 @@ struct TestReceiptBackend {
 }
 
 impl GovernanceReceiptBackend for TestReceiptBackend {
+    // #1868: accept the opaque v3 decision-receipt write so a scoped normal
+    // close does not fail closed in this test (the production gateway
+    // `ReceiptStore` overrides `put_opaque`; this stand-in doesn't assert on v3).
+    fn put_opaque(
+        &self,
+        _class: &str,
+        _key1: &str,
+        _key2: Option<&str>,
+        _recorded_at: u64,
+        _record_hash: [u8; 32],
+        _payload: &[u8],
+    ) -> Result<(), String> {
+        Ok(())
+    }
     fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
         self.governance_by_proposal
             .lock()

--- a/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
@@ -61,6 +61,20 @@ struct TestReceiptBackend {
 }
 
 impl GovernanceReceiptBackend for TestReceiptBackend {
+    // #1868: accept the opaque v3 decision-receipt write so a scoped normal
+    // close does not fail closed in this test (the production gateway
+    // `ReceiptStore` overrides `put_opaque`; this stand-in doesn't assert on v3).
+    fn put_opaque(
+        &self,
+        _class: &str,
+        _key1: &str,
+        _key2: Option<&str>,
+        _recorded_at: u64,
+        _record_hash: [u8; 32],
+        _payload: &[u8],
+    ) -> Result<(), String> {
+        Ok(())
+    }
     fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
         self.governance_by_proposal
             .lock()

--- a/icn/crates/icn-governance/src/handle.rs
+++ b/icn/crates/icn-governance/src/handle.rs
@@ -151,17 +151,28 @@ pub trait GovernanceOps: Send + Sync {
     /// governance influence through pre-existing delegations after a FreezeMember
     /// proposal is accepted.
     ///
-    /// The default implementation ignores `excluded_delegators` and delegates to
-    /// `close_proposal_filtered` (or `close_proposal` if no eligible filter).
-    /// Backends that support delegation expansion (e.g., `GovernanceActor`) should
-    /// override this method.
+    /// The default implementation ignores `excluded_delegators` and
+    /// `capability_scope`, delegating to `close_proposal_filtered` (or
+    /// `close_proposal` if no eligible filter). Backends that support delegation
+    /// expansion (e.g., `GovernanceActor`) should override this method.
+    ///
+    /// `capability_scope` (#1868) is the capability scope the caller actually
+    /// presented at close time, when the close was driven by an authenticated
+    /// request — `Some` only for the scoped HTTP close path (which presents
+    /// `governance:write`); `None` for scheduler/timer auto-close. It is
+    /// **evidence**: it records what was actually presented, never a constant.
+    /// The `GovernanceActor` override carries it into the close so a normal
+    /// democratic close can emit a process-authorized
+    /// `GovernanceDecisionReceiptV3`; the default drops it, so non-actor
+    /// backends emit no v3.
     async fn close_proposal_with_suspension(
         &self,
         proposal_id: ProposalId,
         eligible_voters: Option<std::collections::HashSet<Did>>,
         excluded_delegators: Option<std::collections::HashSet<Did>>,
+        capability_scope: Option<String>,
     ) -> Result<()> {
-        let _ = excluded_delegators;
+        let _ = (excluded_delegators, capability_scope);
         match eligible_voters.as_ref() {
             Some(eligible) => self.close_proposal_filtered(proposal_id, eligible).await,
             None => self.close_proposal(proposal_id).await,


### PR DESCRIPTION
## What

Emit a process-authorized **`GovernanceDecisionReceiptV3`** (the #1937 schema) for normal democratic proposal closes, **alongside** the existing v1 receipt / `GovernanceProofV2`. Honest-path only: emitted exclusively when the close was driven by an authenticated request that actually presented a capability scope. Part of #1868 (decision-receipt authority, design doc `docs/design/governance/decision-receipt-authority-and-grant-minting.md` §5/§7).

## Why

#1937 landed the `ProcessAuthorized` attestation + `GovernanceDecisionReceiptV3` schema but emitted nothing in production. This wires the first honest production emission for the decision-receipt path: a normal democratic close is authorized by the governance **process** (eligible voters, period, quorum/threshold, tally), so it carries `ReceiptMandateAttestation::ProcessAuthorized` — not membership standing, not a personal grant.

## How

- **`receipt_backend`**: new `put_governance_decision_v3` (class `governance_decision_v3`), default-routed through the fail-closed `put_opaque` seam — the gateway never imports the typed v3 receipt (meaning firewall preserved). `recorded_at` is passed in (the close time); a decision receipt carries no timestamp field.
- **`GovernanceOps::close_proposal_with_suspension`** gains `capability_scope: Option<String>`. The `GovernanceActor` overrides it to carry the scope into the `CloseProposal` command (new `capability_scope` field). The HTTP `close_proposal` handler passes `Some("governance:write")` — the scope `require_scope` accepted at that boundary. Scheduler/timer auto-close and the trait default pass `None`.
- **Actor + in-memory manager close paths** build and persist the v3 receipt with `ProcessAuthorized` when (and only when) a scope was presented, before terminal close (fail-closed: a v3 persistence failure fails the close rather than committing without its decision evidence).

## Risk

Low–moderate (touches the `GovernanceOps` close trait method + manager + actor). Mitigations: v1/proof path unchanged; v3 is additive opaque persistence; delegation/suspension behavior is explicitly **unchanged** (the actor override carries scope only — `excluded_delegators` is still submitted as `None`, exactly as the prior trait default produced). Full workspace clippy + targeted test suites green.

## Test plan

From `icn/icn/`: `cargo fmt --all -- --check`; `cargo check --workspace --all-targets`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test -p icn-governance` (645); `cargo test -p icn-governance-actor` (all, incl. the new file); `cargo test -p icn-core` edited integration tests; `cargo test -p icn-gateway --test governance_proof`; compliance linter clean; `git diff --check` clean.

New `governance_decision_receipt_v3_emission.rs` (6 tests, in-memory + actor layers) proves:
- scoped normal close emits exactly one v3 `ProcessAuthorized` (records the actual presented scope `governance:write`, `verify()` true) **alongside** the v1 receipt;
- unscoped (scheduler/timer-shaped) close emits **no** v3;
- v3 routes through fail-closed opaque storage — a backend without `put_opaque` makes the close **fail closed** rather than dropping the evidence;
- forced-accept emits **no** decision v2/v3.

## Honest-path scope (explicit non-claims)

- emits decision v3 **only** for scoped HTTP normal close;
- **skips** scheduler/timer auto-close — no capability scope was presented;
- **skips** forced-accept Bootstrap — that path has no honest `capability_scope_presented` source today (deferred to a separate slice);
- emits **alongside** v1; v1/proof consumers unchanged;
- **no fake** `NoMandateRequired` for democratic close; **no fabricated** scope constants;
- **no** grant-backed execution claim;
- **no** MandateGate handler wiring;
- **no** grant minting;
- **no** TypedScope Federation/Role binding;
- **no** `governance:write` retirement;
- **no** production-readiness / live-federation / demo claim.

Part of #1868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
