### PR TITLE
ci(docs): trigger route inventory on governance source

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -17,6 +17,11 @@ on:
       # outside src/api/ must still fire the drift check. The script and its
       # generated artifact under docs/ are already covered by docs/**.
       - 'icn/crates/icn-gateway/src/**'
+      # route-inventory also scans the governance app's route registrations
+      # (web::resource(...).route(...)) in apps/governance/src/http/, mounted under
+      # the gateway's /gov scope — include that source so governance route changes
+      # also fire the --check drift guard.
+      - 'icn/apps/governance/src/http/**'
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'
@@ -35,6 +40,11 @@ on:
       # outside src/api/ must still fire the drift check. The script and its
       # generated artifact under docs/ are already covered by docs/**.
       - 'icn/crates/icn-gateway/src/**'
+      # route-inventory also scans the governance app's route registrations
+      # (web::resource(...).route(...)) in apps/governance/src/http/, mounted under
+      # the gateway's /gov scope — include that source so governance route changes
+      # also fire the --check drift guard.
+      - 'icn/apps/governance/src/http/**'
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -31,6 +31,10 @@ on:
       - 'ARCHITECTURE.md'
       - 'README.md'
       - 'CONTRIBUTING.md'
+      # include this workflow so a PR that only edits it self-validates on the
+      # pull_request event (push.paths already lists it; matches other
+      # path-filtered workflows e.g. mcp-portability.yml).
+      - '.github/workflows/docs-freshness.yml'
       - 'docs/scripts/doc_control_check.py'
       # gateway route source is code-truth for the API-doc canonical guard
       - 'icn/crates/icn-gateway/src/api/ledger.rs'


### PR DESCRIPTION
## What changed

Adds `icn/apps/governance/src/http/**` to **both** the `push.paths` and `pull_request.paths` filters in `.github/workflows/docs-freshness.yml` (the *Documentation Maintenance* workflow), with a comment matching the existing gateway-source trigger comments. One file, +10/−0.

## Why

`docs/scripts/route_inventory.py` now scans `icn/apps/governance/src/http/configure.rs` for the governance app's route registrations (`web::resource(...).route(...)`, added in #2120). The drift guard that runs `python3 docs/scripts/route_inventory.py --check` lives in the workflow's non-required `route_inventory` job (added in #2117), but its triggers covered only `docs/**` + the gateway crate. So a PR changing **only** governance route source would not fire the drift check until the weekly schedule run. This closes that gap — flagged by Copilot review on #2120.

## Relationship

- **#2120** introduced the governance-source scan (the new input this trigger must cover).
- **#2117** added the `route_inventory` drift-check job + the original trigger paths (this is the same CI lane).
- **Refs #2112** — route/API inventory hygiene lane. **Refs #1779** — public-surface truth-sync.

## What this does NOT do

- Does **not** modify `docs/scripts/route_inventory.py`.
- Does **not** regenerate `docs/reference/project-index/generated/route-inventory.md`.
- Does **not** change runtime behavior, OpenAPI, or any Rust file.
- Does **not** change branch protection or make the `route_inventory` check required (it stays non-required, warn-on-drift).
- Leaves **#2112 open** — the route/API inventory lane continues.

## Validation

- `git diff --check` → clean.
- YAML parses (`yaml.safe_load`); both `push.paths` and `pull_request.paths` contain `icn/apps/governance/src/http/**`; all 7 jobs intact (incl. `route_inventory`, `summary`).
- `python3 docs/scripts/route_inventory.py --check` → OK (unaffected by a trigger-only change).
- Scope: only `.github/workflows/docs-freshness.yml` changed; 0 `.rs`.

## Non-goals (explicit)

No script/artifact change; no runtime/Rust/OpenAPI change; no branch-protection or required-check change; no new workflow; no broad docs; no close-keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
