### PR TITLE
ci: guard rehearsal fixtures against drift

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -215,8 +215,10 @@ jobs:
             echo "::error::Documentation lint failed"
             exit 1
           fi
-          if [ "${{ needs.fixture_bundle.result }}" = "failure" ]; then
-            echo "::error::Rehearsal-shell fixture bundle validation failed (fixture drift)"
+          # Fail closed: a cancelled or skipped fixture job must not pass the
+          # drift guard — anything but explicit success fails the summary.
+          if [ "${{ needs.fixture_bundle.result }}" != "success" ]; then
+            echo "::error::Rehearsal-shell fixture bundle validation did not succeed (result: ${{ needs.fixture_bundle.result }})"
             exit 1
           fi
           if [ "${{ needs.freshness.result }}" = "failure" ]; then

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -11,6 +11,9 @@ on:
       - 'docs/scripts/doc_control_check.py'
       # gateway route source is code-truth for the API-doc canonical guard
       - 'icn/crates/icn-gateway/src/api/ledger.rs'
+      # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
+      # under docs/scripts + docs/contracts are already covered by docs/**
+      - 'web/pilot-ui/fixtures/**'
   pull_request:
     paths:
       - 'docs/**'
@@ -20,6 +23,9 @@ on:
       - 'docs/scripts/doc_control_check.py'
       # gateway route source is code-truth for the API-doc canonical guard
       - 'icn/crates/icn-gateway/src/api/ledger.rs'
+      # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
+      # under docs/scripts + docs/contracts are already covered by docs/**
+      - 'web/pilot-ui/fixtures/**'
   schedule:
     # Sunday at midnight UTC
     - cron: '0 0 * * 0'
@@ -167,9 +173,35 @@ jobs:
           echo "::warning::docs/INDEX.generated.md is out of date. Run: just index"
         continue-on-error: true
 
+  fixture_bundle:
+    name: Rehearsal Fixture Bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install jsonschema
+
+      # Guards the Phase 2 rehearsal path: the committed fixture bundle for the
+      # fixture-backed rehearsal shell (#1726/#1727) must stay demo-only,
+      # network-disabled, schema-valid, and free of forbidden live/private
+      # references. The check is deterministic and offline (<1s); it validates
+      # the bundle, it does NOT implement icnd --demo-mode (#1727 stays open).
+      # Manual equivalent: python3 docs/scripts/validate-rehearsal-shell-fixtures.py
+      - name: Validate rehearsal-shell fixture bundle (offline, deterministic)
+        run: |
+          python3 docs/scripts/validate-rehearsal-shell-fixtures.py
+        continue-on-error: false
+
   summary:
     name: Documentation CI Summary
-    needs: [doc_control, lint, freshness, index]
+    needs: [doc_control, lint, freshness, index, fixture_bundle]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -181,6 +213,10 @@ jobs:
           fi
           if [ "${{ needs.lint.result }}" = "failure" ]; then
             echo "::error::Documentation lint failed"
+            exit 1
+          fi
+          if [ "${{ needs.fixture_bundle.result }}" = "failure" ]; then
+            echo "::error::Rehearsal-shell fixture bundle validation failed (fixture drift)"
             exit 1
           fi
           if [ "${{ needs.freshness.result }}" = "failure" ]; then

--- a/web/pilot-ui/fixtures/icn-organizer-demo/README.md
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/README.md
@@ -77,6 +77,11 @@ repo root:
 python3 docs/scripts/validate-rehearsal-shell-fixtures.py
 ```
 
+CI runs the same harness on every push/PR that touches this directory or
+`docs/**` (job "Rehearsal Fixture Bundle" in the Documentation Maintenance
+workflow, plus its weekly scheduled run), so the committed bundle cannot
+silently drift from the contracts.
+
 That harness asserts demo-mode / network-disabled, runs each packet
 through the existing `docs/scripts/validate-*.py` contract validators,
 checks the manifest's `non_claims`, and runs a deterministic forbidden


### PR DESCRIPTION
## What

Adds a `fixture_bundle` job to the **Documentation Maintenance** workflow (`.github/workflows/docs-freshness.yml`) that runs `docs/scripts/validate-rehearsal-shell-fixtures.py` on every push/PR touching `docs/**` or `web/pilot-ui/fixtures/**`, and on the existing weekly schedule. The summary job now fails if the bundle is invalid. The fixtures README notes the CI enforcement next to the existing manual command.

## Why (Phase 2 / pilot rehearsal)

The committed rehearsal-shell fixture bundle is the load-bearing artifact for the fixture-backed demo mode (#1727) feeding the no-CLI organizer rehearsal shell (#1726) — the path the NYCN pilot gate rehearses on. The validation harness existed but was **manual-only**, so fixture drift (schema breaks, network references, money framing, missing non_claims) could land silently. This closes test-gap item 4 from the Jun 10 review: fixture validation is now CI-enforced.

## How

- New job mirrors the workflow's existing conventions (`actions/checkout@v6`, `actions/setup-python@v6` @ 3.11, `python3 -m pip install`), installs `jsonschema` (required by the delegated contract validators), runs the harness with `continue-on-error: false`.
- `web/pilot-ui/fixtures/**` added to push + PR path filters; validators/schemas/contract packets under `docs/**` were already covered.
- `summary.needs` extended; fixture failure surfaces as `::error::… (fixture drift)` and fails the summary.

## Local commands run (all on this branch @ 2384bc16)

```
python3 docs/scripts/validate-rehearsal-shell-fixtures.py
# -> PASS: 5 read models, exit 0, ~0.6s

# negative test: mutated manifest copy (network="enabled") in /tmp
python3 docs/scripts/validate-rehearsal-shell-fixtures.py /tmp/drifted-manifest.json
# -> FAIL: "manifest.network is 'enabled', expected 'disabled'", exit 1

python3 -c "yaml.safe_load(...)"  # workflow parses; fixture_bundle in jobs + summary.needs
```

## Determinism / network

The check is deterministic and offline by design — validating no-network-ness is literally one of its assertions. The only network use is `pip install jsonschema` at job setup, matching the workflow's existing `pip install tomli` pattern. Delegated validators are subprocess-bounded (60s timeout) so the job cannot hang.

## Limitations / risk

- `actionlint` is not installed on the dev VM — workflow verified by YAML parse + convention review; the first CI run on this PR is the real syntax check.
- This validates the **committed bundle**; it does not implement `icnd --demo-mode` (#1727 remains open) and does not test pilot-ui rendering (that's the a11y/e2e suites).
- Fixture-only changes now also trigger the other Documentation Maintenance jobs (~1–2 min overhead) — accepted to keep workflow count flat.
- **No production code touched** — workflow + README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
