### PR TITLE
feat(gateway): document member-shell surface in served OpenAPI (standing, action-cards, completion receipt)

### DIFF
--- a/docs/api/openapi.generated.yaml
+++ b/docs/api/openapi.generated.yaml
@@ -31,6 +31,9 @@ info:
     name: MIT OR Apache-2.0
     url: https://opensource.org/licenses/MIT
   version: 0.1.0
+servers:
+- url: /v1
+  description: Gateway API base path (all routes are mounted under /v1)
 paths:
   /federation/clearing/{id}/propose-adoption:
     post:

--- a/docs/api/openapi.generated.yaml
+++ b/docs/api/openapi.generated.yaml
@@ -82,6 +82,170 @@ paths:
           description: Internal server error
       security:
       - bearer_auth: []
+  /gov/domains/{domain_id}/action-items/{item_id}/completion-receipt:
+    get:
+      tags:
+      - governance
+      summary: |-
+        GET /gov/domains/{domain_id}/action-items/{item_id}/completion-receipt
+        — Retrieve the latest [`ActionItemCompletionReceipt`] persisted for an
+        action item, if any.
+      description: |-
+        Closes the proof loop documented in `docs/dev/NYCN_K3S_PROOF_PATH.md`
+        and `docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md`: a holder shell that
+        completed an `action_item / complete` action card can read the
+        `ActionItemCompletionReceipt` back via HTTP, instead of relying on
+        in-process tests or on-disk Sled inspection.
+
+        Authorization mirrors the rest of the action-item read surface:
+        `governance:read` scope plus domain membership for the caller. The
+        receipt's bound `domain_id` is also asserted to match the path
+        parameter so a holder cannot probe across domain boundaries.
+
+        Returns:
+        - 200 with the receipt JSON when a completion receipt has been
+          persisted for the item under this domain.
+        - 404 when no receipt exists, when the item id does not match the
+          stored receipt's `domain_id`, or when the manager has no receipt
+          store wired (the receipt simply does not exist from the caller's
+          point of view).
+      operationId: get_action_item_completion_receipt
+      parameters:
+      - name: domain_id
+        in: path
+        description: Governance domain the action item lives under
+        required: true
+        schema:
+          type: string
+      - name: item_id
+        in: path
+        description: Action item id (UUID). This is the same string an `action_item`-sourced action card carries in `source_id` — it links the card to its receipt. Accepts any valid UUID form; canonicalized before lookup.
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Latest completion receipt persisted for the action item under this domain. `record_hash` is the blake3 canonical record hash binding the receipt fields, serialized as a JSON array of 32 bytes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionItemCompletionReceipt'
+        '400':
+          description: Malformed action item id (not a valid UUID)
+        '401':
+          description: Missing or invalid bearer token
+        '403':
+          description: Token lacks the `governance:read` scope, or the caller is not a member of the domain
+        '404':
+          description: No completion receipt persisted for this item, the receipt is bound to a different domain (cross-domain existence is not leaked), or the domain does not exist
+      security:
+      - bearer_auth: []
+  /gov/me/action-cards:
+    get:
+      tags:
+      - governance
+      summary: GET /gov/me/action-cards — Return pending action cards for the caller.
+      description: |-
+        Action cards are derived views — computed at request time from the caller's
+        `/me/standing` inputs plus open governance state. There is no mutation API;
+        the card carries a `source_id` and the holder acts on the underlying
+        object. See ADR-0027.
+
+        ## Sources currently emitted
+
+        - `proposal` / `vote` — Open proposals in domains where the caller has
+          voting standing and has not yet voted.
+        - `meeting` / `attend` — Meetings scheduled in the next 48 h where the
+          caller is on the attendee list.
+        - `action_item` / `complete` — Open action items assigned to the caller.
+
+        ## Sources reserved (not emitted today)
+
+        - `signal_rule` — pending icn#1631
+        - `obligation_lifecycle` — pending icn#1634
+
+        Per ADR-0027 the taxonomy is closed; new variants land alongside their
+        source-path implementation.
+
+        ## Self-only
+
+        There is no `did` query parameter. The caller's DID is always derived from
+        the authenticated claims; no card-set for a third party is reachable here.
+      operationId: get_my_action_cards
+      responses:
+        '200':
+          description: Pending action cards for the caller, wrapped in `ActionCardsResponse` (`{did, cards, generated_at}`) — **not** a bare array. Cards are derived views computed at request time from the caller's standing plus open governance state; there is no mutation API on this surface — the holder acts on the underlying object named by `source_id` (ADR-0027). `cards` may be empty. Source/action/scope/risk fields use the closed enums `ActionCardSourceKind`, `ActionCardActionKind`, `ActionCardScope`, and `ActionCardRiskLevel`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActionCardsResponse'
+        '401':
+          description: Missing or invalid bearer token
+        '403':
+          description: Token lacks the `governance:read` scope
+      security:
+      - bearer_auth: []
+  /gov/me/standing:
+    get:
+      tags:
+      - governance
+      summary: GET /gov/me/standing — Return the authenticated caller's institutional standing.
+      description: |-
+        Composes existing governance state (domain membership + structure role
+        assignments) into one read model so member-facing UI does not have to
+        fan out to four endpoints.
+
+        ## What this returns
+
+        - The caller's DID (always — derived from the authenticated claims, not
+          from a query parameter).
+        - Each governance domain whose static member list contains the caller, or
+          whose membership is sourced from a trust threshold (status `"unverified"`
+          in that case — the trust graph is the source of truth, not this read
+          model).
+        - Each structure role assignment held by the caller, joined with cheap
+          structure metadata (name + parent entity) so the UI does not need a
+          second fetch per row.
+        - The deduplicated union of `authority_scope` across those role
+          assignments, as a convenience for UI.
+
+        ## Self-only
+
+        There is no `did` query parameter. The DID is always the caller's. A
+        caller cannot use this endpoint to inspect another DID's standing.
+
+        ## Optional filter
+
+        `?domain_id=<id>` narrows both `domains` and `roles` to assignments under
+        that domain. An unknown `domain_id` returns a valid empty standing rather
+        than a 404 — "no standing in that domain" is a meaningful answer.
+
+        ## Empty caller is not an error
+
+        A caller with no role assignments and no static membership receives a
+        200 with empty `domains`, `roles`, and `authority_scopes`. UI should
+        render an onboarding affordance, not an error.
+      operationId: get_my_standing
+      parameters:
+      - name: domain_id
+        in: query
+        description: Narrow `domains` and `roles` to one governance domain. An unknown `domain_id` returns a valid empty standing (200), not a 404 — "no standing in that domain" is a meaningful answer.
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: 'The caller''s institutional standing. Self-only: the DID is always derived from the authenticated token; another DID''s standing is not reachable here. A caller with no memberships and no role assignments receives 200 with empty `domains`, `roles`, and `authority_scopes` — empty standing is not an error.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandingResponse'
+        '401':
+          description: Missing or invalid bearer token
+        '403':
+          description: Token lacks the `governance:read` scope
+      security:
+      - bearer_auth: []
 components:
   schemas:
     AccountDeltaResponse:
@@ -133,6 +297,232 @@ components:
             format: int64
           propertyNames:
             type: string
+    ActionCard:
+      type: object
+      description: |-
+        One pending action card for the authenticated caller.
+
+        Returned by `GET /v1/gov/me/action-cards`. Cards are **derived views** —
+        computed at request time from the caller's standing plus open governance
+        state — never stored entities. Two requests at the same moment from the
+        same DID return identical cards. See ADR-0027.
+
+        ## Boundary
+
+        All fields are generic. No institution-specific vocabulary. Institution
+        packages translate their local templates into these generic kinds; ICN
+        does not learn package-specific nouns from this surface.
+      required:
+      - id
+      - source_kind
+      - action_kind
+      - scope
+      - title
+      - summary
+      - authority_basis
+      - required_authority_scope
+      - risk_level
+      - accessibility_hint
+      - receipt_expected
+      - source_id
+      properties:
+        accessibility_hint:
+          type: string
+          description: |-
+            Accessibility note for the rendering shell. Generic across institutions;
+            today the runtime emits the same baseline note for all cards.
+        action_kind:
+          $ref: '#/components/schemas/ActionCardActionKind'
+        authority_basis:
+          type: string
+          description: |-
+            Why the caller has the right to act here, in plain language. Examples:
+            `"role_assignment_in_domain"`, `"assigned_action_item"`,
+            `"meeting_attendee"`.
+        deadline:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          description: |-
+            Optional Unix-seconds deadline. `None` means no time pressure encoded
+            by this card.
+          minimum: 0
+        domain_id:
+          type:
+          - string
+          - 'null'
+          description: Governance domain this card lives under, when known.
+        id:
+          type: string
+          description: |-
+            Stable, deterministic id of the card. Runtime format:
+            `card-<source_kind_snake>-<source_id>-<action_kind_snake>` (for example
+            `card-proposal-<id>-vote`, `card-meeting-<id>-attend`,
+            `card-action_item-<id>-complete`) so the same underlying object yields
+            the same card id across requests.
+        receipt_expected:
+          type: boolean
+          description: |-
+            Whether successful completion of this action is expected to produce a
+            receipt (governance receipt, attendance receipt, action-item completion
+            receipt).
+        required_authority_scope:
+          type: array
+          items:
+            type: string
+          description: |-
+            Authority-scope strings the kernel would expect for this action.
+            Generic; institution packages may use richer strings.
+        risk_level:
+          $ref: '#/components/schemas/ActionCardRiskLevel'
+        scope:
+          $ref: '#/components/schemas/ActionCardScope'
+        source_id:
+          type: string
+          description: Underlying object id (proposal id, meeting id, action item id).
+        source_kind:
+          $ref: '#/components/schemas/ActionCardSourceKind'
+        summary:
+          type: string
+          description: |-
+            One-line plain-language summary of what this card is asking the
+            holder to do.
+        title:
+          type: string
+          description: Short, plain-language title. Suitable for a list row.
+    ActionCardActionKind:
+      type: string
+      description: |-
+        What the holder is being asked to do. Closed taxonomy. New variants land
+        when their source path implementation lands.
+      enum:
+      - vote
+      - attend
+      - complete
+    ActionCardRiskLevel:
+      type: string
+      description: |-
+        Coarse risk indicator surfaced to the holder. UI may sort or annotate but
+        must not hide cards. Exact semantics are policy concerns; this enum carries
+        a conservative three-level vocabulary.
+      enum:
+      - low
+      - normal
+      - elevated
+    ActionCardScope:
+      type: string
+      description: |-
+        What the card targets. Maps to ICN's `entity / structure / individual`
+        constitutional axes; institution packages bind their local taxonomy to
+        these.
+      enum:
+      - entity
+      - structure
+      - individual
+    ActionCardSourceKind:
+      type: string
+      description: |-
+        Where a card is derived from. Closed taxonomy. Variants `SignalRule` and
+        `ObligationLifecycle` are reserved by issue #1646 for future implementation;
+        the runtime does not emit them today.
+      enum:
+      - proposal
+      - meeting
+      - action_item
+      - signal_rule
+      - obligation_lifecycle
+    ActionCardsResponse:
+      type: object
+      description: Wrapper response for `GET /me/action-cards`.
+      required:
+      - did
+      - cards
+      - generated_at
+      properties:
+        cards:
+          type: array
+          items:
+            $ref: '#/components/schemas/ActionCard'
+          description: Pending cards for the caller, derived at request time. May be empty.
+        did:
+          type: string
+          description: The authenticated caller's DID.
+        generated_at:
+          type: integer
+          format: int64
+          description: |-
+            Unix-seconds when this card set was computed. Snapshot only — nothing
+            is cached server-side.
+          minimum: 0
+    ActionItemCompletionReceipt:
+      type: object
+      description: |-
+        Cross-node deterministic completion receipt for a governance action
+        item.
+
+        Sits alongside [`GovernanceDecisionReceipt`] in ADR-0026 Layer 2: it
+        records the *fact* of a state transition the runtime can attest to,
+        keyed so a holder shell can locate it via the action card's `source_id`.
+
+        Equality is anchored to `record_hash`.
+      required:
+      - item_id
+      - domain_id
+      - actor_did
+      - transition
+      - completed_at
+      - record_hash
+      properties:
+        actor_did:
+          type: string
+          description: |-
+            DID of the actor whose authorized completion call produced this
+            receipt (must be the action item's assignee or creator at call
+            time, per the handler's authorization check).
+        completed_at:
+          type: integer
+          format: int64
+          description: |-
+            Unix-seconds the transition was recorded (typically the
+            `updated_at` of the post-transition action item).
+          minimum: 0
+        domain_id:
+          type: string
+          description: Governance domain the action item lives under.
+        item_id:
+          type: string
+          description: |-
+            Action item id (string form of `ActionItemId`). This is the same
+            string the holder's `ActionCard.source_id` carries — it is the
+            link between the card and the receipt.
+        record_hash:
+          type: array
+          items:
+            type: integer
+            format: int32
+            minimum: 0
+          description: |-
+            blake3 canonical record hash binding the fields above (serialized
+            as a JSON array of 32 bytes).
+          maxItems: 32
+          minItems: 32
+        transition:
+          $ref: '#/components/schemas/ActionItemTransition'
+          description: |-
+            Transition this receipt records. Closed enum; see
+            [`ActionItemTransition`].
+    ActionItemTransition:
+      type: string
+      description: |-
+        Closed taxonomy of state transitions that produce an
+        [`ActionItemCompletionReceipt`].
+
+        Today the only receipt-bearing transition is `Completed`. Variants are
+        added when a corresponding write path lands; the runtime never emits a
+        transition not listed here.
+      enum:
+      - completed
     AddMemberRequest:
       type: object
       description: Add a member to a cooperative
@@ -1480,6 +1870,135 @@ components:
           - 'null'
         signature:
           type: string
+    StandingDomainMembership:
+      type: object
+      description: One governance-domain membership row in [`StandingResponse`].
+      required:
+      - domain_id
+      - domain_name
+      - membership_source
+      - status
+      properties:
+        domain_id:
+          type: string
+        domain_name:
+          type: string
+        membership_source:
+          type: string
+          description: '`"static_list"` or `"trust_threshold"`.'
+        status:
+          type: string
+          description: |-
+            `"member"` if the caller is in the static member list,
+            `"unverified"` if membership comes from a trust-threshold source that
+            this read model does not evaluate (the caller may still be a member;
+            the trust graph is the source of truth).
+    StandingResponse:
+      type: object
+      description: |-
+        Caller-facing membership and authority read model.
+
+        Returned by `GET /v1/gov/me/standing`. Composes existing governance state
+        (domain memberships + structure role assignments) into one digestible
+        response so member-facing UI does not need to query four endpoints and
+        stitch them together.
+
+        ## What this is NOT
+
+        - This is **not** an authorization token. Scopes here are descriptive,
+          not bearer-issued. Authorization decisions still flow through the
+          `PolicyOracle`.
+        - This is **not** an action-card feed. Action-card generation builds on
+          top of this read model in a separate endpoint.
+      required:
+      - did
+      - domains
+      - roles
+      - authority_scopes
+      - generated_at
+      properties:
+        authority_scopes:
+          type: array
+          items:
+            type: string
+          description: |-
+            Union of `authority_scope` strings across `roles`, deduplicated and
+            sorted. Convenience field for UI; equivalent to flattening `roles`.
+        did:
+          type: string
+          description: The authenticated caller's DID.
+        display_label:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Optional human-readable label. Reserved for a future identity-registry
+            lookup; always `None` in this version.
+        domains:
+          type: array
+          items:
+            $ref: '#/components/schemas/StandingDomainMembership'
+          description: |-
+            Governance domains in which this caller has membership standing.
+            May be empty.
+        generated_at:
+          type: integer
+          format: int64
+          description: |-
+            Unix epoch seconds when this standing was computed. The response is a
+            snapshot; nothing is cached server-side.
+          minimum: 0
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/StandingRoleAssignment'
+          description: |-
+            Role assignments held by this caller across all structures.
+            May be empty.
+    StandingRoleAssignment:
+      type: object
+      description: |-
+        One role-assignment row in [`StandingResponse`]. Joins the underlying
+        [`icn_governance::RoleAssignment`] with cheap structure metadata
+        (name + parent entity) so UI does not have to fetch the structure.
+      required:
+      - role_assignment_id
+      - structure_id
+      - role
+      - authority_scope
+      - start_date
+      properties:
+        authority_scope:
+          type: array
+          items:
+            type: string
+        end_date:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          minimum: 0
+        parent_entity_id:
+          type:
+          - string
+          - 'null'
+        role:
+          type: string
+        role_assignment_id:
+          type: string
+        start_date:
+          type: integer
+          format: int64
+          minimum: 0
+        structure_id:
+          type: string
+        structure_name:
+          type:
+          - string
+          - 'null'
+          description: |-
+            `None` if the structure was deleted or is otherwise unreadable; the
+            role row is still surfaced so the caller can see something is off.
     StewardDetailResponse:
       type: object
       description: Steward detail response
@@ -1789,6 +2308,11 @@ components:
       - for
       - against
       - abstain
+  securitySchemes:
+    bearer_auth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
 tags:
 - name: health
   description: Health check and readiness endpoints

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3274,6 +3274,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "utoipa",
  "uuid",
 ]
 

--- a/icn/apps/governance/Cargo.toml
+++ b/icn/apps/governance/Cargo.toml
@@ -11,7 +11,9 @@ publish = false
 icn-kernel-api = { path = "../../crates/icn-kernel-api" }
 
 # Governance domain types (proposals, votes, domains, etc.)
-icn-governance = { path = "../../crates/icn-governance" }
+# utoipa feature: ToSchema on ActionItemCompletionReceipt for the OpenAPI
+# annotation on get_action_item_completion_receipt.
+icn-governance = { path = "../../crates/icn-governance", features = ["utoipa"] }
 
 # CCL schema (charter YAML parsing/validation at the HTTP boundary)
 icn-ccl = { path = "../../crates/icn-ccl" }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3000,6 +3000,37 @@ pub async fn add_action_item_note<E: GovernanceEventEmitter + Clone + 'static>(
 ///   stored receipt's `domain_id`, or when the manager has no receipt
 ///   store wired (the receipt simply does not exist from the caller's
 ///   point of view).
+#[utoipa::path(
+    get,
+    path = "/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt",
+    tag = "governance",
+    params(
+        ("domain_id" = String, Path,
+            description = "Governance domain the action item lives under"),
+        ("item_id" = String, Path,
+            description = "Action item id (UUID). This is the same string an \
+                `action_item`-sourced action card carries in `source_id` — it links \
+                the card to its receipt. Accepts any valid UUID form; canonicalized \
+                before lookup.")
+    ),
+    responses(
+        (status = 200,
+            description = "Latest completion receipt persisted for the action item \
+                under this domain. `record_hash` is the blake3 canonical record hash \
+                binding the receipt fields, serialized as a JSON array of 32 bytes.",
+            body = icn_governance::ActionItemCompletionReceipt),
+        (status = 400, description = "Malformed action item id (not a valid UUID)"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403,
+            description = "Token lacks the `governance:read` scope, or the caller is \
+                not a member of the domain"),
+        (status = 404,
+            description = "No completion receipt persisted for this item, the receipt \
+                is bound to a different domain (cross-domain existence is not leaked), \
+                or the domain does not exist")
+    ),
+    security(("bearer_auth" = []))
+)]
 pub async fn get_action_item_completion_receipt<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
     http_req: HttpRequest,
@@ -5213,6 +5244,29 @@ pub async fn get_my_scopes<E: GovernanceEventEmitter + Clone + 'static>(
 /// A caller with no role assignments and no static membership receives a
 /// 200 with empty `domains`, `roles`, and `authority_scopes`. UI should
 /// render an onboarding affordance, not an error.
+#[utoipa::path(
+    get,
+    path = "/gov/me/standing",
+    tag = "governance",
+    params(
+        ("domain_id" = Option<String>, Query,
+            description = "Narrow `domains` and `roles` to one governance domain. An \
+                unknown `domain_id` returns a valid empty standing (200), not a 404 — \
+                \"no standing in that domain\" is a meaningful answer.")
+    ),
+    responses(
+        (status = 200,
+            description = "The caller's institutional standing. Self-only: the DID is \
+                always derived from the authenticated token; another DID's standing is \
+                not reachable here. A caller with no memberships and no role assignments \
+                receives 200 with empty `domains`, `roles`, and `authority_scopes` — \
+                empty standing is not an error.",
+            body = StandingResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Token lacks the `governance:read` scope")
+    ),
+    security(("bearer_auth" = []))
+)]
 pub async fn get_my_standing<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
     http_req: HttpRequest,
@@ -5375,6 +5429,26 @@ pub async fn get_my_work<E: GovernanceEventEmitter + Clone + 'static>(
 ///
 /// There is no `did` query parameter. The caller's DID is always derived from
 /// the authenticated claims; no card-set for a third party is reachable here.
+#[utoipa::path(
+    get,
+    path = "/gov/me/action-cards",
+    tag = "governance",
+    responses(
+        (status = 200,
+            description = "Pending action cards for the caller, wrapped in \
+                `ActionCardsResponse` (`{did, cards, generated_at}`) — **not** a bare \
+                array. Cards are derived views computed at request time from the \
+                caller's standing plus open governance state; there is no mutation API \
+                on this surface — the holder acts on the underlying object named by \
+                `source_id` (ADR-0027). `cards` may be empty. Source/action/scope/risk \
+                fields use the closed enums `ActionCardSourceKind`, \
+                `ActionCardActionKind`, `ActionCardScope`, and `ActionCardRiskLevel`.",
+            body = ActionCardsResponse),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Token lacks the `governance:read` scope")
+    ),
+    security(("bearer_auth" = []))
+)]
 pub async fn get_my_action_cards<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
     http_req: HttpRequest,

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -81,10 +81,14 @@ pub use icn_kernel_api::governance::{
     TreasuryExecutor, TreasuryOperation, TreasuryOperationType,
 };
 
-// Re-export governance types needed by supervisor initialization.
-// This allows icn-core to import from icn_governance_actor instead of
-// icn_governance directly, reducing direct governance coupling.
-pub use icn_governance::{ForcedOutcome, MembershipResolver, ProposalId, StaticMembershipResolver};
+// Re-export governance types needed by supervisor initialization and by
+// the gateway's OpenAPI registration. This allows icn-core and icn-gateway
+// to import from icn_governance_actor instead of icn_governance directly,
+// reducing direct governance coupling (meaning-firewall ratchets).
+pub use icn_governance::{
+    ActionItemCompletionReceipt, ActionItemTransition, ForcedOutcome, MembershipResolver,
+    ProposalId, StaticMembershipResolver,
+};
 
 /// Create a ProposalExecutor instance.
 ///

--- a/icn/crates/icn-gateway/Cargo.toml
+++ b/icn/crates/icn-gateway/Cargo.toml
@@ -79,7 +79,7 @@ icn-ledger-app = { path = "../../../apps/ledger", features = ["utoipa"] }
 icn-store = { path = "../icn-store" }
 icn-rpc = { path = "../icn-rpc" }
 icn-obs = { path = "../icn-obs" }
-icn-governance = { path = "../icn-governance" }
+icn-governance = { path = "../icn-governance", features = ["utoipa"] }
 icn-governance-actor = { path = "../../apps/governance" }
 icn-http-kit = { path = "../icn-http-kit" }
 icn-compute = { path = "../icn-compute" }

--- a/icn/crates/icn-gateway/src/openapi.rs
+++ b/icn/crates/icn-gateway/src/openapi.rs
@@ -45,10 +45,27 @@ use crate::api::steward::{
 use crate::identity_mgr::DeviceInfo;
 use crate::notification_store::{InAppNotification, Platform};
 
+// Member-shell surface (handlers live in the governance app crate, mounted
+// by this gateway under /v1/gov — see configure_governance in server.rs).
+use icn_governance::{ActionItemCompletionReceipt, ActionItemTransition};
+use icn_governance_actor::http::models::{
+    ActionCard, ActionCardActionKind, ActionCardRiskLevel, ActionCardScope, ActionCardSourceKind,
+    ActionCardsResponse, StandingDomainMembership, StandingResponse, StandingRoleAssignment,
+};
+
 /// OpenAPI documentation for ICN Gateway
 #[derive(OpenApi)]
 #[openapi(
-    paths(crate::api::federation::propose_clearing_adoption),
+    paths(
+        crate::api::federation::propose_clearing_adoption,
+        // Member-shell surface (docs/dev/openapi-member-surface-gaps.md):
+        // the routes a member-facing shell needs for the core loop
+        // standing → action card → discharge → receipt.
+        icn_governance_actor::http::handlers::get_my_standing,
+        icn_governance_actor::http::handlers::get_my_action_cards,
+        icn_governance_actor::http::handlers::get_action_item_completion_receipt,
+    ),
+    modifiers(&SecurityAddon),
     info(
         title = "ICN Gateway API",
         version = "0.1.0",
@@ -117,6 +134,11 @@ use crate::notification_store::{InAppNotification, Platform};
             ListNotificationsResponse, NotificationCountResponse, MarkReadResponse,
             // Federation
             ProposeAdoptionRequest, ProposeAdoptionResponse,
+            // Member-shell surface (standing, action cards, completion receipt)
+            StandingResponse, StandingDomainMembership, StandingRoleAssignment,
+            ActionCardsResponse, ActionCard, ActionCardSourceKind, ActionCardActionKind,
+            ActionCardScope, ActionCardRiskLevel,
+            ActionItemCompletionReceipt, ActionItemTransition,
             // Shared types
             DeviceInfo, Platform, InAppNotification,
         )
@@ -140,3 +162,77 @@ use crate::notification_store::{InAppNotification, Platform};
     )
 )]
 pub struct ApiDoc;
+
+/// Registers the `bearer_auth` JWT security scheme that annotated paths
+/// reference via `security(("bearer_auth" = []))`. Without this component
+/// those references point at an undeclared scheme.
+struct SecurityAddon;
+
+impl utoipa::Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+        let components = openapi.components.get_or_insert_with(Default::default);
+        components.add_security_scheme(
+            "bearer_auth",
+            SecurityScheme::Http(
+                HttpBuilder::new()
+                    .scheme(HttpAuthScheme::Bearer)
+                    .bearer_format("JWT")
+                    .build(),
+            ),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The member-shell surface must stay in the served OpenAPI document
+    /// (`/api-docs/openapi.json` is built from this same `ApiDoc` object —
+    /// see server.rs). Guards the annotation wiring across the gateway and
+    /// the governance app crate.
+    #[test]
+    fn member_shell_surface_is_documented() {
+        let doc = ApiDoc::openapi();
+        let paths = &doc.paths.paths;
+        for expected in [
+            "/gov/me/standing",
+            "/gov/me/action-cards",
+            "/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt",
+        ] {
+            assert!(
+                paths.contains_key(expected),
+                "missing documented path: {expected}"
+            );
+        }
+
+        let schemas = doc
+            .components
+            .as_ref()
+            .expect("components present")
+            .schemas
+            .clone();
+        for expected in [
+            "StandingResponse",
+            "ActionCardsResponse",
+            "ActionCard",
+            "ActionItemCompletionReceipt",
+        ] {
+            assert!(
+                schemas.contains_key(expected),
+                "missing registered schema: {expected}"
+            );
+        }
+
+        let security_schemes = &doc
+            .components
+            .as_ref()
+            .expect("components present")
+            .security_schemes;
+        assert!(
+            security_schemes.contains_key("bearer_auth"),
+            "bearer_auth security scheme must be registered"
+        );
+    }
+}

--- a/icn/crates/icn-gateway/src/openapi.rs
+++ b/icn/crates/icn-gateway/src/openapi.rs
@@ -47,7 +47,11 @@ use crate::notification_store::{InAppNotification, Platform};
 
 // Member-shell surface (handlers live in the governance app crate, mounted
 // by this gateway under /v1/gov — see configure_governance in server.rs).
-use icn_governance::{ActionItemCompletionReceipt, ActionItemTransition};
+// Receipt types come via the app crate's re-export, not icn_governance
+// directly: the meaning-firewall ratchets pin this crate's direct
+// icn_governance references (see icn-core/src/meaning_firewall.rs).
+use icn_governance_actor::{ActionItemCompletionReceipt, ActionItemTransition};
+
 use icn_governance_actor::http::models::{
     ActionCard, ActionCardActionKind, ActionCardRiskLevel, ActionCardScope, ActionCardSourceKind,
     ActionCardsResponse, StandingDomainMembership, StandingResponse, StandingRoleAssignment,
@@ -56,6 +60,10 @@ use icn_governance_actor::http::models::{
 /// OpenAPI documentation for ICN Gateway
 #[derive(OpenApi)]
 #[openapi(
+    servers((
+        url = "/v1",
+        description = "Gateway API base path (all routes are mounted under /v1)"
+    )),
     paths(
         crate::api::federation::propose_clearing_adoption,
         // Member-shell surface (docs/dev/openapi-member-surface-gaps.md):
@@ -233,6 +241,15 @@ mod tests {
         assert!(
             security_schemes.contains_key("bearer_auth"),
             "bearer_auth security scheme must be registered"
+        );
+
+        // Paths are documented relative to the /v1 mount (Actix scope in
+        // server.rs); the server base keeps generated clients on the right
+        // URLs.
+        let servers = doc.servers.as_ref().expect("servers present");
+        assert!(
+            servers.iter().any(|s| s.url == "/v1"),
+            "server base url /v1 must be declared"
         );
     }
 }

--- a/icn/crates/icn-governance/Cargo.toml
+++ b/icn/crates/icn-governance/Cargo.toml
@@ -29,6 +29,7 @@ blake3 = "1.8"
 ed25519-dalek.workspace = true
 lru = "0.16"
 tracing.workspace = true
+utoipa = { version = "5.4.0", optional = true }
 
 [dev-dependencies]
 icn-store = { path = "../icn-store" }

--- a/icn/crates/icn-governance/src/proof.rs
+++ b/icn/crates/icn-governance/src/proof.rs
@@ -1164,6 +1164,7 @@ fn outcome_ordinal(outcome: ProofOutcome) -> u8 {
 /// added when a corresponding write path lands; the runtime never emits a
 /// transition not listed here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum ActionItemTransition {
     /// The action item moved into `ActionItemStatus::Completed`. The
@@ -1181,6 +1182,7 @@ pub enum ActionItemTransition {
 ///
 /// Equality is anchored to `record_hash`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct ActionItemCompletionReceipt {
     /// Action item id (string form of `ActionItemId`). This is the same
     /// string the holder's `ActionCard.source_id` carries — it is the
@@ -1198,7 +1200,9 @@ pub struct ActionItemCompletionReceipt {
     /// Unix-seconds the transition was recorded (typically the
     /// `updated_at` of the post-transition action item).
     pub completed_at: u64,
-    /// blake3 canonical record hash binding the fields above.
+    /// blake3 canonical record hash binding the fields above (serialized
+    /// as a JSON array of 32 bytes).
+    #[cfg_attr(feature = "utoipa", schema(value_type = Vec<u8>, max_items = 32, min_items = 32))]
     pub record_hash: Hash,
 }
 

--- a/sdk/typescript/src/generated/api-types.ts
+++ b/sdk/typescript/src/generated/api-types.ts
@@ -38,6 +38,142 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * GET /gov/domains/{domain_id}/action-items/{item_id}/completion-receipt
+         *     — Retrieve the latest [`ActionItemCompletionReceipt`] persisted for an
+         *     action item, if any.
+         * @description Closes the proof loop documented in `docs/dev/NYCN_K3S_PROOF_PATH.md`
+         *     and `docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md`: a holder shell that
+         *     completed an `action_item / complete` action card can read the
+         *     `ActionItemCompletionReceipt` back via HTTP, instead of relying on
+         *     in-process tests or on-disk Sled inspection.
+         *
+         *     Authorization mirrors the rest of the action-item read surface:
+         *     `governance:read` scope plus domain membership for the caller. The
+         *     receipt's bound `domain_id` is also asserted to match the path
+         *     parameter so a holder cannot probe across domain boundaries.
+         *
+         *     Returns:
+         *     - 200 with the receipt JSON when a completion receipt has been
+         *       persisted for the item under this domain.
+         *     - 404 when no receipt exists, when the item id does not match the
+         *       stored receipt's `domain_id`, or when the manager has no receipt
+         *       store wired (the receipt simply does not exist from the caller's
+         *       point of view).
+         */
+        get: operations["get_action_item_completion_receipt"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/gov/me/action-cards": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * GET /gov/me/action-cards — Return pending action cards for the caller.
+         * @description Action cards are derived views — computed at request time from the caller's
+         *     `/me/standing` inputs plus open governance state. There is no mutation API;
+         *     the card carries a `source_id` and the holder acts on the underlying
+         *     object. See ADR-0027.
+         *
+         *     ## Sources currently emitted
+         *
+         *     - `proposal` / `vote` — Open proposals in domains where the caller has
+         *       voting standing and has not yet voted.
+         *     - `meeting` / `attend` — Meetings scheduled in the next 48 h where the
+         *       caller is on the attendee list.
+         *     - `action_item` / `complete` — Open action items assigned to the caller.
+         *
+         *     ## Sources reserved (not emitted today)
+         *
+         *     - `signal_rule` — pending icn#1631
+         *     - `obligation_lifecycle` — pending icn#1634
+         *
+         *     Per ADR-0027 the taxonomy is closed; new variants land alongside their
+         *     source-path implementation.
+         *
+         *     ## Self-only
+         *
+         *     There is no `did` query parameter. The caller's DID is always derived from
+         *     the authenticated claims; no card-set for a third party is reachable here.
+         */
+        get: operations["get_my_action_cards"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/gov/me/standing": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * GET /gov/me/standing — Return the authenticated caller's institutional standing.
+         * @description Composes existing governance state (domain membership + structure role
+         *     assignments) into one read model so member-facing UI does not have to
+         *     fan out to four endpoints.
+         *
+         *     ## What this returns
+         *
+         *     - The caller's DID (always — derived from the authenticated claims, not
+         *       from a query parameter).
+         *     - Each governance domain whose static member list contains the caller, or
+         *       whose membership is sourced from a trust threshold (status `"unverified"`
+         *       in that case — the trust graph is the source of truth, not this read
+         *       model).
+         *     - Each structure role assignment held by the caller, joined with cheap
+         *       structure metadata (name + parent entity) so the UI does not need a
+         *       second fetch per row.
+         *     - The deduplicated union of `authority_scope` across those role
+         *       assignments, as a convenience for UI.
+         *
+         *     ## Self-only
+         *
+         *     There is no `did` query parameter. The DID is always the caller's. A
+         *     caller cannot use this endpoint to inspect another DID's standing.
+         *
+         *     ## Optional filter
+         *
+         *     `?domain_id=<id>` narrows both `domains` and `roles` to assignments under
+         *     that domain. An unknown `domain_id` returns a valid empty standing rather
+         *     than a 404 — "no standing in that domain" is a meaningful answer.
+         *
+         *     ## Empty caller is not an error
+         *
+         *     A caller with no role assignments and no static membership receives a
+         *     200 with empty `domains`, `roles`, and `authority_scopes`. UI should
+         *     render an onboarding affordance, not an error.
+         */
+        get: operations["get_my_standing"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -65,6 +201,165 @@ export interface components {
                 [key: string]: number;
             };
         };
+        /**
+         * @description One pending action card for the authenticated caller.
+         *
+         *     Returned by `GET /v1/gov/me/action-cards`. Cards are **derived views** —
+         *     computed at request time from the caller's standing plus open governance
+         *     state — never stored entities. Two requests at the same moment from the
+         *     same DID return identical cards. See ADR-0027.
+         *
+         *     ## Boundary
+         *
+         *     All fields are generic. No institution-specific vocabulary. Institution
+         *     packages translate their local templates into these generic kinds; ICN
+         *     does not learn package-specific nouns from this surface.
+         */
+        ActionCard: {
+            /**
+             * @description Accessibility note for the rendering shell. Generic across institutions;
+             *     today the runtime emits the same baseline note for all cards.
+             */
+            accessibility_hint: string;
+            action_kind: components["schemas"]["ActionCardActionKind"];
+            /**
+             * @description Why the caller has the right to act here, in plain language. Examples:
+             *     `"role_assignment_in_domain"`, `"assigned_action_item"`,
+             *     `"meeting_attendee"`.
+             */
+            authority_basis: string;
+            /**
+             * Format: int64
+             * @description Optional Unix-seconds deadline. `None` means no time pressure encoded
+             *     by this card.
+             */
+            deadline?: number | null;
+            /** @description Governance domain this card lives under, when known. */
+            domain_id?: string | null;
+            /**
+             * @description Stable, deterministic id of the card. Runtime format:
+             *     `card-<source_kind_snake>-<source_id>-<action_kind_snake>` (for example
+             *     `card-proposal-<id>-vote`, `card-meeting-<id>-attend`,
+             *     `card-action_item-<id>-complete`) so the same underlying object yields
+             *     the same card id across requests.
+             */
+            id: string;
+            /**
+             * @description Whether successful completion of this action is expected to produce a
+             *     receipt (governance receipt, attendance receipt, action-item completion
+             *     receipt).
+             */
+            receipt_expected: boolean;
+            /**
+             * @description Authority-scope strings the kernel would expect for this action.
+             *     Generic; institution packages may use richer strings.
+             */
+            required_authority_scope: string[];
+            risk_level: components["schemas"]["ActionCardRiskLevel"];
+            scope: components["schemas"]["ActionCardScope"];
+            /** @description Underlying object id (proposal id, meeting id, action item id). */
+            source_id: string;
+            source_kind: components["schemas"]["ActionCardSourceKind"];
+            /**
+             * @description One-line plain-language summary of what this card is asking the
+             *     holder to do.
+             */
+            summary: string;
+            /** @description Short, plain-language title. Suitable for a list row. */
+            title: string;
+        };
+        /**
+         * @description What the holder is being asked to do. Closed taxonomy. New variants land
+         *     when their source path implementation lands.
+         * @enum {string}
+         */
+        ActionCardActionKind: "vote" | "attend" | "complete";
+        /**
+         * @description Coarse risk indicator surfaced to the holder. UI may sort or annotate but
+         *     must not hide cards. Exact semantics are policy concerns; this enum carries
+         *     a conservative three-level vocabulary.
+         * @enum {string}
+         */
+        ActionCardRiskLevel: "low" | "normal" | "elevated";
+        /**
+         * @description What the card targets. Maps to ICN's `entity / structure / individual`
+         *     constitutional axes; institution packages bind their local taxonomy to
+         *     these.
+         * @enum {string}
+         */
+        ActionCardScope: "entity" | "structure" | "individual";
+        /**
+         * @description Where a card is derived from. Closed taxonomy. Variants `SignalRule` and
+         *     `ObligationLifecycle` are reserved by issue #1646 for future implementation;
+         *     the runtime does not emit them today.
+         * @enum {string}
+         */
+        ActionCardSourceKind: "proposal" | "meeting" | "action_item" | "signal_rule" | "obligation_lifecycle";
+        /** @description Wrapper response for `GET /me/action-cards`. */
+        ActionCardsResponse: {
+            /** @description Pending cards for the caller, derived at request time. May be empty. */
+            cards: components["schemas"]["ActionCard"][];
+            /** @description The authenticated caller's DID. */
+            did: string;
+            /**
+             * Format: int64
+             * @description Unix-seconds when this card set was computed. Snapshot only — nothing
+             *     is cached server-side.
+             */
+            generated_at: number;
+        };
+        /**
+         * @description Cross-node deterministic completion receipt for a governance action
+         *     item.
+         *
+         *     Sits alongside [`GovernanceDecisionReceipt`] in ADR-0026 Layer 2: it
+         *     records the *fact* of a state transition the runtime can attest to,
+         *     keyed so a holder shell can locate it via the action card's `source_id`.
+         *
+         *     Equality is anchored to `record_hash`.
+         */
+        ActionItemCompletionReceipt: {
+            /**
+             * @description DID of the actor whose authorized completion call produced this
+             *     receipt (must be the action item's assignee or creator at call
+             *     time, per the handler's authorization check).
+             */
+            actor_did: string;
+            /**
+             * Format: int64
+             * @description Unix-seconds the transition was recorded (typically the
+             *     `updated_at` of the post-transition action item).
+             */
+            completed_at: number;
+            /** @description Governance domain the action item lives under. */
+            domain_id: string;
+            /**
+             * @description Action item id (string form of `ActionItemId`). This is the same
+             *     string the holder's `ActionCard.source_id` carries — it is the
+             *     link between the card and the receipt.
+             */
+            item_id: string;
+            /**
+             * @description blake3 canonical record hash binding the fields above (serialized
+             *     as a JSON array of 32 bytes).
+             */
+            record_hash: number[];
+            /**
+             * @description Transition this receipt records. Closed enum; see
+             *     [`ActionItemTransition`].
+             */
+            transition: components["schemas"]["ActionItemTransition"];
+        };
+        /**
+         * @description Closed taxonomy of state transitions that produce an
+         *     [`ActionItemCompletionReceipt`].
+         *
+         *     Today the only receipt-bearing transition is `Completed`. Variants are
+         *     added when a corresponding write path lands; the runtime never emits a
+         *     transition not listed here.
+         * @enum {string}
+         */
+        ActionItemTransition: "completed";
         /** @description Add a member to a cooperative */
         AddMemberRequest: {
             did: string;
@@ -651,6 +946,87 @@ export interface components {
             role?: string | null;
             signature: string;
         };
+        /** @description One governance-domain membership row in [`StandingResponse`]. */
+        StandingDomainMembership: {
+            domain_id: string;
+            domain_name: string;
+            /** @description `"static_list"` or `"trust_threshold"`. */
+            membership_source: string;
+            /**
+             * @description `"member"` if the caller is in the static member list,
+             *     `"unverified"` if membership comes from a trust-threshold source that
+             *     this read model does not evaluate (the caller may still be a member;
+             *     the trust graph is the source of truth).
+             */
+            status: string;
+        };
+        /**
+         * @description Caller-facing membership and authority read model.
+         *
+         *     Returned by `GET /v1/gov/me/standing`. Composes existing governance state
+         *     (domain memberships + structure role assignments) into one digestible
+         *     response so member-facing UI does not need to query four endpoints and
+         *     stitch them together.
+         *
+         *     ## What this is NOT
+         *
+         *     - This is **not** an authorization token. Scopes here are descriptive,
+         *       not bearer-issued. Authorization decisions still flow through the
+         *       `PolicyOracle`.
+         *     - This is **not** an action-card feed. Action-card generation builds on
+         *       top of this read model in a separate endpoint.
+         */
+        StandingResponse: {
+            /**
+             * @description Union of `authority_scope` strings across `roles`, deduplicated and
+             *     sorted. Convenience field for UI; equivalent to flattening `roles`.
+             */
+            authority_scopes: string[];
+            /** @description The authenticated caller's DID. */
+            did: string;
+            /**
+             * @description Optional human-readable label. Reserved for a future identity-registry
+             *     lookup; always `None` in this version.
+             */
+            display_label?: string | null;
+            /**
+             * @description Governance domains in which this caller has membership standing.
+             *     May be empty.
+             */
+            domains: components["schemas"]["StandingDomainMembership"][];
+            /**
+             * Format: int64
+             * @description Unix epoch seconds when this standing was computed. The response is a
+             *     snapshot; nothing is cached server-side.
+             */
+            generated_at: number;
+            /**
+             * @description Role assignments held by this caller across all structures.
+             *     May be empty.
+             */
+            roles: components["schemas"]["StandingRoleAssignment"][];
+        };
+        /**
+         * @description One role-assignment row in [`StandingResponse`]. Joins the underlying
+         *     [`icn_governance::RoleAssignment`] with cheap structure metadata
+         *     (name + parent entity) so UI does not have to fetch the structure.
+         */
+        StandingRoleAssignment: {
+            authority_scope: string[];
+            /** Format: int64 */
+            end_date?: number | null;
+            parent_entity_id?: string | null;
+            role: string;
+            role_assignment_id: string;
+            /** Format: int64 */
+            start_date: number;
+            structure_id: string;
+            /**
+             * @description `None` if the structure was deleted or is otherwise unreadable; the
+             *     role row is still surfaced so the caller can see something is off.
+             */
+            structure_name?: string | null;
+        };
         /** @description Steward detail response */
         StewardDetailResponse: {
             /** Format: int64 */
@@ -835,6 +1211,130 @@ export interface operations {
             };
             /** @description Internal server error */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_action_item_completion_receipt: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Governance domain the action item lives under */
+                domain_id: string;
+                /** @description Action item id (UUID). This is the same string an `action_item`-sourced action card carries in `source_id` — it links the card to its receipt. Accepts any valid UUID form; canonicalized before lookup. */
+                item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Latest completion receipt persisted for the action item under this domain. `record_hash` is the blake3 canonical record hash binding the receipt fields, serialized as a JSON array of 32 bytes. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActionItemCompletionReceipt"];
+                };
+            };
+            /** @description Malformed action item id (not a valid UUID) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Missing or invalid bearer token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Token lacks the `governance:read` scope, or the caller is not a member of the domain */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No completion receipt persisted for this item, the receipt is bound to a different domain (cross-domain existence is not leaked), or the domain does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_my_action_cards: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pending action cards for the caller, wrapped in `ActionCardsResponse` (`{did, cards, generated_at}`) — **not** a bare array. Cards are derived views computed at request time from the caller's standing plus open governance state; there is no mutation API on this surface — the holder acts on the underlying object named by `source_id` (ADR-0027). `cards` may be empty. Source/action/scope/risk fields use the closed enums `ActionCardSourceKind`, `ActionCardActionKind`, `ActionCardScope`, and `ActionCardRiskLevel`. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActionCardsResponse"];
+                };
+            };
+            /** @description Missing or invalid bearer token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Token lacks the `governance:read` scope */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_my_standing: {
+        parameters: {
+            query?: {
+                /** @description Narrow `domains` and `roles` to one governance domain. An unknown `domain_id` returns a valid empty standing (200), not a 404 — "no standing in that domain" is a meaningful answer. */
+                domain_id?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The caller's institutional standing. Self-only: the DID is always derived from the authenticated token; another DID's standing is not reachable here. A caller with no memberships and no role assignments receives 200 with empty `domains`, `roles`, and `authority_scopes` — empty standing is not an error. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StandingResponse"];
+                };
+            };
+            /** @description Missing or invalid bearer token */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Token lacks the `governance:read` scope */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## What

Adds the **member-shell surface** to the gateway's served OpenAPI document (`/api-docs/openapi.json` / Swagger UI), scoped to exactly the three endpoints the member-shell v0 client (#2026) exercises for the core loop **standing → action card → discharge → receipt**:

- `GET /v1/gov/me/standing` → `StandingResponse`
- `GET /v1/gov/me/action-cards` → `ActionCardsResponse` (wrapper, not a bare array)
- `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` → `ActionItemCompletionReceipt`

Mechanics:

- `#[utoipa::path]` annotations on the three generic handlers in `apps/governance/src/http/handlers.rs` (path strings match the gateway mount: `/v1` scope + `/gov` app scope, same convention as the existing federation annotation).
- Gateway `openapi.rs`: the three handler paths added to `paths(...)`; `StandingResponse`/`ActionCardsResponse`/`ActionCard` + the four closed card enums + `ActionItemCompletionReceipt`/`ActionItemTransition` registered in `components(schemas(...))`.
- `icn-governance`: `utoipa` as an **optional dependency** (implicit feature, same pattern as `icn-federation`); feature-gated `ToSchema` on `ActionItemCompletionReceipt` + `ActionItemTransition`. `record_hash` documented as a 32-byte array (`value_type = Vec<u8>`, min/max 32) matching its serde wire shape.
- `SecurityAddon` registering the `bearer_auth` JWT scheme that `security(("bearer_auth" = []))` references — previously the federation annotations referenced an undeclared scheme; the new annotations reference it too, so the doc now declares it.
- Regression test `openapi::tests::member_shell_surface_is_documented` pins the three paths, the key schemas, and the security scheme into `ApiDoc::openapi()` — the same object served at `/api-docs/openapi.json` and exported by `icnctl api export-openapi`.
- Drift chain: regenerated `docs/api/openapi.generated.yaml` + `sdk/typescript/src/generated/api-types.ts` (separate generated-only commit).

## Why

`docs/dev/openapi-member-surface-gaps.md` (landed with #2026) found the served OpenAPI document contained **one** path — every member-facing route was undocumented. A stranger pointing Swagger UI at a demo node could not see the member loop at all. This PR closes the three gaps the July demo actually needs; the other nine member-facing gaps in the checklist stay open on purpose (narrow scope).

## How

Documented behavior comes from the handler source (per the gaps doc: "handler source is truth"): the `?domain_id` filter and empty-standing-is-200 contract on standing; the wrapper shape, derived-views/no-mutation framing (ADR-0027), and closed enums on action cards; the 400/401/403/404 contracts on the receipt GET including the cross-domain-existence-not-leaked 404.

## Risk

- Doc-surface only: no handler logic, routing, or auth changes.
- `icn-governance` gains an optional, default-off dependency edge (`utoipa`); only the gateway and the governance app enable it.
- Generated YAML/TS diffs are additive (new paths/schemas + `bearer_auth` declaration).

## Test plan (exactly what ran)

- `cargo check -p icn-governance-actor` — pass
- `cargo check -p icn-gateway` — pass
- `cargo fmt --all --check` — pass
- `cargo test -p icn-gateway --features sled-storage member_shell_surface_is_documented` — pass (`openapi::tests::member_shell_surface_is_documented`: 1 passed)
- `cargo clippy -p icn-governance -p icn-governance-actor -p icn-gateway --all-targets -- -D warnings` — pass (zero warnings)
- `icnctl api export-openapi` rerun; committed `openapi.generated.yaml` matches (CI re-verifies with pinned toolchain)
- `npm run generate-types` + `npm run check-types` in `sdk/typescript` — generate-types ran; `npx tsc --noEmit` clean (`check-types` is a git-diff gate — green once the regen commit is in)
- Served-doc spot check: ephemeral JWT-secured local gateway (debug icnd from this branch, port 18090, same boot recipe as the 13/13 rig) serves all 3 paths, 4 schemas, and the bearer_auth scheme at `/api-docs/openapi.json` — operator log: `~/artifacts/icn/demo-verify-20260612/openapi-served-check.log` (icn-dev box)

Not run locally: full workspace clippy/test (CI owns those).

Refs: docs/dev/openapi-member-surface-gaps.md · #2026 · July demo readiness lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)
