### PR TITLE
feat(gateway): decompose cast-vote and meeting-create scopes (#1868)

### DIFF
--- a/icn/crates/icn-gateway/src/api/flow_c.rs
+++ b/icn/crates/icn-gateway/src/api/flow_c.rs
@@ -11,7 +11,7 @@ use crate::api::treasury::{do_get_treasury_position, do_propose_spend, SpendRequ
 use crate::error::{GatewayError, Result};
 use crate::events::{EventBroadcaster, GatewayEvent};
 use crate::governance_mgr::GovernanceManager;
-use crate::middleware::{get_claims, require_scope};
+use crate::middleware::{get_claims, require_any_scope, require_scope};
 use crate::models::CastVoteRequest;
 use crate::notifications::NotificationService;
 use crate::treasury_mgr::GatewayTreasuryManager;
@@ -49,7 +49,12 @@ pub async fn cast_vote_alias(
     id: web::Path<String>,
     req: web::Json<CastVoteRequest>,
 ) -> Result<HttpResponse> {
-    require_scope(&http_req, "governance:write")?;
+    // #1868 A2a: narrow the cast-vote alias to the proposal class scope, with the
+    // broad `governance:write` retained as an accepted-also fallback.
+    require_any_scope(
+        &http_req,
+        &["governance:proposal:write", "governance:write"],
+    )?;
 
     let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
@@ -233,6 +238,45 @@ mod tests {
             .to_request();
         let resp = test::call_service(&app, req).await;
         assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// #1868 A2a: the cast-vote alias now gates on
+    /// `["governance:proposal:write", "governance:write"]`. Acceptance is asserted
+    /// as "not 401/403" (a downstream cast on a nonexistent proposal is a non-auth
+    /// error); rejection is 403 at the gate.
+    #[actix_web::test]
+    async fn cast_vote_alias_scope_gate_accepts_proposal_and_broad_rejects_others() {
+        async fn vote_status(scope: &str) -> StatusCode {
+            let app = test::init_service(
+                App::new()
+                    .app_data(web::Data::new(Arc::new(GovernanceManager::new())))
+                    .app_data(web::Data::new(Arc::new(EventBroadcaster::new())))
+                    .app_data(web::Data::new(notification_service()))
+                    .service(web::scope("/proposals").configure(configure_proposals)),
+            )
+            .await;
+            let req = test::TestRequest::post()
+                .uri("/proposals/p-1/vote")
+                .set_json(serde_json::json!({ "choice": "for", "comment": null }))
+                .to_request();
+            req.extensions_mut()
+                .insert(test_claims("test-coop", vec![scope]));
+            test::call_service(&app, req).await.status()
+        }
+
+        let narrow = vote_status("governance:proposal:write").await;
+        assert_ne!(narrow, StatusCode::UNAUTHORIZED);
+        assert_ne!(narrow, StatusCode::FORBIDDEN);
+
+        let broad = vote_status("governance:write").await;
+        assert_ne!(broad, StatusCode::UNAUTHORIZED);
+        assert_ne!(broad, StatusCode::FORBIDDEN);
+
+        assert_eq!(vote_status("governance:read").await, StatusCode::FORBIDDEN);
+        assert_eq!(
+            vote_status("governance:charter:write").await,
+            StatusCode::FORBIDDEN
+        );
     }
 
     #[actix_web::test]

--- a/icn/crates/icn-gateway/src/api/registry.rs
+++ b/icn/crates/icn-gateway/src/api/registry.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::api::receipts::GovernanceReceiptResponse;
 use crate::error::{GatewayError, Result};
-use crate::middleware::{get_claims, require_scope};
+use crate::middleware::{get_claims, require_any_scope, require_scope};
 use crate::receipt_store::ReceiptStore;
 use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus};
 use icn_kernel_api::receipts::CanonicalReceipt;
@@ -494,7 +494,10 @@ pub async fn create_meeting(
     registry: web::Data<Arc<DecisionRegistry>>,
     req: web::Json<CreateMeetingRequest>,
 ) -> Result<HttpResponse> {
-    require_scope(&http_req, "governance:write")?;
+    // #1868 A2a: narrow the decision-registry meeting-create route to the meeting
+    // class scope, with the broad `governance:write` retained as an accepted-also
+    // fallback.
+    require_any_scope(&http_req, &["governance:meeting:write", "governance:write"])?;
 
     let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
@@ -997,6 +1000,57 @@ mod tests {
 
     fn temp_exec_store() -> Arc<dyn Store> {
         Arc::new(SledStore::temporary().expect("temp exec store"))
+    }
+
+    /// #1868 A2a: the decision-registry meeting-create route now gates on
+    /// `["governance:meeting:write", "governance:write"]`. Acceptance is asserted
+    /// as "not 401/403"; rejection is 403 at the gate.
+    #[actix_web::test]
+    async fn create_meeting_scope_gate_accepts_meeting_and_broad_rejects_others() {
+        async fn create_status(scope: &str) -> actix_web::http::StatusCode {
+            let registry = Arc::new(DecisionRegistry::new());
+            let app = actix_test::init_service(
+                App::new()
+                    .app_data(web::Data::new(registry))
+                    .service(web::scope("/registry").configure(configure)),
+            )
+            .await;
+            let claims = TokenClaims {
+                sub: "did:icn:test-user".to_string(),
+                iat: 1_000_000_000,
+                exp: 9_999_999_999,
+                coop_id: "did:icn:test123".to_string(),
+                scopes: vec![scope.to_string()],
+            };
+            let req = actix_test::TestRequest::post()
+                .uri("/registry/meetings")
+                .set_json(serde_json::json!({
+                    "coopId": "did:icn:test123",
+                    "title": "Scope test meeting",
+                    "startsAt": 1_800_000_000u64
+                }))
+                .to_request();
+            req.extensions_mut().insert(claims);
+            actix_test::call_service(&app, req).await.status()
+        }
+
+        use actix_web::http::StatusCode;
+        let narrow = create_status("governance:meeting:write").await;
+        assert_ne!(narrow, StatusCode::UNAUTHORIZED);
+        assert_ne!(narrow, StatusCode::FORBIDDEN);
+
+        let broad = create_status("governance:write").await;
+        assert_ne!(broad, StatusCode::UNAUTHORIZED);
+        assert_ne!(broad, StatusCode::FORBIDDEN);
+
+        assert_eq!(
+            create_status("governance:read").await,
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            create_status("governance:charter:write").await,
+            StatusCode::FORBIDDEN
+        );
     }
 
     #[test]

--- a/icn/crates/icn-gateway/src/middleware.rs
+++ b/icn/crates/icn-gateway/src/middleware.rs
@@ -84,6 +84,36 @@ pub fn require_scope(req: &HttpRequest, required_scope: &str) -> Result<(), Gate
     Ok(())
 }
 
+/// Require the request to carry ANY of the listed scopes (exact match, same
+/// semantics as [`require_scope`]).
+///
+/// List the narrowed class scope first; the broad `governance:write` stays as
+/// an accepted-also fallback during the #1868 capability decomposition. This
+/// preserves the gateway's exact-match semantics — it does **not** introduce
+/// wildcard or sub-prefix matching — so existing tokens behave identically
+/// except that a narrowed class scope is now also accepted. A single
+/// authorization-failure metric (keyed on the preferred/first scope) is emitted
+/// only when none of the candidates match.
+pub fn require_any_scope(req: &HttpRequest, required_scopes: &[&str]) -> Result<(), GatewayError> {
+    let claims = get_claims(req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
+
+    if required_scopes
+        .iter()
+        .any(|scope| claims.scopes.contains(&scope.to_string()))
+    {
+        return Ok(());
+    }
+
+    // None matched — track the failure keyed on the preferred (first) scope,
+    // mirroring `require_scope`, then reject.
+    let preferred = required_scopes.first().copied().unwrap_or("");
+    gateway::authorization_failures_inc(preferred);
+    Err(GatewayError::AuthorizationFailed(format!(
+        "Missing required scope (need one of): {required_scopes:?}"
+    )))
+}
+
 /// Check if request has a scope (non-erroring version)
 ///
 /// Returns true if the authenticated user has the given scope, false otherwise.
@@ -211,7 +241,89 @@ where
 mod tests {
     use super::*;
     use crate::auth::AuthManager;
+    use actix_web::test::TestRequest;
     use icn_identity::IdentityBundle;
+
+    /// Build a request carrying the given exact scopes in its `TokenClaims`.
+    fn req_with_scopes(scopes: &[&str]) -> HttpRequest {
+        let req = TestRequest::default().to_http_request();
+        req.extensions_mut().insert(TokenClaims {
+            sub: "did:icn:test-user".to_string(),
+            iat: 1_000_000_000,
+            exp: 9_999_999_999,
+            coop_id: "test-coop".to_string(),
+            scopes: scopes.iter().map(|s| s.to_string()).collect(),
+        });
+        req
+    }
+
+    #[actix_web::test]
+    async fn require_any_scope_accepts_narrow_exact_scope() {
+        let req = req_with_scopes(&["governance:proposal:write"]);
+        assert!(
+            require_any_scope(&req, &["governance:proposal:write", "governance:write"]).is_ok()
+        );
+    }
+
+    #[actix_web::test]
+    async fn require_any_scope_accepts_broad_fallback() {
+        // Accepted-also fallback: pre-migration `governance:write` tokens still pass.
+        let req = req_with_scopes(&["governance:write"]);
+        assert!(
+            require_any_scope(&req, &["governance:proposal:write", "governance:write"]).is_ok()
+        );
+    }
+
+    #[actix_web::test]
+    async fn require_any_scope_rejects_unrelated_read_scope() {
+        let req = req_with_scopes(&["governance:read"]);
+        assert!(matches!(
+            require_any_scope(&req, &["governance:proposal:write", "governance:write"]),
+            Err(GatewayError::AuthorizationFailed(_))
+        ));
+    }
+
+    #[actix_web::test]
+    async fn require_any_scope_rejects_sibling_write_scope() {
+        let req = req_with_scopes(&["governance:charter:write"]);
+        assert!(matches!(
+            require_any_scope(&req, &["governance:proposal:write", "governance:write"]),
+            Err(GatewayError::AuthorizationFailed(_))
+        ));
+    }
+
+    #[actix_web::test]
+    async fn require_any_scope_is_exact_match_not_subprefix() {
+        // Broad `governance:write` must NOT satisfy a narrow-only candidate list,
+        // and a narrow token must NOT satisfy a broad-only requirement: proves we
+        // did not introduce sub-prefix or wildcard matching.
+        let broad = req_with_scopes(&["governance:write"]);
+        assert!(matches!(
+            require_any_scope(&broad, &["governance:proposal:write"]),
+            Err(GatewayError::AuthorizationFailed(_))
+        ));
+        let narrow = req_with_scopes(&["governance:proposal:write"]);
+        assert!(matches!(
+            require_any_scope(&narrow, &["governance:write"]),
+            Err(GatewayError::AuthorizationFailed(_))
+        ));
+    }
+
+    #[actix_web::test]
+    async fn require_scope_remains_exact_match_unchanged() {
+        // Behavior-neutral: the existing exact-match helper is untouched.
+        let req = req_with_scopes(&["governance:write"]);
+        assert!(require_scope(&req, "governance:write").is_ok());
+        assert!(matches!(
+            require_scope(&req, "governance:proposal:write"),
+            Err(GatewayError::AuthorizationFailed(_))
+        ));
+        let bare = TestRequest::default().to_http_request();
+        assert!(matches!(
+            require_scope(&bare, "governance:write"),
+            Err(GatewayError::AuthenticationFailed(_))
+        ));
+    }
 
     #[actix_web::test]
     async fn test_jwt_auth_valid_token() {

--- a/icn/crates/icn-gateway/src/middleware.rs
+++ b/icn/crates/icn-gateway/src/middleware.rs
@@ -95,6 +95,16 @@ pub fn require_scope(req: &HttpRequest, required_scope: &str) -> Result<(), Gate
 /// authorization-failure metric (keyed on the preferred/first scope) is emitted
 /// only when none of the candidates match.
 pub fn require_any_scope(req: &HttpRequest, required_scopes: &[&str]) -> Result<(), GatewayError> {
+    // An empty candidate list is a server-side wiring error, not a client auth
+    // failure: returning 403 would hide a miswired route and pollute the
+    // `required_scope` metric with an empty label. Reject it explicitly before
+    // touching request claims (mirrors `icn_http_kit::auth::require_any_scope_matched`).
+    let Some((&preferred, _)) = required_scopes.split_first() else {
+        return Err(GatewayError::InternalError(
+            "require_any_scope called with no candidate scopes".to_string(),
+        ));
+    };
+
     let claims = get_claims(req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
 
@@ -107,7 +117,6 @@ pub fn require_any_scope(req: &HttpRequest, required_scopes: &[&str]) -> Result<
 
     // None matched — track the failure keyed on the preferred (first) scope,
     // mirroring `require_scope`, then reject.
-    let preferred = required_scopes.first().copied().unwrap_or("");
     gateway::authorization_failures_inc(preferred);
     Err(GatewayError::AuthorizationFailed(format!(
         "Missing required scope (need one of): {required_scopes:?}"
@@ -263,6 +272,17 @@ mod tests {
         assert!(
             require_any_scope(&req, &["governance:proposal:write", "governance:write"]).is_ok()
         );
+    }
+
+    #[actix_web::test]
+    async fn require_any_scope_rejects_empty_candidate_list() {
+        // An empty candidate list is a server-side wiring error: surface it as an
+        // internal error (before reading claims), never a 403 with an empty label.
+        let req = req_with_scopes(&["governance:write"]);
+        assert!(matches!(
+            require_any_scope(&req, &[]),
+            Err(GatewayError::InternalError(_))
+        ));
     }
 
     #[actix_web::test]


### PR DESCRIPTION
## What

Adds a gateway-local `require_any_scope` accepted-also helper and migrates two clearly classified gateway routes off broad `governance:write`:

* `cast_vote_alias` → `["governance:proposal:write", "governance:write"]`
* `create_meeting` → `["governance:meeting:write", "governance:write"]`

`governance:write` remains as a backward-compatible fallback on both routes.

This is #1868 slice A2a-2: gateway-only.

## Why

After A0 and A1c, the apps/governance HTTP handler family is decomposed. Gateway routes are the next pre-retirement surface.

The gateway has its own exact-match `require_scope` helper and did not have an accepted-also fallback helper. Narrowing these routes safely required a gateway-local `require_any_scope` first.

## How

* Adds `require_any_scope(req, &[&str])` in `middleware.rs`.
* Preserves exact `.contains` semantics.
* Does not add wildcard matching.
* Does not add sub-prefix matching.
* Emits one authorization-failure metric only when none of the candidate scopes match.
* Keeps existing `require_scope` behavior unchanged.
* Migrates `cast_vote_alias` and `create_meeting` to narrow class scope plus broad fallback.
* Leaves `index_decision_endpoint` on broad `governance:write` because its narrower classification is design-unconfirmed and cross-cutting.

## Tests

* 6 helper unit tests:

  * accepts narrow exact scope;
  * accepts broad fallback;
  * rejects unrelated read scope;
  * rejects sibling write scope;
  * proves exact-not-subprefix behavior;
  * proves `require_scope` remains unchanged.

* 2 route-auth tests:

  * `cast_vote_alias`;
  * `create_meeting`.

For both migrated routes, tests prove:

* narrow scope accepted;
* broad fallback accepted;
* `governance:read` rejected;
* sibling class scope rejected.

Validation run:

* `cargo fmt --all -- --check`
* `cargo clippy -p icn-gateway --all-targets -- -D warnings`
* `cargo test -p icn-gateway`
* `python3 .github/scripts/compliance_linter.py`

## Risk

Low / backward-compatible.

Broad `governance:write` tokens still authorize both migrated routes. Exact-match gateway semantics are preserved. The helper is generic string matching on gateway token claims and does not import domain/governance internals.

These gateway routes emit no V3 receipt, so no matched-scope evidence is fabricated.

## Deferred follow-ups

* `index_decision_endpoint` remains on broad `governance:write` pending registry-owner classification.
* JSON-RPC governance methods remain broad pending a separate accepted-also helper/design.
* `governance:write` is not retired.

## Non-claims

This PR does not make ICN production-ready.

This PR does not narrow JSON-RPC.

This PR does not migrate `index_decision_endpoint`.

This PR does not wire MandateGate.

This PR does not add Execution grants.

This PR does not solve Bootstrap/system authority semantics.

This PR does not solve scheduler/timer V3 authority semantics.

This PR does not retire `governance:write`.

This PR migrates only `cast_vote_alias` and `create_meeting` in the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
