### PR TITLE
feat(demo): add dev-gated standing bridge for live gateway demos

### DIFF
--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -467,7 +467,21 @@ pub async fn dev_bootstrap_standing(
             // #1980's proven in-process helper uses). Production obtains real
             // steward attestations via the SDIS ceremony.
             let anchor_id = match commons_manager.get_anchor_by_did(&did).await? {
-                Some(existing_anchor) => hex::encode(existing_anchor.id()),
+                Some(existing_anchor) => {
+                    // A reused anchor that was suspended/revoked at the SDIS-anchor
+                    // level must not yield fresh standing: `create_holder_from_anchor`
+                    // builds an active holder regardless of anchor status, so fail
+                    // closed here before reusing it.
+                    if !existing_anchor.is_active() {
+                        return Err(GatewayError::Forbidden(format!(
+                            "cannot bootstrap standing: personhood anchor is not active \
+                             ({}); a suspended/revoked anchor must be resolved via \
+                             SDIS/governance, not the demo bridge",
+                            existing_anchor.status
+                        )));
+                    }
+                    hex::encode(existing_anchor.id())
+                }
                 None => {
                     let voucher = KeyPair::generate().map_err(|e| {
                         GatewayError::InternalError(format!(

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -485,6 +485,20 @@ pub async fn dev_bootstrap_standing(
                 .await?
         }
     };
+
+    // A holder removed at the commons-holder level (`Suspended`/`Exited`/`Revoked`)
+    // must not regain standing via the dev bridge: the gateway `member_checker`
+    // only checks the jurisdiction affiliation, not the holder's lifecycle status,
+    // so fail closed here before touching affiliations. A freshly enrolled holder
+    // is `Active`, so this only rejects a reused, removed holder.
+    if !holder.is_active() {
+        return Err(GatewayError::Forbidden(format!(
+            "cannot bootstrap standing: commons holder is not active ({}); a removed holder \
+             must be resolved via governance/recovery, not the demo bridge",
+            holder.status
+        )));
+    }
+
     let holder_id = hex::encode(holder.id());
 
     // Resolve the caller's current affiliation (if any) in this jurisdiction.

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -455,19 +455,31 @@ pub async fn dev_bootstrap_standing(
     let holder = match commons_manager.get_holder_by_did(&did).await? {
         Some(existing) => existing,
         None => {
-            // Demo enrollment. The commons Sybil gate (`join_jurisdiction`)
-            // requires at least `Strong` POP level, so we mint a synthetic demo
-            // voucher (a throwaway key) to produce a WebOfTrust/`Strong` anchor —
-            // the same shape PR #1980's proven in-process helper uses. This
-            // SATISFIES the Sybil gate rather than weakening it; production
-            // instead obtains real steward attestations via the SDIS ceremony.
-            let voucher = KeyPair::generate().map_err(|e| {
-                GatewayError::InternalError(format!("demo voucher key generation failed: {e}"))
-            })?;
-            let anchor = commons_manager
-                .create_anchor_from_enrollment(&did, Some(voucher.did()))
-                .await?;
-            let anchor_id = hex::encode(anchor.id());
+            // Idempotent enrollment: reuse an existing personhood anchor for this
+            // DID if one is already present (e.g. from a prior partial run or an
+            // earlier SDIS enrollment) — `create_anchor_from_enrollment` errors on
+            // a duplicate anchor, so only mint a new one when none exists.
+            //
+            // A freshly minted demo anchor uses a synthetic voucher (a throwaway
+            // key) to produce a WebOfTrust/`Strong` anchor: the commons Sybil gate
+            // (`join_jurisdiction`) requires at least `Strong` POP level, so this
+            // SATISFIES the gate rather than weakening it (the same shape PR
+            // #1980's proven in-process helper uses). Production obtains real
+            // steward attestations via the SDIS ceremony.
+            let anchor_id = match commons_manager.get_anchor_by_did(&did).await? {
+                Some(existing_anchor) => hex::encode(existing_anchor.id()),
+                None => {
+                    let voucher = KeyPair::generate().map_err(|e| {
+                        GatewayError::InternalError(format!(
+                            "demo voucher key generation failed: {e}"
+                        ))
+                    })?;
+                    let anchor = commons_manager
+                        .create_anchor_from_enrollment(&did, Some(voucher.did()))
+                        .await?;
+                    hex::encode(anchor.id())
+                }
+            };
             commons_manager
                 .create_holder_from_anchor(&anchor_id, &did)
                 .await?
@@ -475,24 +487,49 @@ pub async fn dev_bootstrap_standing(
     };
     let holder_id = hex::encode(holder.id());
 
-    // Join the jurisdiction if not already affiliated, then advance to Member.
-    let already_affiliated = commons_manager
+    // Resolve the caller's current affiliation (if any) in this jurisdiction.
+    // The dev bridge advances onboarding to `Member`, but it must NOT override
+    // governance-imposed removed/blocked states (`Suspended`/`Banned`/`Exited`):
+    // those must be cleared via the governance/recovery path, not this route, so
+    // a removed identity cannot regain proposal standing through the demo bridge.
+    let existing_status = commons_manager
         .list_affiliations(&holder_id)
         .await?
-        .iter()
-        .any(|a| a.jurisdiction_id == jurisdiction);
-    if !already_affiliated {
-        commons_manager
-            .join_jurisdiction(
-                &holder_id,
-                jurisdiction.clone(),
-                vec![MembershipCapability::Vote],
-            )
-            .await?;
+        .into_iter()
+        .find(|a| a.jurisdiction_id == jurisdiction)
+        .map(|a| a.membership_status);
+
+    match existing_status {
+        // Already an active Member — idempotent no-op.
+        Some(MembershipStatus::Member) => {}
+        // Mid-onboarding — advance to Member (the intended demo path).
+        Some(MembershipStatus::Candidate) | Some(MembershipStatus::Provisional) => {
+            commons_manager
+                .update_affiliation_status(&holder_id, &jurisdiction, MembershipStatus::Member)
+                .await?;
+        }
+        // Not yet affiliated — join (lands at Candidate) then advance to Member.
+        None => {
+            commons_manager
+                .join_jurisdiction(
+                    &holder_id,
+                    jurisdiction.clone(),
+                    vec![MembershipCapability::Vote],
+                )
+                .await?;
+            commons_manager
+                .update_affiliation_status(&holder_id, &jurisdiction, MembershipStatus::Member)
+                .await?;
+        }
+        // Governance-imposed removed/blocked status — refuse; do not reactivate.
+        Some(blocked) => {
+            return Err(GatewayError::Forbidden(format!(
+                "cannot bootstrap standing: existing affiliation status is {blocked:?}; a \
+                 Suspended/Banned/Exited membership must be resolved via governance/recovery, \
+                 not the demo bridge"
+            )));
+        }
     }
-    commons_manager
-        .update_affiliation_status(&holder_id, &jurisdiction, MembershipStatus::Member)
-        .await?;
 
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "status": "member_standing_bootstrapped",

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -513,6 +513,25 @@ pub async fn dev_bootstrap_standing(
         )));
     }
 
+    // The holder's backing personhood anchor must also be active. Anchor status
+    // changes do not cascade to holders, so a reused `Active` holder may be backed
+    // by an anchor that was suspended/revoked after the holder was created. (For
+    // the freshly enrolled path the anchor was just minted/validated `Active`, so
+    // this is a no-op there.)
+    let backing_anchor = commons_manager
+        .get_anchor(&hex::encode(holder.anchor_id))
+        .await?
+        .ok_or_else(|| {
+            GatewayError::InternalError("backing personhood anchor missing for holder".to_string())
+        })?;
+    if !backing_anchor.is_active() {
+        return Err(GatewayError::Forbidden(format!(
+            "cannot bootstrap standing: backing personhood anchor is not active ({}); a \
+             suspended/revoked anchor must be resolved via SDIS/governance, not the demo bridge",
+            backing_anchor.status
+        )));
+    }
+
     let holder_id = hex::encode(holder.id());
 
     // Resolve the caller's current affiliation (if any) in this jurisdiction.

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -15,7 +15,10 @@ use utoipa::ToSchema;
 use crate::commons_mgr::CommonsManager;
 use crate::error::{GatewayError, Result};
 use crate::middleware::get_claims;
-use icn_identity::{Affiliation, CommonsHolderRecord, Did, JurisdictionId, MembershipStatus};
+use icn_identity::{
+    Affiliation, CommonsHolderRecord, Did, JurisdictionId, KeyPair, MembershipCapability,
+    MembershipStatus,
+};
 
 // ============================================================================
 // Response/Request DTOs
@@ -377,6 +380,130 @@ pub async fn leave_jurisdiction(
 }
 
 // ============================================================================
+// Dev/Demo-only standing bootstrap
+// ============================================================================
+
+/// Request body for [`dev_bootstrap_standing`].
+#[derive(Debug, Deserialize)]
+pub struct DevBootstrapStandingRequest {
+    /// Jurisdiction (governance domain id) to establish Member standing in.
+    pub jurisdiction_id: String,
+}
+
+/// Returns `true` only when BOTH dev gates are satisfied:
+/// 1. `ICN_ENABLE_ADMIN_ENDPOINTS=true` (same explicit opt-in as the SDIS
+///    `approve_ceremony` / `approve_recovery` admin endpoints), AND
+/// 2. the governance build posture is NOT `Production`
+///    (`ICN_GOVERNANCE_BUILD_MODE=production`).
+///
+/// Default (no env set) is `false` → the endpoint is unavailable. The posture
+/// gate makes it impossible to enable in production even if the opt-in flag is
+/// set by mistake.
+fn demo_standing_bootstrap_enabled() -> bool {
+    let admin_enabled = std::env::var("ICN_ENABLE_ADMIN_ENDPOINTS")
+        .unwrap_or_else(|_| "false".to_string())
+        .to_lowercase()
+        == "true";
+    let is_production = icn_governance_actor::http::GovernanceContextBuildMode::from_env()
+        == icn_governance_actor::http::GovernanceContextBuildMode::Production;
+    admin_enabled && !is_production
+}
+
+/// POST /v1/commons/dev/bootstrap-standing — DEV/DEMO-ONLY.
+///
+/// Establishes commons `Member` standing for the **authenticated caller's own
+/// DID** (`claims.sub`) in `jurisdiction_id`, so a local secured-gateway demo
+/// (e.g. a NYCN v4 bash flow) can then submit governed proposals, which the
+/// gateway gates on Member standing via `member_checker`.
+///
+/// This deliberately bypasses the multi-steward SDIS proof-of-personhood
+/// ceremony and is therefore **double dev-gated** (see
+/// [`demo_standing_bootstrap_enabled`]): it returns `403 Forbidden` unless
+/// `ICN_ENABLE_ADMIN_ENDPOINTS=true` AND the posture is non-`Production`.
+///
+/// Safety: it grants standing for the caller's own DID only — never an
+/// arbitrary DID — and removes no membership/SDIS/governance check. It adds a
+/// dev path to *create* a commons holder; production enrollment, SDIS, and the
+/// `member_checker` gate are unchanged and still enforced for every request.
+/// It is NOT a production "make me a Member" route.
+#[post("/dev/bootstrap-standing")]
+pub async fn dev_bootstrap_standing(
+    http_req: HttpRequest,
+    body: web::Json<DevBootstrapStandingRequest>,
+    commons_manager: web::Data<Arc<CommonsManager>>,
+) -> Result<HttpResponse> {
+    // Dev gate: disabled by default; impossible to enable in Production posture.
+    if !demo_standing_bootstrap_enabled() {
+        return Err(GatewayError::Forbidden(
+            "Demo standing bootstrap is disabled (requires ICN_ENABLE_ADMIN_ENDPOINTS=true and \
+             non-production posture)"
+                .to_string(),
+        ));
+    }
+
+    // Operate on the caller's own DID only.
+    let claims = get_claims(&http_req)
+        .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
+    let did = claims
+        .sub
+        .parse::<Did>()
+        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
+
+    let jurisdiction = JurisdictionId::new(&body.jurisdiction_id);
+
+    // Idempotent enrollment: reuse an existing holder if the DID already has one.
+    let holder = match commons_manager.get_holder_by_did(&did).await? {
+        Some(existing) => existing,
+        None => {
+            // Demo enrollment. The commons Sybil gate (`join_jurisdiction`)
+            // requires at least `Strong` POP level, so we mint a synthetic demo
+            // voucher (a throwaway key) to produce a WebOfTrust/`Strong` anchor —
+            // the same shape PR #1980's proven in-process helper uses. This
+            // SATISFIES the Sybil gate rather than weakening it; production
+            // instead obtains real steward attestations via the SDIS ceremony.
+            let voucher = KeyPair::generate().map_err(|e| {
+                GatewayError::InternalError(format!("demo voucher key generation failed: {e}"))
+            })?;
+            let anchor = commons_manager
+                .create_anchor_from_enrollment(&did, Some(voucher.did()))
+                .await?;
+            let anchor_id = hex::encode(anchor.id());
+            commons_manager
+                .create_holder_from_anchor(&anchor_id, &did)
+                .await?
+        }
+    };
+    let holder_id = hex::encode(holder.id());
+
+    // Join the jurisdiction if not already affiliated, then advance to Member.
+    let already_affiliated = commons_manager
+        .list_affiliations(&holder_id)
+        .await?
+        .iter()
+        .any(|a| a.jurisdiction_id == jurisdiction);
+    if !already_affiliated {
+        commons_manager
+            .join_jurisdiction(
+                &holder_id,
+                jurisdiction.clone(),
+                vec![MembershipCapability::Vote],
+            )
+            .await?;
+    }
+    commons_manager
+        .update_affiliation_status(&holder_id, &jurisdiction, MembershipStatus::Member)
+        .await?;
+
+    Ok(HttpResponse::Ok().json(serde_json::json!({
+        "status": "member_standing_bootstrapped",
+        "did": did.to_string(),
+        "jurisdiction_id": body.jurisdiction_id,
+        "holder_id": holder_id,
+        "note": "dev/demo-only; not a production enrollment path",
+    })))
+}
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 
@@ -405,6 +532,9 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .service(join_jurisdiction)
         .service(update_affiliation)
         .service(leave_jurisdiction)
+        // Dev/demo-only; refuses unless ICN_ENABLE_ADMIN_ENDPOINTS=true and
+        // non-Production posture (see dev_bootstrap_standing).
+        .service(dev_bootstrap_standing)
         .service(web::scope("/anchor").configure(anchor::configure));
 }
 

--- a/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
+++ b/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
@@ -519,3 +519,54 @@ async fn dev_bootstrap_idempotent_when_anchor_exists_without_holder() {
         "caller must hold Member standing after bootstrap reuses the anchor"
     );
 }
+
+// ── Review fix (codex P2): a holder removed at the holder level is rejected ──
+#[actix_web::test]
+async fn dev_bootstrap_refuses_inactive_holder() {
+    let _env = EnvGuard::acquire(Some("true"), Some("test"));
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+    let bundle = IdentityBundle::generate().unwrap();
+    let did = bundle.did().clone();
+
+    // Pre-existing holder removed at the commons-holder level (`Suspended`) — the
+    // shape a holder-level governance removal leaves behind. There is NO blocked
+    // affiliation in the target jurisdiction, so only the holder-status guard can
+    // catch this; `member_checker` would otherwise honor a fresh Member affiliation.
+    let voucher = KeyPair::generate().unwrap();
+    let anchor = commons
+        .create_anchor_from_enrollment(&did, Some(voucher.did()))
+        .await
+        .unwrap();
+    let holder = commons
+        .create_holder_from_anchor(&hex::encode(anchor.id()), &did)
+        .await
+        .unwrap();
+    let holder_id = hex::encode(holder.id());
+    let mut removed = commons.get_holder(&holder_id).await.unwrap().unwrap();
+    removed.suspend("test removal".to_string(), 0);
+    commons
+        .update_holder_status(&holder_id, removed.status)
+        .await
+        .unwrap();
+
+    let app = build_app(commons.clone(), gov, std::slice::from_ref(&did)).await;
+    let token = get_jwt(&app, &did.to_string(), &bundle).await;
+
+    let resp = test::call_service(&app, bootstrap_request(&token).to_request()).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "the dev bridge must refuse a holder that is not active (holder-level removal)"
+    );
+
+    // No Member affiliation was created for the removed holder.
+    let affiliations = commons.list_affiliations(&holder_id).await.unwrap();
+    assert!(
+        !affiliations.iter().any(|a| {
+            a.jurisdiction_id == JurisdictionId::new(DOMAIN_ID)
+                && a.membership_status == MembershipStatus::Member
+        }),
+        "an inactive holder must not gain a Member affiliation"
+    );
+}

--- a/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
+++ b/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
@@ -43,8 +43,8 @@ use icn_governance_actor::{
     manager::GovernanceManager,
 };
 use icn_identity::{
-    commons::{JurisdictionId, MembershipStatus},
-    Did, IdentityBundle,
+    commons::{JurisdictionId, MembershipCapability, MembershipStatus},
+    Did, IdentityBundle, KeyPair,
 };
 use serde_json::{json, Value};
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -416,5 +416,106 @@ async fn other_did_without_bootstrap_still_rejected() {
         b_prop.status().as_u16(),
         403,
         "DID B (no bootstrap) must still be rejected — member_checker is not bypassed"
+    );
+}
+
+// ── Review fix (codex P2): a removed/blocked affiliation is NOT reactivated ──
+#[actix_web::test]
+async fn dev_bootstrap_refuses_to_reactivate_removed_member() {
+    let _env = EnvGuard::acquire(Some("true"), Some("test"));
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+    let bundle = IdentityBundle::generate().unwrap();
+    let did = bundle.did().clone();
+    let jurisdiction = JurisdictionId::new(DOMAIN_ID);
+
+    // Pre-existing affiliation in a governance-imposed `Banned` state (the shape a
+    // FreezeMember/removal decision leaves behind).
+    let voucher = KeyPair::generate().unwrap();
+    let anchor = commons
+        .create_anchor_from_enrollment(&did, Some(voucher.did()))
+        .await
+        .unwrap();
+    let holder = commons
+        .create_holder_from_anchor(&hex::encode(anchor.id()), &did)
+        .await
+        .unwrap();
+    let holder_id = hex::encode(holder.id());
+    commons
+        .join_jurisdiction(
+            &holder_id,
+            jurisdiction.clone(),
+            vec![MembershipCapability::Vote],
+        )
+        .await
+        .unwrap();
+    commons
+        .update_affiliation_status(&holder_id, &jurisdiction, MembershipStatus::Banned)
+        .await
+        .unwrap();
+
+    let app = build_app(commons.clone(), gov, std::slice::from_ref(&did)).await;
+    let token = get_jwt(&app, &did.to_string(), &bundle).await;
+
+    let resp = test::call_service(&app, bootstrap_request(&token).to_request()).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "the dev bridge must refuse to reactivate a Banned affiliation"
+    );
+
+    // The affiliation must remain `Banned` — the bridge did not override it.
+    let affiliations = commons.list_affiliations(&holder_id).await.unwrap();
+    assert!(
+        affiliations.iter().any(|a| {
+            a.jurisdiction_id == jurisdiction && a.membership_status == MembershipStatus::Banned
+        }),
+        "Banned affiliation must be left unchanged by the dev bridge"
+    );
+}
+
+// ── Review fix (Copilot): idempotent when an anchor exists but no holder ──
+#[actix_web::test]
+async fn dev_bootstrap_idempotent_when_anchor_exists_without_holder() {
+    let _env = EnvGuard::acquire(Some("true"), Some("test"));
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+    let bundle = IdentityBundle::generate().unwrap();
+    let did = bundle.did().clone();
+
+    // Simulate a prior partial run / earlier SDIS enrollment: an anchor exists for
+    // the DID but no commons holder record yet.
+    let voucher = KeyPair::generate().unwrap();
+    commons
+        .create_anchor_from_enrollment(&did, Some(voucher.did()))
+        .await
+        .unwrap();
+
+    let app = build_app(commons.clone(), gov, std::slice::from_ref(&did)).await;
+    let token = get_jwt(&app, &did.to_string(), &bundle).await;
+
+    // Must reuse the existing anchor rather than erroring on "Anchor already exists".
+    let resp = test::call_service(&app, bootstrap_request(&token).to_request()).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "bootstrap must reuse an existing anchor and succeed (idempotent enrollment)"
+    );
+
+    let holder = commons
+        .get_holder_by_did(&did)
+        .await
+        .unwrap()
+        .expect("holder created from the reused anchor");
+    let affiliations = commons
+        .list_affiliations(&hex::encode(holder.id()))
+        .await
+        .unwrap();
+    assert!(
+        affiliations.iter().any(|a| {
+            a.jurisdiction_id == JurisdictionId::new(DOMAIN_ID)
+                && a.membership_status == MembershipStatus::Member
+        }),
+        "caller must hold Member standing after bootstrap reuses the anchor"
     );
 }

--- a/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
+++ b/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
@@ -570,3 +570,45 @@ async fn dev_bootstrap_refuses_inactive_holder() {
         "an inactive holder must not gain a Member affiliation"
     );
 }
+
+// ── Review fix (codex P2): a suspended/revoked anchor is rejected on reuse ──
+#[actix_web::test]
+async fn dev_bootstrap_refuses_inactive_anchor() {
+    let _env = EnvGuard::acquire(Some("true"), Some("test"));
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+    let bundle = IdentityBundle::generate().unwrap();
+    let did = bundle.did().clone();
+
+    // Pre-existing personhood anchor for the DID, suspended at the SDIS-anchor
+    // level, with NO holder record yet — only the anchor-active guard can catch
+    // this (create_holder_from_anchor would otherwise build a fresh active holder).
+    let voucher = KeyPair::generate().unwrap();
+    let anchor = commons
+        .create_anchor_from_enrollment(&did, Some(voucher.did()))
+        .await
+        .unwrap();
+    let anchor_id = hex::encode(anchor.id());
+    let mut removed = commons.get_anchor(&anchor_id).await.unwrap().unwrap();
+    removed.suspend("test removal".to_string(), voucher.did().clone(), None);
+    commons
+        .update_anchor_status(&anchor_id, removed.status)
+        .await
+        .unwrap();
+
+    let app = build_app(commons.clone(), gov, std::slice::from_ref(&did)).await;
+    let token = get_jwt(&app, &did.to_string(), &bundle).await;
+
+    let resp = test::call_service(&app, bootstrap_request(&token).to_request()).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "the dev bridge must refuse a suspended/revoked personhood anchor"
+    );
+
+    // No holder (and thus no Member standing) was created from the inactive anchor.
+    assert!(
+        commons.get_holder_by_did(&did).await.unwrap().is_none(),
+        "no holder may be created from an inactive anchor"
+    );
+}

--- a/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
+++ b/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
@@ -612,3 +612,66 @@ async fn dev_bootstrap_refuses_inactive_anchor() {
         "no holder may be created from an inactive anchor"
     );
 }
+
+// ── Review fix (codex P2): existing holder with a revoked backing anchor → 403 ─
+#[actix_web::test]
+async fn dev_bootstrap_refuses_holder_with_inactive_backing_anchor() {
+    let _env = EnvGuard::acquire(Some("true"), Some("test"));
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+    let bundle = IdentityBundle::generate().unwrap();
+    let did = bundle.did().clone();
+
+    // An ACTIVE holder whose backing anchor is suspended AFTER holder creation.
+    // Anchor status does not cascade to the holder, so the holder stays `Active`
+    // and only the backing-anchor guard can catch this (the no-holder anchor guard
+    // does not run because a holder already exists).
+    let voucher = KeyPair::generate().unwrap();
+    let anchor = commons
+        .create_anchor_from_enrollment(&did, Some(voucher.did()))
+        .await
+        .unwrap();
+    let anchor_id = hex::encode(anchor.id());
+    let holder = commons
+        .create_holder_from_anchor(&anchor_id, &did)
+        .await
+        .unwrap();
+    let holder_id = hex::encode(holder.id());
+    let mut removed_anchor = commons.get_anchor(&anchor_id).await.unwrap().unwrap();
+    removed_anchor.suspend("test removal".to_string(), voucher.did().clone(), None);
+    commons
+        .update_anchor_status(&anchor_id, removed_anchor.status)
+        .await
+        .unwrap();
+
+    // Precondition: the holder is still `Active` (anchor status did not cascade).
+    assert!(
+        commons
+            .get_holder(&holder_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .is_active(),
+        "precondition: holder stays Active when its backing anchor is suspended"
+    );
+
+    let app = build_app(commons.clone(), gov, std::slice::from_ref(&did)).await;
+    let token = get_jwt(&app, &did.to_string(), &bundle).await;
+
+    let resp = test::call_service(&app, bootstrap_request(&token).to_request()).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "an Active holder backed by a suspended/revoked anchor must be refused"
+    );
+
+    // No Member affiliation was granted.
+    let affiliations = commons.list_affiliations(&holder_id).await.unwrap();
+    assert!(
+        !affiliations.iter().any(|a| {
+            a.jurisdiction_id == JurisdictionId::new(DOMAIN_ID)
+                && a.membership_status == MembershipStatus::Member
+        }),
+        "no Member affiliation may be granted when the backing anchor is inactive"
+    );
+}

--- a/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
+++ b/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
@@ -1,0 +1,420 @@
+//! Proof for the dev/demo-only standing bootstrap bridge
+//! (`POST /v1/commons/dev/bootstrap-standing`).
+//!
+//! This is the live/HTTP counterpart to PR #1980's in-process helper. It lets a
+//! local secured-gateway demo (e.g. a NYCN v4 bash flow) establish commons
+//! `Member` standing for the organizer's own DID over HTTP, so the governed
+//! proposal lifecycle (`create → open → vote → close`, all already present) can
+//! produce a receipt chain that `icnctl audit verify --token` can check.
+//!
+//! ## What it proves (the six required cases)
+//!
+//! 1. The endpoint is **disabled by default** (no env) → 403.
+//! 2. It is **refused in Production posture** even with the opt-in flag set → 403.
+//! 3. It is **available only** when `ICN_ENABLE_ADMIN_ENDPOINTS=true` AND posture
+//!    is non-Production → 200, and the caller then holds `Member` standing.
+//! 4. A governed proposal is **rejected before** the bootstrap → 403.
+//! 5. The same governed proposal **succeeds after** the bootstrap → 201.
+//! 6. A *different* authenticated, domain-listed DID that did NOT bootstrap is
+//!    **still rejected** → 403 (the `member_checker` gate is not bypassed).
+//!
+//! It bypasses the multi-steward SDIS proof-of-personhood ceremony, so it is
+//! double dev-gated and confined to a local operator-controlled node. It grants
+//! standing for the caller's own DID only and weakens no production check.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    // The env guard below serializes process-global env vars across these async
+    // tests; its lock is intentionally held across the request `.await`.
+    clippy::await_holding_lock
+)]
+
+use actix_web::{test, web, App};
+use actix_web_httpauth::middleware::HttpAuthentication;
+use icn_gateway::{
+    api, auth::AuthManager, commons_mgr::CommonsManager, middleware::jwt_auth,
+    rate_limit::IpRateLimiter,
+};
+use icn_governance::{GovernanceDomainId, GovernanceParams, MembershipConfig, MembershipSource};
+use icn_governance_actor::{
+    events::NoopEventEmitter,
+    http::configure::{GovernanceContext, MemberStandingChecker},
+    manager::GovernanceManager,
+};
+use icn_identity::{
+    commons::{JurisdictionId, MembershipStatus},
+    Did, IdentityBundle,
+};
+use serde_json::{json, Value};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+const DOMAIN_ID: &str = "dev-standing-bridge-coop";
+const BOOTSTRAP_PATH: &str = "/v1/commons/dev/bootstrap-standing";
+
+/// Serializes mutation of the process-global env vars the gate reads.
+static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Sets `ICN_ENABLE_ADMIN_ENDPOINTS` / `ICN_GOVERNANCE_BUILD_MODE` for the test's
+/// lifetime and restores the previous values on drop, under a shared lock so
+/// parallel tests don't race on this process-wide state.
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    prior_admin: Option<String>,
+    prior_mode: Option<String>,
+}
+
+impl EnvGuard {
+    fn acquire(admin: Option<&str>, mode: Option<&str>) -> Self {
+        let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prior_admin = std::env::var("ICN_ENABLE_ADMIN_ENDPOINTS").ok();
+        let prior_mode = std::env::var("ICN_GOVERNANCE_BUILD_MODE").ok();
+        set_or_clear("ICN_ENABLE_ADMIN_ENDPOINTS", admin);
+        set_or_clear("ICN_GOVERNANCE_BUILD_MODE", mode);
+        Self {
+            _lock: lock,
+            prior_admin,
+            prior_mode,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        set_or_clear("ICN_ENABLE_ADMIN_ENDPOINTS", self.prior_admin.as_deref());
+        set_or_clear("ICN_GOVERNANCE_BUILD_MODE", self.prior_mode.as_deref());
+    }
+}
+
+fn set_or_clear(key: &str, value: Option<&str>) {
+    match value {
+        Some(v) => std::env::set_var(key, v),
+        None => std::env::remove_var(key),
+    }
+}
+
+/// Commons-backed `MemberStandingChecker`, identical to the gateway's production
+/// wiring (`server.rs`) and to PR #1980's gate test.
+fn make_checker(commons: Arc<CommonsManager>) -> MemberStandingChecker {
+    Arc::new(move |did: Did, domain_id: String| {
+        let c = commons.clone();
+        Box::pin(async move {
+            let Ok(Some(holder)) = c.get_holder_by_did(&did).await else {
+                return false;
+            };
+            let holder_id = hex::encode(holder.id());
+            let Ok(affiliations) = c.list_affiliations(&holder_id).await else {
+                return false;
+            };
+            affiliations.iter().any(|a| {
+                a.jurisdiction_id == JurisdictionId::new(&domain_id)
+                    && a.membership_status == MembershipStatus::Member
+            })
+        })
+    })
+}
+
+/// Build a test gateway mounting `/v1/commons` (with the dev endpoint) and
+/// `/v1/gov` (with the live `member_checker` gate), sharing one `CommonsManager`.
+/// `members` seed the domain's `StaticList` so the governance layer admits them —
+/// the only gate left for proposals is the commons checker.
+async fn build_app(
+    commons_mgr: Arc<CommonsManager>,
+    governance_manager: Arc<GovernanceManager>,
+    members: &[Did],
+) -> impl actix_web::dev::Service<
+    actix_http::Request,
+    Response = actix_web::dev::ServiceResponse,
+    Error = actix_web::Error,
+> {
+    governance_manager
+        .create_domain(
+            GovernanceDomainId(DOMAIN_ID.to_string()),
+            "Dev Standing Bridge Coop".to_string(),
+            "cooperative".to_string(),
+            GovernanceParams::new(50, 50, 86_400),
+            MembershipConfig {
+                source: MembershipSource::StaticList(members.to_vec()),
+            },
+        )
+        .await
+        .expect("create_domain");
+
+    let auth_manager = Arc::new(AuthManager::new(
+        b"dev-standing-bridge-jwt-secret-32".to_vec(),
+    ));
+    let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
+
+    let gov_ctx = GovernanceContext {
+        manager: governance_manager.clone(),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: Some(make_checker(commons_mgr.clone())),
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        mandate_gate: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
+    };
+
+    test::init_service(
+        App::new()
+            .app_data(web::Data::new(auth_manager.clone()))
+            .app_data(web::Data::new(ip_limiter))
+            .app_data(web::Data::new(commons_mgr))
+            .service(
+                web::scope("/v1")
+                    .service(api::auth::challenge)
+                    .service(api::auth::verify)
+                    .service(
+                        web::scope("/commons")
+                            .configure(api::commons::configure)
+                            .wrap(HttpAuthentication::bearer(jwt_auth)),
+                    )
+                    .service(
+                        web::scope("/gov")
+                            .configure({
+                                let ctx = gov_ctx.clone();
+                                move |cfg| {
+                                    icn_governance_actor::http::configure::configure(
+                                        cfg,
+                                        ctx.clone(),
+                                    )
+                                }
+                            })
+                            .wrap(HttpAuthentication::bearer(jwt_auth)),
+                    ),
+            ),
+    )
+    .await
+}
+
+/// Mint a JWT for `did` via the challenge/verify handshake.
+async fn get_jwt(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    did: &str,
+    bundle: &IdentityBundle,
+) -> String {
+    let challenge_req = test::TestRequest::post()
+        .uri("/v1/auth/challenge")
+        .set_json(json!({ "did": did }))
+        .to_request();
+    let challenge_resp: Value = test::call_and_read_body_json(app, challenge_req).await;
+    let nonce = challenge_resp["nonce"].as_str().expect("nonce").to_string();
+
+    let nonce_bytes = hex::decode(&nonce).expect("hex nonce");
+    let signature = bundle.sign(&nonce_bytes).expect("sign");
+    let sig_hex = hex::encode(signature.to_bytes());
+
+    let verify_req = test::TestRequest::post()
+        .uri("/v1/auth/verify")
+        .set_json(json!({
+            "did": did,
+            "signature": sig_hex,
+            "coop_id": "dev-standing-bridge",
+            "scopes": ["governance:read", "governance:write"]
+        }))
+        .to_request();
+    let token_resp: Value = test::call_and_read_body_json(app, verify_req).await;
+    token_resp["token"].as_str().expect("token").to_string()
+}
+
+fn bootstrap_request(token: &str) -> test::TestRequest {
+    test::TestRequest::post()
+        .uri(BOOTSTRAP_PATH)
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .set_json(json!({ "jurisdiction_id": DOMAIN_ID }))
+}
+
+fn governed_proposal_request(token: &str, recipient: &str) -> test::TestRequest {
+    test::TestRequest::post()
+        .uri("/v1/gov/proposals")
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .set_json(json!({
+            "domain_id": DOMAIN_ID,
+            "title": "Q1 infrastructure budget",
+            "description": "Allocate compute-hours to cluster maintenance.",
+            "payload": {
+                "type": "budget",
+                "amount": 6000,
+                "recipient": recipient,
+                "currency": "compute-hours",
+                "purpose": "q1-infra"
+            }
+        }))
+}
+
+// ── Case 1: disabled by default ──────────────────────────────────────────────
+#[actix_web::test]
+async fn dev_bootstrap_disabled_by_default() {
+    let _env = EnvGuard::acquire(None, None);
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+    let bundle = IdentityBundle::generate().unwrap();
+    let did = bundle.did().clone();
+
+    let app = build_app(commons, gov, std::slice::from_ref(&did)).await;
+    let token = get_jwt(&app, &did.to_string(), &bundle).await;
+
+    let resp = test::call_service(&app, bootstrap_request(&token).to_request()).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "endpoint must be disabled by default (no ICN_ENABLE_ADMIN_ENDPOINTS)"
+    );
+}
+
+// ── Case 2: refused in Production posture even with the opt-in flag ───────────
+#[actix_web::test]
+async fn dev_bootstrap_refused_in_production_posture() {
+    let _env = EnvGuard::acquire(Some("true"), Some("production"));
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+    let bundle = IdentityBundle::generate().unwrap();
+    let did = bundle.did().clone();
+
+    let app = build_app(commons, gov, std::slice::from_ref(&did)).await;
+    let token = get_jwt(&app, &did.to_string(), &bundle).await;
+
+    let resp = test::call_service(&app, bootstrap_request(&token).to_request()).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "endpoint must be refused in Production posture even if the opt-in flag is set"
+    );
+}
+
+// ── Case 3: available only when dev-gated, and grants Member standing ─────────
+#[actix_web::test]
+async fn dev_bootstrap_enabled_grants_member_standing() {
+    let _env = EnvGuard::acquire(Some("true"), Some("test"));
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+    let bundle = IdentityBundle::generate().unwrap();
+    let did = bundle.did().clone();
+
+    let app = build_app(commons.clone(), gov, std::slice::from_ref(&did)).await;
+    let token = get_jwt(&app, &did.to_string(), &bundle).await;
+
+    let resp = test::call_service(&app, bootstrap_request(&token).to_request()).await;
+    let status = resp.status().as_u16();
+    let body = test::read_body(resp).await;
+    assert_eq!(
+        status,
+        200,
+        "endpoint must succeed when dev-gated and non-production; body={}",
+        String::from_utf8_lossy(&body)
+    );
+
+    // The caller now holds active Member standing in the jurisdiction.
+    let holder = commons
+        .get_holder_by_did(&did)
+        .await
+        .unwrap()
+        .expect("holder created by bootstrap");
+    let affiliations = commons
+        .list_affiliations(&hex::encode(holder.id()))
+        .await
+        .unwrap();
+    assert!(
+        affiliations.iter().any(|a| {
+            a.jurisdiction_id == JurisdictionId::new(DOMAIN_ID)
+                && a.membership_status == MembershipStatus::Member
+        }),
+        "caller must hold Member standing after bootstrap"
+    );
+}
+
+// ── Cases 4 + 5: governed proposal rejected before, accepted after bootstrap ──
+#[actix_web::test]
+async fn governed_proposal_gated_before_and_unlocked_after_bootstrap() {
+    let _env = EnvGuard::acquire(Some("true"), Some("test"));
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+    let bundle = IdentityBundle::generate().unwrap();
+    let did = bundle.did().clone();
+
+    let app = build_app(commons, gov, std::slice::from_ref(&did)).await;
+    let token = get_jwt(&app, &did.to_string(), &bundle).await;
+
+    // Case 4: before bootstrap the governed proposal is rejected by member_checker.
+    let before = test::call_service(
+        &app,
+        governed_proposal_request(&token, &did.to_string()).to_request(),
+    )
+    .await;
+    assert_eq!(
+        before.status().as_u16(),
+        403,
+        "governed proposal must be rejected before standing is established"
+    );
+
+    // Establish standing via the dev-gated bridge.
+    let boot = test::call_service(&app, bootstrap_request(&token).to_request()).await;
+    assert_eq!(boot.status().as_u16(), 200, "bootstrap must succeed");
+
+    // Case 5: after bootstrap the same governed proposal is accepted.
+    let after = test::call_service(
+        &app,
+        governed_proposal_request(&token, &did.to_string()).to_request(),
+    )
+    .await;
+    assert_eq!(
+        after.status().as_u16(),
+        201,
+        "governed proposal must be accepted after the dev-gated standing bootstrap"
+    );
+}
+
+// ── Case 6: a different domain-listed DID that didn't bootstrap is still 403 ──
+#[actix_web::test]
+async fn other_did_without_bootstrap_still_rejected() {
+    let _env = EnvGuard::acquire(Some("true"), Some("test"));
+    let commons = Arc::new(CommonsManager::new());
+    let gov = Arc::new(GovernanceManager::new());
+
+    let bundle_a = IdentityBundle::generate().unwrap();
+    let did_a = bundle_a.did().clone();
+    let bundle_b = IdentityBundle::generate().unwrap();
+    let did_b = bundle_b.did().clone();
+
+    // Both DIDs are in the governance StaticList, so the only gate is the commons
+    // checker — proving the dev bootstrap grants standing for A only, and that B
+    // (which never bootstrapped) is still rejected by member_checker.
+    let app = build_app(commons, gov, &[did_a.clone(), did_b.clone()]).await;
+    let token_a = get_jwt(&app, &did_a.to_string(), &bundle_a).await;
+    let token_b = get_jwt(&app, &did_b.to_string(), &bundle_b).await;
+
+    // A bootstraps its own standing and can propose.
+    let boot = test::call_service(&app, bootstrap_request(&token_a).to_request()).await;
+    assert_eq!(boot.status().as_u16(), 200);
+    let a_prop = test::call_service(
+        &app,
+        governed_proposal_request(&token_a, &did_a.to_string()).to_request(),
+    )
+    .await;
+    assert_eq!(
+        a_prop.status().as_u16(),
+        201,
+        "bootstrapped DID A may propose"
+    );
+
+    // B never bootstrapped → member_checker still rejects it (no blanket bypass).
+    let b_prop = test::call_service(
+        &app,
+        governed_proposal_request(&token_b, &did_b.to_string()).to_request(),
+    )
+    .await;
+    assert_eq!(
+        b_prop.status().as_u16(),
+        403,
+        "DID B (no bootstrap) must still be rejected — member_checker is not bypassed"
+    );
+}


### PR DESCRIPTION
## What

Adds the smallest live-demo bridge needed after #1980: a **strictly dev-gated** HTTP endpoint that lets a local secured-gateway demo (e.g. a NYCN v4 bash flow) establish commons `Member` standing for the organizer's own DID, so the already-complete governed proposal lifecycle can produce a receipt chain `icnctl audit verify --token` can check.

- `POST /v1/commons/dev/bootstrap-standing` (auth required) — establishes `Member` standing for the **authenticated caller's own DID** in a given jurisdiction via the existing internal `CommonsManager` API (`create_anchor_from_enrollment → create_holder_from_anchor → join_jurisdiction → update_affiliation_status(Member)`), idempotently.

Files changed:
- `icn/crates/icn-gateway/src/api/commons/mod.rs` — one handler + a `demo_standing_bootstrap_enabled()` gate helper + route registration.
- `icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs` — new integration test (the 6 required cases).

## Why

After #1980 (test-only proof of the local standing bootstrap + governed receipt chain), the remaining gap for an **external bash NYCN v4** driving a live `icnd` was: no HTTP-reachable way to give the organizer's own signing DID commons `Member` standing. Production routes standing only through the multi-steward SDIS proof-of-personhood ceremony (correctly). Investigation also confirmed the HTTP proposal lifecycle (`create → open → close → vote`, plus `tally/proof/chain/effects`) **already exists**, so no proposal-close work is needed here.

## How / the gate

The endpoint is **double dev-gated** (`demo_standing_bootstrap_enabled()`), returning `403 Forbidden` unless BOTH hold:
1. `ICN_ENABLE_ADMIN_ENDPOINTS=true` — the same explicit opt-in used by the existing SDIS `approve_ceremony` / `approve_recovery` admin endpoints (default off).
2. Posture is **not** `Production` (`icn_governance_actor::http::GovernanceContextBuildMode::from_env() != Production`).

It is deliberately kept **out of the public OpenAPI surface** (no `#[utoipa::path]`, like the other dev endpoints), so no SDK/API-types drift.

**Sybil gate is satisfied, not weakened.** `join_jurisdiction` requires at least `Strong` POP level. The handler mints a *synthetic demo voucher* (a throwaway key → `WebOfTrust`/`Strong` anchor) to meet that bar — the same shape PR #1980's proven in-process helper uses. The gate still runs and still rejects under-attested holders; the demo just satisfies it the legitimate way. Production obtains real steward attestations via the SDIS ceremony.

## Risk / safety

- **Dev-only & impossible to enable in production:** disabled by default; the posture gate hard-refuses when `ICN_GOVERNANCE_BUILD_MODE=production`, even if the opt-in flag is set by mistake.
- **No production "make me a Member" route:** it acts on the **caller's own DID only** (`claims.sub`) — never an arbitrary DID — so it confers no admin "promote anyone" power.
- **No weakening of real checks:** `member_checker`, the SDIS ceremony, steward checks, the `join_jurisdiction` Sybil gate, governance authorization, and receipt verification are untouched and still enforced for every request. The bridge only adds a dev path to *create* a commons holder; it removes/lowers no check. Test case 6 proves a different, domain-listed DID that didn't bootstrap is still rejected.
- It bypasses the multi-steward SDIS ceremony (synthetic demo voucher), so it is only valid on a local node a single operator controls.

## Test plan (all in `dev_standing_bootstrap_gate.rs`, all passing)

1. disabled by default (no env) → `403`
2. flag set **but** `ICN_GOVERNANCE_BUILD_MODE=production` → `403`
3. dev-gated + non-prod → `200`, and the caller then holds `Member` standing
4. governed proposal **before** bootstrap → `403`
5. same governed proposal **after** bootstrap → `201`
6. a different domain-listed DID that didn't bootstrap → still `403` (member_checker not bypassed)

Validation run: `cargo test -p icn-gateway --test dev_standing_bootstrap_gate` (5/5 pass), `cargo fmt --all --check` (clean), clippy (touched lib + test target), `git diff --check` (clean), and the regulatory-compliance / readiness / meaning-firewall linters (pass; meaning-firewall has only pre-existing unrelated entries). No generated files; no secrets.

## What remains for NYCN v4

With this bridge merged, a bash NYCN v4 against a secured live `icnd` (with `ICN_ENABLE_ADMIN_ENDPOINTS=true`, non-production posture) can: mint a JWT → `POST /v1/commons/dev/bootstrap-standing` → create/open/vote/`close` a governed proposal → `GET /v1/receipts/chain/{hash}` → `icnctl audit verify --token`, and honestly report PASS or the next precise blocker. No NYCN-repo changes are included here.

## What was intentionally not touched

SDIS, `member_checker`, the Sybil gate, governance semantics, receipt verification, production enrollment routes, `deny.toml`/RUSTSEC, NYCN, SDK/React Native/CoopWallet/website/docs, and the dirty main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
