### PR TITLE
docs(claude): sync phase-tracking quick reference to Phase 0/1/2 model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,7 @@ CCL (`icn-ccl`) is a domain-specific language for expressing agreements:
 
 ## Roadmap & Phase Tracking
 
-**Standard**: All development is tracked as sequential phases. No parallel tracks, no letter suffixes.
+**Standard**: All development is tracked as sequential phases. No parallel tracks, no letter suffixes. The active sequence is the Phase 0/1/2 model (begun 2026-03-18); the earlier Phase 1–18 numbering (and its planned 19–35 continuation) is retired — history in [docs/PHASE_HISTORY.md](docs/PHASE_HISTORY.md).
 
 ### Phase Format
 
@@ -286,24 +286,17 @@ Each phase in documentation must follow this format:
 
 ### Source of Truth
 
-- **Completed phases**: [docs/PHASE_HISTORY.md](docs/PHASE_HISTORY.md)
+- **Completed phases**: current model (Phases 0–1) in [docs/PHASE_PROGRESS.md](docs/PHASE_PROGRESS.md); pre-reset history (old numbering) in [docs/PHASE_HISTORY.md](docs/PHASE_HISTORY.md)
 - **Current & planned phases**: [docs/STATE.md](docs/STATE.md) and [docs/PHASE_PROGRESS.md](docs/PHASE_PROGRESS.md) (truth-synced, canonical); long-arc planning: [docs/strategy/ICN-Roadmap-Live.md](docs/strategy/ICN-Roadmap-Live.md)
 - **This file**: Quick reference only, not authoritative
 
 ### Current Status
 
-**Last Completed**: Phase 18 (Pre-Pilot Hardening) - 2025-11-27
-**Implementation**: ~75% complete (272K LOC, 2,287 tests)
-**Deployed**: K3s cluster since 2025-12-03
+Quick reference as of 2026-05-22 — [docs/PHASE_PROGRESS.md](docs/PHASE_PROGRESS.md) is the live, canonical version.
 
-**Remaining phases (19-35)**:
-- 19-20: Release Infrastructure + Testing Foundation
-- 21-22: Network Connectivity + Security Hardening
-- 23-26: Identity, SDK, Observability, Documentation
-- 27-29: Ledger/Economics, CCL/Governance, Code Quality
-- 30-33: Mobile, Infrastructure, Federation, CLI/UX
-- 34: Release Candidate
-- 35: Pilot Deployment
+**Current Phase**: Phase 2 — Pilot Launch (in progress, partner-bound). NYCN is the intended first cooperative partner — an active partnership track, not yet a formally committed pilot. Next gate: organizer presentation -> pilot formalization -> first operator rehearsal (per the NYCN rehearsal gate in the partner repo).
+
+**Completed**: Phase 0 — Close the Demo (2026-03-18); Phase 1 — The Charter Engine (2026-03-18).
 
 See [docs/PHASE_PROGRESS.md](docs/PHASE_PROGRESS.md) and [docs/STATE.md](docs/STATE.md) for current state and issue mapping, and [docs/strategy/ICN-Roadmap-Live.md](docs/strategy/ICN-Roadmap-Live.md) for the long-arc roadmap.
 
@@ -311,7 +304,7 @@ See [docs/PHASE_PROGRESS.md](docs/PHASE_PROGRESS.md) and [docs/STATE.md](docs/ST
 
 1. **Never invent new tracking systems** - use phases with sequential numbers
 2. **Never use "Track A/B/C"** - everything is sequential
-3. **Update PHASE_HISTORY.md** when completing a phase
+3. **Record phase completion in docs/PHASE_PROGRESS.md and docs/STATE.md** (status flip + truth-sync edit) — docs/PHASE_HISTORY.md is pre-reset history only; do not add current-model phases to it
 4. **Update docs/STATE.md and docs/PHASE_PROGRESS.md** when phase state changes (they are canonical); update docs/strategy/ICN-Roadmap-Live.md when long-arc planning changes — never the strategy doc alone while canonical phase tracking goes stale
 5. **Keep this section as quick reference only** - detail goes in the dedicated docs
 


### PR DESCRIPTION
## What

The `Roadmap & Phase Tracking > Current Status` quick-reference block in `CLAUDE.md` still described the retired sequential numbering: "Last Completed: Phase 18 (Pre-Pilot Hardening) - 2025-11-27" plus the planned 19–35 phase list. The repo moved to the Phase 0/1/2 model on 2026-03-18; per the canonical, truth-synced docs (`docs/PHASE_PROGRESS.md`, `docs/STATE.md`, last updated 2026-05-22) the current phase is **Phase 2 — Pilot Launch** (in progress, partner-bound).

## Changes (single file, `CLAUDE.md`, within the Roadmap & Phase Tracking section)

- **Current Status block**: rewritten from the canonical docs — Phase 2 in progress (NYCN intended first cooperative partner, active partnership track, not yet a formally committed pilot; next gate organizer presentation -> pilot formalization -> first operator rehearsal); Phases 0–1 completed 2026-03-18. Dropped the volatile LOC/test metrics — the section says "Quick reference only, not authoritative," so kept it brief and pointer-heavy.
- **Standard line**: reconciled — names the active Phase 0/1/2 sequence; old 1–35 numbering marked as retired history.
- **Rules for Agents #3**: "Update PHASE_HISTORY.md when completing a phase" no longer describes practice — new-model completions (Phases 0–1) are recorded in `PHASE_PROGRESS.md`/`STATE.md` via truth-sync edits, and `PHASE_HISTORY.md` contains only pre-reset history (verified: its Phase 0/1 entries are the Jan-2026 kernel/app-separation phases, not the current model).
- **Source of Truth "Completed phases" bullet**: pointed at `PHASE_PROGRESS.md` for current-model completions, `PHASE_HISTORY.md` for pre-reset history. Adjacent to the named scope but required so the section doesn't contradict the fixed Rule 3 — flag if you'd rather drop it.

## Not changed

- No roadmap docs edited (`PHASE_PROGRESS.md`, `STATE.md`, `PHASE_HISTORY.md`, strategy roadmap untouched).
- Dead dev-journal links in this section were already fixed in #2004; the surviving "See …" pointer line is kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)