### PR TITLE
fix(federation): bind decision_hash into control-effect provenance hashes

### DIFF
--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -281,6 +281,53 @@ impl FederationServiceImpl {
         hasher.update(request.decision_receipt_id.as_bytes());
         format!("{:x}", hasher.finalize())
     }
+
+    /// Compute a state change hash for a clearing-termination operation.
+    ///
+    /// Binds the authorizing decision's `decision_hash` in addition to the
+    /// `decision_receipt_id`, so the provenance hash distinguishes two
+    /// decisions that share a receipt id. An empty `decision_hash` is tolerated
+    /// and folded as empty bytes — this hash is an audit/verification artifact,
+    /// not an authorization gate, so absence weakens provenance entropy rather
+    /// than denying the operation.
+    ///
+    /// NOTE: on the main `KernelEffect::Federation` path the bound value is
+    /// currently empty: `FederationEffect::TerminateClearing` carries no
+    /// `decision_hash` field, so `federation_effect_to_operation` sets it to
+    /// `None` and the executor passes `unwrap_or_default()`. This helper makes
+    /// the hash bind `decision_hash` whenever a caller supplies one; propagating
+    /// the canonical decision hash through the federation effect itself is a
+    /// tracked follow-up (see PR #2093 discussion).
+    fn compute_terminate_clearing_hash(
+        request: &FederationTerminateClearingRequest,
+        agreement_id: &str,
+    ) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(b"federation:terminate_clearing:");
+        hasher.update(agreement_id.as_bytes());
+        hasher.update(b":");
+        hasher.update(request.decision_receipt_id.as_bytes());
+        hasher.update(b":");
+        hasher.update(request.decision_hash.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+
+    /// Compute a state change hash for a vouch-revocation operation.
+    ///
+    /// Binds `decision_hash` alongside `decision_receipt_id` (see
+    /// [`Self::compute_terminate_clearing_hash`] for the empty-hash policy).
+    fn compute_revoke_vouch_hash(request: &FederationRevokeVouchRequest) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(b"federation:revoke_vouch:");
+        hasher.update(request.revoker_did.as_bytes());
+        hasher.update(b":");
+        hasher.update(request.target_coop_did.as_bytes());
+        hasher.update(b":");
+        hasher.update(request.decision_receipt_id.as_bytes());
+        hasher.update(b":");
+        hasher.update(request.decision_hash.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
 }
 
 impl FederationService for FederationServiceImpl {
@@ -816,18 +863,15 @@ impl FederationService for FederationServiceImpl {
             partner_coop = %request.partner_coop_did,
             reason = %request.reason,
             decision_receipt_id = %request.decision_receipt_id,
+            decision_hash = %request.decision_hash,
             "Terminating bilateral clearing agreement via governance"
         );
 
         match clearing.terminate_agreement(&request.initiating_coop_did, &request.partner_coop_did)
         {
             Ok(agreement_id) => {
-                let mut hasher = Sha256::new();
-                hasher.update(b"federation:terminate_clearing:");
-                hasher.update(agreement_id.as_bytes());
-                hasher.update(b":");
-                hasher.update(request.decision_receipt_id.as_bytes());
-                let state_change_hash = format!("{:x}", hasher.finalize());
+                let state_change_hash =
+                    Self::compute_terminate_clearing_hash(&request, &agreement_id);
 
                 info!(
                     agreement_id = %agreement_id,
@@ -868,6 +912,7 @@ impl FederationService for FederationServiceImpl {
             target = %request.target_coop_did,
             reason = %request.reason,
             decision_receipt_id = %request.decision_receipt_id,
+            decision_hash = %request.decision_hash,
             "Revoking vouch via governance"
         );
 
@@ -876,14 +921,7 @@ impl FederationService for FederationServiceImpl {
             .remove_vouch(&request.revoker_did, &request.target_coop_did)
         {
             Ok(()) => {
-                let mut hasher = Sha256::new();
-                hasher.update(b"federation:revoke_vouch:");
-                hasher.update(request.revoker_did.as_bytes());
-                hasher.update(b":");
-                hasher.update(request.target_coop_did.as_bytes());
-                hasher.update(b":");
-                hasher.update(request.decision_receipt_id.as_bytes());
-                let state_change_hash = format!("{:x}", hasher.finalize());
+                let state_change_hash = Self::compute_revoke_vouch_hash(&request);
 
                 info!(
                     revoker = %request.revoker_did,
@@ -1142,6 +1180,72 @@ mod tests {
         let (receipt_id, hash) = prov.unwrap();
         assert_eq!(receipt_id, request.decision_receipt_id);
         assert_eq!(hash, request.decision_hash);
+    }
+
+    fn terminate_request(decision_hash: &str) -> FederationTerminateClearingRequest {
+        FederationTerminateClearingRequest {
+            initiating_coop_did: "did:icn:initiator".to_string(),
+            partner_coop_did: "did:icn:partner".to_string(),
+            reason: "governance decision".to_string(),
+            decision_receipt_id: "gov:proposal:terminate:receipt:1".to_string(),
+            decision_hash: decision_hash.to_string(),
+        }
+    }
+
+    fn revoke_request(decision_hash: &str) -> FederationRevokeVouchRequest {
+        FederationRevokeVouchRequest {
+            revoker_did: "did:icn:revoker".to_string(),
+            target_coop_did: "did:icn:target".to_string(),
+            reason: "governance decision".to_string(),
+            decision_receipt_id: "gov:proposal:revoke:receipt:1".to_string(),
+            decision_hash: decision_hash.to_string(),
+        }
+    }
+
+    #[test]
+    fn terminate_clearing_hash_is_deterministic() {
+        let req = terminate_request("sha256:decision-a");
+        let h1 = FederationServiceImpl::compute_terminate_clearing_hash(&req, "agreement-1");
+        let h2 = FederationServiceImpl::compute_terminate_clearing_hash(&req, "agreement-1");
+        assert_eq!(h1, h2);
+    }
+
+    /// Two decisions with the *same* receipt id but different `decision_hash`
+    /// must yield distinct state-change hashes — provenance binds the decision,
+    /// not just the receipt id.
+    #[test]
+    fn terminate_clearing_hash_binds_decision_hash() {
+        let req_a = terminate_request("sha256:decision-a");
+        let req_b = terminate_request("sha256:decision-b");
+        assert_eq!(req_a.decision_receipt_id, req_b.decision_receipt_id);
+        let h_a = FederationServiceImpl::compute_terminate_clearing_hash(&req_a, "agreement-1");
+        let h_b = FederationServiceImpl::compute_terminate_clearing_hash(&req_b, "agreement-1");
+        assert_ne!(
+            h_a, h_b,
+            "terminate_clearing state_change_hash must bind decision_hash"
+        );
+    }
+
+    #[test]
+    fn revoke_vouch_hash_is_deterministic() {
+        let req = revoke_request("sha256:decision-a");
+        let h1 = FederationServiceImpl::compute_revoke_vouch_hash(&req);
+        let h2 = FederationServiceImpl::compute_revoke_vouch_hash(&req);
+        assert_eq!(h1, h2);
+    }
+
+    /// Same receipt id, different `decision_hash` -> distinct hashes.
+    #[test]
+    fn revoke_vouch_hash_binds_decision_hash() {
+        let req_a = revoke_request("sha256:decision-a");
+        let req_b = revoke_request("sha256:decision-b");
+        assert_eq!(req_a.decision_receipt_id, req_b.decision_receipt_id);
+        let h_a = FederationServiceImpl::compute_revoke_vouch_hash(&req_a);
+        let h_b = FederationServiceImpl::compute_revoke_vouch_hash(&req_b);
+        assert_ne!(
+            h_a, h_b,
+            "revoke_vouch state_change_hash must bind decision_hash"
+        );
     }
 
     /// Two-phase durability test: write, close, reopen, verify record survives


### PR DESCRIPTION
## What
Bind the authorizing decision's **`decision_hash`** into the `state_change_hash` for the two federation control effects — `terminate_clearing` and `revoke_vouch` — in `icn-core/src/services/federation_service.rs`, and log `decision_hash` alongside `decision_receipt_id` in both handlers (matching `join`/`leave`). Extracts two `compute_*_hash` helpers matching the file's existing `compute_join_hash` / `compute_leave_hash` / `compute_vouch_hash` / `compute_clearing_hash`.

## Why
Follow-up from the #2092 (post-#2091) replay/idempotency audit. Both handlers already **receive** `request.decision_hash` but folded only `decision_receipt_id` into their provenance hash, so the field was structurally discarded. This is **evidence/audit completeness, not replay safety** — both operations remain state-idempotent (`terminate_agreement` errors before mutating a missing agreement; `remove_vouch` early-returns `Ok` with no write). **This PR does not change Federation replay safety.**

## Scope + a known limitation (important — thanks @chatgpt-codex-connector)
This makes the hash helper **bind `decision_hash` whenever a caller supplies one**, plus tests + log consistency. It is structurally correct but **currently inert on the main `KernelEffect::Federation` path**: `FederationEffect::TerminateClearing` / `RevokeVouch` carry no `decision_hash` field, so `federation_effect_to_operation` sets `decision_hash: None` and the executor passes `unwrap_or_default()` → empty. On that path the bound value is the empty string today (documented in the helper doc-comment so it is not overclaimed).

Propagating the canonical decision hash end-to-end requires adding a `decision_hash` field to those two `FederationEffect` variants and populating it at the governance execution/translation layer — a cross-crate change (kernel-API enum + match sites) that is **out of scope** for this focused provenance-hash PR. Tracked as a follow-up; the same gap affects every federation effect except `SettleClearing` (which already carries `decision_hash`). This PR is the prerequisite hash-helper step.

## How
- Extract `compute_terminate_clearing_hash(request, agreement_id)` and `compute_revoke_vouch_hash(request)`; fold `decision_hash` after `decision_receipt_id`.
- Replace the inline hashing in both handlers with calls to the helpers.
- Add `decision_hash` to both handlers' request-context `info!` logs (consistency with `join`/`leave`).

**Empty-`decision_hash` policy: tolerate** (folded as empty bytes). `state_change_hash` is an audit/verification artifact, not an authorization gate, and authz is enforced upstream; fail-closed would break the main path (which currently always supplies empty).

## Risk
Low. `state_change_hash` is emitted/logged only — **no consumer recomputes or verifies it** (grep-confirmed), so changing its formula is safe (no persisted-compat concern). No public API / request-type / wire / OpenAPI change.

## Test plan
- New unit tests: `terminate_clearing_hash_is_deterministic`, `terminate_clearing_hash_binds_decision_hash`, `revoke_vouch_hash_is_deterministic`, `revoke_vouch_hash_binds_decision_hash` (two decisions, same receipt id, different `decision_hash` → distinct hashes). Written test-first.
- `cargo fmt --all --check` — clean
- `cargo clippy -p icn-core --all-targets --all-features -- -D warnings` — clean
- `cargo test -p icn-core --lib` — all pass (incl. 23 `federation_service` tests + 4 new)
- Rebased onto current `main` (post-#2092, `7669de70`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
