### PR TITLE
docs(github): retarget agent-instruction docs trees off dead docs/dev-journal/

### DIFF
--- a/.github/agents/icn-docs-spec.md
+++ b/.github/agents/icn-docs-spec.md
@@ -93,6 +93,6 @@ docs/
 |------|----------|----------------|
 | Architecture | `docs/ARCHITECTURE.md` | System design changes |
 | API Reference | `docs/api/` | Endpoint changes |
-| Deployment | `docs/HOMELAB_DEPLOYMENT.md` | Ops changes |
+| Deployment | `docs/operations/deployment/HOMELAB_DEPLOYMENT.md` | Ops changes |
 | Glossary | `docs/glossary.md` | New terms introduced |
 | Changelog | `CHANGELOG.md` | Every release |

--- a/.github/agents/icn-docs-spec.md
+++ b/.github/agents/icn-docs-spec.md
@@ -24,13 +24,16 @@ You have expertise in:
 ```
 docs/
 ├── ARCHITECTURE.md           # System design
-├── PHASE_HISTORY.md         # Development phases
-├── HOMELAB_DEPLOYMENT.md    # K3s deployment
+├── STATE.md                 # Current project state (canonical)
+├── PHASE_PROGRESS.md        # Phase tracking (canonical)
+├── PHASE_HISTORY.md         # Completed development phases
 ├── glossary.md              # ICN terminology
-├── production-hardening.md  # Security hardening
-├── dev-journal/             # Session notes
+├── development/sessions/    # Session notes (by month)
+├── dev/                     # Developer handoffs
+├── strategy/                # Roadmaps (ICN-Roadmap-Live.md)
+├── security/                # Security docs (production-hardening.md)
+├── operations/deployment/   # Deployment guides (HOMELAB_DEPLOYMENT.md)
 ├── demo/                    # Demo guides
-├── security/                # Security docs
 ├── api/                     # API specs
 │   └── openapi.generated.yaml
 └── ...

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -465,4 +465,4 @@ All core infrastructure is complete (Phases 1-20, 1134+ tests passing). The syst
 - Distributed compute layer with intelligent scheduling
 - Comprehensive Prometheus metrics
 
-See `ROADMAP.md` for upcoming features and `CHANGELOG.md` for recent changes.
+See `docs/STATE.md` and `docs/PHASE_PROGRESS.md` for current state, `docs/strategy/ICN-Roadmap-Live.md` for upcoming direction, and `CHANGELOG.md` for recent changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -379,10 +379,13 @@ Comprehensive documentation is available in the `docs/` directory:
 
 - **ARCHITECTURE.md**: System architecture and design decisions
 - **GETTING_STARTED.md**: Quick start guide for new contributors
-- **production-hardening.md**: Security hardening measures
-- **governance-primitives.md**: Governance system design
-- **scheduler-evolution-plan.md**: Distributed compute scheduler design
-- **dev-journal/**: Detailed development session notes
+- **STATE.md** / **PHASE_PROGRESS.md**: Current project state and phase tracking (canonical)
+- **strategy/ICN-Roadmap-Live.md**: Long-arc roadmap
+- **security/production-hardening.md**: Security hardening measures
+- **design/governance/governance-primitives.md**: Governance system design
+- **design/scheduler-evolution-plan.md**: Distributed compute scheduler design
+- **development/sessions/**: Development session notes (organized by month)
+- **dev/**: Developer handoffs and working notes
 
 ## Design Principles
 

--- a/.github/instructions/documentation.md
+++ b/.github/instructions/documentation.md
@@ -19,9 +19,13 @@ These instructions apply to documentation files in the `docs/` directory.
 docs/
 ├── ARCHITECTURE.md       # System design and component interactions
 ├── GETTING_STARTED.md    # New developer onboarding
-├── FAQ.md               # Common questions
+├── STATE.md             # Current project state (canonical)
+├── PHASE_PROGRESS.md    # Phase tracking (canonical)
 ├── PHASE_HISTORY.md     # Completed development phases
-├── dev-journal/         # Development session notes
+├── development/         # Development resources (sessions/ = session notes by month)
+├── dev/                 # Developer handoffs and working notes
+├── strategy/            # Roadmaps and strategy (ICN-Roadmap-Live.md)
+├── guides/              # User and developer guides (FAQ.md)
 ├── demo/                # Demo and testing documentation
 ├── security/            # Security audits and threat models
 └── [domain]/            # Domain-specific documentation


### PR DESCRIPTION
## What

Updates the three GitHub agent-instruction files that still described the removed `docs/dev-journal/` directory, and fixes the other moved entries in the same directory-tree blocks so they match the actual `docs/` layout:

- `.github/copilot-instructions.md` — Documentation section bullet list
- `.github/instructions/documentation.md` — Documentation Structure tree
- `.github/agents/icn-docs-spec.md` — Documentation Structure tree

## Why

`docs/dev-journal/` was removed in the 2026 docs reorganization (`docs/REORGANIZATION_2026.md`, line 198). Agent-instruction files pointing at dead paths send Copilot/agents looking for session notes in a directory that no longer exists. Companion to #2004, which fixed the same dead links in root `CLAUDE.md`.

## How

Retargeted to the current layout (verified against the real tree):

- Session notes → `docs/development/sessions/` (organized by month)
- Handoffs → `docs/dev/`
- State/phase truth → `docs/STATE.md` + `docs/PHASE_PROGRESS.md` (canonical)
- Long-arc roadmap → `docs/strategy/ICN-Roadmap-Live.md`
- `production-hardening.md` → `docs/security/`
- `governance-primitives.md` → `docs/design/governance/`
- `scheduler-evolution-plan.md` → `docs/design/`
- `HOMELAB_DEPLOYMENT.md` → `docs/operations/deployment/`
- root `FAQ.md` → `docs/guides/FAQ.md`

## Risk

Docs-only change to instruction files; no code paths affected.

## Test plan

- `grep -rn "dev-journal" .github/` → no matches
- Every path referenced in the updated trees verified to exist on disk (`test -e` over all 18 cited paths — all OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)