### PR TITLE
docs(api): surface unmatched OpenAPI paths

### DIFF
--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-20T16:01:55+00:00
+Generated: 2026-06-20T16:08:37+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -17,7 +17,7 @@ Generated: 2026-06-20T16:01:55+00:00
 
 ## Snapshot
 
-- Source commit: `06cf308b8a703a8eb584c1cfa87e1729b981d9eb`
+- Source commit: `5cfabd25486cd10ddc6a6f4369d32179a73b2ada`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -25,10 +25,10 @@ Generated: 2026-06-20T16:01:55+00:00
 
 - **Discovered gateway route macros: 287** (DELETE 17 · GET 131 · POST 125 · PUT 14)
 - **OpenAPI documented paths: 5**
-- Matched as documented (best-effort path match): 2
+- Matched as documented (best-effort method+path match): 2
 - Not matched to OpenAPI (best-effort): 285 (~99% of discovered)
 - Documented share of discovered routes: ~0.7%
-- **OpenAPI paths not matched to a discovered gateway route: 3** (see section below)
+- **OpenAPI operations (method + path) not matched to a discovered gateway route: 3** (see section below)
 
 > The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside the gateway crate and are not captured by this macro scan — so the documented/undocumented counts here are a best-effort comparison, while the two headline counts (discovered macros, OpenAPI paths) are the robust measured facts.
 

--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-20T13:51:41+00:00
+Generated: 2026-06-20T16:01:55+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -17,7 +17,7 @@ Generated: 2026-06-20T13:51:41+00:00
 
 ## Snapshot
 
-- Source commit: `0d27da7d89df89249db5cd3d07e1c77ad195749e`
+- Source commit: `06cf308b8a703a8eb584c1cfa87e1729b981d9eb`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -28,8 +28,19 @@ Generated: 2026-06-20T13:51:41+00:00
 - Matched as documented (best-effort path match): 2
 - Not matched to OpenAPI (best-effort): 285 (~99% of discovered)
 - Documented share of discovered routes: ~0.7%
+- **OpenAPI paths not matched to a discovered gateway route: 3** (see section below)
 
 > The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside the gateway crate and are not captured by this macro scan — so the documented/undocumented counts here are a best-effort comparison, while the two headline counts (discovered macros, OpenAPI paths) are the robust measured facts.
+
+## OpenAPI paths not matched to discovered gateway routes
+
+These OpenAPI-documented paths did **not** mechanically match any discovered gateway route macro. That is expected when a handler is documented via `#[utoipa::path]` but **registered outside the scanned `icn/crates/icn-gateway/src/**` tree** — e.g. the governance app (`icn-governance-actor` = `icn/apps/governance`) documents its `/gov/*` handlers with utoipa and mounts them via `web::resource("…").route(…)` in `apps/governance/src/http/configure.rs` (no attribute macros). OpenAPI presence does **not** prove a runtime route exists or is mounted; these stay `unknown / needs local verification`.
+
+| Method | OpenAPI path | Matched gateway route | Status | Claim safety |
+|---|---|---|---|---|
+| GET | `/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | no | unknown / needs local verification | needs review |
+| GET | `/gov/me/action-cards` | no | unknown / needs local verification | needs review |
+| GET | `/gov/me/standing` | no | unknown / needs local verification | needs review |
 
 ## Limitations
 

--- a/docs/scripts/route_inventory.py
+++ b/docs/scripts/route_inventory.py
@@ -202,7 +202,7 @@ def md_table_escape(s: str) -> str:
     return s.replace("|", "\\|")
 
 
-def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], reg_candidates: list[dict], commit: str) -> str:
+def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_candidates: list[dict], commit: str) -> str:
     oapi_norm = {norm(e["path"]) for e in oapi}
     matched_oapi: set[str] = set()
     by_method: dict[str, int] = {}

--- a/docs/scripts/route_inventory.py
+++ b/docs/scripts/route_inventory.py
@@ -203,8 +203,11 @@ def md_table_escape(s: str) -> str:
 
 
 def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_candidates: list[dict], commit: str) -> str:
-    oapi_norm = {norm(e["path"]) for e in oapi}
-    matched_oapi: set[str] = set()
+    # Match by (METHOD, normalized-path) pairs, not path alone — otherwise a path
+    # documented for one verb but routed under another would falsely count as
+    # matched and be hidden from the unmatched section (issue #2112, PR4 review).
+    oapi_ops = {(m, norm(e["path"])) for e in oapi for m in (e["methods"] or ["?"])}
+    matched_ops: set = set()
     by_method: dict[str, int] = {}
     documented = 0
     rows = []
@@ -213,15 +216,20 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_can
         scope = scopes.get(r["module"], "")
         fp = full_path(scope, r["path"])
         candidates = {norm(fp), norm(scope + (r["path"] if r["path"].startswith("/") else "/" + r["path"])), norm(r["path"])}
-        hit = candidates & oapi_norm
+        hit = {(r["method"], c) for c in candidates} & oapi_ops
         documented_here = bool(hit)
         if documented_here:
             documented += 1
-            matched_oapi |= hit
+            matched_ops |= hit
         rows.append((r, fp, "yes" if documented_here else "no"))
 
-    # OpenAPI paths that no discovered gateway route matched (issue #2112, PR4).
-    unmatched_oapi = [e for e in oapi if norm(e["path"]) not in matched_oapi]
+    # OpenAPI operations (method + path) that no discovered gateway route matched.
+    unmatched_ops = [
+        {"method": m, "path": e["path"]}
+        for e in oapi
+        for m in (e["methods"] or ["?"])
+        if (m, norm(e["path"])) not in matched_ops
+    ]
 
     total = len(routes)
     undoc = total - documented
@@ -258,10 +266,10 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_can
     out.append("")
     out.append(f"- **Discovered gateway route macros: {total}** ({method_line})")
     out.append(f"- **OpenAPI documented paths: {len(oapi)}**")
-    out.append(f"- Matched as documented (best-effort path match): {documented}")
+    out.append(f"- Matched as documented (best-effort method+path match): {documented}")
     out.append(f"- Not matched to OpenAPI (best-effort): {undoc} (~{undoc / total * 100:.0f}% of discovered)" if total else "- Not matched to OpenAPI: 0")
     out.append(f"- Documented share of discovered routes: ~{pct_doc:.1f}%")
-    out.append(f"- **OpenAPI paths not matched to a discovered gateway route: {len(unmatched_oapi)}** (see section below)")
+    out.append(f"- **OpenAPI operations (method + path) not matched to a discovered gateway route: {len(unmatched_ops)}** (see section below)")
     out.append("")
     out.append("> The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. "
                "Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside "
@@ -279,16 +287,15 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_can
                "OpenAPI presence does **not** prove a runtime route exists or is mounted; these stay "
                "`unknown / needs local verification`.")
     out.append("")
-    if unmatched_oapi:
+    if unmatched_ops:
         out.append("| Method | OpenAPI path | Matched gateway route | Status | Claim safety |")
         out.append("|---|---|---|---|---|")
-        for e in sorted(unmatched_oapi, key=lambda x: x["path"]):
-            methods = " · ".join(e["methods"]) if e["methods"] else "?"
-            out.append(f"| {methods} | `{md_table_escape(e['path'])}` | no | "
+        for op in sorted(unmatched_ops, key=lambda x: (x["path"], x["method"])):
+            out.append(f"| {op['method']} | `{md_table_escape(op['path'])}` | no | "
                        "unknown / needs local verification | needs review |")
         out.append("")
     else:
-        out.append("- None: every OpenAPI path matched a discovered gateway route.")
+        out.append("- None: every OpenAPI operation matched a discovered gateway route.")
         out.append("")
     out.append("## Limitations")
     out.append("")

--- a/docs/scripts/route_inventory.py
+++ b/docs/scripts/route_inventory.py
@@ -60,6 +60,7 @@ SCOPE_RE = re.compile(r'web::scope\("(/[^"]*)"\)')
 # longer crate paths like `icn_kernel_api::services::` or `icn_api::LedgerService::`.
 MODREF_RE = re.compile(r'(?<![A-Za-z0-9_])api::([A-Za-z_]\w*)::')
 OAPI_PATH_RE = re.compile(r'^  (/\S*):\s*$')
+OAPI_METHOD_RE = re.compile(r'^    (get|post|put|delete|patch|head):\s*$')
 # Macro-less route-registration *candidates* (issue #2112, PR3). FLAGGED, not
 # parsed into routes: a quoted `web::resource("…")` literal, and `.route(…)`
 # method bindings. RESOURCE_RE requires a quoted argument, so `web::resource().to()`
@@ -136,10 +137,13 @@ def module_scope_map() -> dict[str, str]:
     return out
 
 
-def openapi_paths() -> list[str]:
+def openapi_paths() -> list[dict]:
+    """Parse the generated OpenAPI `paths:` block into [{path, methods}].
+    Methods are the per-path operation keys (get/post/…), upper-cased."""
     if not OPENAPI.is_file():
         return []
-    paths, in_paths = [], False
+    out: list[dict] = []
+    in_paths, cur = False, None
     for line in OPENAPI.read_text(encoding="utf-8", errors="replace").splitlines():
         if line.rstrip() == "paths:":
             in_paths = True
@@ -148,8 +152,13 @@ def openapi_paths() -> list[str]:
             break
         m = OAPI_PATH_RE.match(line)
         if m:
-            paths.append(m.group(1))
-    return paths
+            cur = {"path": m.group(1), "methods": []}
+            out.append(cur)
+            continue
+        mm = OAPI_METHOD_RE.match(line)
+        if mm and cur is not None:
+            cur["methods"].append(mm.group(1).upper())
+    return out
 
 
 def resource_candidates() -> list[dict]:
@@ -194,7 +203,8 @@ def md_table_escape(s: str) -> str:
 
 
 def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], reg_candidates: list[dict], commit: str) -> str:
-    oapi_norm = {norm(p) for p in oapi}
+    oapi_norm = {norm(e["path"]) for e in oapi}
+    matched_oapi: set[str] = set()
     by_method: dict[str, int] = {}
     documented = 0
     rows = []
@@ -203,10 +213,15 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], reg_cand
         scope = scopes.get(r["module"], "")
         fp = full_path(scope, r["path"])
         candidates = {norm(fp), norm(scope + (r["path"] if r["path"].startswith("/") else "/" + r["path"])), norm(r["path"])}
-        documented_here = bool(candidates & oapi_norm)
+        hit = candidates & oapi_norm
+        documented_here = bool(hit)
         if documented_here:
             documented += 1
+            matched_oapi |= hit
         rows.append((r, fp, "yes" if documented_here else "no"))
+
+    # OpenAPI paths that no discovered gateway route matched (issue #2112, PR4).
+    unmatched_oapi = [e for e in oapi if norm(e["path"]) not in matched_oapi]
 
     total = len(routes)
     undoc = total - documented
@@ -246,6 +261,7 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], reg_cand
     out.append(f"- Matched as documented (best-effort path match): {documented}")
     out.append(f"- Not matched to OpenAPI (best-effort): {undoc} (~{undoc / total * 100:.0f}% of discovered)" if total else "- Not matched to OpenAPI: 0")
     out.append(f"- Documented share of discovered routes: ~{pct_doc:.1f}%")
+    out.append(f"- **OpenAPI paths not matched to a discovered gateway route: {len(unmatched_oapi)}** (see section below)")
     out.append("")
     out.append("> The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. "
                "Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside "
@@ -253,6 +269,27 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[str], reg_cand
                "counts here are a best-effort comparison, while the two headline counts (discovered macros, "
                "OpenAPI paths) are the robust measured facts.")
     out.append("")
+    out.append("## OpenAPI paths not matched to discovered gateway routes")
+    out.append("")
+    out.append("These OpenAPI-documented paths did **not** mechanically match any discovered gateway route macro. "
+               "That is expected when a handler is documented via `#[utoipa::path]` but **registered outside the "
+               "scanned `icn/crates/icn-gateway/src/**` tree** — e.g. the governance app (`icn-governance-actor` = "
+               "`icn/apps/governance`) documents its `/gov/*` handlers with utoipa and mounts them via "
+               "`web::resource(\"…\").route(…)` in `apps/governance/src/http/configure.rs` (no attribute macros). "
+               "OpenAPI presence does **not** prove a runtime route exists or is mounted; these stay "
+               "`unknown / needs local verification`.")
+    out.append("")
+    if unmatched_oapi:
+        out.append("| Method | OpenAPI path | Matched gateway route | Status | Claim safety |")
+        out.append("|---|---|---|---|---|")
+        for e in sorted(unmatched_oapi, key=lambda x: x["path"]):
+            methods = " · ".join(e["methods"]) if e["methods"] else "?"
+            out.append(f"| {methods} | `{md_table_escape(e['path'])}` | no | "
+                       "unknown / needs local verification | needs review |")
+        out.append("")
+    else:
+        out.append("- None: every OpenAPI path matched a discovered gateway route.")
+        out.append("")
     out.append("## Limitations")
     out.append("")
     out.append("- **Full mounted-path resolution is best-effort.** The `Group` column is `/v1` + a `web::scope(\"…\")` "


### PR DESCRIPTION
## What changed

Adds an **"OpenAPI paths not matched to discovered gateway routes"** section to the generated route inventory, and teaches `openapi_paths()` to capture per-path methods. Two files: the script and its generated artifact. This makes OpenAPI↔route drift visible from the *other* direction — not just gateway routes missing from OpenAPI, but OpenAPI paths with no mechanically-matched gateway route.

## Exact OpenAPI paths inspected (5)

| Method | OpenAPI path | `#[utoipa::path]` on | In scanned `icn-gateway/src`? | Matched? |
|---|---|---|---|---|
| POST | `/federation/clearing/{id}/propose-adoption` | `crate::api::federation::propose_clearing_adoption` | ✅ | **yes** |
| GET | `/federation/topology` | `crate::api::federation::get_topology` | ✅ | **yes** |
| GET | `/gov/me/standing` | `icn_governance_actor::http::handlers::get_my_standing` | ❌ apps/governance | **no** |
| GET | `/gov/me/action-cards` | `…::get_my_action_cards` | ❌ apps/governance | **no** |
| GET | `/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `…::get_action_item_completion_receipt` | ❌ apps/governance | **no** |

## Which governance paths were traced + did they match

The **3 `gov/*` paths**. Traced to `#[utoipa::path]` annotations on handlers in `icn/apps/governance/src/http/handlers.rs` (the `icn-governance-actor` crate, registered into the gateway's `ApiDoc` via `#[openapi(paths(...))]` in `icn-gateway/src/openapi.rs`). They are **registered as runtime routes via `web::resource("…").route(web::<method>().to(handlers::…))`** in `apps/governance/src/http/configure.rs` (the governance app uses **zero** route attribute macros) and mounted through `configure_governance` (server.rs). Because they live outside the scanned `icn-gateway/src/**` tree and use no attribute macros, the macro scan never matches them → **unmatched**.

## What the artifact proves

That these 3 OpenAPI paths are documented in the generated spec **and** that no discovered gateway-crate route macro matches them. The match/unmatched split is mechanical (OpenAPI paths minus the set matched by discovered routes).

## What it does NOT prove

That the unmatched paths are (or are not) live runtime routes. OpenAPI presence ≠ a mounted route; route declaration ≠ correctness/auth/tests/runtime health/production readiness. The handlers' out-of-crate registration is described as orientation (verified by inspection), not asserted per-row. Unmatched paths stay `unknown / needs local verification`, claim safety `needs review`.

## Known limitations

- The section lists OpenAPI paths the **gateway-crate macro scan** didn't match; it does not parse `apps/governance` registrations into routes (no Rust parser; out of scope).
- Per-path "OpenAPI source" is explained in the section prose, not extracted per row (the `paths(...)` block maps handler fns, not path strings).
- Method comes from the OpenAPI operation keys.

## Validation (on this branch)

- `route_inventory.py --write` → `287 routes, 5 OpenAPI paths, 4 non-macro candidates`; new line: *OpenAPI paths not matched to a discovered gateway route: 3*.
- `--check` → **OK, idempotent**.
- Section lists exactly the 3 `gov/*` paths (GET); the 2 `federation` paths are correctly **excluded** (matched).
- `doc_control_check.py` → OK, 878 md files, 65 pre-existing warnings, none on changed files.
- `freshness-check.py` → exit 1 = **pre-existing #2047** (`04`/`18`), unchanged here.
- `drift-check.sh` → PASS. Zero `.rs` ⇒ Rust gates N/A.

## Relationship

- **Refs #2112** — fourth mechanical slice (PR1 #2116 artifact+checker; PR2 #2117 CI drift wiring; PR3 #2118 macro-less candidate flagging; this = reverse-direction OpenAPI↔route gap).
- **Refs #1779** — the unmatched view is part of keeping the public-surface inventory honest.

## Non-goals (explicit)

No OpenAPI completion/expansion; no Rust parser / mounted-path reconstruction; no classifying unmatched OpenAPI paths as live runtime routes; no asserting governance-actor HTTP behavior; no gateway route changes; no CI-wiring change; no manual path-equivalence assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
