### PR TITLE
feat(governance): migrate HTTP proposal-family scope to governance:proposal:write (#1868)

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -834,7 +834,10 @@ pub async fn create_proposal<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     req: web::Json<CreateProposalRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:proposal:write", "governance:write"],
+    )?;
     let proposer_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     val::validate_domain_id(&req.domain_id)?;
@@ -1168,7 +1171,10 @@ pub async fn open_proposal<E: GovernanceEventEmitter + Clone + 'static>(
     proposal_id: web::Path<String>,
     req: web::Json<OpenProposalRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:proposal:write", "governance:write"],
+    )?;
     let requester_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let proposal_id = ProposalId(proposal_id.into_inner());
@@ -1799,7 +1805,10 @@ pub async fn cast_vote<E: GovernanceEventEmitter + Clone + 'static>(
     proposal_id: web::Path<String>,
     req: web::Json<CastVoteRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:proposal:write", "governance:write"],
+    )?;
     let voter_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     val::validate_vote_comment(&req.comment)?;
@@ -2504,7 +2513,10 @@ pub async fn create_delegation<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     req: web::Json<CreateDelegationRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:proposal:write", "governance:write"],
+    )?;
     let delegator_did = parse_did(&claims.sub, "Invalid DID in token")?;
     let delegate_did = parse_did(&req.delegate, "Invalid delegate DID")?;
     let scope = parse_delegation_scope(&req.scope)?;
@@ -2634,7 +2646,10 @@ pub async fn revoke_delegation<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     delegation_id: web::Path<String>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:proposal:write", "governance:write"],
+    )?;
     let caller_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let id = DelegationId(delegation_id.into_inner());
@@ -3312,7 +3327,10 @@ pub async fn create_appoint_steward_proposal<E: GovernanceEventEmitter + Clone +
     http_req: HttpRequest,
     req: web::Json<AppointStewardProposalRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:proposal:write", "governance:write"],
+    )?;
     let proposer_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     val::validate_domain_id(&req.domain_id)?;
@@ -3392,7 +3410,10 @@ pub async fn create_remove_steward_proposal<E: GovernanceEventEmitter + Clone + 
     http_req: HttpRequest,
     req: web::Json<RemoveStewardProposalRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:proposal:write", "governance:write"],
+    )?;
     let proposer_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     val::validate_domain_id(&req.domain_id)?;

--- a/icn/apps/governance/tests/proposal_scope_migration.rs
+++ b/icn/apps/governance/tests/proposal_scope_migration.rs
@@ -1,14 +1,18 @@
-//! Proposal *normal-close* capability migration (#1868 slice A0).
+//! Proposal-family capability migration (#1868 slices A0 + A1c).
 //!
-//! Migrates **only** the normal scoped HTTP proposal-close gate
+//! A0 migrated the normal scoped HTTP proposal-close gate
 //! (`POST /proposals/{proposal_id}/close`, `handlers::close_proposal`) from the
-//! broad `governance:write` to `governance:proposal:write`, keeping the legacy
-//! broad scope as an accepted-also fallback. This is intentionally close-only:
-//! it is the one proposal-lifecycle path that emits a
-//! `GovernanceDecisionReceiptV3`, so its `capability_scope_presented` evidence is
-//! the most visible imprecision left after #1938. The rest of the proposal
-//! family (`create_proposal`, `open_proposal`, `cast_vote`, steward/delegation
-//! creators) is a separate, later slice and is NOT migrated here.
+//! broad `governance:write` to `governance:proposal:write` (legacy broad scope
+//! kept as an accepted-also fallback). Close is the one proposal-lifecycle path
+//! that emits a `GovernanceDecisionReceiptV3`, so it additionally records the
+//! actually-matched scope as evidence.
+//!
+//! A1c migrates the remaining HTTP proposal-family gates the same way —
+//! `create_proposal`, `open_proposal`, `cast_vote`, `create_delegation`,
+//! `revoke_delegation`, `create_appoint_steward_proposal`,
+//! `create_remove_steward_proposal` — to
+//! `["governance:proposal:write", "governance:write"]`. These paths emit no v3,
+//! so they use `require_any_scope` (no matched-scope evidence threaded).
 //!
 //! Two properties are pinned:
 //! - **Authorization** — the close gate accepts `governance:proposal:write`,
@@ -42,6 +46,7 @@ use icn_governance_actor::{
 use icn_http_kit::auth::BasicClaims;
 use icn_identity::{Did, IdentityBundle};
 use icn_kernel_api::{AllocationReceipt, Hash};
+use serde_json::{json, Value};
 
 const PROPOSAL_CLASS: &str = "governance:proposal:write";
 const LEGACY_BROAD: &str = "governance:write";
@@ -292,4 +297,169 @@ async fn close_rejects_sibling_write_class_scope() {
         "sibling class {SIBLING_CLASS} must be rejected at the close gate, got {status}"
     );
     assert!(v3s.is_empty(), "a rejected close must emit no v3");
+}
+
+// ============================================================================
+// #1868 A1c — remaining HTTP proposal-family handler gates.
+//
+// These paths emit no v3, so the gate uses `require_any_scope` (no matched-scope
+// evidence). Auth-only coverage in the meeting_scope_migration.rs route-table
+// style: acceptance = "not 401/403" (the gate passes; the downstream status
+// reflects missing domain/proposal state — every optional member/steward/
+// suspension checker is None in the test ctx, so the scope gate is the only
+// 403 source); rejection = 403 at the gate, before any handler logic.
+// ============================================================================
+
+fn make_proposal_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        mandate_gate: None,
+        build_mode: http::GovernanceContextBuildMode::Test,
+    }
+}
+
+/// (method, path, optional JSON body) for each migrated proposal-family route.
+/// Bodies are minimal-but-deserializable so the request reaches the in-handler
+/// scope gate (actix extracts `web::Json` before the handler body runs).
+fn proposal_family_routes() -> Vec<(&'static str, &'static str, Option<Value>)> {
+    vec![
+        (
+            "POST",
+            "/proposals",
+            Some(json!({
+                "domain_id": "test-domain",
+                "title": "Scope migration proposal",
+                "description": "A1c proposal-family auth test.",
+                "payload": { "type": "text", "body": "endorse" }
+            })),
+        ),
+        ("POST", "/proposals/test-proposal/open", Some(json!({}))),
+        (
+            "POST",
+            "/proposals/test-proposal/vote",
+            Some(json!({ "choice": "for" })),
+        ),
+        (
+            "POST",
+            "/delegations",
+            Some(json!({ "delegate": "did:icn:delegate", "scope": "all" })),
+        ),
+        ("DELETE", "/delegations/test-delegation", None),
+        (
+            "POST",
+            "/proposals/sdis/appoint-steward",
+            Some(json!({
+                "domain_id": "test-domain",
+                "title": "Appoint steward",
+                "description": "A1c proposal-family auth test.",
+                "candidate": "did:icn:candidate",
+                "region": "region-1",
+                "bond_amount": 0,
+                "term_length_seconds": 3600
+            })),
+        ),
+        (
+            "POST",
+            "/proposals/sdis/remove-steward",
+            Some(json!({
+                "domain_id": "test-domain",
+                "title": "Remove steward",
+                "description": "A1c proposal-family auth test.",
+                "steward": "did:icn:steward",
+                "reason": "scope migration test"
+            })),
+        ),
+    ]
+}
+
+async fn proposal_family_status(
+    method: &str,
+    path: &str,
+    body: &Option<Value>,
+    scope: &'static str,
+) -> StatusCode {
+    let ctx = make_proposal_ctx();
+    let caller = fresh_did().to_string();
+    let app = test::init_service(
+        App::new()
+            .wrap_fn(move |req, srv| {
+                req.extensions_mut().insert(BasicClaims {
+                    sub: caller.clone(),
+                    scope: Some(scope.to_string()),
+                });
+                srv.call(req)
+            })
+            .configure(|cfg| http::configure(cfg, ctx)),
+    )
+    .await;
+
+    let builder = match method {
+        "POST" => test::TestRequest::post(),
+        "DELETE" => test::TestRequest::delete(),
+        other => panic!("unsupported method {other}"),
+    };
+    let builder = builder.uri(path);
+    let req = match body {
+        Some(b) => builder.set_json(b).to_request(),
+        None => builder.to_request(),
+    };
+    test::call_service(&app, req).await.status()
+}
+
+fn assert_proposal_auth_accepted(status: StatusCode, scope: &str, method: &str, path: &str) {
+    assert!(
+        status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
+        "{scope} must be accepted at {method} {path} (gate passes; {status} is the downstream \
+         outcome, not an auth rejection)"
+    );
+}
+
+#[actix_web::test]
+async fn proposal_family_accepts_proposal_class_scope() {
+    for (m, p, b) in proposal_family_routes() {
+        let status = proposal_family_status(m, p, &b, PROPOSAL_CLASS).await;
+        assert_proposal_auth_accepted(status, PROPOSAL_CLASS, m, p);
+    }
+}
+
+#[actix_web::test]
+async fn proposal_family_accepts_legacy_broad_scope() {
+    // Accepted-also fallback: tokens minted before the migration still work.
+    for (m, p, b) in proposal_family_routes() {
+        let status = proposal_family_status(m, p, &b, LEGACY_BROAD).await;
+        assert_proposal_auth_accepted(status, LEGACY_BROAD, m, p);
+    }
+}
+
+#[actix_web::test]
+async fn proposal_family_rejects_unrelated_read_scope() {
+    for (m, p, b) in proposal_family_routes() {
+        let status = proposal_family_status(m, p, &b, UNRELATED_READ).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "governance:read must be rejected at the {m} {p} gate, got {status}"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn proposal_family_rejects_sibling_write_class_scope() {
+    for (m, p, b) in proposal_family_routes() {
+        let status = proposal_family_status(m, p, &b, SIBLING_CLASS).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "sibling class {SIBLING_CLASS} must be rejected at the {m} {p} gate, got {status}"
+        );
+    }
 }


### PR DESCRIPTION
## What

Migrates the 7 remaining HTTP proposal-family handlers from broad `governance:write` to narrow `governance:proposal:write`, while retaining `governance:write` as an accepted-also fallback.

Handlers migrated:

* `create_proposal`
* `open_proposal`
* `cast_vote`
* `create_delegation`
* `revoke_delegation`
* `create_appoint_steward_proposal`
* `create_remove_steward_proposal`

This is #1868 slice A1c: HTTP-only, proposal-family-only.

## Why

A0 (#1946) migrated only the normal proposal-close gate. This PR completes the remaining HTTP proposal-family gates, advancing the `governance:write` decomposition without introducing a new auth mechanism.

The design scope table assigns these handlers to `governance:proposal:write`. `assign_role` remains separate under `governance:steward:write` and is not touched here.

## How

* Replaces 7 broad gates:

  `require_scope(.., "governance:write")`

  with:

  `require_any_scope(.., &["governance:proposal:write", "governance:write"])`

* Keeps `governance:write` as backward-compatible fallback.

* Uses `require_any_scope`, not `require_any_scope_matched`, because these paths do not emit V3 receipts.

* Extends `proposal_scope_migration.rs` with route-table coverage for all 7 migrated routes.

## Tests

* `cargo test -p icn-governance-actor --test proposal_scope_migration`
* `cargo fmt -p icn-governance-actor -- --check`
* `cargo clippy -p icn-governance-actor --all-targets -- -D warnings`
* `cargo test -p icn-governance-actor`
* `python3 .github/scripts/compliance_linter.py`

## Proven behavior

For all 7 migrated routes:

* `governance:proposal:write` is accepted.
* `governance:write` fallback is accepted.
* `governance:read` is rejected.
* sibling write scope `governance:charter:write` is rejected.

Existing A0 close tests remain covered in the same test file.

## Risk

Low / backward-compatible.

Broad `governance:write` tokens still authorize every migrated route. No change is made to membership, steward, suspension, close V3 behavior, JSON-RPC, gateway routes, MandateGate, grant minting, Bootstrap, or scheduler/timer behavior.

## Non-claims

This PR does not make ICN production-ready.

This PR does not narrow JSON-RPC.

This PR does not narrow gateway routes.

This PR does not wire MandateGate.

This PR does not add Execution grants.

This PR does not solve Bootstrap/system authority semantics.

This PR does not solve scheduler/timer V3 authority semantics.

This PR does not retire `governance:write`.

This PR migrates only the 7 HTTP proposal-family handlers listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
