### PR TITLE
cleanup(api): remove dead governance scope constants

### DIFF
--- a/icn/crates/icn-api/src/scopes.rs
+++ b/icn/crates/icn-api/src/scopes.rs
@@ -33,12 +33,6 @@ pub mod ledger {
 
 /// Governance permission scopes
 pub mod governance {
-    /// Create governance domains
-    pub const CREATE_DOMAIN: &str = "governance:create_domain";
-    /// Create proposals
-    pub const CREATE_PROPOSAL: &str = "governance:create_proposal";
-    /// Cast votes
-    pub const VOTE: &str = "governance:vote";
     /// Query proposals and votes
     pub const READ: &str = "governance:read";
     /// Modify governance state (proposals, domains, voting)
@@ -160,6 +154,6 @@ mod tests {
     fn test_admin_wildcard() {
         assert!(matches(admin::WILDCARD, compute::SUBMIT));
         assert!(matches(admin::WILDCARD, ledger::READ));
-        assert!(matches(admin::WILDCARD, governance::VOTE));
+        assert!(matches(admin::WILDCARD, governance::WRITE));
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #1868 / #1950. #1950 removed the stale handler-level `governance:vote`
scope gate; this removes the now-orphaned public scope constants it left behind.

## What changed
Removes three dead constants from `icn-api::scopes::governance`:
- `governance::CREATE_DOMAIN` (`"governance:create_domain"`)
- `governance::CREATE_PROPOSAL` (`"governance:create_proposal"`)
- `governance::VOTE` (`"governance:vote"`)

Retargets the one in-crate test that referenced the removed constant
(`scopes::tests::test_admin_wildcard`) from `governance::VOTE` to `governance::WRITE`.

## Safety / dead-code confirmation
- Source search (excluding provenance notes) found **zero** Rust symbol-path
  consumers of `governance::{CREATE_DOMAIN, CREATE_PROPOSAL, VOTE}`.
- Remaining bare `"governance:vote"` string literals live in `icn-rpc` /
  `icn-authz` tests and docs. Those are independent string usage
  (`Action::new("governance:vote")`, assertion fixtures), **not** consumers of
  the removed `icn-api` constants, so they are unaffected.

## Validation (run on icn-dev)
- `cargo build -p icn-api` — Finished, no errors
- `cargo test -p icn-api` — 14 passed; 0 failed (incl. retargeted `test_admin_wildcard`)

## Scope
Scope-cleanup only. An unrelated local `chmod` on `.claude/hooks/hook-health.sh`
was deliberately excluded from this commit.