### PR TITLE
docs(sdk): align TypeScript SDK developer surface with canonical ICN ledger primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,6 +594,17 @@ jobs:
         if: needs.changes.outputs.docs_only == 'true' && needs.changes.outputs.has_rust != 'true'
         run: echo "Confirmed docs-only (no SDK files); skipping TypeScript SDK tests."
 
+      # Ties the hand-written SDK docs/examples to the client's actually-exported
+      # methods and the canonical settle/position/unit ledger vocabulary, failing
+      # if deprecated pay/balance/escrow/recurring fintech terms (or methods that
+      # were never shipped) are presented as current API. Runs on every SDK change
+      # incl. docs-only — examples/ are not covered by tsc (rootDir: src). Needs
+      # only python3 (preinstalled). See sdk/typescript/check_sdk_doc_terms.py and
+      # docs/adr/ADR-0006.
+      - name: SDK docs use canonical ICN ledger primitives (no pay/balance/escrow as current)
+        run: python3 check_sdk_doc_terms.py --sdk-root .
+        continue-on-error: false
+
       - name: Free disk space
         if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
         uses: ./.github/actions/free-disk-space

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -29,8 +29,8 @@ const auth = await client.verify('did:icn:alice', signature, 'my-coop', ['ledger
 client.setToken(auth.token);
 
 // Use authenticated APIs
-const balance = await client.getBalance('my-coop', 'did:icn:alice');
-console.log('Balance:', balance.balance);
+const position = await client.getPosition('my-coop', 'did:icn:alice');
+console.log('Position:', position.position, position.unit);
 ```
 
 ## Authentication
@@ -124,10 +124,10 @@ Retries are automatic for transient errors (5xx, 429 rate limiting).
 Efficiently process multiple operations at once:
 
 ```typescript
-// Batch payments
-const results = await client.batchPay('food-coop', [
-  { from: 'admin', to: 'alice', amount: 10, currency: 'hours', memo: 'January work' },
-  { from: 'admin', to: 'bob', amount: 5, currency: 'hours', memo: 'Website help' },
+// Batch settlements
+const results = await client.batchSettle('food-coop', [
+  { from: 'admin', to: 'alice', amount: 10, unit: 'hours', memo: 'January work' },
+  { from: 'admin', to: 'bob', amount: 5, unit: 'hours', memo: 'Website help' },
 ]);
 console.log(`${results.succeeded} succeeded, ${results.failed} failed`);
 
@@ -190,7 +190,7 @@ Available query methods:
 const coop = await client.createCoop({
   id: 'food-coop',
   name: 'Food Cooperative',
-  settings: { currency: 'hours' }
+  settings: { unit: 'hours' }
 });
 
 // Get cooperative
@@ -214,16 +214,16 @@ await client.removeMember('food-coop', 'did:icn:bob');
 ### Ledger
 
 ```typescript
-// Get balance
-const balance = await client.getBalance('food-coop', 'did:icn:alice');
-console.log(`${balance.balance} ${balance.currency}`);
+// Get position
+const position = await client.getPosition('food-coop', 'did:icn:alice');
+console.log(`${position.position} ${position.unit}`);
 
-// Make payment
-const payment = await client.pay('food-coop', {
+// Record a settlement
+const settlement = await client.settle('food-coop', {
   from: 'did:icn:alice',
   to: 'did:icn:bob',
   amount: 2.5,
-  currency: 'hours',
+  unit: 'hours',
   memo: 'Garden help'
 });
 
@@ -429,7 +429,7 @@ All API methods throw `ICNError` on failure:
 import { ICNError } from '@icn/client';
 
 try {
-  await client.pay('food-coop', { ... });
+  await client.settle('food-coop', { ... });
 } catch (error) {
   if (error instanceof ICNError) {
     console.error(`Error ${error.statusCode}: ${error.message}`);
@@ -535,15 +535,15 @@ Subscribe to real-time notifications via WebSocket:
 // Connect to notification stream
 const ws = client.connectNotifications((notification) => {
   console.log('Received:', notification);
-  if (notification.type === 'payment_received') {
-    alert(`Payment received: ${notification.data.amount}`);
+  if (notification.type === 'settlement_recorded') {
+    alert(`Settlement recorded: ${notification.data.amount}`);
   }
 });
 
 // List in-app notifications
 const notifications = await client.listNotifications({
   read: false, // unread only
-  type: 'payment_received',
+  type: 'settlement_recorded',
   limit: 20
 });
 
@@ -554,108 +554,24 @@ await client.markNotificationRead(notificationId);
 const { total, unread } = await client.getNotificationCount();
 ```
 
-### Recurring Payments
+### Recurring payments, escrow & budgets
 
-Automate recurring payments with flexible scheduling:
-
-```typescript
-// Create recurring payment
-const payment = await client.createRecurringPayment({
-  from_account: 'alice-checking',
-  to_account: 'bob-savings',
-  amount: 100,
-  currency: 'USD',
-  frequency: 'monthly', // daily, weekly, monthly, yearly
-  start_date: Date.now() / 1000,
-  end_date: (Date.now() / 1000) + (365 * 24 * 60 * 60), // 1 year
-});
-
-// List recurring payments
-const payments = await client.listRecurringPayments({
-  status: 'active' // active, paused, cancelled, completed
-});
-
-// Update payment
-await client.updateRecurringPayment(paymentId, {
-  amount: 150, // increase amount
-  status: 'paused' // pause temporarily
-});
-
-// Cancel payment
-await client.cancelRecurringPayment(paymentId);
-```
-
-### Payment Escrow
-
-Hold funds with conditional release:
-
-```typescript
-// Create escrow
-const escrow = await client.createEscrow({
-  from_account: 'alice',
-  to_account: 'bob',
-  amount: 500,
-  currency: 'USD',
-  description: 'Payment for freelance work',
-  conditions: [
-    {
-      requires_approval: { did: 'did:icn:charlie' } // arbitrator
-    },
-    {
-      time_release: { timestamp: futureTimestamp } // auto-release
-    }
-  ],
-  expires_at: expirationTimestamp
-});
-
-// List escrows
-const escrows = await client.listEscrows({
-  status: 'pending' // pending, locked, released, refunded, expired
-});
-
-// Release funds (with approval)
-await client.releaseEscrow(escrowId, {
-  proof: 'delivery-confirmation-hash'
-});
-
-// Refund to sender
-await client.refundEscrow(escrowId);
-```
-
-### Budget Limits
-
-Set spending limits with automatic enforcement:
-
-```typescript
-// Create budget
-const budget = await client.createBudget({
-  account: 'alice-spending',
-  currency: 'USD',
-  limit: 1000,
-  period: 'monthly', // daily, weekly, monthly, yearly
-  description: 'Monthly discretionary spending',
-  notification_thresholds: [80, 90, 100] // notify at 80%, 90%, 100%
-});
-
-// List budgets
-const budgets = await client.listBudgets({
-  status: 'active' // active, paused, exceeded, expired
-});
-
-// Get budget details with usage
-const details = await client.getBudget(budgetId);
-console.log(`Used: ${details.percentage_used}%`);
-console.log(`Remaining: $${details.remaining}`);
-
-// Update budget
-await client.updateBudget(budgetId, {
-  limit: 1500, // increase limit
-  status: 'active'
-});
-
-// Delete budget
-await client.deleteBudget(budgetId);
-```
+> **Not implemented in this SDK.** Earlier drafts of this README documented
+> `createRecurringPayment`, `createEscrow`, `createBudget`, and related helpers
+> using fiat-style fields (`from_account`, `currency: 'USD'`, dollar amounts).
+> Those methods were never shipped on `ICNClient`, and ICN does not provide
+> payment, escrow, or banking facilities.
+>
+> The ledger surface that *does* exist records mutual-credit settlements between
+> members and reports their net positions. Amounts are denominated in a
+> cooperative-defined `unit` (e.g. `hours`), never a currency:
+>
+> - `client.settle(coopId, { from, to, amount, unit, memo })` — record a settlement
+> - `client.getPosition(coopId, did)` — read a member's net position
+> - `client.getHistory(coopId, { offset, limit })` — list recorded settlements
+> - `client.crossPay(coopId, …)` — cross-unit settlement via the exchange-rate oracle
+>
+> See the **Ledger** section above for runnable examples.
 
 ### Governance UI Support
 
@@ -699,13 +615,12 @@ All API responses are fully typed. Import types as needed:
 
 ```typescript
 import type {
-  RecurringPayment,
-  PaymentFrequency,
-  Escrow,
-  EscrowCondition,
-  Budget,
-  BudgetPeriod,
-  Notification,
+  Position,
+  SettlementRequest,
+  SettlementResponse,
+  Transaction,
+  TransactionHistory,
+  TreasuryStatus,
 } from '@icn/client';
 ```
 
@@ -713,7 +628,7 @@ import type {
 
 ```typescript
 try {
-  await client.createRecurringPayment(paymentData);
+  await client.settle('food-coop', settlementRequest);
 } catch (error) {
   if (error.status === 401) {
     console.error('Not authenticated');

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -529,30 +529,16 @@ MIT OR Apache-2.0
 
 ### Notifications
 
-Subscribe to real-time notifications via WebSocket:
-
-```typescript
-// Connect to notification stream
-const ws = client.connectNotifications((notification) => {
-  console.log('Received:', notification);
-  if (notification.type === 'settlement_recorded') {
-    alert(`Settlement recorded: ${notification.data.amount}`);
-  }
-});
-
-// List in-app notifications
-const notifications = await client.listNotifications({
-  read: false, // unread only
-  type: 'settlement_recorded',
-  limit: 20
-});
-
-// Mark as read
-await client.markNotificationRead(notificationId);
-
-// Get unread count
-const { total, unread } = await client.getNotificationCount();
-```
+> **Not implemented in this SDK.** Earlier drafts documented
+> `connectNotifications`, `listNotifications`, `markNotificationRead`, and
+> `getNotificationCount`; none of those methods exist on `ICNClient`, and there
+> is no in-app notification store.
+>
+> For real-time updates, subscribe to the gateway WebSocket event stream with the
+> methods that *do* exist — `client.connectWebSocket(coopId, handlers)` or the
+> managed `client.subscribe(coopId, handlers, opts)` — and react to
+> `SettlementCreated`, governance, and compute events. See **WebSocket Events**
+> above.
 
 ### Recurring payments, escrow & budgets
 

--- a/sdk/typescript/check_sdk_doc_terms.py
+++ b/sdk/typescript/check_sdk_doc_terms.py
@@ -68,19 +68,25 @@ DEPRECATED_PATTERNS = [
      "fiat-budget helpers were never shipped"),
     ("PaymentCreated-event", re.compile(r"""['"]PaymentCreated['"]"""),
      "ledger event type is 'SettlementCreated', not 'PaymentCreated'"),
-    # Field / property vocabulary. The canonical ledger field is `unit` and the
-    # canonical position/treasury property is `position` — never `currency` /
-    # `balance`. These catch copy-paste-invalid examples that the method patterns
-    # miss (examples/ are not type-checked: tsconfig rootDir is src). The live
-    # crossPay() FX surface legitimately uses `from_currency` / `to_currency`, so
-    # those are excluded (the `currency:` lookbehind rejects a leading `_`, and
-    # `\.currency` only matches a bare `.currency` property, not `.from_currency`).
-    ("currency-field", re.compile(r"(?<![A-Za-z_])currency\s*:"),
-     "ledger request/settings field is `unit`, not `currency`"),
+    # Deprecated *balance* surface. The canonical position query is the
+    # `/ledger/{coop}/position/{did}` route and the `.position` property. There is
+    # no live `/balance` route and no live `.balance` field anywhere in the SDK
+    # types (TreasuryBalanceResponse exposes `positions`), so these two patterns
+    # are unambiguous and catch copy-paste-invalid examples the method patterns
+    # miss (examples/ are not type-checked: tsconfig rootDir is src).
+    ("balance-route", re.compile(r"/ledger/[^\s'\"`]*?/balance\b"),
+     "ledger route is `/ledger/{coop}/position/{did}`, not `/balance`"),
     ("balance-property", re.compile(r"\.balance\b"),
      "position/treasury responses expose `.position`, not `.balance`"),
-    ("currency-property", re.compile(r"\.currency\b"),
-     "ledger responses expose `.unit`, not `.currency`"),
+    # NOTE: a bare `currency` field/property is deliberately NOT matched. Unlike
+    # the deprecated *balance* surface, `currency` is live vocabulary on two
+    # exported flows: crossPay() FX (`from_currency` / `to_currency`) and the
+    # Flow C `governance.proposeSpend()` treasury API, whose ProposeSpendRequest
+    # accepts `currency?` and ProposeSpendResponse returns `currency` (src/types.ts).
+    # The bare token cannot distinguish deprecated-ledger use from those live uses,
+    # so matching it would reject valid documentation (a worse failure than the
+    # narrow gap of not flagging it). The settlement `unit` field is enforced by
+    # the SDK's own TypeScript types; the method/route/property rules cover the rest.
 ]
 
 # Hand-written developer-facing surface. Generated artifacts (src/api-types.ts,

--- a/sdk/typescript/check_sdk_doc_terms.py
+++ b/sdk/typescript/check_sdk_doc_terms.py
@@ -68,6 +68,19 @@ DEPRECATED_PATTERNS = [
      "fiat-budget helpers were never shipped"),
     ("PaymentCreated-event", re.compile(r"""['"]PaymentCreated['"]"""),
      "ledger event type is 'SettlementCreated', not 'PaymentCreated'"),
+    # Field / property vocabulary. The canonical ledger field is `unit` and the
+    # canonical position/treasury property is `position` — never `currency` /
+    # `balance`. These catch copy-paste-invalid examples that the method patterns
+    # miss (examples/ are not type-checked: tsconfig rootDir is src). The live
+    # crossPay() FX surface legitimately uses `from_currency` / `to_currency`, so
+    # those are excluded (the `currency:` lookbehind rejects a leading `_`, and
+    # `\.currency` only matches a bare `.currency` property, not `.from_currency`).
+    ("currency-field", re.compile(r"(?<![A-Za-z_])currency\s*:"),
+     "ledger request/settings field is `unit`, not `currency`"),
+    ("balance-property", re.compile(r"\.balance\b"),
+     "position/treasury responses expose `.position`, not `.balance`"),
+    ("currency-property", re.compile(r"\.currency\b"),
+     "ledger responses expose `.unit`, not `.currency`"),
 ]
 
 # Hand-written developer-facing surface. Generated artifacts (src/api-types.ts,

--- a/sdk/typescript/check_sdk_doc_terms.py
+++ b/sdk/typescript/check_sdk_doc_terms.py
@@ -44,6 +44,8 @@ FORBIDDEN_METHODS = (
     "createRecurringPayment", "listRecurringPayments",
     "updateRecurringPayment", "cancelRecurringPayment",
     "createBudget", "listBudgets", "updateBudget", "deleteBudget",
+    "connectNotifications", "listNotifications",
+    "markNotificationRead", "getNotificationCount",
 )
 
 # Deprecated tokens that must not appear as *current* SDK API. (rule, regex, hint)

--- a/sdk/typescript/check_sdk_doc_terms.py
+++ b/sdk/typescript/check_sdk_doc_terms.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Guard: the hand-written TypeScript SDK developer surface (README, examples, and
+the in-source docstrings in src/index.ts) must describe the client's *actual*
+exported methods and the canonical ICN ledger vocabulary — settlements and
+positions denominated in a `unit`, not payments/balances in a `currency`.
+
+ICN is mutual-credit infrastructure, not a payment/banking product (see
+docs/adr/ADR-0006 and docs/dev/language-guide.md). Earlier SDK docs had drifted
+to fintech vocabulary (`client.pay()`, `client.getBalance()`, `createEscrow`,
+recurring payments, fiat budgets) and even documented helper methods that were
+never shipped on `ICNClient`. This guard ties the docs back to code truth so the
+drift cannot silently return.
+
+Code-truth anchor: the guard reads the exported `async` methods from
+src/index.ts and asserts that the canonical ledger methods exist
+(settle, getPosition, getHistory, batchSettle) and the deprecated ones do NOT
+(pay, getBalance, batchPay, createEscrow, createRecurringPayment, createBudget,
+...). If those assumptions ever change, it exits 2 (misconfigured) rather than
+giving false confidence — the same fail-loud contract used by
+docs/api/check_api_doc_terms.py.
+
+Exemption: Markdown blockquote lines (`>`-prefixed) are skipped, so a section may
+explicitly name a deprecated / never-shipped helper in order to warn against it
+(the "not implemented" note in README.md). The blockquote is the disclaimer,
+mirroring the banner-as-exemption pattern used elsewhere in the repo.
+
+Exit codes: 0 = clean; 1 = violations found; 2 = guard misconfigured.
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Canonical client methods that MUST exist (code-truth sanity check).
+CANONICAL_METHODS = ("settle", "getPosition", "getHistory", "batchSettle")
+
+# Deprecated / never-shipped methods that must NOT exist on the client. If any of
+# these reappears as a real method, the migration assumptions changed and the
+# guard should be revisited rather than trusted.
+FORBIDDEN_METHODS = (
+    "pay", "getBalance", "batchPay",
+    "createEscrow", "listEscrows", "releaseEscrow", "refundEscrow",
+    "createRecurringPayment", "listRecurringPayments",
+    "updateRecurringPayment", "cancelRecurringPayment",
+    "createBudget", "listBudgets", "updateBudget", "deleteBudget",
+)
+
+# Deprecated tokens that must not appear as *current* SDK API. (rule, regex, hint)
+# Note: `client.crossPay(` and the cross-currency FX surface are intentionally
+# NOT matched — that is a live method with its own field names (from_currency/
+# to_currency) and is out of scope for this guard.
+DEPRECATED_PATTERNS = [
+    ("client.pay", re.compile(r"\bclient\.pay\("),
+     "client.pay() does not exist -> client.settle()"),
+    ("client.getBalance", re.compile(r"\bclient\.getBalance\("),
+     "client.getBalance() does not exist -> client.getPosition()"),
+    ("client.batchPay", re.compile(r"\bclient\.batchPay\("),
+     "client.batchPay() does not exist -> client.batchSettle()"),
+    ("escrow-helpers",
+     re.compile(r"\bclient\.(?:createEscrow|listEscrows|releaseEscrow|refundEscrow)\("),
+     "escrow helpers were never shipped; ICN has no escrow facility"),
+    ("recurring-payment-helpers",
+     re.compile(r"\bclient\.(?:create|list|update|cancel)RecurringPayments?\("),
+     "recurring-payment helpers were never shipped"),
+    ("budget-helpers",
+     re.compile(r"\bclient\.(?:createBudget|listBudgets|updateBudget|deleteBudget)\("),
+     "fiat-budget helpers were never shipped"),
+    ("PaymentCreated-event", re.compile(r"""['"]PaymentCreated['"]"""),
+     "ledger event type is 'SettlementCreated', not 'PaymentCreated'"),
+]
+
+# Hand-written developer-facing surface. Generated artifacts (src/api-types.ts,
+# src/generated/**) are deliberately excluded — they are regenerated from the
+# OpenAPI spec by the api-types workflow and must not be hand-edited.
+CHECKED = [
+    "README.md",
+    "examples/README.md",
+    "examples",      # *.ts under here
+    "src/index.ts",
+]
+
+
+def exported_methods(index_ts: Path) -> set:
+    text = index_ts.read_text(encoding="utf-8")
+    return set(re.findall(r"\basync\s+([A-Za-z0-9_]+)\s*\(", text))
+
+
+def iter_files(sdk_root: Path):
+    seen = set()
+    for entry in CHECKED:
+        p = sdk_root / entry
+        if p.is_dir():
+            for f in sorted(p.glob("**/*.ts")):
+                if f not in seen:
+                    seen.add(f)
+                    yield f
+        elif p.is_file():
+            if p not in seen:
+                seen.add(p)
+                yield p
+
+
+def scan_file(path: Path, sdk_root: Path):
+    violations = []
+    for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if line.lstrip().startswith(">"):  # markdown blockquote = disclaimer, exempt
+            continue
+        for rule, rx, hint in DEPRECATED_PATTERNS:
+            if rx.search(line):
+                violations.append((str(path.relative_to(sdk_root)), i, rule, hint, line.strip()))
+    return violations
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sdk-root", default=".", help="path to sdk/typescript")
+    args = ap.parse_args()
+    sdk_root = Path(args.sdk_root).resolve()
+
+    index_ts = sdk_root / "src" / "index.ts"
+    if not index_ts.is_file():
+        print(f"ERROR: cannot find {index_ts}", file=sys.stderr)
+        return 2
+
+    methods = exported_methods(index_ts)
+    missing = [m for m in CANONICAL_METHODS if m not in methods]
+    resurrected = [m for m in FORBIDDEN_METHODS if m in methods]
+    if missing:
+        print(f"ERROR: canonical client methods missing from src/index.ts: {missing}.\n"
+              "The guard's premise no longer holds; update check_sdk_doc_terms.py.",
+              file=sys.stderr)
+        return 2
+    if resurrected:
+        print(f"ERROR: deprecated fintech methods now exist on the client: {resurrected}.\n"
+              "If these were intentionally (re)introduced, revisit ADR-0006 and update this guard.",
+              file=sys.stderr)
+        return 2
+
+    all_v = []
+    for f in iter_files(sdk_root):
+        all_v.extend(scan_file(f, sdk_root))
+
+    if all_v:
+        print("Deprecated fintech vocabulary presented as current SDK API:\n")
+        for rel, ln, rule, hint, src in all_v:
+            print(f"  {rel}:{ln} [{rule}] {hint}")
+            print(f"      {src}")
+        print(f"\n{len(all_v)} violation(s). ICN exposes settlements/positions in a `unit`, "
+              "not payments/balances in a currency (ADR-0006). Markdown blockquotes are "
+              "exempt so deprecated names can be documented as such.")
+        return 1
+
+    print("OK: SDK docs/examples use canonical ICN ledger primitives "
+          f"(checked against {len(methods)} exported methods in src/index.ts).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdk/typescript/check_sdk_doc_terms.py
+++ b/sdk/typescript/check_sdk_doc_terms.py
@@ -84,10 +84,16 @@ DEPRECATED_PATTERNS = [
     # Flow C `governance.proposeSpend()` treasury API, whose ProposeSpendRequest
     # accepts `currency?` and ProposeSpendResponse returns `currency` (src/types.ts).
     # The bare token cannot distinguish deprecated-ledger use from those live uses,
-    # so matching it would reject valid documentation (a worse failure than the
-    # narrow gap of not flagging it). The settlement `unit` field is enforced by
-    # the SDK's own TypeScript types; the method/route/property rules cover the rest.
+    # so matching it as a blanket rule would reject valid documentation. Instead, a
+    # *settlement-request* `currency:` is caught by the context-aware check in
+    # scan_file() below (only when it appears inside a settle()/batchSettle() call),
+    # which leaves the live crossPay()/Flow C uses untouched.
 ]
+
+# Context-aware settlement check: `currency:` is only deprecated when it appears
+# as a field inside a settle()/batchSettle() request. SettlementRequest uses `unit`.
+_SETTLE_OPEN = re.compile(r"\b(?:settle|batchSettle)\s*\(")
+_SETTLE_CURRENCY = re.compile(r"(?<![A-Za-z_])currency\s*:")
 
 # Hand-written developer-facing surface. Generated artifacts (src/api-types.ts,
 # src/generated/**) are deliberately excluded — they are regenerated from the
@@ -122,12 +128,35 @@ def iter_files(sdk_root: Path):
 
 def scan_file(path: Path, sdk_root: Path):
     violations = []
+    rel = str(path.relative_to(sdk_root))
+    in_settle = False   # inside a settle()/batchSettle() call's argument list
+    depth = 0           # paren depth, counted from the opening settle(
     for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
         if line.lstrip().startswith(">"):  # markdown blockquote = disclaimer, exempt
+            in_settle = False
             continue
         for rule, rx, hint in DEPRECATED_PATTERNS:
             if rx.search(line):
-                violations.append((str(path.relative_to(sdk_root)), i, rule, hint, line.strip()))
+                violations.append((rel, i, rule, hint, line.strip()))
+
+        # Context-aware: flag `currency:` only within a settle()/batchSettle() call.
+        if not in_settle:
+            m = _SETTLE_OPEN.search(line)
+            if m:
+                seg = line[m.end() - 1:]          # from the opening '(' onward
+                if _SETTLE_CURRENCY.search(seg):
+                    violations.append((rel, i, "settlement-currency-field",
+                                       "settlement request field is `unit`, not `currency`",
+                                       line.strip()))
+                depth = seg.count("(") - seg.count(")")
+                in_settle = depth > 0
+        else:
+            if _SETTLE_CURRENCY.search(line):
+                violations.append((rel, i, "settlement-currency-field",
+                                   "settlement request field is `unit`, not `currency`",
+                                   line.strip()))
+            depth += line.count("(") - line.count(")")
+            in_settle = depth > 0
     return violations
 
 

--- a/sdk/typescript/check_sdk_doc_terms.py
+++ b/sdk/typescript/check_sdk_doc_terms.py
@@ -66,6 +66,9 @@ DEPRECATED_PATTERNS = [
     ("budget-helpers",
      re.compile(r"\bclient\.(?:createBudget|listBudgets|updateBudget|deleteBudget)\("),
      "fiat-budget helpers were never shipped"),
+    ("notification-helpers",
+     re.compile(r"\bclient\.(?:connectNotifications|listNotifications|markNotificationRead|getNotificationCount)\("),
+     "notification helpers were never shipped; use connectWebSocket()/subscribe()"),
     ("PaymentCreated-event", re.compile(r"""['"]PaymentCreated['"]"""),
      "ledger event type is 'SettlementCreated', not 'PaymentCreated'"),
     # Deprecated *balance* surface. The canonical position query is the
@@ -94,6 +97,20 @@ DEPRECATED_PATTERNS = [
 # as a field inside a settle()/batchSettle() request. SettlementRequest uses `unit`.
 _SETTLE_OPEN = re.compile(r"\b(?:settle|batchSettle)\s*\(")
 _SETTLE_CURRENCY = re.compile(r"(?<![A-Za-z_])currency\s*:")
+
+# Context-aware ledger-read check. A `.currency` / `.balance` *property* read is
+# only deprecated on the canonical ledger surfaces (Position/Transaction/Treasury
+# all expose `.unit` / `.position`). We bind variables that come from a canonical
+# ledger getter or transaction iteration, then flag `.currency` / `.balance` reads
+# on exactly those. This leaves the live crossPay() result and the Flow C
+# proposeSpend response (whose `.currency` is valid) untouched.
+_LEDGER_ASSIGN = re.compile(
+    r"\b(?:const|let|var)\s+([A-Za-z0-9_]+)\s*=\s*(?:await\s+)?(?:[A-Za-z0-9_]+\.)?"
+    r"(?:getPosition|getHistory|getTreasuryStatus|getTreasuryPosition|settle|batchSettle)\s*\(")
+_LEDGER_ITER = re.compile(
+    r"\.transactions\.(?:forEach|map|filter|reduce|find|some|every)\(\s*(?:async\s*)?\(?\s*([A-Za-z0-9_]+)")
+_LEDGER_FOROF = re.compile(
+    r"\bfor\s*\(\s*(?:const|let)\s+([A-Za-z0-9_]+)\s+of\b[^)]*\.transactions\b")
 
 # Hand-written developer-facing surface. Generated artifacts (src/api-types.ts,
 # src/generated/**) are deliberately excluded — they are regenerated from the
@@ -129,8 +146,9 @@ def iter_files(sdk_root: Path):
 def scan_file(path: Path, sdk_root: Path):
     violations = []
     rel = str(path.relative_to(sdk_root))
-    in_settle = False   # inside a settle()/batchSettle() call's argument list
-    depth = 0           # paren depth, counted from the opening settle(
+    in_settle = False        # inside a settle()/batchSettle() call's argument list
+    depth = 0                # paren depth, counted from the opening settle(
+    ledger_vars = set()      # identifiers bound to a canonical ledger result
     for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
         if line.lstrip().startswith(">"):  # markdown blockquote = disclaimer, exempt
             in_settle = False
@@ -157,6 +175,19 @@ def scan_file(path: Path, sdk_root: Path):
                                    line.strip()))
             depth += line.count("(") - line.count(")")
             in_settle = depth > 0
+
+        # Bind ledger-typed variables (assignment must precede/equal the read line).
+        for rx in (_LEDGER_ASSIGN, _LEDGER_ITER, _LEDGER_FOROF):
+            for var in rx.findall(line):
+                ledger_vars.add(var)
+        # Flag deprecated `.currency` reads on canonical ledger variables only.
+        # (`.balance` is already caught globally by the unambiguous balance rule.)
+        for var in ledger_vars:
+            if re.search(r"\b" + re.escape(var) + r"\.currency\b", line):
+                violations.append((rel, i, "ledger-read-currency",
+                                   "ledger reads expose `.unit`, not `.currency`",
+                                   line.strip()))
+                break
     return violations
 
 

--- a/sdk/typescript/examples/README.md
+++ b/sdk/typescript/examples/README.md
@@ -59,7 +59,7 @@ const appeal = await client.fileAppeal({
 
 Learn how to efficiently process multiple operations:
 
-- **Batch Payments**: Send multiple payments in one operation
+- **Batch Settlements**: Send multiple settlements in one operation
 - **Batch Member Management**: Add or update multiple members at once
 - **Error Handling**: Handle partial failures gracefully
 
@@ -69,10 +69,10 @@ Learn how to efficiently process multiple operations:
 - Batch updates to member roles
 
 ```typescript
-// Send multiple payments at once
-const results = await client.batchPay('food-coop', [
-  { from: 'admin', to: 'alice', amount: 10, currency: 'hours', memo: 'Work' },
-  { from: 'admin', to: 'bob', amount: 5, currency: 'hours', memo: 'Help' },
+// Send multiple settlements at once
+const results = await client.batchSettle('food-coop', [
+  { from: 'admin', to: 'alice', amount: 10, unit: 'hours', memo: 'Work' },
+  { from: 'admin', to: 'bob', amount: 5, unit: 'hours', memo: 'Help' },
 ]);
 console.log(`${results.succeeded} succeeded, ${results.failed} failed`);
 ```
@@ -171,7 +171,7 @@ All SDK methods throw `ICNError` on failure:
 
 ```typescript
 try {
-  await client.pay('food-coop', { ... });
+  await client.settle('food-coop', { ... });
 } catch (error) {
   if (error instanceof ICNError) {
     if (error.statusCode === 401) {
@@ -225,27 +225,27 @@ const all = await client.queryHistory('food-coop')
   .execute();
 
 const csv = all.transactions.map(tx => 
-  `${tx.timestamp},${tx.from},${tx.to},${tx.amount},${tx.currency},${tx.memo}`
+  `${tx.timestamp},${tx.from},${tx.to},${tx.amount},${tx.unit},${tx.memo}`
 ).join('\n');
 
 await fs.writeFile('transactions.csv', csv);
 ```
 
-### Real-time Balance Updates
+### Real-time Position Updates
 
 ```typescript
-let balance = await client.getBalance('food-coop', 'did:icn:alice');
+let position = (await client.getPosition('food-coop', 'did:icn:alice')).position;
 
 subscription.onEvent((event) => {
   if (EventFilter.byDid('did:icn:alice')(event)) {
     if (EventFilter.payments()(event)) {
       const payload = (event as any).payload;
       if (payload.from === 'did:icn:alice') {
-        balance -= payload.amount;
+        position -= payload.amount;
       } else if (payload.to === 'did:icn:alice') {
-        balance += payload.amount;
+        position += payload.amount;
       }
-      console.log(`New balance: ${balance}`);
+      console.log(`New position: ${position}`);
     }
   }
 });
@@ -324,7 +324,7 @@ async function generateMonthlyReport(coopId: string, month: string) {
 4. **Enable auto-reconnect**: For production WebSocket connections
 5. **Set appropriate limits**: Don't fetch more data than you need
 6. **Use query builders**: For complex history queries
-7. **Cache balances**: Update from events instead of polling
+7. **Cache positions**: Update from events instead of polling
 8. **Close connections**: Always clean up WebSocket subscriptions
 
 ## Need Help?

--- a/sdk/typescript/examples/basic-auth.ts
+++ b/sdk/typescript/examples/basic-auth.ts
@@ -77,8 +77,8 @@ async function main() {
 
   // Now make authenticated requests
   console.log('\n--- Authenticated Requests ---');
-  const balance = await client.getBalance('my-coop', myDid);
-  console.log('My balance:', balance.balance, balance.currency);
+  const position = await client.getPosition('my-coop', myDid);
+  console.log('My position:', position.position, position.unit);
 }
 
 main().catch(console.error);

--- a/sdk/typescript/examples/batch-operations.ts
+++ b/sdk/typescript/examples/batch-operations.ts
@@ -17,40 +17,40 @@ async function main() {
   // const signature = await signChallenge(challenge.challenge);
   // await client.authenticate('did:icn:admin', { sign: () => signature }, 'food-coop');
 
-  // Example 1: Batch payments
-  console.log('=== Batch Payments ===');
-  const payments = [
+  // Example 1: Batch settlements
+  console.log('=== Batch Settlements ===');
+  const settlements = [
     {
       from: 'did:icn:admin',
       to: 'did:icn:alice',
       amount: 10,
-      currency: 'hours',
+      unit: 'hours',
       memo: 'January coordination work',
     },
     {
       from: 'did:icn:admin',
       to: 'did:icn:bob',
       amount: 5,
-      currency: 'hours',
+      unit: 'hours',
       memo: 'Website updates',
     },
     {
       from: 'did:icn:admin',
       to: 'did:icn:carol',
       amount: 8,
-      currency: 'hours',
+      unit: 'hours',
       memo: 'Bookkeeping',
     },
   ];
 
-  const paymentResults = await client.batchPay('food-coop', payments);
-  console.log(`Payments: ${paymentResults.succeeded} succeeded, ${paymentResults.failed} failed`);
-  
-  paymentResults.results.forEach((result, i) => {
+  const settlementResults = await client.batchSettle('food-coop', settlements);
+  console.log(`Settlements: ${settlementResults.succeeded} succeeded, ${settlementResults.failed} failed`);
+
+  settlementResults.results.forEach((result, i) => {
     if (result.success) {
-      console.log(`  ✓ Payment ${i + 1}: ${result.payment?.hash}`);
+      console.log(`  ✓ Settlement ${i + 1}: ${result.settlement?.id}`);
     } else {
-      console.log(`  ✗ Payment ${i + 1}: ${result.error}`);
+      console.log(`  ✗ Settlement ${i + 1}: ${result.error}`);
     }
   });
 
@@ -77,29 +77,29 @@ async function main() {
 
   // Example 4: Handle partial failures
   console.log('\n=== Handling Partial Failures ===');
-  const mixedPayments = [
+  const mixedSettlements = [
     {
       from: 'did:icn:admin',
       to: 'did:icn:alice',
       amount: 5,
-      currency: 'hours',
-      memo: 'Valid payment',
+      unit: 'hours',
+      memo: 'Valid settlement',
     },
     {
       from: 'did:icn:nonexistent',
       to: 'did:icn:alice',
       amount: 999999,  // This will likely fail
-      currency: 'hours',
-      memo: 'Invalid payment',
+      unit: 'hours',
+      memo: 'Invalid settlement',
     },
   ];
 
-  const mixedResults = await client.batchPay('food-coop', mixedPayments);
+  const mixedResults = await client.batchSettle('food-coop', mixedSettlements);
   if (mixedResults.failed > 0) {
-    console.log('Some payments failed:');
+    console.log('Some settlements failed:');
     mixedResults.results.forEach((result, i) => {
       if (!result.success) {
-        console.log(`  Payment ${i + 1}: ${result.error}`);
+        console.log(`  Settlement ${i + 1}: ${result.error}`);
       }
     });
   }

--- a/sdk/typescript/examples/query-builder.ts
+++ b/sdk/typescript/examples/query-builder.ts
@@ -81,7 +81,7 @@ async function main() {
     console.log(`Page ${offset / pageSize + 1}: ${page.transactions.length} transactions`);
     
     page.transactions.forEach(tx => {
-      console.log(`  ${tx.from} → ${tx.to}: ${tx.amount} ${tx.currency}`);
+      console.log(`  ${tx.from} → ${tx.to}: ${tx.amount} ${tx.unit}`);
     });
 
     offset += pageSize;

--- a/sdk/typescript/examples/seed-demo-data.ts
+++ b/sdk/typescript/examples/seed-demo-data.ts
@@ -236,7 +236,7 @@ Environment variables:
   console.log(`  Transactions: ${txCount}`);
   console.log(`  Proposals: ${proposalCount}`);
   console.log('\nYou can now:');
-  console.log(`  - View balances: GET ${gateway}/v1/ledger/${coopId}/balance/:did`);
+  console.log(`  - View positions: GET ${gateway}/v1/ledger/${coopId}/position/:did`);
   console.log(`  - View history: GET ${gateway}/v1/ledger/${coopId}/history`);
   console.log(`  - Vote on proposals in the web UI`);
   console.log(`  - Connect via WebSocket for real-time updates`);

--- a/sdk/typescript/examples/seed-demo-data.ts
+++ b/sdk/typescript/examples/seed-demo-data.ts
@@ -120,7 +120,7 @@ Environment variables:
       await client.createCoop({
         id: coopId,
         name: `Demo Timebank - ${coopId}`,
-        settings: { currency: 'hours' },
+        settings: { unit: 'hours' },
       });
       console.log(`  Created cooperative "${coopId}"`);
     } catch (createError: any) {
@@ -168,13 +168,13 @@ Environment variables:
     }
 
     try {
-      // Note: In a real system, this would need to be signed by the payer
+      // Note: In a real system, this would need to be signed by the sender
       // For demo purposes, we're using the admin token to create transactions
-      await client.pay(coopId, {
+      await client.settle(coopId, {
         from: fromDid,
         to: toDid,
         amount: tx.amount,
-        currency: 'hours',
+        unit: 'hours',
         memo: tx.memo,
       });
       console.log(`  ${tx.from} -> ${tx.to}: ${tx.amount}h (${tx.memo.substring(0, 30)}...)`);

--- a/sdk/typescript/examples/timebank.ts
+++ b/sdk/typescript/examples/timebank.ts
@@ -2,7 +2,7 @@
  * Timebank Example
  *
  * Shows how to use ICN for a timebank cooperative:
- * - Check balances
+ * - Check positions
  * - Log service hours
  * - View transaction history
  *
@@ -25,17 +25,17 @@ async function main() {
   const carol = 'did:icn:carol';
 
   // -------------------------------------------------------------------------
-  // Check Current Balances
+  // Check Current Positions
   // -------------------------------------------------------------------------
-  console.log('=== Current Balances ===\n');
+  console.log('=== Current Positions ===\n');
 
-  const aliceBalance = await client.getBalance(COOP_ID, alice);
-  const bobBalance = await client.getBalance(COOP_ID, bob);
-  const carolBalance = await client.getBalance(COOP_ID, carol);
+  const alicePos = await client.getPosition(COOP_ID, alice);
+  const bobPos = await client.getPosition(COOP_ID, bob);
+  const carolPos = await client.getPosition(COOP_ID, carol);
 
-  console.log(`Alice: ${aliceBalance.balance} ${aliceBalance.currency}`);
-  console.log(`Bob:   ${bobBalance.balance} ${bobBalance.currency}`);
-  console.log(`Carol: ${carolBalance.balance} ${carolBalance.currency}`);
+  console.log(`Alice: ${alicePos.position} ${alicePos.unit}`);
+  console.log(`Bob:   ${bobPos.position} ${bobPos.unit}`);
+  console.log(`Carol: ${carolPos.position} ${carolPos.unit}`);
 
   // -------------------------------------------------------------------------
   // Log Service Hours
@@ -44,22 +44,22 @@ async function main() {
 
   // Alice helped Bob with gardening for 2 hours
   try {
-    const payment = await client.pay(COOP_ID, {
+    const settlement = await client.settle(COOP_ID, {
       from: bob, // Bob owes Alice
       to: alice, // Alice receives credit
       amount: 2.0,
-      currency: 'hours',
+      unit: 'hours',
       memo: 'Gardening help - weeding and planting',
     });
 
-    console.log(`Transaction ${payment.id}:`);
-    console.log(`  Bob -> Alice: ${payment.amount} hours`);
-    console.log(`  Memo: ${payment.memo}`);
-    console.log(`  Time: ${new Date(payment.timestamp * 1000).toLocaleString()}`);
+    console.log(`Transaction ${settlement.id}:`);
+    console.log(`  Bob -> Alice: ${settlement.amount} hours`);
+    console.log(`  Memo: ${settlement.memo}`);
+    console.log(`  Time: ${new Date(settlement.timestamp * 1000).toLocaleString()}`);
   } catch (error) {
     if (error instanceof ICNError) {
       if (error.statusCode === 400) {
-        console.error('Payment failed:', error.message);
+        console.error('Settlement failed:', error.message);
         console.error('(Bob may have insufficient credit)');
       } else {
         console.error('API error:', error.statusCode, error.message);
@@ -70,11 +70,11 @@ async function main() {
   }
 
   // Carol did tutoring for Alice for 1.5 hours
-  const tutoring = await client.pay(COOP_ID, {
+  const tutoring = await client.settle(COOP_ID, {
     from: alice,
     to: carol,
     amount: 1.5,
-    currency: 'hours',
+    unit: 'hours',
     memo: 'Spanish tutoring session',
   });
   console.log(`\nCarol earned ${tutoring.amount} hours from Alice (tutoring)`);
@@ -82,15 +82,15 @@ async function main() {
   // -------------------------------------------------------------------------
   // Updated Balances
   // -------------------------------------------------------------------------
-  console.log('\n=== Updated Balances ===\n');
+  console.log('\n=== Updated Positions ===\n');
 
-  const newAlice = await client.getBalance(COOP_ID, alice);
-  const newBob = await client.getBalance(COOP_ID, bob);
-  const newCarol = await client.getBalance(COOP_ID, carol);
+  const newAlice = await client.getPosition(COOP_ID, alice);
+  const newBob = await client.getPosition(COOP_ID, bob);
+  const newCarol = await client.getPosition(COOP_ID, carol);
 
-  console.log(`Alice: ${newAlice.balance} hours (was ${aliceBalance.balance})`);
-  console.log(`Bob:   ${newBob.balance} hours (was ${bobBalance.balance})`);
-  console.log(`Carol: ${newCarol.balance} hours (was ${carolBalance.balance})`);
+  console.log(`Alice: ${newAlice.position} hours (was ${alicePos.position})`);
+  console.log(`Bob:   ${newBob.position} hours (was ${bobPos.position})`);
+  console.log(`Carol: ${newCarol.position} hours (was ${carolPos.position})`);
 
   // -------------------------------------------------------------------------
   // Transaction History
@@ -106,7 +106,7 @@ async function main() {
     const to = tx.to.split(':').pop()?.slice(0, 8);
     const date = new Date(tx.timestamp * 1000).toLocaleDateString();
 
-    console.log(`${date} | ${from}... -> ${to}... | ${tx.amount} ${tx.currency}`);
+    console.log(`${date} | ${from}... -> ${to}... | ${tx.amount} ${tx.unit}`);
     if (tx.memo) {
       console.log(`         ${tx.memo}`);
     }

--- a/sdk/typescript/examples/websocket-events.ts
+++ b/sdk/typescript/examples/websocket-events.ts
@@ -92,24 +92,23 @@ function handleEvent(eventType: CoopEventType, payload: unknown) {
     // -------------------------------------------------------------------------
     // Ledger Events
     // -------------------------------------------------------------------------
-    case 'PaymentCreated': {
+    case 'SettlementCreated': {
       const p = payload as {
-        id: string;
+        coop_id: string;
+        hash: string;
         from: string;
         to: string;
         amount: number;
-        currency: string;
-        memo?: string;
+        unit: string;
       };
 
-      console.log(`[${timestamp}] PAYMENT`);
+      console.log(`[${timestamp}] SETTLEMENT`);
       console.log(`  ${truncate(p.from)} -> ${truncate(p.to)}`);
-      console.log(`  Amount: ${p.amount} ${p.currency}`);
-      if (p.memo) console.log(`  Memo: ${p.memo}`);
+      console.log(`  Amount: ${p.amount} ${p.unit}`);
       console.log();
 
       // Example: Send notification
-      // await sendNotification(p.to, `You received ${p.amount} ${p.currency}`);
+      // await sendNotification(p.to, `You received ${p.amount} ${p.unit}`);
       break;
     }
 
@@ -306,17 +305,17 @@ function notificationExample() {
 
   client.connectWebSocket('timebank-coop', {
     onMessage: async (message) => {
-      if (message.type === 'Event' && message.event_type === 'PaymentCreated') {
-        const payment = message.payload as { to: string; amount: number };
+      if (message.type === 'Event' && message.event_type === 'SettlementCreated') {
+        const settlement = message.payload as { to: string; amount: number };
 
         // Send email notification
-        // await sendEmail(payment.to, `You received ${payment.amount} hours`);
+        // await sendEmail(settlement.to, `You received ${settlement.amount} hours`);
 
         // Or push notification
-        // await sendPushNotification(payment.to, 'New payment received');
+        // await sendPushNotification(settlement.to, 'New settlement received');
 
         // Or update UI
-        // store.dispatch(addTransaction(payment));
+        // store.dispatch(addTransaction(settlement));
       }
     },
   });
@@ -343,7 +342,7 @@ function dashboardExample() {
       if (message.type !== 'Event') return;
 
       switch (message.event_type) {
-        case 'PaymentCreated':
+        case 'SettlementCreated':
           state.recentTransactions.unshift(message.payload);
           state.recentTransactions = state.recentTransactions.slice(0, 10);
           // updateUI();

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -19,8 +19,8 @@
  * // Now use authenticated client
  * client.setToken(auth.token);
  *
- * // Get balance
- * const balance = await client.getBalance('my-coop', 'did:icn:alice');
+ * // Get position
+ * const position = await client.getPosition('my-coop', 'did:icn:alice');
  * ```
  */
 
@@ -1362,7 +1362,7 @@ export class ICNClient {
    * @example
    * ```typescript
    * const status = await client.getTreasuryStatus('my-coop');
-   * console.log(`Balance: ${status.balance} ${status.currency}`);
+   * console.log(`Position: ${status.position} ${status.unit}`);
    * ```
    */
   async getTreasuryStatus(coopId: string): Promise<TreasuryStatus> {
@@ -1393,7 +1393,7 @@ export class ICNClient {
    * const proposal = await client.proposeTreasurySpend('my-coop', {
    *   amount: 1000,
    *   recipient: 'did:icn:bob',
-   *   currency: 'credits',
+   *   unit: 'credits',
    *   memo: 'Equipment purchase',
    * });
    * console.log('Proposal created:', proposal.proposal_id);


### PR DESCRIPTION
## What

Aligns the **TypeScript SDK** developer-facing surface (README, `examples/`, and the docstrings in `src/index.ts`) with the client's *actual* exported methods and ICN's canonical ledger vocabulary, and adds a code-truth-anchored guard so the drift cannot return.

This is the SDK follow-up to #1958 (which aligned the hand-written **API docs**). Same discipline: truth-sync to code + a regression guard, no blind renames, generated artifacts untouched.

## Why

The shipped `ICNClient` exposes mutual-credit **settlements** and **positions** denominated in a `unit` — `settle()`, `getPosition()`, `getHistory()`, `batchSettle()`. But the SDK docs/examples instructed developers to call `client.pay()`, `client.getBalance()`, `client.batchPay()`, plus a whole "Pilot Features" banking block (`createEscrow`, `createRecurringPayment`, `createBudget`, with `from_account` / `currency: 'USD'` / dollar amounts). **None of those methods exist** — the examples were broken *and* misrepresented ICN as a payment/banking product (contra `docs/adr/ADR-0006` and `docs/dev/language-guide.md`).

## Changes

**Truth-sync** (every change checked against `src/types.ts`):

| Was | Now | Verified against |
|---|---|---|
| `client.getBalance()` / `.balance` / `.currency` | `client.getPosition()` / `.position` / `.unit` | `Position {did,position,unit}` |
| `client.pay(...)` | `client.settle(...)` | `SettlementResponse` |
| `client.batchPay(...)` / `result.payment?.hash` | `client.batchSettle(...)` / `result.settlement?.id` | `batchSettle(SettlementRequest[])` |
| request `currency:` field | `unit:` | SettlementRequest / Transaction / CoopSettings / TreasurySpend |
| ws `'PaymentCreated'` + payload `currency` | `'SettlementCreated'` + `unit` | `SettlementCreatedEvent` |

**De-fabricated** the README "Recurring Payments / Payment Escrow / Budget Limits" sections (methods that were never shipped) → one honest **"not implemented"** note that redirects to the real primitives. Import/error examples repointed to real exported types/methods.

**Guard** — `sdk/typescript/check_sdk_doc_terms.py`, wired into the **TypeScript SDK** CI job. Reads exported methods from `src/index.ts`; asserts canonical methods exist + deprecated ones do not (else exit 2); fails if deprecated `pay/balance/escrow` vocabulary or never-shipped methods reappear as current API. `examples/` aren't compiled by tsc (`rootDir: src`), so this is their first regression check. Markdown blockquotes are exempt so deprecated names can still be documented.

## Out of scope (deferred, documented in commit body)
- `crossPay()` / `CrossPaymentRequest` FX surface (`from_currency`/`to_currency` are live field names) — breaking rename
- `TreasuryBalance` type name
- generated `src/api-types.ts` + `src/generated/**` — regenerated via `icnctl`, never hand-edited
- the **react-native** SDK + CoopWallet example — separate, larger surface
- `EventFilter.payments()` / `byType('Payment')` — a live but broken filter (targets a non-existent event type)

## Validation
- Guard exits **0** on this tree (105 exported methods)
- Negative controls: `client.pay`, `'PaymentCreated'`, `createBudget` → exit **1**; blockquote mention → exit **0**; removing a canonical method from `index.ts` → exit **2**
- `src/index.ts` changes are comment-only (no type/behaviour impact); no check weakened

🤖 Generated with [Claude Code](https://claude.com/claude-code)
