### PR TITLE
feat(demo): add local member-standing bootstrap for receipt-chain proofs

### DIFF
--- a/icn/crates/icn-core/tests/demo_member_standing_receipt_chain.rs
+++ b/icn/crates/icn-core/tests/demo_member_standing_receipt_chain.rs
@@ -17,13 +17,18 @@
 //!   execution record → journal entry,
 //! with provenance linked at every hop.
 //!
-//! The 13 conditions asserted below mirror, one-for-one, the checks in
+//! The 13 conditions asserted below correspond to the checks in
 //! `icnctl audit verify`'s `verify_receipt_chain` (icn/bins/icnctl/src/main.rs).
-//! That verifier is private to the `icnctl` binary (not a library), so — exactly
-//! as `icn/bins/icnctl/tests/audit_verify_test.rs` already does — the conditions
-//! are re-expressed here against the real persisted artifacts rather than calling
-//! the function. They operate on the same data `GET /v1/receipts/chain/{hash}`
-//! returns to the CLI.
+//! That verifier is private to the `icnctl` binary (not a library), so — like
+//! `icn/bins/icnctl/tests/audit_verify_test.rs` — the conditions are re-expressed
+//! here rather than by calling the function. They are asserted directly against
+//! the persisted artifacts the chain endpoint reads (the receipt store, the
+//! execution store, and the ledger), not against an assembled
+//! `ReceiptChainResponse`. A few checks are therefore close equivalents of the
+//! endpoint's field-level computation rather than byte-identical — e.g.
+//! `structural_complete` is computed here with the same formula `get_full_chain`
+//! uses. This proves the chain a governed settlement produces would satisfy
+//! `icnctl audit verify`, without standing up the HTTP layer.
 //!
 //! ## What is reconstructed vs. real
 //!
@@ -262,13 +267,26 @@ async fn governed_settlement_by_demo_member_produces_audit_verifiable_chain() ->
     };
     subscription(event);
 
-    // Let the spawned execution task settle.
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
-    // ── Read execution record + journal entries ───────────────────────────────
-    let exec_record = exec_store
-        .get(&decision_hash_hex)?
-        .expect("execution record must exist after dispatch");
+    // Poll (bounded) until the spawned execution task has persisted a *terminal*
+    // record — `truth_summary` is only populated once dispatch completes — instead
+    // of a fixed sleep that flakes on slow/loaded CI runners. This waits for
+    // completion without asserting success (a failed run still sets the summary),
+    // and guarantees the journal entries (written during dispatch) are visible
+    // before we read them below.
+    let exec_record = {
+        let mut settled = None;
+        for _ in 0..100 {
+            match exec_store.get(&decision_hash_hex)? {
+                Some(record) if record.truth_summary.is_some() => {
+                    settled = Some(record);
+                    break;
+                }
+                _ => tokio::time::sleep(Duration::from_millis(50)).await,
+            }
+        }
+        settled
+            .expect("execution record must reach a terminal state after dispatch (waited up to 5s)")
+    };
     let truth = exec_record.truth_summary_or_fallback();
 
     let journal_entries: Vec<_> = ledger
@@ -288,8 +306,15 @@ async fn governed_settlement_by_demo_member_produces_audit_verifiable_chain() ->
     let all_intent_hashes: HashSet<Hash> =
         allocations.iter().flat_map(|a| a.intent_hashes()).collect();
 
+    // Same formula as icn-gateway `get_full_chain`: governance present && every
+    // allocation carries >=1 intent (it does NOT require allocations to be
+    // non-empty). Allocation presence is asserted separately as check #3.
+    let governance_present = backend
+        .get_governance_by_decision(&decision_hash)
+        .map_err(|e| anyhow!(e))?
+        .is_some();
     let structural_complete =
-        !allocations.is_empty() && allocations.iter().all(|a| !a.intents.is_empty());
+        governance_present && allocations.iter().all(|a| !a.intents.is_empty());
 
     let checks: Vec<(&str, bool)> = vec![
         // 1

--- a/icn/crates/icn-core/tests/demo_member_standing_receipt_chain.rs
+++ b/icn/crates/icn-core/tests/demo_member_standing_receipt_chain.rs
@@ -1,0 +1,375 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Gap B full-chain proof: a governed economic action by a (demo) Member produces
+//! a complete, audit-verifiable receipt chain in-process.
+//!
+//! This is the second half of the local/demo Member-standing bootstrap slice. The
+//! first half (`icn-gateway/tests/demo_member_standing_bootstrap.rs`) proves that
+//! the reusable `bootstrap_demo_member_standing` helper flips the gateway
+//! `member_checker` gate (governed proposal 403 → 201). This test starts from the
+//! state that unlocks — an accepted governed proposal — and proves the resulting
+//! chain satisfies every check `icnctl audit verify` performs.
+//!
+//! ## What this proves
+//!
+//! A governed treasury settlement (proposal → vote → accept) produces, keyed to a
+//! single governance `decision_hash`, all six artifact classes the verifier needs:
+//!   governance decision receipt → allocation receipt → settlement intent →
+//!   execution record → journal entry,
+//! with provenance linked at every hop.
+//!
+//! The 13 conditions asserted below mirror, one-for-one, the checks in
+//! `icnctl audit verify`'s `verify_receipt_chain` (icn/bins/icnctl/src/main.rs).
+//! That verifier is private to the `icnctl` binary (not a library), so — exactly
+//! as `icn/bins/icnctl/tests/audit_verify_test.rs` already does — the conditions
+//! are re-expressed here against the real persisted artifacts rather than calling
+//! the function. They operate on the same data `GET /v1/receipts/chain/{hash}`
+//! returns to the CLI.
+//!
+//! ## What is reconstructed vs. real
+//!
+//! The receipts come from the real `GovernanceManager` close path. The executor
+//! (`EffectDispatcher` → `KernelGovernanceExecutor` → `LedgerServiceImpl`, wrapped
+//! by `DecisionExecutor` + `ExecutionStore`) is wired exactly as the daemon wires
+//! it (`create_decision_executor_callback` → `create_effect_subscription`), and is
+//! driven by a `ProposalAccepted` event carrying the *real* governance
+//! `decision_hash` — the single line `actor.rs` emits in the live path. This is the
+//! same reconstruction style as `treasury_spend_governance_provenance.rs`.
+
+use anyhow::{anyhow, Result};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::sync::RwLock;
+
+use icn_core::services::LedgerServiceImpl;
+use icn_core::supervisor::decision_executor::{
+    create_decision_executor_callback, DecisionExecutor,
+};
+use icn_core::supervisor::effect_dispatcher::EffectDispatcher;
+use icn_core::supervisor::execution_store::SledExecutionStore;
+use icn_core::supervisor::governance_executor::KernelGovernanceExecutor;
+
+use icn_governance::proposal::TreasuryProposalOperation;
+use icn_governance::{
+    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    ProofOutcome, ProposalId, ProposalPayload, ProposalScope, VoteChoice,
+};
+use icn_governance_actor::create_effect_subscription;
+use icn_governance_actor::manager::GovernanceManager;
+use icn_governance_actor::receipt_backend::GovernanceReceiptBackend;
+
+use icn_identity::KeyPair;
+use icn_kernel_api::authz::AllowAllOracle;
+use icn_kernel_api::events::SystemEvent;
+use icn_kernel_api::execution::ExecutionStore;
+use icn_kernel_api::protocol_params::StubParamStore;
+use icn_kernel_api::{AllocationReceipt, CanonicalReceipt, Hash};
+use icn_ledger::types::ProvenanceRef;
+use icn_ledger::Ledger;
+use icn_store::SledStore;
+
+/// Minimal in-memory `GovernanceReceiptBackend` capturing the governance and
+/// allocation receipts the manager emits on close. Mirrors the backend used by
+/// `receipt_chain_vertical_slice.rs`; the trait's other methods keep their no-op
+/// defaults (mandates/grants are not part of this chain).
+#[derive(Default)]
+struct ChainReceiptBackend {
+    governance_by_proposal: Mutex<HashMap<String, GovernanceDecisionReceipt>>,
+    governance_by_decision: Mutex<HashMap<Hash, GovernanceDecisionReceipt>>,
+    allocations_by_decision: Mutex<HashMap<Hash, Vec<AllocationReceipt>>>,
+}
+
+impl GovernanceReceiptBackend for ChainReceiptBackend {
+    fn put_governance(&self, receipt: &GovernanceDecisionReceipt) -> Result<(), String> {
+        self.governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.proposal_id.clone(), receipt.clone());
+        self.governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .insert(receipt.decision_hash, receipt.clone());
+        Ok(())
+    }
+
+    fn get_governance_by_proposal(
+        &self,
+        proposal_id: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_proposal
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(proposal_id)
+            .cloned())
+    }
+
+    fn put_allocation(&self, receipt: &AllocationReceipt) -> Result<Hash, String> {
+        self.allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .entry(receipt.decision_hash)
+            .or_default()
+            .push(receipt.clone());
+        Ok(receipt.canonical_hash())
+    }
+
+    fn get_governance_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(self
+            .governance_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned())
+    }
+
+    fn list_allocations_by_decision(
+        &self,
+        decision_hash: &Hash,
+    ) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(self
+            .allocations_by_decision
+            .lock()
+            .map_err(|e| e.to_string())?
+            .get(decision_hash)
+            .cloned()
+            .unwrap_or_default())
+    }
+}
+
+/// Drive a governed treasury settlement end-to-end and assert the resulting chain
+/// passes all 13 `icnctl audit verify` checks.
+#[tokio::test(flavor = "multi_thread")]
+async fn governed_settlement_by_demo_member_produces_audit_verifiable_chain() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("warn")
+        .with_test_writer()
+        .try_init();
+
+    // ── Identities ───────────────────────────────────────────────────────────
+    // `member_did` stands in for the DID that `bootstrap_demo_member_standing`
+    // would have promoted to Member; here it is the domain's sole StaticList voter.
+    let member = KeyPair::generate()?;
+    let member_did = member.did().clone();
+    let treasury = KeyPair::generate()?;
+    let treasury_did = treasury.did().clone();
+    let recipient = KeyPair::generate()?;
+    let recipient_did = recipient.did().clone();
+
+    // ── Governance manager + receipt backend ─────────────────────────────────
+    let backend = Arc::new(ChainReceiptBackend::default());
+    let mgr = GovernanceManager::new().with_receipt_store(backend.clone());
+
+    let domain_id = GovernanceDomainId::new("demo-receipt-chain-coop");
+    mgr.create_domain(
+        domain_id.clone(),
+        "Demo Receipt Chain Coop".to_string(),
+        "cooperative".to_string(),
+        // 1% quorum / 1% approval → the single member vote carries the decision.
+        GovernanceParams::new(1, 1, 604_800),
+        MembershipConfig::static_list(vec![member_did.clone()]),
+    )
+    .await?;
+
+    // ── Governed economic action: a treasury settlement authorized by vote ────
+    let payload = ProposalPayload::Treasury {
+        operation: TreasuryProposalOperation::Spend {
+            treasury_did: treasury_did.clone(),
+            amount: 100,
+            currency: "compute-hours".to_string(),
+            recipient: recipient_did.clone(),
+            memo: "Q1 infrastructure settlement".to_string(),
+            nonce: 0,
+        },
+    };
+
+    let proposal_id = ProposalId::generate();
+    mgr.create_proposal(
+        proposal_id.clone(),
+        domain_id.clone(),
+        member_did.clone(),
+        "Q1 infrastructure settlement".to_string(),
+        "Settle compute-hours to the infrastructure maintainer.".to_string(),
+        payload.clone(),
+        ProposalScope::Local,
+    )
+    .await?;
+    mgr.open_proposal(proposal_id.clone(), 3_600).await?;
+    mgr.cast_vote(
+        proposal_id.clone(),
+        member_did.clone(),
+        VoteChoice::For,
+        None,
+    )
+    .await?;
+    mgr.close_proposal(proposal_id.clone()).await?;
+
+    // ── Read the governance + allocation receipts the close produced ──────────
+    let gov = backend
+        .get_governance_by_proposal(&proposal_id.0)
+        .map_err(|e| anyhow!(e))?
+        .expect("governance decision receipt must exist after accepted close");
+    assert_eq!(
+        gov.outcome,
+        ProofOutcome::Accepted,
+        "single For vote at 1% quorum must accept"
+    );
+    let decision_hash: Hash = gov.decision_hash;
+    let decision_hash_hex = hex::encode(decision_hash);
+
+    let allocations = backend
+        .list_allocations_by_decision(&decision_hash)
+        .map_err(|e| anyhow!(e))?;
+
+    // ── Reconstruct the daemon's executor wiring ──────────────────────────────
+    let tmp = TempDir::new()?;
+    let ledger = Arc::new(RwLock::new(Ledger::new(Arc::new(SledStore::open(
+        tmp.path().join("ledger"),
+    )?))?));
+    let ledger_service = Arc::new(LedgerServiceImpl::new(
+        ledger.clone(),
+        Arc::new(AllowAllOracle::wildcard()),
+        treasury_did.clone(),
+    ));
+    let kernel_executor =
+        KernelGovernanceExecutor::new(Arc::new(StubParamStore)).with_ledger_service(ledger_service);
+    let dispatcher = Arc::new(EffectDispatcher::new(Arc::new(kernel_executor)));
+    let exec_store: Arc<dyn ExecutionStore> = Arc::new(SledExecutionStore::new(Arc::new(
+        SledStore::open(tmp.path().join("exec"))?,
+    )));
+    let decision_executor = Arc::new(DecisionExecutor::new(dispatcher, exec_store.clone()));
+
+    // Same bridge the daemon uses: subscription → DecisionExecutor.
+    let exec_callback = create_decision_executor_callback(decision_executor);
+    let subscription = create_effect_subscription(move |effects, receipt_id| {
+        exec_callback(effects, receipt_id);
+    });
+
+    // Emit the accepted event carrying the REAL governance decision hash so the
+    // execution record + journal key to the same hash as the receipts above
+    // (this reproduces the one event `actor.rs` emits on the live close path).
+    let event = SystemEvent::ProposalAccepted {
+        proposal_id: proposal_id.0.clone(),
+        domain_id: domain_id.0.clone(),
+        payload: serde_json::to_value(&payload)?,
+        decided_at: 1_700_000_000,
+        canonical_payload_hash: None,
+        governance_decision_hash: Some(decision_hash_hex.clone()),
+    };
+    subscription(event);
+
+    // Let the spawned execution task settle.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // ── Read execution record + journal entries ───────────────────────────────
+    let exec_record = exec_store
+        .get(&decision_hash_hex)?
+        .expect("execution record must exist after dispatch");
+    let truth = exec_record.truth_summary_or_fallback();
+
+    let journal_entries: Vec<_> = ledger
+        .read()
+        .await
+        .get_all_entries()?
+        .into_iter()
+        .filter(|e| {
+            matches!(&e.provenance,
+                ProvenanceRef::Governance { decision_hash, .. }
+                    if decision_hash.as_str() == decision_hash_hex)
+        })
+        .collect();
+
+    // ── The 13 audit-verify checks (mirroring icnctl `verify_receipt_chain`) ──
+    let intents: Vec<_> = allocations.iter().flat_map(|a| a.intents.iter()).collect();
+    let all_intent_hashes: HashSet<Hash> =
+        allocations.iter().flat_map(|a| a.intent_hashes()).collect();
+
+    let structural_complete =
+        !allocations.is_empty() && allocations.iter().all(|a| !a.intents.is_empty());
+
+    let checks: Vec<(&str, bool)> = vec![
+        // 1
+        ("governance_receipt_present", true),
+        // 2 (gov receipt's hash anchors the chain we queried)
+        (
+            "decision_hash_consistent",
+            gov.decision_hash == decision_hash,
+        ),
+        // 3
+        ("allocation_receipts_present", !allocations.is_empty()),
+        // 4
+        (
+            "allocation_provenance_linked",
+            allocations.iter().all(|a| a.decision_hash == decision_hash),
+        ),
+        // 5
+        ("settlement_intents_present", !intents.is_empty()),
+        // 6
+        (
+            "intent_provenance_linked",
+            intents.iter().all(|i| i.decision_hash == decision_hash),
+        ),
+        // 7
+        (
+            "no_orphaned_intents",
+            intents
+                .iter()
+                .all(|i| all_intent_hashes.contains(&i.canonical_hash())),
+        ),
+        // 8
+        ("structural_chain_complete", structural_complete),
+        // 9
+        (
+            "execution_counters_consistent",
+            truth.total_effects
+                == truth.executed_effects + truth.not_executed_effects + truth.hard_failed_effects,
+        ),
+        // 10
+        ("execution_complete", truth.execution_complete),
+        // 11
+        (
+            "chain_complete_contract",
+            structural_complete && truth.execution_complete,
+        ),
+        // 12
+        ("journal_entries_present", !journal_entries.is_empty()),
+        // 13
+        (
+            "journal_provenance_matches_decision",
+            journal_entries.iter().all(|e| {
+                matches!(&e.provenance,
+                    ProvenanceRef::Governance { decision_hash, .. }
+                        if decision_hash.as_str() == decision_hash_hex)
+            }),
+        ),
+    ];
+
+    let passed = checks.iter().filter(|(_, p)| *p).count();
+    for (name, p) in &checks {
+        println!(
+            "[audit-verify] {name}: {}",
+            if *p { "PASS" } else { "FAIL" }
+        );
+    }
+    println!(
+        "[audit-verify] decision_hash={decision_hash_hex} RESULT: {passed}/{} checks passed",
+        checks.len()
+    );
+
+    assert_eq!(checks.len(), 13, "must mirror all 13 icnctl checks");
+    assert_eq!(
+        passed,
+        13,
+        "in-process audit verify must pass all 13 checks; got {passed}/13. \
+         truth_summary={truth:?}, allocations={}, intents={}, journal_entries={}",
+        allocations.len(),
+        intents.len(),
+        journal_entries.len()
+    );
+
+    Ok(())
+}

--- a/icn/crates/icn-gateway/tests/demo_member_standing_bootstrap.rs
+++ b/icn/crates/icn-gateway/tests/demo_member_standing_bootstrap.rs
@@ -1,0 +1,301 @@
+//! Gap B proof: a LOCAL/DEMO-only Member-standing bootstrap unlocks governed
+//! proposal submission through the live `member_checker` gate.
+//!
+//! ## What this proves
+//!
+//! The gateway gates governed proposal submission on commons Member standing
+//! (`GovernanceContext::member_checker`, wired in `server.rs` to `CommonsManager`).
+//! A freshly generated organizer DID is rejected with 403 until it holds active
+//! `MembershipStatus::Member` standing in the target domain's jurisdiction.
+//!
+//! [`bootstrap_demo_member_standing`] establishes that standing for a single DID
+//! using the *existing* internal `CommonsManager` enrollment + jurisdiction APIs —
+//! the exact sequence already proven in `e2e_member_standing_gate.rs`. It is the
+//! reusable precondition a future NYCN v4 receipt-chain demo needs.
+//!
+//! Specifically:
+//! - `POST /v1/gov/proposals` (budget payload) before bootstrap → 403 Forbidden
+//! - `POST /v1/gov/proposals` (budget payload) after  bootstrap → 201 Created
+//!
+//! ## Why this is NOT production enrollment
+//!
+//! The real production path to `Member` standing is the multi-steward SDIS
+//! proof-of-personhood ceremony (`/v1/sdis/enrollment/{start,finalize,approve}`),
+//! whose `approve` step is itself already dev-gated by `ICN_ENABLE_ADMIN_ENDPOINTS`.
+//! This helper deliberately bypasses that ceremony and is therefore confined to
+//! test/demo code (it lives in `tests/`, ships in no library, and adds no HTTP
+//! route). It does not weaken production auth, SDIS, or membership semantics, and
+//! it introduces no public self-service "make me a Member" route.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use actix_web::{test, web, App};
+use actix_web_httpauth::middleware::HttpAuthentication;
+use icn_gateway::{
+    api, auth::AuthManager, commons_mgr::CommonsManager, middleware::jwt_auth,
+    rate_limit::IpRateLimiter,
+};
+use icn_governance::{GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource};
+use icn_governance_actor::{
+    events::NoopEventEmitter,
+    http::configure::{GovernanceContext, MemberStandingChecker},
+    manager::GovernanceManager,
+};
+use icn_identity::{
+    commons::{JurisdictionId, MembershipCapability, MembershipStatus},
+    Did, IdentityBundle, KeyPair,
+};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+/// Jurisdiction id that doubles as the governance domain id (same as the
+/// `member_checker` contract: the proposal's `domain_id` is matched against the
+/// caller's commons affiliations).
+const DOMAIN_ID: &str = "demo-standing-bootstrap-coop";
+
+/// DEMO/TEST-ONLY: establish active commons `Member` standing for `did` in
+/// `jurisdiction`, using the existing internal `CommonsManager` API.
+///
+/// This is the reusable Gap B mechanism. It performs, in order, the same four
+/// steps `e2e_member_standing_gate.rs` performs by hand:
+///   1. create a personhood anchor (demo: self-vouched, no steward ceremony),
+///   2. create the commons holder record bound to `did`,
+///   3. join the jurisdiction (lands at `Candidate`),
+///   4. advance `Candidate` → `Member` (the state the gate requires).
+///
+/// It is intentionally NOT a production enrollment path: it bypasses the
+/// multi-steward SDIS proof-of-personhood ceremony and is only safe on a local
+/// demo node a single operator controls. A future NYCN v4 loop mirrors this
+/// sequence to put its organizer DID into a governed-proposal-eligible state.
+pub async fn bootstrap_demo_member_standing(
+    commons: &CommonsManager,
+    did: &Did,
+    jurisdiction: &str,
+) -> anyhow::Result<()> {
+    // 1. Personhood anchor. The voucher is a throwaway demo identity; production
+    //    enrollment instead requires steward attestations through the ceremony.
+    let voucher = KeyPair::generate()?;
+    let anchor = commons
+        .create_anchor_from_enrollment(did, Some(voucher.did()))
+        .await?;
+    let anchor_id = hex::encode(anchor.id());
+
+    // 2. Commons holder record bound to the caller's own signing DID (the DID
+    //    that mints JWTs and casts votes) — not an anchor-derived DID.
+    let holder = commons.create_holder_from_anchor(&anchor_id, did).await?;
+    let holder_id = hex::encode(holder.id());
+
+    // 3. Join the jurisdiction. `join_jurisdiction` lands the affiliation at
+    //    `Candidate`.
+    commons
+        .join_jurisdiction(
+            &holder_id,
+            JurisdictionId::new(jurisdiction),
+            vec![MembershipCapability::Vote],
+        )
+        .await?;
+
+    // 4. Advance to `Member` — the only status the gateway `member_checker`
+    //    accepts. In production this transition is the outcome of a governed
+    //    admission decision, not a direct call.
+    commons
+        .update_affiliation_status(
+            &holder_id,
+            &JurisdictionId::new(jurisdiction),
+            MembershipStatus::Member,
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Commons-backed `MemberStandingChecker`, identical in shape to the gateway's
+/// production wiring (`server.rs`) and to `e2e_member_standing_gate.rs`.
+fn make_checker(commons: Arc<CommonsManager>) -> MemberStandingChecker {
+    Arc::new(move |did: Did, domain_id: String| {
+        let c = commons.clone();
+        Box::pin(async move {
+            let Ok(Some(holder)) = c.get_holder_by_did(&did).await else {
+                return false;
+            };
+            let holder_id = hex::encode(holder.id());
+            let Ok(affiliations) = c.list_affiliations(&holder_id).await else {
+                return false;
+            };
+            affiliations.iter().any(|a| {
+                a.jurisdiction_id == JurisdictionId::new(&domain_id)
+                    && a.membership_status == MembershipStatus::Member
+            })
+        })
+    })
+}
+
+/// Build a test gateway wired with the commons `member_checker` gate. `actor_did`
+/// is placed in the governance domain's `StaticList` so the governance layer never
+/// rejects them — the only gate under test is the commons checker, exactly as in
+/// `e2e_member_standing_gate.rs`.
+async fn build_app(
+    commons_mgr: Arc<CommonsManager>,
+    governance_manager: Arc<GovernanceManager>,
+    actor_did: &Did,
+) -> impl actix_web::dev::Service<
+    actix_http::Request,
+    Response = actix_web::dev::ServiceResponse,
+    Error = actix_web::Error,
+> {
+    governance_manager
+        .create_domain(
+            GovernanceDomainId(DOMAIN_ID.to_string()),
+            "Demo Standing Bootstrap Coop".to_string(),
+            "cooperative".to_string(),
+            GovernanceParams::new(50, 50, 86_400),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![actor_did.clone()]),
+            },
+        )
+        .await
+        .expect("create_domain");
+
+    let jwt_secret = b"demo-standing-bootstrap-jwt-secret".to_vec();
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
+
+    let gov_ctx = GovernanceContext {
+        manager: governance_manager.clone(),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: Some(make_checker(commons_mgr)),
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        mandate_gate: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
+    };
+
+    let auth_mw = HttpAuthentication::bearer(jwt_auth);
+    test::init_service(
+        App::new()
+            .app_data(web::Data::new(auth_manager.clone()))
+            .app_data(web::Data::new(ip_limiter))
+            .service(
+                web::scope("/v1")
+                    .service(api::auth::challenge)
+                    .service(api::auth::verify)
+                    .service(
+                        web::scope("/gov")
+                            .configure({
+                                let ctx = gov_ctx.clone();
+                                move |cfg| {
+                                    icn_governance_actor::http::configure::configure(
+                                        cfg,
+                                        ctx.clone(),
+                                    )
+                                }
+                            })
+                            .wrap(auth_mw),
+                    ),
+            ),
+    )
+    .await
+}
+
+/// Mint a JWT for `did` via the challenge/verify handshake.
+async fn get_jwt(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    did: &str,
+    bundle: &IdentityBundle,
+) -> String {
+    let challenge_req = test::TestRequest::post()
+        .uri("/v1/auth/challenge")
+        .set_json(json!({ "did": did }))
+        .to_request();
+    let challenge_resp: Value = test::call_and_read_body_json(app, challenge_req).await;
+    let nonce = challenge_resp["nonce"].as_str().expect("nonce").to_string();
+
+    let nonce_bytes = hex::decode(&nonce).expect("hex nonce");
+    let signature = bundle.sign(&nonce_bytes).expect("sign");
+    let sig_hex = hex::encode(signature.to_bytes());
+
+    let verify_req = test::TestRequest::post()
+        .uri("/v1/auth/verify")
+        .set_json(json!({
+            "did": did,
+            "signature": sig_hex,
+            "coop_id": "demo-standing-bootstrap",
+            "scopes": ["governance:read", "governance:write"]
+        }))
+        .to_request();
+    let token_resp: Value = test::call_and_read_body_json(app, verify_req).await;
+    token_resp["token"].as_str().expect("token").to_string()
+}
+
+/// The Gap B proof: a governed (budget) proposal is rejected before standing and
+/// accepted after the demo standing bootstrap.
+#[actix_web::test]
+async fn demo_standing_bootstrap_unlocks_governed_proposal() {
+    let commons_mgr = Arc::new(CommonsManager::new());
+    let governance_manager = Arc::new(GovernanceManager::new());
+
+    let actor_bundle = IdentityBundle::generate().expect("IdentityBundle");
+    let actor_did = actor_bundle.did().clone();
+
+    let app = build_app(commons_mgr.clone(), governance_manager, &actor_did).await;
+    let token = get_jwt(&app, &actor_did.to_string(), &actor_bundle).await;
+
+    let governed_proposal = json!({
+        "domain_id": DOMAIN_ID,
+        "title": "Q1 infrastructure budget",
+        "description": "Allocate compute-hours to cluster maintenance.",
+        "payload": {
+            "type": "budget",
+            "amount": 6000,
+            "recipient": actor_did.to_string(),
+            "currency": "compute-hours",
+            "purpose": "q1-infra"
+        }
+    });
+
+    // Before bootstrap: the member_checker gate rejects the governed proposal.
+    let before = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/gov/proposals")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .set_json(&governed_proposal)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        before.status().as_u16(),
+        403,
+        "without Member standing the governed proposal must be rejected with 403"
+    );
+
+    // Establish demo/local Member standing via the reusable bootstrap helper.
+    bootstrap_demo_member_standing(&commons_mgr, &actor_did, DOMAIN_ID)
+        .await
+        .expect("bootstrap_demo_member_standing");
+
+    // After bootstrap: the same governed proposal is admitted.
+    let after = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/gov/proposals")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .set_json(&governed_proposal)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        after.status().as_u16(),
+        201,
+        "after the demo standing bootstrap the governed proposal must be accepted with 201"
+    );
+}


### PR DESCRIPTION
## What

Adds the **local/demo Member-standing bootstrap** (Gap B) needed for a governed economic receipt-chain proof, as two demo/test-only integration tests that use only existing internal manager APIs. No production code, route, auth, SDIS, or enrollment behaviour is added or changed.

- `icn/crates/icn-gateway/tests/demo_member_standing_bootstrap.rs` — the reusable helper `bootstrap_demo_member_standing` (commons enroll → holder → join jurisdiction → promote to `Member`) plus a test proving it flips the live `member_checker` gate: a governed `budget` proposal returns **403 before** bootstrap and **201 after**.
- `icn/crates/icn-core/tests/demo_member_standing_receipt_chain.rs` — drives a governed treasury settlement (proposal → vote → accept) through the **real** `GovernanceManager` close path and the **reconstructed** executor wiring, then asserts all **13** `icnctl audit verify` conditions pass against the persisted chain (**13/13**).

## Which blocker this closes

The remaining demo-readiness blocker: a decision-registry record (NYCN v3) is not an economic receipt chain. The precise sub-blocker was **active Member standing** — the gateway gates governed proposal submission on commons `Member` standing (`GovernanceContext::member_checker`, wired in `server.rs` to `CommonsManager`), and a freshly generated organizer DID is rejected `403` until it holds `MembershipStatus::Member` in the target domain's jurisdiction. This PR provides a safe local/demo way to establish that standing and proves the full chain it unlocks.

## What exact path grants/simulates Member standing

`bootstrap_demo_member_standing(commons, did, jurisdiction)` calls the existing internal `CommonsManager` API, in the same order already exercised by `e2e_member_standing_gate.rs`:
1. `create_anchor_from_enrollment(did, voucher)` — personhood anchor (demo: self-vouched)
2. `create_holder_from_anchor(anchor_id, did)` — holder bound to the caller's own signing DID
3. `join_jurisdiction(holder_id, jurisdiction, [Vote])` — lands at `Candidate`
4. `update_affiliation_status(holder_id, jurisdiction, Member)` — advances to `Member`

## Why this is local/demo/dev-only and not production enrollment

- The real production path to `Member` standing is the **multi-steward SDIS proof-of-personhood ceremony** (`/v1/sdis/enrollment/{start,finalize,approve}`), whose `approve` step is itself already dev-gated by `ICN_ENABLE_ADMIN_ENDPOINTS`. The helper deliberately **bypasses that ceremony** (self-vouched anchor) and is therefore only valid on a local node a single operator controls.
- It lives entirely in `tests/`, ships in **no library**, and **adds no HTTP route, CLI command, or production symbol**. It cannot be reached or enabled in a production daemon.

## Evidence (run live, captured)

- `cargo test -p icn-gateway --test demo_member_standing_bootstrap` → `1 passed` (403 → 201).
- `cargo test -p icn-core --test demo_member_standing_receipt_chain -- --nocapture` → `1 passed`; per-check output:
  `governance_receipt_present, decision_hash_consistent, allocation_receipts_present, allocation_provenance_linked, settlement_intents_present, intent_provenance_linked, no_orphaned_intents, structural_chain_complete, execution_counters_consistent, execution_complete, chain_complete_contract, journal_entries_present, journal_provenance_matches_decision` → **RESULT: 13/13 checks passed**.

## Does `icnctl audit verify --token` PASS now, or what blocker remains

- **In-process:** the chain produced by a governed settlement passes **all 13** of the same conditions `icnctl audit verify` checks (the CLI's `verify_receipt_chain` is private to the `icnctl` binary, so — like `audit_verify_test.rs` already does — the 13 conditions are re-expressed against the real persisted artifacts; they operate on the same data `GET /v1/receipts/chain/{hash}` returns).
- **Against a live secured gateway over HTTP, `icnctl audit verify --token` is not yet runnable end-to-end by an external (bash) NYCN v4**, because the standing bootstrap here is in-process Rust (not HTTP-reachable for a separate daemon), and proposal **closure has no HTTP endpoint** (it is scheduler/time-driven). Closing the external `--token` path would need an explicitly dev-gated local enrollment endpoint (following the existing `ICN_ENABLE_ADMIN_ENDPOINTS` precedent) — intentionally **not** added here.

## Why production auth, SDIS, and membership semantics are not weakened

- `member_checker`, the SDIS ceremony, steward thresholds, and `update_affiliation_status` production semantics are untouched. The gate still rejects non-`Member` DIDs (Test 1 asserts the `403`).
- No public self-service "make me a Member" route is added. The promotion call used by the helper is the existing internal manager API, invoked only from test code on a local node.

## What NYCN v4 can do next

Mirror `bootstrap_demo_member_standing`'s documented sequence to establish demo standing, run a governed settlement, and verify the resulting chain. For a fully external bash + live-`icnd` + `icnctl audit verify --token` PASS, the next safe slice is a strictly dev-gated local enrollment endpoint (disabled by default and in `Production` posture).

## What was intentionally not touched

NYCN (read-only for context only), the dirty main ICN checkout, production routes/auth, SDIS, commons production enrollment, generated artifacts, and the pre-existing meaning-firewall `use icn_trust::` violations (mid-refactor, unrelated).

## Test plan

- `cargo fmt -p icn-gateway -p icn-core -- --check` (clean)
- `cargo clippy` scoped to both new test targets
- `cargo test` for both new tests (pass)
- `.github/scripts/compliance_linter.py` (0), `readiness_overclaim_linter.py` (0), `test_readiness_overclaim_linter.py` (21 OK), `scripts/check-meaning-firewall.sh` (exit 0; 3 pre-existing), `git diff --check` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
