### PR TITLE
chore(deps): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained, no upstream fix)

### DIFF
--- a/icn/deny.toml
+++ b/icn/deny.toml
@@ -65,8 +65,9 @@ ignore = [
 
     # proc-macro-error2 is unmaintained, pulled in transitively via
     # i18n-embed-fl ← age ← icn-identity (Age-encrypted keystore). This is an
-    # "unmaintained" advisory, not an exploitable vulnerability. No upstream fix
-    # exists yet: i18n-embed-fl 0.10 and age 0.11.3 both still depend on
+    # "unmaintained" advisory, not an exploitable vulnerability. Current Cargo.lock
+    # pins i18n-embed-fl 0.9.4 / age 0.11.2; upgrading does not help because the
+    # latest releases (i18n-embed-fl 0.10.0 / age 0.11.3) still depend on
     # proc-macro-error2. Revisit when `age` drops the dependency.
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained (transitive via i18n-embed-fl ← age)
 ]

--- a/icn/deny.toml
+++ b/icn/deny.toml
@@ -62,6 +62,13 @@ ignore = [
     "RUSTSEC-2026-0162",  # pqcrypto-traits unmaintained (PQClean archived)
     "RUSTSEC-2026-0163",  # pqcrypto-internals unmaintained (PQClean archived)
     "RUSTSEC-2026-0166",  # pqcrypto-mldsa unmaintained (PQClean archived)
+
+    # proc-macro-error2 is unmaintained, pulled in transitively via
+    # i18n-embed-fl ← age ← icn-identity (Age-encrypted keystore). This is an
+    # "unmaintained" advisory, not an exploitable vulnerability. No upstream fix
+    # exists yet: i18n-embed-fl 0.10 and age 0.11.3 both still depend on
+    # proc-macro-error2. Revisit when `age` drops the dependency.
+    "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained (transitive via i18n-embed-fl ← age)
 ]
 
 [licenses]


### PR DESCRIPTION
## What
Add `RUSTSEC-2026-0173` (proc-macro-error2, **unmaintained**) to the `[advisories].ignore` list in `icn/deny.toml`, with an inline comment documenting the dependency chain and the lack of an upstream fix. Single-file change.

## Why
`proc-macro-error2` is flagged unmaintained but is pulled in only **transitively** via `i18n-embed-fl ← age ← icn-identity` (the Age-encrypted keystore). This is an "unmaintained" advisory, not an exploitable vulnerability. No upstream fix exists yet: both `i18n-embed-fl 0.10` and `age 0.11.3` still depend on `proc-macro-error2`. This advisory is what keeps the repo-wide **Security Audit** CI job red; this PR clears that red.

This implements batch task **T1** from the 2026-06-14 hardening/hygiene batch. (No issue number — there isn't one.)

## How
Appended one ignore entry to `[advisories].ignore`, matching the existing unmaintained-transitive ignore pattern already used in the file (fxhash, instant, paste, bincode, pqcrypto-*, etc.). Inline comment notes the chain and the revisit trigger: when `age` drops the dependency.

## Risk
Minimal. `ignore` only suppresses a known **unmaintained** advisory; it does not change the dependency graph, lockfile, or any code. The crate has no known vulnerability and is only a build-time proc-macro dependency. Scoped to a single non-source config file.

## Test plan
- `cargo deny check advisories` from `~/projects/icn/icn` → `advisories ok` (exit 0). RUSTSEC-2026-0173 is matched (no `advisory-not-detected` warning for it), confirming the ignore is live and the advisory is genuinely present in the tree.
- The remaining `advisory-not-detected` warnings are pre-existing entries unrelated to this change.

This clears the repo-wide red **Security Audit** CI job.