### PR TITLE
fix(sdk): add React Native client lifecycle teardown

### DIFF
--- a/sdk/react-native/examples/CoopWallet/src/client.ts
+++ b/sdk/react-native/examples/CoopWallet/src/client.ts
@@ -294,23 +294,37 @@ export async function resetIdentity(): Promise<void> {
   // assigned (retained for a retry) if cleanup later rejects.
   const storage = (secureStorage ??= await getPlatformStorage());
   const deviceKeyring = (keyring ??= createKeyring(storage));
+  // Whether we are constructing the client SOLELY to run this cleanup (init never
+  // built one). If so we dispose its network monitor afterwards; a reused live
+  // client is left intact. (Deferred #1975 5-B: a cleanup-only client would
+  // otherwise leak the network monitor ICNMobileClient's constructor starts.)
+  const constructedForCleanup = client === null;
   const mobileClient = (client ??= createMobileClient({
     baseUrl: GATEWAY_URL,
     keyring: deviceKeyring,
     storage,
   }));
 
-  // Canonical cleanup: clears the keyring key pair, the persisted auth session, and
-  // the offline queue. Rejects if any persisted removal fails; let that propagate
-  // WITHOUT clearing the in-memory handles, so a retry can re-run cleanup against
-  // the surviving state. resetIdentity()/deleteKeyPair() are idempotent, so
-  // re-attempting after a partial failure is safe.
-  await mobileClient.resetIdentity();
+  try {
+    // Canonical cleanup: clears the keyring key pair, the persisted auth session,
+    // and the offline queue. Rejects if any persisted removal fails; let that
+    // propagate WITHOUT clearing the in-memory handles, so a retry can re-run
+    // cleanup against the surviving state. resetIdentity()/deleteKeyPair() are
+    // idempotent, so re-attempting after a partial failure is safe.
+    await mobileClient.resetIdentity();
 
-  // Only reached once cleanup SUCCEEDED: drop the in-memory references so the next
-  // initializeClient() provisions a fresh identity. On failure we keep the handles
-  // above so the user can retry the reset.
-  resetClientState();
+    // Only reached once cleanup SUCCEEDED: drop the in-memory references so the
+    // next initializeClient() provisions a fresh identity. On failure we keep the
+    // handles above so the user can retry the reset.
+    resetClientState();
+  } finally {
+    // Release the network monitor of a client we built only for cleanup, whether
+    // the reset succeeded or threw (a retry reuses this same client purely for
+    // idempotent storage cleanup, which needs no monitor).
+    if (constructedForCleanup) {
+      mobileClient.dispose();
+    }
+  }
 }
 
 /**

--- a/sdk/react-native/src/client.test.ts
+++ b/sdk/react-native/src/client.test.ts
@@ -443,6 +443,46 @@ describe('ICNMobileClient', () => {
       expect(await storage.getItem('icn_auth_token')).toBe('preserved-token');
       expect(client.authState.isAuthenticated).toBe(false);
     });
+
+    it('skips a basic-monitor tick still in flight when dispose() runs (no post-teardown side effects)', async () => {
+      jest.useFakeTimers();
+      const realFetch = (globalThis as any).fetch;
+      let resolveFetch: (value?: unknown) => void = () => {};
+      (globalThis as any).fetch = jest.fn(
+        () => new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+      );
+      try {
+        // @react-native-community/netinfo is absent in the SDK test env, so this
+        // client runs the basic-monitoring (setInterval) path.
+        const c = new ICNMobileClient({
+          baseUrl: 'https://icn.example.org',
+          storage: createMockStorage(),
+        });
+        const processQueueSpy = jest
+          .spyOn(c, 'processQueue')
+          .mockResolvedValue(undefined);
+        // Force a transition-to-online on the next successful probe.
+        (c as any)._networkState = 'offline';
+
+        // Fire one heartbeat; its fetch is now pending (awaiting).
+        jest.advanceTimersByTime(30000);
+        // Tear down while the probe is in flight, then let it resolve.
+        c.dispose();
+        resolveFetch({});
+        // Flush the awaited continuation inside the tick callback.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // The post-dispose tick must NOT flip network state or process the queue.
+        expect(processQueueSpy).not.toHaveBeenCalled();
+        expect(c.networkState).toBe('offline');
+      } finally {
+        (globalThis as any).fetch = realFetch;
+        jest.useRealTimers();
+      }
+    });
   });
 
   describe('connectRealtime', () => {

--- a/sdk/react-native/src/client.test.ts
+++ b/sdk/react-native/src/client.test.ts
@@ -396,6 +396,55 @@ describe('ICNMobileClient', () => {
     });
   });
 
+  describe('dispose', () => {
+    it('is idempotent and safe to call more than once', () => {
+      const unsub = jest.fn();
+      // Simulate the NetInfo path having captured an unsubscribe handle.
+      (client as any).netInfoUnsubscribe = unsub;
+      expect(() => {
+        client.dispose();
+        client.dispose();
+      }).not.toThrow();
+      // Second dispose() is a no-op (guarded), so unsubscribe runs exactly once.
+      expect(unsub).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the NetInfo unsubscribe handle when present', () => {
+      const unsub = jest.fn();
+      (client as any).netInfoUnsubscribe = unsub;
+      client.dispose();
+      expect(unsub).toHaveBeenCalledTimes(1);
+      expect((client as any).netInfoUnsubscribe).toBeNull();
+    });
+
+    it('clears the fallback network-monitoring interval (no timer survives)', () => {
+      jest.useFakeTimers();
+      try {
+        // In the SDK test env @react-native-community/netinfo is not installed, so
+        // the constructor takes the basic-monitoring path and schedules one 30s
+        // heartbeat interval. dispose() must clear it.
+        const c = new ICNMobileClient({
+          baseUrl: 'https://icn.example.org',
+          storage: createMockStorage(),
+        });
+        const before = jest.getTimerCount();
+        c.dispose();
+        const after = jest.getTimerCount();
+        expect(after).toBe(0);
+        expect(after).toBeLessThanOrEqual(before);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not clear identity / auth / storage state (lifecycle teardown only)', async () => {
+      await storage.setItem('icn_auth_token', 'preserved-token');
+      client.dispose();
+      expect(await storage.getItem('icn_auth_token')).toBe('preserved-token');
+      expect(client.authState.isAuthenticated).toBe(false);
+    });
+  });
+
   describe('connectRealtime', () => {
     it('should throw without coop ID', () => {
       expect(() => client.connectRealtime()).toThrow('No coop ID provided');

--- a/sdk/react-native/src/client.ts
+++ b/sdk/react-native/src/client.ts
@@ -254,6 +254,9 @@ export class ICNMobileClient extends ICNClient {
    */
   private startBasicNetworkMonitoring(): void {
     const intervalId = setInterval(async () => {
+      // A tick may already have been queued when dispose() cleared the interval;
+      // skip it so teardown stops the heartbeat completely.
+      if (this.disposed) return;
       const baseUrl = (this as unknown as { baseUrl: string }).baseUrl;
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 5000);
@@ -266,12 +269,18 @@ export class ICNMobileClient extends ICNClient {
           signal: controller.signal,
         });
 
+        // dispose() may have run while this probe was in flight; do not apply
+        // network-state changes or trigger queue processing after teardown.
+        if (this.disposed) return;
         if (this._networkState !== 'online') {
           this._networkState = 'online';
           this.notifyNetworkListeners();
           this.processQueue();
         }
       } catch {
+        // dispose() may have run while this probe was in flight (e.g. abort);
+        // do not apply post-teardown network-state changes.
+        if (this.disposed) return;
         if (this._networkState !== 'offline') {
           this._networkState = 'offline';
           this.notifyNetworkListeners();

--- a/sdk/react-native/src/client.ts
+++ b/sdk/react-native/src/client.ts
@@ -71,6 +71,13 @@ export class ICNMobileClient extends ICNClient {
   private reconnectDelay = 1000;
   private intentionalDisconnect = false;
   private reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  // Network-monitoring teardown handles, captured so dispose() can release them.
+  // setupNetworkMonitoring() stores EITHER the NetInfo subscription's unsubscribe
+  // function OR the basic fallback polling interval id (whichever path is active).
+  private netInfoUnsubscribe: (() => void) | null = null;
+  private networkMonitorIntervalId: ReturnType<typeof setInterval> | null = null;
+  // Idempotency guard for dispose().
+  private disposed = false;
 
   constructor(options: ICNMobileClientOptions) {
     // Create base client options
@@ -90,6 +97,41 @@ export class ICNMobileClient extends ICNClient {
     
     // Setup network state monitoring if available
     this.setupNetworkMonitoring();
+  }
+
+  /**
+   * Release lifecycle resources held by this client: the network-state monitor
+   * started in the constructor (the NetInfo subscription, or the basic polling
+   * interval fallback) plus any live WebSocket / pending reconnect timer.
+   *
+   * Idempotent and synchronous -- safe to call on a short-lived or cleanup-only
+   * client (e.g. one constructed solely to run resetIdentity()). This is lifecycle
+   * teardown ONLY: it does NOT clear the Device Keyring, the persisted auth
+   * session, or the offline queue -- use resetIdentity() to forget the on-device
+   * identity.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    // Stop network monitoring: release whichever handle setupNetworkMonitoring()
+    // captured (both are null if neither path started).
+    if (this.netInfoUnsubscribe) {
+      try {
+        this.netInfoUnsubscribe();
+      } catch (error) {
+        // A misbehaving unsubscribe must not break teardown.
+        console.error('NetInfo unsubscribe threw during dispose:', error);
+      }
+      this.netInfoUnsubscribe = null;
+    }
+    if (this.networkMonitorIntervalId !== null) {
+      clearInterval(this.networkMonitorIntervalId);
+      this.networkMonitorIntervalId = null;
+    }
+
+    // Release any open socket and cancel a pending reconnect timer (no-op if none).
+    this.disconnectWebSocket();
   }
 
   /**
@@ -184,7 +226,7 @@ export class ICNMobileClient extends ICNClient {
       // @ts-ignore - dynamic import
       const NetInfo = require('@react-native-community/netinfo');
       
-      NetInfo.addEventListener((state: any) => {
+      this.netInfoUnsubscribe = NetInfo.addEventListener((state: any) => {
         const newState: NetworkState = state.isConnected
           ? state.isInternetReachable === false
             ? 'slow'
@@ -245,6 +287,8 @@ export class ICNMobileClient extends ICNClient {
     // on Node timers (so Jest/Node can exit cleanly); on React Native the timer id
     // is a number and this optional call is a safe no-op.
     (intervalId as { unref?: () => void }).unref?.();
+    // Retain the id so dispose() can clear the heartbeat when the client is torn down.
+    this.networkMonitorIntervalId = intervalId;
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a public `ICNMobileClient.dispose()` lifecycle teardown so clients constructed temporarily — including the **cleanup-only clients** the CoopWallet example builds solely to run `resetIdentity()` — can release the network-monitoring resources their constructor starts. `dispose()` is idempotent, synchronous, and is lifecycle teardown only (it does **not** clear identity/auth/storage).

## Why this exists

This is the deferred SDK lifecycle follow-up from the **#1975 CoopWallet review (Codex round 5-B)**. That review found a real leak: the example sometimes constructs an `ICNMobileClient` only to clear/reset persisted identity, and the constructor starts network monitoring via `setupNetworkMonitoring()` — but fresh inspection found **no public `dispose()`/teardown API, no stored NetInfo unsubscribe handle, no stored 30s interval handle, and no monitoring opt-out**. #1975 correctly deferred this rather than hacking around it (the auth/queue storage keys are module-private, so the example must not hardcode cleanup internals). This PR provides the missing teardown path.

## What changed

**`sdk/react-native/src/client.ts`**
- Capture the NetInfo subscription's unsubscribe handle (`setupNetworkMonitoring()` now stores the `NetInfo.addEventListener(...)` return).
- Capture the basic fallback polling interval id (`startBasicNetworkMonitoring()` now stores `setInterval(...)`).
- Add public **`dispose(): void`** — idempotent (guarded by a `disposed` flag); releases the NetInfo unsubscribe (if present), clears the fallback interval (if present), and disconnects any live WebSocket / cancels a pending reconnect timer via the existing `disconnectWebSocket()`. Does **not** touch the Device Keyring, persisted auth session, or offline queue.
- No constructor behavior change (it still calls `setupNetworkMonitoring()`); the methods just retain their handles now.

**`sdk/react-native/src/client.test.ts`**
- `dispose` suite: idempotency (safe to call twice; unsubscribe runs once), NetInfo-unsubscribe release + handle nulled, fallback-interval cleanup (no timer survives, via fake timers), and that `dispose()` leaves auth/storage untouched.

**`sdk/react-native/examples/CoopWallet/src/client.ts`**
- `resetIdentity()` now disposes a client it constructed **solely for cleanup** (the pre-client path) in a `finally`. A reused live client is left intact, and the retain-handles-on-failure-for-retry semantics are preserved (a retry reuses the same client purely for idempotent storage cleanup, which needs no monitor).

## Validation

- **RN SDK jest: 246/246 pass** across 9 suites (includes the 4 new `dispose` tests; all existing identity-reset / login-concurrency tests still green).
- **`tsc --noEmit`: clean** (no type errors).
- `git diff --check`: clean.
- `compliance_linter.py`, `readiness_overclaim_linter.py` (+ its self-test), `check-meaning-firewall.sh`: all pass.
- Harness: built the `@icn/client` (TS SDK) dist + `npm install` in `sdk/react-native` to run jest/tsc. The CoopWallet **example** has no separate test/typecheck harness, so its call-site change is verified statically — the `mobileClient.dispose()` it now calls is the public method validated by the SDK typecheck + tests.

## Non-goals

- No monitoring opt-out constructor option (dispose is the smaller/safer shape).
- No public identity/keyring API renames.
- No storage-key canonicalization, no generated API artifacts, no Rust `operator_did`, no broad docs.
- No wallet/node-mode terminology cleanup.

## Note

This **does not** implement the optional CoopWallet startup-init generation/cancellation fence (the round-7 advisory from #1975). That remains a separate, optional example-level follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
