### PR TITLE
fix(demo): bootstrap dev-gated member standing in multi-node governance demo

### DIFF
--- a/demo/scripts/demo-governance.py
+++ b/demo/scripts/demo-governance.py
@@ -221,8 +221,9 @@ def bootstrap_standing(identity: Identity):
     }, identity.token)
     if status != 200:
         fail(f"bootstrap-standing failed for {identity.name} — the node must "
-             f"run with ICN_ENABLE_ADMIN_ENDPOINTS=true and "
-             f"ICN_GOVERNANCE_BUILD_MODE=test (see deploy/devnet)", status, resp)
+             f"run with ICN_ENABLE_ADMIN_ENDPOINTS=true and a non-production "
+             f"governance posture (e.g. ICN_GOVERNANCE_BUILD_MODE=test; set by "
+             f"deploy/devnet and the demo launcher scripts)", status, resp)
     narrator(f"  {identity.name} now holds active Member standing in {DOMAIN_ID} (dev bootstrap).")
 
 

--- a/demo/scripts/demo-governance.py
+++ b/demo/scripts/demo-governance.py
@@ -206,6 +206,26 @@ def authenticate(identity: Identity, scopes: list):
     ok(f"Authenticated {identity.name}  {C.DIM}({identity.did[:32]}...){C.RESET}")
 
 
+def bootstrap_standing(identity: Identity):
+    """DEV-ONLY: establish active Member standing in the demo jurisdiction.
+
+    The gateway enforces Commons standing on proposal submission and voting.
+    Real deployments confer standing through governed membership flows; this
+    local demo uses the dev-gated bootstrap bridge, which only exists when the
+    node runs with ICN_ENABLE_ADMIN_ENDPOINTS=true and a non-production
+    governance posture (the devnet compose sets both). Never available in
+    production configuration.
+    """
+    status, resp = api("POST", "/commons/dev/bootstrap-standing", {
+        "jurisdiction_id": DOMAIN_ID,
+    }, identity.token)
+    if status != 200:
+        fail(f"bootstrap-standing failed for {identity.name} — the node must "
+             f"run with ICN_ENABLE_ADMIN_ENDPOINTS=true and "
+             f"ICN_GOVERNANCE_BUILD_MODE=test (see deploy/devnet)", status, resp)
+    narrator(f"  {identity.name} now holds active Member standing in {DOMAIN_ID} (dev bootstrap).")
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def main():
@@ -279,6 +299,15 @@ def main():
         ok(f"Governance domain created: {DOMAIN_ID}")
     else:
         fail("Failed to create governance domain", status, resp)
+    bootstrap_standing(alice)
+
+    # Bob and Carol authenticate and establish standing BEFORE being added as
+    # members: the member-add path creates a holder record without a personhood
+    # anchor, and the dev bootstrap rejects holders that are missing anchors.
+    authenticate(bob, ["governance:read", "governance:write"])
+    bootstrap_standing(bob)
+    authenticate(carol, ["governance:read", "governance:write"])
+    bootstrap_standing(carol)
 
     step(5, "Add Bob to cooperative and governance domain")
     status, resp = api("POST", f"/coops/{COOP_ID}/members", {

--- a/demo/scripts/present-governance.sh
+++ b/demo/scripts/present-governance.sh
@@ -64,6 +64,11 @@ if ss -tlnp 2>/dev/null | grep -q ":${PORT} " || \
   exit 1
 fi
 
+# Dev-gated demo endpoints (POST /v1/commons/dev/bootstrap-standing) used by
+# demo-governance.py. Local demo node only — never set these in production.
+export ICN_ENABLE_ADMIN_ENDPOINTS=true
+export ICN_GOVERNANCE_BUILD_MODE=test
+
 # 1. Build (skip if binary is fresh)
 ICND="$ICN_ROOT/target/debug/icnd"
 if [ -f "$ICND" ] && [ "$ICND" -nt "$ICN_ROOT/Cargo.lock" ]; then

--- a/demo/scripts/start-demo.sh
+++ b/demo/scripts/start-demo.sh
@@ -18,6 +18,11 @@ echo "  Workspace: $ICN_ROOT"
 echo "  Data dir:  $DATA_DIR"
 echo ""
 
+# Dev-gated demo endpoints (POST /v1/commons/dev/bootstrap-standing) used by
+# demo-governance.py. Local demo node only — never set these in production.
+export ICN_ENABLE_ADMIN_ENDPOINTS=true
+export ICN_GOVERNANCE_BUILD_MODE=test
+
 # 1. Build
 echo "[1/4] Building icnd..."
 cd "$ICN_ROOT"

--- a/deploy/devnet/docker-compose.yml
+++ b/deploy/devnet/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       - ICN_METRICS_PORT=9100
       - ICN_BOOTSTRAP_PEERS=
       - ICN_KEYSTORE_PASSPHRASE=devnet-insecure
+      # Dev-gated demo endpoints (POST /v1/commons/dev/bootstrap-standing).
+      # Local devnet only — these gates must never be set in production.
+      - ICN_ENABLE_ADMIN_ENDPOINTS=true
+      - ICN_GOVERNANCE_BUILD_MODE=test
       - ICN_GENESIS_FILE=/devnet/genesis.json
       - RUST_LOG=info,icn_core=debug,icn_gossip=debug,icn_net=debug
     ports:
@@ -51,6 +55,10 @@ services:
       - ICN_METRICS_PORT=9100
       - ICN_BOOTSTRAP_PEERS=icn://node-a:9000
       - ICN_KEYSTORE_PASSPHRASE=devnet-insecure
+      # Dev-gated demo endpoints (POST /v1/commons/dev/bootstrap-standing).
+      # Local devnet only — these gates must never be set in production.
+      - ICN_ENABLE_ADMIN_ENDPOINTS=true
+      - ICN_GOVERNANCE_BUILD_MODE=test
       - ICN_GENESIS_FILE=/devnet/genesis.json
       - RUST_LOG=info,icn_core=debug,icn_gossip=debug,icn_net=debug
     ports:
@@ -89,6 +97,10 @@ services:
       - ICN_METRICS_PORT=9100
       - ICN_BOOTSTRAP_PEERS=icn://node-a:9000,icn://node-b:9000
       - ICN_KEYSTORE_PASSPHRASE=devnet-insecure
+      # Dev-gated demo endpoints (POST /v1/commons/dev/bootstrap-standing).
+      # Local devnet only — these gates must never be set in production.
+      - ICN_ENABLE_ADMIN_ENDPOINTS=true
+      - ICN_GOVERNANCE_BUILD_MODE=test
       - ICN_GENESIS_FILE=/devnet/genesis.json
       - RUST_LOG=info,icn_core=debug,icn_gossip=debug,icn_net=debug
     ports:


### PR DESCRIPTION
## What
Restores the multi-node demo path (`demo/run-all.sh` + `demo/scripts/demo-governance.py`), which failed 0/2 on a fresh devnet built from main @ e056fae6.

## Why
The Commons standing gates (proposal submission, handlers.rs ~:855; voting ~:1841) enforce active Member standing. The March-era demo script predates that enforcement and never establishes standing, failing with `does not have active Member standing in domain coop:finger-lakes-food`. The 13/13 rehearsal and nycn-dogfood paths already use the dev-gated standing bridge (#1980/#1981); this brings the multi-node demo in line.

## How
- `demo-governance.py`: new `bootstrap_standing()` helper calling the dev-gated `POST /v1/commons/dev/bootstrap-standing` for Alice, Bob, and Carol. **Ordering is load-bearing:** standing is bootstrapped before member-add, because the member-add path creates a holder record without a personhood anchor and the bootstrap rejects anchor-less holders (HTTP 500 `backing personhood anchor missing for holder`).
- `deploy/devnet/docker-compose.yml`: enable the dev gate (`ICN_ENABLE_ADMIN_ENDPOINTS=true`, `ICN_GOVERNANCE_BUILD_MODE=test`) on all three nodes, with a comment stating these must never be set in production. The devnet is explicitly a local dev rig (its keystore passphrase is already `devnet-insecure` in-file).

## Risk
Demo/devnet layer only — no Rust changes, no production manifests touched. The dev gate env vars widen the devnet nodes' surface (admin endpoints), acceptable for a local rig and consistent with the local 13/13 rehearsal posture.

## Test plan
- Fresh devnet (`docker compose down -v && up -d`): patched script passes end-to-end against node-a (19 steps, charter ratified, allocation proposal 3-for ACCEPTED with decision receipt).
- `bash demo/run-all.sh` from clean state: **All demos passed (2/2)** (was 0/2). Operator-run evidence logs retained at `~/artifacts/icn/demo-truth-pass-20260611/` on icn-dev.

## Follow-up candidate (not in this PR)
The bootstrap handler 500s on holders missing personhood anchors instead of healing or returning a typed 4xx — worth a small upstream issue if maintainers agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)