### PR TITLE
chore(sdk): typecheck TypeScript SDK examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,6 +624,15 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
         run: npm run build
 
+      # examples/ are not part of the library build (tsconfig.json is src-only),
+      # so example API/field drift — wrong methods, stale fields, wrong event
+      # envelope shape — escaped tsc. tsconfig.examples.json typechecks them
+      # against the real SDK source (compile-only, no gateway). This is the
+      # structural complement to the docs-vocabulary guard (check_sdk_doc_terms.py).
+      - name: Typecheck examples
+        if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
+        run: npm run typecheck:examples
+
       - name: Run tests
         if: needs.changes.outputs.docs_only != 'true' || needs.changes.outputs.has_rust == 'true'
         # All SDK tests use mockFetch — no gateway required. Gate is blocking.

--- a/sdk/typescript/examples/basic-auth.ts
+++ b/sdk/typescript/examples/basic-auth.ts
@@ -45,7 +45,7 @@ async function main() {
   // Method 1: Manual challenge-response flow
   console.log('\n--- Manual Auth Flow ---');
   const challenge = await client.getChallenge(myDid);
-  console.log('Got challenge, expires at:', new Date(challenge.expires_at * 1000));
+  console.log('Got challenge, expires in:', challenge.expires_in, 'seconds');
 
   // Sign the challenge (implement your own signing)
   const signature = 'your-hex-signature';

--- a/sdk/typescript/examples/compute.ts
+++ b/sdk/typescript/examples/compute.ts
@@ -61,7 +61,7 @@ async function main() {
     code: JSON.stringify(cclContract),
     fuel_limit: 10000,
     priority: 'normal',
-    payment_rate: 100, // 100 credits per 1000 fuel
+    settlement_rate: 100, // 100 credits per 1000 fuel
     inputs: { a: 5, b: 3 },
   });
 

--- a/sdk/typescript/examples/websocket-events.ts
+++ b/sdk/typescript/examples/websocket-events.ts
@@ -77,7 +77,7 @@ function handleMessage(message: WsMessage) {
       break;
 
     case 'Event':
-      handleEvent(message.event_type, message.payload);
+      handleEvent(message.event.type, message.event);
       break;
 
     default:
@@ -305,8 +305,8 @@ function notificationExample() {
 
   client.connectWebSocket('timebank-coop', {
     onMessage: async (message) => {
-      if (message.type === 'Event' && message.event_type === 'SettlementCreated') {
-        const settlement = message.payload as { to: string; amount: number };
+      if (message.type === 'Event' && message.event.type === 'SettlementCreated') {
+        const settlement = message.event as { to: string; amount: number };
 
         // Send email notification
         // await sendEmail(settlement.to, `You received ${settlement.amount} hours`);
@@ -341,9 +341,9 @@ function dashboardExample() {
     onMessage: (message) => {
       if (message.type !== 'Event') return;
 
-      switch (message.event_type) {
+      switch (message.event.type) {
         case 'SettlementCreated':
-          state.recentTransactions.unshift(message.payload);
+          state.recentTransactions.unshift(message.event);
           state.recentTransactions = state.recentTransactions.slice(0, 10);
           // updateUI();
           break;
@@ -359,26 +359,26 @@ function dashboardExample() {
           break;
 
         case 'GovernanceProposalOpened':
-          state.activeProposals.push(message.payload);
+          state.activeProposals.push(message.event);
           // updateUI();
           break;
 
         case 'GovernanceProposalClosed':
           state.activeProposals = state.activeProposals.filter(
-            (p: any) => p.proposal_id !== (message.payload as any).proposal_id
+            (p: any) => p.proposal_id !== (message.event as any).proposal_id
           );
           // updateUI();
           break;
 
         case 'ComputeTaskSubmitted':
-          state.activeTasks.push(message.payload);
+          state.activeTasks.push(message.event);
           // updateUI();
           break;
 
         case 'ComputeTaskCompleted':
         case 'ComputeTaskCancelled':
           state.activeTasks = state.activeTasks.filter(
-            (t: any) => t.task_hash !== (message.payload as any).task_hash
+            (t: any) => t.task_hash !== (message.event as any).task_hash
           );
           // updateUI();
           break;
@@ -401,8 +401,8 @@ function auditLogExample() {
       if (message.type === 'Event') {
         const logEntry = {
           timestamp: new Date().toISOString(),
-          event_type: message.event_type,
-          payload: message.payload,
+          event_type: message.event.type,
+          payload: message.event,
         };
 
         // Write to log file

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -12,6 +12,7 @@
     "dev": "tsc --watch",
     "test": "jest",
     "lint": "eslint src --ext .ts",
+    "typecheck:examples": "tsc --noEmit -p tsconfig.examples.json",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run build",
     "seed": "ts-node examples/seed-demo-data.ts",

--- a/sdk/typescript/tsconfig.examples.json
+++ b/sdk/typescript/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "//": "Typecheck-only config for the runnable examples in examples/. The library build (tsconfig.json) is unchanged and still emits from src/ only; examples were never under any compilation path, so API-shape drift in them could not be caught. This config typechecks each example and the SDK source it imports (via the relative '../src' import), without emitting. Examples remain runnable with ts-node.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false
+  },
+  "include": ["examples/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

Brings `sdk/typescript/examples/` under real TypeScript checking so example correctness is enforced **structurally**, instead of by expanding the regex docs-guard into a partial compiler. Direct follow-up to #1960.

## Diagnosis — why examples escaped `tsc`

`tsconfig.json` compiles only `src/**` with `rootDir: src`, and `npm run build` emits just the library. The examples (which import the SDK via relative `'../src'`) were in **no** compilation path, so wrong methods / stale fields / wrong event-envelope shapes could not be caught. #1960's reviewer correctly identified this as the root cause behind the dataflow gaps a regex guard can't close.

## What was added

- **`sdk/typescript/tsconfig.examples.json`** — extends the base, `noEmit: true`, `rootDir: "."`; `include: ["examples/**/*"]`. Typechecks each example against the real SDK source it imports. The library build is **unchanged**.
- **`package.json`** — `"typecheck:examples": "tsc --noEmit -p tsconfig.examples.json"`.
- **`.github/workflows/ci.yml`** — a "Typecheck examples" step in the existing **TypeScript SDK** job (compile-only, no gateway). Complements the always-on `check_sdk_doc_terms.py` vocabulary guard.

## Example drift the typecheck exposed and fixed

| File | Was | Now | Type |
|---|---|---|---|
| `basic-auth.ts` | `challenge.expires_at` | `challenge.expires_in` | `ChallengeResponse` |
| `compute.ts` | `submitTask({ payment_rate })` | `settlement_rate` | `SubmitTaskRequest` (also payment→settlement) |
| `websocket-events.ts` ×12 | `message.event_type` / `message.payload` | `message.event.type` / `message.event` | real `WsEventMessage` shape |

## Validation
- `npm run typecheck:examples` → exit 0; library `tsc -p tsconfig.json` → exit 0 (build unaffected); `check_sdk_doc_terms.py` → exit 0; `git diff --check` clean.
- **Negative control (structural, not the regex guard):** injecting `currency: 'hours'` into a `settle()` request fails the example typecheck — `TS2353: Object literal may only specify known properties, and 'currency' does not exist in type 'SettlementRequest'`. Reverted before commit.

## Deliberately not changed / out of scope
- No public SDK API rename; no generated artifact edits (`src/api-types.ts`, `src/generated/**`); no `src/` behaviour change; no React Native SDK work; no wallet/passport/keyring migration; no broad semantic renaming; no new regex rules.
- **Markdown/JSDoc snippets are still unchecked** (tsc only sees `.ts`): `subscription.onEvent` and `challenge.challenge` (vs `.nonce`) live only in `README.md`/`examples/README.md` and commented-out/JSDoc lines. Typechecking fenced code blocks needs a markdown-snippet extraction step — recommended follow-up.

## Non-claims
No production-readiness, no live-federation-readiness, no completed-governance/banking/wallet/payment claim, no weakening of any meaning/regulatory/firewall check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
