### PR TITLE
fix(core): use federation decision_hash for executor idempotency

### DIFF
--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -818,19 +818,31 @@ pub fn create_decision_executor_callback_with_sink(
     })
 }
 
-/// Extract `decision_hash` from the first effect that carries one.
+/// Extract the governance `decision_hash` from the first effect that carries a
+/// non-empty one, scanning in order. Used as the executor idempotency key.
+///
+/// Both Treasury and Federation effects embed a `decision_hash` (the latter
+/// since #2093/#2094). Empty/legacy hashes are skipped so the caller falls back
+/// to `decision_receipt_id`, preserving backward compatibility for pre-#2094
+/// serialized effects.
 fn extract_decision_hash(effects: &[KernelEffect]) -> Option<String> {
-    use icn_kernel_api::effects::TreasuryEffect;
+    use icn_kernel_api::effects::{FederationEffect, TreasuryEffect};
     for effect in effects {
-        if let KernelEffect::Treasury(
-            TreasuryEffect::Spend { decision_hash, .. }
-            | TreasuryEffect::CreateBudget { decision_hash, .. }
-            | TreasuryEffect::ReleaseEscrow { decision_hash, .. },
-        ) = effect
-        {
-            if !decision_hash.is_empty() {
-                return Some(decision_hash.clone());
-            }
+        let decision_hash = match effect {
+            KernelEffect::Treasury(
+                TreasuryEffect::Spend { decision_hash, .. }
+                | TreasuryEffect::CreateBudget { decision_hash, .. }
+                | TreasuryEffect::ReleaseEscrow { decision_hash, .. },
+            ) => decision_hash,
+            KernelEffect::Federation(
+                FederationEffect::SettleClearing { decision_hash, .. }
+                | FederationEffect::TerminateClearing { decision_hash, .. }
+                | FederationEffect::RevokeVouch { decision_hash, .. },
+            ) => decision_hash,
+            _ => continue,
+        };
+        if !decision_hash.is_empty() {
+            return Some(decision_hash.clone());
         }
     }
     None
@@ -839,7 +851,9 @@ fn extract_decision_hash(effects: &[KernelEffect]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_kernel_api::effects::{EffectResult, KernelEffect, ResourceEffect, TreasuryEffect};
+    use icn_kernel_api::effects::{
+        EffectResult, FederationEffect, KernelEffect, ResourceEffect, TreasuryEffect,
+    };
     use icn_kernel_api::escrow::{EscrowRecord, EscrowStatus, EscrowStore};
     use icn_kernel_api::execution::ExecutionRecord;
     use icn_kernel_api::services::{LedgerEvent, TreasuryEntryRequest, TreasuryEntryResult};
@@ -1258,6 +1272,152 @@ mod tests {
             reason: "only".to_string(),
         }];
         assert_eq!(extract_decision_hash(&no_hash), None);
+    }
+
+    // ---- #2095: federation effects carry decision_hash since #2094 -----------
+    // The executor idempotency key must reflect the propagated federation
+    // decision_hash, not fall back to decision_receipt_id for federation-only
+    // batches. Empty/legacy hashes still yield None (receipt-id fallback).
+
+    #[test]
+    fn test_extract_decision_hash_federation_terminate_clearing() {
+        let effects = vec![KernelEffect::Federation(
+            FederationEffect::TerminateClearing {
+                initiating_coop_did: "coop-a".to_string(),
+                partner_coop_did: "coop-b".to_string(),
+                reason: "governance terminate".to_string(),
+                decision_hash: "sha256:fed-terminate-1".to_string(),
+            },
+        )];
+        assert_eq!(
+            extract_decision_hash(&effects),
+            Some("sha256:fed-terminate-1".to_string())
+        );
+
+        // Empty/legacy hash → None (caller falls back to decision_receipt_id).
+        let legacy = vec![KernelEffect::Federation(
+            FederationEffect::TerminateClearing {
+                initiating_coop_did: "coop-a".to_string(),
+                partner_coop_did: "coop-b".to_string(),
+                reason: "legacy".to_string(),
+                decision_hash: String::new(),
+            },
+        )];
+        assert_eq!(extract_decision_hash(&legacy), None);
+    }
+
+    #[test]
+    fn test_extract_decision_hash_federation_revoke_vouch() {
+        let effects = vec![KernelEffect::Federation(FederationEffect::RevokeVouch {
+            revoker_did: "coop-a".to_string(),
+            target_coop_did: "coop-b".to_string(),
+            reason: "governance revoke".to_string(),
+            decision_hash: "sha256:fed-revoke-1".to_string(),
+        })];
+        assert_eq!(
+            extract_decision_hash(&effects),
+            Some("sha256:fed-revoke-1".to_string())
+        );
+
+        let legacy = vec![KernelEffect::Federation(FederationEffect::RevokeVouch {
+            revoker_did: "coop-a".to_string(),
+            target_coop_did: "coop-b".to_string(),
+            reason: "legacy".to_string(),
+            decision_hash: String::new(),
+        })];
+        assert_eq!(extract_decision_hash(&legacy), None);
+    }
+
+    #[test]
+    fn test_extract_decision_hash_federation_settle_clearing() {
+        let effects = vec![KernelEffect::Federation(FederationEffect::SettleClearing {
+            agreement_id: "agreement-1".to_string(),
+            currency: "HOURS".to_string(),
+            decision_receipt_id: "receipt-1".to_string(),
+            decision_hash: "sha256:fed-settle-1".to_string(),
+        })];
+        assert_eq!(
+            extract_decision_hash(&effects),
+            Some("sha256:fed-settle-1".to_string())
+        );
+
+        let legacy = vec![KernelEffect::Federation(FederationEffect::SettleClearing {
+            agreement_id: "agreement-1".to_string(),
+            currency: "HOURS".to_string(),
+            decision_receipt_id: "receipt-1".to_string(),
+            decision_hash: String::new(),
+        })];
+        assert_eq!(extract_decision_hash(&legacy), None);
+    }
+
+    /// Same federation decision → same key (dedupe-preserving); distinct
+    /// federation decisions → distinct keys (no false dedupe). This underpins
+    /// the executor-level replay-safety behavior.
+    #[test]
+    fn test_extract_decision_hash_federation_distinct_and_deterministic() {
+        let mk = |hash: &str| {
+            vec![KernelEffect::Federation(
+                FederationEffect::TerminateClearing {
+                    initiating_coop_did: "coop-a".to_string(),
+                    partner_coop_did: "coop-b".to_string(),
+                    reason: "r".to_string(),
+                    decision_hash: hash.to_string(),
+                },
+            )]
+        };
+        assert_eq!(
+            extract_decision_hash(&mk("sha256:fed-x")),
+            extract_decision_hash(&mk("sha256:fed-x")),
+            "identical federation decision_hash must produce the same idempotency key"
+        );
+        assert_ne!(
+            extract_decision_hash(&mk("sha256:fed-a")),
+            extract_decision_hash(&mk("sha256:fed-b")),
+            "distinct federation decision_hash must produce distinct idempotency keys"
+        );
+    }
+
+    /// Treasury extraction is unchanged and retains precedence within a mixed
+    /// batch (first non-empty hash wins, scanning in order); a federation-only
+    /// batch — the #2095 gap — now yields the federation hash instead of None.
+    #[test]
+    fn test_extract_decision_hash_treasury_precedence_unchanged() {
+        let treasury_first = vec![
+            KernelEffect::Treasury(TreasuryEffect::Spend {
+                treasury_did: "t".to_string(),
+                recipient_did: "r".to_string(),
+                amount: 1,
+                currency: "ICN".to_string(),
+                memo: "m".to_string(),
+                budget_id: None,
+                expected_nonce: 0,
+                decision_receipt_id: "rid".to_string(),
+                decision_hash: "sha256:treasury-first".to_string(),
+            }),
+            KernelEffect::Federation(FederationEffect::TerminateClearing {
+                initiating_coop_did: "coop-a".to_string(),
+                partner_coop_did: "coop-b".to_string(),
+                reason: "r".to_string(),
+                decision_hash: "sha256:fed-second".to_string(),
+            }),
+        ];
+        assert_eq!(
+            extract_decision_hash(&treasury_first),
+            Some("sha256:treasury-first".to_string())
+        );
+
+        let federation_only = vec![KernelEffect::Federation(
+            FederationEffect::TerminateClearing {
+                initiating_coop_did: "coop-a".to_string(),
+                partner_coop_did: "coop-b".to_string(),
+                reason: "r".to_string(),
+                decision_hash: "sha256:fed-only".to_string(),
+            },
+        )];
+        assert_eq!(
+            extract_decision_hash(&federation_only),
+            Some("sha256:fed-only".to_string())
+        );
     }
 
     #[tokio::test]

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -429,6 +429,33 @@ impl DecisionExecutor {
             }
         }
 
+        // 1b. Backward-compatibility idempotency across the #2094->#2096 upgrade
+        // window. Before federation effects carried an extractable `decision_hash`,
+        // a federation-only decision produced no hash, so the callback keyed its
+        // `ExecutionRecord` under `decision_receipt_id`. Now that the propagated
+        // federation hash is the primary idempotency key, a replay of that same
+        // accepted event would probe `store.get(decision_hash)` (just missed
+        // above), not find the legacy receipt-keyed record, and re-run the
+        // operation. When the key differs from the receipt id, also probe for a
+        // terminal record under the receipt id and dedupe against it. This is a
+        // read-only compatibility shim — no record migration — and is a no-op for
+        // decisions whose key never moved (empty-hash fallback sets
+        // `decision_hash == decision_receipt_id`; treasury decisions were always
+        // hash-keyed, so no receipt-keyed record exists for them).
+        if decision_hash != decision_receipt_id {
+            if let Some(legacy) = self.store.get(decision_receipt_id)? {
+                if legacy.is_terminal() {
+                    debug!(
+                        decision_hash = %decision_hash,
+                        receipt_id = %decision_receipt_id,
+                        status = ?legacy.status,
+                        "Decision already executed under legacy receipt-id key (pre-#2096), skipping"
+                    );
+                    return Ok(vec![]);
+                }
+            }
+        }
+
         // 2. Preserve existing record if present (retains retry count),
         //    otherwise create a new Pending record.
         let (mut record, status_before) = if let Some(existing) = self.store.get(decision_hash)? {

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -410,7 +410,18 @@ impl DecisionExecutor {
         // migration — and a no-op when the key never moved (empty-hash fallback
         // sets `decision_hash == decision_receipt_id`; treasury was always
         // hash-keyed, so no receipt-keyed record exists for it).
-        let decision_hash: &str = if decision_hash != decision_receipt_id {
+        //
+        // When BOTH rows exist for the same decision (reachable only if a node
+        // ran an intermediate hash-keying build before this compat fix landed),
+        // the canonical hash-keyed record wins if it is already terminal: never
+        // re-dispatch under a stale legacy row when the canonical decision is done.
+        let canonical_is_terminal = self
+            .store
+            .get(decision_hash)?
+            .map(|r| r.is_terminal())
+            .unwrap_or(false);
+        let decision_hash: &str = if decision_hash != decision_receipt_id && !canonical_is_terminal
+        {
             match self.store.get(decision_receipt_id)? {
                 Some(legacy)
                     if extract_decision_hash(&legacy.effects).as_deref() == Some(decision_hash) =>

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -391,6 +391,29 @@ impl DecisionExecutor {
         decision_hash: &str,
         proposal_id: &str,
     ) -> Result<Vec<EffectResult>> {
+        // Backward-compatibility across the #2094->#2096 upgrade window. Before
+        // federation effects carried an extractable `decision_hash`, a
+        // federation-only decision produced no hash, so the callback keyed its
+        // `ExecutionRecord` under `decision_receipt_id`. Now that the propagated
+        // federation hash is the primary idempotency key, a replay of that same
+        // accepted event would key a fresh record under `decision_hash` and miss
+        // the legacy receipt-keyed record — re-running a completed operation, or
+        // orphaning an in-flight one and resetting its retry count. If a record
+        // already exists under the receipt id (and the keys differ), keep
+        // operating under that legacy key so its full idempotency state (terminal
+        // dedupe, retry count, in-flight status) is honored. This is read-only
+        // key selection — no record migration — and a no-op when the key never
+        // moved: the empty-hash fallback sets `decision_hash ==
+        // decision_receipt_id`, and treasury decisions were always hash-keyed so
+        // no receipt-keyed record exists for them.
+        let decision_hash: &str = if decision_hash != decision_receipt_id
+            && self.store.get(decision_receipt_id)?.is_some()
+        {
+            decision_receipt_id
+        } else {
+            decision_hash
+        };
+
         // 1. Idempotency check
         if let Some(existing) = self.store.get(decision_hash)? {
             if existing.is_terminal() {
@@ -426,33 +449,6 @@ impl DecisionExecutor {
                 self.store.put(&record)?;
                 self.mark_related_escrows_failed(&record, "max retries exceeded");
                 return Ok(vec![]);
-            }
-        }
-
-        // 1b. Backward-compatibility idempotency across the #2094->#2096 upgrade
-        // window. Before federation effects carried an extractable `decision_hash`,
-        // a federation-only decision produced no hash, so the callback keyed its
-        // `ExecutionRecord` under `decision_receipt_id`. Now that the propagated
-        // federation hash is the primary idempotency key, a replay of that same
-        // accepted event would probe `store.get(decision_hash)` (just missed
-        // above), not find the legacy receipt-keyed record, and re-run the
-        // operation. When the key differs from the receipt id, also probe for a
-        // terminal record under the receipt id and dedupe against it. This is a
-        // read-only compatibility shim — no record migration — and is a no-op for
-        // decisions whose key never moved (empty-hash fallback sets
-        // `decision_hash == decision_receipt_id`; treasury decisions were always
-        // hash-keyed, so no receipt-keyed record exists for them).
-        if decision_hash != decision_receipt_id {
-            if let Some(legacy) = self.store.get(decision_receipt_id)? {
-                if legacy.is_terminal() {
-                    debug!(
-                        decision_hash = %decision_hash,
-                        receipt_id = %decision_receipt_id,
-                        status = ?legacy.status,
-                        "Decision already executed under legacy receipt-id key (pre-#2096), skipping"
-                    );
-                    return Ok(vec![]);
-                }
             }
         }
 

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -818,13 +818,19 @@ pub fn create_decision_executor_callback_with_sink(
     })
 }
 
-/// Extract the governance `decision_hash` from the first effect that carries a
-/// non-empty one, scanning in order. Used as the executor idempotency key.
+/// Extract the governance `decision_hash` to use as the executor idempotency
+/// key, taking it from the first *supported* effect variant (scanning in order)
+/// that carries a non-empty hash.
 ///
-/// Both Treasury and Federation effects embed a `decision_hash` (the latter
-/// since #2093/#2094). Empty/legacy hashes are skipped so the caller falls back
-/// to `decision_receipt_id`, preserving backward compatibility for pre-#2094
-/// serialized effects.
+/// "Supported" is a deliberately narrow allow-list, not every variant that has
+/// a `decision_hash` field: only `TreasuryEffect::{Spend, CreateBudget,
+/// ReleaseEscrow}` and `FederationEffect::{SettleClearing, TerminateClearing,
+/// RevokeVouch}` (the latter carried since #2093/#2094). Other variants and
+/// effect families that also embed `decision_hash` (e.g. the remaining Treasury
+/// variants, or Membership effects) are intentionally not consulted here;
+/// widening the allow-list is a deliberate change, not an oversight. Empty/legacy
+/// hashes are skipped so the caller falls back to `decision_receipt_id`,
+/// preserving backward compatibility for pre-#2094 serialized effects.
 fn extract_decision_hash(effects: &[KernelEffect]) -> Option<String> {
     use icn_kernel_api::effects::{FederationEffect, TreasuryEffect};
     for effect in effects {

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -398,18 +398,27 @@ impl DecisionExecutor {
         // federation hash is the primary idempotency key, a replay of that same
         // accepted event would key a fresh record under `decision_hash` and miss
         // the legacy receipt-keyed record — re-running a completed operation, or
-        // orphaning an in-flight one and resetting its retry count. If a record
-        // already exists under the receipt id (and the keys differ), keep
-        // operating under that legacy key so its full idempotency state (terminal
-        // dedupe, retry count, in-flight status) is honored. This is read-only
-        // key selection — no record migration — and a no-op when the key never
-        // moved: the empty-hash fallback sets `decision_hash ==
-        // decision_receipt_id`, and treasury decisions were always hash-keyed so
-        // no receipt-keyed record exists for them.
-        let decision_hash: &str = if decision_hash != decision_receipt_id
-            && self.store.get(decision_receipt_id)?.is_some()
-        {
-            decision_receipt_id
+        // orphaning an in-flight one and resetting its retry count.
+        //
+        // Adopt the legacy receipt key ONLY when the stored record is the *same*
+        // decision — i.e. its own effects carry the same `decision_hash`. A
+        // receipt id is not unique to one decision (distinct federation decisions
+        // can share it; that is exactly the #2095 same-receipt/different-hash
+        // case), so adopting on mere key existence would let one legacy row
+        // collapse an unrelated decision. Matching on the stored effects' hash
+        // ties adoption to decision identity. Read-only key selection — no record
+        // migration — and a no-op when the key never moved (empty-hash fallback
+        // sets `decision_hash == decision_receipt_id`; treasury was always
+        // hash-keyed, so no receipt-keyed record exists for it).
+        let decision_hash: &str = if decision_hash != decision_receipt_id {
+            match self.store.get(decision_receipt_id)? {
+                Some(legacy)
+                    if extract_decision_hash(&legacy.effects).as_deref() == Some(decision_hash) =>
+                {
+                    decision_receipt_id
+                }
+                _ => decision_hash,
+            }
         } else {
             decision_hash
         };

--- a/icn/crates/icn-core/src/supervisor/decision_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/decision_executor.rs
@@ -434,6 +434,32 @@ impl DecisionExecutor {
             decision_hash
         };
 
+        // Recovery-path canonical-terminal guard. The shadow above keys on the
+        // INPUT decision_hash; on the startup recovery path (`recover_in_flight`)
+        // a legacy receipt-keyed row is re-executed under its stored key, which
+        // equals the receipt id (`decision_hash == decision_receipt_id`), so the
+        // shadow is skipped. If that row's stored effects carry a federation
+        // decision_hash whose canonical record is already terminal, the canonical
+        // record still wins — dedupe instead of re-dispatching the stale row.
+        if decision_hash == decision_receipt_id {
+            if let Some(canonical_hash) = extract_decision_hash(&effects) {
+                if canonical_hash != decision_receipt_id
+                    && self
+                        .store
+                        .get(&canonical_hash)?
+                        .map(|r| r.is_terminal())
+                        .unwrap_or(false)
+                {
+                    debug!(
+                        decision_hash = %canonical_hash,
+                        receipt_id = %decision_receipt_id,
+                        "Canonical terminal record exists for recovered legacy row, skipping"
+                    );
+                    return Ok(vec![]);
+                }
+            }
+        }
+
         // 1. Idempotency check
         if let Some(existing) = self.store.get(decision_hash)? {
             if existing.is_terminal() {

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -18,7 +18,7 @@ use icn_governance::{ProposalPayload, TreasuryProposalOperation};
 use icn_governance_actor::translate_payload_to_effects;
 use icn_identity::Did;
 use icn_kernel_api::budget::{BudgetRecord, BudgetStore};
-use icn_kernel_api::effects::{KernelEffect, TreasuryEffect};
+use icn_kernel_api::effects::{FederationEffect, KernelEffect, TreasuryEffect};
 use icn_kernel_api::execution::{ExecutionRecord, ExecutionStatus, ExecutionStore};
 use icn_kernel_api::protocol_params::StubParamStore;
 use icn_kernel_api::services::LedgerEvent;
@@ -297,6 +297,20 @@ fn content_hash_from_hex(hash_hex: &str) -> Result<ContentHash> {
     Ok(ContentHash::from_bytes(bytes))
 }
 
+/// A federation-only effect batch carrying a governance `decision_hash`
+/// (since #2094). Used to exercise the executor idempotency-key path for
+/// federation decisions (#2095).
+fn terminate_clearing_effect(decision_hash: &str, reason: &str) -> Vec<KernelEffect> {
+    vec![KernelEffect::Federation(
+        FederationEffect::TerminateClearing {
+            initiating_coop_did: "coop-a".to_string(),
+            partner_coop_did: "coop-b".to_string(),
+            reason: reason.to_string(),
+            decision_hash: decision_hash.to_string(),
+        },
+    )]
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -387,6 +401,72 @@ async fn test_callback_idempotent_no_double_execute() {
     // Still confirmed, not re-executed
     let record2 = exec_store.get("hash-idem-1").unwrap().unwrap();
     assert_eq!(record2.status, ExecutionStatus::Confirmed);
+}
+
+/// Issue #2095: federation-only decisions are keyed by their propagated
+/// `decision_hash`, not by `decision_receipt_id`.
+///
+/// Two federation decisions that share a `decision_receipt_id` but carry
+/// distinct `decision_hash` values must BOTH be recorded independently. Before
+/// the fix, `extract_decision_hash` ignored federation effects, so both
+/// collapsed onto the shared receipt id and the second deduped against the
+/// first — exactly the replay hazard #2093/#2094 set out to remove.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_federation_same_receipt_different_hash_not_deduped() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let (executor, exec_store) = make_executor();
+    let callback = create_decision_executor_callback(executor);
+
+    // Same receipt id, two distinct federation decision hashes.
+    callback(
+        terminate_clearing_effect("sha256:fed-decision-a", "first"),
+        "receipt-shared".to_string(),
+    );
+    callback(
+        terminate_clearing_effect("sha256:fed-decision-b", "second"),
+        "receipt-shared".to_string(),
+    );
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+    // Each decision is recorded under its own decision_hash key, proving the
+    // idempotency key reflects the federation decision_hash.
+    assert!(
+        exec_store.get("sha256:fed-decision-a").unwrap().is_some(),
+        "first federation decision must be recorded under its decision_hash"
+    );
+    assert!(
+        exec_store.get("sha256:fed-decision-b").unwrap().is_some(),
+        "second federation decision must be recorded under its decision_hash"
+    );
+    // The shared receipt id is NOT the idempotency key when a non-empty
+    // federation decision_hash is present (it would have collapsed the two).
+    assert!(
+        exec_store.get("receipt-shared").unwrap().is_none(),
+        "receipt id must not key the record when a federation decision_hash is present"
+    );
+}
+
+/// Issue #2095: an empty/legacy federation `decision_hash` preserves prior
+/// behavior — the executor falls back to `decision_receipt_id` as the
+/// idempotency key (no regression for pre-#2094 serialized effects).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_federation_empty_hash_falls_back_to_receipt() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let (executor, exec_store) = make_executor();
+    let callback = create_decision_executor_callback(executor);
+
+    callback(
+        terminate_clearing_effect("", "legacy"),
+        "receipt-legacy".to_string(),
+    );
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+    assert!(
+        exec_store.get("receipt-legacy").unwrap().is_some(),
+        "empty federation decision_hash must fall back to the receipt id key"
+    );
 }
 
 /// Test 3: Startup recovery picks up an Executing record and completes it.

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -518,6 +518,55 @@ async fn test_federation_replay_dedupes_against_legacy_receipt_keyed_record() {
     );
 }
 
+/// Issue #2095 / Codex P1 follow-up (#2096): honor *in-flight / retryable* legacy
+/// receipt-keyed records, not just terminal ones.
+///
+/// A pre-#2096 federation record keyed under `decision_receipt_id` that is still
+/// non-terminal (e.g. a retryable `Failed` from before max-retry promotion) must
+/// continue under its own key on replay. Otherwise the executor would create a
+/// fresh record under the newly-extracted `decision_hash` with retries reset to
+/// zero, orphaning the legacy record and re-dispatching the operation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_federation_replay_honors_legacy_in_flight_receipt_record() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let (executor, exec_store) = make_executor();
+
+    // Pre-#2096 NON-terminal record keyed under the receipt id: a retryable
+    // failure carried over the upgrade (retries already accumulated).
+    let receipt_id = "receipt-inflight-legacy";
+    let mut legacy =
+        ExecutionRecord::new_pending(receipt_id, "proposal-legacy", receipt_id, vec![]);
+    legacy.status = ExecutionStatus::Failed;
+    legacy.retries = 2;
+    exec_store.put(&legacy).unwrap();
+
+    let callback = create_decision_executor_callback(executor);
+    callback(
+        terminate_clearing_effect("sha256:fed-inflight-hash", "replay"),
+        receipt_id.to_string(),
+    );
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+    // No fresh record under the new decision_hash key — the decision continues
+    // under its legacy receipt key.
+    assert!(
+        exec_store
+            .get("sha256:fed-inflight-hash")
+            .unwrap()
+            .is_none(),
+        "replay must not create a second record under the federation decision_hash"
+    );
+    // The legacy record continues under its own key with retry history intact
+    // (not reset to zero).
+    let cont = exec_store.get(receipt_id).unwrap().unwrap();
+    assert!(
+        cont.retries >= 2,
+        "legacy retry count must be preserved, not reset (was {})",
+        cont.retries
+    );
+}
+
 /// Test 3: Startup recovery picks up an Executing record and completes it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_startup_recovery_completes_executing_decision() {

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -681,6 +681,55 @@ async fn test_federation_canonical_terminal_record_wins_over_legacy() {
     );
 }
 
+/// Issue #2095 / Codex P2 (#2096): the canonical-terminal-wins rule must also
+/// hold on the startup recovery path.
+///
+/// `recover_in_flight` re-executes a stale non-terminal record under its stored
+/// key. For a legacy receipt-keyed row that key equals the receipt id, so the
+/// callback-path shadow (which keys on the extracted federation hash) is skipped.
+/// If a terminal canonical record exists for the same decision, recovery must
+/// dedupe against it via the stored effects' federation hash — not re-dispatch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_recovery_honors_canonical_terminal_over_stale_legacy() {
+    let (executor, exec_store) = make_executor();
+
+    let receipt_id = "receipt-recover-both";
+    let decision_hash = "sha256:fed-recover-both";
+
+    // Terminal canonical record under the federation decision_hash.
+    let mut canonical = ExecutionRecord::new_pending(
+        decision_hash,
+        "proposal-canonical",
+        receipt_id,
+        terminate_clearing_effect(decision_hash, "canonical"),
+    );
+    canonical.status = ExecutionStatus::Confirmed;
+    exec_store.put(&canonical).unwrap();
+
+    // Stale legacy receipt-keyed row for the SAME decision, still Executing
+    // (the state recover_in_flight picks up after a crash).
+    let mut legacy = ExecutionRecord::new_pending(
+        receipt_id,
+        "proposal-legacy",
+        receipt_id,
+        terminate_clearing_effect(decision_hash, "legacy"),
+    );
+    legacy.status = ExecutionStatus::Executing;
+    exec_store.put(&legacy).unwrap();
+
+    // Startup recovery scans non-terminal rows and re-executes them.
+    executor.recover_in_flight().await.unwrap();
+
+    // The stale legacy row is NOT re-dispatched — the terminal canonical record
+    // wins, so the legacy row's status is untouched.
+    let legacy_after = exec_store.get(receipt_id).unwrap().unwrap();
+    assert_eq!(
+        legacy_after.status,
+        ExecutionStatus::Executing,
+        "recovery must not re-dispatch a stale legacy row when the canonical record is terminal"
+    );
+}
+
 /// Test 3: Startup recovery picks up an Executing record and completes it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_startup_recovery_completes_executing_decision() {

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -469,6 +469,55 @@ async fn test_federation_empty_hash_falls_back_to_receipt() {
     );
 }
 
+/// Issue #2095 / Codex P1 (#2096): replay safety across the #2094->#2096 upgrade
+/// window.
+///
+/// A node that processed a federation effect *before* this change keyed its
+/// terminal `ExecutionRecord` under `decision_receipt_id` (the old extractor
+/// returned `None`). After the change, a replay of that same accepted event
+/// extracts the propagated federation `decision_hash`; without a compatibility
+/// check the executor would probe `store.get(<decision_hash>)`, miss the legacy
+/// receipt-keyed record, and re-run the terminate/revoke/settle operation. The
+/// executor must detect the legacy terminal record and dedupe instead.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_federation_replay_dedupes_against_legacy_receipt_keyed_record() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let (executor, exec_store) = make_executor();
+
+    // Simulate a pre-#2096 terminal record keyed under the *receipt id* (because
+    // the old extractor ignored federation effects and the callback fell back to
+    // the receipt id as the idempotency key).
+    let receipt_id = "receipt-upgrade-legacy";
+    let mut legacy =
+        ExecutionRecord::new_pending(receipt_id, "proposal-legacy", receipt_id, vec![]);
+    legacy.status = ExecutionStatus::Confirmed;
+    exec_store.put(&legacy).unwrap();
+
+    let callback = create_decision_executor_callback(executor);
+
+    // Replay the same accepted event, now carrying the propagated federation hash.
+    callback(
+        terminate_clearing_effect("sha256:fed-legacy-hash", "replay"),
+        receipt_id.to_string(),
+    );
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+    // No second record is created under the new decision_hash key (deduped
+    // against the legacy receipt-keyed record).
+    assert!(
+        exec_store.get("sha256:fed-legacy-hash").unwrap().is_none(),
+        "replay must not create a second record under the federation decision_hash"
+    );
+    // The legacy receipt-keyed record is untouched and still terminal.
+    let still = exec_store.get(receipt_id).unwrap().unwrap();
+    assert_eq!(
+        still.status,
+        ExecutionStatus::Confirmed,
+        "legacy receipt-keyed record must be preserved (not re-executed)"
+    );
+}
+
 /// Test 3: Startup recovery picks up an Executing record and completes it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_startup_recovery_completes_executing_decision() {

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -621,6 +621,66 @@ async fn test_federation_legacy_record_does_not_collapse_distinct_same_receipt_d
     assert_eq!(a.status, ExecutionStatus::Confirmed);
 }
 
+/// Issue #2095 / Codex P2 (#2096): when BOTH a canonical hash-keyed record and a
+/// stale legacy receipt-keyed record exist for the same decision, the canonical
+/// terminal record wins.
+///
+/// This state is only reachable if a node ran an intermediate hash-keying build
+/// (which created the canonical row) before the legacy-key compatibility fix
+/// landed, leaving a stale non-terminal receipt-keyed row alongside a terminal
+/// hash-keyed row. A replay must dedupe on the terminal canonical record, not
+/// re-dispatch under the stale legacy key.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_federation_canonical_terminal_record_wins_over_legacy() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let (executor, exec_store) = make_executor();
+
+    let receipt_id = "receipt-both-rows";
+    let decision_hash = "sha256:fed-both-rows";
+
+    // Canonical hash-keyed record for the decision: terminal (Confirmed).
+    let mut canonical = ExecutionRecord::new_pending(
+        decision_hash,
+        "proposal-canonical",
+        receipt_id,
+        terminate_clearing_effect(decision_hash, "canonical"),
+    );
+    canonical.status = ExecutionStatus::Confirmed;
+    exec_store.put(&canonical).unwrap();
+
+    // Stale legacy receipt-keyed record for the SAME decision: still non-terminal.
+    let mut legacy = ExecutionRecord::new_pending(
+        receipt_id,
+        "proposal-legacy",
+        receipt_id,
+        terminate_clearing_effect(decision_hash, "legacy"),
+    );
+    legacy.status = ExecutionStatus::Failed;
+    legacy.retries = 1;
+    exec_store.put(&legacy).unwrap();
+
+    let callback = create_decision_executor_callback(executor);
+    callback(
+        terminate_clearing_effect(decision_hash, "replay"),
+        receipt_id.to_string(),
+    );
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+    // The terminal canonical record wins: the stale legacy record is NOT
+    // re-dispatched (its status and retry count are untouched).
+    let legacy_after = exec_store.get(receipt_id).unwrap().unwrap();
+    assert_eq!(
+        legacy_after.status,
+        ExecutionStatus::Failed,
+        "stale legacy record must not be re-dispatched when the canonical record is terminal"
+    );
+    assert_eq!(
+        legacy_after.retries, 1,
+        "stale legacy record retry count must be untouched"
+    );
+}
+
 /// Test 3: Startup recovery picks up an Executing record and completes it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_startup_recovery_completes_executing_decision() {

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -489,8 +489,12 @@ async fn test_federation_replay_dedupes_against_legacy_receipt_keyed_record() {
     // the old extractor ignored federation effects and the callback fell back to
     // the receipt id as the idempotency key).
     let receipt_id = "receipt-upgrade-legacy";
-    let mut legacy =
-        ExecutionRecord::new_pending(receipt_id, "proposal-legacy", receipt_id, vec![]);
+    let mut legacy = ExecutionRecord::new_pending(
+        receipt_id,
+        "proposal-legacy",
+        receipt_id,
+        terminate_clearing_effect("sha256:fed-legacy-hash", "legacy"),
+    );
     legacy.status = ExecutionStatus::Confirmed;
     exec_store.put(&legacy).unwrap();
 
@@ -535,8 +539,12 @@ async fn test_federation_replay_honors_legacy_in_flight_receipt_record() {
     // Pre-#2096 NON-terminal record keyed under the receipt id: a retryable
     // failure carried over the upgrade (retries already accumulated).
     let receipt_id = "receipt-inflight-legacy";
-    let mut legacy =
-        ExecutionRecord::new_pending(receipt_id, "proposal-legacy", receipt_id, vec![]);
+    let mut legacy = ExecutionRecord::new_pending(
+        receipt_id,
+        "proposal-legacy",
+        receipt_id,
+        terminate_clearing_effect("sha256:fed-inflight-hash", "legacy"),
+    );
     legacy.status = ExecutionStatus::Failed;
     legacy.retries = 2;
     exec_store.put(&legacy).unwrap();
@@ -565,6 +573,52 @@ async fn test_federation_replay_honors_legacy_in_flight_receipt_record() {
         "legacy retry count must be preserved, not reset (was {})",
         cont.retries
     );
+}
+
+/// Issue #2095 / Codex P1 (#2096): a legacy receipt-keyed record must NOT collapse
+/// a *different* decision that merely shares the same `decision_receipt_id`.
+///
+/// Multiple distinct federation decisions can share a receipt id but carry
+/// distinct `decision_hash` values (the #2095 same-receipt/different-hash case).
+/// After an upgrade, a pre-#2096 record sits under the receipt id; a later,
+/// distinct decision with the same receipt but a different hash must still
+/// execute under its own hash key — the legacy key is adopted only for the same
+/// decision (matched by the stored record's effects hash), never an unrelated one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_federation_legacy_record_does_not_collapse_distinct_same_receipt_decision() {
+    use icn_core::supervisor::decision_executor::create_decision_executor_callback;
+
+    let (executor, exec_store) = make_executor();
+
+    // Legacy record for decision A (hash fed-a), keyed under the receipt id.
+    let receipt_id = "receipt-shared-upgrade";
+    let mut legacy = ExecutionRecord::new_pending(
+        receipt_id,
+        "proposal-a",
+        receipt_id,
+        terminate_clearing_effect("sha256:fed-decision-a", "decision-a"),
+    );
+    legacy.status = ExecutionStatus::Confirmed;
+    exec_store.put(&legacy).unwrap();
+
+    let callback = create_decision_executor_callback(executor);
+
+    // A DIFFERENT decision B (hash fed-b) shares the same receipt id.
+    callback(
+        terminate_clearing_effect("sha256:fed-decision-b", "decision-b"),
+        receipt_id.to_string(),
+    );
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+    // Decision B executes under its own decision_hash key — it is not forced onto
+    // the legacy receipt key and deduped against the unrelated decision A.
+    assert!(
+        exec_store.get("sha256:fed-decision-b").unwrap().is_some(),
+        "a distinct same-receipt decision must execute under its own hash key"
+    );
+    // Decision A's legacy record is untouched.
+    let a = exec_store.get(receipt_id).unwrap().unwrap();
+    assert_eq!(a.status, ExecutionStatus::Confirmed);
 }
 
 /// Test 3: Startup recovery picks up an Executing record and completes it.


### PR DESCRIPTION
## Summary

Fixes #2095. Extends decision-executor idempotency-key extraction so federation effects with a non-empty `decision_hash` use that hash as the primary idempotency key instead of falling back to `decision_receipt_id`.

## Context

- #2093 bound `decision_hash` into federation terminate/revoke provenance hashes.
- #2094 propagated `decision_hash` through the canonical `KernelEffect::Federation` path into `FederationOperation` and service requests.
- This PR completes the executor-layer follow-up and preserves replay compatibility across the #2094 → #2096 upgrade window.

Before this PR, federation-only decisions returned `None` from `extract_decision_hash`, so the production callback fell back to `decision_receipt_id`. In a same-receipt / different-decision-hash case, a second federation decision could dedupe before the federation service saw the propagated hash.

## What changed

- `extract_decision_hash` now extracts non-empty `decision_hash` from:
  - `FederationEffect::SettleClearing`
  - `FederationEffect::TerminateClearing`
  - `FederationEffect::RevokeVouch`
- Empty/legacy federation hashes still return `None`, preserving the receipt-id fallback.
- Treasury extraction behavior is unchanged.
- Added replay compatibility for #2094-era records:
  - existing receipt-keyed terminal records remain deduped after upgrade;
  - existing receipt-keyed in-flight/retryable records continue under the same legacy key after upgrade;
  - a legacy receipt-keyed row is only sticky when it represents the same decision.
- Distinct same-receipt federation decisions still keep their own `decision_hash` key.

## Replay / idempotency behavior

- Same receipt id + different non-empty federation hashes no longer dedupe incorrectly.
- Identical federation hash still dedupes.
- Empty/legacy federation hash preserves previous receipt-id fallback.
- Existing receipt-keyed terminal federation records remain deduped after upgrade.
- Existing receipt-keyed in-flight/retryable federation records continue under the same legacy key after upgrade.
- A legacy receipt-keyed record does not collapse a distinct same-receipt/different-hash federation decision.

## What did NOT change

- No authorization change.
- No token issuance change.
- No OpenAPI/SDK change.
- No federation service provenance-formula change.
- No `decision_receipt_id` field added to federation effects.
- No NYCN change.
- No live-federation / production / pilot-readiness claim.

## Tests

TDD was used: tests were written red first, then implementation was narrowed until green.

Unit coverage:
- federation extraction for `SettleClearing`, `TerminateClearing`, and `RevokeVouch`;
- empty-hash fallback;
- distinctness / determinism;
- Treasury precedence unchanged.

Integration coverage through `create_decision_executor_callback`:
- same receipt + different federation hashes do not dedupe incorrectly;
- empty federation hash falls back to receipt id;
- legacy receipt-keyed terminal record dedupes replay after upgrade;
- legacy receipt-keyed in-flight/retryable record remains sticky after upgrade;
- legacy receipt-keyed record does not collapse a distinct same-receipt federation decision.

Local validation:
- `cargo fmt --all --check`
- `cargo test -p icn-core --lib decision_executor` → 18 passed
- `cargo test -p icn-core --test decision_executor_runtime_test` → 23 passed
- `cargo test -p icn-core --lib` → 406 passed
- `cargo clippy -p icn-core --all-targets --all-features -- -D warnings`
- `ops/scripts/drift-check.sh` → PASS
