### PR TITLE
docs(apps): classify apps/echo as example-only (#2064)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,17 @@ If a change might impact any invariant:
 - If you touch a crate under `apps/`, you must either:
   - migrate it to `icn/apps/`, or
   - add a tracking issue that classifies it as an example/tool with a migration or removal date.
+- **Example-only crates must be clearly marked** (a `README.md` in the crate dir saying so),
+  so they are not mistaken for an uncovered runtime crate.
+
+**Current state (#2064 complete for runtime crates).** All runtime-integrated top-level app
+crates have been migrated under `icn/apps/*` and are now workspace-covered (`cargo
+test/clippy --workspace`): `icn-ledger-app` (#2070), `icn-governance-app` (#2071),
+`icn-trust-app` (#2072) — each kept distinct from its `icn/apps/*` `*-actor` sibling.
+Top-level `apps/` now holds **only** `apps/echo` (`icn-app-echo`), which is **example-only**
+(no runtime consumers) and intentionally left outside the workspace — see
+[`apps/echo/README.md`](apps/echo/README.md). It is therefore not `--workspace` CI-covered;
+if it ever gains a runtime consumer, migrate it like the three above.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ If a change might impact any invariant:
 
 **Current state (#2064 complete for runtime crates).** All runtime-integrated top-level app
 crates have been migrated under `icn/apps/*` and are now workspace-covered (`cargo
-test/clippy --workspace`): `icn-ledger-app` (#2070), `icn-governance-app` (#2071),
+test --workspace` / `cargo clippy --workspace`): `icn-ledger-app` (#2070), `icn-governance-app` (#2071),
 `icn-trust-app` (#2072) — each kept distinct from its `icn/apps/*` `*-actor` sibling.
 Top-level `apps/` now holds **only** `apps/echo` (`icn-app-echo`), which is **example-only**
 (no runtime consumers) and intentionally left outside the workspace — see

--- a/apps/echo/README.md
+++ b/apps/echo/README.md
@@ -1,0 +1,43 @@
+# `icn-app-echo` — example app (NOT runtime-integrated)
+
+**Classification: example/demo only.** This crate is the minimal reference
+implementation of the ICN app pattern (a `Reducer` + a `Service`, no
+`PolicyOracle`). It exists to prove the app runtime works and to show, by the
+smallest possible example, how a real app is structured. See `src/lib.rs`:
+*"A minimal test app that validates the app runtime works correctly … This app
+exists to prove the runtime works before we extract real apps like trust and
+governance."*
+
+## Why it is at top-level `apps/` and not in the `icn/` workspace
+
+- **It has no runtime consumers.** Nothing in the substrate depends on it — not
+  `icn-core`, not `icnd`, not `icn-gateway`, no other crate, and no CI workflow.
+  (The runtime-integrated app crates *did* have consumers: `icn-ledger-app` ←
+  `icn-gateway`/`icnd`, `icn-governance-app` ← `icnd`, `icn-trust-app` ←
+  `icn-core`/`icnd`.)
+- **[#2064](https://github.com/InterCooperative-Network/icn/issues/2064)'s
+  workspace migration applied to *runtime-integrated* top-level app crates** —
+  those that influence daemon/core/gateway-visible behavior and therefore must be
+  first-class in `cargo test/clippy --workspace`. All of them have been migrated
+  under `icn/apps/*`:
+  - `icn-ledger-app` → `icn/apps/ledger-app` ([#2070](https://github.com/InterCooperative-Network/icn/pull/2070))
+  - `icn-governance-app` → `icn/apps/governance-app` ([#2071](https://github.com/InterCooperative-Network/icn/pull/2071))
+  - `icn-trust-app` → `icn/apps/trust-app` ([#2072](https://github.com/InterCooperative-Network/icn/pull/2072))
+- **This crate is example-only, so it was deliberately *not* migrated** as a
+  runtime crate. It is left at top-level `apps/` and classified here so future
+  agents do not treat it as another #2064 coverage gap.
+
+## Honest caveat (no readiness-laundering)
+
+Because `icn-app-echo` is **not** a member of the `icn/` workspace, the standard
+CI gates (`cargo test --workspace`, `cargo clippy --workspace`) **do not cover
+it** — it compiles only when built directly. It currently builds clean against
+the current `icn-core` app API (verified: `cargo check --manifest-path
+apps/echo/Cargo.toml` succeeds), but as an uncovered crate it *can* drift/bit-rot
+if the app-runtime API changes and nobody rebuilds it. That is an accepted
+tradeoff for a demo example, not a hidden gap.
+
+If this crate ever gains a real runtime consumer, it stops being example-only and
+should be migrated under `icn/apps/` (collision-safe name, e.g. `echo-app`) and
+made a workspace member, exactly like the three crates above. See
+[`AGENTS.md`](../../AGENTS.md) → "App topology rule".

--- a/apps/echo/README.md
+++ b/apps/echo/README.md
@@ -18,8 +18,8 @@ governance."*
 - **[#2064](https://github.com/InterCooperative-Network/icn/issues/2064)'s
   workspace migration applied to *runtime-integrated* top-level app crates** —
   those that influence daemon/core/gateway-visible behavior and therefore must be
-  first-class in `cargo test/clippy --workspace`. All of them have been migrated
-  under `icn/apps/*`:
+  first-class in `cargo test --workspace` / `cargo clippy --workspace`. All of
+  them have been migrated under `icn/apps/*`:
   - `icn-ledger-app` → `icn/apps/ledger-app` ([#2070](https://github.com/InterCooperative-Network/icn/pull/2070))
   - `icn-governance-app` → `icn/apps/governance-app` ([#2071](https://github.com/InterCooperative-Network/icn/pull/2071))
   - `icn-trust-app` → `icn/apps/trust-app` ([#2072](https://github.com/InterCooperative-Network/icn/pull/2072))
@@ -32,8 +32,10 @@ governance."*
 Because `icn-app-echo` is **not** a member of the `icn/` workspace, the standard
 CI gates (`cargo test --workspace`, `cargo clippy --workspace`) **do not cover
 it** — it compiles only when built directly. It currently builds clean against
-the current `icn-core` app API (verified: `cargo check --manifest-path
-apps/echo/Cargo.toml` succeeds), but as an uncovered crate it *can* drift/bit-rot
+the current `icn-core` app API (verified from the **repo root**: `cargo check
+--manifest-path apps/echo/Cargo.toml` succeeds — note this resolves relative to
+the repo root, not the `icn/` workspace dir), but as an uncovered crate it *can*
+drift/bit-rot
 if the app-runtime API changes and nobody rebuilds it. That is an accepted
 tradeoff for a demo example, not a hidden gap.
 


### PR DESCRIPTION
## What
Classifies the **last** remaining top-level app crate, **`apps/echo` (`icn-app-echo`)**, as **example-only** — the final step of #2064. Docs-only: adds `apps/echo/README.md` and records the completed end-state in `AGENTS.md`'s "App topology rule". **No code/manifest change; nothing migrated or removed.**

## #2064 was implemented in slices
- ✅ #2070 — `icn-ledger-app` → `icn/apps/ledger-app` (ledger)
- ✅ #2071 — `icn-governance-app` → `icn/apps/governance-app` (governance)
- ✅ #2072 — `icn-trust-app` → `icn/apps/trust-app` (trust)
- ✅ **this PR** — classify `apps/echo`

## Classification result: example-only (not migrated)
`icn-app-echo` is a minimal reference app — *"validates the app runtime"*; a `Reducer` + a `Service`, **no `PolicyOracle`** (`src/lib.rs`: *"proves the runtime works before we extract real apps like trust and governance"*). Evidence it is **not** runtime-integrated:
- **Zero runtime consumers.** No Cargo manifest depends on it — not `icn-core`, `icnd`, or `icn-gateway`; no other crate; no CI workflow. (The migrated crates all *had* consumers.)
- **Healthy, not stale.** Compiles clean against the current `icn-core` app API (verified: `cargo check --manifest-path apps/echo/Cargo.toml` → exit 0).

Because it has no runtime dependents, **no migration was needed** — #2064's workspace migration applies to *runtime-integrated* crates. It is left at top-level `apps/` and clearly marked as example-only so future agents don't treat it as another coverage gap.

## Final topology
- **Runtime-integrated app crates → `icn/apps/*`, workspace-covered** by `cargo test/clippy --workspace` (ledger-app, governance-app, trust-app), each distinct from its `*-actor` sibling.
- **Top-level `apps/` now holds only `apps/echo`**, classified as example-only.

## Honest caveat (no readiness-laundering)
Because `apps/echo` is outside the `icn/` workspace, `--workspace` CI does **not** cover it — it can bit-rot if the app-runtime API changes and nobody rebuilds it. That is an accepted tradeoff for a demo example (documented in its README), **not** a hidden gap. If it ever gains a runtime consumer, it should be migrated like the three crates above.

## What remains
After this is reviewed/merged, #2064's classification of all top-level `apps/*` is complete. (#2064 should not be claimed fully closed until this merges.)

## Test plan
- Docs-only; no Cargo manifests touched.
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — PASS.
- Relative links resolve (`README → ../../AGENTS.md`, `AGENTS → apps/echo/README.md`).
- `icn-app-echo` standalone build verified green (context for the classification).

Refs #2064.