### PR TITLE
docs(architecture): object-context binding doctrine (§2.11/§3.11/§4.11) + RFC-0018 xref

### DIFF
--- a/docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md
+++ b/docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: yes
-Last Reviewed: 2026-05-16
+Last Reviewed: 2026-06-18
 ---
 
 # Abuse-case hardening strategy
@@ -25,7 +25,7 @@ The doctrine is not a security checklist for transport encryption, key managemen
 - **No new contract URN, no new schema field, no new wire format.** Candidate vocabulary in §6 and §10 is **draft** and explicitly marked as such.
 - **No production-readiness claim, no live-federation claim, no formal-NYCN-pilot claim, no Phase 2 completion claim.** Phase 2 (see [`../PHASE_PROGRESS.md`](../PHASE_PROGRESS.md)) remains ⏳ and partner-bound; this document sequences hardening work that must precede a partner-formalization step that does not exist yet.
 - **No K3s, DNS, Forgejo, gateway-deploy, or NYCN partner-data mutation.**
-- **Code anchors below are pinned to `main` at session start (`d57ff1d6e`).** They may drift; re-verify before citing in follow-up PRs.
+- **Code anchors below are pinned to `main` at session start (`d57ff1d6e`).** They may drift; re-verify before citing in follow-up PRs. The §2.11 / §3.11 / §4.11 additions (2026-06-18) are pinned to `main @ 040e44f0`.
 
 <!-- truth: descriptive -->
 
@@ -91,6 +91,10 @@ Member shell and steward cockpit are designed to render real states: degraded, p
 
 A receipt may exist in the primary store and be missing from a secondary index. In the opaque receipt store this is impossible by construction (atomic primary + index + bind writes). On older typed-receipt paths it is currently possible. Absence from index must never silently become absence from truth.
 
+### 2.11 A global id is not a grant
+
+An object reachable by a globally-keyed id must still be proven to belong to the institutional context named by the request before it is returned. Knowing — or guessing — an object's id is not standing over the object. A correct check on the *caller's* context (path coop, token scope) does not bind the *object* to that context; the object carries its own context and must be matched to the request's. Where they differ, the answer is not-found, and a foreign object must be reported exactly as a missing one, so the endpoint cannot be used to enumerate or confirm objects in contexts the caller has no standing in.
+
 <!-- truth: descriptive -->
 
 ## 3. Abuse stories
@@ -136,6 +140,10 @@ A rendering layer in the cockpit, or a "debug preview" in the shell, dereference
 ### 3.10 Index-skew invisibility
 
 A crash mid-write on an older typed-receipt path leaves the primary record durable but the secondary index missing. The opaque receipt store is atomic by construction; `icn/apps/governance/src/receipt_backend.rs:173-210` documents that the **default** `put_mandate_with_grants` is **not atomic** and depends on the sled-backed gateway override. Other typed write paths have not been inventoried for the same invariant.
+
+### 3.11 Cross-context read by global id
+
+A member holding a valid `coop-a` token requests `GET /treasury/coop-a/budgets/{id}` with a `coop-b` budget id they knew or guessed. The flat guard passes (token coop == path coop), the budget is fetched by its globally-keyed id, and — before #2087 — returned, leaking `coop-b`'s treasury DID, purpose, and amount across the institutional boundary. The leak survived a *correct subject check* because the loaded object was never bound to the named context. Closed for this endpoint by #2087 (`icn/crates/icn-gateway/src/api/treasury.rs:699-702`, the `treasury_did` ownership match in `get_budget`; tests `test_get_budget_cross_coop_read_denied`, `_same_coop_read_ok`, `_path_coop_without_treasury_does_not_reveal_foreign_budget`). The class is older than this instance — caller-context siblings hardened in #2052 / #2056 / #2058 — and the cross-gateway generalization is still open as the enumeration-safe-404 audit **#1642**. Anchor: `icn/crates/icn-gateway/src/api/treasury.rs:647` (`get_budget`; generic `"Budget not found"` at `:670`, ownership match at `:699-702`).
 
 <!-- truth: descriptive -->
 
@@ -359,6 +367,27 @@ Fixture / dev / test bands are explicit and labeled in every surface that touche
 **Doctrine.** *Index absence must not silently become record absence.*
 
 **Anchors.** `icn/apps/governance/src/receipt_backend.rs:42, 80, 106, 146, 178-210, 248` (typed write entry points; default `put_mandate_with_grants` is documented as **not atomic** at lines 178-190).
+
+### 4.11 Object-context binding on global-id reads
+
+**Problem.** Endpoints shaped `/{context}/{collection}/{object_id}` authorize on the path / token context but fetch by a globally-keyed object id. If the loaded object's own context is not matched to the named one, a caller with standing in context A can read an object in context B by id (#2087 in treasury budgets; the class also covers ledger, compute, storage, governance records, federation provenance, and the escrow / invite / recurring objects of #2058).
+
+**Hardening goal.** Every global-id read binds the loaded object to the institutional context named by the request before returning it, and reports a foreign object identically to a missing one (enumeration-safe, per #1642).
+
+**Doctrine.** *A record reached by a globally-keyed id must be proven to belong to the institutional context named by the request before it is returned; a foreign object is reported exactly as a missing one.*
+
+**Draft design.** Object-fetch checklist (the worked shape, from `get_budget`):
+
+1. resolve the institutional context named by the request path (e.g. path coop → its treasury, yielding the context's DID);
+2. load the object by its global id;
+3. prove the object's **own** context binding against that context (e.g. `object.treasury_did == path_treasury.treasury_did`) — not merely the path / token check;
+4. on mismatch, missing, or no-context, return one generic not-found shape carrying no id, owner, DID, or content (no enumeration oracle);
+5. keep any observe-mode / divergence recording firing **before** the enforced denial, so cross-context attempts stay visible as divergence rather than vanishing;
+6. this is the **object axis** and composes with — does not replace — the **subject axis** entity guard (RFC-0018 / ADR-0035, "may this caller act on this entity"). Both must hold.
+
+This is not RBAC and not tenant isolation: it adds no roles and no per-tenant ACL, only a generic context-DID equality between a loaded object and the request's named context. The meaning firewall is untouched.
+
+**Anchors.** `icn/crates/icn-gateway/src/api/treasury.rs:647-705` (`get_budget`, #2087 — the proven example); #1642 (open enumeration-safe-404 audit, the generalization); #2052 / #2056 / #2058 (caller-context siblings). Unbound families to sweep next: ledger, compute, storage, governance records, federation provenance.
 
 <!-- truth: descriptive -->
 

--- a/docs/rfcs/RFC-0018-entity-aware-request-authorization.md
+++ b/docs/rfcs/RFC-0018-entity-aware-request-authorization.md
@@ -311,6 +311,11 @@ staged rather than a sweep.
 - **#1868** — decompose `governance:write` into per-action capabilities (the capability axis).
 - **#1642** — gateway service-discovery auth + enumeration-safe 404.
 - **#2052, #2056, #2058** — flat-regime hardening this generalizes (kept as defense-in-depth).
+- **#2087 / hardening §4.11** — *object-context binding* on global-id reads: the **object axis**
+  (does the returned, globally-keyed object belong to the named context) that composes with this
+  RFC's **subject axis** (may this caller act on this entity). Preserved as defense-in-depth through
+  the entity-aware migration; no flat guard is removed without it still holding. See
+  [`../architecture/ABUSE_CASE_HARDENING_STRATEGY.md`](../architecture/ABUSE_CASE_HARDENING_STRATEGY.md) §2.11 / §4.11.
 - **#2063** — the recurring `list_by_owner` DID-colon fix (already merged; the reliability bug
   #2061 noted is resolved and is **not** part of this authz model).
 - `docs/architecture/{KERNEL_APP_SEPARATION,MEMBER_STANDING,INSTITUTION_PACKAGE_BOUNDARY,THE_COMMONS}.md`;


### PR DESCRIPTION
## What
Add the object-context-binding invariant to the hardening doctrine and cross-reference it from RFC-0018. Docs-only, two files.

- `docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md`:
  - **§2.11 "A global id is not a grant"** (core doctrine)
  - **§3.11 "Cross-context read by global id"** (abuse story: the #2087 cross-coop budget read)
  - **§4.11 "Object-context binding on global-id reads"** (hardening track + object-fetch checklist)
- `docs/rfcs/RFC-0018-entity-aware-request-authorization.md`: one "Related" cross-reference naming object-context binding as the **object axis** that composes with the RFC's **subject axis**.

## Why
#2087 proved (in `get_budget`) that a globally-keyed object must be bound to the institutional context named by the request before it is returned, and that a foreign object must be reported exactly as a missing one (enumeration-safe). That invariant is the capstone of the #2077 → #2079 → #2086 → #2087 arc and the only one with no durable home. It is a recurring class (#2052 / #2056 / #2058 / #2087) and the cross-gateway generalization is still open as #1642. A named doctrine clause plus an object-fetch checklist stops the next object-fetch endpoint from re-opening the leak.

Captured as **hardening doctrine, not a new ADR**: ADRs record decisions (the authz decision already lives in RFC-0018 + ADR-0035); #2087 is *hardening*, and the hardening doc already carries numbered doctrine + abuse story + hardening track. ADR-0036 is reserved (Federation Agreement Support); the candidate registry reserves 0036–0082.

## How
Three subsections matching the doc's existing §2 / §3 / §4 grammar; one RFC-0018 "Related" bullet. Code anchors pinned to `main @ 040e44f0`. Not RBAC / not tenant isolation — only a generic context-DID equality; the meaning firewall is untouched.

## Risk
None functional — docs-only, no code / schema / wire change. `registry.toml` description count (Ten → Eleven) intentionally left as an optional follow-up; the `docs-freshness` doc-control check runs warn-only and is **not** a required check, so there is no gate impact.

## Test plan
- `sanitize-scan --staged` and the pre-push gate both clean.
- Required checks unaffected (docs-only; no Rust / SDK / firewall / a11y / regulatory surface touched).
- Reviewer check: a reviewer can predict why #2087 returns a generic 404 from §2.11 / §4.11 alone, without reading the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
