### PR TITLE
docs(api): ground public surface claims in route inventory

### DIFF
--- a/docs/reference/project-index/runtime-surface-map.md
+++ b/docs/reference/project-index/runtime-surface-map.md
@@ -108,16 +108,16 @@ Before a public, demo, or docs surface claims anything about ICN's API/route sur
 
 **What this evidence proves / does not prove:** it proves route **declarations / registration sites exist in source** at a snapshot commit. It does **not** prove correctness, authn/authz, mounting, test coverage, runtime health, or production readiness. OpenAPI presence does not prove a route is served; a route being served does not prove it is public-safe.
 
-**Shape of the surface (see the inventory for live counts):** the gateway has hundreds of route-macro declarations, plus a **separate** governance-app registration surface (mounted under `/gov`, not gateway macros), while the generated OpenAPI documents only a handful of paths. So "the API" is far larger than OpenAPI describes — most of it is *undocumented*, not absent.
+**Shape of the surface (see the inventory for live counts):** the gateway has hundreds of route-macro declarations, plus a **separate** governance-app registration surface (served under the gateway's `/v1/gov` scope, not gateway macros), while the generated OpenAPI documents only a handful of paths. So "the API" is far larger than OpenAPI describes — most of it is *undocumented*, not absent.
 
 **Safe vs unsafe public/API claim patterns** — use the existing status vocabulary from [`source-of-truth-map.md`](source-of-truth-map.md), bound by proof level in [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md), and demo limits in [`show-readiness-map.md`](show-readiness-map.md):
 
 | Claim | Verdict | Why |
 |---|---|---|
-| "Member standing and action cards exist as member-facing read models" | safe | `GET /v1/gov/me/standing` + `GET /v1/gov/me/action-cards` are governance-registered **and** OpenAPI-documented; fixture-backed in `?mode=demo`. |
+| "Member standing and action cards are **declared + OpenAPI-documented** member-facing read models, fixture-backed in `?mode=demo`" | safe | `GET /v1/gov/me/standing` + `GET /v1/gov/me/action-cards` are governance-registered **and** OpenAPI-documented, and the demo panes are fixture-backed. Bounded to declared/documented + demo — does **not** assert a confirmed-live, authenticated runtime endpoint (per "proves / does not prove" above; confirm via [`docs/STATE.md`](../../STATE.md) + ops). |
 | "The API is documented / complete / fully specified" | **unsafe** | OpenAPI documents only a handful of the hundreds of declared routes; the rest are `unknown / needs local verification`, not specified. |
 | "Endpoint X is live / in production" | **unsafe** unless ops-confirmed | a declaration/registration is not a running, served, authenticated route; defer to [`docs/STATE.md`](../../STATE.md) + current ops evidence. |
-| "Governance `/gov/*` routes are part of the gateway's documented surface" | partial | they are governance-app registrations surfaced as candidates — not gateway route macros, and only a few reach OpenAPI. |
+| "Governance `/v1/gov/*` routes are part of the gateway's documented surface" | partial | they are governance-app registrations surfaced as candidates — not gateway route macros, and only a few reach OpenAPI. |
 
 **Rule:** keep public claims at or below what the generated evidence **plus** current canonical state ([`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md)) support. When unsure, say `unknown / needs local verification` rather than implying coverage.
 

--- a/docs/reference/project-index/runtime-surface-map.md
+++ b/docs/reference/project-index/runtime-surface-map.md
@@ -99,6 +99,28 @@ ICN's runtime surfaces use:
 - **identity, position, obligation, allocation, settlement, unit** — preferred.
 - **payment, currency, wallet, balance** — avoided. A `unit` is not a currency. A `position` is not a balance. A `settlement` is not a payment. The Regulatory Compliance Linter enforces this.
 
+## Reviewing public/API claims against generated evidence
+
+Before a public, demo, or docs surface claims anything about ICN's API/route surface, check it against the **mechanical evidence**, not prose. This supports the public-surface truth-sync work in [#1779](https://github.com/InterCooperative-Network/icn/issues/1779) and the route/API inventory lane [#2112](https://github.com/InterCooperative-Network/icn/issues/2112).
+
+- [`generated/route-inventory.md`](generated/route-inventory.md) — gateway route-macro declarations, unparsed gateway candidates, governance-app route-registration candidates, and OpenAPI matched/unmatched (regenerate/check with `docs/scripts/route_inventory.py`).
+- [`docs/api/openapi.generated.yaml`](../../api/openapi.generated.yaml) — the documented contract.
+
+**What this evidence proves / does not prove:** it proves route **declarations / registration sites exist in source** at a snapshot commit. It does **not** prove correctness, authn/authz, mounting, test coverage, runtime health, or production readiness. OpenAPI presence does not prove a route is served; a route being served does not prove it is public-safe.
+
+**Shape of the surface (see the inventory for live counts):** the gateway has hundreds of route-macro declarations, plus a **separate** governance-app registration surface (mounted under `/gov`, not gateway macros), while the generated OpenAPI documents only a handful of paths. So "the API" is far larger than OpenAPI describes — most of it is *undocumented*, not absent.
+
+**Safe vs unsafe public/API claim patterns** — use the existing status vocabulary from [`source-of-truth-map.md`](source-of-truth-map.md), bound by proof level in [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md), and demo limits in [`show-readiness-map.md`](show-readiness-map.md):
+
+| Claim | Verdict | Why |
+|---|---|---|
+| "Member standing and action cards exist as member-facing read models" | safe | `GET /v1/gov/me/standing` + `GET /v1/gov/me/action-cards` are governance-registered **and** OpenAPI-documented; fixture-backed in `?mode=demo`. |
+| "The API is documented / complete / fully specified" | **unsafe** | OpenAPI documents only a handful of the hundreds of declared routes; the rest are `unknown / needs local verification`, not specified. |
+| "Endpoint X is live / in production" | **unsafe** unless ops-confirmed | a declaration/registration is not a running, served, authenticated route; defer to [`docs/STATE.md`](../../STATE.md) + current ops evidence. |
+| "Governance `/gov/*` routes are part of the gateway's documented surface" | partial | they are governance-app registrations surfaced as candidates — not gateway route macros, and only a few reach OpenAPI. |
+
+**Rule:** keep public claims at or below what the generated evidence **plus** current canonical state ([`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md)) support. When unsure, say `unknown / needs local verification` rather than implying coverage.
+
 ## Where to read deeper
 
 | Topic | Doc |


### PR DESCRIPTION
## What changed

Adds a **"Reviewing public/API claims against generated evidence"** section to `docs/reference/project-index/runtime-surface-map.md` — a claim-review procedure for any public/demo/docs surface that asserts something about ICN's API/route surface. One file, docs-only.

It gives: the mechanical evidence anchors (generated route inventory + OpenAPI), what they prove / don't, the shape of the surface (hundreds of declared routes + a separate governance-app registration surface vs only a handful of OpenAPI paths), and a **safe vs unsafe public-claim pattern** table using the **existing** status vocabulary.

## Why #2122 made this reliable enough to reference

The #2112 lane built the generated route inventory and wired its drift check into CI; **#2122** extended that drift trigger to the governance app route source, so the inventory's governance-candidate + unmatched-OpenAPI evidence now stays current on the surfaces a PR touches. That makes it dependable enough to cite as evidence for #1779 public-surface claims.

## What public/API claim risk this reduces

It prevents over/under-claiming the API surface in public copy — e.g. "the API is documented/complete" (unsafe: OpenAPI = a handful of hundreds), "endpoint X is live/production" (unsafe without ops evidence) — while affirming what the evidence *does* support (member standing + action cards exist as member-facing read models, fixture-backed in `?mode=demo`). This directly serves #1779's "no overclaim / correct Action-Card status / safe vocabulary" goals for the API dimension.

## What this does NOT do

- Does **not** complete or expand OpenAPI.
- Does **not** classify every route as public/production.
- Does **not** change runtime behavior, the route inventory script, the generated artifact, OpenAPI, CI, or branch protection.
- Does **not** edit website or pilot-ui copy (the broader #1779 acceptance-criteria work — a separate, larger change).
- Leaves **#1779 open**; does not touch #2112 status.
- Introduces **no new truth vocabulary** (uses `gateway-backed`, `unknown / needs local verification`, `fixture-backed`, etc. from `source-of-truth-map.md`).

## Validation

- Scope: only `docs/reference/project-index/runtime-surface-map.md`; 0 `.rs`.
- `route_inventory.py --check` → OK (script/artifact untouched).
- `doc_control_check.py` → OK, 878 md files, 65 pre-existing warnings, none on the changed file.
- `freshness-check.py` → exit 1 = **pre-existing #2047** (`04`/`18`), unchanged here.
- `drift-check.sh` → PASS.
- New section uses no forbidden vocabulary (payment/currency/wallet/balance/token) as current claims.

## Relationship

- **Refs #1779** — public-surface truth-sync (API dimension); leaves the website/pilot-ui copy work to that issue's broader scope.
- **Refs #2112** — route/API inventory lane that produced the evidence.
- Builds on the merged chain: #2116 (inventory) → #2117 (CI drift check) → #2118 (gateway non-macro candidates) → #2119 (unmatched OpenAPI) → #2120 (governance candidates) → #2122 (governance drift trigger).

## Non-goals (explicit)

No OpenAPI completion; no new project-index/registry doc (extends the existing API-surface map to avoid a competing source); no website/pilot-ui copy edits; no runtime/script/CI changes; no new vocabulary; no close-keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
