### PR TITLE
feat(appliance): one-command demo launcher + no-paste session flow (+ passphrase-leak fix)

### DIFF
--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -90,11 +90,38 @@ ssh -p 2222 debian@127.0.0.1 sudo icn-demo-seed
 The seed prints the member-shell URLs, the open action item, and a dev
 session JWT (local VM only).
 
-## First URL to open
+## One-command launcher (recommended for a live human demo)
+
+If a node instance is already running (e.g. a Proxmox VM at `192.0.2.50` — use your node's real IP),
+open the whole demo with one command from your workstation — no JWT
+copy/paste, no gateway typing:
+
+```bash
+# direct (this machine can SSH the node and has the demo key):
+ICN_DEMO_VM_IP=192.0.2.50 ICN_DEMO_SSH_KEY=/path/to/smoke_ed25519 \
+  bash deploy/appliance/scripts/open-proxmox-demo.sh
+
+# or jump through a dev host that holds the key and can reach the node:
+ICN_DEMO_VM_IP=192.0.2.50 ICN_DEMO_JUMP=user@dev-host \
+  bash deploy/appliance/scripts/open-proxmox-demo.sh
+```
+
+It opens the SSH tunnels (gateway→18080, shell→18090, demo-session→18091),
+then opens your browser to `…/member-shell/?mode=live&demo=launcher`. In the
+page, the gateway is pre-filled and a **Start local demo** button appears —
+select it once and your standing + a sample action card load automatically.
+Nothing is copied or pasted; the credential lives only in the page's memory.
+Press Ctrl-C in the terminal to close the tunnel when you're done.
+
+This needs a demo-profile image (the `icn-demo-session` endpoint ships with
+`ICN_APPLIANCE_DEMO_PROFILE=1`). Everything below is the manual fallback.
+
+## First URL to open (manual fallback)
 
 > http://localhost:18090/member-shell/
 
-(Use `?mode=demo` for the self-labeled fixture mode that needs no JWT.)
+(Use `?mode=demo` for the self-labeled fixture mode that needs no JWT. The
+manual `?mode=live` paste flow below is the advanced/debug path.)
 
 ## The demo script (5 steps)
 

--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -101,8 +101,11 @@ copy/paste, no gateway typing:
 ICN_DEMO_VM_IP=192.0.2.50 ICN_DEMO_SSH_KEY=/path/to/smoke_ed25519 \
   bash deploy/appliance/scripts/open-proxmox-demo.sh
 
-# or jump through a dev host that holds the key and can reach the node:
+# or jump through a dev host that holds the key and can reach the node
+# (ICN_DEMO_REMOTE_KEY is REQUIRED with ICN_DEMO_JUMP — it is the key path
+# ON the jump host):
 ICN_DEMO_VM_IP=192.0.2.50 ICN_DEMO_JUMP=user@dev-host \
+  ICN_DEMO_REMOTE_KEY=/path/to/smoke_ed25519 \
   bash deploy/appliance/scripts/open-proxmox-demo.sh
 ```
 

--- a/deploy/appliance/build-image.sh
+++ b/deploy/appliance/build-image.sh
@@ -134,10 +134,10 @@ cat <<'EOF_PLAN'
        - copy institutions/ (NYCN fixture package)     -> /usr/share/icn/demo/institutions/
        - copy 13/13 rehearsal scripts + evidence validator + nycn-dogfood kit
                                                         -> /usr/share/icn/demo/repo/
-       - copy icn-member-shell.service                  -> /etc/systemd/system/
+       - copy icn-member-shell.service + icn-demo-session.service -> /etc/systemd/system/
        - copy icnd.service.d/20-demo-profile.conf       -> /etc/systemd/system/icnd.service.d/
-       - copy icn-demo-{seed,verify,reset}.sh           -> /usr/local/sbin/
-       - systemctl enable icn-member-shell.service
+       - copy icn-demo-{seed,verify,reset}.sh + icn-demo-session.py -> /usr/local/sbin/
+       - systemctl enable icn-member-shell.service icn-demo-session.service
        - mark manifest demo_profile: true
 EOF_PLAN
 }
@@ -331,10 +331,12 @@ if [ "$DEMO_PROFILE" = "1" ]; then
     DEMO_SEED_SCRIPT="$APPLIANCE_DIR/scripts/icn-demo-seed.sh"
     DEMO_VERIFY_SCRIPT="$APPLIANCE_DIR/scripts/icn-demo-verify.sh"
     DEMO_RESET_SCRIPT="$APPLIANCE_DIR/scripts/icn-demo-reset.sh"
+    DEMO_SESSION_SCRIPT="$APPLIANCE_DIR/scripts/icn-demo-session.py"
     MEMBER_SHELL_UNIT="$APPLIANCE_DIR/systemd/icn-member-shell.service"
+    DEMO_SESSION_UNIT="$APPLIANCE_DIR/systemd/icn-demo-session.service"
     DEMO_DROPIN="$APPLIANCE_DIR/systemd/icnd.service.d/20-demo-profile.conf"
     for f in "$DEMO_SEED_SCRIPT" "$DEMO_VERIFY_SCRIPT" "$DEMO_RESET_SCRIPT" \
-             "$MEMBER_SHELL_UNIT" "$DEMO_DROPIN"; do
+             "$DEMO_SESSION_SCRIPT" "$MEMBER_SHELL_UNIT" "$DEMO_SESSION_UNIT" "$DEMO_DROPIN"; do
         if [ ! -f "$f" ]; then
             err "Demo profile source file missing: $f"
             exit 7
@@ -391,13 +393,16 @@ if [ "$DEMO_PROFILE" = "1" ]; then
         --copy-in "$DEMO_STAGE/demo/institutions:/usr/share/icn/demo"
         --copy-in "$DEMO_STAGE/demo/repo:/usr/share/icn/demo"
         --copy-in "$MEMBER_SHELL_UNIT:/etc/systemd/system"
+        --copy-in "$DEMO_SESSION_UNIT:/etc/systemd/system"
         --copy-in "$DEMO_DROPIN:/etc/systemd/system/icnd.service.d"
         --copy-in "$DEMO_SEED_SCRIPT:/usr/local/sbin"
         --copy-in "$DEMO_VERIFY_SCRIPT:/usr/local/sbin"
         --copy-in "$DEMO_RESET_SCRIPT:/usr/local/sbin"
-        --run-command "chmod +x /usr/local/sbin/icn-demo-seed.sh /usr/local/sbin/icn-demo-verify.sh /usr/local/sbin/icn-demo-reset.sh"
+        --copy-in "$DEMO_SESSION_SCRIPT:/usr/local/sbin"
+        --run-command "chmod +x /usr/local/sbin/icn-demo-seed.sh /usr/local/sbin/icn-demo-verify.sh /usr/local/sbin/icn-demo-reset.sh /usr/local/sbin/icn-demo-session.py"
         --run-command "ln -sf /usr/local/sbin/icn-demo-seed.sh /usr/local/sbin/icn-demo-seed && ln -sf /usr/local/sbin/icn-demo-verify.sh /usr/local/sbin/icn-demo-verify && ln -sf /usr/local/sbin/icn-demo-reset.sh /usr/local/sbin/icn-demo-reset"
         --run-command "systemctl enable icn-member-shell.service"
+        --run-command "systemctl enable icn-demo-session.service"
         # The bundled 13/13 evidence validator (icn-demo-verify --chain)
         # needs the python3 jsonschema package. Debian genericcloud images
         # provide it transitively via cloud-init; assert it here so a base

--- a/deploy/appliance/scripts/icn-appliance-firstboot.sh
+++ b/deploy/appliance/scripts/icn-appliance-firstboot.sh
@@ -260,7 +260,7 @@ init_identity_block() {
     log "Generating per-instance JWT secret + keystore passphrase (NOT embedded in image)."
     if [ "$DRY_RUN" -eq 1 ]; then
         printf '[firstboot] (dry-run) would generate JWT + keystore passphrase, write %s mode 600.\n' "$ICND_ENV_FILE"
-        printf '[firstboot] (dry-run) would run: ICN_KEYSTORE_PASSPHRASE=... sudo -u %s icnd --init --data-dir %s --init-gateway-port %s --init-gossip-port %s\n' \
+        printf '[firstboot] (dry-run) would run: ICN_KEYSTORE_PASSPHRASE=<REDACTED> runuser -u %s --preserve-environment -- icnd --init --data-dir %s --init-gateway-port %s --init-gossip-port %s\n' \
             "$ICN_USER" "$ICN_DATA_DIR" "$ICN_FIRSTBOOT_INIT_GATEWAY_PORT" "$ICN_FIRSTBOOT_INIT_GOSSIP_PORT"
         return 0
     fi
@@ -297,9 +297,15 @@ init_identity_block() {
     # drift from the runtime bind and from appliance.env's documented ports.
     # The runtime --gateway-bind flag in deploy/icnd.service still wins for
     # the bind address; this just keeps the on-disk config honest.
+    # Drop to the icn user with `runuser`, NOT `sudo -u`. sudo logs the full
+    # command (including ICN_KEYSTORE_PASSPHRASE=<value>) to the auth journal;
+    # runuser does not. firstboot already runs as root, so no outer sudo is
+    # needed (an outer sudo would re-strip the env before runuser). The
+    # passphrase is passed via the environment with --preserve-environment.
+    # Same hardening as icn-demo-{seed,verify}.
     log "Initializing icnd identity (icnd --init) as $ICN_USER..."
     if ICN_KEYSTORE_PASSPHRASE="$pass" \
-        sudo -u "$ICN_USER" -E env "ICN_KEYSTORE_PASSPHRASE=$pass" \
+        runuser -u "$ICN_USER" --preserve-environment -- \
         icnd --init \
             --data-dir "$ICN_DATA_DIR" \
             --init-gateway-port "$ICN_FIRSTBOOT_INIT_GATEWAY_PORT" \
@@ -307,7 +313,7 @@ init_identity_block() {
         log "icnd --init succeeded."
     else
         warn "icnd --init failed. icnd.service may not start until identity is initialized."
-        warn "Inspect: sudo -u $ICN_USER icnd --init --data-dir $ICN_DATA_DIR"
+        warn "Inspect: runuser -u $ICN_USER -- icnd --init --data-dir $ICN_DATA_DIR"
         return 1
     fi
 }

--- a/deploy/appliance/scripts/icn-demo-seed.sh
+++ b/deploy/appliance/scripts/icn-demo-seed.sh
@@ -59,8 +59,17 @@ command -v python3 >/dev/null || fatal "python3 missing"
 [ -n "${ICN_KEYSTORE_PASSPHRASE:-}" ] || fatal "ICN_KEYSTORE_PASSPHRASE not present in $ENV_FILE"
 
 as_icn(){
-  sudo -u icn ICN_KEYSTORE_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" \
-      ICN_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" "$@"
+  # Drop from root to the icn user with `runuser`, NOT `sudo`. sudo records
+  # both its command line AND its environment in the auth journal, so any form
+  # of `sudo … ICN_KEYSTORE_PASSPHRASE=… …` (command-line assignment OR
+  # --preserve-env) leaks the keystore passphrase into the journal. This
+  # script already runs as root, so it does not need sudo to gain privilege —
+  # runuser drops privilege without writing the command or env to any log.
+  # The passphrase is exported only for the runuser call and passed through
+  # with --preserve-environment.
+  ICN_KEYSTORE_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" \
+  ICN_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" \
+    runuser -u icn --preserve-environment -- "$@"
 }
 
 log "waiting for gateway health at $GW ..."

--- a/deploy/appliance/scripts/icn-demo-session.py
+++ b/deploy/appliance/scripts/icn-demo-session.py
@@ -36,7 +36,6 @@
 # ============================================================================
 import json
 import os
-import re
 import subprocess
 import sys
 import threading
@@ -52,29 +51,27 @@ BIND_PORT = int(os.environ.get("ICN_DEMO_SESSION_PORT", "8091"))
 SEED_CMD = ["/usr/local/sbin/icn-demo-seed", "--json"]
 
 # The demo shell is served at 127.0.0.1:8090 in the VM and reached over the
-# operator's tunnel at localhost:18090 (a FIXED host port — the gateway's
-# ICN_CORS_ORIGINS allow-list pins that origin, so open-proxmox-demo.sh offers
-# no shell-port override). We still accept ANY http loopback origin here as
-# defense-in-depth: the CSRF boundary for this seed endpoint is loopback-vs-not,
-# and this set is a strict superset of the gateway's fixed {8090,18090} list, so
-# every origin the demo actually uses is accepted by both. Non-loopback origins
-# are refused.
-_LOOPBACK_ORIGIN = re.compile(r"^http://(localhost|127\.0\.0\.1):([0-9]{1,5})$")
+# operator's tunnel at localhost:18090 (a FIXED host port — open-proxmox-demo.sh
+# offers no shell-port override). This endpoint mints a DEV/DEMO JWT, so it must
+# only answer the demo shell's own origins — NOT any loopback page (e.g. an
+# unrelated http://localhost:3000 dev server, which could otherwise obtain a
+# JWT). The allow-list below is therefore the exact, fixed set, identical to the
+# gateway's ICN_CORS_ORIGINS. Non-listed origins are refused.
+ALLOWED_ORIGINS = (
+    "http://localhost:8090", "http://127.0.0.1:8090",
+    "http://localhost:18090", "http://127.0.0.1:18090",
+)
 
 
 def safe_origin(origin):
-    """If `origin` is an http loopback origin, return a SAFE echo value built
-    only from string literals + an int-parsed port — no request bytes reach the
-    response header, so a tainted Origin can never be reflected (defeats HTTP
-    response-splitting; CodeQL-clean). Returns None for any other origin."""
-    m = _LOOPBACK_ORIGIN.match(origin or "")
-    if not m:
-        return None
-    host, port = m.group(1), int(m.group(2))
-    if not (1 <= port <= 65535):
-        return None
-    host_literal = "localhost" if host == "localhost" else "127.0.0.1"
-    return "http://%s:%d" % (host_literal, port)
+    """Return the matching allow-list member (an exact constant) if `origin` is a
+    demo shell origin, else None. Echoing only a hard-coded constant keeps the
+    response header free of any request bytes (no HTTP response-splitting;
+    CodeQL-clean), and the set matches the gateway's CORS allow-list exactly."""
+    for allowed in ALLOWED_ORIGINS:
+        if origin == allowed:
+            return allowed
+    return None
 
 
 def demo_gated():

--- a/deploy/appliance/scripts/icn-demo-session.py
+++ b/deploy/appliance/scripts/icn-demo-session.py
@@ -27,13 +27,16 @@
 #     governance posture is non-Production (the same gates icn-demo-seed and
 #     the gateway's dev bootstrap require). Returns 403 otherwise.
 #   * Fixed command — no request data influences what is run; no injection.
-#   * CORS is allow-listed to the demo shell origins only.
+#   * CORS accepts only http loopback origins (localhost / 127.0.0.1, any
+#     port — the demo shell, however the operator tunnels it). Every
+#     non-loopback origin is refused, server-side, before any side effect.
 #   * NEVER logs the credential. Logs are redacted by construction.
 #
 # This is NOT a production auth surface. It exists only on demo-profile images.
 # ============================================================================
 import json
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -48,12 +51,28 @@ BIND_HOST = "127.0.0.1"
 BIND_PORT = int(os.environ.get("ICN_DEMO_SESSION_PORT", "8091"))
 SEED_CMD = ["/usr/local/sbin/icn-demo-seed", "--json"]
 
-# The demo shell is served on :8090 in the VM and tunnelled to :18090 on the
-# operator's machine. Allow exactly those loopback origins (both spellings).
-ALLOWED_ORIGINS = {
-    "http://localhost:18090", "http://127.0.0.1:18090",
-    "http://localhost:8090", "http://127.0.0.1:8090",
-}
+# The demo shell is loaded over a loopback tunnel on the operator's machine.
+# Its host port is configurable — open-proxmox-demo.sh documents
+# ICN_DEMO_SHELL_PORT for conflict avoidance — so we cannot hard-code one port:
+# accept ANY http loopback origin (localhost / 127.0.0.1, any port) and refuse
+# everything else. Refusing all non-loopback origins is what stops a cross-site
+# page from triggering a reseed; the specific port is not the boundary.
+_LOOPBACK_ORIGIN = re.compile(r"^http://(localhost|127\.0\.0\.1):([0-9]{1,5})$")
+
+
+def safe_origin(origin):
+    """If `origin` is an http loopback origin, return a SAFE echo value built
+    only from string literals + an int-parsed port — no request bytes reach the
+    response header, so a tainted Origin can never be reflected (defeats HTTP
+    response-splitting; CodeQL-clean). Returns None for any other origin."""
+    m = _LOOPBACK_ORIGIN.match(origin or "")
+    if not m:
+        return None
+    host, port = m.group(1), int(m.group(2))
+    if not (1 <= port <= 65535):
+        return None
+    host_literal = "localhost" if host == "localhost" else "127.0.0.1"
+    return "http://%s:%d" % (host_literal, port)
 
 
 def demo_gated():
@@ -72,16 +91,16 @@ class Handler(BaseHTTPRequestHandler):
     server_version = "icn-demo-session/0"
 
     def _cors(self, origin):
-        # Emit only an exact, hard-coded allow-list member — never the raw
-        # request value — so a tainted Origin header can never be reflected
-        # into a response header (avoids HTTP response-splitting).
-        for allowed in ALLOWED_ORIGINS:
-            if allowed == origin:
-                self.send_header("Access-Control-Allow-Origin", allowed)
-                self.send_header("Vary", "Origin")
-                self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
-                self.send_header("Access-Control-Allow-Headers", "Content-Type")
-                return
+        # Echo only a server-reconstructed loopback origin (literals + an
+        # int-parsed port), never the raw request value — so a tainted Origin
+        # header can never be reflected into a response (avoids HTTP
+        # response-splitting). Non-loopback origins get no CORS headers.
+        safe = safe_origin(origin)
+        if safe is not None:
+            self.send_header("Access-Control-Allow-Origin", safe)
+            self.send_header("Vary", "Origin")
+            self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
 
     def do_OPTIONS(self):
         self.send_response(204)
@@ -96,10 +115,10 @@ class Handler(BaseHTTPRequestHandler):
         # SERVER-SIDE origin check, before any side effect. CORS response
         # headers only control whether the BROWSER reveals the response; they
         # do not stop a cross-site page from reaching this loopback port and
-        # triggering a reseed. Reject any non-allow-listed (or absent) Origin
-        # up front so only the demo shell can cause a reseed.
-        if origin not in ALLOWED_ORIGINS:
-            log("refused: origin not allow-listed")
+        # triggering a reseed. Reject any non-loopback (or absent) Origin up
+        # front so only a local demo shell can cause a reseed.
+        if safe_origin(origin) is None:
+            log("refused: origin not an allowed loopback origin")
             return self._json(403, {"error": "origin not allowed"}, origin)
         if not demo_gated():
             log("refused: dev gates off (ICN_ENABLE_ADMIN_ENDPOINTS / non-production)")

--- a/deploy/appliance/scripts/icn-demo-session.py
+++ b/deploy/appliance/scripts/icn-demo-session.py
@@ -36,7 +36,13 @@ import json
 import os
 import subprocess
 import sys
+import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# Serialize seeding: ThreadingHTTPServer can dispatch concurrent POSTs, and
+# overlapping icn-demo-seed runs would race on node state. Only one seed runs
+# at a time; a second request blocks until the first releases.
+_SEED_LOCK = threading.Lock()
 
 BIND_HOST = "127.0.0.1"
 BIND_PORT = int(os.environ.get("ICN_DEMO_SESSION_PORT", "8091"))
@@ -66,11 +72,16 @@ class Handler(BaseHTTPRequestHandler):
     server_version = "icn-demo-session/0"
 
     def _cors(self, origin):
-        if origin in ALLOWED_ORIGINS:
-            self.send_header("Access-Control-Allow-Origin", origin)
-            self.send_header("Vary", "Origin")
-            self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
-            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        # Emit only an exact, hard-coded allow-list member — never the raw
+        # request value — so a tainted Origin header can never be reflected
+        # into a response header (avoids HTTP response-splitting).
+        for allowed in ALLOWED_ORIGINS:
+            if allowed == origin:
+                self.send_header("Access-Control-Allow-Origin", allowed)
+                self.send_header("Vary", "Origin")
+                self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+                self.send_header("Access-Control-Allow-Headers", "Content-Type")
+                return
 
     def do_OPTIONS(self):
         self.send_response(204)
@@ -82,38 +93,51 @@ class Handler(BaseHTTPRequestHandler):
         origin = self.headers.get("Origin", "")
         if self.path.rstrip("/") != "/v1/dev/demo/session":
             return self._json(404, {"error": "not found"}, origin)
+        # SERVER-SIDE origin check, before any side effect. CORS response
+        # headers only control whether the BROWSER reveals the response; they
+        # do not stop a cross-site page from reaching this loopback port and
+        # triggering a reseed. Reject any non-allow-listed (or absent) Origin
+        # up front so only the demo shell can cause a reseed.
+        if origin not in ALLOWED_ORIGINS:
+            log("refused: origin not allow-listed")
+            return self._json(403, {"error": "origin not allowed"}, origin)
         if not demo_gated():
             log("refused: dev gates off (ICN_ENABLE_ADMIN_ENDPOINTS / non-production)")
             return self._json(403, {"error": "demo session disabled (not a DEV/DEMO posture)"}, origin)
-        try:
-            out = subprocess.run(SEED_CMD, capture_output=True, text=True, timeout=120)
-        except Exception as e:  # noqa: BLE001 - report any spawn failure plainly
-            log("seed spawn failed: %s" % e)
-            return self._json(500, {"error": "seed failed to start"}, origin)
-        if out.returncode != 0:
-            # stderr may name the failure; it does not contain the credential.
-            log("seed exit %d: %s" % (out.returncode, (out.stderr or "").strip()[:200]))
-            return self._json(500, {"error": "seed failed"}, origin)
-        try:
-            session = json.loads(out.stdout)
-        except Exception:  # noqa: BLE001
-            log("seed produced non-JSON output")
-            return self._json(500, {"error": "seed output not JSON"}, origin)
-        note = session.get("standing_note", "")
-        if note != "bootstrap-standing: ok":
-            log("seed standing degraded: %s" % note)
-            return self._json(500, {"error": "standing bootstrap degraded", "standing_note": note}, origin)
-        log("session seeded ok (item %s) — credential returned to caller, not logged"
-            % session.get("item_id", "?"))
-        # Return the seed JSON verbatim (it carries the short-lived credential
-        # under "jwt"); the shell keeps it in page memory only.
-        return self._json(200, session, origin)
+        # Serialize: never run two seeds at once (see _SEED_LOCK).
+        with _SEED_LOCK:
+            try:
+                out = subprocess.run(SEED_CMD, capture_output=True, text=True, timeout=120)
+            except Exception as e:  # noqa: BLE001 - report any spawn failure plainly
+                log("seed spawn failed: %s" % e)
+                return self._json(500, {"error": "seed failed to start"}, origin)
+            if out.returncode != 0:
+                # stderr may name the failure; it does not contain the credential.
+                log("seed exit %d: %s" % (out.returncode, (out.stderr or "").strip()[:200]))
+                return self._json(500, {"error": "seed failed"}, origin)
+            try:
+                session = json.loads(out.stdout)
+            except Exception:  # noqa: BLE001
+                log("seed produced non-JSON output")
+                return self._json(500, {"error": "seed output not JSON"}, origin)
+            note = session.get("standing_note", "")
+            if note != "bootstrap-standing: ok":
+                log("seed standing degraded: %s" % note)
+                return self._json(500, {"error": "standing bootstrap degraded", "standing_note": note}, origin)
+            log("session seeded ok (item %s) — credential returned to caller, not logged"
+                % session.get("item_id", "?"))
+            # Return the seed JSON verbatim (it carries the short-lived
+            # credential under "jwt"); the shell keeps it in page memory only.
+            return self._json(200, session, origin)
 
     def _json(self, code, obj, origin):
         body = json.dumps(obj).encode("utf-8")
         self.send_response(code)
         self._cors(origin)
         self.send_header("Content-Type", "application/json")
+        # The body may carry the short-lived credential — never let any cache
+        # (browser or intermediary) retain it.
+        self.send_header("Cache-Control", "no-store")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)

--- a/deploy/appliance/scripts/icn-demo-session.py
+++ b/deploy/appliance/scripts/icn-demo-session.py
@@ -51,12 +51,14 @@ BIND_HOST = "127.0.0.1"
 BIND_PORT = int(os.environ.get("ICN_DEMO_SESSION_PORT", "8091"))
 SEED_CMD = ["/usr/local/sbin/icn-demo-seed", "--json"]
 
-# The demo shell is loaded over a loopback tunnel on the operator's machine.
-# Its host port is configurable — open-proxmox-demo.sh documents
-# ICN_DEMO_SHELL_PORT for conflict avoidance — so we cannot hard-code one port:
-# accept ANY http loopback origin (localhost / 127.0.0.1, any port) and refuse
-# everything else. Refusing all non-loopback origins is what stops a cross-site
-# page from triggering a reseed; the specific port is not the boundary.
+# The demo shell is served at 127.0.0.1:8090 in the VM and reached over the
+# operator's tunnel at localhost:18090 (a FIXED host port — the gateway's
+# ICN_CORS_ORIGINS allow-list pins that origin, so open-proxmox-demo.sh offers
+# no shell-port override). We still accept ANY http loopback origin here as
+# defense-in-depth: the CSRF boundary for this seed endpoint is loopback-vs-not,
+# and this set is a strict superset of the gateway's fixed {8090,18090} list, so
+# every origin the demo actually uses is accepted by both. Non-loopback origins
+# are refused.
 _LOOPBACK_ORIGIN = re.compile(r"^http://(localhost|127\.0\.0\.1):([0-9]{1,5})$")
 
 

--- a/deploy/appliance/scripts/icn-demo-session.py
+++ b/deploy/appliance/scripts/icn-demo-session.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# ============================================================================
+# icn-demo-session — DEV/DEMO-only local session endpoint for the member-shell.
+# ----------------------------------------------------------------------------
+# DEMO PROFILE ONLY. Installed and enabled by build-image.sh when
+# ICN_APPLIANCE_DEMO_PROFILE=1. Runs as a small loopback HTTP service inside
+# the appliance VM (icn-demo-session.service), 127.0.0.1:8091.
+#
+# Why this exists: the member-shell's live mode needs a gateway address and an
+# access credential. Typing the gateway and pasting a JWT by hand is an
+# unacceptable human-demo step. This endpoint lets the shell's "Start local
+# demo" button obtain a fresh DEV/DEMO session with one click — no copy/paste,
+# no JWT in any URL.
+#
+# What it does: on `POST /v1/dev/demo/session` it runs the existing
+# `icn-demo-seed --json` (the same safe, fictional, dev-gated seed an operator
+# could run by hand) and returns its JSON: a short-lived DEV/DEMO session
+# credential, the seeded item/domain/did, and the standing note. The shell
+# holds the credential in page memory only (it is never persisted, never put
+# in a URL). This service adds no privilege the tunnel-holding operator does
+# not already have (they have SSH + sudo on this throwaway VM).
+#
+# Safety:
+#   * Binds 127.0.0.1 ONLY (loopback) — reachable solely through the operator's
+#     own SSH tunnel, never on the VLAN.
+#   * Double dev-gated: refuses unless ICN_ENABLE_ADMIN_ENDPOINTS=true AND the
+#     governance posture is non-Production (the same gates icn-demo-seed and
+#     the gateway's dev bootstrap require). Returns 403 otherwise.
+#   * Fixed command — no request data influences what is run; no injection.
+#   * CORS is allow-listed to the demo shell origins only.
+#   * NEVER logs the credential. Logs are redacted by construction.
+#
+# This is NOT a production auth surface. It exists only on demo-profile images.
+# ============================================================================
+import json
+import os
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+BIND_HOST = "127.0.0.1"
+BIND_PORT = int(os.environ.get("ICN_DEMO_SESSION_PORT", "8091"))
+SEED_CMD = ["/usr/local/sbin/icn-demo-seed", "--json"]
+
+# The demo shell is served on :8090 in the VM and tunnelled to :18090 on the
+# operator's machine. Allow exactly those loopback origins (both spellings).
+ALLOWED_ORIGINS = {
+    "http://localhost:18090", "http://127.0.0.1:18090",
+    "http://localhost:8090", "http://127.0.0.1:8090",
+}
+
+
+def demo_gated():
+    """True only when both dev gates are on (mirrors icn-demo-seed / gateway)."""
+    admin = os.environ.get("ICN_ENABLE_ADMIN_ENDPOINTS", "false").lower() == "true"
+    production = os.environ.get("ICN_GOVERNANCE_BUILD_MODE", "").lower() == "production"
+    return admin and not production
+
+
+def log(msg):
+    # stdout -> journald via the unit. Never include the credential here.
+    print("[demo-session] %s" % msg, flush=True)
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "icn-demo-session/0"
+
+    def _cors(self, origin):
+        if origin in ALLOWED_ORIGINS:
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Vary", "Origin")
+            self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self._cors(self.headers.get("Origin", ""))
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_POST(self):
+        origin = self.headers.get("Origin", "")
+        if self.path.rstrip("/") != "/v1/dev/demo/session":
+            return self._json(404, {"error": "not found"}, origin)
+        if not demo_gated():
+            log("refused: dev gates off (ICN_ENABLE_ADMIN_ENDPOINTS / non-production)")
+            return self._json(403, {"error": "demo session disabled (not a DEV/DEMO posture)"}, origin)
+        try:
+            out = subprocess.run(SEED_CMD, capture_output=True, text=True, timeout=120)
+        except Exception as e:  # noqa: BLE001 - report any spawn failure plainly
+            log("seed spawn failed: %s" % e)
+            return self._json(500, {"error": "seed failed to start"}, origin)
+        if out.returncode != 0:
+            # stderr may name the failure; it does not contain the credential.
+            log("seed exit %d: %s" % (out.returncode, (out.stderr or "").strip()[:200]))
+            return self._json(500, {"error": "seed failed"}, origin)
+        try:
+            session = json.loads(out.stdout)
+        except Exception:  # noqa: BLE001
+            log("seed produced non-JSON output")
+            return self._json(500, {"error": "seed output not JSON"}, origin)
+        note = session.get("standing_note", "")
+        if note != "bootstrap-standing: ok":
+            log("seed standing degraded: %s" % note)
+            return self._json(500, {"error": "standing bootstrap degraded", "standing_note": note}, origin)
+        log("session seeded ok (item %s) — credential returned to caller, not logged"
+            % session.get("item_id", "?"))
+        # Return the seed JSON verbatim (it carries the short-lived credential
+        # under "jwt"); the shell keeps it in page memory only.
+        return self._json(200, session, origin)
+
+    def _json(self, code, obj, origin):
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self._cors(origin)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):  # silence default access log (could echo paths)
+        return
+
+
+def main():
+    if not demo_gated():
+        # Start anyway (so the unit stays up) but it will 403; log the posture.
+        log("WARNING: starting without DEV/DEMO posture — endpoint will 403 until "
+            "ICN_ENABLE_ADMIN_ENDPOINTS=true and non-production governance mode")
+    httpd = ThreadingHTTPServer((BIND_HOST, BIND_PORT), Handler)
+    log("listening on http://%s:%d  (POST /v1/dev/demo/session, loopback only)" % (BIND_HOST, BIND_PORT))
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/appliance/scripts/icn-demo-verify.sh
+++ b/deploy/appliance/scripts/icn-demo-verify.sh
@@ -69,7 +69,11 @@ command -v python3 >/dev/null || fatal "python3 missing"
 
 # shellcheck disable=SC1090
 . "$ENV_FILE"
-SESSION_JWT="$(sudo -u icn ICN_KEYSTORE_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" ICN_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" /usr/local/bin/icnctl --data-dir "$DATA_DIR" auth token --gateway "$GW" --coop-id "$COOP_ID" -s "governance:read" 2>/dev/null | grep -oE 'eyJ[A-Za-z0-9_.-]+' | head -1)" # vocab-ok: icnctl CLI subcommand name
+# Drop to the icn user with runuser (this script runs as root), passing the
+# passphrase through exported env. NOT sudo: sudo logs its command + env to
+# the auth journal, leaking the keystore passphrase. See icn-demo-seed.sh
+# as_icn() for the rationale.
+SESSION_JWT="$(ICN_KEYSTORE_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" ICN_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" runuser -u icn --preserve-environment -- /usr/local/bin/icnctl --data-dir "$DATA_DIR" auth token --gateway "$GW" --coop-id "$COOP_ID" -s "governance:read" 2>/dev/null | grep -oE 'eyJ[A-Za-z0-9_.-]+' | head -1)" # vocab-ok: icnctl CLI subcommand name
 [ -n "$SESSION_JWT" ] || fatal "could not mint a read JWT"
 
 receipt="$(curl -s -m 10 -H "Authorization: Bearer $SESSION_JWT" \

--- a/deploy/appliance/scripts/open-proxmox-demo.sh
+++ b/deploy/appliance/scripts/open-proxmox-demo.sh
@@ -36,16 +36,25 @@
 #   ICN_DEMO_JUMP         user@host of a jump host (jump route)
 #   ICN_DEMO_REMOTE_KEY   demo key path on the jump host
 #   ICN_DEMO_GW_PORT      host port -> gateway   (default 18080)
-#   ICN_DEMO_SHELL_PORT   host port -> shell     (default 18090)
 #   ICN_DEMO_SESSION_PORT host port -> session   (default 18091)
 #   ICN_DEMO_NO_BROWSER=1 set up tunnels + print the URL, do not open a browser
+# The shell host port is FIXED at 18090: it is the member-shell page Origin,
+# which the node's gateway (ICN_CORS_ORIGINS) and demo session endpoint both
+# pin. GW/SESSION are tunnel destinations (never an Origin), so they stay
+# overridable; the shell port is not.
 # ============================================================================
 set -uo pipefail
 
 VM_IP="${ICN_DEMO_VM_IP:?set ICN_DEMO_VM_IP to your running node instance IP (e.g. 192.0.2.50)}"
 SSH_USER="${ICN_DEMO_SSH_USER:-debian}"
 GW_PORT="${ICN_DEMO_GW_PORT:-18080}"
-SHELL_PORT="${ICN_DEMO_SHELL_PORT:-18090}"
+# FIXED, deliberately not overridable. The member-shell page Origin is
+# http://localhost:18090; the node's gateway (ICN_CORS_ORIGINS) and the demo
+# session endpoint both pin that origin. A custom shell port would pass the
+# session seed but fail every authenticated gateway fetch (CORS), so we do not
+# expose a shell-port knob. GW_PORT / SESSION_PORT are tunnel destinations, not
+# Origins, and remain overridable.
+SHELL_PORT=18090
 SESSION_PORT="${ICN_DEMO_SESSION_PORT:-18091}"
 JUMP="${ICN_DEMO_JUMP:-}"
 # Carry the chosen ports to the shell so it talks to the gateway + session

--- a/deploy/appliance/scripts/open-proxmox-demo.sh
+++ b/deploy/appliance/scripts/open-proxmox-demo.sh
@@ -2,7 +2,7 @@
 # ============================================================================
 # open-proxmox-demo.sh — one command to open the ICN member-shell DEV/DEMO.
 # ----------------------------------------------------------------------------
-# DEV/DEMO ONLY. Run this from your workstation (e.g. Zenith). It:
+# DEV/DEMO ONLY. Run this from your workstation (your laptop or dev box). It:
 #   1. opens SSH tunnels so the browser uses the sealed demo origins. The
 #      node's gateway/shell/session all bind 127.0.0.1 INSIDE the VM and are
 #      never exposed on the VLAN — they are reachable only through your tunnel:

--- a/deploy/appliance/scripts/open-proxmox-demo.sh
+++ b/deploy/appliance/scripts/open-proxmox-demo.sh
@@ -46,11 +46,17 @@ GW_PORT="${ICN_DEMO_GW_PORT:-18080}"
 SHELL_PORT="${ICN_DEMO_SHELL_PORT:-18090}"
 SESSION_PORT="${ICN_DEMO_SESSION_PORT:-18091}"
 JUMP="${ICN_DEMO_JUMP:-}"
-SHELL_URL="http://localhost:${SHELL_PORT}/member-shell/?mode=live&demo=launcher"
+# Carry the chosen ports to the shell so it talks to the gateway + session
+# endpoint on whatever ports this launcher actually forwarded (honoring the
+# ICN_DEMO_*_PORT overrides), not hard-coded defaults.
+SHELL_URL="http://localhost:${SHELL_PORT}/member-shell/?mode=live&demo=launcher&gw=${GW_PORT}&session=${SESSION_PORT}"
 GATEWAY_URL="http://localhost:${GW_PORT}"
 
 log()  { printf '[demo-open] %s\n' "$*"; }
 err()  { printf '[demo-open] ERROR: %s\n' "$*" >&2; }
+
+# curl is used for reachability AND the readiness wait — require it up front.
+command -v curl >/dev/null 2>&1 || { err "curl is required but not found on PATH."; exit 2; }
 
 # ---- preflight: required host ports free ----
 for p in "$GW_PORT" "$SHELL_PORT" "$SESSION_PORT"; do
@@ -63,15 +69,13 @@ done
 
 # ---- reachability ----
 log "Checking the running node instance gateway at ${VM_IP}:8080 ..."
-if command -v curl >/dev/null 2>&1; then
-  if ! curl -sf -m 6 "http://${VM_IP}:8080/v1/health" >/dev/null 2>&1; then
-    err "node instance gateway not reachable at http://${VM_IP}:8080/v1/health from here."
-    err "If you are off the node's network, run this from a host that can reach it, or use ICN_DEMO_JUMP."
-    [ -z "$JUMP" ] && exit 3
-    log "Continuing via jump host ${JUMP} (it will reach the node)."
-  else
-    log "Gateway healthy."
-  fi
+if ! curl -sf -m 6 "http://${VM_IP}:8080/v1/health" >/dev/null 2>&1; then
+  err "node instance gateway not reachable at http://${VM_IP}:8080/v1/health from here."
+  err "If you are off the node's network, run this from a host that can reach it, or use ICN_DEMO_JUMP."
+  [ -z "$JUMP" ] && exit 3
+  log "Continuing via jump host ${JUMP} (it will reach the node)."
+else
+  log "Gateway healthy."
 fi
 
 # ---- build the SSH tunnel command for the chosen route ----
@@ -83,7 +87,11 @@ if [ -n "$JUMP" ]; then
   # key and can reach the node), and forward those local binds back here.
   REMOTE_KEY="${ICN_DEMO_REMOTE_KEY:?set ICN_DEMO_REMOTE_KEY to the demo key path on the jump host}"
   log "Route: jump through ${JUMP} -> ${SSH_USER}@${VM_IP} (key on jump host)."
-  INNER="ssh -N ${FWD[*]} -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=accept-new -i ${REMOTE_KEY} ${SSH_USER}@${VM_IP}"
+  # Build the remote command with shell-escaping so a key path / user / IP
+  # containing spaces or metacharacters cannot break out of the inner command.
+  # The forward flags are numeric ports (safe); the path/user/host are %q-quoted.
+  printf -v INNER 'ssh -N %s -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=accept-new -i %q %q@%q' \
+    "${FWD[*]}" "$REMOTE_KEY" "$SSH_USER" "$VM_IP"
   TUNNEL_CMD=( ssh "${COMMON[@]}"
     -L "${GW_PORT}:127.0.0.1:${GW_PORT}"
     -L "${SHELL_PORT}:127.0.0.1:${SHELL_PORT}"

--- a/deploy/appliance/scripts/open-proxmox-demo.sh
+++ b/deploy/appliance/scripts/open-proxmox-demo.sh
@@ -3,12 +3,17 @@
 # open-proxmox-demo.sh — one command to open the ICN member-shell DEV/DEMO.
 # ----------------------------------------------------------------------------
 # DEV/DEMO ONLY. Run this from your workstation (your laptop or dev box). It:
-#   1. opens SSH tunnels so the browser uses the sealed demo origins. The
-#      node's gateway/shell/session all bind 127.0.0.1 INSIDE the VM and are
-#      never exposed on the VLAN — they are reachable only through your tunnel:
-#        localhost:18080 -> node instance gateway      127.0.0.1:8080
-#        localhost:18090 -> node instance member-shell 127.0.0.1:8090
-#        localhost:18091 -> node instance demo-session  127.0.0.1:8091
+#   1. opens SSH tunnels so the browser uses the sealed demo origins and you
+#      reach the node through forwards you control:
+#        localhost:18080 -> node instance gateway      :8080  (binds 0.0.0.0)
+#        localhost:18090 -> node instance member-shell :8090  (binds 0.0.0.0)
+#        localhost:18091 -> node instance demo-session 127.0.0.1:8091 (loopback)
+#      Binding note: only the demo-session endpoint binds loopback. In the demo
+#      profile the gateway (--gateway-bind 0.0.0.0:8080) and member-shell
+#      (--bind 0.0.0.0) bind all interfaces, so on a BRIDGED Proxmox/cloud VM
+#      they are reachable on that VM's network — run the demo node on a trusted
+#      or isolated network. The tunnel works regardless; this is a DEV/DEMO
+#      image, not a hardened deployment.
 #   2. waits for the member-shell to answer through the tunnel,
 #   3. opens your browser to the member-shell in live mode.
 # After the browser opens you do NOT touch the terminal again: click

--- a/deploy/appliance/scripts/open-proxmox-demo.sh
+++ b/deploy/appliance/scripts/open-proxmox-demo.sh
@@ -3,11 +3,13 @@
 # open-proxmox-demo.sh — one command to open the ICN member-shell DEV/DEMO.
 # ----------------------------------------------------------------------------
 # DEV/DEMO ONLY. Run this from your workstation (e.g. Zenith). It:
-#   1. confirms the demo node instance is reachable,
-#   2. opens SSH tunnels so the browser uses the sealed demo origins:
+#   1. opens SSH tunnels so the browser uses the sealed demo origins. The
+#      node's gateway/shell/session all bind 127.0.0.1 INSIDE the VM and are
+#      never exposed on the VLAN — they are reachable only through your tunnel:
 #        localhost:18080 -> node instance gateway      127.0.0.1:8080
 #        localhost:18090 -> node instance member-shell 127.0.0.1:8090
 #        localhost:18091 -> node instance demo-session  127.0.0.1:8091
+#   2. waits for the member-shell to answer through the tunnel,
 #   3. opens your browser to the member-shell in live mode.
 # After the browser opens you do NOT touch the terminal again: click
 # "Start local demo" in the page — standing and an action card load with no
@@ -55,7 +57,7 @@ GATEWAY_URL="http://localhost:${GW_PORT}"
 log()  { printf '[demo-open] %s\n' "$*"; }
 err()  { printf '[demo-open] ERROR: %s\n' "$*" >&2; }
 
-# curl is used for reachability AND the readiness wait — require it up front.
+# curl is used for the post-tunnel readiness wait — require it up front.
 command -v curl >/dev/null 2>&1 || { err "curl is required but not found on PATH."; exit 2; }
 
 # ---- preflight: required host ports free ----
@@ -67,16 +69,13 @@ for p in "$GW_PORT" "$SHELL_PORT" "$SESSION_PORT"; do
   fi
 done
 
-# ---- reachability ----
-log "Checking the running node instance gateway at ${VM_IP}:8080 ..."
-if ! curl -sf -m 6 "http://${VM_IP}:8080/v1/health" >/dev/null 2>&1; then
-  err "node instance gateway not reachable at http://${VM_IP}:8080/v1/health from here."
-  err "If you are off the node's network, run this from a host that can reach it, or use ICN_DEMO_JUMP."
-  [ -z "$JUMP" ] && exit 3
-  log "Continuing via jump host ${JUMP} (it will reach the node)."
-else
-  log "Gateway healthy."
-fi
+# NOTE: no pre-tunnel reachability probe. The node's services bind 127.0.0.1
+# inside the VM, so a probe to ${VM_IP}:8080 from here would (correctly) fail
+# on a properly sealed node even when SSH works perfectly. The direct route
+# only requires SSH + the demo key, as documented; the jump route requires SSH
+# to the jump host. We validate end-to-end reachability AFTER the tunnel is up,
+# over the real path (curl localhost:${SHELL_PORT}), which is what actually
+# matters. SSH/connectivity failures surface there with an actionable message.
 
 # ---- build the SSH tunnel command for the chosen route ----
 FWD=( -L "${GW_PORT}:127.0.0.1:8080" -L "${SHELL_PORT}:127.0.0.1:8090" -L "${SESSION_PORT}:127.0.0.1:8091" )
@@ -116,11 +115,16 @@ trap cleanup EXIT INT TERM
 log "Establishing tunnel (pid $TUN_PID); waiting for the member-shell ..."
 ok=0
 for _ in $(seq 1 30); do
-  if ! kill -0 "$TUN_PID" 2>/dev/null; then err "tunnel exited early."; exit 5; fi
+  if ! kill -0 "$TUN_PID" 2>/dev/null; then
+    err "SSH tunnel exited before it came up. Check: can you 'ssh ${SSH_USER}@${VM_IP}'"
+    [ -n "$JUMP" ] && err "  via jump host ${JUMP}, with ICN_DEMO_REMOTE_KEY?" \
+                   || err "  with the key in ICN_DEMO_SSH_KEY? (or set ICN_DEMO_JUMP to route through a host that can)."
+    exit 5
+  fi
   if curl -sf -m 3 "http://localhost:${SHELL_PORT}/member-shell/index.html" >/dev/null 2>&1; then ok=1; break; fi
   sleep 1
 done
-[ "$ok" = 1 ] || { err "member-shell did not answer on localhost:${SHELL_PORT}."; exit 6; }
+[ "$ok" = 1 ] || { err "tunnel is up but the member-shell did not answer on localhost:${SHELL_PORT}. Is the node booted and the demo profile running (systemctl status icnd icn-demo-session)?"; exit 6; }
 log "Tunnel up. Shell reachable on localhost:${SHELL_PORT}."
 
 # ---- open the browser ----

--- a/deploy/appliance/scripts/open-proxmox-demo.sh
+++ b/deploy/appliance/scripts/open-proxmox-demo.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# ============================================================================
+# open-proxmox-demo.sh — one command to open the ICN member-shell DEV/DEMO.
+# ----------------------------------------------------------------------------
+# DEV/DEMO ONLY. Run this from your workstation (e.g. Zenith). It:
+#   1. confirms the demo node instance is reachable,
+#   2. opens SSH tunnels so the browser uses the sealed demo origins:
+#        localhost:18080 -> node instance gateway      127.0.0.1:8080
+#        localhost:18090 -> node instance member-shell 127.0.0.1:8090
+#        localhost:18091 -> node instance demo-session  127.0.0.1:8091
+#   3. opens your browser to the member-shell in live mode.
+# After the browser opens you do NOT touch the terminal again: click
+# "Start local demo" in the page — standing and an action card load with no
+# gateway typing and no JWT copy/paste. Ctrl-C here later to close the tunnel.
+#
+# Terminology: the appliance is a reproducible VM image; this connects to a
+# RUNNING NODE INSTANCE (a VM booted from it) on a hypervisor host. Not a
+# physical box, not production, not a pilot.
+#
+# Connectivity (two routes):
+#   * Direct: this machine can SSH the node instance and has the demo key.
+#       ICN_DEMO_VM_IP   (required — your running node instance IP)
+#       ICN_DEMO_SSH_KEY (path to the demo private key)
+#   * Jump:   this machine cannot SSH the node directly (e.g. the key lives on
+#       a dev host). Set ICN_DEMO_JUMP=<user@dev-host> and the tunnel is built
+#       through it; the dev host reaches the node instance and holds the key.
+#       ICN_DEMO_JUMP        (e.g. user@dev-host or an ssh-config alias)
+#       ICN_DEMO_REMOTE_KEY  (key path ON the jump host; required for the jump route)
+#
+# Env (all optional; sensible defaults):
+#   ICN_DEMO_VM_IP        running node instance IP (required, e.g. 192.0.2.50)
+#   ICN_DEMO_SSH_USER     ssh user on the node instance   (default debian)
+#   ICN_DEMO_SSH_KEY      demo private key (direct route)
+#   ICN_DEMO_JUMP         user@host of a jump host (jump route)
+#   ICN_DEMO_REMOTE_KEY   demo key path on the jump host
+#   ICN_DEMO_GW_PORT      host port -> gateway   (default 18080)
+#   ICN_DEMO_SHELL_PORT   host port -> shell     (default 18090)
+#   ICN_DEMO_SESSION_PORT host port -> session   (default 18091)
+#   ICN_DEMO_NO_BROWSER=1 set up tunnels + print the URL, do not open a browser
+# ============================================================================
+set -uo pipefail
+
+VM_IP="${ICN_DEMO_VM_IP:?set ICN_DEMO_VM_IP to your running node instance IP (e.g. 192.0.2.50)}"
+SSH_USER="${ICN_DEMO_SSH_USER:-debian}"
+GW_PORT="${ICN_DEMO_GW_PORT:-18080}"
+SHELL_PORT="${ICN_DEMO_SHELL_PORT:-18090}"
+SESSION_PORT="${ICN_DEMO_SESSION_PORT:-18091}"
+JUMP="${ICN_DEMO_JUMP:-}"
+SHELL_URL="http://localhost:${SHELL_PORT}/member-shell/?mode=live&demo=launcher"
+GATEWAY_URL="http://localhost:${GW_PORT}"
+
+log()  { printf '[demo-open] %s\n' "$*"; }
+err()  { printf '[demo-open] ERROR: %s\n' "$*" >&2; }
+
+# ---- preflight: required host ports free ----
+for p in "$GW_PORT" "$SHELL_PORT" "$SESSION_PORT"; do
+  if (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then
+    exec 3>&- 3<&- 2>/dev/null || true
+    err "host port $p is already in use. Set ICN_DEMO_{GW,SHELL,SESSION}_PORT to free ports, or stop the process holding it."
+    exit 2
+  fi
+done
+
+# ---- reachability ----
+log "Checking the running node instance gateway at ${VM_IP}:8080 ..."
+if command -v curl >/dev/null 2>&1; then
+  if ! curl -sf -m 6 "http://${VM_IP}:8080/v1/health" >/dev/null 2>&1; then
+    err "node instance gateway not reachable at http://${VM_IP}:8080/v1/health from here."
+    err "If you are off the node's network, run this from a host that can reach it, or use ICN_DEMO_JUMP."
+    [ -z "$JUMP" ] && exit 3
+    log "Continuing via jump host ${JUMP} (it will reach the node)."
+  else
+    log "Gateway healthy."
+  fi
+fi
+
+# ---- build the SSH tunnel command for the chosen route ----
+FWD=( -L "${GW_PORT}:127.0.0.1:8080" -L "${SHELL_PORT}:127.0.0.1:8090" -L "${SESSION_PORT}:127.0.0.1:8091" )
+COMMON=( -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 )
+
+if [ -n "$JUMP" ]; then
+  # Jump route: run the per-node tunnel ON the jump host (which holds the demo
+  # key and can reach the node), and forward those local binds back here.
+  REMOTE_KEY="${ICN_DEMO_REMOTE_KEY:?set ICN_DEMO_REMOTE_KEY to the demo key path on the jump host}"
+  log "Route: jump through ${JUMP} -> ${SSH_USER}@${VM_IP} (key on jump host)."
+  INNER="ssh -N ${FWD[*]} -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=accept-new -i ${REMOTE_KEY} ${SSH_USER}@${VM_IP}"
+  TUNNEL_CMD=( ssh "${COMMON[@]}"
+    -L "${GW_PORT}:127.0.0.1:${GW_PORT}"
+    -L "${SHELL_PORT}:127.0.0.1:${SHELL_PORT}"
+    -L "${SESSION_PORT}:127.0.0.1:${SESSION_PORT}"
+    "$JUMP" "$INNER" )
+else
+  KEY="${ICN_DEMO_SSH_KEY:?set ICN_DEMO_SSH_KEY to the demo private key path}"
+  if [ ! -f "$KEY" ]; then
+    err "demo SSH key not found at $KEY. Set ICN_DEMO_SSH_KEY, or use ICN_DEMO_JUMP to route through a host that holds it."
+    exit 4
+  fi
+  log "Route: direct ${SSH_USER}@${VM_IP} (key $KEY)."
+  TUNNEL_CMD=( ssh -N "${COMMON[@]}" "${FWD[@]}" -i "$KEY" "${SSH_USER}@${VM_IP}" )
+fi
+
+# ---- start tunnel in the background, wait for the shell to answer ----
+"${TUNNEL_CMD[@]}" &
+TUN_PID=$!
+cleanup() { log "Closing tunnel (pid $TUN_PID)."; kill "$TUN_PID" 2>/dev/null; }
+trap cleanup EXIT INT TERM
+
+log "Establishing tunnel (pid $TUN_PID); waiting for the member-shell ..."
+ok=0
+for _ in $(seq 1 30); do
+  if ! kill -0 "$TUN_PID" 2>/dev/null; then err "tunnel exited early."; exit 5; fi
+  if curl -sf -m 3 "http://localhost:${SHELL_PORT}/member-shell/index.html" >/dev/null 2>&1; then ok=1; break; fi
+  sleep 1
+done
+[ "$ok" = 1 ] || { err "member-shell did not answer on localhost:${SHELL_PORT}."; exit 6; }
+log "Tunnel up. Shell reachable on localhost:${SHELL_PORT}."
+
+# ---- open the browser ----
+open_browser() {
+  for opener in xdg-open gio open kde-open5 kde-open open; do
+    if command -v "$opener" >/dev/null 2>&1; then
+      [ "$opener" = "gio" ] && { "$opener" open "$1" >/dev/null 2>&1 && return 0 || continue; }
+      "$opener" "$1" >/dev/null 2>&1 && return 0
+    fi
+  done
+  return 1
+}
+
+cat <<EOF
+
+  ============================ ICN LOCAL DEMO OPEN ============================
+   Member shell : ${SHELL_URL}
+   Gateway      : ${GATEWAY_URL}  (pre-filled in the page; do not type it)
+   In the browser: click "Start local demo" — standing + an action card load.
+   No JWT to copy. No gateway to type. No terminal needed after this.
+   Stop the demo: press Ctrl-C in this terminal to close the tunnel.
+  ============================================================================
+
+EOF
+
+if [ "${ICN_DEMO_NO_BROWSER:-0}" = "1" ]; then
+  log "ICN_DEMO_NO_BROWSER=1 — not opening a browser. Open the URL above yourself."
+else
+  if open_browser "$SHELL_URL"; then
+    log "Opened your browser to the member-shell."
+  else
+    log "Could not auto-open a browser. Open this URL manually: ${SHELL_URL}"
+  fi
+fi
+
+log "Tunnel is running. Leave this terminal open during the demo; Ctrl-C to stop."
+wait "$TUN_PID"

--- a/deploy/appliance/systemd/icn-demo-session.service
+++ b/deploy/appliance/systemd/icn-demo-session.service
@@ -32,11 +32,24 @@ ExecStart=/usr/bin/python3 /usr/local/sbin/icn-demo-session.py
 Restart=on-failure
 RestartSec=5
 
-# Sandboxing: loopback-only network; no new privileges beyond the fixed
-# seed command it must run as root.
+# Sandboxing. Loopback-only network; the only thing this runs is the fixed
+# seed command. NOTE: unlike icn-member-shell.service (which runs as the
+# unprivileged `icn` user serving static files), this unit runs as root and
+# the seed it invokes drops to `icn` via `runuser` and writes node state under
+# /var/lib/icn. So NoNewPrivileges=true (would block the runuser privilege
+# transition) and ProtectSystem=strict (would make the state tree read-only)
+# are deliberately NOT set. The directives below harden everything that does
+# not interfere with that legitimate seed path.
 ProtectHome=true
 PrivateTmp=true
 ProtectControlGroups=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectClock=true
+ProtectHostname=true
+RestrictNamespaces=true
+RestrictRealtime=true
+LockPersonality=true
 RestrictAddressFamilies=AF_INET AF_UNIX
 
 StandardOutput=journal

--- a/deploy/appliance/systemd/icn-demo-session.service
+++ b/deploy/appliance/systemd/icn-demo-session.service
@@ -1,0 +1,47 @@
+# DEMO PROFILE ONLY — installed by build-image.sh when
+# ICN_APPLIANCE_DEMO_PROFILE=1. Not on the base image, never production.
+#
+# Loopback DEV/DEMO session endpoint for the member-shell "Start local demo"
+# button (icn-demo-session.py): POST /v1/dev/demo/session runs icn-demo-seed
+# and returns a fresh DEV/DEMO session so the operator never copies/pastes a
+# JWT. Binds 127.0.0.1:8091 only — reachable solely through the operator's own
+# SSH tunnel (open-proxmox-demo.sh forwards it to localhost:18091). The script
+# is double dev-gated and refuses unless ICN_ENABLE_ADMIN_ENDPOINTS=true and a
+# non-production governance posture (it returns 403 otherwise).
+#
+# Runs as root because icn-demo-seed reads /etc/icn/icnd.env. The command is
+# fixed; no request data influences it. This adds no privilege the
+# tunnel-holding operator (SSH + sudo on this throwaway VM) does not already
+# have.
+
+[Unit]
+Description=ICN member-shell DEV/DEMO session endpoint (DEV/DEMO ONLY)
+Documentation=https://github.com/InterCooperative-Network/icn
+After=icnd.service
+Wants=icnd.service
+ConditionPathExists=/usr/local/sbin/icn-demo-session.py
+ConditionPathExists=/usr/local/sbin/icn-demo-seed
+
+[Service]
+Type=simple
+# Dev gates passed through so the endpoint's posture check matches icnd's.
+EnvironmentFile=-/etc/icn/icnd.env
+Environment=ICN_ENABLE_ADMIN_ENDPOINTS=true
+Environment=ICN_GOVERNANCE_BUILD_MODE=test
+ExecStart=/usr/bin/python3 /usr/local/sbin/icn-demo-session.py
+Restart=on-failure
+RestartSec=5
+
+# Sandboxing: loopback-only network; no new privileges beyond the fixed
+# seed command it must run as root.
+ProtectHome=true
+PrivateTmp=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_UNIX
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=icn-demo-session
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/demo/JULY_DEMO_HANDS_ON.md
+++ b/docs/demo/JULY_DEMO_HANDS_ON.md
@@ -93,10 +93,21 @@ artifact**. It is a local dev image.
 > the VM (your laptop's QEMU, a Proxmox box, a cloud instance). The demo is a
 > node instance, never a physical box and never production.
 
-The node's gateway, member-shell, and demo-session endpoint all bind
-**`127.0.0.1` inside the VM**. They are never exposed on your LAN. You reach them
-through port-forwards you control (QEMU hostfwd locally, or an SSH tunnel
-remotely).
+Binding, in the demo profile (be precise about this — it is a security point):
+
+- The **demo-session endpoint** (the one that mints the DEV/DEMO JWT) binds
+  **`127.0.0.1` only** inside the VM. It is never on the network — reachable
+  solely through a port-forward you control.
+- The **gateway** (`0.0.0.0:8080`) and **member-shell** (`0.0.0.0:8090`) bind all
+  interfaces. Under a local QEMU user-mode VM that is host-only (no LAN). But on
+  a **bridged Proxmox/cloud VM they are reachable on that VM's network** — so run
+  the demo node on a **trusted or isolated network** (e.g. an isolated VLAN), or
+  don't bridge it. The launcher reaches everything over the tunnel regardless;
+  the open binds are a dev-profile convenience, not a hardened posture. This is a
+  DEV/DEMO image, not a production deployment.
+
+The recommended path is the SSH tunnel ([§5](#5-launch-it-through-a-remote--proxmox-vm)),
+which works the same whether or not the gateway/shell are also on the LAN.
 
 ---
 
@@ -368,8 +379,9 @@ browser beats screenshots — use these as a fallback if the node isn't reachabl
 1. **(0:00–2:00) Frame it.** What ICN is ([§1](#1-what-this-demo-is)) and the
    honesty boundary ([§2](#2-what-this-demo-is-not)). "I'll show you what's real,
    and I'll be precise about what isn't."
-2. **(2:00–3:00) Launch.** Run the launcher (or have it open). Explain the node
-   binds loopback and you reach it through a tunnel you control.
+2. **(2:00–3:00) Launch.** Run the launcher (or have it open). Explain that the
+   JWT-minting session endpoint binds loopback and you reach the node through a
+   tunnel you control (see the binding note in [§3](#3-what-you-need-before-starting)).
 3. **(3:00–6:00) The loop.** Click through standing → card → discharge → receipt
    → confirmed, narrating with [§7](#7-what-to-say-at-each-stage).
 4. **(6:00–8:00) Evidence.** Expand the receipt; explain the record hash and what

--- a/docs/demo/JULY_DEMO_HANDS_ON.md
+++ b/docs/demo/JULY_DEMO_HANDS_ON.md
@@ -102,26 +102,35 @@ remotely).
 
 ## 4. Launch it locally (laptop / dev box)
 
-This path needs no SSH and no launcher script — you boot the image under QEMU
-with three port-forwards and open the browser. The shell host port **must** be
-`18090` (the node's gateway and session CORS allow-lists pin that origin).
+You boot the image under QEMU and reach it through forwards you control. The
+gateway and member-shell bind `0.0.0.0` inside the VM, so QEMU port-forwards
+reach them directly. The demo-session endpoint binds **loopback only** inside the
+VM (the same security posture as the remote path — it is only ever reached
+through a tunnel), so it needs a one-line SSH local-forward rather than a QEMU
+hostfwd (a hostfwd targets the guest NIC, not the guest's loopback). The shell
+host port **must** be `18090` (the node's gateway and session CORS allow-lists
+pin that origin).
 
 ```bash
-# Boot the demo image with the three loopback forwards and leave it running.
-# 18080 -> gateway(8080)   18090 -> member-shell(8090)   18091 -> session(8091)
+# 1) Boot the demo image. Forward SSH + gateway + member-shell; leave it running.
+#    2222 -> ssh(22)   18080 -> gateway(8080)   18090 -> member-shell(8090)
 qemu-system-x86_64 \
   -machine accel=kvm -cpu host -m 2048 -smp 2 \
   -drive file=/path/to/icn-appliance-<version>-amd64.qcow2,if=virtio \
   -drive file=/path/to/seed.iso,if=virtio,media=cdrom \
   -netdev user,id=n0,\
+hostfwd=tcp:127.0.0.1:2222-:22,\
 hostfwd=tcp:127.0.0.1:18080-:8080,\
-hostfwd=tcp:127.0.0.1:18090-:8090,\
-hostfwd=tcp:127.0.0.1:18091-:8091 \
+hostfwd=tcp:127.0.0.1:18090-:8090 \
   -device virtio-net-pci,netdev=n0 \
   -nographic
+
+# 2) Once the gateway answers, forward the loopback-only session endpoint over
+#    SSH (the demo key matches the cloud-init seed). Leave this running too.
+ssh -i /path/to/demo_key -p 2222 -N -L 18091:127.0.0.1:8091 debian@localhost
 ```
 
-Wait until the node finishes first boot (the gateway answers), then open:
+With both running, open:
 
 ```
 http://localhost:18090/member-shell/?mode=live&demo=launcher&gw=18080&session=18091

--- a/docs/demo/JULY_DEMO_HANDS_ON.md
+++ b/docs/demo/JULY_DEMO_HANDS_ON.md
@@ -1,0 +1,417 @@
+# ICN July Demo — Hands-On Guide
+
+> A complete, click-by-click way through the ICN July Demo Candidate. Written so
+> you can run it yourself, understand what you are looking at, and show it to
+> another person without improvising.
+
+This is a **DEV/DEMO** walkthrough. Read [§2 What this is not](#2-what-this-demo-is-not)
+and [§16 What this proves](#16-what-this-proves) before you show it to anyone, so
+you describe it honestly.
+
+---
+
+## Table of contents
+
+1. [What this demo is](#1-what-this-demo-is)
+2. [What this demo is not](#2-what-this-demo-is-not)
+3. [What you need before starting](#3-what-you-need-before-starting)
+4. [Launch it locally (laptop / dev box)](#4-launch-it-locally-laptop--dev-box)
+5. [Launch it through a remote / Proxmox VM](#5-launch-it-through-a-remote--proxmox-vm)
+6. [The exact click path](#6-the-exact-click-path)
+7. [What to say at each stage](#7-what-to-say-at-each-stage)
+8. [How to reset the demo](#8-how-to-reset-the-demo)
+9. [How to verify receipts](#9-how-to-verify-receipts)
+10. [How to show the OpenAPI surface](#10-how-to-show-the-openapi-surface)
+11. [How to explain the evidence / audit trail](#11-how-to-explain-the-evidence--audit-trail)
+12. [Common failure modes and fixes](#12-common-failure-modes-and-fixes)
+13. [Screenshots](#13-screenshots)
+14. [The 5-minute demo script](#14-the-5-minute-demo-script)
+15. [The 15-minute demo script](#15-the-15-minute-demo-script)
+16. [What this proves](#16-what-this-proves)
+17. [What comes next](#17-what-comes-next)
+
+---
+
+## 1. What this demo is
+
+ICN (the Intercooperative Network) is infrastructure for cooperatives to
+coordinate **without** a central company in the middle. This demo is the first
+hands-on slice of that: a single ICN node, running as a self-contained
+appliance, driving one complete member loop end to end.
+
+The loop is small on purpose. One member, in one context, is shown the things
+they are allowed to act on, completes one of them, and the node produces a
+tamper-evident **receipt** that the action happened. You can then ask the node
+to prove that its record of events is internally consistent.
+
+In plain language, the demo shows a node that can answer four questions and
+prove its answers:
+
+- **Who can act here?** (member standing)
+- **What can they do?** (action cards)
+- **Did they do it?** (discharge + completion receipt)
+- **Can you prove it happened and wasn't edited later?** (receipt evidence +
+  the audit chain)
+
+That is the seed of member-controlled infrastructure: a box a cooperative could
+eventually run themselves, instead of renting a seat in someone else's system.
+
+---
+
+## 2. What this demo is NOT
+
+Be precise about this. The honesty boundary is the most important slide.
+
+| Layer | Status | What it means |
+|-------|--------|---------------|
+| **Live-local** | ✅ real, running here | Node boot, `icnd`, the gateway, member standing, action cards, discharge, completion receipt, receipt↔evidence binding, seed/reset/reseed, the OpenAPI surface, and the 13/13 receipt-chain proof. These genuinely run on the node in front of you. |
+| **Fixture-backed** | 🟡 real software, demo data | The NYCN institution package, the demo member/org identities, and the member-shell panes. The *mechanism* is real; the *people and org* are a scripted fixture, not a live membership roster. |
+| **Design-only / not yet proven** | ⛔ do not claim | Federation, multi-organization behavior, production deployment, real pilot adoption, real member data, the mobile passport / keyring, QR node-claim, commons resource allocation, any wallet / token / payment behavior, and a signed release image. None of this is demonstrated here. |
+
+If someone asks "is this live / in production / handling real money or real
+members?" the answer is **no**. It is a development demonstration of the core
+loop. Say so plainly. The credibility of the project rests on not overclaiming.
+
+This image is **unsigned**, **not immutable**, and **not a partner-distributable
+artifact**. It is a local dev image.
+
+---
+
+## 3. What you need before starting
+
+- The demo appliance image (a `.qcow2` file) — see the project's appliance
+  build docs, or reuse a verified candidate image.
+- A way to run it: either **QEMU/KVM locally** ([§4](#4-launch-it-locally-laptop--dev-box))
+  or a **hypervisor** (Proxmox/KVM/cloud) for the remote path ([§5](#5-launch-it-through-a-remote--proxmox-vm)).
+- A modern browser (Chrome/Chromium/Firefox).
+- For the remote path only: SSH access to the running node and the demo SSH key.
+- The launcher script lives in the repo at
+  `deploy/appliance/scripts/open-proxmox-demo.sh`.
+
+> **Terminology.** The *appliance image* is a reproducible VM template. Booting
+> it gives you a *running node instance*. The *hypervisor host* is whatever runs
+> the VM (your laptop's QEMU, a Proxmox box, a cloud instance). The demo is a
+> node instance, never a physical box and never production.
+
+The node's gateway, member-shell, and demo-session endpoint all bind
+**`127.0.0.1` inside the VM**. They are never exposed on your LAN. You reach them
+through port-forwards you control (QEMU hostfwd locally, or an SSH tunnel
+remotely).
+
+---
+
+## 4. Launch it locally (laptop / dev box)
+
+This path needs no SSH and no launcher script — you boot the image under QEMU
+with three port-forwards and open the browser. The shell host port **must** be
+`18090` (the node's gateway and session CORS allow-lists pin that origin).
+
+```bash
+# Boot the demo image with the three loopback forwards and leave it running.
+# 18080 -> gateway(8080)   18090 -> member-shell(8090)   18091 -> session(8091)
+qemu-system-x86_64 \
+  -machine accel=kvm -cpu host -m 2048 -smp 2 \
+  -drive file=/path/to/icn-appliance-<version>-amd64.qcow2,if=virtio \
+  -drive file=/path/to/seed.iso,if=virtio,media=cdrom \
+  -netdev user,id=n0,\
+hostfwd=tcp:127.0.0.1:18080-:8080,\
+hostfwd=tcp:127.0.0.1:18090-:8090,\
+hostfwd=tcp:127.0.0.1:18091-:8091 \
+  -device virtio-net-pci,netdev=n0 \
+  -nographic
+```
+
+Wait until the node finishes first boot (the gateway answers), then open:
+
+```
+http://localhost:18090/member-shell/?mode=live&demo=launcher&gw=18080&session=18091
+```
+
+Then follow [§6 The exact click path](#6-the-exact-click-path). Nothing to type,
+nothing to paste.
+
+> The repo's `deploy/appliance/smoke/smoke-local.sh --real --demo` boots this
+> same image the same way and drives the loop from the command line — it is the
+> automated proof that the local-boot path works.
+
+---
+
+## 5. Launch it through a remote / Proxmox VM
+
+Use this when the node runs on a hypervisor you reach over SSH. This is the
+**one-command launcher** path. The launcher opens the three tunnels and your
+browser; you never touch the terminal again after it opens.
+
+Set the connection via environment variables (no infra values are baked into the
+script):
+
+```bash
+# Direct route — your workstation can SSH the node and holds the demo key:
+ICN_DEMO_VM_IP=<your-node-ip> \
+ICN_DEMO_SSH_KEY=/path/to/demo_key \
+  bash deploy/appliance/scripts/open-proxmox-demo.sh
+
+# Jump route — the key lives on a dev host that can reach the node:
+ICN_DEMO_VM_IP=<your-node-ip> \
+ICN_DEMO_JUMP=user@dev-host \
+ICN_DEMO_REMOTE_KEY=/path/to/demo_key-on-jump-host \
+  bash deploy/appliance/scripts/open-proxmox-demo.sh
+```
+
+What it does, in order:
+
+1. Opens SSH tunnels: `localhost:18080→gateway`, `localhost:18090→member-shell`,
+   `localhost:18091→demo-session`.
+2. Waits for the member-shell to actually answer through the tunnel.
+3. Opens your browser to the shell in launcher mode.
+4. Prints the URL and the gateway, then runs until you press **Ctrl-C**.
+
+Overridable env (all optional): `ICN_DEMO_SSH_USER` (default `debian`),
+`ICN_DEMO_GW_PORT` (18080), `ICN_DEMO_SESSION_PORT` (18091),
+`ICN_DEMO_NO_BROWSER=1` (set up tunnels, print the URL, don't open a browser).
+The **shell port is fixed at 18090** by design and is not overridable — it is the
+page origin the gateway CORS allow-list pins.
+
+---
+
+## 6. The exact click path
+
+The browser opens to the member-shell in **launcher mode** (`?demo=launcher`).
+
+1. You see an honesty banner at the top and a **"Start local demo"** button. The
+   gateway field is pre-filled (`http://localhost:18080`). The manual connect
+   form is hidden.
+2. Click **Start local demo** — one click. The page asks the loopback session
+   endpoint for a fresh DEV/DEMO session, holds the short-lived credential **in
+   page memory only** (never written to disk, never in the URL), and loads the
+   loop. No gateway typed, no JWT pasted.
+3. **Standing** renders — the member's standing in the demo context (two
+   domains).
+4. **Action card(s)** appear — the things this member can act on.
+5. Click **Mark complete** on a card → a confirm step appears declaring the
+   action and its reversibility.
+6. Click **Confirm — mark complete**.
+7. **Receipt** renders, including the record hash.
+8. Expand the receipt to see the **evidence** detail (the record the network
+   produced).
+9. The action card transitions to **Confirmed** in place.
+
+> **Known nuance — say it out loud if asked.** After discharge, the backend
+> `/me/action-cards` correctly returns **zero open cards** (the obligation is
+> complete). The card you see does **not** vanish from the screen; it flips to a
+> **Confirmed** state in place so the audience can see the result. The
+> on-screen "Confirmed" card and the empty open-cards list are consistent, not a
+> bug.
+
+---
+
+## 7. What to say at each stage
+
+Plain language, no jargon fog. A real person is next to you asking "okay, what am
+I actually looking at?"
+
+- **Standing:** "The node knows who is allowed to act in this context, and what
+  their standing is. Nobody had to ask a central server — the node holds this."
+- **Action card:** "These are the prompts this member can act on — the work or
+  the governance step in front of them. The node decides what to show based on
+  who they are."
+- **Discharge:** "The member completes the action. Notice it tells them what
+  they're about to do and whether it can be undone before they confirm."
+- **Receipt:** "The node produces a receipt — evidence the action happened, with
+  a hash. This isn't a screenshot or a log line you could quietly edit; it's
+  bound to the record."
+- **Evidence / audit:** "And we can ask the node to prove its whole chain of
+  records is internally consistent — that nothing was inserted or rewritten
+  after the fact."
+- **Appliance:** "The whole thing is one node a cooperative could eventually run
+  themselves. This is the seed of member-controlled infrastructure — not a
+  finished federation, but the first working piece."
+
+---
+
+## 8. How to reset the demo
+
+Run inside the node (SSH in, or use the hypervisor console):
+
+```bash
+sudo icn-demo-reset          # destroys the demo's seeded state
+sudo icn-demo-seed --json    # reseeds a fresh member + open action card
+```
+
+After reseed you should see `"standing_note": "bootstrap-standing: ok"` in the
+JSON. Reload the member-shell and the loop is fresh again.
+
+> `icn-demo-reset` destroys the demo's seeded state on that node only. It does
+> not touch any other system.
+
+---
+
+## 9. How to verify receipts
+
+Inside the node:
+
+```bash
+# Verify a single item's record is consistent:
+sudo icn-demo-verify <item-id>
+
+# Verify the full governed receipt chain (the cryptographic proof):
+sudo icn-demo-verify --chain
+```
+
+`--chain` is the strong proof: it audit-verifies the full receipt chain and
+reports **13/13**. A per-item `verify` is a consistency check, not a BLAKE3
+re-derivation — `--chain` is the cryptographic path. Say it that way; don't
+inflate the per-item check.
+
+---
+
+## 10. How to show the OpenAPI surface
+
+The gateway serves its member API surface as OpenAPI. Through the tunnel (or
+QEMU forward) on the gateway port:
+
+```bash
+curl -s http://localhost:18080/api-docs/openapi.json | head -c 400; echo
+```
+
+This is the machine-readable contract for the member surface that landed in
+#2027. It is what an app, an SDK, or a partner integration would build against.
+
+---
+
+## 11. How to explain the evidence / audit trail
+
+The point of the receipt is not the receipt — it's that the record can be
+**proven consistent later**.
+
+- Every meaningful action produces a record the node stores.
+- The receipt binds to that record (the record hash you saw in the UI).
+- `icn-demo-verify --chain` walks the governed receipt chain and confirms every
+  link is consistent — **13/13**. If someone had inserted, deleted, or rewritten
+  a record after the fact, the chain check would not pass.
+
+Why a cooperative cares: it means the history of decisions and actions isn't
+"trust the admin." It's verifiable by anyone who can run the check. That's the
+difference between a platform that *tells* you what happened and infrastructure
+that can *prove* it.
+
+---
+
+## 12. Common failure modes and fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Launcher exits "host port already in use" | 18080/18090/18091 busy on your workstation | Free the port, or override `ICN_DEMO_GW_PORT` / `ICN_DEMO_SESSION_PORT` (shell stays 18090). |
+| Launcher "SSH tunnel exited before it came up" | Can't SSH the node / wrong key / wrong route | Confirm you can `ssh <user>@<node-ip>` with your key, or set `ICN_DEMO_JUMP` to route through a host that can. |
+| Tunnel up but member-shell never answers | Node still booting, or demo profile not running | Wait for first boot; check `systemctl status icnd icn-demo-session` in the VM. |
+| "Start local demo" does nothing / standing never loads | Session endpoint gated off, or dev gates not set | Confirm the image is a **demo-profile** image; check `journalctl -u icn-demo-session`. |
+| Authenticated calls fail CORS | Shell served on a non-18090 origin | Use shell port **18090** (the gateway/session CORS allow-lists pin it). Don't change the shell port. |
+| Cards don't refresh after discharge | Expected — see [§6 nuance](#6-the-exact-click-path) | The card flips to **Confirmed** in place; `/me/action-cards` is correctly empty. |
+
+---
+
+## 13. Screenshots
+
+A real-browser pass captures the six key states. To regenerate them, run the
+launcher (or local boot), then drive the click path with a browser-automation
+script and screenshot each step. The canonical six are:
+
+1. `01-launcher-open` — launcher mode, "Start local demo" visible, gateway
+   pre-filled
+2. `02-standing-auto` — standing rendered after one click
+3. `03-action-card` — open action card
+4. `04-confirm` — the confirm-before-discharge step
+5. `05-receipt` — receipt with record hash
+6. `06-confirmed` — card in Confirmed state
+
+Keep screenshots free of any credential (scrub JWTs). For a live demo, the live
+browser beats screenshots — use these as a fallback if the node isn't reachable.
+
+---
+
+## 14. The 5-minute demo script
+
+> Goal: show the loop and the proof. No setup talk.
+
+1. **(0:00)** "This is one ICN node, running as a self-contained appliance.
+   Watch it run one full member loop." — launcher already open.
+2. **(0:30)** Click **Start local demo**. "One click. No login to type, no token
+   to paste." — standing renders.
+3. **(1:00)** "The node knows who can act here and what their standing is." Point
+   at the two domains.
+4. **(1:30)** "Here's what this member can act on." Open the action card.
+5. **(2:30)** Click **Mark complete** → confirm. "It tells them what they're
+   doing and whether it's reversible, then they confirm." → receipt.
+6. **(3:30)** "The node produced a receipt — evidence, with a hash, bound to the
+   record." Expand evidence.
+7. **(4:00)** Switch to a terminal: `sudo icn-demo-verify --chain` → **13/13**.
+   "And it can prove its whole record chain is consistent. Not 'trust me' —
+   verifiable."
+8. **(4:30)** "That's the seed of infrastructure a cooperative runs themselves.
+   It's a demo of the core loop — not production, not a federation yet."
+
+---
+
+## 15. The 15-minute demo script
+
+> Goal: the loop, the proof, the honesty boundary, and the OpenAPI surface.
+
+1. **(0:00–2:00) Frame it.** What ICN is ([§1](#1-what-this-demo-is)) and the
+   honesty boundary ([§2](#2-what-this-demo-is-not)). "I'll show you what's real,
+   and I'll be precise about what isn't."
+2. **(2:00–3:00) Launch.** Run the launcher (or have it open). Explain the node
+   binds loopback and you reach it through a tunnel you control.
+3. **(3:00–6:00) The loop.** Click through standing → card → discharge → receipt
+   → confirmed, narrating with [§7](#7-what-to-say-at-each-stage).
+4. **(6:00–8:00) Evidence.** Expand the receipt; explain the record hash and what
+   binding means ([§11](#11-how-to-explain-the-evidence--audit-trail)).
+5. **(8:00–10:00) Proof.** Terminal: `sudo icn-demo-verify --chain` → 13/13.
+   Explain why a cooperative cares about verifiable history.
+6. **(10:00–11:30) Reset.** `sudo icn-demo-reset && sudo icn-demo-seed --json`,
+   reload the shell — "fresh loop, repeatable."
+7. **(11:30–13:00) The contract.** Show `…/api-docs/openapi.json` — "this is the
+   surface an app or partner builds against."
+8. **(13:00–15:00) Boundaries + next.** Walk [§2](#2-what-this-demo-is-not) and
+   [§17](#17-what-comes-next). "This is the first working piece. Here's the road
+   to a cooperative actually running one."
+
+---
+
+## 16. What this proves
+
+- A single ICN node boots as a self-contained appliance and runs the **full
+  member loop** from a clean start: standing → action card → discharge →
+  completion receipt → receipt/evidence binding.
+- The loop is reachable from an ordinary browser with **no credential typing or
+  pasting** — the credential is fetched by one click and held in page memory
+  only.
+- The node can **prove its record chain is consistent (13/13)** — verifiable, not
+  asserted.
+- The whole thing is **reproducible**: seed, reset, reseed, and a documented
+  build + smoke path.
+- The member API surface is published as **OpenAPI** for integrators.
+
+It does **not** prove federation, multi-org behavior, production readiness, real
+membership, funds, mobile passport/keyring, or a signed release. ([§2](#2-what-this-demo-is-not).)
+
+---
+
+## 17. What comes next
+
+In rough order of what turns this seed into something a cooperative can lean on:
+
+1. **A baked, signed image** — fold the launcher + session sidecar into a
+   from-`main` candidate (currently branch-based), then move toward a signed,
+   reproducible release artifact.
+2. **A second member and a two-party action** — the loop today is one member;
+   the next proof is two members interacting in one context.
+3. **A real org-claim ceremony** — let a cooperative claim and configure their
+   own node instance (the QR node-claim is design-only today).
+4. **Multi-org / federation** — two nodes coordinating; the actual
+   "intercooperative" step.
+5. **A real pilot** — a cooperative (NYCN is the intended first partner) running
+   a node against real, consented data, with the mobile passport for member
+   identity.
+
+None of these are claimed as done. They're the map from "the core loop works" to
+"members control the infrastructure."

--- a/docs/demo/JULY_DEMO_OPERATOR_CHECKLIST.md
+++ b/docs/demo/JULY_DEMO_OPERATOR_CHECKLIST.md
@@ -1,0 +1,99 @@
+# ICN July Demo — Operator Checklist
+
+> Keep this open during the demo. Full context:
+> [JULY_DEMO_HANDS_ON.md](JULY_DEMO_HANDS_ON.md).
+> This is a **DEV/DEMO**. Not production, not a federation, not real members/funds.
+
+---
+
+## ☐ Preflight (before anyone is watching)
+
+- ☐ Node instance is booted and the gateway answers (first boot finished).
+- ☐ Host ports `18080` / `18090` / `18091` are free on your workstation.
+- ☐ You can reach the node (local QEMU forwards, or `ssh <user>@<node-ip>` works).
+- ☐ Browser open and ready.
+- ☐ Run one full loop privately once, then reset — so the live run is clean.
+- ☐ You can say the honesty boundary in one breath: *"core loop, real; demo data,
+  fixture; federation/production/funds, not yet."*
+
+---
+
+## ☐ Launch command
+
+**Local (QEMU on this box):** boot the image with forwards (see hands-on §4), then open the URL below.
+
+**Remote / Proxmox (one command):**
+```bash
+ICN_DEMO_VM_IP=<your-node-ip> ICN_DEMO_SSH_KEY=/path/to/demo_key \
+  bash deploy/appliance/scripts/open-proxmox-demo.sh
+```
+Jump route: add `ICN_DEMO_JUMP=user@dev-host ICN_DEMO_REMOTE_KEY=/path/to/key`,
+drop `ICN_DEMO_SSH_KEY`.
+
+---
+
+## ☐ Browser URL
+
+```
+http://localhost:18090/member-shell/?mode=live&demo=launcher&gw=18080&session=18091
+```
+(The launcher opens this for you. Shell port is fixed at **18090** — don't change it.)
+
+---
+
+## ☐ Expected visible states (in order)
+
+1. ☐ Launcher view: **"Start local demo"** button, gateway pre-filled, manual form hidden
+2. ☐ One click → **standing** renders (two domains)
+3. ☐ **Action card** appears
+4. ☐ **Mark complete** → confirm step (declares action + reversibility)
+5. ☐ **Confirm — mark complete** → **receipt** with record hash
+6. ☐ Expand → **evidence** detail
+7. ☐ Card shows **Confirmed** in place
+
+> Expected nuance: after discharge `/me/action-cards` is **empty**; the on-screen
+> card flips to **Confirmed** rather than disappearing. Consistent, not a bug.
+
+---
+
+## ☐ Reset command (between runs) — inside the node
+
+```bash
+sudo icn-demo-reset && sudo icn-demo-seed --json
+```
+Look for `"standing_note": "bootstrap-standing: ok"`, then reload the shell.
+
+---
+
+## ☐ Verification commands — inside the node
+
+```bash
+sudo icn-demo-verify <item-id>     # single item consistency
+sudo icn-demo-verify --chain       # full chain → expect 13/13 (the real proof)
+```
+Show the OpenAPI surface (gateway port):
+```bash
+curl -s http://localhost:18080/api-docs/openapi.json | head -c 400; echo
+```
+
+---
+
+## ☐ Panic fixes (live)
+
+| Problem | Do this |
+|---|---|
+| Port in use | Override `ICN_DEMO_GW_PORT` / `ICN_DEMO_SESSION_PORT`; free 18090. |
+| Tunnel exits immediately | Re-check `ssh <user>@<node-ip>` / key; or use `ICN_DEMO_JUMP`. |
+| Shell never answers | Wait for boot; in VM: `systemctl status icnd icn-demo-session`. |
+| Start-demo does nothing | Demo gates: in VM `journalctl -u icn-demo-session`; confirm demo-profile image. |
+| Auth calls fail CORS | Shell must be on **18090**. Don't change it. |
+| Loop got messy | `sudo icn-demo-reset && sudo icn-demo-seed --json`, reload. |
+
+---
+
+## ☐ Final cleanup
+
+- ☐ Press **Ctrl-C** in the launcher terminal to close the tunnels.
+- ☐ Optionally `sudo icn-demo-reset` in the node to leave it clean.
+- ☐ If the node was disposable, shut it down / remove the VM.
+- ☐ No credential was written to disk or a URL; nothing to scrub on the workstation.

--- a/web/member-shell/index.html
+++ b/web/member-shell/index.html
@@ -33,6 +33,23 @@
 
 <main id="main">
 
+  <!-- DEV/DEMO one-click start. Shown only when this page was opened by the
+       local demo launcher (?demo=launcher). Lets the operator start the demo
+       without typing a gateway address or pasting a credential. The launcher
+       forwards a loopback DEV/DEMO session endpoint to localhost:18091. -->
+  <section id="demo-launch-section" hidden aria-labelledby="demo-launch-h">
+    <h2 id="demo-launch-h">Start the local demo</h2>
+    <p>
+      This page was opened by the local DEV/DEMO launcher. Select Start to
+      begin a fresh local demo — your standing and a sample action card load
+      automatically. There is no address to type and no credential to paste.
+      The session is local to this dev node and nothing here is signed.
+    </p>
+    <button type="button" id="demo-launch-button">Start local demo</button>
+    <button type="button" id="demo-advanced-button" class="secondary">Connect manually instead</button>
+    <p id="demo-launch-status" role="status" aria-live="polite"></p>
+  </section>
+
   <!-- Live-mode connect panel. Hidden in demo mode. -->
   <section id="connect-section" hidden aria-labelledby="connect-h">
     <h2 id="connect-h">Connect to a local node</h2>

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -81,6 +81,19 @@
   var params = new URLSearchParams(window.location.search);
   var MODE = params.get("mode") === "demo" ? "demo" : "live";
 
+  // DEV/DEMO one-click launcher context. The local launcher
+  // (deploy/appliance/scripts/open-proxmox-demo.sh) opens this page with
+  // ?demo=launcher and forwards two loopback ports: the gateway to :18080 and
+  // a DEV/DEMO session endpoint to :18091. When present, the shell shows a
+  // "Start local demo" button that obtains a fresh session in one click — no
+  // gateway typing, no credential paste, no credential in any URL. The
+  // credential is held in page memory exactly like the manual flow (never
+  // persisted). The flag is a UI hint only and carries no secret.
+  var DEMO_LAUNCHER = MODE === "live" && params.get("demo") === "launcher";
+  var DEMO_LOOPBACK = window.location.hostname === "127.0.0.1" ? "127.0.0.1" : "localhost";
+  var DEMO_GATEWAY = "http://" + DEMO_LOOPBACK + ":18080";
+  var DEMO_SESSION_URL = "http://" + DEMO_LOOPBACK + ":18091/v1/dev/demo/session";
+
   var state = {
     gateway: null,     // live mode only; validated http(s) origin string
     credential: null,  // live mode only; never persisted
@@ -789,11 +802,64 @@
       banner.textContent = "Live-local node — dev rehearsal, not production.";
       banner.className = "banner live";
       byId("nav-live").setAttribute("aria-current", "true");
+      wireConnectForm();
+      if (DEMO_LAUNCHER) {
+        // One-click DEV/DEMO start. Prefill the gateway for the launcher's
+        // tunnel so even the "connect manually instead" fallback needs no
+        // typing, then show the Start button.
+        byId("gateway-url").value = DEMO_GATEWAY;
+        show("demo-launch-section");
+        setSyncChip(SYNC.DELAYED, "neutral",
+          "Ready. Select Start local demo to load your standing.");
+        wireDemoLaunch();
+      } else {
+        show("connect-section");
+        setSyncChip(SYNC.DELAYED, "neutral",
+          "Not connected yet. Enter your local gateway address above.");
+      }
+    }
+  }
+
+  // DEV/DEMO one-click start: ask the launcher's loopback session endpoint for
+  // a fresh demo session, hold it in page memory (never persisted, never in a
+  // URL), then load standing + cards — the same render path as the manual
+  // flow. Falls back to the manual connect form on any failure.
+  function wireDemoLaunch() {
+    var btn = byId("demo-launch-button");
+    var adv = byId("demo-advanced-button");
+    var st = byId("demo-launch-status");
+    function toManual(msg) {
+      hide("demo-launch-section");
       show("connect-section");
       setSyncChip(SYNC.DELAYED, "neutral",
         "Not connected yet. Enter your local gateway address above.");
-      wireConnectForm();
+      if (msg) { byId("connect-status").textContent = msg; }
     }
+    btn.addEventListener("click", function () {
+      btn.disabled = true;
+      st.textContent = "Starting the local demo…";
+      // Simple cross-origin POST (no custom headers) — no preflight needed.
+      fetch(DEMO_SESSION_URL, { method: "POST" }).then(function (resp) {
+        if (!resp.ok) { throw new Error("HTTP " + resp.status); }
+        return resp.json();
+      }).then(function (session) {
+        var cred = session && session.jwt ? String(session.jwt) : "";
+        if (!cred) { throw new Error("no session credential returned"); }
+        // Use the launcher's tunnelled gateway, not the node-internal address
+        // the endpoint reports. Credential lives only in page memory.
+        state.gateway = DEMO_GATEWAY;
+        state.credential = cred;
+        hide("demo-launch-section");
+        show("connect-section");
+        loadLive();
+      }).catch(function (err) {
+        btn.disabled = false;
+        st.textContent =
+          "Could not start the local demo (" + err.message + "). " +
+          "Use Connect manually instead, or check the launcher tunnel.";
+      });
+    });
+    adv.addEventListener("click", function () { toManual(""); });
   }
 
   init();

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -91,8 +91,17 @@
   // persisted). The flag is a UI hint only and carries no secret.
   var DEMO_LAUNCHER = MODE === "live" && params.get("demo") === "launcher";
   var DEMO_LOOPBACK = window.location.hostname === "127.0.0.1" ? "127.0.0.1" : "localhost";
-  var DEMO_GATEWAY = "http://" + DEMO_LOOPBACK + ":18080";
-  var DEMO_SESSION_URL = "http://" + DEMO_LOOPBACK + ":18091/v1/dev/demo/session";
+  // The launcher forwards the gateway and session endpoint to host ports and
+  // passes them as ?gw / ?session so operator port overrides
+  // (ICN_DEMO_GW_PORT / ICN_DEMO_SESSION_PORT) are honored. Digits only — a
+  // non-numeric value falls back to the default and can never inject into the
+  // URL we build.
+  function demoPort(name, fallback) {
+    var v = params.get(name);
+    return v && /^[0-9]{1,5}$/.test(v) ? v : fallback;
+  }
+  var DEMO_GATEWAY = "http://" + DEMO_LOOPBACK + ":" + demoPort("gw", "18080");
+  var DEMO_SESSION_URL = "http://" + DEMO_LOOPBACK + ":" + demoPort("session", "18091") + "/v1/dev/demo/session";
 
   var state = {
     gateway: null,     // live mode only; validated http(s) origin string


### PR DESCRIPTION
## What

Makes the DEV/DEMO appliance demo openable for a **live human demo with one command and zero terminal interaction after the browser opens** — no JWT copy/paste, no manual gateway typing. Plus a security fix to a passphrase leak the new endpoint would otherwise amplify.

**Feature** (`d15772e1`):
- **`icn-demo-session.py` + `icn-demo-session.service`** — a loopback (`127.0.0.1:8091`) DEV/DEMO-only endpoint, `POST /v1/dev/demo/session`, that runs the existing `icn-demo-seed` and returns a fresh session. Double dev-gated (`ICN_ENABLE_ADMIN_ENDPOINTS` + non-production posture, else `403`); CORS allow-listed to the demo shell origins; the credential is **never logged**. Enabled only on `ICN_APPLIANCE_DEMO_PROFILE=1` images.
- **member-shell** — opened with `?demo=launcher`, a **Start local demo** button appears and the gateway is pre-filled to the tunnelled `localhost:18080`. One click fetches the session, holds the credential **in page memory only** (never persisted, never in a URL — the same privacy property the manual flow already guarantees), and loads standing + cards automatically. The manual paste form stays as the advanced fallback.
- **`open-proxmox-demo.sh`** — one command from the operator's workstation: opens the three SSH tunnels (gateway/shell/session → 18080/18090/18091), opens the browser to `?mode=live&demo=launcher`, prints how to stop. Direct route (key local) or jump route through a dev host that holds the key. No environment-specific defaults — VM IP and key paths are required env vars.
- `build-image.sh` installs + enables the session endpoint in the demo profile; `DEMO_QUICKSTART.md` documents the launcher as the recommended human-demo path.

**Security fix** (`f67eadb8`, separate commit):
- `icn-demo-seed` / `icn-demo-verify` dropped from root to the `icn` user with `sudo -u icn ICN_KEYSTORE_PASSPHRASE=… icnctl …`. **sudo records its command line and environment in the auth journal**, so the per-instance keystore passphrase landed in cleartext under journald on every seed — and the new session endpoint re-seeds on each click. These helpers already run as root, so they don't need sudo to gain privilege: switched to `runuser -u icn --preserve-environment`, which drops privilege without writing the command or env to any log.

## Why

The Proxmox validation proved the loop works, but the workflow required copying a JWT from a terminal, pasting it into the browser, and typing a gateway URL — unacceptable for a live demo. This makes "open the demo" a single command + a single in-browser click.

## How verified (on a running node instance, real Chrome)

- `deploy/appliance/check.sh` — 21/21.
- Session endpoint via tunnel: `POST /v1/dev/demo/session` → `200`, CORS `Access-Control-Allow-Origin: http://localhost:18090`, standing `bootstrap-standing: ok`, credential returned. Post-fix journal check: `journalctl | grep ICN_KEYSTORE_PASSPHRASE=` is **empty** (was leaking before).
- Real-browser pass (Google Chrome via Playwright) through `?mode=live&demo=launcher`: Start-local-demo section shown, gateway pre-filled, manual form hidden; one click → standing (2 domains) → action card → discharge → receipt (record hash shown) → Confirmed. **No gateway typed, no JWT pasted.**
- Per-item `icn-demo-verify` PASS, `icn-demo-verify --chain` 13/13 PASS, reset/reseed PASS — all with the runuser-hardened helpers.

Hardware-network specifics live in the private evidence dir, not the repo (the launcher requires the VM IP/key via env; the sanitize gate confirmed no homelab IPs in the diff).

## Risk

- Demo-profile only; the session endpoint is loopback-bound, dev-gated, and reachable solely through the operator's own SSH tunnel. It adds no privilege the tunnel-holder (SSH + sudo on a throwaway VM) doesn't already have.
- The security fix is strictly a hardening (no behavior change beyond not logging the passphrase).
- Honest non-claims unchanged: not production, not a pilot, not federation, not multi-person; fictional fixture institution; unsigned image.

## Test plan

`bash deploy/appliance/check.sh`; build a demo-profile image and `smoke-local.sh --real --demo`; then `open-proxmox-demo.sh` against a running node instance and click **Start local demo**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
