### PR TITLE
deps(security): bump shell-quote 1.8.3 -> 1.8.4 in examples/mobile-app

### DIFF
--- a/examples/mobile-app/package-lock.json
+++ b/examples/mobile-app/package-lock.json
@@ -9526,9 +9526,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
## Summary

Remediates the new critical Dependabot alert #262 — **GHSA-w7jw-789q-3m8p / CVE-2026-9277** (shell-quote `quote()` does not escape newlines in object `.op` values; vulnerable `>= 1.1.0, <= 1.8.3`, fixed in **1.8.4**).

- Lockfile-only change: `examples/mobile-app/package-lock.json`, shell-quote `1.8.3 -> 1.8.4` (version/resolved/integrity, 3 lines).
- shell-quote is transitive via `react-devtools-core` (range `^1.6.1` — 1.8.4 is in-range, no manifest change needed).

## Deliberately out of scope

The same advisory also fires on `sdk/react-native/examples/CoopWallet/package-lock.json` (alert #263). That lockfile is **out of sync with its package.json on main** — `npm ci` fails with `Missing: expo-localization@17.0.9 from lock file` — so any npm operation there reconciles ~160 lines of unrelated drift. It needs its own lockfile-reconciliation pass first.

## Validation

- `npm ci --ignore-scripts` in `examples/mobile-app` → clean install, 809 packages, shell-quote resolves 1.8.4
- `git diff --check` → clean
- Diff verified confined to the single shell-quote lockfile entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)