### PR TITLE
docs(identity): define passport/keyring boundary for wallet-language migration

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -133,6 +133,7 @@ Feature designs, proposals, and evolution plans:
 - [COMMONS_EVOLUTION.md](design/COMMONS_EVOLUTION.md) - Commons-based governance evolution
 - [MINIMAL-VIABLE-COOP.md](design/MINIMAL-VIABLE-COOP.md) - MVC specification
 - [capability-based-features.md](design/capability-based-features.md) - Capability system design
+- [passport-keyring-position-receipt.md](design/passport-keyring-position-receipt.md) - Passport/Keyring/Position/Receipt identity & custody vocabulary boundary (deprecates "wallet")
 - [compute-substrate-design.md](design/compute-substrate-design.md) - Distributed compute layer
 - [scheduler-evolution-plan.md](design/scheduler-evolution-plan.md) - Task scheduler design
 - [multi-device-identity-design.md](design/multi-device-identity-design.md) - Multi-device identity

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -27,7 +27,7 @@ Last Reviewed: 2026-04-15
 
 Welcome to the ICN (Intercooperative Network) documentation! This index provides clear navigation to all documentation.
 
-**Last Updated**: 2026-04-15  
+**Last Updated**: 2026-06-01
 **Version**: 2.1 (canon-sync pass)
 
 ---

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -40,6 +40,7 @@ Every claim has been verified against the codebase. If a document says "Not Supp
 - [Multi-Device Identity](multi-device-identity-design.md) - Multi-device identity management
 - [Social Recovery](social-recovery-design.md) - Social recovery for key loss
 - [Post-Quantum Crypto](post-quantum-crypto.md) - PQ hybrid cryptography
+- [Passport / Keyring / Position / Receipt](passport-keyring-position-receipt.md) - Identity & custody vocabulary boundary; deprecates "wallet" as ICN-native language
 
 ### Compute
 - [Compute Substrate](compute-substrate-design.md) - Distributed compute design

--- a/docs/design/passport-keyring-position-receipt.md
+++ b/docs/design/passport-keyring-position-receipt.md
@@ -45,9 +45,9 @@ find-and-replace. It is doctrine, not a migration: **it does not rename any code
 |---------|-----------|------------------------------|
 | **Member Passport** | The user-facing **identity / membership / role / credential / delegation / capability presentation** surface. What a person *shows* to participate. | `IDENTITY_MEMBERSHIP_ARCHITECTURE.md`, `AUTH_BRIDGE_AND_DID_LOGIN.md` (DID login) |
 | **Device Keyring** | Local **cryptographic key custody and signing**. Holds private keys on a device; biometrics/PINs unlock *it*, not identity itself. | `multi-device-identity-design.md` (Keystore v3, per-device keys, rotation), `sdk/react-native` key store |
-| **Position** | **Ledger / accounting state** — a derived net view computed from signed entries. Positions are *recorded by the ledger*, never *held inside a wallet*. | `regulatory-safe-verifiable-state.md` Invariant 4; `language-guide.md` |
+| **Position** | **Ledger / accounting state** — a **derived view** recomputed from signed entries. The ledger records the signed entries (the protocol primitive); a position is the interpretation over them, never *recorded as stored state* and never *held inside a wallet*. | `regulatory-safe-verifiable-state.md` Invariant 4; `language-guide.md` |
 | **Receipt** | Verifiable **proof that an action/event/transition occurred**. | `regulatory-safe-verifiable-state.md` (`ExecutionReceipt`, `GovernanceDecisionReceipt`); `glossary.md` |
-| **Settlement** | The canonical **movement / resolution of obligations and positions**. | `language-guide.md` (`payment` → `settle`) |
+| **Settlement** | The canonical **recording of an obligation transition** between participants; positions are recomputed as derived views, not *moved* between accounts. | `language-guide.md` (`payment` → `settle`) |
 | **Credential** | A signed claim a passport presents (membership, role, attestation). Presented, not "held as value". | `glossary.md` (Attestation), `IDENTITY_MEMBERSHIP_ARCHITECTURE.md` |
 | **Capability** | An authority grant a passport may exercise / a keyring may sign for. Scoped, delegable, revocable. | `multi-device-identity-design.md` (capability hierarchy), `capability-based-features.md` |
 
@@ -56,9 +56,9 @@ find-and-replace. It is doctrine, not a migration: **it does not rename any code
 > A **Member Passport** does not hold money, tokens, or balances.
 > A **Member Passport** presents credentials and authorizes signing.
 > A **Device Keyring** protects private keys and produces signatures.
-> The **ledger** records **positions**.
+> The **ledger** records **signed entries**; a **position** is the derived view recomputed from them.
 > **Receipts** prove events.
-> **Settlements** resolve obligations and positions.
+> **Settlements** record obligation transitions; positions follow as recomputed derived views.
 
 Identity is *not* possession of a wallet. Identity is a DID; the member presents it through a
 **passport** and proves control of it through a **keyring**. The two are deliberately separate: a
@@ -144,7 +144,7 @@ When a future slice does migrate a `wallet` hit, the target follows the *meaning
   so this doctrine does not overwrite an existing meaning — but writers must keep them distinct:
   (a) a *metaphor* for a DID ("a DID — like a passport they alone hold", summit workshop docs), which
   is aligned; and (b) the literal **government passport document** used during identity verification
-  (`icn-identity/src/anchor.rs`, `web/pilot-ui/sdis-enrollment`). "Member Passport" is the ICN
+  (`icn-identity/src/anchor.rs`, `web/pilot-ui/sdis-enrollment.html` / `.js`). "Member Passport" is the ICN
   identity-presentation surface; "passport" lowercase in an enrollment/KYC context is a government ID
   document. Do not conflate them.
 - **`keyring`** today means the **OS/system keyring** (Keychain, GNOME Keyring) used to store local

--- a/docs/design/passport-keyring-position-receipt.md
+++ b/docs/design/passport-keyring-position-receipt.md
@@ -1,0 +1,195 @@
+# Passport / Keyring / Position / Receipt — Identity & Custody Vocabulary Boundary
+
+**Status**: Accepted (doctrine) — refines [Regulatory-Safe Verifiable State Architecture](./regulatory-safe-verifiable-state.md)
+**Priority**: Tier 1 — Foundational positioning
+**Companion**: [`../dev/language-guide.md`](../dev/language-guide.md), [`../architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md`](../architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md), [`./multi-device-identity-design.md`](./multi-device-identity-design.md), [`../architecture/AUTH_BRIDGE_AND_DID_LOGIN.md`](../architecture/AUTH_BRIDGE_AND_DID_LOGIN.md)
+
+---
+
+## Why this exists
+
+ICN's [language guide](../dev/language-guide.md) already forbids fintech vocabulary on the value
+axis: `payment` → `settle`, `balance` → `position`, `currency` → `unit`. The website and the
+foundational manual already say, plainly, that ICN **is not a wallet** ("position over wallet,
+obligation over debt, settlement over payment, unit over currency" — `ICN_VISUAL_EXPLAINER_BIBLE.md`).
+
+But "wallet" is overloaded, and the *value* meaning is only one of three. The word also gets used for
+the **identity app** a member opens ("Open your ICN Wallet app and scan this code") and for the
+**key-custody library** in the SDK (`createWallet()`, `HybridWallet`). The existing guide resolves
+only the value meaning (`wallet` → `account`). The identity and custody meanings have no canonical
+target, so today a single word silently teaches the whole crypto/fintech model:
+
+- assets live in the wallet,
+- balances live in the wallet,
+- payments move between wallets,
+- identity *is* possession of a wallet,
+- and therefore the product is crypto-adjacent.
+
+ICN does not teach that model. This document defines the canonical split **before** any broad
+migration, so that a future rename has an architectural target instead of becoming a blind
+find-and-replace. It is doctrine, not a migration: **it does not rename any code.**
+
+---
+
+## The canonical model
+
+| Concept | What it is | Existing architecture anchor |
+|---------|-----------|------------------------------|
+| **Member Passport** | The user-facing **identity / membership / role / credential / delegation / capability presentation** surface. What a person *shows* to participate. | `IDENTITY_MEMBERSHIP_ARCHITECTURE.md`, `AUTH_BRIDGE_AND_DID_LOGIN.md` (DID login) |
+| **Device Keyring** | Local **cryptographic key custody and signing**. Holds private keys on a device; biometrics/PINs unlock *it*, not identity itself. | `multi-device-identity-design.md` (Keystore v3, per-device keys, rotation), `sdk/react-native` key store |
+| **Position** | **Ledger / accounting state** — a derived net view computed from signed entries. Positions are *recorded by the ledger*, never *held inside a wallet*. | `regulatory-safe-verifiable-state.md` Invariant 4; `language-guide.md` |
+| **Receipt** | Verifiable **proof that an action/event/transition occurred**. | `regulatory-safe-verifiable-state.md` (`ExecutionReceipt`, `GovernanceDecisionReceipt`); `glossary.md` |
+| **Settlement** | The canonical **movement / resolution of obligations and positions**. | `language-guide.md` (`payment` → `settle`) |
+| **Credential** | A signed claim a passport presents (membership, role, attestation). Presented, not "held as value". | `glossary.md` (Attestation), `IDENTITY_MEMBERSHIP_ARCHITECTURE.md` |
+| **Capability** | An authority grant a passport may exercise / a keyring may sign for. Scoped, delegable, revocable. | `multi-device-identity-design.md` (capability hierarchy), `capability-based-features.md` |
+
+### The architectural rule
+
+> A **Member Passport** does not hold money, tokens, or balances.
+> A **Member Passport** presents credentials and authorizes signing.
+> A **Device Keyring** protects private keys and produces signatures.
+> The **ledger** records **positions**.
+> **Receipts** prove events.
+> **Settlements** resolve obligations and positions.
+
+Identity is *not* possession of a wallet. Identity is a DID; the member presents it through a
+**passport** and proves control of it through a **keyring**. The two are deliberately separate: a
+person has one passport (identity) backed by potentially many device keyrings (custody), and losing a
+device loses a keyring, not the passport. This separation is already the design in
+`multi-device-identity-design.md` — this doctrine only names it.
+
+---
+
+## Deprecated / avoid term: `wallet`
+
+`wallet` is **not** ICN-native user-facing language. It is allowed **only** for:
+
+- third-party ecosystem references (e.g. an external crypto wallet a user already owns),
+- legacy compatibility / deprecation notes,
+- historical text,
+- the regulatory term of art "**unhosted wallet**", which describes ICN's non-custodial posture
+  relative to a regulatory concept (see `language-guide.md` and `regulatory-safe-verifiable-state.md`),
+- low-level existing code where the concept is *actually key custody* and migration has not happened
+  yet (label it, schedule it — see Migration rules).
+
+It must **not** be introduced as the name of a member-facing surface, an SDK type, an identity app,
+or anything that holds value.
+
+### Boundary examples
+
+| ❌ Avoid | ✅ Use |
+|---------|--------|
+| "member wallet balance" | "the ledger records the member's **position**" |
+| "send payment from wallet" | "**settlement** records the obligation transition" |
+| "wallet holds tokens" | (no token custody exists — describe the actual obligation/position) |
+| "connect wallet to vote" | "the member's **passport** presents the credential that authorizes the vote" |
+| "on-chain wallet history" | "**receipts** prove each action occurred; the **position** is the derived view" |
+| "Open your ICN Wallet app" (sign-in) | "approve sign-in with your **ICN Passport**" (identity/session) |
+| "the wallet signs the action" | "the **device keyring** signs the action" (key custody) |
+| "reset wallet / wallet not ready" (keys) | "rotate/recover the **device keyring**" |
+
+Note the last three rows: a single "wallet app" interaction usually decomposes into **both** a
+passport step (present identity / approve session) **and** a keyring step (sign with a local key).
+"Unlock" is ambiguous on purpose — "**unlock passport**" if the action is user-facing identity/session
+access; "**unlock keyring**" if the action is producing a cryptographic signature.
+
+---
+
+## Classification of existing `wallet` usage
+
+A full repo sweep (≈1,288 occurrences across ≈226 files) sorts into these classes. The point of the
+table is to make the **migration target** explicit per class — not to authorize editing anything now.
+
+| Class | Meaning | Representative hits | Migration target |
+|-------|---------|---------------------|------------------|
+| **A — Key custody internals** | A real local key store + signer | `sdk/react-native` `createWallet()` / `HybridWallet` / `wallet.sign()`; `multi-device-identity-design.md` Keystore | **Device Keyring** (deferred — breaking SDK API) |
+| **B — User-facing identity surface** | The app a member opens to present identity / approve login | "Open your ICN Wallet app and scan this code" (`web/pilot-ui`, `icn-gateway` static); `CoopWallet` login; "member wallet UI" | **Member Passport** (identity/session) + **Device Keyring** (the signing it triggers) |
+| **C — Stale crypto metaphor for identity** | identity expressed *as* a wallet | `icn-kernel-api/src/compute.rs` `wallet_did`, "Wallet-rooted identity for all operations" | DID-/passport-rooted identity (deferred — public API field) |
+| **D — Ledger state mislabeled** | accounting state called "wallet" | `demo/notes/flow-4-notes.md` "surplus to member wallets"; "member wallet balance" | **Position** |
+| **E — Historical / deprecation / non-claim** | "ICN is *not* a wallet"; "unhosted wallet"; archived text | `THE_COMMONS.md` "It is not a wallet."; manual "No wallet balance."; `docs/archive/**`; regulatory "unhosted wallet" | Leave; label historical/deprecated where needed. These are *correct* as-is. |
+| **F — Third-party / unavoidable** | external wallets / hardware wallets | `witness-signature-best-practices.md` "hardware wallets or TPM-backed keys"; references to users' own crypto wallets | Mark **external / third-party only** |
+| **G — Generated / enforcement / do-not-edit** | generated output, or firewall code that *correctly forbids* the word | `docs/api/openapi.generated.yaml`; the `["payment","wallet","balance",...]` forbidden-term lists in `icn-governance` proofs and `apps/governance` tests; `STATE.md`/`PHASE_PROGRESS.md` log lines | Do not edit. Fix the source, not the generated artifact; never weaken the forbidden-term lists. |
+| **H — Ambiguous / needs design** | bundles concepts this doctrine splits | `docs/plans/agent-teams-launch-prompt.md` "node modes: wallet (signing+affiliations)"; `THE_COMMONS.md` "Commons Shell ↔ pilot-ui / CoopWallet" convergence | Resolve using this doctrine: split "signing" → keyring, "affiliations" → passport |
+
+---
+
+## Migration rules
+
+When a future slice does migrate a `wallet` hit, the target follows the *meaning*, not the word:
+
+1. **Do not blindly rename `wallet` → `passport`.** The right target depends on what the hit means.
+2. If it refers to **key custody / signing**, migrate toward **keyring** (class A).
+3. If it refers to **identity / membership / credentials / login**, migrate toward **passport**
+   (class B/C). If the same interaction also signs, name the keyring step too.
+4. If it refers to **ledger / accounting state**, migrate toward **position** (class D).
+5. If it refers to **proof / history**, migrate toward **receipt** (+ the derived **position** view) (class D/E).
+6. If it refers to an **external crypto wallet**, mark it **external / third-party only** — do not
+   adopt it as ICN-native language (class F).
+7. If it is **historical or a non-claim**, leave it; label it historical/deprecated if it could be
+   misread as current (class E).
+8. If it is **generated or firewall-enforcement code**, do not edit it; fix the upstream source and
+   never weaken a forbidden-term list to make examples pass (class G).
+
+### Disambiguation: "passport" and "keyring" already appear
+
+- **`passport`** today means two things, neither of which is the *Member Passport* product concept,
+  so this doctrine does not overwrite an existing meaning — but writers must keep them distinct:
+  (a) a *metaphor* for a DID ("a DID — like a passport they alone hold", summit workshop docs), which
+  is aligned; and (b) the literal **government passport document** used during identity verification
+  (`icn-identity/src/anchor.rs`, `web/pilot-ui/sdis-enrollment`). "Member Passport" is the ICN
+  identity-presentation surface; "passport" lowercase in an enrollment/KYC context is a government ID
+  document. Do not conflate them.
+- **`keyring`** today means the **OS/system keyring** (Keychain, GNOME Keyring) used to store local
+  key material. This is *aligned* with **Device Keyring**: the Device Keyring is the ICN concept of
+  local key custody and may be *backed by* the OS keyring. No conflict.
+
+### Future migration slices this doctrine should guide
+
+These are **named, not scheduled here** — each is its own future PR with its own review:
+
+1. **SDK key-custody rename** — `createWallet` / `HybridWallet` / `Wallet` (TypeScript + React Native)
+   → keyring naming. Breaking public-API change; out of scope for this doctrine.
+2. **Login-copy reframe** — "Open your ICN Wallet app", "Scan with Mobile Wallet" (`web/pilot-ui`,
+   `icn-gateway` static, OpenAPI QR descriptions) → passport-presentation language.
+3. **Example app** — `CoopWallet` example → passport+keyring framing.
+4. **`wallet_did` field** (`icn-kernel-api`) → DID-/passport-rooted identity naming. High-cost public
+   API rename; deferred.
+5. **Demo speaker notes** — "surplus to member wallets" → "member positions".
+6. **"wallet" node mode** terminology (plans) → adopt the passport/keyring split.
+
+---
+
+## Non-claims
+
+This document is vocabulary doctrine only. It explicitly does **not** claim that ICN is, or that this
+doctrine implements:
+
+- a banking product;
+- a crypto wallet product;
+- token custody, or any custody of member assets;
+- member balances held in a wallet (positions are derived ledger views, not stored value);
+- production-ready identity, a live federation, or completed membership/standing governance;
+- that passport/keyring/position/receipt migration is implemented anywhere (it is not — this is the
+  target, not the state).
+
+It does **not** rename code, change any public API, alter SDK behaviour, or weaken any
+meaning/regulatory/firewall check.
+
+---
+
+## Relationship to the firewalls
+
+ICN has two firewalls; this doctrine belongs to the **regulatory/vocabulary** one, not the
+architectural one:
+
+- **Regulatory / vocabulary firewall** — `language-guide.md` + `.github/scripts/compliance_linter.py`
+  (gateway/SDK/UI surfaces) + `regulatory-safe-verifiable-state.md`. This doctrine refines the `wallet`
+  entry of the language guide along the identity/custody axis.
+- **Architectural firewall** — kernel/app semantic separation (`meaning-firewall-audit.md`,
+  `icn-core/src/meaning_firewall.rs`, `firewall_denylist.py`). Unaffected by this doctrine.
+
+The compliance linter scans only gateway/SDK/UI paths, not `docs/`. The bad-examples above are quoted
+illustrations; per the language guide's exception policy, **do not weaken any linter** to accommodate
+deprecated-term examples — keep them in `docs/` (out of the linter's scope) instead.
+
+**See also**: [language-guide.md](../dev/language-guide.md) · [regulatory-safe-verifiable-state.md](./regulatory-safe-verifiable-state.md)

--- a/docs/design/passport-keyring-position-receipt.md
+++ b/docs/design/passport-keyring-position-receipt.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted (doctrine) — refines [Regulatory-Safe Verifiable State Architecture](./regulatory-safe-verifiable-state.md)
 **Priority**: Tier 1 — Foundational positioning
-**Companion**: [`../dev/language-guide.md`](../dev/language-guide.md), [`../architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md`](../architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md), [`./multi-device-identity-design.md`](./multi-device-identity-design.md), [`../architecture/AUTH_BRIDGE_AND_DID_LOGIN.md`](../architecture/AUTH_BRIDGE_AND_DID_LOGIN.md)
+**Companion**: [`../dev/language-guide.md`](../dev/language-guide.md), [`../architecture/CLIENT_MODEL.md`](../architecture/CLIENT_MODEL.md), [`../architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md`](../architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md), [`./multi-device-identity-design.md`](./multi-device-identity-design.md), [`../architecture/AUTH_BRIDGE_AND_DID_LOGIN.md`](../architecture/AUTH_BRIDGE_AND_DID_LOGIN.md)
 
 ---
 
@@ -24,6 +24,14 @@ target, so today a single word silently teaches the whole crypto/fintech model:
 - payments move between wallets,
 - identity *is* possession of a wallet,
 - and therefore the product is crypto-adjacent.
+
+The conflation is not only in copy and SDK types — it is written into the client architecture. The
+architecture doc [`CLIENT_MODEL.md`](../architecture/CLIENT_MODEL.md) (titled "ICN Client and Wallet
+Architecture") defines **"The Wallet"** as the single client object that "manages identity,
+credentials, memberships, and economic interactions" — a `pub trait Wallet` exposing `did()`,
+`sign()` ("keys never leave wallet"), and `transfer()`. That is the god-object this doctrine
+decomposes: **Passport** (identity / credentials / memberships), **Keyring** (keys / signing),
+**Position** + **Settlement** (economic interactions), and **Receipt** (history).
 
 ICN does not teach that model. This document defines the canonical split **before** any broad
 migration, so that a future rename has an architectural target instead of becoming a blind
@@ -109,7 +117,7 @@ table is to make the **migration target** explicit per class — not to authoriz
 | **E — Historical / deprecation / non-claim** | "ICN is *not* a wallet"; "unhosted wallet"; archived text | `THE_COMMONS.md` "It is not a wallet."; manual "No wallet balance."; `docs/archive/**`; regulatory "unhosted wallet" | Leave; label historical/deprecated where needed. These are *correct* as-is. |
 | **F — Third-party / unavoidable** | external wallets / hardware wallets | `witness-signature-best-practices.md` "hardware wallets or TPM-backed keys"; references to users' own crypto wallets | Mark **external / third-party only** |
 | **G — Generated / enforcement / do-not-edit** | generated output, or firewall code that *correctly forbids* the word | `docs/api/openapi.generated.yaml`; the `["payment","wallet","balance",...]` forbidden-term lists in `icn-governance` proofs and `apps/governance` tests; `STATE.md`/`PHASE_PROGRESS.md` log lines | Do not edit. Fix the source, not the generated artifact; never weaken the forbidden-term lists. |
-| **H — Ambiguous / needs design** | bundles concepts this doctrine splits | `docs/plans/agent-teams-launch-prompt.md` "node modes: wallet (signing+affiliations)"; `THE_COMMONS.md` "Commons Shell ↔ pilot-ui / CoopWallet" convergence | Resolve using this doctrine: split "signing" → keyring, "affiliations" → passport |
+| **H — Ambiguous / needs design** | bundles concepts this doctrine splits | `docs/architecture/CLIENT_MODEL.md` `pub trait Wallet` god-object (identity + credentials + memberships + keys + economics); `docs/plans/agent-teams-launch-prompt.md` "node modes: wallet (signing+affiliations)"; `THE_COMMONS.md` "Commons Shell ↔ pilot-ui / CoopWallet" convergence | Resolve using this doctrine: decompose into passport (identity/credentials/memberships) + keyring (keys/signing) + position/settlement (economic) + receipt (history) |
 
 ---
 

--- a/docs/dev/language-guide.md
+++ b/docs/dev/language-guide.md
@@ -75,8 +75,13 @@ The protocol primitive is the signed entry; the position is interpretation.
 | Context | Forbidden | Approved |
 |---------|-----------|----------|
 | UI component | "My Wallet" | "My Account" or "My Accounts" |
-| SDK type | `Wallet` interface | `Account` interface |
+| SDK type (value / account abstraction) | `Wallet` interface | `Account` interface |
 | API concept | "wallet address" | "member account" or "DID" |
+
+The `Wallet` → `Account` row above is the *value/ledger* sense only. A `Wallet` type that is actually
+**key custody** (a signer / key store — e.g. `sdk/react-native/src/wallet.ts`,
+`sdk/react-native/src/hybrid-wallet.ts`, `createWallet()` / `HybridWallet`) maps to **Device Keyring**,
+not `Account` — see the identity & custody axis below.
 
 **Why**: "Wallet" in a hosted context implies the operator controls the keys and can move balances
 unilaterally. ICN accounts are identified by DID; the member controls the signing key.

--- a/docs/dev/language-guide.md
+++ b/docs/dev/language-guide.md
@@ -84,6 +84,14 @@ unilaterally. ICN accounts are identified by DID; the member controls the signin
 **Exception**: "Unhosted wallet" in regulatory/legal documentation is acceptable — it describes
 ICN's non-custodial architecture relative to the regulatory concept.
 
+**Identity & custody axis**: The `wallet` → `account` rule above covers the *value/ledger* meaning.
+When "wallet" instead names an **identity app** (e.g. "Open your ICN Wallet app") or a **key-custody
+type** (e.g. the SDK `createWallet()` / `HybridWallet`), the canonical split is **Member Passport**
+(identity / credential presentation) plus **Device Keyring** (local key custody and signing) — never a
+single "wallet". See [Passport / Keyring / Position / Receipt](../design/passport-keyring-position-receipt.md)
+for the full boundary, the classification of existing `wallet` hits, and the migration rules. That
+document is doctrine, not an implemented rename — no code is renamed by adopting this vocabulary.
+
 ---
 
 ### `send funds` / `transfer funds`
@@ -159,6 +167,8 @@ These terms are architecturally accurate and should be used freely:
 | `allocation` | A governance-authorized resource assignment |
 | `proposal` | A governance action requiring member vote |
 | `provenance` | The authorization chain behind a state change |
+| `Member Passport` | User-facing identity / membership / credential presentation surface (not value-bearing) — see [doctrine](../design/passport-keyring-position-receipt.md) |
+| `Device Keyring` | Local cryptographic key custody and signing on a device — see [doctrine](../design/passport-keyring-position-receipt.md) |
 
 ---
 


### PR DESCRIPTION
## Summary

Doctrine/architecture slice. Defines the canonical identity & custody vocabulary boundary (**Member Passport / Device Keyring / Position / Receipt / Settlement**) so a future "wallet"-language migration has an architectural target — **before** any broad rename. No code is renamed.

## 1. Diagnosis

A repo sweep found ~1,288 `wallet` hits across ~226 files. They do **not** share one meaning:

- **Architecture-level god-object** — `docs/architecture/CLIENT_MODEL.md` ("ICN Client and Wallet Architecture") defines **"The Wallet"** as one client object that "manages identity, credentials, memberships, and economic interactions" (`pub trait Wallet`: `did()` + `sign()` "keys never leave wallet" + `transfer()`). This is the canonical written statement of the conflation the doctrine decomposes.
- **Key custody internals** — `sdk/react-native` `createWallet()` / `HybridWallet` / `wallet.sign()`, `multi-device-identity-design.md` Keystore. (A real local key store + signer.)
- **User-facing identity surface** — "Open your ICN Wallet app and scan this code" (`web/pilot-ui`, `icn-gateway` static), `CoopWallet`, "member wallet UI". (Identity/login app.)
- **Stale crypto metaphor for identity** — `icn-kernel-api/src/compute.rs` `wallet_did`, "Wallet-rooted identity".
- **Ledger state mislabeled** — `demo/notes/flow-4-notes.md` "surplus to member wallets".
- **Historical / non-claim** — "It is not a wallet." (`THE_COMMONS.md`), "No wallet balance." (manual), "unhosted wallet" (regulatory term of art), `docs/archive/**`.
- **Third-party** — "hardware wallets or TPM-backed keys".
- **Generated / enforcement** — `openapi.generated.yaml`; the `["payment","wallet","balance",...]` forbidden-term lists in `icn-governance` / `apps/governance` (which correctly *forbid* the word).

Findings on the target terms:
- **`passport`** has no existing *Member Passport* product meaning — current uses are a DID metaphor (aligned) and the literal government-ID document in KYC/enrollment (must stay distinct). No overwrite.
- **`keyring`** already means the OS/system keyring (Keychain, GNOME Keyring) — *aligned* with Device Keyring; no conflict.
- The existing `language-guide.md` `wallet` entry resolves only the **value/ledger** meaning (`wallet` → `account`). The **identity** and **key-custody** meanings had no canonical target — this is the gap this doctrine closes.

Most-dangerous concentration: the SDK key-custody API and the QR-login UI both still say "wallet" while the website/manual already say ICN "is not a wallet" — an internal contradiction that teaches the crypto-wallet mental model on exactly the surfaces members and developers touch. `CLIENT_MODEL.md` bakes that conflation into the client architecture itself.

## 2. Why "wallet" cannot be blindly renamed to "passport"

The hits mean different things. Key custody → **keyring**; identity/login → **passport**; ledger state → **position**; proof/history → **receipt**; external → external/third-party; historical → leave. A flat `wallet`→`passport` rename would mislabel key custody and ledger state as identity, making the overload worse rather than fixing it. The target must follow the *meaning*, not the word.

## 3. Canonical term split

| Concept | Meaning |
|---|---|
| Member Passport | User-facing identity / membership / credential / capability presentation. Holds no value. |
| Device Keyring | Local cryptographic key custody and signing. |
| Position | Ledger / accounting state (a derived view). |
| Receipt | Proof an action/event occurred. |
| Settlement | Resolution of obligations / positions. |

Rule: a Member Passport presents credentials and authorizes signing; a Device Keyring protects private keys; the ledger records positions; receipts prove events; settlements resolve obligations/positions. Identity is not possession of a wallet — it is a DID, presented through a passport and proven through a keyring. The `CLIENT_MODEL.md` `Wallet` god-object decomposes into exactly these: passport (identity/credentials/memberships) + keyring (keys/signing) + position/settlement (economic) + receipt (history).

## 4. Files changed

- **New** `docs/design/passport-keyring-position-receipt.md` — the doctrine (deprecated term, canonical terms, boundary examples, A–H classification table with per-class migration targets, migration rules, non-claims, firewall relationship). Sits next to `regulatory-safe-verifiable-state.md`, the design home of the regulatory/vocabulary firewall.
- **Changed** `docs/dev/language-guide.md` (+10) — refines the `wallet` entry along the identity/custody axis; adds Member Passport / Device Keyring to the approved-terms table.

## 5. Validation

- `git diff --check` — clean
- `.github/scripts/compliance_linter.py` — 106 files, **0 violations** (docs are out of the linter's scope by design; the bad-examples live only in `docs/`)
- `.github/scripts/readiness_overclaim_linter.py` — **0 overclaims**; self-test (`test_readiness_overclaim_linter.py`) **21/21 pass**
- `scripts/check-meaning-firewall.sh` — 3 pre-existing architectural (kernel-import) violations, **unchanged baseline**; this docs change touches no kernel crates
- `docs/scripts/doc_control_check.py` — passes, **64 enforcement warnings (= baseline, no new warning)**; the new doc needs no registry entry and adds none (mirrors the no-YAML-frontmatter style of its sibling design docs)

## 6. Explicit non-claims

- **No code migration** / no call-site renames.
- **No public API rename** (`wallet_did`, SDK `createWallet` / `HybridWallet` untouched).
- **No React Native SDK work.**
- **No wallet/passport implementation claim** — passport/keyring is the *target*, not the current state, anywhere.
- **No banking / payment / wallet / balance / token-custody product claim.**
- **No production identity readiness claim.**
- **No weakening** of any meaning / regulatory / firewall check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
