### PR TITLE
docs(sdk): clarify wallet-named SDK APIs as key-custody surfaces

### DIFF
--- a/sdk/react-native/README.md
+++ b/sdk/react-native/README.md
@@ -4,7 +4,7 @@ React Native SDK for the InterCooperative Network - mobile-first mutual credit a
 
 ## Features
 
-- **Wallet Management** - Secure key storage with iOS Keychain / Android Keystore
+- **Device Keyring** (key custody) - Secure key storage with iOS Keychain / Android Keystore (legacy-named "wallet"; holds no balances or value)
 - **Hybrid Post-Quantum Cryptography** - Ed25519 + ML-DSA-65 for quantum-resistant signatures
 - **Authentication** - Persistent login with automatic token refresh
 - **Real-time Events** - WebSocket with auto-reconnect
@@ -157,17 +157,24 @@ Load persisted authentication state. Call this on app startup.
 
 #### `client.login(coopId?, scopes?)`
 
-Authenticate using the configured wallet.
+Authenticate using the configured Device Keyring (legacy-named "wallet").
 
 #### `client.logout()`
 
 Clear authentication and disconnect WebSocket.
 
-### Wallet
+### Device Keyring (legacy-named "Wallet")
+
+These APIs are a **Device Keyring** — local private-key custody and signing per the
+[passport / keyring / position / receipt doctrine](../../docs/design/passport-keyring-position-receipt.md).
+They generate, store, and sign with a key pair; they do **not** hold balances, tokens, or value, and
+are not an account. The `createWallet` / `ICNWallet` / `HybridWallet` names are kept for backward
+compatibility; canonical `Keyring` aliases may be introduced in a future compatibility-safe release
+without removing them.
 
 #### `createWallet(storage)`
 
-Create a wallet with secure storage.
+Create a Device Keyring (legacy-named `createWallet`) with secure storage.
 
 ```typescript
 const wallet = createWallet(secureStorage);
@@ -185,9 +192,9 @@ Import an existing private key (hex format).
 
 Sign a message with the stored private key.
 
-### Hybrid Post-Quantum Wallet
+### Hybrid Post-Quantum Device Keyring (legacy-named "Wallet")
 
-For quantum-resistant signatures, use the `HybridWallet` which combines Ed25519 with ML-DSA-65 (NIST FIPS 204 Dilithium).
+For quantum-resistant signatures, use the `HybridWallet` (a Device Keyring) which combines Ed25519 with ML-DSA-65 (NIST FIPS 204 Dilithium).
 
 #### Size Considerations
 
@@ -199,7 +206,7 @@ For quantum-resistant signatures, use the `HybridWallet` which combines Ed25519 
 
 #### `createHybridWallet(storage)`
 
-Create a quantum-resistant wallet.
+Create a quantum-resistant Device Keyring (legacy-named `createHybridWallet`).
 
 ```typescript
 import { createHybridWallet } from '@icn/react-native';

--- a/sdk/react-native/README.md
+++ b/sdk/react-native/README.md
@@ -166,7 +166,7 @@ Clear authentication and disconnect WebSocket.
 ### Device Keyring (legacy-named "Wallet")
 
 These APIs are a **Device Keyring** — local private-key custody and signing per the
-[passport / keyring / position / receipt doctrine](../../docs/design/passport-keyring-position-receipt.md).
+[passport / keyring / position / receipt doctrine](https://github.com/InterCooperative-Network/icn/blob/main/docs/design/passport-keyring-position-receipt.md).
 They generate, store, and sign with a key pair; they do **not** hold balances, tokens, or value, and
 are not an account. The `createWallet` / `ICNWallet` / `HybridWallet` names are kept for backward
 compatibility; canonical `Keyring` aliases may be introduced in a future compatibility-safe release

--- a/sdk/react-native/src/hybrid-wallet.ts
+++ b/sdk/react-native/src/hybrid-wallet.ts
@@ -1,8 +1,13 @@
 /**
- * ICN Hybrid Wallet for React Native
+ * ICN Hybrid Device Keyring for React Native (legacy-named "hybrid wallet")
  *
- * Quantum-resistant wallet using Ed25519 + ML-DSA-65 hybrid signatures.
- * Provides migration path from classical Ed25519-only wallets.
+ * Quantum-resistant local key custody and signing using Ed25519 + ML-DSA-65 hybrid
+ * signatures. In the passport / keyring / position / receipt doctrine this is a
+ * **Device Keyring**: it holds keys and produces signatures — it does NOT hold
+ * balances, tokens, or value. Provides a migration path from classical
+ * Ed25519-only keyrings. The `HybridWallet` / `createHybridWallet` export names are
+ * retained for backward compatibility; canonical `Keyring` aliases may be added
+ * later without removing them.
  *
  * @module hybrid-wallet
  *

--- a/sdk/react-native/src/index.ts
+++ b/sdk/react-native/src/index.ts
@@ -12,7 +12,7 @@
  *   useBalance,
  * } from '@icn/react-native';
  *
- * // Create wallet with secure storage
+ * // Create a Device Keyring (legacy-named createWallet) with secure storage
  * const wallet = createWallet(secureStorage);
  * await wallet.generateKeyPair();
  *
@@ -51,10 +51,10 @@ export { QueueManager } from './queue-manager';
 // Error utilities
 export { parseError, createError, isNetworkError, isAuthError } from './error-utils';
 
-// Wallet (Classical Ed25519)
+// Device Keyring — local key custody + signing (legacy-named "wallet"; holds no value)
 export { ICNWalletImpl, createWallet } from './wallet';
 
-// Hybrid Post-Quantum Wallet (Ed25519 + ML-DSA-65)
+// Hybrid Post-Quantum Device Keyring (Ed25519 + ML-DSA-65; legacy-named "wallet")
 export {
   HybridWallet,
   createHybridWallet,

--- a/sdk/react-native/src/types.ts
+++ b/sdk/react-native/src/types.ts
@@ -48,7 +48,10 @@ export interface KeyPair {
 }
 
 /**
- * Wallet interface for managing identity and signing
+ * Device Keyring interface (legacy-named `ICNWallet`): local key custody + signing.
+ *
+ * Generates / imports / stores a key pair and signs challenges. It does NOT hold
+ * balances, tokens, or value — see the passport / keyring / position / receipt doctrine.
  */
 export interface ICNWallet {
   /**
@@ -104,7 +107,7 @@ export interface PaymentQRData {
 export interface ICNMobileClientOptions {
   /** Gateway base URL */
   baseUrl: string;
-  /** Optional wallet for automatic signing */
+  /** Optional Device Keyring (legacy-named `wallet`) for automatic signing */
   wallet?: ICNWallet;
   /** Request timeout in milliseconds */
   timeout?: number;

--- a/sdk/react-native/src/wallet.ts
+++ b/sdk/react-native/src/wallet.ts
@@ -1,8 +1,18 @@
 /**
- * ICN Wallet for React Native
+ * ICN Device Keyring for React Native (legacy-named "wallet")
  *
- * Manages identity keys with secure storage.
+ * Local private-key custody and signing. Generates / imports / stores an Ed25519
+ * key pair in secure storage (iOS Keychain / Android Keystore) and signs challenges
+ * with it. In the passport / keyring / position / receipt doctrine this is a
+ * **Device Keyring**: it holds keys and produces signatures — it does NOT hold
+ * balances, tokens, or value, and is not an account or a settlement instrument.
+ *
+ * The exported names (`ICNWalletImpl`, `createWallet`, and the `ICNWallet`
+ * interface) are retained for backward compatibility. A future, compatibility-safe
+ * PR may add canonical `Keyring` / `DeviceKeyring` aliases without removing them.
+ *
  * Uses @noble/ed25519 for cryptographic operations.
+ * See ../../../docs/design/passport-keyring-position-receipt.md
  */
 
 import * as ed from '@noble/ed25519';
@@ -20,7 +30,7 @@ const PUBLIC_KEY_KEY = 'icn_wallet_public_key';
 const DID_KEY = 'icn_wallet_did';
 
 /**
- * Wallet implementation using secure storage and @noble/ed25519
+ * Device Keyring implementation (legacy-named "wallet") using secure storage and @noble/ed25519
  *
  * @example
  * ```typescript
@@ -236,7 +246,9 @@ export class ICNWalletImpl implements ICNWallet {
 }
 
 /**
- * Create a wallet with secure storage
+ * Create a Device Keyring (legacy-named `createWallet`) backed by secure storage.
+ *
+ * Returns local key custody + signing only; it holds no balances, tokens, or value.
  */
 export function createWallet(storage: SecureStorage): ICNWallet {
   return new ICNWalletImpl(storage);

--- a/sdk/react-native/src/wallet.ts
+++ b/sdk/react-native/src/wallet.ts
@@ -12,7 +12,7 @@
  * PR may add canonical `Keyring` / `DeviceKeyring` aliases without removing them.
  *
  * Uses @noble/ed25519 for cryptographic operations.
- * See ../../../docs/design/passport-keyring-position-receipt.md
+ * See https://github.com/InterCooperative-Network/icn/blob/main/docs/design/passport-keyring-position-receipt.md
  */
 
 import * as ed from '@noble/ed25519';


### PR DESCRIPTION
## Summary

First **code-facing** wallet-language slice after the doctrine (#1963), login copy (#1964), and
`CLIENT_MODEL.md` (#1965) work. Scoped deliberately to a **documentation / JSDoc truth-sync** of the
React Native SDK's legacy-named key-custody APIs (`ICNWallet` / `createWallet` / `HybridWallet`). **No
code, exports, types, behavior, serialized fields, storage keys, or cryptography were changed.**

## Diagnosis

- **Where defined:** entirely in `sdk/react-native/` — `src/wallet.ts` (`ICNWalletImpl`,
  `createWallet`), `src/hybrid-wallet.ts` (`HybridWallet`, `createHybridWallet`), `src/types.ts`
  (`ICNWallet` interface). The **TypeScript SDK (`sdk/typescript`) has none** of these names.
- **Surface:** React Native SDK only (`@icn/react-native`, v0.1.0, publishable).
- **Public exports?** Yes — `ICNWalletImpl`, `createWallet`, `HybridWallet`, `createHybridWallet`,
  `getHybridCryptoInfo` are exported from `src/index.ts`; the `ICNWallet` interface is exported via
  `export * from './types'` and is part of the client config (`ICNMobileClientOptions.wallet?`).
- **What concept do they map to?** **Device Keyring.** They are pure local private-key custody +
  signing: generate / import / store an Ed25519 (or hybrid Ed25519 + ML-DSA-65) key pair in secure
  storage (iOS Keychain / Android Keystore) and `sign()` challenges. They expose **no** balances,
  tokens, value, accounts, payments, or settlements — those concerns live in separate hooks
  (`useBalance`, `usePayment`, …) that are **out of scope** for this slice.
- **Existing canonical name?** There is **no** `Keyring` / `DeviceKeyring` anywhere in `sdk/`.
- **Breaking if renamed now?** Yes — public exports of a published package, woven into the client
  config type, and backed by persisted secure-storage key constants (`icn_wallet_did`,
  `icn_wallet_private_key`, `icn_hybrid_wallet_keypair`, `icn_wallet_version`, …). Renaming exports or
  storage keys would break the public API and existing installs.

Per the stop conditions (public APIs, no ratified keyring naming yet, persisted storage keys), the
**smallest safe step is a doc/JSDoc truth-sync** — not code aliases (premature) and not a rename
(breaking).

## What changed

Comments / JSDoc / markdown only, across 5 files:

- `src/wallet.ts`, `src/hybrid-wallet.ts` — header JSDoc reframed as a legacy-named **Device Keyring**
  (key custody + signing; holds no value), with a note that canonical `Keyring` aliases may come later.
- `src/types.ts` — `ICNWallet` interface doc + the `wallet?: ICNWallet` client-config field comment.
- `src/index.ts` — export-section comments and the top `@example` comment.
- `README.md` — feature bullet, the `### Wallet` → `### Device Keyring (legacy-named "Wallet")` API
  section (with a doctrine link), and the hybrid section.

## What was deliberately NOT changed

- No exports renamed or removed (`ICNWallet`, `createWallet`, `HybridWallet`, etc. all kept).
- No types, runtime behavior, or method signatures changed.
- No serialized JSON fields or secure-storage key constants changed (`wallet_did` /
  `icn_wallet_did` untouched — explicitly out of scope).
- No cryptography changed.
- No `useBalance` / `usePayment` / Position / Settlement work (separate future slices).
- No TypeScript SDK changes; no CoopWallet example changes; no `client.ts` changes.

## Compatibility notes

Fully backward compatible — additive documentation only. A future, separately-reviewed,
compatibility-safe PR may introduce canonical `Keyring` / `DeviceKeyring` aliases **alongside** (not
replacing) the legacy names.

## Validation

Run from the clean worktree (`origin/main` = `8d51f05e`):

| Check | Result |
|-------|--------|
| `.github/scripts/compliance_linter.py` (scans `sdk/react-native/src/**/*.ts`) | PASS |
| `.github/scripts/readiness_overclaim_linter.py` | PASS |
| `scripts/check-meaning-firewall.sh` | exit 0 |
| `sdk/typescript/check_sdk_doc_terms.py` (TS-scoped sanity) | PASS |
| `git diff --check` | clean |
| RN `npm run build` (tsc) | **94 errors at baseline == 94 with this patch** — all pre-existing `@icn/client` workspace-linking failures (the sibling TS SDK is not resolvable in a standalone install); **zero introduced by this change** |
| RN Device Keyring tests (`jest src/wallet.test.ts src/hybrid-wallet.test.ts`) | **50/50 pass** |

The change is comment/markdown only, so `tsc`/jest output is unaffected; the pre-existing build
failures are an environment/workspace-linking artifact and are delegated to CI.

## Explicit non-claims

- No removal of legacy wallet exports.
- No `wallet_did` / `icn_wallet_did` migration.
- No protocol / API serialization change.
- No token custody.
- No wallet balance.
- No banking / payment product.
- No production identity readiness claim.
- No weakening of meaning / regulatory / firewall checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
