### PR TITLE
docs(state): fix rehearsal script path

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -79,7 +79,7 @@ Last Reviewed: 2026-06-10
 
      (5) Demo / rehearsal layer — **real code, dev-gated**:
        - #1980 local member-standing bootstrap; #1981 dev-gated standing bridge for live gateway demos.
-       - #1997 one-command local 13/13 receipt-chain rehearsal (`demo/scripts/local_receipt_chain_13of13_rehearsal.sh`).
+       - #1997 one-command local 13/13 receipt-chain rehearsal (`scripts/local_receipt_chain_13of13_rehearsal.sh`).
        - #1999 fixture-backed rehearsal shell demo mode (relates to open #1727).
        - #1953 / #1954 nycn-dogfood keystone demo kit (work → obligation → receipt loop; receipts persisted, card asserted, receipt binding verified).
        All demo-layer standing/trust shortcuts are explicitly dev-gated; none weakens audit, auth, trust, or ledger gates in production configuration, and none constitutes live federation.


### PR DESCRIPTION
## What
One-line fix: STATE.md's #1997 entry pointed the one-command 13/13 rehearsal at `demo/scripts/local_receipt_chain_13of13_rehearsal.sh`; the script lives at `scripts/local_receipt_chain_13of13_rehearsal.sh`.

## Why
STATE.md is the canonical truth doc and the reproduce-it-yourself path for the strongest proof. Anyone following it hits "No such file" — caught live during Jun 11 meeting prep. The same wrong path appears in `docs/dev/handoff-2026-06-10-truth-sync.md`, left untouched as a historical session record.

## Test plan
`test -f scripts/local_receipt_chain_13of13_rehearsal.sh` → exists on main. Docs-only change; no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)