### PR TITLE
fix(icnctl): correct stale gov:* scope defaults to governance:*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,7 @@ ICN_PASSPHRASE=dev ICN_GATEWAY_JWT_SECRET=dev-secret-must-be-at-least-32-bytes \
 
 ### Obtaining a JWT token
 
-The default scopes in `icnctl auth token` use `gov:read`/`gov:write`, which the gateway rejects. Use full scope names:
+`icnctl auth token` defaults to `governance:read`/`governance:write` (full scope names the gateway accepts). For broader access request the full set:
 
 ```bash
 ICN_PASSPHRASE=dev ./target/debug/icnctl --data-dir /tmp/icn auth token \

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -365,7 +365,7 @@ enum AuthCommands {
         #[arg(
             short,
             long,
-            default_value = "ledger:read,ledger:write,coop:read,gov:read,gov:write"
+            default_value = "ledger:read,ledger:write,coop:read,governance:read,governance:write"
         )]
         scopes: String,
     },
@@ -9953,7 +9953,7 @@ async fn get_gateway_token(
         "did": did,
         "signature": hex::encode(signature.to_bytes()),
         "coop_id": coop_id,
-        "scopes": ["gov:read", "gov:write"]
+        "scopes": ["governance:read", "governance:write"]
     });
 
     let resp = client


### PR DESCRIPTION
## What
Correct stale `gov:read`/`gov:write` scope strings to `governance:read`/`governance:write` in two icnctl code paths:
- `auth token` default `--scopes` (`bins/icnctl/src/main.rs`)
- hardcoded scopes in `get_gateway_token()`'s `/v1/auth/verify` request body

Also updates the `AGENTS.md` note that had documented this as a manual workaround.

## Why
`gov:read`/`gov:write` are not in the gateway `ALLOWED_SCOPES` (only `governance:read`/`governance:write` plus class-level `governance:*:write`). Running `icnctl auth token` with its default scopes fails: `400 Bad Request — Invalid scope: 'gov:read'`. Reproduced live against a local gateway. `AGENTS.md` already documented the bug as "use full scope names" — this fixes the root cause so the default works.

## How
String-literal corrections only; no auth-model change beyond requesting valid scope names.

## Risk
Low. `gov:read`/`gov:write` are invalid everywhere (rejected by the gateway, not minted, not in the allowlist), so the change is strictly corrective. No tests reference the old strings.

## Test
- Reproduced failure: `icnctl auth token` (old default) → `400 Invalid scope: 'gov:read'`.
- After fix: corrected scopes mint a token successfully against a local gateway; `bootstrap apply` + action-item completion-receipt loop run clean.
- `cargo fmt --all -- --check` ✓ · `cargo clippy -p icnctl -- -D warnings` ✓.

## Scope / follow-up
Code paths only. ~35 stale `gov:*` references remain in docs/examples/openapi/SDK README/demo scripts — deferred to a separate docs-sweep PR.
