### PR TITLE
fix(sdis): make steward sanction slashing idempotent by decision

### DIFF
--- a/icn/crates/icn-commons/src/handle.rs
+++ b/icn/crates/icn-commons/src/handle.rs
@@ -478,6 +478,25 @@ impl CommonsHandle {
             .slash_steward_bond(steward_id, amount)
             .await
     }
+
+    /// Slash a steward's bond idempotently for a governance decision.
+    ///
+    /// `decision_key` (the sanction proposal's receipt id) dedupes by decision
+    /// so a crash-recovery re-dispatch of the same `SanctionSteward` cannot
+    /// double-slash. Returns the amount slashed by THIS call (`0` if already
+    /// applied for this decision).
+    pub async fn slash_steward_bond_for_decision(
+        &self,
+        steward_id: &str,
+        amount: u64,
+        decision_key: &str,
+    ) -> Result<u64> {
+        self.inner
+            .write()
+            .await
+            .slash_steward_bond_for_decision(steward_id, amount, decision_key)
+            .await
+    }
 }
 
 // ============================================================================

--- a/icn/crates/icn-commons/src/handle.rs
+++ b/icn/crates/icn-commons/src/handle.rs
@@ -483,8 +483,8 @@ impl CommonsHandle {
     ///
     /// `decision_key` (the sanction proposal's receipt id) dedupes by decision
     /// so a crash-recovery re-dispatch of the same `SanctionSteward` cannot
-    /// double-slash. Returns the amount slashed by THIS call (`0` if already
-    /// applied for this decision).
+    /// double-slash. Returns the steward's remaining bond after the operation
+    /// (accurate on both the first application and an idempotent replay).
     pub async fn slash_steward_bond_for_decision(
         &self,
         steward_id: &str,

--- a/icn/crates/icn-commons/src/inner.rs
+++ b/icn/crates/icn-commons/src/inner.rs
@@ -1129,6 +1129,28 @@ impl CommonsInner {
         Ok(result)
     }
 
+    /// Slash a steward's bond idempotently for a governance decision.
+    ///
+    /// `decision_key` dedupes by governance decision so a crash-recovery
+    /// re-dispatch of the same `SanctionSteward` cannot double-slash. Returns
+    /// the amount slashed by THIS call (`0` if the decision was already
+    /// applied).
+    pub async fn slash_steward_bond_for_decision(
+        &self,
+        steward_id: &str,
+        amount: u64,
+        decision_key: &str,
+    ) -> Result<u64> {
+        let mut steward = self
+            .store
+            .get_steward(steward_id)?
+            .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
+
+        let result = steward.slash_bond_for_decision(amount, decision_key);
+        self.store.put_steward(&steward)?;
+        Ok(result)
+    }
+
     // ========== Revocation Operations ==========
 
     /// Add a revocation record

--- a/icn/crates/icn-commons/src/inner.rs
+++ b/icn/crates/icn-commons/src/inner.rs
@@ -1146,6 +1146,12 @@ impl CommonsInner {
             .get_steward(steward_id)?
             .ok_or_else(|| anyhow::anyhow!("Steward not found: {steward_id}"))?;
 
+        // On an idempotent replay the decision is already recorded and nothing
+        // changes — skip the redundant durable write and just report the bond.
+        if steward.applied_sanctions.contains(decision_key) {
+            return Ok(steward.bond_amount);
+        }
+
         let result = steward.slash_bond_for_decision(amount, decision_key);
         self.store.put_steward(&steward)?;
         Ok(result)

--- a/icn/crates/icn-commons/src/inner.rs
+++ b/icn/crates/icn-commons/src/inner.rs
@@ -1133,8 +1133,8 @@ impl CommonsInner {
     ///
     /// `decision_key` dedupes by governance decision so a crash-recovery
     /// re-dispatch of the same `SanctionSteward` cannot double-slash. Returns
-    /// the amount slashed by THIS call (`0` if the decision was already
-    /// applied).
+    /// the steward's remaining bond after the operation (accurate on both the
+    /// first application and an idempotent replay).
     pub async fn slash_steward_bond_for_decision(
         &self,
         steward_id: &str,

--- a/icn/crates/icn-core/src/services/sdis_service.rs
+++ b/icn/crates/icn-core/src/services/sdis_service.rs
@@ -482,9 +482,17 @@ impl SdisService for SdisServiceImpl {
                         )
                     })?;
                 let steward_id = record.id().to_hex();
+                // Idempotent per governance decision (the sanction proposal's
+                // receipt id): a crash-recovery re-dispatch of the same
+                // SanctionSteward effect must not slash the bond twice, while
+                // distinct decisions still slash independently.
                 let remaining = self
                     .commons
-                    .slash_steward_bond(&steward_id, request.bond_slash_amount)
+                    .slash_steward_bond_for_decision(
+                        &steward_id,
+                        request.bond_slash_amount,
+                        &request.proposal_id,
+                    )
                     .await?;
                 Ok::<_, anyhow::Error>((steward_id, remaining))
             })
@@ -669,6 +677,77 @@ mod tests {
             Some(expected_receipt_ref),
             "AppointStewardResult.receipt_ref must equal the commons StewardId::to_hex() \
              so kernel-path dispatch evidence carries the real downstream handle"
+        );
+    }
+
+    /// SanctionSteward is idempotent per governance decision: re-dispatching the
+    /// same sanction (same `proposal_id`) — as crash recovery does — slashes the
+    /// bond only once, while a distinct decision slashes again. Guards the
+    /// replay window where a hard crash leaves the execution record non-terminal
+    /// and `recover_in_flight` re-runs the effect.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sanction_steward_idempotent_per_decision() {
+        let (svc, commons) = make_service_with_commons();
+        let holder = test_did(40);
+        let sponsor = test_did(41);
+        create_strong_holder(&commons, &holder, &sponsor).await;
+
+        svc.appoint_steward(AppointStewardRequest {
+            steward_did: holder.to_string(),
+            jurisdiction_id: String::new(),
+            term_length_seconds: 86400 * 365,
+            bond_amount: 1000,
+            region: None,
+            proposal_id: "gov:coop:appoint:receipt".to_string(),
+        })
+        .unwrap();
+
+        let sanction = |proposal_id: &str| SanctionStewardRequest {
+            steward_did: holder.to_string(),
+            bond_slash_amount: 300,
+            suspend_reason: String::new(),
+            reason: "misbehavior".to_string(),
+            proposal_id: proposal_id.to_string(),
+        };
+        let bond_now = |c: Arc<icn_commons::CommonsHandle>, did: icn_identity::Did| async move {
+            c.get_steward_by_did(&did)
+                .await
+                .expect("get_steward_by_did must not error")
+                .expect("steward present")
+                .bond_amount
+        };
+
+        // First dispatch of decision A slashes 300 (1000 -> 700).
+        assert!(
+            svc.sanction_steward(sanction("gov:coop:sanction-A:receipt"))
+                .unwrap()
+                .success
+        );
+        assert_eq!(bond_now(commons.clone(), holder.clone()).await, 700);
+
+        // Re-dispatch of the SAME decision A (crash-recovery replay) must NOT
+        // slash again — the bond stays 700.
+        assert!(
+            svc.sanction_steward(sanction("gov:coop:sanction-A:receipt"))
+                .unwrap()
+                .success
+        );
+        assert_eq!(
+            bond_now(commons.clone(), holder.clone()).await,
+            700,
+            "same sanction decision must not double-slash the bond on replay"
+        );
+
+        // A DISTINCT decision B still slashes (700 -> 400).
+        assert!(
+            svc.sanction_steward(sanction("gov:coop:sanction-B:receipt"))
+                .unwrap()
+                .success
+        );
+        assert_eq!(
+            bond_now(commons.clone(), holder.clone()).await,
+            400,
+            "a distinct sanction decision must still slash"
         );
     }
 

--- a/icn/crates/icn-core/src/services/sdis_service.rs
+++ b/icn/crates/icn-core/src/services/sdis_service.rs
@@ -458,6 +458,31 @@ impl SdisService for SdisServiceImpl {
             proposal_id = %request.proposal_id,
             "Sanctioning steward via governance dispatch (bond slash)"
         );
+
+        // Fail closed without an idempotency key. `proposal_id` is the per-decision
+        // dedupe key for the slash; an empty one would be recorded as "" in
+        // `applied_sanctions`, so the first empty-id sanction would make every later
+        // empty-id sanction look like a replay and silently skip an authorized
+        // slash. A governed sanction always carries a non-empty proposal receipt id.
+        if request.proposal_id.trim().is_empty() {
+            warn!(
+                steward_did = %request.steward_did,
+                "Rejecting SanctionSteward: empty proposal_id (no per-decision idempotency key)"
+            );
+            return Ok(SanctionStewardResult {
+                success: false,
+                remaining_bond: 0,
+                suspended: false,
+                state_change_hash: String::new(),
+                error: Some(
+                    "SanctionSteward requires a non-empty proposal_id as the per-decision \
+                     idempotency key"
+                        .to_string(),
+                ),
+                receipt_ref: None,
+            });
+        }
+
         let steward_did = icn_identity::Did::from_str(&request.steward_did)
             .map_err(|e| anyhow::anyhow!("Invalid steward DID '{}': {}", request.steward_did, e))?;
 
@@ -757,6 +782,50 @@ mod tests {
             400,
             "a distinct sanction decision must still slash"
         );
+    }
+
+    /// A SanctionSteward with an empty `proposal_id` has no idempotency key.
+    /// Recording `""` would make every later empty-id sanction look like a
+    /// replay and silently skip an authorized slash, so the service must reject
+    /// it (fail closed) without slashing.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sanction_steward_rejects_empty_proposal_id() {
+        let (svc, commons) = make_service_with_commons();
+        let holder = test_did(42);
+        let sponsor = test_did(43);
+        create_strong_holder(&commons, &holder, &sponsor).await;
+        svc.appoint_steward(AppointStewardRequest {
+            steward_did: holder.to_string(),
+            jurisdiction_id: String::new(),
+            term_length_seconds: 86400 * 365,
+            bond_amount: 1000,
+            region: None,
+            proposal_id: "gov:coop:appoint:receipt".to_string(),
+        })
+        .unwrap();
+
+        let result = svc
+            .sanction_steward(SanctionStewardRequest {
+                steward_did: holder.to_string(),
+                bond_slash_amount: 300,
+                suspend_reason: String::new(),
+                reason: "misbehavior".to_string(),
+                proposal_id: String::new(), // no idempotency key
+            })
+            .unwrap();
+
+        assert!(
+            !result.success,
+            "empty proposal_id must be rejected (fail closed)"
+        );
+        assert!(result.error.is_some());
+        let bond = commons
+            .get_steward_by_did(&holder)
+            .await
+            .unwrap()
+            .unwrap()
+            .bond_amount;
+        assert_eq!(bond, 1000, "a rejected sanction must not slash the bond");
     }
 
     /// AppointSteward → RevokeSteward → steward record removed from commons.

--- a/icn/crates/icn-core/src/services/sdis_service.rs
+++ b/icn/crates/icn-core/src/services/sdis_service.rs
@@ -717,20 +717,28 @@ mod tests {
                 .bond_amount
         };
 
-        // First dispatch of decision A slashes 300 (1000 -> 700).
-        assert!(
-            svc.sanction_steward(sanction("gov:coop:sanction-A:receipt"))
-                .unwrap()
-                .success
+        // First dispatch of decision A slashes 300 (1000 -> 700) and reports
+        // the remaining bond.
+        let first = svc
+            .sanction_steward(sanction("gov:coop:sanction-A:receipt"))
+            .unwrap();
+        assert!(first.success);
+        assert_eq!(
+            first.remaining_bond, 700,
+            "first dispatch reports the remaining bond"
         );
         assert_eq!(bond_now(commons.clone(), holder.clone()).await, 700);
 
         // Re-dispatch of the SAME decision A (crash-recovery replay) must NOT
-        // slash again — the bond stays 700.
-        assert!(
-            svc.sanction_steward(sanction("gov:coop:sanction-A:receipt"))
-                .unwrap()
-                .success
+        // slash again — the bond stays 700 — and the result must report the
+        // true remaining bond (700), not the per-call slashed amount (0).
+        let replay = svc
+            .sanction_steward(sanction("gov:coop:sanction-A:receipt"))
+            .unwrap();
+        assert!(replay.success);
+        assert_eq!(
+            replay.remaining_bond, 700,
+            "replay must report the true remaining bond (recovery/audit evidence), not 0"
         );
         assert_eq!(
             bond_now(commons.clone(), holder.clone()).await,

--- a/icn/crates/icn-governance/src/steward.rs
+++ b/icn/crates/icn-governance/src/steward.rs
@@ -303,16 +303,23 @@ impl StewardRecord {
     /// `decision_key` is the per-decision governance identifier (the sanction
     /// proposal's receipt id). The first call for a given key slashes
     /// `min(amount, bond_amount)` and records the key; any later call with the
-    /// same key is a no-op returning `0` (bond unchanged). This makes
-    /// `SdisEffect::SanctionSteward` replay-safe — a crash-recovery
-    /// re-dispatch of the same governance decision cannot double-slash — while
-    /// distinct decisions still slash independently.
+    /// same key does not slash again. This makes `SdisEffect::SanctionSteward`
+    /// replay-safe — a crash-recovery re-dispatch of the same governance
+    /// decision cannot double-slash — while distinct decisions still slash
+    /// independently.
+    ///
+    /// Returns the steward's bond *after* the operation (the remaining bond),
+    /// identical across replays, so callers report the true post-sanction bond
+    /// for both the first application and an idempotent replay — not the
+    /// per-call slashed amount, which would be a misleading `0` on replay and
+    /// corrupt the recovery/audit evidence.
     pub fn slash_bond_for_decision(&mut self, amount: u64, decision_key: &str) -> u64 {
-        if !self.applied_sanctions.insert(decision_key.to_string()) {
-            // This decision's slash was already applied; do not slash again.
-            return 0;
+        if self.applied_sanctions.insert(decision_key.to_string()) {
+            // First time this decision is seen: apply the slash exactly once.
+            self.slash_bond(amount);
         }
-        self.slash_bond(amount)
+        // Report the actual post-operation bond, identical across replays.
+        self.bond_amount
     }
 
     /// Get effectiveness score (combination of activity and reputation)
@@ -646,20 +653,24 @@ mod tests {
         let mut steward = create_test_steward();
         assert_eq!(steward.bond_amount, 1000);
 
-        // First sanction by decision A slashes once.
-        let slashed = steward.slash_bond_for_decision(300, "proposal-A");
-        assert_eq!(slashed, 300);
+        // First sanction by decision A slashes once and reports the remaining bond.
+        let remaining = steward.slash_bond_for_decision(300, "proposal-A");
+        assert_eq!(remaining, 700, "returns the remaining bond after the slash");
         assert_eq!(steward.bond_amount, 700);
 
         // Re-dispatch of the SAME decision (e.g. crash-recovery replay) must be
-        // a no-op — the bond must not be slashed twice.
+        // a no-op — the bond must not be slashed twice, and the reported
+        // remaining bond must stay accurate (not 0).
         let replay = steward.slash_bond_for_decision(300, "proposal-A");
-        assert_eq!(replay, 0, "same decision must not slash the bond again");
+        assert_eq!(replay, 700, "replay reports the true remaining bond, not 0");
         assert_eq!(steward.bond_amount, 700, "bond unchanged on replay");
 
         // A DISTINCT decision still slashes independently.
-        let slashed_b = steward.slash_bond_for_decision(200, "proposal-B");
-        assert_eq!(slashed_b, 200);
+        let remaining_b = steward.slash_bond_for_decision(200, "proposal-B");
+        assert_eq!(
+            remaining_b, 500,
+            "returns remaining bond after a distinct slash"
+        );
         assert_eq!(steward.bond_amount, 500);
     }
 

--- a/icn/crates/icn-governance/src/steward.rs
+++ b/icn/crates/icn-governance/src/steward.rs
@@ -12,6 +12,7 @@
 
 use icn_identity::Did;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fmt;
 
 /// Unique identifier for a Steward record
@@ -109,6 +110,16 @@ pub struct StewardRecord {
 
     /// Last update timestamp
     pub updated_at: u64,
+
+    /// Governance decisions (by proposal-receipt id) whose bond slash has
+    /// already been applied to this steward. Makes governance-dispatched
+    /// sanctions replay-safe: a crash-recovery re-dispatch of the same decision
+    /// is a no-op, while distinct decisions still slash independently.
+    ///
+    /// Additive (`#[serde(default)]`) so records persisted before this field
+    /// existed deserialize to an empty set.
+    #[serde(default)]
+    pub applied_sanctions: BTreeSet<String>,
 }
 
 impl StewardRecord {
@@ -143,6 +154,7 @@ impl StewardRecord {
             contact_info: None,
             created_at: now,
             updated_at: now,
+            applied_sanctions: BTreeSet::new(),
         }
     }
 
@@ -284,6 +296,23 @@ impl StewardRecord {
         self.bond_amount -= slashed;
         self.updated_at = icn_time::current_timestamp_secs();
         slashed
+    }
+
+    /// Slash the bond for a governance sanction, idempotent per `decision_key`.
+    ///
+    /// `decision_key` is the per-decision governance identifier (the sanction
+    /// proposal's receipt id). The first call for a given key slashes
+    /// `min(amount, bond_amount)` and records the key; any later call with the
+    /// same key is a no-op returning `0` (bond unchanged). This makes
+    /// `SdisEffect::SanctionSteward` replay-safe — a crash-recovery
+    /// re-dispatch of the same governance decision cannot double-slash — while
+    /// distinct decisions still slash independently.
+    pub fn slash_bond_for_decision(&mut self, amount: u64, decision_key: &str) -> u64 {
+        if !self.applied_sanctions.insert(decision_key.to_string()) {
+            // This decision's slash was already applied; do not slash again.
+            return 0;
+        }
+        self.slash_bond(amount)
     }
 
     /// Get effectiveness score (combination of activity and reputation)
@@ -610,6 +639,28 @@ mod tests {
         let slashed = steward.slash_bond(2000);
         assert_eq!(slashed, 1200);
         assert_eq!(steward.bond_amount, 0);
+    }
+
+    #[test]
+    fn slash_bond_for_decision_is_idempotent_per_decision() {
+        let mut steward = create_test_steward();
+        assert_eq!(steward.bond_amount, 1000);
+
+        // First sanction by decision A slashes once.
+        let slashed = steward.slash_bond_for_decision(300, "proposal-A");
+        assert_eq!(slashed, 300);
+        assert_eq!(steward.bond_amount, 700);
+
+        // Re-dispatch of the SAME decision (e.g. crash-recovery replay) must be
+        // a no-op — the bond must not be slashed twice.
+        let replay = steward.slash_bond_for_decision(300, "proposal-A");
+        assert_eq!(replay, 0, "same decision must not slash the bond again");
+        assert_eq!(steward.bond_amount, 700, "bond unchanged on replay");
+
+        // A DISTINCT decision still slashes independently.
+        let slashed_b = steward.slash_bond_for_decision(200, "proposal-B");
+        assert_eq!(slashed_b, 200);
+        assert_eq!(steward.bond_amount, 500);
     }
 
     #[test]


### PR DESCRIPTION
## What

Make `SdisEffect::SanctionSteward`'s bond slash **idempotent per governance decision**, so a crash-recovery re-dispatch of the same sanction cannot slash a steward bond more than once, while distinct sanction decisions still slash independently.

## Why

Found by the dispatch-recovery audit (follow-up to #1990 / #1993 / #1996). `StewardRecord::slash_bond` was a raw arithmetic subtraction (`bond_amount -= slashed`) with **no idempotency key**, and `sdis_service::sanction_steward` called it without one. On a hard crash between effect dispatch and the terminal `ExecutionRecord` write, `DecisionExecutor::recover_in_flight` re-runs the non-terminal decision's stored effects — so the same `SanctionSteward` could slash the **same bond twice** (irreversible double penalty). Unlike the escrow/budget sagas (`begin_release`/`begin_spend`, keyed by `decision_hash`), the slash had no such guard.

A general flush barrier does **not** fix this: the slash mutation happens *before* the terminal execution-record write, so re-dispatch can still double-apply regardless of flush timing. The correct fix is per-effect idempotency.

## How

Idempotency key = the sanction proposal's receipt id (`proposal_id`), which is already carried by both `SdisEffect::SanctionSteward` and `SanctionStewardRequest` and is replayed identically on recovery — so no dispatcher-signature change is needed (`decision_hash` is not plumbed into `execute_effects`).

- `StewardRecord` (icn-governance): new `applied_sanctions: BTreeSet<String>` field (`#[serde(default)]`, backward-compatible) + `slash_bond_for_decision(amount, decision_key)` — slashes once per key, no-op (returns 0) on replay; distinct keys slash independently.
- `CommonsHandle` / inner (icn-commons): additive `slash_steward_bond_for_decision(steward_id, amount, decision_key)`.
- `sdis_service::sanction_steward` (icn-core): routes the sanction slash through the idempotent method with `request.proposal_id`.

The pre-existing non-keyed `slash_bond` / `slash_steward_bond` are **retained** for the manual gateway admin slash endpoint (human-initiated, not crash-replayed) — out of scope here.

## Risk

Low and contained. Additive field (serde-default) + additive methods; the only behavioral change is on the SanctionSteward effect path (now idempotent). No public API removed/changed; no other effect kinds touched; no governance/ledger refactor.

## Test plan

- New unit test (icn-governance): `slash_bond_for_decision_is_idempotent_per_decision` — same key slashes once, replay is a no-op, distinct key slashes again.
- New service-level test (icn-core): `test_sanction_steward_idempotent_per_decision` — a re-dispatched sanction (same `proposal_id`) slashes the bond once; a distinct decision slashes again.
- `cargo fmt --all --check` → pass
- `cargo clippy -p icn-governance -p icn-commons -p icn-core --all-targets -- -D warnings` → pass
- `cargo test -p icn-governance -p icn-commons -p icn-core --lib` → pass (icn-governance 593, icn-core 396, icn-commons all; 0 failed)

## Scope / not in this PR

- Only `SanctionSteward` (the one source-verified non-idempotent effect from the audit).
- Audit-noted lower-severity items (Federation `TerminateClearing`/`RevokeVouch` audit-ambiguity; ledger `expected_nonce` enforcement verification; ControlService veto/force-close idempotency) are **not** addressed here.
