### PR TITLE
test(core): cover terminal ExecutionRecord durability across sled reopen

### DIFF
--- a/icn/crates/icn-core/src/supervisor/execution_store.rs
+++ b/icn/crates/icn-core/src/supervisor/execution_store.rs
@@ -202,4 +202,75 @@ mod tests {
         assert_eq!(counts.get(&ExecutionStatus::Pending), Some(&2));
         assert_eq!(counts.get(&ExecutionStatus::Confirmed), Some(&1));
     }
+
+    /// Durability characterization for the dispatch-evidence source (Issue #1987).
+    ///
+    /// A terminal `ExecutionRecord` carries the `(effects, results)` pair the
+    /// gateway dispatch-evidence backfill re-derives `EffectDispatchEvidence`
+    /// from. This proves that pair survives a real close-and-reopen of an
+    /// on-disk sled store from the same path — i.e. the evidence source is
+    /// durable across a restart, not merely within one process. The sibling
+    /// tests use `SledStore::temporary()`, which is deleted on drop and so
+    /// cannot demonstrate cross-reopen persistence.
+    ///
+    /// Scope note: this exercises the graceful-shutdown durability barrier
+    /// (explicit `flush()` / flush-on-drop). It does NOT simulate a hard crash
+    /// between an unflushed `put` and process death; that window is covered by
+    /// idempotent recovery (`DecisionExecutor::recover_in_flight`), not here.
+    #[test]
+    fn terminal_record_with_results_survives_reopen_from_path() {
+        use icn_kernel_api::effects::{EffectOutcome, EffectResult};
+
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // A terminal Confirmed record carrying both stored effects and the
+        // per-effect results — the durable input the evidence backfill consumes.
+        let mut record =
+            ExecutionRecord::new_pending("dh-durable", "prop-durable", "receipt-durable", vec![]);
+        record.set_results(vec![EffectResult {
+            effect_id: "receipt-durable".to_string(),
+            success: true,
+            message: "applied".to_string(),
+            state_change_hash: Some("sch-durable".to_string()),
+            ledger_entry_id: Some("ledger-durable".to_string()),
+            not_executed: false,
+            receipt_ref: Some("steward-durable".to_string()),
+            outcome: Some(EffectOutcome::Applied),
+        }]);
+        record.mark_confirmed(vec!["ledger-durable".into()], vec!["sch-durable".into()]);
+        assert!(record.is_terminal());
+
+        // Write + flush through a real on-disk store, then drop it so the sled
+        // file lock is released (mirrors a graceful shutdown).
+        {
+            let store = Arc::new(SledStore::open(dir.path()).unwrap());
+            let exec_store = SledExecutionStore::new(store.clone());
+            exec_store.put(&record).unwrap();
+            // Explicit durability barrier (fsync), matching graceful shutdown.
+            store.flush().unwrap();
+        } // store + exec_store dropped here → sled Db closed, lock released
+
+        // Reopen from the same path with a fresh handle, as a restarted process
+        // would.
+        let reopened = SledExecutionStore::new(Arc::new(SledStore::open(dir.path()).unwrap()));
+        let got = reopened
+            .get("dh-durable")
+            .unwrap()
+            .expect("terminal execution record must survive store reopen");
+
+        assert_eq!(got.status, ExecutionStatus::Confirmed);
+        assert!(got.is_terminal());
+        // The evidence source must round-trip intact across the reopen.
+        assert_eq!(got.results.len(), 1, "per-effect results survive reopen");
+        assert_eq!(
+            got.results[0].ledger_entry_id.as_deref(),
+            Some("ledger-durable")
+        );
+        assert_eq!(
+            got.results[0].receipt_ref.as_deref(),
+            Some("steward-durable"),
+            "evidence attribution (receipt_ref) survives reopen"
+        );
+        assert_eq!(got.ledger_entry_ids, vec!["ledger-durable".to_string()]);
+    }
 }

--- a/icn/crates/icn-core/src/supervisor/execution_store.rs
+++ b/icn/crates/icn-core/src/supervisor/execution_store.rs
@@ -219,16 +219,25 @@ mod tests {
     /// idempotent recovery (`DecisionExecutor::recover_in_flight`), not here.
     #[test]
     fn terminal_record_with_results_survives_reopen_from_path() {
-        use icn_kernel_api::effects::{EffectOutcome, EffectResult};
+        use icn_kernel_api::effects::{EffectOutcome, EffectResult, KernelEffect};
 
         let dir = tempfile::TempDir::new().unwrap();
 
         // A terminal Confirmed record carrying both stored effects and the
         // per-effect results — the durable input the evidence backfill consumes.
-        let mut record =
-            ExecutionRecord::new_pending("dh-durable", "prop-durable", "receipt-durable", vec![]);
+        // Seed a real (if trivial) effect so the test exercises `effects`
+        // persistence, not just `results`.
+        let effects = vec![KernelEffect::NoOp {
+            reason: "ratified-text".to_string(),
+        }];
+        let mut record = ExecutionRecord::new_pending(
+            "dh-durable",
+            "prop-durable",
+            "receipt-durable",
+            effects.clone(),
+        );
         record.set_results(vec![EffectResult {
-            effect_id: "receipt-durable".to_string(),
+            effect_id: "effect-0".to_string(),
             success: true,
             message: "applied".to_string(),
             state_change_hash: Some("sch-durable".to_string()),
@@ -260,7 +269,10 @@ mod tests {
 
         assert_eq!(got.status, ExecutionStatus::Confirmed);
         assert!(got.is_terminal());
-        // The evidence source must round-trip intact across the reopen.
+        // Both halves of the evidence source must round-trip intact across the
+        // reopen — assert `effects` too, not just `results`, so a regression that
+        // only persists/loads `results` cannot pass.
+        assert_eq!(got.effects, effects, "stored effects survive reopen");
         assert_eq!(got.results.len(), 1, "per-effect results survive reopen");
         assert_eq!(
             got.results[0].ledger_entry_id.as_deref(),


### PR DESCRIPTION
## What

Adds one characterization test for `SledExecutionStore`:
`terminal_record_with_results_survives_reopen_from_path`. It proves a terminal
`ExecutionRecord` carrying the `(effects, results)` pair survives a real on-disk
store **close and reopen from the same path**, with the per-effect results and
attribution (`receipt_ref`, `ledger_entry_id`) intact.

**Test-only. No production behavior change.**

## Why

This came out of a read-only audit of the durable-dispatch-evidence chain
(#1987 → #1990/#1993/#1996). `EffectDispatchEvidence` is not stored directly;
the gateway dispatch-evidence backfill **re-derives** it from the durable
`(effects, results)` pair persisted on the `ExecutionRecord` (`icn-kernel-api`
`execution.rs`; persisted by `SledExecutionStore`). That cross-restart
durability is the foundation the #1990 design rests on, but no test exercised
it: the sibling `SledExecutionStore` tests use `SledStore::temporary()`, which
is deleted on drop and therefore **cannot** demonstrate persistence across a
reopen. This test closes that coverage gap by using `SledStore::open(path)`,
writing + flushing a `Confirmed` record, dropping the store (releasing the sled
lock), reopening from the same path, and asserting the record + results
round-trip.

## Scope / honesty note

This exercises the **graceful-shutdown durability barrier** (explicit `flush()` /
flush-on-drop). It deliberately does **not** simulate a hard crash between an
unflushed `put` and process death. `SledStore::put` does not fsync per write, so
that narrow window exists at the source level; it is covered by **idempotent
recovery** (`DecisionExecutor::recover_in_flight` re-dispatches non-terminal
records keyed by `decision_hash`), not by this test. Closing the hard-crash
window (an explicit flush barrier after the terminal put) and a full
per-effect-kind idempotency audit are deferred follow-ups, intentionally **not**
in this PR to keep it minimal and behavior-preserving.

## Risk

Minimal — additive test in `icn-core`'s `execution_store` test module; touches no
production code, no other modules, no dependencies (icn-core already has
`tempfile` + `icn-store` as test deps).

## Test plan

From `icn/`:
- `cargo fmt --all --check` → pass
- `cargo clippy -p icn-core --all-targets -- -D warnings` → pass
- `cargo test -p icn-core --lib` → **395 passed, 0 failed** (incl. the new test)

Relates to #1987 / #1990. Does not modify #1985/#1986/#1988 areas.
