### PR TITLE
ci(docs): check generated route inventory

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -11,11 +11,12 @@ on:
       - 'docs/scripts/doc_control_check.py'
       # gateway route source is code-truth for the API-doc canonical guard
       - 'icn/crates/icn-gateway/src/api/ledger.rs'
-      # route-inventory code-truth: gateway route macros (api/**) + scope wiring
-      # (server.rs) feed docs/scripts/route_inventory.py --check. The script and
-      # its generated artifact under docs/ are already covered by docs/**.
-      - 'icn/crates/icn-gateway/src/api/**'
-      - 'icn/crates/icn-gateway/src/server.rs'
+      # route-inventory code-truth: route_inventory.py scans the WHOLE gateway
+      # crate (GATEWAY_SRC.rglob("*.rs")) for route macros + reads server.rs for
+      # scope wiring, so the trigger matches that scan scope — route macros added
+      # outside src/api/ must still fire the drift check. The script and its
+      # generated artifact under docs/ are already covered by docs/**.
+      - 'icn/crates/icn-gateway/src/**'
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'
@@ -28,11 +29,12 @@ on:
       - 'docs/scripts/doc_control_check.py'
       # gateway route source is code-truth for the API-doc canonical guard
       - 'icn/crates/icn-gateway/src/api/ledger.rs'
-      # route-inventory code-truth: gateway route macros (api/**) + scope wiring
-      # (server.rs) feed docs/scripts/route_inventory.py --check. The script and
-      # its generated artifact under docs/ are already covered by docs/**.
-      - 'icn/crates/icn-gateway/src/api/**'
-      - 'icn/crates/icn-gateway/src/server.rs'
+      # route-inventory code-truth: route_inventory.py scans the WHOLE gateway
+      # crate (GATEWAY_SRC.rglob("*.rs")) for route macros + reads server.rs for
+      # scope wiring, so the trigger matches that scan scope — route macros added
+      # outside src/api/ must still fire the drift check. The script and its
+      # generated artifact under docs/ are already covered by docs/**.
+      - 'icn/crates/icn-gateway/src/**'
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -11,6 +11,11 @@ on:
       - 'docs/scripts/doc_control_check.py'
       # gateway route source is code-truth for the API-doc canonical guard
       - 'icn/crates/icn-gateway/src/api/ledger.rs'
+      # route-inventory code-truth: gateway route macros (api/**) + scope wiring
+      # (server.rs) feed docs/scripts/route_inventory.py --check. The script and
+      # its generated artifact under docs/ are already covered by docs/**.
+      - 'icn/crates/icn-gateway/src/api/**'
+      - 'icn/crates/icn-gateway/src/server.rs'
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'
@@ -23,6 +28,11 @@ on:
       - 'docs/scripts/doc_control_check.py'
       # gateway route source is code-truth for the API-doc canonical guard
       - 'icn/crates/icn-gateway/src/api/ledger.rs'
+      # route-inventory code-truth: gateway route macros (api/**) + scope wiring
+      # (server.rs) feed docs/scripts/route_inventory.py --check. The script and
+      # its generated artifact under docs/ are already covered by docs/**.
+      - 'icn/crates/icn-gateway/src/api/**'
+      - 'icn/crates/icn-gateway/src/server.rs'
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'
@@ -199,9 +209,39 @@ jobs:
           python3 docs/scripts/validate-rehearsal-shell-fixtures.py
         continue-on-error: false
 
+  route_inventory:
+    name: Check Generated Route Inventory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      # Generated-artifact drift guard, mirroring the INDEX.md check above: a stale
+      # docs/reference/project-index/generated/route-inventory.md is a WARNING, not a
+      # merge blocker (the artifact is Canonical: no, orientation-only — issue #2112).
+      # The script is stdlib-only and reads git + gateway source; no extra deps.
+      #   exit 0 = current   ->  pass
+      #   exit 1 = stale      ->  ::warning:: (regenerate with --write); job still succeeds
+      #   exit >=2 = checker itself broke (e.g. no routes found) -> fail
+      - name: Check route inventory is current (warn on drift)
+        run: |
+          python3 docs/scripts/route_inventory.py --check && rc=0 || rc=$?
+          if [ "$rc" = "0" ]; then
+            echo "Route inventory is current."
+          elif [ "$rc" = "1" ]; then
+            echo "::warning::docs/reference/project-index/generated/route-inventory.md is stale vs a fresh gateway scan. Regenerate: python3 docs/scripts/route_inventory.py --write"
+          else
+            echo "::error::route_inventory.py failed (exit $rc) — checker error, not a staleness signal."
+            exit "$rc"
+          fi
+
   summary:
     name: Documentation CI Summary
-    needs: [doc_control, lint, freshness, index, fixture_bundle]
+    needs: [doc_control, lint, freshness, index, fixture_bundle, route_inventory]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -226,6 +266,12 @@ jobs:
           fi
           if [ "${{ needs.index.result }}" = "failure" ]; then
             echo "::error::INDEX.md generation failed"
+            exit 1
+          fi
+          # Drift is emitted as a ::warning:: inside the job (success); a failure here
+          # means the checker itself errored, which is worth surfacing.
+          if [ "${{ needs.route_inventory.result }}" = "failure" ]; then
+            echo "::error::Route inventory checker errored (not a staleness signal)"
             exit 1
           fi
 


### PR DESCRIPTION
## What changed

Adds a **non-required** `route_inventory` job to the **Documentation Maintenance** workflow (`.github/workflows/docs-freshness.yml`) that runs `python3 docs/scripts/route_inventory.py --check`, plus the gateway route source to the workflow's path triggers. One file, +47/−1.

It mirrors the workflow's existing INDEX.md generated-artifact drift guard:

| `--check` exit | meaning | CI behavior |
|---|---|---|
| 0 | inventory current | pass |
| 1 | inventory **stale** vs a fresh gateway scan | `::warning::` (regenerate with `--write`); job still **succeeds** |
| ≥2 | checker itself errored (e.g. no routes found) | **fail** (surfaced in the summary) |

## Where `--check` now runs

In CI on every PR/push that touches `docs/**` (which already covers the script and the generated artifact) **and** now the route inventory's code-truth: `icn/crates/icn-gateway/src/api/**` and `icn/crates/icn-gateway/src/server.rs`. Also on the existing weekly `schedule`. The regenerate/check commands are self-documented in the artifact header (added in #2116).

## What stale condition this catches

A gateway change that adds/removes/moves a route macro (or changes scope wiring in `server.rs`) **without** regenerating `docs/reference/project-index/generated/route-inventory.md`. Because the trigger now includes the gateway `api/**` tree, that drift surfaces as a `::warning::` on the PR that introduces it — instead of silently landing on `main` and only being caught at the next weekly run or docs PR.

## What this does **not** prove

Nothing new about the routes themselves. `--check` only asserts the committed artifact matches a fresh mechanical scan. It does **not** prove route correctness, auth, mounting/serving, test coverage, runtime health, or production readiness — the artifact remains `Canonical: no`, orientation-only.

## Why this does **not** finish #2112

This is one slice. Still open under #2112: capturing `web::resource`/`.route` registrations and out-of-crate handlers (`icn-governance-actor::http`), finer per-route proof levels, full mounted-path/scope resolution, and feeding the inventory into #1779. This PR adds **no** OpenAPI content and does **no** route-parser work.

## Validation (run locally on this branch)

- YAML parses; `jobs` now include `route_inventory`; `summary.needs` includes it; both triggers carry `api/**` + `server.rs`. ✓
- Drift-logic exercised end-to-end:
  - current tree → prints `current`, **exit 0** ✓
  - injected drift → prints `::warning:: stale (regenerate)`, **exit 0** (non-blocking) ✓
  - artifact restored via `git checkout`; `route_inventory.py --check` → `OK (287 routes, 5 OpenAPI paths)` ✓
- `ops/scripts/drift-check.sh` → PASS (0/0). Zero `.rs` touched ⇒ Rust gates N/A.

## Relationship

- **Refs #2112** — second mechanical slice (PR1 = #2116 added the generated artifact + checker; this wires drift detection into CI).
- Builds directly on **#2116** (`docs(api): add generated route inventory`).
- **Refs #1779** — keeps the route-inventory backbone honest as gateway routes evolve.

## Non-goals (explicit)

No branch-protection change; no new **required** check (this job is non-required, like the rest of Documentation Maintenance); no runtime/Rust change; no OpenAPI completion; no hand-annotation of routes; no full route-scope reconstruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
