### PR TITLE
feat(rpc): decompose governance JSON-RPC scopes with accepted-also fallback (#1868)

### DIFF
--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -1016,65 +1016,89 @@ pub mod scopes {
     ];
 }
 
-/// Method to scope mapping
-pub fn required_scope_for_method(method: &str) -> Option<&'static str> {
+/// Method to required-scope-candidates mapping.
+///
+/// Returns the ordered list of capability scopes that authorize a method; a
+/// caller is authorized if it holds **any one** of them (accepted-also). For
+/// most methods this is a single scope. During the #1868 `governance:write`
+/// decomposition, the governance write methods list the narrowed class scope
+/// first and keep broad [`scopes::GOVERNANCE_WRITE`] as a backward-compatible
+/// fallback. The returned slice is never empty.
+pub fn required_scopes_for_method(method: &str) -> Option<&'static [&'static str]> {
     match method {
         // Auth methods don't require scope (auth.revoke checks ownership in handler)
         "auth.challenge" | "auth.verify" | "auth.revoke" => None,
 
         // Network methods
         "network.peers" | "network.stats" | "network.status" | "network.nat_status" => {
-            Some(scopes::NETWORK_READ)
+            Some(&[scopes::NETWORK_READ])
         }
-        "network.dial" => Some(scopes::NETWORK_WRITE),
+        "network.dial" => Some(&[scopes::NETWORK_WRITE]),
 
         // Ledger methods
-        "ledger.head" | "ledger.balance" | "ledger.history" => Some(scopes::LEDGER_READ),
-        "ledger.quarantine.list" | "ledger.quarantine.get" => Some(scopes::LEDGER_READ),
+        "ledger.head" | "ledger.balance" | "ledger.history" => Some(&[scopes::LEDGER_READ]),
+        "ledger.quarantine.list" | "ledger.quarantine.get" => Some(&[scopes::LEDGER_READ]),
         "ledger.quarantine.release" | "ledger.quarantine.drop" | "ledger.quarantine.purge" => {
-            Some(scopes::LEDGER_WRITE)
+            Some(&[scopes::LEDGER_WRITE])
         }
 
         // Contract methods
-        "contract.list" | "receipt.get" => Some(scopes::CONTRACT_READ),
-        "contract.deploy" | "contract.call" => Some(scopes::CONTRACT_WRITE),
+        "contract.list" | "receipt.get" => Some(&[scopes::CONTRACT_READ]),
+        "contract.deploy" | "contract.call" => Some(&[scopes::CONTRACT_WRITE]),
 
         // Governance methods
-        "governance.domain.list" | "governance.domain.get" => Some(scopes::GOVERNANCE_READ),
-        "governance.proposal.list" | "governance.proposal.get" => Some(scopes::GOVERNANCE_READ),
-        "governance.domain.create" => Some(scopes::GOVERNANCE_WRITE),
+        "governance.domain.list" | "governance.domain.get" => Some(&[scopes::GOVERNANCE_READ]),
+        "governance.proposal.list" | "governance.proposal.get" => Some(&[scopes::GOVERNANCE_READ]),
+        // #1868 A2b: accepted-also — narrowed class scope first, broad
+        // `governance:write` second as a backward-compatible fallback.
+        "governance.domain.create" => {
+            Some(&[scopes::GOVERNANCE_CHARTER_WRITE, scopes::GOVERNANCE_WRITE])
+        }
         "governance.proposal.create"
         | "governance.proposal.open"
         | "governance.proposal.close"
-        | "governance.vote.cast" => Some(scopes::GOVERNANCE_WRITE),
+        | "governance.vote.cast" => {
+            Some(&[scopes::GOVERNANCE_PROPOSAL_WRITE, scopes::GOVERNANCE_WRITE])
+        }
 
         // Compute methods
-        "compute.status" => Some(scopes::COMPUTE_READ),
-        "compute.submit" | "compute.cancel" => Some(scopes::COMPUTE_WRITE),
+        "compute.status" => Some(&[scopes::COMPUTE_READ]),
+        "compute.submit" | "compute.cancel" => Some(&[scopes::COMPUTE_WRITE]),
 
         // Policy methods
-        "policy.get" | "policy.list" | "quota.usage" | "quota.list" => Some(scopes::POLICY_READ),
-        "policy.set" | "policy.remove" => Some(scopes::POLICY_WRITE),
+        "policy.get" | "policy.list" | "quota.usage" | "quota.list" => Some(&[scopes::POLICY_READ]),
+        "policy.set" | "policy.remove" => Some(&[scopes::POLICY_WRITE]),
 
         // Trust methods
-        "trust.list" | "trust.compute" => Some(scopes::TRUST_READ),
-        "trust.add" | "trust.remove" => Some(scopes::TRUST_WRITE),
+        "trust.list" | "trust.compute" => Some(&[scopes::TRUST_READ]),
+        "trust.add" | "trust.remove" => Some(&[scopes::TRUST_WRITE]),
 
         // Recovery methods
-        "recovery.list" | "recovery.status" => Some(scopes::RECOVERY_READ),
+        "recovery.list" | "recovery.status" => Some(&[scopes::RECOVERY_READ]),
         "recovery.initiate" | "recovery.attest" | "recovery.finalize" | "recovery.cancel" => {
-            Some(scopes::RECOVERY_WRITE)
+            Some(&[scopes::RECOVERY_WRITE])
         }
 
         // Dispute methods (ledger entry disputes)
-        "dispute.list" | "dispute.get" => Some(scopes::DISPUTE_READ),
+        "dispute.list" | "dispute.get" => Some(&[scopes::DISPUTE_READ]),
         "dispute.file" | "dispute.add_evidence" | "dispute.assign_mediator" | "dispute.resolve" => {
-            Some(scopes::DISPUTE_WRITE)
+            Some(&[scopes::DISPUTE_WRITE])
         }
 
         // Unknown methods - require admin
-        _ => Some(scopes::ADMIN),
+        _ => Some(&[scopes::ADMIN]),
     }
+}
+
+/// Backwards-compatible single-scope accessor: the **preferred** (first)
+/// required scope for a method, or `None` if the method needs no scope.
+///
+/// Prefer [`required_scopes_for_method`] for authorization — it honours the
+/// full accepted-also candidate list. This accessor returns only the first
+/// candidate, so for methods migrated under #1868 it returns the narrowed
+/// class scope (the broad fallback is not reflected here).
+pub fn required_scope_for_method(method: &str) -> Option<&'static str> {
+    required_scopes_for_method(method).and_then(|scopes| scopes.first().copied())
 }
 
 #[cfg(test)]
@@ -1188,13 +1212,135 @@ mod tests {
             required_scope_for_method("compute.submit"),
             Some(scopes::COMPUTE_WRITE)
         );
+        // #1868 A2b: the preferred (first) required scope for governance writes is
+        // now the narrowed class scope; the broad fallback lives in the candidate
+        // list returned by `required_scopes_for_method`.
         assert_eq!(
             required_scope_for_method("governance.vote.cast"),
-            Some(scopes::GOVERNANCE_WRITE)
+            Some(scopes::GOVERNANCE_PROPOSAL_WRITE)
         );
 
         // Auth revoke doesn't require specific scope
         assert_eq!(required_scope_for_method("auth.revoke"), None);
+    }
+
+    // ------------------------------------------------------------------
+    // #1868 A2b — JSON-RPC accepted-also governance scope decomposition.
+    // ------------------------------------------------------------------
+
+    /// (method, expected candidate list) for the 5 migrated governance writes.
+    fn migrated_governance_methods() -> [(&'static str, &'static [&'static str]); 5] {
+        [
+            (
+                "governance.domain.create",
+                &[scopes::GOVERNANCE_CHARTER_WRITE, scopes::GOVERNANCE_WRITE],
+            ),
+            (
+                "governance.proposal.create",
+                &[scopes::GOVERNANCE_PROPOSAL_WRITE, scopes::GOVERNANCE_WRITE],
+            ),
+            (
+                "governance.proposal.open",
+                &[scopes::GOVERNANCE_PROPOSAL_WRITE, scopes::GOVERNANCE_WRITE],
+            ),
+            (
+                "governance.proposal.close",
+                &[scopes::GOVERNANCE_PROPOSAL_WRITE, scopes::GOVERNANCE_WRITE],
+            ),
+            (
+                "governance.vote.cast",
+                &[scopes::GOVERNANCE_PROPOSAL_WRITE, scopes::GOVERNANCE_WRITE],
+            ),
+        ]
+    }
+
+    fn claims_with(scopes_list: &[&str]) -> RpcTokenClaims {
+        RpcTokenClaims {
+            sub: "did:icn:test".to_string(),
+            jti: "test-jti".to_string(),
+            iat: 0,
+            exp: u64::MAX,
+            scopes: scopes_list.iter().map(|s| s.to_string()).collect(),
+            coop_id: None,
+        }
+    }
+
+    /// The exact authorization predicate the central enforcement site applies.
+    fn method_authorized(method: &str, claims: &RpcTokenClaims) -> bool {
+        required_scopes_for_method(method)
+            .expect("method requires a scope")
+            .iter()
+            .any(|s| claims.has_scope(s))
+    }
+
+    #[test]
+    fn migrated_methods_expose_narrow_first_then_broad_fallback() {
+        for (method, expected) in migrated_governance_methods() {
+            assert_eq!(
+                required_scopes_for_method(method),
+                Some(expected),
+                "candidate list mismatch for {method}"
+            );
+        }
+    }
+
+    #[test]
+    fn required_scopes_for_method_never_empty_for_governance() {
+        // Guards the central enforcement's empty-list-is-misconfig invariant.
+        for (method, _) in migrated_governance_methods() {
+            let list = required_scopes_for_method(method).expect("requires scope");
+            assert!(!list.is_empty(), "{method} must have >=1 candidate scope");
+        }
+        // A representative unchanged write method stays single-candidate.
+        assert_eq!(
+            required_scopes_for_method("compute.submit"),
+            Some(&[scopes::COMPUTE_WRITE][..])
+        );
+    }
+
+    #[test]
+    fn migrated_methods_accept_narrow_and_broad_reject_unrelated_and_sibling() {
+        for (method, expected) in migrated_governance_methods() {
+            let narrow = expected[0];
+            // 1. Narrow class scope accepted.
+            assert!(
+                method_authorized(method, &claims_with(&[narrow])),
+                "{method}: narrow scope {narrow} must be accepted"
+            );
+            // 2. Broad GOVERNANCE_WRITE fallback accepted (backward-compatible).
+            assert!(
+                method_authorized(method, &claims_with(&[scopes::GOVERNANCE_WRITE])),
+                "{method}: governance:write fallback must be accepted"
+            );
+            // 3. Unrelated scope rejected.
+            assert!(
+                !method_authorized(method, &claims_with(&[scopes::GOVERNANCE_READ])),
+                "{method}: governance:read must be rejected"
+            );
+            // 4. Sibling write class rejected.
+            let sibling = if narrow == scopes::GOVERNANCE_PROPOSAL_WRITE {
+                scopes::GOVERNANCE_CHARTER_WRITE
+            } else {
+                scopes::GOVERNANCE_PROPOSAL_WRITE
+            };
+            assert!(
+                !method_authorized(method, &claims_with(&[sibling])),
+                "{method}: sibling class {sibling} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn wildcard_behavior_unchanged_for_migrated_methods() {
+        for (method, _) in migrated_governance_methods() {
+            // Global `*` still grants everything.
+            assert!(method_authorized(method, &claims_with(&["*"])));
+            // 2-part namespace wildcard `governance:*` still authorizes via the
+            // broad `governance:write` fallback candidate (which is 2-part).
+            assert!(method_authorized(method, &claims_with(&["governance:*"])));
+            // No sub-prefix matching: a bare `governance` scope grants nothing.
+            assert!(!method_authorized(method, &claims_with(&["governance"])));
+        }
     }
 
     #[test]

--- a/icn/crates/icn-rpc/src/server.rs
+++ b/icn/crates/icn-rpc/src/server.rs
@@ -54,7 +54,7 @@ use icn_ledger::{DisputeManager, Ledger};
 use icn_net::{NetworkHandle, RateLimiter};
 use icn_store::Store;
 
-use crate::auth::{required_scope_for_method, RpcAuthManager, RpcTokenClaims};
+use crate::auth::{required_scopes_for_method, RpcAuthManager, RpcTokenClaims};
 use crate::context::RpcContext;
 use crate::handler;
 use crate::receipt::ReceiptStore;
@@ -455,23 +455,41 @@ async fn handle_request(
     // Check authentication if enabled
     let claims: Option<RpcTokenClaims> = if let Some(auth_manager) = &state.auth_manager {
         // Check if this method requires authentication
-        if let Some(required_scope) = required_scope_for_method(&rpc_request.method) {
+        if let Some(required_scopes) = required_scopes_for_method(&rpc_request.method) {
+            // An empty candidate list is a server-side configuration error, not a
+            // client auth failure: fail closed as an internal error rather than a
+            // 403 (mirrors the gateway `require_any_scope` guard). The mapping
+            // always returns >=1 candidate, so this is defensive.
+            if required_scopes.is_empty() {
+                error!(
+                    "No candidate scopes configured for method {}",
+                    rpc_request.method
+                );
+                gauge!("icn_rpc_active_requests").decrement(1.0);
+                let response = RpcResponse::error(
+                    rpc_request.id,
+                    -32603,
+                    "Internal error: method scope misconfigured".to_string(),
+                );
+                return Ok(json_response(StatusCode::OK, &response));
+            }
             // Method requires auth - verify token
             match bearer_token {
                 Some(token) => match auth_manager.verify_token(&token) {
                     Ok(claims) => {
-                        // Check scope
-                        if !claims.has_scope(required_scope) {
+                        // Check scope: authorized if ANY candidate scope is granted
+                        // (accepted-also). `has_scope` semantics are unchanged.
+                        if !required_scopes.iter().any(|s| claims.has_scope(s)) {
                             warn!(
-                                "Insufficient scope for method {}: required {}, has {:?}",
-                                rpc_request.method, required_scope, claims.scopes
+                                "Insufficient scope for method {}: requires one of {:?}, has {:?}",
+                                rpc_request.method, required_scopes, claims.scopes
                             );
                             counter!("icn_rpc_auth_failures_total", "reason" => "insufficient_scope").increment(1);
                             gauge!("icn_rpc_active_requests").decrement(1.0);
                             let response = RpcResponse::error(
                                 rpc_request.id,
                                 -32403,
-                                format!("Insufficient scope: requires {required_scope}"),
+                                format!("Insufficient scope: requires one of {required_scopes:?}"),
                             );
                             return Ok(json_response(StatusCode::OK, &response));
                         }

--- a/icn/crates/icn-rpc/src/server.rs
+++ b/icn/crates/icn-rpc/src/server.rs
@@ -465,6 +465,12 @@ async fn handle_request(
                     "No candidate scopes configured for method {}",
                     rpc_request.method
                 );
+                counter!(
+                    "icn_rpc_errors_total",
+                    "method" => rpc_request.method.clone(),
+                    "error_code" => "-32603"
+                )
+                .increment(1);
                 gauge!("icn_rpc_active_requests").decrement(1.0);
                 let response = RpcResponse::error(
                     rpc_request.id,
@@ -489,7 +495,10 @@ async fn handle_request(
                             let response = RpcResponse::error(
                                 rpc_request.id,
                                 -32403,
-                                format!("Insufficient scope: requires one of {required_scopes:?}"),
+                                format!(
+                                    "Insufficient scope: requires one of: {}",
+                                    required_scopes.join(", ")
+                                ),
                             );
                             return Ok(json_response(StatusCode::OK, &response));
                         }


### PR DESCRIPTION
## What

Add an accepted-also authorization mechanism to the JSON-RPC layer and migrate the 5 governance write methods from broad `governance:write` to narrow class scopes, with `governance:write` retained as a backward-compatible fallback:

* `governance.domain.create` → `[governance:charter:write, governance:write]`
* `governance.proposal.create` → `[governance:proposal:write, governance:write]`
* `governance.proposal.open` → `[governance:proposal:write, governance:write]`
* `governance.proposal.close` → `[governance:proposal:write, governance:write]`
* `governance.vote.cast` → `[governance:proposal:write, governance:write]`

This is #1868 slice A2b-3: `icn-rpc` only. It decomposes the **central** JSON-RPC method authorization mapping.

> **Scope note (`governance.vote.cast`):** `governance.vote.cast` still has a pre-existing **downstream** handler-level `governance:vote` check (`handler/governance.rs:634`), so the new central `governance:proposal:write` mapping is **not sufficient end-to-end** for that method (only `governance:*`/`*` satisfy both gates — unchanged by this PR). Reconciling that second gate is intentionally **deferred to a follow-up** because it requires a separate scope-taxonomy decision. This PR does not regress `vote.cast`.

## Why

A0, A1c, and A2a-2 decomposed the `apps/governance` HTTP handlers and two gateway routes. The JSON-RPC method mappings are the remaining broad-scope gates. RPC enforcement was single-scope (exact/wildcard) with no accepted-also helper, so narrowing safely required adding one first.

## How

* `auth.rs`: new `required_scopes_for_method(method) -> Option<&'static [&'static str]>` — an ordered candidate list where any one scope authorizes (accepted-also). Single-element and behavior-neutral for unchanged methods; narrow-first + broad fallback for the 5 governance writes; never empty.
* `required_scope_for_method` is preserved (still re-exported) as a delegating wrapper returning the preferred (first) candidate.
* `server.rs`: the single central enforcement site authorizes if **any** candidate is granted via the unchanged `has_scope`. An empty candidate list is treated as a server-config error (`-32603` internal error, counted in `icn_rpc_errors_total`), not a client `403`. The insufficient-scope message renders the candidates as a plain comma-separated list.
* Wildcard semantics (`*`, 2-part `{ns}:*`) preserved exactly; no sub-prefix matching added.
* The RPC close/V3 path is untouched (stays `capability_scope: None`) — no matched-scope evidence is fabricated and nothing is threaded into V3.

## Tests

`auth.rs` (table-driven):

* candidate lists per migrated method (narrow-first + `governance:write`);
* never-empty invariant for governance methods; representative unchanged method stays single-candidate;
* the exact enforcement predicate per method: narrow accepted, `governance:write` fallback accepted, unrelated (`governance:read`) rejected, sibling class rejected;
* wildcard behavior unchanged (`*`, `governance:*`) and no sub-prefix matching;
* updated `required_scope_for_method` assertion to the preferred narrow scope.

Validation run:

* `cargo fmt --all -- --check`
* `cargo clippy -p icn-rpc --all-targets -- -D warnings`
* `cargo test -p icn-rpc` (lib 71 + integration 42 + 4, 0 failed)
* `python3 .github/scripts/compliance_linter.py` (0 violations)

## Risk

Low / backward-compatible. Unchanged methods are byte-for-byte equivalent (single-element candidate slices; existing integration tests pass). Broad `governance:write`, `governance:*`, and `*` tokens still authorize the central gate of the 5 migrated methods. `has_scope` is untouched.

## Deferred follow-ups

* **Reconcile RPC `governance.vote.cast` handler-level authorization:** `handler/governance.rs` currently requires `governance:vote` after central dispatch, so the central `governance:proposal:write` mapping is not sufficient end-to-end for that method (pre-existing; requires a separate scope-taxonomy decision).
* Gateway `index_decision_endpoint` remains on broad `governance:write` (design-unconfirmed classification).
* `governance:write` const, allowlist, and session issuance intentionally retained for compatibility; `governance:write` is not retired.

## Non-claims

This PR does not make ICN production-ready.

This PR does not change gateway routes.

This PR does not change apps/governance.

This PR does not migrate `index_decision_endpoint`.

This PR does not reconcile the `governance.vote.cast` handler-level `governance:vote` gate (deferred).

This PR does not wire MandateGate.

This PR does not add Execution grants.

This PR does not solve Bootstrap/system authority semantics.

This PR does not solve scheduler/timer V3 authority semantics.

This PR does not retire `governance:write`.

This PR does not improve any V3 / matched-scope evidence (the JSON-RPC close path emits no V3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
