### PR TITLE
fix(gateway): page dispatch evidence backfill scan

### DIFF
--- a/icn/crates/icn-gateway/src/dispatch_evidence_backfill.rs
+++ b/icn/crates/icn-gateway/src/dispatch_evidence_backfill.rs
@@ -16,6 +16,10 @@
 //! idempotent: it heals a crash residue exactly once and a clean restart
 //! re-scans and writes nothing. It never re-executes effects (it replays the
 //! stored results), so it cannot cause a duplicate downstream side effect.
+//!
+//! The scan is bounded: it pages the `exec:` keyspace in fixed-size batches
+//! rather than loading every record into memory at once, so startup memory and
+//! readiness stay flat on nodes with a large execution history.
 
 use std::sync::Arc;
 
@@ -29,6 +33,15 @@ use icn_store::Store;
 /// `icn-core`'s `SledExecutionStore` keys with), so the gateway reads exactly
 /// the records the executor persists without the two sides drifting.
 const EXECUTION_PREFIX: &[u8] = EXECUTION_RECORD_KEY_PREFIX.as_bytes();
+
+/// Page size for the startup backfill scan.
+///
+/// Bounds peak memory to one page of execution records at a time instead of
+/// materializing the entire `exec:` keyspace into a `Vec` — on a long-lived node
+/// that keyspace can be large enough to spike memory and delay gateway
+/// readiness. A once-at-startup heal is not latency-sensitive, so a modest page
+/// keeps the resident working set small without meaningfully slowing it.
+const BACKFILL_PAGE_SIZE: usize = 256;
 
 /// Summary of a dispatch-evidence backfill scan (for startup logging).
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -52,46 +65,85 @@ pub(crate) struct EvidenceBackfillReport {
 /// through the live, evidence-writing callback. Only terminal records — whose
 /// effects already applied and will not run again — need their evidence healed
 /// here.
+///
+/// The scan is bounded: it pages through the keyspace via
+/// [`backfill_pending_dispatch_evidence_paged`] at [`BACKFILL_PAGE_SIZE`] rather
+/// than materializing every record at once.
 pub(crate) fn backfill_pending_dispatch_evidence(
     execution_store: &Arc<dyn Store>,
     sink: &DeferredDispatchEvidenceSink,
 ) -> anyhow::Result<EvidenceBackfillReport> {
-    let entries = execution_store.scan(EXECUTION_PREFIX)?;
-    let mut report = EvidenceBackfillReport::default();
+    backfill_pending_dispatch_evidence_paged(execution_store, sink, BACKFILL_PAGE_SIZE)
+}
 
-    for (_key, value) in entries {
-        let record: ExecutionRecord = match serde_json::from_slice(&value) {
-            Ok(record) => record,
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "dispatch-evidence backfill: skipping unparsable execution record"
-                );
-                report.unparsable += 1;
+/// Page-bounded core of the backfill (see [`backfill_pending_dispatch_evidence`]).
+///
+/// Walks the `exec:` keyspace one [`Store::scan_paginated`] page at a time so at
+/// most `page_size` execution records are resident at once, instead of loading
+/// the whole keyspace into a single `Vec`. Offset-based paging is safe here
+/// because the backfill runs at startup *before* the gateway serves and *before*
+/// retention cleanup prunes (so no concurrent writer can shift offsets), and the
+/// sink dedups on read-back, so even a re-observed record cannot double-write.
+fn backfill_pending_dispatch_evidence_paged(
+    execution_store: &Arc<dyn Store>,
+    sink: &DeferredDispatchEvidenceSink,
+    page_size: usize,
+) -> anyhow::Result<EvidenceBackfillReport> {
+    // A zero page would never make progress; clamp defensively.
+    let page_size = page_size.max(1);
+    let mut report = EvidenceBackfillReport::default();
+    let mut offset = 0usize;
+
+    loop {
+        let (page, _total) = execution_store.scan_paginated(EXECUTION_PREFIX, offset, page_size)?;
+        if page.is_empty() {
+            break;
+        }
+        // Advance by raw entries returned (parsable or not) so the offset tracks
+        // store positions; `report.scanned` counts only decoded records.
+        let page_len = page.len();
+
+        for (_key, value) in page {
+            let record: ExecutionRecord = match serde_json::from_slice(&value) {
+                Ok(record) => record,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "dispatch-evidence backfill: skipping unparsable execution record"
+                    );
+                    report.unparsable += 1;
+                    continue;
+                }
+            };
+            report.scanned += 1;
+
+            // Only terminal records carry final results, and only records that
+            // produced results can yield evidence. A non-terminal record (or a
+            // pre-upgrade record with no stored results) has nothing to backfill.
+            if !record.is_terminal() || record.results.is_empty() {
+                report.skipped += 1;
                 continue;
             }
-        };
-        report.scanned += 1;
 
-        // Only terminal records carry final results, and only records that
-        // produced results can yield evidence. A non-terminal record (or a
-        // pre-upgrade record with no stored results) has nothing to backfill.
-        if !record.is_terminal() || record.results.is_empty() {
-            report.skipped += 1;
-            continue;
+            // Reproduce the dispatch's own completion time on replay (mirrors the
+            // close journal's stored `decided_at`) rather than using restart time,
+            // so the healed evidence is timestamped when the dispatch happened.
+            let recorded_at = record.finished_at.unwrap_or(record.started_at);
+            sink.backfill_effects(
+                &record.decision_receipt_id,
+                &record.effects,
+                &record.results,
+                recorded_at,
+            );
+            report.redriven += 1;
         }
 
-        // Reproduce the dispatch's own completion time on replay (mirrors the
-        // close journal's stored `decided_at`) rather than using restart time,
-        // so the healed evidence is timestamped when the dispatch happened.
-        let recorded_at = record.finished_at.unwrap_or(record.started_at);
-        sink.backfill_effects(
-            &record.decision_receipt_id,
-            &record.effects,
-            &record.results,
-            recorded_at,
-        );
-        report.redriven += 1;
+        offset += page_len;
+        // A short page means the keyspace is exhausted; an exact-multiple final
+        // page is caught by the empty-page check on the next iteration.
+        if page_len < page_size {
+            break;
+        }
     }
 
     tracing::debug!(
@@ -260,5 +312,146 @@ mod tests {
             "non-terminal records are left to in-flight execution recovery"
         );
         assert_eq!(report.skipped, 1);
+    }
+
+    /// Concern #2 (bounded scan): the backfill pages through the execution-record
+    /// keyspace instead of materializing it whole, and must still visit and heal
+    /// every terminal record across page boundaries. A page size of 2 over 5
+    /// records forces three pages (2 + 2 + 1); a loop that stops after the first
+    /// page or spins forever fails this. Re-paging stays idempotent.
+    #[test]
+    fn backfill_pages_through_records_across_page_boundaries() {
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let receipt_store = Arc::new(ReceiptStore::new(db));
+        let sink = DeferredDispatchEvidenceSink::new();
+        sink.install_backend(receipt_store.clone() as Arc<dyn GovernanceReceiptBackend>);
+
+        let exec: Arc<dyn Store> = Arc::new(SledStore::temporary().unwrap());
+
+        let mut record_ids = Vec::new();
+        for i in 0..5 {
+            let proposal_id = format!("prop-page-{i}");
+            let ier = InstitutionalEffectRecord::new(
+                &proposal_id,
+                "dom",
+                None,
+                "appoint_steward",
+                Some("did:icn:zSteward".into()),
+                Some("r".into()),
+                None,
+                1,
+                serde_json::json!({}),
+            );
+            receipt_store.put_institutional_effect(&ier).unwrap();
+            record_ids.push(ier.record_id.clone());
+            seed_terminal_record(
+                &exec,
+                &format!("hash-page-{i}"),
+                &format!("gov:dom:{proposal_id}:receipt"),
+                &proposal_id,
+            );
+        }
+
+        // Page size smaller than the record count: a correct loop visits all
+        // three pages; a broken one stops early or never terminates.
+        let report = backfill_pending_dispatch_evidence_paged(&exec, &sink, 2).unwrap();
+        assert_eq!(report.scanned, 5, "every record visited across pages");
+        assert_eq!(
+            report.redriven, 5,
+            "every terminal-with-results record healed"
+        );
+
+        for record_id in &record_ids {
+            assert_eq!(
+                receipt_store
+                    .list_effect_dispatch_evidence_by_record(record_id)
+                    .unwrap()
+                    .len(),
+                1,
+                "each record's evidence healed exactly once"
+            );
+        }
+
+        // Paging stays idempotent: a second pass writes no duplicates.
+        let report2 = backfill_pending_dispatch_evidence_paged(&exec, &sink, 2).unwrap();
+        assert_eq!(report2.redriven, 5);
+        for record_id in &record_ids {
+            assert_eq!(
+                receipt_store
+                    .list_effect_dispatch_evidence_by_record(record_id)
+                    .unwrap()
+                    .len(),
+                1,
+                "re-paging must not duplicate evidence"
+            );
+        }
+    }
+
+    /// Test D (concern #1 regression): the ordering contract that backfill must
+    /// read a terminal execution record *before* retention cleanup prunes it.
+    /// Evidence healed before a prune survives it; a record pruned before
+    /// backfill is gone and its lost evidence can never be reconstructed — which
+    /// is exactly why daemon startup defers cleanup until after the backfill.
+    #[test]
+    fn pruning_after_backfill_keeps_evidence_but_pruning_before_loses_it() {
+        // Correct order: backfill THEN prune.
+        let (receipt_store, ier) = receipt_store_with_ier("prop-order");
+        let sink = DeferredDispatchEvidenceSink::new();
+        sink.install_backend(receipt_store.clone() as Arc<dyn GovernanceReceiptBackend>);
+        let exec: Arc<dyn Store> = Arc::new(SledStore::temporary().unwrap());
+        let key = format!("{EXECUTION_RECORD_KEY_PREFIX}hash-order");
+        seed_terminal_record(
+            &exec,
+            "hash-order",
+            "gov:dom:prop-order:receipt",
+            "prop-order",
+        );
+
+        let report = backfill_pending_dispatch_evidence(&exec, &sink).unwrap();
+        assert_eq!(report.redriven, 1, "backfill heals before any prune");
+        assert_eq!(
+            receipt_store
+                .list_effect_dispatch_evidence_by_record(&ier.record_id)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // Retention cleanup now prunes the (already-healed) terminal record.
+        exec.delete(key.as_bytes()).unwrap();
+        assert_eq!(
+            receipt_store
+                .list_effect_dispatch_evidence_by_record(&ier.record_id)
+                .unwrap()
+                .len(),
+            1,
+            "evidence healed before the prune survives it"
+        );
+
+        // Wrong order: prune THEN backfill — the regression this guards against.
+        let (receipt_store2, ier2) = receipt_store_with_ier("prop-order2");
+        let sink2 = DeferredDispatchEvidenceSink::new();
+        sink2.install_backend(receipt_store2.clone() as Arc<dyn GovernanceReceiptBackend>);
+        let exec2: Arc<dyn Store> = Arc::new(SledStore::temporary().unwrap());
+        let key2 = format!("{EXECUTION_RECORD_KEY_PREFIX}hash-order2");
+        seed_terminal_record(
+            &exec2,
+            "hash-order2",
+            "gov:dom:prop-order2:receipt",
+            "prop-order2",
+        );
+
+        // Cleanup wins the race and prunes the record before backfill runs.
+        exec2.delete(key2.as_bytes()).unwrap();
+        let report2 = backfill_pending_dispatch_evidence(&exec2, &sink2).unwrap();
+        assert_eq!(report2.scanned, 0, "pruned record is gone; nothing to scan");
+        assert_eq!(report2.redriven, 0);
+        assert!(
+            receipt_store2
+                .list_effect_dispatch_evidence_by_record(&ier2.record_id)
+                .unwrap()
+                .is_empty(),
+            "evidence is lost forever when pruning beats backfill"
+        );
     }
 }

--- a/icn/crates/icn-gateway/src/dispatch_evidence_backfill.rs
+++ b/icn/crates/icn-gateway/src/dispatch_evidence_backfill.rs
@@ -78,12 +78,14 @@ pub(crate) fn backfill_pending_dispatch_evidence(
 
 /// Page-bounded core of the backfill (see [`backfill_pending_dispatch_evidence`]).
 ///
-/// Walks the `exec:` keyspace one [`Store::scan_paginated`] page at a time so at
-/// most `page_size` execution records are resident at once, instead of loading
-/// the whole keyspace into a single `Vec`. Offset-based paging is safe here
-/// because the backfill runs at startup *before* the gateway serves and *before*
-/// retention cleanup prunes (so no concurrent writer can shift offsets), and the
-/// sink dedups on read-back, so even a re-observed record cannot double-write.
+/// Pages the `exec:` keyspace with [`Store::scan_after`] cursor pagination — each
+/// page resumes strictly after the previous page's last key — so at most
+/// `page_size` records are resident at once *and* the whole keyspace is
+/// traversed in `O(n)` (a numeric-offset scan would re-walk from the start every
+/// page, `O(n²/page_size)`). The backfill runs at startup before the gateway
+/// serves and before retention cleanup prunes, so no concurrent writer mutates
+/// the keyspace mid-walk; and the sink dedups on read-back, so a re-observed
+/// record cannot double-write.
 fn backfill_pending_dispatch_evidence_paged(
     execution_store: &Arc<dyn Store>,
     sink: &DeferredDispatchEvidenceSink,
@@ -92,16 +94,16 @@ fn backfill_pending_dispatch_evidence_paged(
     // A zero page would never make progress; clamp defensively.
     let page_size = page_size.max(1);
     let mut report = EvidenceBackfillReport::default();
-    let mut offset = 0usize;
+    let mut cursor: Option<Vec<u8>> = None;
 
     loop {
-        let (page, _total) = execution_store.scan_paginated(EXECUTION_PREFIX, offset, page_size)?;
+        let page = execution_store.scan_after(EXECUTION_PREFIX, cursor.as_deref(), page_size)?;
         if page.is_empty() {
             break;
         }
-        // Advance by raw entries returned (parsable or not) so the offset tracks
-        // store positions; `report.scanned` counts only decoded records.
         let page_len = page.len();
+        // Resume the next page strictly after this page's last key.
+        cursor = page.last().map(|(k, _)| k.clone());
 
         for (_key, value) in page {
             let record: ExecutionRecord = match serde_json::from_slice(&value) {
@@ -138,7 +140,6 @@ fn backfill_pending_dispatch_evidence_paged(
             report.redriven += 1;
         }
 
-        offset += page_len;
         // A short page means the keyspace is exhausted; an exact-multiple final
         // page is caught by the empty-page check on the next iteration.
         if page_len < page_size {

--- a/icn/crates/icn-store/src/lib.rs
+++ b/icn/crates/icn-store/src/lib.rs
@@ -381,6 +381,44 @@ pub trait Store: Send + Sync {
         Ok((paginated, total))
     }
 
+    /// Scan up to `limit` entries whose key is strictly greater than `after`
+    /// (or from the start of `prefix` when `after` is `None`), in ascending key
+    /// order.
+    ///
+    /// This is cursor/seek pagination: a caller pages the whole prefix by
+    /// passing the last returned key back as `after`. Unlike repeated
+    /// [`Store::scan_paginated`] (which recomputes a count and re-walks from the
+    /// start on every call — `O(n²/limit)` to traverse the prefix), resuming
+    /// from a key cursor traverses each entry once (`O(n)` total) while keeping
+    /// at most one page resident.
+    ///
+    /// # Arguments
+    /// * `prefix` - Key prefix to scan
+    /// * `after` - Exclusive lower-bound key; `None` starts at the prefix
+    /// * `limit` - Maximum number of entries to return
+    #[allow(clippy::type_complexity)]
+    fn scan_after(
+        &self,
+        prefix: &[u8],
+        after: Option<&[u8]>,
+        limit: usize,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        // Default implementation materializes via scan() then filters — backends
+        // (e.g. Sled) should override with a true seek for streaming behavior.
+        // Relies on scan() yielding keys in ascending order, as the other
+        // paginated defaults already do.
+        let out = self
+            .scan(prefix)?
+            .into_iter()
+            .filter(|(k, _)| match after {
+                Some(a) => k.as_slice() > a,
+                None => true,
+            })
+            .take(limit)
+            .collect();
+        Ok(out)
+    }
+
     // Replica tracking operations (Phase 17)
     /// Get replica metadata for a content hash
     fn get_replica_metadata(&self, content_hash: &ContentHash) -> Result<Option<ReplicaMetadata>>;
@@ -824,6 +862,38 @@ impl Store for SledStore {
         }
 
         Ok((results, total))
+    }
+
+    fn scan_after(
+        &self,
+        prefix: &[u8],
+        after: Option<&[u8]>,
+        limit: usize,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        use std::ops::Bound;
+
+        // Seek directly to the cursor: strictly after the last key on resume,
+        // or at the prefix on the first page. Sled keys are ordered, so this
+        // visits each entry at most once across the whole paged traversal.
+        let lower = match after {
+            Some(a) => Bound::Excluded(a.to_vec()),
+            None => Bound::Included(prefix.to_vec()),
+        };
+
+        let mut results = Vec::with_capacity(limit);
+        for item in self.db.range((lower, Bound::<Vec<u8>>::Unbounded)) {
+            let (k, v) = item?;
+            // range() is unbounded above; stop as soon as we leave the prefix.
+            if !k.starts_with(prefix) {
+                break;
+            }
+            results.push((k.to_vec(), v.to_vec()));
+            if results.len() >= limit {
+                break;
+            }
+        }
+
+        Ok(results)
     }
 
     // Replica tracking implementation
@@ -1284,6 +1354,44 @@ mod tests {
         let (empty, total) = store.scan_paginated(b"items:", 20, 5)?;
         assert_eq!(total, 10);
         assert_eq!(empty.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_store_scan_after_cursor() -> Result<()> {
+        let store = SledStore::temporary()?;
+
+        for i in 0..10 {
+            store.put(format!("items:{i:02}").as_bytes(), b"data")?;
+        }
+        // A key outside the prefix must never leak into results.
+        store.put(b"other:00", b"x")?;
+
+        // First page from the start of the prefix.
+        let page1 = store.scan_after(b"items:", None, 4)?;
+        assert_eq!(page1.len(), 4);
+        assert_eq!(page1[0].0, b"items:00");
+        assert_eq!(page1[3].0, b"items:03");
+
+        // Resume strictly after the last key seen (cursor pagination).
+        let cursor = page1.last().unwrap().0.clone();
+        let page2 = store.scan_after(b"items:", Some(&cursor), 4)?;
+        assert_eq!(page2.len(), 4);
+        assert_eq!(
+            page2[0].0, b"items:04",
+            "resumes after the cursor, no repeat"
+        );
+
+        // Final partial page; stays within the prefix (never "other:00").
+        let cursor2 = page2.last().unwrap().0.clone();
+        let page3 = store.scan_after(b"items:", Some(&cursor2), 4)?;
+        assert_eq!(page3.len(), 2);
+        assert_eq!(page3[1].0, b"items:09");
+
+        // Past the end → empty (loop terminator).
+        let cursor3 = page3.last().unwrap().0.clone();
+        assert!(store.scan_after(b"items:", Some(&cursor3), 4)?.is_empty());
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Completes the remaining #1990 durability review concern by making startup dispatch-evidence backfill page-bounded instead of materializing the whole execution-record keyspace at once.

#1990 already landed the durable effect-dispatch recovery design:

- `ExecutionRecord.results` persists per-effect results.
- backfill reconstructs missing `EffectDispatchEvidence` from durable `(effects, results)`;
- backfill does not re-execute effects;
- cleanup ordering was moved so pruning cannot beat backfill;
- the execution-record key prefix is centralized.

This PR finishes the remaining bounded-scan concern.

## What changed

- Replace the unbounded execution-record scan in gateway dispatch-evidence backfill with `Store::scan_paginated()`.
- Add explicit `BACKFILL_PAGE_SIZE = 256`.
- Preserve idempotent backfill behavior.
- Add/keep regression coverage for multi-page backfill and pruning-vs-backfill ordering.

## Safety

- No production gate weakened.
- No auth/dev/trust/ledger/audit check weakened.
- No effect execution is re-run during backfill.
- No economic state is mutated except persisting missing evidence.
- No UI/demo/product scope added.

## Validation

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p icn-gateway --all-targets --features sled-storage -- -D warnings` — pass
- `cargo test -p icn-gateway --features sled-storage --lib` — 563 passed
- `cargo test -p icn-kernel-api --lib execution` — 9 passed
- `cargo test -p icn-core decision_executor` — 13 passed
- `cargo test -p icn-governance-actor dispatch_evidence` — 18 passed

## Follow-ups

Already tracked:

- #1991 — `perf(api): index ledger entries by decision_hash`
- #1992 — `demo: add one-command local 13/13 receipt-chain rehearsal`
