### PR TITLE
docs(demo): clarify member allocation receipt language

### DIFF
--- a/demo/notes/flow-2-notes.md
+++ b/demo/notes/flow-2-notes.md
@@ -1,7 +1,7 @@
 # Flow 2 — Presenter Notes: BrightWorks Patronage Distribution
 **Audience**: Cooperative members, organizers, community leaders (non-technical)
 **Duration**: ~15 minutes with pauses
-**Key message**: Surplus went from Q1 close → democratic vote → ledger settlement → member balances. The whole chain is verifiable.
+**Key message**: Surplus went from Q1 close → democratic vote → ledger settlement → member positions. The whole chain is verifiable.
 
 ---
 
@@ -68,15 +68,15 @@
 
 ---
 
-## Beat: Step 9 — Live balance
-**Say**: "The cooperative account balance is live. Any member can query their own balance at any time — the coop doesn't have to send a statement."
-**Point to**: The balance result
+## Beat: Step 9 — Live position
+**Say**: "The cooperative account position is live. Any member can query their own position at any time — the coop doesn't have to send a statement."
+**Point to**: The position result
 **If asked**: "Yes, this is real-time. No waiting for month-end accounting."
 
 ---
 
 ## Beat: Step 10 — Full history
-**Say**: "Here's the whole chain: Q1 surplus → allocation formula → member vote → ledger entry → member balance. Every step traceable. This is what a cooperative financial record looks like when it's on the network."
+**Say**: "Here's the whole chain: Q1 surplus → allocation formula → member vote → ledger entry → member position. Every step traceable. This is what a cooperative financial record looks like when it's on the network."
 **Point to**: The history entries
 
 ---

--- a/demo/notes/flow-4-notes.md
+++ b/demo/notes/flow-4-notes.md
@@ -38,7 +38,7 @@
 ---
 
 ## Beat: Step 4 — Full allocation trail
-**Say**: "Every transaction in order. The foundation can trace the full chain from surplus to member wallets. This is not a summary — it's the raw record."
+**Say**: "Every transaction in order. The foundation can trace the full chain from surplus to member positions. This is not a summary — it's the raw record."
 **Point to**: The history
 **If asked**: "Yes, a forensic accountant could follow this. It's designed to be auditable."
 

--- a/demo/notes/flow-5-notes.md
+++ b/demo/notes/flow-5-notes.md
@@ -32,10 +32,10 @@
 
 ## Beat: Step 3 — Ledger position
 **Say**: "Here's Finger Lakes CDN's standing in the mutual credit system. Before any task executes, the system checks whether they have the credit line to cover it. This is credit reservation — like a hold on a card, except it belongs to a cooperative and not a bank."
-**Point to**: The ledger position response (or the 404 / zero balance message)
+**Point to**: The ledger position response (or the 404 / zero position message)
 **If position is 404 or zero**: "They have no prior activity — this is their first interaction with the commons pool. That's allowed. New members can participate; their credit line grows as they contribute. Trust gates access; credits settle after the work is done."
 **If asked "What is mutual credit?"**: "It's a credit system where the cooperative network issues credit based on real contributions — not capital. When Finger Lakes CDN routes traffic for other cooperatives, they earn credits. When they spend compute, they spend credits. No bank, no interest, no extraction."
-**If asked "What if they go negative?"**: "The system has a credit floor — configured by governance, not hard-coded. Going below the floor blocks further spending until the balance is restored through contribution. The cooperative's members set the floor through their own governance policy."
+**If asked "What if they go negative?"**: "The system has a credit floor — configured by governance, not hard-coded. Going below the floor blocks further spending until the position is restored through contribution. The cooperative's members set the floor through their own governance policy."
 
 ---
 


### PR DESCRIPTION
## Summary

Migration slice #5: clean **demo presenter (speaker) notes** that called cooperative ledger accounting state a "wallet" or "balance" — and the specifically-flagged phrase **"surplus to member wallets"** — and reframe them onto the regulatory-safe **position** primitive. The narration now matches ICN's actual model (the network *records member positions and emits receipts*) instead of implying ICN moves funds into personal wallets.

Docs-only. No code, API, UI, schema, or generated artifact is touched.

## Why this exists

The design doc [`docs/design/passport-keyring-position-receipt.md`](docs/design/passport-keyring-position-receipt.md) item **D ("Ledger state mislabeled")** flags accounting state called "wallet"/"balance" → should be **Position**, and item 5 names the demo speaker notes specifically: *"surplus to member wallets" → "member positions."* This PR executes exactly that narrow slice. "wallet"/"balance" framing implies ICN custodies and transfers member money; the accurate primitive is a recorded **position** backed by governance decisions and receipts. External settlement, where it happens, is a separate bridge concern.

## Files changed

- `demo/notes/flow-2-notes.md` — `member balances` → `member positions`; `Step 9 — Live balance` → `Live position`; `account balance is live` → `account position is live`; `query their own balance` → `query their own position`; `The balance result` → `The position result`; `member balance` → `member position`
- `demo/notes/flow-4-notes.md` — `from surplus to member wallets` → `from surplus to member positions`
- `demo/notes/flow-5-notes.md` — `zero balance message` → `zero position message`; `the balance is restored` → `the position is restored`

(3 files, 8 insertions, 8 deletions.)

## Regulatory-safe terminology used

- **position** / **member position** — the approved primitive for cooperative ledger accounting state (replaces "wallet"/"balance").

Preserved deliberately because they are accurate, not overclaim:
- **surplus** — genuine cooperative patronage concept (distributable net margin), not a banned term.
- **credits** / **mutual credit** — the real ICN economic primitive.
- **settlement** / **ledger settlement** / **ledger entry** — approved settlement vocabulary.
- **transaction**, **account** — unchanged; not in the banned set and changing them would be out-of-scope drift.

## Validation

All run from a clean worktree at `origin/main` (`1bce9c01`):

- `git diff --check` → CLEAN
- grep of touched files → **no residual `wallet` / `balance`**
- `python3 .github/scripts/compliance_linter.py` → exit 0 (scanned 106 files, no violations)
- `python3 .github/scripts/readiness_overclaim_linter.py` → exit 0 (no un-disclaimed overclaims)
- `python3 .github/scripts/test_readiness_overclaim_linter.py` → 21 tests OK
- `scripts/check-meaning-firewall.sh` → exit 0 (the 3 pre-existing `icn-gateway`/`icn_trust` imports are an unrelated Rust-crate baseline "expected until Phase 2"; this docs change touches no Rust)

## Non-goals

- **Not** slice #6 (wallet node-mode terminology cleanup).
- **Not** the optional CoopWallet startup-init generation/cancellation fence.
- **Not** broad documentation cleanup.
- **Did not** edit `docs/demo/DEMO_SCRIPT.md:104` ("Balance (hours in the timebank)") — it describes a literal **pilot-UI** dashboard element; changing narration alone would diverge from the UI, and pilot UI is out of scope.
- **Did not** edit `docs/guides/user/summit-demo.md:156` (`"currency": "credits"`) — it is a literal **JSON API field** in a user guide; changing it would misrepresent the API.
- **Did not** edit `docs/design/passport-keyring-position-receipt.md` — it *documents this migration* and intentionally quotes the old phrase as the "before" state.
- No SDK/RN, Rust `operator_did`, generated API, gateway/OpenAPI docs, website, or pilot UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
