### PR TITLE
feat(sdk): accept keyring option in React Native client config

### DIFF
--- a/sdk/react-native/README.md
+++ b/sdk/react-native/README.md
@@ -79,8 +79,8 @@ if (!(await keyring.hasKeyPair())) {
 // Create client
 const client = createMobileClient({
   baseUrl: 'https://icn.mycoop.org',
-  // The client config field is still named `wallet` (legacy); it accepts a keyring.
-  wallet: keyring,
+  // Canonical `keyring` option; the legacy `wallet` option is still accepted.
+  keyring,
   storage: secureStorage,
 });
 
@@ -146,11 +146,16 @@ Create a new mobile ICN client.
 ```typescript
 const client = createMobileClient({
   baseUrl: 'https://icn.mycoop.org',
-  wallet: myWallet,        // Optional: for automatic signing
+  keyring: myKeyring,      // Optional (canonical): Device Keyring for automatic signing
   storage: secureStorage,  // Optional: for persistent auth
   timeout: 30000,          // Optional: request timeout
 });
 ```
+
+The signing keyring may be passed as either `keyring` (canonical) or `wallet` (legacy,
+retained for backward compatibility). They are the same type and role — a Device Keyring
+(local key custody + signing). If both are provided, `keyring` takes precedence; `wallet`
+is never removed.
 
 #### `client.initialize()`
 

--- a/sdk/react-native/src/client.test.ts
+++ b/sdk/react-native/src/client.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { ICNMobileClient, createMobileClient } from './client';
-import { SecureStorage, ICNWallet, KeyPair } from './types';
+import { SecureStorage, ICNWallet, ICNKeyring, KeyPair } from './types';
 
 // Mock secure storage
 function createMockStorage(): SecureStorage & { store: Map<string, string> } {
@@ -273,5 +273,79 @@ describe('createMobileClient', () => {
     });
 
     expect(client).toBeInstanceOf(ICNMobileClient);
+  });
+});
+
+describe('keyring option (canonical alias for legacy wallet)', () => {
+  // A Device Keyring whose sign()/getKeyPair() outputs are tagged, so a test can prove
+  // which configured keyring the client actually used. createCompletionSignature() and
+  // createDeviceProof() exercise only local key custody + signing (no network).
+  function createTaggedKeyring(tag: string): ICNKeyring {
+    const keyPair: KeyPair = { publicKey: `${tag}-pub`, did: `did:icn:${tag}` };
+    return {
+      async generateKeyPair(): Promise<KeyPair> {
+        return keyPair;
+      },
+      async importKeyPair(_privateKey: string): Promise<KeyPair> {
+        return keyPair;
+      },
+      async getKeyPair(): Promise<KeyPair | null> {
+        return keyPair;
+      },
+      async deleteKeyPair(): Promise<void> {},
+      async sign(message: string): Promise<string> {
+        return `${tag}:${message}`;
+      },
+      async hasKeyPair(): Promise<boolean> {
+        return true;
+      },
+    };
+  }
+
+  it('accepts a keyring option and uses it for signing', async () => {
+    const client = new ICNMobileClient({
+      baseUrl: 'https://icn.example.org',
+      keyring: createTaggedKeyring('keyring'),
+    });
+    const sig = await client.createCompletionSignature('enroll-1');
+    expect(sig).toBe('keyring:complete:enroll-1');
+  });
+
+  it('keyring takes precedence over wallet when both are provided', async () => {
+    const client = new ICNMobileClient({
+      baseUrl: 'https://icn.example.org',
+      keyring: createTaggedKeyring('keyring'),
+      wallet: createTaggedKeyring('wallet'),
+    });
+    const sig = await client.createCompletionSignature('enroll-2');
+    expect(sig).toBe('keyring:complete:enroll-2');
+  });
+
+  it('falls back to the legacy wallet option when no keyring is provided', async () => {
+    const client = new ICNMobileClient({
+      baseUrl: 'https://icn.example.org',
+      wallet: createTaggedKeyring('wallet'),
+    });
+    const sig = await client.createCompletionSignature('enroll-3');
+    expect(sig).toBe('wallet:complete:enroll-3');
+  });
+
+  it('throws when neither keyring nor wallet is configured', async () => {
+    const client = new ICNMobileClient({
+      baseUrl: 'https://icn.example.org',
+    });
+    await expect(client.createCompletionSignature('enroll-4')).rejects.toThrow(
+      'No wallet configured'
+    );
+  });
+
+  it('uses the keyring for device-proof key custody (getKeyPair + sign)', async () => {
+    const client = new ICNMobileClient({
+      baseUrl: 'https://icn.example.org',
+      keyring: createTaggedKeyring('keyring'),
+    });
+    const proof = await client.createDeviceProof('enroll-5');
+    expect(proof.ephemeral_did).toBe('did:icn:keyring');
+    expect(proof.signature).toBe('keyring:enroll-5');
   });
 });

--- a/sdk/react-native/src/client.ts
+++ b/sdk/react-native/src/client.ts
@@ -68,7 +68,10 @@ export class ICNMobileClient extends ICNClient {
 
     super(baseOptions);
 
-    this.wallet = options.wallet;
+    // Canonical `keyring` option is preferred; legacy `wallet` is the fallback for
+    // backward compatibility. Same type (ICNKeyring === ICNWallet) and role (a Device
+    // Keyring: local key custody + signing). If both are provided, `keyring` wins.
+    this.wallet = options.keyring ?? options.wallet;
     this.storage = options.storage;
     this.queueManager = new QueueManager(options.storage);
     

--- a/sdk/react-native/src/index.ts
+++ b/sdk/react-native/src/index.ts
@@ -19,7 +19,7 @@
  * // Create client
  * const client = createMobileClient({
  *   baseUrl: 'https://icn.mycoop.org',
- *   wallet: keyring, // config field is still named `wallet` (legacy); it accepts a keyring
+ *   keyring, // canonical option; the legacy `wallet` option is still accepted
  *   storage: secureStorage,
  * });
  *

--- a/sdk/react-native/src/types.ts
+++ b/sdk/react-native/src/types.ts
@@ -117,7 +117,21 @@ export interface PaymentQRData {
 export interface ICNMobileClientOptions {
   /** Gateway base URL */
   baseUrl: string;
-  /** Optional Device Keyring (legacy-named `wallet`) for automatic signing */
+  /**
+   * Optional Device Keyring for automatic signing (canonical option).
+   *
+   * Same type and role as {@link ICNMobileClientOptions.wallet} — a Device Keyring
+   * (local key custody + signing); `keyring` is the preferred, doctrine-aligned name.
+   * If both `keyring` and `wallet` are provided, `keyring` takes precedence and
+   * `wallet` is ignored.
+   */
+  keyring?: ICNKeyring;
+  /**
+   * Optional Device Keyring for automatic signing (legacy-named `wallet`).
+   *
+   * Retained for backward compatibility; prefer {@link ICNMobileClientOptions.keyring}.
+   * Used only when `keyring` is not provided.
+   */
   wallet?: ICNWallet;
   /** Request timeout in milliseconds */
   timeout?: number;


### PR DESCRIPTION
## Summary

Adds `ICNMobileClientOptions.keyring?` as a **canonical alias** for the legacy
`wallet?` React Native client option. Callers can now pass `keyring` (doctrine-aligned)
while the existing `wallet` option, behavior, exports, storage keys, and public
compatibility are fully preserved. Follows #1967 (canonical Keyring aliases for the
legacy wallet-named RN key-custody APIs).

## Diagnosis

- **Where `wallet?` is defined:** `sdk/react-native/src/types.ts` — `wallet?: ICNWallet`
  in `interface ICNMobileClientOptions`.
- **Where the client reads it:** `sdk/react-native/src/client.ts` constructor —
  `this.wallet = options.wallet;` (private field `private wallet?: ICNWallet`). It is
  consumed only in `login()`, `createDeviceProof()`, and `createCompletionSignature()`,
  each of which calls `getKeyPair` / `generateKeyPair` / `sign`.
- **Why it maps to Device Keyring (not Member Passport):** every use is local key
  custody + signing. The `ICNWallet` interface is `generateKeyPair` / `importKeyPair` /
  `getKeyPair` / `deleteKeyPair` / `sign` / `hasKeyPair` only — no balances, tokens, or
  value. This is a **Device Keyring** per the
  [passport / keyring / position / receipt doctrine](https://github.com/InterCooperative-Network/icn/blob/main/docs/design/passport-keyring-position-receipt.md).
  `ICNKeyring = ICNWallet` already exists as the canonical type alias.

## What changed

- `types.ts`: add `keyring?: ICNKeyring` to `ICNMobileClientOptions`; document that it is
  the canonical name for the same Device Keyring role; relabel `wallet?` as the retained
  legacy option.
- `client.ts`: constructor now reads `this.wallet = options.keyring ?? options.wallet;`
  (internal field name unchanged).
- `client.test.ts`: 5 new tests (see Validation).
- `index.ts` JSDoc + `README.md`: examples prefer `keyring`; `wallet` documented as the
  retained legacy alias with a precedence note.

## Compatibility behavior

- `keyring` and `wallet` are the **same type** (`ICNKeyring === ICNWallet`) and role.
- **Precedence:** `options.keyring ?? options.wallet` —
  - `keyring` provided → used (canonical, preferred);
  - only `wallet` provided → used, byte-identical to prior behavior (legacy fallback);
  - **both provided → `keyring` wins** (deterministic; no throw, no warning — the
    least-surprising compatibility-safe choice);
  - neither provided → unchanged "No wallet configured" error at call sites.

## Legacy names retained

`wallet?` option, `ICNWallet` / `ICNWalletImpl`, `HybridWallet`, `createWallet` /
`createHybridWallet`, and all existing exports are unchanged. Nothing is removed or
renamed.

## Storage-key / serialization non-change

This change is option read-logic + types/docs only. It writes **no** persisted
secure-storage keys, does not touch `wallet_did` / `icn_wallet_did`, and changes no JSON
serialization, cryptography, or network/API behavior. (Storage-key invariance for the
keyring itself is covered by the existing `keyring-aliases.test.ts`.)

## Validation

- `git diff --check`: clean.
- New `client.test.ts` cases: keyring accepted + used for signing; precedence over wallet
  when both set; wallet fallback preserved; throws when neither set; device-proof key
  custody via keyring.
- Full RN SDK Jest suite: **212 tests / 8 suites pass** (incl. `wallet.test.ts`,
  `hybrid-wallet.test.ts`, `keyring-aliases.test.ts`, `client.test.ts`).
- `tsc --noEmit`: **0 errors** (with `@icn/client` dist present).
- `compliance_linter.py`, `readiness_overclaim_linter.py`, readiness linter self-test
  (21): clean. `check-meaning-firewall.sh`: only 3 pre-existing `icn-gateway` Rust
  violations, untouched by this RN-only change.

## Explicit non-claims

- No removal of `wallet?`.
- No removal of legacy wallet exports.
- No `wallet_did` migration.
- No secure-storage key migration.
- No protocol / API serialization change.
- No token custody.
- No wallet balance.
- No banking / payment product.
- No production identity readiness claim.
- No weakening of meaning / regulatory / firewall checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
