### PR TITLE
fix(rust): rename wallet did surface to operator did

### DIFF
--- a/docs/architecture/CLIENT_MODEL.md
+++ b/docs/architecture/CLIENT_MODEL.md
@@ -645,7 +645,7 @@ instead of becoming a blind find-and-replace.
   reviewed PR (see the doctrine's [migration rules](../design/passport-keyring-position-receipt.md#migration-rules)):
   - **SDK key-custody rename** — `createWallet` / `HybridWallet` (TypeScript + React Native) → keyring
     naming. Breaking public-API change; deferred.
-  - **`wallet_did` field** (`icn-kernel-api`) → DID-/passport-rooted naming. Public-API rename; deferred.
+  - **`wallet_did` → `operator_did` field** (`icn-kernel-api`) → operator-DID naming. Public-API rename; **done** — direct rename, no serde alias (see [Wallet DID Migration Boundary](../design/wallet-did-migration-boundary.md)).
   - **Example app** `CoopWallet` → passport + keyring framing.
   - **Residual `wallet`-named CLI / config** in illustrative examples (this doc shows target naming).
 - Where the word "wallet" still appears in this document it is either (a) the **rejected

--- a/docs/design/passport-keyring-position-receipt.md
+++ b/docs/design/passport-keyring-position-receipt.md
@@ -112,7 +112,7 @@ table is to make the **migration target** explicit per class — not to authoriz
 |-------|---------|---------------------|------------------|
 | **A — Key custody internals** | A real local key store + signer | `sdk/react-native` `createWallet()` / `HybridWallet` / `wallet.sign()`; `multi-device-identity-design.md` Keystore | **Device Keyring** (deferred — breaking SDK API) |
 | **B — User-facing identity surface** | The app a member opens to present identity / approve login | "Open your ICN Wallet app and scan this code" (`web/pilot-ui`, `icn-gateway` static); `CoopWallet` login; "member wallet UI" | **Member Passport** (identity/session) + **Device Keyring** (the signing it triggers) |
-| **C — Stale crypto metaphor for identity** | identity expressed *as* a wallet | `icn-kernel-api/src/compute.rs` `wallet_did`, "Wallet-rooted identity for all operations" | DID-/passport-rooted identity (deferred — public API field) |
+| **C — Stale crypto metaphor for identity** | identity expressed *as* a wallet | `icn-kernel-api/src/compute.rs` `wallet_did`, "Wallet-rooted identity for all operations" | DID-/passport-rooted identity (**done** — renamed to `operator_did`) |
 | **D — Ledger state mislabeled** | accounting state called "wallet" | `demo/notes/flow-4-notes.md` "surplus to member wallets"; "member wallet balance" | **Position** |
 | **E — Historical / deprecation / non-claim** | "ICN is *not* a wallet"; "unhosted wallet"; archived text | `THE_COMMONS.md` "It is not a wallet."; manual "No wallet balance."; `docs/archive/**`; regulatory "unhosted wallet" | Leave; label historical/deprecated where needed. These are *correct* as-is. |
 | **F — Third-party / unavoidable** | external wallets / hardware wallets | `witness-signature-best-practices.md` "hardware wallets or TPM-backed keys"; references to users' own crypto wallets | Mark **external / third-party only** |
@@ -161,7 +161,8 @@ These are **named, not scheduled here** — each is its own future PR with its o
    `icn-gateway` static, OpenAPI QR descriptions) → passport-presentation language.
 3. **Example app** — `CoopWallet` example → passport+keyring framing.
 4. **`wallet_did` field** (`icn-kernel-api`) → DID-/passport-rooted identity naming. High-cost public
-   API rename; deferred.
+   API rename; **done** — direct rename to `operator_did` (no serde alias; see
+   [Wallet DID Migration Boundary](./wallet-did-migration-boundary.md)).
 5. **Demo speaker notes** — "surplus to member wallets" → "member positions".
 6. **"wallet" node mode** terminology (plans) → adopt the passport/keyring split.
 

--- a/docs/design/wallet-did-migration-boundary.md
+++ b/docs/design/wallet-did-migration-boundary.md
@@ -10,7 +10,7 @@
 > `icn_keyring_*` / `icn_hybrid_keyring_*`, with a defensive legacy purge on delete and a new
 > `ICNMobileClient.resetIdentity()` that also clears persisted auth (`icn_auth_*`) and the offline
 > queue. The Surface 1 sections below are retained as the original design record (this doc itself
-> still changes nothing). Surface 2 (the Rust `wallet_did` field) remains future work as described.
+> still changes nothing). Surface 2 (the Rust `wallet_did` field) has since been implemented (2026-06-02) as a direct rename to `operator_did` (the canonical serialized / public field name). Per the exposure re-check (Surface 2 below) — no OpenAPI, HTTP handler, persisted store, gossip path, or TypeScript-SDK consumer of `OperatorMode`, serialized only by its own unit tests — it was a **direct rename with no serde alias**, treated as a semver-relevant change to `icn-kernel-api`. This doc itself still changes nothing.
 
 ---
 

--- a/icn/crates/icn-kernel-api/src/compute.rs
+++ b/icn/crates/icn-kernel-api/src/compute.rs
@@ -45,11 +45,11 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Individual Nodes
 ///
-/// Individual nodes are operated by a person using their wallet DID as the
+/// Individual nodes are operated by a person using their operator DID as the
 /// root identity. This enables:
 /// - Personal data sovereignty (your node, your data)
 /// - Optional contribution to commons compute
-/// - Wallet-rooted identity for all operations
+/// - Operator-rooted identity for all operations
 ///
 /// # Organizational Nodes
 ///
@@ -74,8 +74,8 @@ pub enum OperatorMode {
     },
     /// Node operated by an individual (personal infrastructure)
     Individual {
-        /// The wallet DID that owns this node
-        wallet_did: Did,
+        /// The operator DID that owns this node
+        operator_did: Did,
         /// Whether this node contributes to commons compute
         contributes_to_commons: bool,
     },
@@ -114,13 +114,13 @@ impl OperatorMode {
         }
     }
 
-    /// Get the operator identifier (entity_id or wallet_did as string).
+    /// Get the operator identifier (entity_id or operator_did as string).
     ///
     /// This is used for cell join compatibility checks.
     pub fn operator_id(&self) -> &str {
         match self {
             Self::Organization { entity_id, .. } => entity_id,
-            Self::Individual { wallet_did, .. } => wallet_did.as_str(),
+            Self::Individual { operator_did, .. } => operator_did.as_str(),
         }
     }
 
@@ -134,9 +134,14 @@ impl OperatorMode {
             (Self::Organization { entity_id: a, .. }, Self::Organization { entity_id: b, .. }) => {
                 a == b
             }
-            (Self::Individual { wallet_did: a, .. }, Self::Individual { wallet_did: b, .. }) => {
-                a == b
-            }
+            (
+                Self::Individual {
+                    operator_did: a, ..
+                },
+                Self::Individual {
+                    operator_did: b, ..
+                },
+            ) => a == b,
             _ => false, // Mixed modes not compatible
         }
     }
@@ -635,7 +640,7 @@ mod tests {
         assert!(org.is_organization());
 
         let individual = OperatorMode::Individual {
-            wallet_did: "did:icn:abc123".into(),
+            operator_did: "did:icn:abc123".into(),
             contributes_to_commons: true,
         };
         assert!(individual.is_individual());
@@ -653,14 +658,14 @@ mod tests {
 
         // Individuals can opt in
         let ind_yes = OperatorMode::Individual {
-            wallet_did: "did:icn:abc123".into(),
+            operator_did: "did:icn:abc123".into(),
             contributes_to_commons: true,
         };
         assert!(ind_yes.contributes_to_commons());
 
         // Individuals can opt out
         let ind_no = OperatorMode::Individual {
-            wallet_did: "did:icn:abc123".into(),
+            operator_did: "did:icn:abc123".into(),
             contributes_to_commons: false,
         };
         assert!(!ind_no.contributes_to_commons());
@@ -675,7 +680,7 @@ mod tests {
         assert_eq!(org.operator_id(), "coop-123");
 
         let individual = OperatorMode::Individual {
-            wallet_did: "did:icn:abc123".into(),
+            operator_did: "did:icn:abc123".into(),
             contributes_to_commons: true,
         };
         assert_eq!(individual.operator_id(), "did:icn:abc123");
@@ -702,21 +707,21 @@ mod tests {
         assert!(!org1.is_compatible_with(&org2));
 
         let ind1 = OperatorMode::Individual {
-            wallet_did: "did:icn:abc123".into(),
+            operator_did: "did:icn:abc123".into(),
             contributes_to_commons: true,
         };
         let ind1_clone = OperatorMode::Individual {
-            wallet_did: "did:icn:abc123".into(),
+            operator_did: "did:icn:abc123".into(),
             contributes_to_commons: false, // Different contrib setting
         };
         let ind2 = OperatorMode::Individual {
-            wallet_did: "did:icn:def456".into(),
+            operator_did: "did:icn:def456".into(),
             contributes_to_commons: true,
         };
 
-        // Same wallet DID = compatible
+        // Same operator DID = compatible
         assert!(ind1.is_compatible_with(&ind1_clone));
-        // Different wallet DID = incompatible
+        // Different operator DID = incompatible
         assert!(!ind1.is_compatible_with(&ind2));
 
         // Mixed modes = incompatible
@@ -742,12 +747,16 @@ mod tests {
     #[test]
     fn test_operator_mode_serde_individual() {
         let ind = OperatorMode::Individual {
-            wallet_did: "did:icn:abc123".into(),
+            operator_did: "did:icn:abc123".into(),
             contributes_to_commons: true,
         };
         let json = serde_json::to_string(&ind).unwrap();
         assert!(json.contains(r#""individual""#));
-        assert!(json.contains(r#""wallet_did":"did:icn:abc123""#));
+        assert!(json.contains(r#""operator_did":"did:icn:abc123""#));
+        assert!(
+            !json.contains("wallet_did"),
+            "serialized OperatorMode must use canonical operator_did, never legacy wallet_did"
+        );
         assert!(json.contains(r#""contributes_to_commons":true"#));
 
         let parsed: OperatorMode = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## What changed

Renames the Rust **Surface 2** operator-identifier field from `wallet_did` to the
canonical `operator_did` in `icn-kernel-api`. This is the deferred Rust-side
counterpart to the wallet/keyring language migration (companion to the React Native
keyring storage-key work in #1970).

- `icn/crates/icn-kernel-api/src/compute.rs`
  - `OperatorMode::Individual.wallet_did: Did` -> `operator_did: Did`
  - In-repo consumers updated: `operator_id()` and `is_compatible_with()`
  - Field/enum doc comments: "wallet DID" / "Wallet-rooted identity" -> operator-DID language
  - Tests: all `OperatorMode::Individual { wallet_did: .. }` constructors -> `operator_did`
  - Serde lock test now asserts the canonical `"operator_did"` JSON key **and** adds a
    regression guard asserting the serialized form **never** emits `wallet_did`
- Doc trackers flipped from *deferred* -> *done* for this one item only:
  - `docs/design/wallet-did-migration-boundary.md` (Surface 2 status note)
  - `docs/architecture/CLIENT_MODEL.md` (named-migrations bullet)
  - `docs/design/passport-keyring-position-receipt.md` (class C row + slice #4)

## Why `operator_did` is the canonical name

The field is the subject DID of the node **operator** (operator boundary E5/E6). The
enclosing type is `OperatorMode` and its accessor is `operator_id()`, so `operator_did`
is the most boundary-accurate name. Per the doctrine, **a DID is not a wallet**: no key
custody happens in this field (that is the Device Keyring, Surface 1), so `wallet_did`
was misleading crypto-metaphor language. This matches the canonical target prescribed in
`docs/design/wallet-did-migration-boundary.md` (Surface 2 -> `operator_did`).

## Compatibility behavior

**Direct rename, no serde alias.** I re-ran the exposure check the design doc mandates
(step 1) and re-confirmed `OperatorMode` has **no** external / wire consumer:

- not derived with `ToSchema` / utoipa and absent from every OpenAPI document
- no occurrence in any `*.json` / `*.yaml` artifact
- no HTTP handler, persisted store, gossip path, or TypeScript-SDK consumer
- only in-repo references are `compute.rs`, `services.rs` (via methods, not the field),
  and the `lib.rs` re-export; the only serializer is the crate's own unit tests

Because there is no serialized consumer today, per the design doc this is a
**semver-relevant direct rename**, not a compat-aliased one. A deserialize-only alias was
deliberately **not** added (the doc reserves serde `rename` + `alias` for *if/when* a wire
or persistence contract is later adopted). The serialized output is now `operator_did`,
and a test guard prevents regression back to `wallet_did` as the canonical key.

## Exact changed files

```
docs/architecture/CLIENT_MODEL.md                |  2 +-
docs/design/passport-keyring-position-receipt.md |  5 ++-
docs/design/wallet-did-migration-boundary.md     |  2 +-
icn/crates/icn-kernel-api/src/compute.rs         | 49 ++++++++++++++----------
4 files changed, 34 insertions(+), 24 deletions(-)
```

## Tests / validation run

- `cargo fmt -p icn-kernel-api -- --check` -- clean (rustfmt re-wrapped one match arm)
- `cargo test -p icn-kernel-api operator_mode` -- 3 OperatorMode tests pass (7 passed / 0 failed)
- `git diff --check` -- no whitespace errors
- `python3 .github/scripts/compliance_linter.py` -- no violations (106 files)
- `python3 .github/scripts/readiness_overclaim_linter.py` -- no overclaims
- `python3 .github/scripts/test_readiness_overclaim_linter.py` -- 21/21
- `scripts/check-meaning-firewall.sh` -- only the pre-existing `icn-gateway` `icn_trust`
  baseline (untouched by this PR; script exits 0)

## Non-goals / deferred (explicitly out of scope)

- **No** React Native secure-storage key changes (Surface 1, done in #1970)
- **No** TypeScript / RN auth-concurrency changes (#1972 / #1973)
- **No** CoopWallet example cleanup
- **No** demo speaker-note / member-wallet / "records are on-chain" language changes
- **No** generated OpenAPI / API artifact changes (none required -- `OperatorMode` is not in
  any generated artifact)
- **No** broader wallet terminology cleanup
- The unrelated dirty WIP checkout at `/home/ubuntu/projects/icn` was left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
