### PR TITLE
fix(gateway): require coop access on create_meeting (cross-coop write hardening)

### DIFF
--- a/icn/crates/icn-gateway/src/api/registry.rs
+++ b/icn/crates/icn-gateway/src/api/registry.rs
@@ -516,6 +516,14 @@ pub async fn create_meeting(
         ));
     }
 
+    // #1868: bind the mutation to the token's cooperative. The class scopes
+    // (`governance:meeting:write`) are requestable per coop, so the scope gate
+    // alone does not establish that the caller may write under the body-supplied
+    // `coop_id`. Without this, a meeting-scoped token for coop A could create a
+    // meeting record under coop B. CRITICAL: Prevent cross-coop attacks.
+    // Mirrors the guard added to `index_decision_endpoint` in #2052.
+    require_coop_access(&http_req, &req.coop_id)?;
+
     // Generate meeting ID
     let now = icn_time::current_timestamp_secs();
     let meeting_id = format!(
@@ -1067,6 +1075,55 @@ mod tests {
         );
         assert_eq!(
             create_status("governance:charter:write").await,
+            StatusCode::FORBIDDEN
+        );
+    }
+
+    /// #1868: a validly-scoped token must not create a meeting under a coop other
+    /// than its own. The class scopes are requestable per coop, so the route binds
+    /// the body-supplied `coop_id` to the token's coop via `require_coop_access`.
+    /// A same-coop create succeeds (201); a cross-coop create is rejected (403)
+    /// without mutating the registry. Mirrors `index_decision_rejects_cross_coop_write`.
+    #[actix_web::test]
+    async fn create_meeting_rejects_cross_coop_write() {
+        async fn create_status(token_coop: &str, body_coop: &str) -> actix_web::http::StatusCode {
+            let registry = Arc::new(DecisionRegistry::new());
+            let app = actix_test::init_service(
+                App::new()
+                    .app_data(web::Data::new(registry))
+                    .service(web::scope("/registry").configure(configure)),
+            )
+            .await;
+            let claims = TokenClaims {
+                sub: "did:icn:test-user".to_string(),
+                iat: 1_000_000_000,
+                exp: 9_999_999_999,
+                coop_id: token_coop.to_string(),
+                // Validly scoped: passes the scope gate so the coop binding is the
+                // only thing under test.
+                scopes: vec!["governance:meeting:write".to_string()],
+            };
+            let req = actix_test::TestRequest::post()
+                .uri("/registry/meetings")
+                .set_json(serde_json::json!({
+                    "coopId": body_coop,
+                    "title": "Cross-coop test meeting",
+                    "startsAt": 1_800_000_000u64
+                }))
+                .to_request();
+            req.extensions_mut().insert(claims);
+            actix_test::call_service(&app, req).await.status()
+        }
+
+        use actix_web::http::StatusCode;
+        // Same coop: the write is bound to the token's coop and succeeds.
+        assert_eq!(
+            create_status("did:icn:coopA", "did:icn:coopA").await,
+            StatusCode::CREATED
+        );
+        // Cross coop: a coopA token cannot create a meeting under coopB.
+        assert_eq!(
+            create_status("did:icn:coopA", "did:icn:coopB").await,
             StatusCode::FORBIDDEN
         );
     }

--- a/icn/crates/icn-gateway/src/api/registry.rs
+++ b/icn/crates/icn-gateway/src/api/registry.rs
@@ -1082,15 +1082,28 @@ mod tests {
     /// #1868: a validly-scoped token must not create a meeting under a coop other
     /// than its own. The class scopes are requestable per coop, so the route binds
     /// the body-supplied `coop_id` to the token's coop via `require_coop_access`.
-    /// A same-coop create succeeds (201); a cross-coop create is rejected (403)
-    /// without mutating the registry. Mirrors `index_decision_rejects_cross_coop_write`.
+    /// A same-coop create succeeds (201) and creates the meeting; a cross-coop
+    /// create is rejected (403) without mutating the registry. The registry-state
+    /// assertions below (not just the HTTP status) prove the "without mutating"
+    /// claim. Mirrors `index_decision_rejects_cross_coop_write`.
     #[actix_web::test]
     async fn create_meeting_rejects_cross_coop_write() {
-        async fn create_status(token_coop: &str, body_coop: &str) -> actix_web::http::StatusCode {
+        // Returns the response status alongside a handle to the same registry the
+        // app mutates, so the caller can assert on its contents afterward. The
+        // `Arc` is cloned before being moved into the app, so both views point at
+        // one shared `DecisionRegistry`. The handler extracts
+        // `web::Data<Arc<DecisionRegistry>>`, so the app data must be
+        // `web::Data::new(Arc<..>)` (which yields `Data<Arc<..>>`), not
+        // `web::Data::from(Arc<..>)` (which would yield the mismatched
+        // `Data<DecisionRegistry>` and make extraction fail with 500).
+        async fn create_status(
+            token_coop: &str,
+            body_coop: &str,
+        ) -> (actix_web::http::StatusCode, Arc<DecisionRegistry>) {
             let registry = Arc::new(DecisionRegistry::new());
             let app = actix_test::init_service(
                 App::new()
-                    .app_data(web::Data::new(registry))
+                    .app_data(web::Data::new(registry.clone()))
                     .service(web::scope("/registry").configure(configure)),
             )
             .await;
@@ -1112,19 +1125,39 @@ mod tests {
                 }))
                 .to_request();
             req.extensions_mut().insert(claims);
-            actix_test::call_service(&app, req).await.status()
+            let status = actix_test::call_service(&app, req).await.status();
+            (status, registry)
         }
 
         use actix_web::http::StatusCode;
-        // Same coop: the write is bound to the token's coop and succeeds.
+        // Same coop: the write is bound to the token's coop and succeeds, and the
+        // meeting is actually persisted under that coop.
+        let (same_coop_status, same_coop_registry) =
+            create_status("did:icn:coopA", "did:icn:coopA").await;
+        assert_eq!(same_coop_status, StatusCode::CREATED);
         assert_eq!(
-            create_status("did:icn:coopA", "did:icn:coopA").await,
-            StatusCode::CREATED
+            same_coop_registry.list_meetings("did:icn:coopA").len(),
+            1,
+            "same-coop create should persist exactly one meeting under coopA"
         );
-        // Cross coop: a coopA token cannot create a meeting under coopB.
-        assert_eq!(
-            create_status("did:icn:coopA", "did:icn:coopB").await,
-            StatusCode::FORBIDDEN
+
+        // Cross coop: a coopA token cannot create a meeting under coopB, and the
+        // rejection must leave the registry unmutated (no meeting under coopB, and
+        // none leaked under the token's own coopA either).
+        let (cross_coop_status, cross_coop_registry) =
+            create_status("did:icn:coopA", "did:icn:coopB").await;
+        assert_eq!(cross_coop_status, StatusCode::FORBIDDEN);
+        assert!(
+            cross_coop_registry
+                .list_meetings("did:icn:coopB")
+                .is_empty(),
+            "cross-coop reject must not create a meeting under coopB"
+        );
+        assert!(
+            cross_coop_registry
+                .list_meetings("did:icn:coopA")
+                .is_empty(),
+            "cross-coop reject must not create a meeting under coopA either"
         );
     }
 


### PR DESCRIPTION
## What
Adds `require_coop_access(&http_req, &req.coop_id)` to the `create_meeting` route in `icn-gateway` `registry.rs`, after DID-format validation.

## Why
`create_meeting` gated on `governance:meeting:write` (with `governance:write` fallback) but never bound the body-supplied `coop_id` to the caller's cooperative. Because the class scopes are requestable per coop, a meeting-scoped token for coop A could create a meeting record under coop B — a cross-cooperative write bypass. Same bug class fixed for the sibling `index_decision_endpoint` in #2052.

## How
After the existing DID-format check, call `require_coop_access` (import already present on `main` from #2052). Bad DID format still returns 400; cross-coop now returns 403.

## Risk
Low. Tokens acting on their own coop are unaffected; only cross-coop writes are newly rejected.

## Test plan
Added `create_meeting_rejects_cross_coop_write`: same-coop create → 201 CREATED, cross-coop → 403 FORBIDDEN.
Audited the whole file: the only write handlers are `create_meeting` and `index_decision_endpoint` — both now call `require_coop_access`; the read handlers (`list_meetings`, `list_decisions`, `get_decision`, `get_decision_trace`) are `governance:read` and do not index a body-supplied coop_id. No other instances of this hole.

Verified locally: `cargo fmt --all -- --check` clean; `cargo clippy -p icn-gateway --all-targets -- -D warnings` clean; `cargo test -p icn-gateway` 562 pass incl. the new test.

Completes the cross-coop-access hardening started in #2052.