### PR TITLE
docs(demo): clarify July demo reset and reseed paths

### DIFF
--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -157,11 +157,18 @@ manual `?mode=live` paste flow below is the advanced/debug path.)
 
 ## Reset
 
+`sudo icn-demo-reset` clears this node's demo state — it proves nothing and does
+**not** reseed; nothing shows until you reseed or relaunch.
+
 - Cheapest: power off and delete `overlay.qcow2`, recreate, reboot —
   whole-disk reset, nothing persists.
 - In-place: `ssh -p 2222 debian@127.0.0.1 sudo icn-demo-reset` destroys
-  node state and re-runs firstboot. It does **not** reseed — run
-  `sudo icn-demo-seed` again afterwards for a fresh loop.
+  node state and re-runs firstboot.
+- Reseed — **launcher (recommended live path):** rerun the one-command
+  launcher, or click **Start local demo** again; it seeds one fresh card with
+  no JWT to paste. **Manual / debug fallback:** `sudo icn-demo-seed` reseeds
+  directly but prints a local DEV credential — keep that credential out of
+  docs, screenshots, terminal transcripts, and PRs.
 
 ## Troubleshooting
 

--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -164,11 +164,13 @@ manual `?mode=live` paste flow below is the advanced/debug path.)
   whole-disk reset, nothing persists.
 - In-place: `ssh -p 2222 debian@127.0.0.1 sudo icn-demo-reset` destroys
   node state and re-runs firstboot.
-- Reseed — **launcher (recommended live path):** rerun the one-command
-  launcher, or click **Start local demo** again; it seeds one fresh card with
-  no JWT to paste. **Manual / debug fallback:** `sudo icn-demo-seed` reseeds
-  directly but prints a local DEV credential — keep that credential out of
-  docs, screenshots, terminal transcripts, and PRs.
+- Reseed — **launcher (recommended live path):** reload the launcher (rerun the
+  one-command launcher, or refresh the launcher URL) and click **Start local
+  demo** — the Start button only shows on a fresh page load, so a reset alone
+  won't restore it on an already-open tab. It seeds one fresh card with no JWT
+  to paste. **Manual / debug fallback:** `sudo icn-demo-seed` reseeds directly
+  but prints a local DEV credential — keep that credential out of docs,
+  screenshots, terminal transcripts, and PRs.
 
 ## Troubleshooting
 

--- a/docs/demo/JULY_DEMO_HANDS_ON.md
+++ b/docs/demo/JULY_DEMO_HANDS_ON.md
@@ -264,9 +264,10 @@ shows in the shell until you reseed or relaunch:
   `open-proxmox-demo.sh`, or refresh the launcher URL in the browser — then click
   **Start local demo**. The **Start** button only appears on a fresh page load;
   it hides after the first session, so a reset alone won't bring it back on an
-  already-open tab. The session endpoint then seeds one fresh member + open
-  action card for you, with no JWT to paste. Don't also run `icn-demo-seed` by
-  hand, or you'll get a duplicate card.
+  already-open tab. The session endpoint then mints a fresh session and one
+  open action card for you — it reuses the VM's existing operator identity, so
+  no new member is created — with no JWT to paste. Don't also run
+  `icn-demo-seed` by hand, or you'll get a duplicate card.
 - **Manual / debug flow:** `sudo icn-demo-seed --json` reseeds directly and
   prints a **local DEV credential** for this disposable VM. Use it only for the
   advanced paste/debug path. After reseed you should see

--- a/docs/demo/JULY_DEMO_HANDS_ON.md
+++ b/docs/demo/JULY_DEMO_HANDS_ON.md
@@ -260,10 +260,13 @@ sudo icn-demo-reset          # clears this node's seeded demo state
 Reset only clears state — it proves nothing and does **not** reseed. Nothing
 shows in the shell until you reseed or relaunch:
 
-- **Launcher flow (recommended):** after reset, rerun the launcher — or, if the
-  page is still open, click **Start local demo** again. The session endpoint
-  seeds one fresh member + open action card for you, with no JWT to paste. Don't
-  also run `icn-demo-seed` by hand, or you'll get a duplicate card.
+- **Launcher flow (recommended):** after reset, **reload the launcher** — rerun
+  `open-proxmox-demo.sh`, or refresh the launcher URL in the browser — then click
+  **Start local demo**. The **Start** button only appears on a fresh page load;
+  it hides after the first session, so a reset alone won't bring it back on an
+  already-open tab. The session endpoint then seeds one fresh member + open
+  action card for you, with no JWT to paste. Don't also run `icn-demo-seed` by
+  hand, or you'll get a duplicate card.
 - **Manual / debug flow:** `sudo icn-demo-seed --json` reseeds directly and
   prints a **local DEV credential** for this disposable VM. Use it only for the
   advanced paste/debug path. After reseed you should see

--- a/docs/demo/JULY_DEMO_HANDS_ON.md
+++ b/docs/demo/JULY_DEMO_HANDS_ON.md
@@ -254,12 +254,22 @@ I actually looking at?"
 Run inside the node (SSH in, or use the hypervisor console):
 
 ```bash
-sudo icn-demo-reset          # destroys the demo's seeded state
-sudo icn-demo-seed --json    # reseeds a fresh member + open action card
+sudo icn-demo-reset          # clears this node's seeded demo state
 ```
 
-After reseed you should see `"standing_note": "bootstrap-standing: ok"` in the
-JSON. Reload the member-shell and the loop is fresh again.
+Reset only clears state — it proves nothing and does **not** reseed. Nothing
+shows in the shell until you reseed or relaunch:
+
+- **Launcher flow (recommended):** after reset, rerun the launcher — or, if the
+  page is still open, click **Start local demo** again. The session endpoint
+  seeds one fresh member + open action card for you, with no JWT to paste. Don't
+  also run `icn-demo-seed` by hand, or you'll get a duplicate card.
+- **Manual / debug flow:** `sudo icn-demo-seed --json` reseeds directly and
+  prints a **local DEV credential** for this disposable VM. Use it only for the
+  advanced paste/debug path. After reseed you should see
+  `"standing_note": "bootstrap-standing: ok"`; reload the shell. **Never paste
+  that credential into docs, screenshots, terminal transcripts, PRs, or any
+  public artifact** — it is local and disposable, but keep it off the record.
 
 > `icn-demo-reset` destroys the demo's seeded state on that node only. It does
 > not touch any other system.

--- a/docs/demo/JULY_DEMO_OPERATOR_CHECKLIST.md
+++ b/docs/demo/JULY_DEMO_OPERATOR_CHECKLIST.md
@@ -61,9 +61,13 @@ http://localhost:18090/member-shell/?mode=live&demo=launcher&gw=18080&session=18
 ## ☐ Reset command (between runs) — inside the node
 
 ```bash
-sudo icn-demo-reset && sudo icn-demo-seed --json
+sudo icn-demo-reset                 # clears state; reseed or relaunch after
 ```
-Look for `"standing_note": "bootstrap-standing: ok"`, then reload the shell.
+Reset proves nothing and does not reseed. Then **launcher (recommended):** click
+**Start local demo** again (seeds one card, no paste). **Manual/debug:**
+`sudo icn-demo-seed --json` (prints a local DEV credential — don't paste it into
+public artifacts); look for `"standing_note": "bootstrap-standing: ok"`. Reload
+the shell.
 
 ---
 
@@ -89,7 +93,7 @@ curl -s http://localhost:18080/api-docs/openapi.json | head -c 400; echo
 | Shell never answers | Wait for boot; in VM: `systemctl status icnd icn-demo-session`. |
 | Start-demo does nothing | Demo gates: in VM `journalctl -u icn-demo-session`; confirm demo-profile image. |
 | Auth calls fail CORS | Shell must be on **18090**. Don't change it. |
-| Loop got messy | `sudo icn-demo-reset && sudo icn-demo-seed --json`, reload. |
+| Loop got messy / extra cards | `sudo icn-demo-reset`, then click **Start local demo** again (launcher reseeds one card) — or `sudo icn-demo-seed --json` for the manual path. Reload. |
 
 ---
 

--- a/docs/demo/JULY_DEMO_OPERATOR_CHECKLIST.md
+++ b/docs/demo/JULY_DEMO_OPERATOR_CHECKLIST.md
@@ -63,11 +63,12 @@ http://localhost:18090/member-shell/?mode=live&demo=launcher&gw=18080&session=18
 ```bash
 sudo icn-demo-reset                 # clears state; reseed or relaunch after
 ```
-Reset proves nothing and does not reseed. Then **launcher (recommended):** click
-**Start local demo** again (seeds one card, no paste). **Manual/debug:**
-`sudo icn-demo-seed --json` (prints a local DEV credential — don't paste it into
-public artifacts); look for `"standing_note": "bootstrap-standing: ok"`. Reload
-the shell.
+Reset proves nothing and does not reseed. Then **launcher (recommended):**
+reload the launcher URL, then click **Start local demo** — the button hides
+after the first session, so a reset alone won't restore it on an open tab
+(seeds one card, no paste). **Manual/debug:** `sudo icn-demo-seed --json`
+(prints a local DEV credential — don't paste it into public artifacts); look for
+`"standing_note": "bootstrap-standing: ok"`. Reload the shell.
 
 ---
 
@@ -93,7 +94,7 @@ curl -s http://localhost:18080/api-docs/openapi.json | head -c 400; echo
 | Shell never answers | Wait for boot; in VM: `systemctl status icnd icn-demo-session`. |
 | Start-demo does nothing | Demo gates: in VM `journalctl -u icn-demo-session`; confirm demo-profile image. |
 | Auth calls fail CORS | Shell must be on **18090**. Don't change it. |
-| Loop got messy / extra cards | `sudo icn-demo-reset`, then click **Start local demo** again (launcher reseeds one card) — or `sudo icn-demo-seed --json` for the manual path. Reload. |
+| Loop got messy / extra cards | `sudo icn-demo-reset`, then **reload the launcher URL** and click **Start local demo** (the button hides after the first session, so reset alone won't restore it) — or `sudo icn-demo-seed --json` for the manual path. |
 
 ---
 


### PR DESCRIPTION
## What
**Docs-only** consistency pass across the July demo docs (3 files: `JULY_DEMO_HANDS_ON.md` §8, `deploy/appliance/DEMO_QUICKSTART.md` "Reset", `JULY_DEMO_OPERATOR_CHECKLIST.md` reset command + panic row). **No runtime behavior changed.**

## Why
The operator-script runbook (#2034) carries a precise launcher-vs-manual reseed caveat; the older docs still gave the generic `icn-demo-reset && icn-demo-seed --json`. In the **launcher** flow that double-seeds — clicking "Start local demo" already reseeds via the session endpoint, so a manual `seed` on top leaves a duplicate action card. This aligns all the docs.

## How — clarifies reset/reseed behavior
- **Reset** (`sudo icn-demo-reset`) clears this node's demo state, **proves nothing**, and does **not** reseed — nothing shows until you reseed or relaunch.
- **Launcher path remains the recommended human-demo path:** after reset, rerun the launcher / click **Start local demo** again — it seeds one fresh card with no JWT to paste.
- **Manual seed/paste remains the fallback/debug path:** `sudo icn-demo-seed --json` reseeds directly but prints a **local DEV credential**; it must not be pasted into docs, screenshots, terminal transcripts, or PRs (local/disposable, but keep it off the record).

## Risk
Minimal — documentation only. No runtime, scripts, ports, CORS, service binds, gateway, member-shell, demo-session, OpenAPI, or appliance build touched. No STATE.md / PHASE_PROGRESS.md / capability-matrix / generated-index / registry changes.

## Test plan — checks run and results
- `git diff --check` — clean
- `bash deploy/appliance/check.sh` — **21/21** (forbidden-vocab + secret scans clean)
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — exit 0
- leak / forbidden-vocab scan on added lines — clean (no IPs/hostnames/JWTs/keys/names/homelab refs)

**No live appliance pass claimed** — static, script-grounded docs alignment.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)