### PR TITLE
fix(website): redirect legacy cooperative URLs to current pages

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -8,6 +8,13 @@ export default defineConfig({
   integrations: [sitemap()],
   site: "https://intercooperative.network",
   base: "",
+  // Legacy routes from the pre-Astro site structure that external parties
+  // still link to / have bookmarked (reported 404 by an outside developer,
+  // Dec 2025). Static output renders these as meta-refresh redirect pages.
+  redirects: {
+    "/docs/cooperatives/getting-started": "/for-cooperatives",
+    "/community/cooperatives": "/community",
+  },
   markdown: {
     shikiConfig: {
       theme: "github-dark",


### PR DESCRIPTION
## What
Add two redirects to website/astro.config.mjs for legacy pre-Astro URLs that still 404:
- /docs/cooperatives/getting-started → /for-cooperatives
- /community/cooperatives → /community

## Why
Reported by an outside developer (Cooperative Codebase, Dec 2025). These URLs are linked/bookmarked externally; current site has no equivalents at those paths. Verified both 404 on the live site while current pages render fine.

## How
Astro static `redirects` config — generates meta-refresh redirect pages in the static build.

## Risk
Minimal: additive config only, no page or content changes.

## Test plan
After merge, website-deploy.yml runs on the website/** path change. Verify:
- https://intercooperative.network/docs/cooperatives/getting-started → /for-cooperatives
- https://intercooperative.network/community/cooperatives → /community