### PR TITLE
feat(web): member-shell v0 reference client (fixture + live-local modes)

### DIFF
--- a/docs/dev/openapi-member-surface-gaps.md
+++ b/docs/dev/openapi-member-surface-gaps.md
@@ -1,0 +1,130 @@
+---
+Status: descriptive
+Authority: dev checklist
+Canonical: no
+Last verified: 2026-06-12
+---
+
+# OpenAPI member-surface gaps — annotation checklist
+
+**What this is:** a checklist comparing the utoipa `paths(...)` list in
+`icn/crates/icn-gateway/src/openapi.rs` against the member-facing routes
+actually registered by the governance app
+(`icn/apps/governance/src/http/configure.rs`, handlers in
+`icn/apps/governance/src/http/handlers.rs`, mounted by the gateway under
+`/v1/gov`). **Checklist only — no annotations are added here.**
+
+**Why it matters:** the gateway serves Swagger UI at `/swagger-ui/` backed
+by `/api-docs/openapi.json` (`icn/crates/icn-gateway/src/server.rs`,
+`SwaggerUi::new(...).url("/api-docs/openapi.json", ...)`). Once a handler
+carries a `#[utoipa::path(...)]` annotation and is listed in
+`openapi.rs` `paths(...)`, it lands in that served document automatically.
+The static `web/api-docs/openapi.yaml` is stale (last touched 2026-03-03;
+zero member endpoints) — handler source is truth.
+
+**Current `paths(...)` contents (verified 2026-06-12):** exactly one entry,
+`crate::api::federation::propose_clearing_adoption`. Every member-facing
+route below is therefore missing from the served OpenAPI document.
+
+**Mechanism note:** these handlers live in the `icn-governance-actor` app
+crate, not in `icn-gateway`. Annotating them means adding
+`#[utoipa::path]` to the app-crate handlers (the response models in
+`icn/apps/governance/src/http/models.rs` already derive `ToSchema`) and
+referencing them from the gateway's `paths(...)` / `components(schemas(...))`
+lists, or merging a second `OpenApi` doc from the app crate. Generic
+handlers (`<E: GovernanceEventEmitter>`) may need concrete-fn shims for
+utoipa registration — that design choice belongs to the implementation PR,
+not this checklist.
+
+## Missing member-facing endpoints (12)
+
+### Standing and caller-scoped views
+
+- [ ] `GET /v1/gov/me/standing` — handler `get_my_standing` — scope
+      `governance:read` — response `StandingResponse`
+      (`models.rs`). Annotation needed: document the `?domain_id` filter and
+      the empty-standing-is-200 contract.
+- [ ] `GET /v1/gov/me/action-cards` — handler `get_my_action_cards` — scope
+      `governance:read` — response `ActionCardsResponse` **wrapper**
+      `{did, cards, generated_at}`, not a bare array. Annotation needed:
+      schema for `ActionCard` + the four closed enums.
+- [ ] `GET /v1/gov/me/scopes` — handler `get_my_scopes` — scope
+      `governance:read` — response `Vec<RoleAssignmentResponse>`.
+      Annotation needed: flat-list shape across all structures.
+- [ ] `GET /v1/gov/me/work` — handler `get_my_work` — scope
+      `governance:read` — response `Vec<ActionItemResponse>`. Annotation
+      needed: document the filter query params (`build_my_work_filter`).
+
+### Action items + completion receipts
+
+- [ ] `GET /v1/gov/domains/{domain_id}/action-items` — handler
+      `list_action_items` — scope `governance:read` — response
+      `Vec<ActionItemResponse>`. Annotation needed: filter params.
+- [ ] `GET /v1/gov/domains/{domain_id}/action-items/{item_id}` — handler
+      `get_action_item` — scope `governance:read` — response
+      `ActionItemResponse`. Annotation needed: 404 contract.
+- [ ] `PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status` —
+      handler `update_action_item_status` — scopes
+      `governance:meeting:write` | `governance:write` (narrowest-first via
+      `require_any_scope_matched`; creator/assignee + domain membership also
+      enforced) — request `StatusUpdateRequest` (`{"status": "pending" |
+      "in_progress" | "completed" | "deferred" | "cancelled"}`) — response
+      `ActionItemResponse`. Annotation needed: note that first transition to
+      `completed` emits an `ActionItemCompletionReceipt`.
+- [ ] `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt`
+      — handler `get_action_item_completion_receipt` — scope
+      `governance:read` — response `icn_governance::ActionItemCompletionReceipt`
+      (`icn/crates/icn-governance/src/proof.rs`; would need a `ToSchema`
+      derive or a gateway-side mirror type). Annotation needed: 404-when-
+      absent/cross-domain contract.
+
+### Meetings / attendance receipts
+
+- [ ] `PUT /v1/gov/meetings/{meeting_id}/attendance` — handler
+      `mark_attendance` — scopes `governance:meeting:write` |
+      `governance:write` (+ domain membership) — response `MeetingResponse`.
+      Annotation needed: note that a transition into `Present`/`Remote`
+      emits a `MeetingAttendanceReceipt` (ADR-0026 Layer 2).
+      **Adjacent observation (not an annotation gap):** there is no GET
+      retrieval endpoint for attendance receipts today — the receipt is
+      emitted and stored (`receipt_backend.rs`) but a member shell has no
+      route to fetch it. That is an endpoint gap, tracked by the
+      `meeting`/`attend` follow-up noted in ADR-0020 §7.
+
+### Proposals / votes / decision receipts
+
+- [ ] `POST /v1/gov/proposals/{proposal_id}/vote` — handler `cast_vote` —
+      scopes `governance:proposal:write` | `governance:write` — request
+      `CastVoteRequest` — response: the updated proposal object (re-fetched
+      after the vote). Annotation needed: choice strings
+      `for`/`against`/`abstain`.
+- [ ] `GET /v1/gov/proposals/{proposal_id}/tally` — handler
+      `get_vote_tally` — scope `governance:read` — response: handler-local
+      `VoteTallyResponse` struct (`for_votes`, `against_votes`,
+      `abstain_votes`, `total_votes`). Annotation needed: the struct is
+      private to the handler body and would need promotion to `models.rs`
+      for `ToSchema`.
+- [ ] `GET /v1/gov/proposals/{proposal_id}/proof` — handler `get_proof` —
+      scope `governance:read` — response: `GovernanceProof` (decision
+      receipt + attestations; served only after signature/hash
+      verification). Annotation needed: schema exposure for the proof
+      envelope.
+- [ ] `GET /v1/gov/proposals/{proposal_id}/chain` — handler `get_chain` —
+      scope `governance:read` — response: `ProvenanceChain`
+      (`apps/governance/src/manager.rs::get_chain`; governance decision
+      receipt + linked allocation receipts + effect records). Annotation
+      needed: schema exposure for the chain object.
+
+## Count
+
+12 member-facing endpoints missing from `paths(...)`, plus 1 adjacent
+observation (no attendance-receipt retrieval endpoint exists to annotate).
+
+## Out of scope for this checklist
+
+- Adding the annotations themselves.
+- Non-member-facing governance routes (domain admin, charters, programs,
+  delegations, discussion, federation/SDIS proposals) — also unannotated,
+  but not part of the member-shell surface this checklist tracks.
+- Regenerating `web/api-docs/openapi.yaml` or the TypeScript SDK types
+  (that follows the annotation PR per the drift chain in `CLAUDE.md`).

--- a/web/member-shell/README.md
+++ b/web/member-shell/README.md
@@ -1,0 +1,168 @@
+# ICN Member Shell — v0 reference client
+
+A thin, dependency-free reference client that proves the
+[member-shell-v0 rendering contract](../../docs/spec/member-shell-v0.md)
+is implementable against the real endpoint shapes. Static HTML + CSS +
+vanilla JS. **No framework, no build step, no npm, no service worker.**
+
+This is **not** a revival of `web/pilot-ui` and not the production member
+shell. It exists so a member-facing surface — standing, action cards,
+receipts — can be demonstrated honestly, with the maturity tier named on
+screen at all times.
+
+## What it renders
+
+Per `docs/spec/member-shell-v0.md`, ADR-0020 (`/me/standing`), ADR-0027
+(ActionCard), and the structs in `icn/apps/governance/src/http/models.rs`:
+
+- **Who am I** — display label first; DID under a "Show technical
+  identifier" disclosure.
+- **My standing** — memberships per domain and roles with plain-language
+  authority descriptions; raw scope strings and ids under "Show technical
+  detail".
+- **Action cards** — title, plain summary, mapped (never raw) action/source
+  kinds, scope (`entity` / `structure` / `individual`) in plain words,
+  authority basis, an authorization check against the member's own
+  `authority_scopes` ("You are authorized for this." / "This requires
+  authority you do not currently hold: …"), deadline as relative time with
+  the absolute timestamp under a disclosure ("No time pressure." when
+  absent), risk level as glyph + label (never color alone),
+  `accessibility_hint` as a preamble before any controls, and a
+  what-happens-if-I-act line driven by `receipt_expected`.
+- **Receipts** — plain summary first (who acted, what obligation it
+  satisfied, when), with the record class, ids, actor DID, and the raw
+  `record_hash` (hex) behind a "Show evidence detail" disclosure.
+- **Records status** — only the closed plain-language vocabulary from the
+  spec (`Synced`, `Sync delayed`, `Some records are being verified`,
+  `Action paused until records sync`, `Receipt available`,
+  `Review required`, `Sync delayed / degraded`). No invented strings.
+
+The shell-vs-cockpit boundary is observed: no divergence detail, no peer
+DIDs, no digest forms ever reach this surface.
+
+## Modes and maturity tiers
+
+A banner naming the active tier is permanently visible.
+
+| Mode | URL | Banner | Maturity |
+|---|---|---|---|
+| **Demo** | `?mode=demo` | "Fixture-backed demo — no live node, nothing signed." | Fixture rendering rehearsal only. Consumes the committed pilot-ui fixture pack (`web/pilot-ui/fixtures/icn-organizer-demo/standing.json` + `action-cards.json`) by relative fetch — those files are CI-drift-guarded and are **not** duplicated here. Deadlines are read relative to the fixture's own `generated_at` snapshot (and the UI says so), because frozen data must not pretend to be current. |
+| **Live** | default (or `?mode=live`) | "Live-local node — dev rehearsal, not production." | Talks to a locally running gateway (default `http://localhost:8080`). Dev rehearsal against real endpoint shapes; no production, pilot, or live-federation claim. |
+
+### Demo-mode receipt fixture
+
+The pilot-ui fixture pack carries no receipt packet, so this directory adds
+one member-shell-local file, `fixtures/demo-completion-receipt.json`, shaped
+verbatim like the wire form of `ActionItemCompletionReceipt`
+(`icn/crates/icn-governance/src/proof.rs`: `item_id`, `domain_id`,
+`actor_did`, `transition`, `completed_at`, `record_hash` as a 32-byte
+array). It is fictional (`did:icn:example-*-not-live` convention) and its
+`record_hash` is **illustrative bytes, not a real blake3 binding** — the
+demo banner and the receipt's own caption both say nothing was signed.
+
+## Live mode: endpoints used
+
+Treat `icn/apps/governance/src/http/handlers.rs` +
+`configure.rs` as truth (the static `web/api-docs/openapi.yaml` is stale —
+see `docs/dev/openapi-member-surface-gaps.md`):
+
+| Call | Endpoint | Required scope |
+|---|---|---|
+| Standing | `GET /v1/gov/me/standing` | `governance:read` |
+| Action cards | `GET /v1/gov/me/action-cards` | `governance:read` |
+| Mark task complete | `PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status` body `{"status":"completed"}` | `governance:meeting:write` or `governance:write` (plus: caller must be the item's creator or assignee, and a member of the domain — enforced server-side) |
+| Completion receipt | `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `governance:read` |
+
+**The one mutation shipped (dogfood loop):** marking an `action_item` /
+`complete` card as completed, behind a pre-confirm summary (what changes,
+authority basis, scope, receipt expected, permanence warning, distinct
+Confirm/Cancel), then fetching and rendering the completion receipt. The
+card moves through the closed lifecycle strings: `Open` →
+`Sent — waiting for receipt` → `Confirmed` (+ `Receipt available`).
+Rejections render the gateway's reason; nothing fails silently. All other
+surfaces are read-only.
+
+**Credential handling:** the paste-credential field is `type="password"`,
+held in a closure variable for the life of the page only — never written to
+localStorage/sessionStorage/cookies/URL, never hardcoded, sent only as an
+`Authorization: Bearer` header to the gateway address you typed.
+
+## How to run
+
+Serve the **`web/` directory** as the root (the demo fixture fetch crosses
+into `web/pilot-ui/`, so serving `web/member-shell/` alone breaks demo
+mode):
+
+```bash
+cd web
+python3 -m http.server 8000
+```
+
+Then open:
+
+- Demo: <http://localhost:8000/member-shell/?mode=demo>
+- Live: <http://localhost:8000/member-shell/> (gateway at
+  `http://localhost:8080`)
+
+Live-mode note: the browser enforces CORS. The gateway must be started with
+a CORS mode that allows the shell's origin (see `configure_cors` in
+`icn/crates/icn-gateway/src/security.rs`), or the shell must be served from
+the same origin as the gateway. Otherwise the shell reports the failure in
+plain language ("Your standing is currently unavailable…") with the
+technical detail beneath.
+
+## ADR-0028 accessibility checklist (honest)
+
+Implemented in this v0 client:
+
+- [x] Semantic HTML (header/nav/main/sections/headings/lists/dl); ARIA used
+      only to extend (`role="status"`, `aria-live`, `aria-current`,
+      `aria-describedby`)
+- [x] WCAG 2.2 AA contrast — palette chosen against AA and documented in
+      `shell.css` (computed ratios noted per color; not yet verified by an
+      external audit tool)
+- [x] `:focus-visible` ring on every interactive element (links, buttons,
+      inputs, disclosure summaries)
+- [x] `prefers-reduced-motion` respected (no motion used; guard rule kills
+      any future animation/transition)
+- [x] No information by color alone — every status carries glyph + text
+      label; grayscale-safe
+- [x] Scalable type — rem units throughout, `html { font-size: 100% }`
+      respects the user's setting
+- [x] Plain language first, jargon explained inline (DID defined where
+      shown; raw enums/ids/hashes only under "details" disclosures)
+- [x] Stable layout — single column, fixed section order, no layout shift
+      on status change
+- [x] Visible what's-next affordances (mode links, connect button, per-card
+      action or explanation of why none, "Check again", help section)
+- [x] ≥ 44px (2.75rem) hit targets on buttons and inputs
+- [x] Consequences explained pre-action; permanence stated; distinct
+      Confirm/Cancel (cognitive-load floor)
+
+NOT yet implemented (declared gaps, per ADR-0028's "partial floor
+compliance with the gap declared"):
+
+- [ ] Glossary endpoint integration (icn#1610 — endpoint does not exist yet)
+- [ ] Multi-language / translation tagging (icn#1740; all strings are
+      English; no "translation pending" path)
+- [ ] Offline tolerance — no caching, no draft-intent queue, no service
+      worker; this client requires the network it names
+- [ ] Screen-reader and switch-control testing — not performed; semantics
+      are in place but untested with real AT
+- [ ] 200% zoom and low-end-device verification — not performed by a human
+- [ ] Privacy-preserving accommodation path (no accommodation profile
+      exists in this client)
+- [ ] Deadline-justice metadata rendering (cards do not carry it yet)
+- [ ] Captions/transcripts — no media in this client (floor not exercised)
+
+## What this does NOT claim
+
+- Not the production member shell; no platform decision (iOS/Android/PWA/
+  native) is made or implied.
+- Not the full member-shell-v0 information architecture — the spec's ten
+  surfaces include Decisions/Governance, Records/Artifacts, Privacy/Access,
+  and a scope switcher that this client does not implement.
+- No offline support, no local cache, no draft-intent queue.
+- No private-record (ScopedVault) surface.
+- Demo mode signs nothing and proves no runtime behavior; live mode is a
+  local dev rehearsal, not a pilot, not production, not a live federation.

--- a/web/member-shell/README.md
+++ b/web/member-shell/README.md
@@ -104,12 +104,21 @@ Then open:
 - Live: <http://localhost:8000/member-shell/> (gateway at
   `http://localhost:8080`)
 
-Live-mode note: the browser enforces CORS. The gateway must be started with
-a CORS mode that allows the shell's origin (see `configure_cors` in
-`icn/crates/icn-gateway/src/security.rs`), or the shell must be served from
-the same origin as the gateway. Otherwise the shell reports the failure in
-plain language ("Your standing is currently unavailable…") with the
-technical detail beneath.
+Live-mode note: the browser enforces CORS, and the shell's requests carry
+an `Authorization` header, which forces a CORS preflight. Start the node
+with the shell's page origin allowed:
+
+```bash
+ICN_CORS_ORIGINS="http://localhost:8000" icnd --config ... --gateway-enable ...
+```
+
+(`ICN_DEV_MODE` also switches to the dev CORS config; see `configure_cors`
+in `icn/crates/icn-gateway/src/security.rs`.) Without it the preflight is
+rejected and the shell reports "Technical detail: Failed to fetch" — that
+symptom means CORS, not a broken node. With the origin allowed, real
+gateway answers come through and render in plain language (verified
+end-to-end 2026-06-12: a rejected credential renders "The node answered
+401: Authentication failed…" with the degraded-sync chip).
 
 ## ADR-0028 accessibility checklist (honest)
 

--- a/web/member-shell/fixtures/demo-completion-receipt.json
+++ b/web/member-shell/fixtures/demo-completion-receipt.json
@@ -1,0 +1,13 @@
+{
+  "item_id": "demo-action-item-000",
+  "domain_id": "demo.coop.organizing",
+  "actor_did": "did:icn:example-organizer-demo-not-live",
+  "transition": "completed",
+  "completed_at": 1729900000,
+  "record_hash": [
+    17, 42, 8, 213, 96, 7, 154, 33,
+    201, 5, 88, 119, 64, 240, 11, 73,
+    156, 29, 222, 47, 101, 134, 90, 3,
+    68, 175, 52, 199, 26, 145, 83, 60
+  ]
+}

--- a/web/member-shell/index.html
+++ b/web/member-shell/index.html
@@ -59,6 +59,9 @@
           Needs the <code>governance:read</code> scope to read your standing
           and action cards. Marking a task complete additionally needs
           <code>governance:meeting:write</code> or <code>governance:write</code>.
+          If connecting fails immediately with "Failed to fetch", the node
+          was not started with this page's address in
+          <code>ICN_CORS_ORIGINS</code> — see this directory's README.
         </p>
       </div>
       <button type="submit" id="connect-button">Connect and load my standing</button>

--- a/web/member-shell/index.html
+++ b/web/member-shell/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ICN Member Shell — v0 reference client</title>
+<link rel="stylesheet" href="shell.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to main content</a>
+
+<header>
+  <!-- Honesty banner: permanently visible, names the active maturity tier.
+       Text is set by shell.js from the active mode. Never hidden. -->
+  <div id="honesty-banner" class="banner" role="status" aria-live="polite">
+    Loading&hellip;
+  </div>
+
+  <h1>ICN Member Shell <span class="subtitle">v0 reference client</span></h1>
+  <p class="lede">
+    Your view of your own participation: who you are here, what you are
+    authorized to do, what needs your attention, and the receipts that prove
+    what happened.
+  </p>
+
+  <nav aria-label="Mode">
+    <ul class="mode-nav">
+      <li><a id="nav-demo" href="?mode=demo">Demo mode (fixture data)</a></li>
+      <li><a id="nav-live" href="?mode=live">Live mode (local node)</a></li>
+    </ul>
+  </nav>
+</header>
+
+<main id="main">
+
+  <!-- Live-mode connect panel. Hidden in demo mode. -->
+  <section id="connect-section" hidden aria-labelledby="connect-h">
+    <h2 id="connect-h">Connect to a local node</h2>
+    <p>
+      Enter the address of a locally running ICN gateway and paste an access
+      credential (the signed authorization string issued by the gateway's
+      sign-in flow). Your credential is kept only on this page while it is
+      open. It is never saved, never written to storage, and never sent
+      anywhere except the gateway address you enter.
+    </p>
+    <form id="connect-form">
+      <div class="field">
+        <label for="gateway-url">Gateway address</label>
+        <input type="url" id="gateway-url" name="gateway-url"
+               value="http://localhost:8080" required
+               spellcheck="false" autocomplete="off">
+      </div>
+      <div class="field">
+        <label for="credential">Access credential</label>
+        <input type="password" id="credential" name="credential" required
+               autocomplete="off" placeholder="Paste credential"
+               aria-describedby="credential-help">
+        <p id="credential-help" class="help">
+          Needs the <code>governance:read</code> scope to read your standing
+          and action cards. Marking a task complete additionally needs
+          <code>governance:meeting:write</code> or <code>governance:write</code>.
+        </p>
+      </div>
+      <button type="submit" id="connect-button">Connect and load my standing</button>
+    </form>
+    <p id="connect-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- Sync / records status. Uses ONLY the closed member-facing vocabulary
+       from docs/spec/member-shell-v0.md ("Member-facing status vocabulary"). -->
+  <section id="sync-section" aria-labelledby="sync-h">
+    <h2 id="sync-h">Records status</h2>
+    <p>
+      <span id="sync-chip" class="chip" role="status" aria-live="polite"></span>
+    </p>
+    <p id="sync-detail" class="muted"></p>
+  </section>
+
+  <!-- Who am I -->
+  <section id="identity-section" hidden aria-labelledby="identity-h">
+    <h2 id="identity-h">Who am I here</h2>
+    <p id="identity-label" class="identity-label"></p>
+    <details>
+      <summary>Show technical identifier</summary>
+      <p>
+        Your network identity (a <dfn>DID</dfn> &mdash; decentralized
+        identifier, the address your participation records are tied to):
+      </p>
+      <p><code id="identity-did"></code></p>
+    </details>
+  </section>
+
+  <!-- Standing -->
+  <section id="standing-section" hidden aria-labelledby="standing-h">
+    <h2 id="standing-h">My standing</h2>
+    <p class="explain">
+      Standing is what this institution currently recognizes about you:
+      where you are a member, which roles you hold, and what those roles
+      authorize you to do.
+    </p>
+    <h3>Memberships</h3>
+    <ul id="domains-list" class="card-list"></ul>
+    <h3>Roles and authority</h3>
+    <ul id="roles-list" class="card-list"></ul>
+  </section>
+
+  <!-- Action cards -->
+  <section id="cards-section" hidden aria-labelledby="cards-h">
+    <h2 id="cards-h">Things you can act on</h2>
+    <p class="explain">
+      Each card below is something open to you right now, with what it is,
+      why you are allowed to act, and what will happen if you do.
+    </p>
+    <ul id="cards-list" class="card-list"></ul>
+  </section>
+
+  <!-- Receipts -->
+  <section id="receipts-section" hidden aria-labelledby="receipts-h">
+    <h2 id="receipts-h">Receipts</h2>
+    <p class="explain">
+      A receipt is the record that proves something happened: who acted,
+      what obligation it satisfied, and when. The plain-language summary
+      comes first; the formal evidence is available under
+      &ldquo;Show evidence detail.&rdquo;
+    </p>
+    <ul id="receipts-list" class="card-list"></ul>
+  </section>
+
+  <!-- Help path: the spec requires a visible way to ask for help. -->
+  <section id="help-section" aria-labelledby="help-h">
+    <h2 id="help-h">Need help?</h2>
+    <p>
+      If something here looks wrong &mdash; a missing membership, a card you
+      cannot act on, a record you want reviewed &mdash; contact your steward.
+      In this reference client the steward contact path is not wired; a real
+      deployment fills this in from its institution package.
+    </p>
+  </section>
+
+</main>
+
+<footer>
+  <p>
+    This is a <strong>reference client</strong> proving the
+    <a href="https://github.com/InterCooperative-Network/icn/blob/main/docs/spec/member-shell-v0.md">member-shell-v0
+    rendering contract</a> is implementable. It is not the production member
+    shell, makes no platform decision, has no offline support, and claims no
+    live-federation or production posture. See the README in this directory
+    for the honest maturity and accessibility checklist.
+  </p>
+</footer>
+
+<script src="shell.js"></script>
+</body>
+</html>

--- a/web/member-shell/shell.css
+++ b/web/member-shell/shell.css
@@ -1,0 +1,222 @@
+/* ICN Member Shell — v0 reference client styles.
+ *
+ * ADR-0028 sensory-layer floor:
+ *  - WCAG 2.2 AA contrast on all text (palette documented per rule below)
+ *  - rem units throughout; respects the user's base font size
+ *  - :focus-visible ring on every interactive element
+ *  - prefers-reduced-motion respected (no motion is used; transition reset
+ *    kept as a guard)
+ *  - no information carried by color alone (every status has glyph + text)
+ *  - >= 44px (2.75rem) hit targets on buttons and summaries
+ */
+
+:root {
+  --ink: #1c1c21;        /* on white: ~16.1:1 */
+  --ink-muted: #4d4d57;  /* on white: ~7.9:1  */
+  --accent: #0f4f4a;     /* on white: ~8.7:1; white on it: ~8.7:1 */
+  --line: #c5c5cd;
+  --bg: #ffffff;
+  --panel: #f5f5f2;
+  --banner-demo-bg: #fff3cd;
+  --banner-demo-ink: #594400;   /* on #fff3cd: ~7.3:1 */
+  --banner-live-bg: #dceefb;
+  --banner-live-ink: #07395c;   /* on #dceefb: ~9.4:1 */
+  --ok-bg: #e6f4ea;
+  --ok-ink: #1d5c33;            /* on #e6f4ea: ~6.9:1 */
+  --warn-bg: #fdeceb;
+  --warn-ink: #79302a;          /* on #fdeceb: ~7.2:1 */
+}
+
+* { box-sizing: border-box; }
+
+html { font-size: 100%; } /* never override user preference */
+
+body {
+  margin: 0 auto;
+  padding: 0 1rem 3rem;
+  max-width: 46rem;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+/* Skip link: hidden until focused, then clearly visible. */
+.skip-link {
+  position: absolute;
+  left: -999rem;
+  background: var(--ink);
+  color: var(--bg);
+  padding: 0.75rem 1rem;
+}
+.skip-link:focus-visible {
+  left: 1rem;
+  top: 1rem;
+  z-index: 10;
+}
+
+/* Honesty banner: permanently visible, never collapsed. */
+.banner {
+  margin: 0.75rem 0;
+  padding: 0.75rem 1rem;
+  border: 2px solid currentColor;
+  border-radius: 0.375rem;
+  font-weight: 600;
+}
+.banner.demo { background: var(--banner-demo-bg); color: var(--banner-demo-ink); }
+.banner.live { background: var(--banner-live-bg); color: var(--banner-live-ink); }
+
+h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+h2 { font-size: 1.25rem; margin-top: 2rem; border-bottom: 1px solid var(--line); padding-bottom: 0.25rem; }
+h3 { font-size: 1.05rem; }
+.subtitle { font-weight: 400; font-size: 1rem; color: var(--ink-muted); }
+.lede { color: var(--ink-muted); }
+.muted { color: var(--ink-muted); }
+.explain { color: var(--ink-muted); }
+
+.mode-nav {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+}
+.mode-nav a {
+  display: inline-block;
+  padding: 0.5rem 0.25rem; /* enlarge hit area */
+  color: var(--accent);
+}
+.mode-nav a[aria-current="true"] {
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom: 3px solid var(--accent);
+}
+
+a { color: var(--accent); }
+
+/* Forms */
+.field { margin: 1rem 0; }
+label { display: block; font-weight: 600; margin-bottom: 0.25rem; }
+input {
+  width: 100%;
+  font-size: 1rem;
+  padding: 0.6rem;
+  min-height: 2.75rem;
+  border: 1px solid var(--ink-muted);
+  border-radius: 0.25rem;
+  color: var(--ink);
+  background: var(--bg);
+}
+.help { font-size: 0.9rem; color: var(--ink-muted); margin-top: 0.25rem; }
+
+button {
+  font-size: 1rem;
+  font-weight: 600;
+  min-height: 2.75rem;
+  min-width: 2.75rem;
+  padding: 0.6rem 1.1rem;
+  border: 2px solid var(--accent);
+  border-radius: 0.375rem;
+  background: var(--accent);
+  color: #ffffff;
+  cursor: pointer;
+}
+button.secondary {
+  background: var(--bg);
+  color: var(--accent);
+}
+button:disabled {
+  background: var(--panel);
+  color: var(--ink-muted);
+  border-color: var(--ink-muted);
+  cursor: not-allowed;
+}
+
+/* Focus visibility — every interactive element. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+summary:focus-visible {
+  outline: 3px solid var(--ink);
+  outline-offset: 2px;
+}
+
+/* Lists of cards */
+.card-list { list-style: none; padding: 0; }
+.card-list > li {
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin: 0.75rem 0;
+  background: var(--bg);
+}
+
+.card-list h3 { margin-top: 0; }
+
+dl.kv { margin: 0.75rem 0; }
+dl.kv dt { font-weight: 600; margin-top: 0.5rem; }
+dl.kv dd { margin: 0 0 0 0; color: var(--ink-muted); }
+
+/* Status chips: glyph + text, color reinforces only. */
+.chip {
+  display: inline-block;
+  padding: 0.3rem 0.7rem;
+  border: 1.5px solid currentColor;
+  border-radius: 1rem;
+  font-weight: 600;
+}
+.chip.ok { background: var(--ok-bg); color: var(--ok-ink); }
+.chip.warn { background: var(--warn-bg); color: var(--warn-ink); }
+.chip.neutral { background: var(--panel); color: var(--ink); }
+
+.identity-label { font-size: 1.15rem; font-weight: 600; }
+
+details {
+  margin: 0.75rem 0;
+  border-left: 3px solid var(--line);
+  padding-left: 0.75rem;
+}
+summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--accent);
+  padding: 0.5rem 0; /* enlarge hit area toward 44px */
+  min-height: 1.75rem;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.95em;
+  background: var(--panel);
+  padding: 0.1rem 0.3rem;
+  border-radius: 0.2rem;
+  overflow-wrap: anywhere;
+}
+
+/* Pre-confirm panel for the one mutating action. */
+.confirm-panel {
+  border: 2px solid var(--accent);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-top: 0.75rem;
+  background: var(--panel);
+}
+.confirm-panel .actions { display: flex; gap: 1rem; flex-wrap: wrap; margin-top: 0.75rem; }
+
+footer {
+  margin-top: 3rem;
+  border-top: 1px solid var(--line);
+  padding-top: 1rem;
+  font-size: 0.9rem;
+  color: var(--ink-muted);
+}
+
+/* No motion is used by this client; this guard ensures any future
+   transition also respects the user's preference. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/web/member-shell/shell.css
+++ b/web/member-shell/shell.css
@@ -78,6 +78,7 @@ h3 { font-size: 1.05rem; }
 .mode-nav {
   list-style: none;
   display: flex;
+  flex-wrap: wrap; /* mode links wrap on narrow viewports instead of overflowing */
   gap: 1rem;
   padding: 0;
 }

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -118,6 +118,7 @@
   }
   function byId(id) { return document.getElementById(id); }
   function show(id) { byId(id).hidden = false; }
+  function hide(id) { byId(id).hidden = true; }
   function clear(node) { while (node.firstChild) { node.removeChild(node.firstChild); } }
 
   function kvRow(dl, term, value) {
@@ -669,12 +670,27 @@
     setSyncChip(SYNC.VERIFYING, "neutral", "Asking the node for your standing…");
     byId("connect-status").textContent = "";
 
+    // A new connect attempt invalidates whatever member view is on screen.
+    // The previous member's identity, standing, cards, and receipts must not
+    // remain visible during the load or after a FAILED load — on a shared
+    // browser that would expose their records under someone else's attempt.
+    // Same-member receipts are restored once the new standing confirms the
+    // DID matches.
+    var prior = {
+      did: state.standing && state.standing.did,
+      receipts: state.receipts
+    };
+    state.standing = null;
+    state.cards = null;
+    state.receipts = [];
+    hide("identity-section");
+    clear(byId("domains-list"));
+    clear(byId("cards-list"));
+    renderReceipts();
+
     liveFetch("/v1/gov/me/standing").then(function (standing) {
-      // Reconnecting as a different member must not carry the previous
-      // member's receipts into the new view (action history is theirs,
-      // not the shared browser's).
-      if (state.standing && state.standing.did !== standing.did) {
-        state.receipts = [];
+      if (prior.did && prior.did === standing.did) {
+        state.receipts = prior.receipts;
       }
       state.standing = standing;
       renderIdentity(standing);

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -305,6 +305,12 @@
     var auth = authorityCheck(card, standing);
     var reserved = card.source_kind === "signal_rule" ||
       card.source_kind === "obligation_lifecycle";
+    // Assigned-task completion is authorized by the gateway at request time
+    // (token scope + creator/assignee + domain membership), not by the
+    // role-derived scopes flattened into /me/standing. Do not gate it on
+    // the client; the node's accept/reject answer is rendered honestly.
+    var assignedCompletion = card.source_kind === "action_item" &&
+      card.action_kind === "complete";
 
     li.appendChild(el("h3", { text: card.title || "(untitled card)" }));
 
@@ -320,11 +326,12 @@
     // states it can honestly know: reserved → inert; missing authority →
     // Closed — insufficient authority; otherwise Open. Mutation flow moves
     // a card to Sent/Confirmed below.
+    var actionable = auth.authorized || assignedCompletion;
     var status = reserved ? SOURCE_KIND_LABEL[card.source_kind]
-      : auth.authorized ? LIFECYCLE.OPEN
+      : actionable ? LIFECYCLE.OPEN
       : LIFECYCLE.CLOSED_AUTHORITY;
-    var chipTone = reserved ? "neutral" : auth.authorized ? "ok" : "warn";
-    var chipGlyph = reserved ? "● " : auth.authorized ? "✓ " : "⚠ ";
+    var chipTone = reserved ? "neutral" : actionable ? "ok" : "warn";
+    var chipGlyph = reserved ? "● " : actionable ? "✓ " : "⚠ ";
     var statusChip = el("span", { class: "chip " + chipTone, role: "status", text: chipGlyph + status });
     li.appendChild(el("p", {}, [statusChip]));
 
@@ -338,6 +345,11 @@
 
     if (auth.authorized) {
       kvRow(dl, "Authorization", "You are authorized for this.");
+    } else if (assignedCompletion) {
+      kvRow(dl, "Authorization",
+        "The node checks your authorization when you confirm. Assigned " +
+        "tasks are authorized by your assignment, which this view cannot " +
+        "evaluate from your standing alone.");
     } else {
       kvRow(dl, "Authorization",
         "This requires authority you do not currently hold: " +
@@ -383,9 +395,8 @@
     // The one mutating action this v0 client implements (live mode only):
     // mark an assigned task complete, then fetch and render its completion
     // receipt. Everything else is read-only.
-    if (MODE === "live" && !reserved &&
-        card.source_kind === "action_item" && card.action_kind === "complete") {
-      li.appendChild(buildCompleteFlow(card, auth, statusChip));
+    if (MODE === "live" && !reserved && assignedCompletion) {
+      li.appendChild(buildCompleteFlow(card, statusChip));
     }
     return li;
   }
@@ -399,7 +410,13 @@
   //   member — the gateway enforces this; we render its answer honestly.)
   // Then GET .../completion-receipt (scope governance:read).
   // ---------------------------------------------------------------------
-  function buildCompleteFlow(card, auth, statusChip) {
+  // Note: completion is never scope-gated client-side. /me/standing only
+  // flattens role-assignment scopes, so an ordinary assignee may not show
+  // the card's required_authority_scope even though the gateway will accept
+  // the request (token scope + creator/assignee + domain membership). The
+  // gateway authorizes the actual PUT; a refusal is rendered with its
+  // reason by the rejection path below.
+  function buildCompleteFlow(card, statusChip) {
     var holder = el("div");
 
     if (!card.domain_id) {
@@ -486,17 +503,6 @@
       });
     });
 
-    if (!auth.authorized) {
-      openBtn.disabled = true;
-      holder.appendChild(el("p", {
-        class: "muted",
-        text: "Action unavailable here: your standing does not list the " +
-          "required authority (" + auth.missing.map(scopePlain).join("; ") +
-          "). The node makes the final decision; this client will not send " +
-          "an action it can already see is not authorized."
-      }));
-    }
-
     holder.appendChild(openBtn);
     holder.appendChild(panel);
     return holder;
@@ -556,7 +562,12 @@
     kvRow(dl, "Actor", el("code", { text: String(receipt.actor_did || "") }));
     kvRow(dl, "Transition", String(receipt.transition || ""));
     kvRow(dl, "Completed at (unix seconds)", String(receipt.completed_at || ""));
-    kvRow(dl, "Record hash (blake3, canonical binding of the fields above)",
+    // Maturity-tier honesty: the demo fixture's hash is illustrative only —
+    // it is not a real blake3 binding and nothing is signed. Only live mode
+    // may claim the canonical binding.
+    kvRow(dl, MODE === "demo"
+        ? "Record hash (illustrative fixture value — not a real blake3 binding)"
+        : "Record hash (blake3, canonical binding of the fields above)",
       el("code", { text: hashToHex(receipt.record_hash) }));
     details.appendChild(dl);
     li.appendChild(details);
@@ -667,11 +678,19 @@
         return;
       }
       state.gateway = url.origin;
-      state.credential = byId("credential").value.trim();
-      if (!state.credential) {
+      var credentialInput = byId("credential");
+      var credential = credentialInput.value.trim();
+      // Accept a pasted full header value ("Bearer <value>") and normalize
+      // it to the bare credential.
+      credential = credential.replace(/^Bearer\s+/i, "").trim();
+      if (!credential) {
         byId("connect-status").textContent = "Paste an access credential first.";
         return;
       }
+      state.credential = credential;
+      // The credential now lives only in page memory; clear the DOM input
+      // so it is not left readable in the field.
+      credentialInput.value = "";
       loadLive();
     });
   }

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -479,21 +479,37 @@
         body: JSON.stringify({ status: "completed" })
       }).then(function () {
         statusLine.textContent = LIFECYCLE.SENT + " — completion accepted, fetching the receipt.";
+        // Past this point the completion is COMMITTED on the node. A failure
+        // to read the receipt back must never be reported as "nothing was
+        // recorded" — that would be the shell lying about a recorded action.
         return liveFetch("/v1/gov/domains/" + encodeURIComponent(card.domain_id) +
                          "/action-items/" + encodeURIComponent(card.source_id) +
-                         "/completion-receipt", { method: "GET" });
-      }).then(function (receipt) {
-        statusChip.textContent = "✓ " + LIFECYCLE.CONFIRMED;
-        statusChip.className = "chip ok";
-        statusLine.textContent = LIFECYCLE.CONFIRMED + ". " + SYNC.RECEIPT +
-          " — see your Receipts below.";
-        addReceipt(receipt, "You marked a task complete.");
-        setSyncChip(SYNC.RECEIPT, "ok",
-          "Your latest action produced a receipt. Records were last refreshed at " +
-          new Date().toLocaleString() + ".");
+                         "/completion-receipt", { method: "GET" })
+          .then(function (receipt) {
+            statusChip.textContent = "✓ " + LIFECYCLE.CONFIRMED;
+            statusChip.className = "chip ok";
+            statusLine.textContent = LIFECYCLE.CONFIRMED + ". " + SYNC.RECEIPT +
+              " — see your Receipts below.";
+            addReceipt(receipt, "You marked a task complete.");
+            setSyncChip(SYNC.RECEIPT, "ok",
+              "Your latest action produced a receipt. Records were last refreshed at " +
+              new Date().toLocaleString() + ".");
+          })
+          .catch(function (err) {
+            // Receipt read failed AFTER the completion was accepted: keep the
+            // committed state, do not re-enable Confirm, say exactly what is
+            // and is not known.
+            statusChip.textContent = "● " + LIFECYCLE.SENT;
+            statusChip.className = "chip neutral";
+            statusLine.textContent = "Your completion was accepted and recorded. " +
+              "The receipt could not be retrieved right now (" + err.message + "). " +
+              "Do not redo the task — refresh your Receipts later or ask your steward.";
+            cancelBtn.textContent = "Close";
+            cancelBtn.disabled = false;
+          });
       }).catch(function (err) {
-        // "rejected with reason" — the gateway's answer, rendered plainly,
-        // never a silent failure.
+        // The completion itself was refused — the gateway's answer, rendered
+        // plainly, never a silent failure. Nothing was recorded.
         statusLine.textContent = "Rejected with reason: " + err.message +
           " Nothing was recorded. You can try again or contact your steward.";
         statusChip.textContent = "⚠ " + LIFECYCLE.OPEN;

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -326,8 +326,12 @@
     // states it can honestly know: reserved → inert; missing authority →
     // Closed — insufficient authority; otherwise Open. Mutation flow moves
     // a card to Sent/Confirmed below.
-    var actionable = auth.authorized || assignedCompletion;
+    // A card whose deadline is already behind the anchor is closed no matter
+    // what authority says (spec: "Closed — deadline passed").
+    var expired = typeof card.deadline === "number" && card.deadline < anchorSec;
+    var actionable = !expired && (auth.authorized || assignedCompletion);
     var status = reserved ? SOURCE_KIND_LABEL[card.source_kind]
+      : expired ? LIFECYCLE.CLOSED_DEADLINE
       : actionable ? LIFECYCLE.OPEN
       : LIFECYCLE.CLOSED_AUTHORITY;
     var chipTone = reserved ? "neutral" : actionable ? "ok" : "warn";
@@ -395,7 +399,7 @@
     // The one mutating action this v0 client implements (live mode only):
     // mark an assigned task complete, then fetch and render its completion
     // receipt. Everything else is read-only.
-    if (MODE === "live" && !reserved && assignedCompletion) {
+    if (MODE === "live" && !reserved && assignedCompletion && !expired) {
       li.appendChild(buildCompleteFlow(card, statusChip));
     }
     return li;
@@ -654,6 +658,12 @@
     byId("connect-status").textContent = "";
 
     liveFetch("/v1/gov/me/standing").then(function (standing) {
+      // Reconnecting as a different member must not carry the previous
+      // member's receipts into the new view (action history is theirs,
+      // not the shared browser's).
+      if (state.standing && state.standing.did !== standing.did) {
+        state.receipts = [];
+      }
       state.standing = standing;
       renderIdentity(standing);
       renderStanding(standing);

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -344,6 +344,18 @@
       ACTION_KIND_LABEL[card.action_kind] || ("Act (" + String(card.action_kind) + ")"));
     kvRow(dl, "Where this comes from",
       SOURCE_KIND_LABEL[card.source_kind] || String(card.source_kind));
+    // The member must see WHICH domain this card acts in before confirming,
+    // not just the constitutional axis (spec: "What scope am I acting in?").
+    // standing.domains carries the human-readable name for the card's domain.
+    var domainName = String(card.domain_id);
+    var domains = (standing && standing.domains) || [];
+    for (var di = 0; di < domains.length; di++) {
+      if (domains[di].domain_id === card.domain_id) {
+        domainName = (domains[di].domain_name || String(card.domain_id));
+        break;
+      }
+    }
+    kvRow(dl, "Where this applies", domainName);
     kvRow(dl, "Scope", SCOPE_LABEL[card.scope] || String(card.scope));
     kvRow(dl, "Why you can act here", card.authority_basis || "(no authority basis given)");
 

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -484,6 +484,10 @@
     });
 
     confirmBtn.addEventListener("click", function () {
+      // Bind this flow to the connect attempt it started under. If a newer
+      // attempt (possibly another member) takes the view while the PUT or
+      // receipt GET is in flight, the callbacks must not render into it.
+      var flowSeq = liveLoadSeq;
       confirmBtn.disabled = true;
       cancelBtn.disabled = true;
       statusLine.textContent = LIFECYCLE.SENT;
@@ -495,6 +499,7 @@
         method: "PUT",
         body: JSON.stringify({ status: "completed" })
       }).then(function () {
+        if (flowSeq !== liveLoadSeq) { return null; }  // view changed hands; do not fetch under the new credential
         statusLine.textContent = LIFECYCLE.SENT + " — completion accepted, fetching the receipt.";
         // Past this point the completion is COMMITTED on the node. A failure
         // to read the receipt back must never be reported as "nothing was
@@ -503,6 +508,7 @@
                          "/action-items/" + encodeURIComponent(card.source_id) +
                          "/completion-receipt", { method: "GET" })
           .then(function (receipt) {
+            if (flowSeq !== liveLoadSeq) { return; }  // never render one member's receipt in another's view
             statusChip.textContent = "✓ " + LIFECYCLE.CONFIRMED;
             statusChip.className = "chip ok";
             statusLine.textContent = LIFECYCLE.CONFIRMED + ". " + SYNC.RECEIPT +
@@ -513,6 +519,7 @@
               new Date().toLocaleString() + ".");
           })
           .catch(function (err) {
+            if (flowSeq !== liveLoadSeq) { return; }
             // Receipt read failed AFTER the completion was accepted: keep the
             // committed state, do not re-enable Confirm, say exactly what is
             // and is not known.
@@ -527,6 +534,7 @@
       }).catch(function (err) {
         // The completion itself was refused — the gateway's answer, rendered
         // plainly, never a silent failure. Nothing was recorded.
+        if (flowSeq !== liveLoadSeq) { return; }
         statusLine.textContent = "Rejected with reason: " + err.message +
           " Nothing was recorded. You can try again or contact your steward.";
         statusChip.textContent = "⚠ " + LIFECYCLE.OPEN;
@@ -690,7 +698,9 @@
     state.cards = null;
     state.receipts = [];
     hide("identity-section");
+    hide("standing-section");
     clear(byId("domains-list"));
+    clear(byId("roles-list"));
     clear(byId("cards-list"));
     renderReceipts();
 

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -1,0 +1,708 @@
+/* ICN Member Shell — v0 reference client.
+ *
+ * Dependency-free vanilla JS. No framework, no build step, no storage.
+ *
+ * Contract sources (do not invent beyond these):
+ *  - docs/spec/member-shell-v0.md          (rendering contract, closed vocabulary)
+ *  - docs/adr/ADR-0027-action-card-contract.md (ActionCard schema)
+ *  - docs/adr/ADR-0020-*                   (/me/standing read model)
+ *  - docs/adr/ADR-0028-*                   (accessibility baseline)
+ *  - icn/apps/governance/src/http/models.rs (StandingResponse, ActionCardsResponse)
+ *
+ * Two modes:
+ *  - ?mode=demo  → renders the committed pilot-ui fixture pack. No network
+ *                  beyond static file fetches. Nothing signed, nothing sent.
+ *  - live (default) → connect panel against a locally running gateway.
+ *                  Dev rehearsal only; not production.
+ *
+ * The access credential is held in a function-scoped variable for the life
+ * of the page only. It is never written to localStorage, sessionStorage,
+ * cookies, or the URL.
+ */
+(function () {
+  "use strict";
+
+  // ---------------------------------------------------------------------
+  // Closed member-facing vocabulary (docs/spec/member-shell-v0.md
+  // §"Member-facing status vocabulary"). Strings are verbatim; inventing
+  // new ones is a v0 violation.
+  // ---------------------------------------------------------------------
+  var SYNC = {
+    SYNCED: "Synced",
+    DELAYED: "Sync delayed",
+    VERIFYING: "Some records are being verified",
+    PAUSED: "Action paused until records sync",
+    RECEIPT: "Receipt available",
+    REVIEW: "Review required",
+    DEGRADED: "Sync delayed / degraded"
+  };
+
+  var LIFECYCLE = {
+    OPEN: "Open",
+    OPEN_PAUSED: "Open but paused",
+    SENT: "Sent — waiting for receipt",
+    CONFIRMED: "Confirmed",
+    DECLINED: "Declined",
+    CLOSED_DEADLINE: "Closed — deadline passed",
+    CLOSED_SUPERSEDED: "Closed — superseded",
+    CLOSED_AUTHORITY: "Closed — insufficient authority"
+  };
+
+  // Plain-language maps for the closed ADR-0027 enums. The raw enum value
+  // is never the primary surface (spec §"ActionCard rendering contract").
+  var ACTION_KIND_LABEL = {
+    vote: "Cast a vote",
+    attend: "Confirm attendance",
+    complete: "Mark a task complete"
+  };
+  var SOURCE_KIND_LABEL = {
+    proposal: "A proposal in your domain",
+    meeting: "A scheduled meeting",
+    action_item: "A task assigned to you",
+    // Reserved source paths (icn#1631 / icn#1634): render as inert
+    // "available soon" placeholders, never as live cards.
+    signal_rule: "Available soon (not yet enabled)",
+    obligation_lifecycle: "Available soon (not yet enabled)"
+  };
+  var SCOPE_LABEL = {
+    entity: "Affects your whole organization",
+    structure: "Affects one body within your organization (a committee or working group)",
+    individual: "Affects only you"
+  };
+  var RISK_LABEL = {
+    low: { glyph: "○", text: "Low impact" },        // ○
+    normal: { glyph: "◐", text: "Normal impact" },  // ◐
+    elevated: { glyph: "▲", text: "Take extra care" } // ▲
+  };
+
+  // ---------------------------------------------------------------------
+  // Mode + page state
+  // ---------------------------------------------------------------------
+  var params = new URLSearchParams(window.location.search);
+  var MODE = params.get("mode") === "demo" ? "demo" : "live";
+
+  var state = {
+    gateway: null,     // live mode only; validated http(s) origin string
+    credential: null,  // live mode only; never persisted
+    standing: null,    // StandingResponse
+    cards: null,       // ActionCardsResponse
+    receipts: []       // rendered receipt objects {receipt, plainContext}
+  };
+
+  // Fixture paths are relative to this page. They resolve only when the
+  // serve root is web/ (see README): /member-shell/.. → /pilot-ui/...
+  var FIXTURES = {
+    standing: "../pilot-ui/fixtures/icn-organizer-demo/standing.json",
+    cards: "../pilot-ui/fixtures/icn-organizer-demo/action-cards.json",
+    // member-shell-local receipt fixture (the pilot-ui pack carries no
+    // receipt packet); wire-shaped per icn-governance proof.rs
+    // ActionItemCompletionReceipt.
+    completionReceipt: "fixtures/demo-completion-receipt.json"
+  };
+
+  // ---------------------------------------------------------------------
+  // Small DOM helpers — element construction only, no innerHTML with
+  // dynamic data, so fixture/gateway strings can never inject markup.
+  // ---------------------------------------------------------------------
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      Object.keys(attrs).forEach(function (k) {
+        if (k === "text") { node.textContent = attrs[k]; }
+        else if (k === "class") { node.className = attrs[k]; }
+        else { node.setAttribute(k, attrs[k]); }
+      });
+    }
+    (children || []).forEach(function (c) { node.appendChild(c); });
+    return node;
+  }
+  function byId(id) { return document.getElementById(id); }
+  function show(id) { byId(id).hidden = false; }
+  function clear(node) { while (node.firstChild) { node.removeChild(node.firstChild); } }
+
+  function kvRow(dl, term, value) {
+    dl.appendChild(el("dt", { text: term }));
+    if (typeof value === "string") {
+      dl.appendChild(el("dd", { text: value }));
+    } else {
+      var dd = el("dd");
+      dd.appendChild(value);
+      dl.appendChild(dd);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Formatting helpers
+  // ---------------------------------------------------------------------
+  function fmtAbs(unixSeconds) {
+    if (typeof unixSeconds !== "number") { return "(no timestamp)"; }
+    return new Date(unixSeconds * 1000).toLocaleString();
+  }
+
+  // Relative time, anchored to an explicit reference point so the demo
+  // fixture (a frozen snapshot) renders honestly against its own
+  // generated_at rather than pretending the snapshot is current.
+  function fmtRel(targetSec, anchorSec) {
+    var delta = targetSec - anchorSec;
+    var abs = Math.abs(delta);
+    var unit, n;
+    if (abs >= 86400) { n = Math.round(abs / 86400); unit = n === 1 ? "day" : "days"; }
+    else if (abs >= 3600) { n = Math.round(abs / 3600); unit = n === 1 ? "hour" : "hours"; }
+    else { n = Math.max(1, Math.round(abs / 60)); unit = n === 1 ? "minute" : "minutes"; }
+    return delta >= 0
+      ? "closes in about " + n + " " + unit
+      : "deadline passed about " + n + " " + unit + " ago";
+  }
+
+  function hashToHex(recordHash) {
+    // Wire form is a 32-byte array (icn-governance proof.rs `Hash = [u8; 32]`).
+    if (Array.isArray(recordHash)) {
+      return recordHash.map(function (b) {
+        return ("0" + (b & 0xff).toString(16)).slice(-2);
+      }).join("");
+    }
+    if (typeof recordHash === "string") { return recordHash; }
+    return "(unavailable)";
+  }
+
+  function setSyncChip(text, tone, detail) {
+    var chip = byId("sync-chip");
+    var glyph = tone === "ok" ? "✓ " : tone === "warn" ? "⚠ " : "● ";
+    chip.textContent = glyph + text;
+    chip.className = "chip " + (tone || "neutral");
+    byId("sync-detail").textContent = detail || "";
+  }
+
+  // ---------------------------------------------------------------------
+  // Identity + standing rendering (ADR-0020 read model)
+  // ---------------------------------------------------------------------
+  function renderIdentity(standing) {
+    var label = standing.display_label || "(no display name configured)";
+    byId("identity-label").textContent = label;
+    byId("identity-did").textContent = standing.did || "(unknown)";
+    show("identity-section");
+  }
+
+  function membershipPlain(domain) {
+    if (domain.status === "member") {
+      return "You are a member of this domain (you are on its member list).";
+    }
+    if (domain.status === "unverified") {
+      return "Your membership here comes from a participation-trust source " +
+        "and is shown as unverified in this view. That does not mean you " +
+        "are not a member — it means this view does not evaluate it.";
+    }
+    return "Membership status: " + String(domain.status);
+  }
+
+  function renderStanding(standing) {
+    var domainsList = byId("domains-list");
+    clear(domainsList);
+    if (!standing.domains || standing.domains.length === 0) {
+      domainsList.appendChild(el("li", {
+        text: "No memberships are recorded for you yet. If you expect to " +
+          "see one, please contact your steward."
+      }));
+    } else {
+      standing.domains.forEach(function (d) {
+        var li = el("li");
+        li.appendChild(el("h3", { text: d.domain_name || d.domain_id }));
+        li.appendChild(el("p", { text: membershipPlain(d) }));
+        var details = el("details");
+        details.appendChild(el("summary", { text: "Show technical detail" }));
+        var dl = el("dl", { class: "kv" });
+        kvRow(dl, "Domain id", d.domain_id || "");
+        kvRow(dl, "Membership source", d.membership_source || "");
+        kvRow(dl, "Status", d.status || "");
+        details.appendChild(dl);
+        li.appendChild(details);
+        domainsList.appendChild(li);
+      });
+    }
+
+    var rolesList = byId("roles-list");
+    clear(rolesList);
+    if (!standing.roles || standing.roles.length === 0) {
+      rolesList.appendChild(el("li", { text: "You hold no recorded roles right now." }));
+    } else {
+      standing.roles.forEach(function (r) {
+        var li = el("li");
+        var structureName = r.structure_name || ("structure " + r.structure_id +
+          " (its name is currently unavailable — something may be off; you can ask your steward)");
+        li.appendChild(el("h3", { text: capitalize(r.role) + " — " + structureName }));
+        li.appendChild(el("p", {
+          text: "This role authorizes you to act in these areas: " +
+            (r.authority_scope && r.authority_scope.length
+              ? r.authority_scope.map(scopePlain).join("; ")
+              : "(none recorded)") + "."
+        }));
+        li.appendChild(el("p", {
+          class: "muted",
+          text: "Held since " + fmtAbs(r.start_date) +
+            (r.end_date ? ("; ends " + fmtAbs(r.end_date)) : "")
+        }));
+        var details = el("details");
+        details.appendChild(el("summary", { text: "Show technical detail" }));
+        var dl = el("dl", { class: "kv" });
+        kvRow(dl, "Role assignment id", r.role_assignment_id || "");
+        kvRow(dl, "Structure id", r.structure_id || "");
+        kvRow(dl, "Parent entity", r.parent_entity_id || "(none)");
+        kvRow(dl, "Authority scope strings", (r.authority_scope || []).join(", "));
+        details.appendChild(dl);
+        li.appendChild(details);
+        rolesList.appendChild(li);
+      });
+    }
+    show("standing-section");
+  }
+
+  // Turn an authority-scope string like "program_review" into readable
+  // words. This is a presentation aid only; the raw string stays available
+  // under "Show technical detail".
+  function scopePlain(scope) {
+    return String(scope).replace(/[_:]/g, " ");
+  }
+  function capitalize(s) {
+    s = String(s || "");
+    return s.charAt(0).toUpperCase() + s.slice(1);
+  }
+
+  // ---------------------------------------------------------------------
+  // Action cards (ADR-0027 rendering contract)
+  // ---------------------------------------------------------------------
+  function authorityCheck(card, standing) {
+    var held = (standing && standing.authority_scopes) || [];
+    var required = card.required_authority_scope || [];
+    var missing = required.filter(function (s) { return held.indexOf(s) === -1; });
+    return { authorized: missing.length === 0, missing: missing };
+  }
+
+  function renderCards(cardsResponse, standing, anchorSec) {
+    var list = byId("cards-list");
+    clear(list);
+    var cards = (cardsResponse && cardsResponse.cards) || [];
+    if (cards.length === 0) {
+      var li = el("li");
+      li.appendChild(el("p", { text: "Nothing needs your attention right now." }));
+      if (MODE === "live") {
+        var again = el("button", { class: "secondary", text: "Check again" });
+        again.addEventListener("click", function () { loadLive(); });
+        li.appendChild(again);
+      }
+      list.appendChild(li);
+      show("cards-section");
+      return;
+    }
+
+    cards.forEach(function (card) {
+      list.appendChild(renderCard(card, standing, anchorSec));
+    });
+    show("cards-section");
+  }
+
+  function renderCard(card, standing, anchorSec) {
+    var li = el("li");
+    var auth = authorityCheck(card, standing);
+    var reserved = card.source_kind === "signal_rule" ||
+      card.source_kind === "obligation_lifecycle";
+
+    li.appendChild(el("h3", { text: card.title || "(untitled card)" }));
+
+    // accessibility_hint renders as plain-language preamble BEFORE any
+    // decision controls (ADR-0028 / spec rendering table).
+    if (card.accessibility_hint) {
+      li.appendChild(el("p", { class: "muted", text: "Before you decide: " + card.accessibility_hint }));
+    }
+
+    li.appendChild(el("p", { text: card.summary || "" }));
+
+    // Lifecycle status chip (closed vocabulary). This client derives only
+    // states it can honestly know: reserved → inert; missing authority →
+    // Closed — insufficient authority; otherwise Open. Mutation flow moves
+    // a card to Sent/Confirmed below.
+    var status = reserved ? SOURCE_KIND_LABEL[card.source_kind]
+      : auth.authorized ? LIFECYCLE.OPEN
+      : LIFECYCLE.CLOSED_AUTHORITY;
+    var chipTone = reserved ? "neutral" : auth.authorized ? "ok" : "warn";
+    var chipGlyph = reserved ? "● " : auth.authorized ? "✓ " : "⚠ ";
+    var statusChip = el("span", { class: "chip " + chipTone, role: "status", text: chipGlyph + status });
+    li.appendChild(el("p", {}, [statusChip]));
+
+    var dl = el("dl", { class: "kv" });
+    kvRow(dl, "What you are being asked to do",
+      ACTION_KIND_LABEL[card.action_kind] || ("Act (" + String(card.action_kind) + ")"));
+    kvRow(dl, "Where this comes from",
+      SOURCE_KIND_LABEL[card.source_kind] || String(card.source_kind));
+    kvRow(dl, "Scope", SCOPE_LABEL[card.scope] || String(card.scope));
+    kvRow(dl, "Why you can act here", card.authority_basis || "(no authority basis given)");
+
+    if (auth.authorized) {
+      kvRow(dl, "Authorization", "You are authorized for this.");
+    } else {
+      kvRow(dl, "Authorization",
+        "This requires authority you do not currently hold: " +
+        auth.missing.map(scopePlain).join("; ") + ".");
+    }
+
+    if (typeof card.deadline === "number") {
+      var rel = fmtRel(card.deadline, anchorSec);
+      var dd = el("span", { text: rel + " " });
+      var det = el("details");
+      det.appendChild(el("summary", { text: "Exact time" }));
+      det.appendChild(el("p", { text: fmtAbs(card.deadline) + " (your local time)" }));
+      var wrap = el("span");
+      wrap.appendChild(dd);
+      wrap.appendChild(det);
+      kvRow(dl, "Time pressure", wrap);
+    } else {
+      // Spec: absent deadline renders as "no time pressure", not "no deadline".
+      kvRow(dl, "Time pressure", "No time pressure.");
+    }
+
+    var risk = RISK_LABEL[card.risk_level] || { glyph: "●", text: String(card.risk_level) };
+    kvRow(dl, "Care level", risk.glyph + " " + risk.text);
+
+    kvRow(dl, "What happens if you act",
+      card.receipt_expected
+        ? "Acting will produce a receipt — a permanent record you can review in your Receipts."
+        : "Acting is not expected to produce a receipt.");
+    li.appendChild(dl);
+
+    // Technical identifiers live under "details", never as primary surface.
+    var details = el("details");
+    details.appendChild(el("summary", { text: "Show technical detail" }));
+    var tdl = el("dl", { class: "kv" });
+    kvRow(tdl, "Card id", card.id || "");
+    kvRow(tdl, "Underlying record id", card.source_id || "");
+    kvRow(tdl, "Domain id", card.domain_id || "(not carried on this card)");
+    kvRow(tdl, "Raw kind / action / scope / risk",
+      [card.source_kind, card.action_kind, card.scope, card.risk_level].join(" / "));
+    details.appendChild(tdl);
+    li.appendChild(details);
+
+    // The one mutating action this v0 client implements (live mode only):
+    // mark an assigned task complete, then fetch and render its completion
+    // receipt. Everything else is read-only.
+    if (MODE === "live" && !reserved &&
+        card.source_kind === "action_item" && card.action_kind === "complete") {
+      li.appendChild(buildCompleteFlow(card, auth, statusChip));
+    }
+    return li;
+  }
+
+  // ---------------------------------------------------------------------
+  // The single mutation: complete an action item (live mode).
+  // PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status
+  //   body {"status": "completed"}
+  //   scopes: governance:meeting:write OR governance:write
+  //   (caller must also be the item's creator or assignee and a domain
+  //   member — the gateway enforces this; we render its answer honestly.)
+  // Then GET .../completion-receipt (scope governance:read).
+  // ---------------------------------------------------------------------
+  function buildCompleteFlow(card, auth, statusChip) {
+    var holder = el("div");
+
+    if (!card.domain_id) {
+      holder.appendChild(el("p", {
+        class: "muted",
+        text: "This card does not carry a domain reference, so this client " +
+          "cannot address the completion endpoint for it."
+      }));
+      return holder;
+    }
+
+    var openBtn = el("button", { text: "Mark complete…" });
+    var panel = el("div", { class: "confirm-panel", hidden: "hidden" });
+
+    // Pre-confirm summary (spec §"Signing / confirmation flow"): authority
+    // basis, scope, consequence, receipt expected, reversibility honesty.
+    panel.appendChild(el("h4", { text: "Before you confirm" }));
+    var pdl = el("dl", { class: "kv" });
+    kvRow(pdl, "What will change",
+      "This task will be recorded as completed, in your name.");
+    kvRow(pdl, "Why you may do this", card.authority_basis || "(no authority basis given)");
+    kvRow(pdl, "Scope", SCOPE_LABEL[card.scope] || String(card.scope));
+    kvRow(pdl, "Receipt", card.receipt_expected
+      ? "A completion receipt will be produced and shown in your Receipts."
+      : "No receipt is expected for this action.");
+    kvRow(pdl, "Can this be undone?",
+      "The completion record is permanent once accepted. This client " +
+      "offers no undo; if you complete it in error, contact your steward.");
+    panel.appendChild(pdl);
+
+    var statusLine = el("p", { role: "status", "aria-live": "polite" });
+
+    var confirmBtn = el("button", { text: "Confirm — mark complete" });
+    var cancelBtn = el("button", { class: "secondary", text: "Cancel" });
+    var actions = el("div", { class: "actions" }, [confirmBtn, cancelBtn]);
+    panel.appendChild(actions);
+    panel.appendChild(statusLine);
+
+    openBtn.addEventListener("click", function () {
+      panel.hidden = false;
+      openBtn.hidden = true;
+      confirmBtn.focus();
+    });
+    cancelBtn.addEventListener("click", function () {
+      panel.hidden = true;
+      openBtn.hidden = false;
+      openBtn.focus();
+    });
+
+    confirmBtn.addEventListener("click", function () {
+      confirmBtn.disabled = true;
+      cancelBtn.disabled = true;
+      statusLine.textContent = LIFECYCLE.SENT;
+      statusChip.textContent = "● " + LIFECYCLE.SENT;
+      statusChip.className = "chip neutral";
+
+      liveFetch("/v1/gov/domains/" + encodeURIComponent(card.domain_id) +
+                "/action-items/" + encodeURIComponent(card.source_id) + "/status", {
+        method: "PUT",
+        body: JSON.stringify({ status: "completed" })
+      }).then(function () {
+        statusLine.textContent = LIFECYCLE.SENT + " — completion accepted, fetching the receipt.";
+        return liveFetch("/v1/gov/domains/" + encodeURIComponent(card.domain_id) +
+                         "/action-items/" + encodeURIComponent(card.source_id) +
+                         "/completion-receipt", { method: "GET" });
+      }).then(function (receipt) {
+        statusChip.textContent = "✓ " + LIFECYCLE.CONFIRMED;
+        statusChip.className = "chip ok";
+        statusLine.textContent = LIFECYCLE.CONFIRMED + ". " + SYNC.RECEIPT +
+          " — see your Receipts below.";
+        addReceipt(receipt, "You marked a task complete.");
+        setSyncChip(SYNC.RECEIPT, "ok",
+          "Your latest action produced a receipt. Records were last refreshed at " +
+          new Date().toLocaleString() + ".");
+      }).catch(function (err) {
+        // "rejected with reason" — the gateway's answer, rendered plainly,
+        // never a silent failure.
+        statusLine.textContent = "Rejected with reason: " + err.message +
+          " Nothing was recorded. You can try again or contact your steward.";
+        statusChip.textContent = "⚠ " + LIFECYCLE.OPEN;
+        statusChip.className = "chip warn";
+        confirmBtn.disabled = false;
+        cancelBtn.disabled = false;
+      });
+    });
+
+    if (!auth.authorized) {
+      openBtn.disabled = true;
+      holder.appendChild(el("p", {
+        class: "muted",
+        text: "Action unavailable here: your standing does not list the " +
+          "required authority (" + auth.missing.map(scopePlain).join("; ") +
+          "). The node makes the final decision; this client will not send " +
+          "an action it can already see is not authorized."
+      }));
+    }
+
+    holder.appendChild(openBtn);
+    holder.appendChild(panel);
+    return holder;
+  }
+
+  // ---------------------------------------------------------------------
+  // Receipts (plain summary first; formal record under a disclosure)
+  // ---------------------------------------------------------------------
+  function addReceipt(receipt, plainContext) {
+    state.receipts.push({ receipt: receipt, plainContext: plainContext });
+    renderReceipts();
+  }
+
+  function renderReceipts() {
+    var list = byId("receipts-list");
+    clear(list);
+    if (state.receipts.length === 0) {
+      list.appendChild(el("li", {
+        text: "No receipts to show yet. When you complete an action that " +
+          "produces a receipt, it appears here."
+      }));
+    } else {
+      state.receipts.forEach(function (entry) {
+        list.appendChild(renderCompletionReceipt(entry.receipt, entry.plainContext));
+      });
+    }
+    show("receipts-section");
+  }
+
+  // Renders an ActionItemCompletionReceipt (icn-governance proof.rs):
+  // { item_id, domain_id, actor_did, transition, completed_at, record_hash }.
+  function renderCompletionReceipt(receipt, plainContext) {
+    var li = el("li");
+    var isSelf = state.standing && receipt.actor_did === state.standing.did;
+    var who = isSelf ? "You" : "Another member (identifier under evidence detail)";
+
+    li.appendChild(el("h3", { text: "Action completed" }));
+    li.appendChild(el("p", {}, [
+      el("span", { class: "chip ok", text: "✓ " + SYNC.RECEIPT })
+    ]));
+    li.appendChild(el("p", {
+      text: who + " marked a task as complete on " + fmtAbs(receipt.completed_at) + "."
+    }));
+    li.appendChild(el("p", {
+      class: "muted",
+      text: "What this proves: who acted (the actor recorded below), which " +
+        "obligation it satisfied (the task identified below), and when. " +
+        (plainContext || "")
+    }));
+
+    var details = el("details");
+    details.appendChild(el("summary", { text: "Show evidence detail" }));
+    var dl = el("dl", { class: "kv" });
+    kvRow(dl, "Record class", "ActionItemCompletionReceipt");
+    kvRow(dl, "Task (action item) id", String(receipt.item_id || ""));
+    kvRow(dl, "Domain id", String(receipt.domain_id || ""));
+    kvRow(dl, "Actor", el("code", { text: String(receipt.actor_did || "") }));
+    kvRow(dl, "Transition", String(receipt.transition || ""));
+    kvRow(dl, "Completed at (unix seconds)", String(receipt.completed_at || ""));
+    kvRow(dl, "Record hash (blake3, canonical binding of the fields above)",
+      el("code", { text: hashToHex(receipt.record_hash) }));
+    details.appendChild(dl);
+    li.appendChild(details);
+    return li;
+  }
+
+  // ---------------------------------------------------------------------
+  // Demo mode: fixture-backed, nothing signed, no live node.
+  // ---------------------------------------------------------------------
+  function loadDemo() {
+    setSyncChip(SYNC.VERIFYING, "neutral", "Loading the committed fixture snapshot…");
+    Promise.all([
+      fetchJson(FIXTURES.standing),
+      fetchJson(FIXTURES.cards),
+      fetchJson(FIXTURES.completionReceipt)
+    ]).then(function (results) {
+      state.standing = results[0];
+      state.cards = results[1];
+      var anchor = state.cards.generated_at || state.standing.generated_at;
+
+      renderIdentity(state.standing);
+      renderStanding(state.standing);
+      renderCards(state.cards, state.standing, anchor);
+      addReceipt(results[2],
+        "This is a fictional demonstration receipt for a previously " +
+        "completed task; it is not tied to any card above.");
+
+      setSyncChip(SYNC.SYNCED, "ok",
+        "Fixture snapshot generated at " + fmtAbs(anchor) +
+        ". Deadlines above are read relative to that snapshot moment, " +
+        "because fixture data does not move with the clock.");
+    }).catch(function (err) {
+      setSyncChip(SYNC.DEGRADED, "warn",
+        "The fixture files could not be loaded (" + err.message + "). " +
+        "Make sure the page is served from the web/ directory — see the README.");
+    });
+  }
+
+  // ---------------------------------------------------------------------
+  // Live mode: local gateway, dev rehearsal.
+  // ---------------------------------------------------------------------
+  function liveFetch(path, opts) {
+    opts = opts || {};
+    var headers = {
+      "Authorization": "Bearer " + state.credential,
+      "Accept": "application/json"
+    };
+    if (opts.body) { headers["Content-Type"] = "application/json"; }
+    return fetch(state.gateway + path, {
+      method: opts.method || "GET",
+      headers: headers,
+      body: opts.body || undefined
+    }).then(function (resp) {
+      if (!resp.ok) {
+        return resp.text().then(function (bodyText) {
+          var reason;
+          try { reason = JSON.parse(bodyText).error || bodyText; }
+          catch (e) { reason = bodyText || ("HTTP " + resp.status); }
+          throw new Error("The node answered " + resp.status + ": " + String(reason).slice(0, 300));
+        });
+      }
+      return resp.json();
+    });
+  }
+
+  function loadLive() {
+    setSyncChip(SYNC.VERIFYING, "neutral", "Asking the node for your standing…");
+    byId("connect-status").textContent = "";
+
+    liveFetch("/v1/gov/me/standing").then(function (standing) {
+      state.standing = standing;
+      renderIdentity(standing);
+      renderStanding(standing);
+      return liveFetch("/v1/gov/me/action-cards");
+    }).then(function (cardsResponse) {
+      state.cards = cardsResponse;
+      var anchor = Math.floor(Date.now() / 1000);
+      renderCards(cardsResponse, state.standing, anchor);
+      renderReceipts();
+      setSyncChip(SYNC.SYNCED, "ok",
+        "Records last refreshed at " + new Date().toLocaleString() +
+        ". This view is a snapshot; refresh to re-check.");
+      byId("connect-status").textContent = "Connected. Your standing and open actions are shown below.";
+    }).catch(function (err) {
+      // Failure-table disposition (spec §"Failure and safety table"):
+      // plain language first, no error code as primary surface, help path
+      // always visible.
+      setSyncChip(SYNC.DEGRADED, "warn",
+        "Your standing is currently unavailable. We'll keep trying. " +
+        "If this persists, please contact your steward.");
+      byId("connect-status").textContent =
+        "Could not load your records. Technical detail: " + err.message;
+    });
+  }
+
+  function wireConnectForm() {
+    byId("connect-form").addEventListener("submit", function (ev) {
+      ev.preventDefault();
+      var url;
+      try {
+        url = new URL(byId("gateway-url").value);
+      } catch (e) {
+        byId("connect-status").textContent = "That gateway address is not a valid URL.";
+        return;
+      }
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        byId("connect-status").textContent = "The gateway address must start with http:// or https://.";
+        return;
+      }
+      state.gateway = url.origin;
+      state.credential = byId("credential").value.trim();
+      if (!state.credential) {
+        byId("connect-status").textContent = "Paste an access credential first.";
+        return;
+      }
+      loadLive();
+    });
+  }
+
+  function fetchJson(path) {
+    return fetch(path).then(function (resp) {
+      if (!resp.ok) { throw new Error("HTTP " + resp.status + " for " + path); }
+      return resp.json();
+    });
+  }
+
+  // ---------------------------------------------------------------------
+  // Boot
+  // ---------------------------------------------------------------------
+  function init() {
+    var banner = byId("honesty-banner");
+    if (MODE === "demo") {
+      banner.textContent = "Fixture-backed demo — no live node, nothing signed.";
+      banner.className = "banner demo";
+      byId("nav-demo").setAttribute("aria-current", "true");
+      loadDemo();
+    } else {
+      banner.textContent = "Live-local node — dev rehearsal, not production.";
+      banner.className = "banner live";
+      byId("nav-live").setAttribute("aria-current", "true");
+      show("connect-section");
+      setSyncChip(SYNC.DELAYED, "neutral",
+        "Not connected yet. Enter your local gateway address above.");
+      wireConnectForm();
+    }
+  }
+
+  init();
+})();

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -666,7 +666,13 @@
     });
   }
 
+  // Monotonic load sequence: responses from an abandoned connect attempt
+  // must never render over a newer attempt's view (overlapping submits on
+  // a shared browser could otherwise mix two members' records).
+  var liveLoadSeq = 0;
+
   function loadLive() {
+    var seq = ++liveLoadSeq;
     setSyncChip(SYNC.VERIFYING, "neutral", "Asking the node for your standing…");
     byId("connect-status").textContent = "";
 
@@ -689,6 +695,7 @@
     renderReceipts();
 
     liveFetch("/v1/gov/me/standing").then(function (standing) {
+      if (seq !== liveLoadSeq) { return null; }  // a newer attempt owns the view
       if (prior.did && prior.did === standing.did) {
         state.receipts = prior.receipts;
       }
@@ -697,6 +704,7 @@
       renderStanding(standing);
       return liveFetch("/v1/gov/me/action-cards");
     }).then(function (cardsResponse) {
+      if (cardsResponse === null || seq !== liveLoadSeq) { return; }
       state.cards = cardsResponse;
       var anchor = Math.floor(Date.now() / 1000);
       renderCards(cardsResponse, state.standing, anchor);
@@ -706,6 +714,7 @@
         ". This view is a snapshot; refresh to re-check.");
       byId("connect-status").textContent = "Connected. Your standing and open actions are shown below.";
     }).catch(function (err) {
+      if (seq !== liveLoadSeq) { return; }  // stale failure must not clobber a newer attempt
       // Failure-table disposition (spec §"Failure and safety table"):
       // plain language first, no error code as primary surface, help path
       // always visible.


### PR DESCRIPTION
## What

A thin **member-shell v0 reference client** at `web/member-shell/` — dependency-free static HTML/CSS/vanilla JS (no framework, no build step, no npm) — plus `docs/dev/openapi-member-surface-gaps.md`, a checklist of member-facing endpoints missing from the gateway's served OpenAPI.

This is the member-facing demo centerpiece: standing, action cards, and receipts rendered per the `docs/spec/member-shell-v0.md` contract. It is explicitly **not** a revival of pilot-ui and **not** the production member shell.

Files:
- `web/member-shell/index.html`, `shell.css`, `shell.js`
- `web/member-shell/fixtures/demo-completion-receipt.json` (fictional, wire-shaped `ActionItemCompletionReceipt`; its `record_hash` is illustrative bytes, not a real blake3 binding — the demo banner says nothing is signed)
- `web/member-shell/README.md` (maturity tiers + honest ADR-0028 checklist)
- `docs/dev/openapi-member-surface-gaps.md`

## Why

The member-shell-v0 spec is a rendering contract with no client proving it implementable against the real endpoint shapes. This client proves it in two honestly-labeled tiers, reusing the existing CI-drift-guarded pilot-ui fixture pack (consumed by relative fetch, **not duplicated**). Refs: #1818.

## How

**Maturity tiers (banner permanently visible):**

| Mode | Banner | What it is |
|---|---|---|
| Demo (`?mode=demo`) | "Fixture-backed demo — no live node, nothing signed." | Renders `web/pilot-ui/fixtures/icn-organizer-demo/{standing,action-cards}.json` + a member-shell-local receipt fixture. Deadlines are read relative to the fixture's own `generated_at` (and the UI says so) — frozen data does not pretend to be current. |
| Live (default) | "Live-local node — dev rehearsal, not production." | Connect panel (gateway default `http://localhost:8080`; paste-credential field is `type=password`, held in a closure variable for the page's life only — never persisted, never hardcoded). `GET /v1/gov/me/standing`, `GET /v1/gov/me/action-cards`, completion-receipt endpoint. |

**Rendering per spec/ADR-0027:** plain-language-first everywhere; mapped (never raw) enums; authorization check against the member's own `authority_scopes`; deadline relative + absolute under disclosure ("No time pressure." when absent); risk as glyph+label; `accessibility_hint` as preamble before controls; receipts as plain summary (who/what obligation/when) with raw `record_hash` behind "Show evidence detail"; sync status uses ONLY the closed seven-string vocabulary. Shell-vs-cockpit boundary observed: no divergence detail, peer DIDs, or digest forms.

**Mutation: SHIPPED (one action, the dogfood loop).** Live mode marks an `action_item`/`complete` card completed via `PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status` `{"status":"completed"}` (scopes `governance:meeting:write` | `governance:write`; creator/assignee + domain membership enforced server-side), behind a pre-confirm summary (what changes, authority basis, scope, receipt expected, permanence warning, distinct Confirm/Cancel), then fetches and renders the completion receipt. Lifecycle: `Open` → `Sent — waiting for receipt` → `Confirmed` + `Receipt available`. Rejections render the gateway's reason. Everything else is read-only.

**OpenAPI gaps doc:** the utoipa `paths(...)` list in `icn/crates/icn-gateway/src/openapi.rs` contains exactly one entry (`propose_clearing_adoption`). The checklist names **12 missing member-facing endpoints** (standing, action-cards, me/scopes, me/work, action-items list/get/status/completion-receipt, meeting attendance, vote, tally, proof, chain) with route/handler/scope/response + a one-line "annotation needed" each, plus 1 adjacent observation: no GET retrieval endpoint exists for attendance receipts at all. Checklist only — no annotations added. The gateway serves Swagger UI from `/api-docs/openapi.json`, so annotations land there automatically once added.

## ADR-0028 checklist (honest)

Implemented: semantic HTML + ARIA-to-extend; AA-targeted palette (ratios documented in `shell.css`); `:focus-visible` on every interactive element; `prefers-reduced-motion` respected; no color-only information (glyph + text on every status); rem-based scalable type; plain language with jargon explained inline (technical ids/hashes under disclosures); stable single-column layout; visible what's-next affordances; ≥44px hit targets; pre-action consequence + permanence + distinct Confirm/Cancel.

NOT yet implemented (declared): glossary endpoint integration (#1610 — endpoint doesn't exist), multi-language/translation tagging (#1740), offline tolerance (no cache/queue/service worker), real screen-reader/switch-control testing, human 200%-zoom/low-end-device verification, accommodation path, deadline-justice metadata, captions/transcripts (no media).

## Risk

- Pure additive: 6 new files, zero existing files modified. No Rust, no SDK, no CI changes.
- `web/member-shell/**` is not in the compliance linter's scan globs; vocabulary was checked manually anyway (zero hits for wallet/payment/balance/token/currency framing).
- Live mode depends on gateway CORS allowing the shell's origin (documented in README, with the same-origin alternative).
- Demo mode depends on the pilot-ui fixture pack's shape; that pack is already CI-drift-guarded (fixture_bundle job), so drift breaks loudly, not silently.

## Test plan (what was actually run)

- `python3 -m http.server` from `web/` + curl: **200** for all 6 client assets and both pilot-ui fixture paths, including relative `../pilot-ui/...` resolution from `/member-shell/`.
- `node --check shell.js`: syntax OK. Receipt fixture: valid JSON, 32-byte `record_hash`.
- Python `html.parser` structural smoke: required ids/semantic tags/labelled inputs/skip link/lang/viewport; closed vocabulary verbatim in JS; endpoints present; no storage or `innerHTML` usage in code; no JWT-shaped literals; no private IPs (localhost only); a11y CSS floors present — **all passed**.
- Headless demo-mode render smoke (node + minimal DOM stub, real fixture files): banner text/class, identity, 2 domains, 2 roles, 3 cards, 1 receipt, authorization positive path, snapshot-relative deadlines, accessibility-hint preamble, lifecycle chip, risk label, receipt hex hash, `✓ Synced` chip, no mutation button in demo — **26/26 assertions passed**.
- `sanitize-scan --tree web/member-shell` and `--tree docs/dev`: exit 0. Pre-commit + pre-push sanitize hooks ran clean.
- Repo linters locally: compliance linter ✅, readiness-overclaim linter ✅, `doc_control_check.py` OK (new doc covered by `docs/dev/` prefix defaults), `validate-rehearsal-shell-fixtures.py` PASS.
- `cargo fmt --all --check` PASS (no Rust touched; per /push skill, clippy/test scope was empty).

**NOT verified:** actual visual rendering in a browser (layout, contrast as perceived, focus order, zoom) — needs a human pass. Live mode was NOT exercised against a running gateway (no live node in this lane); the live code path follows handler-source truth but its first live run is part of demo rehearsal. No screen-reader/AT testing performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
