### PR TITLE
fix(appliance): correct demo launcher port-conflict guidance

### DIFF
--- a/deploy/appliance/scripts/open-proxmox-demo.sh
+++ b/deploy/appliance/scripts/open-proxmox-demo.sh
@@ -78,7 +78,7 @@ command -v curl >/dev/null 2>&1 || { err "curl is required but not found on PATH
 for p in "$GW_PORT" "$SHELL_PORT" "$SESSION_PORT"; do
   if (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then
     exec 3>&- 3<&- 2>/dev/null || true
-    err "host port $p is already in use. Set ICN_DEMO_{GW,SHELL,SESSION}_PORT to free ports, or stop the process holding it."
+    err "host port $p is already in use. Override ICN_DEMO_GW_PORT (gateway) or ICN_DEMO_SESSION_PORT (demo-session) to a free tunnel port; the shell port 18090 is FIXED (the gateway + demo-session CORS allow-lists pin the shell origin), so if 18090 is the conflict, free that port instead of overriding it."
     exit 2
   fi
 done


### PR DESCRIPTION
## What
A **tiny script-message fix** — one line in `deploy/appliance/scripts/open-proxmox-demo.sh`. No behavior change.

## Why
The port-conflict preflight error told the operator to *"Set `ICN_DEMO_{GW,SHELL,SESSION}_PORT`"*, implying a shell-port override that **does not exist**. `SHELL_PORT` is hardcoded to `18090` (the member-shell page Origin that the gateway and demo-session CORS allow-lists pin). Only the **gateway** and **demo-session** tunnel ports are overridable. The old message sent operators chasing a nonexistent `ICN_DEMO_SHELL_PORT` instead of just freeing port 18090.

## How
```diff
-    err "host port $p is already in use. Set ICN_DEMO_{GW,SHELL,SESSION}_PORT to free ports, or stop the process holding it."
+    err "host port $p is already in use. Override ICN_DEMO_GW_PORT (gateway) or ICN_DEMO_SESSION_PORT (demo-session) to a free tunnel port; the shell port 18090 is FIXED (the gateway + demo-session CORS allow-lists pin the shell origin), so if 18090 is the conflict, free that port instead of overriding it."
```

The corrected guidance now states:
- `ICN_DEMO_GW_PORT` / `ICN_DEMO_SESSION_PORT` are overridable.
- The shell/browser origin port **18090 is fixed** (because the gateway + demo-session CORS allow-lists expect that origin).
- If 18090 is busy, **free the port** rather than trying to override it.

## Risk
None — **message text only**. No ports, bind addresses, CORS allow-lists, env handling, or control flow touched. The header comments already documented the fixed shell port; this just makes the runtime error message agree with them.

## Test plan
- `git diff --check` — clean
- `bash -n deploy/appliance/scripts/open-proxmox-demo.sh` — syntax OK
- `shellcheck …` — clean on the changed line (two pre-existing SC2015 *info* notes on unrelated lines 134/148 left as-is, per scope discipline)
- `bash deploy/appliance/check.sh` — **21/21**

Companion to the docs hardening in #2032 (which documents the same fixed-shell-port behavior on the operator side); this makes the launcher's own message match.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)