### PR TITLE
docs(demo): route demo index to July candidate docs

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -17,7 +17,7 @@
 | [JULY_DEMO_HANDS_ON.md](JULY_DEMO_HANDS_ON.md) | **Detailed presenter/operator flow** — click-by-click, "what to say" at each step, and the full failure-mode table. |
 | [JULY_DEMO_OPERATOR_CHECKLIST.md](JULY_DEMO_OPERATOR_CHECKLIST.md) | **Keep-open live-demo card** — preflight, launch command, expected states, and panic fixes. |
 | [JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md](JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md) | **Reviewer / evidence-hygiene handoff** — claim boundary by proof level, secret/evidence capture, known-gaps map, reviewer checklist. |
-| [../../deploy/appliance/DEMO_QUICKSTART.md](../../deploy/appliance/DEMO_QUICKSTART.md) | **Appliance build/run** — image build, the one-command launcher, and the manual fallback. |
+| [deploy/appliance/DEMO_QUICKSTART.md](../../deploy/appliance/DEMO_QUICKSTART.md) | **Appliance build/run** — image build, the one-command launcher, and the manual fallback. |
 
 > The sections below describe the older one-click tool-library / devnet demo,
 > not the July Candidate appliance.

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,6 +1,26 @@
 # ICN Demo: Start Here
 
-**Last Updated**: 2026-02-11
+**Last Updated**: 2026-06-13
+
+---
+
+## July Demo Candidate 0.1 (current single-actor proof loop)
+
+> **DEV/DEMO only — local, single-node, single-actor, fictional institution
+> data.** Not production, not federation, not a formal pilot, no real member or
+> funds data. It demonstrates the cooperative-participation spine — standing →
+> action card → discharge → receipt → evidence/audit — as **proof of path, not
+> deployment readiness.**
+
+| Doc | Use it for |
+|-----|-----------|
+| [JULY_DEMO_HANDS_ON.md](JULY_DEMO_HANDS_ON.md) | **Detailed presenter/operator flow** — click-by-click, "what to say" at each step, and the full failure-mode table. |
+| [JULY_DEMO_OPERATOR_CHECKLIST.md](JULY_DEMO_OPERATOR_CHECKLIST.md) | **Keep-open live-demo card** — preflight, launch command, expected states, and panic fixes. |
+| [JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md](JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md) | **Reviewer / evidence-hygiene handoff** — claim boundary by proof level, secret/evidence capture, known-gaps map, reviewer checklist. |
+| [../../deploy/appliance/DEMO_QUICKSTART.md](../../deploy/appliance/DEMO_QUICKSTART.md) | **Appliance build/run** — image build, the one-command launcher, and the manual fallback. |
+
+> The sections below describe the older one-click tool-library / devnet demo,
+> not the July Candidate appliance.
 
 ---
 


### PR DESCRIPTION
## What
One-section addition to `docs/demo/README.md` ("ICN Demo: Start Here") so it routes readers to the **July Demo Candidate 0.1** doc set. **Docs-only**, one file.

## Why
The demo index predated the July Candidate docs (it was last touched 2026-02-11 and describes the older one-click tool-library / devnet demo). A reader landing on "Start Here" had no pointer to the current appliance demo or its operator/reviewer docs.

## How
Added a top-of-index "July Demo Candidate 0.1 (current)" section with a 4-row table and clear per-doc framing:
- `JULY_DEMO_HANDS_ON.md` — detailed presenter/operator flow
- `JULY_DEMO_OPERATOR_CHECKLIST.md` — keep-open live-demo card
- `JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md` — reviewer / evidence-hygiene handoff
- `deploy/appliance/DEMO_QUICKSTART.md` — appliance build/run/launcher/manual fallback

Honesty labels preserved up front: **DEV/DEMO, local, single-node, single-actor, fictional-data; not production, not federation, not a formal pilot, no real member/funds data; proof of path, not deployment readiness.** A one-line note clarifies the older sections below describe the previous demo (not rewritten).

## Risk
Minimal — documentation only. No runtime, scripts, ports, CORS, services, STATE/PHASE, or capability matrix touched. The existing demo history is left intact.

## Test plan
- `git diff --check` — clean
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — exit 0
- relative-link check on the 4 added links — all resolve
- honesty-label + leak/vocab scan — clean

Follows the merged July-demo lane (#2032/#2033/#2034). No live appliance pass claimed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)