### PR TITLE
docs(sdk): separate DID key authentication from institutional authority issuance (#2083)

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -27,7 +27,7 @@ console.log('Gateway status:', health.status);
 // fail-closed in production. DID key control is not cooperative authority.
 // See "Authentication" below for the production-shaped pattern.
 const challenge = await client.getChallenge('did:icn:alice');
-const signature = await signWithYourKey(challenge.challenge);
+const signature = await signWithYourKey(challenge.nonce);
 const auth = await client.verify('did:icn:alice', signature, 'my-coop', ['ledger:read', 'ledger:write']);
 client.setToken(auth.token);
 
@@ -56,7 +56,7 @@ console.log('Position:', position.position, position.unit);
 ### Production: how `coop_id` is treated today
 
 Passing a caller-chosen `coop_id` to `/auth/verify` is **fail-closed in production**
-(issue [#2077](https://github.com/InterCooperative-Network/icn/issues/2077)): the gateway
+(PR [#2077](https://github.com/InterCooperative-Network/icn/pull/2077)): the gateway
 refuses to bind self-asserted cooperative authority into a token. A trusted production
 issuance path (first-admin bootstrap, invite/session, membership-resolved issuance) is
 **planned, not yet shipped** — tracked by
@@ -78,10 +78,10 @@ const client = new ICNClient({ baseUrl: 'http://localhost:8080', token });
 ### Dev/demo only: self-serve challenge → verify → token
 
 The challenge/verify flow below mints a token carrying a **caller-supplied, unverified**
-`coop_id`. The gateway honors it only when it is explicitly built for a dev/demo posture
-(`AuthManager::with_self_asserted_coop(true)`, which production never enables); per ICN's
-dev-gate doctrine such a posture must also be confined to an explicit opt-in
-(`ICN_DEV_MODE`) plus a loopback bind. This is **not** how production cooperative
+`coop_id`. The gateway honors it only under an explicit dev opt-in — `ICN_DEV_MODE`, or
+the daemon's `--insecure-gateway-no-jwt` flag — **and** a loopback bind; on any
+non-loopback bind it stays fail-closed (production leaves
+`AuthManager::with_self_asserted_coop` off). This is **not** how production cooperative
 authority is obtained — do not ship it as a login flow.
 
 1. Request a challenge for your DID
@@ -91,11 +91,11 @@ authority is obtained — do not ship it as a login flow.
 
 ```typescript
 // DEV/DEMO ONLY — fail-closed in production (see above).
-// 1. Get challenge
-const { challenge, expires_at } = await client.getChallenge('did:icn:alice');
+// 1. Get challenge (returns { nonce, expires_in })
+const { nonce } = await client.getChallenge('did:icn:alice');
 
-// 2. Sign challenge (implement your own signing logic)
-const signature = await ed25519Sign(challenge, privateKey);
+// 2. Sign the challenge nonce (implement your own signing logic)
+const signature = await ed25519Sign(nonce, privateKey);
 
 // 3. Verify and get token — the coop_id here is a SELF-ASSERTED claim,
 //    accepted only under a dev/demo gateway posture, not production authority.
@@ -130,9 +130,11 @@ const auth = await client.authenticate('did:icn:alice', signer, 'my-coop');
 
 #### Automatic Token Refresh
 
-`autoRefresh` re-runs whatever authentication you configured when the token nears expiry,
-so it inherits that flow's posture: with the dev/demo challenge/verify flow it stays
-dev/demo-only; in production it refreshes a token sourced from a trusted issuer.
+`autoRefresh` only re-runs the **dev/demo challenge/verify flow**: it works solely when
+`authenticate()` has stored a signer and DID, and there is no refresh path for a token you
+injected directly (the production-shaped pattern above). A production token obtained from a
+trusted issuer is therefore **not** auto-refreshed — re-issue it through that issuer before
+it expires.
 
 ```typescript
 const client = new ICNClient({

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -22,7 +22,10 @@ const client = new ICNClient({
 const health = await client.health();
 console.log('Gateway status:', health.status);
 
-// Authenticate (you need to provide your own signing logic)
+// Authenticate — challenge/verify proves control of your DID key.
+// NOTE: passing a coop_id here is dev/demo-only self-serve issuance and is
+// fail-closed in production. DID key control is not cooperative authority.
+// See "Authentication" below for the production-shaped pattern.
 const challenge = await client.getChallenge('did:icn:alice');
 const signature = await signWithYourKey(challenge.challenge);
 const auth = await client.verify('did:icn:alice', signature, 'my-coop', ['ledger:read', 'ledger:write']);
@@ -35,27 +38,71 @@ console.log('Position:', position.position, position.unit);
 
 ## Authentication
 
-ICN uses DID-based authentication with JWT tokens.
+**Two different things, often confused. Keep them separate.**
 
-### Challenge-Response Flow
+- **DID key authentication** — the challenge/verify flow proves you *control a DID's
+  key*. That is all it proves. It does not prove membership, standing, or any authority
+  to act for a cooperative.
+- **Institutional authority issuance** — a cooperative-scoped token (one whose `coop_id`
+  the gateway will *trust*) must come from a trusted institutional path: membership,
+  standing, role, capability, delegation, invite, session, or SDIS-backed proof. It is
+  never minted from a `coop_id` the caller picked.
+
+> **DID key control is not cooperative authority. A capability token is not a mandate.**
+> See [`ABUSE_CASE_HARDENING_STRATEGY.md`](../../docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md),
+> [RFC-0018](../../docs/rfcs/RFC-0018-entity-aware-request-authorization.md), and
+> [ADR-0035](../../docs/adr/ADR-0035-entity-aware-request-authorization.md).
+
+### Production: how `coop_id` is treated today
+
+Passing a caller-chosen `coop_id` to `/auth/verify` is **fail-closed in production**
+(issue [#2077](https://github.com/InterCooperative-Network/icn/issues/2077)): the gateway
+refuses to bind self-asserted cooperative authority into a token. A trusted production
+issuance path (first-admin bootstrap, invite/session, membership-resolved issuance) is
+**planned, not yet shipped** — tracked by
+[#2080](https://github.com/InterCooperative-Network/icn/issues/2080). Entity-aware
+authorization enforcement is tracked by
+[#2081](https://github.com/InterCooperative-Network/icn/issues/2081), and the canonical
+`coop_id ↔ EntityId` mapping by
+[#2082](https://github.com/InterCooperative-Network/icn/issues/2082).
+
+Until #2080 lands, application code obtains a cooperative-scoped token from a trusted
+issuer out of band and hands it to the client directly:
+
+```typescript
+// Production-shaped: the token comes from a trusted institutional path,
+// not from a coop_id the client asserted. (See examples/seed-demo-data.ts.)
+const client = new ICNClient({ baseUrl: 'http://localhost:8080', token });
+```
+
+### Dev/demo only: self-serve challenge → verify → token
+
+The challenge/verify flow below mints a token carrying a **caller-supplied, unverified**
+`coop_id`. The gateway honors it only when it is explicitly built for a dev/demo posture
+(`AuthManager::with_self_asserted_coop(true)`, which production never enables); per ICN's
+dev-gate doctrine such a posture must also be confined to an explicit opt-in
+(`ICN_DEV_MODE`) plus a loopback bind. This is **not** how production cooperative
+authority is obtained — do not ship it as a login flow.
 
 1. Request a challenge for your DID
 2. Sign the challenge with your Ed25519 private key
-3. Verify the signature to get a JWT token
+3. Verify the signature to get a JWT token *(dev/demo posture only)*
 4. Use the token for authenticated requests
 
 ```typescript
+// DEV/DEMO ONLY — fail-closed in production (see above).
 // 1. Get challenge
 const { challenge, expires_at } = await client.getChallenge('did:icn:alice');
 
 // 2. Sign challenge (implement your own signing logic)
 const signature = await ed25519Sign(challenge, privateKey);
 
-// 3. Verify and get token
+// 3. Verify and get token — the coop_id here is a SELF-ASSERTED claim,
+//    accepted only under a dev/demo gateway posture, not production authority.
 const { token } = await client.verify(
   'did:icn:alice',
   signature,
-  'my-coop',           // cooperative ID
+  'my-coop',           // self-asserted coop_id (dev/demo only)
   ['ledger:read', 'ledger:write', 'coop:read']  // requested scopes
 );
 
@@ -63,9 +110,10 @@ const { token } = await client.verify(
 client.setToken(token);
 ```
 
-### Using a Signature Provider
+#### Using a Signature Provider
 
-You can implement `SignatureProvider` for cleaner auth:
+`SignatureProvider` cleans up the signing step of the same **dev/demo** flow — the
+self-asserted `coop_id` caveat above still applies:
 
 ```typescript
 const signer: SignatureProvider = {
@@ -75,13 +123,16 @@ const signer: SignatureProvider = {
   }
 };
 
+// DEV/DEMO ONLY — self-asserted coop_id, fail-closed in production.
 const auth = await client.authenticate('did:icn:alice', signer, 'my-coop');
 // Token is automatically set
 ```
 
-### Automatic Token Refresh
+#### Automatic Token Refresh
 
-Enable `autoRefresh` to automatically re-authenticate when the token expires:
+`autoRefresh` re-runs whatever authentication you configured when the token nears expiry,
+so it inherits that flow's posture: with the dev/demo challenge/verify flow it stays
+dev/demo-only; in production it refreshes a token sourced from a trusted issuer.
 
 ```typescript
 const client = new ICNClient({
@@ -90,7 +141,7 @@ const client = new ICNClient({
   refreshBeforeExpiry: 60,  // Refresh 60 seconds before expiry
 });
 
-// Authenticate once - credentials are stored for auto-refresh
+// Dev/demo: re-authenticates via challenge/verify before expiry.
 await client.authenticate('did:icn:alice', signer, 'my-coop');
 
 // Token will be automatically refreshed before expiring

--- a/sdk/typescript/examples/README.md
+++ b/sdk/typescript/examples/README.md
@@ -138,30 +138,39 @@ subscription.onEvent((event) => {
 
 ### Authentication
 
-All examples require authentication. Here's the pattern:
+All examples need a token. **DID key control is not cooperative authority**, so *how* you
+get that token matters:
+
+**Production** — obtain a cooperative-scoped token from a trusted institutional path
+(membership / invite / session / SDIS) out of band and pass it to the client. Self-asserted
+`coop_id` issuance at `/auth/verify` is fail-closed in production (issue
+[#2077](https://github.com/InterCooperative-Network/icn/issues/2077); trusted issuance is
+tracked by [#2080](https://github.com/InterCooperative-Network/icn/issues/2080)). See
+[`seed-demo-data.ts`](./seed-demo-data.ts) for this pattern.
 
 ```typescript
 import { ICNClient } from '@icn/client';
 
-const client = new ICNClient({
-  baseUrl: 'http://localhost:8080',
-});
+// Production-shaped: token comes from a trusted issuer, not a self-asserted coop_id.
+const client = new ICNClient({ baseUrl: 'http://localhost:8080', token });
+```
 
-// Get challenge
+**Dev/demo only** — the challenge/verify flow mints a token from a caller-supplied,
+**unverified** `coop_id`, accepted only under a dev/demo gateway posture. Do not ship it as
+a login flow. (See the SDK README's Authentication section for the full caveat.)
+
+```typescript
+const client = new ICNClient({ baseUrl: 'http://localhost:8080' });
+
+// DEV/DEMO ONLY — self-asserted coop_id, fail-closed in production.
 const challenge = await client.getChallenge('did:icn:alice');
-
-// Sign it (you need Ed25519 signing logic)
-const signature = await signChallenge(challenge.challenge);
-
-// Authenticate
+const signature = await signChallenge(challenge.challenge);  // your Ed25519 signing
 const auth = await client.verify(
   'did:icn:alice',
   signature,
-  'food-coop',
+  'food-coop',         // self-asserted coop_id (dev/demo only)
   ['ledger:read', 'ledger:write', 'coop:admin']
 );
-
-// Set token for future requests
 client.setToken(auth.token, auth.expires_at);
 ```
 
@@ -185,7 +194,9 @@ try {
 
 ### Automatic Token Refresh
 
-Enable auto-refresh to avoid managing token expiration:
+Enable auto-refresh to avoid managing token expiration. It re-runs the configured auth
+flow, so it inherits that flow's posture (the example below uses the dev/demo
+challenge/verify flow — see the Authentication note above):
 
 ```typescript
 const client = new ICNClient({
@@ -194,7 +205,7 @@ const client = new ICNClient({
   refreshBeforeExpiry: 60,  // Refresh 60s before expiry
 });
 
-// Authenticate once with a signer
+// Dev/demo: re-authenticates via challenge/verify (self-asserted coop_id) before expiry.
 await client.authenticate('did:icn:alice', signer, 'food-coop');
 
 // Token automatically refreshes - no manual handling needed

--- a/sdk/typescript/examples/README.md
+++ b/sdk/typescript/examples/README.md
@@ -143,9 +143,9 @@ get that token matters:
 
 **Production** — obtain a cooperative-scoped token from a trusted institutional path
 (membership / invite / session / SDIS) out of band and pass it to the client. Self-asserted
-`coop_id` issuance at `/auth/verify` is fail-closed in production (issue
-[#2077](https://github.com/InterCooperative-Network/icn/issues/2077); trusted issuance is
-tracked by [#2080](https://github.com/InterCooperative-Network/icn/issues/2080)). See
+`coop_id` issuance at `/auth/verify` is fail-closed in production (PR
+[#2077](https://github.com/InterCooperative-Network/icn/pull/2077); trusted issuance is
+tracked by issue [#2080](https://github.com/InterCooperative-Network/icn/issues/2080)). See
 [`seed-demo-data.ts`](./seed-demo-data.ts) for this pattern.
 
 ```typescript
@@ -164,7 +164,7 @@ const client = new ICNClient({ baseUrl: 'http://localhost:8080' });
 
 // DEV/DEMO ONLY — self-asserted coop_id, fail-closed in production.
 const challenge = await client.getChallenge('did:icn:alice');
-const signature = await signChallenge(challenge.challenge);  // your Ed25519 signing
+const signature = await signChallenge(challenge.nonce);  // your Ed25519 signing
 const auth = await client.verify(
   'did:icn:alice',
   signature,
@@ -194,9 +194,10 @@ try {
 
 ### Automatic Token Refresh
 
-Enable auto-refresh to avoid managing token expiration. It re-runs the configured auth
-flow, so it inherits that flow's posture (the example below uses the dev/demo
-challenge/verify flow — see the Authentication note above):
+Enable auto-refresh to avoid managing token expiration. It only re-runs the **dev/demo
+challenge/verify flow** (it needs the signer + DID stored by `authenticate()`); a
+production token injected directly is **not** auto-refreshed. See the Authentication note
+above.
 
 ```typescript
 const client = new ICNClient({

--- a/sdk/typescript/examples/basic-auth.ts
+++ b/sdk/typescript/examples/basic-auth.ts
@@ -6,8 +6,9 @@
  * IMPORTANT: this demonstrates DID *key control* plus dev/demo self-serve token
  * issuance, where the caller supplies its own `coop_id`. DID key control is NOT
  * cooperative authority. Passing a caller-chosen `coop_id` to `/auth/verify` is
- * fail-closed in production (issue #2077); the gateway honors it only under an
- * explicit dev/demo posture (loopback + ICN_DEV_MODE). This is NOT how production
+ * fail-closed in production (PR #2077); the gateway honors it only under an explicit
+ * dev opt-in (ICN_DEV_MODE or the daemon's --insecure-gateway-no-jwt) on a loopback
+ * bind. This is NOT how production
  * cooperative authority is obtained — trusted issuance is tracked by #2080. In
  * production, obtain a cooperative-scoped token from a trusted institutional path
  * and pass it to the client directly (see examples/seed-demo-data.ts).
@@ -66,7 +67,7 @@ async function main() {
     'my-coop', // self-asserted coop_id (dev/demo only)
     ['ledger:read', 'ledger:write', 'coop:read'] // scopes
   );
-  console.log('Token expires at:', new Date(auth.expires_at * 1000));
+  console.log('Token expires at:', new Date(auth.expires_at));
 
   // Set token for future requests
   client.setToken(auth.token);
@@ -82,7 +83,7 @@ async function main() {
     'my-coop', // self-asserted coop_id (dev/demo only)
     ['ledger:read', 'ledger:write']
   );
-  console.log('Authenticated! Token expires at:', new Date(authResult.expires_at * 1000));
+  console.log('Authenticated! Token expires at:', new Date(authResult.expires_at));
 
   // Now make authenticated requests
   console.log('\n--- Authenticated Requests ---');

--- a/sdk/typescript/examples/basic-auth.ts
+++ b/sdk/typescript/examples/basic-auth.ts
@@ -1,7 +1,16 @@
 /**
- * Basic Authentication Example
+ * Basic Authentication Example — DEV/DEMO ONLY
  *
- * Shows how to authenticate with the ICN Gateway API.
+ * Shows DID key authentication (challenge/verify) against the ICN Gateway API.
+ *
+ * IMPORTANT: this demonstrates DID *key control* plus dev/demo self-serve token
+ * issuance, where the caller supplies its own `coop_id`. DID key control is NOT
+ * cooperative authority. Passing a caller-chosen `coop_id` to `/auth/verify` is
+ * fail-closed in production (issue #2077); the gateway honors it only under an
+ * explicit dev/demo posture (loopback + ICN_DEV_MODE). This is NOT how production
+ * cooperative authority is obtained — trusted issuance is tracked by #2080. In
+ * production, obtain a cooperative-scoped token from a trusted institutional path
+ * and pass it to the client directly (see examples/seed-demo-data.ts).
  *
  * Run: npx ts-node examples/basic-auth.ts
  */
@@ -50,11 +59,11 @@ async function main() {
   // Sign the challenge (implement your own signing)
   const signature = 'your-hex-signature';
 
-  // Verify and get token
+  // Verify and get token (DEV/DEMO ONLY — self-asserted coop_id, fail-closed in production)
   const auth = await client.verify(
     myDid,
     signature,
-    'my-coop', // cooperative ID
+    'my-coop', // self-asserted coop_id (dev/demo only)
     ['ledger:read', 'ledger:write', 'coop:read'] // scopes
   );
   console.log('Token expires at:', new Date(auth.expires_at * 1000));
@@ -66,11 +75,11 @@ async function main() {
   console.log('\n--- SignatureProvider Auth ---');
   const signer = await createMockSigner(myPrivateKey);
 
-  // This handles the full flow automatically
+  // This handles the full flow automatically (still DEV/DEMO ONLY — self-asserted coop_id)
   const authResult = await client.authenticate(
     myDid,
     signer,
-    'my-coop',
+    'my-coop', // self-asserted coop_id (dev/demo only)
     ['ledger:read', 'ledger:write']
   );
   console.log('Authenticated! Token expires at:', new Date(authResult.expires_at * 1000));


### PR DESCRIPTION
## What
Docs-only cleanup of the TypeScript SDK so it stops teaching the old unsafe authority model. Separates **DID key authentication** (challenge/verify proves key control) from **institutional authority issuance** (a cooperative-scoped token comes from a trusted institutional path). Labels the self-asserted `coop_id` challenge/verify flow dev/demo-only and states the current production fail-closed behavior.

Three files, `+113 / -38` (two commits):
- `sdk/typescript/README.md` — rewrites the Authentication section (distinction → production fail-closed → dev/demo-only flow); flags the Quick Start snippet.
- `sdk/typescript/examples/README.md` — leads the auth pattern with production token-injection (points at `seed-demo-data.ts`); marks challenge/verify dev/demo-only.
- `sdk/typescript/examples/basic-auth.ts` — dev/demo-only banner + inline `self-asserted coop_id` labels, plus the two example-correctness fixes noted under Risk.

## Why
Closes #2083. After PR #2077, production self-asserted `coop_id` issuance at `/auth/verify` is fail-closed, but the SDK docs/examples still taught `challenge → verify → caller-provided coop_id → authority token` with no dev-only label. The docs lagged the runtime. This stops the old model surviving as copy-paste folklore: **DID key control is not cooperative authority; a capability token is not a mandate.** Key control proves control of a key only — not membership, role, delegation, cooperative standing, or institutional authority.

## How
- Reuses the canonical doctrine wording already in `icn/crates/icn-gateway/src/auth.rs` and `CLAUDE.md` (self-asserted issuance fail-closed by default; dev posture = `with_self_asserted_coop(true)`, gated by `ICN_DEV_MODE` **or** the daemon's `--insecure-gateway-no-jwt`, loopback-only — `server.rs:655-678`).
- Cross-references PR #2077 (fail-closed), #2080 (trusted issuance — **planned, not shipped**), #2081 (enforcement cutover), #2082 (coop_id↔EntityId mapping), plus RFC-0018 / ADR-0035 / the #2088 object-context-binding doctrine.
- Meaning Firewall preserved: generic actor/DID/entity/membership/issuer vocabulary; no SaaS-tenant/admin-onboarding framing.

## Risk
Docs/examples only. **No SDK `src/`, schema, wire, or runtime behavior change**; no generated types touched → no API-types drift.

After review, this PR also fixes two **pre-existing example-correctness bugs** in `basic-auth.ts` (and the matching README snippets):
- `getChallenge()` returns `nonce`, not `challenge` (`src/types.ts`: `ChallengeResponse = { nonce, expires_in }`).
- `VerifyResponse.expires_at` is already a millisecond timestamp (`Date.now() + expires_in * 1000`), so the example no longer multiplies it by 1000.

Because the example `.ts` file now contains code corrections (not just comments), **TypeScript SDK CI must pass** for this PR — it does on the current head.

## Test plan
- TypeScript SDK CI green on head `b777a26b`, along with all required checks (Build Release, Clippy, Test, Format, Meaning Firewall, Regulatory Compliance, Kernel Forbidden Dependencies, Firewall Contract Enforcement, Accessibility, Agent Tooling Drift).
- Example snippets verified against the SDK types: `getChallenge` → `nonce`; `verify`/`authenticate` return `expires_at` in ms.
- `git diff` touches only the 3 listed files; no lockfile / `src/` / generated changes.
- All cross-reference link targets exist (RFC-0018, ADR-0035, ABUSE_CASE_HARDENING_STRATEGY.md, `seed-demo-data.ts`); markdown fences balanced.

## Out of scope (deferred, not dropped)
RN SDK README, `docs/guides/institution-setup.md`, and onboarding/workshop/OPENAPI/demo docs carry the same pattern but are outside #2083's TS-SDK scope — tracked as a sibling `type:doc` follow-up. RN `client.ts` runtime behavior and trusted issuance belong to #2080/#2081/#2082.
