### PR TITLE
docs(github): fix stale HOMELAB_DEPLOYMENT.md paths in homelab agent doc

### DIFF
--- a/.github/agents/icn-homelab-infra.md
+++ b/.github/agents/icn-homelab-infra.md
@@ -22,11 +22,11 @@ You have deep expertise in:
 
 ## Lab Environment
 
-> **Note**: Lab details below are documented in `docs/HOMELAB_DEPLOYMENT.md`. Always verify current values using the discovery commands listed.
+> **Note**: Lab details below are documented in `docs/operations/deployment/HOMELAB_DEPLOYMENT.md`. Always verify current values using the discovery commands listed.
 
 ### K3s Cluster
 
-Cluster details are in `docs/HOMELAB_DEPLOYMENT.md`. Discover current state:
+Cluster details are in `docs/operations/deployment/HOMELAB_DEPLOYMENT.md`. Discover current state:
 
 ```bash
 # Get cluster nodes
@@ -67,7 +67,7 @@ ssh ubuntu@<CONTROL_NODE> "cd ~/actions-runner && sudo ./svc.sh status"
 
 ## Common Commands
 
-Reference: `docs/HOMELAB_DEPLOYMENT.md` and `deploy/k8s/README.md`
+Reference: `docs/operations/deployment/HOMELAB_DEPLOYMENT.md` and `deploy/k8s/README.md`
 
 ```bash
 # Deployment
@@ -80,7 +80,7 @@ make status
 make logs
 
 # Identity (discover current DID)
-# Replace <CONTROL_NODE> with your control plane IP from docs/HOMELAB_DEPLOYMENT.md
+# Replace <CONTROL_NODE> with your control plane IP from docs/operations/deployment/HOMELAB_DEPLOYMENT.md
 ssh ubuntu@<CONTROL_NODE> "sudo kubectl -n icn exec deploy/icn-daemon -- /usr/local/bin/icnctl id show"
 
 # Runner status


### PR DESCRIPTION
## Summary

Retargets the four `docs/HOMELAB_DEPLOYMENT.md` references in `.github/agents/icn-homelab-infra.md` to the file's current location, `docs/operations/deployment/HOMELAB_DEPLOYMENT.md` (verified present on main).

## Why

Same failure class as #2005 (dead doc paths in `.github` agent-instruction files), flagged during that PR's review but outside its declared scope. This closes the last known dead doc path in the `.github` agent files.

## Validation

- `git diff --check` → clean
- `python3 docs/scripts/doc_control_check.py --strict` → OK (863 docs, 63 warnings — unchanged main baseline)
- `grep -c docs/operations/deployment/HOMELAB_DEPLOYMENT.md` → 4 (all four refs retargeted); zero stale refs remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)