### PR TITLE
fix(ledger): recurring list_by_owner returns empty for DID owners (colon-split bug)

### DIFF
--- a/apps/ledger/src/recurring.rs
+++ b/apps/ledger/src/recurring.rs
@@ -139,16 +139,19 @@ impl RecurringPaymentStore {
 
     /// List payments by owner
     pub fn list_by_owner(&self, owner: &str) -> Result<Vec<RecurringPayment>> {
-        let prefix = format!("idx_owner:{owner}");
+        // Key format is `idx_owner:{owner}:{id}`. Recover the id by stripping the
+        // full `idx_owner:{owner}:` prefix rather than splitting on ':'. Owners are
+        // DIDs (`did:icn:<base58>`) which themselves contain ':', so a naive
+        // `split(':')` over-segments the key and the owner never matches. The
+        // trailing colon also pins the owner segment exactly (no `alice`/`alice2`
+        // prefix collision). Mirrors `EscrowStore::list_by_user`.
+        let prefix = format!("idx_owner:{owner}:");
         let mut payments = Vec::new();
 
         for item in self.db.scan_prefix(prefix.as_bytes()) {
             let (key, _) = item?;
             let key_str = std::str::from_utf8(&key)?;
-            // Format: idx_owner:{owner}:{id}
-            let parts: Vec<&str> = key_str.split(':').collect();
-            if parts.len() == 3 {
-                let id = parts[2];
+            if let Some(id) = key_str.strip_prefix(&prefix) {
                 if let Some(payment) = self.get(id)? {
                     payments.push(payment);
                 }
@@ -270,6 +273,39 @@ mod tests {
 
         let bob_payments = store.list_by_owner("bob")?;
         assert_eq!(bob_payments.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn list_by_owner_matches_did_owners_with_colons() -> Result<()> {
+        // Regression: owners are DIDs (`did:icn:<base58>`) which contain ':'. The
+        // index key is `idx_owner:{owner}:{id}`; the previous `split(':')` +
+        // `len() == 3` parser never matched DID owners, so `list_by_owner` — and the
+        // live `GET /settlements/recurring` (lists by `claims.sub`) — returned empty
+        // for every real user. A literal DID-shaped owner reproduces the failure;
+        // the bug is purely about ':' in the key, not DID cryptography.
+        let db = temp_db();
+        let store = RecurringPaymentStore::new(db);
+
+        let owner = "did:icn:z6MkpTHR8VNsBxYAGF1cooperativeOwnerExample";
+        let payment = RecurringPayment {
+            id: "pay-1".to_string(),
+            owner: owner.to_string(),
+            ..Default::default()
+        };
+        store.insert(payment)?;
+
+        let listed = store.list_by_owner(owner)?;
+        assert_eq!(
+            listed.len(),
+            1,
+            "list_by_owner must return payments for DID owners (':' in index key)"
+        );
+        assert_eq!(listed[0].id, "pay-1");
+
+        // A different DID owner must not match (no prefix collision / cross-owner leak).
+        assert!(store.list_by_owner("did:icn:someoneElse")?.is_empty());
 
         Ok(())
     }

--- a/icn/crates/icn-gateway/src/api/recurring_settlements.rs
+++ b/icn/crates/icn-gateway/src/api/recurring_settlements.rs
@@ -476,10 +476,9 @@ mod tests {
         // The success path parses claims.sub into a Did, so use a real DID subject.
         let sub = icn_identity::KeyPair::generate().unwrap().did().to_string();
 
-        // Assert on persisted state via `list()` (full primary-key scan) rather than
-        // `list_by_owner()`: the latter splits the index key on ':' expecting 3 parts
-        // and so cannot match DID owners (which themselves contain ':'). That's a
-        // pre-existing store-layer limitation, out of scope for this authz fix.
+        // Assert on persisted state via `list()` (a simple full primary-key scan).
+        // `list_by_owner()` for DID owners is exercised separately below in
+        // `list_recurring_settlements_returns_did_owner_settlements`.
         let (same, same_store) = run("coopA", "coopA", &sub).await;
         assert_eq!(same, StatusCode::CREATED);
         assert_eq!(
@@ -493,6 +492,67 @@ mod tests {
         assert!(
             cross_store.list().unwrap().is_empty(),
             "cross-coop reject must not create a recurring settlement"
+        );
+    }
+
+    /// Regression (#2063): `list_recurring_settlements` lists by `claims.sub` (a DID,
+    /// which contains ':'), so the store's owner index must match DID owners. This test
+    /// lives in icn-gateway — a workspace member CI runs via `cargo test -p icn-gateway`
+    /// — because the equivalent unit test in the `icn-ledger-app` crate (top-level
+    /// `apps/ledger`) is NOT executed by CI's `--workspace` runs (topology gap, #2064).
+    /// Guards the `list_by_owner` colon-split bug from reappearing on the live endpoint.
+    #[actix_web::test]
+    async fn list_recurring_settlements_returns_did_owner_settlements() {
+        let db = sled::Config::new().temporary(true).open().unwrap();
+        let store = RecurringPaymentStore::new(db);
+
+        // Owner is a real DID (contains ':').
+        let owner = icn_identity::KeyPair::generate().unwrap().did().to_string();
+        store
+            .insert(RecurringPayment {
+                id: "rp-did-1".to_string(),
+                coop_id: "coopA".to_string(),
+                owner: owner.clone(),
+                from_account: "acct-from".to_string(),
+                to_account: "acct-to".to_string(),
+                amount: 100,
+                currency: "hours".to_string(),
+                frequency: PaymentFrequency::Daily,
+                next_execution: 1,
+                end_date: None,
+                status: RecurringStatus::Active,
+                execution_count: 0,
+                last_execution: None,
+                created_at: 1,
+                updated_at: 1,
+            })
+            .unwrap();
+
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(web::Data::new(store))
+                .service(list_recurring_settlements),
+        )
+        .await;
+
+        let claims = TokenClaims {
+            sub: owner.clone(),
+            iat: 1_000_000_000,
+            exp: 9_999_999_999,
+            coop_id: "coopA".to_string(),
+            scopes: vec!["settlements:read".to_string()],
+        };
+        let req = actix_test::TestRequest::get()
+            .uri("/settlements/recurring")
+            .to_request();
+        req.extensions_mut().insert(claims);
+        let resp = actix_test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body: serde_json::Value = actix_test::read_body_json(resp).await;
+        assert_eq!(
+            body["count"], 1,
+            "DID-owned recurring settlement must be listed (regression #2063)"
         );
     }
 }


### PR DESCRIPTION
## What

Fixes `RecurringPaymentStore::list_by_owner` in `apps/ledger/src/recurring.rs`
(`icn-ledger-app`) so it actually returns payments for DID owners.

## Why

The owner index key is `idx_owner:{owner}:{id}`, but `list_by_owner` parsed it with
`key_str.split(':')` and required `parts.len() == 3`. Owners are DIDs
(`did:icn:<base58>`) which contain `:`, so the key splits into 5+ parts and the
`== 3` check never matches. Result: `list_by_owner` returns empty for every real DID
owner — and the live gateway endpoint `GET /v1/.../settlements/recurring`
(`list_recurring_settlements`, which lists by `claims.sub`, a DID) returns empty for
every real user.

Discovered during the cross-coop authz sweep (#2058) and tracked in #2061.

## How

Recover the id by stripping the full `idx_owner:{owner}:` prefix instead of splitting
on `:` — mirroring the working `EscrowStore::list_by_user`. The trailing colon also
pins the owner segment exactly, closing a latent prefix collision (`alice` vs
`alice2`). Behavior for colon-free owners is unchanged.

## Risk

Low. One internal method; signature unchanged, so no downstream/API impact. Existing
`test_indices` (colon-free owners) still passes; the new test covers DID owners.

## Test plan

Added `list_by_owner_matches_did_owners_with_colons` (a literal DID-shaped owner
reproduces the failure — the bug is purely `:` handling, not DID crypto, so no new
dependency is needed). Verified:
- `cargo test --manifest-path apps/ledger/Cargo.toml recurring` — 3 pass
  (`test_crud`, `test_indices`, `list_by_owner_matches_did_owners_with_colons`), 0 failed
- `cargo fmt --manifest-path apps/ledger/Cargo.toml --check` — pass
- `recurring.rs` is clippy-clean (a pre-existing `manual_saturating_arithmetic` lint in
  `config.rs` is unrelated and left untouched)

> Build note: tests were run against a dep graph where `ml-dsa` resolves consistently
> (the transitive `icn-crypto-pq` build is otherwise mid-migration on #2062); this
> change itself is `sled`/string-only and independent of that.

## NOTE — CI coverage gap (out of scope)

`icn-ledger-app` is a path dependency of `icn-gateway`, **not** a member of the `icn/`
workspace. CI's `cargo test/clippy --workspace` therefore compiles it (as a dep, with
cap-lints allowed) but never runs its unit tests or lints. That is why this bug — and
the pre-existing `config.rs` clippy lint — went unnoticed. Worth a follow-up to bring
the repo-root `apps/*` crates into CI test/lint coverage; tracked alongside #2061.
