### PR TITLE
fix(gateway): bind caller token to coop_id namespace on escrow/invites/recurring (flat-namespace hardening)

### DIFF
--- a/icn/crates/icn-gateway/src/api/escrow.rs
+++ b/icn/crates/icn-gateway/src/api/escrow.rs
@@ -13,7 +13,7 @@ use utoipa::ToSchema;
 
 use crate::error::{GatewayError, Result};
 use crate::ledger_mgr::LedgerManager;
-use crate::middleware::{get_claims, require_scope};
+use crate::middleware::{get_claims, require_coop_access, require_scope};
 
 /// Request to create escrow
 #[derive(Debug, Deserialize, ToSchema)]
@@ -43,6 +43,10 @@ pub async fn create_escrow(
     req: web::Json<CreateEscrowRequest>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "settlements:write")?;
+    // Bind the body-supplied coop_id to the caller's token coop. `settlements:write`
+    // is requestable per coop, so without this a token for coop A could create an
+    // escrow under coop B. CRITICAL: prevent cross-coop write.
+    require_coop_access(&http_req, &req.coop_id)?;
 
     let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
@@ -167,6 +171,11 @@ pub async fn release_escrow(
         .get(&escrow_id)
         .map_err(|e| GatewayError::InternalError(format!("Store error: {e}")))?
         .ok_or_else(|| GatewayError::NotFound(format!("Escrow not found: {escrow_id}")))?;
+
+    // The escrow belongs to a specific coop; only a caller bound to that coop may
+    // approve/release it (and trigger a settlement on that coop's ledger).
+    // CRITICAL: prevent cross-coop release.
+    require_coop_access(&http_req, &escrow.coop_id)?;
 
     // Check status
     if escrow.status != EscrowStatus::Pending && escrow.status != EscrowStatus::Locked {
@@ -362,4 +371,140 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .service(get_escrow)
         .service(release_escrow)
         .service(refund_escrow);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::TokenClaims;
+    use actix_web::http::StatusCode;
+    use actix_web::{test as actix_test, App, HttpMessage};
+
+    fn write_claims(coop: &str, sub: &str) -> TokenClaims {
+        TokenClaims {
+            sub: sub.to_string(),
+            iat: 1_000_000_000,
+            exp: 9_999_999_999,
+            coop_id: coop.to_string(),
+            // Validly scoped, so the coop binding is the only thing under test.
+            scopes: vec!["settlements:write".to_string()],
+        }
+    }
+
+    fn fresh_db() -> sled::Db {
+        sled::Config::new().temporary(true).open().unwrap()
+    }
+
+    /// `settlements:write` is requestable per coop, so `create_escrow` binds the
+    /// body-supplied coop_id to the token's coop. A same-coop create succeeds (201)
+    /// and persists exactly one escrow; a cross-coop create is rejected (403) and
+    /// leaves the store empty. The store-state assertions (not just the HTTP status)
+    /// prove "no mutation on reject". Mirrors `create_meeting_rejects_cross_coop_write`.
+    #[actix_web::test]
+    async fn create_escrow_rejects_cross_coop_write() {
+        async fn run(token_coop: &str, body_coop: &str, sub: &str) -> (StatusCode, EscrowStore) {
+            // Two store handles over one temp db so we can assert on what the app wrote.
+            let db = fresh_db();
+            let store = EscrowStore::new(db.clone());
+            let probe = EscrowStore::new(db);
+            let app = actix_test::init_service(
+                App::new()
+                    .app_data(web::Data::new(store))
+                    .service(create_escrow),
+            )
+            .await;
+            let req = actix_test::TestRequest::post()
+                .uri("/escrow")
+                .set_json(serde_json::json!({
+                    "coop_id": body_coop,
+                    "from_account": "acct-from",
+                    "to_account": "acct-to",
+                    "amount": 100,
+                    "unit": "hours",
+                    "description": "test escrow",
+                    "conditions": []
+                }))
+                .to_request();
+            req.extensions_mut().insert(write_claims(token_coop, sub));
+            let status = actix_test::call_service(&app, req).await.status();
+            (status, probe)
+        }
+
+        // The success path parses claims.sub into a Did, so use a real DID subject.
+        let sub = icn_identity::KeyPair::generate().unwrap().did().to_string();
+
+        let (same, same_store) = run("coopA", "coopA", &sub).await;
+        assert_eq!(same, StatusCode::CREATED);
+        assert_eq!(
+            same_store.list_by_user(&sub).unwrap().len(),
+            1,
+            "same-coop create should persist exactly one escrow"
+        );
+
+        let (cross, cross_store) = run("coopA", "coopB", &sub).await;
+        assert_eq!(cross, StatusCode::FORBIDDEN);
+        assert!(
+            cross_store.list_by_user(&sub).unwrap().is_empty(),
+            "cross-coop reject must not create an escrow"
+        );
+    }
+
+    /// An escrow belongs to a specific coop; `release_escrow` binds the caller to
+    /// that coop. A coopA token cannot approve/release a coopB escrow: the request
+    /// is rejected (403) and the stored escrow is left untouched (still Pending, no
+    /// approvals recorded) — proving the cross-coop call never reached the mutation.
+    #[actix_web::test]
+    async fn release_escrow_rejects_cross_coop_release() {
+        let db = fresh_db();
+        let store = EscrowStore::new(db.clone());
+        let probe = EscrowStore::new(db);
+
+        // Seed a pending escrow owned by coopB.
+        store
+            .insert(Escrow {
+                id: "esc-1".to_string(),
+                coop_id: "coopB".to_string(),
+                creator: "did:icn:creator".to_string(),
+                from_account: "acct-from".to_string(),
+                to_account: "acct-to".to_string(),
+                amount: 100,
+                currency: "hours".to_string(),
+                status: EscrowStatus::Pending,
+                conditions: vec![],
+                approvals: vec![],
+                expires_at: None,
+                description: "seeded".to_string(),
+                created_at: 1,
+                updated_at: 1,
+            })
+            .unwrap();
+
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(web::Data::new(store))
+                .app_data(web::Data::new(Arc::new(LedgerManager::new())))
+                .service(release_escrow),
+        )
+        .await;
+
+        let sub = icn_identity::KeyPair::generate().unwrap().did().to_string();
+        let req = actix_test::TestRequest::post()
+            .uri("/escrow/esc-1/release")
+            .set_json(serde_json::json!({ "proof": null }))
+            .to_request();
+        req.extensions_mut().insert(write_claims("coopA", &sub));
+        let status = actix_test::call_service(&app, req).await.status();
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        let after = probe.get("esc-1").unwrap().expect("escrow still present");
+        assert_eq!(
+            after.status,
+            EscrowStatus::Pending,
+            "cross-coop release must not change escrow status"
+        );
+        assert!(
+            after.approvals.is_empty(),
+            "cross-coop release must not record an approval"
+        );
+    }
 }

--- a/icn/crates/icn-gateway/src/api/escrow.rs
+++ b/icn/crates/icn-gateway/src/api/escrow.rs
@@ -43,9 +43,10 @@ pub async fn create_escrow(
     req: web::Json<CreateEscrowRequest>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "settlements:write")?;
-    // Bind the body-supplied coop_id to the caller's token coop. `settlements:write`
-    // is requestable per coop, so without this a token for coop A could create an
-    // escrow under coop B. CRITICAL: prevent cross-coop write.
+    // Flat coop-namespace guard (NOT entity/community/federation hierarchy — that is
+    // tracked in #2061): bind the body-supplied coop_id to the caller's token
+    // namespace. `settlements:write` is requestable per namespace, so without this a
+    // token for coop A could create an escrow under coop B. Prevent a cross-namespace write.
     require_coop_access(&http_req, &req.coop_id)?;
 
     let claims = get_claims(&http_req)
@@ -172,9 +173,9 @@ pub async fn release_escrow(
         .map_err(|e| GatewayError::InternalError(format!("Store error: {e}")))?
         .ok_or_else(|| GatewayError::NotFound(format!("Escrow not found: {escrow_id}")))?;
 
-    // The escrow belongs to a specific coop; only a caller bound to that coop may
-    // approve/release it (and trigger a settlement on that coop's ledger).
-    // CRITICAL: prevent cross-coop release.
+    // The escrow lives in a specific coop namespace; only a caller bound to that
+    // namespace may approve/release it (and trigger a settlement on its ledger).
+    // Flat coop-namespace guard, not entity hierarchy (#2061). Prevent a cross-namespace release.
     require_coop_access(&http_req, &escrow.coop_id)?;
 
     // Check status

--- a/icn/crates/icn-gateway/src/api/invites.rs
+++ b/icn/crates/icn-gateway/src/api/invites.rs
@@ -43,9 +43,10 @@ pub async fn create_invite(
 
     // Validate inputs
     validation::validate_coop_id(&req.coop_id)?;
-    // Bind the body-supplied coop_id to the caller's token coop. `coop:admin` is
-    // requestable per coop, so without this a coop A admin could mint invites
-    // (which grant membership) for coop B. CRITICAL: prevent cross-coop write.
+    // Flat coop-namespace guard (NOT entity/community/federation hierarchy — see
+    // #2061): bind the body-supplied coop_id to the caller's token namespace.
+    // `coop:admin` is requestable per namespace, so without this a coop A admin could
+    // mint invites (which grant membership) for coop B. Prevent a cross-namespace write.
     require_coop_access(&http_req, &req.coop_id)?;
     validation::validate_role(&req.role)?;
 
@@ -113,8 +114,9 @@ pub async fn list_invites(
 
     validation::validate_coop_id(coop_id)?;
     // Invite codes are membership-granting bearer secrets; binding the queried
-    // coop_id to the caller's token coop stops a coop A reader from listing (and
-    // then redeeming) coop B's invites. CRITICAL: prevent cross-coop exposure.
+    // coop_id to the caller's token namespace stops a coop A reader from listing (and
+    // then redeeming) coop B's invites. Flat coop-namespace guard, not entity
+    // hierarchy (#2061). Prevent cross-namespace exposure.
     require_coop_access(&http_req, coop_id)?;
 
     // List invites

--- a/icn/crates/icn-gateway/src/api/invites.rs
+++ b/icn/crates/icn-gateway/src/api/invites.rs
@@ -9,7 +9,7 @@ use crate::auth::AuthManager;
 use crate::commons_mgr::CommonsManager;
 use crate::error::Result;
 use crate::invite::InviteManager;
-use crate::middleware::{get_claims, require_scope};
+use crate::middleware::{get_claims, require_coop_access, require_scope};
 use crate::models::{
     CreateInviteRequest, InviteInfo, InviteListResponse, InviteResponse, JoinRequest, JoinResponse,
 };
@@ -43,6 +43,10 @@ pub async fn create_invite(
 
     // Validate inputs
     validation::validate_coop_id(&req.coop_id)?;
+    // Bind the body-supplied coop_id to the caller's token coop. `coop:admin` is
+    // requestable per coop, so without this a coop A admin could mint invites
+    // (which grant membership) for coop B. CRITICAL: prevent cross-coop write.
+    require_coop_access(&http_req, &req.coop_id)?;
     validation::validate_role(&req.role)?;
 
     // Default to 7 days if not specified
@@ -108,6 +112,10 @@ pub async fn list_invites(
     })?;
 
     validation::validate_coop_id(coop_id)?;
+    // Invite codes are membership-granting bearer secrets; binding the queried
+    // coop_id to the caller's token coop stops a coop A reader from listing (and
+    // then redeeming) coop B's invites. CRITICAL: prevent cross-coop exposure.
+    require_coop_access(&http_req, coop_id)?;
 
     // List invites
     let invites = invite_mgr.list_invites(coop_id).await.map_err(|e| {
@@ -184,4 +192,98 @@ pub async fn join_via_invite(
         role: invite.role,
         private_key: String::new(), // Client generates their own keypair
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::TokenClaims;
+    use crate::commons_mgr::CommonsManager;
+    use crate::invite::InviteManager;
+    use actix_web::http::StatusCode;
+    use actix_web::{test as actix_test, App, HttpMessage};
+
+    fn admin_claims(coop: &str, sub: &str) -> TokenClaims {
+        TokenClaims {
+            sub: sub.to_string(),
+            iat: 1_000_000_000,
+            exp: 9_999_999_999,
+            coop_id: coop.to_string(),
+            scopes: vec!["coop:admin".to_string(), "coop:read".to_string()],
+        }
+    }
+
+    /// `coop:admin` is requestable per coop, so `create_invite` binds the body
+    /// coop_id to the token's coop. A same-coop admin mints an invite (201) that is
+    /// then listed; a cross-coop admin is rejected (403) and creates nothing under
+    /// the target coop. Invites grant membership, so this is a privilege-escalation
+    /// boundary. (coop_ids avoid ':' to satisfy validate_coop_id.)
+    #[actix_web::test]
+    async fn create_invite_rejects_cross_coop_write() {
+        async fn run(
+            token_coop: &str,
+            body_coop: &str,
+            sub: &str,
+        ) -> (StatusCode, Arc<InviteManager>) {
+            let invite_mgr = Arc::new(InviteManager::new());
+            let commons_mgr = Arc::new(CommonsManager::new());
+            let app = actix_test::init_service(
+                App::new()
+                    .app_data(web::Data::new(invite_mgr.clone()))
+                    .app_data(web::Data::new(commons_mgr))
+                    .service(web::scope("/invites").service(create_invite)),
+            )
+            .await;
+            let req = actix_test::TestRequest::post()
+                .uri("/invites")
+                .set_json(serde_json::json!({ "coop_id": body_coop, "role": "member" }))
+                .to_request();
+            req.extensions_mut().insert(admin_claims(token_coop, sub));
+            let status = actix_test::call_service(&app, req).await.status();
+            (status, invite_mgr)
+        }
+
+        // The success path parses claims.sub into a Did, so use a real DID subject.
+        let sub = icn_identity::KeyPair::generate().unwrap().did().to_string();
+
+        let (same, same_mgr) = run("coopA", "coopA", &sub).await;
+        assert_eq!(same, StatusCode::CREATED);
+        assert_eq!(
+            same_mgr.list_invites("coopA").await.unwrap().len(),
+            1,
+            "same-coop admin should create exactly one invite"
+        );
+
+        let (cross, cross_mgr) = run("coopA", "coopB", &sub).await;
+        assert_eq!(cross, StatusCode::FORBIDDEN);
+        assert!(
+            cross_mgr.list_invites("coopB").await.unwrap().is_empty(),
+            "cross-coop reject must not create an invite under coopB"
+        );
+    }
+
+    /// Invite codes are membership-granting bearer secrets; `list_invites` binds the
+    /// queried coop_id to the token's coop so a coopA reader cannot enumerate (and
+    /// then redeem) coopB's invites. Same-coop read succeeds (200); cross-coop is 403.
+    #[actix_web::test]
+    async fn list_invites_rejects_cross_coop_read() {
+        async fn run(token_coop: &str, query_coop: &str) -> StatusCode {
+            let invite_mgr = Arc::new(InviteManager::new());
+            let app = actix_test::init_service(
+                App::new()
+                    .app_data(web::Data::new(invite_mgr))
+                    .service(web::scope("/invites").service(list_invites)),
+            )
+            .await;
+            let req = actix_test::TestRequest::get()
+                .uri(&format!("/invites?coop_id={query_coop}"))
+                .to_request();
+            req.extensions_mut()
+                .insert(admin_claims(token_coop, "did:icn:reader"));
+            actix_test::call_service(&app, req).await.status()
+        }
+
+        assert_eq!(run("coopA", "coopA").await, StatusCode::OK);
+        assert_eq!(run("coopA", "coopB").await, StatusCode::FORBIDDEN);
+    }
 }

--- a/icn/crates/icn-gateway/src/api/recurring_settlements.rs
+++ b/icn/crates/icn-gateway/src/api/recurring_settlements.rs
@@ -48,9 +48,10 @@ pub async fn create_recurring_settlement(
     req: web::Json<CreateRecurringSettlementRequest>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "settlements:write")?;
-    // Bind the body-supplied coop_id to the caller's token coop. `settlements:write`
-    // is requestable per coop, so without this a token for coop A could schedule a
-    // recurring settlement under coop B. CRITICAL: prevent cross-coop write.
+    // Flat coop-namespace guard (NOT entity/community/federation hierarchy — see
+    // #2061): bind the body-supplied coop_id to the caller's token namespace.
+    // `settlements:write` is requestable per namespace, so without this a token for
+    // coop A could schedule a recurring settlement under coop B. Prevent a cross-namespace write.
     require_coop_access(&http_req, &req.coop_id)?;
 
     let claims = get_claims(&http_req)

--- a/icn/crates/icn-gateway/src/api/recurring_settlements.rs
+++ b/icn/crates/icn-gateway/src/api/recurring_settlements.rs
@@ -15,7 +15,7 @@ use utoipa::ToSchema;
 
 use crate::error::{GatewayError, Result};
 use crate::ledger_mgr::LedgerManager;
-use crate::middleware::{get_claims, require_scope};
+use crate::middleware::{get_claims, require_coop_access, require_scope};
 
 /// Request to create recurring settlement
 #[derive(Debug, Deserialize, ToSchema)]
@@ -48,6 +48,10 @@ pub async fn create_recurring_settlement(
     req: web::Json<CreateRecurringSettlementRequest>,
 ) -> Result<HttpResponse> {
     require_scope(&http_req, "settlements:write")?;
+    // Bind the body-supplied coop_id to the caller's token coop. `settlements:write`
+    // is requestable per coop, so without this a token for coop A could schedule a
+    // recurring settlement under coop B. CRITICAL: prevent cross-coop write.
+    require_coop_access(&http_req, &req.coop_id)?;
 
     let claims = get_claims(&http_req)
         .ok_or_else(|| GatewayError::AuthenticationFailed("No claims found".to_string()))?;
@@ -413,4 +417,81 @@ pub fn start_scheduler(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::TokenClaims;
+    use actix_web::http::StatusCode;
+    use actix_web::{test as actix_test, App, HttpMessage};
+
+    fn write_claims(coop: &str, sub: &str) -> TokenClaims {
+        TokenClaims {
+            sub: sub.to_string(),
+            iat: 1_000_000_000,
+            exp: 9_999_999_999,
+            coop_id: coop.to_string(),
+            scopes: vec!["settlements:write".to_string()],
+        }
+    }
+
+    /// `settlements:write` is requestable per coop, so `create_recurring_settlement`
+    /// binds the body coop_id to the token's coop. Same-coop create succeeds (201)
+    /// and persists exactly one settlement; cross-coop is rejected (403) and stores
+    /// nothing. Store-state assertions prove "no mutation on reject".
+    #[actix_web::test]
+    async fn create_recurring_settlement_rejects_cross_coop_write() {
+        async fn run(
+            token_coop: &str,
+            body_coop: &str,
+            sub: &str,
+        ) -> (StatusCode, RecurringPaymentStore) {
+            let db = sled::Config::new().temporary(true).open().unwrap();
+            let store = RecurringPaymentStore::new(db.clone());
+            let probe = RecurringPaymentStore::new(db);
+            let app = actix_test::init_service(
+                App::new()
+                    .app_data(web::Data::new(store))
+                    .service(create_recurring_settlement),
+            )
+            .await;
+            let req = actix_test::TestRequest::post()
+                .uri("/settlements/recurring")
+                .set_json(serde_json::json!({
+                    "coop_id": body_coop,
+                    "from_account": "acct-from",
+                    "to_account": "acct-to",
+                    "amount": 100,
+                    "unit": "hours",
+                    "frequency": "daily"
+                }))
+                .to_request();
+            req.extensions_mut().insert(write_claims(token_coop, sub));
+            let status = actix_test::call_service(&app, req).await.status();
+            (status, probe)
+        }
+
+        // The success path parses claims.sub into a Did, so use a real DID subject.
+        let sub = icn_identity::KeyPair::generate().unwrap().did().to_string();
+
+        // Assert on persisted state via `list()` (full primary-key scan) rather than
+        // `list_by_owner()`: the latter splits the index key on ':' expecting 3 parts
+        // and so cannot match DID owners (which themselves contain ':'). That's a
+        // pre-existing store-layer limitation, out of scope for this authz fix.
+        let (same, same_store) = run("coopA", "coopA", &sub).await;
+        assert_eq!(same, StatusCode::CREATED);
+        assert_eq!(
+            same_store.list().unwrap().len(),
+            1,
+            "same-coop create should persist exactly one recurring settlement"
+        );
+
+        let (cross, cross_store) = run("coopA", "coopB", &sub).await;
+        assert_eq!(cross, StatusCode::FORBIDDEN);
+        assert!(
+            cross_store.list().unwrap().is_empty(),
+            "cross-coop reject must not create a recurring settlement"
+        );
+    }
 }


### PR DESCRIPTION
## Scope boundary (read first)

This PR is **flat coop-namespace hardening only**. It binds the caller token's
`claims.coop_id` to the request/derived `coop_id` on gateway surfaces that still
operate in the flat coop-namespace regime (same mechanism as #2052/#2056, the
existing `require_coop_access` used at ~24 sites).

It does **NOT** implement entity-, community-, or federation-aware authorization,
and must not be read as solving the entity hierarchy. ICN's unified entity model
(`icn-entity`: individuals/cooperatives/communities/federations + membership graph
+ roles incl. `FederatedMember`) is a separate authorization regime; converging
flat `coop_id` guards onto entity/membership-aware authz is tracked design-first in
**#2061**. This PR is defense-in-depth for the current flat regime; #2061 owns the
future model.

## What

Adds the flat coop-namespace guard (`require_coop_access`) to gateway handlers that
derived `coop_id` from caller input and then mutated/exposed namespace-scoped data
while only checking a broad scope:

| File | Handler | Guard added |
|------|---------|-------------|
| `api/escrow.rs` | `create_escrow` | `require_coop_access(&http_req, &req.coop_id)?` |
| `api/escrow.rs` | `release_escrow` | `require_coop_access(&http_req, &escrow.coop_id)?` (post-lookup) |
| `api/invites.rs` | `create_invite` | `require_coop_access(&http_req, &req.coop_id)?` |
| `api/invites.rs` | `list_invites` | `require_coop_access(&http_req, coop_id)?` |
| `api/recurring_settlements.rs` | `create_recurring_settlement` | `require_coop_access(&http_req, &req.coop_id)?` |

## Why

Same flat-namespace bypass class fixed in #2052 (decision-index) and #2056
(`create_meeting`): a handler accepts/derives `coop_id` from caller input, checks
only a broad scope (`settlements:write`, `coop:admin`) that any authenticated caller
in *any* coop namespace can hold, then mutates/exposes that namespace's data without
binding the caller's token to it. A fresh sweep found these still live on `main`.
`create_invite`/`list_invites` are the sharpest: invite codes are membership-granting
bearer secrets, so a coop A admin could mint invites for coop B, and a coop A reader
could enumerate (then redeem) coop B's. Refs #1868.

## How

Reuses `require_coop_access` (`middleware.rs:138`) — `claims.coop_id == coop_id`
string equality (the flat-regime primitive) — placed after the scope gate and before
any mutation/exposure, mirroring `create_meeting` (#2056).

## Not changed (verified safe in the flat regime)

- `refund_escrow` — gated by `escrow.creator == caller` (stronger than namespace).
- recurring `update`/`cancel`/`get`/`list` — owner-gated (`payment.owner == caller`).
- `update_member_profile` — self-DID gated; mutation keyed on DID.
- `start_enrollment` — intentionally public new-member bootstrap (caller has no token yet).
- `register_coop` (federation), `deploy_contract` — federation-admin / owner-scoped
  meta surfaces, not the flat same-namespace write class. Entity-aware treatment is #2061.

## Risk

Low. Only behavioral change: a caller whose token namespace differs from the target
`coop_id` now gets 403 instead of succeeding; same-namespace behavior is unchanged.
No request/response shapes change → no OpenAPI/TypeScript regeneration.

## Test plan

5 regression tests (same-namespace succeeds 201/200; different-namespace → 403; store
left unmutated on reject), mirroring `create_meeting_rejects_cross_coop_write`. Test
names keep the established `cross_coop` convention used by the 6 sibling tests:
`create_escrow_rejects_cross_coop_write`, `release_escrow_rejects_cross_coop_release`,
`create_invite_rejects_cross_coop_write`, `list_invites_rejects_cross_coop_read`,
`create_recurring_settlement_rejects_cross_coop_write`.

Local gates (toolchain 1.95.0):
- `cargo fmt --all --check` — pass
- `cargo clippy -p icn-gateway --all-targets --features sled-storage -- -D warnings` — pass (0 warnings)
- `cargo test -p icn-gateway --features sled-storage` — pass (lib 579 + all integration; 0 failed)

## NOTE (out of scope, captured in #2061)

`apps/ledger/src/recurring.rs::list_by_owner` splits its index key on `:` expecting 3
parts; DID owners contain colons, so it never matches — the live `GET /settlements/recurring`
(`list_recurring_settlements`, lists by `claims.sub`) returns empty for real DID owners.
Not fixed here (separate reliability bug); tracked in #2061.
