### PR TITLE
feat(appliance): DEV/DEMO image profile — member loop end-to-end in one VM

### DIFF
--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -98,9 +98,12 @@ session JWT (local VM only).
 
 ## The demo script (5 steps)
 
-1. **Inspect standing** — open the shell in live mode, paste the JWT from
-   `icn-demo-seed`. The standing pane shows the operator's domain
-   membership in the fictional NYCN institution.
+1. **Inspect standing** — open the shell in live mode, set the **Gateway
+   address** field to `http://localhost:18080` (the forwarded gateway —
+   the shell's default of `:8080` points at an unforwarded host port in
+   this setup), and paste the JWT from `icn-demo-seed`. The standing pane
+   shows the operator's domain membership in the fictional NYCN
+   institution.
 2. **Inspect the action card** — one open card: "Confirm Summit 2026 venue
    booking" (`action_item / complete`, fictional).
 3. **Discharge the action** — complete it in the shell (live-mode

--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -1,0 +1,140 @@
+# ICN July Demo Image — Quickstart
+
+One VM. One browser. The core ICN loop, honestly labeled:
+
+**standing → action card → discharge → receipt → evidence/audit**
+
+## What this demonstrates
+
+- A real ICN node (`icnd`) booting on a disposable VM and serving its
+  JWT-authenticated HTTP gateway.
+- Member standing, pending action cards, action discharge, and a
+  cryptographic completion receipt — rendered in the member-shell
+  reference client, served by the same VM.
+- Evidence you can re-verify: the receipt's 32-byte BLAKE3 `record_hash`
+  binding, and (optional, deeper) a 13/13 governed receipt-chain proof run
+  entirely inside the VM.
+
+## What this does NOT demonstrate
+
+No production deployment. No pilot adoption. No federation or
+multi-organization anything. No real member data — the institution is a
+fictional fixture (NYCN package, in-tree). The image is unsigned and
+mutable. Dev gates are enabled and labeled. If someone tells you this VM
+is production infrastructure, they are wrong on purpose.
+
+## System requirements
+
+- Linux host with QEMU (`qemu-system-x86`, `qemu-utils`), `ssh`, `curl`,
+  `jq`, `cloud-image-utils` (only if you need to build a cloud-init seed).
+- ~4 GB free disk, 2 GB RAM for the VM (`-m 2048` recommended).
+- For building the image: Rust toolchain + `libguestfs-tools`, a staged
+  Debian cloud base image (glibc ≥ your build host's — see
+  "Host / image compatibility" in [README.md](README.md)).
+
+## Get or build the image
+
+There is no prebuilt download. Build from a public checkout:
+
+```bash
+git clone https://github.com/InterCooperative-Network/icn && cd icn
+export ICN_APPLIANCE_BASE_IMAGE=/path/to/debian-13-genericcloud-amd64.qcow2
+export ICN_APPLIANCE_OUTPUT_DIR=$HOME/icn-appliance-build
+export ICN_APPLIANCE_VERSION=0.0.2-demo
+export ICN_APPLIANCE_DEMO_PROFILE=1
+bash deploy/appliance/build-image.sh --real
+```
+
+Output: `$ICN_APPLIANCE_OUTPUT_DIR/icn-appliance-0.0.2-demo-amd64.qcow2`
+plus a manifest JSON with the image SHA256 and `demo_profile: true`.
+
+## Run it
+
+Prepare a one-off SSH key + cloud-init seed (see "Real local build + boot
+smoke" in [README.md](README.md)), then either:
+
+**Scripted (recommended first run):**
+
+```bash
+ICN_APPLIANCE_IMAGE=$HOME/icn-appliance-build/icn-appliance-0.0.2-demo-amd64.qcow2 \
+ICN_APPLIANCE_SSH_KEY=/path/to/smoke_ed25519 \
+ICN_APPLIANCE_CLOUD_INIT_SEED=/path/to/seed.iso \
+ICN_APPLIANCE_VM_MEMORY=2048 \
+bash deploy/appliance/smoke/smoke-local.sh --real --demo
+```
+
+That boots the VM on a disposable overlay, seeds the demo, drives the whole
+loop headlessly, and prints PASS/FAIL. It is the same path your browser
+will take.
+
+**Manual (for the browser demo):** boot QEMU yourself with the demo ports
+forwarded:
+
+```bash
+qemu-img create -f qcow2 -b "$IMAGE" -F qcow2 overlay.qcow2
+qemu-system-x86_64 -machine accel=kvm:tcg -m 2048 -smp 2 -display none \
+  -drive if=virtio,format=qcow2,file=overlay.qcow2 \
+  -drive if=virtio,format=raw,file=seed.iso,readonly=on \
+  -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2222-:22,hostfwd=tcp:127.0.0.1:18080-:8080,hostfwd=tcp:127.0.0.1:18090-:8090 \
+  -device virtio-net-pci,netdev=net0 -nographic
+```
+
+Then seed it:
+
+```bash
+ssh -p 2222 debian@127.0.0.1 sudo icn-demo-seed
+```
+
+The seed prints the member-shell URLs, the open action item, and a dev
+session JWT (local VM only).
+
+## First URL to open
+
+> http://localhost:18090/member-shell/
+
+(Use `?mode=demo` for the self-labeled fixture mode that needs no JWT.)
+
+## The demo script (5 steps)
+
+1. **Inspect standing** — open the shell in live mode, paste the JWT from
+   `icn-demo-seed`. The standing pane shows the operator's domain
+   membership in the fictional NYCN institution.
+2. **Inspect the action card** — one open card: "Confirm Summit 2026 venue
+   booking" (`action_item / complete`, fictional).
+3. **Discharge the action** — complete it in the shell (live-mode
+   mutation: `PUT .../status {"status":"completed"}` under the hood).
+4. **View the receipt** — the shell fetches the completion receipt: item,
+   domain, actor DID, transition, timestamp, and the 32-byte BLAKE3
+   `record_hash` that binds them.
+5. **Verify evidence/audit** — in the VM:
+   `sudo icn-demo-verify <item-id>` re-fetches and checks the receipt
+   binding; `sudo icn-demo-verify --chain` runs the full 13/13 governed
+   receipt-chain rehearsal on a fresh ephemeral node and emits a
+   schema-validated evidence packet to `/var/lib/icn-demo/`.
+
+## Reset
+
+- Cheapest: power off and delete `overlay.qcow2`, recreate, reboot —
+  whole-disk reset, nothing persists.
+- In-place: `ssh -p 2222 debian@127.0.0.1 sudo icn-demo-reset` (destroys
+  node state, re-runs firstboot, then `sudo icn-demo-seed` again).
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| Shell says "Technical detail: Failed to fetch" in live mode | CORS or wrong gateway port. The demo drop-in allows origins `localhost:8090/18090` and `127.0.0.1:8090/18090`. Open the shell via one of those exactly; the gateway must be the hostfwd'd 18080 (or in-VM 8080). |
+| Port already in use on the host | Another process holds 2222/18080/18090. Change the hostfwd host-side numbers; if you change the shell port, the gateway CORS allowlist must contain that origin (edit `/etc/systemd/system/icnd.service.d/20-demo-profile.conf` in the VM, `systemctl daemon-reload && systemctl restart icnd`). |
+| `icn-demo-seed` fails: "$ENV_FILE missing" | Firstboot has not completed. `journalctl -u icn-appliance-firstboot`. The icnd unit is gated on firstboot success by design. |
+| Passphrase/identity errors from icnctl | The VM's keystore passphrase lives in `/etc/icn/icnd.env` (root, mode 600). The demo scripts read it themselves — run them with `sudo`, don't export your own. |
+| QEMU: KVM permission denied | Your user lacks /dev/kvm access; the launch line falls back to TCG (slow but works). `usermod -aG kvm $USER` for speed. |
+| Stale state after re-running the demo | Each `icn-demo-seed` adds a new open card. Old JWTs die with `icn-demo-reset` (new per-instance secret). When in doubt: overlay reset. |
+| 13/13 rehearsal slow | It builds nothing (uses installed binaries) but runs a full governed lifecycle; a few minutes at 2 GB RAM is normal. |
+
+## Honesty labels
+
+| Tier | Surfaces |
+|---|---|
+| **live-local** | node boot, `/v1/health`, standing, action cards, discharge, completion receipt, receipt binding check, 13/13 chain rehearsal — on this VM's own node |
+| **fixture-backed** | member-shell `?mode=demo` panes (self-labeled), NYCN institution package contents |
+| **design-only / absent** | production posture, signed/immutable image, federation, multi-org, pilots, attendance-receipt retrieval endpoint (known gap, `docs/dev/openapi-member-surface-gaps.md`) |

--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -11,9 +11,11 @@ One VM. One browser. The core ICN loop, honestly labeled:
 - Member standing, pending action cards, action discharge, and a
   cryptographic completion receipt — rendered in the member-shell
   reference client, served by the same VM.
-- Evidence you can re-verify: the receipt's 32-byte BLAKE3 `record_hash`
-  binding, and (optional, deeper) a 13/13 governed receipt-chain proof run
-  entirely inside the VM.
+- Evidence you can re-check: `icn-demo-verify <item-id>` re-fetches the
+  receipt and consistency-checks it (32-byte `record_hash` shape + field
+  binding — it does not re-derive the BLAKE3 hash), and (deeper,
+  cryptographic) `icn-demo-verify --chain` runs a 13/13 governed
+  receipt-chain proof entirely inside the VM via `icnctl audit verify`.
 
 ## What this does NOT demonstrate
 
@@ -107,17 +109,20 @@ session JWT (local VM only).
    domain, actor DID, transition, timestamp, and the 32-byte BLAKE3
    `record_hash` that binds them.
 5. **Verify evidence/audit** — in the VM:
-   `sudo icn-demo-verify <item-id>` re-fetches and checks the receipt
-   binding; `sudo icn-demo-verify --chain` runs the full 13/13 governed
-   receipt-chain rehearsal on a fresh ephemeral node and emits a
-   schema-validated evidence packet to `/var/lib/icn-demo/`.
+   `sudo icn-demo-verify <item-id>` re-fetches the receipt and
+   consistency-checks it (shape + field binding; not a BLAKE3
+   re-derivation); `sudo icn-demo-verify --chain` runs the full 13/13
+   governed receipt-chain rehearsal (`icnctl audit verify`) on a fresh
+   ephemeral node and emits a schema-validated evidence packet to
+   `/var/lib/icn-demo/`.
 
 ## Reset
 
 - Cheapest: power off and delete `overlay.qcow2`, recreate, reboot —
   whole-disk reset, nothing persists.
-- In-place: `ssh -p 2222 debian@127.0.0.1 sudo icn-demo-reset` (destroys
-  node state, re-runs firstboot, then `sudo icn-demo-seed` again).
+- In-place: `ssh -p 2222 debian@127.0.0.1 sudo icn-demo-reset` destroys
+  node state and re-runs firstboot. It does **not** reseed — run
+  `sudo icn-demo-seed` again afterwards for a fresh loop.
 
 ## Troubleshooting
 

--- a/deploy/appliance/README.md
+++ b/deploy/appliance/README.md
@@ -318,6 +318,56 @@ To rotate: remove `/var/lib/icn/.firstboot-complete` AND the keystore
 file `/var/lib/icn/identity.age` (plus `config.toml` / `genesis.json` in
 the same directory), then reboot or rerun firstboot.
 
+## Demo profile (DEV/DEMO image variant)
+
+`ICN_APPLIANCE_DEMO_PROFILE=1` at build time produces a **demo image**: the
+base appliance plus everything needed to run the member loop
+**standing -> action card -> discharge -> receipt -> evidence** against the
+VM's own node, from a stranger's browser on the host.
+
+What it adds (and the base image does NOT have):
+
+| Piece | Where | What it is |
+|---|---|---|
+| member-shell + pilot-ui fixtures | `/usr/share/icn/static/web/` | static reference client (#2026), fixture + live-local modes |
+| `icn-member-shell.service` | `:8090` | python3 stdlib static server, dev-only |
+| `20-demo-profile.conf` drop-in | `icnd.service.d/` | gateway bind `0.0.0.0:8080` (hostfwd reachability), dev gates (`ICN_ENABLE_ADMIN_ENDPOINTS`, `ICN_GOVERNANCE_BUILD_MODE=test`), `ICN_CORS_ORIGINS` for the shell |
+| `icn-demo-seed` | `/usr/local/sbin/` | seeds NYCN fixture institution + one open action item; prints the dev session JWT + URLs |
+| `icn-demo-verify` | `/usr/local/sbin/` | receipt binding check; `--chain` runs the bundled 13/13 governed receipt-chain rehearsal on an ephemeral in-VM node |
+| `icn-demo-reset` | `/usr/local/sbin/` | destructive reset: wipe node state, re-run firstboot, reseed |
+| NYCN package + dogfood kit + 13/13 scripts | `/usr/share/icn/demo/` | fixture institution and bundled evidence tooling |
+
+Build and smoke it:
+
+```bash
+export ICN_APPLIANCE_BASE_IMAGE=/path/to/debian-13-genericcloud-amd64.qcow2
+export ICN_APPLIANCE_OUTPUT_DIR=$HOME/icn-appliance-build
+export ICN_APPLIANCE_VERSION=0.0.2-demo
+export ICN_APPLIANCE_DEMO_PROFILE=1
+bash deploy/appliance/build-image.sh --real
+
+ICN_APPLIANCE_IMAGE=$ICN_APPLIANCE_OUTPUT_DIR/icn-appliance-0.0.2-demo-amd64.qcow2 \
+ICN_APPLIANCE_SSH_KEY=... ICN_APPLIANCE_CLOUD_INIT_SEED=... \
+bash deploy/appliance/smoke/smoke-local.sh --real --demo
+```
+
+`--demo` forwards the gateway (host `18080`) and shell (host `18090`), seeds
+the loop in-VM, then drives **standing -> card -> complete -> receipt** from
+the host through the forwarded ports — the same path a stranger's browser
+takes — and checks the receipt's 32-byte `record_hash` binding.
+
+Honesty labels for the demo image:
+
+- **Live-local:** node boot, health, standing/action-card/receipt endpoints,
+  action-item discharge, completion receipt, 13/13 receipt-chain rehearsal
+  (`icn-demo-verify --chain`). All on the VM's own node.
+- **Fixture-backed:** the shell's `?mode=demo` surfaces (self-labeled), the
+  NYCN institution package (fictional data).
+- **Not present / not claimed:** production posture, signed image, pilot
+  adoption, federation, multi-org deployment, real member data. The dev
+  gates in the drop-in are the same labeled non-production gates the local
+  devnet uses — never enable them outside a disposable demo VM.
+
 ## Security posture (dev-image, not production)
 
 - **No secrets are committed in this directory or embedded in the image.**

--- a/deploy/appliance/build-image.sh
+++ b/deploy/appliance/build-image.sh
@@ -398,6 +398,14 @@ if [ "$DEMO_PROFILE" = "1" ]; then
         --run-command "chmod +x /usr/local/sbin/icn-demo-seed.sh /usr/local/sbin/icn-demo-verify.sh /usr/local/sbin/icn-demo-reset.sh"
         --run-command "ln -sf /usr/local/sbin/icn-demo-seed.sh /usr/local/sbin/icn-demo-seed && ln -sf /usr/local/sbin/icn-demo-verify.sh /usr/local/sbin/icn-demo-verify && ln -sf /usr/local/sbin/icn-demo-reset.sh /usr/local/sbin/icn-demo-reset"
         --run-command "systemctl enable icn-member-shell.service"
+        # The bundled 13/13 evidence validator (icn-demo-verify --chain)
+        # needs the python3 jsonschema package. Debian genericcloud images
+        # provide it transitively via cloud-init; assert it here so a base
+        # image without it fails the BUILD with a clear message instead of
+        # failing the advertised --chain path at demo time. (No apt install:
+        # the libguestfs appliance cannot rely on network/DNS — see the
+        # python3-not-jq note in the demo scripts.)
+        --run-command "python3 -c \"import jsonschema\" || { echo \"ERROR: demo profile requires python3-jsonschema in the base image (Debian genericcloud ships it via cloud-init); this base image lacks it\" >&2; exit 1; }"
     )
 fi
 

--- a/deploy/appliance/build-image.sh
+++ b/deploy/appliance/build-image.sh
@@ -130,7 +130,6 @@ cat <<'EOF_PLAN'
      commit, build timestamp, and an explicit non-production flag.
 
   When ICN_APPLIANCE_DEMO_PROFILE=1, step 5 additionally (DEV/DEMO only):
-       - apt install jq
        - copy web/member-shell + web/pilot-ui/fixtures -> /usr/share/icn/static/web/
        - copy institutions/ (NYCN fixture package)     -> /usr/share/icn/demo/institutions/
        - copy 13/13 rehearsal scripts + evidence validator + nycn-dogfood kit
@@ -387,7 +386,6 @@ if [ "$DEMO_PROFILE" = "1" ]; then
     fi
 
     VIRT_CUSTOMIZE_ARGS+=(
-        --install "jq"
         --mkdir /usr/share/icn/demo
         --copy-in "$DEMO_STAGE/static/web:/usr/share/icn/static"
         --copy-in "$DEMO_STAGE/demo/institutions:/usr/share/icn/demo"

--- a/deploy/appliance/build-image.sh
+++ b/deploy/appliance/build-image.sh
@@ -21,6 +21,17 @@
 #   ICN_APPLIANCE_IMAGE_FORMAT   qcow2 (default) | raw
 #   ICN_APPLIANCE_ARCH           amd64 (default)
 #   ICN_APPLIANCE_IMAGE_NAME     Override the output basename.
+#   ICN_APPLIANCE_DEMO_PROFILE   1 = additionally install the DEV/DEMO
+#                                profile: member-shell static payload +
+#                                serving unit (:8090), demo env drop-in for
+#                                icnd (0.0.0.0:8080 bind, dev gates, CORS),
+#                                in-image icn-demo-seed / icn-demo-verify /
+#                                icn-demo-reset, the NYCN fixture
+#                                institution package, and the bundled 13/13
+#                                receipt-chain rehearsal. Demo images are
+#                                labeled in the manifest (demo_profile:
+#                                true) and remain non-production dev
+#                                artifacts. Default 0 (base image only).
 #
 # Required tools for --real:
 #   qemu-img, virt-customize, virt-sysprep, sha256sum, cargo
@@ -75,6 +86,7 @@ REPO_ROOT="$(cd "$DEPLOY_DIR/.." && pwd)"
 
 ARCH="${ICN_APPLIANCE_ARCH:-amd64}"
 IMAGE_FORMAT="${ICN_APPLIANCE_IMAGE_FORMAT:-qcow2}"
+DEMO_PROFILE="${ICN_APPLIANCE_DEMO_PROFILE:-0}"
 
 log "Mode: $MODE"
 log "Repo root:        $REPO_ROOT"
@@ -85,6 +97,7 @@ log "Base image:       ${ICN_APPLIANCE_BASE_IMAGE:-<unset>}"
 log "Version:          ${ICN_APPLIANCE_VERSION:-<unset>}"
 log "Output dir:       ${ICN_APPLIANCE_OUTPUT_DIR:-<unset>}"
 log "Base SHA256:      ${ICN_APPLIANCE_BASE_SHA256:-<not set; will not verify>}"
+log "Demo profile:     $DEMO_PROFILE (1 = DEV/DEMO payload + units installed)"
 echo
 
 # ---------- dry-run plan (printed in both modes for transparency) ----------
@@ -115,6 +128,18 @@ cat <<'EOF_PLAN'
   8) Compute output SHA256.
   9) Emit a manifest JSON next to the image with version, hashes, git
      commit, build timestamp, and an explicit non-production flag.
+
+  When ICN_APPLIANCE_DEMO_PROFILE=1, step 5 additionally (DEV/DEMO only):
+       - apt install jq
+       - copy web/member-shell + web/pilot-ui/fixtures -> /usr/share/icn/static/web/
+       - copy institutions/ (NYCN fixture package)     -> /usr/share/icn/demo/institutions/
+       - copy 13/13 rehearsal scripts + evidence validator + nycn-dogfood kit
+                                                        -> /usr/share/icn/demo/repo/
+       - copy icn-member-shell.service                  -> /etc/systemd/system/
+       - copy icnd.service.d/20-demo-profile.conf       -> /etc/systemd/system/icnd.service.d/
+       - copy icn-demo-{seed,verify,reset}.sh           -> /usr/local/sbin/
+       - systemctl enable icn-member-shell.service
+       - mark manifest demo_profile: true
 EOF_PLAN
 }
 
@@ -297,7 +322,92 @@ if [ -f "$HEALTH_CHECK_BIN" ]; then
     )
 fi
 
+# ---------- DEV/DEMO profile (ICN_APPLIANCE_DEMO_PROFILE=1) ----------
+# Everything in this block is demo-only payload and configuration. None of
+# it is installed on the base image, and the manifest records the choice
+# (demo_profile: true). See deploy/appliance/README.md "Demo profile".
+DEMO_STAGE=""
+if [ "$DEMO_PROFILE" = "1" ]; then
+    log "Demo profile requested: staging DEV/DEMO payload..."
+    DEMO_SEED_SCRIPT="$APPLIANCE_DIR/scripts/icn-demo-seed.sh"
+    DEMO_VERIFY_SCRIPT="$APPLIANCE_DIR/scripts/icn-demo-verify.sh"
+    DEMO_RESET_SCRIPT="$APPLIANCE_DIR/scripts/icn-demo-reset.sh"
+    MEMBER_SHELL_UNIT="$APPLIANCE_DIR/systemd/icn-member-shell.service"
+    DEMO_DROPIN="$APPLIANCE_DIR/systemd/icnd.service.d/20-demo-profile.conf"
+    for f in "$DEMO_SEED_SCRIPT" "$DEMO_VERIFY_SCRIPT" "$DEMO_RESET_SCRIPT" \
+             "$MEMBER_SHELL_UNIT" "$DEMO_DROPIN"; do
+        if [ ! -f "$f" ]; then
+            err "Demo profile source file missing: $f"
+            exit 7
+        fi
+    done
+    for d in "$REPO_ROOT/web/member-shell" "$REPO_ROOT/web/pilot-ui/fixtures" \
+             "$REPO_ROOT/institutions/nycn" "$REPO_ROOT/demo/nycn-dogfood"; do
+        if [ ! -d "$d" ]; then
+            err "Demo profile payload directory missing: $d"
+            exit 7
+        fi
+    done
+    for f in "$REPO_ROOT/scripts/local_receipt_chain_13of13_rehearsal.sh" \
+             "$REPO_ROOT/scripts/local_economic_receipt_chain_demo.sh" \
+             "$REPO_ROOT/docs/scripts/validate-rehearsal-evidence.py"; do
+        if [ ! -f "$f" ]; then
+            err "Demo profile payload file missing: $f"
+            exit 7
+        fi
+    done
+
+    # Stage a directory tree so virt-customize --copy-in can install whole
+    # directories with their relative layout preserved:
+    #   static/web/{member-shell, pilot-ui/fixtures}   (shell's relative
+    #       fixture fetch path "../pilot-ui/fixtures/..." must keep working)
+    #   demo/institutions/nycn                          (fixture institution)
+    #   demo/repo/{scripts, docs/scripts, docs/contracts, demo/nycn-dogfood}
+    #       (the 13/13 wrapper resolves ROOT as dirname($0)/.., so the
+    #        bundled copy must preserve the repo-relative layout)
+    DEMO_STAGE="$ICN_APPLIANCE_OUTPUT_DIR/.demo-stage.$$"
+    rm -rf "$DEMO_STAGE"
+    mkdir -p \
+        "$DEMO_STAGE/static/web/pilot-ui" \
+        "$DEMO_STAGE/demo/institutions" \
+        "$DEMO_STAGE/demo/repo/scripts" \
+        "$DEMO_STAGE/demo/repo/docs/scripts" \
+        "$DEMO_STAGE/demo/repo/demo"
+    cp -r "$REPO_ROOT/web/member-shell"            "$DEMO_STAGE/static/web/"
+    cp -r "$REPO_ROOT/web/pilot-ui/fixtures"       "$DEMO_STAGE/static/web/pilot-ui/"
+    cp -r "$REPO_ROOT/institutions/nycn"           "$DEMO_STAGE/demo/institutions/"
+    cp -r "$REPO_ROOT/demo/nycn-dogfood"           "$DEMO_STAGE/demo/repo/demo/"
+    cp "$REPO_ROOT/scripts/local_receipt_chain_13of13_rehearsal.sh" \
+       "$REPO_ROOT/scripts/local_economic_receipt_chain_demo.sh" \
+       "$DEMO_STAGE/demo/repo/scripts/"
+    cp "$REPO_ROOT/docs/scripts/validate-rehearsal-evidence.py" \
+       "$DEMO_STAGE/demo/repo/docs/scripts/"
+    if [ -d "$REPO_ROOT/docs/contracts" ]; then
+        cp -r "$REPO_ROOT/docs/contracts" "$DEMO_STAGE/demo/repo/docs/"
+    fi
+
+    VIRT_CUSTOMIZE_ARGS+=(
+        --install "jq"
+        --mkdir /usr/share/icn/demo
+        --copy-in "$DEMO_STAGE/static/web:/usr/share/icn/static"
+        --copy-in "$DEMO_STAGE/demo/institutions:/usr/share/icn/demo"
+        --copy-in "$DEMO_STAGE/demo/repo:/usr/share/icn/demo"
+        --copy-in "$MEMBER_SHELL_UNIT:/etc/systemd/system"
+        --copy-in "$DEMO_DROPIN:/etc/systemd/system/icnd.service.d"
+        --copy-in "$DEMO_SEED_SCRIPT:/usr/local/sbin"
+        --copy-in "$DEMO_VERIFY_SCRIPT:/usr/local/sbin"
+        --copy-in "$DEMO_RESET_SCRIPT:/usr/local/sbin"
+        --run-command "chmod +x /usr/local/sbin/icn-demo-seed.sh /usr/local/sbin/icn-demo-verify.sh /usr/local/sbin/icn-demo-reset.sh"
+        --run-command "ln -sf /usr/local/sbin/icn-demo-seed.sh /usr/local/sbin/icn-demo-seed && ln -sf /usr/local/sbin/icn-demo-verify.sh /usr/local/sbin/icn-demo-verify && ln -sf /usr/local/sbin/icn-demo-reset.sh /usr/local/sbin/icn-demo-reset"
+        --run-command "systemctl enable icn-member-shell.service"
+    )
+fi
+
 virt-customize "${VIRT_CUSTOMIZE_ARGS[@]}"
+
+if [ -n "$DEMO_STAGE" ]; then
+    rm -rf "$DEMO_STAGE"
+fi
 
 # virt-sysprep to scrub instance-specific state. --operations chosen
 # narrowly so we don't accidentally wipe what we just installed.
@@ -332,10 +442,13 @@ cat > "$OUT_MANIFEST" <<EOF_MANIFEST
   "non_production": true,
   "signed": false,
   "immutable": false,
+  "demo_profile": $([ "$DEMO_PROFILE" = "1" ] && echo true || echo false),
   "notes": [
     "Local dev appliance image. NOT a signed release.",
     "Contains no embedded secrets; per-instance JWT and keystore passphrase",
-    "are generated by icn-appliance-firstboot.service on first boot."
+    "are generated by icn-appliance-firstboot.service on first boot.",
+    "demo_profile=true means DEV/DEMO units, dev gates, fixture institution,",
+    "and the member-shell payload are installed — never production posture."
   ]
 }
 EOF_MANIFEST

--- a/deploy/appliance/check.sh
+++ b/deploy/appliance/check.sh
@@ -80,8 +80,13 @@ fi
 # silently inert. -w is portable across GNU and BSD grep.
 section "forbidden vocabulary scan"
 FORBIDDEN_PATTERN='(payment|wallet|currency|balance|token|blockchain|crypto|timebank)'
+# Lines tagged `vocab-ok: <justification>` are explicit, reviewable
+# exceptions (same spirit as the sanitize gate's sanitize-ok marker). The
+# only sanctioned use today is the literal `icnctl auth token` CLI
+# subcommand name in the demo-profile scripts — a command name, not
+# economic vocabulary. Tag sparingly; every tag is visible in review.
 HITS="$(grep -rwniE "$FORBIDDEN_PATTERN" "$APPLIANCE_DIR" \
-    --exclude="check.sh" 2>/dev/null || true)"
+    --exclude="check.sh" 2>/dev/null | grep -v 'vocab-ok' || true)"
 if [ -z "$HITS" ]; then
     ok "no forbidden ICN-native vocabulary present"
 else

--- a/deploy/appliance/check.sh
+++ b/deploy/appliance/check.sh
@@ -86,7 +86,7 @@ FORBIDDEN_PATTERN='(payment|wallet|currency|balance|token|blockchain|crypto|time
 # subcommand name in the demo-profile scripts — a command name, not
 # economic vocabulary. Tag sparingly; every tag is visible in review.
 HITS="$(grep -rwniE "$FORBIDDEN_PATTERN" "$APPLIANCE_DIR" \
-    --exclude="check.sh" 2>/dev/null | grep -v 'vocab-ok' || true)"
+    --exclude="check.sh" 2>/dev/null | grep -v 'vocab-ok:' || true)"
 if [ -z "$HITS" ]; then
     ok "no forbidden ICN-native vocabulary present"
 else

--- a/deploy/appliance/scripts/icn-demo-reset.sh
+++ b/deploy/appliance/scripts/icn-demo-reset.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ============================================================================
-# icn-demo-reset — wipe this demo VM's node state and reseed from scratch.
+# icn-demo-reset — wipe this demo VM's node state back to a fresh first boot.
 # ----------------------------------------------------------------------------
 # DEMO PROFILE ONLY. Installed by build-image.sh when
 # ICN_APPLIANCE_DEMO_PROFILE=1. Run as root inside the appliance VM:
@@ -10,8 +10,13 @@
 # DESTRUCTIVE — by design. This removes the VM's node state (identity,
 # keystore, journal, receipts, config) and per-instance secrets, then
 # re-runs firstboot so the VM provisions itself fresh, exactly like a
-# first boot. Old receipts/tokens stop being valid. That is the point:
-# a clean, rerunnable demo.
+# first boot. Old receipts and session JWTs stop being valid. That is the
+# point: a clean, rerunnable demo.
+#
+# This does NOT reseed. After a reset the VM has no institution, no
+# action item, and no session JWT until you run `sudo icn-demo-seed`
+# yourself — reset and seed stay separate so an operator can also reset
+# without seeding.
 #
 # Cheaper alternative when running from a QEMU overlay (the smoke script
 # pattern): just discard the overlay file and boot again — that resets the
@@ -32,8 +37,9 @@ rm -f /etc/icn/icnd.env
 
 log "re-running firstboot provisioning..."
 systemctl restart icn-appliance-firstboot.service
-if ! systemctl is-active --quiet icn-appliance-firstboot.service \
-   && ! [ -f /var/lib/icn/.firstboot-complete ]; then
+# The marker file is the single source of truth for firstboot success
+# (the unit is a oneshot; its is-active state is not a reliable signal).
+if ! [ -f /var/lib/icn/.firstboot-complete ]; then
   echo "[demo-reset] firstboot did not complete; inspect: journalctl -u icn-appliance-firstboot" >&2
   exit 1
 fi
@@ -42,4 +48,5 @@ log "starting icnd + member shell..."
 systemctl start icnd.service
 systemctl start icn-member-shell.service 2>/dev/null || true
 
-log "done. Reseed the demo with: sudo icn-demo-seed"
+log "done. The VM is back to a fresh first boot — no demo data yet."
+log "to seed the demo loop again, run: sudo icn-demo-seed"

--- a/deploy/appliance/scripts/icn-demo-reset.sh
+++ b/deploy/appliance/scripts/icn-demo-reset.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# ============================================================================
+# icn-demo-reset — wipe this demo VM's node state and reseed from scratch.
+# ----------------------------------------------------------------------------
+# DEMO PROFILE ONLY. Installed by build-image.sh when
+# ICN_APPLIANCE_DEMO_PROFILE=1. Run as root inside the appliance VM:
+#
+#     sudo icn-demo-reset
+#
+# DESTRUCTIVE — by design. This removes the VM's node state (identity,
+# keystore, journal, receipts, config) and per-instance secrets, then
+# re-runs firstboot so the VM provisions itself fresh, exactly like a
+# first boot. Old receipts/tokens stop being valid. That is the point:
+# a clean, rerunnable demo.
+#
+# Cheaper alternative when running from a QEMU overlay (the smoke script
+# pattern): just discard the overlay file and boot again — that resets the
+# whole disk, not only ICN state, and needs no in-VM action.
+# ============================================================================
+set -euo pipefail
+
+log(){ echo "[demo-reset] $*"; }
+[ "$(id -u)" -eq 0 ] || { echo "[demo-reset] run as root: sudo icn-demo-reset" >&2; exit 1; }
+
+log "stopping icnd (and member shell)..."
+systemctl stop icnd.service 2>/dev/null || true
+systemctl stop icn-member-shell.service 2>/dev/null || true
+
+log "wiping node state in /var/lib/icn and per-instance secrets..."
+rm -rf /var/lib/icn/* /var/lib/icn/.firstboot-complete 2>/dev/null || true
+rm -f /etc/icn/icnd.env
+
+log "re-running firstboot provisioning..."
+systemctl restart icn-appliance-firstboot.service
+if ! systemctl is-active --quiet icn-appliance-firstboot.service \
+   && ! [ -f /var/lib/icn/.firstboot-complete ]; then
+  echo "[demo-reset] firstboot did not complete; inspect: journalctl -u icn-appliance-firstboot" >&2
+  exit 1
+fi
+
+log "starting icnd + member shell..."
+systemctl start icnd.service
+systemctl start icn-member-shell.service 2>/dev/null || true
+
+log "done. Reseed the demo with: sudo icn-demo-seed"

--- a/deploy/appliance/scripts/icn-demo-seed.sh
+++ b/deploy/appliance/scripts/icn-demo-seed.sh
@@ -90,9 +90,12 @@ log "institution package applied."
 
 # Dev-gated standing bootstrap (best-effort; the action-item loop does not
 # strictly require it, but the shell's standing pane is richer with it).
+# The endpoint bootstraps the AUTHENTICATED caller's DID (claims.sub) in the
+# given jurisdiction — the body carries jurisdiction_id only, never a DID
+# (see icn-gateway api/commons dev_bootstrap_standing).
 standing_note="bootstrap-standing: ok"
 if ! curl -sf -m 5 -X POST -H "$AUTH" -H 'Content-Type: application/json' \
-      -d "{\"did\":\"$DID\"}" "$GW/v1/commons/dev/bootstrap-standing" >/dev/null 2>&1; then
+      -d "{\"jurisdiction_id\":\"$DOMAIN\"}" "$GW/v1/commons/dev/bootstrap-standing" >/dev/null 2>&1; then
   standing_note="bootstrap-standing: unavailable (dev gate off or endpoint shape changed) — standing pane may be sparse; action-item loop unaffected"
   log "WARN: $standing_note"
 fi

--- a/deploy/appliance/scripts/icn-demo-seed.sh
+++ b/deploy/appliance/scripts/icn-demo-seed.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# ============================================================================
+# icn-demo-seed — seed the appliance DEMO PROFILE with a runnable member loop.
+# ----------------------------------------------------------------------------
+# DEMO PROFILE ONLY. Installed by build-image.sh when
+# ICN_APPLIANCE_DEMO_PROFILE=1. Run as root inside the appliance VM:
+#
+#     sudo icn-demo-seed [--json]
+#
+# What it does (all against THIS VM's own gateway on 127.0.0.1:8080):
+#   1. Waits for the gateway to be healthy.
+#   2. Resolves the node operator DID and mints a dev session JWT
+#      (signed with this VM's per-instance JWT secret).
+#   3. Applies the in-tree NYCN institution package (fictional fixture
+#      institution — same package the nycn-dogfood rehearsal kit uses).
+#   4. Dev-gated standing bootstrap for the operator DID (so the shell's
+#      standing pane has something honest to show). Best-effort: if the
+#      dev gate is unavailable the seed continues and says so.
+#   5. Creates ONE open action item assigned to the operator DID — this is
+#      the action card the operator discharges in the member-shell.
+#   6. Prints the demo JWT + URLs + honesty labels (or JSON with --json).
+#
+# What it does NOT do:
+#   - No production claims. Fictional institution, test posture, local VM.
+#   - No external network access. Everything is loopback inside the VM.
+#   - The printed JWT is a LOCAL DEV credential for this disposable VM
+#     only. It is not a secret worth protecting beyond the VM's lifetime,
+#     but it is also never printed to the journal by the units — only by
+#     this command, in your terminal, on request.
+#
+# Idempotency: re-running re-applies the institution package (a no-op when
+# already applied) and creates an additional open action item. For a clean
+# slate use icn-demo-reset.
+# ============================================================================
+set -uo pipefail
+
+GW="${ICN_DEMO_GW:-http://127.0.0.1:8080}"
+DATA_DIR=/var/lib/icn
+ENV_FILE=/etc/icn/icnd.env
+PKG=/usr/share/icn/demo/institutions/nycn
+COOP_ID="${ICN_DEMO_COOP_ID:-nycn}"
+DOMAIN="${ICN_DEMO_DOMAIN:-nycn-federation-gov}"
+SCOPES="governance:read,governance:write,coop:read,coop:write,coop:admin"
+JSON_OUT=0
+[ "${1:-}" = "--json" ] && JSON_OUT=1
+
+log(){ [ "$JSON_OUT" = 1 ] || echo "[demo-seed] $*"; }
+fatal(){ echo "[demo-seed] FATAL: $*" >&2; exit 1; }
+
+[ "$(id -u)" -eq 0 ] || fatal "run as root: sudo icn-demo-seed"
+[ -f "$ENV_FILE" ]   || fatal "$ENV_FILE missing — has icn-appliance-firstboot run?"
+[ -d "$PKG" ]        || fatal "demo institution package missing at $PKG (image built without ICN_APPLIANCE_DEMO_PROFILE=1?)"
+command -v curl >/dev/null || fatal "curl missing"
+command -v jq   >/dev/null || fatal "jq missing (demo profile installs it at image build)"
+
+# Per-instance keystore passphrase, generated on this VM by firstboot.
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+[ -n "${ICN_KEYSTORE_PASSPHRASE:-}" ] || fatal "ICN_KEYSTORE_PASSPHRASE not present in $ENV_FILE"
+
+as_icn(){
+  sudo -u icn ICN_KEYSTORE_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" \
+      ICN_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" "$@"
+}
+
+log "waiting for gateway health at $GW ..."
+for i in $(seq 1 30); do
+  curl -sf -m 3 "$GW/v1/health" >/dev/null 2>&1 && break
+  [ "$i" = 30 ] && fatal "gateway never became healthy at $GW (journalctl -u icnd)"
+  sleep 2
+done
+log "gateway healthy."
+
+id_out="$(as_icn /usr/local/bin/icnctl --data-dir "$DATA_DIR" id show 2>/dev/null || true)"
+DID="$(grep -oE 'did:icn:[A-Za-z0-9]+' <<<"$id_out" | head -1)"
+[ -n "$DID" ] || fatal "could not resolve node operator DID (icnctl --data-dir $DATA_DIR id show)"
+log "operator DID: $DID"
+
+jwt_out="$(as_icn /usr/local/bin/icnctl --data-dir "$DATA_DIR" auth token --gateway "$GW" --coop-id "$COOP_ID" -s "$SCOPES" 2>/dev/null || true)" # vocab-ok: icnctl CLI subcommand name
+SESSION_JWT="$(grep -oE 'eyJ[A-Za-z0-9_.-]+' <<<"$jwt_out" | head -1)"
+[ -n "$SESSION_JWT" ] || fatal "session JWT mint failed (icnctl auth subcommand)"
+AUTH="Authorization: Bearer $SESSION_JWT"
+log "dev session JWT minted (printed at the end — local VM only)."
+
+log "applying NYCN institution package (fictional fixture institution)..."
+as_icn /usr/local/bin/icnctl --data-dir "$DATA_DIR" institution bootstrap apply \
+  -g "$GW" -c "$COOP_ID" --package "$PKG" >/tmp/icn-demo-seed-bootstrap.log 2>&1 \
+  || fatal "institution bootstrap apply failed (see /tmp/icn-demo-seed-bootstrap.log)"
+log "institution package applied."
+
+# Dev-gated standing bootstrap (best-effort; the action-item loop does not
+# strictly require it, but the shell's standing pane is richer with it).
+standing_note="bootstrap-standing: ok"
+if ! curl -sf -m 5 -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+      -d "{\"did\":\"$DID\"}" "$GW/v1/commons/dev/bootstrap-standing" >/dev/null 2>&1; then
+  standing_note="bootstrap-standing: unavailable (dev gate off or endpoint shape changed) — standing pane may be sparse; action-item loop unaffected"
+  log "WARN: $standing_note"
+fi
+
+log "creating one open action item assigned to $DID ..."
+item_json="$(curl -s -m 10 -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+  -d "{\"title\":\"Confirm Summit 2026 venue booking\",\"description\":\"Demo obligation (fictional): confirm the venue contract for the 2026 Summit\",\"assignee\":\"$DID\",\"priority\":\"high\",\"meeting_context\":\"demo organizing team\"}" \
+  "$GW/v1/gov/domains/$DOMAIN/action-items")"
+ITEM_ID="$(jq -r '.id // empty' <<<"$item_json" 2>/dev/null)"
+[ -n "$ITEM_ID" ] || fatal "action item creation failed: $item_json"
+log "action item created: $ITEM_ID"
+
+cards_json="$(curl -s -m 10 -H "$AUTH" "$GW/v1/gov/me/action-cards")"
+card_n="$(jq --arg id "$ITEM_ID" '[.cards[]? | select(.source_id==$id)] | length' <<<"$cards_json" 2>/dev/null || echo 0)"
+[ "$card_n" = "1" ] || fatal "expected 1 action card for $ITEM_ID, found ${card_n:-0}: $cards_json"
+log "action card visible via /v1/gov/me/action-cards."
+
+if [ "$JSON_OUT" = 1 ]; then
+  jq -n --arg did "$DID" --arg jwt "$SESSION_JWT" --arg item "$ITEM_ID" \
+        --arg domain "$DOMAIN" --arg gw "$GW" --arg standing "$standing_note" \
+        '{did:$did, jwt:$jwt, item_id:$item, domain:$domain, gateway:$gw, standing_note:$standing}'
+  exit 0
+fi
+
+cat <<EOF
+
+============================ ICN DEMO SEEDED =============================
+ Gateway (in-VM):    $GW   (host: whatever you hostfwd'd 8080 to)
+ Member shell:       http://localhost:8090/member-shell/        (live-local)
+                     http://localhost:8090/member-shell/?mode=demo (fixtures)
+                     (replace 8090 with your hostfwd port if different)
+ Operator DID:       $DID
+ Domain:             $DOMAIN
+ Open action item:   $ITEM_ID
+ $standing_note
+
+ Dev session JWT (LOCAL VM ONLY — paste into the shell's live mode):
+ $SESSION_JWT
+
+ Honesty labels:
+   live-local : node, gateway, standing/action-card/receipt endpoints,
+                action-item completion, completion receipt — all on THIS VM.
+   fixture    : ?mode=demo surfaces (self-labeled in the shell).
+   NOT real   : no production, no pilot, no federation, no real members —
+                fictional institution data on a disposable dev VM.
+
+ Demo loop: open the shell → standing → action card → complete → receipt.
+ Evidence:  sudo icn-demo-verify   (receipt re-fetch + 13/13 chain proof)
+ Reset:     sudo icn-demo-reset
+==========================================================================
+EOF

--- a/deploy/appliance/scripts/icn-demo-seed.sh
+++ b/deploy/appliance/scripts/icn-demo-seed.sh
@@ -151,7 +151,9 @@ cat <<EOF
                 fictional institution data on a disposable dev VM.
 
  Demo loop: open the shell → standing → action card → complete → receipt.
- Evidence:  sudo icn-demo-verify   (receipt re-fetch + 13/13 chain proof)
- Reset:     sudo icn-demo-reset
+ Evidence:  sudo icn-demo-verify $ITEM_ID   (receipt re-fetch + consistency check,
+            after you complete the action)
+            sudo icn-demo-verify --chain    (full 13/13 governed chain proof)
+ Reset:     sudo icn-demo-reset             (then re-run icn-demo-seed)
 ==========================================================================
 EOF

--- a/deploy/appliance/scripts/icn-demo-seed.sh
+++ b/deploy/appliance/scripts/icn-demo-seed.sh
@@ -50,8 +50,8 @@ fatal(){ echo "[demo-seed] FATAL: $*" >&2; exit 1; }
 [ "$(id -u)" -eq 0 ] || fatal "run as root: sudo icn-demo-seed"
 [ -f "$ENV_FILE" ]   || fatal "$ENV_FILE missing — has icn-appliance-firstboot run?"
 [ -d "$PKG" ]        || fatal "demo institution package missing at $PKG (image built without ICN_APPLIANCE_DEMO_PROFILE=1?)"
-command -v curl >/dev/null || fatal "curl missing"
-command -v jq   >/dev/null || fatal "jq missing (demo profile installs it at image build)"
+command -v curl    >/dev/null || fatal "curl missing"
+command -v python3 >/dev/null || fatal "python3 missing"
 
 # Per-instance keystore passphrase, generated on this VM by firstboot.
 # shellcheck disable=SC1090
@@ -101,19 +101,30 @@ log "creating one open action item assigned to $DID ..."
 item_json="$(curl -s -m 10 -X POST -H "$AUTH" -H 'Content-Type: application/json' \
   -d "{\"title\":\"Confirm Summit 2026 venue booking\",\"description\":\"Demo obligation (fictional): confirm the venue contract for the 2026 Summit\",\"assignee\":\"$DID\",\"priority\":\"high\",\"meeting_context\":\"demo organizing team\"}" \
   "$GW/v1/gov/domains/$DOMAIN/action-items")"
-ITEM_ID="$(jq -r '.id // empty' <<<"$item_json" 2>/dev/null)"
+ITEM_ID="$(python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("id", ""))
+except Exception:
+    print("")' <<<"$item_json")"
 [ -n "$ITEM_ID" ] || fatal "action item creation failed: $item_json"
 log "action item created: $ITEM_ID"
 
 cards_json="$(curl -s -m 10 -H "$AUTH" "$GW/v1/gov/me/action-cards")"
-card_n="$(jq --arg id "$ITEM_ID" '[.cards[]? | select(.source_id==$id)] | length' <<<"$cards_json" 2>/dev/null || echo 0)"
+card_n="$(python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+    print(sum(1 for c in d.get("cards", []) if c.get("source_id") == sys.argv[1]))
+except Exception:
+    print(0)' "$ITEM_ID" <<<"$cards_json")"
 [ "$card_n" = "1" ] || fatal "expected 1 action card for $ITEM_ID, found ${card_n:-0}: $cards_json"
 log "action card visible via /v1/gov/me/action-cards."
 
 if [ "$JSON_OUT" = 1 ]; then
-  jq -n --arg did "$DID" --arg jwt "$SESSION_JWT" --arg item "$ITEM_ID" \
-        --arg domain "$DOMAIN" --arg gw "$GW" --arg standing "$standing_note" \
-        '{did:$did, jwt:$jwt, item_id:$item, domain:$domain, gateway:$gw, standing_note:$standing}'
+  python3 -c 'import json,sys
+print(json.dumps({"did": sys.argv[1], "jwt": sys.argv[2], "item_id": sys.argv[3],
+                  "domain": sys.argv[4], "gateway": sys.argv[5],
+                  "standing_note": sys.argv[6]}))' \
+    "$DID" "$SESSION_JWT" "$ITEM_ID" "$DOMAIN" "$GW" "$standing_note"
   exit 0
 fi
 

--- a/deploy/appliance/scripts/icn-demo-verify.sh
+++ b/deploy/appliance/scripts/icn-demo-verify.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ============================================================================
+# icn-demo-verify — evidence/audit step of the appliance demo loop.
+# ----------------------------------------------------------------------------
+# DEMO PROFILE ONLY. Installed by build-image.sh when
+# ICN_APPLIANCE_DEMO_PROFILE=1. Run as root inside the appliance VM.
+#
+# Two evidence paths, both honest about what they prove:
+#
+#   sudo icn-demo-verify <item-id> [domain]
+#       Re-fetches the completion receipt for that action item from THIS
+#       VM's gateway and checks the binding shape: a 32-byte BLAKE3
+#       record_hash over {item_id, domain_id, actor_did, transition,
+#       completed_at} (canonical hasher in icn-governance proof.rs).
+#       Proves: THIS actor discharged THIS obligation at THIS time on this
+#       node. Does not prove production, federation, or pilot adoption.
+#
+#   sudo icn-demo-verify --chain
+#       Runs the bundled 13/13 governed receipt-chain rehearsal
+#       (scripts/local_receipt_chain_13of13_rehearsal.sh) against a FRESH
+#       ephemeral node on loopback :18080 inside this VM. Asserts
+#       `icnctl audit verify` reports a complete 13/13 receipt chain and
+#       emits a schema-validated, repo-safe evidence packet.
+#       Output: /var/lib/icn-demo/receipt-chain-13of13/
+# ============================================================================
+set -uo pipefail
+
+GW="${ICN_DEMO_GW:-http://127.0.0.1:8080}"
+DATA_DIR=/var/lib/icn
+ENV_FILE=/etc/icn/icnd.env
+REPO=/usr/share/icn/demo/repo
+COOP_ID="${ICN_DEMO_COOP_ID:-nycn}"
+
+log(){ echo "[demo-verify] $*"; }
+fatal(){ echo "[demo-verify] FATAL: $*" >&2; exit 1; }
+[ "$(id -u)" -eq 0 ] || fatal "run as root: sudo icn-demo-verify"
+
+if [ "${1:-}" = "--chain" ]; then
+  RUNNER="$REPO/scripts/local_receipt_chain_13of13_rehearsal.sh"
+  [ -f "$RUNNER" ] || fatal "bundled 13/13 rehearsal missing at $RUNNER"
+  OUT=/var/lib/icn-demo
+  mkdir -p "$OUT"
+  log "running the 13/13 governed receipt-chain rehearsal (fresh ephemeral node, loopback :18080)..."
+  log "this is the real proof path; it takes a few minutes on small VMs."
+  ICND=/usr/local/bin/icnd ICNCTL=/usr/local/bin/icnctl ICN_GW_PORT=18080 \
+    bash "$RUNNER" --fresh --no-build
+  rc=$?
+  if [ -d "$REPO/demo/output/receipt-chain-13of13" ]; then
+    rm -rf "$OUT/receipt-chain-13of13"
+    cp -r "$REPO/demo/output/receipt-chain-13of13" "$OUT/" 2>/dev/null || true
+    log "evidence copied to $OUT/receipt-chain-13of13/"
+  fi
+  exit "$rc"
+fi
+
+ITEM_ID="${1:-}"
+DOMAIN="${2:-nycn-federation-gov}"
+[ -n "$ITEM_ID" ] || fatal "usage: icn-demo-verify <item-id> [domain]   (or --chain)"
+[ -f "$ENV_FILE" ] || fatal "$ENV_FILE missing — has firstboot run?"
+command -v jq >/dev/null || fatal "jq missing"
+
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+SESSION_JWT="$(sudo -u icn ICN_KEYSTORE_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" ICN_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" /usr/local/bin/icnctl --data-dir "$DATA_DIR" auth token --gateway "$GW" --coop-id "$COOP_ID" -s "governance:read" 2>/dev/null | grep -oE 'eyJ[A-Za-z0-9_.-]+' | head -1)" # vocab-ok: icnctl CLI subcommand name
+[ -n "$SESSION_JWT" ] || fatal "could not mint a read JWT"
+
+receipt="$(curl -s -m 10 -H "Authorization: Bearer $SESSION_JWT" \
+  "$GW/v1/gov/domains/$DOMAIN/action-items/$ITEM_ID/completion-receipt")"
+echo "$receipt" | jq . 2>/dev/null || fatal "receipt fetch failed: $receipt"
+
+jq -e --arg id "$ITEM_ID" --arg dom "$DOMAIN" \
+  '(.record_hash | type == "array" and length == 32 and all(.[]; type == "number" and . >= 0 and . <= 255))
+   and .item_id == $id and .domain_id == $dom and .transition == "completed"
+   and (.completed_at | type == "number" and . > 0)' <<<"$receipt" >/dev/null \
+  || fatal "receipt failed the binding check (32-byte record_hash over item/domain/actor/transition/time)"
+
+log "PASS — receipt is well-formed and bound to this item/domain/transition."
+log "Proves: this actor discharged this obligation at this time, on this VM's node."
+log "Does NOT prove: production deployment, federation, or pilot adoption."
+log "Deeper proof: sudo icn-demo-verify --chain   (13/13 governed receipt chain)"

--- a/deploy/appliance/scripts/icn-demo-verify.sh
+++ b/deploy/appliance/scripts/icn-demo-verify.sh
@@ -40,6 +40,12 @@ if [ "${1:-}" = "--chain" ]; then
   [ -f "$RUNNER" ] || fatal "bundled 13/13 rehearsal missing at $RUNNER"
   OUT=/var/lib/icn-demo
   mkdir -p "$OUT"
+  # The rehearsal wrapper's binary gate only looks in $ROOT/icn/target/
+  # (its ICND/ICNCTL env overrides apply to the inner script, not the
+  # gate), so expose the installed binaries at the expected location.
+  mkdir -p "$REPO/icn/target/release"
+  ln -sf /usr/local/bin/icnd "$REPO/icn/target/release/icnd"
+  ln -sf /usr/local/bin/icnctl "$REPO/icn/target/release/icnctl"
   log "running the 13/13 governed receipt-chain rehearsal (fresh ephemeral node, loopback :18080)..."
   log "this is the real proof path; it takes a few minutes on small VMs."
   ICND=/usr/local/bin/icnd ICNCTL=/usr/local/bin/icnctl ICN_GW_PORT=18080 \

--- a/deploy/appliance/scripts/icn-demo-verify.sh
+++ b/deploy/appliance/scripts/icn-demo-verify.sh
@@ -57,7 +57,7 @@ ITEM_ID="${1:-}"
 DOMAIN="${2:-nycn-federation-gov}"
 [ -n "$ITEM_ID" ] || fatal "usage: icn-demo-verify <item-id> [domain]   (or --chain)"
 [ -f "$ENV_FILE" ] || fatal "$ENV_FILE missing — has firstboot run?"
-command -v jq >/dev/null || fatal "jq missing"
+command -v python3 >/dev/null || fatal "python3 missing"
 
 # shellcheck disable=SC1090
 . "$ENV_FILE"
@@ -66,13 +66,31 @@ SESSION_JWT="$(sudo -u icn ICN_KEYSTORE_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" IC
 
 receipt="$(curl -s -m 10 -H "Authorization: Bearer $SESSION_JWT" \
   "$GW/v1/gov/domains/$DOMAIN/action-items/$ITEM_ID/completion-receipt")"
-echo "$receipt" | jq . 2>/dev/null || fatal "receipt fetch failed: $receipt"
+echo "$receipt" | python3 -m json.tool 2>/dev/null || fatal "receipt fetch failed: $receipt"
 
-jq -e --arg id "$ITEM_ID" --arg dom "$DOMAIN" \
-  '(.record_hash | type == "array" and length == 32 and all(.[]; type == "number" and . >= 0 and . <= 255))
-   and .item_id == $id and .domain_id == $dom and .transition == "completed"
-   and (.completed_at | type == "number" and . > 0)' <<<"$receipt" >/dev/null \
-  || fatal "receipt failed the binding check (32-byte record_hash over item/domain/actor/transition/time)"
+if ! RECEIPT_JSON="$receipt" python3 - "$ITEM_ID" "$DOMAIN" <<'PY'
+import json
+import os
+import sys
+
+r = json.loads(os.environ["RECEIPT_JSON"])
+item, dom = sys.argv[1], sys.argv[2]
+h = r.get("record_hash")
+ok = (
+    isinstance(h, list)
+    and len(h) == 32
+    and all(isinstance(b, int) and 0 <= b <= 255 for b in h)
+    and r.get("item_id") == item
+    and r.get("domain_id") == dom
+    and r.get("transition") == "completed"
+    and isinstance(r.get("completed_at"), (int, float))
+    and r.get("completed_at") > 0
+)
+sys.exit(0 if ok else 1)
+PY
+then
+  fatal "receipt failed the binding check (32-byte record_hash over item/domain/actor/transition/time)"
+fi
 
 log "PASS — receipt is well-formed and bound to this item/domain/transition."
 log "Proves: this actor discharged this obligation at this time, on this VM's node."

--- a/deploy/appliance/scripts/icn-demo-verify.sh
+++ b/deploy/appliance/scripts/icn-demo-verify.sh
@@ -9,11 +9,13 @@
 #
 #   sudo icn-demo-verify <item-id> [domain]
 #       Re-fetches the completion receipt for that action item from THIS
-#       VM's gateway and checks the binding shape: a 32-byte BLAKE3
-#       record_hash over {item_id, domain_id, actor_did, transition,
-#       completed_at} (canonical hasher in icn-governance proof.rs).
-#       Proves: THIS actor discharged THIS obligation at THIS time on this
-#       node. Does not prove production, federation, or pilot adoption.
+#       VM's gateway and runs a CONSISTENCY CHECK: record_hash has the
+#       32-byte shape and the receipt fields (item_id, domain_id,
+#       transition, completed_at) match what was asked for. It does NOT
+#       re-derive the BLAKE3 record_hash — the canonical hasher lives in
+#       icn-governance proof.rs, and cryptographic verification of the
+#       chain is what `--chain` (icnctl audit verify) does.
+#       Does not prove production, federation, or pilot adoption.
 #
 #   sudo icn-demo-verify --chain
 #       Runs the bundled 13/13 governed receipt-chain rehearsal
@@ -98,7 +100,8 @@ then
   fatal "receipt failed the binding check (32-byte record_hash over item/domain/actor/transition/time)"
 fi
 
-log "PASS — receipt is well-formed and bound to this item/domain/transition."
-log "Proves: this actor discharged this obligation at this time, on this VM's node."
+log "PASS — receipt re-fetched; consistency check OK (32-byte record_hash shape +"
+log "field binding to this item/domain/transition). NOT a BLAKE3 re-derivation —"
+log "cryptographic verification is the --chain path (icnctl audit verify)."
 log "Does NOT prove: production deployment, federation, or pilot adoption."
 log "Deeper proof: sudo icn-demo-verify --chain   (13/13 governed receipt chain)"

--- a/deploy/appliance/smoke/smoke-local.sh
+++ b/deploy/appliance/smoke/smoke-local.sh
@@ -438,6 +438,24 @@ if [ "$DEMO" = 1 ]; then
         || { err "[demo] fixture pack missing from the served payload"; exit 11; }
     log "[demo] member-shell + fixture pack served."
 
+    # curl does not enforce CORS, but the browser this smoke stands in for
+    # does (the shell's Authorization header forces a preflight). Assert the
+    # gateway actually allows the shell origin for the configured forward
+    # port, so a custom SHELL_FWD_PORT outside the image's CORS allowlist
+    # cannot produce a DEMO PASS that a real browser would contradict.
+    log "[demo] CORS preflight for browser origin http://localhost:${SHELL_FWD_PORT}..."
+    CORS_HEADERS="$(curl -s -m 10 -X OPTIONS -D - -o /dev/null \
+        -H "Origin: http://localhost:${SHELL_FWD_PORT}" \
+        -H "Access-Control-Request-Method: GET" \
+        -H "Access-Control-Request-Headers: authorization" \
+        "http://127.0.0.1:${GW_FWD_PORT}/v1/gov/me/standing" 2>/dev/null)"
+    if ! grep -qiE "access-control-allow-origin: *(http://localhost:${SHELL_FWD_PORT}|\*)" <<<"$CORS_HEADERS"; then
+        err "[demo] gateway CORS does not allow http://localhost:${SHELL_FWD_PORT} — a real browser would fail here even though curl checks pass."
+        err "[demo] the demo image allowlists shell ports 8090/18090; use those, or extend ICN_CORS_ORIGINS in the image's icnd drop-in."
+        exit 11
+    fi
+    log "[demo] CORS preflight ok for http://localhost:${SHELL_FWD_PORT}."
+
     log "[demo] Seeding the demo loop in the VM (sudo icn-demo-seed --json)..."
     SEED_JSON="$(run_in_vm "sudo icn-demo-seed --json" 2>/dev/null)" || {
         err "[demo] icn-demo-seed failed."

--- a/deploy/appliance/smoke/smoke-local.sh
+++ b/deploy/appliance/smoke/smoke-local.sh
@@ -443,18 +443,24 @@ if [ "$DEMO" = 1 ]; then
     # gateway actually allows the shell origin for the configured forward
     # port, so a custom SHELL_FWD_PORT outside the image's CORS allowlist
     # cannot produce a DEMO PASS that a real browser would contradict.
-    log "[demo] CORS preflight for browser origin http://localhost:${SHELL_FWD_PORT}..."
-    CORS_HEADERS="$(curl -s -m 10 -X OPTIONS -D - -o /dev/null \
-        -H "Origin: http://localhost:${SHELL_FWD_PORT}" \
-        -H "Access-Control-Request-Method: GET" \
-        -H "Access-Control-Request-Headers: authorization" \
-        "http://127.0.0.1:${GW_FWD_PORT}/v1/gov/me/standing" 2>/dev/null)"
-    if ! grep -qiE "access-control-allow-origin: *(http://localhost:${SHELL_FWD_PORT}|\*)" <<<"$CORS_HEADERS"; then
-        err "[demo] gateway CORS does not allow http://localhost:${SHELL_FWD_PORT} — a real browser would fail here even though curl checks pass."
-        err "[demo] the demo image allowlists shell ports 8090/18090; use those, or extend ICN_CORS_ORIGINS in the image's icnd drop-in."
-        exit 11
-    fi
-    log "[demo] CORS preflight ok for http://localhost:${SHELL_FWD_PORT}."
+    # Assert BOTH loopback spellings for the configured port: the smoke
+    # prints 127.0.0.1 URLs while docs use localhost, and the browser sends
+    # whichever the operator typed. The demo drop-in allowlists both for
+    # the supported ports; a custom port must too.
+    for ORIGIN in "http://localhost:${SHELL_FWD_PORT}" "http://127.0.0.1:${SHELL_FWD_PORT}"; do
+        log "[demo] CORS preflight for browser origin ${ORIGIN}..."
+        CORS_HEADERS="$(curl -s -m 10 -X OPTIONS -D - -o /dev/null \
+            -H "Origin: ${ORIGIN}" \
+            -H "Access-Control-Request-Method: GET" \
+            -H "Access-Control-Request-Headers: authorization" \
+            "http://127.0.0.1:${GW_FWD_PORT}/v1/gov/me/standing" 2>/dev/null)"
+        if ! grep -qiE "access-control-allow-origin: *(${ORIGIN}|\*)" <<<"$CORS_HEADERS"; then
+            err "[demo] gateway CORS does not allow ${ORIGIN} — a real browser at that URL would fail even though curl checks pass."
+            err "[demo] the demo image allowlists both loopback spellings for shell ports 8090/18090; use those, or extend ICN_CORS_ORIGINS in the image's icnd drop-in."
+            exit 11
+        fi
+    done
+    log "[demo] CORS preflight ok for both loopback origins on port ${SHELL_FWD_PORT}."
 
     log "[demo] Seeding the demo loop in the VM (sudo icn-demo-seed --json)..."
     SEED_JSON="$(run_in_vm "sudo icn-demo-seed --json" 2>/dev/null)" || {

--- a/deploy/appliance/smoke/smoke-local.sh
+++ b/deploy/appliance/smoke/smoke-local.sh
@@ -9,6 +9,21 @@
 #              user-mode networking, wait for SSH, verify icnd is alive,
 #              and confirm /v1/health on port 8080 from inside the VM.
 #
+# Demo-profile add-on (requires an image built with
+# ICN_APPLIANCE_DEMO_PROFILE=1):
+#   --demo     After the base checks pass, additionally:
+#                - forward the gateway and member-shell ports to the host
+#                  (hostfwd 127.0.0.1:GW_FWD->8080, 127.0.0.1:SHELL_FWD->8090)
+#                - verify the member-shell static server answers (host-side,
+#                  the stranger path)
+#                - run `sudo icn-demo-seed --json` in the VM
+#                - drive the member loop from the HOST through the forwarded
+#                  gateway: standing -> action card -> complete -> receipt,
+#                  with the receipt binding check (32-byte record_hash)
+#              A --demo pass means the demo loop works end-to-end against
+#              this image from a clean boot. It still does NOT mean
+#              production, pilot, or federation.
+#
 # Required for --real:
 #   ICN_APPLIANCE_IMAGE      Path to the QCOW2 produced by build-image.sh.
 #   ICN_APPLIANCE_SSH_KEY    Path to the smoke-only SSH private key. The
@@ -25,9 +40,13 @@
 #                                  cloud-localds (operator must replace
 #                                  the placeholder SSH key first; the
 #                                  script refuses the placeholder).
-#   ICN_APPLIANCE_VM_MEMORY      Default: 1024 (MiB).
+#   ICN_APPLIANCE_VM_MEMORY      Default: 1024 (MiB; consider 2048 with --demo).
 #   ICN_APPLIANCE_VM_CPUS        Default: 2.
 #   ICN_APPLIANCE_VM_TIMEOUT     Default: 300 (seconds; total smoke budget).
+#   ICN_APPLIANCE_GW_FWD_PORT    Default: 18080 (host port forwarded to the
+#                                VM gateway :8080; --demo only).
+#   ICN_APPLIANCE_SHELL_FWD_PORT Default: 18090 (host port forwarded to the
+#                                VM member-shell :8090; --demo only).
 #
 # Required tools for --real:
 #   qemu-system-x86_64, ssh, curl, sha256sum
@@ -57,10 +76,13 @@ usage() {
     exit 0
 }
 
+DEMO=0
+
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --dry-run) MODE="dry-run" ; shift ;;
         --real)    MODE="real"    ; shift ;;
+        --demo)    DEMO=1         ; shift ;;
         --help|-h) usage ;;
         *)
             err "unknown argument: $1"
@@ -77,8 +99,11 @@ HEALTH_PORT="${ICN_APPLIANCE_HEALTH_PORT:-8080}"
 VM_MEMORY="${ICN_APPLIANCE_VM_MEMORY:-1024}"
 VM_CPUS="${ICN_APPLIANCE_VM_CPUS:-2}"
 VM_TIMEOUT="${ICN_APPLIANCE_VM_TIMEOUT:-300}"
+GW_FWD_PORT="${ICN_APPLIANCE_GW_FWD_PORT:-18080}"
+SHELL_FWD_PORT="${ICN_APPLIANCE_SHELL_FWD_PORT:-18090}"
 
 log "Mode: $MODE"
+log "Demo add-on:      $DEMO"
 log "VM SSH:           ${SSH_USER}@127.0.0.1:${SSH_PORT}"
 log "Health port:      ${HEALTH_PORT} (checked inside VM via SSH; never 8000)"
 log "VM memory:        ${VM_MEMORY} MiB"
@@ -265,7 +290,15 @@ log "Creating disposable overlay $OVERLAY (backing format: $BACKING_FORMAT) ..."
 qemu-img create -f qcow2 -b "$ICN_APPLIANCE_IMAGE" -F "$BACKING_FORMAT" "$OVERLAY" >/dev/null
 
 # Launch QEMU under user-mode networking. We do NOT touch host networking.
-log "Launching QEMU (user-mode net, hostfwd ${SSH_PORT}->22)..."
+NETDEV="user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22"
+if [ "$DEMO" = 1 ]; then
+    # Demo add-on: forward the gateway and member-shell so the loop can be
+    # driven from the host — the same path a stranger's browser takes.
+    NETDEV="${NETDEV},hostfwd=tcp:127.0.0.1:${GW_FWD_PORT}-:8080,hostfwd=tcp:127.0.0.1:${SHELL_FWD_PORT}-:8090"
+    log "Launching QEMU (user-mode net, hostfwd ${SSH_PORT}->22, ${GW_FWD_PORT}->8080, ${SHELL_FWD_PORT}->8090)..."
+else
+    log "Launching QEMU (user-mode net, hostfwd ${SSH_PORT}->22)..."
+fi
 qemu-system-x86_64 \
     -machine accel=kvm:tcg \
     -m "$VM_MEMORY" \
@@ -274,7 +307,7 @@ qemu-system-x86_64 \
     -serial file:"$WORK_DIR/serial.log" \
     -drive "if=virtio,format=qcow2,file=$OVERLAY" \
     -drive "if=virtio,format=raw,file=$SEED_ISO,readonly=on" \
-    -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22" \
+    -netdev "$NETDEV" \
     -device "virtio-net-pci,netdev=net0" \
     -nographic \
     >"$WORK_DIR/qemu.stdout" 2>"$WORK_DIR/qemu.stderr" &
@@ -381,6 +414,81 @@ if [ "$HEALTH_OK" -ne 1 ]; then
 fi
 log "/v1/health returned 200."
 
+# ---------- --demo add-on: drive the member loop from the host ----------
+if [ "$DEMO" = 1 ]; then
+    command -v jq >/dev/null 2>&1 || { err "--demo requires jq on the host"; exit 10; }
+
+    log "[demo] Verifying member-shell static server from the HOST (stranger path)..."
+    SHELL_DEADLINE=$(( $(date +%s) + 60 ))
+    SHELL_OK=0
+    while [ "$(date +%s)" -lt "$SHELL_DEADLINE" ]; do
+        if curl -sf -m 5 "http://127.0.0.1:${SHELL_FWD_PORT}/member-shell/index.html" >/dev/null 2>&1; then
+            SHELL_OK=1
+            break
+        fi
+        sleep 3
+    done
+    if [ "$SHELL_OK" -ne 1 ]; then
+        err "[demo] member-shell never answered on host port ${SHELL_FWD_PORT} (is the image built with ICN_APPLIANCE_DEMO_PROFILE=1?)"
+        run_in_vm "sudo systemctl status icn-member-shell.service --no-pager" || true
+        run_in_vm "sudo journalctl -u icn-member-shell.service --no-pager -n 50" || true
+        exit 11
+    fi
+    curl -sf -m 5 "http://127.0.0.1:${SHELL_FWD_PORT}/pilot-ui/fixtures/icn-organizer-demo/standing.json" >/dev/null 2>&1 \
+        || { err "[demo] fixture pack missing from the served payload"; exit 11; }
+    log "[demo] member-shell + fixture pack served."
+
+    log "[demo] Seeding the demo loop in the VM (sudo icn-demo-seed --json)..."
+    SEED_JSON="$(run_in_vm "sudo icn-demo-seed --json" 2>/dev/null)" || {
+        err "[demo] icn-demo-seed failed."
+        run_in_vm "sudo journalctl -u icnd.service --no-pager -n 100" || true
+        exit 12
+    }
+    DEMO_JWT="$(jq -r '.jwt // empty' <<<"$SEED_JSON")"
+    DEMO_ITEM="$(jq -r '.item_id // empty' <<<"$SEED_JSON")"
+    DEMO_DOMAIN="$(jq -r '.domain // empty' <<<"$SEED_JSON")"
+    DEMO_DID="$(jq -r '.did // empty' <<<"$SEED_JSON")"
+    if [ -z "$DEMO_JWT" ] || [ -z "$DEMO_ITEM" ] || [ -z "$DEMO_DOMAIN" ]; then
+        err "[demo] seed output incomplete: $SEED_JSON"
+        exit 12
+    fi
+    log "[demo] seeded: item $DEMO_ITEM in $DEMO_DOMAIN for $DEMO_DID"
+
+    GWH="http://127.0.0.1:${GW_FWD_PORT}"
+    AUTH="Authorization: Bearer $DEMO_JWT"
+
+    log "[demo] 1/4 standing (host-side GET /v1/gov/me/standing)..."
+    curl -sf -m 10 -H "$AUTH" "$GWH/v1/gov/me/standing" | jq -e '.did' >/dev/null \
+        || { err "[demo] standing fetch failed"; exit 13; }
+
+    log "[demo] 2/4 action card visible (GET /v1/gov/me/action-cards)..."
+    CARDS="$(curl -sf -m 10 -H "$AUTH" "$GWH/v1/gov/me/action-cards")" \
+        || { err "[demo] action-cards fetch failed"; exit 13; }
+    N_BEFORE="$(jq --arg id "$DEMO_ITEM" '[.cards[]? | select(.source_id==$id)] | length' <<<"$CARDS")"
+    [ "$N_BEFORE" = "1" ] || { err "[demo] expected 1 open card for $DEMO_ITEM, found $N_BEFORE"; exit 13; }
+
+    log "[demo] 3/4 discharge (PUT status completed)..."
+    curl -sf -m 10 -X PUT -H "$AUTH" -H 'Content-Type: application/json' \
+        -d '{"status":"completed"}' \
+        "$GWH/v1/gov/domains/$DEMO_DOMAIN/action-items/$DEMO_ITEM" >/dev/null \
+        || { err "[demo] completion PUT failed"; exit 13; }
+
+    log "[demo] 4/4 receipt (GET completion-receipt + binding check)..."
+    RECEIPT="$(curl -sf -m 10 -H "$AUTH" \
+        "$GWH/v1/gov/domains/$DEMO_DOMAIN/action-items/$DEMO_ITEM/completion-receipt")" \
+        || { err "[demo] receipt fetch failed"; exit 13; }
+    jq -e --arg id "$DEMO_ITEM" --arg dom "$DEMO_DOMAIN" --arg did "$DEMO_DID" \
+        '(.record_hash | type == "array" and length == 32 and all(.[]; type == "number" and . >= 0 and . <= 255))
+         and .item_id == $id and .domain_id == $dom and .actor_did == $did
+         and .transition == "completed"' <<<"$RECEIPT" >/dev/null \
+        || { err "[demo] receipt failed the binding check: $RECEIPT"; exit 13; }
+
+    N_AFTER="$(curl -sf -m 10 -H "$AUTH" "$GWH/v1/gov/me/action-cards" \
+        | jq --arg id "$DEMO_ITEM" '[.cards[]? | select(.source_id==$id)] | length')"
+    [ "$N_AFTER" = "0" ] || { err "[demo] card did not clear after completion"; exit 13; }
+    log "[demo] loop complete: standing -> card -> discharge -> receipt -> card cleared."
+fi
+
 cat <<EOF_PASS
 [appliance-smoke] PASS
   image:   $ICN_APPLIANCE_IMAGE
@@ -391,3 +499,17 @@ cat <<EOF_PASS
 NOTE: PASS means the local dev image boots and icnd is healthy. It does
 NOT mean the appliance is production, signed, or fit for partner federation.
 EOF_PASS
+
+if [ "$DEMO" = 1 ]; then
+    cat <<EOF_DEMO
+[appliance-smoke] DEMO PASS
+  shell:    http://127.0.0.1:${SHELL_FWD_PORT}/member-shell/ (host-forwarded)
+  gateway:  http://127.0.0.1:${GW_FWD_PORT} (host-forwarded, JWT-auth)
+  loop:     standing -> action card -> discharge -> receipt (verified host-side)
+
+NOTE: DEMO PASS means the member loop works end-to-end on this image from a
+clean boot, over the same forwarded ports a stranger's browser would use.
+Fictional fixture institution, dev gates, test posture — NOT production,
+NOT a pilot, NOT federation.
+EOF_DEMO
+fi

--- a/deploy/appliance/smoke/smoke-local.sh
+++ b/deploy/appliance/smoke/smoke-local.sh
@@ -467,10 +467,10 @@ if [ "$DEMO" = 1 ]; then
     N_BEFORE="$(jq --arg id "$DEMO_ITEM" '[.cards[]? | select(.source_id==$id)] | length' <<<"$CARDS")"
     [ "$N_BEFORE" = "1" ] || { err "[demo] expected 1 open card for $DEMO_ITEM, found $N_BEFORE"; exit 13; }
 
-    log "[demo] 3/4 discharge (PUT status completed)..."
+    log "[demo] 3/4 discharge (PUT .../status {\"status\":\"completed\"} — the member-shell's documented call)..."
     curl -sf -m 10 -X PUT -H "$AUTH" -H 'Content-Type: application/json' \
         -d '{"status":"completed"}' \
-        "$GWH/v1/gov/domains/$DEMO_DOMAIN/action-items/$DEMO_ITEM" >/dev/null \
+        "$GWH/v1/gov/domains/$DEMO_DOMAIN/action-items/$DEMO_ITEM/status" >/dev/null \
         || { err "[demo] completion PUT failed"; exit 13; }
 
     log "[demo] 4/4 receipt (GET completion-receipt + binding check)..."

--- a/deploy/appliance/smoke/smoke-local.sh
+++ b/deploy/appliance/smoke/smoke-local.sh
@@ -452,7 +452,15 @@ if [ "$DEMO" = 1 ]; then
         err "[demo] seed output incomplete: $SEED_JSON"
         exit 12
     fi
-    log "[demo] seeded: item $DEMO_ITEM in $DEMO_DOMAIN for $DEMO_DID"
+    # Fail closed if the standing bootstrap silently degraded — the standing
+    # pane is step 1 of the demo, and the seed downgrades a failed bootstrap
+    # to a warning that a happy-path check would never see.
+    STANDING_NOTE="$(jq -r '.standing_note // empty' <<<"$SEED_JSON")"
+    if [ "$STANDING_NOTE" != "bootstrap-standing: ok" ]; then
+        err "[demo] standing bootstrap did not succeed: $STANDING_NOTE"
+        exit 12
+    fi
+    log "[demo] seeded: item $DEMO_ITEM in $DEMO_DOMAIN for $DEMO_DID (standing bootstrap ok)"
 
     GWH="http://127.0.0.1:${GW_FWD_PORT}"
     AUTH="Authorization: Bearer $DEMO_JWT"

--- a/deploy/appliance/systemd/icn-member-shell.service
+++ b/deploy/appliance/systemd/icn-member-shell.service
@@ -1,0 +1,44 @@
+# DEMO PROFILE ONLY — installed by build-image.sh when
+# ICN_APPLIANCE_DEMO_PROFILE=1. Not part of the base appliance image and
+# never part of a production deployment.
+#
+# Serves the static member-shell reference client (web/member-shell/) and
+# the pilot-ui fixture pack from /usr/share/icn/static/web using python3's
+# stdlib HTTP server. This is a dev/demo serving path: no TLS, no caching,
+# no hardening beyond systemd sandboxing. The shell itself labels its modes
+# honestly (fixture vs live-local); this unit adds no claims.
+#
+# Port 8090 (0.0.0.0): inside a QEMU user-mode-network VM this is reachable
+# from the host only through an explicit hostfwd mapping. The gateway the
+# shell's live mode talks to stays JWT-authenticated.
+
+[Unit]
+Description=ICN member-shell static server (DEV/DEMO ONLY)
+Documentation=https://github.com/InterCooperative-Network/icn
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/usr/share/icn/static/web/member-shell/index.html
+
+[Service]
+Type=simple
+User=icn
+Group=icn
+WorkingDirectory=/usr/share/icn/static/web
+ExecStart=/usr/bin/python3 -m http.server 8090 --bind 0.0.0.0 --directory /usr/share/icn/static/web
+
+Restart=always
+RestartSec=5
+
+# Sandboxing: payload is read-only; the server needs no write access.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=icn-member-shell
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/appliance/systemd/icnd.service.d/20-demo-profile.conf
+++ b/deploy/appliance/systemd/icnd.service.d/20-demo-profile.conf
@@ -1,0 +1,35 @@
+# DEMO PROFILE ONLY — installed by build-image.sh when
+# ICN_APPLIANCE_DEMO_PROFILE=1. Never installed on the base appliance
+# image and never appropriate for production or partner deployments.
+#
+# What this changes, and why each change is demo-scoped:
+#
+# 1. Gateway bind 0.0.0.0:8080 (base unit binds 127.0.0.1:8080).
+#    A stranger runs the image in QEMU with user-mode networking and a
+#    hostfwd mapping; user-mode hostfwd targets the guest NIC address, so a
+#    loopback-bound gateway is unreachable from the host browser. Inside the
+#    user-net VM, 0.0.0.0 is still host-only exposure (no bridge, no LAN).
+#    JWT auth stays enforced — firstboot's per-instance secret is unchanged.
+#
+# 2. ICN_ENABLE_ADMIN_ENDPOINTS + ICN_GOVERNANCE_BUILD_MODE=test.
+#    The dev gate pair behind POST /v1/commons/dev/bootstrap-standing
+#    (same pair the local devnet demo uses — see deploy/devnet and PR #2024).
+#    Used by icn-demo-seed to make member standing visible in the shell and
+#    to unlock the optional proposal/vote demo path. `test` posture is
+#    permissive governance wiring — a labeled non-production stance.
+#
+# 3. ICN_CORS_ORIGINS — the member-shell live mode runs in the operator's
+#    browser on the host; its requests carry an Authorization header, which
+#    forces a CORS preflight. The origins listed here are the hostfwd'd
+#    shell URLs. Setting this also switches the gateway to its dev CORS
+#    config (see crates/icn-gateway/src/security.rs).
+
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/icnd \
+    --data-dir /var/lib/icn \
+    --gateway-enable \
+    --gateway-bind 0.0.0.0:8080
+Environment=ICN_ENABLE_ADMIN_ENDPOINTS=true
+Environment=ICN_GOVERNANCE_BUILD_MODE=test
+Environment=ICN_CORS_ORIGINS=http://localhost:8090,http://127.0.0.1:8090,http://localhost:18090,http://127.0.0.1:18090


### PR DESCRIPTION
## What

An optional **demo profile** for the appliance image build (`ICN_APPLIANCE_DEMO_PROFILE=1`), turning the existing bootable dev QCOW2 into the July demo image: one VM that shows the core loop **standing → action card → discharge → receipt → evidence/audit** to a stranger's browser, with no private infrastructure.

Added under `deploy/appliance/` only:

- **Payload:** member-shell (#2026) + pilot-ui fixture pack at `/usr/share/icn/static/web/`; NYCN fixture institution package + nycn-dogfood kit + the 13/13 receipt-chain rehearsal scripts and evidence validator at `/usr/share/icn/demo/`.
- **Units:** `icn-member-shell.service` (python3 stdlib static server, :8090, dev-labeled) and an `icnd.service.d/20-demo-profile.conf` drop-in — gateway bind `0.0.0.0:8080` (QEMU user-net hostfwd cannot reach a loopback-bound guest service), the labeled dev-gate pair from #2024 (`ICN_ENABLE_ADMIN_ENDPOINTS`, `ICN_GOVERNANCE_BUILD_MODE=test`), and `ICN_CORS_ORIGINS` for the shell origins.
- **In-image commands:** `icn-demo-seed` (institution + standing bootstrap + one open action item; prints the dev session JWT on request only), `icn-demo-verify` (receipt binding check; `--chain` runs the bundled 13/13 rehearsal on an ephemeral in-VM node), `icn-demo-reset` (destructive wipe → firstboot → reseed).
- **Smoke:** `smoke-local.sh --demo` forwards gateway+shell to the host and drives the full loop host-side (the stranger path), including the 32-byte `record_hash` binding check and card-cleared assertion.
- **Docs:** `DEMO_QUICKSTART.md` (stranger-run: build, run, 5-step demo script, reset, troubleshooting, honesty labels) + README section.
- `check.sh` vocabulary scan gains a `vocab-ok:`-tagged exception mechanism (sanitize-ok spirit); only sanctioned use is the literal `icnctl auth token` CLI subcommand name.
- Manifest records `demo_profile: true|false`. Base (non-demo) build behavior unchanged.

## Why

July demo readiness: the appliance already boots to a healthy icnd (PRs #1865/#1866, #2020), and every demo asset passes individually on main (13/13, run-all 2/2, dogfood, member-shell). This PR composes them into one stranger-runnable image — the demo spine, honestly labeled.

## How verified (exactly what ran, on icn-dev)

- `deploy/appliance/check.sh` — 20/20 pass (syntax, dry-runs, YAML, vocabulary, secrets).
- Real build from this branch: `build-image.sh --real` with `ICN_APPLIANCE_DEMO_PROFILE=1`, Debian 13 base → `icn-appliance-0.0.2-demo-20260612-amd64.qcow2`, final sha256 `b087cd9fa2159e95e95dbf09dd38b73b37fdcc2e6890ec96ac40555ad3210ce5` (manifest records `demo_profile: true`, git 708f92de); the --demo smoke passed on both image iterations, final run log `smoke-demo-final.log`.
- `smoke-local.sh --real --demo` from a clean boot: base PASS (firstboot → icnd active → health 200) **and DEMO PASS** — member-shell + fixtures served host-side, `icn-demo-seed` succeeded in-VM, then host-side standing → card → discharge → receipt (binding check) → card cleared. Operator logs: `~/artifacts/icn/demo-image-20260612/{build/build2.log,smoke-demo.log}`.
- Second boot of the same image: rerun cleanliness + in-VM `icn-demo-verify --chain` — **PASS** — `RESULT: PASS — local governed receipt chain audit-verified 13/13.` on an ephemeral in-VM node; schema-valid evidence packet exported to `/var/lib/icn-demo/receipt-chain-13of13/` (operator log: `~/artifacts/icn/demo-image-20260612/chain-in-vm.log`). The binary-resolution fix this surfaced is 708f92de.

Known build-environment note: the libguestfs appliance has no DNS on this builder, so the demo profile deliberately adds **no** apt packages (python3 already ships in the base image; jq was dropped in 960f2840). Host-side `--demo` smoke uses jq (documented).

## Risk

- Zero impact on the base image path (demo block is fully gated; manifest labels the variant).
- Dev gates are demo-only and loudly labeled in the drop-in, seed output, README, and quickstart — same gate pair the local devnet uses.
- No secrets in the image (firstboot generates per-instance JWT secret + passphrase; #2020's negative smoke still applies).

## Honesty labels

live-local: node, health, standing/cards/discharge/receipt, receipt binding, 13/13 chain rehearsal — all on the VM's own node. fixture: shell `?mode=demo`, NYCN package (fictional). Not claimed: production, signed image, pilots, federation, multi-org, real member data.

Refs: July demo readiness lane · #2024 (dev gates) · #2026 (member-shell) · #2027 (OpenAPI member surface, pending) · #1866/#2020 (appliance build + smokes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
