### PR TITLE
docs(claude): fix two dead doc links in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ ICN implements a **constraint enforcement architecture** where Policy Oracles (a
 
 ## Live Deployment
 
-ICN daemon running on K3s cluster (deployed 2025-12-03). See **[docs/HOMELAB_DEPLOYMENT.md](docs/HOMELAB_DEPLOYMENT.md)** for:
+ICN daemon running on K3s cluster (deployed 2025-12-03). See **[docs/operations/deployment/HOMELAB_DEPLOYMENT.md](docs/operations/deployment/HOMELAB_DEPLOYMENT.md)** for:
 - Cluster details and node identity
 - Quick access commands
 - CI/CD pipeline and monitoring
@@ -499,7 +499,7 @@ See **[.github/ISSUE_POLICY.md](.github/ISSUE_POLICY.md)** for the complete issu
 - Partner (0.4-0.7): 100 msg/sec
 - Federated (0.7+): 200 msg/sec
 
-See [docs/production-hardening.md](docs/production-hardening.md) for complete details.
+See [docs/security/production-hardening.md](docs/security/production-hardening.md) for complete details.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Retargets the two remaining dead `docs/` links in `CLAUDE.md`: the Live Deployment section's `docs/HOMELAB_DEPLOYMENT.md` → `docs/operations/deployment/HOMELAB_DEPLOYMENT.md`, and the Security section's `docs/production-hardening.md` → `docs/security/production-hardening.md`. Both targets verified present on main.

## Why

Found in the final stale-reference sweep after #2005/#2009/#2010: a scripted existence check of every `docs/` path referenced in `CLAUDE.md` showed exactly these two dead links — the last dead doc paths in active agent guidance (`CLAUDE.md`, `AGENTS.md`, `.github/`). Deliberately narrow: the stale `/push` command reference in CLAUDE.md is *not* touched, since fixing it requires a workflow-policy decision rather than a mechanical path retarget.

## Validation

- `git diff --check` → clean
- `python3 docs/scripts/doc_control_check.py --strict` → OK (863 docs, 63 warnings — unchanged main baseline)
- Scripted link check: every `docs/*.{md,toml,yaml}` path referenced in CLAUDE.md now exists on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)