### PR TITLE
docs(project-index): drop stale src/content/docs row from website-truth-map

### DIFF
--- a/docs/reference/project-index/website-truth-map.md
+++ b/docs/reference/project-index/website-truth-map.md
@@ -43,7 +43,6 @@ When the website and repo disagree, defer to the source-of-truth hierarchy, then
 | `for-cooperatives.astro` | Adoption framing. | high: can imply readiness or formal pilots. |
 | `for-developers.astro` | Contributor/developer framing. | medium: can point to stale commands or surfaces. |
 | `get-involved.astro` | Participation path. | medium: can overpromise. |
-| `src/content/docs/` | Website docs mirror/content. | high: can become stale duplicate documentation. |
 
 ## Public claim checklist
 


### PR DESCRIPTION
## What changed

Drops one stale row from the "Important website surfaces" table in `docs/reference/project-index/website-truth-map.md`: it listed `src/content/docs/` as a current website surface ("Website docs mirror/content", high stale-duplicate risk). One line removed.

## Why

#2124 removed `website/src/content/docs/` (the obsolete Astro docs mirror) and updated the curated maps — but its cleanup grep used the full `website/src/content/docs` path and **missed this row, which uses the relative `src/content/docs/`**. The surface no longer exists; the website renders `/docs/*` from repo-root `docs/` via `resolveRepoDocsRoot`. This completes #2124's curated-map cleanup.

## Relationship

- Follow-up to **#2124** (obsolete mirror removal). **Refs #1779** (public-surface truth-sync). 
- The generated `docs/reference/project-index/generated/icn-file-record.{md,json}` still references the old path; that is a **separate generated-record maintenance pass** (the file is generated, not hand-edited) — out of scope here.

## What this does NOT do

- No public/demo copy change; no runtime/Rust; no route inventory; no OpenAPI; no CI/branch-protection change.
- Does not touch the generated repo-record snapshot.
- Leaves #1779 open; no change to #2112.

## Validation

- Scope: 1 doc file, 0 `.rs`. After this, the curated project-index maps are grep-clean of `src/content/docs` (only the generated record retains it, deliberately deferred).
- `doc_control_check.py` → OK (65 pre-existing warnings, none new); `drift-check.sh` → PASS; `route_inventory.py --check` → OK.

Refs #1779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
