### PR TITLE
chore(ci): ignore unmaintained pqcrypto-* advisories to unblock main

### DIFF
--- a/icn/deny.toml
+++ b/icn/deny.toml
@@ -49,6 +49,19 @@ ignore = [
     # (no URI name constraints in ICN's TLS setup; no wildcard cert validation).
     "RUSTSEC-2026-0098",  # rustls-webpki URI name constraints (transitive via reqwest)
     "RUSTSEC-2026-0099",  # rustls-webpki wildcard name constraints (transitive via reqwest)
+
+    # The pqcrypto-* crates (NIST PQ crypto: ML-DSA signatures, ML-KEM KEM) were
+    # all flagged unmaintained on 2026-06-04 because upstream PQClean is being
+    # archived (July 2026, see PQClean/PQClean#604). These are "unmaintained"
+    # advisories, not exploitable vulnerabilities, and the advisories state that
+    # no safe upgrade is available. ICN depends on them via icn-crypto →
+    # icn-crypto-pq. Migrating to a maintained PQ provider (RustCrypto ml-dsa/ml-kem
+    # or aws-lc-rs) is tracked as future work; until then these are ignored so the
+    # unmaintained-no-fix advisories don't block CI.
+    "RUSTSEC-2026-0161",  # pqcrypto-mlkem unmaintained (PQClean archived)
+    "RUSTSEC-2026-0162",  # pqcrypto-traits unmaintained (PQClean archived)
+    "RUSTSEC-2026-0163",  # pqcrypto-internals unmaintained (PQClean archived)
+    "RUSTSEC-2026-0166",  # pqcrypto-mldsa unmaintained (PQClean archived)
 ]
 
 [licenses]


### PR DESCRIPTION
## What
Add four RustSec advisory IDs to `icn/deny.toml`'s `[advisories].ignore` list:

| RUSTSEC | Crate | Role |
|---|---|---|
| RUSTSEC-2026-0161 | `pqcrypto-mlkem` | ML-KEM (Kyber) KEM |
| RUSTSEC-2026-0162 | `pqcrypto-traits` | shared traits |
| RUSTSEC-2026-0163 | `pqcrypto-internals` | FFI internals |
| RUSTSEC-2026-0166 | `pqcrypto-mldsa` | ML-DSA (Dilithium) signatures |

## Why
`main` went red on **Security Audit → `cargo-deny check advisories`** (runs [26991088174](https://github.com/InterCooperative-Network/icn/actions/runs/26991088174) and prior). Upstream **PQClean is being archived** (July 2026, [PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)), so RustSec flagged the entire `pqcrypto-*` stack as **unmaintained**. These are `unmaintained` advisories with **no safe upgrade available** — not exploitable vulnerabilities. The failure is time-triggered (fresh advisory-db each CI run); **no ICN code changed**. Every other CI job stayed green.

## How
Append the 4 IDs to the existing `ignore` list with a documented rationale, matching the established pattern already used for 9 other unmaintained-transitive advisories (one already annotated "via pqcrypto-mldsa").

## Risk
Low. `deny.toml` is config only — not compiled, so the already-green jobs (Test, Clippy, Build, Coverage) are unaffected. The trade-off: ICN will no longer be alerted to *new* advisories on these specific crates until the migration lands. These are unmaintained-status flags, not active CVEs.

## Test plan
Reproduced on `origin/main` with a refreshed advisory-db, then confirmed the fix locally:
- `cargo deny check advisories` → was **FAILED (4 errors)**, now **advisories ok (exit 0)**
- `cargo deny check licenses` → **licenses ok (exit 0)**

## Follow-up (out of scope)
Migrate off the archived PQClean stack to a maintained PQ provider (RustCrypto `ml-dsa`/`ml-kem` or `aws-lc-rs`), then drop these ignores. Noted in the deny.toml comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)