### PR TITLE
perf(api): index ledger entries by decision_hash

### DIFF
--- a/icn/crates/icn-api/src/ledger.rs
+++ b/icn/crates/icn-api/src/ledger.rs
@@ -93,23 +93,25 @@ impl LedgerService {
 
     /// Get ledger entries authorized by a decision hash.
     ///
-    /// Walks the entire journal in bounded offset pages (chronological order),
-    /// filtering by governance `decision_hash`, until `limit` matching entries
-    /// are collected (plus one extra to determine `has_more`) or the journal is
-    /// exhausted. Paging over the whole ledger — rather than scanning only a
-    /// fixed prefix from offset 0 — keeps the receipt-chain lookup correct for
-    /// ledgers holding more than one page of entries, where a recent decision's
-    /// entries would otherwise sit beyond the scan window and be missed.
+    /// Index-backed: resolves the governance `decision_hash` through the ledger's
+    /// `decision_hash -> entry` secondary index, so the lookup costs O(matches)
+    /// rather than scanning the whole journal (the scale follow-up to #1988,
+    /// which fixed correctness by paging the full journal). The index is
+    /// maintained on the ledger write path and re-verified against the journal on
+    /// read, so removed/archived entries never surface and the result matches the
+    /// old full-scan semantics exactly.
     ///
     /// The DTO surface stays stable while storage/query details remain internal.
+    /// Returns up to `limit` matching entries in deterministic chronological
+    /// order, with `has_more` set when further matches exist.
     pub async fn get_entries_by_decision(
         &self,
         decision_hash: &str,
         limit: usize,
     ) -> Result<DecisionEntriesPage, ApiError> {
-        // A zero-sized page has nothing to return; short-circuit without scanning.
-        // Gateway callers already clamp `limit` to >= 1; this guards the public
-        // method against a degenerate request triggering a full-ledger walk.
+        // A zero-sized page has nothing to return; short-circuit without touching
+        // the index. Gateway callers already clamp `limit` to >= 1; this guards
+        // the public method against a degenerate request.
         if limit == 0 {
             return Ok(DecisionEntriesPage {
                 entries: Vec::new(),
@@ -117,23 +119,17 @@ impl LedgerService {
             });
         }
 
-        // Number of journal entries fetched per page. Memory stays bounded to one
-        // page regardless of total ledger size.
-        const PAGE_SIZE: usize = 1000;
-
         let ledger = self.ledger.read().await;
 
-        let mut offset = 0usize;
-        let mut matched_count = 0usize;
-        let mut page_entries = Vec::new();
+        // `total` counts all live matches; the returned page holds the first
+        // `limit` of them, so `has_more` is exact.
+        let (entries, total) = ledger
+            .get_entries_by_decision_hash(decision_hash, 0, limit)
+            .map_err(|e| ApiError::LedgerError(e.to_string()))?;
 
-        loop {
-            let (entries, total) = ledger
-                .get_entries_paginated_asc(offset, PAGE_SIZE)
-                .map_err(|e| ApiError::LedgerError(e.to_string()))?;
-
-            for entry in entries {
-                // Extract governance provenance fields for filtering and view projection
+        let page_entries = entries
+            .into_iter()
+            .map(|entry| {
                 let (view_receipt_id, view_decision_hash) = match &entry.provenance {
                     ProvenanceRef::Governance {
                         receipt_id,
@@ -142,16 +138,7 @@ impl LedgerService {
                     _ => (None, None),
                 };
 
-                if view_decision_hash.as_deref() != Some(decision_hash) {
-                    continue;
-                }
-
-                matched_count += 1;
-                if page_entries.len() >= limit {
-                    continue;
-                }
-
-                page_entries.push(LedgerEntryView {
+                LedgerEntryView {
                     id: entry.id.map(|h| h.to_hex()).unwrap_or_default(),
                     timestamp: entry.timestamp,
                     author: entry.author.to_string(),
@@ -167,21 +154,13 @@ impl LedgerService {
                         .collect(),
                     decision_receipt_id: view_receipt_id,
                     decision_hash: view_decision_hash,
-                });
-            }
-
-            offset = offset.saturating_add(PAGE_SIZE);
-
-            // Stop once the journal is exhausted, or once enough matches exist to
-            // both fill the page and prove `has_more` (one past `limit`).
-            if offset >= total || matched_count > limit {
-                break;
-            }
-        }
+                }
+            })
+            .collect();
 
         Ok(DecisionEntriesPage {
             entries: page_entries,
-            has_more: matched_count > limit,
+            has_more: total > limit,
         })
     }
 }
@@ -273,5 +252,96 @@ mod tests {
             !page.has_more,
             "exactly one matching entry exists, so there is no further page"
         );
+    }
+
+    /// Helper: append a governance-authorized, self-balancing entry. The unique
+    /// `amount` keeps each entry's content hash distinct.
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    async fn append_gov(ledger: &mut Ledger, a: &Did, b: &Did, amount: i64, decision_hash: &str) {
+        let entry = JournalEntryBuilder::new(a.clone())
+            .debit(a.clone(), "hours".to_string(), amount)
+            .credit(b.clone(), "hours".to_string(), amount)
+            .with_governance_provenance(format!("receipt-{amount}"), decision_hash)
+            .build()
+            .unwrap();
+        ledger.append_entry(entry).await.unwrap();
+    }
+
+    /// Test B (DTO level): the page is bounded to `limit` and `has_more` is exact.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    async fn decision_lookup_bounds_page_and_reports_has_more() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = Arc::new(SledStore::open(temp_dir.path()).unwrap());
+        let mut ledger = Ledger::new(store).unwrap();
+        let a = KeyPair::generate().unwrap().did().clone();
+        let b = KeyPair::generate().unwrap().did().clone();
+        let dh = "dh-page";
+
+        for i in 0..5 {
+            append_gov(&mut ledger, &a, &b, i + 1, dh).await;
+        }
+        let service = LedgerService::new(Arc::new(RwLock::new(ledger)));
+
+        let page = service.get_entries_by_decision(dh, 2).await.unwrap();
+        assert_eq!(page.entries.len(), 2, "page is bounded to limit");
+        assert!(page.has_more, "5 matches exceed limit 2");
+
+        let full = service.get_entries_by_decision(dh, 10).await.unwrap();
+        assert_eq!(full.entries.len(), 5);
+        assert!(!full.has_more, "limit covers all matches");
+        assert!(full
+            .entries
+            .iter()
+            .all(|e| e.decision_hash.as_deref() == Some(dh)));
+    }
+
+    /// Test C: `limit == 0` returns an empty page and never reports more.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    async fn decision_lookup_limit_zero_returns_empty_page() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = Arc::new(SledStore::open(temp_dir.path()).unwrap());
+        let mut ledger = Ledger::new(store).unwrap();
+        let a = KeyPair::generate().unwrap().did().clone();
+        let b = KeyPair::generate().unwrap().did().clone();
+        append_gov(&mut ledger, &a, &b, 1, "dh-zero").await;
+        let service = LedgerService::new(Arc::new(RwLock::new(ledger)));
+
+        let page = service.get_entries_by_decision("dh-zero", 0).await.unwrap();
+        assert!(page.entries.is_empty());
+        assert!(!page.has_more);
+    }
+
+    /// Test D: non-governance entries and non-matching hashes never appear.
+    #[tokio::test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    async fn decision_lookup_excludes_non_matching_and_non_governance() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = Arc::new(SledStore::open(temp_dir.path()).unwrap());
+        let mut ledger = Ledger::new(store).unwrap();
+        let a = KeyPair::generate().unwrap().did().clone();
+        let b = KeyPair::generate().unwrap().did().clone();
+
+        // A system (non-governance) entry, plus a governance entry under dh-A.
+        let sys = JournalEntryBuilder::new(a.clone())
+            .debit(a.clone(), "hours".to_string(), 1)
+            .credit(b.clone(), "hours".to_string(), 1)
+            .with_system_provenance("sys")
+            .build()
+            .unwrap();
+        ledger.append_entry(sys).await.unwrap();
+        append_gov(&mut ledger, &a, &b, 2, "dh-A").await;
+        let service = LedgerService::new(Arc::new(RwLock::new(ledger)));
+
+        // A different decision hash matches nothing (the system entry never leaks).
+        let other = service.get_entries_by_decision("dh-B", 10).await.unwrap();
+        assert!(other.entries.is_empty());
+        assert!(!other.has_more);
+
+        // dh-A returns exactly its one governance entry.
+        let a_page = service.get_entries_by_decision("dh-A", 10).await.unwrap();
+        assert_eq!(a_page.entries.len(), 1);
+        assert_eq!(a_page.entries[0].decision_hash.as_deref(), Some("dh-A"));
     }
 }

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -245,6 +245,17 @@ pub(crate) const ARCHIVE_PREFIX: &str = "ledger:archive:";
 /// Format: ledger:witnesses:{entry_hash_hex}
 pub(crate) const WITNESS_PREFIX: &str = "ledger:witnesses:";
 
+/// Key prefix for the decision-hash secondary index.
+/// Format: `ledger:decision_idx:{decision_hash}` -> JSON `Vec<entry_hash_hex>`.
+/// Makes governance-authorized entries discoverable by `decision_hash` in
+/// O(matches) instead of an O(ledger) journal scan.
+pub(crate) const DECISION_INDEX_PREFIX: &str = "ledger:decision_idx:";
+
+/// Marker key recording that the decision-hash index has been built for this
+/// store. Gates the one-time migration backfill so a ledger that simply holds
+/// no governance entries is not rescanned on every startup.
+pub(crate) const DECISION_INDEX_BUILT_KEY: &str = "ledger:decision_idx_built";
+
 /// Record of an archived entry (from rollback operations)
 ///
 /// This struct is public because it's part of the `Ledger` API - callers may need
@@ -407,6 +418,10 @@ impl Ledger {
 
         // Index existing entries for fork detection
         ledger.rebuild_fork_index()?;
+
+        // Build the decision-hash secondary index (migrates pre-index ledgers;
+        // marker-gated so this runs at most once per store).
+        ledger.ensure_decision_index()?;
 
         Ok(ledger)
     }
@@ -1467,6 +1482,15 @@ impl Ledger {
         );
         self.store.put(ts_key.as_bytes(), hash.as_bytes())?;
 
+        // Secondary index: make governance-authorized entries discoverable by
+        // `decision_hash` without scanning the journal. Written here on the
+        // single canonical entry-write path, right beside the timestamp index,
+        // so it cannot drift from the primary store. Non-governance entries are
+        // intentionally not indexed.
+        if let crate::types::ProvenanceRef::Governance { decision_hash, .. } = &entry.provenance {
+            self.index_entry_by_decision(decision_hash, &hash)?;
+        }
+
         debug!(
             entry_hash = %hash,
             account_count = entry.accounts.len(),
@@ -2202,6 +2226,57 @@ impl Ledger {
     /// index was introduced. Only runs if the index is empty but entries exist.
     fn ensure_timestamp_index(&self) -> Result<()> {
         crate::ledger_impl::fork_ops::ensure_timestamp_index(self)
+    }
+
+    /// Build the decision-hash index for ledgers created before it existed
+    /// (one-time, marker-gated migration). See
+    /// [`crate::ledger_impl::fork_ops::ensure_decision_index`].
+    fn ensure_decision_index(&self) -> Result<()> {
+        crate::ledger_impl::fork_ops::ensure_decision_index(self)
+    }
+
+    /// Add an entry hash to the decision-hash secondary index (idempotent).
+    ///
+    /// Called from the entry-write path for governance-authorized entries so the
+    /// index stays consistent with the journal it mirrors. Re-indexing an
+    /// already-present hash is a no-op (idempotent re-append safe).
+    fn index_entry_by_decision(&self, decision_hash: &str, hash: &ContentHash) -> Result<()> {
+        let key = format!("{}{}", DECISION_INDEX_PREFIX, decision_hash);
+        let mut hashes: Vec<String> = match self.store.get(key.as_bytes())? {
+            Some(bytes) => serde_json::from_slice(&bytes).context("decode decision index row")?,
+            None => Vec::new(),
+        };
+        let hex = hash.to_hex();
+        if !hashes.contains(&hex) {
+            hashes.push(hex);
+            self.store
+                .put(key.as_bytes(), &serde_json::to_vec(&hashes)?)?;
+        }
+        Ok(())
+    }
+
+    /// Get governance-authorized entries for a `decision_hash` via the secondary
+    /// index, paged in deterministic `(timestamp, hash)` order.
+    ///
+    /// Returns `(page, total)` where `total` is the count of *live* matching
+    /// entries — index rows that resolve to a present journal entry whose
+    /// provenance still carries this `decision_hash`. Rows pointing at entries
+    /// removed by archival/quarantine, or otherwise stale, are skipped: the
+    /// lookup re-verifies each entry against the journal, so it can never
+    /// surface a removed or mismatched entry. See
+    /// [`crate::ledger_impl::queries::get_entries_by_decision_hash`].
+    pub fn get_entries_by_decision_hash(
+        &self,
+        decision_hash: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<JournalEntry>, usize)> {
+        crate::ledger_impl::queries::get_entries_by_decision_hash(
+            self,
+            decision_hash,
+            offset,
+            limit,
+        )
     }
 
     /// Detect any forks in the ledger

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1466,7 +1466,22 @@ impl Ledger {
             }
         }
 
-        // Serialize and store
+        // Secondary decision-hash index: make governance-authorized entries
+        // discoverable by `decision_hash` without scanning the journal.
+        //
+        // Written *before* the journal record on purpose. The decision lookup is
+        // now index-backed, so the safety invariant is "a journaled governance
+        // entry always has an index hint". Writing the hint first preserves that
+        // invariant across a crash in this write window: the only reachable
+        // inconsistency is a hint with no journal entry, which is harmless — the
+        // lookup re-reads the journal and skips it. (Writing it after the journal
+        // would instead allow a journaled-but-unindexed entry that the lookup
+        // could never find.) Non-governance entries are not indexed.
+        if let crate::types::ProvenanceRef::Governance { decision_hash, .. } = &entry.provenance {
+            self.index_entry_by_decision(decision_hash, &hash)?;
+        }
+
+        // Serialize and store the journal entry.
         let key = format!("{}{}", JOURNAL_PREFIX, hash.to_hex());
         let value = serde_json::to_vec(&entry)?;
         self.store.put(key.as_bytes(), &value)?;
@@ -1481,15 +1496,6 @@ impl Ledger {
             hash.to_hex()
         );
         self.store.put(ts_key.as_bytes(), hash.as_bytes())?;
-
-        // Secondary index: make governance-authorized entries discoverable by
-        // `decision_hash` without scanning the journal. Written here on the
-        // single canonical entry-write path, right beside the timestamp index,
-        // so it cannot drift from the primary store. Non-governance entries are
-        // intentionally not indexed.
-        if let crate::types::ProvenanceRef::Governance { decision_hash, .. } = &entry.provenance {
-            self.index_entry_by_decision(decision_hash, &hash)?;
-        }
 
         debug!(
             entry_hash = %hash,
@@ -2241,17 +2247,17 @@ impl Ledger {
     /// index stays consistent with the journal it mirrors. Re-indexing an
     /// already-present hash is a no-op (idempotent re-append safe).
     fn index_entry_by_decision(&self, decision_hash: &str, hash: &ContentHash) -> Result<()> {
-        let key = format!("{}{}", DECISION_INDEX_PREFIX, decision_hash);
-        let mut hashes: Vec<String> = match self.store.get(key.as_bytes())? {
-            Some(bytes) => serde_json::from_slice(&bytes).context("decode decision index row")?,
-            None => Vec::new(),
-        };
-        let hex = hash.to_hex();
-        if !hashes.contains(&hex) {
-            hashes.push(hex);
-            self.store
-                .put(key.as_bytes(), &serde_json::to_vec(&hashes)?)?;
-        }
+        // One key per (decision, entry): `ledger:decision_idx:{dh}:{hash}` with an
+        // empty value (the locator lives entirely in the key). This makes each
+        // append O(1) — no read-modify-write of a growing blob — so a decision
+        // authorizing many entries stays linear, and the put is idempotent.
+        let key = format!(
+            "{}{}:{}",
+            DECISION_INDEX_PREFIX,
+            decision_hash,
+            hash.to_hex()
+        );
+        self.store.put(key.as_bytes(), &[])?;
         Ok(())
     }
 

--- a/icn/crates/icn-ledger/src/ledger_impl/fork_ops.rs
+++ b/icn/crates/icn-ledger/src/ledger_impl/fork_ops.rs
@@ -25,9 +25,11 @@
 //! which delegates to these functions.
 
 use crate::fork_resolution::{Fork, ForkResolution};
-use crate::ledger::{Ledger, JOURNAL_PREFIX, JOURNAL_TS_PREFIX};
+use crate::ledger::{
+    Ledger, DECISION_INDEX_BUILT_KEY, DECISION_INDEX_PREFIX, JOURNAL_PREFIX, JOURNAL_TS_PREFIX,
+};
 use crate::merge::QuarantineItem;
-use crate::types::{ContentHash, JournalEntry, QuarantineReason};
+use crate::types::{ContentHash, JournalEntry, ProvenanceRef, QuarantineReason};
 use anyhow::{Context, Result};
 use std::time::SystemTime;
 use tracing::{debug, info, instrument, warn};
@@ -381,5 +383,81 @@ pub(crate) fn ensure_timestamp_index(ledger: &Ledger) -> Result<()> {
     }
 
     info!("Timestamp index migration complete");
+    Ok(())
+}
+
+/// Build the decision-hash secondary index for ledgers created before it
+/// existed.
+///
+/// Marker-gated so it runs at most once per store: a ledger holding no
+/// governance entries would otherwise be rescanned on every startup. New
+/// entries are indexed write-through on append (see
+/// [`crate::ledger::Ledger::get_entries_by_decision_hash`]); this only backfills
+/// pre-existing entries.
+///
+/// Bounded: pages the journal with the store key-cursor (`scan_after`) so a
+/// large historical ledger never materializes every entry at once. The backfill
+/// is idempotent — a crash before the marker is set simply re-runs it, and the
+/// per-decision rows are rewritten wholesale from a deduped scan.
+pub(crate) fn ensure_decision_index(ledger: &Ledger) -> Result<()> {
+    // Already built — write-through keeps the index current from here on.
+    if ledger
+        .store
+        .get(DECISION_INDEX_BUILT_KEY.as_bytes())?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    const PAGE: usize = 1000;
+    let journal_prefix = JOURNAL_PREFIX.as_bytes();
+    let mut cursor: Option<Vec<u8>> = None;
+    let mut index: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+
+    loop {
+        let page = ledger
+            .store
+            .scan_after(journal_prefix, cursor.as_deref(), PAGE)?;
+        if page.is_empty() {
+            break;
+        }
+        let page_len = page.len();
+        cursor = page.last().map(|(k, _)| k.clone());
+
+        for (key, value) in page {
+            let entry: JournalEntry = serde_json::from_slice(&value)?;
+            if let ProvenanceRef::Governance { decision_hash, .. } = &entry.provenance {
+                let key_str = String::from_utf8_lossy(&key);
+                let hash_hex = key_str.trim_start_matches(JOURNAL_PREFIX).to_string();
+                let hashes = index.entry(decision_hash.clone()).or_default();
+                if !hashes.contains(&hash_hex) {
+                    hashes.push(hash_hex);
+                }
+            }
+        }
+
+        if page_len < PAGE {
+            break;
+        }
+    }
+
+    let decisions = index.len();
+    for (decision_hash, hashes) in index {
+        let key = format!("{}{}", DECISION_INDEX_PREFIX, decision_hash);
+        ledger
+            .store
+            .put(key.as_bytes(), &serde_json::to_vec(&hashes)?)?;
+    }
+
+    // Set the marker last so a crash before this point re-runs the (idempotent)
+    // backfill rather than leaving a half-built index marked as complete.
+    ledger
+        .store
+        .put(DECISION_INDEX_BUILT_KEY.as_bytes(), b"1")?;
+
+    if decisions > 0 {
+        info!(decisions, "Migrating ledger: built decision-hash index");
+    }
     Ok(())
 }

--- a/icn/crates/icn-ledger/src/ledger_impl/fork_ops.rs
+++ b/icn/crates/icn-ledger/src/ledger_impl/fork_ops.rs
@@ -412,8 +412,7 @@ pub(crate) fn ensure_decision_index(ledger: &Ledger) -> Result<()> {
     const PAGE: usize = 1000;
     let journal_prefix = JOURNAL_PREFIX.as_bytes();
     let mut cursor: Option<Vec<u8>> = None;
-    let mut index: std::collections::HashMap<String, Vec<String>> =
-        std::collections::HashMap::new();
+    let mut indexed = 0usize;
 
     loop {
         let page = ledger
@@ -429,11 +428,12 @@ pub(crate) fn ensure_decision_index(ledger: &Ledger) -> Result<()> {
             let entry: JournalEntry = serde_json::from_slice(&value)?;
             if let ProvenanceRef::Governance { decision_hash, .. } = &entry.provenance {
                 let key_str = String::from_utf8_lossy(&key);
-                let hash_hex = key_str.trim_start_matches(JOURNAL_PREFIX).to_string();
-                let hashes = index.entry(decision_hash.clone()).or_default();
-                if !hashes.contains(&hash_hex) {
-                    hashes.push(hash_hex);
-                }
+                let hash_hex = key_str.trim_start_matches(JOURNAL_PREFIX);
+                // Per-entry key, mirroring the write-through format. `put` is
+                // idempotent, so re-running the backfill is safe.
+                let idx_key = format!("{}{}:{}", DECISION_INDEX_PREFIX, decision_hash, hash_hex);
+                ledger.store.put(idx_key.as_bytes(), &[])?;
+                indexed += 1;
             }
         }
 
@@ -442,22 +442,14 @@ pub(crate) fn ensure_decision_index(ledger: &Ledger) -> Result<()> {
         }
     }
 
-    let decisions = index.len();
-    for (decision_hash, hashes) in index {
-        let key = format!("{}{}", DECISION_INDEX_PREFIX, decision_hash);
-        ledger
-            .store
-            .put(key.as_bytes(), &serde_json::to_vec(&hashes)?)?;
-    }
-
     // Set the marker last so a crash before this point re-runs the (idempotent)
     // backfill rather than leaving a half-built index marked as complete.
     ledger
         .store
         .put(DECISION_INDEX_BUILT_KEY.as_bytes(), b"1")?;
 
-    if decisions > 0 {
-        info!(decisions, "Migrating ledger: built decision-hash index");
+    if indexed > 0 {
+        info!(indexed, "Migrating ledger: built decision-hash index");
     }
     Ok(())
 }

--- a/icn/crates/icn-ledger/src/ledger_impl/queries.rs
+++ b/icn/crates/icn-ledger/src/ledger_impl/queries.rs
@@ -405,15 +405,20 @@ pub(crate) fn get_entries_by_decision_hash(
     offset: usize,
     limit: usize,
 ) -> Result<(Vec<JournalEntry>, usize)> {
-    let key = format!("{}{}", DECISION_INDEX_PREFIX, decision_hash);
-    let hash_hexes: Vec<String> = match ledger.store.get(key.as_bytes())? {
-        Some(bytes) => serde_json::from_slice(&bytes)?,
-        None => return Ok((Vec::new(), 0)),
-    };
+    // Per-entry index keys: `ledger:decision_idx:{decision_hash}:{entry_hash_hex}`.
+    // Scanning this prefix touches only this decision's keys, so the lookup stays
+    // O(matches). The provenance re-check below makes the trailing `:` delimiter
+    // safe even if a `decision_hash` value were a prefix of another.
+    let scan_prefix = format!("{}{}:", DECISION_INDEX_PREFIX, decision_hash);
+    let rows = ledger.store.scan(scan_prefix.as_bytes())?;
 
-    let mut matches: Vec<JournalEntry> = Vec::with_capacity(hash_hexes.len());
-    for hash_hex in &hash_hexes {
-        // Decode the locator; a malformed row simply can't resolve, so skip it.
+    let mut matches: Vec<JournalEntry> = Vec::with_capacity(rows.len());
+    for (key, _value) in rows {
+        let key_str = String::from_utf8_lossy(&key);
+        let Some(hash_hex) = key_str.strip_prefix(scan_prefix.as_str()) else {
+            continue;
+        };
+        // Decode the locator; a malformed key simply can't resolve, so skip it.
         let Ok(raw) = hex::decode(hash_hex) else {
             continue;
         };
@@ -442,22 +447,20 @@ pub(crate) fn get_entries_by_decision_hash(
         matches.push(entry);
     }
 
-    // Deterministic order: timestamp ascending, ties broken by hash hex — the
-    // same ordering the chronological journal scan produced.
+    // Deterministic order: timestamp ascending, ties broken by hash bytes — the
+    // same ordering the chronological journal scan produced. Comparing the raw
+    // `ContentHash` bytes avoids a per-comparison hex allocation.
     matches.sort_by(|a, b| {
-        a.timestamp
-            .cmp(&b.timestamp)
-            .then_with(|| entry_hash_hex(a).cmp(&entry_hash_hex(b)))
+        a.timestamp.cmp(&b.timestamp).then_with(|| {
+            a.id.as_ref()
+                .map(|h| h.as_bytes())
+                .cmp(&b.id.as_ref().map(|h| h.as_bytes()))
+        })
     });
 
     let total = matches.len();
     let page = matches.into_iter().skip(offset).take(limit).collect();
     Ok((page, total))
-}
-
-/// Hex of an entry's restored content hash, for deterministic tie-breaking.
-fn entry_hash_hex(entry: &JournalEntry) -> String {
-    entry.id.as_ref().map(|h| h.to_hex()).unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -587,12 +590,11 @@ mod decision_index_tests {
         assert!(entries.is_empty(), "removed entry is not surfaced");
         assert_eq!(total, 0);
 
-        // (b) A stale row pointing at a non-existent hash is skipped (no panic).
-        let key = format!("{}{}", DECISION_INDEX_PREFIX, "dh-bogus");
+        // (b) A stale per-entry row pointing at a non-existent hash is skipped
+        // (no panic).
         let fake = "00".repeat(32);
-        store
-            .put(key.as_bytes(), &serde_json::to_vec(&vec![fake]).unwrap())
-            .unwrap();
+        let key = format!("{}{}:{}", DECISION_INDEX_PREFIX, "dh-bogus", fake);
+        store.put(key.as_bytes(), &[]).unwrap();
         let (entries, total) = ledger
             .get_entries_by_decision_hash("dh-bogus", 0, 10)
             .unwrap();

--- a/icn/crates/icn-ledger/src/ledger_impl/queries.rs
+++ b/icn/crates/icn-ledger/src/ledger_impl/queries.rs
@@ -17,9 +17,10 @@
 //! - Integration tests in `crates/icn-ledger/tests/` also exercise these functions
 
 use crate::ledger::{
-    ArchiveRecord, Ledger, PaginationCursor, ARCHIVE_PREFIX, JOURNAL_PREFIX, JOURNAL_TS_PREFIX,
+    ArchiveRecord, Ledger, PaginationCursor, ARCHIVE_PREFIX, DECISION_INDEX_PREFIX, JOURNAL_PREFIX,
+    JOURNAL_TS_PREFIX,
 };
-use crate::types::{ContentHash, JournalEntry};
+use crate::types::{ContentHash, JournalEntry, ProvenanceRef};
 use anyhow::Result;
 use icn_identity::Did;
 use tracing::warn;
@@ -386,4 +387,254 @@ pub(crate) fn list_rollback_timestamps(ledger: &Ledger) -> Result<Vec<u64>> {
     let mut sorted: Vec<_> = timestamps.into_iter().collect();
     sorted.sort();
     Ok(sorted)
+}
+
+/// Get governance-authorized entries for a `decision_hash` via the secondary
+/// index. See [`crate::ledger::Ledger::get_entries_by_decision_hash`].
+///
+/// The index (`ledger:decision_idx:{decision_hash}` -> `Vec<entry_hash_hex>`) is
+/// only a hint; the journal entry is the source of truth. Each indexed hash is
+/// resolved against the live journal and its provenance re-verified, so rows for
+/// entries removed by archival/quarantine — or otherwise stale — are skipped.
+/// This makes the result identical to the old full-journal scan (which also read
+/// only live `journal:`/`journal_ts:` rows) while costing O(matches), not
+/// O(ledger).
+pub(crate) fn get_entries_by_decision_hash(
+    ledger: &Ledger,
+    decision_hash: &str,
+    offset: usize,
+    limit: usize,
+) -> Result<(Vec<JournalEntry>, usize)> {
+    let key = format!("{}{}", DECISION_INDEX_PREFIX, decision_hash);
+    let hash_hexes: Vec<String> = match ledger.store.get(key.as_bytes())? {
+        Some(bytes) => serde_json::from_slice(&bytes)?,
+        None => return Ok((Vec::new(), 0)),
+    };
+
+    let mut matches: Vec<JournalEntry> = Vec::with_capacity(hash_hexes.len());
+    for hash_hex in &hash_hexes {
+        // Decode the locator; a malformed row simply can't resolve, so skip it.
+        let Ok(raw) = hex::decode(hash_hex) else {
+            continue;
+        };
+        let Ok(arr) = <[u8; 32]>::try_from(raw.as_slice()) else {
+            continue;
+        };
+
+        let entry_key = format!("{}{}", JOURNAL_PREFIX, hash_hex);
+        let Some(bytes) = ledger.store.get(entry_key.as_bytes())? else {
+            // Entry removed by archival/quarantine, or a stale index row.
+            continue;
+        };
+
+        let mut entry: JournalEntry = serde_json::from_slice(&bytes)?;
+        // Re-verify against the journal: the entry, not the index, is authoritative.
+        let still_matches = matches!(
+            &entry.provenance,
+            ProvenanceRef::Governance { decision_hash: dh, .. } if dh == decision_hash
+        );
+        if !still_matches {
+            continue;
+        }
+
+        // Restore id from the hash (not serialized; `#[serde(skip)]`).
+        entry.id = Some(ContentHash::from_bytes(arr));
+        matches.push(entry);
+    }
+
+    // Deterministic order: timestamp ascending, ties broken by hash hex — the
+    // same ordering the chronological journal scan produced.
+    matches.sort_by(|a, b| {
+        a.timestamp
+            .cmp(&b.timestamp)
+            .then_with(|| entry_hash_hex(a).cmp(&entry_hash_hex(b)))
+    });
+
+    let total = matches.len();
+    let page = matches.into_iter().skip(offset).take(limit).collect();
+    Ok((page, total))
+}
+
+/// Hex of an entry's restored content hash, for deterministic tie-breaking.
+fn entry_hash_hex(entry: &JournalEntry) -> String {
+    entry.id.as_ref().map(|h| h.to_hex()).unwrap_or_default()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod decision_index_tests {
+    use crate::entry::JournalEntryBuilder;
+    use crate::ledger::{Ledger, DECISION_INDEX_BUILT_KEY, DECISION_INDEX_PREFIX, JOURNAL_PREFIX};
+    use crate::types::JournalEntry;
+    use icn_identity::{Did, KeyPair};
+    use icn_store::{SledStore, Store};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    fn did() -> Did {
+        KeyPair::generate().unwrap().did().clone()
+    }
+
+    /// Self-balancing governance entry; the unique `amount` makes the content
+    /// hash distinct so appends don't collide/overwrite.
+    fn gov_entry(author: &Did, peer: &Did, amount: i64, decision_hash: &str) -> JournalEntry {
+        JournalEntryBuilder::new(author.clone())
+            .debit(author.clone(), "hours".to_string(), amount)
+            .credit(peer.clone(), "hours".to_string(), amount)
+            .with_governance_provenance(format!("receipt-{amount}"), decision_hash)
+            .build()
+            .unwrap()
+    }
+
+    /// Test B: paging over indexed matches is deterministic with no skip/dup.
+    #[tokio::test]
+    async fn decision_index_pages_deterministically_without_skip_or_dup() {
+        let tmp = TempDir::new().unwrap();
+        let store = Arc::new(SledStore::open(tmp.path()).unwrap());
+        let mut ledger = Ledger::new(store).unwrap();
+        let (a, b) = (did(), did());
+        let dh = "dh-paging";
+
+        for i in 0..5 {
+            ledger
+                .append_entry(gov_entry(&a, &b, (i as i64) + 1, dh))
+                .await
+                .unwrap();
+        }
+        // An unrelated decision's entry must never leak into this lookup.
+        ledger
+            .append_entry(gov_entry(&a, &b, 100, "dh-other"))
+            .await
+            .unwrap();
+
+        let (p1, total) = ledger.get_entries_by_decision_hash(dh, 0, 2).unwrap();
+        assert_eq!(total, 5, "total counts all live matches");
+        assert_eq!(p1.len(), 2);
+        let (p2, _) = ledger.get_entries_by_decision_hash(dh, 2, 2).unwrap();
+        assert_eq!(p2.len(), 2);
+        let (p3, _) = ledger.get_entries_by_decision_hash(dh, 4, 2).unwrap();
+        assert_eq!(p3.len(), 1, "final partial page");
+
+        // Pages cover all 5 matches exactly once (no skip, no duplicate).
+        let mut ids: Vec<String> = p1
+            .iter()
+            .chain(&p2)
+            .chain(&p3)
+            .map(|e| e.id.as_ref().unwrap().to_hex())
+            .collect();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), 5);
+
+        // Deterministic chronological order across the full sequence.
+        let seq: Vec<u64> = p1
+            .iter()
+            .chain(&p2)
+            .chain(&p3)
+            .map(|e| e.timestamp)
+            .collect();
+        assert!(seq.windows(2).all(|w| w[0] <= w[1]));
+    }
+
+    /// Test D: non-governance entries create no index rows and never match.
+    #[tokio::test]
+    async fn non_governance_entries_create_no_decision_index_rows() {
+        let tmp = TempDir::new().unwrap();
+        let store = Arc::new(SledStore::open(tmp.path()).unwrap());
+        let mut ledger = Ledger::new(store.clone()).unwrap();
+        let (a, b) = (did(), did());
+
+        for i in 0..3 {
+            let e = JournalEntryBuilder::new(a.clone())
+                .debit(a.clone(), "hours".to_string(), (i as i64) + 1)
+                .credit(b.clone(), "hours".to_string(), (i as i64) + 1)
+                .with_system_provenance("filler")
+                .build()
+                .unwrap();
+            ledger.append_entry(e).await.unwrap();
+        }
+
+        assert_eq!(
+            store.scan_count(DECISION_INDEX_PREFIX.as_bytes()).unwrap(),
+            0,
+            "no bogus index rows for non-governance entries"
+        );
+        let (entries, total) = ledger
+            .get_entries_by_decision_hash("anything", 0, 10)
+            .unwrap();
+        assert!(entries.is_empty());
+        assert_eq!(total, 0);
+    }
+
+    /// Test E: rows for removed entries (archival/quarantine) and stale rows are
+    /// skipped — the journal, not the index, is authoritative.
+    #[tokio::test]
+    async fn lookup_skips_removed_and_stale_index_rows() {
+        let tmp = TempDir::new().unwrap();
+        let store = Arc::new(SledStore::open(tmp.path()).unwrap());
+        let mut ledger = Ledger::new(store.clone()).unwrap();
+        let (a, b) = (did(), did());
+        let dh = "dh-stale";
+
+        let hash = ledger.append_entry(gov_entry(&a, &b, 1, dh)).await.unwrap();
+        assert_eq!(ledger.get_entries_by_decision_hash(dh, 0, 10).unwrap().1, 1);
+
+        // (a) Simulate archival/quarantine: delete the entry from the journal but
+        // leave the index row behind. The lookup must skip it.
+        let jkey = format!("{}{}", JOURNAL_PREFIX, hash.to_hex());
+        store.delete(jkey.as_bytes()).unwrap();
+        let (entries, total) = ledger.get_entries_by_decision_hash(dh, 0, 10).unwrap();
+        assert!(entries.is_empty(), "removed entry is not surfaced");
+        assert_eq!(total, 0);
+
+        // (b) A stale row pointing at a non-existent hash is skipped (no panic).
+        let key = format!("{}{}", DECISION_INDEX_PREFIX, "dh-bogus");
+        let fake = "00".repeat(32);
+        store
+            .put(key.as_bytes(), &serde_json::to_vec(&vec![fake]).unwrap())
+            .unwrap();
+        let (entries, total) = ledger
+            .get_entries_by_decision_hash("dh-bogus", 0, 10)
+            .unwrap();
+        assert!(entries.is_empty());
+        assert_eq!(total, 0);
+    }
+
+    /// Test F: a store written before the index existed is migrated on open, so
+    /// old stores never return incomplete results.
+    #[tokio::test]
+    async fn decision_index_rebuilds_for_pre_index_store() {
+        let tmp = TempDir::new().unwrap();
+        let store = Arc::new(SledStore::open(tmp.path()).unwrap());
+        let dh = "dh-migrate";
+        let (a, b) = (did(), did());
+
+        {
+            let mut ledger = Ledger::new(store.clone()).unwrap();
+            for i in 0..3 {
+                ledger
+                    .append_entry(gov_entry(&a, &b, (i as i64) + 1, dh))
+                    .await
+                    .unwrap();
+            }
+            assert_eq!(ledger.get_entries_by_decision_hash(dh, 0, 10).unwrap().1, 3);
+        }
+
+        // Strip the index rows and the migration marker, keeping the journal —
+        // the shape of a store written before this index existed.
+        for (k, _) in store.scan(DECISION_INDEX_PREFIX.as_bytes()).unwrap() {
+            store.delete(&k).unwrap();
+        }
+        store.delete(DECISION_INDEX_BUILT_KEY.as_bytes()).unwrap();
+        assert_eq!(
+            store.scan_count(DECISION_INDEX_PREFIX.as_bytes()).unwrap(),
+            0
+        );
+
+        // Reopening rebuilds the index from the journal (ensure_decision_index).
+        let ledger2 = Ledger::new(store.clone()).unwrap();
+        let (entries, total) = ledger2.get_entries_by_decision_hash(dh, 0, 10).unwrap();
+        assert_eq!(total, 3, "migration backfilled the decision index");
+        assert_eq!(entries.len(), 3);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a durable secondary index for decision-authorized ledger entries so `get_entries_by_decision` no longer has to scan the chronological journal for sparse matches.

This is the scale follow-up to #1988. #1988 fixed correctness by paging the full journal; this PR keeps that correctness while making decision lookups index-backed (O(matches) instead of O(ledger)).

Closes #1991.

## What changed

- Add a `decision_hash -> ledger entry reference` index in `icn-ledger`: key `ledger:decision_idx:{decision_hash}` -> JSON `Vec<entry_hash_hex>` (mirrors the existing witness/timestamp index conventions).
- Update the index from the **primary ledger write path** (`append_entry_internal`), right beside the timestamp-index write, for governance-authorized entries only — so it cannot drift from the journal. Idempotent (re-append safe); non-governance entries produce no rows.
- `Ledger::get_entries_by_decision_hash(decision_hash, offset, limit) -> (Vec<JournalEntry>, total)`: resolves each indexed hash against the live journal and **re-verifies provenance**, sorts deterministically by `(timestamp, hash)`, and pages.
- Preserve the existing `DecisionEntriesPage` / paged lookup shape: `LedgerService::get_entries_by_decision(decision_hash, limit)` is unchanged externally (calls the index-backed method with offset 0; `has_more` and the `limit == 0` short-circuit are preserved).
- Old-store safety via **marker-gated startup rebuild** (`ensure_decision_index` in `Ledger::new`, mirroring `ensure_timestamp_index`): a one-time backfill over the journal using the bounded `scan_after` cursor (from #1993), gated by a `ledger:decision_idx_built` marker so a ledger with no governance entries isn't rescanned each startup. Chosen over per-query fallback because it is deterministic, complete, and adds no read-path branch.

## Archival / fork-resolution coherence

`rollback_to_entry` (archival) and `quarantine_forked_entry` (fork-resolution) already **delete** removed entries from `journal:` and `journal_ts:`. The old lookup scanned `journal_ts:`, so removed entries already vanished from results. The index lookup loads each indexed hash from `journal:` and re-verifies provenance, so a removed entry resolves to `None` and is skipped — **identical** behavior to the old scan, with **no changes to the sensitive reorg paths**. Stale index rows are therefore harmless (no panic, no incorrect inclusion); they are skipped on read and re-collapsed by the migration rebuild if ever needed.

## Safety

- Does not weaken receipt-chain verification, ledger correctness, fork-resolution, archival, or audit-chain semantics.
- Does not weaken auth/dev/trust/ledger/audit gates.
- Does not change governance proof semantics.
- Does not add demo/UI/product scope.
- Avoids payment/wallet/balance/currency framing.

## Validation

Run from `icn/icn`:

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p icn-ledger -p icn-api --all-targets -- -D warnings` — pass
- `cargo test -p icn-ledger` — 419 + 7 + 11 + 1 + 8 + 7 + 7 passed, 0 failed
- `cargo test -p icn-api` — 18 passed, 0 failed (incl. #1988 regression `finds_decision_entry_beyond_first_1000_entries`)
- `cargo test -p icn-gateway --features sled-storage --lib ledger` — 28 passed, 0 failed (downstream boundary)

New regression coverage:
- **Sparse deep match** (#1988 test, now index-backed).
- **Pagination** over indexed matches — deterministic, no skip/duplicate, exact `has_more`/`total`.
- **`limit == 0`** returns an empty page without work.
- **Non-governance entries** create no index rows and never match.
- **Stale/removed rows** (archival/quarantine + bogus row) are skipped — no panic, not surfaced.
- **Pre-index store migration** rebuilds the index on open.

## Follow-ups

- #1992 remains the next planned slice: one-command local 13/13 receipt-chain rehearsal.
