### PR TITLE
docs(claude): retarget roadmap pointers off dead docs/dev-journal/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,7 @@ See [docs/PHASE_PROGRESS.md](docs/PHASE_PROGRESS.md) and [docs/STATE.md](docs/ST
 1. **Never invent new tracking systems** - use phases with sequential numbers
 2. **Never use "Track A/B/C"** - everything is sequential
 3. **Update PHASE_HISTORY.md** when completing a phase
-4. **Update docs/strategy/ICN-Roadmap-Live.md** when planning changes
+4. **Update docs/STATE.md and docs/PHASE_PROGRESS.md** when phase state changes (they are canonical); update docs/strategy/ICN-Roadmap-Live.md when long-arc planning changes — never the strategy doc alone while canonical phase tracking goes stale
 5. **Keep this section as quick reference only** - detail goes in the dedicated docs
 
 ## Common Development Workflows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ Each phase in documentation must follow this format:
 ### Source of Truth
 
 - **Completed phases**: [docs/PHASE_HISTORY.md](docs/PHASE_HISTORY.md)
-- **Current & planned phases**: [docs/dev-journal/ROADMAP.md](docs/dev-journal/ROADMAP.md)
+- **Current & planned phases**: [docs/STATE.md](docs/STATE.md) and [docs/PHASE_PROGRESS.md](docs/PHASE_PROGRESS.md) (truth-synced, canonical); long-arc planning: [docs/strategy/ICN-Roadmap-Live.md](docs/strategy/ICN-Roadmap-Live.md)
 - **This file**: Quick reference only, not authoritative
 
 ### Current Status
@@ -305,14 +305,14 @@ Each phase in documentation must follow this format:
 - 34: Release Candidate
 - 35: Pilot Deployment
 
-See [docs/dev-journal/ROADMAP.md](docs/dev-journal/ROADMAP.md) for full details and issue mapping.
+See [docs/PHASE_PROGRESS.md](docs/PHASE_PROGRESS.md) and [docs/STATE.md](docs/STATE.md) for current state and issue mapping, and [docs/strategy/ICN-Roadmap-Live.md](docs/strategy/ICN-Roadmap-Live.md) for the long-arc roadmap.
 
 ### Rules for Agents
 
 1. **Never invent new tracking systems** - use phases with sequential numbers
 2. **Never use "Track A/B/C"** - everything is sequential
 3. **Update PHASE_HISTORY.md** when completing a phase
-4. **Update ROADMAP.md** when planning changes
+4. **Update docs/strategy/ICN-Roadmap-Live.md** when planning changes
 5. **Keep this section as quick reference only** - detail goes in the dedicated docs
 
 ## Common Development Workflows


### PR DESCRIPTION
## What

CLAUDE.md's "Roadmap & Phase Tracking" section still pointed at `docs/dev-journal/ROADMAP.md` as the source of truth for current & planned phases (twice), and "Rules for Agents" item 4 told agents to update a `ROADMAP.md` that no longer exists anywhere. `docs/dev-journal/` was removed in the docs reorganization.

Same class of dead link as InterCooperative-Network/.github#1 (org profile, fixed 2026-06-09 by pointing at https://intercooperative.network/roadmap).

## Fix

Repoint at the actual source-of-truth hierarchy the repo already declares:

- **`docs/STATE.md`** (frontmatter `Canonical: yes`) + **`docs/PHASE_PROGRESS.md`** — truth-synced, re-bumped with every state-changing PR
- **`docs/strategy/ICN-Roadmap-Live.md`** — long-arc planning companion; its own header defers to the two docs above as canonical

Three lines changed in CLAUDE.md. No roadmap doc content is touched.

## Not changed (deliberately)

- `AGENTS.md:298` — already a correct *warning* against inventing `docs/dev-journal/` (handoff context); left as-is
- `CHANGELOG.md:2259` — historical entry
- The stale "Current Status" block in the same CLAUDE.md section (Phase 18 / phases 19–35, pre-renumbering) — content update, out of scope for a pointer fix
- `.github/copilot-instructions.md`, `.github/instructions/documentation.md`, `.github/agents/icn-docs-spec.md` — stale directory trees listing `dev-journal/`; same class of rot but not root docs, flagged for follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)