### PR TITLE
docs(api): expand route inventory coverage

### DIFF
--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-20T13:02:09+00:00
+Generated: 2026-06-20T13:46:22+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -17,7 +17,7 @@ Generated: 2026-06-20T13:02:09+00:00
 
 ## Snapshot
 
-- Source commit: `0d0e7d656122b8e54f0bbe2433886f5b23fe23eb`
+- Source commit: `7f241718e55dfd27c8864b1e702d635cca5ce9ae`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -34,7 +34,7 @@ Generated: 2026-06-20T13:02:09+00:00
 ## Limitations (PR1)
 
 - **Full mounted-path resolution is best-effort.** The `Group` column is `/v1` + a `web::scope("…")` segment associated from `server.rs` `.service(...)`/`.configure(...)` registration sites (matched at identifier boundaries, keyed by the handler's top-level `icn/crates/icn-gateway/src/api/<group>` module) + the relative macro path. It is **not** a real Rust parser and may be wrong for deeply-nested or conditional scopes. The relative macro `Path` and the `Source` file are authoritative.
-- Scans **attribute macros only** in `icn-gateway/src`. `web::resource("…")`/`.route("…")` registrations and out-of-crate handlers (e.g. `icn-governance-actor::http`) are not fully captured.
+- The route table is **attribute macros only**. Macro-less `web::resource("…")`/`.route(…)` registrations are now **flagged** below (see *Unparsed route-registration candidates*) but **not** parsed into routes; out-of-crate handlers (e.g. `icn-governance-actor::http`) are still not captured.
 - This is **generated-map work, not API documentation completion** (issue #2112). It does not add or change any OpenAPI content or runtime behavior.
 
 ## Routes
@@ -330,4 +330,17 @@ Status vocabulary is the existing set from `source-of-truth-map.md`; no new labe
 | GET | `/trust/{did}/edges` | `/v1/trust/trust/{did}/edges` | `icn/crates/icn-gateway/src/api/trust.rs`:72 | `get_trust_edges` | no | unknown / needs local verification | needs review |
 | GET | `/trust/{did}/network` | `/v1/trust/trust/{did}/network` | `icn/crates/icn-gateway/src/api/trust.rs`:143 | `get_trust_network` | no | unknown / needs local verification | needs review |
 | GET | `/ws/{coop_id}` | `/v1/ws/{coop_id}` | `icn/crates/icn-gateway/src/api/websocket.rs`:12 | `websocket` | no | unknown / needs local verification | needs review |
+
+## Unparsed route-registration candidates
+
+Beyond attribute macros, Actix can also register routes via `web::resource("…").route(web::<method>().to(handler))`. This scan **flags** such sites mechanically but does **not** parse them into routes: a regex cannot reliably tell a production registration from a **test fixture** (e.g. inside `#[cfg(test)]` / `test::init_service`), and it does not resolve the mounted path without a real parser. They are **not** counted in the route total above and remain `unknown / needs local verification` — treat them as leads for human review.
+
+- **Candidates flagged: 4** (`web::resource("…")`: 2 · `.route(…)`: 2)
+
+| Kind | Resource literal | Source |
+|---|---|---|
+| `web::resource` | `/notifications/register` | `icn/crates/icn-gateway/src/api/notifications.rs`:315 |
+| `.route` | — | `icn/crates/icn-gateway/src/api/notifications.rs`:316 |
+| `web::resource` | `/{session_id}/approve` | `icn/crates/icn-gateway/src/server.rs`:1968 |
+| `.route` | — | `icn/crates/icn-gateway/src/server.rs`:1969 |
 

--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-20T13:46:22+00:00
+Generated: 2026-06-20T13:51:41+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -17,7 +17,7 @@ Generated: 2026-06-20T13:46:22+00:00
 
 ## Snapshot
 
-- Source commit: `7f241718e55dfd27c8864b1e702d635cca5ce9ae`
+- Source commit: `0d27da7d89df89249db5cd3d07e1c77ad195749e`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -31,7 +31,7 @@ Generated: 2026-06-20T13:46:22+00:00
 
 > The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside the gateway crate and are not captured by this macro scan — so the documented/undocumented counts here are a best-effort comparison, while the two headline counts (discovered macros, OpenAPI paths) are the robust measured facts.
 
-## Limitations (PR1)
+## Limitations
 
 - **Full mounted-path resolution is best-effort.** The `Group` column is `/v1` + a `web::scope("…")` segment associated from `server.rs` `.service(...)`/`.configure(...)` registration sites (matched at identifier boundaries, keyed by the handler's top-level `icn/crates/icn-gateway/src/api/<group>` module) + the relative macro path. It is **not** a real Rust parser and may be wrong for deeply-nested or conditional scopes. The relative macro `Path` and the `Source` file are authoritative.
 - The route table is **attribute macros only**. Macro-less `web::resource("…")`/`.route(…)` registrations are now **flagged** below (see *Unparsed route-registration candidates*) but **not** parsed into routes; out-of-crate handlers (e.g. `icn-governance-actor::http`) are still not captured.
@@ -39,7 +39,7 @@ Generated: 2026-06-20T13:46:22+00:00
 
 ## Routes
 
-Status vocabulary is the existing set from `source-of-truth-map.md`; no new labels are introduced. A static macro scan proves only that a routing macro is **declared** in source — not that the handler is mounted and served (registration happens elsewhere via `.service(...)` / `.configure(...)`, which this pass does not resolve). PR1 therefore **cannot** assert `gateway-backed`: every discovered route's status defaults to `unknown / needs local verification` and claim-safety to `needs review`, pending human or runtime confirmation.
+Status vocabulary is the existing set from `source-of-truth-map.md`; no new labels are introduced. A static macro scan proves only that a routing macro is **declared** in source — not that the handler is mounted and served (registration happens elsewhere via `.service(...)` / `.configure(...)`, which this pass does not resolve). This scan therefore **cannot** assert `gateway-backed`: every discovered route's status defaults to `unknown / needs local verification` and claim-safety to `needs review`, pending human or runtime confirmation.
 
 | Method | Path (macro) | Group (best-effort) | Source | Handler | OpenAPI | Status | Claim safety |
 |---|---|---|---|---|---|---|---|

--- a/docs/scripts/route_inventory.py
+++ b/docs/scripts/route_inventory.py
@@ -7,7 +7,7 @@ Scans the gateway Rust source for Actix routing **attribute macros**
 route declarations against the documented OpenAPI paths, and writes a
 claim-disciplined markdown inventory.
 
-This is deliberately humble (issue #2112, PR1):
+This is deliberately humble (issue #2112):
 - It proves route **declarations** exist in source. It does NOT prove route
   correctness, authentication, test coverage, production readiness, or public
   safety. "OpenAPI documented" does not mean complete or correct.
@@ -166,10 +166,12 @@ def resource_candidates() -> list[dict]:
     for rs in sorted(GATEWAY_SRC.rglob("*.rs")):
         rel = rs.relative_to(ROOT).as_posix()
         for i, line in enumerate(rs.read_text(encoding="utf-8", errors="replace").splitlines()):
+            # Independent checks (not elif): a one-line `web::resource("…").route(…)`
+            # must record BOTH candidates, not just the resource.
             rm = RESOURCE_RE.search(line)
             if rm:
                 out.append({"kind": "web::resource", "literal": rm.group(1), "file": rel, "line": i + 1})
-            elif ROUTE_CALL_RE.search(line):
+            if ROUTE_CALL_RE.search(line):
                 out.append({"kind": ".route", "literal": "", "file": rel, "line": i + 1})
     return out
 
@@ -251,7 +253,7 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], reg_cand
                "counts here are a best-effort comparison, while the two headline counts (discovered macros, "
                "OpenAPI paths) are the robust measured facts.")
     out.append("")
-    out.append("## Limitations (PR1)")
+    out.append("## Limitations")
     out.append("")
     out.append("- **Full mounted-path resolution is best-effort.** The `Group` column is `/v1` + a `web::scope(\"…\")` "
                "segment associated from `server.rs` `.service(...)`/`.configure(...)` registration sites (matched at "
@@ -269,7 +271,7 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], reg_cand
     out.append("Status vocabulary is the existing set from `source-of-truth-map.md`; no new labels are introduced. "
                "A static macro scan proves only that a routing macro is **declared** in source — not that the handler "
                "is mounted and served (registration happens elsewhere via `.service(...)` / `.configure(...)`, which "
-               "this pass does not resolve). PR1 therefore **cannot** assert `gateway-backed`: every discovered route's "
+               "this pass does not resolve). This scan therefore **cannot** assert `gateway-backed`: every discovered route's "
                "status defaults to `unknown / needs local verification` and claim-safety to `needs review`, pending "
                "human or runtime confirmation.")
     out.append("")

--- a/docs/scripts/route_inventory.py
+++ b/docs/scripts/route_inventory.py
@@ -14,9 +14,10 @@ This is deliberately humble (issue #2112, PR1):
 - Full mounted-path resolution is **best-effort** (a module->scope heuristic
   read from server.rs), not a real Rust parser. The relative macro path and the
   source file are authoritative; the "group" column is approximate.
-- It scans the gateway crate's attribute macros only. `web::resource`/`.route`
-  registrations and out-of-crate HTTP handlers (e.g. `icn-governance-actor`) are
-  not fully captured.
+- It scans the gateway crate's attribute macros for the route table, and
+  additionally FLAGS macro-less `web::resource("…")`/`.route(…)` registration
+  *candidates* by file:line (not parsed into routes — see `resource_candidates`).
+  Out-of-crate HTTP handlers (e.g. `icn-governance-actor`) are still not captured.
 
 Usage:
     python3 docs/scripts/route_inventory.py --write    # regenerate the artifact
@@ -59,6 +60,12 @@ SCOPE_RE = re.compile(r'web::scope\("(/[^"]*)"\)')
 # longer crate paths like `icn_kernel_api::services::` or `icn_api::LedgerService::`.
 MODREF_RE = re.compile(r'(?<![A-Za-z0-9_])api::([A-Za-z_]\w*)::')
 OAPI_PATH_RE = re.compile(r'^  (/\S*):\s*$')
+# Macro-less route-registration *candidates* (issue #2112, PR3). FLAGGED, not
+# parsed into routes: a quoted `web::resource("…")` literal, and `.route(…)`
+# method bindings. RESOURCE_RE requires a quoted argument, so `web::resource().to()`
+# in a doc comment does not match.
+RESOURCE_RE = re.compile(r'web::resource\("([^"]*)"\)')
+ROUTE_CALL_RE = re.compile(r'\.route\(')
 
 
 def discover_routes() -> list[dict]:
@@ -145,6 +152,28 @@ def openapi_paths() -> list[str]:
     return paths
 
 
+def resource_candidates() -> list[dict]:
+    """Mechanically FLAG macro-less Actix route-registration candidates in the
+    gateway crate: `web::resource("…")` resource literals and `.route(…)` method
+    bindings. These are deliberately NOT counted as routes and NOT path-resolved:
+    a regex scan cannot reliably distinguish a production registration from a
+    test fixture (e.g. inside `#[cfg(test)]` / `test::init_service`), nor resolve
+    the mounted path without a real parser. They are surfaced by file:line for
+    human review and stay `unknown / needs local verification`."""
+    out: list[dict] = []
+    if not GATEWAY_SRC.is_dir():
+        return out
+    for rs in sorted(GATEWAY_SRC.rglob("*.rs")):
+        rel = rs.relative_to(ROOT).as_posix()
+        for i, line in enumerate(rs.read_text(encoding="utf-8", errors="replace").splitlines()):
+            rm = RESOURCE_RE.search(line)
+            if rm:
+                out.append({"kind": "web::resource", "literal": rm.group(1), "file": rel, "line": i + 1})
+            elif ROUTE_CALL_RE.search(line):
+                out.append({"kind": ".route", "literal": "", "file": rel, "line": i + 1})
+    return out
+
+
 def norm(p: str) -> str:
     p = re.sub(r"\{[^}]+\}", "{}", p)
     p = re.sub(r"/+", "/", p)
@@ -162,7 +191,7 @@ def md_table_escape(s: str) -> str:
     return s.replace("|", "\\|")
 
 
-def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], commit: str) -> str:
+def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], reg_candidates: list[dict], commit: str) -> str:
     oapi_norm = {norm(p) for p in oapi}
     by_method: dict[str, int] = {}
     documented = 0
@@ -229,8 +258,9 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], commit: 
                "identifier boundaries, keyed by the handler's top-level `icn/crates/icn-gateway/src/api/<group>` "
                "module) + the relative macro path. It is **not** a real Rust parser and may be wrong for "
                "deeply-nested or conditional scopes. The relative macro `Path` and the `Source` file are authoritative.")
-    out.append("- Scans **attribute macros only** in `icn-gateway/src`. `web::resource(\"…\")`/`.route(\"…\")` "
-               "registrations and out-of-crate handlers (e.g. `icn-governance-actor::http`) are not fully captured.")
+    out.append("- The route table is **attribute macros only**. Macro-less `web::resource(\"…\")`/`.route(…)` "
+               "registrations are now **flagged** below (see *Unparsed route-registration candidates*) but **not** "
+               "parsed into routes; out-of-crate handlers (e.g. `icn-governance-actor::http`) are still not captured.")
     out.append("- This is **generated-map work, not API documentation completion** (issue #2112). It does not add or "
                "change any OpenAPI content or runtime behavior.")
     out.append("")
@@ -251,6 +281,29 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], commit: 
             f"`{r['file']}`:{r['line']} | `{md_table_escape(r['handler'])}` | {doc} | unknown / needs local verification | needs review |"
         )
     out.append("")
+
+    # Macro-less route-registration candidates (issue #2112, PR3) — flagged, not parsed.
+    res_n = sum(1 for c in reg_candidates if c["kind"] == "web::resource")
+    route_n = sum(1 for c in reg_candidates if c["kind"] == ".route")
+    out.append("## Unparsed route-registration candidates")
+    out.append("")
+    out.append("Beyond attribute macros, Actix can also register routes via "
+               "`web::resource(\"…\").route(web::<method>().to(handler))`. This scan **flags** such sites "
+               "mechanically but does **not** parse them into routes: a regex cannot reliably tell a production "
+               "registration from a **test fixture** (e.g. inside `#[cfg(test)]` / `test::init_service`), and it does "
+               "not resolve the mounted path without a real parser. They are **not** counted in the route total "
+               "above and remain `unknown / needs local verification` — treat them as leads for human review.")
+    out.append("")
+    out.append(f"- **Candidates flagged: {len(reg_candidates)}** "
+               f"(`web::resource(\"…\")`: {res_n} · `.route(…)`: {route_n})")
+    out.append("")
+    if reg_candidates:
+        out.append("| Kind | Resource literal | Source |")
+        out.append("|---|---|---|")
+        for c in sorted(reg_candidates, key=lambda x: (x["file"], x["line"])):
+            lit = f"`{md_table_escape(c['literal'])}`" if c["literal"] else "—"
+            out.append(f"| `{c['kind']}` | {lit} | `{c['file']}`:{c['line']} |")
+        out.append("")
     return "\n".join(out)
 
 
@@ -279,15 +332,17 @@ def main() -> int:
     routes = discover_routes()
     scopes = module_scope_map()
     oapi = openapi_paths()
+    reg_candidates = resource_candidates()
     if not routes:
         print(f"ERROR: no routes discovered under {GATEWAY_SRC} — wrong repo root?", file=sys.stderr)
         return 2
-    content = render(routes, scopes, oapi, commit)
+    content = render(routes, scopes, oapi, reg_candidates, commit)
 
     if args.write:
         ARTIFACT.parent.mkdir(parents=True, exist_ok=True)
         ARTIFACT.write_text(content + "\n", encoding="utf-8")
-        print(f"wrote {ARTIFACT.relative_to(ROOT)}: {len(routes)} routes, {len(oapi)} OpenAPI paths")
+        print(f"wrote {ARTIFACT.relative_to(ROOT)}: {len(routes)} routes, {len(oapi)} OpenAPI paths, "
+              f"{len(reg_candidates)} non-macro candidates")
         return 0
 
     # --check
@@ -296,7 +351,8 @@ def main() -> int:
         return 1
     committed = ARTIFACT.read_text(encoding="utf-8")
     if strip_volatile(committed).strip() == strip_volatile(content).strip():
-        print(f"OK: route inventory up to date ({len(routes)} routes, {len(oapi)} OpenAPI paths)")
+        print(f"OK: route inventory up to date ({len(routes)} routes, {len(oapi)} OpenAPI paths, "
+              f"{len(reg_candidates)} non-macro candidates)")
         return 0
     print(f"STALE: {ARTIFACT.relative_to(ROOT)} differs from a fresh scan — run --write and commit", file=sys.stderr)
     return 1

--- a/docs/scripts/route_inventory.py
+++ b/docs/scripts/route_inventory.py
@@ -166,10 +166,10 @@ def resource_candidates() -> list[dict]:
     for rs in sorted(GATEWAY_SRC.rglob("*.rs")):
         rel = rs.relative_to(ROOT).as_posix()
         for i, line in enumerate(rs.read_text(encoding="utf-8", errors="replace").splitlines()):
-            # Independent checks (not elif): a one-line `web::resource("…").route(…)`
-            # must record BOTH candidates, not just the resource.
-            rm = RESOURCE_RE.search(line)
-            if rm:
+            # Independent checks (not elif), and finditer over resources, so a
+            # one-line `web::resource("…").route(…)` — or several resource literals
+            # on one line — are all recorded, not just the first match.
+            for rm in RESOURCE_RE.finditer(line):
                 out.append({"kind": "web::resource", "literal": rm.group(1), "file": rel, "line": i + 1})
             if ROUTE_CALL_RE.search(line):
                 out.append({"kind": ".route", "literal": "", "file": rel, "line": i + 1})


### PR DESCRIPTION
## What changed

Extends `docs/scripts/route_inventory.py` to **flag** macro-less Actix route-registration *candidates*, and regenerates the artifact with a new **"Unparsed route-registration candidates"** section. Two files: the script and its generated artifact.

## What route forms are now detected (flagged)

Beyond attribute macros, the scan now flags:
- `web::resource("…")` resource literals (quoted-arg only, so `web::resource().to()` in a doc comment is excluded), and
- `.route(…)` method bindings.

It **flags by `file:line`** — it does **not** parse them into routes.

## Counts before / after

| | Before (PR1/PR2) | After (this PR) |
|---|---|---|
| Gateway route macros | 287 | **287** (unchanged) |
| OpenAPI paths | 5 | **5** (unchanged) |
| Best-effort documented matches | 2 | **2** (unchanged) |
| Macro-less candidates flagged | 0 | **4** (`web::resource`: 2 · `.route`: 2) |

The 4 candidates are 2 sites: `server.rs:1968` (`/{session_id}/approve` under `web::scope("/sessions")` — a **real production route** the macro scan misses) and `api/notifications.rs:315` (inside `#[cfg(test)] test::init_service` — a **test fixture**, not a production route).

## What the inventory proves

That these route declarations / registration sites **exist in the gateway source** at the snapshot commit.

## What it does NOT prove

Route correctness, auth, mounting/serving, test coverage, runtime health, or production readiness. Candidates specifically are **not** routes: the scan cannot tell a production registration from a test fixture, nor resolve the mounted path. They stay `unknown / needs local verification` and are **not** counted in the route total.

## Known limitations

- Candidates are mechanical leads, not classified production-vs-test and not path-resolved (no Rust parser — explicit non-goal).
- Out-of-crate handlers (e.g. `icn-governance-actor::http`) are still not captured.
- The 3 `gov/*` OpenAPI paths are not literal strings in any crate `.rs` (likely utoipa/path-constant) — a separate follow-up.

## Validation (run on this branch)

- `route_inventory.py --write` → `287 routes, 5 OpenAPI paths, 4 non-macro candidates`.
- `route_inventory.py --check` → `OK (… 4 non-macro candidates)` — **idempotent**.
- `doc_control_check.py --repo . --registry docs/registry.toml` → OK, 878 md files, 65 pre-existing warnings, none on the changed files.
- `freshness-check.py` → exit 1 = **pre-existing #2047** staleness (`04`/`18`), unchanged by this PR (touches no ARCHITECTURE/freshness/status).
- `drift-check.sh` → PASS. Zero `.rs` touched ⇒ Rust gates N/A.

## Relationship

- **Refs #2112** — third mechanical slice (PR1 #2116 = artifact + checker; PR2 #2117 = CI drift wiring; this = coverage beyond attribute macros, via flagging).
- **Refs #1779** — keeps the route-inventory backbone honest about its own coverage gaps.

## Non-goals (explicit)

No OpenAPI completion; no Rust parser / full mounted-path reconstruction; no hand-annotation of routes; no production-vs-test classification of candidates; no runtime/Rust change; no CI-wiring change (the `--check` contract is unchanged — candidates don't alter exit codes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
