### PR TITLE
docs(institutions): fix dead NYCN spec link

### DIFF
--- a/institutions/nycn/README.md
+++ b/institutions/nycn/README.md
@@ -47,5 +47,5 @@ The summit is a NYCN activity and program domain, not a platform primitive. ICN 
 ## Current Status
 
 - Canonical platform boundary remains [`docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`](../../docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md)
-- Repo-grounded NYCN architecture remains in [`docs/strategy/NYCN-Repo-Architecture-Spec.md`](../../docs/strategy/NYCN-Repo-Architecture-Spec.md)
+- Repo-grounded NYCN architecture remains in [`docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md`](../../docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md)
 - This package is the operational home for institution-owned artifacts going forward

--- a/institutions/nycn/README.md
+++ b/institutions/nycn/README.md
@@ -47,5 +47,5 @@ The summit is a NYCN activity and program domain, not a platform primitive. ICN 
 ## Current Status
 
 - Canonical platform boundary remains [`docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`](../../docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md)
-- Repo-grounded NYCN architecture remains in [`docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md`](../../docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md)
+- Conceptual ICN/NYCN package-boundary clarification is in [`docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md`](../../docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md)
 - This package is the operational home for institution-owned artifacts going forward


### PR DESCRIPTION
## What
Fix a dead link in `institutions/nycn/README.md` (Current Status section). The "Repo-grounded NYCN architecture" bullet pointed at `docs/strategy/NYCN-Repo-Architecture-Spec.md`, which no longer exists on `main`. Repointed to the surviving strategy-level doc `docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md` ("ICN, NYCN, and the Institution Package Boundary").

## Why
The original spec was added in #1544 and **deleted in #1813** ("strip NYCN identifier and product framing from public site"). The README pointer was never updated, leaving a dead link in the public repo. The line above it (`docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md`, the canonical *platform* boundary) is intact; this restores the companion *strategy*-level NYCN/ICN boundary link.

## How
One-line docs edit — both the displayed `code` path and the URL updated to the surviving doc. Preserves the architecture-vs-strategy distinction between the two bullets.

## Risk
None. Docs-only link fix; no runtime/code change.

## Test plan
- New target resolves from the README's location (`institutions/nycn/../../docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md` exists).
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` exits 0.