### PR TITLE
docs(identity): clarify wallet node-mode terminology

### DIFF
--- a/docs/plans/agent-teams-launch-prompt.md
+++ b/docs/plans/agent-teams-launch-prompt.md
@@ -101,8 +101,8 @@ ICN is "online" when:
 4. **Rights are durable**: cooperatives can revoke membership; they cannot revoke personhood/commons rights.
 5. **Receipts for everything**: if it's a decision, allocation, settlement, or enforcement — it produces an inspectable receipt.
 6. **CCL is living law**: orgs author policies that compile to enforceable constraints. Humans must be able to read what governs them.
-7. **Passport-first UX** for regular humans; CLI remains for power users.
-8. **Node modes are explicit**: passport/individual, org-operator, dev/service — each with clear "must do / may do / must never be required to do."
+7. **Member Passport**-first UX for regular humans; CLI remains for power users.
+8. **Node modes are explicit**: individual-member, org-operator, dev/service — each with clear "must do / may do / must never be required to do."
 
 ## Team Roles
 
@@ -114,9 +114,9 @@ ICN is "online" when:
 
 4. **CCL + DISPUTES**: Map CCL as living constitutional layer. Current state: ContractRegistry with deploy/revoke/deprecate, DisputeResolutionSystem with mediation/penalties, governance Appeals. Identify gaps: policy registry browsing, human-readable policy rendering, dispute filing UX, evidence chain-of-custody, cross-org dispute escalation, federation agreement authoring.
 
-5. **HUMAN INTERFACE**: Define citizen/member/steward/operator journeys across scope. Map existing surfaces (pilot-ui, CoopWallet, icnctl) to what's needed. Design scope navigation, affiliations home screen, receipts provenance view, "what law applies here?" surface. Account for node modes: passport/keyring (affiliations + signing), org-operator (services+monitoring), dev (build+deploy under policy).
+5. **HUMAN INTERFACE**: Define citizen/member/steward/operator journeys across scope. Map existing surfaces (pilot-ui, CoopWallet, icnctl) to what's needed. Design scope navigation, affiliations home screen, receipts provenance view, "what law applies here?" surface. Account for node modes: individual-member (Member Passport for affiliations + Device Keyring for signing), org-operator (services+monitoring), dev (build+deploy under policy).
 
-6. **SECURITY / OPS / RESILIENCE**: Threat model (capture, sybil, coercion, censorship, dependency attacks). NAT traversal plan. Naming resilience (no single DNS choke). Key management + recovery. Operational playbooks. Packaging/distribution for nodes + the member passport/keyring client. Observability mapping to scope.
+6. **SECURITY / OPS / RESILIENCE**: Threat model (capture, sybil, coercion, censorship, dependency attacks). NAT traversal plan. Naming resilience (no single DNS choke). Key management + recovery. Operational playbooks. Packaging/distribution for nodes + the member client (Member Passport + Device Keyring). Observability mapping to scope.
 
 ## Mission
 
@@ -136,7 +136,7 @@ Produce a single "State → Vision → Gap → Phase Plan" document that enginee
 - **Phase 1**: Scope-aware governance + treasury + membership end-to-end. Decision→treasury spend→receipt→audit loop complete and visible. Multi-org affiliations experience begins.
 - **Phase 2**: CCL as living law — policy registry browsing, human-readable rendering, "what governs this?" surfaces. Dispute filing MVP (claims, evidence, mediation, appeals) integrated with receipts.
 - **Phase 3**: Federation as contract — agreement authoring in CCL, cross-org credit clearing UX, federation-scoped governance. Naming/discovery primitive for human navigation.
-- **Phase 4**: Member client evolution — keyring/signer → lightweight node → optional commons participation. Mobile-first identity + offline queue + affiliations.
+- **Phase 4**: Member client evolution — Device Keyring (signer) → lightweight node → optional commons participation. Mobile-first identity + offline queue + affiliations.
 - **Phase 5**: Resilience hardening — NAT traversal, naming without DNS dependence, anti-censorship, packaging/distribution.
 
 **E) Phase 0 Execution Plan**: 15-25 concrete tasks mapped to files/issues, with validation steps. Every task must be demonstrable on LAN from a workstation.

--- a/docs/plans/agent-teams-launch-prompt.md
+++ b/docs/plans/agent-teams-launch-prompt.md
@@ -21,7 +21,7 @@ ICN is a civilizational consensus technology. Not a blockchain. Not a federation
 - **CCL** (Cooperative Contract Language) is the constitutional layer where cooperatives, communities, and federations write enforceable policies and inter-org contracts
 - **Cooperatives, communities, and federations** are the primary organizational units — each with their own policies, governance, economics, and dispute resolution
 - **Federations** can be any shape/size — overlapping, temporary, regional, sectoral — and they operate via cooperative contracts (treaties), not centralized authority
-- **Individuals** participate through wallet/mobile as their primary interface, with rights that persist beyond any single membership
+- **Individuals** participate through their Member Passport on mobile as their primary interface, with rights that persist beyond any single membership
 - **Developers/operators** run services on nodes for their orgs or as commons/public services
 
 The purpose is to defang state and capital by making legitimacy computable, coordination auditable, and participation non-capturable.
@@ -87,7 +87,7 @@ ICN is "online" when:
 3. A **community** can govern shared resources, resolve disputes, and coordinate members without external authority
 4. A **federation** can form via cooperative contracts (CCL treaties), clear credit across member orgs, resolve cross-org disputes, and govern shared resources — with the federation itself governed by its member orgs
 5. All of the above operates through **scope-aware interfaces** where users always know: "Where am I?" (jurisdiction), "What law applies?" (policies/contracts), "What can I do?" (capabilities), "What happened and why?" (receipt chain)
-6. **Wallet/mobile** is the citizen interface for identity, rights, affiliations, signing, and daily participation — with offline capability
+6. The **Member Passport** on mobile (signing via the **Device Keyring**) is the citizen interface for identity, rights, affiliations, and daily participation — with offline capability
 7. Every significant action produces **inspectable receipts** (decision→effect→settlement→audit)
 8. **Disputes** have a procedural pathway (evidence→mediation→arbitration→appeal) with enforced outcomes and receipt provenance
 9. **Services** are how orgs "exist" — discoverable, named, capability-gated, scoped
@@ -101,8 +101,8 @@ ICN is "online" when:
 4. **Rights are durable**: cooperatives can revoke membership; they cannot revoke personhood/commons rights.
 5. **Receipts for everything**: if it's a decision, allocation, settlement, or enforcement — it produces an inspectable receipt.
 6. **CCL is living law**: orgs author policies that compile to enforceable constraints. Humans must be able to read what governs them.
-7. **Wallet-first UX** for regular humans; CLI remains for power users.
-8. **Node modes are explicit**: wallet/individual, org-operator, dev/service — each with clear "must do / may do / must never be required to do."
+7. **Passport-first UX** for regular humans; CLI remains for power users.
+8. **Node modes are explicit**: passport/individual, org-operator, dev/service — each with clear "must do / may do / must never be required to do."
 
 ## Team Roles
 
@@ -114,9 +114,9 @@ ICN is "online" when:
 
 4. **CCL + DISPUTES**: Map CCL as living constitutional layer. Current state: ContractRegistry with deploy/revoke/deprecate, DisputeResolutionSystem with mediation/penalties, governance Appeals. Identify gaps: policy registry browsing, human-readable policy rendering, dispute filing UX, evidence chain-of-custody, cross-org dispute escalation, federation agreement authoring.
 
-5. **HUMAN INTERFACE**: Define citizen/member/steward/operator journeys across scope. Map existing surfaces (pilot-ui, CoopWallet, icnctl) to what's needed. Design scope navigation, affiliations home screen, receipts provenance view, "what law applies here?" surface. Account for node modes: wallet (signing+affiliations), org-operator (services+monitoring), dev (build+deploy under policy).
+5. **HUMAN INTERFACE**: Define citizen/member/steward/operator journeys across scope. Map existing surfaces (pilot-ui, CoopWallet, icnctl) to what's needed. Design scope navigation, affiliations home screen, receipts provenance view, "what law applies here?" surface. Account for node modes: passport/keyring (affiliations + signing), org-operator (services+monitoring), dev (build+deploy under policy).
 
-6. **SECURITY / OPS / RESILIENCE**: Threat model (capture, sybil, coercion, censorship, dependency attacks). NAT traversal plan. Naming resilience (no single DNS choke). Key management + recovery. Operational playbooks. Packaging/distribution for nodes + wallet. Observability mapping to scope.
+6. **SECURITY / OPS / RESILIENCE**: Threat model (capture, sybil, coercion, censorship, dependency attacks). NAT traversal plan. Naming resilience (no single DNS choke). Key management + recovery. Operational playbooks. Packaging/distribution for nodes + the member passport/keyring client. Observability mapping to scope.
 
 ## Mission
 
@@ -136,7 +136,7 @@ Produce a single "State → Vision → Gap → Phase Plan" document that enginee
 - **Phase 1**: Scope-aware governance + treasury + membership end-to-end. Decision→treasury spend→receipt→audit loop complete and visible. Multi-org affiliations experience begins.
 - **Phase 2**: CCL as living law — policy registry browsing, human-readable rendering, "what governs this?" surfaces. Dispute filing MVP (claims, evidence, mediation, appeals) integrated with receipts.
 - **Phase 3**: Federation as contract — agreement authoring in CCL, cross-org credit clearing UX, federation-scoped governance. Naming/discovery primitive for human navigation.
-- **Phase 4**: Wallet evolution — signer → lightweight node → optional commons participation. Mobile-first identity + offline queue + affiliations.
+- **Phase 4**: Member client evolution — keyring/signer → lightweight node → optional commons participation. Mobile-first identity + offline queue + affiliations.
 - **Phase 5**: Resilience hardening — NAT traversal, naming without DNS dependence, anti-censorship, packaging/distribution.
 
 **E) Phase 0 Execution Plan**: 15-25 concrete tasks mapped to files/issues, with validation steps. Every task must be demonstrable on LAN from a workstation.


### PR DESCRIPTION
## Summary

Slice #6 of the **passport / keyring / position / receipt** vocabulary doctrine (`docs/design/passport-keyring-position-receipt.md` — follow-up slice #6 at line 167; class-H catalog entry at line 120). Cleans up the narrow **node-mode / member-client** terminology in `docs/plans/agent-teams-launch-prompt.md` where "wallet" was used for identity / signing / member-node concepts, adopting the doctrine's passport/keyring split per the *meaning* of each hit (not a blind rename).

- Preserves legitimate legacy / API / generated / historical / third-party uses.
- Does **not** rename public API fields, serialized fields, or generated artifacts.
- Docs-only; no code, behavior, or API change.

## Classification

### A — In-scope node-mode / member-client drift — fixed (1 file, 7 edits)

| Line | Before | After | Meaning -> target |
|---|---|---|---|
| 24 | `participate through wallet/mobile as their primary interface` | `through their Member Passport on mobile` | member identity surface -> **passport** |
| 90 | `**Wallet/mobile** is the citizen interface for identity, rights, affiliations, signing` | `The **Member Passport** on mobile (signing via the **Device Keyring**) ... identity, rights, affiliations` | decompose identity/affiliations -> **passport**, signing -> **keyring** |
| 104 | `**Wallet-first UX**` | `**Passport-first UX**` | member-facing UX -> **passport** |
| 105 | node modes: `wallet/individual` | `passport/individual` | individual member node mode -> **passport** |
| 117 | node modes: `wallet (signing+affiliations)` | `passport/keyring (affiliations + signing)` | doctrine-named class-H hit -> **passport + keyring** |
| 119 | `Packaging/distribution for nodes + wallet` | `nodes + the member passport/keyring client` | member client artifact -> **passport/keyring** |
| 139 | `Phase 4: Wallet evolution - signer -> lightweight node` | `Member client evolution - keyring/signer -> lightweight node` | member-node evolution -> **keyring / member client** |

### B — Remaining `wallet` hits in the touched file — intentionally left

- Lines 71 & 117: **`CoopWallet`** — the proper-noun name of the actual React Native example app (`sdk/react-native/examples/CoopWallet/`). Renaming it in prose would misname a real artifact; reframing that example is doctrine **slice #3**, not #6.

### C / D / E — Out-of-scope `wallet` hits deferred (not edited)

- `docs/planning/icn-ecosystem-map.md` (13 hits) — uses "wallet" pervasively for the **"Local Identity Wallet"** key-custody / identity layer (CLI / browser / mobile wallet, "wallet UI", "local wallets"). That is doctrine **slices #1 / #2** (SDK key-custody + login-copy); editing it would be the broad documentation sweep this slice explicitly avoids.
- `sdk/react-native/examples/CoopWallet/src/screens/IdentityScreen.tsx`, `sdk/react-native/src/sdis-hooks.ts` — `"Wallet mode"` in **RN / SDK code** comments -> non-goal (no RN lifecycle edits); doctrine slices #1 / #3.
- `docs/ARCHITECTURE.md:251` — `"cold wallet" / "hot wallet" operator logic` is a **negative claim** (ICN does *not* do this); correct as-is (class E).
- `docs/design/passport-keyring-position-receipt.md` (line 120 class-H catalog, line 167 slice tracker), `docs/design/wallet-did-migration-boundary.md`, `docs/architecture/CLIENT_MODEL.md`, `docs/spec/steward-cockpit-v0.md`, `docs/registry.toml`, etc. — **doctrine / migration / forbidden-term / historical** references (classes C / E / G). Left unchanged; line 120 deliberately keeps the old `"node modes: wallet (signing+affiliations)"` quote as the before-state example. The slice-#6 tracker (line 167) is left un-annotated, matching how the just-completed slice #5 (PR #1977) was handled.
- `docs/reference/project-index/generated/icn-file-record.{json,md}` — **generated** artifact (class D). Its embedded sha256 of the edited file is now stale, but no CI workflow regenerates or hash-validates it (confirmed: no `.github/workflows` reference to `icn-file-record` / `project-index`), so this does not break CI.

## Validation

All run from the worktree (`~/projects/icn-wt/wallet-node-mode-terminology`, branch `docs/wallet-node-mode-terminology`):

| Check | Result |
|---|---|
| `git diff --check` | exit 0 |
| `.github/scripts/compliance_linter.py` | exit 0 — no violations (106 files) |
| `.github/scripts/readiness_overclaim_linter.py` | exit 0 — no overclaims |
| `.github/scripts/test_readiness_overclaim_linter.py` | exit 0 — 21 tests OK |
| `scripts/check-meaning-firewall.sh` | exit 0 — known Phase-2 baseline only (3 `icn-gateway`->`icn_trust` imports; script exits 0 by design; **unrelated** to this docs change) |
| `docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` | OK — 854 docs validated; 64 pre-existing yaml-mismatch warnings in unrelated files; touched file not flagged |
| `docs/api/check_api_doc_terms.py --repo-root .` | exit 0 — OK |
| `docs/scripts/freshness-check.py ...` | pre-existing subsystem staleness only (touched file not involved); `continue-on-error` in CI |

## Non-goals (honored)

- No Rust `wallet_did -> operator_did` (slice #4, already done separately).
- No generated API / OpenAPI / SDK-type changes.
- No React Native client lifecycle changes.
- No CoopWallet startup-init generation / cancellation fence.
- No broad `wallet` cleanup; no website / pilot-UI / user-manual sweep (none touched).
- Single file, 7 line edits.
