### PR TITLE
feat(coop): bind entity map during activation

### DIFF
--- a/icn/crates/icn-coop/src/actor.rs
+++ b/icn/crates/icn-coop/src/actor.rs
@@ -33,9 +33,11 @@ pub type CoopEntityMapHandle = Arc<dyn CoopEntityMap + Send + Sync>;
 /// [`CoopEntityMap`] during cooperative activation.
 ///
 /// This is an **observability signal only**. A mapping bind never gates
-/// activation success, and a binding confers no authority.
+/// activation success, and a binding confers no authority. Shared by the local
+/// activation handler and the gossip coop-update sync path so both perform the
+/// same deterministic bind.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum EntityMapBindOutcome {
+pub enum EntityMapBindOutcome {
     /// `coop_id` was bound (or was already bound) to this cooperative `EntityId`.
     Mapped(EntityId),
     /// `coop_id` is not a valid cooperative `EntityId` slug, so it was left
@@ -53,8 +55,10 @@ pub(crate) enum EntityMapBindOutcome {
 /// Returns the [`EntityMapBindOutcome`] without ever propagating an error: a
 /// mapping bind is an observability side effect and must not fail activation.
 /// `bind_projected` is idempotent for an identical pair, so repeated binds are
-/// safe.
-pub(crate) fn bind_coop_entity_map(
+/// safe. Used by both cooperative activation and the gossip coop-update sync
+/// path so a binding is recorded deterministically on every node that accepts an
+/// activated cooperative.
+pub fn bind_coop_entity_map(
     map: &(dyn CoopEntityMap + Send + Sync),
     coop_id: &str,
 ) -> EntityMapBindOutcome {

--- a/icn/crates/icn-coop/src/actor.rs
+++ b/icn/crates/icn-coop/src/actor.rs
@@ -2,6 +2,7 @@ use crate::{
     AssetDistributionPlan, CoopStore, CoopType, Cooperative, FormationRequest, LifecycleEvent,
     LifecycleManager, Member, MemberRole, MembershipManager, Result,
 };
+use icn_entity::{CoopEntityMap, CoopEntityMapError, EntityId};
 use icn_gossip::GossipActor;
 use icn_governance::charter::FounderSignature;
 use icn_identity::Did;
@@ -19,6 +20,52 @@ pub type GossipHandle = Arc<RwLock<GossipActor>>;
 /// Handle type for treasury manager (shared with governance handlers)
 pub type TreasuryManagerHandle = Arc<RwLock<TreasuryManager>>;
 
+/// Handle to the canonical `coop_id ↔ EntityId` name-binding store.
+///
+/// A binding written through this handle is a **name binding only**: it grants
+/// no standing, role, capability, mandate, or permission. Authority in ICN still
+/// flows from memberships, charters, roles, capabilities, governance decisions,
+/// receipts, and executed effects — never from the existence of a mapping entry.
+/// See [`icn_entity::coop_entity_map`].
+pub type CoopEntityMapHandle = Arc<dyn CoopEntityMap + Send + Sync>;
+
+/// Outcome of attempting to bind a `coop_id` into the canonical
+/// [`CoopEntityMap`] during cooperative activation.
+///
+/// This is an **observability signal only**. A mapping bind never gates
+/// activation success, and a binding confers no authority.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EntityMapBindOutcome {
+    /// `coop_id` was bound (or was already bound) to this cooperative `EntityId`.
+    Mapped(EntityId),
+    /// `coop_id` is not a valid cooperative `EntityId` slug, so it was left
+    /// unbound. Default ids such as `coop:<uuid>` fall here — this is the
+    /// expected common case, not an error.
+    NotMappable(String),
+    /// The binding conflicts with an existing one; nothing was written.
+    Conflict(String),
+    /// A storage (or other) error occurred while binding; nothing was written.
+    StorageError(String),
+}
+
+/// Attempt a non-authoritative `coop_id → EntityId` name binding.
+///
+/// Returns the [`EntityMapBindOutcome`] without ever propagating an error: a
+/// mapping bind is an observability side effect and must not fail activation.
+/// `bind_projected` is idempotent for an identical pair, so repeated binds are
+/// safe.
+pub(crate) fn bind_coop_entity_map(
+    map: &(dyn CoopEntityMap + Send + Sync),
+    coop_id: &str,
+) -> EntityMapBindOutcome {
+    match map.bind_projected(coop_id) {
+        Ok(entity_id) => EntityMapBindOutcome::Mapped(entity_id),
+        Err(CoopEntityMapError::NotMappable(reason)) => EntityMapBindOutcome::NotMappable(reason),
+        Err(CoopEntityMapError::Conflict(reason)) => EntityMapBindOutcome::Conflict(reason),
+        Err(e) => EntityMapBindOutcome::StorageError(e.to_string()),
+    }
+}
+
 pub struct CoopActor {
     rx: mpsc::Receiver<CoopMessage>,
     store: CoopStore,
@@ -27,6 +74,9 @@ pub struct CoopActor {
     gossip: Option<GossipHandle>,
     /// Optional treasury manager for registering treasury accounts in the ledger
     treasury_manager: Option<TreasuryManagerHandle>,
+    /// Optional canonical `coop_id ↔ EntityId` name-binding store. When present,
+    /// it is populated during activation as a non-authoritative side effect.
+    coop_entity_map: Option<CoopEntityMapHandle>,
 }
 
 pub enum CoopMessage {
@@ -134,6 +184,22 @@ impl CoopActor {
         gossip: Option<GossipHandle>,
         treasury_manager: Option<TreasuryManagerHandle>,
     ) -> mpsc::Sender<CoopMessage> {
+        Self::spawn_with_treasury_and_map(store, gossip, treasury_manager, None)
+    }
+
+    /// Spawn actor with optional treasury manager and optional canonical
+    /// `coop_id ↔ EntityId` name-binding store.
+    ///
+    /// When `coop_entity_map` is `Some`, cooperative activation records a
+    /// non-authoritative `coop_id ↔ EntityId` binding as a side effect (a
+    /// binding grants no permission, and a bind failure never fails activation).
+    /// When `None`, behavior is identical to [`Self::spawn_with_treasury`].
+    pub fn spawn_with_treasury_and_map(
+        store: CoopStore,
+        gossip: Option<GossipHandle>,
+        treasury_manager: Option<TreasuryManagerHandle>,
+        coop_entity_map: Option<CoopEntityMapHandle>,
+    ) -> mpsc::Sender<CoopMessage> {
         let (tx, rx) = mpsc::channel(100);
 
         let lifecycle = LifecycleManager::new();
@@ -146,6 +212,7 @@ impl CoopActor {
             membership,
             gossip,
             treasury_manager,
+            coop_entity_map,
         };
 
         tokio::spawn(async move {
@@ -389,6 +456,43 @@ impl CoopActor {
         }
 
         self.store.save_cooperative(&coop)?;
+
+        // Non-authoritative name binding (#2082 PR2): record the canonical
+        // `coop_id ↔ EntityId` mapping when a map is wired. A binding grants NO
+        // authority, and a bind failure — including the common NotMappable case
+        // for default `coop:<uuid>` ids — is reported but never fails activation.
+        if let Some(ref map) = self.coop_entity_map {
+            match bind_coop_entity_map(map.as_ref(), &coop_id) {
+                EntityMapBindOutcome::Mapped(entity_id) => tracing::info!(
+                    target: "coop_entity_bind",
+                    coop_id = %coop_id,
+                    entity_id = %entity_id,
+                    outcome = "mapped",
+                    "bound coop_id to cooperative EntityId during activation (name binding only; grants no authority)"
+                ),
+                EntityMapBindOutcome::NotMappable(reason) => tracing::info!(
+                    target: "coop_entity_bind",
+                    coop_id = %coop_id,
+                    outcome = "not_mappable",
+                    reason = %reason,
+                    "coop_id is not a mappable cooperative EntityId slug; left unbound; activation unaffected"
+                ),
+                EntityMapBindOutcome::Conflict(reason) => tracing::error!(
+                    target: "coop_entity_bind",
+                    coop_id = %coop_id,
+                    outcome = "conflict",
+                    reason = %reason,
+                    "coop_id/entity mapping conflict during activation; binding skipped; activation NOT failed"
+                ),
+                EntityMapBindOutcome::StorageError(reason) => tracing::error!(
+                    target: "coop_entity_bind",
+                    coop_id = %coop_id,
+                    outcome = "storage_error",
+                    reason = %reason,
+                    "coop_entity_map bind failed during activation; binding skipped; activation NOT failed"
+                ),
+            }
+        }
 
         tracing::info!(
             coop_id = %coop.id,
@@ -684,6 +788,7 @@ mod tests {
         AssetDistributionPlan, BalanceAction, CapitalReturnMethod, CoopHandle, CoopStatus,
         CoopType, DebtAction, FormationRequest, MemberRole, MemberStatus,
     };
+    use icn_entity::InMemoryCoopEntityMap;
     use icn_identity::KeyPair;
     use std::sync::Arc;
     use tempfile::tempdir;
@@ -1765,6 +1870,237 @@ mod tests {
         assert!(
             result.is_err(),
             "CreateTreasury after activation must be rejected — treasury already exists"
+        );
+    }
+
+    // === Entity-map binding during activation (#2082 PR2) ===
+    //
+    // A binding is a non-authoritative name binding only. These tests prove that
+    // activation populates the canonical CoopEntityMap when the id is mappable,
+    // reports (and never fails on) non-mappable ids, and grants no authority.
+
+    fn map_handle(map: &Arc<InMemoryCoopEntityMap>) -> CoopEntityMapHandle {
+        map.clone()
+    }
+
+    fn spawn_test_actor_with_map() -> (CoopHandle, Arc<InMemoryCoopEntityMap>) {
+        let store = create_test_store();
+        let map = Arc::new(InMemoryCoopEntityMap::new());
+        let tx = CoopActor::spawn_with_treasury_and_map(store, None, None, Some(map_handle(&map)));
+        (CoopHandle::new(tx), map)
+    }
+
+    fn spawn_test_actor_with_treasury_and_map() -> (
+        CoopHandle,
+        TreasuryManagerHandle,
+        Arc<InMemoryCoopEntityMap>,
+    ) {
+        let store = create_test_store();
+        let treasury_mgr = Arc::new(RwLock::new(icn_ledger::TreasuryManager::new()));
+        let map = Arc::new(InMemoryCoopEntityMap::new());
+        let tx = CoopActor::spawn_with_treasury_and_map(
+            store,
+            None,
+            Some(treasury_mgr.clone()),
+            Some(map_handle(&map)),
+        );
+        (CoopHandle::new(tx), treasury_mgr, map)
+    }
+
+    // T1: a mappable coop_id is bound (forward + reverse) on activation.
+    #[tokio::test]
+    async fn test_activation_binds_mappable_coop_id() {
+        let (handle, map) = spawn_test_actor_with_map();
+        let founder = create_test_did();
+        let coop = handle
+            .create_cooperative(
+                Some("good-coop".to_string()),
+                "Good Coop".to_string(),
+                CoopType::Worker,
+                founder,
+            )
+            .await
+            .unwrap();
+        handle
+            .activate_cooperative(coop.id.clone(), "charter".to_string())
+            .await
+            .unwrap();
+
+        let entity = EntityId::cooperative("good-coop").unwrap();
+        assert_eq!(
+            map.entity_for_coop("good-coop").unwrap(),
+            Some(entity.clone())
+        );
+        assert_eq!(
+            map.coop_for_entity(&entity).unwrap(),
+            Some("good-coop".to_string())
+        );
+    }
+
+    // T2: the default `coop:<uuid>` id is non-mappable; activation must NOT fail
+    // and must write nothing.
+    #[tokio::test]
+    async fn test_activation_non_mappable_default_id_does_not_fail() {
+        let (handle, map) = spawn_test_actor_with_map();
+        let founder = create_test_did();
+        // Default-generated id is `coop:<uuid>` (the colon makes it a non-slug).
+        let coop = handle
+            .create_cooperative(
+                None,
+                "Default Id Coop".to_string(),
+                CoopType::Worker,
+                founder,
+            )
+            .await
+            .unwrap();
+        assert!(
+            coop.id.starts_with("coop:"),
+            "default cooperative id should be coop:<uuid>, got {}",
+            coop.id
+        );
+
+        let activated = handle
+            .activate_cooperative(coop.id.clone(), "charter".to_string())
+            .await
+            .unwrap();
+        assert_eq!(activated.id, coop.id, "activation must succeed unchanged");
+        assert_eq!(
+            map.entity_for_coop(&coop.id).unwrap(),
+            None,
+            "a non-mappable id must not be bound"
+        );
+    }
+
+    // T6: existing treasury behavior is preserved and PR2 does NOT populate
+    // treasury entity_id.
+    #[tokio::test]
+    async fn test_activation_with_map_preserves_treasury_behavior() {
+        let (handle, treasury_mgr, map) = spawn_test_actor_with_treasury_and_map();
+        let founder = create_test_did();
+        let coop = handle
+            .create_cooperative(
+                Some("treasury-coop".to_string()),
+                "Treasury Coop".to_string(),
+                CoopType::Worker,
+                founder,
+            )
+            .await
+            .unwrap();
+        let activated = handle
+            .activate_cooperative(coop.id.clone(), "charter".to_string())
+            .await
+            .unwrap();
+        assert!(activated.treasury_did.is_some());
+
+        let guard = treasury_mgr.read().await;
+        let treasury = guard
+            .get_treasury_by_coop(&coop.id)
+            .expect("treasury must still register during activation");
+        assert_eq!(treasury.coop_id, coop.id);
+        assert!(treasury.is_active);
+        // PR2 must NOT populate treasury entity_id (deferred, separate change).
+        assert!(
+            treasury.entity_id().is_none(),
+            "PR2 must not populate treasury entity_id"
+        );
+
+        // The mappable coop_id is still bound as a pure name binding.
+        let entity = EntityId::cooperative("treasury-coop").unwrap();
+        assert_eq!(map.entity_for_coop("treasury-coop").unwrap(), Some(entity));
+    }
+
+    // T7: an actor without a map handle behaves exactly as before.
+    #[tokio::test]
+    async fn test_activation_without_map_handle_unchanged() {
+        let handle = spawn_test_actor(); // spawn() -> no treasury, no map
+        let founder = create_test_did();
+        let coop = handle
+            .create_cooperative(
+                Some("no-map-coop".to_string()),
+                "No Map Coop".to_string(),
+                CoopType::Worker,
+                founder,
+            )
+            .await
+            .unwrap();
+        let activated = handle
+            .activate_cooperative(coop.id.clone(), "charter".to_string())
+            .await
+            .unwrap();
+        assert_eq!(activated.id, coop.id);
+        assert!(activated.treasury_did.is_some());
+    }
+
+    // === bind_coop_entity_map outcome helper (pure, no actor) ===
+
+    // T3a: a mappable id yields Mapped and writes the binding.
+    #[test]
+    fn test_bind_outcome_mapped_writes_binding() {
+        let map = InMemoryCoopEntityMap::new();
+        let outcome = bind_coop_entity_map(&map, "good-coop");
+        assert_eq!(
+            outcome,
+            EntityMapBindOutcome::Mapped(EntityId::cooperative("good-coop").unwrap())
+        );
+        assert_eq!(
+            map.entity_for_coop("good-coop").unwrap(),
+            Some(EntityId::cooperative("good-coop").unwrap())
+        );
+    }
+
+    // T3b: non-mappable ids (default colon shape, uppercase/underscore) yield
+    // NotMappable and write nothing — this is the reported, expected path.
+    #[test]
+    fn test_bind_outcome_not_mappable_writes_nothing() {
+        let map = InMemoryCoopEntityMap::new();
+        for id in ["coop:11111111-2222-3333-4444-555555555555", "coop_A"] {
+            let outcome = bind_coop_entity_map(&map, id);
+            assert!(
+                matches!(outcome, EntityMapBindOutcome::NotMappable(_)),
+                "{id} should be NotMappable, got {outcome:?}"
+            );
+            assert_eq!(map.entity_for_coop(id).unwrap(), None);
+        }
+    }
+
+    // T4: repeated bind of an identical pair is idempotent.
+    #[test]
+    fn test_bind_outcome_idempotent_for_same_pair() {
+        let map = InMemoryCoopEntityMap::new();
+        let first = bind_coop_entity_map(&map, "good-coop");
+        let second = bind_coop_entity_map(&map, "good-coop");
+        assert_eq!(first, second);
+        assert_eq!(
+            second,
+            EntityMapBindOutcome::Mapped(EntityId::cooperative("good-coop").unwrap())
+        );
+    }
+
+    // T5: a conflict is reported and grants no authority — the pre-existing
+    // binding is untouched and no one-sided write is made.
+    #[test]
+    fn test_bind_outcome_conflict_is_reported_and_grants_no_authority() {
+        let map = InMemoryCoopEntityMap::new();
+        // Pre-seed a conflicting forward binding: good-coop -> other-coop entity.
+        map.bind_exact("good-coop", &EntityId::cooperative("other-coop").unwrap())
+            .unwrap();
+
+        // An activation-style bind projects good-coop -> good-coop, which conflicts.
+        let outcome = bind_coop_entity_map(&map, "good-coop");
+        assert!(
+            matches!(outcome, EntityMapBindOutcome::Conflict(_)),
+            "expected Conflict, got {outcome:?}"
+        );
+        // The pre-existing binding is unchanged.
+        assert_eq!(
+            map.entity_for_coop("good-coop").unwrap(),
+            Some(EntityId::cooperative("other-coop").unwrap())
+        );
+        // No one-sided reverse write was made for good-coop's own projected entity.
+        assert_eq!(
+            map.coop_for_entity(&EntityId::cooperative("good-coop").unwrap())
+                .unwrap(),
+            None
         );
     }
 }

--- a/icn/crates/icn-coop/src/lib.rs
+++ b/icn/crates/icn-coop/src/lib.rs
@@ -17,7 +17,9 @@ pub mod store;
 /// Cooperative types and data structures
 pub mod types;
 
-pub use actor::{CoopActor, CoopMessage, GossipHandle, TreasuryManagerHandle, COOP_TOPIC};
+pub use actor::{
+    CoopActor, CoopEntityMapHandle, CoopMessage, GossipHandle, TreasuryManagerHandle, COOP_TOPIC,
+};
 pub use handle::CoopHandle;
 pub use lifecycle::{
     derive_treasury_anchor, derive_treasury_did, LifecycleEvent, LifecycleManager,

--- a/icn/crates/icn-coop/src/lib.rs
+++ b/icn/crates/icn-coop/src/lib.rs
@@ -18,7 +18,8 @@ pub mod store;
 pub mod types;
 
 pub use actor::{
-    CoopActor, CoopEntityMapHandle, CoopMessage, GossipHandle, TreasuryManagerHandle, COOP_TOPIC,
+    bind_coop_entity_map, CoopActor, CoopEntityMapHandle, CoopMessage, EntityMapBindOutcome,
+    GossipHandle, TreasuryManagerHandle, COOP_TOPIC,
 };
 pub use handle::CoopHandle;
 pub use lifecycle::{

--- a/icn/crates/icn-core/src/supervisor/init_coop.rs
+++ b/icn/crates/icn-core/src/supervisor/init_coop.rs
@@ -1,7 +1,8 @@
 //! Cooperative actor initialization
 
 use anyhow::Result;
-use icn_coop::{CoopActor, CoopHandle, CoopStore, TreasuryManagerHandle};
+use icn_coop::{CoopActor, CoopEntityMapHandle, CoopHandle, CoopStore, TreasuryManagerHandle};
+use icn_entity::SledCoopEntityMap;
 use icn_gossip::GossipActor;
 use icn_identity::Did;
 use icn_store::SledStore;
@@ -20,6 +21,12 @@ pub struct CoopServices {
     pub coop_handle: CoopHandle,
     /// Direct access to cooperative store (for potential gateway use)
     pub coop_store: Arc<CoopStore>,
+    /// Canonical `coop_id ↔ EntityId` name-binding store, shared with the actor.
+    ///
+    /// A binding is a name binding only and grants no authority. Exposed here so
+    /// the supervisor/gateway can resolve identifiers; it is **not** an
+    /// authorization surface.
+    pub coop_entity_map: CoopEntityMapHandle,
 }
 
 /// Initialize cooperative services
@@ -63,6 +70,12 @@ pub async fn init_coop_services_with_treasury(
     // CoopStore needs direct Sled Db access
     let db = Arc::new(sled_store.db().clone());
     let coop_store = CoopStore::new(db.clone());
+
+    // Canonical coop_id <-> EntityId name-binding store, backed by the SAME
+    // cooperative sled DB (no separate database). Populated during activation as
+    // a non-authoritative side effect (#2082): a binding grants no authority.
+    let coop_entity_map: CoopEntityMapHandle = Arc::new(SledCoopEntityMap::new(db.clone()));
+
     let coop_store_for_gateway = Arc::new(CoopStore::new(db));
 
     info!("Cooperative store initialized at {:?}", store_path);
@@ -78,8 +91,14 @@ pub async fn init_coop_services_with_treasury(
         }
     }
 
-    // Spawn CoopActor with store, gossip handle, and optional treasury manager
-    let tx = CoopActor::spawn_with_treasury(coop_store, Some(gossip_handle), treasury_manager);
+    // Spawn CoopActor with store, gossip handle, optional treasury manager, and
+    // the canonical coop_id <-> EntityId name-binding map (shared via Arc).
+    let tx = CoopActor::spawn_with_treasury_and_map(
+        coop_store,
+        Some(gossip_handle),
+        treasury_manager,
+        Some(coop_entity_map.clone()),
+    );
     let coop_handle = CoopHandle::new(tx);
 
     info!("✓ Cooperative actor spawned");
@@ -87,5 +106,6 @@ pub async fn init_coop_services_with_treasury(
     Ok(CoopServices {
         coop_handle,
         coop_store: coop_store_for_gateway,
+        coop_entity_map,
     })
 }

--- a/icn/crates/icn-core/src/supervisor/init_notifications.rs
+++ b/icn/crates/icn-core/src/supervisor/init_notifications.rs
@@ -64,6 +64,10 @@ pub struct NotificationDeps {
     pub profile_cache: ProfileCache,
     /// Cooperative store
     pub coop_store: Arc<icn_coop::CoopStore>,
+    /// Canonical `coop_id ↔ EntityId` name-binding store (non-authoritative).
+    /// Used to mirror the activation-time bind when an activated coop is synced
+    /// from a peer, keeping the resolver node-independent.
+    pub coop_entity_map: icn_coop::CoopEntityMapHandle,
     /// Community store for civic engine sync
     pub community_store: CommunityStoreHandle,
     /// Optional federation handler
@@ -706,7 +710,18 @@ pub async fn handle_node_profile(
 }
 
 /// Handle cooperative update messages
-pub async fn handle_coop_update(entry_data: Vec<u8>, coop_store: Arc<icn_coop::CoopStore>) {
+///
+/// When a peer gossips an **activated** cooperative, the receiving node records
+/// the same canonical `coop_id ↔ EntityId` name binding that the activating node
+/// made locally, so the resolver exposed via `CoopServices.coop_entity_map` is
+/// node-independent. The bind is deterministic, idempotent, non-authoritative,
+/// and non-fatal — a bind failure (including the common non-mappable case) never
+/// blocks the gossip sync.
+pub async fn handle_coop_update(
+    entry_data: Vec<u8>,
+    coop_store: Arc<icn_coop::CoopStore>,
+    coop_entity_map: Option<icn_coop::CoopEntityMapHandle>,
+) {
     match icn_encoding::decode::<icn_coop::Cooperative>(&entry_data) {
         Ok(coop) => {
             let existing = coop_store.get_cooperative(&coop.id);
@@ -729,6 +744,48 @@ pub async fn handle_coop_update(entry_data: Vec<u8>, coop_store: Arc<icn_coop::C
                     coop_name = %coop.name,
                     "Synced cooperative from gossip"
                 );
+
+                // Mirror the activation-time bind for activated coops only, so a
+                // peer records exactly the bindings the origin recorded (no more,
+                // no less). Same deterministic helper as the local path.
+                if coop.status == icn_coop::CoopStatus::Active {
+                    if let Some(ref map) = coop_entity_map {
+                        match icn_coop::bind_coop_entity_map(map.as_ref(), &coop.id) {
+                            icn_coop::EntityMapBindOutcome::Mapped(entity_id) => debug!(
+                                target: "coop_entity_bind",
+                                coop_id = %coop.id,
+                                entity_id = %entity_id,
+                                outcome = "mapped",
+                                source = "gossip",
+                                "bound coop_id to cooperative EntityId from gossip sync (name binding only; grants no authority)"
+                            ),
+                            icn_coop::EntityMapBindOutcome::NotMappable(reason) => debug!(
+                                target: "coop_entity_bind",
+                                coop_id = %coop.id,
+                                outcome = "not_mappable",
+                                source = "gossip",
+                                reason = %reason,
+                                "synced coop_id is not a mappable cooperative EntityId slug; left unbound"
+                            ),
+                            icn_coop::EntityMapBindOutcome::Conflict(reason) => warn!(
+                                target: "coop_entity_bind",
+                                coop_id = %coop.id,
+                                outcome = "conflict",
+                                source = "gossip",
+                                reason = %reason,
+                                "coop_id/entity mapping conflict during gossip sync; binding skipped"
+                            ),
+                            icn_coop::EntityMapBindOutcome::StorageError(reason) => warn!(
+                                target: "coop_entity_bind",
+                                coop_id = %coop.id,
+                                outcome = "storage_error",
+                                source = "gossip",
+                                reason = %reason,
+                                "coop_entity_map bind failed during gossip sync; binding skipped"
+                            ),
+                        }
+                    }
+                }
             }
         }
         Err(e) => {
@@ -998,8 +1055,9 @@ pub fn create_notification_callback(
         } else if topic == init_coop::COOP_UPDATES_TOPIC {
             if let Some(data) = entry_data {
                 let coop_store = deps.coop_store.clone();
+                let coop_entity_map = deps.coop_entity_map.clone();
                 tokio::spawn(async move {
-                    handle_coop_update(data, coop_store).await;
+                    handle_coop_update(data, coop_store, Some(coop_entity_map)).await;
                 });
             }
         } else if topic == icn_community::COMMUNITY_TOPIC {
@@ -1154,5 +1212,92 @@ mod tests {
             forwarded,
             "matching author/submitter must pass the guard (returns true even when handle is None)"
         );
+    }
+
+    // === Coop-update gossip path binds the canonical entity map (#2082 PR2) ===
+    //
+    // A coop activated on one node is gossiped to peers; the receiving node must
+    // record the same deterministic, non-authoritative coop_id -> EntityId binding
+    // so the canonical resolver is node-independent.
+
+    fn coop_store_and_map() -> (
+        tempfile::TempDir,
+        Arc<icn_coop::CoopStore>,
+        Arc<icn_entity::InMemoryCoopEntityMap>,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let sled_store = icn_store::SledStore::open(dir.path()).unwrap();
+        let db = Arc::new(sled_store.db().clone());
+        let coop_store = Arc::new(icn_coop::CoopStore::new(db));
+        let map = Arc::new(icn_entity::InMemoryCoopEntityMap::new());
+        // Return `dir` so the temp directory outlives the open sled handle.
+        (dir, coop_store, map)
+    }
+
+    #[tokio::test]
+    async fn test_coop_update_binds_active_mappable_coop() {
+        use icn_entity::{CoopEntityMap, EntityId};
+        let (_dir, coop_store, map) = coop_store_and_map();
+        let map_handle: icn_coop::CoopEntityMapHandle = map.clone();
+
+        let mut coop = icn_coop::Cooperative::new_with_id(
+            "synced-coop".to_string(),
+            "Synced Coop".to_string(),
+            icn_coop::CoopType::Worker,
+        );
+        coop.status = icn_coop::CoopStatus::Active;
+        let data = icn_encoding::encode(&coop).unwrap();
+
+        handle_coop_update(data, coop_store.clone(), Some(map_handle)).await;
+
+        // Saved AND bound through the canonical map.
+        assert!(coop_store.get_cooperative("synced-coop").is_ok());
+        assert_eq!(
+            map.entity_for_coop("synced-coop").unwrap(),
+            Some(EntityId::cooperative("synced-coop").unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_coop_update_does_not_bind_forming_coop() {
+        use icn_entity::CoopEntityMap;
+        let (_dir, coop_store, map) = coop_store_and_map();
+        let map_handle: icn_coop::CoopEntityMapHandle = map.clone();
+
+        // A Forming coop is not yet activated; the origin does not bind it, so a
+        // peer must not bind it either (keeps the map symmetric across nodes).
+        let coop = icn_coop::Cooperative::new_with_id(
+            "forming-coop".to_string(),
+            "Forming Coop".to_string(),
+            icn_coop::CoopType::Worker,
+        );
+        assert_eq!(coop.status, icn_coop::CoopStatus::Forming);
+        let data = icn_encoding::encode(&coop).unwrap();
+
+        handle_coop_update(data, coop_store.clone(), Some(map_handle)).await;
+
+        assert!(coop_store.get_cooperative("forming-coop").is_ok());
+        assert_eq!(map.entity_for_coop("forming-coop").unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_coop_update_active_non_mappable_saved_but_not_bound() {
+        use icn_entity::CoopEntityMap;
+        let (_dir, coop_store, map) = coop_store_and_map();
+        let map_handle: icn_coop::CoopEntityMapHandle = map.clone();
+
+        // Default id is `coop:<uuid>` (non-mappable). Activation-sync must still
+        // save the coop and must not fail or bind.
+        let mut coop =
+            icn_coop::Cooperative::new("Default Id Coop".to_string(), icn_coop::CoopType::Worker);
+        coop.status = icn_coop::CoopStatus::Active;
+        let coop_id = coop.id.clone();
+        assert!(coop_id.starts_with("coop:"));
+        let data = icn_encoding::encode(&coop).unwrap();
+
+        handle_coop_update(data, coop_store.clone(), Some(map_handle)).await;
+
+        assert!(coop_store.get_cooperative(&coop_id).is_ok());
+        assert_eq!(map.entity_for_coop(&coop_id).unwrap(), None);
     }
 }

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -435,6 +435,7 @@ async fn spawn_actors_with_identity(
     icn_obs::metrics::supervisor::actor_active_set("coop", true);
     let coop_handle = coop_services.coop_handle.clone();
     let coop_store = coop_services.coop_store.clone();
+    let coop_entity_map = coop_services.coop_entity_map.clone();
 
     // Initialize community services (civic engine)
     let community_services =
@@ -623,6 +624,7 @@ async fn spawn_actors_with_identity(
         &recovery_store,
         &ledger_handle,
         &coop_store,
+        &coop_entity_map,
         &community_store,
         &snapshot_coordinator,
         &compute_handle_holder,
@@ -1319,6 +1321,7 @@ async fn configure_gossip_actor(
     recovery_store: &Arc<dyn icn_store::Store>,
     ledger_handle: &super::actors::LedgerHandle,
     coop_store: &Arc<icn_coop::CoopStore>,
+    coop_entity_map: &icn_coop::CoopEntityMapHandle,
     community_store: &Arc<icn_community::CommunityStore>,
     snapshot_coordinator: &Arc<RwLock<icn_snapshot::SnapshotCoordinator>>,
     compute_handle_holder: &Arc<RwLock<Option<icn_compute::ComputeHandle>>>,
@@ -1369,6 +1372,7 @@ async fn configure_gossip_actor(
             node_profile: node_profile_handle.clone(),
             profile_cache: profile_cache.clone(),
             coop_store: coop_store.clone(),
+            coop_entity_map: coop_entity_map.clone(),
             community_store: community_store.clone(),
             federation_handler: federation_handler.clone(),
             attestation_rate_limiter,

--- a/icn/crates/icn-core/tests/coop_entity_map_wiring.rs
+++ b/icn/crates/icn-core/tests/coop_entity_map_wiring.rs
@@ -1,0 +1,98 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! #2082 PR2: verify cooperative activation is wired to the canonical
+//! `CoopEntityMap`, that the map is constructed from the existing shared sled DB
+//! (no new database), and that the actor uses the handle during activation.
+//!
+//! A binding written here is a non-authoritative name binding only.
+
+use std::sync::Arc;
+
+use icn_coop::CoopType;
+use icn_core::config::Config;
+use icn_core::supervisor::init_coop::init_coop_services_with_treasury;
+use icn_entity::EntityId;
+use icn_gossip::GossipActor;
+use icn_identity::KeyPair;
+use icn_ledger::TreasuryManager;
+use tokio::sync::RwLock;
+
+/// Activating a cooperative with a mappable id binds it through the wired map,
+/// proving (a) a `SledCoopEntityMap` is constructed in the treasury-enabled
+/// path, and (b) the actor received and used the same handle.
+#[tokio::test]
+async fn activation_binds_through_wired_coop_entity_map() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = Config {
+        data_dir: temp.path().to_path_buf(),
+        ..Config::default()
+    };
+
+    let node_did = KeyPair::generate().unwrap().did().clone();
+    let gossip = GossipActor::spawn(node_did.clone(), None);
+    let treasury_mgr = Arc::new(RwLock::new(TreasuryManager::new()));
+
+    let services = init_coop_services_with_treasury(&config, gossip, node_did, Some(treasury_mgr))
+        .await
+        .expect("init coop services should succeed");
+
+    let founder = KeyPair::generate().unwrap().did().clone();
+    let coop = services
+        .coop_handle
+        .create_cooperative(
+            Some("wiring-coop".to_string()),
+            "Wiring Coop".to_string(),
+            CoopType::Worker,
+            founder,
+        )
+        .await
+        .unwrap();
+    services
+        .coop_handle
+        .activate_cooperative(coop.id.clone(), "charter".to_string())
+        .await
+        .unwrap();
+
+    // The actor received the same map handle and bound the mappable id.
+    let entity = EntityId::cooperative("wiring-coop").unwrap();
+    assert_eq!(
+        services
+            .coop_entity_map
+            .entity_for_coop("wiring-coop")
+            .unwrap(),
+        Some(entity.clone()),
+        "activation must bind through the wired CoopEntityMap"
+    );
+    assert_eq!(
+        services.coop_entity_map.coop_for_entity(&entity).unwrap(),
+        Some("wiring-coop".to_string())
+    );
+}
+
+/// The map shares the cooperative sled store: no separate database directory is
+/// created for it.
+#[tokio::test]
+async fn wiring_creates_no_separate_map_database() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = Config {
+        data_dir: temp.path().to_path_buf(),
+        ..Config::default()
+    };
+
+    let node_did = KeyPair::generate().unwrap().did().clone();
+    let gossip = GossipActor::spawn(node_did.clone(), None);
+    let treasury_mgr = Arc::new(RwLock::new(TreasuryManager::new()));
+
+    let _services = init_coop_services_with_treasury(&config, gossip, node_did, Some(treasury_mgr))
+        .await
+        .expect("init coop services should succeed");
+
+    // The cooperative sled store is opened once; the map reuses that same DB.
+    assert!(
+        config.store_path().join("cooperative").exists(),
+        "cooperative sled store must exist"
+    );
+    assert!(
+        !config.store_path().join("coop_entity_map").exists(),
+        "no separate coop_entity_map database should be created"
+    );
+}


### PR DESCRIPTION
## Summary

PR2 for the #2082 lane. Wires the canonical `CoopEntityMap` foundation into cooperative activation as a non-authoritative lifecycle side effect.

## What changed

- Adds an optional `CoopEntityMap` handle to `CoopActor` (`spawn_with_treasury_and_map`; `spawn_with_treasury` delegates with `None`, so existing callers/tests are unchanged).
- Binds mappable cooperative IDs during activation, after the cooperative is durably saved, via `bind_projected`.
- Mirrors the same deterministic bind on the gossip coop-update sync path: when a peer receives an **activated** cooperative, it records the identical `coop_id ↔ EntityId` binding the origin made, so the resolver exposed on `CoopServices` is node-independent (addresses review). Gated on `Active`, non-fatal, non-authoritative.
- Reports `NotMappable` IDs explicitly without failing activation.
- Reports mapping conflicts/storage errors without granting authority and without failing activation.
- Wires `SledCoopEntityMap` from the existing shared cooperative sled DB in `init_coop_services_with_treasury` (no new database); exposes the handle on `CoopServices`.

## Why

PR1 (#2103) created the durable `coop_id ↔ EntityId` mapping foundation but did not populate it. This PR starts populating the map from a real lifecycle event (activation) without making the map authoritative for auth.

## Important behavior

Default cooperative IDs are generated as `coop:<uuid>`, which are not valid `EntityId` slugs (the colon is rejected). Therefore `NotMappable` is the expected common path and is non-fatal: only deliberately slug-shaped IDs bind. The bind is an observability side effect (`tracing` target `coop_entity_bind`, outcomes `mapped` / `not_mappable` / `conflict` / `storage_error`).

## What did NOT change

- No gateway auth change.
- No `/auth/verify` change.
- No token issuance change.
- No `require_coop_access` change.
- No `require_entity_access` enforcement.
- No treasury entity-auth enforcement (treasury `entity_id` is still `None`).
- No backfill writes.
- No generated surrogate slug allocation.
- No silent normalization.
- No production/pilot readiness claim.

## Authority invariant

A mapping is not authority. The mapping grants no membership, role, capability, mandate, permission, or standing. The bind runs after the cooperative is saved, is non-fatal, and is never read by any authorization path in this PR.

## How

- `icn-coop`: `CoopEntityMapHandle` type, `EntityMapBindOutcome` + `bind_coop_entity_map` helper (testable without log capture; `pub` so the activation and gossip-sync paths share one deterministic bind), optional actor field, new constructor, non-fatal bind in `handle_activate_cooperative`.
- `icn-core`: construct `SledCoopEntityMap` from the existing shared sled DB and pass it to the actor; expose it on `CoopServices`; thread the same handle into `NotificationDeps` → `handle_coop_update` (via `configure_gossip_actor`) so accepted activated coop updates bind on peers.

## Risk

Low. New behavior is gated on a `Some(map)` handle and cannot fail activation or gossip sync. Existing callers that use `spawn_with_treasury` pass `None` and are unchanged. No auth/economic state is touched.

## Test plan

- `cargo fmt --all --check` — clean
- `cargo test -p icn-coop` — 148 passed (8 new: mappable bind, non-mappable non-fatal, idempotent, conflict-reported-no-authority, treasury-unchanged, no-map backward-compat, plus pure-helper outcomes)
- `cargo test -p icn-core` — 678 passed across 63 suites (2 wiring tests: binds through the shared map, no separate DB created; 3 gossip-path tests: Active mappable binds, Forming does not, Active non-mappable is saved but not bound)
- `cargo clippy -p icn-coop -p icn-core --all-targets --all-features -- -D warnings` — clean
- `ops/scripts/drift-check.sh` — PASS

## Follow-ups (not in this PR)

- #2082 lane continues with #2080 (token issuance / `/auth/verify` replacement) then #2081 (treasury entity-auth enforcement).
- Candidate separate issues: dry-run backfill report for existing coop IDs; cooperative slug-ID strategy / surrogate allocation (so the default `coop:<uuid>` scheme can bind); treasury `entity_id` population; gateway persisted-map observe-mode read (part of #2080).
