### PR TITLE
docs(api): cross-reference governance route candidates

### DIFF
--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-20T16:08:37+00:00
+Generated: 2026-06-20T16:19:03+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -17,7 +17,7 @@ Generated: 2026-06-20T16:08:37+00:00
 
 ## Snapshot
 
-- Source commit: `5cfabd25486cd10ddc6a6f4369d32179a73b2ada`
+- Source commit: `4b47261a3fb9b2c7bd7c979d6556e3fb06bb0ce2`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -29,6 +29,7 @@ Generated: 2026-06-20T16:08:37+00:00
 - Not matched to OpenAPI (best-effort): 285 (~99% of discovered)
 - Documented share of discovered routes: ~0.7%
 - **OpenAPI operations (method + path) not matched to a discovered gateway route: 3** (see section below)
+- **Governance app route-registration candidates (separate surface, not gateway macros): 80** (see section below)
 
 > The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside the gateway crate and are not captured by this macro scan — so the documented/undocumented counts here are a best-effort comparison, while the two headline counts (discovered macros, OpenAPI paths) are the robust measured facts.
 
@@ -36,16 +37,103 @@ Generated: 2026-06-20T16:08:37+00:00
 
 These OpenAPI-documented paths did **not** mechanically match any discovered gateway route macro. That is expected when a handler is documented via `#[utoipa::path]` but **registered outside the scanned `icn/crates/icn-gateway/src/**` tree** — e.g. the governance app (`icn-governance-actor` = `icn/apps/governance`) documents its `/gov/*` handlers with utoipa and mounts them via `web::resource("…").route(…)` in `apps/governance/src/http/configure.rs` (no attribute macros). OpenAPI presence does **not** prove a runtime route exists or is mounted; these stay `unknown / needs local verification`.
 
-| Method | OpenAPI path | Matched gateway route | Status | Claim safety |
-|---|---|---|---|---|
-| GET | `/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | no | unknown / needs local verification | needs review |
-| GET | `/gov/me/action-cards` | no | unknown / needs local verification | needs review |
-| GET | `/gov/me/standing` | no | unknown / needs local verification | needs review |
+| Method | OpenAPI path | Matched gateway route | Governance registration candidate | Status | Claim safety |
+|---|---|---|---|---|---|
+| GET | `/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | no | `get_action_item_completion_receipt` @ `icn/apps/governance/src/http/configure.rs`:682 | unknown / needs local verification | needs review |
+| GET | `/gov/me/action-cards` | no | `get_my_action_cards` @ `icn/apps/governance/src/http/configure.rs`:834 | unknown / needs local verification | needs review |
+| GET | `/gov/me/standing` | no | `get_my_standing` @ `icn/apps/governance/src/http/configure.rs`:830 | unknown / needs local verification | needs review |
+
+## Governance app route-registration candidates
+
+The governance app (`icn-governance-actor` = `icn/apps/governance`) registers its HTTP routes via `web::resource("…").route(web::<verb>().to(handlers::…))` in `apps/governance/src/http/configure.rs`, mounted under the gateway's `web::scope("/gov")` (the served path is `/gov` + the relative path below). It uses **no route attribute macros**, so the gateway macro scan above never sees these: they are a **separate registration surface**, listed here as candidates and **not** counted among the 287 gateway macros. This is why the unmatched `/gov/*` OpenAPI operations have no gateway-macro match — their handlers are registered here. The scan is mechanical (one `configure.rs`, one pattern); a registration site does **not** prove correctness, auth, mounting health, tests, or production readiness, so candidates stay `unknown / needs local verification`. `OpenAPI documented` = this candidate's `(verb, /gov + path)` matches a generated OpenAPI operation.
+
+| Method | Path (relative, under `/gov`) | Source | Handler | OpenAPI documented | Status | Claim safety |
+|---|---|---|---|---|---|---|
+| GET | `/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:707 | `get_activity` | no | unknown / needs local verification | needs review |
+| POST | `/charters` | `icn/apps/governance/src/http/configure.rs`:587 | `activate_charter` | no | unknown / needs local verification | needs review |
+| GET | `/delegations` | `icn/apps/governance/src/http/configure.rs`:654 | `list_delegations` | no | unknown / needs local verification | needs review |
+| POST | `/delegations` | `icn/apps/governance/src/http/configure.rs`:653 | `create_delegation` | no | unknown / needs local verification | needs review |
+| DELETE | `/delegations/{delegation_id}` | `icn/apps/governance/src/http/configure.rs`:658 | `revoke_delegation` | no | unknown / needs local verification | needs review |
+| GET | `/digest` | `icn/apps/governance/src/http/configure.rs`:827 | `get_digest` | no | unknown / needs local verification | needs review |
+| GET | `/domains` | `icn/apps/governance/src/http/configure.rs`:576 | `list_domains` | no | unknown / needs local verification | needs review |
+| POST | `/domains` | `icn/apps/governance/src/http/configure.rs`:575 | `create_domain` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}` | `icn/apps/governance/src/http/configure.rs`:579 | `get_domain` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/action-items` | `icn/apps/governance/src/http/configure.rs`:664 | `list_action_items` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/action-items` | `icn/apps/governance/src/http/configure.rs`:663 | `create_action_item` | no | unknown / needs local verification | needs review |
+| DELETE | `/domains/{domain_id}/action-items/{item_id}` | `icn/apps/governance/src/http/configure.rs`:670 | `delete_action_item` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/action-items/{item_id}` | `icn/apps/governance/src/http/configure.rs`:668 | `get_action_item` | no | unknown / needs local verification | needs review |
+| PUT | `/domains/{domain_id}/action-items/{item_id}` | `icn/apps/governance/src/http/configure.rs`:669 | `update_action_item` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `icn/apps/governance/src/http/configure.rs`:682 | `get_action_item_completion_receipt` | yes | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/action-items/{item_id}/notes` | `icn/apps/governance/src/http/configure.rs`:678 | `add_action_item_note` | no | unknown / needs local verification | needs review |
+| PUT | `/domains/{domain_id}/action-items/{item_id}/status` | `icn/apps/governance/src/http/configure.rs`:674 | `update_action_item_status` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:758 | `list_meetings` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:757 | `create_meeting` | no | unknown / needs local verification | needs review |
+| DELETE | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:584 | `remove_domain_member` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:583 | `add_domain_member` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:713 | `list_programs_by_domain` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:712 | `create_program` | no | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:703 | `list_activities` | no | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:702 | `create_activity` | no | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:688 | `list_structures` | no | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:687 | `create_structure` | no | unknown / needs local verification | needs review |
+| GET | `/me/action-cards` | `icn/apps/governance/src/http/configure.rs`:834 | `get_my_action_cards` | yes | unknown / needs local verification | needs review |
+| GET | `/me/scopes` | `icn/apps/governance/src/http/configure.rs`:829 | `get_my_scopes` | no | unknown / needs local verification | needs review |
+| GET | `/me/standing` | `icn/apps/governance/src/http/configure.rs`:830 | `get_my_standing` | yes | unknown / needs local verification | needs review |
+| GET | `/me/work` | `icn/apps/governance/src/http/configure.rs`:831 | `get_my_work` | no | unknown / needs local verification | needs review |
+| GET | `/meetings/{meeting_id}` | `icn/apps/governance/src/http/configure.rs`:762 | `get_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/agenda` | `icn/apps/governance/src/http/configure.rs`:782 | `add_agenda_item` | no | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/agenda/{item_id}` | `icn/apps/governance/src/http/configure.rs`:786 | `update_agenda_item` | no | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/attendance` | `icn/apps/governance/src/http/configure.rs`:778 | `mark_attendance` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/attendees` | `icn/apps/governance/src/http/configure.rs`:774 | `add_attendee` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/end` | `icn/apps/governance/src/http/configure.rs`:770 | `end_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/start` | `icn/apps/governance/src/http/configure.rs`:766 | `start_meeting` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:743 | `get_milestone` | no | unknown / needs local verification | needs review |
+| PATCH | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:744 | `update_milestone_status` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/history` | `icn/apps/governance/src/http/configure.rs`:752 | `get_milestone_history` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/preview` | `icn/apps/governance/src/http/configure.rs`:748 | `preview_milestone` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}` | `icn/apps/governance/src/http/configure.rs`:717 | `get_program` | no | unknown / needs local verification | needs review |
+| DELETE | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:739 | `unlink_activity_from_program` | no | unknown / needs local verification | needs review |
+| PUT | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:738 | `link_activity_to_program` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/dashboard` | `icn/apps/governance/src/http/configure.rs`:725 | `get_program_dashboard` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:734 | `list_milestones_by_program` | no | unknown / needs local verification | needs review |
+| POST | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:733 | `create_milestone` | no | unknown / needs local verification | needs review |
+| PATCH | `/programs/{program_id}/status` | `icn/apps/governance/src/http/configure.rs`:721 | `update_program_status` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/summary` | `icn/apps/governance/src/http/configure.rs`:729 | `get_program_summary` | no | unknown / needs local verification | needs review |
+| GET | `/proposals` | `icn/apps/governance/src/http/configure.rs`:592 | `list_proposals` | no | unknown / needs local verification | needs review |
+| POST | `/proposals` | `icn/apps/governance/src/http/configure.rs`:591 | `create_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/establish` | `icn/apps/governance/src/http/configure.rs`:799 | `create_establish_clearing_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/terminate` | `icn/apps/governance/src/http/configure.rs`:803 | `create_terminate_clearing_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/join` | `icn/apps/governance/src/http/configure.rs`:791 | `create_join_federation_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/leave` | `icn/apps/governance/src/http/configure.rs`:795 | `create_leave_federation_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/policy` | `icn/apps/governance/src/http/configure.rs`:815 | `create_update_federation_policy_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch` | `icn/apps/governance/src/http/configure.rs`:807 | `create_vouch_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch/revoke` | `icn/apps/governance/src/http/configure.rs`:811 | `create_revoke_vouch_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/appoint-steward` | `icn/apps/governance/src/http/configure.rs`:820 | `create_appoint_steward_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/remove-steward` | `icn/apps/governance/src/http/configure.rs`:824 | `create_remove_steward_proposal` | no | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}` | `icn/apps/governance/src/http/configure.rs`:596 | `get_proposal` | no | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/chain` | `icn/apps/governance/src/http/configure.rs`:620 | `get_chain` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/close` | `icn/apps/governance/src/http/configure.rs`:604 | `close_proposal` | no | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/deliberation` | `icn/apps/governance/src/http/configure.rs`:624 | `get_proposal_deliberation` | no | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/discussion` | `icn/apps/governance/src/http/configure.rs`:633 | `get_discussion` | no | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/discussion/comments` | `icn/apps/governance/src/http/configure.rs`:638 | `list_comments` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/discussion/comments` | `icn/apps/governance/src/http/configure.rs`:637 | `add_comment` | no | unknown / needs local verification | needs review |
+| DELETE | `/proposals/{proposal_id}/discussion/comments/{comment_id}` | `icn/apps/governance/src/http/configure.rs`:643 | `delete_comment` | no | unknown / needs local verification | needs review |
+| PUT | `/proposals/{proposal_id}/discussion/comments/{comment_id}` | `icn/apps/governance/src/http/configure.rs`:642 | `edit_comment` | no | unknown / needs local verification | needs review |
+| DELETE | `/proposals/{proposal_id}/discussion/comments/{comment_id}/reactions` | `icn/apps/governance/src/http/configure.rs`:648 | `remove_reaction` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/discussion/comments/{comment_id}/reactions` | `icn/apps/governance/src/http/configure.rs`:647 | `add_reaction` | no | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/effects` | `icn/apps/governance/src/http/configure.rs`:628 | `list_proposal_effects` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/open` | `icn/apps/governance/src/http/configure.rs`:600 | `open_proposal` | no | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/proof` | `icn/apps/governance/src/http/configure.rs`:616 | `get_proof` | no | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/tally` | `icn/apps/governance/src/http/configure.rs`:612 | `get_vote_tally` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/vote` | `icn/apps/governance/src/http/configure.rs`:608 | `cast_vote` | no | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}` | `icn/apps/governance/src/http/configure.rs`:692 | `get_structure` | no | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:697 | `list_roles` | no | unknown / needs local verification | needs review |
+| POST | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:696 | `assign_role` | no | unknown / needs local verification | needs review |
 
 ## Limitations
 
 - **Full mounted-path resolution is best-effort.** The `Group` column is `/v1` + a `web::scope("…")` segment associated from `server.rs` `.service(...)`/`.configure(...)` registration sites (matched at identifier boundaries, keyed by the handler's top-level `icn/crates/icn-gateway/src/api/<group>` module) + the relative macro path. It is **not** a real Rust parser and may be wrong for deeply-nested or conditional scopes. The relative macro `Path` and the `Source` file are authoritative.
-- The route table is **attribute macros only**. Macro-less `web::resource("…")`/`.route(…)` registrations are now **flagged** below (see *Unparsed route-registration candidates*) but **not** parsed into routes; out-of-crate handlers (e.g. `icn-governance-actor::http`) are still not captured.
+- The route table is **attribute macros only**. Macro-less `web::resource("…")`/`.route(…)` registrations in the gateway crate are **flagged** under *Unparsed route-registration candidates*; the governance app's out-of-crate registrations are listed under *Governance app route-registration candidates*. Neither is parsed into the gateway route table or counted as a gateway macro.
 - This is **generated-map work, not API documentation completion** (issue #2112). It does not add or change any OpenAPI content or runtime behavior.
 
 ## Routes

--- a/docs/scripts/route_inventory.py
+++ b/docs/scripts/route_inventory.py
@@ -51,6 +51,11 @@ SERVER_RS = GATEWAY_SRC / "server.rs"
 OPENAPI = ROOT / "docs" / "api" / "openapi.generated.yaml"
 ARTIFACT = ROOT / "docs" / "reference" / "project-index" / "generated" / "route-inventory.md"
 SCRIPT_REL = "docs/scripts/route_inventory.py"
+# Governance app (icn-governance-actor) HTTP route registrations. The governance
+# app uses NO route attribute macros — it mounts routes via
+# `web::resource("…").route(web::<verb>().to(handlers::…))` in configure.rs, under
+# the gateway's `web::scope("/gov")`. These are outside the gateway macro scan.
+GOV_CONFIGURE = ROOT / "icn" / "apps" / "governance" / "src" / "http" / "configure.rs"
 
 ATTR_RE = re.compile(r'#\[(get|post|put|delete|patch|head)\("([^"]*)"\)\]')
 ROUTE_RE = re.compile(r'#\[route\("([^"]*)"\s*,\s*method\s*=\s*"([A-Za-z]+)"')
@@ -67,6 +72,9 @@ OAPI_METHOD_RE = re.compile(r'^    (get|post|put|delete|patch|head):\s*$')
 # in a doc comment does not match.
 RESOURCE_RE = re.compile(r'web::resource\("([^"]*)"\)')
 ROUTE_CALL_RE = re.compile(r'\.route\(')
+# Governance app registration ops: `.route(web::<verb>().to(handlers::<name>...))`.
+# The path comes from the nearest preceding `web::resource("…")` (RESOURCE_RE).
+GOV_OP_RE = re.compile(r'\.route\(\s*web::(get|post|put|delete|patch|head)\(\)\s*\.to\(\s*handlers::([A-Za-z_]\w*)')
 
 
 def discover_routes() -> list[dict]:
@@ -185,6 +193,46 @@ def resource_candidates() -> list[dict]:
     return out
 
 
+def governance_candidates() -> list[dict]:
+    """Mechanically discover the governance app's route registrations in
+    configure.rs: `web::resource("REL").route(web::<verb>().to(handlers::<name>…))`,
+    mounted under the gateway's `web::scope("/gov")`. These are real registration
+    sites the gateway *macro* scan cannot see — the governance app uses no route
+    attribute macros and lives outside `icn-gateway/src/**`. They are listed as
+    candidates, NOT folded into the gateway macro count, and stay
+    `unknown / needs local verification`. The relative `web::resource` literal is
+    the authoritative path fragment; the `/gov` mount prefix is applied by the
+    gateway (server.rs `web::scope("/gov")`), so it is not reconstructed here."""
+    out: list[dict] = []
+    if not GOV_CONFIGURE.is_file():
+        return out
+    rel = GOV_CONFIGURE.relative_to(ROOT).as_posix()
+    current_lit = ""
+    for i, line in enumerate(GOV_CONFIGURE.read_text(encoding="utf-8", errors="replace").splitlines()):
+        # The nearest preceding (or same-line) `web::resource("…")` literal owns
+        # the `.route(...)` ops that follow it, until the next resource.
+        res = RESOURCE_RE.findall(line)
+        if res:
+            current_lit = res[-1]
+        for m in GOV_OP_RE.finditer(line):
+            out.append({
+                "verb": m.group(1).upper(),
+                "path": current_lit,
+                "handler": m.group(2),
+                "file": rel,
+                "line": i + 1,
+            })
+    return out
+
+
+def gov_matches_op(c: dict, method: str, oapi_path: str) -> bool:
+    """A governance candidate matches an OpenAPI operation when verbs agree and the
+    OpenAPI path ends with the candidate's relative `web::resource` literal (the
+    `/gov` scope prefix is mount-applied). Prefix-agnostic, segment-boundary safe
+    because the literal starts with `/`."""
+    return bool(c["path"]) and c["verb"] == method and norm(oapi_path).endswith(norm(c["path"]))
+
+
 def norm(p: str) -> str:
     p = re.sub(r"\{[^}]+\}", "{}", p)
     p = re.sub(r"/+", "/", p)
@@ -202,7 +250,7 @@ def md_table_escape(s: str) -> str:
     return s.replace("|", "\\|")
 
 
-def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_candidates: list[dict], commit: str) -> str:
+def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_candidates: list[dict], gov_candidates: list[dict], commit: str) -> str:
     # Match by (METHOD, normalized-path) pairs, not path alone — otherwise a path
     # documented for one verb but routed under another would falsely count as
     # matched and be hidden from the unmatched section (issue #2112, PR4 review).
@@ -230,6 +278,14 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_can
         for m in (e["methods"] or ["?"])
         if (m, norm(e["path"])) not in matched_ops
     ]
+    # Cross-reference each unmatched op to a governance-app registration candidate
+    # (longest suffix match wins, so /me/standing beats a hypothetical /standing).
+    for op in unmatched_ops:
+        regs = sorted(
+            (c for c in gov_candidates if gov_matches_op(c, op["method"], op["path"])),
+            key=lambda c: len(norm(c["path"])), reverse=True,
+        )
+        op["registration"] = regs[0] if regs else None
 
     total = len(routes)
     undoc = total - documented
@@ -270,6 +326,7 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_can
     out.append(f"- Not matched to OpenAPI (best-effort): {undoc} (~{undoc / total * 100:.0f}% of discovered)" if total else "- Not matched to OpenAPI: 0")
     out.append(f"- Documented share of discovered routes: ~{pct_doc:.1f}%")
     out.append(f"- **OpenAPI operations (method + path) not matched to a discovered gateway route: {len(unmatched_ops)}** (see section below)")
+    out.append(f"- **Governance app route-registration candidates (separate surface, not gateway macros): {len(gov_candidates)}** (see section below)")
     out.append("")
     out.append("> The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. "
                "Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside "
@@ -288,15 +345,41 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_can
                "`unknown / needs local verification`.")
     out.append("")
     if unmatched_ops:
-        out.append("| Method | OpenAPI path | Matched gateway route | Status | Claim safety |")
-        out.append("|---|---|---|---|---|")
+        out.append("| Method | OpenAPI path | Matched gateway route | Governance registration candidate | Status | Claim safety |")
+        out.append("|---|---|---|---|---|---|")
         for op in sorted(unmatched_ops, key=lambda x: (x["path"], x["method"])):
-            out.append(f"| {op['method']} | `{md_table_escape(op['path'])}` | no | "
+            reg = op.get("registration")
+            reg_cell = f"`{reg['handler']}` @ `{reg['file']}`:{reg['line']}" if reg else "none"
+            out.append(f"| {op['method']} | `{md_table_escape(op['path'])}` | no | {reg_cell} | "
                        "unknown / needs local verification | needs review |")
         out.append("")
     else:
         out.append("- None: every OpenAPI operation matched a discovered gateway route.")
         out.append("")
+
+    # Governance app route-registration candidates (issue #2112, PR5).
+    out.append("## Governance app route-registration candidates")
+    out.append("")
+    out.append("The governance app (`icn-governance-actor` = `icn/apps/governance`) registers its HTTP routes via "
+               "`web::resource(\"…\").route(web::<verb>().to(handlers::…))` in `apps/governance/src/http/configure.rs`, "
+               "mounted under the gateway's `web::scope(\"/gov\")` (the served path is `/gov` + the relative path "
+               "below). It uses **no route attribute macros**, so the gateway macro scan above never sees these: they "
+               "are a **separate registration surface**, listed here as candidates and **not** counted among the "
+               f"{total} gateway macros. This is why the unmatched `/gov/*` OpenAPI operations have no gateway-macro "
+               "match — their handlers are registered here. The scan is mechanical (one `configure.rs`, one pattern); "
+               "a registration site does **not** prove correctness, auth, mounting health, tests, or production "
+               "readiness, so candidates stay `unknown / needs local verification`. `OpenAPI documented` = this "
+               "candidate's `(verb, /gov + path)` matches a generated OpenAPI operation.")
+    out.append("")
+    if gov_candidates:
+        out.append("| Method | Path (relative, under `/gov`) | Source | Handler | OpenAPI documented | Status | Claim safety |")
+        out.append("|---|---|---|---|---|---|---|")
+        for c in sorted(gov_candidates, key=lambda x: (x["path"], x["verb"])):
+            oapi_doc = "yes" if any(gov_matches_op(c, m, e["path"]) for e in oapi for m in (e["methods"] or ["?"])) else "no"
+            out.append(f"| {c['verb']} | `{md_table_escape(c['path'] or '(none)')}` | `{c['file']}`:{c['line']} | "
+                       f"`{md_table_escape(c['handler'])}` | {oapi_doc} | unknown / needs local verification | needs review |")
+        out.append("")
+
     out.append("## Limitations")
     out.append("")
     out.append("- **Full mounted-path resolution is best-effort.** The `Group` column is `/v1` + a `web::scope(\"…\")` "
@@ -305,8 +388,9 @@ def render(routes: list[dict], scopes: dict[str, str], oapi: list[dict], reg_can
                "module) + the relative macro path. It is **not** a real Rust parser and may be wrong for "
                "deeply-nested or conditional scopes. The relative macro `Path` and the `Source` file are authoritative.")
     out.append("- The route table is **attribute macros only**. Macro-less `web::resource(\"…\")`/`.route(…)` "
-               "registrations are now **flagged** below (see *Unparsed route-registration candidates*) but **not** "
-               "parsed into routes; out-of-crate handlers (e.g. `icn-governance-actor::http`) are still not captured.")
+               "registrations in the gateway crate are **flagged** under *Unparsed route-registration candidates*; the "
+               "governance app's out-of-crate registrations are listed under *Governance app route-registration "
+               "candidates*. Neither is parsed into the gateway route table or counted as a gateway macro.")
     out.append("- This is **generated-map work, not API documentation completion** (issue #2112). It does not add or "
                "change any OpenAPI content or runtime behavior.")
     out.append("")
@@ -379,16 +463,17 @@ def main() -> int:
     scopes = module_scope_map()
     oapi = openapi_paths()
     reg_candidates = resource_candidates()
+    gov_candidates = governance_candidates()
     if not routes:
         print(f"ERROR: no routes discovered under {GATEWAY_SRC} — wrong repo root?", file=sys.stderr)
         return 2
-    content = render(routes, scopes, oapi, reg_candidates, commit)
+    content = render(routes, scopes, oapi, reg_candidates, gov_candidates, commit)
 
     if args.write:
         ARTIFACT.parent.mkdir(parents=True, exist_ok=True)
         ARTIFACT.write_text(content + "\n", encoding="utf-8")
         print(f"wrote {ARTIFACT.relative_to(ROOT)}: {len(routes)} routes, {len(oapi)} OpenAPI paths, "
-              f"{len(reg_candidates)} non-macro candidates")
+              f"{len(reg_candidates)} non-macro candidates, {len(gov_candidates)} governance candidates")
         return 0
 
     # --check
@@ -398,7 +483,7 @@ def main() -> int:
     committed = ARTIFACT.read_text(encoding="utf-8")
     if strip_volatile(committed).strip() == strip_volatile(content).strip():
         print(f"OK: route inventory up to date ({len(routes)} routes, {len(oapi)} OpenAPI paths, "
-              f"{len(reg_candidates)} non-macro candidates)")
+              f"{len(reg_candidates)} non-macro candidates, {len(gov_candidates)} governance candidates)")
         return 0
     print(f"STALE: {ARTIFACT.relative_to(ROOT)} differs from a fresh scan — run --write and commit", file=sys.stderr)
     return 1


### PR DESCRIPTION
## What changed

Adds a **"Governance app route-registration candidates"** section to the generated route inventory, and cross-references the unmatched `gov/*` OpenAPI operations to their governance-app registration sites. Two files: the script and its generated artifact.

## Governance registration patterns now detected

`route_inventory.py` now scans `icn/apps/governance/src/http/configure.rs` for `web::resource("REL").route(web::<verb>().to(handlers::<name>…))` (the nearest preceding `web::resource("…")` literal owns the following `.route(...)` ops). The governance app uses **no route attribute macros** and is mounted under the gateway's `web::scope("/gov")`, so the served path is `/gov` + the relative literal.

## The 3 `gov/*` paths — each matched a registration candidate

| OpenAPI operation | Governance registration candidate |
|---|---|
| `GET /gov/me/standing` | `get_my_standing` @ `apps/governance/src/http/configure.rs:830` |
| `GET /gov/me/action-cards` | `get_my_action_cards` @ `…/configure.rs:834` |
| `GET /gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `get_action_item_completion_receipt` @ `…/configure.rs:682` |

Cross-reference is mechanical: verb match + the OpenAPI path ends with the candidate's relative `web::resource` literal (longest-suffix wins; `/gov` is mount-applied, not reconstructed). All 3 unmatched ops resolved to exactly one governance candidate; those 3 (of 80) are flagged `OpenAPI documented = yes`.

## Updated counts (kept strictly separate)

| Surface | Count |
|---|---|
| Gateway route **macros** | **287** (unchanged) |
| Unparsed gateway **candidates** (`web::resource`/`.route`) | **4** (unchanged) |
| OpenAPI documented paths | **5** (unchanged) |
| OpenAPI operations **not matched** to a discovered gateway route | **3** (unchanged) |
| **Governance app route-registration candidates** (new) | **80** |

The 80 governance candidates are **not** folded into the 287 gateway macros — separate surface, separate section.

## What the artifact proves

That the governance app mechanically registers ~80 HTTP routes in `configure.rs` (one file, one pattern), and that the 3 unmatched `gov/*` OpenAPI operations correspond to 3 of those registration sites.

## What it does NOT prove

A registration site proves neither correctness, auth, mounting health, tests, runtime health, nor production readiness; OpenAPI presence ≠ a mounted route. Governance candidates stay `unknown / needs local verification`, claim safety `needs review`. They are **not** gateway macro routes and are not counted as such.

## Known limitations

- Path is the **relative** `web::resource` literal; the `/gov` mount prefix is documented (server.rs `web::scope("/gov")`) but not reconstructed per-row (no Rust parser).
- Cross-reference is verb + path-suffix (longest-suffix wins) — robust for the current small OpenAPI set; not a full mounted-path resolver.
- No production-vs-test classification (these are in the production `configure` fn, not `#[cfg(test)]`, confirmed by inspection — but not asserted per-row by the script).

## Validation (on this branch)

- `route_inventory.py --write` → `287 routes, 5 OpenAPI paths, 4 non-macro candidates, 80 governance candidates`; `--check` → **OK, idempotent**.
- 3 unmatched `gov/*` ops cross-reference `configure.rs:830/834/682`; governance section = 80 rows, exactly 3 with `OpenAPI documented = yes` (cross-ref consistent).
- `doc_control_check.py` → OK, 878 md files, 65 pre-existing warnings, none on changed files.
- `freshness-check.py` → exit 1 = **pre-existing #2047** (`04`/`18`), unchanged here.
- `drift-check.sh` → PASS. Zero `.rs` ⇒ Rust gates N/A.

## Relationship

- **Refs #2112** — fifth mechanical slice (PR1 #2116 artifact+checker; PR2 #2117 CI drift wiring; PR3 #2118 macro-less candidate flagging; PR4 #2119 unmatched-OpenAPI section; this = explains *why* the gov/* are unmatched by cross-referencing the governance registration surface).
- **Refs #1779** — surfacing the governance route surface feeds the public-surface truth-sync.

## Non-goals (explicit)

No folding governance candidates into the 287 gateway count; no claiming app candidates are served publicly; no Rust parser / arbitrary-syntax parsing; no full mounted-path/scope reconstruction; no production-vs-test classification; no OpenAPI expansion; no gateway route changes; no CI-wiring change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
