### PR TITLE
docs/ci: reinforce meaning firewall around readiness and fintech vocabulary

### DIFF
--- a/.github/scripts/fixtures/readiness/bad_unbannered.md
+++ b/.github/scripts/fixtures/readiness/bad_unbannered.md
@@ -1,0 +1,6 @@
+# Example Deploy Guide (fixture: SHOULD be flagged)
+
+**Status:** ✅ PRODUCTION READY
+**Date:** 2025-12-12
+
+This guide is ready for production deployment.

--- a/.github/scripts/fixtures/readiness/good_bannered.md
+++ b/.github/scripts/fixtures/readiness/good_bannered.md
@@ -1,0 +1,9 @@
+# Example Deploy Guide (fixture: bannered, should NOT be flagged)
+
+> Historical deployment snapshot from 2025-12-12.
+> Not current deployment truth; for current readiness see `docs/ci/CI_CURRENT_STATUS.md`.
+
+**Status:** ✅ PRODUCTION READY
+**Date:** 2025-12-12
+
+This guide was ready for production deployment as assessed on the snapshot date.

--- a/.github/scripts/fixtures/readiness/good_negated.md
+++ b/.github/scripts/fixtures/readiness/good_negated.md
@@ -1,0 +1,7 @@
+# Example Maturity Note (fixture: non-claims, should NOT be flagged)
+
+ICN is not production-ready.
+There is no live federation in production today.
+In a production deployment, settlements would be visible here.
+Do not claim the system is production-ready.
+Target: production-ready by a future milestone.

--- a/.github/scripts/readiness_overclaim_linter.py
+++ b/.github/scripts/readiness_overclaim_linter.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Readiness Overclaim Linter - CI Script
+
+Scans ACTIVE deployment/operations guidance for un-disclaimed, affirmative,
+present-tense readiness claims that misrepresent ICN's maturity:
+
+  - production-readiness   ("PRODUCTION READY", "ready for production", ...)
+  - live-federation        ("live federation")
+  - blanket operability    ("all systems operational")
+  - general availability   ("generally available")
+
+ICN is research-grade cooperative-coordination infrastructure. Dated readiness
+snapshots are valuable history, so a claim is allowed when the file carries a
+stale/archive BANNER, when the line is negated/conditional/aspirational, or when
+it is explicitly allowlisted below. This mirrors the discipline the repo already
+practices on docs/deployment/*.md (see the already-bannered siblings).
+
+This complements compliance_linter.py (fintech vocabulary in API surfaces); it
+does NOT replace it. See docs/dev/language-guide.md and docs/ci/GATE_RATCHET_PLAN.md.
+
+Usage:
+    python3 .github/scripts/readiness_overclaim_linter.py [--repo-root PATH]
+
+Exit codes:
+    0: No un-disclaimed readiness overclaims detected
+    1: Overclaim(s) detected
+    2: Script error
+"""
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import List
+
+# ---------------------------------------------------------------------------
+# Scan scope (directories, relative to repo root). Intentionally narrow for the
+# first ratchet iteration: the deployment/operations guidance surface, where
+# "PRODUCTION READY" headline claims are most dangerous and highest-precision.
+# Widening scope is a deliberate ratchet step (docs/ci/GATE_RATCHET_PLAN.md).
+# ---------------------------------------------------------------------------
+SCAN_DIRS = [
+    "docs/deployment",
+    "docs/operations/deployment",
+]
+
+# Affirmative readiness-claim patterns (case-insensitive).
+OVERCLAIM_PATTERNS = [
+    (re.compile(r"\bproduction[\s-]?ready\b", re.IGNORECASE), "production-ready"),
+    (re.compile(r"\bready for production\b", re.IGNORECASE), "ready for production"),
+    (re.compile(r"\bapproved for production\b", re.IGNORECASE), "approved for production"),
+    (re.compile(r"\bdeployment[\s-]?ready\b", re.IGNORECASE), "deployment-ready"),
+    (re.compile(r"\blive federation\b", re.IGNORECASE), "live federation"),
+    (re.compile(r"\ball systems operational\b", re.IGNORECASE), "all systems operational"),
+    (re.compile(r"\bgeneral(ly)? availab", re.IGNORECASE), "general availability"),
+]
+
+# If any of these appear on the line, it is a non-claim (negated / conditional /
+# aspirational / rule-describing) -> NOT a violation. Precision over recall: when
+# in doubt we do NOT flag, because the repo deliberately uses many such non-claims.
+NEGATION_RE = re.compile(
+    r"(?i)("
+    r"\bnot\b|n't|\bno\b|\bnever\b|not yet|\bwould\b|\bif\b|\bonce\b|\bwhen\b|"
+    r"\btarget\b|\bgoal\b|aspir|roadmap|\bfuture\b|do not|don't|must not|\bavoid\b|"
+    r"forbidden|prerequisite|before production|in a production deployment|in production:|"
+    r"\U0001F7E1"  # yellow-circle status marker used for "assessed, not production-ready"
+    r")"
+)
+
+# A recognised stale/archive banner near the top of a file exempts the whole file
+# (the claim is then clearly labelled history, like the bannered deployment siblings).
+BANNER_RE = re.compile(
+    r"(?i)(historical|archiv|point[\s-]in[\s-]time|not current (deployment|operational)|snapshot)"
+)
+BANNER_SCAN_LINES = 15
+
+# Explicit allowlist of legitimate, bounded exceptions: "relpath:line" -> reason.
+# Keep this SMALL and justified. Adding an entry is the supported way to record a
+# false positive WITHOUT weakening the patterns. See the exception policy in
+# docs/dev/language-guide.md. (Empty at baseline: banners cover every current hit.)
+ALLOWLIST = {
+    # "docs/deployment/EXAMPLE.md:42": "why this affirmative line is genuinely fine",
+}
+
+
+@dataclass
+class Violation:
+    file: str
+    line: int
+    text: str
+    rule: str
+
+
+@dataclass
+class LintResult:
+    violations: List[Violation] = field(default_factory=list)
+    files_scanned: int = 0
+    files_exempt: List[str] = field(default_factory=list)
+
+
+def is_banner_exempt(lines):
+    """True if a stale/archive banner appears within the first BANNER_SCAN_LINES."""
+    for line in lines[:BANNER_SCAN_LINES]:
+        if BANNER_RE.search(line):
+            return True
+    return False
+
+
+def scan_lines(rel_path, lines):
+    """Flag affirmative readiness claims; honour banner, negation, and allowlist."""
+    if is_banner_exempt(lines):
+        return []
+
+    violations = []
+    for line_num, line in enumerate(lines, start=1):
+        if NEGATION_RE.search(line):
+            continue
+        for pattern, rule in OVERCLAIM_PATTERNS:
+            if pattern.search(line):
+                key = rel_path + ":" + str(line_num)
+                if key in ALLOWLIST:
+                    continue
+                violations.append(
+                    Violation(file=rel_path, line=line_num, text=line.rstrip()[:160], rule=rule)
+                )
+                break  # one violation per line is enough
+    return violations
+
+
+def scan_file(rel_path, abs_path):
+    try:
+        with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.read().splitlines()
+    except OSError as e:
+        print("Warning: could not read " + rel_path + ": " + str(e), file=sys.stderr)
+        return []
+    return scan_lines(rel_path, lines)
+
+
+def run_lint(repo_root):
+    result = LintResult()
+    for scan_dir in SCAN_DIRS:
+        abs_dir = os.path.join(repo_root, scan_dir)
+        if not os.path.isdir(abs_dir):
+            continue
+        for dirpath, _dirnames, filenames in os.walk(abs_dir):
+            for name in sorted(filenames):
+                if not name.endswith(".md"):
+                    continue
+                abs_path = os.path.join(dirpath, name)
+                rel_path = os.path.relpath(abs_path, repo_root).replace(os.sep, "/")
+                result.files_scanned += 1
+                with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+                    lines = f.read().splitlines()
+                if is_banner_exempt(lines):
+                    result.files_exempt.append(rel_path)
+                    continue
+                result.violations.extend(scan_lines(rel_path, lines))
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ICN Readiness Overclaim Linter")
+    parser.add_argument("--repo-root", default=os.getcwd(), help="Repository root (default: cwd)")
+    args = parser.parse_args()
+    repo_root = os.path.abspath(args.repo_root)
+
+    print("=" * 70)
+    print("Readiness Overclaim Linter")
+    print("Un-disclaimed production/live-federation readiness claims in active guidance")
+    print("=" * 70)
+    print()
+    print("Repo root: " + repo_root)
+    print("Scope: " + ", ".join(SCAN_DIRS))
+    print("Reference: docs/dev/language-guide.md")
+    print()
+
+    result = run_lint(repo_root)
+    print("Scanned " + str(result.files_scanned) + " files; " + str(len(result.files_exempt)) +
+          " exempt (stale/archive banner present)")
+    print()
+
+    if not result.violations:
+        print("No un-disclaimed readiness overclaims detected.")
+        print()
+        print("Active deployment guidance either avoids affirmative readiness claims")
+        print("or carries a stale/archive banner labelling them as historical.")
+        return 0
+
+    by_file = {}
+    for v in result.violations:
+        by_file.setdefault(v.file, []).append(v)
+
+    print(str(len(result.violations)) + " READINESS OVERCLAIM(S) DETECTED:")
+    print()
+    for filepath in sorted(by_file.keys()):
+        print("  " + filepath + ":")
+        for v in by_file[filepath]:
+            print("    L" + str(v.line) + ": [" + v.rule + "]")
+            print("           " + v.text)
+        print()
+    print("To fix, choose ONE (do NOT weaken the patterns):")
+    print("  1. If the doc is a dated snapshot: add a stale/archive banner near the top")
+    print("     (see the bannered docs/deployment/*.md siblings; point to docs/ci/CI_CURRENT_STATUS.md).")
+    print("  2. If the claim is current and true: keep it (it stays flagged until proven by CI).")
+    print("  3. If it is a genuine bounded exception: add it to ALLOWLIST with a reason.")
+    print("See docs/dev/language-guide.md (Readiness claims + exception policy).")
+    print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/readiness_overclaim_linter.py
+++ b/.github/scripts/readiness_overclaim_linter.py
@@ -55,6 +55,11 @@ OVERCLAIM_PATTERNS = [
     (re.compile(r"\blive federation\b", re.IGNORECASE), "live federation"),
     (re.compile(r"\ball systems operational\b", re.IGNORECASE), "all systems operational"),
     (re.compile(r"\bgeneral(ly)? availab", re.IGNORECASE), "general availability"),
+    # Governance-completion overclaims. The firewall contract (docs/dev/language-guide.md
+    # "Readiness claims" and docs/ci/GATE_RATCHET_PLAN.md) names this claim class, so the
+    # gate must actually detect it. Kept narrow to avoid false positives.
+    (re.compile(r"\bgovernance\b[^.\n;|]{0,40}\b(?:is|are)\b[^.\n;|]{0,20}\bcomplete\b", re.IGNORECASE), "governance-completion"),
+    (re.compile(r"\b(?:proposal|vote|voting|member[\s-]standing)\b[^.\n;|]{0,60}\b(?:is|are)\b[^.\n;|]{0,24}\b(?:complete|fully (?:working|operational|implemented))\b", re.IGNORECASE), "governance-completion"),
 ]
 
 # If any of these appear on the line, it is a non-claim (negated / conditional /
@@ -71,8 +76,15 @@ NEGATION_RE = re.compile(
 
 # A recognised stale/archive banner near the top of a file exempts the whole file
 # (the claim is then clearly labelled history, like the bannered deployment siblings).
+# The bare word "snapshot" is NOT sufficient on its own (e.g. "Snapshot frequency is
+# configurable." must not exempt a doc); require explicit archival framing, or
+# "snapshot" qualified as historical/dated.
 BANNER_RE = re.compile(
-    r"(?i)(historical|archiv|point[\s-]in[\s-]time|not current (deployment|operational)|snapshot)"
+    r"(?i)("
+    r"historical|archiv|point[\s-]in[\s-]time|not current (?:deployment|operational)|"
+    r"(?:historical|archived|dated|point[\s-]in[\s-]time)\s+snapshot|"
+    r"snapshot\s+(?:from|as of|dated|date:)"
+    r")"
 )
 BANNER_SCAN_LINES = 15
 
@@ -108,6 +120,25 @@ def is_banner_exempt(lines):
     return False
 
 
+# Clause delimiters used to scope a negation to the same clause as the overclaim,
+# so an unrelated negation in a *separate* clause cannot bypass the gate (e.g.
+# "ICN is not experimental; it is PRODUCTION READY." must still flag on the second
+# clause). Comma is deliberately NOT a delimiter, so a leading conditional clause
+# like "Once hardened, ICN becomes production-ready." stays exempt (precision).
+_CLAUSE_DELIMS = set(".;:|()") | {"—"}  # strong delimiters + em dash; not comma
+
+
+def _clause_around(line, start, end):
+    """Return the clause (between delimiters) containing the [start, end) match."""
+    lo = start
+    while lo > 0 and line[lo - 1] not in _CLAUSE_DELIMS:
+        lo -= 1
+    hi = end
+    while hi < len(line) and line[hi] not in _CLAUSE_DELIMS:
+        hi += 1
+    return line[lo:hi]
+
+
 def scan_lines(rel_path, lines):
     """Flag affirmative readiness claims; honour banner, negation, and allowlist."""
     if is_banner_exempt(lines):
@@ -115,17 +146,21 @@ def scan_lines(rel_path, lines):
 
     violations = []
     for line_num, line in enumerate(lines, start=1):
-        if NEGATION_RE.search(line):
-            continue
         for pattern, rule in OVERCLAIM_PATTERNS:
-            if pattern.search(line):
-                key = rel_path + ":" + str(line_num)
-                if key in ALLOWLIST:
-                    continue
-                violations.append(
-                    Violation(file=rel_path, line=line_num, text=line.rstrip()[:160], rule=rule)
-                )
-                break  # one violation per line is enough
+            m = pattern.search(line)
+            if not m:
+                continue
+            # Only the overclaim's own clause exempts it — not an unrelated
+            # negation/conditional elsewhere on the same line.
+            if NEGATION_RE.search(_clause_around(line, m.start(), m.end())):
+                continue
+            key = rel_path + ":" + str(line_num)
+            if key in ALLOWLIST:
+                continue
+            violations.append(
+                Violation(file=rel_path, line=line_num, text=line.rstrip()[:160], rule=rule)
+            )
+            break  # one violation per line is enough
     return violations
 
 
@@ -169,7 +204,7 @@ def main():
 
     print("=" * 70)
     print("Readiness Overclaim Linter")
-    print("Un-disclaimed production/live-federation readiness claims in active guidance")
+    print("Un-disclaimed production / live-federation / governance-completion claims in active guidance")
     print("=" * 70)
     print()
     print("Repo root: " + repo_root)
@@ -177,7 +212,11 @@ def main():
     print("Reference: docs/dev/language-guide.md")
     print()
 
-    result = run_lint(repo_root)
+    try:
+        result = run_lint(repo_root)
+    except Exception as e:  # documented exit code 2 for unexpected script errors
+        print("ERROR: readiness linter failed: " + str(e), file=sys.stderr)
+        return 2
     print("Scanned " + str(result.files_scanned) + " files; " + str(len(result.files_exempt)) +
           " exempt (stale/archive banner present)")
     print()

--- a/.github/scripts/test_readiness_overclaim_linter.py
+++ b/.github/scripts/test_readiness_overclaim_linter.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Self-test for readiness_overclaim_linter.py.
+
+Proves the readiness firewall catches affirmative readiness overclaims while
+allowing the legitimate bounded contexts the repo relies on (stale/archive
+banners, negations, conditionals, "do not claim" rule lines). This is the
+regression guard for the linter itself: if someone weakens the patterns to make
+CI pass, these assertions fail.
+
+Run:
+    python3 .github/scripts/test_readiness_overclaim_linter.py
+"""
+
+import importlib.util
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIX = os.path.join(HERE, "fixtures", "readiness")
+
+_spec = importlib.util.spec_from_file_location(
+    "readiness_overclaim_linter", os.path.join(HERE, "readiness_overclaim_linter.py")
+)
+linter = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(linter)
+
+
+class TestBannerExempt(unittest.TestCase):
+    def test_banner_detected(self):
+        self.assertTrue(linter.is_banner_exempt(["# Title", "> Historical snapshot from 2025-12-12."]))
+
+    def test_no_banner(self):
+        self.assertFalse(linter.is_banner_exempt(["# Title", "**Status:** PRODUCTION READY"]))
+
+
+class TestScanLines(unittest.TestCase):
+    def test_flags_affirmative_production_ready(self):
+        v = linter.scan_lines("x.md", ["# T", "**Status:** PRODUCTION READY"])
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].rule, "production-ready")
+
+    def test_flags_affirmative_live_federation(self):
+        v = linter.scan_lines("x.md", ["ICN runs a live federation across cooperatives."])
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].rule, "live federation")
+
+    def test_flags_approved_for_production(self):
+        v = linter.scan_lines("x.md", ["Deployment readiness: APPROVED FOR PRODUCTION."])
+        self.assertEqual(len(v), 1)
+
+    def test_banner_exempts_whole_file(self):
+        lines = ["# T", "> Historical snapshot.", "**Status:** PRODUCTION READY"]
+        self.assertEqual(linter.scan_lines("x.md", lines), [])
+
+    def test_negation_not_flagged(self):
+        self.assertEqual(linter.scan_lines("x.md", ["ICN is not production-ready."]), [])
+
+    def test_conditional_once_not_flagged(self):
+        self.assertEqual(linter.scan_lines("x.md", ["Once hardened, ICN becomes production-ready."]), [])
+
+    def test_hypothetical_deployment_not_flagged(self):
+        line = "In a production deployment, each member would see their position here."
+        self.assertEqual(linter.scan_lines("x.md", [line]), [])
+
+    def test_do_not_claim_not_flagged(self):
+        self.assertEqual(linter.scan_lines("x.md", ["Do not claim the federation is production-ready."]), [])
+
+    def test_future_target_not_flagged(self):
+        self.assertEqual(linter.scan_lines("x.md", ["Target: production-ready by a future milestone."]), [])
+
+    def test_allowlist_suppresses(self):
+        try:
+            linter.ALLOWLIST["x.md:2"] = "test exception"
+            v = linter.scan_lines("x.md", ["# T", "**Status:** PRODUCTION READY"])
+            self.assertEqual(v, [])
+        finally:
+            linter.ALLOWLIST.pop("x.md:2", None)
+
+
+class TestFixturesEndToEnd(unittest.TestCase):
+    def test_bad_fixture_flagged(self):
+        v = linter.scan_file("bad_unbannered.md", os.path.join(FIX, "bad_unbannered.md"))
+        self.assertGreaterEqual(len(v), 1)
+
+    def test_good_bannered_clean(self):
+        self.assertEqual(linter.scan_file("good_bannered.md", os.path.join(FIX, "good_bannered.md")), [])
+
+    def test_good_negated_clean(self):
+        self.assertEqual(linter.scan_file("good_negated.md", os.path.join(FIX, "good_negated.md")), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_readiness_overclaim_linter.py
+++ b/.github/scripts/test_readiness_overclaim_linter.py
@@ -77,6 +77,33 @@ class TestScanLines(unittest.TestCase):
         finally:
             linter.ALLOWLIST.pop("x.md:2", None)
 
+    # --- governance-completion coverage (firewall contract claims this class) ---
+    def test_flags_governance_completion(self):
+        v = linter.scan_lines("x.md", ["Proposal, vote, and member-standing governance is complete."])
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].rule, "governance-completion")
+
+    def test_governance_completion_negated_not_flagged(self):
+        self.assertEqual(linter.scan_lines("x.md", ["Governance is not complete yet."]), [])
+
+    # --- negation must be scoped to the overclaim's own clause ---
+    def test_negation_in_separate_clause_does_not_mask(self):
+        v = linter.scan_lines("x.md", ["ICN is not experimental; it is PRODUCTION READY."])
+        self.assertEqual(len(v), 1)
+
+    def test_leading_conditional_comma_preserved(self):
+        # Comma is not a clause delimiter: a leading conditional still exempts.
+        self.assertEqual(linter.scan_lines("x.md", ["Once hardened, ICN becomes production-ready."]), [])
+
+    # --- bare word "snapshot" must not exempt a whole file ---
+    def test_snapshot_word_alone_does_not_exempt(self):
+        lines = ["# Deploy", "Snapshot frequency is configurable.", "**Status:** PRODUCTION READY"]
+        self.assertEqual(len(linter.scan_lines("x.md", lines)), 1)
+
+    def test_real_historical_banner_still_exempts(self):
+        lines = ["# Deploy", "> Historical deployment snapshot from 2025-12-12.", "**Status:** PRODUCTION READY"]
+        self.assertEqual(linter.scan_lines("x.md", lines), [])
+
 
 class TestFixturesEndToEnd(unittest.TestCase):
     def test_bad_fixture_flagged(self):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ env:
   GATE_RATCHET_PHASE_SDK_TESTS: blocking
   GATE_RATCHET_PHASE_A11Y: blocking
   GATE_RATCHET_PHASE_COMPLIANCE: blocking
+  GATE_RATCHET_PHASE_READINESS: warning
   # Scope controls for staged boundary enforcement
   GATE_RATCHET_KERNEL_DEPS_SCOPE: core-only
 
@@ -283,6 +284,38 @@ jobs:
             exit 1
           fi
 
+          echo "Non-blocking phase ($PHASE): allowing CI to continue"
+          exit 0
+
+  readiness-overclaim:
+    name: Readiness Overclaim Check
+    needs: [changes]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Self-test the readiness linter
+        run: python3 .github/scripts/test_readiness_overclaim_linter.py
+
+      - name: Run readiness overclaim linter
+        run: |
+          set -euo pipefail
+          if python3 .github/scripts/readiness_overclaim_linter.py; then
+            echo "Readiness overclaim check passed"
+            exit 0
+          fi
+
+          PHASE="${GATE_RATCHET_PHASE_READINESS}"
+          echo "Ratchet phase: $PHASE"
+          if [ "$PHASE" != "observational" ]; then
+            echo "::warning title=Readiness overclaim detected::Un-disclaimed production/live-federation readiness claim in active deployment guidance. Phase=$PHASE. See docs/dev/language-guide.md and docs/ci/GATE_RATCHET_PLAN.md"
+          fi
+          echo "WARNING: Readiness overclaim detected. See docs/dev/language-guide.md"
+          if [ "$PHASE" = "blocking" ]; then
+            echo "::error title=Readiness overclaim (blocking)::Failing CI because phase=blocking and a readiness overclaim was detected."
+            echo "BLOCKING: failing CI due to readiness overclaim"
+            exit 1
+          fi
           echo "Non-blocking phase ($PHASE): allowing CI to continue"
           exit 0
 

--- a/docs/ci/GATE_RATCHET_PLAN.md
+++ b/docs/ci/GATE_RATCHET_PLAN.md
@@ -99,6 +99,28 @@ Graduation path: WARNING → BLOCKING → add to branch protection required chec
 
 Owner: @core-arch
 
+#### Readiness Overclaim Check (`GATE_RATCHET_PHASE_READINESS`) — NEW (2026-05-31)
+Phase: WARNING (observational entry; non-blocking).
+
+Scans active deployment guidance (`docs/deployment/**`, `docs/operations/deployment/**`) for
+un-disclaimed, affirmative production / live-federation / governance-completion claims. A dated
+readiness claim is allowed when the file carries a stale/archive banner; negated/conditional lines
+and an explicit `ALLOWLIST` are honoured. Complements the Regulatory Compliance Linter (fintech
+vocabulary); does not replace it.
+
+Scope (by design, to keep precision high): deployment guidance only. It deliberately does NOT yet
+cover the broader SDK / website / user-manual fintech-vocabulary debt — that is tracked separately.
+Widening scope is a later ratchet step, taken as each surface is cleaned.
+
+Remediation on failure: banner the dated doc (point to `docs/ci/CI_CURRENT_STATUS.md`), or fix the
+claim, or add an `ALLOWLIST` entry with a reason. Never weaken the patterns. Self-test:
+`.github/scripts/test_readiness_overclaim_linter.py` (run by the CI job before scanning).
+
+Graduation path: WARNING → (widen scope as surfaces are cleaned) → BLOCKING → add
+`Readiness Overclaim Check` to branch protection required checks.
+
+Owner: @core-arch
+
 #### TypeScript SDK Tests (`GATE_RATCHET_PHASE_SDK_TESTS`) ✅ GRADUATED (2026-03-24)
 Phase advanced to BLOCKING. `continue-on-error` removed.
 
@@ -145,6 +167,7 @@ restart command.
 - Forbidden deps: @core-arch
 - Firewall contracts: @security
 - Compliance linter: @core-arch
+- Readiness overclaims: @core-arch
 - SDK tests: @sdk
 - Accessibility: @frontend
 - Coverage: @ci
@@ -157,6 +180,7 @@ restart command.
 | `GATE_RATCHET_PHASE_KERNEL_DEPS` | `blocking` | Kernel Forbidden Dependencies |
 | `GATE_RATCHET_PHASE_FIREWALL_CONTRACT` | `blocking` | Firewall Contract Enforcement |
 | `GATE_RATCHET_PHASE_COMPLIANCE` | `blocking` GRADUATED | Regulatory Compliance Linter |
+| `GATE_RATCHET_PHASE_READINESS` | `warning` (added 2026-05-31) | Readiness Overclaim Check |
 | `GATE_RATCHET_PHASE_SDK_TESTS` | `blocking` ✅ required check | TypeScript SDK |
 | `GATE_RATCHET_PHASE_A11Y` | `blocking` ✅ required check | Accessibility Tests |
 | `GATE_RATCHET_PHASE_COVERAGE` | `observational` | Test Coverage |

--- a/docs/deployment/DEPLOY_TEST_NETWORK.md
+++ b/docs/deployment/DEPLOY_TEST_NETWORK.md
@@ -1,6 +1,10 @@
 # Deploy ICN Test Network
 
-**Status**: ✅ Production-ready configuration
+> Historical test-network deployment snapshot (last verified 2025-12-04).
+> Treat this as archival context, not current deployment truth.
+> For current readiness, rely on live CI/runtime verification and `docs/ci/CI_CURRENT_STATUS.md`.
+
+**Status (2025-12-04 snapshot):** Test-network configuration validated at that date — not a current production-readiness claim.
 **Last Verified**: 2025-12-04
 
 ---

--- a/docs/deployment/QUICK_START.md
+++ b/docs/deployment/QUICK_START.md
@@ -1,6 +1,10 @@
 # 🚀 ICN Quick Start - Full Stack
 
-**Status:** ✅ PRODUCTION READY  
+> Historical quick-start snapshot from 2025-12-12.
+> Treat this as archival context, not current deployment truth.
+> For current readiness, rely on live CI/runtime verification and `docs/ci/CI_CURRENT_STATUS.md`.
+
+**Status (2025-12-12 snapshot):** Assessed full-stack-ready at that date — not a current production-readiness claim.  
 **Date:** 2025-12-12
 
 ## 🎯 What We Have

--- a/docs/dev/language-guide.md
+++ b/docs/dev/language-guide.md
@@ -164,13 +164,22 @@ These terms are architecturally accurate and should be used freely:
 
 ## Scope of This Guide
 
-**In scope** (enforced):
-- Gateway REST API endpoints (`/v1/...`)
-- WebSocket event type names
-- OAuth scope strings
-- SDK method names and type fields (`sdk/typescript/`, `sdk/react-native/`)
+**Enforced by `compliance_linter.py`** (fintech/payment vocabulary) — scanned on every PR:
+- Gateway REST API surface (`icn-gateway/src/models.rs`, `icn-gateway/src/api/**`)
+- WebSocket event type names and OAuth scope strings on that surface
+- SDK method names and type fields (`sdk/typescript/src/`, `sdk/react-native/src/`)
 - User-visible UI text in `web/pilot-ui/`
-- Public documentation in `docs/`
+
+**Enforced by `readiness_overclaim_linter.py`** (production / live-federation / governance-completion claims):
+- Active deployment guidance: `docs/deployment/**`, `docs/operations/deployment/**`.
+  A dated readiness claim must carry a stale/archive banner (see the bannered
+  `docs/deployment/*.md` siblings).
+
+**Guideline, enforced by review (not yet CI-scanned)**:
+- Public documentation in `docs/` more broadly, and the fintech vocabulary above when it appears
+  in prose. The compliance linter does **not** currently scan `docs/` for the fintech term list,
+  so reviewers must apply this guide there by hand. Closing this scope gap is a tracked ratchet
+  step, not a settled state — do not read "passes CI" as "docs are clean".
 
 **Out of scope** (internal, not enforced here):
 - `icn-ledger` internals (`get_balance()`, `recompute_balances()`) — standard bookkeeping
@@ -182,10 +191,41 @@ These terms are architecturally accurate and should be used freely:
 
 ## Enforcement
 
-1. **CI gate** — the `compliance-linter` job (`.github/scripts/compliance_linter.py`) scans
-   gateway, SDK, and UI files for forbidden terms on every PR. Currently `warning` phase
-   (non-blocking); will ratchet to `blocking` once pre-existing violations are resolved.
-2. **PR checklist** — the CONTRIBUTING.md regulatory invariants checklist includes a language check.
-3. **Code review** — reviewers should flag forbidden terms in any changed API, SDK, or UI file.
+1. **CI gate (fintech vocabulary)** — the `Regulatory Compliance Linter` job
+   (`.github/scripts/compliance_linter.py`) scans the gateway API, SDK, and UI paths above for
+   forbidden fintech terms on every PR. Phase: `blocking` (`GATE_RATCHET_PHASE_COMPLIANCE`).
+2. **CI gate (readiness overclaims)** — the `Readiness Overclaim Check` job
+   (`.github/scripts/readiness_overclaim_linter.py`) scans active deployment guidance for
+   un-disclaimed production / live-federation / governance-completion claims. Phase: `warning`
+   (`GATE_RATCHET_PHASE_READINESS`); graduation tracked in `docs/ci/GATE_RATCHET_PLAN.md`.
+3. **PR checklist** — the CONTRIBUTING.md regulatory invariants checklist includes a language check.
+4. **Code review** — reviewers should flag forbidden terms in any changed API, SDK, UI, or doc file.
+
+### Readiness claims
+
+ICN is research-grade cooperative-coordination infrastructure. Active guidance must not assert, as
+currently true, that ICN is production-ready, that a live federation is operating, or that
+proposal/vote/member-standing governance is complete. Two safe patterns:
+
+- **Dated snapshot** — a readiness assessment that was true at a point in time keeps its claims but
+  carries a stale/archive **banner** at the top (see the bannered `docs/deployment/*.md` siblings;
+  point readers to `docs/ci/CI_CURRENT_STATUS.md`). The readiness linter treats a banner as the
+  whole-file exemption.
+- **Non-claim** — phrase as negated / conditional / aspirational ("not production-ready", "in a
+  production deployment, X would…", "target: …"). The repo already does this extensively in
+  `STATE.md`, `PHASE_PROGRESS.md`, and the `source-of-truth-map` / `show-readiness-map` docs.
+
+### Exception policy (do not make the firewall stupid)
+
+If a check produces a genuine false positive, **do not weaken the patterns**. Instead:
+
+- Readiness linter: add a `relpath:line` entry to `ALLOWLIST` in `readiness_overclaim_linter.py`
+  with a one-line reason.
+- Compliance linter: add a narrowly-scoped `SKIP_PATTERNS` / scope exclusion with a reason.
+
+Allowlist entries are reviewed like code. Broadening a pattern, deleting a rule, or silencing a
+whole path to make CI green is a firewall regression, not a fix. The readiness linter ships a
+self-test (`test_readiness_overclaim_linter.py`) that the CI job runs before scanning; it must
+keep passing.
 
 **See also**: [Regulatory-Safe Verifiable State Architecture](../design/regulatory-safe-verifiable-state.md)

--- a/docs/operations/deployment/MONITORING_VERIFICATION.md
+++ b/docs/operations/deployment/MONITORING_VERIFICATION.md
@@ -1,7 +1,11 @@
 # ICN Monitoring Verification Results
 
+> Historical monitoring-verification snapshot from 2025-12-16.
+> Treat this as archival context, not current deployment truth.
+> Readiness statements below describe the monitoring stack as assessed on that date; for current status rely on live CI/runtime verification and `docs/ci/CI_CURRENT_STATUS.md`.
+
 **Verification Date**: 2025-12-16  
-**Status**: ✅ **VERIFIED - PRODUCTION READY**  
+**Status (2025-12-16 snapshot)**: Monitoring stack validated at that date — not a current production-readiness claim.  
 
 ---
 


### PR DESCRIPTION
## Summary

Reinforces ICN's **regulatory/meaning firewall** (the fintech-vocabulary one — `compliance_linter.py` + `docs/dev/language-guide.md`; *not* the architectural kernel/app firewall) against the **readiness-overclaim vector** on the deployment guidance surface. Narrowly scoped: one new check + its tests + CI wiring, three banners, and a guide/policy correction. No repo-wide vocabulary migration, no protocol/semantic change.

## Enforcement gap found

The regulatory firewall had a blind spot the mission targets:

1. **No readiness check existed.** Nothing in CI caught "PRODUCTION READY", "live federation", or governance-completion claims. As a result, three deployment docs asserted production-readiness with **no archival banner**, while nine sibling deployment docs already carried one:
   - `docs/deployment/QUICK_START.md` — `Status: ✅ PRODUCTION READY`
   - `docs/deployment/DEPLOY_TEST_NETWORK.md` — `Status: ✅ Production-ready configuration`
   - `docs/operations/deployment/MONITORING_VERIFICATION.md` — `VERIFIED - PRODUCTION READY` / `APPROVED FOR PRODUCTION`
2. **`language-guide.md` overstated enforcement.** It listed "Public documentation in `docs/`" as "In scope (enforced)", but `compliance_linter.py` never scans `docs/` — only the gateway API, SDKs, and pilot-ui. The promise was untrue.
3. **The compliance linter had no tests** — its patterns could be silently gutted with CI staying green.

(Most of the ~600 raw readiness-term hits across the repo are the firewall *working* — disciplined non-claims in `STATE.md`/`PHASE_PROGRESS.md`, "Not production-ready" in `OVERVIEW.md`, "in a production deployment … would" in demo scripts. Any new check therefore has to be negation/banner-aware, which this one is.)

## What changed

- **New `.github/scripts/readiness_overclaim_linter.py`** — flags un-disclaimed, affirmative production / live-federation / governance-completion claims in `docs/deployment/**` and `docs/operations/deployment/**`. A stale/archive **banner exempts the whole file**; negated/conditional lines and an explicit `ALLOWLIST` are honoured.
- **New `test_readiness_overclaim_linter.py` + fixtures** (15 tests, stdlib `unittest`, no new tooling) — prove it catches bad active language and allows banners / non-claims / conditionals / allowlisted lines. The CI job runs this self-test **before** scanning, so the patterns cannot be silently weakened.
- **New CI job `Readiness Overclaim Check`** at `GATE_RATCHET_PHASE_READINESS=warning` — non-blocking observational entry, per the established ratchet discipline (does not require a branch-protection change). Registered in `docs/ci/GATE_RATCHET_PLAN.md` with owner, scope, and graduation path.
- **Banners** on the three un-disclaimed deployment docs, matching the established sibling format (point to `docs/ci/CI_CURRENT_STATUS.md`). Dated status lines re-qualified as snapshots.
- **`docs/dev/language-guide.md`** — corrected the false "docs/ is enforced" scope claim, documented the readiness check, and added an explicit exception policy (*"do not make the firewall stupid"*).

## Active vs archive/stale (after this PR)

- **Now clearly archival** (banner added): `QUICK_START.md`, `DEPLOY_TEST_NETWORK.md`, `MONITORING_VERIFICATION.md` — content preserved, labelled as dated snapshots.
- **Active guidance** stays active and is now guarded: any future un-bannered "PRODUCTION READY"-style claim in the deployment surface is flagged in CI.

## Deliberately preserved / out of scope

- All historical deployment snapshots keep their content (banners, not deletions).
- Broader fintech-vocabulary debt in the **SDK/example READMEs** (`client.pay()`, `getBalance()`, "Wallet"), **`docs/api` reference docs**, **`web/pilot-ui`**, the **user manual**, and a few demo/website prose overclaims is **documented as tracked debt, not changed here**. The SDK names are an API rename (semantic change) — out of scope for a docs/firewall pass. Widening the readiness check's scope to these surfaces is a future ratchet step.
- Files owned by open PR #1907 (`docs/strategy/**`, `docs/status/**`, `web/dev-portal/**`, `scripts/printing-press/**`, `out/**`) are untouched — verified zero overlap.

## What the firewall catches now that it did not before

A new un-bannered, affirmative production / live-federation / governance-completion claim in `docs/deployment/**` or `docs/operations/deployment/**` is now surfaced in CI (`Readiness Overclaim Check`, warning phase), with negation/banner/allowlist awareness to avoid flagging the repo's many legitimate non-claims.

## Validation (run on the branch)

| Command | Result |
|---|---|
| `python3 .github/scripts/readiness_overclaim_linter.py` | **exit 0** — 17 scanned, 10 exempt, 0 overclaims |
| `python3 .github/scripts/test_readiness_overclaim_linter.py` | **15/15 OK** |
| `python3 .github/scripts/compliance_linter.py` | **exit 0** — unchanged (106 files) |
| `./scripts/check-meaning-firewall.sh` | **exit 0** — architectural firewall unchanged |
| `python3 docs/scripts/doc_control_check.py` | **passes** — pre-existing warnings only, none on changed files |
| Negative control: inject `PRODUCTION READY` into an unbannered in-scope doc | linter **exit 1**, flags it; restored clean |
| YAML lint `ci.yml` | valid; 18 jobs incl. `readiness-overclaim` |

## Explicit non-claims

- **No production-readiness claim** is introduced.
- **No live-federation-readiness claim** is introduced.
- **No proposal/vote/member-standing completion claim** is introduced.
- **No payment / wallet / balance claim** is introduced.
- **No weakening of any firewall check** — `compliance_linter.py` and the architectural meaning-firewall are unchanged and still pass; the new check is additive and self-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
