### PR TITLE
feat(sdk): add keyring aliases for legacy React Native wallet APIs

### DIFF
--- a/sdk/react-native/README.md
+++ b/sdk/react-native/README.md
@@ -171,8 +171,11 @@ These APIs are a **Device Keyring** — local private-key custody and signing pe
 They generate, store, and sign with a key pair; they do **not** hold balances, tokens, or value, and
 are not an account. The `createWallet` / `ICNWallet` / `HybridWallet` names are kept for backward
 compatibility. Canonical `Keyring` aliases are now available — `createKeyring`, `ICNKeyring`,
-`ICNKeyringImpl`, `HybridKeyring`, `createHybridKeyring` — and the `createWallet` / `ICNWallet` /
-`HybridWallet` names remain as backward-compatible (deprecated) aliases; they are not removed.
+`ICNKeyringImpl`, `HybridKeyring`, `createHybridKeyring`. The legacy factory functions
+`createWallet` and `createHybridWallet` are marked `@deprecated` in favor of the canonical
+factories. The legacy `ICNWallet` / `ICNWalletImpl` / `HybridWallet` names are retained and are
+**not** `@deprecated` — so the canonical aliases that share their symbols stay clean, and
+`ICNWallet` remains the type of `ICNMobileClientOptions.wallet?`. No legacy name is removed.
 
 #### `createKeyring(storage)`  (canonical; alias `createWallet`)
 

--- a/sdk/react-native/README.md
+++ b/sdk/react-native/README.md
@@ -63,23 +63,24 @@ const secureStorage: SecureStorage = {
 };
 ```
 
-### 2. Create wallet and client
+### 2. Create a keyring and client
 
 ```typescript
-import { createWallet, createMobileClient } from '@icn/react-native';
+import { createKeyring, createMobileClient } from '@icn/react-native';
 
-// Create wallet
-const wallet = createWallet(secureStorage);
+// Create a Device Keyring (local key custody + signing)
+const keyring = createKeyring(secureStorage);
 
 // Generate or load key pair
-if (!(await wallet.hasKeyPair())) {
-  await wallet.generateKeyPair();
+if (!(await keyring.hasKeyPair())) {
+  await keyring.generateKeyPair();
 }
 
 // Create client
 const client = createMobileClient({
   baseUrl: 'https://icn.mycoop.org',
-  wallet,
+  // The client config field is still named `wallet` (legacy); it accepts a keyring.
+  wallet: keyring,
   storage: secureStorage,
 });
 
@@ -169,26 +170,27 @@ These APIs are a **Device Keyring** — local private-key custody and signing pe
 [passport / keyring / position / receipt doctrine](https://github.com/InterCooperative-Network/icn/blob/main/docs/design/passport-keyring-position-receipt.md).
 They generate, store, and sign with a key pair; they do **not** hold balances, tokens, or value, and
 are not an account. The `createWallet` / `ICNWallet` / `HybridWallet` names are kept for backward
-compatibility; canonical `Keyring` aliases may be introduced in a future compatibility-safe release
-without removing them.
+compatibility. Canonical `Keyring` aliases are now available — `createKeyring`, `ICNKeyring`,
+`ICNKeyringImpl`, `HybridKeyring`, `createHybridKeyring` — and the `createWallet` / `ICNWallet` /
+`HybridWallet` names remain as backward-compatible (deprecated) aliases; they are not removed.
 
-#### `createWallet(storage)`
+#### `createKeyring(storage)`  (canonical; alias `createWallet`)
 
-Create a Device Keyring (legacy-named `createWallet`) with secure storage.
+Create a Device Keyring with secure storage. `createWallet` is a deprecated, identical alias.
 
 ```typescript
-const wallet = createWallet(secureStorage);
+const keyring = createKeyring(secureStorage);
 ```
 
-#### `wallet.generateKeyPair()`
+#### `keyring.generateKeyPair()`
 
 Generate a new Ed25519 key pair.
 
-#### `wallet.importKeyPair(privateKey)`
+#### `keyring.importKeyPair(privateKey)`
 
 Import an existing private key (hex format).
 
-#### `wallet.sign(message)`
+#### `keyring.sign(message)`
 
 Sign a message with the stored private key.
 
@@ -204,17 +206,17 @@ For quantum-resistant signatures, use the `HybridWallet` (a Device Keyring) whic
 | Public Key | 32 bytes | ~2 KB |
 | Secret Key | 32 bytes | ~4 KB |
 
-#### `createHybridWallet(storage)`
+#### `createHybridKeyring(storage)`  (canonical; alias `createHybridWallet`)
 
-Create a quantum-resistant Device Keyring (legacy-named `createHybridWallet`).
+Create a quantum-resistant Device Keyring. `createHybridWallet` is a deprecated, identical alias.
 
 ```typescript
-import { createHybridWallet } from '@icn/react-native';
+import { createHybridKeyring } from '@icn/react-native';
 
-const hybridWallet = createHybridWallet(secureStorage);
+const hybridKeyring = createHybridKeyring(secureStorage);
 
 // Generate hybrid keypair (Ed25519 + ML-DSA-65)
-const keyInfo = await hybridWallet.generateKeyPair();
+const keyInfo = await hybridKeyring.generateKeyPair();
 console.log('DID:', keyInfo.did);
 console.log('Public key size:', keyInfo.publicKeySize, 'bytes');
 console.log('Is hybrid:', keyInfo.isHybrid);
@@ -224,13 +226,13 @@ console.log('Is hybrid:', keyInfo.isHybrid);
 
 ```typescript
 // Sign with hybrid signatures (both Ed25519 + ML-DSA)
-const signature = await hybridWallet.sign(messageHex);
+const signature = await hybridKeyring.sign(messageHex);
 
 // Sign with Ed25519 only (for short-lived proofs like QR codes)
-const classicalSig = await hybridWallet.signClassicalOnly(messageHex);
+const classicalSig = await hybridKeyring.signClassicalOnly(messageHex);
 
 // Sign with JSON output for interoperability
-const sigJson = await hybridWallet.sign(messageHex, { asJson: true });
+const sigJson = await hybridKeyring.sign(messageHex, { asJson: true });
 ```
 
 #### Verification (Static)

--- a/sdk/react-native/src/hybrid-wallet.ts
+++ b/sdk/react-native/src/hybrid-wallet.ts
@@ -85,8 +85,9 @@ export interface HybridSignOptions extends HybridCryptoOptions {
 /**
  * Hybrid (Ed25519 + ML-DSA-65) Device Keyring implementation.
  *
- * @deprecated Prefer the canonical {@link HybridKeyring}. `HybridWallet` is retained as a
- * backward-compatible alias (identical class; same behavior and storage keys).
+ * Legacy name; prefer the canonical {@link HybridKeyring} (the same class reference). The
+ * class symbol is intentionally not `@deprecated` so the canonical alias does not inherit a
+ * deprecation marker; only the legacy factory {@link createHybridWallet} is `@deprecated`.
  */
 export class HybridWallet {
   private storage: SecureStorage;

--- a/sdk/react-native/src/hybrid-wallet.ts
+++ b/sdk/react-native/src/hybrid-wallet.ts
@@ -83,7 +83,10 @@ export interface HybridSignOptions extends HybridCryptoOptions {
 }
 
 /**
- * Hybrid Wallet implementation
+ * Hybrid (Ed25519 + ML-DSA-65) Device Keyring implementation.
+ *
+ * @deprecated Prefer the canonical {@link HybridKeyring}. `HybridWallet` is retained as a
+ * backward-compatible alias (identical class; same behavior and storage keys).
  */
 export class HybridWallet {
   private storage: SecureStorage;
@@ -486,13 +489,27 @@ export class HybridWallet {
 }
 
 /**
- * Create a hybrid wallet instance
+ * Create a hybrid (Ed25519 + ML-DSA-65) Device Keyring instance.
  *
  * @param storage - Secure storage implementation
+ * @deprecated Prefer the canonical {@link createHybridKeyring}. `createHybridWallet` is
+ * retained as a backward-compatible alias and behaves identically (same storage keys).
  */
 export function createHybridWallet(storage: SecureStorage): HybridWallet {
   return new HybridWallet(storage);
 }
+
+/**
+ * Canonical hybrid Device Keyring class — preferred alias of {@link HybridWallet}.
+ */
+export { HybridWallet as HybridKeyring };
+
+/**
+ * Canonical hybrid Device Keyring factory — preferred alias of {@link createHybridWallet}.
+ *
+ * Identical behavior, signature, and persisted storage keys; no migration occurs.
+ */
+export const createHybridKeyring = createHybridWallet;
 
 /**
  * Get hybrid cryptography info (sizes, etc.)

--- a/sdk/react-native/src/index.ts
+++ b/sdk/react-native/src/index.ts
@@ -7,19 +7,19 @@
  * ```typescript
  * import {
  *   createMobileClient,
- *   createWallet,
+ *   createKeyring,
  *   useAuth,
  *   useBalance,
  * } from '@icn/react-native';
  *
- * // Create a Device Keyring (legacy-named createWallet) with secure storage
- * const wallet = createWallet(secureStorage);
- * await wallet.generateKeyPair();
+ * // Create a Device Keyring with secure storage
+ * const keyring = createKeyring(secureStorage);
+ * await keyring.generateKeyPair();
  *
  * // Create client
  * const client = createMobileClient({
  *   baseUrl: 'https://icn.mycoop.org',
- *   wallet,
+ *   wallet: keyring, // config field is still named `wallet` (legacy); it accepts a keyring
  *   storage: secureStorage,
  * });
  *
@@ -51,14 +51,23 @@ export { QueueManager } from './queue-manager';
 // Error utilities
 export { parseError, createError, isNetworkError, isAuthError } from './error-utils';
 
-// Device Keyring — local key custody + signing (legacy-named "wallet"; holds no value)
-export { ICNWalletImpl, createWallet } from './wallet';
+// Device Keyring — local key custody + signing (holds no value).
+// Canonical: ICNKeyringImpl / createKeyring. Legacy aliases (deprecated): ICNWalletImpl / createWallet.
+export {
+  ICNWalletImpl,
+  createWallet,
+  ICNKeyringImpl,
+  createKeyring,
+} from './wallet';
 
-// Hybrid Post-Quantum Device Keyring (Ed25519 + ML-DSA-65; legacy-named "wallet")
+// Hybrid Post-Quantum Device Keyring (Ed25519 + ML-DSA-65).
+// Canonical: HybridKeyring / createHybridKeyring. Legacy aliases (deprecated): HybridWallet / createHybridWallet.
 export {
   HybridWallet,
   createHybridWallet,
   getHybridCryptoInfo,
+  HybridKeyring,
+  createHybridKeyring,
 } from './hybrid-wallet';
 export type { HybridKeyPairInfo, HybridSignOptions } from './hybrid-wallet';
 

--- a/sdk/react-native/src/index.ts
+++ b/sdk/react-native/src/index.ts
@@ -52,7 +52,8 @@ export { QueueManager } from './queue-manager';
 export { parseError, createError, isNetworkError, isAuthError } from './error-utils';
 
 // Device Keyring — local key custody + signing (holds no value).
-// Canonical: ICNKeyringImpl / createKeyring. Legacy aliases (deprecated): ICNWalletImpl / createWallet.
+// Canonical: ICNKeyringImpl / createKeyring. Legacy (retained): ICNWalletImpl / createWallet.
+// Only the legacy factory createWallet is @deprecated; ICNWalletImpl shares the class symbol with ICNKeyringImpl and is not deprecated.
 export {
   ICNWalletImpl,
   createWallet,
@@ -61,7 +62,8 @@ export {
 } from './wallet';
 
 // Hybrid Post-Quantum Device Keyring (Ed25519 + ML-DSA-65).
-// Canonical: HybridKeyring / createHybridKeyring. Legacy aliases (deprecated): HybridWallet / createHybridWallet.
+// Canonical: HybridKeyring / createHybridKeyring. Legacy (retained): HybridWallet / createHybridWallet.
+// Only the legacy factory createHybridWallet is @deprecated; HybridWallet shares the class symbol with HybridKeyring and is not deprecated.
 export {
   HybridWallet,
   createHybridWallet,

--- a/sdk/react-native/src/keyring-aliases.test.ts
+++ b/sdk/react-native/src/keyring-aliases.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for canonical Keyring aliases (added in feat/rn-sdk-keyring-aliases).
+ *
+ * Proves the canonical Keyring names are exact, behavior-preserving aliases of the legacy
+ * wallet-named exports: identical references, working key custody + signing, and unchanged
+ * persisted secure-storage keys (i.e. no migration). Imports come from the source modules
+ * (./wallet, ./hybrid-wallet, ./types) — matching the existing tests — to avoid pulling the
+ * `@icn/client` workspace dependency through ./index.
+ */
+
+import {
+  ICNWalletImpl,
+  createWallet,
+  ICNKeyringImpl,
+  createKeyring,
+} from './wallet';
+import {
+  HybridWallet,
+  createHybridWallet,
+  HybridKeyring,
+  createHybridKeyring,
+} from './hybrid-wallet';
+import { SecureStorage, ICNWallet, ICNKeyring } from './types';
+
+// Mock secure storage implementation
+function createMockStorage(): SecureStorage & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async setItem(key: string, value: string): Promise<void> {
+      store.set(key, value);
+    },
+    async getItem(key: string): Promise<string | null> {
+      return store.get(key) ?? null;
+    },
+    async removeItem(key: string): Promise<void> {
+      store.delete(key);
+    },
+    async hasItem(key: string): Promise<boolean> {
+      return store.has(key);
+    },
+  };
+}
+
+describe('Keyring aliases', () => {
+  it('canonical names are the exact same references as the legacy wallet names', () => {
+    expect(createKeyring).toBe(createWallet);
+    expect(ICNKeyringImpl).toBe(ICNWalletImpl);
+    expect(HybridKeyring).toBe(HybridWallet);
+    expect(createHybridKeyring).toBe(createHybridWallet);
+  });
+
+  it('createKeyring produces a working Device Keyring (generate + sign)', async () => {
+    const keyring: ICNKeyring = createKeyring(createMockStorage());
+    const kp = await keyring.generateKeyPair();
+    expect(kp.did).toMatch(/^did:icn:z/);
+    const sig = await keyring.sign('00');
+    expect(typeof sig).toBe('string');
+    expect(sig.length).toBeGreaterThan(0);
+  });
+
+  it('legacy createWallet still works and shares the implementation class', async () => {
+    const legacy: ICNWallet = createWallet(createMockStorage());
+    expect(legacy).toBeInstanceOf(ICNKeyringImpl); // ICNKeyringImpl === ICNWalletImpl
+    expect(await legacy.hasKeyPair()).toBe(false);
+  });
+
+  it('persisted secure-storage keys are unchanged (no migration)', async () => {
+    const storage = createMockStorage();
+    const keyring = createKeyring(storage);
+    await keyring.generateKeyPair();
+    // Canonical naming must not migrate or rename the legacy persisted keys.
+    expect(storage.store.has('icn_wallet_private_key')).toBe(true);
+    expect(storage.store.has('icn_wallet_public_key')).toBe(true);
+    expect(storage.store.has('icn_wallet_did')).toBe(true);
+  });
+
+  it('createHybridKeyring produces a working hybrid Device Keyring', async () => {
+    const hybridKeyring = createHybridKeyring(createMockStorage());
+    expect(hybridKeyring).toBeInstanceOf(HybridWallet); // HybridKeyring === HybridWallet
+    const info = await hybridKeyring.generateKeyPair();
+    expect(info.did).toMatch(/^did:icn:z/);
+  });
+});

--- a/sdk/react-native/src/types.ts
+++ b/sdk/react-native/src/types.ts
@@ -48,10 +48,20 @@ export interface KeyPair {
 }
 
 /**
- * Device Keyring interface (legacy-named `ICNWallet`): local key custody + signing.
+ * Canonical name for the Device Keyring interface — local key custody + signing.
+ *
+ * `ICNKeyring` is the preferred alias of {@link ICNWallet}; they are the same type.
+ */
+export type ICNKeyring = ICNWallet;
+
+/**
+ * Device Keyring interface — local key custody + signing.
  *
  * Generates / imports / stores a key pair and signs challenges. It does NOT hold
  * balances, tokens, or value — see the passport / keyring / position / receipt doctrine.
+ *
+ * Canonical alias: {@link ICNKeyring}. The `ICNWallet` name is retained for backward
+ * compatibility and is the type of the legacy `ICNMobileClientOptions.wallet?` field.
  */
 export interface ICNWallet {
   /**

--- a/sdk/react-native/src/wallet.ts
+++ b/sdk/react-native/src/wallet.ts
@@ -246,10 +246,25 @@ export class ICNWalletImpl implements ICNWallet {
 }
 
 /**
- * Create a Device Keyring (legacy-named `createWallet`) backed by secure storage.
+ * Create a Device Keyring backed by secure storage.
  *
  * Returns local key custody + signing only; it holds no balances, tokens, or value.
+ *
+ * @deprecated Prefer the canonical {@link createKeyring}. `createWallet` is retained as a
+ * backward-compatible alias and behaves identically (same return type and storage keys).
  */
 export function createWallet(storage: SecureStorage): ICNWallet {
   return new ICNWalletImpl(storage);
 }
+
+/**
+ * Canonical Device Keyring factory — preferred alias of {@link createWallet}.
+ *
+ * Identical behavior, signature, and persisted storage keys; no migration occurs.
+ */
+export const createKeyring = createWallet;
+
+/**
+ * Canonical Device Keyring implementation class — preferred alias of {@link ICNWalletImpl}.
+ */
+export { ICNWalletImpl as ICNKeyringImpl };


### PR DESCRIPTION
## Summary

Compatibility-preserving code/API slice following #1966 (which documented the React Native SDK's
wallet-named key-custody APIs as a **Device Keyring**). This adds canonical `Keyring`-named aliases
**alongside** the existing wallet-named exports — no legacy export is removed or renamed, and no
behavior, serialization, persisted storage key, or cryptography changes.

## Diagnosis

- **Where defined / exported:** `ICNWallet` interface (`src/types.ts`); `ICNWalletImpl` class +
  `createWallet` (`src/wallet.ts`); `HybridWallet` class + `createHybridWallet` (+ `getHybridCryptoInfo`)
  (`src/hybrid-wallet.ts`). Re-exported from `src/index.ts`; `ICNWallet` flows via `export * from './types'`.
- **Public exports?** Yes — all of the above are public exports of the publishable `@icn/react-native`.
  `ICNWallet` is also the type of `ICNMobileClientOptions.wallet?`.
- **Concept mapping:** **Device Keyring** — local private-key custody + signing (Ed25519 / hybrid
  Ed25519+ML-DSA-65, secure storage, challenge signing). No balances, tokens, value, accounts, payments,
  or settlements. Not Member Passport / Position / Settlement / Receipt.
- **Why aliases (not rename):** the names are public exports, persisted secure-storage keys
  (`icn_wallet_did`, `icn_wallet_private_key`, …) exist, and there was no canonical `Keyring` API yet —
  a rename would be breaking. Additive aliases are compatibility-safe.

## What changed

Canonical aliases added (exact, additive aliases of the legacy symbols — reference identity preserved):

| Canonical | Legacy alias (retained) |
|-----------|-------------------------|
| `ICNKeyring` | `ICNWallet` (interface) |
| `ICNKeyringImpl` | `ICNWalletImpl` |
| `createKeyring` | `createWallet` |
| `HybridKeyring` | `HybridWallet` |
| `createHybridKeyring` | `createHybridWallet` |

- Legacy factory/class names marked `@deprecated` in JSDoc, pointing at the canonical aliases.
- `README.md` and the `index.ts` `@example` now prefer the canonical names.
- New `src/keyring-aliases.test.ts` proves: canonical names are the **same references** as legacy;
  `createKeyring` produces a working keyring (generate + sign); legacy `createWallet` still works and
  shares the impl class; **persisted storage keys are unchanged** (`icn_wallet_private_key` /
  `_public_key` / `_did` still present — no migration); hybrid keyring works.

## What legacy names remain

All of them — `ICNWallet`, `ICNWalletImpl`, `createWallet`, `HybridWallet`, `createHybridWallet`,
`getHybridCryptoInfo` are still exported. Nothing removed or renamed.

## Compatibility notes

Fully backward compatible and additive. `ICNMobileClientOptions.wallet?` is **deliberately left as-is**
(it still types as `ICNWallet`); adding a `keyring?` field would require client read-logic changes, so it
is deferred to a future slice. For that reason the `ICNWallet` interface is documented with its canonical
alias (`ICNKeyring`) but **not** hard-`@deprecated`, to avoid casting deprecation across the still-supported
config field.

## Storage-key / serialization non-change

No persisted secure-storage key was renamed or migrated (`icn_wallet_*` unchanged); no serialized JSON
field changed; no `wallet_did` / `icn_wallet_did` migration; no cryptography change. A test asserts the
storage keys remain.

## Validation (clean worktree from `origin/main` = `d1f34121`)

| Check | Result |
|-------|--------|
| `compliance_linter.py` (scans `sdk/react-native/src/**/*.ts`) | PASS |
| `readiness_overclaim_linter.py` | PASS |
| `scripts/check-meaning-firewall.sh` | exit 0 |
| `git diff --check` | clean |
| RN `npm run build` (tsc) | **94 errors with patch == 94 baseline** (stash/compare) — all pre-existing `@icn/client` workspace-linking; **zero introduced** (`.test.ts` excluded from build per tsconfig) |
| RN tests `jest wallet.test.ts hybrid-wallet.test.ts keyring-aliases.test.ts` | **55/55 pass** (50 existing + 5 new alias tests) |

## Explicit non-claims

- No removal of legacy wallet exports.
- No `wallet_did` / `icn_wallet_did` migration.
- No secure-storage key migration.
- No protocol/API serialization change.
- No token custody.
- No wallet balance.
- No banking/payment product.
- No production identity readiness claim.
- No weakening of meaning/regulatory/firewall checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
