### PR TITLE
fix(example): reframe CoopWallet identity around passport and keyring

### DIFF
--- a/sdk/react-native/examples/CoopWallet/App.tsx
+++ b/sdk/react-native/examples/CoopWallet/App.tsx
@@ -2388,7 +2388,26 @@ export default function App() {
         const timeoutPromise = new Promise<boolean>((_, reject) =>
           setTimeout(() => reject(new Error('Init timeout after 15s')), 15000)
         );
-        const success = await Promise.race([initializeClient(), timeoutPromise]);
+        // Serialize the startup initializer with the Reset Identity / Try Again
+        // actions through the shared lock. Hold it for the REAL initializeClient()
+        // run -- released when that promise settles, below -- not just until the 15s
+        // UI race resolves. Otherwise an init slower than the timeout keeps
+        // doInitialize() running (reading/generating keys) after the login screen
+        // renders, so a Reset Identity tap could delete + regenerate keys against
+        // the same module-level handles concurrently.
+        resetInProgress = true;
+        const initPromise = initializeClient();
+        // Release on settle (fulfilled OR rejected); both branches are handled so
+        // this side-channel never raises an unhandled rejection.
+        void initPromise.then(
+          () => {
+            resetInProgress = false;
+          },
+          () => {
+            resetInProgress = false;
+          },
+        );
+        const success = await Promise.race([initPromise, timeoutPromise]);
         console.log('initializeClient completed, success:', success);
 
         if (!success) {

--- a/sdk/react-native/examples/CoopWallet/App.tsx
+++ b/sdk/react-native/examples/CoopWallet/App.tsx
@@ -2,7 +2,7 @@
  * Coop Wallet - ICN React Native App
  *
  * Features:
- * - Authentication with secure wallet
+ * - Authentication with an on-device Device Keyring
  * - Balance display and payment
  * - QR code scan-to-pay
  * - Governance voting
@@ -85,6 +85,7 @@ let initializeClient: () => Promise<boolean> = async () => {
 };
 let retryInitialization: () => Promise<boolean> = async () => false;
 let resetClientState: () => void = () => {};
+let resetIdentity: () => Promise<void> = async () => {};
 let isClientReady: () => boolean = () => false;
 let getClientState: () => string = () => 'uninitialized';
 let getLastInitError: () => any = () => null;
@@ -98,6 +99,7 @@ try {
   initializeClient = clientModule.initializeClient;
   retryInitialization = clientModule.retryInitialization || (async () => initializeClient());
   resetClientState = clientModule.resetClientState || (() => {});
+  resetIdentity = clientModule.resetIdentity || (async () => resetClientState());
   isClientReady = clientModule.isClientReady || (() => getClient() !== null);
   getClientState = () => clientModule?.clientState || 'uninitialized';
   getLastInitError = () => clientModule?.lastInitError || null;
@@ -217,12 +219,12 @@ function LoginScreen({ onLogin }: { onLogin: (coopId: string, did: string) => vo
       }
 
       if (client) {
-        // Get the wallet's DID for debugging
-        const walletModule = require('./src/client');
-        const wallet = walletModule.wallet;
-        if (wallet) {
-          const keyPair = await wallet.getKeyPair();
-          console.log('Wallet DID:', keyPair?.did);
+        // Get the Device Keyring's DID for debugging
+        const keyringModule = require('./src/client');
+        const keyring = keyringModule.keyring;
+        if (keyring) {
+          const keyPair = await keyring.getKeyPair();
+          console.log('Keyring DID:', keyPair?.did);
           if (keyPair?.did) {
             console.log('DID length:', keyPair.did.length);
             // Show first 50 chars to verify format
@@ -241,7 +243,7 @@ function LoginScreen({ onLogin }: { onLogin: (coopId: string, did: string) => vo
         console.log('Login successful:', authState);
         onLogin(coopId.trim(), authState.did || '');
       } else {
-        throw new Error('Wallet not ready. Please wait for initialization or restart the app.');
+        throw new Error('Identity not ready. Please wait for initialization or restart the app.');
       }
     } catch (err) {
       console.error('Login error details:', err);
@@ -323,28 +325,32 @@ function LoginScreen({ onLogin }: { onLogin: (coopId: string, did: string) => vo
           style={[styles.secondaryButton, { marginTop: 20 }]}
           onPress={async () => {
             try {
-              // Clear localStorage on web
+              // Forget the on-device identity (Device Keyring key pair, auth
+              // session, and queued operations) so stale identity/auth state
+              // cannot survive the reset.
+              await resetIdentity();
+              // Clear any web localStorage fallback as well.
               if (Platform.OS === 'web') {
                 localStorage.clear();
                 console.log('localStorage cleared');
               }
-              // Reinitialize client
+              // Reinitialize to provision a fresh Device Keyring.
               await initializeClient();
               setError(null);
               // Alert doesn't work on web, use console and update UI
-              console.log('Wallet reset! New keys generated.');
+              console.log('Identity reset. A new Device Keyring was generated.');
               if (Platform.OS === 'web') {
-                window.alert('Wallet reset! New keys generated. Please try logging in again.');
+                window.alert('Identity reset. A new Device Keyring was generated. Please try logging in again.');
               } else {
-                Alert.alert('Wallet Reset', 'New keys generated. Please try logging in again.');
+                Alert.alert('Identity Reset', 'A new Device Keyring was generated. Please try logging in again.');
               }
             } catch (e) {
               console.error('Reset error:', e);
-              setError('Failed to reset wallet: ' + (e as Error).message);
+              setError('Failed to reset identity: ' + (e as Error).message);
             }
           }}
         >
-          <Text style={[styles.buttonText, { color: '#666' }]}>Reset Wallet</Text>
+          <Text style={[styles.buttonText, { color: '#666' }]}>Reset Identity</Text>
         </TouchableOpacity>
       </View>
     </KeyboardAvoidingView>
@@ -746,7 +752,7 @@ function PaymentScreen({
     try {
       const client = getClient();
       if (!client) {
-        throw new Error('Wallet not ready. Please wait for initialization or restart the app.');
+        throw new Error('Identity not ready. Please wait for initialization or restart the app.');
       }
 
       // Make real payment via API
@@ -1605,7 +1611,7 @@ function VerifyScreen({ navigation }: { navigation: any }) {
     try {
       const client = getClient();
       if (!client) {
-        throw new Error('Wallet not ready. Please wait for initialization or restart the app.');
+        throw new Error('Identity not ready. Please wait for initialization or restart the app.');
       }
 
       // Call SDIS verification API
@@ -2092,7 +2098,7 @@ function BiometricLockScreen({ onUnlock }: { onUnlock: () => void }) {
     <View style={styles.biometricContainer}>
       <View style={styles.biometricContent}>
         <Text style={styles.biometricIcon}>🔒</Text>
-        <Text style={styles.biometricTitle}>Wallet Locked</Text>
+        <Text style={styles.biometricTitle}>App Locked</Text>
         <Text style={styles.biometricSubtitle}>
           Use your fingerprint or face to unlock
         </Text>
@@ -2191,13 +2197,13 @@ function InitializationErrorScreen({
             onPress={onReset}
           >
             <Text style={[styles.initErrorButtonText, { color: '#666' }]}>
-              Reset Wallet
+              Reset Identity
             </Text>
           </TouchableOpacity>
         </View>
 
         <Text style={styles.initErrorHint}>
-          If problems persist, try resetting your wallet. This will generate new keys.
+          If problems persist, try resetting your identity. This clears this device's keyring and signs you out.
         </Text>
       </View>
     </View>
@@ -2293,7 +2299,10 @@ export default function App() {
   }, []);
 
   const handleInitReset = useCallback(async () => {
-    resetClientState();
+    // Forget the on-device identity (Device Keyring key pair, auth session, and
+    // queued operations) before dropping in-memory state, so a reset cannot leave
+    // stale auth bound to a discarded keyring DID.
+    await resetIdentity();
 
     // Clear localStorage on web
     if (Platform.OS === 'web') {

--- a/sdk/react-native/examples/CoopWallet/App.tsx
+++ b/sdk/react-native/examples/CoopWallet/App.tsx
@@ -86,10 +86,12 @@ let initializeClient: () => Promise<boolean> = async () => {
 let retryInitialization: () => Promise<boolean> = async () => false;
 let resetClientState: () => void = () => {};
 let resetIdentity: () => Promise<void> = async () => {};
-// Serializes the full reset-plus-reinitialize sequence (shared by both Reset
-// Identity actions) so a double-tap cannot interleave two reset/initialize runs
-// against the same storage -- which could drop shared handles and provision keys
-// concurrently. A duplicate tap while one is in flight is a no-op.
+// Serializes every identity-mutating sequence -- the two Reset Identity actions
+// AND the initialization-error "Try Again" retry -- against the shared module-level
+// storage/keyring/client handles. Without this, a Reset Identity (which deletes the
+// key pair then reprovisions) could interleave with a retry's doInitialize() (which
+// generates a key pair), racing deletion against generation and overwriting the
+// shared client. A duplicate/competing tap while one is in flight is a no-op.
 let resetInProgress = false;
 let isClientReady: () => boolean = () => false;
 let getClientState: () => string = () => 'uninitialized';
@@ -2293,6 +2295,11 @@ export default function App() {
   const [initError, setInitError] = useState<InitErrorInfo | null>(null);
 
   const handleInitRetry = useCallback(async () => {
+    // Share the reset lock so a retry cannot interleave with an in-flight Reset
+    // Identity: its key deletion/reprovision must not race this retry's
+    // doInitialize() key generation against the same storage/keyring/client.
+    if (resetInProgress) return;
+    resetInProgress = true;
     setInitFailed(false);
     setInitError(null);
 
@@ -2318,6 +2325,8 @@ export default function App() {
         retriable: true,
         details: (error as Error).message,
       });
+    } finally {
+      resetInProgress = false;
     }
   }, []);
 

--- a/sdk/react-native/examples/CoopWallet/App.tsx
+++ b/sdk/react-native/examples/CoopWallet/App.tsx
@@ -2299,29 +2299,45 @@ export default function App() {
   }, []);
 
   const handleInitReset = useCallback(async () => {
-    // Forget the on-device identity (Device Keyring key pair, auth session, and
-    // queued operations) before dropping in-memory state, so a reset cannot leave
-    // stale auth bound to a discarded keyring DID.
-    await resetIdentity();
+    try {
+      // Forget the on-device identity (Device Keyring key pair, auth session, and
+      // queued operations) before dropping in-memory state, so a reset cannot leave
+      // stale auth bound to a discarded keyring DID. resetIdentity() rejects if any
+      // persisted cleanup fails, so we catch below to surface that instead of
+      // leaving an unhandled promise rejection or falsely claiming success.
+      await resetIdentity();
 
-    // Clear localStorage on web
-    if (Platform.OS === 'web') {
-      try {
-        localStorage.clear();
-        console.log('localStorage cleared');
-      } catch (e) {
-        console.error('Failed to clear localStorage:', e);
+      // Clear localStorage on web
+      if (Platform.OS === 'web') {
+        try {
+          localStorage.clear();
+          console.log('localStorage cleared');
+        } catch (e) {
+          console.error('Failed to clear localStorage:', e);
+        }
       }
-    }
 
-    // Retry initialization
-    setInitFailed(false);
-    setInitError(null);
+      // Retry initialization
+      setInitFailed(false);
+      setInitError(null);
 
-    const success = await initializeClient();
-    if (!success) {
+      const success = await initializeClient();
+      if (!success) {
+        setInitFailed(true);
+        setInitError(getLastInitError());
+      }
+    } catch (error) {
+      // A persisted cleanup failure means the identity was NOT fully forgotten --
+      // surface a recovery message instead of an unhandled rejection, and do not
+      // claim the reset succeeded.
+      console.error('Identity reset error:', error);
       setInitFailed(true);
-      setInitError(getLastInitError());
+      setInitError({
+        message: 'Could not fully reset this device identity. Some stored keys may remain. Try again, or reinstall the app.',
+        code: 'RESET_ERROR',
+        retriable: true,
+        details: (error as Error).message,
+      });
     }
   }, []);
 

--- a/sdk/react-native/examples/CoopWallet/App.tsx
+++ b/sdk/react-native/examples/CoopWallet/App.tsx
@@ -334,8 +334,19 @@ function LoginScreen({ onLogin }: { onLogin: (coopId: string, did: string) => vo
                 localStorage.clear();
                 console.log('localStorage cleared');
               }
-              // Reinitialize to provision a fresh Device Keyring.
-              await initializeClient();
+              // Reinitialize to provision a fresh Device Keyring. Check the result:
+              // the persisted identity is cleared, but if reprovisioning fails we must
+              // not clear the error and claim a new keyring was generated.
+              const reinitialized = await initializeClient();
+              if (!reinitialized) {
+                const initErr = getLastInitError();
+                setError(
+                  'Identity cleared, but setting up a new Device Keyring failed: ' +
+                    (initErr?.message || 'initialization failed') +
+                    '. Please try again.',
+                );
+                return;
+              }
               setError(null);
               // Alert doesn't work on web, use console and update UI
               console.log('Identity reset. A new Device Keyring was generated.');

--- a/sdk/react-native/examples/CoopWallet/App.tsx
+++ b/sdk/react-native/examples/CoopWallet/App.tsx
@@ -86,6 +86,11 @@ let initializeClient: () => Promise<boolean> = async () => {
 let retryInitialization: () => Promise<boolean> = async () => false;
 let resetClientState: () => void = () => {};
 let resetIdentity: () => Promise<void> = async () => {};
+// Serializes the full reset-plus-reinitialize sequence (shared by both Reset
+// Identity actions) so a double-tap cannot interleave two reset/initialize runs
+// against the same storage -- which could drop shared handles and provision keys
+// concurrently. A duplicate tap while one is in flight is a no-op.
+let resetInProgress = false;
 let isClientReady: () => boolean = () => false;
 let getClientState: () => string = () => 'uninitialized';
 let getLastInitError: () => any = () => null;
@@ -324,6 +329,11 @@ function LoginScreen({ onLogin }: { onLogin: (coopId: string, did: string) => vo
         <TouchableOpacity
           style={[styles.secondaryButton, { marginTop: 20 }]}
           onPress={async () => {
+            // Serialize: ignore a duplicate tap while a reset is already running,
+            // so two reset/reinitialize sequences cannot interleave against the same
+            // storage. The skipped tap makes no UI claim of success.
+            if (resetInProgress) return;
+            resetInProgress = true;
             try {
               // Forget the on-device identity (Device Keyring key pair, auth
               // session, and queued operations) so stale identity/auth state
@@ -358,6 +368,8 @@ function LoginScreen({ onLogin }: { onLogin: (coopId: string, did: string) => vo
             } catch (e) {
               console.error('Reset error:', e);
               setError('Failed to reset identity: ' + (e as Error).message);
+            } finally {
+              resetInProgress = false;
             }
           }}
         >
@@ -2310,6 +2322,10 @@ export default function App() {
   }, []);
 
   const handleInitReset = useCallback(async () => {
+    // Serialize: ignore a duplicate tap while a reset is already running so two
+    // reset/reinitialize sequences cannot interleave against the same storage.
+    if (resetInProgress) return;
+    resetInProgress = true;
     try {
       // Forget the on-device identity (Device Keyring key pair, auth session, and
       // queued operations) before dropping in-memory state, so a reset cannot leave
@@ -2349,6 +2365,8 @@ export default function App() {
         retriable: true,
         details: (error as Error).message,
       });
+    } finally {
+      resetInProgress = false;
     }
   }, []);
 

--- a/sdk/react-native/examples/CoopWallet/README.md
+++ b/sdk/react-native/examples/CoopWallet/README.md
@@ -2,9 +2,15 @@
 
 Example React Native app demonstrating the ICN mobile SDK.
 
+> **Identity model.** "Coop Wallet" is this example app's brand name only. The app
+> follows ICN doctrine: a member's identity and standing is their **Member Passport**,
+> on-device key custody and signing is the **Device Keyring** (the SDK's `createKeyring`),
+> and economic state is tracked as **positions, receipts, and obligations** -- not as a
+> stored-value wallet balance.
+
 ## Features
 
-- **Secure Authentication** - Login with your cooperative using Ed25519 keys stored in device secure storage
+- **Secure Authentication** - Login with your cooperative using a Device Keyring (Ed25519 keys held in device secure storage)
 - **Balance Display** - View your hour balance with real-time updates
 - **Send Payments** - Transfer hours to other members
 - **QR Payments** - Scan-to-pay and receive via QR codes
@@ -113,7 +119,7 @@ CoopWallet/
 ### Setup Client
 
 ```typescript
-import { createWallet, createMobileClient, SecureStorage } from '@icn/react-native';
+import { createKeyring, createMobileClient, SecureStorage } from '@icn/react-native';
 import * as SecureStore from 'expo-secure-store';
 
 const storage: SecureStorage = {
@@ -123,10 +129,10 @@ const storage: SecureStorage = {
   hasItem: async (key) => (await SecureStore.getItemAsync(key)) !== null,
 };
 
-const wallet = createWallet(storage);
+const keyring = createKeyring(storage);
 const client = createMobileClient({
   baseUrl: 'https://icn.mycoop.org',
-  wallet,
+  keyring,
   storage,
 });
 ```

--- a/sdk/react-native/examples/CoopWallet/src/client.ts
+++ b/sdk/react-native/examples/CoopWallet/src/client.ts
@@ -6,7 +6,7 @@
  */
 
 import { Platform } from 'react-native';
-import { createWallet, createMobileClient, SecureStorage, ICNWallet, ICNMobileClient } from '@icn/react-native';
+import { createKeyring, createMobileClient, SecureStorage, ICNKeyring, ICNMobileClient } from '@icn/react-native';
 import { GATEWAY_URL, APP_CONFIG } from './config';
 
 /** Client initialization state */
@@ -72,9 +72,14 @@ const getNativeStorage = async (): Promise<SecureStorage> => {
   };
 };
 
-// Storage, wallet, and client are initialized asynchronously
+// Storage, Device Keyring, and client are initialized asynchronously
 let secureStorage: SecureStorage | null = null;
-export let wallet: ICNWallet | null = null;
+/**
+ * The Device Keyring: on-device key custody + signing. Bound to the SDK's
+ * canonical createKeyring()/ICNKeyring (the legacy createWallet alias is
+ * @deprecated). Holds no value -- economic state lives in positions/receipts.
+ */
+export let keyring: ICNKeyring | null = null;
 export let client: ICNMobileClient | null = null;
 
 /**
@@ -149,24 +154,24 @@ async function doInitialize(): Promise<void> {
   }
   if (APP_CONFIG.debug) console.log('Storage initialized');
 
-  // Create wallet for key management
-  wallet = createWallet(secureStorage);
-  if (APP_CONFIG.debug) console.log('Wallet created');
+  // Create the Device Keyring for on-device key custody + signing
+  keyring = createKeyring(secureStorage);
+  if (APP_CONFIG.debug) console.log('Device Keyring created');
 
-  // Ensure wallet has a key pair
-  if (!(await wallet.hasKeyPair())) {
+  // Ensure the keyring has a key pair
+  if (!(await keyring.hasKeyPair())) {
     if (APP_CONFIG.debug) console.log('Generating new key pair...');
-    const keyPair = await wallet.generateKeyPair();
+    const keyPair = await keyring.generateKeyPair();
     if (APP_CONFIG.debug) console.log('Key pair generated, DID:', keyPair.did);
   } else {
-    const keyPair = await wallet.getKeyPair();
+    const keyPair = await keyring.getKeyPair();
     if (APP_CONFIG.debug) console.log('Existing key pair found, DID:', keyPair?.did);
   }
 
   // Create mobile client
   client = createMobileClient({
     baseUrl: GATEWAY_URL,
-    wallet,
+    keyring,
     storage: secureStorage,
   });
   if (APP_CONFIG.debug) console.log('Mobile client created');
@@ -245,15 +250,38 @@ export async function retryInitialization(): Promise<boolean> {
 }
 
 /**
- * Reset client state completely (for wallet reset scenarios).
+ * Reset the in-memory client state (for identity reset / reprovision scenarios).
+ *
+ * This only drops the in-memory references; it does NOT clear persisted identity.
+ * To forget the on-device identity (Device Keyring key pair, auth session, and the
+ * offline operation queue) call `resetIdentity()` first, then re-initialize.
  */
 export function resetClientState(): void {
   clientState = ClientState.Uninitialized;
   lastInitError = null;
   initAttempts = 0;
-  wallet = null;
+  keyring = null;
   client = null;
   secureStorage = null;
+}
+
+/**
+ * Forget the on-device identity, then drop in-memory client state.
+ *
+ * Delegates to `ICNMobileClient.resetIdentity()` (added in #1970), which clears the
+ * Device Keyring key pair, the persisted auth session, and the queued offline
+ * operations, and invalidates the in-memory session so stale auth/identity state
+ * cannot survive a reset. After this returns, call `initializeClient()` to provision
+ * a fresh Device Keyring.
+ */
+export async function resetIdentity(): Promise<void> {
+  try {
+    if (client) {
+      await client.resetIdentity();
+    }
+  } finally {
+    resetClientState();
+  }
 }
 
 /**

--- a/sdk/react-native/examples/CoopWallet/src/client.ts
+++ b/sdk/react-native/examples/CoopWallet/src/client.ts
@@ -72,6 +72,17 @@ const getNativeStorage = async (): Promise<SecureStorage> => {
   };
 };
 
+/**
+ * Resolve the platform-appropriate secure storage adapter. Shared by init and by
+ * resetIdentity(), which must be able to reacquire storage that initialization
+ * never assigned (e.g. when an early failure left no retained handles).
+ */
+async function getPlatformStorage(): Promise<SecureStorage> {
+  if (Platform.OS === 'web') return webStorage;
+  // Use native secure storage on iOS/Android.
+  return getNativeStorage();
+}
+
 // Storage, Device Keyring, and client are initialized asynchronously
 let secureStorage: SecureStorage | null = null;
 /**
@@ -146,12 +157,7 @@ async function doInitialize(): Promise<void> {
   }
 
   // Get platform-appropriate storage
-  if (Platform.OS === 'web') {
-    secureStorage = webStorage;
-  } else {
-    // Use native secure storage on iOS/Android
-    secureStorage = await getNativeStorage();
-  }
+  secureStorage = await getPlatformStorage();
   if (APP_CONFIG.debug) console.log('Storage initialized');
 
   // Create the Device Keyring for on-device key custody + signing
@@ -275,39 +281,35 @@ export function resetClientState(): void {
  * a fresh Device Keyring.
  */
 export async function resetIdentity(): Promise<void> {
-  // Pre-client case: initialization can fail after the Device Keyring and secure
-  // storage are created but before createMobileClient() runs (e.g. a transient
-  // hasKeyPair()/generateKeyPair()/getKeyPair() storage error), leaving `client`
-  // null while persisted identity still exists. Construct the client now so the
-  // canonical ICNMobileClient.resetIdentity() can clear the keyring key pair, the
-  // auth session, and the offline queue -- otherwise the reset would only drop
-  // in-memory references and a later init could silently reuse the old identity.
-  if (!client && keyring && secureStorage) {
-    client = createMobileClient({
-      baseUrl: GATEWAY_URL,
-      keyring,
-      storage: secureStorage,
-    });
-  }
+  // Reacquire any handles that initialization never created, so a reset can still
+  // clear a previously-persisted identity even when init failed early -- e.g. a
+  // transient expo-secure-store import failure in getPlatformStorage() before
+  // `secureStorage` or `keyring` were ever assigned. If storage or the keyring
+  // cannot be reacquired, the throw below rejects the reset (the caller surfaces
+  // it) rather than falsely reporting success after clearing only in-memory state.
+  // We assign to the module-level handles so a failed reset retains them for a
+  // retry. (Constructing the client mirrors the normal init/reset->reinit flow.)
+  // `??=` assigns the module-level handle only when missing and yields a non-null
+  // local, so this both reacquires what init never created AND keeps the handles
+  // assigned (retained for a retry) if cleanup later rejects.
+  const storage = (secureStorage ??= await getPlatformStorage());
+  const deviceKeyring = (keyring ??= createKeyring(storage));
+  const mobileClient = (client ??= createMobileClient({
+    baseUrl: GATEWAY_URL,
+    keyring: deviceKeyring,
+    storage,
+  }));
 
-  // Attempt the persisted cleanup. These reject if any removal fails; let that
-  // propagate (the caller surfaces it) WITHOUT clearing the in-memory handles, so a
-  // retry can re-run the cleanup against the surviving keyring/auth/queue. The
-  // canonical resetIdentity()/deleteKeyPair() are idempotent, so re-attempting
-  // after a partial failure is safe.
-  if (client) {
-    await client.resetIdentity();
-  } else if (keyring) {
-    // Last resort if no secure storage is available to build a client from (should
-    // not happen, since the keyring is created from secure storage): still clear the
-    // persisted keyring key pair.
-    await keyring.deleteKeyPair();
-  }
+  // Canonical cleanup: clears the keyring key pair, the persisted auth session, and
+  // the offline queue. Rejects if any persisted removal fails; let that propagate
+  // WITHOUT clearing the in-memory handles, so a retry can re-run cleanup against
+  // the surviving state. resetIdentity()/deleteKeyPair() are idempotent, so
+  // re-attempting after a partial failure is safe.
+  await mobileClient.resetIdentity();
 
-  // Only reached once cleanup SUCCEEDED: now it is safe to drop the in-memory
-  // references so the next initializeClient() provisions a fresh identity. On a
-  // cleanup failure we intentionally keep the handles above so the user can retry
-  // the reset instead of being left with a stranded, partially-cleared identity.
+  // Only reached once cleanup SUCCEEDED: drop the in-memory references so the next
+  // initializeClient() provisions a fresh identity. On failure we keep the handles
+  // above so the user can retry the reset.
   resetClientState();
 }
 

--- a/sdk/react-native/examples/CoopWallet/src/client.ts
+++ b/sdk/react-native/examples/CoopWallet/src/client.ts
@@ -276,10 +276,34 @@ export function resetClientState(): void {
  */
 export async function resetIdentity(): Promise<void> {
   try {
+    // Pre-client case: initialization can fail after the Device Keyring and secure
+    // storage are created but before createMobileClient() runs (e.g. a transient
+    // hasKeyPair()/generateKeyPair()/getKeyPair() storage error), leaving `client`
+    // null while persisted identity still exists. Construct the client now so the
+    // canonical ICNMobileClient.resetIdentity() can clear the keyring key pair, the
+    // auth session, and the offline queue -- otherwise the reset would only drop
+    // in-memory references and a later init could silently reuse the old identity.
+    if (!client && keyring && secureStorage) {
+      client = createMobileClient({
+        baseUrl: GATEWAY_URL,
+        keyring,
+        storage: secureStorage,
+      });
+    }
     if (client) {
+      // Rejects if any persisted cleanup fails, so the caller can report that the
+      // identity was not fully forgotten (we must not swallow this).
       await client.resetIdentity();
+    } else if (keyring) {
+      // Last resort if no secure storage is available to build a client from
+      // (should not happen, since the keyring is created from secure storage):
+      // still clear the persisted keyring key pair, and let a failure propagate.
+      await keyring.deleteKeyPair();
     }
   } finally {
+    // Always drop in-memory references so state is coherent for a fresh init. This
+    // runs after any throw above WITHOUT masking it -- the rejection still
+    // propagates to the caller, which surfaces the failure in the UI.
     resetClientState();
   }
 }

--- a/sdk/react-native/examples/CoopWallet/src/client.ts
+++ b/sdk/react-native/examples/CoopWallet/src/client.ts
@@ -275,37 +275,40 @@ export function resetClientState(): void {
  * a fresh Device Keyring.
  */
 export async function resetIdentity(): Promise<void> {
-  try {
-    // Pre-client case: initialization can fail after the Device Keyring and secure
-    // storage are created but before createMobileClient() runs (e.g. a transient
-    // hasKeyPair()/generateKeyPair()/getKeyPair() storage error), leaving `client`
-    // null while persisted identity still exists. Construct the client now so the
-    // canonical ICNMobileClient.resetIdentity() can clear the keyring key pair, the
-    // auth session, and the offline queue -- otherwise the reset would only drop
-    // in-memory references and a later init could silently reuse the old identity.
-    if (!client && keyring && secureStorage) {
-      client = createMobileClient({
-        baseUrl: GATEWAY_URL,
-        keyring,
-        storage: secureStorage,
-      });
-    }
-    if (client) {
-      // Rejects if any persisted cleanup fails, so the caller can report that the
-      // identity was not fully forgotten (we must not swallow this).
-      await client.resetIdentity();
-    } else if (keyring) {
-      // Last resort if no secure storage is available to build a client from
-      // (should not happen, since the keyring is created from secure storage):
-      // still clear the persisted keyring key pair, and let a failure propagate.
-      await keyring.deleteKeyPair();
-    }
-  } finally {
-    // Always drop in-memory references so state is coherent for a fresh init. This
-    // runs after any throw above WITHOUT masking it -- the rejection still
-    // propagates to the caller, which surfaces the failure in the UI.
-    resetClientState();
+  // Pre-client case: initialization can fail after the Device Keyring and secure
+  // storage are created but before createMobileClient() runs (e.g. a transient
+  // hasKeyPair()/generateKeyPair()/getKeyPair() storage error), leaving `client`
+  // null while persisted identity still exists. Construct the client now so the
+  // canonical ICNMobileClient.resetIdentity() can clear the keyring key pair, the
+  // auth session, and the offline queue -- otherwise the reset would only drop
+  // in-memory references and a later init could silently reuse the old identity.
+  if (!client && keyring && secureStorage) {
+    client = createMobileClient({
+      baseUrl: GATEWAY_URL,
+      keyring,
+      storage: secureStorage,
+    });
   }
+
+  // Attempt the persisted cleanup. These reject if any removal fails; let that
+  // propagate (the caller surfaces it) WITHOUT clearing the in-memory handles, so a
+  // retry can re-run the cleanup against the surviving keyring/auth/queue. The
+  // canonical resetIdentity()/deleteKeyPair() are idempotent, so re-attempting
+  // after a partial failure is safe.
+  if (client) {
+    await client.resetIdentity();
+  } else if (keyring) {
+    // Last resort if no secure storage is available to build a client from (should
+    // not happen, since the keyring is created from secure storage): still clear the
+    // persisted keyring key pair.
+    await keyring.deleteKeyPair();
+  }
+
+  // Only reached once cleanup SUCCEEDED: now it is safe to drop the in-memory
+  // references so the next initializeClient() provisions a fresh identity. On a
+  // cleanup failure we intentionally keep the handles above so the user can retry
+  // the reset instead of being left with a stranded, partially-cleared identity.
+  resetClientState();
 }
 
 /**


### PR DESCRIPTION
## Summary

Reframes the **CoopWallet** React Native example away from the "wallet" identity/key metaphor toward current ICN doctrine, and wires the SDK's `ICNMobileClient.resetIdentity()` (added in #1970) into the example's identity-reset paths.

Doctrine framing applied:
- **Member Passport** — member-facing identity / standing.
- **Device Keyring** — on-device key custody + signing (holds no value).
- **Positions / receipts / obligations** — economic/accounting state (not a stored-value "wallet" balance).

Behavioral fix: on native, the example's "Reset" buttons previously only cleared in-memory state (and web `localStorage`), so the persisted keyring was silently reused on the next init — the reset didn't actually reset. Both reset flows now call `resetIdentity()`, which clears the Device Keyring key pair, the persisted auth session, and the offline operation queue, then invalidates the in-memory session, before re-initializing to provision a fresh keyring.

## Scope

`sdk/react-native/examples/CoopWallet/**` only — three files:
- `src/client.ts`
- `App.tsx`
- `README.md`

## What changed

**`src/client.ts`**
- Adopt the canonical `createKeyring()` / `ICNKeyring` API (the `createWallet` / `ICNWallet` aliases the example used are `@deprecated`).
- Rename the example's Device Keyring handle `wallet` → `keyring`; pass the canonical `keyring` option to `createMobileClient`.
- Add an async `resetIdentity()` helper that delegates to `ICNMobileClient.resetIdentity()` and then clears in-memory client state.
- Clarify `resetClientState()` docs (in-memory only; does not clear persisted identity).

**`App.tsx`**
- Wire `resetIdentity()` into both reset flows (login-error "Reset" and the initialization-error "Reset") so persisted identity is actually forgotten on reset.
- Reframe member-facing copy: `Reset Wallet` → `Reset Identity`, `Wallet Locked` → `App Locked`, `Wallet not ready` → `Identity not ready`, reset alerts → "Identity reset / A new Device Keyring was generated", debug `Wallet DID` → `Keyring DID`, `secure wallet` → `Device Keyring`.
- Keep the product brand **"Coop Wallet"** (header, login title, biometric unlock prompt, Home title) and **all build identifiers** (directory `CoopWallet`, package `coop-wallet`, bundle id `org.icn.coopwallet`) unchanged.

**`README.md`**
- Add an "Identity model" note (Member Passport / Device Keyring / positions+receipts; "Coop Wallet" is brand only).
- Reframe the auth feature bullet to Device Keyring.
- Switch the SDK "Setup Client" sample to the canonical `createKeyring()`.

## Validation

| Check | Result |
| --- | --- |
| `git diff --check` | clean |
| `python3 .github/scripts/compliance_linter.py` | exit 0 — no violations (106 files) |
| `python3 .github/scripts/readiness_overclaim_linter.py` | exit 0 — no overclaims |
| `python3 .github/scripts/test_readiness_overclaim_linter.py` | 21 tests OK |
| `scripts/check-meaning-firewall.sh` | exit 0 (pre-existing 3 `icn-gateway` kernel-crate items only; not touched here) |
| SDK symbol verification | `createKeyring`, `ICNKeyring`, `createMobileClient({ keyring })`, and `ICNMobileClient.resetIdentity(): Promise<void>` confirmed exported/typed in `sdk/react-native/src` |

**Not run — example typecheck / RN jest:** the example has no test harness and no `typecheck`/`test` script, and the worktree has no `node_modules` / built SDK `dist`. A real typecheck requires a full `npm install`, whose `postinstall` rebuilds both the TypeScript and React Native SDKs (network-dependent and known to intermittently bus-error in CI) — disproportionate for an example copy/wiring change. The SDK's own `resetIdentity()` test suite (`sdk/react-native/src/client.test.ts`) already passes on `main` and is unchanged here.

## Non-goals (explicitly out of scope)

- **No Rust `operator_did` changes.** #1974 is already merged; this PR does not touch it.
- No React Native storage-key canonicalization outside this example.
- No SDK public API renames — the example only switches its own usage from the deprecated `createWallet` alias to the canonical `createKeyring`.
- No generated API artifacts.
- No gateway/OpenAPI docs, website, pilot UI, user manual, demo speaker notes, or broader docs.
- No "wallet" node-mode terminology cleanup.
- No payment → settlement terminology change (separate compliance slice).
- The dead/parallel `src/screens/*` files (not imported by `App.tsx`) are intentionally left untouched to avoid cosmetic churn.

## Note

PR #1974 (`fix(rust): rename wallet did surface to operator did`) is already merged; this PR is a separate, narrow example-only slice and does **not** touch Rust `operator_did`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
