### PR TITLE
docs(api): add generated route inventory

### DIFF
--- a/docs/reference/project-index/README.md
+++ b/docs/reference/project-index/README.md
@@ -36,6 +36,7 @@ ICN already has several truth- and freshness-tracking systems. **This index does
 | Is an `ARCHITECTURE.md` section stale? | [`docs/freshness.toml`](../../freshness.toml) (checked by `docs/scripts/freshness-check.py`; broader SME re-review tracked in [#2047](https://github.com/InterCooperative-Network/icn/issues/2047)) |
 | What is real now vs planned? | [`current-truth-map.md`](current-truth-map.md) → then [`docs/STATE.md`](../../STATE.md) + [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md) |
 | What is safe to show / claim publicly? | [`show-readiness-map.md`](show-readiness-map.md) + [`website-truth-map.md`](website-truth-map.md) |
+| What routes does the gateway actually expose, and which reach OpenAPI? | [`generated/route-inventory.md`](generated/route-inventory.md) — mechanical scan, regenerate with `docs/scripts/route_inventory.py` ([#2112](https://github.com/InterCooperative-Network/icn/issues/2112)) |
 
 **Discipline (for humans and agents):**
 

--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,0 +1,333 @@
+---
+Status: generated
+Canonical: no
+Generated: 2026-06-20T12:46:59+00:00
+---
+
+# Gateway Route Inventory (generated)
+
+> Generated mechanically by [`docs/scripts/route_inventory.py`](../../../scripts/route_inventory.py). **Do not hand-edit** — rerun the script.
+> Regenerate: `python3 docs/scripts/route_inventory.py --write`  ·  Check drift: `python3 docs/scripts/route_inventory.py --check`
+
+## What this proves / does not prove
+
+- **Proves:** these route declarations (Actix routing attribute macros) exist in the gateway source at the snapshot commit.
+- **Does NOT prove:** route correctness, authentication/authorization, test coverage, runtime health, production readiness, or public-claim safety. `OpenAPI documented = yes` does **not** mean the contract is complete or correct.
+- Defer to canonical truth/precedence: [`source-of-truth-map.md`](../source-of-truth-map.md) and proof levels in [`proof-level-taxonomy-capability-matrix.md`](../proof-level-taxonomy-capability-matrix.md). This is an orientation artifact (`Canonical: no`).
+
+## Snapshot
+
+- Source commit: `3ac5935ba425c4d3fbdd3fb63573f93e0c8fd725`
+- Gateway source scanned: `icn/crates/icn-gateway/src/**`
+- OpenAPI spec: `docs/api/openapi.generated.yaml`
+
+## Coverage summary
+
+- **Discovered gateway route macros: 287** (DELETE 17 · GET 131 · POST 125 · PUT 14)
+- **OpenAPI documented paths: 5**
+- Matched as documented (best-effort path match): 2
+- Not matched to OpenAPI (best-effort): 285 (~99% of discovered)
+- Documented share of discovered routes: ~0.7%
+
+> The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside the gateway crate and are not captured by this macro scan — so the documented/undocumented counts here are a best-effort comparison, while the two headline counts (discovered macros, OpenAPI paths) are the robust measured facts.
+
+## Limitations (PR1)
+
+- **Full mounted-path resolution is best-effort.** The `Group` column is inferred from a simple `web::scope("…")` ↔ `api::<module>::` association read from `server.rs`; it is **not** a real Rust parser and may be wrong for deeply-nested or conditional scopes. The relative macro `Path` and the `Source` file are authoritative.
+- Scans **attribute macros only** in `icn-gateway/src`. `web::resource("…")`/`.route("…")` registrations and out-of-crate handlers (e.g. `icn-governance-actor::http`) are not fully captured.
+- This is **generated-map work, not API documentation completion** (issue #2112). It does not add or change any OpenAPI content or runtime behavior.
+
+## Routes
+
+Status vocabulary is the existing set from `source-of-truth-map.md`. PR1 defaults every discovered route to `gateway-backed` (it is served by the gateway) and claim-safety to `needs review` (per-route proof level is `unknown / needs local verification` pending human review).
+
+| Method | Path (macro) | Group (best-effort) | Source | Handler | OpenAPI | Status | Claim safety |
+|---|---|---|---|---|---|---|---|
+| GET | `(empty)` | `/v1` | `icn/crates/icn-gateway/src/api/agreements.rs`:789 | `list_agreements` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1` | `icn/crates/icn-gateway/src/api/agreements.rs`:855 | `create_agreement` | no | gateway-backed | needs review |
+| DELETE | `/{id}` | `/v1/{id}` | `icn/crates/icn-gateway/src/api/agreements.rs`:936 | `delete_agreement` | no | gateway-backed | needs review |
+| GET | `/{id}` | `/v1/{id}` | `icn/crates/icn-gateway/src/api/agreements.rs`:900 | `get_agreement` | no | gateway-backed | needs review |
+| GET | `/{id}/amendments` | `/v1/{id}/amendments` | `icn/crates/icn-gateway/src/api/agreements.rs`:1302 | `list_amendments` | no | gateway-backed | needs review |
+| POST | `/{id}/amendments` | `/v1/{id}/amendments` | `icn/crates/icn-gateway/src/api/agreements.rs`:1358 | `propose_amendment` | no | gateway-backed | needs review |
+| POST | `/{id}/amendments/{amendment_id}/sign` | `/v1/{id}/amendments/{amendment_id}/sign` | `icn/crates/icn-gateway/src/api/agreements.rs`:1419 | `sign_amendment` | no | gateway-backed | needs review |
+| POST | `/{id}/parties` | `/v1/{id}/parties` | `icn/crates/icn-gateway/src/api/agreements.rs`:971 | `add_party` | no | gateway-backed | needs review |
+| POST | `/{id}/propose` | `/v1/{id}/propose` | `icn/crates/icn-gateway/src/api/agreements.rs`:1092 | `propose_agreement` | no | gateway-backed | needs review |
+| POST | `/{id}/resume` | `/v1/{id}/resume` | `icn/crates/icn-gateway/src/api/agreements.rs`:1196 | `resume_agreement` | no | gateway-backed | needs review |
+| POST | `/{id}/sign` | `/v1/{id}/sign` | `icn/crates/icn-gateway/src/api/agreements.rs`:1126 | `sign_agreement` | no | gateway-backed | needs review |
+| POST | `/{id}/suspend` | `/v1/{id}/suspend` | `icn/crates/icn-gateway/src/api/agreements.rs`:1161 | `suspend_agreement` | no | gateway-backed | needs review |
+| POST | `/{id}/terminate` | `/v1/{id}/terminate` | `icn/crates/icn-gateway/src/api/agreements.rs`:1231 | `terminate_agreement` | no | gateway-backed | needs review |
+| PUT | `/{id}/terms` | `/v1/{id}/terms` | `icn/crates/icn-gateway/src/api/agreements.rs`:1033 | `set_terms` | no | gateway-backed | needs review |
+| GET | `/by-did/{did}` | `/v1/by-did/{did}` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:123 | `get_anchor_by_did` | no | gateway-backed | needs review |
+| POST | `/devices/add` | `/v1/devices/add` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:332 | `add_device` | no | gateway-backed | needs review |
+| POST | `/rotate-keys` | `/v1/rotate-keys` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:271 | `rotate_keys` | no | gateway-backed | needs review |
+| GET | `/{anchor_id}` | `/v1/{anchor_id}` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:107 | `get_anchor_by_id` | no | gateway-backed | needs review |
+| GET | `/{anchor_id}` | `/v1/{anchor_id}` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:246 | `get_anchor` | no | gateway-backed | needs review |
+| GET | `/{anchor_id}/attestations` | `/v1/{anchor_id}/attestations` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:146 | `list_attestations` | no | gateway-backed | needs review |
+| POST | `/{anchor_id}/attestations` | `/v1/{anchor_id}/attestations` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:168 | `add_attestation` | no | gateway-backed | needs review |
+| GET | `/{anchor_id}/devices` | `/v1/{anchor_id}/devices` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:368 | `list_devices` | no | gateway-backed | needs review |
+| GET | `/{anchor_id}/history` | `/v1/{anchor_id}/history` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:311 | `get_rotation_history` | no | gateway-backed | needs review |
+| PUT | `/{anchor_id}/status` | `/v1/{anchor_id}/status` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:280 | `update_anchor_status` | no | gateway-backed | needs review |
+| GET | `/appeals/dashboard` | `/v1/appeals/dashboard` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:233 | `get_appeals_dashboard` | no | gateway-backed | needs review |
+| POST | `/appeals/{id}/assign-reviewer` | `/v1/appeals/{id}/assign-reviewer` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:174 | `assign_reviewer` | no | gateway-backed | needs review |
+| GET | `/appeals/{id}/status` | `/v1/appeals/{id}/status` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:141 | `get_appeal_status` | no | gateway-backed | needs review |
+| GET | `/appeals/{id}/timeline` | `/v1/appeals/{id}/timeline` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:107 | `get_appeal_timeline` | no | gateway-backed | needs review |
+| POST | `/auth/challenge` | `/v1/auth/challenge` | `icn/crates/icn-gateway/src/api/auth.rs`:38 | `challenge` | no | gateway-backed | needs review |
+| POST | `/auth/verify` | `/v1/auth/verify` | `icn/crates/icn-gateway/src/api/auth.rs`:68 | `verify` | no | gateway-backed | needs review |
+| GET | `/budgets` | `/v1/budgets` | `icn/crates/icn-gateway/src/api/budgets.rs`:87 | `list_budgets` | no | gateway-backed | needs review |
+| POST | `/budgets` | `/v1/budgets` | `icn/crates/icn-gateway/src/api/budgets.rs`:35 | `create_budget` | no | gateway-backed | needs review |
+| DELETE | `/budgets/{id}` | `/v1/budgets/{id}` | `icn/crates/icn-gateway/src/api/budgets.rs`:212 | `delete_budget` | no | gateway-backed | needs review |
+| GET | `/budgets/{id}` | `/v1/budgets/{id}` | `icn/crates/icn-gateway/src/api/budgets.rs`:127 | `get_budget` | no | gateway-backed | needs review |
+| PUT | `/budgets/{id}` | `/v1/budgets/{id}` | `icn/crates/icn-gateway/src/api/budgets.rs`:161 | `update_budget` | no | gateway-backed | needs review |
+| GET | `(empty)` | `/v1/charter` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:241 | `list_charters` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1/charter` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:162 | `create_charter` | no | gateway-backed | needs review |
+| GET | `/by-domain/{domain_id}` | `/v1/charter/by-domain/{domain_id}` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:225 | `get_charter_by_domain` | no | gateway-backed | needs review |
+| GET | `/{charter_id}` | `/v1/charter/{charter_id}` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:209 | `get_charter` | no | gateway-backed | needs review |
+| POST | `/{charter_id}/activate` | `/v1/charter/{charter_id}/activate` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:308 | `activate_charter` | no | gateway-backed | needs review |
+| GET | `/{charter_id}/founders` | `/v1/charter/{charter_id}/founders` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:478 | `get_charter_founders` | no | gateway-backed | needs review |
+| POST | `/{charter_id}/sign` | `/v1/charter/{charter_id}/sign` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:267 | `sign_charter` | no | gateway-backed | needs review |
+| PUT | `/{charter_id}/status` | `/v1/charter/{charter_id}/status` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:346 | `update_charter_status` | no | gateway-backed | needs review |
+| GET | `/{charter_id}/summary` | `/v1/charter/{charter_id}/summary` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:462 | `get_charter_summary` | no | gateway-backed | needs review |
+| GET | `/{charter_id}/timeline` | `/v1/charter/{charter_id}/timeline` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:517 | `get_charter_timeline` | no | gateway-backed | needs review |
+| POST | `/dev/bootstrap-standing` | `/v1/commons/dev/bootstrap-standing` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:429 | `dev_bootstrap_standing` | no | gateway-backed | needs review |
+| GET | `/holder/id/{holder_id}` | `/v1/commons/holder/id/{holder_id}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:180 | `get_holder_by_id` | no | gateway-backed | needs review |
+| GET | `/holder/{did}` | `/v1/commons/holder/{did}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:154 | `get_holder_by_did` | no | gateway-backed | needs review |
+| GET | `/holder/{did}/affiliations` | `/v1/commons/holder/{did}/affiliations` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:226 | `list_affiliations` | no | gateway-backed | needs review |
+| POST | `/holder/{did}/affiliations` | `/v1/commons/holder/{did}/affiliations` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:261 | `join_jurisdiction` | no | gateway-backed | needs review |
+| DELETE | `/holder/{did}/affiliations/{jurisdiction}` | `/v1/commons/holder/{did}/affiliations/{jurisdiction}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:342 | `leave_jurisdiction` | no | gateway-backed | needs review |
+| PUT | `/holder/{did}/affiliations/{jurisdiction}` | `/v1/commons/holder/{did}/affiliations/{jurisdiction}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:303 | `update_affiliation` | no | gateway-backed | needs review |
+| GET | `/status` | `/v1/commons/status` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:116 | `get_commons_status` | no | gateway-backed | needs review |
+| GET | `(empty)` | `/v1/gov` | `icn/crates/icn-gateway/src/api/communities.rs`:137 | `list_communities` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1/gov` | `icn/crates/icn-gateway/src/api/communities.rs`:99 | `create_community` | no | gateway-backed | needs review |
+| DELETE | `/{id}` | `/v1/gov/{id}` | `icn/crates/icn-gateway/src/api/communities.rs`:196 | `dissolve_community` | no | gateway-backed | needs review |
+| GET | `/{id}` | `/v1/gov/{id}` | `icn/crates/icn-gateway/src/api/communities.rs`:150 | `get_community` | no | gateway-backed | needs review |
+| PUT | `/{id}` | `/v1/gov/{id}` | `icn/crates/icn-gateway/src/api/communities.rs`:164 | `update_community` | no | gateway-backed | needs review |
+| POST | `/{id}/activate` | `/v1/gov/{id}/activate` | `icn/crates/icn-gateway/src/api/communities.rs`:182 | `activate_community` | no | gateway-backed | needs review |
+| GET | `/{id}/members` | `/v1/gov/{id}/members` | `icn/crates/icn-gateway/src/api/communities.rs`:283 | `list_members` | no | gateway-backed | needs review |
+| POST | `/{id}/members` | `/v1/gov/{id}/members` | `icn/crates/icn-gateway/src/api/communities.rs`:215 | `join_community` | no | gateway-backed | needs review |
+| DELETE | `/{id}/members/{member_id}` | `/v1/gov/{id}/members/{member_id}` | `icn/crates/icn-gateway/src/api/communities.rs`:253 | `leave_community` | no | gateway-backed | needs review |
+| GET | `/{id}/resources` | `/v1/gov/{id}/resources` | `icn/crates/icn-gateway/src/api/communities.rs`:320 | `get_resource_pools` | no | gateway-backed | needs review |
+| POST | `/{id}/resources` | `/v1/gov/{id}/resources` | `icn/crates/icn-gateway/src/api/communities.rs`:297 | `allocate_resource` | no | gateway-backed | needs review |
+| POST | `/cancel/{task_hash}` | `/v1/compute/cancel/{task_hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:310 | `cancel_task` | no | gateway-backed | needs review |
+| GET | `/settlement/receipt/{hash}` | `/v1/compute/settlement/receipt/{hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:586 | `query_settlement_by_receipt` | no | gateway-backed | needs review |
+| GET | `/settlement/{task_id}` | `/v1/compute/settlement/{task_id}` | `icn/crates/icn-gateway/src/api/compute.rs`:565 | `query_settlement` | no | gateway-backed | needs review |
+| GET | `/status/{task_hash}` | `/v1/compute/status/{task_hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:263 | `get_status` | no | gateway-backed | needs review |
+| POST | `/submit` | `/v1/compute/submit` | `icn/crates/icn-gateway/src/api/compute.rs`:117 | `submit_task` | no | gateway-backed | needs review |
+| GET | `/wasm` | `/v1/compute/wasm` | `icn/crates/icn-gateway/src/api/compute.rs`:501 | `list_wasm` | no | gateway-backed | needs review |
+| POST | `/wasm/upload` | `/v1/compute/wasm/upload` | `icn/crates/icn-gateway/src/api/compute.rs`:442 | `upload_wasm` | no | gateway-backed | needs review |
+| GET | `/wasm/{hash}` | `/v1/compute/wasm/{hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:527 | `get_wasm_metadata` | no | gateway-backed | needs review |
+| GET | `/amendments` | `/v1/constitutional/amendments` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:690 | `list_amendments` | no | gateway-backed | needs review |
+| POST | `/amendments` | `/v1/constitutional/amendments` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:565 | `create_amendment` | no | gateway-backed | needs review |
+| GET | `/amendments/{id}` | `/v1/constitutional/amendments/{id}` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:731 | `get_amendment` | no | gateway-backed | needs review |
+| POST | `/amendments/{id}/changes` | `/v1/constitutional/amendments/{id}/changes` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:875 | `add_amendment_change` | no | gateway-backed | needs review |
+| POST | `/amendments/{id}/ratify` | `/v1/constitutional/amendments/{id}/ratify` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:827 | `ratify_amendment` | no | gateway-backed | needs review |
+| POST | `/amendments/{id}/submit` | `/v1/constitutional/amendments/{id}/submit` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:759 | `submit_amendment` | no | gateway-backed | needs review |
+| POST | `/amendments/{id}/vote` | `/v1/constitutional/amendments/{id}/vote` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:793 | `open_amendment_voting` | no | gateway-backed | needs review |
+| POST | `/amendments/{id}/withdraw` | `/v1/constitutional/amendments/{id}/withdraw` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:931 | `withdraw_amendment` | no | gateway-backed | needs review |
+| GET | `/appeals` | `/v1/constitutional/appeals` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1069 | `list_appeals` | no | gateway-backed | needs review |
+| POST | `/appeals` | `/v1/constitutional/appeals` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:976 | `file_appeal` | no | gateway-backed | needs review |
+| GET | `/appeals/{id}` | `/v1/constitutional/appeals/{id}` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1108 | `get_appeal` | no | gateway-backed | needs review |
+| POST | `/appeals/{id}/evidence` | `/v1/constitutional/appeals/{id}/evidence` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1136 | `add_appeal_evidence` | no | gateway-backed | needs review |
+| POST | `/appeals/{id}/resolve` | `/v1/constitutional/appeals/{id}/resolve` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1282 | `resolve_appeal` | no | gateway-backed | needs review |
+| POST | `/appeals/{id}/respond` | `/v1/constitutional/appeals/{id}/respond` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1210 | `add_appeal_response` | no | gateway-backed | needs review |
+| POST | `/appeals/{id}/review` | `/v1/constitutional/appeals/{id}/review` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1255 | `begin_appeal_review` | no | gateway-backed | needs review |
+| POST | `/appeals/{id}/withdraw` | `/v1/constitutional/appeals/{id}/withdraw` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1317 | `withdraw_appeal` | no | gateway-backed | needs review |
+| GET | `(empty)` | `/v1/contracts` | `icn/crates/icn-gateway/src/api/contracts.rs`:406 | `list_contracts` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1/contracts` | `icn/crates/icn-gateway/src/api/contracts.rs`:346 | `deploy_contract` | no | gateway-backed | needs review |
+| GET | `/name/{name}/versions` | `/v1/contracts/name/{name}/versions` | `icn/crates/icn-gateway/src/api/contracts.rs`:717 | `get_version_history` | no | gateway-backed | needs review |
+| DELETE | `/{hash}` | `/v1/contracts/{hash}` | `icn/crates/icn-gateway/src/api/contracts.rs`:561 | `revoke_contract` | no | gateway-backed | needs review |
+| GET | `/{hash}` | `/v1/contracts/{hash}` | `icn/crates/icn-gateway/src/api/contracts.rs`:450 | `get_contract` | no | gateway-backed | needs review |
+| POST | `/{hash}/deprecate` | `/v1/contracts/{hash}/deprecate` | `icn/crates/icn-gateway/src/api/contracts.rs`:636 | `deprecate_contract` | no | gateway-backed | needs review |
+| GET | `/{hash}/metadata` | `/v1/contracts/{hash}/metadata` | `icn/crates/icn-gateway/src/api/contracts.rs`:608 | `get_contract_metadata` | no | gateway-backed | needs review |
+| GET | `/{hash}/status` | `/v1/contracts/{hash}/status` | `icn/crates/icn-gateway/src/api/contracts.rs`:689 | `get_contract_status` | no | gateway-backed | needs review |
+| GET | `/{hash}/summary` | `/v1/contracts/{hash}/summary` | `icn/crates/icn-gateway/src/api/contracts.rs`:496 | `get_contract_summary` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1/members` | `icn/crates/icn-gateway/src/api/coops.rs`:37 | `create_coop` | no | gateway-backed | needs review |
+| GET | `/coops/{id}/stats` | `/v1/members/coops/{id}/stats` | `icn/crates/icn-gateway/src/api/coops.rs`:337 | `get_coop_stats` | no | gateway-backed | needs review |
+| DELETE | `/{id}` | `/v1/members/{id}` | `icn/crates/icn-gateway/src/api/coops.rs`:143 | `delete_coop` | no | gateway-backed | needs review |
+| GET | `/{id}` | `/v1/members/{id}` | `icn/crates/icn-gateway/src/api/coops.rs`:74 | `get_coop` | no | gateway-backed | needs review |
+| POST | `/{id}/members` | `/v1/members/{id}/members` | `icn/crates/icn-gateway/src/api/coops.rs`:174 | `add_member` | no | gateway-backed | needs review |
+| DELETE | `/{id}/members/{did}` | `/v1/members/{id}/members/{did}` | `icn/crates/icn-gateway/src/api/coops.rs`:230 | `remove_member` | no | gateway-backed | needs review |
+| PUT | `/{id}/members/{did}/role` | `/v1/members/{id}/members/{did}/role` | `icn/crates/icn-gateway/src/api/coops.rs`:268 | `update_member_role` | no | gateway-backed | needs review |
+| PUT | `/{id}/settings` | `/v1/members/{id}/settings` | `icn/crates/icn-gateway/src/api/coops.rs`:89 | `update_settings` | no | gateway-backed | needs review |
+| GET | `/{did}` | `/v1/devices/{did}` | `icn/crates/icn-gateway/src/api/devices.rs`:134 | `list_devices` | no | gateway-backed | needs review |
+| POST | `/{did}` | `/v1/devices/{did}` | `icn/crates/icn-gateway/src/api/devices.rs`:77 | `register_device` | no | gateway-backed | needs review |
+| DELETE | `/{did}/{device_id}` | `/v1/devices/{did}/{device_id}` | `icn/crates/icn-gateway/src/api/devices.rs`:174 | `revoke_device` | no | gateway-backed | needs review |
+| GET | `/{did}/{device_id}` | `/v1/devices/{did}/{device_id}` | `icn/crates/icn-gateway/src/api/devices.rs`:222 | `get_device` | no | gateway-backed | needs review |
+| POST | `/start` | `/v1/start` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:258 | `start_enrollment` | no | gateway-backed | needs review |
+| GET | `/{ceremony_id}` | `/v1/{ceremony_id}` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:294 | `get_enrollment_status` | no | gateway-backed | needs review |
+| POST | `/{ceremony_id}/approve` | `/v1/{ceremony_id}/approve` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:368 | `approve_ceremony` | no | gateway-backed | needs review |
+| POST | `/{ceremony_id}/finalize` | `/v1/{ceremony_id}/finalize` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:318 | `finalize_enrollment` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1/entities` | `icn/crates/icn-gateway/src/api/entity.rs`:289 | `register_entity` | no | gateway-backed | needs review |
+| POST | `/audit/prune` | `/v1/entities/audit/prune` | `icn/crates/icn-gateway/src/api/entity.rs`:1739 | `prune_audit` | no | gateway-backed | needs review |
+| GET | `/audit/stats` | `/v1/entities/audit/stats` | `icn/crates/icn-gateway/src/api/entity.rs`:1829 | `audit_stats` | no | gateway-backed | needs review |
+| DELETE | `/{id}` | `/v1/entities/{id}` | `icn/crates/icn-gateway/src/api/entity.rs`:632 | `delete_entity` | no | gateway-backed | needs review |
+| GET | `/{id}` | `/v1/entities/{id}` | `icn/crates/icn-gateway/src/api/entity.rs`:482 | `get_entity` | no | gateway-backed | needs review |
+| PUT | `/{id}` | `/v1/entities/{id}` | `icn/crates/icn-gateway/src/api/entity.rs`:513 | `update_entity` | no | gateway-backed | needs review |
+| GET | `/{id}/audit` | `/v1/entities/{id}/audit` | `icn/crates/icn-gateway/src/api/entity.rs`:1667 | `get_entity_audit` | no | gateway-backed | needs review |
+| DELETE | `/{id}/dissolution` | `/v1/entities/{id}/dissolution` | `icn/crates/icn-gateway/src/api/entity.rs`:1521 | `cancel_dissolution` | no | gateway-backed | needs review |
+| POST | `/{id}/dissolution` | `/v1/entities/{id}/dissolution` | `icn/crates/icn-gateway/src/api/entity.rs`:1129 | `initiate_dissolution` | no | gateway-backed | needs review |
+| POST | `/{id}/dissolution/complete` | `/v1/entities/{id}/dissolution/complete` | `icn/crates/icn-gateway/src/api/entity.rs`:1335 | `complete_dissolution` | no | gateway-backed | needs review |
+| GET | `/{id}/members` | `/v1/entities/{id}/members` | `icn/crates/icn-gateway/src/api/entity.rs`:720 | `list_members` | no | gateway-backed | needs review |
+| POST | `/{id}/members` | `/v1/entities/{id}/members` | `icn/crates/icn-gateway/src/api/entity.rs`:832 | `add_membership` | no | gateway-backed | needs review |
+| DELETE | `/{id}/members/{member_id}` | `/v1/entities/{id}/members/{member_id}` | `icn/crates/icn-gateway/src/api/entity.rs`:971 | `remove_membership` | no | gateway-backed | needs review |
+| GET | `/escrow` | `/v1/escrow` | `icn/crates/icn-gateway/src/api/escrow.rs`:86 | `list_escrows` | no | gateway-backed | needs review |
+| POST | `/escrow` | `/v1/escrow` | `icn/crates/icn-gateway/src/api/escrow.rs`:39 | `create_escrow` | no | gateway-backed | needs review |
+| GET | `/escrow/{id}` | `/v1/escrow/{id}` | `icn/crates/icn-gateway/src/api/escrow.rs`:127 | `get_escrow` | no | gateway-backed | needs review |
+| POST | `/escrow/{id}/refund` | `/v1/escrow/{id}/refund` | `icn/crates/icn-gateway/src/api/escrow.rs`:275 | `refund_escrow` | no | gateway-backed | needs review |
+| POST | `/escrow/{id}/release` | `/v1/escrow/{id}/release` | `icn/crates/icn-gateway/src/api/escrow.rs`:156 | `release_escrow` | no | gateway-backed | needs review |
+| GET | `/records` | `/v1/execution/records` | `icn/crates/icn-gateway/src/api/execution.rs`:119 | `list_records` | no | gateway-backed | needs review |
+| GET | `/records/{decision_hash}` | `/v1/execution/records/{decision_hash}` | `icn/crates/icn-gateway/src/api/execution.rs`:137 | `get_record` | no | gateway-backed | needs review |
+| POST | `/attestations` | `/v1/federation/attestations` | `icn/crates/icn-gateway/src/api/federation.rs`:719 | `issue_attestation` | no | gateway-backed | needs review |
+| GET | `/attestations/{member_did}` | `/v1/federation/attestations/{member_did}` | `icn/crates/icn-gateway/src/api/federation.rs`:701 | `get_attestations` | no | gateway-backed | needs review |
+| GET | `/clearing` | `/v1/federation/clearing` | `icn/crates/icn-gateway/src/api/federation.rs`:790 | `list_agreements` | no | gateway-backed | needs review |
+| POST | `/clearing` | `/v1/federation/clearing` | `icn/crates/icn-gateway/src/api/federation.rs`:894 | `create_agreement` | no | gateway-backed | needs review |
+| POST | `/clearing/netting/{unit}` | `/v1/federation/clearing/netting/{unit}` | `icn/crates/icn-gateway/src/api/federation.rs`:1140 | `perform_multilateral_netting` | no | gateway-backed | needs review |
+| POST | `/clearing/netting/{unit}/apply` | `/v1/federation/clearing/netting/{unit}/apply` | `icn/crates/icn-gateway/src/api/federation.rs`:1176 | `apply_multilateral_netting` | no | gateway-backed | needs review |
+| POST | `/clearing/settle-scheduled` | `/v1/federation/clearing/settle-scheduled` | `icn/crates/icn-gateway/src/api/federation.rs`:1105 | `process_scheduled_settlements` | no | gateway-backed | needs review |
+| GET | `/clearing/{agreement_id}` | `/v1/federation/clearing/{agreement_id}` | `icn/crates/icn-gateway/src/api/federation.rs`:841 | `get_agreement` | no | gateway-backed | needs review |
+| GET | `/clearing/{agreement_id}/position` | `/v1/federation/clearing/{agreement_id}/position` | `icn/crates/icn-gateway/src/api/federation.rs`:1030 | `get_position` | no | gateway-backed | needs review |
+| POST | `/clearing/{agreement_id}/settle` | `/v1/federation/clearing/{agreement_id}/settle` | `icn/crates/icn-gateway/src/api/federation.rs`:1079 | `trigger_settlement` | no | gateway-backed | needs review |
+| POST | `/clearing/{id}/propose-adoption` | `/v1/federation/clearing/{id}/propose-adoption` | `icn/crates/icn-gateway/src/api/federation.rs`:972 | `propose_clearing_adoption` | yes | gateway-backed | needs review |
+| POST | `/connect` | `/v1/federation/connect` | `icn/crates/icn-gateway/src/api/federation.rs`:1210 | `federation_connect` | no | gateway-backed | needs review |
+| GET | `/coops` | `/v1/federation/coops` | `icn/crates/icn-gateway/src/api/federation.rs`:255 | `list_coops` | no | gateway-backed | needs review |
+| POST | `/coops` | `/v1/federation/coops` | `icn/crates/icn-gateway/src/api/federation.rs`:337 | `register_coop` | no | gateway-backed | needs review |
+| GET | `/coops/{coop_id}` | `/v1/federation/coops/{coop_id}` | `icn/crates/icn-gateway/src/api/federation.rs`:295 | `get_coop` | no | gateway-backed | needs review |
+| POST | `/coops/{coop_id}/vouch` | `/v1/federation/coops/{coop_id}/vouch` | `icn/crates/icn-gateway/src/api/federation.rs`:415 | `vouch_for_coop` | no | gateway-backed | needs review |
+| GET | `/coops/{coop_id}/vouches` | `/v1/federation/coops/{coop_id}/vouches` | `icn/crates/icn-gateway/src/api/federation.rs`:381 | `get_vouches` | no | gateway-backed | needs review |
+| POST | `/init` | `/v1/federation/init` | `icn/crates/icn-gateway/src/api/federation.rs`:208 | `init_federation` | no | gateway-backed | needs review |
+| GET | `/status` | `/v1/federation/status` | `icn/crates/icn-gateway/src/api/federation.rs`:166 | `get_status` | no | gateway-backed | needs review |
+| GET | `/topology` | `/v1/federation/topology` | `icn/crates/icn-gateway/src/api/federation.rs`:562 | `get_topology` | yes | gateway-backed | needs review |
+| POST | `/{coop_id}/proposals` | `/v1/coops/{coop_id}/proposals` | `icn/crates/icn-gateway/src/api/flow_c.rs`:22 | `propose_spend_alias` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/treasury/position` | `/v1/coops/{coop_id}/treasury/position` | `icn/crates/icn-gateway/src/api/flow_c.rs`:35 | `get_treasury_position_alias` | no | gateway-backed | needs review |
+| GET | `/{id}/proof` | `/v1/coops/{id}/proof` | `icn/crates/icn-gateway/src/api/flow_c.rs`:112 | `get_proof_alias` | no | gateway-backed | needs review |
+| POST | `/{id}/vote` | `/v1/coops/{id}/vote` | `icn/crates/icn-gateway/src/api/flow_c.rs`:46 | `cast_vote_alias` | no | gateway-backed | needs review |
+| GET | `/governance/{charter_id}/dashboard` | `/v1/gov/governance/{charter_id}/dashboard` | `icn/crates/icn-gateway/src/api/governance_dashboard.rs`:21 | `get_governance_dashboard` | no | gateway-backed | needs review |
+| GET | `/health` | `/v1/health` | `icn/crates/icn-gateway/src/api/health.rs`:169 | `health` | no | gateway-backed | needs review |
+| GET | `/health/detailed` | `/v1/health/detailed` | `icn/crates/icn-gateway/src/api/health.rs`:182 | `health_detailed` | no | gateway-backed | needs review |
+| GET | `/health/full` | `/v1/health/full` | `icn/crates/icn-gateway/src/api/health.rs`:284 | `health_full` | no | gateway-backed | needs review |
+| GET | `/healthz` | `/v1/healthz` | `icn/crates/icn-gateway/src/api/health.rs`:36 | `liveness` | no | gateway-backed | needs review |
+| GET | `/ready` | `/v1/ready` | `icn/crates/icn-gateway/src/api/health.rs`:100 | `ready` | no | gateway-backed | needs review |
+| GET | `/readyz` | `/v1/readyz` | `icn/crates/icn-gateway/src/api/health.rs`:48 | `readiness` | no | gateway-backed | needs review |
+| GET | `/health` | `/v1/identity/health` | `icn/crates/icn-gateway/src/api/identity.rs`:100 | `identity_health` | no | gateway-backed | needs review |
+| GET | `/resolve/{did}` | `/v1/identity/resolve/{did}` | `icn/crates/icn-gateway/src/api/identity.rs`:60 | `resolve_did` | no | gateway-backed | needs review |
+| GET | `(empty)` | `/v1/invites` | `icn/crates/icn-gateway/src/api/invites.rs`:101 | `list_invites` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1/invites` | `icn/crates/icn-gateway/src/api/invites.rs`:25 | `create_invite` | no | gateway-backed | needs review |
+| POST | `/join` | `/v1/invites/join` | `icn/crates/icn-gateway/src/api/invites.rs`:146 | `join_via_invite` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/entries/by-decision` | `/v1/ledger/{coop_id}/entries/by-decision` | `icn/crates/icn-gateway/src/api/ledger.rs`:389 | `get_entries_by_decision` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/history` | `/v1/ledger/{coop_id}/history` | `icn/crates/icn-gateway/src/api/ledger.rs`:237 | `get_history` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/position/{did}` | `/v1/ledger/{coop_id}/position/{did}` | `icn/crates/icn-gateway/src/api/ledger.rs`:22 | `get_position` | no | gateway-backed | needs review |
+| POST | `/{coop_id}/settle` | `/v1/ledger/{coop_id}/settle` | `icn/crates/icn-gateway/src/api/ledger.rs`:55 | `create_settlement` | no | gateway-backed | needs review |
+| POST | `/{coop_id}/settle/convert` | `/v1/ledger/{coop_id}/settle/convert` | `icn/crates/icn-gateway/src/api/ledger.rs`:546 | `create_cross_settlement` | no | gateway-backed | needs review |
+| POST | `/{coop_id}/settle/convert/quote` | `/v1/ledger/{coop_id}/settle/convert/quote` | `icn/crates/icn-gateway/src/api/ledger.rs`:657 | `get_cross_settlement_quote` | no | gateway-backed | needs review |
+| GET | `(empty)` | `/v1/listings` | `icn/crates/icn-gateway/src/api/listings.rs`:637 | `list_listings` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1/listings` | `icn/crates/icn-gateway/src/api/listings.rs`:576 | `create_listing` | no | gateway-backed | needs review |
+| GET | `/my` | `/v1/listings/my` | `icn/crates/icn-gateway/src/api/listings.rs`:1013 | `get_my_listings` | no | gateway-backed | needs review |
+| DELETE | `/{id}` | `/v1/listings/{id}` | `icn/crates/icn-gateway/src/api/listings.rs`:786 | `delete_listing` | no | gateway-backed | needs review |
+| GET | `/{id}` | `/v1/listings/{id}` | `icn/crates/icn-gateway/src/api/listings.rs`:681 | `get_listing` | no | gateway-backed | needs review |
+| PUT | `/{id}` | `/v1/listings/{id}` | `icn/crates/icn-gateway/src/api/listings.rs`:715 | `update_listing` | no | gateway-backed | needs review |
+| POST | `/{id}/interest` | `/v1/listings/{id}/interest` | `icn/crates/icn-gateway/src/api/listings.rs`:895 | `express_interest` | no | gateway-backed | needs review |
+| GET | `/{id}/interests` | `/v1/listings/{id}/interests` | `icn/crates/icn-gateway/src/api/listings.rs`:973 | `get_interests` | no | gateway-backed | needs review |
+| PUT | `/{id}/status` | `/v1/listings/{id}/status` | `icn/crates/icn-gateway/src/api/listings.rs`:830 | `update_listing_status` | no | gateway-backed | needs review |
+| GET | `/members/{coop_id}/{did}` | `/v1/identity/members/{coop_id}/{did}` | `icn/crates/icn-gateway/src/api/members.rs`:40 | `get_member_profile` | no | gateway-backed | needs review |
+| PUT | `/{coop_id}/{did}/profile` | `/v1/identity/{coop_id}/{did}/profile` | `icn/crates/icn-gateway/src/api/members.rs`:130 | `update_member_profile` | no | gateway-backed | needs review |
+| POST | `/apply` | `/v1/membership/apply` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:136 | `apply_for_membership` | no | gateway-backed | needs review |
+| POST | `/approve` | `/v1/membership/approve` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:225 | `approve_membership` | no | gateway-backed | needs review |
+| POST | `/ban` | `/v1/membership/ban` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:345 | `ban_member` | no | gateway-backed | needs review |
+| GET | `/capability/check` | `/v1/membership/capability/check` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:506 | `check_capability` | no | gateway-backed | needs review |
+| POST | `/capability/grant` | `/v1/membership/capability/grant` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:440 | `grant_capability` | no | gateway-backed | needs review |
+| POST | `/capability/revoke` | `/v1/membership/capability/revoke` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:473 | `revoke_capability` | no | gateway-backed | needs review |
+| POST | `/exit` | `/v1/membership/exit` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:703 | `exit_membership` | no | gateway-backed | needs review |
+| GET | `/list/{jurisdiction}` | `/v1/membership/list/{jurisdiction}` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:611 | `list_members` | no | gateway-backed | needs review |
+| POST | `/promote` | `/v1/membership/promote` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:255 | `promote_member` | no | gateway-backed | needs review |
+| POST | `/reinstate` | `/v1/membership/reinstate` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:315 | `reinstate_member` | no | gateway-backed | needs review |
+| POST | `/revoke` | `/v1/membership/revoke` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:387 | `revoke_membership` | no | gateway-backed | needs review |
+| POST | `/role/add` | `/v1/membership/role/add` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:536 | `add_role` | no | gateway-backed | needs review |
+| POST | `/role/remove` | `/v1/membership/role/remove` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:566 | `remove_role` | no | gateway-backed | needs review |
+| GET | `/status/{jurisdiction}` | `/v1/membership/status/{jurisdiction}` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:180 | `get_membership_status` | no | gateway-backed | needs review |
+| POST | `/suspend` | `/v1/membership/suspend` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:285 | `suspend_member` | no | gateway-backed | needs review |
+| GET | `/{path:.*}` | `/v1/names/{path:.*}` | `icn/crates/icn-gateway/src/api/names.rs`:138 | `resolve_name` | no | gateway-backed | needs review |
+| GET | `/notifications` | `/v1/notifications/notifications` | `icn/crates/icn-gateway/src/api/notifications.rs`:118 | `list_notifications` | no | gateway-backed | needs review |
+| GET | `/notifications/count` | `/v1/notifications/notifications/count` | `icn/crates/icn-gateway/src/api/notifications.rs`:154 | `get_notification_count` | no | gateway-backed | needs review |
+| POST | `/notifications/read-all` | `/v1/notifications/notifications/read-all` | `icn/crates/icn-gateway/src/api/notifications.rs`:196 | `mark_all_read` | no | gateway-backed | needs review |
+| POST | `/notifications/register` | `/v1/notifications/notifications/register` | `icn/crates/icn-gateway/src/api/notifications.rs`:36 | `register_device` | no | gateway-backed | needs review |
+| DELETE | `/notifications/unregister` | `/v1/notifications/notifications/unregister` | `icn/crates/icn-gateway/src/api/notifications.rs`:57 | `unregister_device` | no | gateway-backed | needs review |
+| DELETE | `/notifications/{notification_id}` | `/v1/notifications/notifications/{notification_id}` | `icn/crates/icn-gateway/src/api/notifications.rs`:213 | `delete_notification` | no | gateway-backed | needs review |
+| POST | `/notifications/{notification_id}/read` | `/v1/notifications/notifications/{notification_id}/read` | `icn/crates/icn-gateway/src/api/notifications.rs`:171 | `mark_notification_read` | no | gateway-backed | needs review |
+| GET | `/notifications/{notification_id}/status` | `/v1/notifications/notifications/{notification_id}/status` | `icn/crates/icn-gateway/src/api/notifications.rs`:241 | `get_delivery_status` | no | gateway-backed | needs review |
+| POST | `/convert` | `/v1/convert` | `icn/crates/icn-gateway/src/api/oracle.rs`:280 | `convert_amount` | no | gateway-backed | needs review |
+| POST | `/rate` | `/v1/rate` | `icn/crates/icn-gateway/src/api/oracle.rs`:380 | `set_rate` | no | gateway-backed | needs review |
+| GET | `/rate/{from}/{to}` | `/v1/rate/{from}/{to}` | `icn/crates/icn-gateway/src/api/oracle.rs`:213 | `get_rate` | no | gateway-backed | needs review |
+| GET | `/sources` | `/v1/sources` | `icn/crates/icn-gateway/src/api/oracle.rs`:355 | `list_sources` | no | gateway-backed | needs review |
+| GET | `/allocations` | `/v1/receipts/allocations` | `icn/crates/icn-gateway/src/api/receipts.rs`:569 | `list_allocations` | no | gateway-backed | needs review |
+| GET | `/allocations/{hash}` | `/v1/receipts/allocations/{hash}` | `icn/crates/icn-gateway/src/api/receipts.rs`:282 | `get_allocation` | no | gateway-backed | needs review |
+| GET | `/chain` | `/v1/receipts/chain` | `icn/crates/icn-gateway/src/api/receipts.rs`:331 | `get_chain` | no | gateway-backed | needs review |
+| GET | `/chain/{decision_hash}` | `/v1/receipts/chain/{decision_hash}` | `icn/crates/icn-gateway/src/api/receipts.rs`:381 | `get_full_chain` | no | gateway-backed | needs review |
+| GET | `/intents` | `/v1/receipts/intents` | `icn/crates/icn-gateway/src/api/receipts.rs`:598 | `list_intents` | no | gateway-backed | needs review |
+| GET | `/intents/{hash}` | `/v1/receipts/intents/{hash}` | `icn/crates/icn-gateway/src/api/receipts.rs`:305 | `get_intent` | no | gateway-backed | needs review |
+| POST | `/start` | `/v1/start` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:216 | `start_recovery` | no | gateway-backed | needs review |
+| GET | `/{recovery_id}` | `/v1/{recovery_id}` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:252 | `get_recovery_status` | no | gateway-backed | needs review |
+| POST | `/{recovery_id}/approve` | `/v1/{recovery_id}/approve` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:329 | `approve_recovery` | no | gateway-backed | needs review |
+| POST | `/{recovery_id}/complete` | `/v1/{recovery_id}/complete` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:275 | `complete_recovery` | no | gateway-backed | needs review |
+| GET | `/settlements/recurring` | `/v1/settlements/recurring` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:94 | `list_recurring_settlements` | no | gateway-backed | needs review |
+| POST | `/settlements/recurring` | `/v1/settlements/recurring` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:44 | `create_recurring_settlement` | no | gateway-backed | needs review |
+| DELETE | `/settlements/recurring/{id}` | `/v1/settlements/recurring/{id}` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:214 | `cancel_recurring_settlement` | no | gateway-backed | needs review |
+| GET | `/settlements/recurring/{id}` | `/v1/settlements/recurring/{id}` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:135 | `get_recurring_settlement` | no | gateway-backed | needs review |
+| PUT | `/settlements/recurring/{id}` | `/v1/settlements/recurring/{id}` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:164 | `update_recurring_settlement` | no | gateway-backed | needs review |
+| GET | `/decisions` | `/v1/decisions` | `icn/crates/icn-gateway/src/api/registry.rs`:702 | `list_decisions` | no | gateway-backed | needs review |
+| POST | `/decisions` | `/v1/decisions` | `icn/crates/icn-gateway/src/api/registry.rs`:598 | `index_decision_endpoint` | no | gateway-backed | needs review |
+| GET | `/decisions/{id}` | `/v1/decisions/{id}` | `icn/crates/icn-gateway/src/api/registry.rs`:745 | `get_decision` | no | gateway-backed | needs review |
+| GET | `/decisions/{id}/trace` | `/v1/decisions/{id}/trace` | `icn/crates/icn-gateway/src/api/registry.rs`:781 | `get_decision_trace` | no | gateway-backed | needs review |
+| GET | `/meetings` | `/v1/meetings` | `icn/crates/icn-gateway/src/api/registry.rs`:564 | `list_meetings` | no | gateway-backed | needs review |
+| POST | `/meetings` | `/v1/meetings` | `icn/crates/icn-gateway/src/api/registry.rs`:491 | `create_meeting` | no | gateway-backed | needs review |
+| GET | `/summary` | `/v1/rights/summary` | `icn/crates/icn-gateway/src/api/rights.rs`:12 | `rights_summary` | no | gateway-backed | needs review |
+| POST | `/ephemeral/generate` | `/v1/ephemeral/generate` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:301 | `generate_ephemeral` | no | gateway-backed | needs review |
+| GET | `/health` | `/v1/health` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:175 | `sdis_health` | no | gateway-backed | needs review |
+| POST | `/verify/level1` | `/v1/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:189 | `verify_level1` | no | gateway-backed | needs review |
+| POST | `/verify/level2` | `/v1/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:209 | `verify_level2` | no | gateway-backed | needs review |
+| GET | `(empty)` | `/v1` | `icn/crates/icn-gateway/src/api/services.rs`:494 | `query_services` | no | gateway-backed | needs review |
+| POST | `/announce` | `/v1/announce` | `icn/crates/icn-gateway/src/api/services.rs`:238 | `announce_service` | no | gateway-backed | needs review |
+| GET | `/discover` | `/v1/discover` | `icn/crates/icn-gateway/src/api/services.rs`:388 | `discover_services` | no | gateway-backed | needs review |
+| DELETE | `/{service_id}` | `/v1/{service_id}` | `icn/crates/icn-gateway/src/api/services.rs`:347 | `withdraw_service` | no | gateway-backed | needs review |
+| GET | `/{service_id}` | `/v1/{service_id}` | `icn/crates/icn-gateway/src/api/services.rs`:550 | `get_service` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1/sessions` | `icn/crates/icn-gateway/src/api/sessions.rs`:137 | `create_session` | no | gateway-backed | needs review |
+| GET | `/{session_id}` | `/v1/sessions/{session_id}` | `icn/crates/icn-gateway/src/api/sessions.rs`:184 | `get_session_status` | no | gateway-backed | needs review |
+| POST | `/{session_id}/approve` | `/v1/sessions/{session_id}/approve` | `icn/crates/icn-gateway/src/api/sessions.rs`:251 | `approve_session` | no | gateway-backed | needs review |
+| POST | `/enrollment/complete` | `/v1/enrollment/complete` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:501 | `complete_enrollment` | no | gateway-backed | needs review |
+| POST | `/enrollment/start` | `/v1/enrollment/start` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:281 | `start_enrollment` | no | gateway-backed | needs review |
+| POST | `/enrollment/verify/level1` | `/v1/enrollment/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:331 | `verify_level1` | no | gateway-backed | needs review |
+| POST | `/enrollment/verify/level2` | `/v1/enrollment/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:406 | `verify_level2` | no | gateway-backed | needs review |
+| POST | `/reject/{enrollment_id}` | `/v1/reject/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:913 | `reject_enrollment` | no | gateway-backed | needs review |
+| POST | `/vouch/{enrollment_id}` | `/v1/vouch/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:824 | `steward_vouch` | no | gateway-backed | needs review |
+| GET | `(empty)` | `/v1/steward` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:170 | `list_stewards` | no | gateway-backed | needs review |
+| POST | `(empty)` | `/v1/steward` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:72 | `register_steward` | no | gateway-backed | needs review |
+| GET | `/attesters` | `/v1/steward/attesters` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:195 | `list_attesters` | no | gateway-backed | needs review |
+| GET | `/by-did/{did}` | `/v1/steward/by-did/{did}` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:150 | `get_steward_by_did` | no | gateway-backed | needs review |
+| GET | `/{steward_id}` | `/v1/steward/{steward_id}` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:133 | `get_steward` | no | gateway-backed | needs review |
+| POST | `/{steward_id}/attestation` | `/v1/steward/{steward_id}/attestation` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:570 | `record_attestation` | no | gateway-backed | needs review |
+| POST | `/{steward_id}/bond/add` | `/v1/steward/{steward_id}/bond/add` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:432 | `add_bond` | no | gateway-backed | needs review |
+| POST | `/{steward_id}/bond/slash` | `/v1/steward/{steward_id}/bond/slash` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:484 | `slash_bond` | no | gateway-backed | needs review |
+| POST | `/{steward_id}/dispute` | `/v1/steward/{steward_id}/dispute` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:624 | `record_dispute` | no | gateway-backed | needs review |
+| POST | `/{steward_id}/dispute-won` | `/v1/steward/{steward_id}/dispute-won` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:686 | `record_dispute_won` | no | gateway-backed | needs review |
+| POST | `/{steward_id}/extend-term` | `/v1/steward/{steward_id}/extend-term` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:360 | `extend_steward_term` | no | gateway-backed | needs review |
+| POST | `/{steward_id}/retire` | `/v1/steward/{steward_id}/retire` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:319 | `retire_steward` | no | gateway-backed | needs review |
+| PUT | `/{steward_id}/status` | `/v1/steward/{steward_id}/status` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:214 | `update_steward_status` | no | gateway-backed | needs review |
+| GET | `/{coop_id}` | `/v1/treasury/{coop_id}` | `icn/crates/icn-gateway/src/api/treasury.rs`:375 | `get_treasury_status` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/audit` | `/v1/treasury/{coop_id}/audit` | `icn/crates/icn-gateway/src/api/treasury.rs`:939 | `get_audit_trail` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/budgets` | `/v1/treasury/{coop_id}/budgets` | `icn/crates/icn-gateway/src/api/treasury.rs`:576 | `list_budgets` | no | gateway-backed | needs review |
+| POST | `/{coop_id}/budgets` | `/v1/treasury/{coop_id}/budgets` | `icn/crates/icn-gateway/src/api/treasury.rs`:732 | `create_budget` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/budgets/{budget_id}` | `/v1/treasury/{coop_id}/budgets/{budget_id}` | `icn/crates/icn-gateway/src/api/treasury.rs`:646 | `get_budget` | no | gateway-backed | needs review |
+| POST | `/{coop_id}/deposit` | `/v1/treasury/{coop_id}/deposit` | `icn/crates/icn-gateway/src/api/treasury.rs`:1029 | `deposit_to_treasury` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/nonce` | `/v1/treasury/{coop_id}/nonce` | `icn/crates/icn-gateway/src/api/treasury.rs`:521 | `get_treasury_nonce` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/position` | `/v1/treasury/{coop_id}/position` | `icn/crates/icn-gateway/src/api/treasury.rs`:450 | `get_treasury_position` | no | gateway-backed | needs review |
+| POST | `/{coop_id}/spend` | `/v1/treasury/{coop_id}/spend` | `icn/crates/icn-gateway/src/api/treasury.rs`:1163 | `propose_spend` | no | gateway-backed | needs review |
+| GET | `/{coop_id}/spending-rules` | `/v1/treasury/{coop_id}/spending-rules` | `icn/crates/icn-gateway/src/api/treasury.rs`:872 | `list_spending_rules` | no | gateway-backed | needs review |
+| POST | `/trust/attest` | `/v1/trust/trust/attest` | `icn/crates/icn-gateway/src/api/trust.rs`:103 | `create_trust_attestation` | no | gateway-backed | needs review |
+| POST | `/trust/revoke` | `/v1/trust/trust/revoke` | `icn/crates/icn-gateway/src/api/trust.rs`:179 | `revoke_trust_attestation` | no | gateway-backed | needs review |
+| GET | `/trust/{did}` | `/v1/trust/trust/{did}` | `icn/crates/icn-gateway/src/api/trust.rs`:35 | `get_trust_score` | no | gateway-backed | needs review |
+| GET | `/trust/{did}/edges` | `/v1/trust/trust/{did}/edges` | `icn/crates/icn-gateway/src/api/trust.rs`:72 | `get_trust_edges` | no | gateway-backed | needs review |
+| GET | `/trust/{did}/network` | `/v1/trust/trust/{did}/network` | `icn/crates/icn-gateway/src/api/trust.rs`:143 | `get_trust_network` | no | gateway-backed | needs review |
+| GET | `/amendments/{id}/my-vote` | `/v1/amendments/{id}/my-vote` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:422 | `get_my_vote` | no | gateway-backed | needs review |
+| GET | `/amendments/{id}/results` | `/v1/amendments/{id}/results` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:317 | `get_results` | no | gateway-backed | needs review |
+| GET | `/amendments/{id}/votes` | `/v1/amendments/{id}/votes` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:288 | `list_votes` | no | gateway-backed | needs review |
+| POST | `/amendments/{id}/votes` | `/v1/amendments/{id}/votes` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:193 | `cast_vote` | no | gateway-backed | needs review |
+| GET | `/ws/{coop_id}` | `/v1/ws/{coop_id}` | `icn/crates/icn-gateway/src/api/websocket.rs`:12 | `websocket` | no | gateway-backed | needs review |
+

--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-20T12:46:59+00:00
+Generated: 2026-06-20T13:02:09+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -17,7 +17,7 @@ Generated: 2026-06-20T12:46:59+00:00
 
 ## Snapshot
 
-- Source commit: `3ac5935ba425c4d3fbdd3fb63573f93e0c8fd725`
+- Source commit: `0d0e7d656122b8e54f0bbe2433886f5b23fe23eb`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -33,301 +33,301 @@ Generated: 2026-06-20T12:46:59+00:00
 
 ## Limitations (PR1)
 
-- **Full mounted-path resolution is best-effort.** The `Group` column is inferred from a simple `web::scope("…")` ↔ `api::<module>::` association read from `server.rs`; it is **not** a real Rust parser and may be wrong for deeply-nested or conditional scopes. The relative macro `Path` and the `Source` file are authoritative.
+- **Full mounted-path resolution is best-effort.** The `Group` column is `/v1` + a `web::scope("…")` segment associated from `server.rs` `.service(...)`/`.configure(...)` registration sites (matched at identifier boundaries, keyed by the handler's top-level `icn/crates/icn-gateway/src/api/<group>` module) + the relative macro path. It is **not** a real Rust parser and may be wrong for deeply-nested or conditional scopes. The relative macro `Path` and the `Source` file are authoritative.
 - Scans **attribute macros only** in `icn-gateway/src`. `web::resource("…")`/`.route("…")` registrations and out-of-crate handlers (e.g. `icn-governance-actor::http`) are not fully captured.
 - This is **generated-map work, not API documentation completion** (issue #2112). It does not add or change any OpenAPI content or runtime behavior.
 
 ## Routes
 
-Status vocabulary is the existing set from `source-of-truth-map.md`. PR1 defaults every discovered route to `gateway-backed` (it is served by the gateway) and claim-safety to `needs review` (per-route proof level is `unknown / needs local verification` pending human review).
+Status vocabulary is the existing set from `source-of-truth-map.md`; no new labels are introduced. A static macro scan proves only that a routing macro is **declared** in source — not that the handler is mounted and served (registration happens elsewhere via `.service(...)` / `.configure(...)`, which this pass does not resolve). PR1 therefore **cannot** assert `gateway-backed`: every discovered route's status defaults to `unknown / needs local verification` and claim-safety to `needs review`, pending human or runtime confirmation.
 
 | Method | Path (macro) | Group (best-effort) | Source | Handler | OpenAPI | Status | Claim safety |
 |---|---|---|---|---|---|---|---|
-| GET | `(empty)` | `/v1` | `icn/crates/icn-gateway/src/api/agreements.rs`:789 | `list_agreements` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1` | `icn/crates/icn-gateway/src/api/agreements.rs`:855 | `create_agreement` | no | gateway-backed | needs review |
-| DELETE | `/{id}` | `/v1/{id}` | `icn/crates/icn-gateway/src/api/agreements.rs`:936 | `delete_agreement` | no | gateway-backed | needs review |
-| GET | `/{id}` | `/v1/{id}` | `icn/crates/icn-gateway/src/api/agreements.rs`:900 | `get_agreement` | no | gateway-backed | needs review |
-| GET | `/{id}/amendments` | `/v1/{id}/amendments` | `icn/crates/icn-gateway/src/api/agreements.rs`:1302 | `list_amendments` | no | gateway-backed | needs review |
-| POST | `/{id}/amendments` | `/v1/{id}/amendments` | `icn/crates/icn-gateway/src/api/agreements.rs`:1358 | `propose_amendment` | no | gateway-backed | needs review |
-| POST | `/{id}/amendments/{amendment_id}/sign` | `/v1/{id}/amendments/{amendment_id}/sign` | `icn/crates/icn-gateway/src/api/agreements.rs`:1419 | `sign_amendment` | no | gateway-backed | needs review |
-| POST | `/{id}/parties` | `/v1/{id}/parties` | `icn/crates/icn-gateway/src/api/agreements.rs`:971 | `add_party` | no | gateway-backed | needs review |
-| POST | `/{id}/propose` | `/v1/{id}/propose` | `icn/crates/icn-gateway/src/api/agreements.rs`:1092 | `propose_agreement` | no | gateway-backed | needs review |
-| POST | `/{id}/resume` | `/v1/{id}/resume` | `icn/crates/icn-gateway/src/api/agreements.rs`:1196 | `resume_agreement` | no | gateway-backed | needs review |
-| POST | `/{id}/sign` | `/v1/{id}/sign` | `icn/crates/icn-gateway/src/api/agreements.rs`:1126 | `sign_agreement` | no | gateway-backed | needs review |
-| POST | `/{id}/suspend` | `/v1/{id}/suspend` | `icn/crates/icn-gateway/src/api/agreements.rs`:1161 | `suspend_agreement` | no | gateway-backed | needs review |
-| POST | `/{id}/terminate` | `/v1/{id}/terminate` | `icn/crates/icn-gateway/src/api/agreements.rs`:1231 | `terminate_agreement` | no | gateway-backed | needs review |
-| PUT | `/{id}/terms` | `/v1/{id}/terms` | `icn/crates/icn-gateway/src/api/agreements.rs`:1033 | `set_terms` | no | gateway-backed | needs review |
-| GET | `/by-did/{did}` | `/v1/by-did/{did}` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:123 | `get_anchor_by_did` | no | gateway-backed | needs review |
-| POST | `/devices/add` | `/v1/devices/add` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:332 | `add_device` | no | gateway-backed | needs review |
-| POST | `/rotate-keys` | `/v1/rotate-keys` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:271 | `rotate_keys` | no | gateway-backed | needs review |
-| GET | `/{anchor_id}` | `/v1/{anchor_id}` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:107 | `get_anchor_by_id` | no | gateway-backed | needs review |
-| GET | `/{anchor_id}` | `/v1/{anchor_id}` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:246 | `get_anchor` | no | gateway-backed | needs review |
-| GET | `/{anchor_id}/attestations` | `/v1/{anchor_id}/attestations` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:146 | `list_attestations` | no | gateway-backed | needs review |
-| POST | `/{anchor_id}/attestations` | `/v1/{anchor_id}/attestations` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:168 | `add_attestation` | no | gateway-backed | needs review |
-| GET | `/{anchor_id}/devices` | `/v1/{anchor_id}/devices` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:368 | `list_devices` | no | gateway-backed | needs review |
-| GET | `/{anchor_id}/history` | `/v1/{anchor_id}/history` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:311 | `get_rotation_history` | no | gateway-backed | needs review |
-| PUT | `/{anchor_id}/status` | `/v1/{anchor_id}/status` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:280 | `update_anchor_status` | no | gateway-backed | needs review |
-| GET | `/appeals/dashboard` | `/v1/appeals/dashboard` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:233 | `get_appeals_dashboard` | no | gateway-backed | needs review |
-| POST | `/appeals/{id}/assign-reviewer` | `/v1/appeals/{id}/assign-reviewer` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:174 | `assign_reviewer` | no | gateway-backed | needs review |
-| GET | `/appeals/{id}/status` | `/v1/appeals/{id}/status` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:141 | `get_appeal_status` | no | gateway-backed | needs review |
-| GET | `/appeals/{id}/timeline` | `/v1/appeals/{id}/timeline` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:107 | `get_appeal_timeline` | no | gateway-backed | needs review |
-| POST | `/auth/challenge` | `/v1/auth/challenge` | `icn/crates/icn-gateway/src/api/auth.rs`:38 | `challenge` | no | gateway-backed | needs review |
-| POST | `/auth/verify` | `/v1/auth/verify` | `icn/crates/icn-gateway/src/api/auth.rs`:68 | `verify` | no | gateway-backed | needs review |
-| GET | `/budgets` | `/v1/budgets` | `icn/crates/icn-gateway/src/api/budgets.rs`:87 | `list_budgets` | no | gateway-backed | needs review |
-| POST | `/budgets` | `/v1/budgets` | `icn/crates/icn-gateway/src/api/budgets.rs`:35 | `create_budget` | no | gateway-backed | needs review |
-| DELETE | `/budgets/{id}` | `/v1/budgets/{id}` | `icn/crates/icn-gateway/src/api/budgets.rs`:212 | `delete_budget` | no | gateway-backed | needs review |
-| GET | `/budgets/{id}` | `/v1/budgets/{id}` | `icn/crates/icn-gateway/src/api/budgets.rs`:127 | `get_budget` | no | gateway-backed | needs review |
-| PUT | `/budgets/{id}` | `/v1/budgets/{id}` | `icn/crates/icn-gateway/src/api/budgets.rs`:161 | `update_budget` | no | gateway-backed | needs review |
-| GET | `(empty)` | `/v1/charter` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:241 | `list_charters` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1/charter` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:162 | `create_charter` | no | gateway-backed | needs review |
-| GET | `/by-domain/{domain_id}` | `/v1/charter/by-domain/{domain_id}` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:225 | `get_charter_by_domain` | no | gateway-backed | needs review |
-| GET | `/{charter_id}` | `/v1/charter/{charter_id}` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:209 | `get_charter` | no | gateway-backed | needs review |
-| POST | `/{charter_id}/activate` | `/v1/charter/{charter_id}/activate` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:308 | `activate_charter` | no | gateway-backed | needs review |
-| GET | `/{charter_id}/founders` | `/v1/charter/{charter_id}/founders` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:478 | `get_charter_founders` | no | gateway-backed | needs review |
-| POST | `/{charter_id}/sign` | `/v1/charter/{charter_id}/sign` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:267 | `sign_charter` | no | gateway-backed | needs review |
-| PUT | `/{charter_id}/status` | `/v1/charter/{charter_id}/status` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:346 | `update_charter_status` | no | gateway-backed | needs review |
-| GET | `/{charter_id}/summary` | `/v1/charter/{charter_id}/summary` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:462 | `get_charter_summary` | no | gateway-backed | needs review |
-| GET | `/{charter_id}/timeline` | `/v1/charter/{charter_id}/timeline` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:517 | `get_charter_timeline` | no | gateway-backed | needs review |
-| POST | `/dev/bootstrap-standing` | `/v1/commons/dev/bootstrap-standing` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:429 | `dev_bootstrap_standing` | no | gateway-backed | needs review |
-| GET | `/holder/id/{holder_id}` | `/v1/commons/holder/id/{holder_id}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:180 | `get_holder_by_id` | no | gateway-backed | needs review |
-| GET | `/holder/{did}` | `/v1/commons/holder/{did}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:154 | `get_holder_by_did` | no | gateway-backed | needs review |
-| GET | `/holder/{did}/affiliations` | `/v1/commons/holder/{did}/affiliations` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:226 | `list_affiliations` | no | gateway-backed | needs review |
-| POST | `/holder/{did}/affiliations` | `/v1/commons/holder/{did}/affiliations` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:261 | `join_jurisdiction` | no | gateway-backed | needs review |
-| DELETE | `/holder/{did}/affiliations/{jurisdiction}` | `/v1/commons/holder/{did}/affiliations/{jurisdiction}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:342 | `leave_jurisdiction` | no | gateway-backed | needs review |
-| PUT | `/holder/{did}/affiliations/{jurisdiction}` | `/v1/commons/holder/{did}/affiliations/{jurisdiction}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:303 | `update_affiliation` | no | gateway-backed | needs review |
-| GET | `/status` | `/v1/commons/status` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:116 | `get_commons_status` | no | gateway-backed | needs review |
-| GET | `(empty)` | `/v1/gov` | `icn/crates/icn-gateway/src/api/communities.rs`:137 | `list_communities` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1/gov` | `icn/crates/icn-gateway/src/api/communities.rs`:99 | `create_community` | no | gateway-backed | needs review |
-| DELETE | `/{id}` | `/v1/gov/{id}` | `icn/crates/icn-gateway/src/api/communities.rs`:196 | `dissolve_community` | no | gateway-backed | needs review |
-| GET | `/{id}` | `/v1/gov/{id}` | `icn/crates/icn-gateway/src/api/communities.rs`:150 | `get_community` | no | gateway-backed | needs review |
-| PUT | `/{id}` | `/v1/gov/{id}` | `icn/crates/icn-gateway/src/api/communities.rs`:164 | `update_community` | no | gateway-backed | needs review |
-| POST | `/{id}/activate` | `/v1/gov/{id}/activate` | `icn/crates/icn-gateway/src/api/communities.rs`:182 | `activate_community` | no | gateway-backed | needs review |
-| GET | `/{id}/members` | `/v1/gov/{id}/members` | `icn/crates/icn-gateway/src/api/communities.rs`:283 | `list_members` | no | gateway-backed | needs review |
-| POST | `/{id}/members` | `/v1/gov/{id}/members` | `icn/crates/icn-gateway/src/api/communities.rs`:215 | `join_community` | no | gateway-backed | needs review |
-| DELETE | `/{id}/members/{member_id}` | `/v1/gov/{id}/members/{member_id}` | `icn/crates/icn-gateway/src/api/communities.rs`:253 | `leave_community` | no | gateway-backed | needs review |
-| GET | `/{id}/resources` | `/v1/gov/{id}/resources` | `icn/crates/icn-gateway/src/api/communities.rs`:320 | `get_resource_pools` | no | gateway-backed | needs review |
-| POST | `/{id}/resources` | `/v1/gov/{id}/resources` | `icn/crates/icn-gateway/src/api/communities.rs`:297 | `allocate_resource` | no | gateway-backed | needs review |
-| POST | `/cancel/{task_hash}` | `/v1/compute/cancel/{task_hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:310 | `cancel_task` | no | gateway-backed | needs review |
-| GET | `/settlement/receipt/{hash}` | `/v1/compute/settlement/receipt/{hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:586 | `query_settlement_by_receipt` | no | gateway-backed | needs review |
-| GET | `/settlement/{task_id}` | `/v1/compute/settlement/{task_id}` | `icn/crates/icn-gateway/src/api/compute.rs`:565 | `query_settlement` | no | gateway-backed | needs review |
-| GET | `/status/{task_hash}` | `/v1/compute/status/{task_hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:263 | `get_status` | no | gateway-backed | needs review |
-| POST | `/submit` | `/v1/compute/submit` | `icn/crates/icn-gateway/src/api/compute.rs`:117 | `submit_task` | no | gateway-backed | needs review |
-| GET | `/wasm` | `/v1/compute/wasm` | `icn/crates/icn-gateway/src/api/compute.rs`:501 | `list_wasm` | no | gateway-backed | needs review |
-| POST | `/wasm/upload` | `/v1/compute/wasm/upload` | `icn/crates/icn-gateway/src/api/compute.rs`:442 | `upload_wasm` | no | gateway-backed | needs review |
-| GET | `/wasm/{hash}` | `/v1/compute/wasm/{hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:527 | `get_wasm_metadata` | no | gateway-backed | needs review |
-| GET | `/amendments` | `/v1/constitutional/amendments` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:690 | `list_amendments` | no | gateway-backed | needs review |
-| POST | `/amendments` | `/v1/constitutional/amendments` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:565 | `create_amendment` | no | gateway-backed | needs review |
-| GET | `/amendments/{id}` | `/v1/constitutional/amendments/{id}` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:731 | `get_amendment` | no | gateway-backed | needs review |
-| POST | `/amendments/{id}/changes` | `/v1/constitutional/amendments/{id}/changes` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:875 | `add_amendment_change` | no | gateway-backed | needs review |
-| POST | `/amendments/{id}/ratify` | `/v1/constitutional/amendments/{id}/ratify` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:827 | `ratify_amendment` | no | gateway-backed | needs review |
-| POST | `/amendments/{id}/submit` | `/v1/constitutional/amendments/{id}/submit` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:759 | `submit_amendment` | no | gateway-backed | needs review |
-| POST | `/amendments/{id}/vote` | `/v1/constitutional/amendments/{id}/vote` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:793 | `open_amendment_voting` | no | gateway-backed | needs review |
-| POST | `/amendments/{id}/withdraw` | `/v1/constitutional/amendments/{id}/withdraw` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:931 | `withdraw_amendment` | no | gateway-backed | needs review |
-| GET | `/appeals` | `/v1/constitutional/appeals` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1069 | `list_appeals` | no | gateway-backed | needs review |
-| POST | `/appeals` | `/v1/constitutional/appeals` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:976 | `file_appeal` | no | gateway-backed | needs review |
-| GET | `/appeals/{id}` | `/v1/constitutional/appeals/{id}` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1108 | `get_appeal` | no | gateway-backed | needs review |
-| POST | `/appeals/{id}/evidence` | `/v1/constitutional/appeals/{id}/evidence` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1136 | `add_appeal_evidence` | no | gateway-backed | needs review |
-| POST | `/appeals/{id}/resolve` | `/v1/constitutional/appeals/{id}/resolve` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1282 | `resolve_appeal` | no | gateway-backed | needs review |
-| POST | `/appeals/{id}/respond` | `/v1/constitutional/appeals/{id}/respond` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1210 | `add_appeal_response` | no | gateway-backed | needs review |
-| POST | `/appeals/{id}/review` | `/v1/constitutional/appeals/{id}/review` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1255 | `begin_appeal_review` | no | gateway-backed | needs review |
-| POST | `/appeals/{id}/withdraw` | `/v1/constitutional/appeals/{id}/withdraw` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1317 | `withdraw_appeal` | no | gateway-backed | needs review |
-| GET | `(empty)` | `/v1/contracts` | `icn/crates/icn-gateway/src/api/contracts.rs`:406 | `list_contracts` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1/contracts` | `icn/crates/icn-gateway/src/api/contracts.rs`:346 | `deploy_contract` | no | gateway-backed | needs review |
-| GET | `/name/{name}/versions` | `/v1/contracts/name/{name}/versions` | `icn/crates/icn-gateway/src/api/contracts.rs`:717 | `get_version_history` | no | gateway-backed | needs review |
-| DELETE | `/{hash}` | `/v1/contracts/{hash}` | `icn/crates/icn-gateway/src/api/contracts.rs`:561 | `revoke_contract` | no | gateway-backed | needs review |
-| GET | `/{hash}` | `/v1/contracts/{hash}` | `icn/crates/icn-gateway/src/api/contracts.rs`:450 | `get_contract` | no | gateway-backed | needs review |
-| POST | `/{hash}/deprecate` | `/v1/contracts/{hash}/deprecate` | `icn/crates/icn-gateway/src/api/contracts.rs`:636 | `deprecate_contract` | no | gateway-backed | needs review |
-| GET | `/{hash}/metadata` | `/v1/contracts/{hash}/metadata` | `icn/crates/icn-gateway/src/api/contracts.rs`:608 | `get_contract_metadata` | no | gateway-backed | needs review |
-| GET | `/{hash}/status` | `/v1/contracts/{hash}/status` | `icn/crates/icn-gateway/src/api/contracts.rs`:689 | `get_contract_status` | no | gateway-backed | needs review |
-| GET | `/{hash}/summary` | `/v1/contracts/{hash}/summary` | `icn/crates/icn-gateway/src/api/contracts.rs`:496 | `get_contract_summary` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1/members` | `icn/crates/icn-gateway/src/api/coops.rs`:37 | `create_coop` | no | gateway-backed | needs review |
-| GET | `/coops/{id}/stats` | `/v1/members/coops/{id}/stats` | `icn/crates/icn-gateway/src/api/coops.rs`:337 | `get_coop_stats` | no | gateway-backed | needs review |
-| DELETE | `/{id}` | `/v1/members/{id}` | `icn/crates/icn-gateway/src/api/coops.rs`:143 | `delete_coop` | no | gateway-backed | needs review |
-| GET | `/{id}` | `/v1/members/{id}` | `icn/crates/icn-gateway/src/api/coops.rs`:74 | `get_coop` | no | gateway-backed | needs review |
-| POST | `/{id}/members` | `/v1/members/{id}/members` | `icn/crates/icn-gateway/src/api/coops.rs`:174 | `add_member` | no | gateway-backed | needs review |
-| DELETE | `/{id}/members/{did}` | `/v1/members/{id}/members/{did}` | `icn/crates/icn-gateway/src/api/coops.rs`:230 | `remove_member` | no | gateway-backed | needs review |
-| PUT | `/{id}/members/{did}/role` | `/v1/members/{id}/members/{did}/role` | `icn/crates/icn-gateway/src/api/coops.rs`:268 | `update_member_role` | no | gateway-backed | needs review |
-| PUT | `/{id}/settings` | `/v1/members/{id}/settings` | `icn/crates/icn-gateway/src/api/coops.rs`:89 | `update_settings` | no | gateway-backed | needs review |
-| GET | `/{did}` | `/v1/devices/{did}` | `icn/crates/icn-gateway/src/api/devices.rs`:134 | `list_devices` | no | gateway-backed | needs review |
-| POST | `/{did}` | `/v1/devices/{did}` | `icn/crates/icn-gateway/src/api/devices.rs`:77 | `register_device` | no | gateway-backed | needs review |
-| DELETE | `/{did}/{device_id}` | `/v1/devices/{did}/{device_id}` | `icn/crates/icn-gateway/src/api/devices.rs`:174 | `revoke_device` | no | gateway-backed | needs review |
-| GET | `/{did}/{device_id}` | `/v1/devices/{did}/{device_id}` | `icn/crates/icn-gateway/src/api/devices.rs`:222 | `get_device` | no | gateway-backed | needs review |
-| POST | `/start` | `/v1/start` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:258 | `start_enrollment` | no | gateway-backed | needs review |
-| GET | `/{ceremony_id}` | `/v1/{ceremony_id}` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:294 | `get_enrollment_status` | no | gateway-backed | needs review |
-| POST | `/{ceremony_id}/approve` | `/v1/{ceremony_id}/approve` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:368 | `approve_ceremony` | no | gateway-backed | needs review |
-| POST | `/{ceremony_id}/finalize` | `/v1/{ceremony_id}/finalize` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:318 | `finalize_enrollment` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1/entities` | `icn/crates/icn-gateway/src/api/entity.rs`:289 | `register_entity` | no | gateway-backed | needs review |
-| POST | `/audit/prune` | `/v1/entities/audit/prune` | `icn/crates/icn-gateway/src/api/entity.rs`:1739 | `prune_audit` | no | gateway-backed | needs review |
-| GET | `/audit/stats` | `/v1/entities/audit/stats` | `icn/crates/icn-gateway/src/api/entity.rs`:1829 | `audit_stats` | no | gateway-backed | needs review |
-| DELETE | `/{id}` | `/v1/entities/{id}` | `icn/crates/icn-gateway/src/api/entity.rs`:632 | `delete_entity` | no | gateway-backed | needs review |
-| GET | `/{id}` | `/v1/entities/{id}` | `icn/crates/icn-gateway/src/api/entity.rs`:482 | `get_entity` | no | gateway-backed | needs review |
-| PUT | `/{id}` | `/v1/entities/{id}` | `icn/crates/icn-gateway/src/api/entity.rs`:513 | `update_entity` | no | gateway-backed | needs review |
-| GET | `/{id}/audit` | `/v1/entities/{id}/audit` | `icn/crates/icn-gateway/src/api/entity.rs`:1667 | `get_entity_audit` | no | gateway-backed | needs review |
-| DELETE | `/{id}/dissolution` | `/v1/entities/{id}/dissolution` | `icn/crates/icn-gateway/src/api/entity.rs`:1521 | `cancel_dissolution` | no | gateway-backed | needs review |
-| POST | `/{id}/dissolution` | `/v1/entities/{id}/dissolution` | `icn/crates/icn-gateway/src/api/entity.rs`:1129 | `initiate_dissolution` | no | gateway-backed | needs review |
-| POST | `/{id}/dissolution/complete` | `/v1/entities/{id}/dissolution/complete` | `icn/crates/icn-gateway/src/api/entity.rs`:1335 | `complete_dissolution` | no | gateway-backed | needs review |
-| GET | `/{id}/members` | `/v1/entities/{id}/members` | `icn/crates/icn-gateway/src/api/entity.rs`:720 | `list_members` | no | gateway-backed | needs review |
-| POST | `/{id}/members` | `/v1/entities/{id}/members` | `icn/crates/icn-gateway/src/api/entity.rs`:832 | `add_membership` | no | gateway-backed | needs review |
-| DELETE | `/{id}/members/{member_id}` | `/v1/entities/{id}/members/{member_id}` | `icn/crates/icn-gateway/src/api/entity.rs`:971 | `remove_membership` | no | gateway-backed | needs review |
-| GET | `/escrow` | `/v1/escrow` | `icn/crates/icn-gateway/src/api/escrow.rs`:86 | `list_escrows` | no | gateway-backed | needs review |
-| POST | `/escrow` | `/v1/escrow` | `icn/crates/icn-gateway/src/api/escrow.rs`:39 | `create_escrow` | no | gateway-backed | needs review |
-| GET | `/escrow/{id}` | `/v1/escrow/{id}` | `icn/crates/icn-gateway/src/api/escrow.rs`:127 | `get_escrow` | no | gateway-backed | needs review |
-| POST | `/escrow/{id}/refund` | `/v1/escrow/{id}/refund` | `icn/crates/icn-gateway/src/api/escrow.rs`:275 | `refund_escrow` | no | gateway-backed | needs review |
-| POST | `/escrow/{id}/release` | `/v1/escrow/{id}/release` | `icn/crates/icn-gateway/src/api/escrow.rs`:156 | `release_escrow` | no | gateway-backed | needs review |
-| GET | `/records` | `/v1/execution/records` | `icn/crates/icn-gateway/src/api/execution.rs`:119 | `list_records` | no | gateway-backed | needs review |
-| GET | `/records/{decision_hash}` | `/v1/execution/records/{decision_hash}` | `icn/crates/icn-gateway/src/api/execution.rs`:137 | `get_record` | no | gateway-backed | needs review |
-| POST | `/attestations` | `/v1/federation/attestations` | `icn/crates/icn-gateway/src/api/federation.rs`:719 | `issue_attestation` | no | gateway-backed | needs review |
-| GET | `/attestations/{member_did}` | `/v1/federation/attestations/{member_did}` | `icn/crates/icn-gateway/src/api/federation.rs`:701 | `get_attestations` | no | gateway-backed | needs review |
-| GET | `/clearing` | `/v1/federation/clearing` | `icn/crates/icn-gateway/src/api/federation.rs`:790 | `list_agreements` | no | gateway-backed | needs review |
-| POST | `/clearing` | `/v1/federation/clearing` | `icn/crates/icn-gateway/src/api/federation.rs`:894 | `create_agreement` | no | gateway-backed | needs review |
-| POST | `/clearing/netting/{unit}` | `/v1/federation/clearing/netting/{unit}` | `icn/crates/icn-gateway/src/api/federation.rs`:1140 | `perform_multilateral_netting` | no | gateway-backed | needs review |
-| POST | `/clearing/netting/{unit}/apply` | `/v1/federation/clearing/netting/{unit}/apply` | `icn/crates/icn-gateway/src/api/federation.rs`:1176 | `apply_multilateral_netting` | no | gateway-backed | needs review |
-| POST | `/clearing/settle-scheduled` | `/v1/federation/clearing/settle-scheduled` | `icn/crates/icn-gateway/src/api/federation.rs`:1105 | `process_scheduled_settlements` | no | gateway-backed | needs review |
-| GET | `/clearing/{agreement_id}` | `/v1/federation/clearing/{agreement_id}` | `icn/crates/icn-gateway/src/api/federation.rs`:841 | `get_agreement` | no | gateway-backed | needs review |
-| GET | `/clearing/{agreement_id}/position` | `/v1/federation/clearing/{agreement_id}/position` | `icn/crates/icn-gateway/src/api/federation.rs`:1030 | `get_position` | no | gateway-backed | needs review |
-| POST | `/clearing/{agreement_id}/settle` | `/v1/federation/clearing/{agreement_id}/settle` | `icn/crates/icn-gateway/src/api/federation.rs`:1079 | `trigger_settlement` | no | gateway-backed | needs review |
-| POST | `/clearing/{id}/propose-adoption` | `/v1/federation/clearing/{id}/propose-adoption` | `icn/crates/icn-gateway/src/api/federation.rs`:972 | `propose_clearing_adoption` | yes | gateway-backed | needs review |
-| POST | `/connect` | `/v1/federation/connect` | `icn/crates/icn-gateway/src/api/federation.rs`:1210 | `federation_connect` | no | gateway-backed | needs review |
-| GET | `/coops` | `/v1/federation/coops` | `icn/crates/icn-gateway/src/api/federation.rs`:255 | `list_coops` | no | gateway-backed | needs review |
-| POST | `/coops` | `/v1/federation/coops` | `icn/crates/icn-gateway/src/api/federation.rs`:337 | `register_coop` | no | gateway-backed | needs review |
-| GET | `/coops/{coop_id}` | `/v1/federation/coops/{coop_id}` | `icn/crates/icn-gateway/src/api/federation.rs`:295 | `get_coop` | no | gateway-backed | needs review |
-| POST | `/coops/{coop_id}/vouch` | `/v1/federation/coops/{coop_id}/vouch` | `icn/crates/icn-gateway/src/api/federation.rs`:415 | `vouch_for_coop` | no | gateway-backed | needs review |
-| GET | `/coops/{coop_id}/vouches` | `/v1/federation/coops/{coop_id}/vouches` | `icn/crates/icn-gateway/src/api/federation.rs`:381 | `get_vouches` | no | gateway-backed | needs review |
-| POST | `/init` | `/v1/federation/init` | `icn/crates/icn-gateway/src/api/federation.rs`:208 | `init_federation` | no | gateway-backed | needs review |
-| GET | `/status` | `/v1/federation/status` | `icn/crates/icn-gateway/src/api/federation.rs`:166 | `get_status` | no | gateway-backed | needs review |
-| GET | `/topology` | `/v1/federation/topology` | `icn/crates/icn-gateway/src/api/federation.rs`:562 | `get_topology` | yes | gateway-backed | needs review |
-| POST | `/{coop_id}/proposals` | `/v1/coops/{coop_id}/proposals` | `icn/crates/icn-gateway/src/api/flow_c.rs`:22 | `propose_spend_alias` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/treasury/position` | `/v1/coops/{coop_id}/treasury/position` | `icn/crates/icn-gateway/src/api/flow_c.rs`:35 | `get_treasury_position_alias` | no | gateway-backed | needs review |
-| GET | `/{id}/proof` | `/v1/coops/{id}/proof` | `icn/crates/icn-gateway/src/api/flow_c.rs`:112 | `get_proof_alias` | no | gateway-backed | needs review |
-| POST | `/{id}/vote` | `/v1/coops/{id}/vote` | `icn/crates/icn-gateway/src/api/flow_c.rs`:46 | `cast_vote_alias` | no | gateway-backed | needs review |
-| GET | `/governance/{charter_id}/dashboard` | `/v1/gov/governance/{charter_id}/dashboard` | `icn/crates/icn-gateway/src/api/governance_dashboard.rs`:21 | `get_governance_dashboard` | no | gateway-backed | needs review |
-| GET | `/health` | `/v1/health` | `icn/crates/icn-gateway/src/api/health.rs`:169 | `health` | no | gateway-backed | needs review |
-| GET | `/health/detailed` | `/v1/health/detailed` | `icn/crates/icn-gateway/src/api/health.rs`:182 | `health_detailed` | no | gateway-backed | needs review |
-| GET | `/health/full` | `/v1/health/full` | `icn/crates/icn-gateway/src/api/health.rs`:284 | `health_full` | no | gateway-backed | needs review |
-| GET | `/healthz` | `/v1/healthz` | `icn/crates/icn-gateway/src/api/health.rs`:36 | `liveness` | no | gateway-backed | needs review |
-| GET | `/ready` | `/v1/ready` | `icn/crates/icn-gateway/src/api/health.rs`:100 | `ready` | no | gateway-backed | needs review |
-| GET | `/readyz` | `/v1/readyz` | `icn/crates/icn-gateway/src/api/health.rs`:48 | `readiness` | no | gateway-backed | needs review |
-| GET | `/health` | `/v1/identity/health` | `icn/crates/icn-gateway/src/api/identity.rs`:100 | `identity_health` | no | gateway-backed | needs review |
-| GET | `/resolve/{did}` | `/v1/identity/resolve/{did}` | `icn/crates/icn-gateway/src/api/identity.rs`:60 | `resolve_did` | no | gateway-backed | needs review |
-| GET | `(empty)` | `/v1/invites` | `icn/crates/icn-gateway/src/api/invites.rs`:101 | `list_invites` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1/invites` | `icn/crates/icn-gateway/src/api/invites.rs`:25 | `create_invite` | no | gateway-backed | needs review |
-| POST | `/join` | `/v1/invites/join` | `icn/crates/icn-gateway/src/api/invites.rs`:146 | `join_via_invite` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/entries/by-decision` | `/v1/ledger/{coop_id}/entries/by-decision` | `icn/crates/icn-gateway/src/api/ledger.rs`:389 | `get_entries_by_decision` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/history` | `/v1/ledger/{coop_id}/history` | `icn/crates/icn-gateway/src/api/ledger.rs`:237 | `get_history` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/position/{did}` | `/v1/ledger/{coop_id}/position/{did}` | `icn/crates/icn-gateway/src/api/ledger.rs`:22 | `get_position` | no | gateway-backed | needs review |
-| POST | `/{coop_id}/settle` | `/v1/ledger/{coop_id}/settle` | `icn/crates/icn-gateway/src/api/ledger.rs`:55 | `create_settlement` | no | gateway-backed | needs review |
-| POST | `/{coop_id}/settle/convert` | `/v1/ledger/{coop_id}/settle/convert` | `icn/crates/icn-gateway/src/api/ledger.rs`:546 | `create_cross_settlement` | no | gateway-backed | needs review |
-| POST | `/{coop_id}/settle/convert/quote` | `/v1/ledger/{coop_id}/settle/convert/quote` | `icn/crates/icn-gateway/src/api/ledger.rs`:657 | `get_cross_settlement_quote` | no | gateway-backed | needs review |
-| GET | `(empty)` | `/v1/listings` | `icn/crates/icn-gateway/src/api/listings.rs`:637 | `list_listings` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1/listings` | `icn/crates/icn-gateway/src/api/listings.rs`:576 | `create_listing` | no | gateway-backed | needs review |
-| GET | `/my` | `/v1/listings/my` | `icn/crates/icn-gateway/src/api/listings.rs`:1013 | `get_my_listings` | no | gateway-backed | needs review |
-| DELETE | `/{id}` | `/v1/listings/{id}` | `icn/crates/icn-gateway/src/api/listings.rs`:786 | `delete_listing` | no | gateway-backed | needs review |
-| GET | `/{id}` | `/v1/listings/{id}` | `icn/crates/icn-gateway/src/api/listings.rs`:681 | `get_listing` | no | gateway-backed | needs review |
-| PUT | `/{id}` | `/v1/listings/{id}` | `icn/crates/icn-gateway/src/api/listings.rs`:715 | `update_listing` | no | gateway-backed | needs review |
-| POST | `/{id}/interest` | `/v1/listings/{id}/interest` | `icn/crates/icn-gateway/src/api/listings.rs`:895 | `express_interest` | no | gateway-backed | needs review |
-| GET | `/{id}/interests` | `/v1/listings/{id}/interests` | `icn/crates/icn-gateway/src/api/listings.rs`:973 | `get_interests` | no | gateway-backed | needs review |
-| PUT | `/{id}/status` | `/v1/listings/{id}/status` | `icn/crates/icn-gateway/src/api/listings.rs`:830 | `update_listing_status` | no | gateway-backed | needs review |
-| GET | `/members/{coop_id}/{did}` | `/v1/identity/members/{coop_id}/{did}` | `icn/crates/icn-gateway/src/api/members.rs`:40 | `get_member_profile` | no | gateway-backed | needs review |
-| PUT | `/{coop_id}/{did}/profile` | `/v1/identity/{coop_id}/{did}/profile` | `icn/crates/icn-gateway/src/api/members.rs`:130 | `update_member_profile` | no | gateway-backed | needs review |
-| POST | `/apply` | `/v1/membership/apply` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:136 | `apply_for_membership` | no | gateway-backed | needs review |
-| POST | `/approve` | `/v1/membership/approve` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:225 | `approve_membership` | no | gateway-backed | needs review |
-| POST | `/ban` | `/v1/membership/ban` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:345 | `ban_member` | no | gateway-backed | needs review |
-| GET | `/capability/check` | `/v1/membership/capability/check` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:506 | `check_capability` | no | gateway-backed | needs review |
-| POST | `/capability/grant` | `/v1/membership/capability/grant` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:440 | `grant_capability` | no | gateway-backed | needs review |
-| POST | `/capability/revoke` | `/v1/membership/capability/revoke` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:473 | `revoke_capability` | no | gateway-backed | needs review |
-| POST | `/exit` | `/v1/membership/exit` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:703 | `exit_membership` | no | gateway-backed | needs review |
-| GET | `/list/{jurisdiction}` | `/v1/membership/list/{jurisdiction}` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:611 | `list_members` | no | gateway-backed | needs review |
-| POST | `/promote` | `/v1/membership/promote` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:255 | `promote_member` | no | gateway-backed | needs review |
-| POST | `/reinstate` | `/v1/membership/reinstate` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:315 | `reinstate_member` | no | gateway-backed | needs review |
-| POST | `/revoke` | `/v1/membership/revoke` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:387 | `revoke_membership` | no | gateway-backed | needs review |
-| POST | `/role/add` | `/v1/membership/role/add` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:536 | `add_role` | no | gateway-backed | needs review |
-| POST | `/role/remove` | `/v1/membership/role/remove` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:566 | `remove_role` | no | gateway-backed | needs review |
-| GET | `/status/{jurisdiction}` | `/v1/membership/status/{jurisdiction}` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:180 | `get_membership_status` | no | gateway-backed | needs review |
-| POST | `/suspend` | `/v1/membership/suspend` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:285 | `suspend_member` | no | gateway-backed | needs review |
-| GET | `/{path:.*}` | `/v1/names/{path:.*}` | `icn/crates/icn-gateway/src/api/names.rs`:138 | `resolve_name` | no | gateway-backed | needs review |
-| GET | `/notifications` | `/v1/notifications/notifications` | `icn/crates/icn-gateway/src/api/notifications.rs`:118 | `list_notifications` | no | gateway-backed | needs review |
-| GET | `/notifications/count` | `/v1/notifications/notifications/count` | `icn/crates/icn-gateway/src/api/notifications.rs`:154 | `get_notification_count` | no | gateway-backed | needs review |
-| POST | `/notifications/read-all` | `/v1/notifications/notifications/read-all` | `icn/crates/icn-gateway/src/api/notifications.rs`:196 | `mark_all_read` | no | gateway-backed | needs review |
-| POST | `/notifications/register` | `/v1/notifications/notifications/register` | `icn/crates/icn-gateway/src/api/notifications.rs`:36 | `register_device` | no | gateway-backed | needs review |
-| DELETE | `/notifications/unregister` | `/v1/notifications/notifications/unregister` | `icn/crates/icn-gateway/src/api/notifications.rs`:57 | `unregister_device` | no | gateway-backed | needs review |
-| DELETE | `/notifications/{notification_id}` | `/v1/notifications/notifications/{notification_id}` | `icn/crates/icn-gateway/src/api/notifications.rs`:213 | `delete_notification` | no | gateway-backed | needs review |
-| POST | `/notifications/{notification_id}/read` | `/v1/notifications/notifications/{notification_id}/read` | `icn/crates/icn-gateway/src/api/notifications.rs`:171 | `mark_notification_read` | no | gateway-backed | needs review |
-| GET | `/notifications/{notification_id}/status` | `/v1/notifications/notifications/{notification_id}/status` | `icn/crates/icn-gateway/src/api/notifications.rs`:241 | `get_delivery_status` | no | gateway-backed | needs review |
-| POST | `/convert` | `/v1/convert` | `icn/crates/icn-gateway/src/api/oracle.rs`:280 | `convert_amount` | no | gateway-backed | needs review |
-| POST | `/rate` | `/v1/rate` | `icn/crates/icn-gateway/src/api/oracle.rs`:380 | `set_rate` | no | gateway-backed | needs review |
-| GET | `/rate/{from}/{to}` | `/v1/rate/{from}/{to}` | `icn/crates/icn-gateway/src/api/oracle.rs`:213 | `get_rate` | no | gateway-backed | needs review |
-| GET | `/sources` | `/v1/sources` | `icn/crates/icn-gateway/src/api/oracle.rs`:355 | `list_sources` | no | gateway-backed | needs review |
-| GET | `/allocations` | `/v1/receipts/allocations` | `icn/crates/icn-gateway/src/api/receipts.rs`:569 | `list_allocations` | no | gateway-backed | needs review |
-| GET | `/allocations/{hash}` | `/v1/receipts/allocations/{hash}` | `icn/crates/icn-gateway/src/api/receipts.rs`:282 | `get_allocation` | no | gateway-backed | needs review |
-| GET | `/chain` | `/v1/receipts/chain` | `icn/crates/icn-gateway/src/api/receipts.rs`:331 | `get_chain` | no | gateway-backed | needs review |
-| GET | `/chain/{decision_hash}` | `/v1/receipts/chain/{decision_hash}` | `icn/crates/icn-gateway/src/api/receipts.rs`:381 | `get_full_chain` | no | gateway-backed | needs review |
-| GET | `/intents` | `/v1/receipts/intents` | `icn/crates/icn-gateway/src/api/receipts.rs`:598 | `list_intents` | no | gateway-backed | needs review |
-| GET | `/intents/{hash}` | `/v1/receipts/intents/{hash}` | `icn/crates/icn-gateway/src/api/receipts.rs`:305 | `get_intent` | no | gateway-backed | needs review |
-| POST | `/start` | `/v1/start` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:216 | `start_recovery` | no | gateway-backed | needs review |
-| GET | `/{recovery_id}` | `/v1/{recovery_id}` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:252 | `get_recovery_status` | no | gateway-backed | needs review |
-| POST | `/{recovery_id}/approve` | `/v1/{recovery_id}/approve` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:329 | `approve_recovery` | no | gateway-backed | needs review |
-| POST | `/{recovery_id}/complete` | `/v1/{recovery_id}/complete` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:275 | `complete_recovery` | no | gateway-backed | needs review |
-| GET | `/settlements/recurring` | `/v1/settlements/recurring` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:94 | `list_recurring_settlements` | no | gateway-backed | needs review |
-| POST | `/settlements/recurring` | `/v1/settlements/recurring` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:44 | `create_recurring_settlement` | no | gateway-backed | needs review |
-| DELETE | `/settlements/recurring/{id}` | `/v1/settlements/recurring/{id}` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:214 | `cancel_recurring_settlement` | no | gateway-backed | needs review |
-| GET | `/settlements/recurring/{id}` | `/v1/settlements/recurring/{id}` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:135 | `get_recurring_settlement` | no | gateway-backed | needs review |
-| PUT | `/settlements/recurring/{id}` | `/v1/settlements/recurring/{id}` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:164 | `update_recurring_settlement` | no | gateway-backed | needs review |
-| GET | `/decisions` | `/v1/decisions` | `icn/crates/icn-gateway/src/api/registry.rs`:702 | `list_decisions` | no | gateway-backed | needs review |
-| POST | `/decisions` | `/v1/decisions` | `icn/crates/icn-gateway/src/api/registry.rs`:598 | `index_decision_endpoint` | no | gateway-backed | needs review |
-| GET | `/decisions/{id}` | `/v1/decisions/{id}` | `icn/crates/icn-gateway/src/api/registry.rs`:745 | `get_decision` | no | gateway-backed | needs review |
-| GET | `/decisions/{id}/trace` | `/v1/decisions/{id}/trace` | `icn/crates/icn-gateway/src/api/registry.rs`:781 | `get_decision_trace` | no | gateway-backed | needs review |
-| GET | `/meetings` | `/v1/meetings` | `icn/crates/icn-gateway/src/api/registry.rs`:564 | `list_meetings` | no | gateway-backed | needs review |
-| POST | `/meetings` | `/v1/meetings` | `icn/crates/icn-gateway/src/api/registry.rs`:491 | `create_meeting` | no | gateway-backed | needs review |
-| GET | `/summary` | `/v1/rights/summary` | `icn/crates/icn-gateway/src/api/rights.rs`:12 | `rights_summary` | no | gateway-backed | needs review |
-| POST | `/ephemeral/generate` | `/v1/ephemeral/generate` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:301 | `generate_ephemeral` | no | gateway-backed | needs review |
-| GET | `/health` | `/v1/health` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:175 | `sdis_health` | no | gateway-backed | needs review |
-| POST | `/verify/level1` | `/v1/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:189 | `verify_level1` | no | gateway-backed | needs review |
-| POST | `/verify/level2` | `/v1/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:209 | `verify_level2` | no | gateway-backed | needs review |
-| GET | `(empty)` | `/v1` | `icn/crates/icn-gateway/src/api/services.rs`:494 | `query_services` | no | gateway-backed | needs review |
-| POST | `/announce` | `/v1/announce` | `icn/crates/icn-gateway/src/api/services.rs`:238 | `announce_service` | no | gateway-backed | needs review |
-| GET | `/discover` | `/v1/discover` | `icn/crates/icn-gateway/src/api/services.rs`:388 | `discover_services` | no | gateway-backed | needs review |
-| DELETE | `/{service_id}` | `/v1/{service_id}` | `icn/crates/icn-gateway/src/api/services.rs`:347 | `withdraw_service` | no | gateway-backed | needs review |
-| GET | `/{service_id}` | `/v1/{service_id}` | `icn/crates/icn-gateway/src/api/services.rs`:550 | `get_service` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1/sessions` | `icn/crates/icn-gateway/src/api/sessions.rs`:137 | `create_session` | no | gateway-backed | needs review |
-| GET | `/{session_id}` | `/v1/sessions/{session_id}` | `icn/crates/icn-gateway/src/api/sessions.rs`:184 | `get_session_status` | no | gateway-backed | needs review |
-| POST | `/{session_id}/approve` | `/v1/sessions/{session_id}/approve` | `icn/crates/icn-gateway/src/api/sessions.rs`:251 | `approve_session` | no | gateway-backed | needs review |
-| POST | `/enrollment/complete` | `/v1/enrollment/complete` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:501 | `complete_enrollment` | no | gateway-backed | needs review |
-| POST | `/enrollment/start` | `/v1/enrollment/start` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:281 | `start_enrollment` | no | gateway-backed | needs review |
-| POST | `/enrollment/verify/level1` | `/v1/enrollment/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:331 | `verify_level1` | no | gateway-backed | needs review |
-| POST | `/enrollment/verify/level2` | `/v1/enrollment/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:406 | `verify_level2` | no | gateway-backed | needs review |
-| POST | `/reject/{enrollment_id}` | `/v1/reject/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:913 | `reject_enrollment` | no | gateway-backed | needs review |
-| POST | `/vouch/{enrollment_id}` | `/v1/vouch/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:824 | `steward_vouch` | no | gateway-backed | needs review |
-| GET | `(empty)` | `/v1/steward` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:170 | `list_stewards` | no | gateway-backed | needs review |
-| POST | `(empty)` | `/v1/steward` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:72 | `register_steward` | no | gateway-backed | needs review |
-| GET | `/attesters` | `/v1/steward/attesters` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:195 | `list_attesters` | no | gateway-backed | needs review |
-| GET | `/by-did/{did}` | `/v1/steward/by-did/{did}` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:150 | `get_steward_by_did` | no | gateway-backed | needs review |
-| GET | `/{steward_id}` | `/v1/steward/{steward_id}` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:133 | `get_steward` | no | gateway-backed | needs review |
-| POST | `/{steward_id}/attestation` | `/v1/steward/{steward_id}/attestation` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:570 | `record_attestation` | no | gateway-backed | needs review |
-| POST | `/{steward_id}/bond/add` | `/v1/steward/{steward_id}/bond/add` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:432 | `add_bond` | no | gateway-backed | needs review |
-| POST | `/{steward_id}/bond/slash` | `/v1/steward/{steward_id}/bond/slash` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:484 | `slash_bond` | no | gateway-backed | needs review |
-| POST | `/{steward_id}/dispute` | `/v1/steward/{steward_id}/dispute` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:624 | `record_dispute` | no | gateway-backed | needs review |
-| POST | `/{steward_id}/dispute-won` | `/v1/steward/{steward_id}/dispute-won` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:686 | `record_dispute_won` | no | gateway-backed | needs review |
-| POST | `/{steward_id}/extend-term` | `/v1/steward/{steward_id}/extend-term` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:360 | `extend_steward_term` | no | gateway-backed | needs review |
-| POST | `/{steward_id}/retire` | `/v1/steward/{steward_id}/retire` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:319 | `retire_steward` | no | gateway-backed | needs review |
-| PUT | `/{steward_id}/status` | `/v1/steward/{steward_id}/status` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:214 | `update_steward_status` | no | gateway-backed | needs review |
-| GET | `/{coop_id}` | `/v1/treasury/{coop_id}` | `icn/crates/icn-gateway/src/api/treasury.rs`:375 | `get_treasury_status` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/audit` | `/v1/treasury/{coop_id}/audit` | `icn/crates/icn-gateway/src/api/treasury.rs`:939 | `get_audit_trail` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/budgets` | `/v1/treasury/{coop_id}/budgets` | `icn/crates/icn-gateway/src/api/treasury.rs`:576 | `list_budgets` | no | gateway-backed | needs review |
-| POST | `/{coop_id}/budgets` | `/v1/treasury/{coop_id}/budgets` | `icn/crates/icn-gateway/src/api/treasury.rs`:732 | `create_budget` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/budgets/{budget_id}` | `/v1/treasury/{coop_id}/budgets/{budget_id}` | `icn/crates/icn-gateway/src/api/treasury.rs`:646 | `get_budget` | no | gateway-backed | needs review |
-| POST | `/{coop_id}/deposit` | `/v1/treasury/{coop_id}/deposit` | `icn/crates/icn-gateway/src/api/treasury.rs`:1029 | `deposit_to_treasury` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/nonce` | `/v1/treasury/{coop_id}/nonce` | `icn/crates/icn-gateway/src/api/treasury.rs`:521 | `get_treasury_nonce` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/position` | `/v1/treasury/{coop_id}/position` | `icn/crates/icn-gateway/src/api/treasury.rs`:450 | `get_treasury_position` | no | gateway-backed | needs review |
-| POST | `/{coop_id}/spend` | `/v1/treasury/{coop_id}/spend` | `icn/crates/icn-gateway/src/api/treasury.rs`:1163 | `propose_spend` | no | gateway-backed | needs review |
-| GET | `/{coop_id}/spending-rules` | `/v1/treasury/{coop_id}/spending-rules` | `icn/crates/icn-gateway/src/api/treasury.rs`:872 | `list_spending_rules` | no | gateway-backed | needs review |
-| POST | `/trust/attest` | `/v1/trust/trust/attest` | `icn/crates/icn-gateway/src/api/trust.rs`:103 | `create_trust_attestation` | no | gateway-backed | needs review |
-| POST | `/trust/revoke` | `/v1/trust/trust/revoke` | `icn/crates/icn-gateway/src/api/trust.rs`:179 | `revoke_trust_attestation` | no | gateway-backed | needs review |
-| GET | `/trust/{did}` | `/v1/trust/trust/{did}` | `icn/crates/icn-gateway/src/api/trust.rs`:35 | `get_trust_score` | no | gateway-backed | needs review |
-| GET | `/trust/{did}/edges` | `/v1/trust/trust/{did}/edges` | `icn/crates/icn-gateway/src/api/trust.rs`:72 | `get_trust_edges` | no | gateway-backed | needs review |
-| GET | `/trust/{did}/network` | `/v1/trust/trust/{did}/network` | `icn/crates/icn-gateway/src/api/trust.rs`:143 | `get_trust_network` | no | gateway-backed | needs review |
-| GET | `/amendments/{id}/my-vote` | `/v1/amendments/{id}/my-vote` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:422 | `get_my_vote` | no | gateway-backed | needs review |
-| GET | `/amendments/{id}/results` | `/v1/amendments/{id}/results` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:317 | `get_results` | no | gateway-backed | needs review |
-| GET | `/amendments/{id}/votes` | `/v1/amendments/{id}/votes` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:288 | `list_votes` | no | gateway-backed | needs review |
-| POST | `/amendments/{id}/votes` | `/v1/amendments/{id}/votes` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:193 | `cast_vote` | no | gateway-backed | needs review |
-| GET | `/ws/{coop_id}` | `/v1/ws/{coop_id}` | `icn/crates/icn-gateway/src/api/websocket.rs`:12 | `websocket` | no | gateway-backed | needs review |
+| GET | `(empty)` | `/v1` | `icn/crates/icn-gateway/src/api/agreements.rs`:789 | `list_agreements` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1` | `icn/crates/icn-gateway/src/api/agreements.rs`:855 | `create_agreement` | no | unknown / needs local verification | needs review |
+| DELETE | `/{id}` | `/v1/{id}` | `icn/crates/icn-gateway/src/api/agreements.rs`:936 | `delete_agreement` | no | unknown / needs local verification | needs review |
+| GET | `/{id}` | `/v1/{id}` | `icn/crates/icn-gateway/src/api/agreements.rs`:900 | `get_agreement` | no | unknown / needs local verification | needs review |
+| GET | `/{id}/amendments` | `/v1/{id}/amendments` | `icn/crates/icn-gateway/src/api/agreements.rs`:1302 | `list_amendments` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/amendments` | `/v1/{id}/amendments` | `icn/crates/icn-gateway/src/api/agreements.rs`:1358 | `propose_amendment` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/amendments/{amendment_id}/sign` | `/v1/{id}/amendments/{amendment_id}/sign` | `icn/crates/icn-gateway/src/api/agreements.rs`:1419 | `sign_amendment` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/parties` | `/v1/{id}/parties` | `icn/crates/icn-gateway/src/api/agreements.rs`:971 | `add_party` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/propose` | `/v1/{id}/propose` | `icn/crates/icn-gateway/src/api/agreements.rs`:1092 | `propose_agreement` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/resume` | `/v1/{id}/resume` | `icn/crates/icn-gateway/src/api/agreements.rs`:1196 | `resume_agreement` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/sign` | `/v1/{id}/sign` | `icn/crates/icn-gateway/src/api/agreements.rs`:1126 | `sign_agreement` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/suspend` | `/v1/{id}/suspend` | `icn/crates/icn-gateway/src/api/agreements.rs`:1161 | `suspend_agreement` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/terminate` | `/v1/{id}/terminate` | `icn/crates/icn-gateway/src/api/agreements.rs`:1231 | `terminate_agreement` | no | unknown / needs local verification | needs review |
+| PUT | `/{id}/terms` | `/v1/{id}/terms` | `icn/crates/icn-gateway/src/api/agreements.rs`:1033 | `set_terms` | no | unknown / needs local verification | needs review |
+| POST | `/auth/challenge` | `/v1/auth/challenge` | `icn/crates/icn-gateway/src/api/auth.rs`:38 | `challenge` | no | unknown / needs local verification | needs review |
+| POST | `/auth/verify` | `/v1/auth/verify` | `icn/crates/icn-gateway/src/api/auth.rs`:68 | `verify` | no | unknown / needs local verification | needs review |
+| GET | `/budgets` | `/v1/gov/budgets` | `icn/crates/icn-gateway/src/api/budgets.rs`:87 | `list_budgets` | no | unknown / needs local verification | needs review |
+| POST | `/budgets` | `/v1/gov/budgets` | `icn/crates/icn-gateway/src/api/budgets.rs`:35 | `create_budget` | no | unknown / needs local verification | needs review |
+| DELETE | `/budgets/{id}` | `/v1/gov/budgets/{id}` | `icn/crates/icn-gateway/src/api/budgets.rs`:212 | `delete_budget` | no | unknown / needs local verification | needs review |
+| GET | `/budgets/{id}` | `/v1/gov/budgets/{id}` | `icn/crates/icn-gateway/src/api/budgets.rs`:127 | `get_budget` | no | unknown / needs local verification | needs review |
+| PUT | `/budgets/{id}` | `/v1/gov/budgets/{id}` | `icn/crates/icn-gateway/src/api/budgets.rs`:161 | `update_budget` | no | unknown / needs local verification | needs review |
+| GET | `(empty)` | `/v1/charter` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:241 | `list_charters` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/charter` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:162 | `create_charter` | no | unknown / needs local verification | needs review |
+| GET | `/by-domain/{domain_id}` | `/v1/charter/by-domain/{domain_id}` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:225 | `get_charter_by_domain` | no | unknown / needs local verification | needs review |
+| GET | `/{charter_id}` | `/v1/charter/{charter_id}` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:209 | `get_charter` | no | unknown / needs local verification | needs review |
+| POST | `/{charter_id}/activate` | `/v1/charter/{charter_id}/activate` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:308 | `activate_charter` | no | unknown / needs local verification | needs review |
+| GET | `/{charter_id}/founders` | `/v1/charter/{charter_id}/founders` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:478 | `get_charter_founders` | no | unknown / needs local verification | needs review |
+| POST | `/{charter_id}/sign` | `/v1/charter/{charter_id}/sign` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:267 | `sign_charter` | no | unknown / needs local verification | needs review |
+| PUT | `/{charter_id}/status` | `/v1/charter/{charter_id}/status` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:346 | `update_charter_status` | no | unknown / needs local verification | needs review |
+| GET | `/{charter_id}/summary` | `/v1/charter/{charter_id}/summary` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:462 | `get_charter_summary` | no | unknown / needs local verification | needs review |
+| GET | `/{charter_id}/timeline` | `/v1/charter/{charter_id}/timeline` | `icn/crates/icn-gateway/src/api/charter/mod.rs`:517 | `get_charter_timeline` | no | unknown / needs local verification | needs review |
+| GET | `/by-did/{did}` | `/v1/commons/by-did/{did}` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:123 | `get_anchor_by_did` | no | unknown / needs local verification | needs review |
+| POST | `/dev/bootstrap-standing` | `/v1/commons/dev/bootstrap-standing` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:429 | `dev_bootstrap_standing` | no | unknown / needs local verification | needs review |
+| GET | `/holder/id/{holder_id}` | `/v1/commons/holder/id/{holder_id}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:180 | `get_holder_by_id` | no | unknown / needs local verification | needs review |
+| GET | `/holder/{did}` | `/v1/commons/holder/{did}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:154 | `get_holder_by_did` | no | unknown / needs local verification | needs review |
+| GET | `/holder/{did}/affiliations` | `/v1/commons/holder/{did}/affiliations` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:226 | `list_affiliations` | no | unknown / needs local verification | needs review |
+| POST | `/holder/{did}/affiliations` | `/v1/commons/holder/{did}/affiliations` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:261 | `join_jurisdiction` | no | unknown / needs local verification | needs review |
+| DELETE | `/holder/{did}/affiliations/{jurisdiction}` | `/v1/commons/holder/{did}/affiliations/{jurisdiction}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:342 | `leave_jurisdiction` | no | unknown / needs local verification | needs review |
+| PUT | `/holder/{did}/affiliations/{jurisdiction}` | `/v1/commons/holder/{did}/affiliations/{jurisdiction}` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:303 | `update_affiliation` | no | unknown / needs local verification | needs review |
+| GET | `/status` | `/v1/commons/status` | `icn/crates/icn-gateway/src/api/commons/mod.rs`:116 | `get_commons_status` | no | unknown / needs local verification | needs review |
+| GET | `/{anchor_id}` | `/v1/commons/{anchor_id}` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:107 | `get_anchor_by_id` | no | unknown / needs local verification | needs review |
+| GET | `/{anchor_id}/attestations` | `/v1/commons/{anchor_id}/attestations` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:146 | `list_attestations` | no | unknown / needs local verification | needs review |
+| POST | `/{anchor_id}/attestations` | `/v1/commons/{anchor_id}/attestations` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:168 | `add_attestation` | no | unknown / needs local verification | needs review |
+| PUT | `/{anchor_id}/status` | `/v1/commons/{anchor_id}/status` | `icn/crates/icn-gateway/src/api/commons/anchor.rs`:280 | `update_anchor_status` | no | unknown / needs local verification | needs review |
+| GET | `(empty)` | `/v1/gov` | `icn/crates/icn-gateway/src/api/communities.rs`:137 | `list_communities` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/gov` | `icn/crates/icn-gateway/src/api/communities.rs`:99 | `create_community` | no | unknown / needs local verification | needs review |
+| DELETE | `/{id}` | `/v1/gov/{id}` | `icn/crates/icn-gateway/src/api/communities.rs`:196 | `dissolve_community` | no | unknown / needs local verification | needs review |
+| GET | `/{id}` | `/v1/gov/{id}` | `icn/crates/icn-gateway/src/api/communities.rs`:150 | `get_community` | no | unknown / needs local verification | needs review |
+| PUT | `/{id}` | `/v1/gov/{id}` | `icn/crates/icn-gateway/src/api/communities.rs`:164 | `update_community` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/activate` | `/v1/gov/{id}/activate` | `icn/crates/icn-gateway/src/api/communities.rs`:182 | `activate_community` | no | unknown / needs local verification | needs review |
+| GET | `/{id}/members` | `/v1/gov/{id}/members` | `icn/crates/icn-gateway/src/api/communities.rs`:283 | `list_members` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/members` | `/v1/gov/{id}/members` | `icn/crates/icn-gateway/src/api/communities.rs`:215 | `join_community` | no | unknown / needs local verification | needs review |
+| DELETE | `/{id}/members/{member_id}` | `/v1/gov/{id}/members/{member_id}` | `icn/crates/icn-gateway/src/api/communities.rs`:253 | `leave_community` | no | unknown / needs local verification | needs review |
+| GET | `/{id}/resources` | `/v1/gov/{id}/resources` | `icn/crates/icn-gateway/src/api/communities.rs`:320 | `get_resource_pools` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/resources` | `/v1/gov/{id}/resources` | `icn/crates/icn-gateway/src/api/communities.rs`:297 | `allocate_resource` | no | unknown / needs local verification | needs review |
+| POST | `/cancel/{task_hash}` | `/v1/compute/cancel/{task_hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:310 | `cancel_task` | no | unknown / needs local verification | needs review |
+| GET | `/settlement/receipt/{hash}` | `/v1/compute/settlement/receipt/{hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:586 | `query_settlement_by_receipt` | no | unknown / needs local verification | needs review |
+| GET | `/settlement/{task_id}` | `/v1/compute/settlement/{task_id}` | `icn/crates/icn-gateway/src/api/compute.rs`:565 | `query_settlement` | no | unknown / needs local verification | needs review |
+| GET | `/status/{task_hash}` | `/v1/compute/status/{task_hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:263 | `get_status` | no | unknown / needs local verification | needs review |
+| POST | `/submit` | `/v1/compute/submit` | `icn/crates/icn-gateway/src/api/compute.rs`:117 | `submit_task` | no | unknown / needs local verification | needs review |
+| GET | `/wasm` | `/v1/compute/wasm` | `icn/crates/icn-gateway/src/api/compute.rs`:501 | `list_wasm` | no | unknown / needs local verification | needs review |
+| POST | `/wasm/upload` | `/v1/compute/wasm/upload` | `icn/crates/icn-gateway/src/api/compute.rs`:442 | `upload_wasm` | no | unknown / needs local verification | needs review |
+| GET | `/wasm/{hash}` | `/v1/compute/wasm/{hash}` | `icn/crates/icn-gateway/src/api/compute.rs`:527 | `get_wasm_metadata` | no | unknown / needs local verification | needs review |
+| GET | `/amendments` | `/v1/constitutional/amendments` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:690 | `list_amendments` | no | unknown / needs local verification | needs review |
+| POST | `/amendments` | `/v1/constitutional/amendments` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:565 | `create_amendment` | no | unknown / needs local verification | needs review |
+| GET | `/amendments/{id}` | `/v1/constitutional/amendments/{id}` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:731 | `get_amendment` | no | unknown / needs local verification | needs review |
+| POST | `/amendments/{id}/changes` | `/v1/constitutional/amendments/{id}/changes` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:875 | `add_amendment_change` | no | unknown / needs local verification | needs review |
+| GET | `/amendments/{id}/my-vote` | `/v1/constitutional/amendments/{id}/my-vote` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:422 | `get_my_vote` | no | unknown / needs local verification | needs review |
+| POST | `/amendments/{id}/ratify` | `/v1/constitutional/amendments/{id}/ratify` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:827 | `ratify_amendment` | no | unknown / needs local verification | needs review |
+| GET | `/amendments/{id}/results` | `/v1/constitutional/amendments/{id}/results` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:317 | `get_results` | no | unknown / needs local verification | needs review |
+| POST | `/amendments/{id}/submit` | `/v1/constitutional/amendments/{id}/submit` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:759 | `submit_amendment` | no | unknown / needs local verification | needs review |
+| POST | `/amendments/{id}/vote` | `/v1/constitutional/amendments/{id}/vote` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:793 | `open_amendment_voting` | no | unknown / needs local verification | needs review |
+| GET | `/amendments/{id}/votes` | `/v1/constitutional/amendments/{id}/votes` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:288 | `list_votes` | no | unknown / needs local verification | needs review |
+| POST | `/amendments/{id}/votes` | `/v1/constitutional/amendments/{id}/votes` | `icn/crates/icn-gateway/src/api/constitutional/voting.rs`:193 | `cast_vote` | no | unknown / needs local verification | needs review |
+| POST | `/amendments/{id}/withdraw` | `/v1/constitutional/amendments/{id}/withdraw` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:931 | `withdraw_amendment` | no | unknown / needs local verification | needs review |
+| GET | `/appeals` | `/v1/constitutional/appeals` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1069 | `list_appeals` | no | unknown / needs local verification | needs review |
+| POST | `/appeals` | `/v1/constitutional/appeals` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:976 | `file_appeal` | no | unknown / needs local verification | needs review |
+| GET | `/appeals/dashboard` | `/v1/constitutional/appeals/dashboard` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:233 | `get_appeals_dashboard` | no | unknown / needs local verification | needs review |
+| GET | `/appeals/{id}` | `/v1/constitutional/appeals/{id}` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1108 | `get_appeal` | no | unknown / needs local verification | needs review |
+| POST | `/appeals/{id}/assign-reviewer` | `/v1/constitutional/appeals/{id}/assign-reviewer` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:174 | `assign_reviewer` | no | unknown / needs local verification | needs review |
+| POST | `/appeals/{id}/evidence` | `/v1/constitutional/appeals/{id}/evidence` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1136 | `add_appeal_evidence` | no | unknown / needs local verification | needs review |
+| POST | `/appeals/{id}/resolve` | `/v1/constitutional/appeals/{id}/resolve` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1282 | `resolve_appeal` | no | unknown / needs local verification | needs review |
+| POST | `/appeals/{id}/respond` | `/v1/constitutional/appeals/{id}/respond` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1210 | `add_appeal_response` | no | unknown / needs local verification | needs review |
+| POST | `/appeals/{id}/review` | `/v1/constitutional/appeals/{id}/review` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1255 | `begin_appeal_review` | no | unknown / needs local verification | needs review |
+| GET | `/appeals/{id}/status` | `/v1/constitutional/appeals/{id}/status` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:141 | `get_appeal_status` | no | unknown / needs local verification | needs review |
+| GET | `/appeals/{id}/timeline` | `/v1/constitutional/appeals/{id}/timeline` | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs`:107 | `get_appeal_timeline` | no | unknown / needs local verification | needs review |
+| POST | `/appeals/{id}/withdraw` | `/v1/constitutional/appeals/{id}/withdraw` | `icn/crates/icn-gateway/src/api/constitutional/mod.rs`:1317 | `withdraw_appeal` | no | unknown / needs local verification | needs review |
+| GET | `(empty)` | `/v1/contracts` | `icn/crates/icn-gateway/src/api/contracts.rs`:406 | `list_contracts` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/contracts` | `icn/crates/icn-gateway/src/api/contracts.rs`:346 | `deploy_contract` | no | unknown / needs local verification | needs review |
+| GET | `/name/{name}/versions` | `/v1/contracts/name/{name}/versions` | `icn/crates/icn-gateway/src/api/contracts.rs`:717 | `get_version_history` | no | unknown / needs local verification | needs review |
+| DELETE | `/{hash}` | `/v1/contracts/{hash}` | `icn/crates/icn-gateway/src/api/contracts.rs`:561 | `revoke_contract` | no | unknown / needs local verification | needs review |
+| GET | `/{hash}` | `/v1/contracts/{hash}` | `icn/crates/icn-gateway/src/api/contracts.rs`:450 | `get_contract` | no | unknown / needs local verification | needs review |
+| POST | `/{hash}/deprecate` | `/v1/contracts/{hash}/deprecate` | `icn/crates/icn-gateway/src/api/contracts.rs`:636 | `deprecate_contract` | no | unknown / needs local verification | needs review |
+| GET | `/{hash}/metadata` | `/v1/contracts/{hash}/metadata` | `icn/crates/icn-gateway/src/api/contracts.rs`:608 | `get_contract_metadata` | no | unknown / needs local verification | needs review |
+| GET | `/{hash}/status` | `/v1/contracts/{hash}/status` | `icn/crates/icn-gateway/src/api/contracts.rs`:689 | `get_contract_status` | no | unknown / needs local verification | needs review |
+| GET | `/{hash}/summary` | `/v1/contracts/{hash}/summary` | `icn/crates/icn-gateway/src/api/contracts.rs`:496 | `get_contract_summary` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/members` | `icn/crates/icn-gateway/src/api/coops.rs`:37 | `create_coop` | no | unknown / needs local verification | needs review |
+| GET | `/coops/{id}/stats` | `/v1/members/coops/{id}/stats` | `icn/crates/icn-gateway/src/api/coops.rs`:337 | `get_coop_stats` | no | unknown / needs local verification | needs review |
+| DELETE | `/{id}` | `/v1/members/{id}` | `icn/crates/icn-gateway/src/api/coops.rs`:143 | `delete_coop` | no | unknown / needs local verification | needs review |
+| GET | `/{id}` | `/v1/members/{id}` | `icn/crates/icn-gateway/src/api/coops.rs`:74 | `get_coop` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/members` | `/v1/members/{id}/members` | `icn/crates/icn-gateway/src/api/coops.rs`:174 | `add_member` | no | unknown / needs local verification | needs review |
+| DELETE | `/{id}/members/{did}` | `/v1/members/{id}/members/{did}` | `icn/crates/icn-gateway/src/api/coops.rs`:230 | `remove_member` | no | unknown / needs local verification | needs review |
+| PUT | `/{id}/members/{did}/role` | `/v1/members/{id}/members/{did}/role` | `icn/crates/icn-gateway/src/api/coops.rs`:268 | `update_member_role` | no | unknown / needs local verification | needs review |
+| PUT | `/{id}/settings` | `/v1/members/{id}/settings` | `icn/crates/icn-gateway/src/api/coops.rs`:89 | `update_settings` | no | unknown / needs local verification | needs review |
+| GET | `/{did}` | `/v1/devices/{did}` | `icn/crates/icn-gateway/src/api/devices.rs`:134 | `list_devices` | no | unknown / needs local verification | needs review |
+| POST | `/{did}` | `/v1/devices/{did}` | `icn/crates/icn-gateway/src/api/devices.rs`:77 | `register_device` | no | unknown / needs local verification | needs review |
+| DELETE | `/{did}/{device_id}` | `/v1/devices/{did}/{device_id}` | `icn/crates/icn-gateway/src/api/devices.rs`:174 | `revoke_device` | no | unknown / needs local verification | needs review |
+| GET | `/{did}/{device_id}` | `/v1/devices/{did}/{device_id}` | `icn/crates/icn-gateway/src/api/devices.rs`:222 | `get_device` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/entities` | `icn/crates/icn-gateway/src/api/entity.rs`:289 | `register_entity` | no | unknown / needs local verification | needs review |
+| POST | `/audit/prune` | `/v1/entities/audit/prune` | `icn/crates/icn-gateway/src/api/entity.rs`:1739 | `prune_audit` | no | unknown / needs local verification | needs review |
+| GET | `/audit/stats` | `/v1/entities/audit/stats` | `icn/crates/icn-gateway/src/api/entity.rs`:1829 | `audit_stats` | no | unknown / needs local verification | needs review |
+| DELETE | `/{id}` | `/v1/entities/{id}` | `icn/crates/icn-gateway/src/api/entity.rs`:632 | `delete_entity` | no | unknown / needs local verification | needs review |
+| GET | `/{id}` | `/v1/entities/{id}` | `icn/crates/icn-gateway/src/api/entity.rs`:482 | `get_entity` | no | unknown / needs local verification | needs review |
+| PUT | `/{id}` | `/v1/entities/{id}` | `icn/crates/icn-gateway/src/api/entity.rs`:513 | `update_entity` | no | unknown / needs local verification | needs review |
+| GET | `/{id}/audit` | `/v1/entities/{id}/audit` | `icn/crates/icn-gateway/src/api/entity.rs`:1667 | `get_entity_audit` | no | unknown / needs local verification | needs review |
+| DELETE | `/{id}/dissolution` | `/v1/entities/{id}/dissolution` | `icn/crates/icn-gateway/src/api/entity.rs`:1521 | `cancel_dissolution` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/dissolution` | `/v1/entities/{id}/dissolution` | `icn/crates/icn-gateway/src/api/entity.rs`:1129 | `initiate_dissolution` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/dissolution/complete` | `/v1/entities/{id}/dissolution/complete` | `icn/crates/icn-gateway/src/api/entity.rs`:1335 | `complete_dissolution` | no | unknown / needs local verification | needs review |
+| GET | `/{id}/members` | `/v1/entities/{id}/members` | `icn/crates/icn-gateway/src/api/entity.rs`:720 | `list_members` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/members` | `/v1/entities/{id}/members` | `icn/crates/icn-gateway/src/api/entity.rs`:832 | `add_membership` | no | unknown / needs local verification | needs review |
+| DELETE | `/{id}/members/{member_id}` | `/v1/entities/{id}/members/{member_id}` | `icn/crates/icn-gateway/src/api/entity.rs`:971 | `remove_membership` | no | unknown / needs local verification | needs review |
+| GET | `/escrow` | `/v1/gov/escrow` | `icn/crates/icn-gateway/src/api/escrow.rs`:86 | `list_escrows` | no | unknown / needs local verification | needs review |
+| POST | `/escrow` | `/v1/gov/escrow` | `icn/crates/icn-gateway/src/api/escrow.rs`:39 | `create_escrow` | no | unknown / needs local verification | needs review |
+| GET | `/escrow/{id}` | `/v1/gov/escrow/{id}` | `icn/crates/icn-gateway/src/api/escrow.rs`:127 | `get_escrow` | no | unknown / needs local verification | needs review |
+| POST | `/escrow/{id}/refund` | `/v1/gov/escrow/{id}/refund` | `icn/crates/icn-gateway/src/api/escrow.rs`:275 | `refund_escrow` | no | unknown / needs local verification | needs review |
+| POST | `/escrow/{id}/release` | `/v1/gov/escrow/{id}/release` | `icn/crates/icn-gateway/src/api/escrow.rs`:156 | `release_escrow` | no | unknown / needs local verification | needs review |
+| GET | `/records` | `/v1/execution/records` | `icn/crates/icn-gateway/src/api/execution.rs`:119 | `list_records` | no | unknown / needs local verification | needs review |
+| GET | `/records/{decision_hash}` | `/v1/execution/records/{decision_hash}` | `icn/crates/icn-gateway/src/api/execution.rs`:137 | `get_record` | no | unknown / needs local verification | needs review |
+| POST | `/attestations` | `/v1/federation/attestations` | `icn/crates/icn-gateway/src/api/federation.rs`:719 | `issue_attestation` | no | unknown / needs local verification | needs review |
+| GET | `/attestations/{member_did}` | `/v1/federation/attestations/{member_did}` | `icn/crates/icn-gateway/src/api/federation.rs`:701 | `get_attestations` | no | unknown / needs local verification | needs review |
+| GET | `/clearing` | `/v1/federation/clearing` | `icn/crates/icn-gateway/src/api/federation.rs`:790 | `list_agreements` | no | unknown / needs local verification | needs review |
+| POST | `/clearing` | `/v1/federation/clearing` | `icn/crates/icn-gateway/src/api/federation.rs`:894 | `create_agreement` | no | unknown / needs local verification | needs review |
+| POST | `/clearing/netting/{unit}` | `/v1/federation/clearing/netting/{unit}` | `icn/crates/icn-gateway/src/api/federation.rs`:1140 | `perform_multilateral_netting` | no | unknown / needs local verification | needs review |
+| POST | `/clearing/netting/{unit}/apply` | `/v1/federation/clearing/netting/{unit}/apply` | `icn/crates/icn-gateway/src/api/federation.rs`:1176 | `apply_multilateral_netting` | no | unknown / needs local verification | needs review |
+| POST | `/clearing/settle-scheduled` | `/v1/federation/clearing/settle-scheduled` | `icn/crates/icn-gateway/src/api/federation.rs`:1105 | `process_scheduled_settlements` | no | unknown / needs local verification | needs review |
+| GET | `/clearing/{agreement_id}` | `/v1/federation/clearing/{agreement_id}` | `icn/crates/icn-gateway/src/api/federation.rs`:841 | `get_agreement` | no | unknown / needs local verification | needs review |
+| GET | `/clearing/{agreement_id}/position` | `/v1/federation/clearing/{agreement_id}/position` | `icn/crates/icn-gateway/src/api/federation.rs`:1030 | `get_position` | no | unknown / needs local verification | needs review |
+| POST | `/clearing/{agreement_id}/settle` | `/v1/federation/clearing/{agreement_id}/settle` | `icn/crates/icn-gateway/src/api/federation.rs`:1079 | `trigger_settlement` | no | unknown / needs local verification | needs review |
+| POST | `/clearing/{id}/propose-adoption` | `/v1/federation/clearing/{id}/propose-adoption` | `icn/crates/icn-gateway/src/api/federation.rs`:972 | `propose_clearing_adoption` | yes | unknown / needs local verification | needs review |
+| POST | `/connect` | `/v1/federation/connect` | `icn/crates/icn-gateway/src/api/federation.rs`:1210 | `federation_connect` | no | unknown / needs local verification | needs review |
+| GET | `/coops` | `/v1/federation/coops` | `icn/crates/icn-gateway/src/api/federation.rs`:255 | `list_coops` | no | unknown / needs local verification | needs review |
+| POST | `/coops` | `/v1/federation/coops` | `icn/crates/icn-gateway/src/api/federation.rs`:337 | `register_coop` | no | unknown / needs local verification | needs review |
+| GET | `/coops/{coop_id}` | `/v1/federation/coops/{coop_id}` | `icn/crates/icn-gateway/src/api/federation.rs`:295 | `get_coop` | no | unknown / needs local verification | needs review |
+| POST | `/coops/{coop_id}/vouch` | `/v1/federation/coops/{coop_id}/vouch` | `icn/crates/icn-gateway/src/api/federation.rs`:415 | `vouch_for_coop` | no | unknown / needs local verification | needs review |
+| GET | `/coops/{coop_id}/vouches` | `/v1/federation/coops/{coop_id}/vouches` | `icn/crates/icn-gateway/src/api/federation.rs`:381 | `get_vouches` | no | unknown / needs local verification | needs review |
+| POST | `/init` | `/v1/federation/init` | `icn/crates/icn-gateway/src/api/federation.rs`:208 | `init_federation` | no | unknown / needs local verification | needs review |
+| GET | `/status` | `/v1/federation/status` | `icn/crates/icn-gateway/src/api/federation.rs`:166 | `get_status` | no | unknown / needs local verification | needs review |
+| GET | `/topology` | `/v1/federation/topology` | `icn/crates/icn-gateway/src/api/federation.rs`:562 | `get_topology` | yes | unknown / needs local verification | needs review |
+| POST | `/{coop_id}/proposals` | `/v1/coops/{coop_id}/proposals` | `icn/crates/icn-gateway/src/api/flow_c.rs`:22 | `propose_spend_alias` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/treasury/position` | `/v1/coops/{coop_id}/treasury/position` | `icn/crates/icn-gateway/src/api/flow_c.rs`:35 | `get_treasury_position_alias` | no | unknown / needs local verification | needs review |
+| GET | `/{id}/proof` | `/v1/coops/{id}/proof` | `icn/crates/icn-gateway/src/api/flow_c.rs`:112 | `get_proof_alias` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/vote` | `/v1/coops/{id}/vote` | `icn/crates/icn-gateway/src/api/flow_c.rs`:46 | `cast_vote_alias` | no | unknown / needs local verification | needs review |
+| GET | `/governance/{charter_id}/dashboard` | `/v1/gov/governance/{charter_id}/dashboard` | `icn/crates/icn-gateway/src/api/governance_dashboard.rs`:21 | `get_governance_dashboard` | no | unknown / needs local verification | needs review |
+| GET | `/health` | `/v1/health` | `icn/crates/icn-gateway/src/api/health.rs`:169 | `health` | no | unknown / needs local verification | needs review |
+| GET | `/health/detailed` | `/v1/health/detailed` | `icn/crates/icn-gateway/src/api/health.rs`:182 | `health_detailed` | no | unknown / needs local verification | needs review |
+| GET | `/health/full` | `/v1/health/full` | `icn/crates/icn-gateway/src/api/health.rs`:284 | `health_full` | no | unknown / needs local verification | needs review |
+| GET | `/healthz` | `/v1/healthz` | `icn/crates/icn-gateway/src/api/health.rs`:36 | `liveness` | no | unknown / needs local verification | needs review |
+| GET | `/ready` | `/v1/ready` | `icn/crates/icn-gateway/src/api/health.rs`:100 | `ready` | no | unknown / needs local verification | needs review |
+| GET | `/readyz` | `/v1/readyz` | `icn/crates/icn-gateway/src/api/health.rs`:48 | `readiness` | no | unknown / needs local verification | needs review |
+| GET | `/health` | `/v1/identity/health` | `icn/crates/icn-gateway/src/api/identity.rs`:100 | `identity_health` | no | unknown / needs local verification | needs review |
+| GET | `/resolve/{did}` | `/v1/identity/resolve/{did}` | `icn/crates/icn-gateway/src/api/identity.rs`:60 | `resolve_did` | no | unknown / needs local verification | needs review |
+| GET | `(empty)` | `/v1/invites` | `icn/crates/icn-gateway/src/api/invites.rs`:101 | `list_invites` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/invites` | `icn/crates/icn-gateway/src/api/invites.rs`:25 | `create_invite` | no | unknown / needs local verification | needs review |
+| POST | `/join` | `/v1/invites/join` | `icn/crates/icn-gateway/src/api/invites.rs`:146 | `join_via_invite` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/entries/by-decision` | `/v1/ledger/{coop_id}/entries/by-decision` | `icn/crates/icn-gateway/src/api/ledger.rs`:389 | `get_entries_by_decision` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/history` | `/v1/ledger/{coop_id}/history` | `icn/crates/icn-gateway/src/api/ledger.rs`:237 | `get_history` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/position/{did}` | `/v1/ledger/{coop_id}/position/{did}` | `icn/crates/icn-gateway/src/api/ledger.rs`:22 | `get_position` | no | unknown / needs local verification | needs review |
+| POST | `/{coop_id}/settle` | `/v1/ledger/{coop_id}/settle` | `icn/crates/icn-gateway/src/api/ledger.rs`:55 | `create_settlement` | no | unknown / needs local verification | needs review |
+| POST | `/{coop_id}/settle/convert` | `/v1/ledger/{coop_id}/settle/convert` | `icn/crates/icn-gateway/src/api/ledger.rs`:546 | `create_cross_settlement` | no | unknown / needs local verification | needs review |
+| POST | `/{coop_id}/settle/convert/quote` | `/v1/ledger/{coop_id}/settle/convert/quote` | `icn/crates/icn-gateway/src/api/ledger.rs`:657 | `get_cross_settlement_quote` | no | unknown / needs local verification | needs review |
+| GET | `(empty)` | `/v1/listings` | `icn/crates/icn-gateway/src/api/listings.rs`:637 | `list_listings` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/listings` | `icn/crates/icn-gateway/src/api/listings.rs`:576 | `create_listing` | no | unknown / needs local verification | needs review |
+| GET | `/my` | `/v1/listings/my` | `icn/crates/icn-gateway/src/api/listings.rs`:1013 | `get_my_listings` | no | unknown / needs local verification | needs review |
+| DELETE | `/{id}` | `/v1/listings/{id}` | `icn/crates/icn-gateway/src/api/listings.rs`:786 | `delete_listing` | no | unknown / needs local verification | needs review |
+| GET | `/{id}` | `/v1/listings/{id}` | `icn/crates/icn-gateway/src/api/listings.rs`:681 | `get_listing` | no | unknown / needs local verification | needs review |
+| PUT | `/{id}` | `/v1/listings/{id}` | `icn/crates/icn-gateway/src/api/listings.rs`:715 | `update_listing` | no | unknown / needs local verification | needs review |
+| POST | `/{id}/interest` | `/v1/listings/{id}/interest` | `icn/crates/icn-gateway/src/api/listings.rs`:895 | `express_interest` | no | unknown / needs local verification | needs review |
+| GET | `/{id}/interests` | `/v1/listings/{id}/interests` | `icn/crates/icn-gateway/src/api/listings.rs`:973 | `get_interests` | no | unknown / needs local verification | needs review |
+| PUT | `/{id}/status` | `/v1/listings/{id}/status` | `icn/crates/icn-gateway/src/api/listings.rs`:830 | `update_listing_status` | no | unknown / needs local verification | needs review |
+| GET | `/members/{coop_id}/{did}` | `/v1/identity/members/{coop_id}/{did}` | `icn/crates/icn-gateway/src/api/members.rs`:40 | `get_member_profile` | no | unknown / needs local verification | needs review |
+| PUT | `/{coop_id}/{did}/profile` | `/v1/identity/{coop_id}/{did}/profile` | `icn/crates/icn-gateway/src/api/members.rs`:130 | `update_member_profile` | no | unknown / needs local verification | needs review |
+| POST | `/apply` | `/v1/membership/apply` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:136 | `apply_for_membership` | no | unknown / needs local verification | needs review |
+| POST | `/approve` | `/v1/membership/approve` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:225 | `approve_membership` | no | unknown / needs local verification | needs review |
+| POST | `/ban` | `/v1/membership/ban` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:345 | `ban_member` | no | unknown / needs local verification | needs review |
+| GET | `/capability/check` | `/v1/membership/capability/check` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:506 | `check_capability` | no | unknown / needs local verification | needs review |
+| POST | `/capability/grant` | `/v1/membership/capability/grant` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:440 | `grant_capability` | no | unknown / needs local verification | needs review |
+| POST | `/capability/revoke` | `/v1/membership/capability/revoke` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:473 | `revoke_capability` | no | unknown / needs local verification | needs review |
+| POST | `/exit` | `/v1/membership/exit` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:703 | `exit_membership` | no | unknown / needs local verification | needs review |
+| GET | `/list/{jurisdiction}` | `/v1/membership/list/{jurisdiction}` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:611 | `list_members` | no | unknown / needs local verification | needs review |
+| POST | `/promote` | `/v1/membership/promote` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:255 | `promote_member` | no | unknown / needs local verification | needs review |
+| POST | `/reinstate` | `/v1/membership/reinstate` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:315 | `reinstate_member` | no | unknown / needs local verification | needs review |
+| POST | `/revoke` | `/v1/membership/revoke` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:387 | `revoke_membership` | no | unknown / needs local verification | needs review |
+| POST | `/role/add` | `/v1/membership/role/add` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:536 | `add_role` | no | unknown / needs local verification | needs review |
+| POST | `/role/remove` | `/v1/membership/role/remove` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:566 | `remove_role` | no | unknown / needs local verification | needs review |
+| GET | `/status/{jurisdiction}` | `/v1/membership/status/{jurisdiction}` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:180 | `get_membership_status` | no | unknown / needs local verification | needs review |
+| POST | `/suspend` | `/v1/membership/suspend` | `icn/crates/icn-gateway/src/api/membership/mod.rs`:285 | `suspend_member` | no | unknown / needs local verification | needs review |
+| GET | `/{path:.*}` | `/v1/names/{path:.*}` | `icn/crates/icn-gateway/src/api/names.rs`:138 | `resolve_name` | no | unknown / needs local verification | needs review |
+| GET | `/notifications` | `/v1/notifications/notifications` | `icn/crates/icn-gateway/src/api/notifications.rs`:118 | `list_notifications` | no | unknown / needs local verification | needs review |
+| GET | `/notifications/count` | `/v1/notifications/notifications/count` | `icn/crates/icn-gateway/src/api/notifications.rs`:154 | `get_notification_count` | no | unknown / needs local verification | needs review |
+| POST | `/notifications/read-all` | `/v1/notifications/notifications/read-all` | `icn/crates/icn-gateway/src/api/notifications.rs`:196 | `mark_all_read` | no | unknown / needs local verification | needs review |
+| POST | `/notifications/register` | `/v1/notifications/notifications/register` | `icn/crates/icn-gateway/src/api/notifications.rs`:36 | `register_device` | no | unknown / needs local verification | needs review |
+| DELETE | `/notifications/unregister` | `/v1/notifications/notifications/unregister` | `icn/crates/icn-gateway/src/api/notifications.rs`:57 | `unregister_device` | no | unknown / needs local verification | needs review |
+| DELETE | `/notifications/{notification_id}` | `/v1/notifications/notifications/{notification_id}` | `icn/crates/icn-gateway/src/api/notifications.rs`:213 | `delete_notification` | no | unknown / needs local verification | needs review |
+| POST | `/notifications/{notification_id}/read` | `/v1/notifications/notifications/{notification_id}/read` | `icn/crates/icn-gateway/src/api/notifications.rs`:171 | `mark_notification_read` | no | unknown / needs local verification | needs review |
+| GET | `/notifications/{notification_id}/status` | `/v1/notifications/notifications/{notification_id}/status` | `icn/crates/icn-gateway/src/api/notifications.rs`:241 | `get_delivery_status` | no | unknown / needs local verification | needs review |
+| POST | `/convert` | `/v1/oracle/convert` | `icn/crates/icn-gateway/src/api/oracle.rs`:280 | `convert_amount` | no | unknown / needs local verification | needs review |
+| POST | `/rate` | `/v1/oracle/rate` | `icn/crates/icn-gateway/src/api/oracle.rs`:380 | `set_rate` | no | unknown / needs local verification | needs review |
+| GET | `/rate/{from}/{to}` | `/v1/oracle/rate/{from}/{to}` | `icn/crates/icn-gateway/src/api/oracle.rs`:213 | `get_rate` | no | unknown / needs local verification | needs review |
+| GET | `/sources` | `/v1/oracle/sources` | `icn/crates/icn-gateway/src/api/oracle.rs`:355 | `list_sources` | no | unknown / needs local verification | needs review |
+| GET | `/allocations` | `/v1/receipts/allocations` | `icn/crates/icn-gateway/src/api/receipts.rs`:569 | `list_allocations` | no | unknown / needs local verification | needs review |
+| GET | `/allocations/{hash}` | `/v1/receipts/allocations/{hash}` | `icn/crates/icn-gateway/src/api/receipts.rs`:282 | `get_allocation` | no | unknown / needs local verification | needs review |
+| GET | `/chain` | `/v1/receipts/chain` | `icn/crates/icn-gateway/src/api/receipts.rs`:331 | `get_chain` | no | unknown / needs local verification | needs review |
+| GET | `/chain/{decision_hash}` | `/v1/receipts/chain/{decision_hash}` | `icn/crates/icn-gateway/src/api/receipts.rs`:381 | `get_full_chain` | no | unknown / needs local verification | needs review |
+| GET | `/intents` | `/v1/receipts/intents` | `icn/crates/icn-gateway/src/api/receipts.rs`:598 | `list_intents` | no | unknown / needs local verification | needs review |
+| GET | `/intents/{hash}` | `/v1/receipts/intents/{hash}` | `icn/crates/icn-gateway/src/api/receipts.rs`:305 | `get_intent` | no | unknown / needs local verification | needs review |
+| GET | `/settlements/recurring` | `/v1/gov/settlements/recurring` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:94 | `list_recurring_settlements` | no | unknown / needs local verification | needs review |
+| POST | `/settlements/recurring` | `/v1/gov/settlements/recurring` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:44 | `create_recurring_settlement` | no | unknown / needs local verification | needs review |
+| DELETE | `/settlements/recurring/{id}` | `/v1/gov/settlements/recurring/{id}` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:214 | `cancel_recurring_settlement` | no | unknown / needs local verification | needs review |
+| GET | `/settlements/recurring/{id}` | `/v1/gov/settlements/recurring/{id}` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:135 | `get_recurring_settlement` | no | unknown / needs local verification | needs review |
+| PUT | `/settlements/recurring/{id}` | `/v1/gov/settlements/recurring/{id}` | `icn/crates/icn-gateway/src/api/recurring_settlements.rs`:164 | `update_recurring_settlement` | no | unknown / needs local verification | needs review |
+| GET | `/decisions` | `/v1/registry/decisions` | `icn/crates/icn-gateway/src/api/registry.rs`:702 | `list_decisions` | no | unknown / needs local verification | needs review |
+| POST | `/decisions` | `/v1/registry/decisions` | `icn/crates/icn-gateway/src/api/registry.rs`:598 | `index_decision_endpoint` | no | unknown / needs local verification | needs review |
+| GET | `/decisions/{id}` | `/v1/registry/decisions/{id}` | `icn/crates/icn-gateway/src/api/registry.rs`:745 | `get_decision` | no | unknown / needs local verification | needs review |
+| GET | `/decisions/{id}/trace` | `/v1/registry/decisions/{id}/trace` | `icn/crates/icn-gateway/src/api/registry.rs`:781 | `get_decision_trace` | no | unknown / needs local verification | needs review |
+| GET | `/meetings` | `/v1/registry/meetings` | `icn/crates/icn-gateway/src/api/registry.rs`:564 | `list_meetings` | no | unknown / needs local verification | needs review |
+| POST | `/meetings` | `/v1/registry/meetings` | `icn/crates/icn-gateway/src/api/registry.rs`:491 | `create_meeting` | no | unknown / needs local verification | needs review |
+| GET | `/summary` | `/v1/rights/summary` | `icn/crates/icn-gateway/src/api/rights.rs`:12 | `rights_summary` | no | unknown / needs local verification | needs review |
+| POST | `/devices/add` | `/v1/sdis/devices/add` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:332 | `add_device` | no | unknown / needs local verification | needs review |
+| POST | `/enrollment/complete` | `/v1/sdis/enrollment/complete` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:501 | `complete_enrollment` | no | unknown / needs local verification | needs review |
+| POST | `/enrollment/start` | `/v1/sdis/enrollment/start` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:281 | `start_enrollment` | no | unknown / needs local verification | needs review |
+| POST | `/enrollment/verify/level1` | `/v1/sdis/enrollment/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:331 | `verify_level1` | no | unknown / needs local verification | needs review |
+| POST | `/enrollment/verify/level2` | `/v1/sdis/enrollment/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:406 | `verify_level2` | no | unknown / needs local verification | needs review |
+| POST | `/ephemeral/generate` | `/v1/sdis/ephemeral/generate` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:301 | `generate_ephemeral` | no | unknown / needs local verification | needs review |
+| GET | `/health` | `/v1/sdis/health` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:175 | `sdis_health` | no | unknown / needs local verification | needs review |
+| POST | `/reject/{enrollment_id}` | `/v1/sdis/reject/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:913 | `reject_enrollment` | no | unknown / needs local verification | needs review |
+| POST | `/rotate-keys` | `/v1/sdis/rotate-keys` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:271 | `rotate_keys` | no | unknown / needs local verification | needs review |
+| POST | `/start` | `/v1/sdis/start` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:258 | `start_enrollment` | no | unknown / needs local verification | needs review |
+| POST | `/start` | `/v1/sdis/start` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:216 | `start_recovery` | no | unknown / needs local verification | needs review |
+| POST | `/verify/level1` | `/v1/sdis/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:189 | `verify_level1` | no | unknown / needs local verification | needs review |
+| POST | `/verify/level2` | `/v1/sdis/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:209 | `verify_level2` | no | unknown / needs local verification | needs review |
+| POST | `/vouch/{enrollment_id}` | `/v1/sdis/vouch/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:824 | `steward_vouch` | no | unknown / needs local verification | needs review |
+| GET | `/{anchor_id}` | `/v1/sdis/{anchor_id}` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:246 | `get_anchor` | no | unknown / needs local verification | needs review |
+| GET | `/{anchor_id}/devices` | `/v1/sdis/{anchor_id}/devices` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:368 | `list_devices` | no | unknown / needs local verification | needs review |
+| GET | `/{anchor_id}/history` | `/v1/sdis/{anchor_id}/history` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:311 | `get_rotation_history` | no | unknown / needs local verification | needs review |
+| GET | `/{ceremony_id}` | `/v1/sdis/{ceremony_id}` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:294 | `get_enrollment_status` | no | unknown / needs local verification | needs review |
+| POST | `/{ceremony_id}/approve` | `/v1/sdis/{ceremony_id}/approve` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:368 | `approve_ceremony` | no | unknown / needs local verification | needs review |
+| POST | `/{ceremony_id}/finalize` | `/v1/sdis/{ceremony_id}/finalize` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:318 | `finalize_enrollment` | no | unknown / needs local verification | needs review |
+| GET | `/{recovery_id}` | `/v1/sdis/{recovery_id}` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:252 | `get_recovery_status` | no | unknown / needs local verification | needs review |
+| POST | `/{recovery_id}/approve` | `/v1/sdis/{recovery_id}/approve` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:329 | `approve_recovery` | no | unknown / needs local verification | needs review |
+| POST | `/{recovery_id}/complete` | `/v1/sdis/{recovery_id}/complete` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:275 | `complete_recovery` | no | unknown / needs local verification | needs review |
+| GET | `(empty)` | `/v1/services` | `icn/crates/icn-gateway/src/api/services.rs`:494 | `query_services` | no | unknown / needs local verification | needs review |
+| POST | `/announce` | `/v1/services/announce` | `icn/crates/icn-gateway/src/api/services.rs`:238 | `announce_service` | no | unknown / needs local verification | needs review |
+| GET | `/discover` | `/v1/services/discover` | `icn/crates/icn-gateway/src/api/services.rs`:388 | `discover_services` | no | unknown / needs local verification | needs review |
+| DELETE | `/{service_id}` | `/v1/services/{service_id}` | `icn/crates/icn-gateway/src/api/services.rs`:347 | `withdraw_service` | no | unknown / needs local verification | needs review |
+| GET | `/{service_id}` | `/v1/services/{service_id}` | `icn/crates/icn-gateway/src/api/services.rs`:550 | `get_service` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/sessions` | `icn/crates/icn-gateway/src/api/sessions.rs`:137 | `create_session` | no | unknown / needs local verification | needs review |
+| GET | `/{session_id}` | `/v1/sessions/{session_id}` | `icn/crates/icn-gateway/src/api/sessions.rs`:184 | `get_session_status` | no | unknown / needs local verification | needs review |
+| POST | `/{session_id}/approve` | `/v1/sessions/{session_id}/approve` | `icn/crates/icn-gateway/src/api/sessions.rs`:251 | `approve_session` | no | unknown / needs local verification | needs review |
+| GET | `(empty)` | `/v1/steward` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:170 | `list_stewards` | no | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/steward` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:72 | `register_steward` | no | unknown / needs local verification | needs review |
+| GET | `/attesters` | `/v1/steward/attesters` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:195 | `list_attesters` | no | unknown / needs local verification | needs review |
+| GET | `/by-did/{did}` | `/v1/steward/by-did/{did}` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:150 | `get_steward_by_did` | no | unknown / needs local verification | needs review |
+| GET | `/{steward_id}` | `/v1/steward/{steward_id}` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:133 | `get_steward` | no | unknown / needs local verification | needs review |
+| POST | `/{steward_id}/attestation` | `/v1/steward/{steward_id}/attestation` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:570 | `record_attestation` | no | unknown / needs local verification | needs review |
+| POST | `/{steward_id}/bond/add` | `/v1/steward/{steward_id}/bond/add` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:432 | `add_bond` | no | unknown / needs local verification | needs review |
+| POST | `/{steward_id}/bond/slash` | `/v1/steward/{steward_id}/bond/slash` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:484 | `slash_bond` | no | unknown / needs local verification | needs review |
+| POST | `/{steward_id}/dispute` | `/v1/steward/{steward_id}/dispute` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:624 | `record_dispute` | no | unknown / needs local verification | needs review |
+| POST | `/{steward_id}/dispute-won` | `/v1/steward/{steward_id}/dispute-won` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:686 | `record_dispute_won` | no | unknown / needs local verification | needs review |
+| POST | `/{steward_id}/extend-term` | `/v1/steward/{steward_id}/extend-term` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:360 | `extend_steward_term` | no | unknown / needs local verification | needs review |
+| POST | `/{steward_id}/retire` | `/v1/steward/{steward_id}/retire` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:319 | `retire_steward` | no | unknown / needs local verification | needs review |
+| PUT | `/{steward_id}/status` | `/v1/steward/{steward_id}/status` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:214 | `update_steward_status` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}` | `/v1/treasury/{coop_id}` | `icn/crates/icn-gateway/src/api/treasury.rs`:375 | `get_treasury_status` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/audit` | `/v1/treasury/{coop_id}/audit` | `icn/crates/icn-gateway/src/api/treasury.rs`:939 | `get_audit_trail` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/budgets` | `/v1/treasury/{coop_id}/budgets` | `icn/crates/icn-gateway/src/api/treasury.rs`:576 | `list_budgets` | no | unknown / needs local verification | needs review |
+| POST | `/{coop_id}/budgets` | `/v1/treasury/{coop_id}/budgets` | `icn/crates/icn-gateway/src/api/treasury.rs`:732 | `create_budget` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/budgets/{budget_id}` | `/v1/treasury/{coop_id}/budgets/{budget_id}` | `icn/crates/icn-gateway/src/api/treasury.rs`:646 | `get_budget` | no | unknown / needs local verification | needs review |
+| POST | `/{coop_id}/deposit` | `/v1/treasury/{coop_id}/deposit` | `icn/crates/icn-gateway/src/api/treasury.rs`:1029 | `deposit_to_treasury` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/nonce` | `/v1/treasury/{coop_id}/nonce` | `icn/crates/icn-gateway/src/api/treasury.rs`:521 | `get_treasury_nonce` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/position` | `/v1/treasury/{coop_id}/position` | `icn/crates/icn-gateway/src/api/treasury.rs`:450 | `get_treasury_position` | no | unknown / needs local verification | needs review |
+| POST | `/{coop_id}/spend` | `/v1/treasury/{coop_id}/spend` | `icn/crates/icn-gateway/src/api/treasury.rs`:1163 | `propose_spend` | no | unknown / needs local verification | needs review |
+| GET | `/{coop_id}/spending-rules` | `/v1/treasury/{coop_id}/spending-rules` | `icn/crates/icn-gateway/src/api/treasury.rs`:872 | `list_spending_rules` | no | unknown / needs local verification | needs review |
+| POST | `/trust/attest` | `/v1/trust/trust/attest` | `icn/crates/icn-gateway/src/api/trust.rs`:103 | `create_trust_attestation` | no | unknown / needs local verification | needs review |
+| POST | `/trust/revoke` | `/v1/trust/trust/revoke` | `icn/crates/icn-gateway/src/api/trust.rs`:179 | `revoke_trust_attestation` | no | unknown / needs local verification | needs review |
+| GET | `/trust/{did}` | `/v1/trust/trust/{did}` | `icn/crates/icn-gateway/src/api/trust.rs`:35 | `get_trust_score` | no | unknown / needs local verification | needs review |
+| GET | `/trust/{did}/edges` | `/v1/trust/trust/{did}/edges` | `icn/crates/icn-gateway/src/api/trust.rs`:72 | `get_trust_edges` | no | unknown / needs local verification | needs review |
+| GET | `/trust/{did}/network` | `/v1/trust/trust/{did}/network` | `icn/crates/icn-gateway/src/api/trust.rs`:143 | `get_trust_network` | no | unknown / needs local verification | needs review |
+| GET | `/ws/{coop_id}` | `/v1/ws/{coop_id}` | `icn/crates/icn-gateway/src/api/websocket.rs`:12 | `websocket` | no | unknown / needs local verification | needs review |
 

--- a/docs/reference/project-index/runtime-surface-map.md
+++ b/docs/reference/project-index/runtime-surface-map.md
@@ -10,6 +10,8 @@ Last Reviewed: 2026-04-29
 
 This document points at the gateway endpoints, primitives, and proof artifacts that exist as real runtime surfaces in the current main. It is not exhaustive — a full API reference lives in [`docs/reference/api/API_REFERENCE.md`](../api/API_REFERENCE.md) — and it does not over-document implementation details. It is a fast routing layer.
 
+> For a **mechanical inventory of every gateway route declaration** (Actix attribute macros) versus OpenAPI coverage, see the generated [`generated/route-inventory.md`](generated/route-inventory.md) (regenerate/check with `docs/scripts/route_inventory.py`; issue [#2112](https://github.com/InterCooperative-Network/icn/issues/2112)). It proves declarations exist in source — not correctness, auth, tests, or production readiness.
+
 ## The gateway
 
 The `icn-gateway` crate exposes the REST + WebSocket surface used by member-facing apps and SDKs.

--- a/docs/scripts/route_inventory.py
+++ b/docs/scripts/route_inventory.py
@@ -55,7 +55,9 @@ ATTR_RE = re.compile(r'#\[(get|post|put|delete|patch|head)\("([^"]*)"\)\]')
 ROUTE_RE = re.compile(r'#\[route\("([^"]*)"\s*,\s*method\s*=\s*"([A-Za-z]+)"')
 FN_RE = re.compile(r'\b(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)')
 SCOPE_RE = re.compile(r'web::scope\("(/[^"]*)"\)')
-MODREF_RE = re.compile(r'api::([A-Za-z_]\w*)::')
+# Anchored at an identifier boundary so it does NOT match `api::<seg>::` *inside*
+# longer crate paths like `icn_kernel_api::services::` or `icn_api::LedgerService::`.
+MODREF_RE = re.compile(r'(?<![A-Za-z0-9_])api::([A-Za-z_]\w*)::')
 OAPI_PATH_RE = re.compile(r'^  (/\S*):\s*$')
 
 
@@ -63,10 +65,19 @@ def discover_routes() -> list[dict]:
     routes: list[dict] = []
     if not GATEWAY_SRC.is_dir():
         return routes
+    api_root = GATEWAY_SRC / "api"
     for rs in sorted(GATEWAY_SRC.rglob("*.rs")):
         lines = rs.read_text(encoding="utf-8", errors="replace").splitlines()
         rel = rs.relative_to(ROOT).as_posix()
-        module = rs.stem if rs.stem != "mod" else rs.parent.name
+        # Key by the TOP-LEVEL `src/api/<group>` segment (what server.rs registers as
+        # `api::<group>::...`), not the leaf filename — otherwise nested files such as
+        # `api/sdis/simple_enrollment.rs` would key on `simple_enrollment` and never
+        # resolve a scope. Files directly under `api/` use their own stem.
+        try:
+            parts = rs.relative_to(api_root).parts
+            module = parts[0][:-3] if len(parts) == 1 else parts[0]
+        except ValueError:
+            module = rs.stem if rs.stem != "mod" else rs.parent.name
         for i, line in enumerate(lines):
             method = path = None
             m = ATTR_RE.search(line)
@@ -98,8 +109,11 @@ def discover_routes() -> list[dict]:
 
 
 def module_scope_map() -> dict[str, str]:
-    """Best-effort: associate each `web::scope("/seg")` with the api::<module>:: refs
-    that textually follow it (until the next scope). Approximate, not a real parser."""
+    """Best-effort: associate each `web::scope("/seg")` with the `api::<module>::` refs
+    that appear in `.service(...)`/`.configure(...)` *registration* calls beneath it
+    (until the next scope). Only registration sites count — bare type references
+    (e.g. `crate::api::sdis::SdisState::new()`) are skipped so they cannot win the
+    `setdefault` and mislead the mapping. Approximate, not a real parser."""
     out: dict[str, str] = {}
     if not SERVER_RS.is_file():
         return out
@@ -108,6 +122,8 @@ def module_scope_map() -> dict[str, str]:
         sm = SCOPE_RE.search(line)
         if sm:
             current = sm.group(1) if sm.group(1) != "/v1" else ""
+        if ".service(" not in line and ".configure(" not in line:
+            continue
         for mod in MODREF_RE.findall(line):
             out.setdefault(mod, current)
     return out
@@ -208,10 +224,11 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], commit: 
     out.append("")
     out.append("## Limitations (PR1)")
     out.append("")
-    out.append("- **Full mounted-path resolution is best-effort.** The `Group` column is inferred from a simple "
-               "`web::scope(\"…\")` ↔ `api::<module>::` association read from `server.rs`; it is **not** a real Rust "
-               "parser and may be wrong for deeply-nested or conditional scopes. The relative macro `Path` and the "
-               "`Source` file are authoritative.")
+    out.append("- **Full mounted-path resolution is best-effort.** The `Group` column is `/v1` + a `web::scope(\"…\")` "
+               "segment associated from `server.rs` `.service(...)`/`.configure(...)` registration sites (matched at "
+               "identifier boundaries, keyed by the handler's top-level `icn/crates/icn-gateway/src/api/<group>` "
+               "module) + the relative macro path. It is **not** a real Rust parser and may be wrong for "
+               "deeply-nested or conditional scopes. The relative macro `Path` and the `Source` file are authoritative.")
     out.append("- Scans **attribute macros only** in `icn-gateway/src`. `web::resource(\"…\")`/`.route(\"…\")` "
                "registrations and out-of-crate handlers (e.g. `icn-governance-actor::http`) are not fully captured.")
     out.append("- This is **generated-map work, not API documentation completion** (issue #2112). It does not add or "
@@ -219,16 +236,19 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], commit: 
     out.append("")
     out.append("## Routes")
     out.append("")
-    out.append("Status vocabulary is the existing set from `source-of-truth-map.md`. PR1 defaults every discovered "
-               "route to `gateway-backed` (it is served by the gateway) and claim-safety to `needs review` "
-               "(per-route proof level is `unknown / needs local verification` pending human review).")
+    out.append("Status vocabulary is the existing set from `source-of-truth-map.md`; no new labels are introduced. "
+               "A static macro scan proves only that a routing macro is **declared** in source — not that the handler "
+               "is mounted and served (registration happens elsewhere via `.service(...)` / `.configure(...)`, which "
+               "this pass does not resolve). PR1 therefore **cannot** assert `gateway-backed`: every discovered route's "
+               "status defaults to `unknown / needs local verification` and claim-safety to `needs review`, pending "
+               "human or runtime confirmation.")
     out.append("")
     out.append("| Method | Path (macro) | Group (best-effort) | Source | Handler | OpenAPI | Status | Claim safety |")
     out.append("|---|---|---|---|---|---|---|---|")
     for r, fp, doc in rows:
         out.append(
             f"| {r['method']} | `{md_table_escape(r['path'] or '(empty)')}` | `{md_table_escape(fp)}` | "
-            f"`{r['file']}`:{r['line']} | `{md_table_escape(r['handler'])}` | {doc} | gateway-backed | needs review |"
+            f"`{r['file']}`:{r['line']} | `{md_table_escape(r['handler'])}` | {doc} | unknown / needs local verification | needs review |"
         )
     out.append("")
     return "\n".join(out)

--- a/docs/scripts/route_inventory.py
+++ b/docs/scripts/route_inventory.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Generate (or --check) a mechanical route inventory for the ICN gateway.
+
+Scans the gateway Rust source for Actix routing **attribute macros**
+(`#[get("...")]`, `#[post(...)]`, `#[put(...)]`, `#[delete(...)]`, `#[patch(...)]`,
+`#[head(...)]`, and `#[route("...", method = "...")]`), compares the discovered
+route declarations against the documented OpenAPI paths, and writes a
+claim-disciplined markdown inventory.
+
+This is deliberately humble (issue #2112, PR1):
+- It proves route **declarations** exist in source. It does NOT prove route
+  correctness, authentication, test coverage, production readiness, or public
+  safety. "OpenAPI documented" does not mean complete or correct.
+- Full mounted-path resolution is **best-effort** (a module->scope heuristic
+  read from server.rs), not a real Rust parser. The relative macro path and the
+  source file are authoritative; the "group" column is approximate.
+- It scans the gateway crate's attribute macros only. `web::resource`/`.route`
+  registrations and out-of-crate HTTP handlers (e.g. `icn-governance-actor`) are
+  not fully captured.
+
+Usage:
+    python3 docs/scripts/route_inventory.py --write    # regenerate the artifact
+    python3 docs/scripts/route_inventory.py --check     # exit 1 if the artifact is stale
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    try:
+        top = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=Path(__file__).resolve().parent,
+            text=True,
+        ).strip()
+        return Path(top)
+    except Exception:
+        return Path(__file__).resolve().parents[2]
+
+
+ROOT = repo_root()
+GATEWAY_SRC = ROOT / "icn" / "crates" / "icn-gateway" / "src"
+SERVER_RS = GATEWAY_SRC / "server.rs"
+OPENAPI = ROOT / "docs" / "api" / "openapi.generated.yaml"
+ARTIFACT = ROOT / "docs" / "reference" / "project-index" / "generated" / "route-inventory.md"
+SCRIPT_REL = "docs/scripts/route_inventory.py"
+
+ATTR_RE = re.compile(r'#\[(get|post|put|delete|patch|head)\("([^"]*)"\)\]')
+ROUTE_RE = re.compile(r'#\[route\("([^"]*)"\s*,\s*method\s*=\s*"([A-Za-z]+)"')
+FN_RE = re.compile(r'\b(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)')
+SCOPE_RE = re.compile(r'web::scope\("(/[^"]*)"\)')
+MODREF_RE = re.compile(r'api::([A-Za-z_]\w*)::')
+OAPI_PATH_RE = re.compile(r'^  (/\S*):\s*$')
+
+
+def discover_routes() -> list[dict]:
+    routes: list[dict] = []
+    if not GATEWAY_SRC.is_dir():
+        return routes
+    for rs in sorted(GATEWAY_SRC.rglob("*.rs")):
+        lines = rs.read_text(encoding="utf-8", errors="replace").splitlines()
+        rel = rs.relative_to(ROOT).as_posix()
+        module = rs.stem if rs.stem != "mod" else rs.parent.name
+        for i, line in enumerate(lines):
+            method = path = None
+            m = ATTR_RE.search(line)
+            if m:
+                method, path = m.group(1).upper(), m.group(2)
+            else:
+                rm = ROUTE_RE.search(line)
+                if rm:
+                    path, method = rm.group(1), rm.group(2).upper()
+            if not method:
+                continue
+            handler = "?"
+            for j in range(i + 1, min(i + 8, len(lines))):
+                fm = FN_RE.search(lines[j])
+                if fm:
+                    handler = fm.group(1)
+                    break
+            routes.append(
+                {
+                    "method": method,
+                    "path": path,
+                    "file": rel,
+                    "line": i + 1,
+                    "handler": handler,
+                    "module": module,
+                }
+            )
+    return routes
+
+
+def module_scope_map() -> dict[str, str]:
+    """Best-effort: associate each `web::scope("/seg")` with the api::<module>:: refs
+    that textually follow it (until the next scope). Approximate, not a real parser."""
+    out: dict[str, str] = {}
+    if not SERVER_RS.is_file():
+        return out
+    current = ""
+    for line in SERVER_RS.read_text(encoding="utf-8", errors="replace").splitlines():
+        sm = SCOPE_RE.search(line)
+        if sm:
+            current = sm.group(1) if sm.group(1) != "/v1" else ""
+        for mod in MODREF_RE.findall(line):
+            out.setdefault(mod, current)
+    return out
+
+
+def openapi_paths() -> list[str]:
+    if not OPENAPI.is_file():
+        return []
+    paths, in_paths = [], False
+    for line in OPENAPI.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.rstrip() == "paths:":
+            in_paths = True
+            continue
+        if in_paths and line and not line[0].isspace():
+            break
+        m = OAPI_PATH_RE.match(line)
+        if m:
+            paths.append(m.group(1))
+    return paths
+
+
+def norm(p: str) -> str:
+    p = re.sub(r"\{[^}]+\}", "{}", p)
+    p = re.sub(r"/+", "/", p)
+    return p.rstrip("/") or "/"
+
+
+def full_path(scope: str, rel: str) -> str:
+    rel = rel if rel.startswith("/") or rel == "" else "/" + rel
+    fp = "/v1" + scope + rel
+    fp = re.sub(r"/+", "/", fp)
+    return fp.rstrip("/") or "/v1"
+
+
+def md_table_escape(s: str) -> str:
+    return s.replace("|", "\\|")
+
+
+def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], commit: str) -> str:
+    oapi_norm = {norm(p) for p in oapi}
+    by_method: dict[str, int] = {}
+    documented = 0
+    rows = []
+    for r in sorted(routes, key=lambda x: (x["module"], x["path"], x["method"])):
+        by_method[r["method"]] = by_method.get(r["method"], 0) + 1
+        scope = scopes.get(r["module"], "")
+        fp = full_path(scope, r["path"])
+        candidates = {norm(fp), norm(scope + (r["path"] if r["path"].startswith("/") else "/" + r["path"])), norm(r["path"])}
+        documented_here = bool(candidates & oapi_norm)
+        if documented_here:
+            documented += 1
+        rows.append((r, fp, "yes" if documented_here else "no"))
+
+    total = len(routes)
+    undoc = total - documented
+    pct_doc = (documented / total * 100) if total else 0.0
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    method_line = " · ".join(f"{m} {by_method[m]}" for m in sorted(by_method))
+
+    out: list[str] = []
+    out.append("---")
+    out.append("Status: generated")
+    out.append("Canonical: no")
+    out.append(f"Generated: {now}")
+    out.append("---")
+    out.append("")
+    out.append("# Gateway Route Inventory (generated)")
+    out.append("")
+    out.append(f"> Generated mechanically by [`{SCRIPT_REL}`](../../../scripts/route_inventory.py). "
+               "**Do not hand-edit** — rerun the script.")
+    out.append(f"> Regenerate: `python3 {SCRIPT_REL} --write`  ·  Check drift: `python3 {SCRIPT_REL} --check`")
+    out.append("")
+    out.append("## What this proves / does not prove")
+    out.append("")
+    out.append("- **Proves:** these route declarations (Actix routing attribute macros) exist in the gateway source at the snapshot commit.")
+    out.append("- **Does NOT prove:** route correctness, authentication/authorization, test coverage, runtime health, production readiness, or public-claim safety. `OpenAPI documented = yes` does **not** mean the contract is complete or correct.")
+    out.append("- Defer to canonical truth/precedence: [`source-of-truth-map.md`](../source-of-truth-map.md) and proof levels in [`proof-level-taxonomy-capability-matrix.md`](../proof-level-taxonomy-capability-matrix.md). This is an orientation artifact (`Canonical: no`).")
+    out.append("")
+    out.append("## Snapshot")
+    out.append("")
+    out.append(f"- Source commit: `{commit}`")
+    out.append("- Gateway source scanned: `icn/crates/icn-gateway/src/**`")
+    out.append("- OpenAPI spec: `docs/api/openapi.generated.yaml`")
+    out.append("")
+    out.append("## Coverage summary")
+    out.append("")
+    out.append(f"- **Discovered gateway route macros: {total}** ({method_line})")
+    out.append(f"- **OpenAPI documented paths: {len(oapi)}**")
+    out.append(f"- Matched as documented (best-effort path match): {documented}")
+    out.append(f"- Not matched to OpenAPI (best-effort): {undoc} (~{undoc / total * 100:.0f}% of discovered)" if total else "- Not matched to OpenAPI: 0")
+    out.append(f"- Documented share of discovered routes: ~{pct_doc:.1f}%")
+    out.append("")
+    out.append("> The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. "
+               "Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside "
+               "the gateway crate and are not captured by this macro scan — so the documented/undocumented "
+               "counts here are a best-effort comparison, while the two headline counts (discovered macros, "
+               "OpenAPI paths) are the robust measured facts.")
+    out.append("")
+    out.append("## Limitations (PR1)")
+    out.append("")
+    out.append("- **Full mounted-path resolution is best-effort.** The `Group` column is inferred from a simple "
+               "`web::scope(\"…\")` ↔ `api::<module>::` association read from `server.rs`; it is **not** a real Rust "
+               "parser and may be wrong for deeply-nested or conditional scopes. The relative macro `Path` and the "
+               "`Source` file are authoritative.")
+    out.append("- Scans **attribute macros only** in `icn-gateway/src`. `web::resource(\"…\")`/`.route(\"…\")` "
+               "registrations and out-of-crate handlers (e.g. `icn-governance-actor::http`) are not fully captured.")
+    out.append("- This is **generated-map work, not API documentation completion** (issue #2112). It does not add or "
+               "change any OpenAPI content or runtime behavior.")
+    out.append("")
+    out.append("## Routes")
+    out.append("")
+    out.append("Status vocabulary is the existing set from `source-of-truth-map.md`. PR1 defaults every discovered "
+               "route to `gateway-backed` (it is served by the gateway) and claim-safety to `needs review` "
+               "(per-route proof level is `unknown / needs local verification` pending human review).")
+    out.append("")
+    out.append("| Method | Path (macro) | Group (best-effort) | Source | Handler | OpenAPI | Status | Claim safety |")
+    out.append("|---|---|---|---|---|---|---|---|")
+    for r, fp, doc in rows:
+        out.append(
+            f"| {r['method']} | `{md_table_escape(r['path'] or '(empty)')}` | `{md_table_escape(fp)}` | "
+            f"`{r['file']}`:{r['line']} | `{md_table_escape(r['handler'])}` | {doc} | gateway-backed | needs review |"
+        )
+    out.append("")
+    return "\n".join(out)
+
+
+def strip_volatile(text: str) -> str:
+    """Remove non-deterministic lines so --check ignores timestamp/commit churn."""
+    keep = []
+    for line in text.splitlines():
+        if line.startswith("Generated:") or line.startswith("- Source commit:"):
+            continue
+        keep.append(line)
+    return "\n".join(keep)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Generate or check the gateway route inventory.")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--write", action="store_true", help="regenerate the inventory artifact")
+    g.add_argument("--check", action="store_true", help="exit 1 if the committed artifact is stale")
+    args = ap.parse_args()
+
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip()
+    except Exception:
+        commit = "unknown"
+
+    routes = discover_routes()
+    scopes = module_scope_map()
+    oapi = openapi_paths()
+    if not routes:
+        print(f"ERROR: no routes discovered under {GATEWAY_SRC} — wrong repo root?", file=sys.stderr)
+        return 2
+    content = render(routes, scopes, oapi, commit)
+
+    if args.write:
+        ARTIFACT.parent.mkdir(parents=True, exist_ok=True)
+        ARTIFACT.write_text(content + "\n", encoding="utf-8")
+        print(f"wrote {ARTIFACT.relative_to(ROOT)}: {len(routes)} routes, {len(oapi)} OpenAPI paths")
+        return 0
+
+    # --check
+    if not ARTIFACT.is_file():
+        print(f"STALE: {ARTIFACT.relative_to(ROOT)} does not exist — run --write", file=sys.stderr)
+        return 1
+    committed = ARTIFACT.read_text(encoding="utf-8")
+    if strip_volatile(committed).strip() == strip_volatile(content).strip():
+        print(f"OK: route inventory up to date ({len(routes)} routes, {len(oapi)} OpenAPI paths)")
+        return 0
+    print(f"STALE: {ARTIFACT.relative_to(ROOT)} differs from a fresh scan — run --write and commit", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
First small PR for #2112. Turns "we *think* OpenAPI is badly out of sync" into a reproducible, generated, claim-disciplined map. Generated-map work — **not** API-documentation completion. No runtime/Rust change.

## 1. What changed (4 files)
- **`docs/scripts/route_inventory.py`** (new) — mechanical route inventory generator/checker.
- **`docs/reference/project-index/generated/route-inventory.md`** (new, generated) — the inventory artifact (287 routes).
- **`docs/reference/project-index/README.md`** — one row in the Truth-Layer table linking the inventory.
- **`docs/reference/project-index/runtime-surface-map.md`** — one pointer line to the inventory.

## 2. How routes are discovered
The gateway registers routes via Actix **attribute macros on handlers** (`#[get("…")]`, `#[post]`, `#[put]`, `#[delete]`, `#[patch]`, `#[head]`, and `#[route("…", method="…")]`), not `.route("…")` calls. The script scans `icn/crates/icn-gateway/src/**` for those macros and captures method · relative path · source `file:line` · nearby handler fn · source module. A **best-effort** `web::scope("…")` ↔ `api::<module>::` association read from `server.rs` gives an approximate mounted "Group".

## 3. How OpenAPI coverage is compared
The script parses the `paths:` block of `docs/api/openapi.generated.yaml` (the utoipa-generated spec) and normalizes `{param}`/slashes, then marks each discovered route documented yes/no by best-effort path match.

## 4. What the inventory proves
That these route **declarations exist in the gateway source** at the snapshot commit, and how few of them reach the generated OpenAPI spec. **Measured: 287 gateway route macros (131 GET / 125 POST / 17 DELETE / 14 PUT) vs 5 OpenAPI paths → ~99% of discovered routes are not represented in the spec.**

## 5. What the inventory does NOT prove
Route correctness, authentication/authorization, test coverage, runtime health, production readiness, or public-claim safety. `OpenAPI documented = yes` does **not** mean the contract is complete or correct. The artifact is `Canonical: no` and defers to `source-of-truth-map.md` + proof levels.

## 6. Why full mounted-path resolution is not solved in PR1
Resolving the exact mounted path requires walking nested `web::scope(...)` chains in `server.rs` — a real Rust-parser job. PR1 deliberately avoids a brittle resolver: the relative macro **Path** and **Source** file are authoritative; the **Group** column is an explicitly-flagged best-effort approximation. Only 2 of the 5 OpenAPI paths (the gateway-crate federation routes) match in-scan; the other 3 are `icn-governance-actor` handlers outside the gateway crate — so the documented/undocumented split is best-effort while the two headline counts are robust.

## 7. Validation commands and results
```
python3 docs/scripts/route_inventory.py --write   # wrote artifact: 287 routes, 5 OpenAPI paths
python3 docs/scripts/route_inventory.py --check    # OK: route inventory up to date (idempotent)
python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml
                                                   # OK (878 md files; 65 pre-existing warnings, none new, none of my files flagged)
cd docs && python3 scripts/freshness-check.py       # exit 1 = PRE-EXISTING #2047 staleness (§04/§18); this PR touches no ARCHITECTURE/freshness/status
ops/scripts/drift-check.sh                          # PASS (0/0)
```
No Rust touched (`git diff --name-only` = the 4 docs/tooling files) ⇒ `cargo fmt/clippy/test` N/A.

## 8. Relationship to #2112 and #1779
Refs **#2112** (first mechanical slice; CI drift-gate + finer per-route proof levels are follow-ups, so this does not fully close it). Feeds **#1779** (public-surface truth-sync) — the route inventory is its mechanical backbone.

## 9. Explicit non-goals
Not adding/changing OpenAPI content. Not hand-annotating missing routes. Not a brittle nested-scope resolver. No CI requirement in this PR. No new `docs/truth/` tree. No new truth vocabulary (reuses `gateway-backed` / `needs review` / `unknown / needs local verification`). No #2080/#2081. No `docs/ARCHITECTURE.md` semantic edits (#2047 lane). No production/live/pilot claims.

## 10. Generated-map work, not API completion
This PR makes the gap **mechanically visible and regenerable** (`route_inventory.py --check` detects drift). It is not an attempt to document the API — that's separate, larger work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
