### PR TITLE
feat(entity): add coop surrogate backfill command

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -237,6 +237,28 @@ enum CoopMaintenanceCommands {
         #[arg(long)]
         preview_surrogates: bool,
     },
+
+    /// Controlled surrogate backfill: bind each non-mappable cooperative ID
+    /// (e.g. the default `coop:<uuid>`) to its deterministic surrogate
+    /// `EntityId` (#2082 lane). Dry-run by default — writes require `--apply`.
+    ///
+    /// Selects only safe, collision-free non-mappable IDs, preserves each
+    /// original `coop_id` byte-for-byte, and never normalizes. A mapping grants
+    /// no authority. Reads the local cooperative store directly, so run it with
+    /// the daemon stopped (the daemon holds an exclusive lock).
+    EntityBackfillSurrogates {
+        /// Perform the binds. Without this flag the command is a dry run and
+        /// writes nothing.
+        #[arg(long)]
+        apply: bool,
+        /// Explicitly request a dry run (the default). Mutually exclusive with
+        /// `--apply`; useful to make the read-only intent unambiguous.
+        #[arg(long, conflicts_with = "apply")]
+        dry_run: bool,
+        /// Emit machine-readable JSON instead of a human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -2035,13 +2057,18 @@ fn get_store_path(data_dir: &Path) -> PathBuf {
     data_dir.join("store")
 }
 
-/// Dispatch read-only cooperative maintenance subcommands.
+/// Dispatch cooperative maintenance subcommands.
 fn handle_coop_maintenance_command(cmd: CoopMaintenanceCommands, data_dir: &Path) -> Result<()> {
     match cmd {
         CoopMaintenanceCommands::EntityReport {
             json,
             preview_surrogates,
         } => coop_entity_report(data_dir, json, preview_surrogates),
+        CoopMaintenanceCommands::EntityBackfillSurrogates {
+            apply,
+            dry_run: _,
+            json,
+        } => coop_entity_backfill_surrogates(data_dir, json, apply),
     }
 }
 
@@ -2188,6 +2215,163 @@ fn render_coop_entity_inventory(
             }
             if let Some(err) = &entry.error {
                 print!(" ({err})");
+            }
+            println!();
+        }
+    }
+
+    Ok(())
+}
+
+/// Run a controlled surrogate backfill over the local cooperative store
+/// (#2082 lane). Dry-run by default; `apply` performs the binds.
+///
+/// Opens the existing cooperative sled store, lists the stored cooperatives, and
+/// binds each safe, collision-free non-mappable id (e.g. the default
+/// `coop:<uuid>`) to its deterministic surrogate `EntityId` via
+/// [`icn_entity::CoopEntityMap::bind_resolved`]. The original `coop_id` is
+/// preserved byte-for-byte and nothing is normalized; a mapping grants no
+/// authority. In dry-run mode it writes nothing. Returns a non-zero exit (via
+/// `Err`) when an `--apply` run hits a bind conflict/error, a refused surrogate
+/// collision, or a storage error.
+fn coop_entity_backfill_surrogates(data_dir: &Path, json: bool, apply: bool) -> Result<()> {
+    use icn_coop::CoopStore;
+    use icn_entity::{
+        backfill_coop_surrogates, InMemoryCoopEntityMap, SledCoopEntityMap, SurrogateBackfillMode,
+    };
+    use std::sync::Arc;
+
+    let mode = if apply {
+        SurrogateBackfillMode::Apply
+    } else {
+        SurrogateBackfillMode::DryRun
+    };
+
+    let coop_store_path = get_store_path(data_dir).join("cooperative");
+
+    // No store -> nothing to back-fill. Never create a database (apply included):
+    // an absent store is reported as an empty result, not materialized on disk.
+    if !coop_store_path.exists() {
+        if !json {
+            eprintln!(
+                "No cooperative store found at {} — nothing to back-fill (nothing was created).",
+                coop_store_path.display()
+            );
+        }
+        let empty =
+            backfill_coop_surrogates(Vec::<String>::new(), &InMemoryCoopEntityMap::new(), mode);
+        return render_coop_surrogate_backfill(&empty, json);
+    }
+
+    let sled_store = SledStore::open(&coop_store_path).with_context(|| {
+        format!(
+            "Failed to open cooperative store at {} (stop the daemon first; it holds an exclusive lock)",
+            coop_store_path.display()
+        )
+    })?;
+
+    // Share one Db between the cooperative store and the canonical map, exactly
+    // as the daemon does in init_coop — no separate database is opened.
+    let db = Arc::new(sled_store.db().clone());
+    let coop_store = CoopStore::new(db.clone());
+    let map = SledCoopEntityMap::new(db);
+
+    let coop_ids: Vec<String> = coop_store
+        .list_cooperatives()
+        .context("Failed to list cooperatives from the store")?
+        .into_iter()
+        .map(|coop| coop.id)
+        .collect();
+
+    let report = backfill_coop_surrogates(coop_ids, &map, mode);
+    render_coop_surrogate_backfill(&report, json)?;
+
+    // An --apply run that could not cleanly complete (a bind conflict/error, a
+    // refused collision, or a storage error) exits non-zero so callers can gate
+    // on it. The report above already details each affected entry.
+    if report.apply_had_failures() {
+        bail!(
+            "surrogate backfill --apply did not fully complete: {} applied, {} conflict(s), \
+             {} bind error(s), {} collision(s), {} storage error(s) — see report above",
+            report.applied,
+            report.bind_conflict,
+            report.bind_error,
+            report.surrogate_collision,
+            report.skipped_storage_error,
+        );
+    }
+    Ok(())
+}
+
+/// Print a [`icn_entity::CoopSurrogateBackfill`] as JSON or a human table.
+fn render_coop_surrogate_backfill(
+    report: &icn_entity::CoopSurrogateBackfill,
+    json: bool,
+) -> Result<()> {
+    use icn_entity::{SurrogateBackfillAction, SurrogateBackfillMode};
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(report)
+                .context("Failed to serialize the backfill report as JSON")?
+        );
+        return Ok(());
+    }
+
+    let mode = match report.mode {
+        SurrogateBackfillMode::DryRun => "dry-run (no writes; pass --apply to bind)",
+        SurrogateBackfillMode::Apply => "apply (binds performed)",
+    };
+    println!(
+        "coop surrogate backfill [{mode}] (a mapping grants no authority; coop_id preserved exactly)"
+    );
+    println!();
+    println!("  total:                    {}", report.total);
+    println!("  eligible:                 {}", report.eligible);
+    println!("  applied:                  {}", report.applied);
+    println!(
+        "  skipped_already_bound:    {}",
+        report.skipped_already_bound
+    );
+    println!(
+        "  skipped_mappable_unbound: {}",
+        report.skipped_mappable_unbound
+    );
+    println!(
+        "  skipped_reverse_conflict: {}",
+        report.skipped_reverse_conflict
+    );
+    println!(
+        "  skipped_storage_error:    {}",
+        report.skipped_storage_error
+    );
+    println!("  surrogate_collision:      {}", report.surrogate_collision);
+    println!("  bind_conflict:            {}", report.bind_conflict);
+    println!("  bind_error:               {}", report.bind_error);
+
+    if !report.entries.is_empty() {
+        println!();
+        println!("  detail:");
+        for entry in &report.entries {
+            let action = match entry.action {
+                SurrogateBackfillAction::WouldBind => "would_bind",
+                SurrogateBackfillAction::Bound => "bound",
+                SurrogateBackfillAction::SkippedAlreadyBound => "skipped_already_bound",
+                SurrogateBackfillAction::SkippedMappableUnbound => "skipped_mappable_unbound",
+                SurrogateBackfillAction::SkippedReverseConflict => "skipped_reverse_conflict",
+                SurrogateBackfillAction::SkippedStorageError => "skipped_storage_error",
+                SurrogateBackfillAction::SurrogateCollision => "surrogate_collision",
+                SurrogateBackfillAction::BindConflict => "bind_conflict",
+                SurrogateBackfillAction::BindError => "bind_error",
+            };
+            print!("    [{action}] {}", entry.coop_id);
+            if let Some(surrogate) = &entry.proposed_entity_id {
+                print!(" -> {}", surrogate.as_str());
+            }
+            print!(" ({})", entry.reason);
+            if let Some(err) = &entry.error {
+                print!(" [error: {err}]");
             }
             println!();
         }

--- a/icn/bins/icnctl/tests/coop_entity_backfill_test.rs
+++ b/icn/bins/icnctl/tests/coop_entity_backfill_test.rs
@@ -1,0 +1,361 @@
+//! Integration tests for `icnctl coop entity-backfill-surrogates` (#2082 lane,
+//! PR6).
+//!
+//! End-to-end: seed a cooperative store with one mappable id and one default
+//! `coop:<uuid>` id, run the real binary, and assert the dry-run/apply behavior,
+//! idempotency, collision handling, exit codes, and that the original `coop_id`
+//! is preserved byte-for-byte. A mapping grants no authority — these tests only
+//! exercise the name binding.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::Arc;
+
+use icn_coop::{CoopStore, CoopType, Cooperative};
+use icn_entity::{CoopEntityMap, SledCoopEntityMap};
+use icn_store::SledStore;
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// Path to the icnctl binary (respects custom target directories).
+fn icnctl_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
+}
+
+/// Cooperative store path used by the daemon and by `icnctl`:
+/// `<data_dir>/store/cooperative`.
+fn coop_store_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("store").join("cooperative")
+}
+
+/// Seed one mappable coop ("real-coop") and one default `coop:<uuid>` coop;
+/// return the default (non-mappable) id. Releases the sled lock on return.
+fn seed_two_cooperatives(data_dir: &Path) -> String {
+    let store = SledStore::open(coop_store_path(data_dir)).unwrap();
+    let db = Arc::new(store.db().clone());
+    let coop_store = CoopStore::new(db.clone());
+
+    // Mappable: "real-coop" is already a valid EntityId slug.
+    let mappable = Cooperative::new_with_id(
+        "real-coop".to_string(),
+        "Real Coop".to_string(),
+        CoopType::Worker,
+    );
+    coop_store.save_cooperative(&mappable).unwrap();
+
+    // Default: Cooperative::new() generates `coop:<uuid>` (non-mappable).
+    let default_coop = Cooperative::new("Default Coop".to_string(), CoopType::Worker);
+    let default_id = default_coop.id.clone();
+    coop_store.save_cooperative(&default_coop).unwrap();
+
+    db.flush().unwrap();
+    // store, db, coop_store drop here -> sled lock released for the binary.
+    default_id
+}
+
+/// Occupy the surrogate target of `coop_id` with a DIFFERENT cooperative, so a
+/// later backfill of `coop_id` would collide on bind. Releases the lock on
+/// return.
+fn occupy_surrogate_target(data_dir: &Path, coop_id: &str, by: &str) {
+    let store = SledStore::open(coop_store_path(data_dir)).unwrap();
+    let db = Arc::new(store.db().clone());
+    let map = SledCoopEntityMap::new(db.clone());
+    let surrogate = icn_entity::propose_surrogate_entity_id(coop_id).unwrap();
+    map.bind_exact(by, &surrogate).unwrap();
+    db.flush().unwrap();
+}
+
+/// Re-open the canonical map (read-only inspection) after the binary has run.
+fn open_map(data_dir: &Path) -> (SledStore, SledCoopEntityMap) {
+    let store = SledStore::open(coop_store_path(data_dir)).unwrap();
+    let db = Arc::new(store.db().clone());
+    let map = SledCoopEntityMap::new(db);
+    (store, map)
+}
+
+/// Run `icnctl coop entity-backfill-surrogates <args...>`.
+fn run(data_dir: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(icnctl_bin());
+    cmd.env("RUST_LOG", "off")
+        .arg("--data-dir")
+        .arg(data_dir)
+        .arg("coop")
+        .arg("entity-backfill-surrogates");
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.output().unwrap()
+}
+
+fn parse_json(output: &Output) -> Value {
+    let stdout = String::from_utf8(output.stdout.clone()).unwrap();
+    serde_json::from_str(stdout.trim()).expect("stdout should be valid JSON")
+}
+
+// ----------------------------------------------------------------------------
+// Dry-run is the default and writes nothing.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn dry_run_is_default_reports_surrogate_and_writes_nothing() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+
+    // No --apply -> dry run by default.
+    let output = run(&data_dir, &["--json"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = parse_json(&output);
+    assert_eq!(v["mode"].as_str(), Some("dry_run"));
+    assert_eq!(v["total"].as_u64(), Some(2));
+    assert_eq!(v["eligible"].as_u64(), Some(1)); // only the default coop:<uuid>
+    assert_eq!(v["applied"].as_u64(), Some(0));
+    assert_eq!(v["skipped_mappable_unbound"].as_u64(), Some(1)); // real-coop
+
+    let expected = icn_entity::propose_surrogate_entity_id(&default_id)
+        .unwrap()
+        .as_str()
+        .to_string();
+    let entries = v["entries"].as_array().unwrap();
+    let def = entries
+        .iter()
+        .find(|e| e["coop_id"].as_str() == Some(default_id.as_str()))
+        .expect("default coop entry present");
+    assert_eq!(def["action"].as_str(), Some("would_bind"));
+    assert_eq!(def["proposed_entity_id"].as_str(), Some(expected.as_str()));
+    assert!(def["reason"].as_str().is_some());
+
+    // Read-only: nothing bound.
+    let (_store, map) = open_map(&data_dir);
+    assert_eq!(map.entity_for_coop(&default_id).unwrap(), None);
+}
+
+#[test]
+fn human_output_is_readable() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    seed_two_cooperatives(&data_dir);
+
+    let output = run(&data_dir, &[]); // dry-run default, human output
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("coop surrogate backfill"));
+    assert!(stdout.contains("dry-run"));
+    assert!(stdout.contains("eligible:"));
+    assert!(stdout.contains("would_bind"));
+}
+
+// ----------------------------------------------------------------------------
+// Apply binds the deterministic surrogate, preserving the original coop_id.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn apply_binds_default_coop_to_deterministic_surrogate_and_preserves_coop_id() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+
+    let output = run(&data_dir, &["--apply", "--json"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v = parse_json(&output);
+    assert_eq!(v["mode"].as_str(), Some("apply"));
+    assert_eq!(v["applied"].as_u64(), Some(1));
+    assert_eq!(v["bind_conflict"].as_u64(), Some(0));
+    assert_eq!(v["bind_error"].as_u64(), Some(0));
+
+    let surrogate = icn_entity::propose_surrogate_entity_id(&default_id).unwrap();
+    let (_store, map) = open_map(&data_dir);
+    // Forward binds to the surrogate...
+    assert_eq!(
+        map.entity_for_coop(&default_id).unwrap(),
+        Some(surrogate.clone())
+    );
+    // ...and the reverse preserves the original coop_id byte-for-byte.
+    assert_eq!(
+        map.coop_for_entity(&surrogate).unwrap(),
+        Some(default_id.clone())
+    );
+    // The mappable coop was NOT bound by the surrogate path.
+    assert_eq!(map.entity_for_coop("real-coop").unwrap(), None);
+}
+
+#[test]
+fn apply_is_idempotent_when_rerun() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    seed_two_cooperatives(&data_dir);
+
+    let first = run(&data_dir, &["--apply", "--json"]);
+    assert!(first.status.success());
+    assert_eq!(parse_json(&first)["applied"].as_u64(), Some(1));
+
+    // Rerun: the default coop is now already-bound, so it is skipped.
+    let second = run(&data_dir, &["--apply", "--json"]);
+    assert!(second.status.success());
+    let v = parse_json(&second);
+    assert_eq!(v["applied"].as_u64(), Some(0));
+    assert_eq!(v["skipped_already_bound"].as_u64(), Some(1));
+    assert_eq!(v["eligible"].as_u64(), Some(0));
+}
+
+#[test]
+fn dry_run_skips_already_bound_after_apply() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    seed_two_cooperatives(&data_dir);
+
+    assert!(run(&data_dir, &["--apply", "--json"]).status.success());
+
+    // Explicit --dry-run flag (the default) must also skip the now-bound coop.
+    let output = run(&data_dir, &["--dry-run", "--json"]);
+    assert!(output.status.success());
+    let v = parse_json(&output);
+    assert_eq!(v["mode"].as_str(), Some("dry_run"));
+    assert_eq!(v["skipped_already_bound"].as_u64(), Some(1));
+    assert_eq!(v["eligible"].as_u64(), Some(0));
+}
+
+// ----------------------------------------------------------------------------
+// Collisions: reported, not applied, non-zero exit under --apply.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn apply_surrogate_collision_is_reported_not_applied_and_exits_nonzero() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+    // A different coop already occupies the default coop's surrogate target.
+    occupy_surrogate_target(&data_dir, &default_id, "alpha-coop");
+
+    let output = run(&data_dir, &["--apply", "--json"]);
+    // A collision during --apply means the run did not fully complete: non-zero.
+    assert!(
+        !output.status.success(),
+        "apply with a refused collision must exit non-zero"
+    );
+    // The JSON report is still emitted on stdout, ahead of the error.
+    let v = parse_json(&output);
+    assert_eq!(v["surrogate_collision"].as_u64(), Some(1));
+    assert_eq!(v["applied"].as_u64(), Some(0));
+    let entries = v["entries"].as_array().unwrap();
+    let def = entries
+        .iter()
+        .find(|e| e["coop_id"].as_str() == Some(default_id.as_str()))
+        .unwrap();
+    assert_eq!(def["action"].as_str(), Some("surrogate_collision"));
+
+    // The default coop is still unbound; its surrogate stays with alpha-coop.
+    let surrogate = icn_entity::propose_surrogate_entity_id(&default_id).unwrap();
+    let (_store, map) = open_map(&data_dir);
+    assert_eq!(map.entity_for_coop(&default_id).unwrap(), None);
+    assert_eq!(
+        map.coop_for_entity(&surrogate).unwrap(),
+        Some("alpha-coop".to_string())
+    );
+}
+
+#[test]
+fn dry_run_reports_collision_without_failing() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+    occupy_surrogate_target(&data_dir, &default_id, "alpha-coop");
+
+    // A dry run is a preview: collisions are findings, not failures -> exit 0.
+    let output = run(&data_dir, &["--json"]);
+    assert!(output.status.success());
+    let v = parse_json(&output);
+    assert_eq!(v["mode"].as_str(), Some("dry_run"));
+    assert_eq!(v["surrogate_collision"].as_u64(), Some(1));
+    assert_eq!(v["applied"].as_u64(), Some(0));
+}
+
+// ----------------------------------------------------------------------------
+// Flag handling and empty/missing store.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn apply_and_dry_run_are_mutually_exclusive() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+
+    let output = run(&data_dir, &["--apply", "--dry-run"]);
+    assert!(
+        !output.status.success(),
+        "clap must reject --apply with --dry-run"
+    );
+    // Nothing was bound (clap errors before the handler runs).
+    let (_store, map) = open_map(&data_dir);
+    assert_eq!(map.entity_for_coop(&default_id).unwrap(), None);
+}
+
+#[test]
+fn missing_store_reports_empty_and_creates_nothing_even_with_apply() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data"); // never created
+
+    let output = run(&data_dir, &["--apply", "--json"]);
+    assert!(output.status.success());
+    let v = parse_json(&output);
+    assert_eq!(v["total"].as_u64(), Some(0));
+    assert_eq!(v["applied"].as_u64(), Some(0));
+
+    // A read/apply over a missing store must not create a database.
+    assert!(
+        !coop_store_path(&data_dir).exists(),
+        "backfill must not create a store when none exists"
+    );
+}
+
+// ----------------------------------------------------------------------------
+// The PR3/PR4 report still works after an apply.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn entity_report_preview_surrogates_still_works_after_apply() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+
+    assert!(run(&data_dir, &["--apply", "--json"]).status.success());
+
+    // entity-report --json --preview-surrogates still runs, and now classifies
+    // the default coop as already-bound (no surrogate proposed for it).
+    let output = Command::new(icnctl_bin())
+        .env("RUST_LOG", "off")
+        .arg("--data-dir")
+        .arg(&data_dir)
+        .arg("coop")
+        .arg("entity-report")
+        .arg("--json")
+        .arg("--preview-surrogates")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: Value = serde_json::from_str(String::from_utf8(output.stdout).unwrap().trim()).unwrap();
+    assert_eq!(v["already_bound"].as_u64(), Some(1));
+    assert_eq!(v["non_mappable"].as_u64(), Some(0));
+    // No non-mappable ids remain, so no surrogate is proposed.
+    assert_eq!(v["surrogate_proposed"].as_u64().unwrap_or(0), 0);
+
+    let entries = v["entries"].as_array().unwrap();
+    let def = entries
+        .iter()
+        .find(|e| e["coop_id"].as_str() == Some(default_id.as_str()))
+        .unwrap();
+    assert_eq!(def["class"].as_str(), Some("already_bound"));
+}

--- a/icn/crates/icn-entity/src/coop_entity_backfill.rs
+++ b/icn/crates/icn-entity/src/coop_entity_backfill.rs
@@ -1,0 +1,929 @@
+//! Controlled, auditable surrogate backfill/apply over `coop_id`s (#2082 lane,
+//! PR6).
+//!
+//! # What this is
+//!
+//! The first **mutation orchestrator** in the lane. It composes three earlier,
+//! single-purpose primitives behind one operator-controlled, dry-run-by-default
+//! operation:
+//!
+//! - read-only classification ([`classify_coop_ids`](crate::classify_coop_ids),
+//!   PR3),
+//! - deterministic surrogate proposal
+//!   ([`propose_surrogate_entity_id`](crate::propose_surrogate_entity_id), PR4),
+//! - the reversible write primitive
+//!   ([`CoopEntityMap::bind_resolved`](crate::CoopEntityMap::bind_resolved),
+//!   PR5).
+//!
+//! Given a set of flat `coop_id`s and the canonical map, it selects the *safe,
+//! non-mappable* entries (a default `coop:<uuid>` cannot project to a valid
+//! cooperative slug), proposes each one's deterministic surrogate, and — only
+//! under an explicit [`SurrogateBackfillMode::Apply`] — binds the pair with
+//! `bind_resolved`. [`SurrogateBackfillMode::DryRun`] is the default and writes
+//! nothing.
+//!
+//! # A mapping is NOT authority
+//!
+//! Binding a `coop_id` to a surrogate cooperative `EntityId` grants **zero**
+//! membership, role, capability, mandate, permission, or standing. It is only a
+//! reversible *name binding*. Authority in ICN still flows from identity →
+//! standing → membership → role/mandate/capability → governance decision →
+//! receipt → effect → durable execution record — never from the existence of a
+//! mapping entry. This operation moves names, not power.
+//!
+//! # No normalization, no silent writes, no stealing
+//!
+//! - **No normalization.** The original `coop_id` is preserved byte-for-byte;
+//!   the surrogate is a *new generated handle*, never a rewrite of the input.
+//! - **No silent writes.** Dry-run is the default; a write happens only in
+//!   [`SurrogateBackfillMode::Apply`], and only for collision-free entries.
+//! - **No stealing.** A proposed surrogate that would occupy an `EntityId`
+//!   already claimed by another `coop_id` (already reverse-bound, or another
+//!   same-batch proposal/projection) is reported as a
+//!   [`SurrogateBackfillAction::SurrogateCollision`] and is **never** bound.
+//!   This mirrors the read-only collision rule of
+//!   [`classify_coop_ids_with_surrogate_preview`](crate::classify_coop_ids_with_surrogate_preview),
+//!   so the orchestrator refuses the whole colliding set up front instead of
+//!   binding one entry and letting `bind_resolved` reject its twin (which would
+//!   leave an ambiguous partial result).
+
+use crate::coop_entity_inventory::{classify_coop_ids, CoopEntityClass, CoopEntityInventoryEntry};
+use crate::coop_entity_map::{CoopEntityMap, CoopEntityMapError};
+use crate::coop_entity_surrogate::propose_surrogate_entity_id;
+use crate::entity::EntityId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Whether the backfill only previews (`DryRun`) or actually binds (`Apply`).
+///
+/// `DryRun` is the default for the operation: it computes the identical plan as
+/// `Apply` but performs **no** writes, so it is safe to run repeatedly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurrogateBackfillMode {
+    /// Compute and report the plan; bind nothing.
+    DryRun,
+    /// Bind each eligible, collision-free non-mappable `coop_id` to its
+    /// deterministic surrogate via [`CoopEntityMap::bind_resolved`].
+    Apply,
+}
+
+/// The outcome (or, in dry-run, the *intended* outcome) for a single `coop_id`.
+///
+/// Exactly one action is assigned per entry, and every action maps to exactly
+/// one aggregate counter, so the per-entry actions partition
+/// [`CoopSurrogateBackfill::total`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurrogateBackfillAction {
+    /// Dry-run: an eligible, collision-free non-mappable id that *would* be
+    /// bound to its surrogate under `--apply`. No write performed.
+    WouldBind,
+    /// Apply: an eligible non-mappable id successfully bound to its surrogate.
+    Bound,
+    /// Skipped: the `coop_id` already has a healthy binding (nothing to do).
+    SkippedAlreadyBound,
+    /// Skipped: the `coop_id` is mappable and resolves by projection; surrogate
+    /// backfill is only for non-mappable ids, so it is left untouched.
+    SkippedMappableUnbound,
+    /// Skipped: the `coop_id` is mappable but its projected `EntityId` is
+    /// already reverse-bound to a different `coop_id`.
+    SkippedReverseConflict,
+    /// Skipped: classification (or the surrogate reverse-lookup) hit a storage
+    /// read error or an internally inconsistent mapping; safety cannot be
+    /// established, so nothing is proposed or bound.
+    SkippedStorageError,
+    /// Not applied: the proposed surrogate `EntityId` would collide on bind —
+    /// already reverse-bound to a different `coop_id`, or claimed by another
+    /// `coop_id` in this same batch. Reported, never bound.
+    SurrogateCollision,
+    /// Apply: `bind_resolved` rejected the surrogate as a forward/reverse
+    /// mapping conflict (a real concurrent-state change between plan and write).
+    BindConflict,
+    /// Apply: `bind_resolved` failed with a storage/other error.
+    BindError,
+}
+
+/// Per-`coop_id` audit detail. The original `coop_id` is preserved
+/// byte-for-byte; nothing here is normalized.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SurrogateBackfillEntry {
+    /// The original flat `coop_id`, exactly as supplied.
+    pub coop_id: String,
+    /// The deterministic surrogate cooperative `EntityId` proposed for this
+    /// `coop_id`. Present for every non-mappable entry that produced a proposal
+    /// (eligible, collision, or surrogate-lookup error); `None` for the
+    /// skipped-by-class entries that never get a proposal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposed_entity_id: Option<EntityId>,
+    /// The action taken (or, in dry-run, that would be taken) for this entry.
+    pub action: SurrogateBackfillAction,
+    /// A short, human-readable explanation of the action.
+    pub reason: String,
+    /// The underlying map/bind error string when one exists (storage read
+    /// failure, bind conflict, or bind error). `None` for clean outcomes and
+    /// for collisions (a collision is a policy finding, surfaced in `reason`,
+    /// not a map error).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Aggregate, auditable result of a surrogate backfill (dry-run or apply).
+///
+/// The skip/collision/eligible counters partition [`total`](Self::total):
+/// `total == eligible + surrogate_collision + skipped_already_bound +
+/// skipped_mappable_unbound + skipped_reverse_conflict + skipped_storage_error`.
+/// `eligible` is the count of collision-free non-mappable proposals selected for
+/// binding; in `Apply` mode `eligible == applied + bind_conflict + bind_error`,
+/// and in `DryRun` mode `eligible` equals the number of `would_bind` entries
+/// (with `applied`, `bind_conflict`, and `bind_error` all zero).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoopSurrogateBackfill {
+    /// The mode this result was produced under.
+    pub mode: SurrogateBackfillMode,
+    /// Total number of `coop_id`s processed (`== entries.len()`).
+    pub total: usize,
+    /// Collision-free non-mappable proposals selected for binding.
+    pub eligible: usize,
+    /// Eligible entries actually bound (`Apply` only; always `0` in `DryRun`).
+    pub applied: usize,
+    /// Skipped because already healthily bound.
+    pub skipped_already_bound: usize,
+    /// Skipped because mappable-and-unbound (projection path, not surrogate).
+    pub skipped_mappable_unbound: usize,
+    /// Skipped because mappable but the projected `EntityId` is reverse-bound
+    /// to a different `coop_id`.
+    pub skipped_reverse_conflict: usize,
+    /// Skipped because classification or the surrogate reverse-lookup hit a
+    /// storage error / inconsistent state.
+    pub skipped_storage_error: usize,
+    /// Non-mappable entries whose proposed surrogate would collide on bind.
+    pub surrogate_collision: usize,
+    /// Eligible entries whose `bind_resolved` was rejected as a conflict
+    /// (`Apply` only).
+    pub bind_conflict: usize,
+    /// Eligible entries whose `bind_resolved` failed with a storage/other error
+    /// (`Apply` only).
+    pub bind_error: usize,
+    /// Per-`coop_id` detail, in input order.
+    pub entries: Vec<SurrogateBackfillEntry>,
+}
+
+impl CoopSurrogateBackfill {
+    /// An empty result for the given mode (used for an empty / missing store).
+    fn new(mode: SurrogateBackfillMode) -> Self {
+        Self {
+            mode,
+            total: 0,
+            eligible: 0,
+            applied: 0,
+            skipped_already_bound: 0,
+            skipped_mappable_unbound: 0,
+            skipped_reverse_conflict: 0,
+            skipped_storage_error: 0,
+            surrogate_collision: 0,
+            bind_conflict: 0,
+            bind_error: 0,
+            entries: Vec::new(),
+        }
+    }
+
+    /// Record one classified entry, bumping the matching counter and `total`.
+    fn record(&mut self, entry: SurrogateBackfillEntry) {
+        match entry.action {
+            SurrogateBackfillAction::WouldBind => self.eligible += 1,
+            SurrogateBackfillAction::Bound => {
+                self.eligible += 1;
+                self.applied += 1;
+            }
+            SurrogateBackfillAction::BindConflict => {
+                self.eligible += 1;
+                self.bind_conflict += 1;
+            }
+            SurrogateBackfillAction::BindError => {
+                self.eligible += 1;
+                self.bind_error += 1;
+            }
+            SurrogateBackfillAction::SurrogateCollision => self.surrogate_collision += 1,
+            SurrogateBackfillAction::SkippedAlreadyBound => self.skipped_already_bound += 1,
+            SurrogateBackfillAction::SkippedMappableUnbound => self.skipped_mappable_unbound += 1,
+            SurrogateBackfillAction::SkippedReverseConflict => self.skipped_reverse_conflict += 1,
+            SurrogateBackfillAction::SkippedStorageError => self.skipped_storage_error += 1,
+        }
+        self.total += 1;
+        self.entries.push(entry);
+    }
+
+    /// Whether an `Apply` run finished with anything that blocked a clean,
+    /// complete backfill: a bind conflict/error, a refused collision, or a
+    /// storage error. Callers use this to choose a non-zero process exit.
+    /// Always `false` for a `DryRun` (a preview reports findings, it does not
+    /// fail).
+    pub fn apply_had_failures(&self) -> bool {
+        self.mode == SurrogateBackfillMode::Apply
+            && (self.bind_conflict > 0
+                || self.bind_error > 0
+                || self.surrogate_collision > 0
+                || self.skipped_storage_error > 0)
+    }
+}
+
+/// Plan (and, in `Apply` mode, perform) a controlled surrogate backfill over
+/// `coop_ids` against the canonical [`CoopEntityMap`].
+///
+/// This is dry-run-safe by construction: in [`SurrogateBackfillMode::DryRun`] it
+/// performs only read operations and binds nothing; in
+/// [`SurrogateBackfillMode::Apply`] it binds each eligible, collision-free
+/// non-mappable `coop_id` to its deterministic surrogate via
+/// [`CoopEntityMap::bind_resolved`], preserving the original `coop_id`
+/// byte-for-byte. A binding confers no authority.
+pub fn backfill_coop_surrogates(
+    coop_ids: impl IntoIterator<Item = String>,
+    map: &dyn CoopEntityMap,
+    mode: SurrogateBackfillMode,
+) -> CoopSurrogateBackfill {
+    // Step 1: read-only classification — the same machinery `coop entity-report`
+    // uses, so a backfill plan lines up exactly with the inventory the operator
+    // just inspected. No writes, no normalization.
+    let inventory = classify_coop_ids(coop_ids, map);
+
+    // Step 2 (pure): propose a surrogate for each NonMappable entry and tally,
+    // per EntityId, how many entries in this batch would occupy it on a bind. The
+    // occupancy count includes BOTH proposed surrogates AND the projected/bound
+    // id of mappable/already-bound entries, so a surrogate that coincides with a
+    // same-batch mappable projection is caught here — mirroring
+    // `classify_coop_ids_with_surrogate_preview`'s read-only collision rule (PR4).
+    let mut surrogate_for: Vec<Option<EntityId>> = Vec::with_capacity(inventory.entries.len());
+    let mut entity_claims: HashMap<String, usize> = HashMap::new();
+    for entry in &inventory.entries {
+        let surrogate = if entry.class == CoopEntityClass::NonMappable {
+            // Valid by construction; an (unreachable) error means "no proposal".
+            propose_surrogate_entity_id(&entry.coop_id).ok()
+        } else {
+            None
+        };
+        if let Some(claimed) = surrogate
+            .as_ref()
+            .or(entry.projected_entity_id.as_ref())
+            .or(entry.bound_entity_id.as_ref())
+        {
+            *entity_claims
+                .entry(claimed.as_str().to_string())
+                .or_insert(0) += 1;
+        }
+        surrogate_for.push(surrogate);
+    }
+
+    // Step 3: decide one action per entry and, in Apply mode, perform the bind for
+    // each collision-free non-mappable entry. Dry-run writes nothing.
+    let mut report = CoopSurrogateBackfill::new(mode);
+    for (entry, surrogate) in inventory.entries.iter().zip(surrogate_for) {
+        report.record(plan_entry(entry, surrogate, &entity_claims, map, mode));
+    }
+    report
+}
+
+/// Decide the backfill action for one classified entry — and, in `Apply` mode,
+/// perform the `bind_resolved` write for a collision-free non-mappable entry.
+///
+/// Pure for every non-`NonMappable` class and for collisions/storage errors; the
+/// only write is `bind_resolved` on an eligible entry in `Apply` mode.
+fn plan_entry(
+    entry: &CoopEntityInventoryEntry,
+    surrogate: Option<EntityId>,
+    entity_claims: &HashMap<String, usize>,
+    map: &dyn CoopEntityMap,
+    mode: SurrogateBackfillMode,
+) -> SurrogateBackfillEntry {
+    let make = |action: SurrogateBackfillAction,
+                proposed: Option<EntityId>,
+                reason: String,
+                error: Option<String>| SurrogateBackfillEntry {
+        coop_id: entry.coop_id.clone(),
+        proposed_entity_id: proposed,
+        action,
+        reason,
+        error,
+    };
+
+    match entry.class {
+        CoopEntityClass::AlreadyBound => {
+            let to = entry
+                .bound_entity_id
+                .as_ref()
+                .map(|e| e.as_str())
+                .unwrap_or("<unknown>");
+            make(
+                SurrogateBackfillAction::SkippedAlreadyBound,
+                None,
+                format!("already bound to {to}"),
+                None,
+            )
+        }
+        CoopEntityClass::MappableUnbound => make(
+            SurrogateBackfillAction::SkippedMappableUnbound,
+            entry.projected_entity_id.clone(),
+            "mappable coop_id resolves by projection; surrogate backfill is only for non-mappable ids"
+                .into(),
+            None,
+        ),
+        CoopEntityClass::MappableReverseConflict => make(
+            SurrogateBackfillAction::SkippedReverseConflict,
+            entry.projected_entity_id.clone(),
+            format!(
+                "mappable but the projected EntityId is reverse-bound to another coop_id ({:?})",
+                entry.reverse_bound_coop_id
+            ),
+            None,
+        ),
+        CoopEntityClass::StorageError => make(
+            SurrogateBackfillAction::SkippedStorageError,
+            None,
+            "classification hit a storage error or inconsistent mapping".into(),
+            entry.error.clone(),
+        ),
+        CoopEntityClass::NonMappable => {
+            let Some(surrogate) = surrogate else {
+                // propose_surrogate_entity_id failed — an internal-invariant guard
+                // that never fires in practice; with no surrogate there is nothing
+                // to bind, so it is surfaced rather than panicking.
+                return make(
+                    SurrogateBackfillAction::SkippedStorageError,
+                    None,
+                    "could not derive a surrogate EntityId".into(),
+                    entry
+                        .error
+                        .clone()
+                        .or_else(|| Some("surrogate derivation failed".into())),
+                );
+            };
+
+            // Within-batch collision: another entry in this batch would occupy the
+            // same EntityId (another surrogate proposal, or a mappable/bound
+            // projection). Refuse the whole colliding set here so Apply never binds
+            // one twin and lets `bind_resolved` reject the other — which would leave
+            // an ambiguous partial result.
+            if entity_claims.get(surrogate.as_str()).copied().unwrap_or(0) > 1 {
+                return make(
+                    SurrogateBackfillAction::SurrogateCollision,
+                    Some(surrogate.clone()),
+                    format!(
+                        "proposed surrogate {} collides within-batch with another coop_id",
+                        surrogate.as_str()
+                    ),
+                    None,
+                );
+            }
+
+            // Reverse-binding collision (or read failure) against persisted state.
+            match map.coop_for_entity(&surrogate) {
+                Ok(Some(occupant)) if occupant != entry.coop_id => {
+                    return make(
+                        SurrogateBackfillAction::SurrogateCollision,
+                        Some(surrogate.clone()),
+                        format!(
+                            "proposed surrogate {} already reverse-bound to {occupant:?}",
+                            surrogate.as_str()
+                        ),
+                        None,
+                    );
+                }
+                // Free, or already reverse-bound to THIS coop_id (a one-sided state
+                // that `bind_resolved` completes): eligible.
+                Ok(_) => {}
+                Err(e) => {
+                    return make(
+                        SurrogateBackfillAction::SkippedStorageError,
+                        Some(surrogate.clone()),
+                        format!(
+                            "surrogate {} reverse-lookup failed; cannot verify it is free",
+                            surrogate.as_str()
+                        ),
+                        Some(e.to_string()),
+                    );
+                }
+            }
+
+            // Eligible, collision-free. Dry-run reports the intent; Apply binds the
+            // original coop_id to its surrogate (preserved byte-for-byte).
+            match mode {
+                SurrogateBackfillMode::DryRun => make(
+                    SurrogateBackfillAction::WouldBind,
+                    Some(surrogate.clone()),
+                    format!("would bind to surrogate {}", surrogate.as_str()),
+                    None,
+                ),
+                SurrogateBackfillMode::Apply => {
+                    match map.bind_resolved(&entry.coop_id, &surrogate) {
+                        Ok(()) => make(
+                            SurrogateBackfillAction::Bound,
+                            Some(surrogate.clone()),
+                            format!("bound to surrogate {}", surrogate.as_str()),
+                            None,
+                        ),
+                        Err(CoopEntityMapError::Conflict(msg)) => make(
+                            SurrogateBackfillAction::BindConflict,
+                            Some(surrogate.clone()),
+                            "bind_resolved rejected the surrogate as a forward/reverse conflict"
+                                .into(),
+                            Some(msg),
+                        ),
+                        Err(e) => make(
+                            SurrogateBackfillAction::BindError,
+                            Some(surrogate.clone()),
+                            "bind_resolved failed".into(),
+                            Some(e.to_string()),
+                        ),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::coop_entity_map::InMemoryCoopEntityMap;
+
+    /// A non-mappable default cooperative id (`coop:<uuid>`).
+    const UUID_COOP: &str = "coop:550e8400-e29b-41d4-a716-446655440000";
+    /// PR4's golden surrogate for [`UUID_COOP`].
+    const UUID_SURROGATE: &str = "entity:icn:cooperative:coop-legacy-edf6152975301bd80c13";
+
+    fn coop_eid(slug: &str) -> EntityId {
+        EntityId::cooperative(slug).unwrap()
+    }
+
+    fn ids(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ------------------------------------------------------------------
+    // Dry-run (default): reports findings, writes nothing.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn dry_run_reports_non_mappable_with_proposed_surrogate_and_writes_nothing() {
+        let map = InMemoryCoopEntityMap::new();
+        let report =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::DryRun);
+
+        assert_eq!(report.mode, SurrogateBackfillMode::DryRun);
+        assert_eq!(report.total, 1);
+        assert_eq!(report.eligible, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.entries.len(), 1);
+
+        let entry = &report.entries[0];
+        assert_eq!(entry.coop_id, UUID_COOP);
+        assert_eq!(entry.action, SurrogateBackfillAction::WouldBind);
+        assert_eq!(
+            entry.proposed_entity_id.as_ref().unwrap().as_str(),
+            UUID_SURROGATE
+        );
+
+        // Read-only: nothing bound.
+        assert_eq!(map.entity_for_coop(UUID_COOP).unwrap(), None);
+        assert_eq!(
+            map.coop_for_entity(&coop_eid("coop-legacy-edf6152975301bd80c13"))
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn dry_run_is_default_safe_to_run_repeatedly() {
+        let map = InMemoryCoopEntityMap::new();
+        let first =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::DryRun);
+        let second =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::DryRun);
+        assert_eq!(first, second);
+        assert_eq!(map.entity_for_coop(UUID_COOP).unwrap(), None);
+    }
+
+    // ------------------------------------------------------------------
+    // Apply: binds the deterministic surrogate, idempotently.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn apply_binds_non_mappable_to_deterministic_surrogate() {
+        let map = InMemoryCoopEntityMap::new();
+        let report =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+
+        assert_eq!(report.mode, SurrogateBackfillMode::Apply);
+        assert_eq!(report.eligible, 1);
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.entries[0].action, SurrogateBackfillAction::Bound);
+
+        // The forward binding now resolves to the golden surrogate.
+        assert_eq!(
+            map.entity_for_coop(UUID_COOP).unwrap().unwrap().as_str(),
+            UUID_SURROGATE
+        );
+    }
+
+    #[test]
+    fn apply_preserves_original_coop_id_exactly_in_reverse_lookup() {
+        let map = InMemoryCoopEntityMap::new();
+        backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        let surrogate = propose_surrogate_entity_id(UUID_COOP).unwrap();
+        // Reverse lookup returns the original coop_id byte-for-byte (colon, uuid).
+        assert_eq!(
+            map.coop_for_entity(&surrogate).unwrap(),
+            Some(UUID_COOP.to_string())
+        );
+    }
+
+    #[test]
+    fn apply_is_idempotent_when_rerun() {
+        let map = InMemoryCoopEntityMap::new();
+        let first = backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(first.applied, 1);
+
+        // Rerun: the id is now AlreadyBound, so it is skipped, not re-bound.
+        let second =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(second.applied, 0);
+        assert_eq!(second.skipped_already_bound, 1);
+        assert_eq!(second.eligible, 0);
+        assert_eq!(
+            second.entries[0].action,
+            SurrogateBackfillAction::SkippedAlreadyBound
+        );
+        // The binding is unchanged.
+        assert_eq!(
+            map.entity_for_coop(UUID_COOP).unwrap().unwrap().as_str(),
+            UUID_SURROGATE
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Skips by class.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn dry_run_skips_already_bound() {
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved(UUID_COOP, &propose_surrogate_entity_id(UUID_COOP).unwrap())
+            .unwrap();
+        let report =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::DryRun);
+        assert_eq!(report.skipped_already_bound, 1);
+        assert_eq!(report.eligible, 0);
+        assert_eq!(
+            report.entries[0].action,
+            SurrogateBackfillAction::SkippedAlreadyBound
+        );
+    }
+
+    #[test]
+    fn apply_skips_mappable_unbound_without_binding_a_surrogate() {
+        // A mappable coop_id resolves by projection; the backfill must not give
+        // it a surrogate.
+        let map = InMemoryCoopEntityMap::new();
+        let report =
+            backfill_coop_surrogates(ids(&["food-coop"]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(report.skipped_mappable_unbound, 1);
+        assert_eq!(report.applied, 0);
+        let entry = &report.entries[0];
+        assert_eq!(
+            entry.action,
+            SurrogateBackfillAction::SkippedMappableUnbound
+        );
+        assert_eq!(entry.proposed_entity_id, Some(coop_eid("food-coop")));
+        // Nothing bound by the surrogate path.
+        assert_eq!(map.entity_for_coop("food-coop").unwrap(), None);
+    }
+
+    #[test]
+    fn apply_skips_mappable_reverse_conflict() {
+        // `food-coop` projects to an EntityId already reverse-bound to a
+        // different coop.
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_exact("alpha-coop", &coop_eid("food-coop"))
+            .unwrap();
+        let report =
+            backfill_coop_surrogates(ids(&["food-coop"]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(report.skipped_reverse_conflict, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(
+            report.entries[0].action,
+            SurrogateBackfillAction::SkippedReverseConflict
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Surrogate collisions: reported, never applied.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn apply_does_not_bind_a_surrogate_already_reverse_bound_to_another_coop() {
+        let map = InMemoryCoopEntityMap::new();
+        let surrogate = propose_surrogate_entity_id(UUID_COOP).unwrap();
+        // A DIFFERENT coop already occupies the surrogate target.
+        map.bind_exact("alpha-coop", &surrogate).unwrap();
+
+        let report =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(report.surrogate_collision, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.eligible, 0);
+        let entry = &report.entries[0];
+        assert_eq!(entry.action, SurrogateBackfillAction::SurrogateCollision);
+        assert!(
+            entry.reason.to_lowercase().contains("reverse-bound"),
+            "reason should explain the reverse-bound collision; got: {}",
+            entry.reason
+        );
+        // The non-mappable id was NOT bound (its surrogate stays with alpha-coop).
+        assert_eq!(map.entity_for_coop(UUID_COOP).unwrap(), None);
+        assert_eq!(
+            map.coop_for_entity(&surrogate).unwrap(),
+            Some("alpha-coop".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_refuses_whole_within_batch_colliding_set_no_partial_bind() {
+        // Two identical non-mappable ids propose the same surrogate. The backfill
+        // must refuse BOTH (no partial bind of the first), so the colliding set
+        // is reported and the map stays untouched.
+        let map = InMemoryCoopEntityMap::new();
+        let report = backfill_coop_surrogates(
+            ids(&[UUID_COOP, UUID_COOP]),
+            &map,
+            SurrogateBackfillMode::Apply,
+        );
+        assert_eq!(
+            report.surrogate_collision, 2,
+            "both colliding entries flagged"
+        );
+        assert_eq!(
+            report.applied, 0,
+            "no partial application of a colliding set"
+        );
+        for entry in &report.entries {
+            assert_eq!(entry.action, SurrogateBackfillAction::SurrogateCollision);
+            assert!(entry.reason.contains("within-batch"));
+        }
+        assert_eq!(map.entity_for_coop(UUID_COOP).unwrap(), None);
+    }
+
+    #[test]
+    fn apply_flags_surrogate_colliding_with_same_batch_mappable_projection() {
+        // A mappable coop literally named the surrogate slug projects to the
+        // exact EntityId being proposed for the non-mappable coop. Binding the
+        // surrogate would steal the mappable's projection, so it must collide.
+        let map = InMemoryCoopEntityMap::new();
+        let surrogate = propose_surrogate_entity_id(UUID_COOP).unwrap();
+        let collider = surrogate.identifier().to_string(); // a valid, unbound slug
+
+        let report = backfill_coop_surrogates(
+            vec![UUID_COOP.to_string(), collider.clone()],
+            &map,
+            SurrogateBackfillMode::Apply,
+        );
+        assert_eq!(report.surrogate_collision, 1);
+        assert_eq!(report.skipped_mappable_unbound, 1);
+        assert_eq!(report.applied, 0);
+        // Neither the surrogate nor the mappable projection was bound.
+        assert_eq!(map.entity_for_coop(UUID_COOP).unwrap(), None);
+        assert_eq!(map.entity_for_coop(&collider).unwrap(), None);
+    }
+
+    // ------------------------------------------------------------------
+    // Apply-time bind conflict / bind error via test doubles.
+    // (Eligible-at-plan-time but failing at write-time: only a test double
+    // returning inconsistent reads vs. writes can manufacture this.)
+    // ------------------------------------------------------------------
+
+    /// A map that classifies `coop_A`-style ids as non-mappable-and-unbound
+    /// (forward None) with a free surrogate target (reverse None), then fails
+    /// the actual `bind_resolved` write with a caller-chosen error.
+    struct BindFailMap {
+        err: fn() -> CoopEntityMapError,
+    }
+    impl CoopEntityMap for BindFailMap {
+        fn bind_resolved(&self, _: &str, _: &EntityId) -> Result<(), CoopEntityMapError> {
+            Err((self.err)())
+        }
+        fn entity_for_coop(&self, _: &str) -> Result<Option<EntityId>, CoopEntityMapError> {
+            Ok(None)
+        }
+        fn coop_for_entity(&self, _: &EntityId) -> Result<Option<String>, CoopEntityMapError> {
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn apply_reports_bind_conflict_clearly() {
+        let map = BindFailMap {
+            err: || {
+                CoopEntityMapError::Conflict("entity already bound to a different coop_id".into())
+            },
+        };
+        let report =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(report.eligible, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.bind_conflict, 1);
+        assert_eq!(report.bind_error, 0);
+        let entry = &report.entries[0];
+        assert_eq!(entry.action, SurrogateBackfillAction::BindConflict);
+        assert!(entry.error.as_ref().unwrap().contains("different coop_id"));
+    }
+
+    #[test]
+    fn apply_reports_bind_error_clearly() {
+        let map = BindFailMap {
+            err: || CoopEntityMapError::Storage("sled write failed".into()),
+        };
+        let report =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(report.eligible, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.bind_error, 1);
+        assert_eq!(report.bind_conflict, 0);
+        let entry = &report.entries[0];
+        assert_eq!(entry.action, SurrogateBackfillAction::BindError);
+        assert!(entry.error.as_ref().unwrap().contains("sled write failed"));
+    }
+
+    // ------------------------------------------------------------------
+    // Storage error paths: classification read failure and surrogate
+    // reverse-lookup failure both report as SkippedStorageError, no write.
+    // ------------------------------------------------------------------
+
+    /// Forward read fails -> classification reports StorageError.
+    struct ForwardErrMap;
+    impl CoopEntityMap for ForwardErrMap {
+        fn bind_resolved(&self, _: &str, _: &EntityId) -> Result<(), CoopEntityMapError> {
+            unreachable!("must not bind when classification storage-errored");
+        }
+        fn entity_for_coop(&self, _: &str) -> Result<Option<EntityId>, CoopEntityMapError> {
+            Err(CoopEntityMapError::Storage(
+                "forward index unreadable".into(),
+            ))
+        }
+        fn coop_for_entity(&self, _: &EntityId) -> Result<Option<String>, CoopEntityMapError> {
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn apply_reports_classification_storage_error_and_binds_nothing() {
+        let report = backfill_coop_surrogates(
+            ids(&[UUID_COOP]),
+            &ForwardErrMap,
+            SurrogateBackfillMode::Apply,
+        );
+        assert_eq!(report.skipped_storage_error, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.eligible, 0);
+        assert_eq!(
+            report.entries[0].action,
+            SurrogateBackfillAction::SkippedStorageError
+        );
+    }
+
+    /// Forward read says "unbound" (None), but the surrogate reverse-lookup
+    /// fails -> the entry cannot be verified safe, so SkippedStorageError.
+    struct ReverseErrMap;
+    impl CoopEntityMap for ReverseErrMap {
+        fn bind_resolved(&self, _: &str, _: &EntityId) -> Result<(), CoopEntityMapError> {
+            unreachable!("must not bind when the surrogate reverse-lookup errored");
+        }
+        fn entity_for_coop(&self, _: &str) -> Result<Option<EntityId>, CoopEntityMapError> {
+            Ok(None)
+        }
+        fn coop_for_entity(&self, _: &EntityId) -> Result<Option<String>, CoopEntityMapError> {
+            Err(CoopEntityMapError::Storage(
+                "reverse index unreadable".into(),
+            ))
+        }
+    }
+
+    #[test]
+    fn apply_reports_surrogate_lookup_storage_error_and_binds_nothing() {
+        let report = backfill_coop_surrogates(
+            ids(&[UUID_COOP]),
+            &ReverseErrMap,
+            SurrogateBackfillMode::Apply,
+        );
+        assert_eq!(report.skipped_storage_error, 1);
+        assert_eq!(
+            report.surrogate_collision, 0,
+            "a lookup error is not a collision"
+        );
+        assert_eq!(report.applied, 0);
+        let entry = &report.entries[0];
+        assert_eq!(entry.action, SurrogateBackfillAction::SkippedStorageError);
+        assert!(entry
+            .error
+            .as_ref()
+            .unwrap()
+            .contains("reverse index unreadable"));
+    }
+
+    // ------------------------------------------------------------------
+    // Counts partition the input; mixed batch.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn counts_partition_total_on_mixed_batch() {
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved("bound-uuid:1", &coop_eid("bound-surrogate"))
+            .unwrap();
+        let report = backfill_coop_surrogates(
+            ids(&[
+                "bound-uuid:1", // AlreadyBound
+                "free-coop",    // MappableUnbound
+                UUID_COOP,      // NonMappable -> eligible
+                "coop_A",       // NonMappable -> eligible
+            ]),
+            &map,
+            SurrogateBackfillMode::DryRun,
+        );
+        assert_eq!(report.total, 4);
+        assert_eq!(
+            report.eligible
+                + report.surrogate_collision
+                + report.skipped_already_bound
+                + report.skipped_mappable_unbound
+                + report.skipped_reverse_conflict
+                + report.skipped_storage_error,
+            report.total
+        );
+        assert_eq!(report.skipped_already_bound, 1);
+        assert_eq!(report.skipped_mappable_unbound, 1);
+        assert_eq!(report.eligible, 2);
+    }
+
+    #[test]
+    fn apply_eligible_partitions_into_applied_conflict_error() {
+        let map = InMemoryCoopEntityMap::new();
+        let report = backfill_coop_surrogates(
+            ids(&[UUID_COOP, "coop_A"]),
+            &map,
+            SurrogateBackfillMode::Apply,
+        );
+        assert_eq!(
+            report.applied + report.bind_conflict + report.bind_error,
+            report.eligible
+        );
+        assert_eq!(report.applied, 2);
+    }
+
+    // ------------------------------------------------------------------
+    // JSON shape: counts and entry fields serialize with expected keys.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn json_includes_expected_counts_and_entry_fields() {
+        let map = InMemoryCoopEntityMap::new();
+        let report =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::DryRun);
+        let v: serde_json::Value = serde_json::to_value(&report).unwrap();
+        assert_eq!(v["mode"].as_str(), Some("dry_run"));
+        assert_eq!(v["total"].as_u64(), Some(1));
+        assert_eq!(v["eligible"].as_u64(), Some(1));
+        assert_eq!(v["applied"].as_u64(), Some(0));
+        assert!(v.get("skipped_already_bound").is_some());
+        assert!(v.get("bind_conflict").is_some());
+        let entry = &v["entries"][0];
+        assert_eq!(entry["coop_id"].as_str(), Some(UUID_COOP));
+        assert_eq!(entry["action"].as_str(), Some("would_bind"));
+        assert_eq!(entry["proposed_entity_id"].as_str(), Some(UUID_SURROGATE));
+        assert!(entry["reason"].as_str().is_some());
+    }
+
+    #[test]
+    fn apply_had_failures_only_for_apply_with_problems() {
+        let map = InMemoryCoopEntityMap::new();
+        // Clean apply: no failures.
+        let clean = backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        assert!(!clean.apply_had_failures());
+
+        // Dry-run with a collision: never a "failure" (it is a preview).
+        let map2 = InMemoryCoopEntityMap::new();
+        let dry = backfill_coop_surrogates(
+            ids(&[UUID_COOP, UUID_COOP]),
+            &map2,
+            SurrogateBackfillMode::DryRun,
+        );
+        assert!(!dry.apply_had_failures());
+
+        // Apply with a collision: a failure.
+        let map3 = InMemoryCoopEntityMap::new();
+        let apply = backfill_coop_surrogates(
+            ids(&[UUID_COOP, UUID_COOP]),
+            &map3,
+            SurrogateBackfillMode::Apply,
+        );
+        assert!(apply.apply_had_failures());
+    }
+}

--- a/icn/crates/icn-entity/src/lib.rs
+++ b/icn/crates/icn-entity/src/lib.rs
@@ -76,6 +76,7 @@
 //! - [`error`] - Error types
 
 pub mod actor;
+pub mod coop_entity_backfill;
 pub mod coop_entity_inventory;
 pub mod coop_entity_map;
 pub mod coop_entity_surrogate;
@@ -90,6 +91,10 @@ pub mod sled_registry;
 
 // Re-export main types at crate root
 pub use actor::{EntityActor, GossipHandle, ENTITY_TOPIC};
+pub use coop_entity_backfill::{
+    backfill_coop_surrogates, CoopSurrogateBackfill, SurrogateBackfillAction,
+    SurrogateBackfillEntry, SurrogateBackfillMode,
+};
 pub use coop_entity_inventory::{
     classify_coop_ids, classify_coop_ids_with_surrogate_preview, CoopEntityClass,
     CoopEntityInventory, CoopEntityInventoryEntry,


### PR DESCRIPTION
This is PR6 in the #2082 lane.

## What

Adds a controlled, dry-run-by-default `icnctl coop entity-backfill-surrogates`
command that binds each safe, non-mappable cooperative id (e.g. the default
`coop:<uuid>`) to its deterministic surrogate cooperative `EntityId`, plus the
pure orchestration logic in `icn-entity` that drives it.

New public API in `icn-entity` (`coop_entity_backfill` module):
- `backfill_coop_surrogates(coop_ids, &map, mode) -> CoopSurrogateBackfill`
- `SurrogateBackfillMode { DryRun, Apply }`, `SurrogateBackfillAction`,
  `SurrogateBackfillEntry`, `CoopSurrogateBackfill`

New CLI subcommand:
- `icnctl coop entity-backfill-surrogates [--apply] [--dry-run] [--json]`
  (dry-run is the default; writes require `--apply`).

## Why

PR4 can preview deterministic surrogate ids; PR5 added the `bind_resolved` write
primitive. PR6 connects them through one explicit, auditable, operator-controlled
operation — it turns surrogate preview into a controlled backfill/apply.

**Mapping is not authority.** A `coop_id ↔ EntityId` binding grants no
membership, role, mandate, capability, permission, standing, or treasury access.
It only persists a reversible name binding.

## How

- `classify_coop_ids` (PR3) for read-only classification → `propose_surrogate_entity_id`
  (PR4) for each non-mappable id → `CoopEntityMap::bind_resolved` (PR5) **only**
  under `--apply`.
- Selects only safe, collision-free non-mappable ids. Within-batch collision
  detection (mirroring the PR4 preview rule) refuses the whole colliding set up
  front, so apply never binds one twin and lets `bind_resolved` reject the other
  (no ambiguous partial application).
- Preserves the original `coop_id` byte-for-byte; never normalizes.
- Reports `eligible` / `applied` / `skipped_already_bound` /
  `skipped_mappable_unbound` / `skipped_reverse_conflict` / `skipped_storage_error`
  / `surrogate_collision` / `bind_conflict` / `bind_error` counts, plus per-entry
  `action` / `reason` / `error`.
- `--apply` exits non-zero on a collision / conflict / bind error / storage error
  so callers can gate; the JSON report is still emitted on stdout ahead of the
  error.
- Reads the local cooperative store directly (run with the daemon stopped);
  creates no store if missing, reporting an empty no-op.

## Risk

Low and contained:
- New module + new CLI subcommand; no existing behavior changed. `entity-report`
  (PR3/PR4) is untouched and still works after an apply (covered by a test).
- The only write path is `bind_resolved` under an explicit `--apply`; dry-run is
  the default and writes nothing.
- No auth/token, treasury, gateway-enforcement, activation/gossip, community/
  federation mapping, node identity, CCL, or SDK/generated-type changes.

## Test plan

- `cargo test -p icn-entity` → 225 passed (incl. 19 new pure backfill tests:
  dry-run/apply/idempotency/collision/within-batch/bind-conflict/bind-error/
  storage-error/partition/JSON shape).
- `cargo test -p icnctl --test coop_entity_backfill_test` → 10 passed.
- `cargo test -p icnctl --test coop_entity_report_test` → 8 passed (no regression).
- `cargo fmt --all --check` → clean.
- `cargo clippy -p icn-entity -p icnctl --all-targets -- -D warnings` → clean.

continues the #2082 lane.
