### PR TITLE
feat(entity): preview surrogate coop entity ids

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3136,6 +3136,7 @@ dependencies = [
  "icn-time",
  "serde",
  "serde_json",
+ "sha2",
  "sled",
  "tempfile",
  "thiserror 2.0.18",

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -231,6 +231,11 @@ enum CoopMaintenanceCommands {
         /// Emit machine-readable JSON instead of a human-readable table.
         #[arg(long)]
         json: bool,
+        /// Preview the deterministic surrogate `EntityId` that a later
+        /// allocation PR would propose for each non-mappable cooperative ID,
+        /// and flag any that would collide on bind. Read-only; binds nothing.
+        #[arg(long)]
+        preview_surrogates: bool,
     },
 }
 
@@ -2033,7 +2038,10 @@ fn get_store_path(data_dir: &Path) -> PathBuf {
 /// Dispatch read-only cooperative maintenance subcommands.
 fn handle_coop_maintenance_command(cmd: CoopMaintenanceCommands, data_dir: &Path) -> Result<()> {
     match cmd {
-        CoopMaintenanceCommands::EntityReport { json } => coop_entity_report(data_dir, json),
+        CoopMaintenanceCommands::EntityReport {
+            json,
+            preview_surrogates,
+        } => coop_entity_report(data_dir, json, preview_surrogates),
     }
 }
 
@@ -2045,9 +2053,12 @@ fn handle_coop_maintenance_command(cmd: CoopMaintenanceCommands, data_dir: &Path
 /// writes**, allocates **no** surrogate IDs, normalizes nothing, and changes
 /// no authorization state — a mapping is a name binding only and grants no
 /// authority.
-fn coop_entity_report(data_dir: &Path, json: bool) -> Result<()> {
+fn coop_entity_report(data_dir: &Path, json: bool, preview_surrogates: bool) -> Result<()> {
     use icn_coop::CoopStore;
-    use icn_entity::{classify_coop_ids, CoopEntityInventory, SledCoopEntityMap};
+    use icn_entity::{
+        classify_coop_ids, classify_coop_ids_with_surrogate_preview, CoopEntityInventory,
+        SledCoopEntityMap,
+    };
     use std::sync::Arc;
 
     let coop_store_path = get_store_path(data_dir).join("cooperative");
@@ -2062,7 +2073,11 @@ fn coop_entity_report(data_dir: &Path, json: bool) -> Result<()> {
                 coop_store_path.display()
             );
         }
-        return render_coop_entity_inventory(&CoopEntityInventory::default(), json);
+        return render_coop_entity_inventory(
+            &CoopEntityInventory::default(),
+            json,
+            preview_surrogates,
+        );
     }
 
     let sled_store = SledStore::open(&coop_store_path).with_context(|| {
@@ -2085,15 +2100,26 @@ fn coop_entity_report(data_dir: &Path, json: bool) -> Result<()> {
         .map(|coop| coop.id)
         .collect();
 
-    // Pure, read-only classification: no binds, no normalization.
-    let inventory = classify_coop_ids(coop_ids, &map);
-    render_coop_entity_inventory(&inventory, json)
+    // Read-only classification: no binds, no normalization. With
+    // --preview-surrogates, also propose (but never bind) a deterministic
+    // surrogate EntityId for each non-mappable id and flag bind collisions.
+    let inventory = if preview_surrogates {
+        classify_coop_ids_with_surrogate_preview(coop_ids, &map)
+    } else {
+        classify_coop_ids(coop_ids, &map)
+    };
+    render_coop_entity_inventory(&inventory, json, preview_surrogates)
 }
 
 /// Print a [`icn_entity::CoopEntityInventory`] as JSON or a human table.
+///
+/// `preview` controls only the human-readable extras (surrogate counts and the
+/// per-entry proposed surrogate); the JSON form carries the optional surrogate
+/// fields whenever they are present, so JSON callers see them regardless.
 fn render_coop_entity_inventory(
     inventory: &icn_entity::CoopEntityInventory,
     json: bool,
+    preview: bool,
 ) -> Result<()> {
     use icn_entity::CoopEntityClass;
 
@@ -2120,6 +2146,18 @@ fn render_coop_entity_inventory(
     );
     println!("  non_mappable:              {}", inventory.non_mappable);
     println!("  storage_error:             {}", inventory.storage_error);
+    if preview {
+        // Surrogate proposals are previews only — a proposal binds nothing and
+        // grants no authority. A collision is reported, never auto-resolved.
+        println!(
+            "  surrogate_proposed:        {}",
+            inventory.surrogate_proposed
+        );
+        println!(
+            "  surrogate_collision:       {}",
+            inventory.surrogate_collision
+        );
+    }
 
     if !inventory.entries.is_empty() {
         println!();
@@ -2141,6 +2179,11 @@ fn render_coop_entity_inventory(
             if entry.class == CoopEntityClass::MappableReverseConflict {
                 if let Some(other) = &entry.reverse_bound_coop_id {
                     print!(" (target already bound to {other:?})");
+                }
+            }
+            if preview {
+                if let Some(surrogate) = &entry.proposed_surrogate_entity_id {
+                    print!(" [proposed surrogate: {}]", surrogate.as_str());
                 }
             }
             if let Some(err) = &entry.error {

--- a/icn/bins/icnctl/tests/coop_entity_report_test.rs
+++ b/icn/bins/icnctl/tests/coop_entity_report_test.rs
@@ -177,3 +177,155 @@ fn entity_report_on_missing_store_reports_empty() {
         "report must not create a database when none exists"
     );
 }
+
+// ----------------------------------------------------------------------------
+// Surrogate preview (#2082 PR4): --preview-surrogates is read-only and additive.
+// ----------------------------------------------------------------------------
+
+/// Without the flag, the JSON shape is exactly the pre-surrogate report: no
+/// `surrogate_*` aggregates and no per-entry `proposed_surrogate_entity_id`.
+#[test]
+fn default_json_omits_surrogate_fields() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    seed_two_cooperatives(&data_dir);
+
+    let output = Command::new(icnctl_bin())
+        .env("RUST_LOG", "off")
+        .arg("--data-dir")
+        .arg(&data_dir)
+        .arg("coop")
+        .arg("entity-report")
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: Value = serde_json::from_str(stdout.trim()).unwrap();
+
+    assert!(v.get("surrogate_proposed").is_none());
+    assert!(v.get("surrogate_collision").is_none());
+    for entry in v["entries"].as_array().unwrap() {
+        assert!(
+            entry.get("proposed_surrogate_entity_id").is_none(),
+            "default report must not include surrogate proposals"
+        );
+    }
+}
+
+/// With `--preview-surrogates --json`, the non-mappable default `coop:<uuid>`
+/// carries its deterministic proposed surrogate; the mappable coop does not.
+#[test]
+fn preview_json_includes_proposed_surrogate_for_default_id() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+
+    let output = Command::new(icnctl_bin())
+        .env("RUST_LOG", "off")
+        .arg("--data-dir")
+        .arg(&data_dir)
+        .arg("coop")
+        .arg("entity-report")
+        .arg("--preview-surrogates")
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: Value = serde_json::from_str(stdout.trim()).unwrap();
+
+    assert_eq!(v["surrogate_proposed"].as_u64(), Some(1));
+    // `surrogate_collision` is omitted when zero (skip_serializing_if), so an
+    // absent key means "no collisions" — treat absent as 0.
+    assert_eq!(v["surrogate_collision"].as_u64().unwrap_or(0), 0);
+
+    let expected = icn_entity::propose_surrogate_entity_id(&default_id)
+        .unwrap()
+        .as_str()
+        .to_string();
+
+    let entries = v["entries"].as_array().unwrap();
+    let default_entry = entries
+        .iter()
+        .find(|e| e["coop_id"].as_str() == Some(default_id.as_str()))
+        .expect("default coop entry present");
+    assert_eq!(default_entry["class"].as_str(), Some("non_mappable"));
+    assert_eq!(
+        default_entry["proposed_surrogate_entity_id"].as_str(),
+        Some(expected.as_str())
+    );
+
+    let mappable_entry = entries
+        .iter()
+        .find(|e| e["coop_id"].as_str() == Some("real-coop"))
+        .expect("mappable coop entry present");
+    assert!(
+        mappable_entry.get("proposed_surrogate_entity_id").is_none(),
+        "mappable coop must not get a surrogate proposal"
+    );
+}
+
+/// Human output under `--preview-surrogates` shows the surrogate count and the
+/// proposed value.
+#[test]
+fn preview_human_output_includes_surrogate_count_and_value() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+
+    let output = Command::new(icnctl_bin())
+        .env("RUST_LOG", "off")
+        .arg("--data-dir")
+        .arg(&data_dir)
+        .arg("coop")
+        .arg("entity-report")
+        .arg("--preview-surrogates")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert!(stdout.contains("surrogate_proposed:"));
+    let expected = icn_entity::propose_surrogate_entity_id(&default_id)
+        .unwrap()
+        .as_str()
+        .to_string();
+    assert!(
+        stdout.contains("proposed surrogate:") && stdout.contains(&expected),
+        "human preview output missing surrogate value; got:\n{stdout}"
+    );
+}
+
+/// The preview path is read-only: it must not bind the non-mappable id, its
+/// proposed surrogate target, or the mappable id.
+#[test]
+fn preview_writes_no_bindings() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+
+    let status = Command::new(icnctl_bin())
+        .env("RUST_LOG", "off")
+        .arg("--data-dir")
+        .arg(&data_dir)
+        .arg("coop")
+        .arg("entity-report")
+        .arg("--preview-surrogates")
+        .arg("--json")
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let store = SledStore::open(coop_store_path(&data_dir)).unwrap();
+    let db = Arc::new(store.db().clone());
+    let map = SledCoopEntityMap::new(db);
+    assert_eq!(map.entity_for_coop("real-coop").unwrap(), None);
+    assert_eq!(map.entity_for_coop(&default_id).unwrap(), None);
+    let surrogate = icn_entity::propose_surrogate_entity_id(&default_id).unwrap();
+    assert_eq!(map.coop_for_entity(&surrogate).unwrap(), None);
+}

--- a/icn/crates/icn-entity/Cargo.toml
+++ b/icn/crates/icn-entity/Cargo.toml
@@ -21,6 +21,7 @@ thiserror.workspace = true
 tracing.workspace = true
 tokio.workspace = true
 sled.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/icn/crates/icn-entity/src/coop_entity_inventory.rs
+++ b/icn/crates/icn-entity/src/coop_entity_inventory.rs
@@ -33,8 +33,17 @@
 //!   for non-mappable ids; that is deliberately later work.
 
 use crate::coop_entity_map::{project_coop_id, CoopEntityMap, CoopEntityMapError};
+use crate::coop_entity_surrogate::propose_surrogate_entity_id;
 use crate::entity::EntityId;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Serde helper: omit a `usize` field when it is zero, so the surrogate-preview
+/// aggregates do not appear in the default (non-preview) report — keeping that
+/// output byte-identical to the pre-surrogate inventory.
+fn is_zero(n: &usize) -> bool {
+    *n == 0
+}
 
 /// How a single `coop_id` stands relative to the canonical mapping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -87,8 +96,17 @@ pub struct CoopEntityInventoryEntry {
     pub reverse_bound_coop_id: Option<String>,
     /// A human-readable reason, for `NonMappable` (why the slug is invalid) and
     /// `StorageError` (the read failure or the consistency violation). `None`
-    /// otherwise.
+    /// otherwise. When surrogate preview is enabled, a collision note for the
+    /// proposed surrogate is appended here.
     pub error: Option<String>,
+    /// The deterministic surrogate cooperative `EntityId` a later allocation PR
+    /// would propose for this `coop_id`. Populated **only** by
+    /// [`classify_coop_ids_with_surrogate_preview`] and **only** for
+    /// [`CoopEntityClass::NonMappable`] entries; `None` otherwise (including the
+    /// default [`classify_coop_ids`] path). A surrogate is a name proposal only
+    /// and grants no authority; nothing is bound.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposed_surrogate_entity_id: Option<EntityId>,
 }
 
 /// Aggregate, read-only inventory of a set of `coop_id`s against the canonical
@@ -107,6 +125,18 @@ pub struct CoopEntityInventory {
     pub non_mappable: usize,
     /// Count of [`CoopEntityClass::StorageError`].
     pub storage_error: usize,
+    /// Count of `NonMappable` entries for which a surrogate `EntityId` was
+    /// proposed. Set only by [`classify_coop_ids_with_surrogate_preview`]; `0`
+    /// (and omitted from JSON) on the default [`classify_coop_ids`] path. This
+    /// is a preview statistic, **not** part of the class partition.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub surrogate_proposed: usize,
+    /// Count of proposed surrogates that would collide on a later bind — either
+    /// already reverse-bound to a *different* `coop_id`, or duplicated by another
+    /// `coop_id` within this same batch. Set only by the preview path; `0` (and
+    /// omitted from JSON) otherwise. A collision is reported, never auto-resolved.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub surrogate_collision: usize,
     /// Per-`coop_id` detail, in input order.
     pub entries: Vec<CoopEntityInventoryEntry>,
 }
@@ -135,6 +165,8 @@ fn classify_one(coop_id: &str, map: &dyn CoopEntityMap) -> CoopEntityInventoryEn
         bound_entity_id: bound,
         reverse_bound_coop_id: reverse,
         error,
+        // Surrogate preview is opt-in; the base classifier never proposes one.
+        proposed_surrogate_entity_id: None,
     };
 
     // Forward lookup first: a present binding means AlreadyBound regardless of
@@ -286,8 +318,99 @@ pub fn classify_coop_ids(
     inventory
 }
 
+/// Classify a set of `coop_id`s and, for every [`CoopEntityClass::NonMappable`]
+/// entry, attach the deterministic surrogate cooperative `EntityId` that a later
+/// allocation/backfill PR would propose to bind — **read-only**, binding nothing.
+///
+/// Beyond the base [`classify_coop_ids`] classification this:
+/// - sets [`CoopEntityInventoryEntry::proposed_surrogate_entity_id`] for
+///   `NonMappable` entries (and leaves it `None` for every other class),
+/// - counts proposals in [`CoopEntityInventory::surrogate_proposed`],
+/// - flags, in [`CoopEntityInventory::surrogate_collision`] and the entry's
+///   `error`, any proposed surrogate that would collide on a later bind: one
+///   already reverse-bound to a *different* `coop_id`, or one duplicated by
+///   another `coop_id` within this same batch.
+///
+/// It performs **no writes** and **no normalization**: the only map access is
+/// the read-only [`CoopEntityMap::coop_for_entity`], used to detect collisions.
+/// A surrogate is a name proposal only and grants no authority.
+pub fn classify_coop_ids_with_surrogate_preview(
+    coop_ids: impl IntoIterator<Item = String>,
+    map: &dyn CoopEntityMap,
+) -> CoopEntityInventory {
+    // Base classification first (read-only, identical to classify_coop_ids).
+    let mut inventory = classify_coop_ids(coop_ids, map);
+
+    // Pass 1 (pure): propose a surrogate for each NonMappable entry and tally how
+    // many entries land on each surrogate, so within-batch duplicates are visible.
+    let mut surrogate_for: Vec<Option<EntityId>> = Vec::with_capacity(inventory.entries.len());
+    let mut surrogate_counts: HashMap<String, usize> = HashMap::new();
+    for entry in &inventory.entries {
+        let surrogate = if entry.class == CoopEntityClass::NonMappable {
+            // The surrogate is valid by construction; an (unreachable) error is
+            // treated as "no proposal" rather than panicking.
+            propose_surrogate_entity_id(&entry.coop_id).ok()
+        } else {
+            None
+        };
+        if let Some(s) = &surrogate {
+            *surrogate_counts.entry(s.as_str().to_string()).or_insert(0) += 1;
+        }
+        surrogate_for.push(surrogate);
+    }
+
+    // Pass 2: attach proposals, detect collisions (read-only: coop_for_entity
+    // only), and update the preview aggregates.
+    for (entry, surrogate) in inventory.entries.iter_mut().zip(surrogate_for) {
+        let Some(surrogate) = surrogate else { continue };
+        inventory.surrogate_proposed += 1;
+
+        let mut notes: Vec<String> = Vec::new();
+
+        // Within-batch: another entry proposes the same surrogate.
+        if surrogate_counts
+            .get(surrogate.as_str())
+            .copied()
+            .unwrap_or(0)
+            > 1
+        {
+            notes.push(format!(
+                "proposed surrogate {} collides within-batch with another coop_id",
+                surrogate.as_str()
+            ));
+        }
+
+        // Reverse-binding: the surrogate target is already bound to a *different*
+        // coop_id, so a later bind_exact would be rejected as a conflict.
+        match map.coop_for_entity(&surrogate) {
+            Ok(Some(occupant)) if occupant != entry.coop_id => notes.push(format!(
+                "proposed surrogate {} already reverse-bound to {occupant:?}",
+                surrogate.as_str()
+            )),
+            Ok(_) => {}
+            Err(e) => notes.push(format!(
+                "proposed surrogate {} reverse-lookup failed: {e}",
+                surrogate.as_str()
+            )),
+        }
+
+        if !notes.is_empty() {
+            inventory.surrogate_collision += 1;
+            let joined = notes.join("; ");
+            entry.error = Some(match entry.error.take() {
+                Some(existing) => format!("{existing}; {joined}"),
+                None => joined,
+            });
+        }
+
+        entry.proposed_surrogate_entity_id = Some(surrogate);
+    }
+
+    inventory
+}
+
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::coop_entity_map::{CoopEntityMap, InMemoryCoopEntityMap};
@@ -530,5 +653,138 @@ mod tests {
                 + inv.storage_error,
             inv.total
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Surrogate preview (#2082 PR4) — read-only, proposes but never binds.
+    // ------------------------------------------------------------------
+
+    const DEFAULT_COOP: &str = "coop:550e8400-e29b-41d4-a716-446655440000";
+
+    #[test]
+    fn default_classify_attaches_no_surrogate() {
+        // The non-preview path must not propose surrogates or set the aggregates.
+        let map = InMemoryCoopEntityMap::new();
+        let inv = classify_coop_ids(ids(&[DEFAULT_COOP]), &map);
+        assert_eq!(inv.non_mappable, 1);
+        assert_eq!(inv.surrogate_proposed, 0);
+        assert_eq!(inv.surrogate_collision, 0);
+        assert_eq!(inv.entries[0].proposed_surrogate_entity_id, None);
+    }
+
+    #[test]
+    fn preview_attaches_surrogate_to_non_mappable() {
+        let map = InMemoryCoopEntityMap::new();
+        let inv = classify_coop_ids_with_surrogate_preview(ids(&[DEFAULT_COOP]), &map);
+        assert_eq!(inv.non_mappable, 1);
+        assert_eq!(inv.surrogate_proposed, 1);
+        assert_eq!(inv.surrogate_collision, 0);
+        let entry = &inv.entries[0];
+        assert_eq!(entry.class, CoopEntityClass::NonMappable);
+        assert_eq!(
+            entry.proposed_surrogate_entity_id,
+            Some(propose_surrogate_entity_id(DEFAULT_COOP).unwrap())
+        );
+        // The golden vector pins the exact proposed handle.
+        assert_eq!(
+            entry
+                .proposed_surrogate_entity_id
+                .as_ref()
+                .unwrap()
+                .as_str(),
+            "entity:icn:cooperative:coop-legacy-edf6152975301bd80c13"
+        );
+    }
+
+    #[test]
+    fn preview_leaves_mappable_unbound_without_surrogate() {
+        let map = InMemoryCoopEntityMap::new();
+        let inv = classify_coop_ids_with_surrogate_preview(ids(&["food-coop"]), &map);
+        assert_eq!(inv.mappable_unbound, 1);
+        assert_eq!(inv.surrogate_proposed, 0);
+        assert_eq!(inv.entries[0].proposed_surrogate_entity_id, None);
+    }
+
+    #[test]
+    fn preview_leaves_already_bound_without_surrogate() {
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_projected("coop-a").unwrap();
+        let inv = classify_coop_ids_with_surrogate_preview(ids(&["coop-a"]), &map);
+        assert_eq!(inv.already_bound, 1);
+        assert_eq!(inv.surrogate_proposed, 0);
+        assert_eq!(inv.entries[0].proposed_surrogate_entity_id, None);
+    }
+
+    #[test]
+    fn preview_detects_reverse_binding_collision() {
+        // Occupy the surrogate target with a DIFFERENT (mappable) coop, so the
+        // proposed surrogate for DEFAULT_COOP would conflict on a later bind.
+        let map = InMemoryCoopEntityMap::new();
+        let surrogate = propose_surrogate_entity_id(DEFAULT_COOP).unwrap();
+        map.bind_exact("alpha-coop", &surrogate).unwrap();
+
+        let inv = classify_coop_ids_with_surrogate_preview(ids(&[DEFAULT_COOP]), &map);
+        assert_eq!(inv.non_mappable, 1);
+        assert_eq!(inv.surrogate_proposed, 1);
+        assert_eq!(inv.surrogate_collision, 1);
+        let entry = &inv.entries[0];
+        // The surrogate is still surfaced...
+        assert_eq!(entry.proposed_surrogate_entity_id, Some(surrogate));
+        // ...and the collision is reported in the entry's error.
+        let err = entry.error.as_ref().expect("collision note expected");
+        assert!(
+            err.contains("alpha-coop") && err.to_lowercase().contains("reverse-bound"),
+            "got error: {err}"
+        );
+    }
+
+    #[test]
+    fn preview_detects_within_batch_collision() {
+        // Two coop_ids that propose the same surrogate. SHA-256 makes distinct
+        // inputs collide only astronomically, so we exercise the dedup logic with
+        // a duplicated id (real `list_cooperatives` input is distinct).
+        let map = InMemoryCoopEntityMap::new();
+        let inv =
+            classify_coop_ids_with_surrogate_preview(ids(&[DEFAULT_COOP, DEFAULT_COOP]), &map);
+        assert_eq!(inv.non_mappable, 2);
+        assert_eq!(inv.surrogate_proposed, 2);
+        assert_eq!(inv.surrogate_collision, 2, "both colliding entries flagged");
+        for entry in &inv.entries {
+            let err = entry.error.as_ref().expect("collision note expected");
+            assert!(err.contains("within-batch"), "got error: {err}");
+        }
+    }
+
+    #[test]
+    fn preview_writes_nothing() {
+        let map = InMemoryCoopEntityMap::new();
+        let _ = classify_coop_ids_with_surrogate_preview(ids(&[DEFAULT_COOP, "food-coop"]), &map);
+        // Neither the non-mappable id, its surrogate target, nor the mappable id
+        // was bound as a side effect.
+        assert_eq!(map.entity_for_coop(DEFAULT_COOP).unwrap(), None);
+        assert_eq!(map.entity_for_coop("food-coop").unwrap(), None);
+        let surrogate = propose_surrogate_entity_id(DEFAULT_COOP).unwrap();
+        assert_eq!(map.coop_for_entity(&surrogate).unwrap(), None);
+    }
+
+    #[test]
+    fn preview_class_counts_still_partition_total() {
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_projected("bound-coop").unwrap();
+        let inv = classify_coop_ids_with_surrogate_preview(
+            ids(&["bound-coop", "free-coop", DEFAULT_COOP, "coop_A"]),
+            &map,
+        );
+        // surrogate_proposed/collision are separate statistics, not classes.
+        assert_eq!(
+            inv.already_bound
+                + inv.mappable_unbound
+                + inv.mappable_reverse_conflict
+                + inv.non_mappable
+                + inv.storage_error,
+            inv.total
+        );
+        assert_eq!(inv.non_mappable, 2);
+        assert_eq!(inv.surrogate_proposed, 2);
     }
 }

--- a/icn/crates/icn-entity/src/coop_entity_inventory.rs
+++ b/icn/crates/icn-entity/src/coop_entity_inventory.rs
@@ -341,10 +341,14 @@ pub fn classify_coop_ids_with_surrogate_preview(
     // Base classification first (read-only, identical to classify_coop_ids).
     let mut inventory = classify_coop_ids(coop_ids, map);
 
-    // Pass 1 (pure): propose a surrogate for each NonMappable entry and tally how
-    // many entries land on each surrogate, so within-batch duplicates are visible.
+    // Pass 1 (pure): propose a surrogate for each NonMappable entry and tally,
+    // per EntityId, how many entries in this batch would occupy it on a later
+    // bind. The occupancy count includes BOTH proposed surrogates and the
+    // projected/bound EntityId of mappable/already-bound entries — otherwise a
+    // surrogate that coincides with a same-batch mappable coop's projection (its
+    // slug literally equals the surrogate) would go undetected until PR5's bind.
     let mut surrogate_for: Vec<Option<EntityId>> = Vec::with_capacity(inventory.entries.len());
-    let mut surrogate_counts: HashMap<String, usize> = HashMap::new();
+    let mut entity_claims: HashMap<String, usize> = HashMap::new();
     for entry in &inventory.entries {
         let surrogate = if entry.class == CoopEntityClass::NonMappable {
             // The surrogate is valid by construction; an (unreachable) error is
@@ -353,8 +357,17 @@ pub fn classify_coop_ids_with_surrogate_preview(
         } else {
             None
         };
-        if let Some(s) = &surrogate {
-            *surrogate_counts.entry(s.as_str().to_string()).or_insert(0) += 1;
+        // The EntityId this entry would occupy on a bind: a NonMappable claims its
+        // proposed surrogate; a mappable claims its projection; an already-bound
+        // entry its bound id. StorageError entries claim nothing.
+        if let Some(claimed) = surrogate
+            .as_ref()
+            .or(entry.projected_entity_id.as_ref())
+            .or(entry.bound_entity_id.as_ref())
+        {
+            *entity_claims
+                .entry(claimed.as_str().to_string())
+                .or_insert(0) += 1;
         }
         surrogate_for.push(surrogate);
     }
@@ -371,13 +384,10 @@ pub fn classify_coop_ids_with_surrogate_preview(
         let mut collision_notes: Vec<String> = Vec::new();
         let mut error_notes: Vec<String> = Vec::new();
 
-        // Within-batch: another entry proposes the same surrogate.
-        if surrogate_counts
-            .get(surrogate.as_str())
-            .copied()
-            .unwrap_or(0)
-            > 1
-        {
+        // Within-batch: another entry in this batch would occupy the same
+        // EntityId (another surrogate proposal, or a mappable/bound entry whose
+        // projected/bound id equals this surrogate).
+        if entity_claims.get(surrogate.as_str()).copied().unwrap_or(0) > 1 {
             collision_notes.push(format!(
                 "proposed surrogate {} collides within-batch with another coop_id",
                 surrogate.as_str()
@@ -835,5 +845,40 @@ mod tests {
             err.contains("reverse-lookup failed"),
             "lookup error must still be surfaced; got: {err}"
         );
+    }
+
+    #[test]
+    fn preview_flags_surrogate_colliding_with_same_batch_mappable_projection() {
+        // A mappable coop literally named the surrogate slug of a non-mappable
+        // coop projects to the EXACT EntityId being proposed. Neither is bound,
+        // so the reverse-index check is empty — but binding both later would
+        // conflict on the same entity id, so the in-batch occupancy check must
+        // include mappable projections, not just other surrogate proposals.
+        let map = InMemoryCoopEntityMap::new();
+        let surrogate = propose_surrogate_entity_id(DEFAULT_COOP).unwrap();
+        let collider = surrogate.identifier().to_string(); // valid slug, unbound
+
+        let inv = classify_coop_ids_with_surrogate_preview(
+            vec![DEFAULT_COOP.to_string(), collider.clone()],
+            &map,
+        );
+
+        assert_eq!(inv.non_mappable, 1);
+        assert_eq!(inv.mappable_unbound, 1);
+        assert_eq!(inv.surrogate_proposed, 1);
+        assert_eq!(
+            inv.surrogate_collision, 1,
+            "surrogate must collide with a same-batch mappable projection"
+        );
+        let nm = inv
+            .entries
+            .iter()
+            .find(|e| e.coop_id == DEFAULT_COOP)
+            .unwrap();
+        assert!(nm
+            .error
+            .as_ref()
+            .expect("collision note")
+            .contains("within-batch"));
     }
 }

--- a/icn/crates/icn-entity/src/coop_entity_inventory.rs
+++ b/icn/crates/icn-entity/src/coop_entity_inventory.rs
@@ -365,7 +365,11 @@ pub fn classify_coop_ids_with_surrogate_preview(
         let Some(surrogate) = surrogate else { continue };
         inventory.surrogate_proposed += 1;
 
-        let mut notes: Vec<String> = Vec::new();
+        // Collision notes count toward `surrogate_collision` (a later bind would
+        // be rejected); error notes are surfaced but are read failures, not
+        // collisions, so they must not inflate the collision count.
+        let mut collision_notes: Vec<String> = Vec::new();
+        let mut error_notes: Vec<String> = Vec::new();
 
         // Within-batch: another entry proposes the same surrogate.
         if surrogate_counts
@@ -374,28 +378,34 @@ pub fn classify_coop_ids_with_surrogate_preview(
             .unwrap_or(0)
             > 1
         {
-            notes.push(format!(
+            collision_notes.push(format!(
                 "proposed surrogate {} collides within-batch with another coop_id",
                 surrogate.as_str()
             ));
         }
 
         // Reverse-binding: the surrogate target is already bound to a *different*
-        // coop_id, so a later bind_exact would be rejected as a conflict.
+        // coop_id, so a later bind_exact would be rejected as a conflict. A read
+        // failure is surfaced as an error, not counted as a collision.
         match map.coop_for_entity(&surrogate) {
-            Ok(Some(occupant)) if occupant != entry.coop_id => notes.push(format!(
+            Ok(Some(occupant)) if occupant != entry.coop_id => collision_notes.push(format!(
                 "proposed surrogate {} already reverse-bound to {occupant:?}",
                 surrogate.as_str()
             )),
             Ok(_) => {}
-            Err(e) => notes.push(format!(
+            Err(e) => error_notes.push(format!(
                 "proposed surrogate {} reverse-lookup failed: {e}",
                 surrogate.as_str()
             )),
         }
 
-        if !notes.is_empty() {
+        if !collision_notes.is_empty() {
             inventory.surrogate_collision += 1;
+        }
+
+        // Surface both collision and lookup-error notes on the entry.
+        let notes: Vec<String> = collision_notes.into_iter().chain(error_notes).collect();
+        if !notes.is_empty() {
             let joined = notes.join("; ");
             entry.error = Some(match entry.error.take() {
                 Some(existing) => format!("{existing}; {joined}"),
@@ -786,5 +796,44 @@ mod tests {
         );
         assert_eq!(inv.non_mappable, 2);
         assert_eq!(inv.surrogate_proposed, 2);
+    }
+
+    #[test]
+    fn preview_reverse_lookup_error_is_not_counted_as_collision() {
+        // A `coop_for_entity` *read failure* during preview is surfaced in the
+        // entry's error, but it is NOT a collision: `surrogate_collision` counts
+        // bind conflicts (within-batch dup / already-reverse-bound) only.
+        struct ReverseErrMap;
+        impl CoopEntityMap for ReverseErrMap {
+            fn bind_exact(&self, _: &str, _: &EntityId) -> Result<(), CoopEntityMapError> {
+                unreachable!("preview must never write through the map");
+            }
+            // Ok(None) keeps "coop_A" classified NonMappable (unbound + unmappable).
+            fn entity_for_coop(&self, _: &str) -> Result<Option<EntityId>, CoopEntityMapError> {
+                Ok(None)
+            }
+            // The surrogate reverse-lookup fails.
+            fn coop_for_entity(&self, _: &EntityId) -> Result<Option<String>, CoopEntityMapError> {
+                Err(CoopEntityMapError::Storage(
+                    "reverse index unreadable".into(),
+                ))
+            }
+        }
+
+        let inv = classify_coop_ids_with_surrogate_preview(ids(&["coop_A"]), &ReverseErrMap);
+        assert_eq!(inv.non_mappable, 1);
+        assert_eq!(inv.surrogate_proposed, 1);
+        assert_eq!(
+            inv.surrogate_collision, 0,
+            "a reverse-lookup error is a read failure, not a bind collision"
+        );
+        let err = inv.entries[0]
+            .error
+            .as_ref()
+            .expect("lookup error surfaced");
+        assert!(
+            err.contains("reverse-lookup failed"),
+            "lookup error must still be surfaced; got: {err}"
+        );
     }
 }

--- a/icn/crates/icn-entity/src/coop_entity_surrogate.rs
+++ b/icn/crates/icn-entity/src/coop_entity_surrogate.rs
@@ -197,6 +197,7 @@ mod tests {
         // Every shape the inventory classifies NonMappable must still produce a
         // valid surrogate (the function must not choke on uppercase, underscore,
         // Unicode, short ids, leading digits, consecutive hyphens, or colons).
+        let long = "x".repeat(4096);
         for coop_id in [
             "coop:550e8400-e29b-41d4-a716-446655440000",
             "coop_A",
@@ -206,7 +207,7 @@ mod tests {
             "1coop",
             "coop--east",
             "",
-            &"x".repeat(4096),
+            long.as_str(),
         ] {
             let surrogate = propose_surrogate_entity_id(coop_id)
                 .unwrap_or_else(|e| panic!("surrogate failed for {coop_id:?}: {e}"));

--- a/icn/crates/icn-entity/src/coop_entity_surrogate.rs
+++ b/icn/crates/icn-entity/src/coop_entity_surrogate.rs
@@ -1,0 +1,247 @@
+//! Deterministic surrogate `EntityId` proposal for non-mappable `coop_id`s
+//! (#2082 lane, PR4).
+//!
+//! # Why this exists
+//!
+//! Default cooperative ids are shaped like `coop:<uuid>` (see
+//! `icn_coop::Cooperative::new`), and the gateway's `validate_coop_id` also
+//! admits uppercase, underscore, and Unicode ids. None of those are valid
+//! cooperative [`EntityId`](crate::EntityId) slugs, so
+//! [`project_coop_id`](crate::coop_entity_map::project_coop_id) reports them as
+//! [`NotMappable`](crate::coop_entity_map::CoopEntityMapError::NotMappable) and
+//! the canonical map cannot be populated for them by projection alone.
+//!
+//! This module proposes a **deterministic surrogate** cooperative `EntityId` for
+//! such ids: a stable, valid slug derived from a domain-separated SHA-256 of the
+//! original `coop_id`. It is the algorithm a later allocation/backfill PR would
+//! use to *write* bindings; this PR only *proposes* — it never binds.
+//!
+//! # Why deterministic (not random)
+//!
+//! Cooperative activation binds the map on every node, and the gossip-sync path
+//! mirrors that bind (#2104). So the same `coop_id` is bound independently on
+//! multiple nodes. A surrogate must therefore be a pure, node-independent
+//! function of the `coop_id` — two nodes must compute the identical surrogate
+//! with no coordination. Durable-random allocation would diverge across nodes
+//! and is out of scope for this lane.
+//!
+//! # A surrogate is NOT authority, and NOT normalization
+//!
+//! A surrogate `EntityId` grants **zero** membership, role, capability, mandate,
+//! permission, or standing — exactly like every other binding (a mapping is a
+//! name binding only). And it is **not** a rewrite of the original `coop_id`:
+//! the original is preserved byte-for-byte; the surrogate is a *new generated
+//! handle*. `coop_A` is never silently turned into `coop-a`; instead both get
+//! distinct surrogate handles derived from their exact bytes.
+
+use crate::coop_entity_map::CoopEntityMapError;
+use crate::entity::EntityId;
+use sha2::{Digest, Sha256};
+
+/// Domain-separation tag for v1 of the surrogate scheme. Frozen: any change to
+/// the derivation is a new version (`v2`) with a new tag, never a silent
+/// redefinition of `v1` (which would change already-proposed surrogates).
+pub const SURROGATE_DOMAIN_V1: &[u8] = b"icn:coop-entity-surrogate:v1";
+
+/// Visible slug prefix marking a generated surrogate handle (as opposed to a
+/// projected or user-chosen slug). The full slug is `{SURROGATE_PREFIX}-{hex}`.
+pub const SURROGATE_PREFIX: &str = "coop-legacy";
+
+/// Number of leading digest bytes used for the surrogate fragment. 10 bytes =
+/// 80 bits = 20 lowercase-hex characters. The birthday bound (~2^40 surrogates
+/// for a 50% collision chance) leaves ample headroom for realistic populations.
+const SURROGATE_HASH_BYTES: usize = 10;
+
+/// Lowercase-hex encode a byte slice without pulling in an encoding dependency.
+fn to_lower_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Propose a deterministic surrogate cooperative [`EntityId`] for a `coop_id`.
+///
+/// The surrogate is `entity:icn:cooperative:coop-legacy-<20 lowercase hex>`,
+/// where the 20 hex chars are the first [`SURROGATE_HASH_BYTES`] of
+/// `SHA-256(SURROGATE_DOMAIN_V1 || 0x00 || coop_id)`. Deterministic,
+/// node-independent, and a pure function of the input bytes.
+///
+/// This proposes only; it performs no storage and binds nothing. The returned
+/// slug is always a valid cooperative slug by construction (prefix starts with a
+/// lowercase letter; body is `[a-z0-9-]` with no consecutive hyphens; length is
+/// well within 4..=64), so the error arm is an internal-invariant guard that
+/// never fires in practice — it exists so the function never panics.
+pub fn propose_surrogate_entity_id(coop_id: &str) -> Result<EntityId, CoopEntityMapError> {
+    // Domain-separated hash: tag || NUL || original coop_id bytes. The NUL
+    // terminator keeps the fixed (NUL-free) tag from blending into the id.
+    let mut hasher = Sha256::new();
+    hasher.update(SURROGATE_DOMAIN_V1);
+    hasher.update([0u8]);
+    hasher.update(coop_id.as_bytes());
+    let digest = hasher.finalize();
+
+    let fragment = to_lower_hex(&digest[..SURROGATE_HASH_BYTES]);
+    let slug = format!("{SURROGATE_PREFIX}-{fragment}");
+
+    // The slug is valid by construction (starts with the lowercase letter 'c';
+    // body is `[a-z0-9-]` with non-adjacent hyphens; length 32 ∈ 4..=64), so the
+    // error arm is an internal-invariant guard that never fires — we surface it
+    // rather than panic to honor the no-unwrap/expect rule.
+    EntityId::cooperative(&slug).map_err(|e| {
+        CoopEntityMapError::Storage(format!(
+            "internal invariant: surrogate slug {slug:?} failed EntityId validation: {e}"
+        ))
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // Golden vector — pins the v1 algorithm. Any drift in domain tag, hash,
+    // byte count, encoding, or prefix breaks this.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn golden_vector_default_coop_uuid() {
+        let surrogate =
+            propose_surrogate_entity_id("coop:550e8400-e29b-41d4-a716-446655440000").unwrap();
+        assert_eq!(
+            surrogate.as_str(),
+            "entity:icn:cooperative:coop-legacy-edf6152975301bd80c13"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Determinism
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn deterministic_same_input_same_output() {
+        let a = propose_surrogate_entity_id("coop:abc-123").unwrap();
+        let b = propose_surrogate_entity_id("coop:abc-123").unwrap();
+        assert_eq!(a, b);
+    }
+
+    // ------------------------------------------------------------------
+    // No silent normalization: distinct inputs -> distinct surrogates.
+    // `coop_A` must NEVER collapse onto `coop-a`.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn coop_underscore_a_and_coop_dash_a_get_distinct_surrogates() {
+        let underscore = propose_surrogate_entity_id("coop_A").unwrap();
+        let dash = propose_surrogate_entity_id("coop-a").unwrap();
+        assert_ne!(
+            underscore, dash,
+            "coop_A and coop-a are distinct identities; surrogates must not collapse them"
+        );
+    }
+
+    #[test]
+    fn colon_uuid_and_dash_uuid_do_not_collapse() {
+        let colon =
+            propose_surrogate_entity_id("coop:550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let dash =
+            propose_surrogate_entity_id("coop-550e8400-e29b-41d4-a716-446655440000").unwrap();
+        assert_ne!(colon, dash);
+    }
+
+    #[test]
+    fn surrogate_is_not_the_naive_colon_to_dash_rewrite() {
+        // The surrogate must be a generated handle, not `coop:<uuid>` with the
+        // colon swapped for a hyphen.
+        let coop_id = "coop:550e8400-e29b-41d4-a716-446655440000";
+        let surrogate = propose_surrogate_entity_id(coop_id).unwrap();
+        let naive = coop_id.replace(':', "-");
+        assert_ne!(surrogate.identifier(), naive);
+    }
+
+    // ------------------------------------------------------------------
+    // Validity, prefix, length — including adversarial / non-mappable inputs.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn surrogate_is_a_valid_cooperative_entity_id() {
+        let surrogate = propose_surrogate_entity_id("coop_A").unwrap();
+        assert!(surrogate.is_cooperative());
+        // Re-parsing re-runs slug validation: a valid surrogate round-trips.
+        assert_eq!(
+            EntityId::cooperative(surrogate.identifier()).unwrap(),
+            surrogate
+        );
+    }
+
+    #[test]
+    fn surrogate_identifier_has_prefix_and_fixed_length() {
+        let surrogate = propose_surrogate_entity_id("food_coop").unwrap();
+        let ident = surrogate.identifier();
+        assert!(ident.starts_with("coop-legacy-"), "got {ident}");
+        // prefix "coop-legacy-" (12) + 20 hex chars = 32.
+        assert_eq!(ident.len(), 32);
+        let hex = ident.strip_prefix("coop-legacy-").unwrap();
+        assert_eq!(hex.len(), 20);
+        assert!(hex
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+    }
+
+    #[test]
+    fn all_non_mappable_shapes_yield_valid_surrogates() {
+        // Every shape the inventory classifies NonMappable must still produce a
+        // valid surrogate (the function must not choke on uppercase, underscore,
+        // Unicode, short ids, leading digits, consecutive hyphens, or colons).
+        for coop_id in [
+            "coop:550e8400-e29b-41d4-a716-446655440000",
+            "coop_A",
+            "food_coop",
+            "café-coop",
+            "abc",
+            "1coop",
+            "coop--east",
+            "",
+            &"x".repeat(4096),
+        ] {
+            let surrogate = propose_surrogate_entity_id(coop_id)
+                .unwrap_or_else(|e| panic!("surrogate failed for {coop_id:?}: {e}"));
+            assert!(surrogate.is_cooperative());
+            assert!(surrogate.identifier().starts_with("coop-legacy-"));
+        }
+    }
+
+    #[test]
+    fn distinct_inputs_generally_distinct_surrogates() {
+        use std::collections::HashSet;
+        let inputs = [
+            "coop:550e8400-e29b-41d4-a716-446655440000",
+            "coop_A",
+            "coop-a",
+            "food_coop",
+            "café-coop",
+            "abc",
+            "1coop",
+            "coop--east",
+        ];
+        let surrogates: HashSet<String> = inputs
+            .iter()
+            .map(|c| propose_surrogate_entity_id(c).unwrap().as_str().to_string())
+            .collect();
+        assert_eq!(
+            surrogates.len(),
+            inputs.len(),
+            "no surrogate collisions expected"
+        );
+    }
+
+    #[test]
+    fn lower_hex_encodes_known_bytes() {
+        assert_eq!(to_lower_hex(&[0x00, 0x0f, 0xa5, 0xff]), "000fa5ff");
+        assert_eq!(to_lower_hex(&[]), "");
+    }
+}

--- a/icn/crates/icn-entity/src/lib.rs
+++ b/icn/crates/icn-entity/src/lib.rs
@@ -78,6 +78,7 @@
 pub mod actor;
 pub mod coop_entity_inventory;
 pub mod coop_entity_map;
+pub mod coop_entity_surrogate;
 pub mod entity;
 pub mod error;
 pub mod handle;
@@ -90,10 +91,14 @@ pub mod sled_registry;
 // Re-export main types at crate root
 pub use actor::{EntityActor, GossipHandle, ENTITY_TOPIC};
 pub use coop_entity_inventory::{
-    classify_coop_ids, CoopEntityClass, CoopEntityInventory, CoopEntityInventoryEntry,
+    classify_coop_ids, classify_coop_ids_with_surrogate_preview, CoopEntityClass,
+    CoopEntityInventory, CoopEntityInventoryEntry,
 };
 pub use coop_entity_map::{
     project_coop_id, CoopEntityMap, CoopEntityMapError, InMemoryCoopEntityMap, SledCoopEntityMap,
+};
+pub use coop_entity_surrogate::{
+    propose_surrogate_entity_id, SURROGATE_DOMAIN_V1, SURROGATE_PREFIX,
 };
 pub use entity::{
     AccountId, AccountReference, CommunityProfile, CooperativeEntity, CooperativeProfile, EntityId,


### PR DESCRIPTION
## Summary

Adds deterministic surrogate `EntityId` proposal and read-only preview for non-mappable cooperative IDs in the coop/entity inventory report. PR4 in the #2082 lane.

## What changed

- Adds a deterministic surrogate proposal helper in `icn-entity`
  (`propose_surrogate_entity_id`).
- Uses SHA-256 over a domain-separated input:
  `icn:coop-entity-surrogate:v1 || NUL || coop_id`, first 80 bits.
- Produces valid cooperative `EntityId`s shaped like `coop-legacy-<20hex>`
  (a tiny inline lowercase-hex encoder; no broad dependency, `sha2.workspace`).
- Extends inventory classification with optional surrogate preview data
  (`classify_coop_ids_with_surrogate_preview`, additive
  `proposed_surrogate_entity_id` / `surrogate_proposed` / `surrogate_collision`).
- Adds `--preview-surrogates` to `icnctl coop entity-report`.
- Keeps default report behavior unchanged (preview fields are omitted when
  absent/zero via `skip_serializing_if`).
- Performs no writes.

## Why

Default cooperative IDs are shaped like `coop:<uuid>`, which are not valid
`EntityId` slugs. #2105 added a read-only inventory report. This PR lets
operators preview the canonical surrogate IDs that a later backfill/allocation
PR would write, without mutating any state.

Golden vector:

`coop:550e8400-e29b-41d4-a716-446655440000`
→ `entity:icn:cooperative:coop-legacy-edf6152975301bd80c13`

## Collision handling (preview-only)

For each `NonMappable` entry the preview flags, but never resolves, a proposed
surrogate that would collide on a later bind: one already reverse-bound to a
*different* `coop_id`, or one duplicated by another `coop_id` within the same
batch. Collisions are counted in `surrogate_collision` and noted on the entry.

## Authority invariant

A surrogate `EntityId` grants no authority. Mapping is not membership, role,
capability, mandate, permission, or standing.

## What did NOT change

- No binding writes.
- No backfill writes.
- No surrogate allocation.
- No cooperative ID generation change.
- No activation behavior change.
- No gossip behavior change.
- No gateway auth change.
- No `/auth/verify` change.
- No token issuance change.
- No `require_coop_access` change.
- No `require_entity_access` enforcement.
- No treasury entity-auth enforcement.
- No NYCN change.
- No production/pilot readiness claim.

## Validation

- `cargo fmt --all --check` — clean
- `cargo test -p icn-entity` — 185 passed (incl. 10 surrogate, 8 preview)
- `cargo test -p icnctl` — all 5 test binaries pass (incl. 8 entity-report integration tests)
- `cargo build -p icnctl` — ok
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — 0 errors
- `ops/scripts/drift-check.sh` — PASS (0 errors, 0 warnings)

## Test plan

TDD: surrogate algorithm (golden vector, determinism, no-normalization,
adversarial-input validity) and inventory preview (attachment, no-surrogate for
mappable/bound, reverse-binding + within-batch collisions, read-only) were
written test-first. `icnctl` integration tests confirm the default JSON shape is
unchanged and `--preview-surrogates` surfaces the proposal while binding nothing.