### PR TITLE
docs(api): align legacy payment/balance surfaces with ICN semantic primitives

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -46,6 +46,14 @@ jobs:
           python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml
         continue-on-error: false
 
+      # Ties the hand-written API docs to the gateway's actual ICN-native routes
+      # (settle/position), failing if the deprecated payment/balance vocabulary is
+      # presented as current. See docs/adr/ADR-0006 and docs/api/check_api_doc_terms.py.
+      - name: API docs use canonical ICN primitives (no payment/balance as current)
+        run: |
+          python3 docs/api/check_api_doc_terms.py --repo-root .
+        continue-on-error: false
+
   lint:
     name: Lint Architecture Doc
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -9,6 +9,8 @@ on:
       - 'CONTRIBUTING.md'
       - '.github/workflows/docs-freshness.yml'
       - 'docs/scripts/doc_control_check.py'
+      # gateway route source is code-truth for the API-doc canonical guard
+      - 'icn/crates/icn-gateway/src/api/ledger.rs'
   pull_request:
     paths:
       - 'docs/**'
@@ -16,6 +18,8 @@ on:
       - 'README.md'
       - 'CONTRIBUTING.md'
       - 'docs/scripts/doc_control_check.py'
+      # gateway route source is code-truth for the API-doc canonical guard
+      - 'icn/crates/icn-gateway/src/api/ledger.rs'
   schedule:
     # Sunday at midnight UTC
     - cron: '0 0 * * 0'

--- a/docs/api/OPENAPI.md
+++ b/docs/api/OPENAPI.md
@@ -75,7 +75,7 @@ Most endpoints require JWT authentication:
 - `GET /v1/coops/:coop_id/stats` - Get statistics
 
 #### Ledger Operations
-- `GET /v1/ledger/:coop_id/position/:did` - Get net position (the legacy `/balance` route was renamed per ADR-0006; the authoritative endpoint list is `docs/api/openapi.generated.yaml`)
+- `GET /v1/ledger/:coop_id/position/:did` - Get net position (the legacy `/balance` route was renamed per ADR-0006; for the canonical route list see `docs/api/README.md` and `icn/crates/icn-gateway/src/api/ledger.rs`)
 - `POST /v1/coops/:coop_id/ledger/transactions` - Record transaction
 - `GET /v1/coops/:coop_id/ledger/transactions` - List transactions
 - `GET /v1/coops/:coop_id/ledger/transactions/:tx_id` - Get transaction details

--- a/docs/api/OPENAPI.md
+++ b/docs/api/OPENAPI.md
@@ -75,7 +75,7 @@ Most endpoints require JWT authentication:
 - `GET /v1/coops/:coop_id/stats` - Get statistics
 
 #### Ledger Operations
-- `GET /v1/coops/:coop_id/ledger/balance` - Get balance
+- `GET /v1/ledger/:coop_id/position/:did` - Get net position (the legacy `/balance` route was renamed per ADR-0006; the authoritative endpoint list is `docs/api/openapi.generated.yaml`)
 - `POST /v1/coops/:coop_id/ledger/transactions` - Record transaction
 - `GET /v1/coops/:coop_id/ledger/transactions` - List transactions
 - `GET /v1/coops/:coop_id/ledger/transactions/:tx_id` - Get transaction details

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -68,9 +68,22 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 | Method | Endpoint | Scope Required | Description |
 |--------|----------|----------------|-------------|
-| GET | `/v1/ledger/{coop}/balance/{did}` | `ledger:read` | Get balance |
-| POST | `/v1/ledger/{coop}/payment` | `ledger:write` | Create payment |
-| GET | `/v1/ledger/{coop}/history` | `ledger:read` | Transaction history |
+| GET | `/v1/ledger/{coop}/position/{did}` | `ledger:read` | Get net position (derived from signed receipts) |
+| POST | `/v1/ledger/{coop}/settle` | `ledger:write` | Record a settlement (transfer of obligations) |
+| POST | `/v1/ledger/{coop}/settle/convert` | `ledger:write` | Record a cross-unit settlement |
+| GET | `/v1/ledger/{coop}/history` | `ledger:read` | State-change journal history |
+| GET | `/v1/ledger/{coop}/entries/by-decision` | `ledger:read` | Journal entries by governance decision |
+
+#### Legacy vocabulary (deprecated — not served)
+
+Earlier drafts of this doc used payment-rail terms. Per [ADR-0006](../adr/ADR-0006-compliance-chain-verifiable-state-architecture.md) (renamed in PR #1315) these were replaced with ICN-native primitives. The old names are **not served** by the gateway and return `404`:
+
+| Deprecated (removed) | Canonical ICN primitive |
+|----------------------|-------------------------|
+| `POST /v1/ledger/{coop}/payment` | `POST /v1/ledger/{coop}/settle` — settlement of obligations |
+| `GET /v1/ledger/{coop}/balance/{did}` | `GET /v1/ledger/{coop}/position/{did}` — net position |
+| `currency` request field | `unit` request field |
+| `PaymentCreated` event | `SettlementCreated` event |
 
 ### Governance
 
@@ -108,16 +121,17 @@ curl -X POST http://localhost:8080/v1/coops \
   }'
 ```
 
-### Make a Payment
+### Record a Settlement
 
 ```bash
-curl -X POST http://localhost:8080/v1/ledger/food-coop/payment \
+curl -X POST http://localhost:8080/v1/ledger/food-coop/settle \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
+    "from": "did:icn:sender",
     "to": "did:icn:recipient",
     "amount": 2,
-    "currency": "hours",
+    "unit": "hours",
     "memo": "Garden help - 2 hours weeding"
   }'
 ```
@@ -189,7 +203,7 @@ All errors return JSON with `error` and `message` fields:
 | 403 | Forbidden - Insufficient permissions |
 | 404 | Not Found - Resource doesn't exist |
 | 409 | Conflict - Resource already exists |
-| 422 | Unprocessable - Business logic error (e.g., insufficient balance) |
+| 422 | Unprocessable - Business logic error (e.g., settlement exceeds the account's credit limit) |
 | 429 | Too Many Requests - Rate limited |
 
 ## WebSocket Events
@@ -198,7 +212,7 @@ After authentication, you'll receive events as they occur:
 
 | Event Type | Description |
 |------------|-------------|
-| `PaymentCreated` | New payment in the ledger |
+| `SettlementCreated` | New settlement recorded in the journal |
 | `MemberAdded` | Member joined cooperative |
 | `MemberRemoved` | Member left cooperative |
 | `RoleUpdated` | Member's role changed |
@@ -226,7 +240,7 @@ The script demonstrates:
 - Health checks
 - Cooperative management
 - Member management
-- Ledger operations (balance, payments)
+- Ledger operations (position, settlement)
 - Governance (domains, proposals, voting)
 
 ## Viewing the OpenAPI Spec

--- a/docs/api/check_api_doc_terms.py
+++ b/docs/api/check_api_doc_terms.py
@@ -10,11 +10,14 @@ Per ADR-0006 (PR #1315) the gateway renamed its ledger surface:
     balance  -> position     (GET  /v1/ledger/{coop}/position/{did})
     currency -> unit         (settlement request field)
 The old routes are NOT served (they 404). The canonical names are verified
-below by reading the route attributes in icn-gateway/src/api/ledger.rs.
+below by reading the route attributes in icn/crates/icn-gateway/src/api/ledger.rs.
 
 This guard checks only the hand-written API docs (the machine spec
-docs/api/openapi.generated.yaml is kept in sync with code by the api-types CI
-job, and the SDK client is already canonical). It is intentionally narrow.
+docs/api/openapi.generated.yaml is regenerated from code by the api-types CI
+job). It is intentionally narrow. NOTE: the SDK *client* methods (settle /
+getPosition) are already canonical, but the SDK README/examples still carry
+legacy pay()/getBalance() naming — that is tracked as separate SDK debt and is
+out of scope here.
 
 Checked docs:
     docs/api/README.md, docs/api/OPENAPI.md, docs/api/examples.sh
@@ -54,6 +57,11 @@ DEPRECATED_PATTERNS = [
     (re.compile(r"ledger/[^\s`'\"]*balance"), "legacy balance route -> GET /v1/ledger/{coop}/position/{did}"),
     (re.compile(r"\bPaymentCreated\b"), "legacy event PaymentCreated -> SettlementCreated"),
     (re.compile(r"(?i)\bmake a payment\b"), '"Make a Payment" -> "Record a Settlement"'),
+    # The settlement request field renamed currency -> unit (ADR-0006). Catch the
+    # JSON field shape so a runnable example cannot regress to a body that
+    # create_settlement rejects. The legacy-mapping table is exempt (it is under a
+    # "Legacy/Deprecated" heading), so the old name can still be documented there.
+    (re.compile(r'(?i)"currency"\s*:'), 'legacy "currency" request field -> "unit"'),
 ]
 
 # A line is exempt if it is clearly labelled as legacy/deprecated context.

--- a/docs/api/check_api_doc_terms.py
+++ b/docs/api/check_api_doc_terms.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+API Doc Canonical-Vocabulary Guard - CI Script
+
+Ties the hand-written API prose docs to the ACTUAL gateway route code, so they
+cannot drift back to the pre-#1315 payment-rail vocabulary.
+
+Per ADR-0006 (PR #1315) the gateway renamed its ledger surface:
+    payment  -> settlement   (POST /v1/ledger/{coop}/settle, event SettlementCreated)
+    balance  -> position     (GET  /v1/ledger/{coop}/position/{did})
+    currency -> unit         (settlement request field)
+The old routes are NOT served (they 404). The canonical names are verified
+below by reading the route attributes in icn-gateway/src/api/ledger.rs.
+
+This guard checks only the hand-written API docs (the machine spec
+docs/api/openapi.generated.yaml is kept in sync with code by the api-types CI
+job, and the SDK client is already canonical). It is intentionally narrow.
+
+Checked docs:
+    docs/api/README.md, docs/api/OPENAPI.md, docs/api/examples.sh
+
+A deprecated term is allowed only inside a heading section whose title contains
+"legacy" or "deprecated", or on a line explicitly marking it as such
+(deprecated / legacy / renamed / not served / removed / a -> mapping arrow).
+This lets the docs keep an honest old->new migration table without regressing.
+
+Usage:
+    python3 docs/api/check_api_doc_terms.py [--repo-root PATH]
+
+Exit codes:
+    0: docs use canonical primitives; no deprecated vocabulary presented as current
+    1: deprecated vocabulary presented as current (violation)
+    2: could not verify code truth (gateway ledger routes not found)
+"""
+
+import argparse
+import os
+import re
+import sys
+
+LEDGER_ROUTES_FILE = "icn/crates/icn-gateway/src/api/ledger.rs"
+
+CHECKED_DOCS = [
+    "docs/api/README.md",
+    "docs/api/OPENAPI.md",
+    "docs/api/examples.sh",
+]
+
+# Deprecated forms that must NOT appear as current API. Path-shaped patterns only
+# (no bare words like "balance"/"payment" which legitimately appear in prose such
+# as "credit limit" or internal double-entry balances).
+DEPRECATED_PATTERNS = [
+    (re.compile(r"ledger/[^\s`'\"]*payment"), "legacy payment route -> POST /v1/ledger/{coop}/settle"),
+    (re.compile(r"ledger/[^\s`'\"]*balance"), "legacy balance route -> GET /v1/ledger/{coop}/position/{did}"),
+    (re.compile(r"\bPaymentCreated\b"), "legacy event PaymentCreated -> SettlementCreated"),
+    (re.compile(r"(?i)\bmake a payment\b"), '"Make a Payment" -> "Record a Settlement"'),
+]
+
+# A line is exempt if it is clearly labelled as legacy/deprecated context.
+LINE_EXEMPT_RE = re.compile(r"(?i)(deprecated|legacy|renamed|not served|removed|->|→|↦)")
+# A heading whose text marks a legacy/deprecated section exempts following lines.
+HEADING_RE = re.compile(r"^#{1,6}\s+(.*)$")
+LEGACY_HEADING_RE = re.compile(r"(?i)(legacy|deprecated)")
+
+
+def canonical_routes_from_code(repo_root):
+    """Read route attributes from the gateway ledger source (code truth)."""
+    path = os.path.join(repo_root, LEDGER_ROUTES_FILE)
+    if not os.path.isfile(path):
+        return None
+    segments = set()
+    attr_re = re.compile(r'#\[(?:get|post|put|delete)\("([^"]+)"\)\]')
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            m = attr_re.search(line)
+            if m:
+                for seg in m.group(1).strip("/").split("/"):
+                    if seg and not seg.startswith("{"):
+                        segments.add(seg)
+    return segments
+
+
+def scan_doc(repo_root, rel_path):
+    """Return list of (line_no, text, rule) violations for one doc."""
+    abs_path = os.path.join(repo_root, rel_path)
+    if not os.path.isfile(abs_path):
+        return []
+    violations = []
+    in_legacy_section = False
+    with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+        for line_num, line in enumerate(f, start=1):
+            heading = HEADING_RE.match(line.strip())
+            if heading:
+                in_legacy_section = bool(LEGACY_HEADING_RE.search(heading.group(1)))
+                continue
+            if in_legacy_section or LINE_EXEMPT_RE.search(line):
+                continue
+            for pattern, rule in DEPRECATED_PATTERNS:
+                if pattern.search(line):
+                    violations.append((line_num, line.rstrip()[:140], rule))
+                    break
+    return violations
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ICN API doc canonical-vocabulary guard")
+    parser.add_argument("--repo-root", default=os.getcwd(), help="Repository root (default: cwd)")
+    args = parser.parse_args()
+    repo_root = os.path.abspath(args.repo_root)
+
+    print("=" * 70)
+    print("API Doc Canonical-Vocabulary Guard")
+    print("Hand-written API docs must match the gateway's ICN-native routes")
+    print("=" * 70)
+    print()
+
+    routes = canonical_routes_from_code(repo_root)
+    if not routes:
+        print("ERROR: could not read gateway ledger routes from " + LEDGER_ROUTES_FILE, file=sys.stderr)
+        print("Cannot verify doc/code agreement; refusing to pass.", file=sys.stderr)
+        return 2
+    for required in ("settle", "position"):
+        if required not in routes:
+            print("ERROR: canonical route segment '" + required + "' not found in code.", file=sys.stderr)
+            print("Routes seen: " + ", ".join(sorted(routes)), file=sys.stderr)
+            print("Either the gateway changed or the guard is stale; refusing to pass.", file=sys.stderr)
+            return 2
+    print("Code truth (icn-gateway ledger routes): settle, position present. OK")
+    print()
+
+    all_violations = {}
+    for rel in CHECKED_DOCS:
+        v = scan_doc(repo_root, rel)
+        if v:
+            all_violations[rel] = v
+
+    # Positive assertion: README must present the canonical surface.
+    readme = os.path.join(repo_root, "docs/api/README.md")
+    missing = []
+    if os.path.isfile(readme):
+        text = open(readme, "r", encoding="utf-8", errors="replace").read()
+        for needle in ("/ledger/{coop}/settle", "/ledger/{coop}/position/{did}", "SettlementCreated"):
+            if needle not in text:
+                missing.append(needle)
+
+    if not all_violations and not missing:
+        print("OK: API docs use canonical ICN primitives (settle / position /")
+        print("SettlementCreated); no deprecated payment/balance vocabulary is")
+        print("presented as current.")
+        return 0
+
+    if missing:
+        print("MISSING canonical references in docs/api/README.md:")
+        for m in missing:
+            print("  - expected to find: " + m)
+        print()
+
+    if all_violations:
+        total = sum(len(v) for v in all_violations.values())
+        print(str(total) + " DEPRECATED-AS-CURRENT VOCABULARY VIOLATION(S):")
+        print()
+        for rel in sorted(all_violations):
+            print("  " + rel + ":")
+            for line_num, text, rule in all_violations[rel]:
+                print("    L" + str(line_num) + ": [" + rule + "]")
+                print("           " + text)
+            print()
+
+    print("Fix: use the canonical route/event names (see ADR-0006). If you must")
+    print("reference the old names, put them under a heading containing 'Legacy' or")
+    print("'Deprecated', or mark the line as deprecated/renamed. Do NOT present the")
+    print("old /payment, /balance, or PaymentCreated names as the current API.")
+    print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/api/examples.sh
+++ b/docs/api/examples.sh
@@ -63,21 +63,22 @@ curl -s -X POST $BASE_URL/v1/coops/example-coop/members \
     }' | jq
 echo ""
 
-# Get Balance
-echo -e "${GREEN}6. Get Balance${NC}"
-curl -s $BASE_URL/v1/ledger/example-coop/balance/did:icn:alice \
+# Get Position (net position, derived from signed receipts)
+echo -e "${GREEN}6. Get Position${NC}"
+curl -s $BASE_URL/v1/ledger/example-coop/position/did:icn:alice \
     -H "Authorization: Bearer $TOKEN" | jq
 echo ""
 
-# Create Payment
-echo -e "${GREEN}7. Create Payment${NC}"
-curl -s -X POST $BASE_URL/v1/ledger/example-coop/payment \
+# Record a Settlement
+echo -e "${GREEN}7. Record a Settlement${NC}"
+curl -s -X POST $BASE_URL/v1/ledger/example-coop/settle \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{
+        "from": "did:icn:alice",
         "to": "did:icn:bob",
         "amount": 5,
-        "currency": "hours",
+        "unit": "hours",
         "memo": "Garden help"
     }' | jq
 echo ""

--- a/docs/api/examples.sh
+++ b/docs/api/examples.sh
@@ -70,6 +70,10 @@ curl -s $BASE_URL/v1/ledger/example-coop/position/did:icn:alice \
 echo ""
 
 # Record a Settlement
+# NOTE: the gateway requires "from" to equal the authenticated DID (the token
+# subject). example-coop and the did:icn:* values below are placeholders for the
+# request shape; substitute your own coop and DIDs (and a token whose subject
+# matches "from") for a runnable call.
 echo -e "${GREEN}7. Record a Settlement${NC}"
 curl -s -X POST $BASE_URL/v1/ledger/example-coop/settle \
     -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
## 1. The real architecture issue

ICN's gateway renamed its ledger surface to ICN-native primitives in **PR #1315** per **[ADR-0006](https://github.com/InterCooperative-Network/icn/blob/main/docs/adr/ADR-0006-compliance-chain-verifiable-state-architecture.md)** (`payment → settlement`, `balance → position`, `currency → unit`). The **code** completed that migration, but the **hand-written API prose docs did not** — they still presented the removed `/payment` and `/balance` routes, the `currency` field, and the `PaymentCreated` event as the *current* API. This is a real contract-vs-docs mismatch: a developer following `docs/api/README.md` or running `docs/api/examples.sh` would POST to `/payment` and get a **404**.

This is the second ("regulatory/semantic") meaning firewall, at the API/docs layer — not the architectural kernel/app firewall.

## 2. Are `/payment` and `/balance` active routes?

**No — they are removed/stale docs (Class B), not active routes and not compatibility aliases.** Verified against code:

| Doc claimed (stale) | Actual gateway route (code truth) | Source |
|---|---|---|
| `POST /v1/ledger/{coop}/payment` | `POST /v1/ledger/{coop}/settle` → `create_settlement` | `icn-gateway/src/api/ledger.rs` `#[post("/{coop_id}/settle")]` |
| `GET /v1/ledger/{coop}/balance/{did}` | `GET /v1/ledger/{coop}/position/{did}` → `AccountStateResponse{positions,credit_limits}` | `ledger.rs` `#[get("/{coop_id}/position/{did}")]` |
| `PaymentCreated` event | `SettlementCreated` event | `icn-gateway/src/events.rs` |
| `currency` request field | `unit` field | `ledger.rs` `validate_unit(&req.unit)` |

The gateway does **not** serve the old names (no compatibility alias exists) — so the correct fix is **doc truth-sync + a guard**, not adding deprecated aliases.

## 3. Canonical ICN-native concept per old term

- payment → **settlement** (`/settle`, `SettlementCreated`, "transfer of obligations")
- balance → **position** (net position derived from the signed-receipt graph)
- currency → **unit**
- (real, already-canonical neighbours: `/settle/convert` cross-unit settlement, `/escrow`, `recurring_settlements`)

## 4. What changed

- **`docs/api/README.md`** — ledger route table now lists the real routes (`position`, `settle`, `settle/convert`, `history`, `entries/by-decision`); "Make a Payment" → "Record a Settlement" with the **real** `RecordTransferRequest` body (`from/to/amount/unit/memo`); `PaymentCreated` → `SettlementCreated`; "insufficient balance" → "settlement exceeds the account's credit limit"; added a **"Legacy vocabulary (deprecated — not served)"** mapping table citing ADR-0006/#1315.
- **`docs/api/OPENAPI.md`**, **`docs/api/examples.sh`** — same `balance→position`, `payment→settle`, `currency→unit` truth-sync (the script was runnable and would 404).
- **NEW `docs/api/check_api_doc_terms.py`** — architecture-bearing guard: reads canonical routes from `ledger.rs` (code truth), then fails if any checked doc presents `/payment`, `/balance`, or `PaymentCreated` as current *outside* an explicitly-labelled legacy/deprecated section. Positively asserts the docs reference `/settle`, `/position`, `SettlementCreated`.
- **`.github/workflows/docs-freshness.yml`** — runs the guard in the existing `doc_control` job (no new workflow; does not touch the `ci.yml` owned by open PR #1957).

## 5. Deliberately NOT changed

- **Internal handler vocabulary** in `ledger.rs` (comments, `validate_payment_amount`, `balance_queries_inc`) — legitimate internal bookkeeping (Class D), never user-facing; renaming it would be a broad code churn out of scope.
- **`docs/api/openapi.generated.yaml` + generated SDK `api-types.ts`** — machine artifacts kept in sync with code by the `api-types` CI job; regenerating requires `icnctl` (separate slice). Noted as follow-up.
- **SDK README** (`pay()`, `getBalance()`, "Payment Escrow") + SDK `index.ts` docstring, and **demo** `FEDERATION_RUNBOOK.md` "records are on-chain" — separate slices (Options B/C), documented for follow-up. One slice only, per scope.

## 6. Validation (run on the branch)

| Check | Result |
|---|---|
| `python3 docs/api/check_api_doc_terms.py` | **exit 0** — code truth (settle/position) verified; no deprecated-as-current vocab |
| Negative control: inject a current `/payment` row into README | guard **exit 1** (caught); restored clean |
| `python3 .github/scripts/compliance_linter.py` | **exit 0** — unchanged |
| `./scripts/check-meaning-firewall.sh` | **PASS** — architectural firewall unchanged |
| `python3 docs/scripts/doc_control_check.py` | passes; **none of the changed files flagged** |
| `git diff --check` | clean |
| YAML lint `docs-freshness.yml` | valid |

## 7. Explicit non-claims

- **No production-readiness claim.**
- **No live-federation-readiness claim.**
- **No banking/payment/wallet/balance product claim** — the change *removes* payment/balance framing from active docs.
- **No completed proposal/vote/member-standing governance claim.**
- **No weakening of any firewall check** — compliance linter and architectural meaning-firewall are unchanged and still pass; this PR *adds* a code-tied doc guard.

Base: `origin/main` (PR #1957 and #1907 are open; this PR touches none of their files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
