### PR TITLE
test(gateway): characterize self-asserted coop_id authz gap (#2075)

### DIFF
--- a/icn/crates/icn-gateway/src/middleware.rs
+++ b/icn/crates/icn-gateway/src/middleware.rs
@@ -402,4 +402,92 @@ mod tests {
         let result = auth2.verify_token(&token);
         assert!(matches!(result, Err(GatewayError::AuthenticationFailed(_))));
     }
+
+    /// Characterization test for #2075 — token issuance accepts a self-asserted
+    /// `coop_id`, and `require_coop_access` then trusts that unverified claim.
+    ///
+    /// THIS PINS CURRENT (INSECURE) BEHAVIOR, NOT DESIRED BEHAVIOR.
+    ///
+    /// An arbitrary DID proves only *ownership* of its own key (challenge →
+    /// sign → verify). The gateway nonetheless mints it a capability token whose
+    /// `coop_id` and `scopes` are whatever the caller asked for, with **no
+    /// membership/agency check** binding that DID to that cooperative
+    /// (`auth::issue_token`). `require_coop_access` is a plain
+    /// `claims.coop_id == coop_id` equality, so the holder passes the cross-coop
+    /// guard on a cooperative it never joined.
+    ///
+    /// The `is_ok()` assertion below encodes the bypass so it is pinned in CI.
+    /// When the token↔coop binding gate from RFC-0018 (#2074) lands, this
+    /// expectation MUST flip to rejection — that inversion is the signal the
+    /// fix is complete. This PR does **not** fix the bug; it characterizes it.
+    /// See #2075.
+    #[actix_web::test]
+    async fn self_asserted_coop_id_currently_passes_require_coop_access() {
+        // An attacker controls a fresh DID — and nothing else.
+        let auth = Arc::new(AuthManager::new(b"test_secret".to_vec()));
+        let attacker = IdentityBundle::generate().unwrap();
+
+        // A cooperative the attacker is NOT a member of.
+        let victim_coop = "victim-coop";
+
+        // 1) Prove DID ownership: challenge → sign → verify.
+        let nonce = auth.create_challenge(attacker.did()).unwrap();
+        let nonce_bytes = hex::decode(&nonce).unwrap();
+        let signature = attacker
+            .sign(&nonce_bytes)
+            .expect("test setup: bundle must be able to sign nonce (software key configured)");
+
+        // 2) Mint a token asserting authority over `victim_coop` + a write scope.
+        //    The gateway performs NO membership check on the supplied `coop_id`.
+        let token = auth
+            .verify_challenge(
+                attacker.did(),
+                &signature.to_bytes(),
+                victim_coop,
+                vec!["ledger:write".to_string()],
+            )
+            .unwrap();
+
+        // 3) The issued token carries the self-asserted coop_id verbatim.
+        let claims = auth.verify_token(&token).unwrap();
+        assert_eq!(claims.sub, attacker.did().to_string());
+        assert_eq!(
+            claims.coop_id, victim_coop,
+            "current behavior: issuance stores the caller-supplied coop_id with no binding check",
+        );
+
+        // 4) The flat cross-coop guard trusts that self-minted claim.
+        let req = TestRequest::default().to_http_request();
+        req.extensions_mut().insert(claims);
+
+        // KNOWN GAP (#2075): once the token↔coop binding gate lands this SHOULD
+        // be denied. It currently passes because the DID was never bound to the
+        // coop. When the fix lands, invert this assertion.
+        assert!(
+            require_coop_access(&req, victim_coop).is_ok(),
+            "characterization: require_coop_access currently accepts a self-asserted coop_id",
+        );
+    }
+
+    /// Companion to the #2075 characterization: the equality check inside
+    /// `require_coop_access` is itself sound — a token for coop A is still
+    /// rejected against coop B. This localizes the #2075 gap to *issuance*
+    /// (which never binds the DID to the coop), NOT to a broken comparison, so a
+    /// future fix targets the right layer and does not weaken this guard.
+    #[actix_web::test]
+    async fn require_coop_access_rejects_token_for_a_different_coop() {
+        let req = TestRequest::default().to_http_request();
+        req.extensions_mut().insert(TokenClaims {
+            sub: "did:icn:test-user".to_string(),
+            iat: 1_000_000_000,
+            exp: 9_999_999_999,
+            coop_id: "coop-a".to_string(),
+            scopes: vec!["ledger:write".to_string()],
+        });
+
+        assert!(matches!(
+            require_coop_access(&req, "coop-b"),
+            Err(GatewayError::AuthorizationFailed(_))
+        ));
+    }
 }


### PR DESCRIPTION
## What

First slice of #2075. Adds two in-process **characterization tests** to `icn-gateway`'s
middleware test module that pin the current token↔coop authorization behavior. **No
production code changes — test-only. This PR does not fix the bug.**

- `self_asserted_coop_id_currently_passes_require_coop_access` — drives the full path: a
  fresh DID proves only key *ownership* (challenge → sign → verify), is issued a token whose
  `coop_id` + `scopes` are caller-supplied with no membership check, and then passes
  `require_coop_access` for a cooperative it never joined. The assertion encodes the bypass.
- `require_coop_access_rejects_token_for_a_different_coop` — companion proving the guard's
  `claims.coop_id == coop_id` equality is itself sound. This localizes the gap to *issuance*
  (the DID is never bound to the coop), not to a broken comparison.

## Why

Surfaced while reviewing RFC-0018 (#2074) and traced in #2075: `auth::issue_token` writes a
self-asserted `coop_id`/`scopes` into `TokenClaims` after verifying **only** DID ownership, so
`require_coop_access` (`middleware.rs:138`) trusts a claim the gateway never verified. At the
code level an arbitrary DID can mint a token for any well-formed `coop_id` and pass the flat
cross-coop guard. Pinning this in CI gives the fix a concrete tripwire and documents the gap
where reviewers will see it, not only in prose.

**This is a code-level authorization weakness, not a demonstrated production incident** — the
only thing preventing exploitation today is pre-production / non-exposure posture (no live
deployment confirmed reachable by untrusted token requesters). The commons/jurisdiction layer
(`require_*_in_jurisdiction`) is unaffected; only the flat `require_scope`+`require_coop_access`
endpoints are.

## How

Tests live next to `require_coop_access` (the trust point) and reuse the module's existing
fixtures (`AuthManager`, `IdentityBundle`, `TestRequest`, `TokenClaims` injection) — no new
dependencies, no live service, no network. Style is *passing characterization*: the assertions
match current behavior so `main` stays releasable. A loud doc-comment marks them as pinning
**insecure** behavior and instructs the fixer to invert the `is_ok()` expectation when the
binding gate lands — that inversion is the signal the fix is complete.

## Risk

Minimal — test-only, additive (+88 lines, one file). Worst case is a future maintainer
misreading a passing test as desired behavior; mitigated by the explicit "THIS PINS CURRENT
(INSECURE) BEHAVIOR" doc-comment and the #2075 references.

## Test plan

- `cargo fmt --all --check` — clean.
- `cargo test -p icn-gateway --lib` — both new tests pass alongside the existing suite.
- `cargo clippy -p icn-gateway --all-targets -- -D warnings` — clean.

## Boundaries / honesty

- Confirms the **token↔coop binding gate** from RFC-0018 is necessary; does **not** implement
  it. No broad `require_entity_access` / entity-aware auth here.
- No existing guard weakened; no endpoint families migrated; no NYCN-specific rules.
- Follow-up PR (#2075) implements the binding fix with equivalent-or-stronger tests, keeping
  any self-service/demo issuance behind an explicit dev gate.

Refs #2075. Related: RFC-0018 (#2074), #2061, #2058 / #2052 / #2056,
`docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md`.
