### PR TITLE
fix(deps): reconcile React Native example lockfiles (expo-localization drift, shell-quote #263)

### DIFF
--- a/sdk/react-native/examples/CoopWallet/package-lock.json
+++ b/sdk/react-native/examples/CoopWallet/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "coop-wallet",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@icn/client": "file:../../../../sdk/typescript",
         "@icn/react-native": "file:../../",
@@ -20,18 +21,20 @@
         "expo-camera": "~17.0.10",
         "expo-file-system": "~19.0.21",
         "expo-local-authentication": "^17.0.8",
+        "expo-localization": "~17.0.0",
         "expo-secure-store": "~15.0.8",
         "expo-sharing": "~14.0.8",
         "expo-status-bar": "~3.0.9",
+        "i18next": "^24.0.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-i18next": "^15.0.0",
         "react-native": "0.81.5",
         "react-native-get-random-values": "^1.11.0",
         "react-native-qrcode-svg": "^6.2.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
-        "react-native-vision-camera": "^4.7.3",
         "react-native-web": "^0.21.0"
       },
       "devDependencies": {
@@ -47,17 +50,20 @@
       "dependencies": {
         "@icn/client": "^0.1.0",
         "@noble/ed25519": "^3.0.0",
-        "@noble/hashes": "^2.0.1"
+        "@noble/hashes": "^2.0.1",
+        "@noble/post-quantum": "^0.6.0"
       },
       "devDependencies": {
-        "@types/jest": "^29.5.0",
-        "@types/react": "^18.2.0",
-        "@types/react-native": "^0.72.0",
-        "jest": "^29.7.0",
-        "react": "^18.2.0",
-        "react-native": "^0.72.0",
+        "@babel/preset-env": "^7.28.5",
+        "@babel/preset-typescript": "^7.28.5",
+        "@types/jest": "^30.0.0",
+        "@types/react": "^19.2.7",
+        "@types/react-native": "^0.73.0",
+        "jest": "^30.2.0",
+        "react": "^19.2.3",
+        "react-native": "^0.85.1",
         "ts-jest": "^29.1.0",
-        "typescript": "^5.3.0"
+        "typescript": "^6.0.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -72,12 +78,15 @@
       "version": "0.1.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
-        "@types/jest": "^29.5.0",
-        "@types/node": "^20.10.0",
+        "@types/jest": "^30.0.0",
+        "@types/node": "^25.9.1",
         "@types/ws": "^8.5.10",
-        "jest": "^29.7.0",
-        "openapi-typescript": "^7.0.0",
-        "ts-jest": "^29.1.0",
+        "@typescript-eslint/eslint-plugin": "^8.59.4",
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^10.4.0",
+        "jest": "^30.4.2",
+        "openapi-typescript": "^7.13.0",
+        "ts-jest": "^29.4.10",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.0"
       },
@@ -4272,6 +4281,19 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-localization": {
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-17.0.9.tgz",
+      "integrity": "sha512-k5eYHr7iLMob3M8cHH6bgDrDRmqnZG8xKGLhpx8ST+LsFXmSgYpJ/t0VwWm0gz64C/K669XhObdG3D6QwCGqhw==",
+      "license": "MIT",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.23",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.23.tgz",
@@ -4817,6 +4839,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -4860,6 +4891,37 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -7040,6 +7102,32 @@
         "react": ">=17.0.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
+      "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.4.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
@@ -7179,30 +7267,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-vision-camera": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/react-native-vision-camera/-/react-native-vision-camera-4.7.3.tgz",
-      "integrity": "sha512-g1/neOyjSqn1kaAa2FxI/qp5KzNvPcF0bnQw6NntfbxH6tm0+8WFZszlgb5OV+iYlB6lFUztCbDtyz5IpL47OA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@shopify/react-native-skia": "*",
-        "react": "*",
-        "react-native": "*",
-        "react-native-reanimated": "*",
-        "react-native-worklets-core": "*"
-      },
-      "peerDependenciesMeta": {
-        "@shopify/react-native-skia": {
-          "optional": true
-        },
-        "react-native-reanimated": {
-          "optional": true
-        },
-        "react-native-worklets-core": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-native-web": {
@@ -7575,6 +7639,12 @@
         "node": "*"
       }
     },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -7758,9 +7828,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8323,7 +8393,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8524,6 +8594,15 @@
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",


### PR DESCRIPTION
## What
Reconcile the **CoopWallet** React Native example lockfile (`sdk/react-native/examples/CoopWallet/package-lock.json`). Node lockfile only — no source, no Rust, no `package.json` changes.

Two fixes, both lockfile-only:
1. **expo-localization drift:** `package.json` declares `expo-localization ~17.0.0` (plus `i18next`, `react-i18next`) but the lockfile had no entries, so `npm ci` failed with `Missing: expo-localization@17.0.9 from lock file` (+ `i18next`, `react-i18next`, `rtl-detect`, `html-parse-stringify`, `void-elements`). Reconciling the lockfile adds those entries.
2. **shell-quote (critical):** the CoopWallet lockfile pinned the transitive `shell-quote@1.8.3` (GHSA-w7jw-789q-3m8p, CVSS 8.1, Dependabot **critical alert #263**). Bumped within the existing `^1.6.1` constraint (via `react-devtools-core`) to **1.8.4** (the fixed release). No direct dependency was added.

## Why
`npm ci` is broken in CoopWallet (lockfile out of sync with `package.json`), which blocks any clean install / CI of that example. The pinned `shell-quote@1.8.3` is a critical Dependabot finding (#263). Both are lockfile-level problems fixable without changing dependency semantics.

## How
From `sdk/react-native/examples/CoopWallet/`:
- `npm install --package-lock-only` to reconcile the `expo-localization`/i18n drift into the lockfile.
- `npm update shell-quote --package-lock-only` to move the transitive `shell-quote` to `1.8.4` within its existing `^1.6.1` range.

`package.json` was not modified (verified: `git diff` shows only the one lockfile). Diff is +121 / −42 in `package-lock.json`, lockfileVersion 3 intact, valid JSON.

## Scope
Only **CoopWallet** changed. The other two RN dirs named in the task brief were checked and left untouched because they already install clean:
- `examples/mobile-app/` — `npm ci` exit 0, `shell-quote` already 1.8.4 (landed in #2016). Not churned.
- `sdk/react-native/` — `npm ci` exit 0, `shell-quote` already 1.8.4. Not churned.

## Risk
Low. Lockfile-only; no `package.json` version/semantics changed. `shell-quote` 1.8.3 → 1.8.4 is a patch within the already-allowed `^1.6.1` range. expo-localization/i18n entries reflect what `package.json` already declares.

## Test plan (verified)
From `sdk/react-native/examples/CoopWallet/`:
- `npm ci --ignore-scripts` → **exit 0** (was exit 1 before: `Missing: expo-localization@17.0.9`).
- Full `npm ci` (with the SDK-building `postinstall`) → **exit 0**; `node_modules/shell-quote` = **1.8.4**, `expo-localization` installed.
- `npm audit` → `shell-quote` no longer present in vulnerabilities (critical count for this dir 1 → 0).
- `git status` → only `sdk/react-native/examples/CoopWallet/package-lock.json` modified; no `package.json`, no Rust/Cargo, no committed `node_modules`.

Unblocks `npm ci` for CoopWallet and clears critical Dependabot **alert #263** (shell-quote) for this directory.

## Coordination note (for the human — do not auto-close)
The task brief flagged open npm Dependabot PRs **#2029, #2018, #1995** as superseded. On inspection, those PRs target **different directories** than this PR:
- #2029 / #2018 → `examples/mobile-app/` + `ops/mcp/` (and touch `package.json`)
- #1995 → `sdk/typescript/`

This PR touches **only CoopWallet**, so it does **not** actually overlap their file changes and does not functionally replace them. The `examples/mobile-app/` shell-quote fix they would have made is already in main (#2016). Leaving the close/keep decision on #2029/#2018/#1995 to the human, as instructed — not closing them here.
