### PR TITLE
fix(gateway): gate self-asserted coop issuance (#2075)

### DIFF
--- a/demo/nycn-dogfood/run.sh
+++ b/demo/nycn-dogfood/run.sh
@@ -158,7 +158,11 @@ start_gw(){
   "$ICND" --init --data-dir "$DATA_DIR" --init-gateway-port "$GW_PORT" --init-gossip-port "$GOSSIP_PORT" </dev/null >"$RUN_DIR/node-init.log" 2>&1 || die "node identity init failed (see $RUN_DIR/node-init.log)"
   sed -i "s#^listen_addr = \"0.0.0.0:${GOSSIP_PORT}\"#listen_addr = \"127.0.0.1:${GOSSIP_PORT}\"#" "$DATA_DIR/config.toml" 2>/dev/null || true
   local secret; secret="$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
-  setsid "$ICND" --config "$DATA_DIR/config.toml" --data-dir "$DATA_DIR" --gateway-enable \
+  # Dev gate (issue #2075): self-asserted /auth/verify coop issuance is fail-closed
+  # unless ICN_DEV_MODE is set. This rehearsal mints tokens that way on a loopback
+  # gateway, so opt into the explicit dev posture for this process only. Never set
+  # this on a production gateway.
+  ICN_DEV_MODE=1 setsid "$ICND" --config "$DATA_DIR/config.toml" --data-dir "$DATA_DIR" --gateway-enable \
     --gateway-bind "127.0.0.1:${GW_PORT}" --gateway-jwt-secret "$secret" \
     --log-level warn >"$LOG" 2>&1 </dev/null &
   local pid=$!

--- a/demo/scripts/start-demo.sh
+++ b/demo/scripts/start-demo.sh
@@ -49,6 +49,7 @@ fi
 echo "[4/4] Starting gateway on port 8080..."
 ICN_KEYSTORE_PASSPHRASE=demo \
 ICN_GATEWAY_JWT_SECRET="$JWT_SECRET" \
+ICN_DEV_MODE=1 \
 nohup "$ICND" \
   --gateway-enable \
   --gateway-bind "$BIND" \

--- a/demo/scripts/start-demo.sh
+++ b/demo/scripts/start-demo.sh
@@ -47,9 +47,13 @@ if [ ! -f "$DATA_DIR/identity.age" ]; then
 fi
 
 echo "[4/4] Starting gateway on port 8080..."
+# NOTE (issue #2075): this demo binds the gateway to all interfaces ($BIND, default
+# 0.0.0.0). Self-asserted /auth/verify coop issuance is gated on a loopback bind, so
+# do NOT set ICN_DEV_MODE here — it would not enable self-serve on 0.0.0.0 anyway
+# (fail-closed by design), and must never be combined with an all-interfaces bind.
+# For a local self-serve demo, bind loopback (127.0.0.1) and set ICN_DEV_MODE=1.
 ICN_KEYSTORE_PASSPHRASE=demo \
 ICN_GATEWAY_JWT_SECRET="$JWT_SECRET" \
-ICN_DEV_MODE=1 \
 nohup "$ICND" \
   --gateway-enable \
   --gateway-bind "$BIND" \

--- a/icn/bins/icnctl/src/institution_bootstrap.rs
+++ b/icn/bins/icnctl/src/institution_bootstrap.rs
@@ -1727,7 +1727,7 @@ mod tests {
         async fn start_test_server() -> (tokio::task::JoinHandle<()>, String, BootstrapAuthContext)
         {
             let jwt_secret = b"bootstrap-apply-integration-test!".to_vec();
-            let auth_mgr = Arc::new(AuthManager::new(jwt_secret));
+            let auth_mgr = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
             let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
             let entity_mgr = Arc::new(EntityManager::new());
             let store = Arc::new(SledStore::temporary().expect("temp sled store"));

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -647,6 +647,19 @@ async fn main() -> Result<()> {
         // intentionally public and constant: in this dev-only mode auth is not a
         // real boundary, which the loopback guard above makes safe to expose.
         config.gateway.jwt_secret = INSECURE_DEV_JWT_SECRET.to_string();
+
+        // SECURITY (issue #2075): the gateway now fail-closes self-asserted
+        // `/auth/verify` coop issuance unless its dev posture (`ICN_DEV_MODE`)
+        // is set. This loopback-only insecure-no-jwt hatch IS a dev posture and
+        // its challenge/verify flow is expected to work (above), so opt into the
+        // dev posture here — otherwise the documented local `icnctl auth token`
+        // / bootstrap smoke paths would start returning 403. Only set it when
+        // unset so an explicit operator `ICN_DEV_MODE` value still wins; the
+        // loopback guard above keeps this bounded to local dev. (edition 2021:
+        // `set_var` is safe.)
+        if std::env::var_os("ICN_DEV_MODE").is_none() {
+            std::env::set_var("ICN_DEV_MODE", "1");
+        }
     }
 
     // Handle --validate-config flag

--- a/icn/bins/icnd/src/main.rs
+++ b/icn/bins/icnd/src/main.rs
@@ -649,17 +649,16 @@ async fn main() -> Result<()> {
         config.gateway.jwt_secret = INSECURE_DEV_JWT_SECRET.to_string();
 
         // SECURITY (issue #2075): the gateway now fail-closes self-asserted
-        // `/auth/verify` coop issuance unless its dev posture (`ICN_DEV_MODE`)
-        // is set. This loopback-only insecure-no-jwt hatch IS a dev posture and
-        // its challenge/verify flow is expected to work (above), so opt into the
-        // dev posture here — otherwise the documented local `icnctl auth token`
-        // / bootstrap smoke paths would start returning 403. Only set it when
-        // unset so an explicit operator `ICN_DEV_MODE` value still wins; the
-        // loopback guard above keeps this bounded to local dev. (edition 2021:
-        // `set_var` is safe.)
-        if std::env::var_os("ICN_DEV_MODE").is_none() {
-            std::env::set_var("ICN_DEV_MODE", "1");
-        }
+        // `/auth/verify` coop issuance unless a dev posture is set. This
+        // loopback-only insecure-no-jwt hatch IS a dev posture and its
+        // challenge/verify flow is expected to work (above), so opt into it via
+        // config — otherwise the documented local `icnctl auth token` /
+        // bootstrap smoke paths would start returning 403. Carried through
+        // `GatewayConfig` to `GatewayServer::with_dev_self_serve_auth` rather
+        // than mutating `ICN_DEV_MODE` in the process env, which would race other
+        // threads reading the environment after the Tokio runtime has started.
+        // The loopback guard above keeps this bounded to local dev.
+        config.gateway.dev_self_serve_auth = true;
     }
 
     // Handle --validate-config flag

--- a/icn/crates/icn-core/src/config/gateway.rs
+++ b/icn/crates/icn-core/src/config/gateway.rs
@@ -45,12 +45,17 @@ pub struct GatewayConfig {
     pub service_discovery_persist: bool,
 
     /// Dev/demo posture: allow self-asserted `/auth/verify` coop issuance without
-    /// the `ICN_DEV_MODE` env var (issue #2075). Off by default (fail-closed);
-    /// the daemon sets this for the loopback-only `--insecure-gateway-no-jwt`
-    /// hatch so its challenge/verify smoke path keeps working without mutating
-    /// process environment after the Tokio runtime starts. Not a config-file
-    /// knob today; defaults false on deserialization.
-    #[serde(default)]
+    /// the `ICN_DEV_MODE` env var (issue #2075). Runtime-only — the daemon sets
+    /// this in-memory for the loopback-only `--insecure-gateway-no-jwt` hatch so
+    /// its challenge/verify smoke path keeps working without mutating process
+    /// environment after the Tokio runtime starts.
+    ///
+    /// SECURITY: `#[serde(skip)]` (NOT `serde(default)`) so it can NEVER be set
+    /// from a config file. Otherwise `[gateway] dev_self_serve_auth = true` in
+    /// operator TOML would silently reopen arbitrary coop-token issuance on an
+    /// externally-bound, real-JWT gateway. It is reachable only via the
+    /// insecure-loopback CLI path. Always deserializes to `false`.
+    #[serde(skip)]
     pub dev_self_serve_auth: bool,
 }
 

--- a/icn/crates/icn-core/src/config/gateway.rs
+++ b/icn/crates/icn-core/src/config/gateway.rs
@@ -43,6 +43,15 @@ pub struct GatewayConfig {
     /// are automatically expired on reload.
     #[serde(default)]
     pub service_discovery_persist: bool,
+
+    /// Dev/demo posture: allow self-asserted `/auth/verify` coop issuance without
+    /// the `ICN_DEV_MODE` env var (issue #2075). Off by default (fail-closed);
+    /// the daemon sets this for the loopback-only `--insecure-gateway-no-jwt`
+    /// hatch so its challenge/verify smoke path keeps working without mutating
+    /// process environment after the Tokio runtime starts. Not a config-file
+    /// knob today; defaults false on deserialization.
+    #[serde(default)]
+    pub dev_self_serve_auth: bool,
 }
 
 fn default_gateway_bind_addr() -> String {
@@ -68,6 +77,7 @@ impl Default for GatewayConfig {
             audit_retention: AuditRetentionConfig::default(),
             default_trust_score: None,
             service_discovery_persist: false,
+            dev_self_serve_auth: false,
         }
     }
 }

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -150,6 +150,10 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let execution_query_store = handles.execution_query_store;
     let post_backfill_cleanup = handles.post_backfill_cleanup;
     let default_trust_score = config.default_trust_score;
+    // Dev/demo posture (issue #2075): carried by config (set for the loopback
+    // `--insecure-gateway-no-jwt` hatch) instead of an env var, so it does not
+    // race threads reading the environment after the runtime has started.
+    let dev_self_serve_auth = config.dev_self_serve_auth;
 
     // Spawn gateway in a dedicated thread (actix-web has its own runtime)
     std::thread::spawn(move || {
@@ -167,6 +171,9 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
             } else {
                 icn_gateway::GatewayServer::new(gateway_addr, jwt_secret)
             };
+
+            // Dev/demo self-serve auth posture (issue #2075), race-free via config.
+            gateway_server = gateway_server.with_dev_self_serve_auth(dev_self_serve_auth);
 
             // Connect optional handles
             if let Some(handle) = compute_handle {

--- a/icn/crates/icn-gateway/src/api/auth.rs
+++ b/icn/crates/icn-gateway/src/api/auth.rs
@@ -170,7 +170,9 @@ mod tests {
 
     #[actix_web::test]
     async fn test_verify_endpoint_success() {
-        let auth = Arc::new(AuthManager::new(b"test_secret".to_vec()));
+        // Dev/demo self-service issuance: caller supplies its own coop_id (#2075).
+        let auth =
+            Arc::new(AuthManager::new(b"test_secret".to_vec()).with_self_asserted_coop(true));
         let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
         let bundle = IdentityBundle::generate().unwrap();
 

--- a/icn/crates/icn-gateway/src/auth.rs
+++ b/icn/crates/icn-gateway/src/auth.rs
@@ -26,7 +26,10 @@
 //! # use icn_identity::IdentityBundle;
 //! # use icn_gateway::auth::AuthManager;
 //! let bundle = IdentityBundle::generate().unwrap();
-//! let auth = AuthManager::new(b"secret".to_vec());
+//! // Dev/demo only: enable self-service issuance with a caller-supplied coop_id.
+//! // Production leaves this off (fail-closed) and binds coop authority via
+//! // trusted issuance paths (invites/sessions/enrollment). See issue #2075.
+//! let auth = AuthManager::new(b"secret".to_vec()).with_self_asserted_coop(true);
 //!
 //! // Get challenge
 //! let nonce = auth.create_challenge(bundle.did()).unwrap();
@@ -52,7 +55,10 @@
 //! # use std::sync::Arc;
 //! # use ed25519_dalek::SigningKey;
 //! # use rand_core::OsRng;
-//! let auth = AuthManager::new(b"secret".to_vec());
+//! // Dev/demo only: enable self-service issuance with a caller-supplied coop_id.
+//! // Production leaves this off (fail-closed) and binds coop authority via
+//! // trusted issuance paths (invites/sessions/enrollment). See issue #2075.
+//! let auth = AuthManager::new(b"secret".to_vec()).with_self_asserted_coop(true);
 //!
 //! // Hardware-backed key (private key in HSM/TPM)
 //! # let sk = SigningKey::generate(&mut OsRng);
@@ -121,17 +127,49 @@ pub struct AuthManager {
     jwt_secret: Vec<u8>,
     challenge_ttl: Duration,
     token_ttl: Duration,
+    /// Whether the challenge/verify flow may mint a token carrying a
+    /// **caller-supplied** `coop_id` (see [`AuthManager::verify_challenge`]).
+    ///
+    /// SECURITY (issue #2075): DID ownership proves only that the caller holds a
+    /// key — it does **not** authorize that DID to act for an arbitrary
+    /// cooperative. When this is `false` (the safe default), `verify_challenge`
+    /// fails closed instead of binding self-asserted coop authority into a token.
+    /// It may be enabled only for dev/demo deployments via
+    /// [`AuthManager::with_self_asserted_coop`]. Production binds coop authority
+    /// through trusted issuance paths (invites/sessions/enrollment) and,
+    /// ultimately, RFC-0018's membership/entity binding.
+    allow_self_asserted_coop: bool,
 }
 
 impl AuthManager {
-    /// Create new auth manager
+    /// Create new auth manager.
+    ///
+    /// Self-asserted cooperative authority via the challenge/verify flow is
+    /// **disabled by default** (fail-closed); enable it for dev/demo only with
+    /// [`AuthManager::with_self_asserted_coop`].
     pub fn new(jwt_secret: Vec<u8>) -> Self {
         Self {
             challenges: Arc::new(RwLock::new(HashMap::new())),
             jwt_secret,
             challenge_ttl: Duration::from_secs(300), // 5 minutes
             token_ttl: Duration::from_secs(3600),    // 1 hour
+            allow_self_asserted_coop: false,
         }
+    }
+
+    /// Enable (or disable) self-service capability-token issuance via the
+    /// challenge/verify flow, where the caller chooses its own `coop_id`.
+    ///
+    /// SECURITY (issue #2075): enabling this permits a DID that has proven only
+    /// key ownership to mint a token carrying an **unverified** `coop_id`, which
+    /// `require_coop_access` then trusts. It MUST be restricted to dev/demo
+    /// deployments. The gateway wires this from the `ICN_DEV_MODE` posture; it is
+    /// off in production, where coop authority is bound through trusted issuance
+    /// paths (invites/sessions/enrollment) until RFC-0018's membership/entity
+    /// binding lands.
+    pub fn with_self_asserted_coop(mut self, enabled: bool) -> Self {
+        self.allow_self_asserted_coop = enabled;
+        self
     }
 
     /// Generate a challenge for a DID
@@ -229,6 +267,22 @@ impl AuthManager {
         // Short-circuit || would skip expiration check if signature invalid, creating timing leak
         if !signature_valid | is_expired {
             return Err(auth_error());
+        }
+
+        // SECURITY (issue #2075): identity is now proven, but the caller-supplied
+        // `coop_id` is NOT. DID ownership does not authorize this DID to act for
+        // an arbitrary cooperative, and `require_coop_access` trusts whatever
+        // `coop_id` lands in the token. Fail closed: refuse to bind self-asserted
+        // coop authority unless explicitly enabled for a dev/demo deployment.
+        // Production binds coop authority via trusted issuance paths
+        // (invites/sessions/enrollment) and, ultimately, RFC-0018's
+        // membership/entity binding. AuthorizationFailed (403), not
+        // AuthenticationFailed (401): the identity check passed; the coop claim
+        // is what is unauthorized.
+        if !self.allow_self_asserted_coop {
+            return Err(GatewayError::AuthorizationFailed(
+                "self-asserted cooperative authority is not permitted".to_string(),
+            ));
         }
 
         // Issue JWT token
@@ -354,7 +408,8 @@ mod tests {
 
     #[test]
     fn test_verify_challenge_success() {
-        let auth = AuthManager::new(b"test_secret".to_vec());
+        // Dev/demo self-service issuance: caller supplies its own coop_id (#2075).
+        let auth = AuthManager::new(b"test_secret".to_vec()).with_self_asserted_coop(true);
         let bundle = IdentityBundle::generate().unwrap();
 
         // Create challenge
@@ -426,7 +481,8 @@ mod tests {
         use rand_core::OsRng;
         use std::sync::Arc;
 
-        let auth = AuthManager::new(b"test_secret".to_vec());
+        // Dev/demo self-service issuance: caller supplies its own coop_id (#2075).
+        let auth = AuthManager::new(b"test_secret".to_vec()).with_self_asserted_coop(true);
 
         // Create a software signing key (for the backend), but present it as "hardware" to the bundle
         let signing_key = SigningKey::generate(&mut OsRng);
@@ -461,5 +517,60 @@ mod tests {
             .unwrap();
 
         assert!(!token.is_empty());
+    }
+
+    /// SECURITY (#2075): with the safe default (`AuthManager::new`), a DID that
+    /// has proven only key ownership must NOT be able to mint a token for a
+    /// self-asserted `coop_id`. Issuance fails closed with AuthorizationFailed
+    /// even though the signature is valid — identity is proven, but the coop
+    /// claim is not authorized.
+    #[test]
+    fn test_verify_challenge_self_asserted_coop_rejected_by_default() {
+        let auth = AuthManager::new(b"test_secret".to_vec()); // fail-closed default
+        let bundle = IdentityBundle::generate().unwrap();
+
+        let nonce = auth.create_challenge(bundle.did()).unwrap();
+        let nonce_bytes = hex::decode(&nonce).unwrap();
+        let signature = bundle
+            .sign(&nonce_bytes)
+            .expect("test setup: bundle must be able to sign nonce");
+
+        let result = auth.verify_challenge(
+            bundle.did(),
+            &signature.to_bytes(),
+            "some-coop",
+            vec!["ledger:write".to_string()],
+        );
+
+        assert!(
+            matches!(result, Err(GatewayError::AuthorizationFailed(_))),
+            "self-asserted coop authority must be rejected when not explicitly enabled",
+        );
+    }
+
+    /// The dev/demo bypass is opt-in and explicit: with
+    /// `with_self_asserted_coop(true)` the same flow succeeds and the token
+    /// carries the requested coop_id. This documents the intentional dev path.
+    #[test]
+    fn test_verify_challenge_self_asserted_coop_allowed_in_dev() {
+        let auth = AuthManager::new(b"test_secret".to_vec()).with_self_asserted_coop(true);
+        let bundle = IdentityBundle::generate().unwrap();
+
+        let nonce = auth.create_challenge(bundle.did()).unwrap();
+        let nonce_bytes = hex::decode(&nonce).unwrap();
+        let signature = bundle
+            .sign(&nonce_bytes)
+            .expect("test setup: bundle must be able to sign nonce");
+
+        let token = auth
+            .verify_challenge(
+                bundle.did(),
+                &signature.to_bytes(),
+                "some-coop",
+                vec!["ledger:write".to_string()],
+            )
+            .expect("dev mode permits self-service issuance");
+        let claims = auth.verify_token(&token).unwrap();
+        assert_eq!(claims.coop_id, "some-coop");
     }
 }

--- a/icn/crates/icn-gateway/src/middleware.rs
+++ b/icn/crates/icn-gateway/src/middleware.rs
@@ -347,7 +347,9 @@ mod tests {
 
     #[actix_web::test]
     async fn test_jwt_auth_valid_token() {
-        let auth = Arc::new(AuthManager::new(b"test_secret".to_vec()));
+        // Dev/demo self-service issuance: caller supplies its own coop_id (#2075).
+        let auth =
+            Arc::new(AuthManager::new(b"test_secret".to_vec()).with_self_asserted_coop(true));
         let bundle = IdentityBundle::generate().unwrap();
 
         // Create challenge and get token
@@ -383,8 +385,8 @@ mod tests {
 
     #[actix_web::test]
     async fn test_jwt_auth_expired_token() {
-        // Create token with different secret
-        let auth1 = Arc::new(AuthManager::new(b"secret1".to_vec()));
+        // Create token with different secret (dev self-service issuance for the mint).
+        let auth1 = Arc::new(AuthManager::new(b"secret1".to_vec()).with_self_asserted_coop(true));
         let auth2 = Arc::new(AuthManager::new(b"secret2".to_vec()));
 
         let bundle = IdentityBundle::generate().unwrap();
@@ -403,69 +405,66 @@ mod tests {
         assert!(matches!(result, Err(GatewayError::AuthenticationFailed(_))));
     }
 
-    /// Characterization test for #2075 — token issuance accepts a self-asserted
-    /// `coop_id`, and `require_coop_access` then trusts that unverified claim.
+    /// Regression test for #2075 — self-asserted cooperative authority is
+    /// rejected at issuance by default.
     ///
-    /// THIS PINS CURRENT (INSECURE) BEHAVIOR, NOT DESIRED BEHAVIOR.
-    ///
-    /// An arbitrary DID proves only *ownership* of its own key (challenge →
-    /// sign → verify). The gateway nonetheless mints it a capability token whose
-    /// `coop_id` and `scopes` are whatever the caller asked for, with **no
-    /// membership/agency check** binding that DID to that cooperative
-    /// (`auth::issue_token`). `require_coop_access` is a plain
-    /// `claims.coop_id == coop_id` equality, so the holder passes the cross-coop
-    /// guard on a cooperative it never joined.
-    ///
-    /// The `is_ok()` assertion below encodes the bypass so it is pinned in CI.
-    /// When the token↔coop binding gate from RFC-0018 (#2074) lands, this
-    /// expectation MUST flip to rejection — that inversion is the signal the
-    /// fix is complete. This PR does **not** fix the bug; it characterizes it.
-    /// See #2075.
+    /// This is the inversion of the original #2076 characterization
+    /// (`self_asserted_coop_id_currently_passes_require_coop_access`), which
+    /// pinned the *insecure* behavior: a DID that proved only key ownership could
+    /// mint a token carrying any `coop_id`, and `require_coop_access` trusted it.
+    /// With the #2075 fix, `verify_challenge` fails closed unless self-asserted
+    /// issuance is explicitly enabled for dev/demo. The second half shows the
+    /// dev/demo bypass still mints such a token — which is exactly why that path
+    /// must stay gated: once minted, the flat guard trusts the claim.
     #[actix_web::test]
-    async fn self_asserted_coop_id_currently_passes_require_coop_access() {
+    async fn self_asserted_coop_id_is_rejected_at_issuance_by_default() {
         // An attacker controls a fresh DID — and nothing else.
-        let auth = Arc::new(AuthManager::new(b"test_secret".to_vec()));
         let attacker = IdentityBundle::generate().unwrap();
-
         // A cooperative the attacker is NOT a member of.
         let victim_coop = "victim-coop";
 
-        // 1) Prove DID ownership: challenge → sign → verify.
+        // ── Production posture (safe default): issuance fails closed. ──────────
+        let auth = Arc::new(AuthManager::new(b"test_secret".to_vec()));
         let nonce = auth.create_challenge(attacker.did()).unwrap();
         let nonce_bytes = hex::decode(&nonce).unwrap();
         let signature = attacker
             .sign(&nonce_bytes)
             .expect("test setup: bundle must be able to sign nonce (software key configured)");
 
-        // 2) Mint a token asserting authority over `victim_coop` + a write scope.
-        //    The gateway performs NO membership check on the supplied `coop_id`.
-        let token = auth
+        // DID ownership is proven, but the self-asserted `coop_id` is not
+        // authorized: issuance is refused. The bypass is closed at the source.
+        let result = auth.verify_challenge(
+            attacker.did(),
+            &signature.to_bytes(),
+            victim_coop,
+            vec!["ledger:write".to_string()],
+        );
+        assert!(
+            matches!(result, Err(GatewayError::AuthorizationFailed(_))),
+            "#2075 fix: self-asserted coop authority must be rejected at issuance",
+        );
+
+        // ── Dev/demo posture (explicit opt-in): issuance still works, and the
+        //    flat guard trusts the self-minted claim — the reason it stays gated.
+        let dev_auth =
+            Arc::new(AuthManager::new(b"test_secret".to_vec()).with_self_asserted_coop(true));
+        let nonce = dev_auth.create_challenge(attacker.did()).unwrap();
+        let nonce_bytes = hex::decode(&nonce).unwrap();
+        let signature = attacker.sign(&nonce_bytes).expect("sign nonce");
+        let token = dev_auth
             .verify_challenge(
                 attacker.did(),
                 &signature.to_bytes(),
                 victim_coop,
                 vec!["ledger:write".to_string()],
             )
-            .unwrap();
-
-        // 3) The issued token carries the self-asserted coop_id verbatim.
-        let claims = auth.verify_token(&token).unwrap();
-        assert_eq!(claims.sub, attacker.did().to_string());
-        assert_eq!(
-            claims.coop_id, victim_coop,
-            "current behavior: issuance stores the caller-supplied coop_id with no binding check",
-        );
-
-        // 4) The flat cross-coop guard trusts that self-minted claim.
+            .expect("dev mode permits self-service issuance");
+        let claims = dev_auth.verify_token(&token).unwrap();
         let req = TestRequest::default().to_http_request();
         req.extensions_mut().insert(claims);
-
-        // KNOWN GAP (#2075): once the token↔coop binding gate lands this SHOULD
-        // be denied. It currently passes because the DID was never bound to the
-        // coop. When the fix lands, invert this assertion.
         assert!(
             require_coop_access(&req, victim_coop).is_ok(),
-            "characterization: require_coop_access currently accepts a self-asserted coop_id",
+            "dev-mode self-asserted token still passes the flat guard (why issuance must be gated)",
         );
     }
 

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -601,12 +601,16 @@ impl GatewayServer {
         // token carrying its own `coop_id`, which `require_coop_access` then
         // trusts. DID ownership alone does not authorize that coop, so this
         // self-asserted issuance is fail-closed by default and only enabled for
-        // dev/demo deployments via the existing `ICN_DEV_MODE` posture (matching
-        // the gateway's dev-security convention used for CORS above). Production
+        // dev/demo deployments via an explicit truthy `ICN_DEV_MODE` ("1"/"true",
+        // matching the `ICN_SKIP_CORS` toggle convention in `security.rs`). The
+        // truthy parse is stricter than the CORS dev gate's bare presence check
+        // on purpose: `ICN_DEV_MODE=0` must NOT open this auth bypass. Production
         // binds coop authority through trusted issuance paths
         // (invites/sessions/enrollment) until RFC-0018's membership/entity
         // binding lands.
-        let allow_self_asserted_coop = std::env::var("ICN_DEV_MODE").is_ok();
+        let allow_self_asserted_coop = std::env::var("ICN_DEV_MODE")
+            .map(|v| v == "1" || v == "true")
+            .unwrap_or(false);
         if allow_self_asserted_coop {
             warn!(
                 "⚠️  ICN_DEV_MODE: self-asserted cooperative authority is ENABLED at \

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -166,6 +166,18 @@ pub struct GatewayServer {
     dev_self_serve_auth: bool,
 }
 
+/// Decide whether self-asserted `/auth/verify` coop issuance may be enabled
+/// (issue #2075).
+///
+/// Requires BOTH an opted-in dev posture AND a loopback bind. The loopback
+/// condition is the safety invariant: self-serve can never be reached by an
+/// untrusted remote caller, even if a dev posture is mistakenly set on an
+/// all-interfaces listener. Mirrors the `--insecure-gateway-no-jwt` loopback
+/// guard. Kept as a free function so the invariant is unit-tested directly.
+fn self_serve_coop_allowed(dev_opt_in: bool, bind_addr: &SocketAddr) -> bool {
+    dev_opt_in && bind_addr.ip().is_loopback()
+}
+
 impl GatewayServer {
     /// Create a new gateway server (uses temporary storage for testing)
     pub fn new(bind_addr: SocketAddr, jwt_secret: Vec<u8>) -> Self {
@@ -328,7 +340,9 @@ impl GatewayServer {
     /// loopback-only local-dev hatch) to keep its challenge/verify smoke path
     /// working without mutating process environment after the Tokio runtime has
     /// started. `run()` OR's this with the `ICN_DEV_MODE` env read, so it never
-    /// disables an env-configured dev posture — it only adds one.
+    /// disables an env-configured dev posture — it only adds one. Self-serve is
+    /// additionally gated on a loopback bind (see `self_serve_coop_allowed`), so
+    /// setting this on an all-interfaces listener does NOT expose `/auth/verify`.
     pub fn with_dev_self_serve_auth(mut self, enabled: bool) -> Self {
         self.dev_self_serve_auth = enabled;
         self
@@ -623,27 +637,41 @@ impl GatewayServer {
         // SECURITY (issue #2075): the challenge/verify flow lets a caller mint a
         // token carrying its own `coop_id`, which `require_coop_access` then
         // trusts. DID ownership alone does not authorize that coop, so this
-        // self-asserted issuance is fail-closed by default and only enabled for
-        // dev/demo deployments. Two opt-in channels, OR'd together:
-        //   1. an explicit truthy `ICN_DEV_MODE` ("1"/"true", matching the
-        //      `ICN_SKIP_CORS` toggle convention in `security.rs`; stricter than
-        //      the CORS dev gate's bare presence check on purpose — `ICN_DEV_MODE=0`
-        //      must NOT open this auth bypass); and
-        //   2. `dev_self_serve_auth` set via `with_dev_self_serve_auth`, the
-        //      race-free channel for `icnd --insecure-gateway-no-jwt` (no env
-        //      mutation after the Tokio runtime starts).
-        // Production binds coop authority through trusted issuance paths
+        // self-asserted issuance is fail-closed and enabled ONLY when BOTH hold:
+        //   (a) a dev posture is opted in — an explicit truthy `ICN_DEV_MODE`
+        //       ("1"/"true", matching `ICN_SKIP_CORS` in `security.rs`; stricter
+        //       than the CORS dev gate's bare presence check so `ICN_DEV_MODE=0`
+        //       cannot open it), OR `dev_self_serve_auth` set via
+        //       `with_dev_self_serve_auth` (the race-free channel for
+        //       `icnd --insecure-gateway-no-jwt`); AND
+        //   (b) the gateway is bound to a LOOPBACK address.
+        // The loopback condition makes self-serve safe-by-construction: it can
+        // never be reached by an untrusted remote caller, even if a dev posture
+        // is mistakenly set on an all-interfaces listener. This matches the
+        // existing `--insecure-gateway-no-jwt` loopback guard. Production (and any
+        // routable-bind demo) binds coop authority through trusted issuance paths
         // (invites/sessions/enrollment) until RFC-0018's membership/entity
         // binding lands.
         let dev_mode_env = std::env::var("ICN_DEV_MODE")
             .map(|v| v == "1" || v == "true")
             .unwrap_or(false);
-        let allow_self_asserted_coop = self.dev_self_serve_auth || dev_mode_env;
+        let dev_opt_in = self.dev_self_serve_auth || dev_mode_env;
+        let allow_self_asserted_coop = self_serve_coop_allowed(dev_opt_in, &self.bind_addr);
         if allow_self_asserted_coop {
             warn!(
-                "⚠️  ICN_DEV_MODE: self-asserted cooperative authority is ENABLED at \
-                 /auth/verify — any DID may mint a token for any coop_id. DEV/DEMO ONLY; \
-                 never enable on a production gateway (see issue #2075)."
+                "⚠️  self-asserted cooperative authority is ENABLED at /auth/verify on loopback \
+                 bind {} — any local DID may mint a token for any coop_id. DEV/DEMO ONLY; never \
+                 use a dev posture on a production gateway (see issue #2075).",
+                self.bind_addr
+            );
+        } else if dev_opt_in {
+            // Dev posture requested but the bind is not loopback: stay fail-closed
+            // and say so, so the operator understands why /auth/verify returns 403.
+            warn!(
+                "Dev self-serve auth was requested (ICN_DEV_MODE / insecure-no-jwt) but the gateway \
+                 is bound to non-loopback {} — self-asserted /auth/verify issuance stays DISABLED \
+                 (fail-closed). Bind to loopback for local-dev self-serve (see issue #2075).",
+                self.bind_addr
             );
         }
         let auth_manager = Arc::new(
@@ -2394,6 +2422,29 @@ fn get_static_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// SECURITY (#2075): self-asserted coop issuance requires BOTH a dev opt-in
+    /// AND a loopback bind. A dev posture on a routable/all-interfaces listener
+    /// must NOT enable it.
+    #[test]
+    fn self_serve_coop_requires_dev_optin_and_loopback() {
+        let loopback_v4: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let loopback_v6: SocketAddr = "[::1]:8080".parse().unwrap();
+        let all_ifaces: SocketAddr = "0.0.0.0:8080".parse().unwrap();
+        let routable: SocketAddr = "10.0.0.5:8080".parse().unwrap();
+
+        // dev opt-in + loopback => enabled
+        assert!(self_serve_coop_allowed(true, &loopback_v4));
+        assert!(self_serve_coop_allowed(true, &loopback_v6));
+
+        // dev opt-in but NOT loopback => disabled (the #2075 exposure guard)
+        assert!(!self_serve_coop_allowed(true, &all_ifaces));
+        assert!(!self_serve_coop_allowed(true, &routable));
+
+        // no dev opt-in => disabled regardless of bind
+        assert!(!self_serve_coop_allowed(false, &loopback_v4));
+        assert!(!self_serve_coop_allowed(false, &all_ifaces));
+    }
 
     #[tokio::test]
     async fn test_jwt_secret_empty_fails_startup() {

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -595,8 +595,28 @@ impl GatewayServer {
             )));
         }
 
-        // Create shared managers
-        let auth_manager = Arc::new(AuthManager::new(self.jwt_secret));
+        // Create shared managers.
+        //
+        // SECURITY (issue #2075): the challenge/verify flow lets a caller mint a
+        // token carrying its own `coop_id`, which `require_coop_access` then
+        // trusts. DID ownership alone does not authorize that coop, so this
+        // self-asserted issuance is fail-closed by default and only enabled for
+        // dev/demo deployments via the existing `ICN_DEV_MODE` posture (matching
+        // the gateway's dev-security convention used for CORS above). Production
+        // binds coop authority through trusted issuance paths
+        // (invites/sessions/enrollment) until RFC-0018's membership/entity
+        // binding lands.
+        let allow_self_asserted_coop = std::env::var("ICN_DEV_MODE").is_ok();
+        if allow_self_asserted_coop {
+            warn!(
+                "⚠️  ICN_DEV_MODE: self-asserted cooperative authority is ENABLED at \
+                 /auth/verify — any DID may mint a token for any coop_id. DEV/DEMO ONLY; \
+                 never enable on a production gateway (see issue #2075)."
+            );
+        }
+        let auth_manager = Arc::new(
+            AuthManager::new(self.jwt_secret).with_self_asserted_coop(allow_self_asserted_coop),
+        );
 
         // Create cooperative manager (uses actor if handle available, otherwise in-memory)
         let coop_manager: Arc<CoopManager> = if let Some(handle) = self.coop_handle {

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -157,6 +157,13 @@ pub struct GatewayServer {
     /// backfill ensures pruning cannot delete a terminal execution record whose
     /// evidence was lost in the crash window before the backfill heals it.
     post_backfill_cleanup: Option<Arc<dyn Fn() + Send + Sync>>,
+    /// Dev/demo posture: force-enable self-asserted `/auth/verify` coop issuance
+    /// without relying on the `ICN_DEV_MODE` env var (issue #2075). This is the
+    /// race-free channel for `icnd --insecure-gateway-no-jwt` (a loopback-only
+    /// dev hatch) to opt in, instead of mutating process env after the Tokio
+    /// runtime has started. `run()` OR's this with the `ICN_DEV_MODE` env read,
+    /// so explicit dev deployments that set the env var keep working too.
+    dev_self_serve_auth: bool,
 }
 
 impl GatewayServer {
@@ -195,6 +202,7 @@ impl GatewayServer {
             dispatch_evidence_sink_installer: None,
             execution_query_store: None,
             post_backfill_cleanup: None,
+            dev_self_serve_auth: false,
         }
     }
 
@@ -245,6 +253,7 @@ impl GatewayServer {
             dispatch_evidence_sink_installer: None,
             execution_query_store: None,
             post_backfill_cleanup: None,
+            dev_self_serve_auth: false,
         }
     }
 
@@ -296,6 +305,7 @@ impl GatewayServer {
             dispatch_evidence_sink_installer: None,
             execution_query_store: None,
             post_backfill_cleanup: None,
+            dev_self_serve_auth: false,
         }
     }
 
@@ -308,6 +318,19 @@ impl GatewayServer {
     /// Set default trust score
     pub fn with_default_trust_score(mut self, score: f64) -> Self {
         self.default_trust_score = Some(score);
+        self
+    }
+
+    /// Force-enable self-asserted `/auth/verify` coop issuance for a dev/demo
+    /// posture, independent of the `ICN_DEV_MODE` env var (issue #2075).
+    ///
+    /// This is the race-free way for `icnd --insecure-gateway-no-jwt` (a
+    /// loopback-only local-dev hatch) to keep its challenge/verify smoke path
+    /// working without mutating process environment after the Tokio runtime has
+    /// started. `run()` OR's this with the `ICN_DEV_MODE` env read, so it never
+    /// disables an env-configured dev posture — it only adds one.
+    pub fn with_dev_self_serve_auth(mut self, enabled: bool) -> Self {
+        self.dev_self_serve_auth = enabled;
         self
     }
 
@@ -601,16 +624,21 @@ impl GatewayServer {
         // token carrying its own `coop_id`, which `require_coop_access` then
         // trusts. DID ownership alone does not authorize that coop, so this
         // self-asserted issuance is fail-closed by default and only enabled for
-        // dev/demo deployments via an explicit truthy `ICN_DEV_MODE` ("1"/"true",
-        // matching the `ICN_SKIP_CORS` toggle convention in `security.rs`). The
-        // truthy parse is stricter than the CORS dev gate's bare presence check
-        // on purpose: `ICN_DEV_MODE=0` must NOT open this auth bypass. Production
-        // binds coop authority through trusted issuance paths
+        // dev/demo deployments. Two opt-in channels, OR'd together:
+        //   1. an explicit truthy `ICN_DEV_MODE` ("1"/"true", matching the
+        //      `ICN_SKIP_CORS` toggle convention in `security.rs`; stricter than
+        //      the CORS dev gate's bare presence check on purpose — `ICN_DEV_MODE=0`
+        //      must NOT open this auth bypass); and
+        //   2. `dev_self_serve_auth` set via `with_dev_self_serve_auth`, the
+        //      race-free channel for `icnd --insecure-gateway-no-jwt` (no env
+        //      mutation after the Tokio runtime starts).
+        // Production binds coop authority through trusted issuance paths
         // (invites/sessions/enrollment) until RFC-0018's membership/entity
         // binding lands.
-        let allow_self_asserted_coop = std::env::var("ICN_DEV_MODE")
+        let dev_mode_env = std::env::var("ICN_DEV_MODE")
             .map(|v| v == "1" || v == "true")
             .unwrap_or(false);
+        let allow_self_asserted_coop = self.dev_self_serve_auth || dev_mode_env;
         if allow_self_asserted_coop {
             warn!(
                 "⚠️  ICN_DEV_MODE: self-asserted cooperative authority is ENABLED at \

--- a/icn/crates/icn-gateway/tests/demo_member_standing_bootstrap.rs
+++ b/icn/crates/icn-gateway/tests/demo_member_standing_bootstrap.rs
@@ -157,7 +157,7 @@ async fn build_app(
         .expect("create_domain");
 
     let jwt_secret = b"demo-standing-bootstrap-jwt-secret".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     let gov_ctx = GovernanceContext {

--- a/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
+++ b/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
@@ -140,9 +140,11 @@ async fn build_app(
         .await
         .expect("create_domain");
 
-    let auth_manager = Arc::new(AuthManager::new(
-        b"dev-standing-bridge-jwt-secret-32".to_vec(),
-    ));
+    let auth_manager = Arc::new(
+        // Dev/demo self-service issuance: caller supplies its own coop_id (#2075).
+        AuthManager::new(b"dev-standing-bridge-jwt-secret-32".to_vec())
+            .with_self_asserted_coop(true),
+    );
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     let gov_ctx = GovernanceContext {

--- a/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
+++ b/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
@@ -212,7 +212,7 @@ async fn build_app_with_proposal(
         .expect("open_proposal");
 
     let jwt_secret = b"close-revalidation-jwt-secret-32b".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     let gov_ctx = GovernanceContext {

--- a/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
@@ -272,7 +272,7 @@ async fn test_suspended_member_cannot_create_delegation() {
 
     // ── Build test app ────────────────────────────────────────────────────────
     let jwt_secret = b"delegation-gate-enforcement-sec32".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
     let governance_manager = Arc::new(
         GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
@@ -507,7 +507,7 @@ async fn test_suspended_member_cannot_create_blanket_delegation() {
 
     // ── Build test app ────────────────────────────────────────────────────────
     let jwt_secret = b"blanket-gate-enforcement-sec--32".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
     let governance_manager = Arc::new(
         GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -309,7 +309,7 @@ async fn test_e2e_freeze_member_suspends_commons_affiliation() {
 
     // ── Build test app (governance + auth) ───────────────────────────────────
     let jwt_secret = b"e2e-institutional-flow-test-secret32".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
     let governance_manager = Arc::new(
         GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
@@ -568,7 +568,7 @@ async fn test_e2e_unfreeze_member_reinstates_commons_affiliation() {
 
     // ── Build test app ────────────────────────────────────────────────────────
     let jwt_secret = b"e2e-unfreeze-flow-test-secret-min32".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
     let governance_manager = Arc::new(
         GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),
@@ -916,7 +916,7 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
 
     // ── Build test app ────────────────────────────────────────────────────────
     let jwt_secret = b"e2e-scoped-steward-test-secret-32bc".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
     let governance_manager = Arc::new(
         GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),

--- a/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
@@ -225,7 +225,7 @@ async fn test_freeze_member_blocks_ledger_entries_after_governance_acceptance() 
 
     // ── Build test app (governance + auth) ───────────────────────────────────
     let jwt_secret = b"ledger-freeze-enforcement-test-sec32".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
     let governance_manager = Arc::new(
         GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),

--- a/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
@@ -124,7 +124,7 @@ async fn build_app(
         .expect("create_domain");
 
     let jwt_secret = b"standing-gate-test-jwt-secret-32b".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     let gov_ctx = GovernanceContext {

--- a/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
@@ -210,7 +210,7 @@ async fn test_suspended_member_cannot_open_proposal() {
 
     // ── Build test app ────────────────────────────────────────────────────────
     let jwt_secret = b"open-proposal-gate-enforcement-sec32".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
     let governance_manager = Arc::new(
         GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),

--- a/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
@@ -244,7 +244,7 @@ async fn test_suspended_member_cannot_submit_proposals() {
 
     // ── Build test app (governance + auth) ───────────────────────────────────
     let jwt_secret = b"proposal-gate-enforcement-test-sec32".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
     let governance_manager = Arc::new(
         GovernanceManager::new().with_receipt_store(Arc::new(TestReceiptBackend::default())),

--- a/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
@@ -124,7 +124,7 @@ async fn build_app(
         .expect("create_domain");
 
     let jwt_secret = b"steward-gate-test-jwt-secret-32b".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     let gov_ctx = GovernanceContext {

--- a/icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs
@@ -163,7 +163,7 @@ async fn build_app_with_trust_resolver(
     String, // actor JWT
 ) {
     let jwt_secret = b"trust-threshold-enforcement-sec32".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     let resolver = Arc::new(TrustManagerMembershipResolver::new(trust_manager));

--- a/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
@@ -147,7 +147,7 @@ async fn build_app_with_open_proposal(
         .expect("open_proposal");
 
     let jwt_secret = b"vote-gate-test-jwt-secret-32bytes".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     let gov_ctx = GovernanceContext {
@@ -401,7 +401,7 @@ async fn build_app_with_suspension_checker(
         Arc::new(move |_did, _domain| Box::pin(async move { is_suspended }));
 
     let jwt_secret = b"suspension-gate-test-jwt-secret32".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     let gov_ctx = GovernanceContext {

--- a/icn/crates/icn-gateway/tests/governance_proof.rs
+++ b/icn/crates/icn-gateway/tests/governance_proof.rs
@@ -59,7 +59,7 @@ use std::sync::Arc;
 async fn test_governance_proposal_full_lifecycle_with_real_auth() {
     // ── Setup ────────────────────────────────────────────────────────────────
     let jwt_secret = b"governance-proof-test-secret-min32!".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     // In-memory governance manager.
@@ -337,7 +337,7 @@ async fn test_governance_proposal_full_lifecycle_with_real_auth() {
 #[actix_web::test]
 async fn test_auth_rejects_invalid_signature() {
     let jwt_secret = b"governance-proof-test-secret-min32!".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
 
     let app = test::init_service(
@@ -384,7 +384,7 @@ async fn test_auth_rejects_invalid_signature() {
 #[actix_web::test]
 async fn test_governance_endpoints_require_auth() {
     let jwt_secret = b"governance-proof-test-secret-min32!".to_vec();
-    let auth_manager = Arc::new(AuthManager::new(jwt_secret));
+    let auth_manager = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
     let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
     let governance_manager = Arc::new(GovernanceManager::new());
     let gov_ctx = GovernanceContext {

--- a/scripts/local_audit_verify_auth_demo.sh
+++ b/scripts/local_audit_verify_auth_demo.sh
@@ -87,6 +87,10 @@ log "icnctl = $ICNCTL"
 export ICN_KEYSTORE_PASSPHRASE="audit-auth-demo-passphrase-not-secret-0000"
 JWT_SECRET="$(openssl rand -hex 32)"
 export ICN_GATEWAY_JWT_SECRET="$JWT_SECRET"
+# Dev gate (issue #2075): self-asserted /auth/verify coop issuance is fail-closed
+# unless ICN_DEV_MODE is set. This LOCAL loopback demo mints a token that way, so
+# opt into the explicit dev posture. Never set this on a production gateway.
+export ICN_DEV_MODE=1
 log "[1/5] init + start JWT-secured local gateway on $GW"
 "$ICND" --init --data-dir "$OUT/data" --node-name audit-auth-demo \
   --init-gateway-port "$PORT" --init-gossip-port "$((PORT+1000))" >"$OUT/init.log" 2>&1 \

--- a/scripts/local_economic_receipt_chain_demo.sh
+++ b/scripts/local_economic_receipt_chain_demo.sh
@@ -105,6 +105,10 @@ log "icnctl = $ICNCTL"
 export ICN_KEYSTORE_PASSPHRASE="econ-chain-demo-passphrase-not-secret-0000"
 JWT_SECRET="$(openssl rand -hex 32)"
 export ICN_GATEWAY_JWT_SECRET="$JWT_SECRET"
+# Dev gate (issue #2075): self-asserted /auth/verify coop issuance is fail-closed
+# unless ICN_DEV_MODE is set. This LOCAL loopback demo mints tokens that way, so
+# opt into the explicit dev posture. Never set this on a production gateway.
+export ICN_DEV_MODE=1
 # Dev gate for POST /v1/commons/dev/bootstrap-standing: requires admin endpoints
 # enabled AND a non-Production posture. Both are set for this LOCAL demo only.
 export ICN_ENABLE_ADMIN_ENDPOINTS=true


### PR DESCRIPTION
## What

Closes the #2075 gateway-auth weakness: a DID that has proven only key ownership can no
longer mint a capability token carrying an **arbitrary, caller-supplied `coop_id`**. The fix is
**issuance-side** and **fail-closed by default**.

- `AuthManager` gains `allow_self_asserted_coop` (default **false**) + a `with_self_asserted_coop(bool)`
  builder. `AuthManager::new` is now safe-by-default.
- `verify_challenge` — the only path that takes a *caller-supplied* `coop_id` (`api/auth.rs` →
  `/auth/verify`) — now, **after** proving DID ownership, refuses to bind a self-asserted coop
  unless self-service issuance is explicitly enabled. It returns `AuthorizationFailed` (403):
  identity passed, the coop claim is unauthorized.
- The gateway (`server.rs`) enables self-service issuance only under the existing **`ICN_DEV_MODE`**
  dev posture, with a loud startup warning. Production (no `ICN_DEV_MODE`) is fail-closed.

`issue_token` is **unchanged** — the trusted server-side paths that derive `coop_id` from
verified state (`/v1/invites/join` → `invite.coop_id`, `/v1/sessions/*` → `session.coop_id`,
SDIS enrollment) keep working. The bug was specifically the *caller-supplied* path.

## Why (#2075)

DID ownership proves a caller holds a key; it does **not** authorize that DID to act for a
cooperative. `verify_challenge` wrote the caller's `coop_id`/`scopes` straight into the token, and
`require_coop_access` (`middleware.rs:138`, plain `claims.coop_id == coop_id`) trusted it — so any
DID could mint a token for any well-formed `coop_id` and pass the flat cross-coop guard on ~30
endpoints. #2076 pinned this as a CI tripwire; this PR flips it.

## How #2076's characterization test was inverted

`middleware.rs`: `self_asserted_coop_id_currently_passes_require_coop_access` →
`self_asserted_coop_id_is_rejected_at_issuance_by_default`. It no longer asserts `is_ok()`; it
asserts the default (fail-closed) `AuthManager` **rejects** issuance with `AuthorizationFailed`.
A second half shows the dev/demo opt-in still mints such a token *and* the flat guard then trusts
it — documenting exactly why that path must stay gated. The companion
(`require_coop_access_rejects_token_for_a_different_coop`) is unchanged. The doc comment no longer
calls the bypass "current behavior."

New positive/negative unit tests in `auth.rs`:
`test_verify_challenge_self_asserted_coop_rejected_by_default` and
`..._allowed_in_dev`.

## Fix location

**Issuance-side** (Option A), in its honest minimal form: there is no trusted flat-`coop_id`
membership source wired into the gateway's issuance path yet, so the "check trusted state"
degenerates to **fail closed unless dev/demo**. The guard (`require_coop_access`) is left intact as
defense-in-depth. Guard-side resolution (Option B) and the positive membership/entity binding are
RFC-0018 follow-up.

## Dev/demo bypass (retained, explicit, named, loopback-bounded, fail-closed outside dev)

Self-service `/auth/verify` issuance requires **both** an opted-in dev posture **and** a **loopback
bind** — `self_serve_coop_allowed(dev_opt_in, bind) = dev_opt_in && bind.is_loopback()`. The loopback
condition is the safety invariant (per review): self-serve can **never** be reached by an untrusted
remote caller, even if a dev posture is mistakenly set on an all-interfaces listener. This mirrors the
existing `--insecure-gateway-no-jwt` loopback guard and is unit-tested. The dev posture itself is
`ICN_DEV_MODE` (or the insecure-no-jwt config flag); off by default, loud warning when on. The
`ICN_DEV_MODE` flag requires an **explicit truthy value** (`"1"`/`"true"`, matching the
`ICN_SKIP_CORS` convention) — `ICN_DEV_MODE=0` does **not** open the bypass. `icnd --insecure-gateway-no-jwt` (the loopback-only
local-dev hatch whose challenge/verify flow is documented to work) opts into the dev posture by
carrying a `dev_self_serve_auth` flag through `GatewayConfig` →
`GatewayServer::with_dev_self_serve_auth` (OR'd with the `ICN_DEV_MODE` env read), **not** by
mutating process env after the Tokio runtime starts (avoids a cross-thread env race / edition-2024
`unsafe`). It stays bounded to loopback by the existing insecure-mode fail-closed guard. The
`dev_self_serve_auth` config field is `#[serde(skip)]` (per review) — it can **never** be set from
config TOML, so operator config cannot reopen the bypass on an externally-bound gateway; it is
reachable only via the insecure-loopback CLI path.

### Consequence to flag (intended posture, not a regression to hide)

Two existing flows authenticate via the **self-asserted** `/auth/verify` path and therefore now
require the gateway to run under the dev posture (`ICN_DEV_MODE`) until the trusted-binding path lands:

- `icnctl institution bootstrap` (`institution_bootstrap.rs` → `/v1/auth/verify` with the operator's
  own `coop_id` + `entity:write`/`governance:write`). **Local loopback dev** (`--insecure-gateway-no-jwt`)
  is preserved automatically (it now sets `ICN_DEV_MODE=1`). On a **production gateway** (real JWT
  secret, no `ICN_DEV_MODE`) this self-asserted bootstrap path fail-closes (403) — intended, since it
  *is* an instance of the #2075 weakness; the first-admin bootstrap should move to a trusted/privileged
  path under RFC-0018.
- Demo/devnet flows hitting `/auth/verify`. The **loopback** local launchers that mint tokens this
  way set `ICN_DEV_MODE=1` and keep working: `scripts/local_audit_verify_auth_demo.sh`,
  `scripts/local_economic_receipt_chain_demo.sh`, `demo/nycn-dogfood/run.sh` (all bind `127.0.0.1`).
  **All-interfaces (`0.0.0.0`) demos are now correctly fail-closed** by the loopback gate —
  `demo/scripts/start-demo.sh` (its `ICN_DEV_MODE` line was reverted), `demo/scripts/present-governance.sh`,
  and the devnet (`deploy/devnet/*` + `scripts/governance-demo.sh`). To regain self-serve they must
  bind loopback or move to trusted issuance (invites) — tracked as follow-up. Production deploy
  configs (k8s/docker/systemd/`icn.toml`) deliberately do **not** set the dev posture. `pilot-ui`'s
  trusted `/v1/invites/join` path is unaffected.

Demo/deploy scripts are **not** modified here (out of scope); any production deployment intentionally
relying on self-asserted issuance is documented as follow-up. No silent breakage.

## Risk

- Production `/auth/verify` self-asserted issuance now returns 403 (intended). Request/response
  models are unchanged → no OpenAPI/TS-type drift.
- Blast radius is contained to issuance; ~13 e2e/integration harnesses and the bootstrap test were
  updated to opt into dev self-service issuance (they exercise that flow) — mechanical one-line
  changes, no assertion logic changed.

## Test plan

- `cargo fmt --all --check` — clean.
- `cargo test -p icn-gateway` — lib + e2e/integration green, incl. the inverted #2076 test and new
  `auth.rs` security tests.
- `cargo clippy -p icn-gateway --all-targets -- -D warnings` — clean.
- `cargo check -p icnctl --tests` + clippy (bootstrap test touched).

## Still future RFC-0018 work (NOT in this PR)

This is the authz-correctness prerequisite, **not** entity-aware authorization. Not implemented here:
- `coop_id ↔ EntityId` mapping/backfill (normalization + rejection + stored backfill);
- optional `entity_id` token claim;
- `require_entity_access(caller, target_entity, action)`;
- endpoint-family migrations off the flat guard;
- delegation-aware authorization;
- the positive trusted-binding issuance path (membership/invite/entity) that would let production
  mint coop tokens again without a dev gate.

## Boundaries / honesty

- This does **not** implement full entity-aware authorization, and does **not** claim all cross-coop
  authorization is solved — only the proven #2075 self-asserted-issuance path is addressed; the flat
  guard and other regimes are unchanged.
- No NYCN-specific rules; meaning firewall preserved.

Closes #2075. Related: RFC-0018 (#2074), characterization #2076, #2061; flat-regime hardening
#2058/#2052/#2056; `docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md`.
