### PR TITLE
fix(federation): propagate decision_hash through federation effects

### DIFF
--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -382,7 +382,7 @@ pub fn translate_payload_to_effects(
 
         // Federation proposals
         ProposalPayload::Federation(fed_proposal) => {
-            translate_federation_proposal(fed_proposal, domain_id)
+            translate_federation_proposal(fed_proposal, domain_id, decision_hash)
         }
 
         // Resource access proposals
@@ -623,6 +623,7 @@ fn translate_membership_action(
 fn translate_federation_proposal(
     proposal: &icn_governance::FederationProposal,
     domain_id: &str,
+    decision_hash: &str,
 ) -> Result<Vec<KernelEffect>, TranslationError> {
     use icn_governance::FederationProposal;
 
@@ -684,6 +685,7 @@ fn translate_federation_proposal(
                 initiating_coop_did: domain_id.to_string(),
                 partner_coop_did: partner_coop_id.clone(),
                 reason: reason.clone(),
+                decision_hash: decision_hash.to_string(),
             },
         )]),
         FederationProposal::RevokeVouch {
@@ -694,6 +696,7 @@ fn translate_federation_proposal(
                 revoker_did: domain_id.to_string(),
                 target_coop_did: target_coop_id.clone(),
                 reason: reason.clone(),
+                decision_hash: decision_hash.to_string(),
             },
         )]),
         // Fallback for other federation proposals (UpdateFederationPolicy etc.)
@@ -1143,6 +1146,7 @@ mod tests {
                     initiating_coop_did,
                     partner_coop_did,
                     reason,
+                    decision_hash,
                 },
             ) => {
                 assert_eq!(
@@ -1151,6 +1155,10 @@ mod tests {
                 );
                 assert_eq!(partner_coop_did, "coop-beta");
                 assert_eq!(reason, "persistent imbalance violations");
+                assert_eq!(
+                    decision_hash, "hash-tc-1",
+                    "effect must carry the decision_hash passed to translate_payload_to_effects"
+                );
             }
             other => panic!("expected TerminateClearing effect, got {other:?}"),
         }
@@ -1173,6 +1181,7 @@ mod tests {
                 revoker_did,
                 target_coop_did,
                 reason,
+                decision_hash,
             }) => {
                 assert_eq!(
                     revoker_did, "coop-alpha",
@@ -1180,6 +1189,10 @@ mod tests {
                 );
                 assert_eq!(target_coop_did, "coop-gamma");
                 assert_eq!(reason, "governance misconduct");
+                assert_eq!(
+                    decision_hash, "hash-rv-1",
+                    "effect must carry the decision_hash passed to translate_payload_to_effects"
+                );
             }
             other => panic!("expected RevokeVouch effect, got {other:?}"),
         }

--- a/icn/crates/icn-core/src/services/federation_service.rs
+++ b/icn/crates/icn-core/src/services/federation_service.rs
@@ -291,13 +291,14 @@ impl FederationServiceImpl {
     /// not an authorization gate, so absence weakens provenance entropy rather
     /// than denying the operation.
     ///
-    /// NOTE: on the main `KernelEffect::Federation` path the bound value is
-    /// currently empty: `FederationEffect::TerminateClearing` carries no
-    /// `decision_hash` field, so `federation_effect_to_operation` sets it to
-    /// `None` and the executor passes `unwrap_or_default()`. This helper makes
-    /// the hash bind `decision_hash` whenever a caller supplies one; propagating
-    /// the canonical decision hash through the federation effect itself is a
-    /// tracked follow-up (see PR #2093 discussion).
+    /// On the main `KernelEffect::Federation` path the bound value is now
+    /// non-empty for governance-authorized terminations:
+    /// `FederationEffect::TerminateClearing` carries a `decision_hash` field,
+    /// `federation_effect_to_operation` forwards it as `Some(..)`, and the
+    /// executor threads it into this request — completing the canonical-path
+    /// propagation that the #2093 binding (above) depended on. An empty
+    /// `decision_hash` (legacy/unset) still folds as empty bytes per the policy
+    /// above; it is tolerated, not rejected.
     fn compute_terminate_clearing_hash(
         request: &FederationTerminateClearingRequest,
         agreement_id: &str,

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -364,6 +364,11 @@ pub enum FederationEffect {
         partner_coop_did: String,
         /// Human-readable reason for audit trail.
         reason: String,
+        /// Canonical hash of the governance decision authorizing this
+        /// termination, bound into the operation's provenance hash for audit.
+        /// Empty string for legacy/backwards-compatible serialized effects.
+        #[serde(default)]
+        decision_hash: String,
     },
     /// Revoke a previously-issued vouch for another cooperative.
     ///
@@ -376,6 +381,11 @@ pub enum FederationEffect {
         target_coop_did: String,
         /// Human-readable reason for audit trail.
         reason: String,
+        /// Canonical hash of the governance decision authorizing this
+        /// revocation, bound into the operation's provenance hash for audit.
+        /// Empty string for legacy/backwards-compatible serialized effects.
+        #[serde(default)]
+        decision_hash: String,
     },
 }
 
@@ -715,6 +725,70 @@ pub trait DispatchEvidenceSink: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn terminate_clearing_deserializes_legacy_record_without_decision_hash() {
+        // Pre-fix serialized effects carry no `decision_hash`. `#[serde(default)]`
+        // must let them deserialize to an empty hash (load-bearing for the
+        // federated two-node pilot, which serde-round-trips FederationEffect).
+        let legacy = r#"{
+            "federation_action": "terminate_clearing",
+            "initiating_coop_did": "coop-alpha",
+            "partner_coop_did": "coop-beta",
+            "reason": "persistent imbalance"
+        }"#;
+        let effect: FederationEffect = serde_json::from_str(legacy).unwrap();
+        match effect {
+            FederationEffect::TerminateClearing { decision_hash, .. } => {
+                assert_eq!(
+                    decision_hash, "",
+                    "legacy record must default to empty hash"
+                );
+            }
+            other => panic!("expected TerminateClearing, got {other:?}"),
+        }
+
+        // Round-trip with a populated hash preserves it.
+        let populated = FederationEffect::TerminateClearing {
+            initiating_coop_did: "coop-alpha".to_string(),
+            partner_coop_did: "coop-beta".to_string(),
+            reason: "persistent imbalance".to_string(),
+            decision_hash: "sha256:decision-a".to_string(),
+        };
+        let json = serde_json::to_string(&populated).unwrap();
+        let parsed: FederationEffect = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, populated);
+    }
+
+    #[test]
+    fn revoke_vouch_deserializes_legacy_record_without_decision_hash() {
+        let legacy = r#"{
+            "federation_action": "revoke_vouch",
+            "revoker_did": "coop-alpha",
+            "target_coop_did": "coop-gamma",
+            "reason": "governance misconduct"
+        }"#;
+        let effect: FederationEffect = serde_json::from_str(legacy).unwrap();
+        match effect {
+            FederationEffect::RevokeVouch { decision_hash, .. } => {
+                assert_eq!(
+                    decision_hash, "",
+                    "legacy record must default to empty hash"
+                );
+            }
+            other => panic!("expected RevokeVouch, got {other:?}"),
+        }
+
+        let populated = FederationEffect::RevokeVouch {
+            revoker_did: "coop-alpha".to_string(),
+            target_coop_did: "coop-gamma".to_string(),
+            reason: "governance misconduct".to_string(),
+            decision_hash: "sha256:decision-b".to_string(),
+        };
+        let json = serde_json::to_string(&populated).unwrap();
+        let parsed: FederationEffect = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, populated);
+    }
 
     #[test]
     fn kernel_effect_subsystem_labels_are_stable_lowercase() {

--- a/icn/crates/icn-kernel-api/src/governance.rs
+++ b/icn/crates/icn-kernel-api/src/governance.rs
@@ -664,12 +664,17 @@ pub fn federation_effect_to_operation(effect: &FederationEffect) -> FederationOp
             initiating_coop_did,
             partner_coop_did,
             reason: _,
+            decision_hash,
         } => FederationOperation {
             operation_type: FederationOperationType::TerminateClearing,
             coop_did: initiating_coop_did.clone(),
             target_id: Some(partner_coop_did.clone()),
             agreement_hash: None,
-            decision_hash: None,
+            decision_hash: if decision_hash.is_empty() {
+                None
+            } else {
+                Some(decision_hash.clone())
+            },
             settlement_interval: None,
             max_imbalance: None,
             source_agreement_id: None,
@@ -678,12 +683,17 @@ pub fn federation_effect_to_operation(effect: &FederationEffect) -> FederationOp
             revoker_did,
             target_coop_did,
             reason: _,
+            decision_hash,
         } => FederationOperation {
             operation_type: FederationOperationType::RevokeVouch,
             coop_did: revoker_did.clone(),
             target_id: Some(target_coop_did.clone()),
             agreement_hash: None,
-            decision_hash: None,
+            decision_hash: if decision_hash.is_empty() {
+                None
+            } else {
+                Some(decision_hash.clone())
+            },
             settlement_interval: None,
             max_imbalance: None,
             source_agreement_id: None,
@@ -699,6 +709,71 @@ mod tests {
     fn test_decision_receipt_id() {
         let id = DecisionReceiptId::new("proposal-123");
         assert_eq!(id.to_string(), "proposal-123");
+    }
+
+    #[test]
+    fn terminate_clearing_effect_forwards_decision_hash() {
+        // Canonical KernelEffect::Federation path: a non-empty decision_hash on
+        // the effect must reach FederationOperation.decision_hash (Some), and
+        // distinct decision hashes must produce distinct operations so the
+        // downstream terminate_clearing state_change_hash differs per decision.
+        let op_a = federation_effect_to_operation(&FederationEffect::TerminateClearing {
+            initiating_coop_did: "coop-alpha".to_string(),
+            partner_coop_did: "coop-beta".to_string(),
+            reason: "persistent imbalance".to_string(),
+            decision_hash: "sha256:decision-a".to_string(),
+        });
+        let op_b = federation_effect_to_operation(&FederationEffect::TerminateClearing {
+            initiating_coop_did: "coop-alpha".to_string(),
+            partner_coop_did: "coop-beta".to_string(),
+            reason: "persistent imbalance".to_string(),
+            decision_hash: "sha256:decision-b".to_string(),
+        });
+        assert_eq!(op_a.decision_hash, Some("sha256:decision-a".to_string()));
+        assert_eq!(op_b.decision_hash, Some("sha256:decision-b".to_string()));
+        assert_ne!(
+            op_a.decision_hash, op_b.decision_hash,
+            "distinct decision hashes must propagate distinctly"
+        );
+
+        // Empty decision_hash stays None (tolerated provenance, not an auth gate).
+        let op_empty = federation_effect_to_operation(&FederationEffect::TerminateClearing {
+            initiating_coop_did: "coop-alpha".to_string(),
+            partner_coop_did: "coop-beta".to_string(),
+            reason: "persistent imbalance".to_string(),
+            decision_hash: String::new(),
+        });
+        assert_eq!(op_empty.decision_hash, None);
+    }
+
+    #[test]
+    fn revoke_vouch_effect_forwards_decision_hash() {
+        let op_a = federation_effect_to_operation(&FederationEffect::RevokeVouch {
+            revoker_did: "coop-alpha".to_string(),
+            target_coop_did: "coop-gamma".to_string(),
+            reason: "governance misconduct".to_string(),
+            decision_hash: "sha256:decision-a".to_string(),
+        });
+        let op_b = federation_effect_to_operation(&FederationEffect::RevokeVouch {
+            revoker_did: "coop-alpha".to_string(),
+            target_coop_did: "coop-gamma".to_string(),
+            reason: "governance misconduct".to_string(),
+            decision_hash: "sha256:decision-b".to_string(),
+        });
+        assert_eq!(op_a.decision_hash, Some("sha256:decision-a".to_string()));
+        assert_eq!(op_b.decision_hash, Some("sha256:decision-b".to_string()));
+        assert_ne!(
+            op_a.decision_hash, op_b.decision_hash,
+            "distinct decision hashes must propagate distinctly"
+        );
+
+        let op_empty = federation_effect_to_operation(&FederationEffect::RevokeVouch {
+            revoker_did: "coop-alpha".to_string(),
+            target_coop_did: "coop-gamma".to_string(),
+            reason: "governance misconduct".to_string(),
+            decision_hash: String::new(),
+        });
+        assert_eq!(op_empty.decision_hash, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Complete the canonical `KernelEffect::Federation` path so `TerminateClearing` and `RevokeVouch` carry a non-empty `decision_hash` into `FederationOperation`, then into the service requests, then into the #2093 terminate/revoke provenance-hash binding. This finishes the canonical-path limitation explicitly documented as a follow-up by #2093.

## Changes

- `crates/icn-kernel-api/src/effects.rs`: add `#[serde(default)] decision_hash: String` to `FederationEffect::TerminateClearing` and `FederationEffect::RevokeVouch` (mirrors the existing `SettleClearing` field).
- `crates/icn-kernel-api/src/governance.rs`: `federation_effect_to_operation` now forwards the effect's `decision_hash` as `Some(..)` when non-empty / `None` when empty, exactly like `SettleClearing`.
- `apps/governance/src/handlers/execution.rs`: thread `decision_hash: &str` into `translate_federation_proposal` and populate it on both effect constructions.
- `crates/icn-core/src/services/federation_service.rs`: correct the now-stale doc-comment NOTE on `compute_terminate_clearing_hash` (the canonical path is no longer empty). **Doc only — no hashing logic changed.**

## Motivation

#2093 made `compute_terminate_clearing_hash` / `compute_revoke_vouch_hash` bind `request.decision_hash`, but on the real `KernelEffect::Federation` path that binding was **inert**: the two effect variants had no `decision_hash` field, so `federation_effect_to_operation` hardcoded `None` and the executor folded it to an empty string. Two distinct governance decisions terminating the same agreement (or revoking the same vouch) therefore produced identical `state_change_hash` values. This change makes the canonical path carry the value end to end.

## Scope / honest limitations

- This is **provenance/audit completeness only**. It does **not** change replay/idempotency or authorization semantics, and makes no replay-safety claim.
- An empty `decision_hash` (legacy/unset) remains **tolerated** — it maps to `None` / empty bytes, not a rejection. The hash is an audit artifact, not an auth gate.
- `decision_receipt_id` is intentionally **not** added to the effect: it is already propagated end-to-end via the executor's separate `receipt_id` parameter.
- This does **not** make all Federation provenance helpers `decision_hash`-bound. Broader `join`/`leave`/`vouch`/`clearing` consistency remains an optional follow-up (`fix/federation-provenance-hash-consistency`).

## Testing

- [x] Unit tests added (kernel-api propagation + serde backward-compat)
- [x] Existing governance translation + icn-core federation binding tests updated/pass
- [x] Manual testing: N/A (pure library/provenance change)

New tests:
- `governance::tests::terminate_clearing_effect_forwards_decision_hash` / `revoke_vouch_effect_forwards_decision_hash` — distinct non-empty hashes propagate to distinct `FederationOperation.decision_hash`; empty maps to `None`.
- `effects::tests::terminate_clearing_deserializes_legacy_record_without_decision_hash` / `revoke_vouch_...` — old serialized records (no `decision_hash`) deserialize to `""`.
- `test_translate_terminate_clearing` / `test_translate_revoke_vouch` — now assert the effect carries the passed `decision_hash`.

## Invariants

- [x] No panics introduced in protocol paths (production change is field add + `if/else` clone; `unwrap` only in tests)
- [x] Determinism preserved (`decision_hash` and the bound hash are deterministic)
- [x] Canonical encodings unchanged / backward-compatible — additive field with `#[serde(default)]`; legacy `FederationEffect` JSON (serde-round-tripped on the federated two-node pilot path) still deserializes
- [x] Trust gates not weakened (no auth/idempotency change; empty hash still tolerated)
- [x] Kernel/app boundaries respected (no new domain imports in `icn-kernel-api`; verified)

## Verification

```
cargo fmt --all --check                                              # clean
cargo clippy -p icn-kernel-api -p icn-core -p icn-governance-actor \
  --all-targets --all-features -- -D warnings                        # exit 0, 0 warnings
cargo test -p icn-kernel-api --lib                                   # 609 passed, 0 failed
cargo test -p icn-governance-actor --lib                             # 274 passed, 0 failed
cargo test -p icn-core --lib federation                              # 27 passed, 0 failed
  (incl. #2093 terminate_clearing_hash_binds_decision_hash / revoke_vouch_hash_binds_decision_hash)
ops/scripts/drift-check.sh                                           # STATUS: PASS
```

## Documentation

- [x] Docs updated — corrected the stale `compute_terminate_clearing_hash` NOTE in `federation_service.rs`
- [x] API changes reflected in OpenAPI — N/A (effect is insulated behind `FederationOperation`; no wire/OpenAPI/SDK change)

---

## Known limitation — idempotency-layer dedup (deferred follow-up)

Review (codex, [comment](https://github.com/InterCooperative-Network/icn/pull/2094#discussion_r3439713890)) correctly noted: on the production `create_decision_executor_callback` path, `extract_decision_hash` (`crates/icn-core/src/supervisor/decision_executor.rs:822-837`) only matches Treasury effects, so a federation-only decision falls back to `decision_receipt_id` as the idempotency key (`:722`), and `DecisionExecutor::execute` dedupes on it (`:395`). In the specific same-`decision_receipt_id` / different-`decision_hash` scenario, the second federation decision is skipped *before* the federation service binds the newly-propagated hash.

**This is intentionally out of scope for this PR:**
- It changes the **idempotency key** for federation decisions — replay-safety-sensitive, adjacent to #2092 — which this PR explicitly does not touch.
- It is **pre-existing**: `extract_decision_hash` handled only Treasury before this change too.
- It deserves its own focused PR with replay-safety tests (proposed `fix/federation-idempotency-decision-hash-key`).

This PR completes the provenance **plumbing** (effect → operation → request → `state_change_hash` binding), which is a prerequisite for any such end-to-end fix and is correct and verifiable on its own.
