### PR TITLE
demo(pilot): add fixture-backed rehearsal shell demo mode

### DIFF
--- a/docs/pilots/no-cli-organizer-member-rehearsal-workflow.md
+++ b/docs/pilots/no-cli-organizer-member-rehearsal-workflow.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-05-04
+Last Reviewed: 2026-06-09
 ---
 
 # No-CLI organizer and member rehearsal workflow (generic ICN)
@@ -86,6 +86,8 @@ Track as discrete work items (GitHub issues welcome; not all may exist yet):
 
 - **UI prototype** — Single guided shell (organizer mode) with the §3 screen list.
 - **Fixture-backed demo** — Deterministic fixture load with no network by default.
+  - **Bridge slice (landed):** a repo-safe read-model bundle the future shell can load by default lives at [`rehearsal-shell.manifest.json`](../../web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json) (extending the existing `?mode=demo` fixture pack with the `preview-review` `preview_kind: pending_publish_summary` wrapper, the `pending-publish-summary` rows, and the `rehearsal-evidence-export` packet, alongside the existing `standing` / `action-cards` fixtures). It is validated **offline** by [`validate-rehearsal-shell-fixtures.py`](../scripts/validate-rehearsal-shell-fixtures.py), which asserts demo-mode / network-disabled, runs each packet through the existing contract validators, and runs a deterministic forbidden live/private-reference guard. The wrapper and rows are composed **by URN, not nested** (per [`pending-publish-summary.md`](../contracts/pending-publish-summary.md)).
+  - **Still open:** this slice is the docs/fixtures bridge only. The backend `--demo-mode` flag on icnd that [ICN#1727](https://github.com/InterCooperative-Network/icn/issues/1727) ultimately tracks remains **OPEN**; [ICN#1726](https://github.com/InterCooperative-Network/icn/issues/1726) (organizer shell that renders these packets) and [ICN#1730](https://github.com/InterCooperative-Network/icn/issues/1730) (private-overlay / DID activation boundary) remain separate follow-ups.
 - **Generic preview/review API contract** — Stable read models for “pending publish” summaries (package-agnostic shapes). Substrate contract: [`preview-review.schema.json`](../contracts/preview-review.schema.json) with companion notes at [`preview-review.md`](../contracts/preview-review.md). `$id` is the non-DNS URN `urn:icn:contract:preview-review:v1` ([ICN#1728](https://github.com/InterCooperative-Network/icn/issues/1728)).
   - **Row-level pending-publish body** — The individual rows rendered inside a `preview_kind: pending_publish_summary` review boundary (action items, decisions, attendance, obligations, allocations, settlements). Composed substrate contract: [`pending-publish-summary.schema.json`](../contracts/pending-publish-summary.schema.json) with companion notes at [`pending-publish-summary.md`](../contracts/pending-publish-summary.md). `$id` is the non-DNS URN `urn:icn:contract:pending-publish-summary:v1` ([ICN#1728](https://github.com/InterCooperative-Network/icn/issues/1728)). Composes with — does not replace — `preview-review`.
 - **Evidence export contract** — Machine-readable **repo-safe** evidence summary schema shared with partners. Substrate contract: [`rehearsal-evidence-export.schema.json`](../contracts/rehearsal-evidence-export.schema.json) with companion notes at [`rehearsal-evidence-export.md`](../contracts/rehearsal-evidence-export.md). `$id` is the non-DNS URN `urn:icn:contract:rehearsal-evidence-export:v1` ([ICN#1729](https://github.com/InterCooperative-Network/icn/issues/1729)).
@@ -96,6 +98,7 @@ Track as discrete work items (GitHub issues welcome; not all may exist yet):
 ## 8. See also
 
 - [runtime-surface-map.md](../reference/project-index/runtime-surface-map.md) — ICN runtime surfaces for organizers
+- [rehearsal-shell.manifest.json](../../web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json) — fixture-backed demo-mode read-model bundle (no-network), validated by [validate-rehearsal-shell-fixtures.py](../scripts/validate-rehearsal-shell-fixtures.py)
 - [Institution package ActionCard notes](../contracts/institution-package/README.md)
 - [STATE.md](../STATE.md), [PHASE_PROGRESS.md](../PHASE_PROGRESS.md)
 - Partner-specific organizer materials and pilot rehearsal gate live in the partner NYCN repo.

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -3356,8 +3356,8 @@ audiences = ["team"]
 category = "reference"
 status = "living"
 title = "No-CLI organizer and member rehearsal workflow (generic ICN)"
-description = "Guided browser/mobile-first rehearsal story: standing, action cards, action items, receipts, provenance, repo-safe evidence; organizer vs steward vs member paths; preview-before-mutation; CLI as operator layer only; follow-ups for UI/API/evidence contracts. Partner companion doc lives in NYCN repo."
-last_updated = "2026-05-04"
+description = "Guided browser/mobile-first rehearsal story: standing, action cards, action items, receipts, provenance, repo-safe evidence; organizer vs steward vs member paths; preview-before-mutation; CLI as operator layer only; follow-ups for UI/API/evidence contracts including the landed fixture-backed demo-mode bridge slice. Partner companion doc lives in NYCN repo."
+last_updated = "2026-06-09"
 owner = "matt"
 audiences = ["team", "organizers"]
 truth_class = "descriptive"
@@ -3366,7 +3366,7 @@ canonical = "no"
 freshness = "current"
 domain_tags = ["pilot", "nycn", "communications", "action-cards", "accessibility"]
 recommended_action = "keep"
-last_reviewed = "2026-05-04"
+last_reviewed = "2026-06-09"
 
 [docs."docs/contracts/institution-package/README.md"]
 category = "reference"

--- a/docs/scripts/validate-rehearsal-shell-fixtures.py
+++ b/docs/scripts/validate-rehearsal-shell-fixtures.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Validate the fixture-backed rehearsal-shell demo-mode bundle.
+
+This is the validation harness for the fixture-mode bridge slice of
+ICN #1727 ("fixture-backed demo mode for the rehearsal shell, no
+network by default"). It does NOT implement the full backend
+`--demo-mode` flag on icnd that #1727 ultimately tracks; that remains
+OPEN. It proves a smaller, honest thing: that a committed, repo-safe,
+deterministic read-model bundle exists for the future no-CLI
+organizer/member shell (#1726) to load, and that loading/validating it
+requires no network.
+
+What it checks, given a manifest:
+
+  1. The manifest declares demo mode and disabled network
+     (`mode: "demo"`, `network: "disabled"`).
+  2. The manifest carries `non_claims` covering the standing safety
+     themes (no production, no network, no mutation, no private data).
+  3. Every referenced read_model file exists and is valid JSON.
+  4. Each read_model with `validate: "schema"` passes its named
+     contract validator (this script shells out to the existing
+     docs/scripts/validate-*.py validators rather than re-implementing
+     JSON Schema, so the substrate contracts stay the single source of
+     truth). Each `validate: "shape_only"` read_model has its declared
+     `structural_keys` present at the top level.
+  5. A simple, deterministic forbidden-reference guard runs over every
+     referenced packet and the manifest itself: no live cloud-sync
+     hostnames, no insecure URLs, no off-allowlist https hosts, no
+     JWT-looking strings, no absolute private paths, and no
+     payment/wallet/balance/currency framing outside `non_claims`.
+
+The guard is intentionally small and deterministic — it is NOT a
+general-purpose privacy scanner. The contract schemas
+(`additionalProperties: false`, `x-icn-must-not-include`) are the real
+privacy boundary; this guard is a cheap smoke check on top.
+
+Usage:
+    python3 docs/scripts/validate-rehearsal-shell-fixtures.py
+        # Validates the bundled rehearsal-shell manifest by default.
+
+    python3 docs/scripts/validate-rehearsal-shell-fixtures.py path/to/manifest.json
+        # Validates an arbitrary manifest (used by negative tests and
+        # partner repositories that pin their own bundle).
+
+Exit codes:
+    0: the whole bundle validates and the guard is clean
+    1: a check failed, or an input file / schema / validator is invalid
+
+Requires: Python 3.11+ and the `jsonschema` library (only because the
+delegated contract validators require it).
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = (
+    REPO_ROOT
+    / "web"
+    / "pilot-ui"
+    / "fixtures"
+    / "icn-organizer-demo"
+    / "rehearsal-shell.manifest.json"
+)
+
+# Standing safety themes the manifest's non_claims must mention. Each entry
+# is a list of acceptable substrings (any one satisfies the theme). Mirrors
+# the machine-enforced non_claims discipline in the contract validators.
+REQUIRED_NON_CLAIM_THEMES = {
+    "no production deployment": ["production"],
+    "no network by default": ["network"],
+    "no mutation": ["mutation"],
+    "no private data": ["private", "fictional"],
+}
+
+# Forbidden raw substrings (case-insensitive). Live cloud-sync hostnames and
+# insecure URLs must never appear, even inside non_claims (the contract
+# examples disclaim "Google Drive / Groups / Sheets" as words, never as
+# hostnames, so matching hostnames here is false-positive-safe).
+FORBIDDEN_SUBSTRINGS = [
+    "drive.google.com",
+    "docs.google.com",
+    "groups.google.com",
+    "sheets.google.com",
+    "spreadsheets/d/",
+    "http://",
+]
+
+# Absolute private path prefixes that must never appear in a repo-safe packet.
+FORBIDDEN_PATH_PREFIXES = ["/home/", "/users/", "c:\\"]
+
+# A JWT-looking string: base64url header "." base64url payload.
+JWT_RE = re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}")
+
+# Money-transmission framing forbidden OUTSIDE non_claims. Cooperative
+# coordination vocabulary (allocation / settlement / unit / position) is
+# deliberately NOT here — it is regulatory-safe and expected in the rows.
+MONEY_RE = re.compile(
+    r"\bwallet\b|\busd\b|\bpaypal\b|\bstripe\b|\bcredit card\b|\$\s?\d",
+    re.IGNORECASE,
+)
+
+HTTPS_HOST_RE = re.compile(r"https://([A-Za-z0-9._-]+)")
+
+
+def load_json(path: Path, label: str) -> dict:
+    if not path.exists():
+        print(f"ERROR: {label} not found at {path}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: {label} at {path} is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def strip_non_claims(node: object) -> object:
+    """Return a copy of `node` with every `non_claims` array removed, so the
+    money-framing check does not flag the disclaimers that are *supposed* to
+    name the forbidden vocabulary."""
+    if isinstance(node, dict):
+        return {
+            k: strip_non_claims(v) for k, v in node.items() if k != "non_claims"
+        }
+    if isinstance(node, list):
+        return [strip_non_claims(v) for v in node]
+    return node
+
+
+def forbidden_reference_findings(
+    label: str, data: object, raw_text: str, allowlist_hosts: list
+) -> list:
+    """Return a list of human-readable findings (empty == clean)."""
+    findings = []
+    lowered = raw_text.lower()
+
+    for needle in FORBIDDEN_SUBSTRINGS:
+        if needle in lowered:
+            findings.append(f"{label}: forbidden reference {needle!r}")
+
+    for prefix in FORBIDDEN_PATH_PREFIXES:
+        if prefix in lowered:
+            findings.append(f"{label}: forbidden absolute private path {prefix!r}")
+
+    if JWT_RE.search(raw_text):
+        findings.append(f"{label}: JWT-looking string present")
+
+    for host in set(HTTPS_HOST_RE.findall(raw_text)):
+        if host not in allowlist_hosts:
+            findings.append(
+                f"{label}: off-allowlist https host {host!r} "
+                f"(allowed: {', '.join(allowlist_hosts)})"
+            )
+
+    money_text = json.dumps(strip_non_claims(data))
+    match = MONEY_RE.search(money_text)
+    if match:
+        findings.append(
+            f"{label}: payment/wallet/currency framing outside non_claims "
+            f"({match.group(0)!r})"
+        )
+
+    return findings
+
+
+def run_contract_validator(validator_rel: str, schema_rel: str, packet: Path) -> tuple:
+    """Shell out to an existing docs/scripts/validate-*.py. Returns (ok, output)."""
+    validator = REPO_ROOT / validator_rel
+    if not validator.exists():
+        return False, f"validator not found: {validator_rel}"
+    cmd = [sys.executable, str(validator)]
+    if schema_rel:
+        cmd += ["--schema", str(REPO_ROOT / schema_rel)]
+    cmd.append(str(packet))
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    output = (proc.stdout + proc.stderr).strip()
+    return proc.returncode == 0, output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "manifest",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="Fixture manifest JSON (defaults to the bundled rehearsal-shell manifest).",
+    )
+    args = parser.parse_args()
+
+    manifest_path = args.manifest
+    manifest = load_json(manifest_path, "manifest")
+    failures = []
+
+    print(f"Validating rehearsal-shell fixture bundle: {manifest_path}")
+
+    # 1. demo mode + network disabled
+    if manifest.get("mode") != "demo":
+        failures.append(f"manifest.mode is {manifest.get('mode')!r}, expected 'demo'")
+    if manifest.get("network") != "disabled":
+        failures.append(
+            f"manifest.network is {manifest.get('network')!r}, expected 'disabled'"
+        )
+    else:
+        print("  [ok] demo mode declared, network disabled")
+
+    # 2. non_claims cover the standing safety themes
+    non_claims = manifest.get("non_claims")
+    if not isinstance(non_claims, list) or not non_claims:
+        failures.append("manifest.non_claims missing or empty")
+    else:
+        joined = " ".join(non_claims).lower()
+        for theme, needles in REQUIRED_NON_CLAIM_THEMES.items():
+            if not any(n in joined for n in needles):
+                failures.append(f"manifest.non_claims missing theme: {theme}")
+        print(f"  [ok] non_claims present ({len(non_claims)} entries)")
+
+    allowlist_hosts = manifest.get("url_allowlist_hosts", ["github.com"])
+
+    # Guard the manifest itself.
+    manifest_raw = manifest_path.read_text(encoding="utf-8")
+    for finding in forbidden_reference_findings(
+        "manifest", manifest, manifest_raw, allowlist_hosts
+    ):
+        failures.append(finding)
+
+    # 3 + 4 + 5. each read_model
+    read_models = manifest.get("read_models", [])
+    if not read_models:
+        failures.append("manifest.read_models is empty")
+
+    for rm in read_models:
+        name = rm.get("name", "<unnamed>")
+        rel = rm.get("path", "")
+        packet_path = REPO_ROOT / rel
+        if not packet_path.exists():
+            failures.append(f"{name}: referenced packet missing: {rel}")
+            continue
+        data = load_json(packet_path, f"{name} packet")
+        raw_text = packet_path.read_text(encoding="utf-8")
+
+        mode = rm.get("validate")
+        if mode == "schema":
+            ok, output = run_contract_validator(
+                rm.get("validator", ""), rm.get("schema", ""), packet_path
+            )
+            if ok:
+                print(f"  [ok] {name}: schema-valid ({rm.get('urn', rel)})")
+            else:
+                failures.append(f"{name}: schema validation failed -> {output}")
+        elif mode == "shape_only":
+            missing = [
+                k for k in rm.get("structural_keys", []) if k not in data
+            ]
+            if missing:
+                failures.append(f"{name}: missing structural keys {missing}")
+            else:
+                print(f"  [ok] {name}: shape-only keys present")
+        else:
+            failures.append(f"{name}: unknown validate mode {mode!r}")
+
+        for finding in forbidden_reference_findings(
+            name, data, raw_text, allowlist_hosts
+        ):
+            failures.append(finding)
+
+    print()
+    if failures:
+        print(f"FAIL: {len(failures)} problem(s) found:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print(f"PASS: rehearsal-shell fixture bundle is demo-only, no-network, and clean "
+          f"({len(read_models)} read models).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/scripts/validate-rehearsal-shell-fixtures.py
+++ b/docs/scripts/validate-rehearsal-shell-fixtures.py
@@ -68,6 +68,11 @@ DEFAULT_MANIFEST = (
     / "rehearsal-shell.manifest.json"
 )
 
+# Bound each delegated contract validator so a hung/deadlocked subprocess can
+# never hang the offline bundle check (or CI). Mirrors the explicit timeouts
+# other repo scripts (e.g. docs/scripts/freshness-check.py) use for determinism.
+DELEGATE_TIMEOUT_SECONDS = 60
+
 # Standing safety themes the manifest's non_claims must mention. Each entry
 # is a list of acceptable substrings (any one satisfies the theme). Mirrors
 # the machine-enforced non_claims discipline in the contract validators.
@@ -169,16 +174,49 @@ def forbidden_reference_findings(
     return findings
 
 
+def resolve_repo_relative(rel: object, label: str) -> tuple:
+    """Resolve a manifest-supplied path, failing CLOSED on anything that is not
+    a committed, in-repo, repo-relative path. Returns (Path, None) on success or
+    (None, finding) on rejection. This validator's whole purpose is to prove the
+    bundle is repo-safe, so a manifest that points outside the repo root (absolute
+    path, `..` traversal, symlink escape, or non-string) must not be trusted."""
+    if not isinstance(rel, str) or not rel:
+        return None, f"{label}: path must be a non-empty string (got {rel!r})"
+    p = Path(rel)
+    if p.is_absolute():
+        return None, f"{label}: path must be repo-relative, not absolute: {rel!r}"
+    if ".." in p.parts:
+        return None, f"{label}: path must not contain '..' traversal: {rel!r}"
+    resolved = (REPO_ROOT / p).resolve()
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError:
+        return None, f"{label}: path escapes the repo root: {rel!r}"
+    return resolved, None
+
+
 def run_contract_validator(validator_rel: str, schema_rel: str, packet: Path) -> tuple:
     """Shell out to an existing docs/scripts/validate-*.py. Returns (ok, output)."""
-    validator = REPO_ROOT / validator_rel
+    validator, err = resolve_repo_relative(validator_rel, "validator")
+    if err:
+        return False, err
     if not validator.exists():
         return False, f"validator not found: {validator_rel}"
     cmd = [sys.executable, str(validator)]
     if schema_rel:
-        cmd += ["--schema", str(REPO_ROOT / schema_rel)]
+        schema, serr = resolve_repo_relative(schema_rel, "schema")
+        if serr:
+            return False, serr
+        cmd += ["--schema", str(schema)]
     cmd.append(str(packet))
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=DELEGATE_TIMEOUT_SECONDS
+        )
+    except subprocess.TimeoutExpired:
+        return False, (
+            f"validator timed out after {DELEGATE_TIMEOUT_SECONDS}s: {validator_rel}"
+        )
     output = (proc.stdout + proc.stderr).strip()
     return proc.returncode == 0, output
 
@@ -240,7 +278,10 @@ def main() -> int:
     for rm in read_models:
         name = rm.get("name", "<unnamed>")
         rel = rm.get("path", "")
-        packet_path = REPO_ROOT / rel
+        packet_path, path_err = resolve_repo_relative(rel, name)
+        if path_err:
+            failures.append(path_err)
+            continue
         if not packet_path.exists():
             failures.append(f"{name}: referenced packet missing: {rel}")
             continue

--- a/web/pilot-ui/fixtures/icn-organizer-demo/README.md
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/README.md
@@ -62,13 +62,13 @@ at committed read-model packets:
 | Member standing | [`standing.json`](standing.json) | shape-only (no committed schema; shape pinned by the e2e tests) |
 | Per-member action cards | [`action-cards.json`](action-cards.json) | shape-only wrapper; each card matches `action-card.schema.json` |
 | Pending-publish **review boundary** | [`preview-review.pending-publish-summary.json`](preview-review.pending-publish-summary.json) | `urn:icn:contract:preview-review:v1`, `preview_kind: pending_publish_summary` |
-| Pending-publish **rows** | [`../../../docs/contracts/pending-publish-summary.example.json`](../../../docs/contracts/pending-publish-summary.example.json) | `urn:icn:contract:pending-publish-summary:v1` |
-| Rehearsal evidence export | [`../../../docs/contracts/rehearsal-evidence-export.example.json`](../../../docs/contracts/rehearsal-evidence-export.example.json) | `urn:icn:contract:rehearsal-evidence-export:v1` |
+| Pending-publish **rows** | [`pending-publish-summary.example.json`](../../../../docs/contracts/pending-publish-summary.example.json) | `urn:icn:contract:pending-publish-summary:v1` |
+| Rehearsal evidence export | [`rehearsal-evidence-export.example.json`](../../../../docs/contracts/rehearsal-evidence-export.example.json) | `urn:icn:contract:rehearsal-evidence-export:v1` |
 
 The pending-publish **review boundary** and **rows** are composed **by
 URN, not nested** — `preview-review` is `additionalProperties: false`
 and carries no field that can embed the rows (see
-[`pending-publish-summary.md`](../../../docs/contracts/pending-publish-summary.md)).
+[`pending-publish-summary.md`](../../../../docs/contracts/pending-publish-summary.md)).
 
 Validate the whole bundle **offline** (no network, no gateway), from the
 repo root:
@@ -84,7 +84,7 @@ live/private-reference guard. **It does not implement the backend
 `--demo-mode` flag on icnd; that remains OPEN at
 [#1727](https://github.com/InterCooperative-Network/icn/issues/1727).**
 Rendering any of these packets in a UI is still subject to the
-[`ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md`](../../../docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md)
+[`ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md`](../../../../docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md)
 gate (a future #1726 concern; no UI ships in this slice).
 
 ## What this slice does NOT cover

--- a/web/pilot-ui/fixtures/icn-organizer-demo/README.md
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/README.md
@@ -48,6 +48,45 @@ and the response struct definitions for `StandingResponse` /
 `icn/apps/governance/src/http/models.rs`. Schema field names are used
 verbatim — no invented fields.
 
+## Rehearsal-shell read-model bundle (manifest)
+
+[`rehearsal-shell.manifest.json`](rehearsal-shell.manifest.json) is the
+**fixture-mode bridge slice** for the future no-CLI organizer/member
+shell ([icn#1726](https://github.com/InterCooperative-Network/icn/issues/1726)):
+a single deterministic, no-network manifest the shell can load by
+default. It declares `mode: "demo"`, `network: "disabled"`, and points
+at committed read-model packets:
+
+| Read-model | Packet | Contract / schema |
+|---|---|---|
+| Member standing | [`standing.json`](standing.json) | shape-only (no committed schema; shape pinned by the e2e tests) |
+| Per-member action cards | [`action-cards.json`](action-cards.json) | shape-only wrapper; each card matches `action-card.schema.json` |
+| Pending-publish **review boundary** | [`preview-review.pending-publish-summary.json`](preview-review.pending-publish-summary.json) | `urn:icn:contract:preview-review:v1`, `preview_kind: pending_publish_summary` |
+| Pending-publish **rows** | [`../../../docs/contracts/pending-publish-summary.example.json`](../../../docs/contracts/pending-publish-summary.example.json) | `urn:icn:contract:pending-publish-summary:v1` |
+| Rehearsal evidence export | [`../../../docs/contracts/rehearsal-evidence-export.example.json`](../../../docs/contracts/rehearsal-evidence-export.example.json) | `urn:icn:contract:rehearsal-evidence-export:v1` |
+
+The pending-publish **review boundary** and **rows** are composed **by
+URN, not nested** — `preview-review` is `additionalProperties: false`
+and carries no field that can embed the rows (see
+[`pending-publish-summary.md`](../../../docs/contracts/pending-publish-summary.md)).
+
+Validate the whole bundle **offline** (no network, no gateway), from the
+repo root:
+
+```bash
+python3 docs/scripts/validate-rehearsal-shell-fixtures.py
+```
+
+That harness asserts demo-mode / network-disabled, runs each packet
+through the existing `docs/scripts/validate-*.py` contract validators,
+checks the manifest's `non_claims`, and runs a deterministic forbidden
+live/private-reference guard. **It does not implement the backend
+`--demo-mode` flag on icnd; that remains OPEN at
+[#1727](https://github.com/InterCooperative-Network/icn/issues/1727).**
+Rendering any of these packets in a UI is still subject to the
+[`ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md`](../../../docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md)
+gate (a future #1726 concern; no UI ships in this slice).
+
 ## What this slice does NOT cover
 
 The following pilot-ui surfaces remain unaffected by this fixture

--- a/web/pilot-ui/fixtures/icn-organizer-demo/preview-review.pending-publish-summary.json
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/preview-review.pending-publish-summary.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "0.1.0",
+  "preview_id": "preview-example-pending-publish-summary-2026-06-09-001",
+  "preview_kind": "pending_publish_summary",
+  "created_at": "2026-06-09T00:05:00Z",
+  "created_by_role": "facilitator",
+  "scope": "structure",
+  "source_material": [
+    {
+      "kind": "example-snippet",
+      "basename": "example-organizing-circle-notes.fixture.md",
+      "summary": "Fictional organizing-circle notes the pending-publish rows were summarized from. No real people or organization."
+    },
+    {
+      "kind": "example-snippet",
+      "basename": "example-allocation-draft.fixture.json",
+      "summary": "Fictional allocation draft referenced by the allocation row. No real units, positions, or partner data."
+    }
+  ],
+  "proposed_artifact": {
+    "kind": "publish_summary",
+    "title": "EXAMPLE — Four pending-publish rows staged for organizer review",
+    "summary": "A pending-publish summary of four fictional rows (one action item, one decision, one attendance record, one internal-unit allocation) presented to the reviewer before any documented next step.",
+    "detail": "This wrapper records the review boundary for a pending_publish_summary. The individual rows it summarizes live in the sibling packet urn:icn:contract:pending-publish-summary:v1 (docs/contracts/pending-publish-summary.example.json) and are composed by URN, not nested into this object — preview-review.schema.json is additionalProperties:false and defines no field that can carry the rows. Each row would, if approved, be created by a separate, named, documented endpoint; rendering this preview creates nothing. Holder-label to DID binding is a separate documented step under the private-overlay / DID activation flow (icn#1730)."
+  },
+  "review_status": "ready_for_review",
+  "review_requirements": [
+    "privacy_review",
+    "accessibility_review",
+    "repo_safety_review",
+    "scope_confirmation",
+    "no_mutation_check"
+  ],
+  "reviewer_actions": [
+    {
+      "action": "opened",
+      "by_role": "facilitator",
+      "recorded_at": "2026-06-09T00:05:00Z",
+      "notes": "Pending-publish summary assembled from the bundled fictional source material; presented to the reviewer for the first time."
+    }
+  ],
+  "privacy_review": {
+    "reviewer_role": "facilitator",
+    "status": "reviewed-clean",
+    "notes": "All rows summarized here are fictional; no real names, contacts, sponsors, attendee rolls, accommodation needs, tokens, DIDs, or partner Drive / Groups / Sheets paths were present at any point. The preview is checked into a public repository deliberately as a schema-conformance reference."
+  },
+  "repo_safety": {
+    "classification": "repo-safe",
+    "notes": "All source material is fictional and committed under the repo (or referenced by basename only); no partner-internal data is present. The preview is safe to render in any public surface."
+  },
+  "evidence_links": [
+    {
+      "kind": "public-doc",
+      "contract_urn": "urn:icn:contract:pending-publish-summary:v1",
+      "title": "Row-level body contract composed inside this pending_publish_summary review boundary (sibling packet, by URN — not nested here)."
+    },
+    {
+      "kind": "rehearsal-evidence-export",
+      "contract_urn": "urn:icn:contract:rehearsal-evidence-export:v1",
+      "title": "Upstream evidence-export contract a separate, documented next step would write to once approved."
+    }
+  ],
+  "non_claims": [
+    "This preview is a schema-conformance fixture, not a real review record.",
+    "Not a mutation; rendering this preview does not publish, apply, create, or export anything.",
+    "Not a production deployment.",
+    "Not a formally committed NYCN cooperative pilot authorization.",
+    "Not private-data handling; all material is fictional and repo-safe by construction.",
+    "Not a literal container for the pending-publish rows; the rows live in the sibling urn:icn:contract:pending-publish-summary:v1 packet and are composed by URN, never nested into this wrapper.",
+    "Not a payment, wallet, balance, or currency surface; allocation / settlement vocabulary in the composed rows refers to internal cooperative coordination primitives only, never money transmission or stored value.",
+    "Not a self-declared organizer-ready surface; the gate at docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md still runs against any UI that renders this preview."
+  ]
+}

--- a/web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json
@@ -1,0 +1,69 @@
+{
+  "fixture_id": "icn-organizer-rehearsal-shell-demo-v1",
+  "schema_version": "1.0.0",
+  "mode": "demo",
+  "network": "disabled",
+  "generated_from": "committed-fixtures",
+  "title": "ICN organizer/member rehearsal-shell fixture bundle (demo mode, no network)",
+  "description": "Deterministic, repo-safe read-model bundle the future no-CLI organizer/member rehearsal shell (icn#1726) can load by default — without any network access or live partner data. This manifest is the fixture-mode bridge slice for icn#1727; the full backend `--demo-mode` flag on icnd remains OPEN. Each read_model points at an already-committed, fictional packet and (where a schema exists) the validator that checks it.",
+  "read_models": [
+    {
+      "name": "member_standing",
+      "surface": "GET /v1/gov/me/standing (StandingResponse)",
+      "path": "web/pilot-ui/fixtures/icn-organizer-demo/standing.json",
+      "validate": "shape_only",
+      "structural_keys": ["did", "domains", "roles", "authority_scopes", "generated_at"],
+      "notes": "No committed substrate schema; field shapes are pinned by the pilot-ui e2e tests (tests/e2e/demo-fixture-preload.spec.js) against icn/apps/governance/src/http/models.rs."
+    },
+    {
+      "name": "member_action_cards",
+      "surface": "GET /v1/gov/me/action-cards (ActionCardsResponse wrapper)",
+      "path": "web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json",
+      "validate": "shape_only",
+      "structural_keys": ["did", "cards", "generated_at"],
+      "notes": "Wrapper { did, cards, generated_at }; each cards[i] matches docs/contracts/institution-package/action-card.schema.json (validated per-card by tests/e2e/standing-action-cards.spec.js, not by this slice)."
+    },
+    {
+      "name": "preview_review_pending_publish_summary",
+      "surface": "Review boundary (wrapper) the shell renders around the pending-publish rows",
+      "urn": "urn:icn:contract:preview-review:v1",
+      "preview_kind": "pending_publish_summary",
+      "path": "web/pilot-ui/fixtures/icn-organizer-demo/preview-review.pending-publish-summary.json",
+      "validate": "schema",
+      "validator": "docs/scripts/validate-preview-review.py",
+      "schema": "docs/contracts/preview-review.schema.json"
+    },
+    {
+      "name": "pending_publish_summary_rows",
+      "surface": "Row-level body the shell lists one item at a time (no-CLI workflow §3 step 6)",
+      "urn": "urn:icn:contract:pending-publish-summary:v1",
+      "composes_with": "preview_review_pending_publish_summary",
+      "composition": "sibling-by-urn — the rows are NOT nested into the preview-review wrapper",
+      "path": "docs/contracts/pending-publish-summary.example.json",
+      "validate": "schema",
+      "validator": "docs/scripts/validate-preview-review.py",
+      "schema": "docs/contracts/pending-publish-summary.schema.json"
+    },
+    {
+      "name": "rehearsal_evidence_export",
+      "surface": "Repo-safe evidence packet a separate documented step would export after review",
+      "urn": "urn:icn:contract:rehearsal-evidence-export:v1",
+      "path": "docs/contracts/rehearsal-evidence-export.example.json",
+      "validate": "schema",
+      "validator": "docs/scripts/validate-rehearsal-evidence.py",
+      "schema": "docs/contracts/rehearsal-evidence-export.schema.json"
+    }
+  ],
+  "url_allowlist_hosts": ["github.com", "raw.githubusercontent.com"],
+  "non_claims": [
+    "Demo fixture bundle only; not a production deployment.",
+    "No network by default; the validator performs no network access and this manifest declares network: disabled.",
+    "No mutation; loading or validating these packets publishes, applies, creates, or exports nothing.",
+    "No live Google Drive / Groups / Sheets / Calendar / mail sync, no federation, no K3s / DNS / Forgejo mutation.",
+    "No private organizer / member / sponsor / attendee data; every identifier is fictional (did:icn:example-*-not-live, demo.* labels).",
+    "Not a formally committed NYCN cooperative pilot authorization.",
+    "Not real holder-label to DID activation; that boundary is icn#1730 and is out of scope here.",
+    "Not a payment, wallet, balance, or currency surface; allocation / settlement vocabulary refers to internal cooperative coordination primitives only.",
+    "Does not implement the icn#1726 organizer shell UI, nor the full backend --demo-mode flag on icnd that icn#1727 ultimately tracks."
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the fixture-backed demo-mode bridge slice for #1727.

This gives the future no-CLI rehearsal shell deterministic, repo-safe packets to load by default, without network access or live partner data. It does not implement the backend `icnd --demo-mode` flag and does not build the organizer shell UI.

## What changed

- Add a rehearsal-shell fixture manifest in the existing pilot-ui fixture directory.
- Add a `preview-review` wrapper packet for `preview_kind: pending_publish_summary` (composed with the rows **by URN, not nested**, per `pending-publish-summary.md`).
- Wire the fixture bundle to the existing `preview-review`, `pending-publish-summary`, and rehearsal-evidence contracts.
- Add an offline bundle validator that reuses the existing per-contract validators and adds demo/no-network/private-reference checks.
- Document how the fixture-backed bundle supports the #1746 organizer-operability milestone without claiming production or live pilot status.

## Safety / non-claims

- Demo fixtures only.
- No network by default.
- No mutation endpoint.
- No live Drive/Groups/Sheets sync.
- No private organizer/member/sponsor/attendee data.
- No production deployment.
- No formal NYCN pilot claim.
- No payment/wallet/balance/currency framing.
- Does not implement the #1726 organizer shell UI.
- Does not implement #1730 private-overlay / DID activation.
- Does not implement the backend `icnd --demo-mode` flag.

## Validation

- `python3 docs/scripts/validate-rehearsal-shell-fixtures.py`
- negative fixture-validator battery for fail-closed behavior
- `python3 -m json.tool web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json`
- `python3 -m json.tool web/pilot-ui/fixtures/icn-organizer-demo/preview-review.pending-publish-summary.json`
- `python3 docs/scripts/validate-preview-review.py docs/contracts/preview-review.example.json`
- `python3 docs/scripts/validate-preview-review.py --schema docs/contracts/pending-publish-summary.schema.json docs/contracts/pending-publish-summary.example.json`
- `python3 docs/scripts/validate-preview-review.py web/pilot-ui/fixtures/icn-organizer-demo/preview-review.pending-publish-summary.json`
- `python3 docs/scripts/validate-rehearsal-evidence.py`
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml`
- `python3 docs/api/check_api_doc_terms.py --repo-root .`
- `git diff --check`
- `cd icn && cargo fmt --all -- --check`

## Follow-ups

- #1726 can render these fixture packets in the thin organizer shell.
- #1727 backend `icnd --demo-mode` remains open and separate.
- #1730 remains the private-overlay / holder-label to DID activation boundary.
- #1746 remains the overall organizer rehearsal operability milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
