### PR TITLE
fix(rpc): reconcile governance.vote.cast handler authorization (#1868)

### DIFF
--- a/icn/crates/icn-rpc/src/handler/governance.rs
+++ b/icn/crates/icn-rpc/src/handler/governance.rs
@@ -611,14 +611,19 @@ pub async fn handle_governance_proposal_open(
 
 /// Handle governance.vote.cast RPC call - cast a vote on a proposal
 ///
-/// Requires scope: `governance:vote` or `governance:*`
+/// Scope authorization is enforced centrally by the JSON-RPC dispatcher
+/// (`required_scopes_for_method` → `[governance:proposal:write,
+/// governance:write]`), the same accepted-also gate the other proposal-family
+/// methods use (#1868). This handler only requires an authenticated context so
+/// the caller DID can be recorded as the voter; it does not re-check scopes.
 pub async fn handle_governance_vote_cast(
     id: u64,
     params: &serde_json::Value,
     state: &Arc<RpcServer>,
     ctx: Option<&RpcContext>,
 ) -> RpcResponse {
-    // Require authentication with governance:vote scope
+    // The caller DID is the voter identity, so an authenticated context is
+    // required. Scope authorization already happened at central dispatch.
     let ctx = match ctx {
         Some(c) => c,
         None => {
@@ -629,19 +634,6 @@ pub async fn handle_governance_vote_cast(
             );
         }
     };
-
-    // Verify caller has required scope
-    if !ctx.has_scope("governance:vote") {
-        tracing::warn!(
-            caller = %ctx.caller_did,
-            "Vote attempt denied: missing governance:vote scope"
-        );
-        return RpcResponse::error(
-            id,
-            crate::error_codes::SCOPE_INSUFFICIENT,
-            "Insufficient scope: governance:vote required".to_string(),
-        );
-    }
 
     tracing::debug!(
         caller = %ctx.caller_did,

--- a/icn/crates/icn-rpc/tests/rpc_integration.rs
+++ b/icn/crates/icn-rpc/tests/rpc_integration.rs
@@ -1891,3 +1891,84 @@ async fn test_internal_error_sanitization() {
 
     handle.abort();
 }
+
+// ============================================================================
+// #1868 A3b — RPC `governance.vote.cast` authorization.
+//
+// Authorization for `governance.vote.cast` is enforced solely by central JSON-RPC
+// dispatch (`required_scopes_for_method` → `[governance:proposal:write,
+// governance:write]`, accepted-also), matching the sibling governance methods and
+// the already-migrated HTTP `cast_vote` surface. The downstream handler no longer
+// re-checks a separate legacy `governance:vote` scope.
+// ============================================================================
+
+/// End-to-end: which scopes authorize `governance.vote.cast` over the RPC path.
+///
+/// The test server wires no governance handle, so a request that PASSES the scope
+/// gate reaches the handler and surfaces `RESOURCE_NOT_AVAILABLE` (-32000) —
+/// "accepted" means "not rejected at the scope gate", mirroring the HTTP A1c
+/// convention. A request REJECTED at central dispatch surfaces -32403 (insufficient
+/// scope) and never reaches the handler. Both codes are stable wire values embedded
+/// by the client as `RPC error {code}: ...`.
+#[tokio::test]
+async fn governance_vote_cast_central_scope_authorization() {
+    let (addr, handle) = start_test_server(true).await.unwrap();
+
+    // (scope presented, should the scope gate accept it?)
+    let cases: &[(&str, bool)] = &[
+        // Canonical proposal-family class scope — the #1868 target. Must work
+        // end-to-end now that the stale handler gate is gone.
+        ("governance:proposal:write", true),
+        // Legacy broad scope — accepted-also fallback, still authorizes.
+        ("governance:write", true),
+        // Unrelated read scope — rejected.
+        ("governance:read", false),
+        // Sibling write class — rejected (not in the candidate list).
+        ("governance:charter:write", false),
+        // Stale legacy vote scope — NOT in the central candidate list, so it is
+        // intentionally rejected. It is not silently preserved as a gate.
+        ("governance:vote", false),
+    ];
+
+    for &(scope, accepted) in cases {
+        let keypair = Arc::new(KeyPair::generate().unwrap());
+        let mut client = RpcClient::with_credentials(addr, keypair);
+        client
+            .authenticate(vec![scope.to_string()])
+            .await
+            .unwrap_or_else(|e| panic!("authenticate({scope}) failed: {e:?}"));
+
+        let params = serde_json::json!({
+            "proposal_id": "prop-a3b",
+            "choice": "for",
+        });
+        let result = client.call("governance.vote.cast", params).await;
+
+        // No governance handle is wired, so an authorized call cannot succeed.
+        let err =
+            result.expect_err("governance.vote.cast must not succeed without a governance handle");
+        let msg = err.to_string();
+
+        if accepted {
+            // Passed the scope gate; failed downstream for lack of a handle.
+            assert!(
+                msg.contains("-32000"),
+                "scope {scope} must be authorized end-to-end (expected -32000 \
+                 RESOURCE_NOT_AVAILABLE downstream), got: {msg}"
+            );
+            assert!(
+                !msg.contains("-32403"),
+                "scope {scope} must not be rejected at the central scope gate, got: {msg}"
+            );
+        } else {
+            // Rejected at central dispatch before reaching the handler.
+            assert!(
+                msg.contains("-32403"),
+                "scope {scope} must be rejected at the central scope gate \
+                 (expected -32403 insufficient scope), got: {msg}"
+            );
+        }
+    }
+
+    handle.abort();
+}


### PR DESCRIPTION
## What

Removes the stale downstream `governance:vote` handler-level scope gate from `handle_governance_vote_cast`.

After A2b-3, central JSON-RPC dispatch already authorizes `governance.vote.cast` with:

`[governance:proposal:write, governance:write]`

This PR makes the downstream handler rely on that central dispatch authorization, matching the sibling governance RPC handlers.

The handler still requires an authenticated context so the caller DID can be recorded as the voter.

## Why

A2b-3 decomposed the central JSON-RPC method authorization mapping, but `governance.vote.cast` still had a pre-existing downstream handler gate requiring legacy `governance:vote`.

That made the effective requirement:

`governance:vote AND (governance:proposal:write OR governance:write)`

So a canonical `governance:proposal:write` token passed central dispatch but failed inside the handler.

The audit found `governance:vote` is stale legacy scope drift: it is not minted by standard paths, is not in the gateway allowlist, and was checked in exactly this one production handler. The design maps vote casting to the proposal-family scope.

## How

* Deletes only the handler-level `ctx.has_scope("governance:vote")` block.
* Keeps the authenticated-context check.
* Keeps caller DID extraction.
* Keeps payload parsing.
* Keeps the manager call.
* Keeps downstream error behavior.
* Updates the handler doc/comment to point at central dispatch authorization.

No central mapping changes are made in this PR.

## Tests

Adds `governance_vote_cast_central_scope_authorization`, a table-driven RPC integration test.

The test proves:

* `governance:proposal:write` is accepted end-to-end through authorization and reaches the downstream no-governance-handle error.
* `governance:write` fallback is accepted the same way.
* `governance:read` is rejected at central dispatch.
* `governance:charter:write` is rejected at central dispatch.
* `governance:vote` alone is rejected at central dispatch and is not silently preserved.

Validation run:

* `cargo fmt --all -- --check`
* `cargo clippy -p icn-rpc --all-targets -- -D warnings`
* `cargo test -p icn-rpc --test rpc_integration governance_vote_cast_central_scope_authorization`
* `cargo test -p icn-rpc`
* `cargo test -p icn-rpc --lib`
* `python3 .github/scripts/compliance_linter.py`

## Risk

Low.

This removes a stale contradictory double-gate and makes RPC vote casting match central dispatch and HTTP cast-vote authorization.

No standard issuance path mints `governance:vote`. Wildcard scopes such as `governance:*` and `*` still authorize through central dispatch. `governance:write` remains an accepted-also fallback.

## Deferred follow-ups

* Retire stale legacy `icn-api::scopes::VOTE` and related stale docs/examples in a later cleanup slice.
* `governance:write` retirement remains future work.

## Non-claims

This PR does not make ICN production-ready.

This PR does not retire `governance:write`.

This PR does not wire MandateGate.

This PR does not add Execution grants.

This PR does not solve Bootstrap/system authority semantics.

This PR does not solve scheduler/timer V3 semantics.

This PR does not add or change V3/matched-scope evidence.

This PR does not change gateway or apps/governance behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
