### PR TITLE
docs(project-index): refresh generated repo file-record snapshot

### DIFF
--- a/docs/reference/project-index/generated/icn-file-record.json
+++ b/docs/reference/project-index/generated/icn-file-record.json
@@ -1,71 +1,74 @@
 {
-  "branch": "docs/generated-repo-record-snapshot",
+  "branch": "docs/record-refresh-2126",
   "directories": [
     {
-      "child_directory_count": 24,
+      "child_directory_count": 25,
       "depth": 0,
       "extensions": {
-        "(none)": 13,
-        ".astro": 30,
+        "(none)": 19,
+        ".astro": 31,
         ".bat": 1,
-        ".conf": 2,
-        ".css": 9,
+        ".cjs": 1,
+        ".conf": 4,
+        ".css": 10,
         ".dockerignore": 4,
         ".example": 10,
         ".fast": 1,
         ".gitattributes": 1,
-        ".gitignore": 15,
-        ".gitkeep": 1,
+        ".gitignore": 16,
         ".gradle": 3,
-        ".html": 14,
+        ".html": 19,
         ".hurl": 1,
         ".icnd": 1,
         ".icnd-fast": 1,
         ".ipynb": 1,
         ".jar": 1,
-        ".js": 36,
-        ".json": 131,
+        ".js": 43,
+        ".json": 154,
         ".keystore": 1,
         ".kt": 2,
-        ".lock": 2,
+        ".lock": 3,
         ".log": 1,
-        ".md": 1004,
+        ".md": 1168,
         ".mermaid": 1,
         ".mjs": 2,
+        ".pdf": 5,
         ".png": 24,
+        ".pptx": 1,
         ".pro": 1,
         ".properties": 2,
-        ".py": 24,
-        ".rs": 897,
-        ".service": 1,
-        ".sh": 104,
-        ".svg": 4,
+        ".py": 40,
+        ".rs": 940,
+        ".service": 4,
+        ".sh": 119,
+        ".svg": 5,
         ".test": 1,
-        ".toml": 109,
+        ".toml": 112,
         ".tpl": 1,
-        ".ts": 92,
+        ".ts": 112,
         ".tsx": 43,
-        ".txt": 4,
+        ".txt": 5,
+        ".wasm": 1,
         ".webp": 15,
         ".xml": 11,
-        ".yaml": 84,
-        ".yml": 54
+        ".yaml": 92,
+        ".yml": 59
       },
-      "file_count": 2760,
+      "file_count": 3093,
       "path": ".",
       "role_guess": "repo root",
-      "total_size_bytes": 39151683
+      "total_size_bytes": 48274562
     },
     {
       "child_directory_count": 1,
       "depth": 1,
       "extensions": {
-        ".md": 24
+        ".md": 25
       },
-      "file_count": 24,
+      "file_count": 25,
       "path": ".agents",
       "role_guess": "repo configuration",
-      "total_size_bytes": 66504
+      "total_size_bytes": 71663
     },
     {
       "child_directory_count": 5,
@@ -73,14 +76,14 @@
       "extensions": {
         ".conf": 1,
         ".json": 1,
-        ".md": 49,
+        ".md": 53,
         ".py": 3,
         ".sh": 7
       },
-      "file_count": 61,
+      "file_count": 65,
       "path": ".claude",
       "role_guess": "repo configuration",
-      "total_size_bytes": 192712
+      "total_size_bytes": 228531
     },
     {
       "child_directory_count": 2,
@@ -105,7 +108,7 @@
       "file_count": 1,
       "path": ".cursor",
       "role_guess": "repo configuration",
-      "total_size_bytes": 132
+      "total_size_bytes": 135
     },
     {
       "child_directory_count": 0,
@@ -116,20 +119,20 @@
       "file_count": 1,
       "path": ".devcontainer",
       "role_guess": "repo configuration",
-      "total_size_bytes": 1320
+      "total_size_bytes": 1307
     },
     {
       "child_directory_count": 6,
       "depth": 1,
       "extensions": {
-        ".md": 32,
-        ".py": 2,
-        ".yml": 24
+        ".md": 35,
+        ".py": 4,
+        ".yml": 29
       },
-      "file_count": 58,
+      "file_count": 68,
       "path": ".github",
       "role_guess": "repo configuration",
-      "total_size_bytes": 234091
+      "total_size_bytes": 284056
     },
     {
       "child_directory_count": 1,
@@ -144,19 +147,19 @@
       "total_size_bytes": 1837
     },
     {
-      "child_directory_count": 4,
+      "child_directory_count": 1,
       "depth": 1,
       "extensions": {
-        ".gitignore": 4,
+        ".gitignore": 1,
         ".md": 1,
-        ".rs": 22,
-        ".toml": 4,
-        ".yaml": 3
+        ".rs": 1,
+        ".toml": 1,
+        ".yaml": 1
       },
-      "file_count": 34,
+      "file_count": 5,
       "path": "apps",
       "role_guess": "legacy/top-level app",
-      "total_size_bytes": 273802
+      "total_size_bytes": 11841
     },
     {
       "child_directory_count": 0,
@@ -187,45 +190,49 @@
       "total_size_bytes": 98869
     },
     {
-      "child_directory_count": 5,
+      "child_directory_count": 6,
       "depth": 1,
       "extensions": {
+        ".gitignore": 1,
+        ".html": 1,
         ".json": 8,
-        ".md": 15,
-        ".py": 1,
-        ".sh": 21,
+        ".md": 16,
+        ".py": 2,
+        ".sh": 22,
         ".test": 1,
-        ".toml": 1
+        ".toml": 1,
+        ".txt": 1
       },
-      "file_count": 47,
+      "file_count": 53,
       "path": "demo",
       "role_guess": "demo",
-      "total_size_bytes": 471677
+      "total_size_bytes": 512850
     },
     {
-      "child_directory_count": 9,
+      "child_directory_count": 10,
       "depth": 1,
       "extensions": {
         "(none)": 2,
-        ".conf": 1,
+        ".conf": 3,
         ".example": 5,
         ".gitignore": 2,
         ".icnd": 1,
         ".icnd-fast": 1,
         ".js": 1,
         ".json": 4,
-        ".md": 14,
-        ".service": 1,
-        ".sh": 21,
+        ".md": 17,
+        ".py": 1,
+        ".service": 4,
+        ".sh": 30,
         ".toml": 1,
         ".tpl": 1,
-        ".yaml": 36,
+        ".yaml": 44,
         ".yml": 13
       },
-      "file_count": 104,
+      "file_count": 130,
       "path": "deploy",
       "role_guess": "deployment",
-      "total_size_bytes": 383265
+      "total_size_bytes": 571828
     },
     {
       "child_directory_count": 0,
@@ -242,21 +249,25 @@
       "total_size_bytes": 17165
     },
     {
-      "child_directory_count": 45,
+      "child_directory_count": 46,
       "depth": 1,
       "extensions": {
-        ".json": 7,
-        ".md": 755,
+        ".html": 3,
+        ".json": 16,
+        ".md": 881,
         ".mermaid": 1,
-        ".py": 4,
+        ".pdf": 5,
+        ".pptx": 1,
+        ".py": 10,
         ".sh": 1,
+        ".svg": 1,
         ".toml": 45,
         ".yaml": 4
       },
-      "file_count": 817,
+      "file_count": 968,
       "path": "docs",
       "role_guess": "documentation",
-      "total_size_bytes": 9982723
+      "total_size_bytes": 15760928
     },
     {
       "child_directory_count": 5,
@@ -276,7 +287,7 @@
       "file_count": 43,
       "path": "examples",
       "role_guess": "uncategorized",
-      "total_size_bytes": 612341
+      "total_size_bytes": 562715
     },
     {
       "child_directory_count": 9,
@@ -285,23 +296,25 @@
         ".css": 1,
         ".dockerignore": 1,
         ".example": 2,
+        ".gitignore": 3,
         ".html": 4,
         ".hurl": 1,
         ".js": 6,
         ".json": 43,
-        ".lock": 2,
-        ".md": 9,
-        ".rs": 874,
+        ".lock": 3,
+        ".md": 11,
+        ".rs": 938,
         ".sh": 2,
-        ".toml": 50,
+        ".toml": 56,
         ".txt": 1,
-        ".yaml": 5,
+        ".wasm": 1,
+        ".yaml": 7,
         ".yml": 1
       },
-      "file_count": 1002,
+      "file_count": 1081,
       "path": "icn",
       "role_guess": "uncategorized",
-      "total_size_bytes": 19698385
+      "total_size_bytes": 21916668
     },
     {
       "child_directory_count": 1,
@@ -313,7 +326,7 @@
       "file_count": 40,
       "path": "institutions",
       "role_guess": "institution package",
-      "total_size_bytes": 97783
+      "total_size_bytes": 102081
     },
     {
       "child_directory_count": 0,
@@ -333,31 +346,32 @@
       "depth": 1,
       "extensions": {
         ".gitignore": 1,
-        ".json": 14,
-        ".md": 20,
+        ".json": 15,
+        ".md": 24,
         ".py": 1,
         ".sh": 3,
-        ".ts": 21,
+        ".ts": 39,
         ".yaml": 3,
         ".yml": 1
       },
-      "file_count": 64,
+      "file_count": 87,
       "path": "ops",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 545508
+      "total_size_bytes": 843723
     },
     {
       "child_directory_count": 0,
       "depth": 1,
       "extensions": {
-        ".py": 4,
-        ".sh": 38,
+        ".js": 1,
+        ".py": 9,
+        ".sh": 42,
         ".txt": 1
       },
-      "file_count": 43,
+      "file_count": 53,
       "path": "scripts",
       "role_guess": "script",
-      "total_size_bytes": 279218
+      "total_size_bytes": 423147
     },
     {
       "child_directory_count": 2,
@@ -369,22 +383,23 @@
         ".gradle": 3,
         ".jar": 1,
         ".js": 7,
-        ".json": 13,
+        ".json": 14,
         ".keystore": 1,
         ".kt": 2,
         ".md": 5,
         ".png": 8,
         ".pro": 1,
         ".properties": 2,
-        ".ts": 59,
+        ".py": 1,
+        ".ts": 61,
         ".tsx": 30,
         ".webp": 15,
         ".xml": 11
       },
-      "file_count": 164,
+      "file_count": 168,
       "path": "sdk",
       "role_guess": "uncategorized",
-      "total_size_bytes": 2214796
+      "total_size_bytes": 2524210
     },
     {
       "child_directory_count": 1,
@@ -403,70 +418,84 @@
       "total_size_bytes": 92514
     },
     {
-      "child_directory_count": 3,
+      "child_directory_count": 1,
+      "depth": 1,
+      "extensions": {
+        "(none)": 5,
+        ".json": 4,
+        ".md": 17
+      },
+      "file_count": 26,
+      "path": "tools",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 88907
+    },
+    {
+      "child_directory_count": 4,
       "depth": 1,
       "extensions": {
         "(none)": 3,
-        ".css": 7,
+        ".cjs": 1,
+        ".css": 8,
         ".dockerignore": 1,
         ".gitignore": 1,
-        ".html": 10,
-        ".js": 21,
-        ".json": 6,
-        ".md": 22,
+        ".html": 11,
+        ".js": 27,
+        ".json": 14,
+        ".md": 24,
         ".png": 11,
         ".sh": 4,
         ".yaml": 1
       },
-      "file_count": 87,
+      "file_count": 106,
       "path": "web",
       "role_guess": "uncategorized",
-      "total_size_bytes": 1433099
+      "total_size_bytes": 1667858
     },
     {
       "child_directory_count": 6,
       "depth": 1,
       "extensions": {
-        "(none)": 2,
-        ".astro": 30,
+        "(none)": 3,
+        ".astro": 31,
         ".css": 1,
         ".gitignore": 1,
-        ".gitkeep": 1,
         ".json": 7,
-        ".md": 10,
+        ".md": 9,
         ".mjs": 2,
         ".png": 1,
+        ".sh": 1,
         ".svg": 4,
         ".ts": 9,
         ".txt": 1,
         ".yml": 1
       },
-      "file_count": 70,
+      "file_count": 71,
       "path": "website",
       "role_guess": "public website",
-      "total_size_bytes": 1893195
+      "total_size_bytes": 1910144
     },
     {
-      "child_directory_count": 24,
+      "child_directory_count": 25,
       "depth": 2,
       "extensions": {
-        ".md": 24
+        ".md": 25
       },
-      "file_count": 24,
+      "file_count": 25,
       "path": ".agents/skills",
       "role_guess": "repo configuration",
-      "total_size_bytes": 66504
+      "total_size_bytes": 71663
     },
     {
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 15
+        ".md": 16
       },
-      "file_count": 15,
+      "file_count": 16,
       "path": ".claude/agents",
       "role_guess": "repo configuration",
-      "total_size_bytes": 69783
+      "total_size_bytes": 82164
     },
     {
       "child_directory_count": 0,
@@ -491,29 +520,29 @@
       "file_count": 12,
       "path": ".claude/hooks",
       "role_guess": "repo configuration",
-      "total_size_bytes": 19357
+      "total_size_bytes": 20657
     },
     {
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 4
+        ".md": 5
       },
-      "file_count": 4,
+      "file_count": 5,
       "path": ".claude/rules",
       "role_guess": "repo configuration",
-      "total_size_bytes": 5713
+      "total_size_bytes": 9922
     },
     {
-      "child_directory_count": 24,
+      "child_directory_count": 26,
       "depth": 2,
       "extensions": {
-        ".md": 24
+        ".md": 26
       },
-      "file_count": 24,
+      "file_count": 26,
       "path": ".claude/skills",
       "role_guess": "repo configuration",
-      "total_size_bytes": 79871
+      "total_size_bytes": 97800
     },
     {
       "child_directory_count": 0,
@@ -544,12 +573,12 @@
       "depth": 2,
       "extensions": {
         ".md": 1,
-        ".yml": 3
+        ".yml": 8
       },
-      "file_count": 4,
+      "file_count": 9,
       "path": ".github/ISSUE_TEMPLATE",
       "role_guess": "repo configuration",
-      "total_size_bytes": 4015
+      "total_size_bytes": 15085
     },
     {
       "child_directory_count": 2,
@@ -571,7 +600,7 @@
       "file_count": 22,
       "path": ".github/agents",
       "role_guess": "agent definition",
-      "total_size_bytes": 58675
+      "total_size_bytes": 59062
     },
     {
       "child_directory_count": 0,
@@ -582,19 +611,19 @@
       "file_count": 5,
       "path": ".github/instructions",
       "role_guess": "repo configuration",
-      "total_size_bytes": 28655
+      "total_size_bytes": 28980
     },
     {
-      "child_directory_count": 0,
+      "child_directory_count": 1,
       "depth": 2,
       "extensions": {
-        ".md": 1,
-        ".py": 2
+        ".md": 4,
+        ".py": 4
       },
-      "file_count": 3,
+      "file_count": 8,
       "path": ".github/scripts",
       "role_guess": "repo configuration",
-      "total_size_bytes": 22628
+      "total_size_bytes": 39349
     },
     {
       "child_directory_count": 0,
@@ -605,7 +634,7 @@
       "file_count": 17,
       "path": ".github/workflows",
       "role_guess": "GitHub Actions workflow",
-      "total_size_bytes": 88198
+      "total_size_bytes": 108418
     },
     {
       "child_directory_count": 0,
@@ -623,56 +652,15 @@
       "depth": 2,
       "extensions": {
         ".gitignore": 1,
+        ".md": 1,
         ".rs": 1,
         ".toml": 1,
         ".yaml": 1
       },
-      "file_count": 4,
+      "file_count": 5,
       "path": "apps/echo",
       "role_guess": "legacy/top-level app",
-      "total_size_bytes": 9026
-    },
-    {
-      "child_directory_count": 1,
-      "depth": 2,
-      "extensions": {
-        ".gitignore": 1,
-        ".rs": 3,
-        ".toml": 1
-      },
-      "file_count": 5,
-      "path": "apps/governance",
-      "role_guess": "legacy/top-level app",
-      "total_size_bytes": 18612
-    },
-    {
-      "child_directory_count": 1,
-      "depth": 2,
-      "extensions": {
-        ".gitignore": 1,
-        ".rs": 8,
-        ".toml": 1,
-        ".yaml": 1
-      },
-      "file_count": 11,
-      "path": "apps/ledger",
-      "role_guess": "legacy/top-level app",
-      "total_size_bytes": 68220
-    },
-    {
-      "child_directory_count": 3,
-      "depth": 2,
-      "extensions": {
-        ".gitignore": 1,
-        ".md": 1,
-        ".rs": 10,
-        ".toml": 1,
-        ".yaml": 1
-      },
-      "file_count": 14,
-      "path": "apps/trust",
-      "role_guess": "legacy/top-level app",
-      "total_size_bytes": 177944
+      "total_size_bytes": 11841
     },
     {
       "child_directory_count": 0,
@@ -739,7 +727,7 @@
       "file_count": 7,
       "path": "demo/docs",
       "role_guess": "demo",
-      "total_size_bytes": 85878
+      "total_size_bytes": 85887
     },
     {
       "child_directory_count": 0,
@@ -750,7 +738,23 @@
       "file_count": 5,
       "path": "demo/notes",
       "role_guess": "demo",
-      "total_size_bytes": 33969
+      "total_size_bytes": 33979
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 2,
+      "extensions": {
+        ".gitignore": 1,
+        ".html": 1,
+        ".md": 1,
+        ".py": 1,
+        ".sh": 1,
+        ".txt": 1
+      },
+      "file_count": 6,
+      "path": "demo/nycn-dogfood",
+      "role_guess": "demo",
+      "total_size_bytes": 44667
     },
     {
       "child_directory_count": 0,
@@ -763,7 +767,23 @@
       "file_count": 21,
       "path": "demo/scripts",
       "role_guess": "demo",
-      "total_size_bytes": 290211
+      "total_size_bytes": 292655
+    },
+    {
+      "child_directory_count": 4,
+      "depth": 2,
+      "extensions": {
+        ".conf": 2,
+        ".md": 3,
+        ".py": 1,
+        ".service": 3,
+        ".sh": 9,
+        ".yaml": 8
+      },
+      "file_count": 26,
+      "path": "deploy/appliance",
+      "role_guess": "deployment",
+      "total_size_bytes": 187873
     },
     {
       "child_directory_count": 0,
@@ -815,7 +835,7 @@
       "file_count": 8,
       "path": "deploy/devnet",
       "role_guess": "deployment",
-      "total_size_bytes": 20249
+      "total_size_bytes": 20939
     },
     {
       "child_directory_count": 0,
@@ -890,12 +910,12 @@
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 35
+        ".md": 36
       },
-      "file_count": 35,
+      "file_count": 36,
       "path": "docs/adr",
       "role_guess": "architecture decision record",
-      "total_size_bytes": 289086
+      "total_size_bytes": 300071
     },
     {
       "child_directory_count": 0,
@@ -913,24 +933,25 @@
       "depth": 2,
       "extensions": {
         ".md": 2,
+        ".py": 1,
         ".sh": 1,
         ".yaml": 2
       },
-      "file_count": 5,
+      "file_count": 6,
       "path": "docs/api",
       "role_guess": "documentation",
-      "total_size_bytes": 107028
+      "total_size_bytes": 143308
     },
     {
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 36
+        ".md": 43
       },
-      "file_count": 36,
+      "file_count": 43,
       "path": "docs/architecture",
       "role_guess": "documentation",
-      "total_size_bytes": 1062755
+      "total_size_bytes": 1241547
     },
     {
       "child_directory_count": 2,
@@ -941,7 +962,7 @@
       "file_count": 78,
       "path": "docs/archive",
       "role_guess": "documentation",
-      "total_size_bytes": 1052773
+      "total_size_bytes": 1050816
     },
     {
       "child_directory_count": 0,
@@ -952,18 +973,19 @@
       "file_count": 3,
       "path": "docs/ci",
       "role_guess": "documentation",
-      "total_size_bytes": 12404
+      "total_size_bytes": 13817
     },
     {
       "child_directory_count": 1,
       "depth": 2,
       "extensions": {
-        ".json": 1
+        ".json": 8,
+        ".md": 5
       },
-      "file_count": 1,
+      "file_count": 13,
       "path": "docs/contracts",
       "role_guess": "documentation",
-      "total_size_bytes": 4322
+      "total_size_bytes": 138697
     },
     {
       "child_directory_count": 0,
@@ -980,12 +1002,12 @@
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 6
+        ".md": 14
       },
-      "file_count": 6,
+      "file_count": 14,
       "path": "docs/demo",
       "role_guess": "documentation",
-      "total_size_bytes": 62929
+      "total_size_bytes": 191732
     },
     {
       "child_directory_count": 0,
@@ -996,18 +1018,19 @@
       "file_count": 12,
       "path": "docs/deployment",
       "role_guess": "documentation",
-      "total_size_bytes": 109523
+      "total_size_bytes": 110143
     },
     {
-      "child_directory_count": 3,
+      "child_directory_count": 6,
       "depth": 2,
       "extensions": {
-        ".md": 51
+        ".md": 75,
+        ".svg": 1
       },
-      "file_count": 51,
+      "file_count": 76,
       "path": "docs/design",
       "role_guess": "documentation",
-      "total_size_bytes": 778243
+      "total_size_bytes": 1131479
     },
     {
       "child_directory_count": 0,
@@ -1018,18 +1041,18 @@
       "file_count": 3,
       "path": "docs/design-language",
       "role_guess": "documentation",
-      "total_size_bytes": 38437
+      "total_size_bytes": 39612
     },
     {
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 7
+        ".md": 36
       },
-      "file_count": 7,
+      "file_count": 36,
       "path": "docs/dev",
       "role_guess": "documentation",
-      "total_size_bytes": 77044
+      "total_size_bytes": 626299
     },
     {
       "child_directory_count": 3,
@@ -1040,7 +1063,7 @@
       "file_count": 189,
       "path": "docs/development",
       "role_guess": "documentation",
-      "total_size_bytes": 2245202
+      "total_size_bytes": 2245017
     },
     {
       "child_directory_count": 1,
@@ -1069,12 +1092,23 @@
       "child_directory_count": 3,
       "depth": 2,
       "extensions": {
-        ".md": 34
+        ".md": 38
       },
-      "file_count": 34,
+      "file_count": 38,
       "path": "docs/guides",
       "role_guess": "documentation",
-      "total_size_bytes": 247024
+      "total_size_bytes": 284127
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 2,
+      "extensions": {
+        ".md": 1
+      },
+      "file_count": 1,
+      "path": "docs/handoffs",
+      "role_guess": "documentation",
+      "total_size_bytes": 10078
     },
     {
       "child_directory_count": 3,
@@ -1102,12 +1136,12 @@
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 1
+        ".md": 8
       },
-      "file_count": 1,
+      "file_count": 8,
       "path": "docs/manual",
       "role_guess": "documentation",
-      "total_size_bytes": 41675
+      "total_size_bytes": 155426
     },
     {
       "child_directory_count": 0,
@@ -1129,7 +1163,7 @@
       "file_count": 6,
       "path": "docs/mobile",
       "role_guess": "documentation",
-      "total_size_bytes": 72777
+      "total_size_bytes": 74162
     },
     {
       "child_directory_count": 0,
@@ -1162,18 +1196,18 @@
       "file_count": 6,
       "path": "docs/operations",
       "role_guess": "documentation",
-      "total_size_bytes": 78722
+      "total_size_bytes": 79099
     },
     {
       "child_directory_count": 1,
       "depth": 2,
       "extensions": {
-        ".md": 3
+        ".md": 5
       },
-      "file_count": 3,
+      "file_count": 5,
       "path": "docs/ops",
       "role_guess": "documentation",
-      "total_size_bytes": 7517
+      "total_size_bytes": 23101
     },
     {
       "child_directory_count": 0,
@@ -1201,12 +1235,12 @@
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 6
+        ".md": 4
       },
-      "file_count": 6,
+      "file_count": 4,
       "path": "docs/pilots",
       "role_guess": "documentation",
-      "total_size_bytes": 53808
+      "total_size_bytes": 38839
     },
     {
       "child_directory_count": 0,
@@ -1217,7 +1251,7 @@
       "file_count": 7,
       "path": "docs/planning",
       "role_guess": "documentation",
-      "total_size_bytes": 101764
+      "total_size_bytes": 102284
     },
     {
       "child_directory_count": 1,
@@ -1228,41 +1262,42 @@
       "file_count": 17,
       "path": "docs/plans",
       "role_guess": "documentation",
-      "total_size_bytes": 414822
+      "total_size_bytes": 415015
     },
     {
       "child_directory_count": 3,
       "depth": 2,
       "extensions": {
-        ".md": 23,
+        ".json": 2,
+        ".md": 37,
         ".yaml": 1
       },
-      "file_count": 24,
+      "file_count": 40,
       "path": "docs/reference",
       "role_guess": "documentation",
-      "total_size_bytes": 192710
+      "total_size_bytes": 2290330
     },
     {
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 7
+        ".md": 8
       },
-      "file_count": 7,
+      "file_count": 8,
       "path": "docs/rfcs",
       "role_guess": "request for comments",
-      "total_size_bytes": 152136
+      "total_size_bytes": 176908
     },
     {
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".py": 4
+        ".py": 9
       },
-      "file_count": 4,
+      "file_count": 9,
       "path": "docs/scripts",
       "role_guess": "documentation",
-      "total_size_bytes": 51791
+      "total_size_bytes": 105739
     },
     {
       "child_directory_count": 0,
@@ -1290,12 +1325,12 @@
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 2
+        ".md": 16
       },
-      "file_count": 2,
+      "file_count": 16,
       "path": "docs/spec",
       "role_guess": "documentation",
-      "total_size_bytes": 52569
+      "total_size_bytes": 527494
     },
     {
       "child_directory_count": 0,
@@ -1323,13 +1358,16 @@
       "child_directory_count": 1,
       "depth": 2,
       "extensions": {
-        ".md": 30,
+        ".html": 3,
+        ".md": 39,
+        ".pdf": 5,
+        ".pptx": 1,
         ".yaml": 1
       },
-      "file_count": 31,
+      "file_count": 49,
       "path": "docs/strategy",
       "role_guess": "documentation",
-      "total_size_bytes": 453732
+      "total_size_bytes": 1623575
     },
     {
       "child_directory_count": 0,
@@ -1340,7 +1378,7 @@
       "file_count": 1,
       "path": "docs/summit",
       "role_guess": "documentation",
-      "total_size_bytes": 9261
+      "total_size_bytes": 13525
     },
     {
       "child_directory_count": 2,
@@ -1384,7 +1422,7 @@
       "file_count": 3,
       "path": "docs/vision",
       "role_guess": "documentation",
-      "total_size_bytes": 48885
+      "total_size_bytes": 48916
     },
     {
       "child_directory_count": 0,
@@ -1438,7 +1476,7 @@
       "file_count": 27,
       "path": "examples/mobile-app",
       "role_guess": "uncategorized",
-      "total_size_bytes": 552052
+      "total_size_bytes": 502426
     },
     {
       "child_directory_count": 1,
@@ -1477,31 +1515,32 @@
       "total_size_bytes": 779
     },
     {
-      "child_directory_count": 4,
+      "child_directory_count": 7,
       "depth": 2,
       "extensions": {
-        ".md": 1,
-        ".rs": 77,
-        ".toml": 4,
-        ".yaml": 1
+        ".gitignore": 3,
+        ".md": 2,
+        ".rs": 111,
+        ".toml": 7,
+        ".yaml": 3
       },
-      "file_count": 83,
+      "file_count": 126,
       "path": "icn/apps",
       "role_guess": "runtime app crate",
-      "total_size_bytes": 2141681
+      "total_size_bytes": 2841591
     },
     {
       "child_directory_count": 3,
       "depth": 2,
       "extensions": {
-        ".rs": 9,
+        ".rs": 11,
         ".toml": 3,
         ".yaml": 2
       },
-      "file_count": 14,
+      "file_count": 16,
       "path": "icn/bins",
       "role_guess": "Rust binary",
-      "total_size_bytes": 655701
+      "total_size_bytes": 712750
     },
     {
       "child_directory_count": 0,
@@ -1515,7 +1554,7 @@
       "total_size_bytes": 8247
     },
     {
-      "child_directory_count": 35,
+      "child_directory_count": 38,
       "depth": 2,
       "extensions": {
         ".css": 1,
@@ -1523,17 +1562,18 @@
         ".hurl": 1,
         ".js": 6,
         ".json": 43,
-        ".lock": 1,
-        ".md": 6,
-        ".rs": 787,
-        ".toml": 36,
+        ".lock": 2,
+        ".md": 7,
+        ".rs": 815,
+        ".toml": 39,
+        ".wasm": 1,
         ".yaml": 2,
         ".yml": 1
       },
-      "file_count": 888,
+      "file_count": 922,
       "path": "icn/crates",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 16640221
+      "total_size_bytes": 18095675
     },
     {
       "child_directory_count": 0,
@@ -1578,7 +1618,7 @@
       "file_count": 39,
       "path": "institutions/nycn",
       "role_guess": "institution package",
-      "total_size_bytes": 97254
+      "total_size_bytes": 101552
     },
     {
       "child_directory_count": 1,
@@ -1626,29 +1666,29 @@
       "total_size_bytes": 45626
     },
     {
-      "child_directory_count": 2,
+      "child_directory_count": 3,
       "depth": 2,
       "extensions": {
-        ".md": 7,
+        ".md": 11,
         ".py": 1,
         ".yaml": 1
       },
-      "file_count": 9,
+      "file_count": 13,
       "path": "ops/ideas",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 97487
+      "total_size_bytes": 276322
     },
     {
       "child_directory_count": 1,
       "depth": 2,
       "extensions": {
         ".json": 4,
-        ".ts": 21
+        ".ts": 39
       },
-      "file_count": 25,
+      "file_count": 43,
       "path": "ops/mcp",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 189028
+      "total_size_bytes": 296740
     },
     {
       "child_directory_count": 0,
@@ -1665,13 +1705,13 @@
       "child_directory_count": 5,
       "depth": 2,
       "extensions": {
-        ".json": 10,
+        ".json": 11,
         ".md": 3
       },
-      "file_count": 13,
+      "file_count": 14,
       "path": "ops/state",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 35981
+      "total_size_bytes": 47649
     },
     {
       "child_directory_count": 3,
@@ -1690,15 +1730,15 @@
         ".png": 8,
         ".pro": 1,
         ".properties": 2,
-        ".ts": 40,
+        ".ts": 42,
         ".tsx": 30,
         ".webp": 15,
         ".xml": 11
       },
-      "file_count": 137,
+      "file_count": 139,
       "path": "sdk/react-native",
       "role_guess": "React Native SDK",
-      "total_size_bytes": 1577732
+      "total_size_bytes": 1829453
     },
     {
       "child_directory_count": 2,
@@ -1706,14 +1746,15 @@
       "extensions": {
         ".gitignore": 1,
         ".js": 2,
-        ".json": 3,
+        ".json": 4,
         ".md": 2,
+        ".py": 1,
         ".ts": 19
       },
-      "file_count": 27,
+      "file_count": 29,
       "path": "sdk/typescript",
       "role_guess": "TypeScript SDK",
-      "total_size_bytes": 637064
+      "total_size_bytes": 694757
     },
     {
       "child_directory_count": 2,
@@ -1730,6 +1771,19 @@
       "path": "sims/mutual-credit",
       "role_guess": "uncategorized",
       "total_size_bytes": 92514
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 2,
+      "extensions": {
+        "(none)": 5,
+        ".json": 4,
+        ".md": 17
+      },
+      "file_count": 26,
+      "path": "tools/claude-code",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 88907
     },
     {
       "child_directory_count": 0,
@@ -1764,7 +1818,23 @@
       "total_size_bytes": 53602
     },
     {
-      "child_directory_count": 4,
+      "child_directory_count": 1,
+      "depth": 2,
+      "extensions": {
+        ".cjs": 1,
+        ".css": 1,
+        ".html": 1,
+        ".js": 2,
+        ".json": 4,
+        ".md": 1
+      },
+      "file_count": 10,
+      "path": "web/member-shell",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 106320
+    },
+    {
+      "child_directory_count": 5,
       "depth": 2,
       "extensions": {
         "(none)": 1,
@@ -1772,16 +1842,16 @@
         ".dockerignore": 1,
         ".gitignore": 1,
         ".html": 8,
-        ".js": 20,
-        ".json": 5,
-        ".md": 20,
+        ".js": 24,
+        ".json": 9,
+        ".md": 21,
         ".png": 11,
         ".sh": 2
       },
-      "file_count": 75,
+      "file_count": 84,
       "path": "web/pilot-ui",
       "role_guess": "pilot UI",
-      "total_size_bytes": 1328347
+      "total_size_bytes": 1456786
     },
     {
       "child_directory_count": 1,
@@ -1818,45 +1888,45 @@
       "total_size_bytes": 294
     },
     {
-      "child_directory_count": 1,
+      "child_directory_count": 2,
       "depth": 2,
       "extensions": {
-        "(none)": 1,
+        "(none)": 2,
         ".png": 1,
         ".svg": 4,
         ".txt": 1
       },
-      "file_count": 7,
+      "file_count": 8,
       "path": "website/public",
       "role_guess": "public website",
-      "total_size_bytes": 1256597
+      "total_size_bytes": 1256683
     },
     {
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".mjs": 1
+        ".mjs": 1,
+        ".sh": 1
       },
-      "file_count": 1,
+      "file_count": 2,
       "path": "website/scripts",
       "role_guess": "public website",
-      "total_size_bytes": 3707
+      "total_size_bytes": 5449
     },
     {
       "child_directory_count": 8,
       "depth": 2,
       "extensions": {
-        ".astro": 30,
+        ".astro": 31,
         ".css": 1,
-        ".gitkeep": 1,
         ".json": 1,
-        ".md": 7,
+        ".md": 6,
         ".ts": 9
       },
-      "file_count": 49,
+      "file_count": 48,
       "path": "website/src",
       "role_guess": "public website",
-      "total_size_bytes": 374149
+      "total_size_bytes": 386966
     },
     {
       "child_directory_count": 0,
@@ -1879,6 +1949,17 @@
       "path": ".agents/skills/changelog",
       "role_guess": "repo configuration",
       "total_size_bytes": 2594
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".md": 1
+      },
+      "file_count": 1,
+      "path": ".agents/skills/ci-status",
+      "role_guess": "repo configuration",
+      "total_size_bytes": 5159
     },
     {
       "child_directory_count": 0,
@@ -2151,6 +2232,17 @@
         ".md": 1
       },
       "file_count": 1,
+      "path": ".claude/skills/ci-status",
+      "role_guess": "repo configuration",
+      "total_size_bytes": 5159
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".md": 1
+      },
+      "file_count": 1,
       "path": ".claude/skills/demo-validate",
       "role_guess": "repo configuration",
       "total_size_bytes": 1473
@@ -2220,6 +2312,17 @@
       "path": ".claude/skills/handoff",
       "role_guess": "repo configuration",
       "total_size_bytes": 2857
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".md": 1
+      },
+      "file_count": 1,
+      "path": ".claude/skills/icn-commons-design",
+      "role_guess": "repo configuration",
+      "total_size_bytes": 12770
     },
     {
       "child_directory_count": 0,
@@ -2492,6 +2595,17 @@
       "total_size_bytes": 548
     },
     {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        ".md": 3
+      },
+      "file_count": 3,
+      "path": ".github/scripts/fixtures",
+      "role_guess": "repo configuration",
+      "total_size_bytes": 803
+    },
+    {
       "child_directory_count": 0,
       "depth": 3,
       "extensions": {
@@ -2506,68 +2620,72 @@
       "child_directory_count": 0,
       "depth": 3,
       "extensions": {
-        ".rs": 3
-      },
-      "file_count": 3,
-      "path": "apps/governance/src",
-      "role_guess": "legacy/top-level app",
-      "total_size_bytes": 17619
-    },
-    {
-      "child_directory_count": 0,
-      "depth": 3,
-      "extensions": {
-        ".rs": 8
-      },
-      "file_count": 8,
-      "path": "apps/ledger/src",
-      "role_guess": "legacy/top-level app",
-      "total_size_bytes": 65088
-    },
-    {
-      "child_directory_count": 0,
-      "depth": 3,
-      "extensions": {
-        ".md": 1,
-        ".rs": 1
-      },
-      "file_count": 2,
-      "path": "apps/trust/benches",
-      "role_guess": "legacy/top-level app",
-      "total_size_bytes": 11863
-    },
-    {
-      "child_directory_count": 0,
-      "depth": 3,
-      "extensions": {
-        ".rs": 8
-      },
-      "file_count": 8,
-      "path": "apps/trust/src",
-      "role_guess": "legacy/top-level app",
-      "total_size_bytes": 144707
-    },
-    {
-      "child_directory_count": 0,
-      "depth": 3,
-      "extensions": {
-        ".rs": 1
-      },
-      "file_count": 1,
-      "path": "apps/trust/tests",
-      "role_guess": "legacy/top-level app",
-      "total_size_bytes": 18302
-    },
-    {
-      "child_directory_count": 0,
-      "depth": 3,
-      "extensions": {
         ".md": 2
       },
       "file_count": 2,
       "path": "demo/docs/plans",
       "role_guess": "demo",
       "total_size_bytes": 39539
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".html": 1,
+        ".txt": 1
+      },
+      "file_count": 2,
+      "path": "demo/nycn-dogfood/sample",
+      "role_guess": "demo",
+      "total_size_bytes": 17889
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".yaml": 5
+      },
+      "file_count": 5,
+      "path": "deploy/appliance/roles",
+      "role_guess": "deployment",
+      "total_size_bytes": 11101
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".py": 1,
+        ".sh": 5
+      },
+      "file_count": 6,
+      "path": "deploy/appliance/scripts",
+      "role_guess": "deployment",
+      "total_size_bytes": 51340
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        ".md": 1,
+        ".sh": 2,
+        ".yaml": 2
+      },
+      "file_count": 5,
+      "path": "deploy/appliance/smoke",
+      "role_guess": "deployment",
+      "total_size_bytes": 52449
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        ".conf": 2,
+        ".service": 3
+      },
+      "file_count": 5,
+      "path": "deploy/appliance/systemd",
+      "role_guess": "deployment",
+      "total_size_bytes": 9433
     },
     {
       "child_directory_count": 1,
@@ -2688,18 +2806,41 @@
       "file_count": 32,
       "path": "docs/archive/2026",
       "role_guess": "documentation",
-      "total_size_bytes": 406815
+      "total_size_bytes": 404858
     },
     {
       "child_directory_count": 0,
       "depth": 3,
       "extensions": {
-        ".json": 1
+        ".json": 2,
+        ".md": 1
       },
-      "file_count": 1,
+      "file_count": 3,
       "path": "docs/contracts/institution-package",
       "role_guess": "documentation",
-      "total_size_bytes": 4322
+      "total_size_bytes": 13758
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        ".md": 8
+      },
+      "file_count": 8,
+      "path": "docs/design/assets",
+      "role_guess": "documentation",
+      "total_size_bytes": 51764
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".md": 3
+      },
+      "file_count": 3,
+      "path": "docs/design/claude-design-seed",
+      "role_guess": "documentation",
+      "total_size_bytes": 27675
     },
     {
       "child_directory_count": 0,
@@ -2716,12 +2857,24 @@
       "child_directory_count": 0,
       "depth": 3,
       "extensions": {
-        ".md": 6
+        ".md": 9
       },
-      "file_count": 6,
+      "file_count": 9,
       "path": "docs/design/governance",
       "role_guess": "documentation",
-      "total_size_bytes": 77508
+      "total_size_bytes": 134866
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".md": 1,
+        ".svg": 1
+      },
+      "file_count": 2,
+      "path": "docs/design/icons",
+      "role_guess": "documentation",
+      "total_size_bytes": 34376
     },
     {
       "child_directory_count": 0,
@@ -2743,7 +2896,7 @@
       "file_count": 159,
       "path": "docs/development/sessions",
       "role_guess": "documentation",
-      "total_size_bytes": 1985413
+      "total_size_bytes": 1985228
     },
     {
       "child_directory_count": 0,
@@ -2783,12 +2936,12 @@
       "child_directory_count": 0,
       "depth": 3,
       "extensions": {
-        ".md": 5
+        ".md": 9
       },
-      "file_count": 5,
+      "file_count": 9,
       "path": "docs/guides/developer",
       "role_guess": "documentation",
-      "total_size_bytes": 19977
+      "total_size_bytes": 57159
     },
     {
       "child_directory_count": 1,
@@ -2931,7 +3084,7 @@
       "file_count": 5,
       "path": "docs/operations/deployment",
       "role_guess": "documentation",
-      "total_size_bytes": 77036
+      "total_size_bytes": 77413
     },
     {
       "child_directory_count": 0,
@@ -2979,15 +3132,16 @@
       "total_size_bytes": 24982
     },
     {
-      "child_directory_count": 0,
+      "child_directory_count": 1,
       "depth": 3,
       "extensions": {
-        ".md": 11
+        ".json": 2,
+        ".md": 25
       },
-      "file_count": 11,
+      "file_count": 27,
       "path": "docs/reference/project-index",
       "role_guess": "project index / atlas",
-      "total_size_bytes": 74703
+      "total_size_bytes": 2172323
     },
     {
       "child_directory_count": 0,
@@ -3072,13 +3226,26 @@
       "child_directory_count": 2,
       "depth": 3,
       "extensions": {
-        ".rs": 37,
+        ".rs": 50,
         ".toml": 1
       },
-      "file_count": 38,
+      "file_count": 51,
       "path": "icn/apps/governance",
       "role_guess": "runtime app crate",
-      "total_size_bytes": 1495230
+      "total_size_bytes": 1928731
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        ".gitignore": 1,
+        ".rs": 3,
+        ".toml": 1
+      },
+      "file_count": 5,
+      "path": "icn/apps/governance-app",
+      "role_guess": "runtime app crate",
+      "total_size_bytes": 18596
     },
     {
       "child_directory_count": 2,
@@ -3096,6 +3263,20 @@
       "child_directory_count": 1,
       "depth": 3,
       "extensions": {
+        ".gitignore": 1,
+        ".rs": 8,
+        ".toml": 1,
+        ".yaml": 1
+      },
+      "file_count": 11,
+      "path": "icn/apps/ledger-app",
+      "role_guess": "runtime app crate",
+      "total_size_bytes": 69873
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
         ".md": 1,
         ".rs": 32,
         ".toml": 1,
@@ -3105,6 +3286,21 @@
       "path": "icn/apps/membership",
       "role_guess": "runtime app crate",
       "total_size_bytes": 603618
+    },
+    {
+      "child_directory_count": 3,
+      "depth": 3,
+      "extensions": {
+        ".gitignore": 1,
+        ".md": 1,
+        ".rs": 10,
+        ".toml": 1,
+        ".yaml": 1
+      },
+      "file_count": 14,
+      "path": "icn/apps/trust-app",
+      "role_guess": "runtime app crate",
+      "total_size_bytes": 177940
     },
     {
       "child_directory_count": 1,
@@ -3122,14 +3318,14 @@
       "child_directory_count": 3,
       "depth": 3,
       "extensions": {
-        ".rs": 6,
+        ".rs": 8,
         ".toml": 1,
         ".yaml": 2
       },
-      "file_count": 9,
+      "file_count": 11,
       "path": "icn/bins/icnctl",
       "role_guess": "Rust binary",
-      "total_size_bytes": 569816
+      "total_size_bytes": 611032
     },
     {
       "child_directory_count": 1,
@@ -3141,7 +3337,7 @@
       "file_count": 3,
       "path": "icn/bins/icnd",
       "role_guess": "Rust binary",
-      "total_size_bytes": 50043
+      "total_size_bytes": 65876
     },
     {
       "child_directory_count": 1,
@@ -3154,7 +3350,7 @@
       "file_count": 8,
       "path": "icn/crates/icn-api",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 57465
+      "total_size_bytes": 65967
     },
     {
       "child_directory_count": 2,
@@ -3167,6 +3363,45 @@
       "path": "icn/crates/icn-authz",
       "role_guess": "Rust library crate",
       "total_size_bytes": 48635
+    },
+    {
+      "child_directory_count": 2,
+      "depth": 3,
+      "extensions": {
+        ".md": 1,
+        ".rs": 9,
+        ".toml": 1,
+        ".wasm": 1
+      },
+      "file_count": 12,
+      "path": "icn/crates/icn-baseline-lock",
+      "role_guess": "Rust library crate",
+      "total_size_bytes": 72017
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        ".lock": 1,
+        ".rs": 1,
+        ".toml": 1
+      },
+      "file_count": 3,
+      "path": "icn/crates/icn-baseline-lock-guest",
+      "role_guess": "Rust library crate",
+      "total_size_bytes": 7884
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        ".rs": 2,
+        ".toml": 1
+      },
+      "file_count": 3,
+      "path": "icn/crates/icn-boundary",
+      "role_guess": "Rust library crate",
+      "total_size_bytes": 4048
     },
     {
       "child_directory_count": 4,
@@ -3193,7 +3428,7 @@
       "file_count": 10,
       "path": "icn/crates/icn-commons",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 178380
+      "total_size_bytes": 191868
     },
     {
       "child_directory_count": 2,
@@ -3217,7 +3452,7 @@
       "file_count": 36,
       "path": "icn/crates/icn-compute",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 1041041
+      "total_size_bytes": 1042294
     },
     {
       "child_directory_count": 1,
@@ -3229,19 +3464,19 @@
       "file_count": 8,
       "path": "icn/crates/icn-coop",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 182967
+      "total_size_bytes": 197308
     },
     {
       "child_directory_count": 2,
       "depth": 3,
       "extensions": {
-        ".rs": 137,
+        ".rs": 139,
         ".toml": 1
       },
-      "file_count": 138,
+      "file_count": 140,
       "path": "icn/crates/icn-core",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 2532599
+      "total_size_bytes": 2610494
     },
     {
       "child_directory_count": 1,
@@ -3265,7 +3500,7 @@
       "file_count": 11,
       "path": "icn/crates/icn-crypto-pq",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 148568
+      "total_size_bytes": 149222
     },
     {
       "child_directory_count": 1,
@@ -3283,13 +3518,13 @@
       "child_directory_count": 1,
       "depth": 3,
       "extensions": {
-        ".rs": 10,
+        ".rs": 14,
         ".toml": 1
       },
-      "file_count": 11,
+      "file_count": 15,
       "path": "icn/crates/icn-entity",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 252990
+      "total_size_bytes": 384840
     },
     {
       "child_directory_count": 2,
@@ -3302,7 +3537,7 @@
       "file_count": 27,
       "path": "icn/crates/icn-federation",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 549383
+      "total_size_bytes": 549567
     },
     {
       "child_directory_count": 5,
@@ -3314,15 +3549,15 @@
         ".js": 6,
         ".json": 4,
         ".md": 2,
-        ".rs": 131,
+        ".rs": 137,
         ".toml": 1,
         ".yaml": 2,
         ".yml": 1
       },
-      "file_count": 152,
+      "file_count": 158,
       "path": "icn/crates/icn-gateway",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 3491740
+      "total_size_bytes": 3802638
     },
     {
       "child_directory_count": 3,
@@ -3335,7 +3570,7 @@
       "file_count": 36,
       "path": "icn/crates/icn-gossip",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 609707
+      "total_size_bytes": 614926
     },
     {
       "child_directory_count": 2,
@@ -3347,7 +3582,7 @@
       "file_count": 48,
       "path": "icn/crates/icn-governance",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 1099898
+      "total_size_bytes": 1274237
     },
     {
       "child_directory_count": 1,
@@ -3359,7 +3594,7 @@
       "file_count": 6,
       "path": "icn/crates/icn-http-kit",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 30588
+      "total_size_bytes": 39014
     },
     {
       "child_directory_count": 3,
@@ -3371,19 +3606,19 @@
       "file_count": 26,
       "path": "icn/crates/icn-identity",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 518202
+      "total_size_bytes": 518615
     },
     {
-      "child_directory_count": 1,
+      "child_directory_count": 2,
       "depth": 3,
       "extensions": {
-        ".rs": 29,
+        ".rs": 33,
         ".toml": 1
       },
-      "file_count": 30,
+      "file_count": 34,
       "path": "icn/crates/icn-kernel-api",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 587941
+      "total_size_bytes": 1172315
     },
     {
       "child_directory_count": 4,
@@ -3395,7 +3630,7 @@
       "file_count": 53,
       "path": "icn/crates/icn-ledger",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 1123750
+      "total_size_bytes": 1141873
     },
     {
       "child_directory_count": 1,
@@ -3419,7 +3654,7 @@
       "file_count": 41,
       "path": "icn/crates/icn-net",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 848164
+      "total_size_bytes": 848264
     },
     {
       "child_directory_count": 2,
@@ -3432,7 +3667,7 @@
       "file_count": 24,
       "path": "icn/crates/icn-obs",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 413932
+      "total_size_bytes": 415208
     },
     {
       "child_directory_count": 2,
@@ -3444,7 +3679,7 @@
       "file_count": 7,
       "path": "icn/crates/icn-privacy",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 68900
+      "total_size_bytes": 68864
     },
     {
       "child_directory_count": 1,
@@ -3468,7 +3703,7 @@
       "file_count": 23,
       "path": "icn/crates/icn-rpc",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 402031
+      "total_size_bytes": 417356
     },
     {
       "child_directory_count": 1,
@@ -3516,7 +3751,7 @@
       "file_count": 16,
       "path": "icn/crates/icn-steward",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 231521
+      "total_size_bytes": 231660
     },
     {
       "child_directory_count": 2,
@@ -3528,7 +3763,7 @@
       "file_count": 7,
       "path": "icn/crates/icn-store",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 160420
+      "total_size_bytes": 165196
     },
     {
       "child_directory_count": 2,
@@ -3552,7 +3787,7 @@
       "file_count": 6,
       "path": "icn/crates/icn-time",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 41421
+      "total_size_bytes": 41429
     },
     {
       "child_directory_count": 3,
@@ -3576,7 +3811,7 @@
       "file_count": 18,
       "path": "icn/crates/icn-zkp",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 188674
+      "total_size_bytes": 188632
     },
     {
       "child_directory_count": 0,
@@ -3657,7 +3892,7 @@
       "file_count": 5,
       "path": "institutions/nycn/summit",
       "role_guess": "institution package",
-      "total_size_bytes": 10641
+      "total_size_bytes": 14905
     },
     {
       "child_directory_count": 1,
@@ -3719,12 +3954,23 @@
       "child_directory_count": 0,
       "depth": 3,
       "extensions": {
-        ".md": 1
+        ".md": 2
       },
-      "file_count": 1,
+      "file_count": 2,
+      "path": "ops/ideas/dogfood",
+      "role_guess": "operations / coordination",
+      "total_size_bytes": 70885
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".md": 3
+      },
+      "file_count": 3,
       "path": "ops/ideas/framing",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 17682
+      "total_size_bytes": 106667
     },
     {
       "child_directory_count": 0,
@@ -3738,16 +3984,16 @@
       "total_size_bytes": 20805
     },
     {
-      "child_directory_count": 4,
+      "child_directory_count": 6,
       "depth": 3,
       "extensions": {
         ".json": 1,
-        ".ts": 20
+        ".ts": 38
       },
-      "file_count": 21,
+      "file_count": 39,
       "path": "ops/mcp/src",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 75148
+      "total_size_bytes": 188529
     },
     {
       "child_directory_count": 0,
@@ -3802,7 +4048,7 @@
       "file_count": 4,
       "path": "ops/state/truth",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 13934
+      "total_size_bytes": 14882
     },
     {
       "child_directory_count": 0,
@@ -3840,18 +4086,18 @@
       "file_count": 94,
       "path": "sdk/react-native/examples",
       "role_guess": "React Native SDK",
-      "total_size_bytes": 856592
+      "total_size_bytes": 868144
     },
     {
       "child_directory_count": 1,
       "depth": 3,
       "extensions": {
-        ".ts": 34
+        ".ts": 36
       },
-      "file_count": 34,
+      "file_count": 36,
       "path": "sdk/react-native/src",
       "role_guess": "React Native SDK",
-      "total_size_bytes": 382000
+      "total_size_bytes": 449844
     },
     {
       "child_directory_count": 0,
@@ -3863,7 +4109,7 @@
       "file_count": 11,
       "path": "sdk/typescript/examples",
       "role_guess": "TypeScript SDK",
-      "total_size_bytes": 73414
+      "total_size_bytes": 75568
     },
     {
       "child_directory_count": 1,
@@ -3874,7 +4120,7 @@
       "file_count": 9,
       "path": "sdk/typescript/src",
       "role_guess": "TypeScript SDK",
-      "total_size_bytes": 317361
+      "total_size_bytes": 357779
     },
     {
       "child_directory_count": 0,
@@ -3899,6 +4145,30 @@
       "total_size_bytes": 5395
     },
     {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        "(none)": 5,
+        ".json": 4,
+        ".md": 17
+      },
+      "file_count": 26,
+      "path": "tools/claude-code/plugins",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 88907
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 3,
+      "extensions": {
+        ".json": 4
+      },
+      "file_count": 4,
+      "path": "web/member-shell/fixtures",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 2606
+    },
+    {
       "child_directory_count": 0,
       "depth": 3,
       "extensions": {
@@ -3908,6 +4178,18 @@
       "path": "web/pilot-ui/components",
       "role_guess": "pilot UI",
       "total_size_bytes": 11066
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        ".json": 4,
+        ".md": 1
+      },
+      "file_count": 5,
+      "path": "web/pilot-ui/fixtures",
+      "role_guess": "pilot UI",
+      "total_size_bytes": 21453
     },
     {
       "child_directory_count": 0,
@@ -3935,13 +4217,13 @@
       "child_directory_count": 1,
       "depth": 3,
       "extensions": {
-        ".js": 7,
+        ".js": 11,
         ".md": 1
       },
-      "file_count": 8,
+      "file_count": 12,
       "path": "web/pilot-ui/tests",
       "role_guess": "pilot UI",
-      "total_size_bytes": 72711
+      "total_size_bytes": 101204
     },
     {
       "child_directory_count": 0,
@@ -3966,6 +4248,17 @@
       "total_size_bytes": 1004
     },
     {
+      "child_directory_count": 1,
+      "depth": 3,
+      "extensions": {
+        "(none)": 1
+      },
+      "file_count": 1,
+      "path": "website/public/.well-known",
+      "role_guess": "public website",
+      "total_size_bytes": 86
+    },
+    {
       "child_directory_count": 0,
       "depth": 3,
       "extensions": {
@@ -3981,25 +4274,24 @@
       "child_directory_count": 0,
       "depth": 3,
       "extensions": {
-        ".astro": 11
+        ".astro": 12
       },
-      "file_count": 11,
+      "file_count": 12,
       "path": "website/src/components",
       "role_guess": "public website",
-      "total_size_bytes": 67748
+      "total_size_bytes": 88159
     },
     {
-      "child_directory_count": 2,
+      "child_directory_count": 1,
       "depth": 3,
       "extensions": {
-        ".gitkeep": 1,
-        ".md": 6,
+        ".md": 5,
         ".ts": 1
       },
-      "file_count": 8,
+      "file_count": 6,
       "path": "website/src/content",
       "role_guess": "public website",
-      "total_size_bytes": 25897
+      "total_size_bytes": 18519
     },
     {
       "child_directory_count": 0,
@@ -4022,7 +4314,7 @@
       "file_count": 1,
       "path": "website/src/design",
       "role_guess": "public website",
-      "total_size_bytes": 1721
+      "total_size_bytes": 3426
     },
     {
       "child_directory_count": 0,
@@ -4044,7 +4336,7 @@
       "file_count": 3,
       "path": "website/src/lib",
       "role_guess": "public website",
-      "total_size_bytes": 3365
+      "total_size_bytes": 4283
     },
     {
       "child_directory_count": 2,
@@ -4056,7 +4348,7 @@
       "file_count": 19,
       "path": "website/src/pages",
       "role_guess": "public website",
-      "total_size_bytes": 217389
+      "total_size_bytes": 214837
     },
     {
       "child_directory_count": 0,
@@ -4147,6 +4439,39 @@
       "total_size_bytes": 269
     },
     {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".md": 3
+      },
+      "file_count": 3,
+      "path": ".github/scripts/fixtures/readiness",
+      "role_guess": "repo configuration",
+      "total_size_bytes": 803
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".yaml": 2
+      },
+      "file_count": 2,
+      "path": "deploy/appliance/smoke/cloud-init",
+      "role_guess": "deployment",
+      "total_size_bytes": 3469
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".conf": 2
+      },
+      "file_count": 2,
+      "path": "deploy/appliance/systemd/icnd.service.d",
+      "role_guess": "deployment",
+      "total_size_bytes": 3204
+    },
+    {
       "child_directory_count": 2,
       "depth": 4,
       "extensions": {
@@ -4203,7 +4528,7 @@
       "file_count": 20,
       "path": "docs/archive/2026/demo-sessions",
       "role_guess": "documentation",
-      "total_size_bytes": 151044
+      "total_size_bytes": 149087
     },
     {
       "child_directory_count": 0,
@@ -4215,6 +4540,17 @@
       "path": "docs/archive/2026/plans-scratch",
       "role_guess": "documentation",
       "total_size_bytes": 180770
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".md": 5
+      },
+      "file_count": 5,
+      "path": "docs/design/assets/briefs",
+      "role_guess": "documentation",
+      "total_size_bytes": 33007
     },
     {
       "child_directory_count": 0,
@@ -4236,7 +4572,7 @@
       "file_count": 37,
       "path": "docs/development/sessions/2025-12",
       "role_guess": "documentation",
-      "total_size_bytes": 312202
+      "total_size_bytes": 312017
     },
     {
       "child_directory_count": 0,
@@ -4440,6 +4776,18 @@
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
+        ".json": 2,
+        ".md": 2
+      },
+      "file_count": 4,
+      "path": "docs/reference/project-index/generated",
+      "role_guess": "project index / atlas",
+      "total_size_bytes": 1997717
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
         ".ts": 1
       },
       "file_count": 1,
@@ -4481,26 +4829,48 @@
       "total_size_bytes": 16217
     },
     {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".rs": 3
+      },
+      "file_count": 3,
+      "path": "icn/apps/governance-app/src",
+      "role_guess": "runtime app crate",
+      "total_size_bytes": 17619
+    },
+    {
       "child_directory_count": 4,
       "depth": 4,
       "extensions": {
-        ".rs": 23
+        ".rs": 25
       },
-      "file_count": 23,
+      "file_count": 25,
       "path": "icn/apps/governance/src",
       "role_guess": "runtime app crate",
-      "total_size_bytes": 1236571
+      "total_size_bytes": 1444562
     },
     {
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
-        ".rs": 14
+        ".rs": 25
       },
-      "file_count": 14,
+      "file_count": 25,
       "path": "icn/apps/governance/tests",
       "role_guess": "runtime app crate",
-      "total_size_bytes": 256490
+      "total_size_bytes": 481851
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".rs": 8
+      },
+      "file_count": 8,
+      "path": "icn/apps/ledger-app/src",
+      "role_guess": "runtime app crate",
+      "total_size_bytes": 66769
     },
     {
       "child_directory_count": 0,
@@ -4539,6 +4909,40 @@
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
+        ".md": 1,
+        ".rs": 1
+      },
+      "file_count": 2,
+      "path": "icn/apps/trust-app/benches",
+      "role_guess": "runtime app crate",
+      "total_size_bytes": 11863
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".rs": 8
+      },
+      "file_count": 8,
+      "path": "icn/apps/trust-app/src",
+      "role_guess": "runtime app crate",
+      "total_size_bytes": 144731
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".rs": 1
+      },
+      "file_count": 1,
+      "path": "icn/apps/trust-app/tests",
+      "role_guess": "runtime app crate",
+      "total_size_bytes": 18302
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
         ".rs": 1
       },
       "file_count": 1,
@@ -4566,18 +4970,18 @@
       "file_count": 2,
       "path": "icn/bins/icnctl/src",
       "role_guess": "Rust binary",
-      "total_size_bytes": 500994
+      "total_size_bytes": 516916
     },
     {
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
-        ".rs": 4
+        ".rs": 6
       },
-      "file_count": 4,
+      "file_count": 6,
       "path": "icn/bins/icnctl/tests",
       "role_guess": "Rust binary",
-      "total_size_bytes": 50193
+      "total_size_bytes": 75322
     },
     {
       "child_directory_count": 0,
@@ -4588,7 +4992,7 @@
       "file_count": 2,
       "path": "icn/bins/icnd/src",
       "role_guess": "Rust binary",
-      "total_size_bytes": 48566
+      "total_size_bytes": 64396
     },
     {
       "child_directory_count": 0,
@@ -4599,7 +5003,7 @@
       "file_count": 6,
       "path": "icn/crates/icn-api/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 47927
+      "total_size_bytes": 56373
     },
     {
       "child_directory_count": 3,
@@ -4622,6 +5026,51 @@
       "path": "icn/crates/icn-authz/tests",
       "role_guess": "Rust library crate",
       "total_size_bytes": 7533
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".rs": 1
+      },
+      "file_count": 1,
+      "path": "icn/crates/icn-baseline-lock-guest/src",
+      "role_guess": "Rust library crate",
+      "total_size_bytes": 3766
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".rs": 8
+      },
+      "file_count": 8,
+      "path": "icn/crates/icn-baseline-lock/src",
+      "role_guess": "Rust library crate",
+      "total_size_bytes": 32891
+    },
+    {
+      "child_directory_count": 1,
+      "depth": 4,
+      "extensions": {
+        ".rs": 1,
+        ".wasm": 1
+      },
+      "file_count": 2,
+      "path": "icn/crates/icn-baseline-lock/tests",
+      "role_guess": "Rust library crate",
+      "total_size_bytes": 36433
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".rs": 2
+      },
+      "file_count": 2,
+      "path": "icn/crates/icn-boundary/src",
+      "role_guess": "Rust library crate",
+      "total_size_bytes": 3306
     },
     {
       "child_directory_count": 0,
@@ -4680,7 +5129,7 @@
       "file_count": 5,
       "path": "icn/crates/icn-commons/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 140774
+      "total_size_bytes": 154262
     },
     {
       "child_directory_count": 0,
@@ -4746,7 +5195,7 @@
       "file_count": 29,
       "path": "icn/crates/icn-compute/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 929116
+      "total_size_bytes": 930111
     },
     {
       "child_directory_count": 0,
@@ -4757,7 +5206,7 @@
       "file_count": 4,
       "path": "icn/crates/icn-compute/tests",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 94329
+      "total_size_bytes": 94328
     },
     {
       "child_directory_count": 0,
@@ -4768,7 +5217,7 @@
       "file_count": 7,
       "path": "icn/crates/icn-coop/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 181964
+      "total_size_bytes": 196305
     },
     {
       "child_directory_count": 6,
@@ -4779,18 +5228,18 @@
       "file_count": 79,
       "path": "icn/crates/icn-core/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 1463579
+      "total_size_bytes": 1505599
     },
     {
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
-        ".rs": 58
+        ".rs": 60
       },
-      "file_count": 58,
+      "file_count": 60,
       "path": "icn/crates/icn-core/tests",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 1066996
+      "total_size_bytes": 1102749
     },
     {
       "child_directory_count": 0,
@@ -4801,7 +5250,7 @@
       "file_count": 9,
       "path": "icn/crates/icn-crypto-pq/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 123586
+      "total_size_bytes": 124095
     },
     {
       "child_directory_count": 0,
@@ -4840,12 +5289,12 @@
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
-        ".rs": 10
+        ".rs": 14
       },
-      "file_count": 10,
+      "file_count": 14,
       "path": "icn/crates/icn-entity/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 252371
+      "total_size_bytes": 384199
     },
     {
       "child_directory_count": 1,
@@ -4857,7 +5306,7 @@
       "file_count": 21,
       "path": "icn/crates/icn-federation/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 397063
+      "total_size_bytes": 397127
     },
     {
       "child_directory_count": 0,
@@ -4868,7 +5317,7 @@
       "file_count": 5,
       "path": "icn/crates/icn-federation/tests",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 151103
+      "total_size_bytes": 151102
     },
     {
       "child_directory_count": 0,
@@ -4896,12 +5345,12 @@
       "child_directory_count": 1,
       "depth": 4,
       "extensions": {
-        ".rs": 96
+        ".rs": 99
       },
-      "file_count": 96,
+      "file_count": 99,
       "path": "icn/crates/icn-gateway/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 2307285
+      "total_size_bytes": 2569554
     },
     {
       "child_directory_count": 1,
@@ -4916,19 +5365,19 @@
       "file_count": 14,
       "path": "icn/crates/icn-gateway/static",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 551597
+      "total_size_bytes": 551652
     },
     {
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
         ".hurl": 1,
-        ".rs": 34
+        ".rs": 37
       },
-      "file_count": 35,
+      "file_count": 38,
       "path": "icn/crates/icn-gateway/tests",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 595852
+      "total_size_bytes": 644106
     },
     {
       "child_directory_count": 0,
@@ -4950,7 +5399,7 @@
       "file_count": 29,
       "path": "icn/crates/icn-gossip/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 527868
+      "total_size_bytes": 533087
     },
     {
       "child_directory_count": 0,
@@ -4972,7 +5421,7 @@
       "file_count": 45,
       "path": "icn/crates/icn-governance/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 1054616
+      "total_size_bytes": 1228907
     },
     {
       "child_directory_count": 0,
@@ -4994,7 +5443,7 @@
       "file_count": 5,
       "path": "icn/crates/icn-http-kit/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 30163
+      "total_size_bytes": 38589
     },
     {
       "child_directory_count": 0,
@@ -5016,7 +5465,7 @@
       "file_count": 21,
       "path": "icn/crates/icn-identity/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 490111
+      "total_size_bytes": 490526
     },
     {
       "child_directory_count": 0,
@@ -5027,7 +5476,7 @@
       "file_count": 3,
       "path": "icn/crates/icn-identity/tests",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 22386
+      "total_size_bytes": 22384
     },
     {
       "child_directory_count": 0,
@@ -5038,7 +5487,18 @@
       "file_count": 29,
       "path": "icn/crates/icn-kernel-api/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 587168
+      "total_size_bytes": 984110
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".rs": 4
+      },
+      "file_count": 4,
+      "path": "icn/crates/icn-kernel-api/tests",
+      "role_guess": "Rust library crate",
+      "total_size_bytes": 187094
     },
     {
       "child_directory_count": 0,
@@ -5049,7 +5509,7 @@
       "file_count": 1,
       "path": "icn/crates/icn-ledger/benches",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 4365
+      "total_size_bytes": 4364
     },
     {
       "child_directory_count": 0,
@@ -5071,7 +5531,7 @@
       "file_count": 45,
       "path": "icn/crates/icn-ledger/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 1031624
+      "total_size_bytes": 1049600
     },
     {
       "child_directory_count": 0,
@@ -5115,7 +5575,7 @@
       "file_count": 31,
       "path": "icn/crates/icn-net/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 729007
+      "total_size_bytes": 729107
     },
     {
       "child_directory_count": 0,
@@ -5137,7 +5597,7 @@
       "file_count": 22,
       "path": "icn/crates/icn-obs/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 397109
+      "total_size_bytes": 398385
     },
     {
       "child_directory_count": 0,
@@ -5159,7 +5619,7 @@
       "file_count": 5,
       "path": "icn/crates/icn-privacy/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 47517
+      "total_size_bytes": 47483
     },
     {
       "child_directory_count": 0,
@@ -5170,7 +5630,7 @@
       "file_count": 1,
       "path": "icn/crates/icn-privacy/tests",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 20727
+      "total_size_bytes": 20725
     },
     {
       "child_directory_count": 0,
@@ -5192,7 +5652,7 @@
       "file_count": 21,
       "path": "icn/crates/icn-rpc/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 347030
+      "total_size_bytes": 358587
     },
     {
       "child_directory_count": 0,
@@ -5203,7 +5663,7 @@
       "file_count": 1,
       "path": "icn/crates/icn-rpc/tests",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 53922
+      "total_size_bytes": 57690
     },
     {
       "child_directory_count": 0,
@@ -5247,7 +5707,7 @@
       "file_count": 13,
       "path": "icn/crates/icn-steward/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 194415
+      "total_size_bytes": 194423
     },
     {
       "child_directory_count": 0,
@@ -5269,7 +5729,7 @@
       "file_count": 5,
       "path": "icn/crates/icn-store/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 148455
+      "total_size_bytes": 153231
     },
     {
       "child_directory_count": 0,
@@ -5313,7 +5773,7 @@
       "file_count": 4,
       "path": "icn/crates/icn-time/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 26204
+      "total_size_bytes": 26212
     },
     {
       "child_directory_count": 0,
@@ -5368,7 +5828,7 @@
       "file_count": 17,
       "path": "icn/crates/icn-zkp/src",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 186955
+      "total_size_bytes": 186913
     },
     {
       "child_directory_count": 0,
@@ -5379,7 +5839,7 @@
       "file_count": 1,
       "path": "institutions/nycn/summit/docs",
       "role_guess": "institution package",
-      "total_size_bytes": 9261
+      "total_size_bytes": 13525
     },
     {
       "child_directory_count": 0,
@@ -5440,12 +5900,23 @@
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
+        ".ts": 11
+      },
+      "file_count": 11,
+      "path": "ops/mcp/src/diagnostics",
+      "role_guess": "operations / coordination",
+      "total_size_bytes": 65232
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
         ".ts": 4
       },
       "file_count": 4,
       "path": "ops/mcp/src/polling",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 7656
+      "total_size_bytes": 9725
     },
     {
       "child_directory_count": 0,
@@ -5456,30 +5927,41 @@
       "file_count": 3,
       "path": "ops/mcp/src/state",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 6704
+      "total_size_bytes": 6774
     },
     {
       "child_directory_count": 1,
       "depth": 4,
       "extensions": {
         ".json": 1,
-        ".ts": 3
+        ".ts": 7
       },
-      "file_count": 4,
+      "file_count": 8,
       "path": "ops/mcp/src/tests",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 10838
+      "total_size_bytes": 38791
     },
     {
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
-        ".ts": 8
+        ".ts": 9
       },
-      "file_count": 8,
+      "file_count": 9,
       "path": "ops/mcp/src/tools",
       "role_guess": "operations / coordination",
-      "total_size_bytes": 46007
+      "total_size_bytes": 54782
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".ts": 2
+      },
+      "file_count": 2,
+      "path": "ops/mcp/src/utils",
+      "role_guess": "operations / coordination",
+      "total_size_bytes": 6173
     },
     {
       "child_directory_count": 0,
@@ -5517,7 +5999,7 @@
       "file_count": 94,
       "path": "sdk/react-native/examples/CoopWallet",
       "role_guess": "React Native SDK",
-      "total_size_bytes": 856592
+      "total_size_bytes": 868144
     },
     {
       "child_directory_count": 0,
@@ -5539,18 +6021,54 @@
       "file_count": 1,
       "path": "sdk/typescript/src/generated",
       "role_guess": "TypeScript SDK",
-      "total_size_bytes": 31417
+      "total_size_bytes": 61644
+    },
+    {
+      "child_directory_count": 5,
+      "depth": 4,
+      "extensions": {
+        "(none)": 5,
+        ".json": 4,
+        ".md": 17
+      },
+      "file_count": 26,
+      "path": "tools/claude-code/plugins/icn-agent-pack",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 88907
     },
     {
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
-        ".js": 4
+        ".json": 4,
+        ".md": 1
       },
-      "file_count": 4,
+      "file_count": 5,
+      "path": "web/pilot-ui/fixtures/icn-organizer-demo",
+      "role_guess": "pilot UI",
+      "total_size_bytes": 21453
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        ".js": 8
+      },
+      "file_count": 8,
       "path": "web/pilot-ui/tests/e2e",
       "role_guess": "pilot UI",
-      "total_size_bytes": 47215
+      "total_size_bytes": 75708
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 4,
+      "extensions": {
+        "(none)": 1
+      },
+      "file_count": 1,
+      "path": "website/public/.well-known/matrix",
+      "role_guess": "public website",
+      "total_size_bytes": 86
     },
     {
       "child_directory_count": 0,
@@ -5561,19 +6079,7 @@
       "file_count": 5,
       "path": "website/src/content/blog",
       "role_guess": "public website",
-      "total_size_bytes": 18224
-    },
-    {
-      "child_directory_count": 0,
-      "depth": 4,
-      "extensions": {
-        ".gitkeep": 1,
-        ".md": 1
-      },
-      "file_count": 2,
-      "path": "website/src/content/docs",
-      "role_guess": "public website",
-      "total_size_bytes": 7291
+      "total_size_bytes": 18137
     },
     {
       "child_directory_count": 0,
@@ -5662,7 +6168,7 @@
       "file_count": 2,
       "path": "icn/apps/governance/src/handlers",
       "role_guess": "runtime app crate",
-      "total_size_bytes": 50207
+      "total_size_bytes": 50813
     },
     {
       "child_directory_count": 0,
@@ -5673,7 +6179,7 @@
       "file_count": 5,
       "path": "icn/apps/governance/src/http",
       "role_guess": "runtime app crate",
-      "total_size_bytes": 428496
+      "total_size_bytes": 497152
     },
     {
       "child_directory_count": 0,
@@ -5751,6 +6257,17 @@
       "path": "icn/crates/icn-authz/src/model",
       "role_guess": "Rust library crate",
       "total_size_bytes": 32319
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 5,
+      "extensions": {
+        ".wasm": 1
+      },
+      "file_count": 1,
+      "path": "icn/crates/icn-baseline-lock/tests/fixtures",
+      "role_guess": "Rust library crate",
+      "total_size_bytes": 22399
     },
     {
       "child_directory_count": 3,
@@ -5849,7 +6366,7 @@
       "file_count": 17,
       "path": "icn/crates/icn-core/src/config",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 173091
+      "total_size_bytes": 173955
     },
     {
       "child_directory_count": 0,
@@ -5871,7 +6388,7 @@
       "file_count": 7,
       "path": "icn/crates/icn-core/src/services",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 277091
+      "total_size_bytes": 288342
     },
     {
       "child_directory_count": 0,
@@ -5882,7 +6399,7 @@
       "file_count": 30,
       "path": "icn/crates/icn-core/src/supervisor",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 603799
+      "total_size_bytes": 633716
     },
     {
       "child_directory_count": 0,
@@ -5904,7 +6421,7 @@
       "file_count": 49,
       "path": "icn/crates/icn-gateway/src/api",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 1101537
+      "total_size_bytes": 1198204
     },
     {
       "child_directory_count": 0,
@@ -5959,7 +6476,7 @@
       "file_count": 6,
       "path": "icn/crates/icn-ledger/src/ledger_impl",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 60766
+      "total_size_bytes": 73700
     },
     {
       "child_directory_count": 1,
@@ -6014,7 +6531,7 @@
       "file_count": 16,
       "path": "icn/crates/icn-obs/src/metrics",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 122018
+      "total_size_bytes": 123294
     },
     {
       "child_directory_count": 0,
@@ -6025,7 +6542,7 @@
       "file_count": 12,
       "path": "icn/crates/icn-rpc/src/handler",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 163336
+      "total_size_bytes": 163337
     },
     {
       "child_directory_count": 0,
@@ -6058,7 +6575,7 @@
       "file_count": 5,
       "path": "icn/crates/icn-zkp/src/circuit",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 52833
+      "total_size_bytes": 52798
     },
     {
       "child_directory_count": 0,
@@ -6126,7 +6643,62 @@
       "file_count": 37,
       "path": "sdk/react-native/examples/CoopWallet/src",
       "role_guess": "React Native SDK",
-      "total_size_bytes": 291022
+      "total_size_bytes": 294884
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 5,
+      "extensions": {
+        ".json": 1
+      },
+      "file_count": 1,
+      "path": "tools/claude-code/plugins/icn-agent-pack/.claude-plugin",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 670
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 5,
+      "extensions": {
+        ".md": 6
+      },
+      "file_count": 6,
+      "path": "tools/claude-code/plugins/icn-agent-pack/agents",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 26694
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 5,
+      "extensions": {
+        "(none)": 5
+      },
+      "file_count": 5,
+      "path": "tools/claude-code/plugins/icn-agent-pack/bin",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 12793
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 5,
+      "extensions": {
+        ".json": 1
+      },
+      "file_count": 1,
+      "path": "tools/claude-code/plugins/icn-agent-pack/hooks",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 937
+    },
+    {
+      "child_directory_count": 6,
+      "depth": 5,
+      "extensions": {
+        ".md": 10
+      },
+      "file_count": 10,
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 34294
     },
     {
       "child_directory_count": 0,
@@ -6203,7 +6775,7 @@
       "file_count": 2,
       "path": "icn/crates/icn-gateway/src/api/commons",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 28301
+      "total_size_bytes": 38530
     },
     {
       "child_directory_count": 0,
@@ -6236,7 +6808,7 @@
       "file_count": 8,
       "path": "icn/crates/icn-gateway/src/api/sdis",
       "role_guess": "Rust library crate",
-      "total_size_bytes": 156080
+      "total_size_bytes": 156058
     },
     {
       "child_directory_count": 0,
@@ -6335,6 +6907,72 @@
       "path": "sdk/react-native/examples/CoopWallet/src/screens",
       "role_guess": "React Native SDK",
       "total_size_bytes": 229887
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 6,
+      "extensions": {
+        ".md": 2
+      },
+      "file_count": 2,
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/authority-spine",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 6996
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 6,
+      "extensions": {
+        ".md": 1
+      },
+      "file_count": 1,
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/doctor",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 3167
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 6,
+      "extensions": {
+        ".md": 2
+      },
+      "file_count": 2,
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/navigator",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 7602
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 6,
+      "extensions": {
+        ".md": 1
+      },
+      "file_count": 1,
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/preflight",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 2605
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 6,
+      "extensions": {
+        ".md": 2
+      },
+      "file_count": 2,
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/route-impact",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 6333
+    },
+    {
+      "child_directory_count": 0,
+      "depth": 6,
+      "extensions": {
+        ".md": 2
+      },
+      "file_count": 2,
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/truth-sync",
+      "role_guess": "uncategorized",
+      "total_size_bytes": 7591
     },
     {
       "child_directory_count": 3,
@@ -6649,6 +7287,19 @@
       "tracked": true
     },
     {
+      "directory": ".agents/skills/ci-status",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SKILL.md",
+      "path": ".agents/skills/ci-status/SKILL.md",
+      "role_guess": "repo configuration",
+      "sha256": "ad03d16aacfe2e71af576d5720650ee49e496e42ae90859a268d910d1d11efa8",
+      "size_bytes": 5159,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": ".agents/skills/demo-validate",
       "extension": ".md",
       "kind": "file",
@@ -6957,6 +7608,19 @@
       "role_guess": "repo configuration",
       "sha256": "b661a2885f1eb6a2fd3ff45a6bf032fc4aa3b57bf86a3bc1d8897773b61fb5ce",
       "size_bytes": 3415,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".claude/agents",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "icn-design-advisor.md",
+      "path": ".claude/agents/icn-design-advisor.md",
+      "role_guess": "repo configuration",
+      "sha256": "b1d17479515ed381f47e2e7043c748958195a5c467622bc90d10aade9353b433",
+      "size_bytes": 12381,
       "symlink_target": null,
       "tracked": true
     },
@@ -7332,8 +7996,8 @@
       "name": "todo-guard.sh",
       "path": ".claude/hooks/todo-guard.sh",
       "role_guess": "repo configuration",
-      "sha256": "3385d52cc168bfb5728ca12c4138484e742de236c97c9b5bca1760ac537c4af8",
-      "size_bytes": 1369,
+      "sha256": "ea793bc48b1dcb32721c58fcf028c6113ff6aabe0bf56b4f363a086df4211332",
+      "size_bytes": 2669,
       "symlink_target": null,
       "tracked": true
     },
@@ -7360,6 +8024,19 @@
       "role_guess": "repo configuration",
       "sha256": "3d733bb62cdb0bf1aefccea1dc20083efc72be1477de445a17aad98c3902743f",
       "size_bytes": 1004,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".claude/rules",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "design.md",
+      "path": ".claude/rules/design.md",
+      "role_guess": "repo configuration",
+      "sha256": "e1421e3c65bc4b6c2879a22898335fa66830222ff70d8e2b7a463785be0cabf9",
+      "size_bytes": 4209,
       "symlink_target": null,
       "tracked": true
     },
@@ -7438,6 +8115,19 @@
       "role_guess": "repo configuration",
       "sha256": "2eb0b991dd71a81843415754c9a5686953cc0483296cf82f816c98df46972974",
       "size_bytes": 2594,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".claude/skills/ci-status",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SKILL.md",
+      "path": ".claude/skills/ci-status/SKILL.md",
+      "role_guess": "repo configuration",
+      "sha256": "ad03d16aacfe2e71af576d5720650ee49e496e42ae90859a268d910d1d11efa8",
+      "size_bytes": 5159,
       "symlink_target": null,
       "tracked": true
     },
@@ -7529,6 +8219,19 @@
       "role_guess": "repo configuration",
       "sha256": "b8afca3245006544abcc7d5a3e1a1879e36c16822969165180213bad831509b9",
       "size_bytes": 2857,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".claude/skills/icn-commons-design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SKILL.md",
+      "path": ".claude/skills/icn-commons-design/SKILL.md",
+      "role_guess": "repo configuration",
+      "sha256": "6d5f05beeecbc567e7f3c6be71e89b8c56b608372b4b0e49b5b8b0f298578cb1",
+      "size_bytes": 12770,
       "symlink_target": null,
       "tracked": true
     },
@@ -7956,8 +8659,8 @@
       "name": "mcp.json",
       "path": ".cursor/mcp.json",
       "role_guess": "repo configuration",
-      "sha256": "f773c33f8b03630a014ddebaae8087d04ded6d0ec08aace31db58576ac6affe6",
-      "size_bytes": 132,
+      "sha256": "1e365a870be91c6c154b88a439da630a535e67e28524c84b5afc8102262a1f3a",
+      "size_bytes": 135,
       "symlink_target": null,
       "tracked": true
     },
@@ -7969,8 +8672,8 @@
       "name": "devcontainer.json",
       "path": ".devcontainer/devcontainer.json",
       "role_guess": "repo configuration",
-      "sha256": "51035dc4e08e34d8edd4da2708e0c4cf3855024df0e3b3af1ed10f46aa5ee63c",
-      "size_bytes": 1320,
+      "sha256": "7efa47ecdce13f7067d31be4f6aa0eb0f110428b88762dc718acd2bb73900b97",
+      "size_bytes": 1307,
       "symlink_target": null,
       "tracked": true
     },
@@ -8054,6 +8757,19 @@
     },
     {
       "directory": ".github/ISSUE_TEMPLATE",
+      "extension": ".yml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "design_accessibility.yml",
+      "path": ".github/ISSUE_TEMPLATE/design_accessibility.yml",
+      "role_guess": "repo configuration",
+      "sha256": "00409836445ba7b574330de7db0dd964b2bb9969ec8dd50854e09ea39fd86bf0",
+      "size_bytes": 2398,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/ISSUE_TEMPLATE",
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
@@ -8062,6 +8778,58 @@
       "role_guess": "repo configuration",
       "sha256": "279c134b429daa375072262689b90e19ded2d65691e42f0a2be92ed9a609366c",
       "size_bytes": 962,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/ISSUE_TEMPLATE",
+      "extension": ".yml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "documentation_issue.yml",
+      "path": ".github/ISSUE_TEMPLATE/documentation_issue.yml",
+      "role_guess": "repo configuration",
+      "sha256": "624b3213eabad756ad7b1b158a4364d12d9cf5f3e680735427e452d47a1fe6da",
+      "size_bytes": 1947,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/ISSUE_TEMPLATE",
+      "extension": ".yml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "governance_process.yml",
+      "path": ".github/ISSUE_TEMPLATE/governance_process.yml",
+      "role_guess": "repo configuration",
+      "sha256": "6740051a62983da1458533d459cdc6a6356296ba4fcb64906ec6b27f012459cf",
+      "size_bytes": 2230,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/ISSUE_TEMPLATE",
+      "extension": ".yml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "rfc_proposal.yml",
+      "path": ".github/ISSUE_TEMPLATE/rfc_proposal.yml",
+      "role_guess": "repo configuration",
+      "sha256": "e122de048b8187556ad0b9de39f0f30ec3d9bc69e3c79cb6a7f329b0529bca0d",
+      "size_bytes": 2891,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/ISSUE_TEMPLATE",
+      "extension": ".yml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "security_redirect.yml",
+      "path": ".github/ISSUE_TEMPLATE/security_redirect.yml",
+      "role_guess": "repo configuration",
+      "sha256": "ae0d88d116ba80f36fc6488c4f909ad0649e2e29bce32e374ee94cbd12ab86c9",
+      "size_bytes": 1604,
       "symlink_target": null,
       "tracked": true
     },
@@ -8177,8 +8945,8 @@
       "name": "icn-docs-spec.md",
       "path": ".github/agents/icn-docs-spec.md",
       "role_guess": "agent definition",
-      "sha256": "ef86d471bfafa73b6b46d61dd50a0743befbc52a094971994183f9497004995c",
-      "size_bytes": 2690,
+      "sha256": "5994902ae827be47979be35a2964c838a426057923e19d7bece1e8d1d2fad8c9",
+      "size_bytes": 2989,
       "symlink_target": null,
       "tracked": true
     },
@@ -8242,8 +9010,8 @@
       "name": "icn-homelab-infra.md",
       "path": ".github/agents/icn-homelab-infra.md",
       "role_guess": "agent definition",
-      "sha256": "5269876f52a7ac511e6aab91e35334730556d3f4b15de330b25139971100ebe8",
-      "size_bytes": 3400,
+      "sha256": "b43ef08b4506537da7f6b04b4076e11d66ff4bb457aedbb9541cadda03d116a0",
+      "size_bytes": 3488,
       "symlink_target": null,
       "tracked": true
     },
@@ -8398,8 +9166,8 @@
       "name": "copilot-instructions.md",
       "path": ".github/copilot-instructions.md",
       "role_guess": "repo configuration",
-      "sha256": "ba5420e1477883be636422b2d7ea4dba35116c0080ce2fd2e51888e302acbbdd",
-      "size_bytes": 18528,
+      "sha256": "abad52452b378e3fc34478614b7891427c7c975d4b7b198cfe904491d810f3d2",
+      "size_bytes": 18867,
       "symlink_target": null,
       "tracked": true
     },
@@ -8437,8 +9205,8 @@
       "name": "documentation.md",
       "path": ".github/instructions/documentation.md",
       "role_guess": "repo configuration",
-      "sha256": "0242c94cad67eb9660d2a2b7c3fb86e8d6bbff487f4fcb9d3b0cd6b47f9045e8",
-      "size_bytes": 5587,
+      "sha256": "36e61c1f45af49a4a504aab18d7f8ffe3b4269aae81834bbf705a5fb434dcb76",
+      "size_bytes": 5912,
       "symlink_target": null,
       "tracked": true
     },
@@ -8489,8 +9257,8 @@
       "name": "pull_request_template.md",
       "path": ".github/pull_request_template.md",
       "role_guess": "repo configuration",
-      "sha256": "b0adff9d42cd27bb8f6afae2be5294a4df1bb33d558ad921a648e41197f2633e",
-      "size_bytes": 3549,
+      "sha256": "b13accb67f7167524ccbde7c733048bacc3af561b33ca6cb4a4b1d3844ad538e",
+      "size_bytes": 4452,
       "symlink_target": null,
       "tracked": true
     },
@@ -8534,6 +9302,71 @@
       "tracked": true
     },
     {
+      "directory": ".github/scripts/fixtures/readiness",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "bad_unbannered.md",
+      "path": ".github/scripts/fixtures/readiness/bad_unbannered.md",
+      "role_guess": "repo configuration",
+      "sha256": "d4f271f3c7df8a39542c739da3f878b098db09d96b87c75038789a74b6e687f9",
+      "size_bytes": 155,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/scripts/fixtures/readiness",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "good_bannered.md",
+      "path": ".github/scripts/fixtures/readiness/good_bannered.md",
+      "role_guess": "repo configuration",
+      "sha256": "d827689652701930f71d9aaa75d5965fa55cac13d069f43468c8bebfbb8594e6",
+      "size_bytes": 344,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/scripts/fixtures/readiness",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "good_negated.md",
+      "path": ".github/scripts/fixtures/readiness/good_negated.md",
+      "role_guess": "repo configuration",
+      "sha256": "c2db26885c5078e7fffe517d1d3936aac4a5943f70faaaee2e74359b344b9bc6",
+      "size_bytes": 304,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "readiness_overclaim_linter.py",
+      "path": ".github/scripts/readiness_overclaim_linter.py",
+      "role_guess": "repo configuration",
+      "sha256": "ff439735a3b33f68c526bfd4b7962aa49b70ba318e8ec3247d0c8e5e7c063735",
+      "size_bytes": 10688,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "test_readiness_overclaim_linter.py",
+      "path": ".github/scripts/test_readiness_overclaim_linter.py",
+      "role_guess": "repo configuration",
+      "sha256": "f88e203dabe3fa9b5e27e4f9a179061595ea66e5c951d27c94a1e1221bf10dd3",
+      "size_bytes": 5230,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": ".github/workflows",
       "extension": ".yml",
       "kind": "file",
@@ -8541,8 +9374,8 @@
       "name": "agent-drift-check.yml",
       "path": ".github/workflows/agent-drift-check.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "280fe210fb018c052b38fec92b36302a9ab9088a6e48a17ab15c389501b77325",
-      "size_bytes": 1252,
+      "sha256": "77a32c55b27ed37405bd3c8b53f4732c47a24e326405c47227ec881118cc4224",
+      "size_bytes": 1283,
       "symlink_target": null,
       "tracked": true
     },
@@ -8554,8 +9387,8 @@
       "name": "api-types.yml",
       "path": ".github/workflows/api-types.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "d53ed06da41563e07beb730a7dbdb630318910475ebc040bc9f6bdbff6464c5e",
-      "size_bytes": 2895,
+      "sha256": "21ff932b492fade8f11b02751fbf6693e5dcb23e52d9df405cefee0f989acf6d",
+      "size_bytes": 2926,
       "symlink_target": null,
       "tracked": true
     },
@@ -8567,8 +9400,8 @@
       "name": "benchmark.yml",
       "path": ".github/workflows/benchmark.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "b2dee746e63f50a56f7f9e23bf65935ce41626ffc31725a5525d13e1fb97b6e9",
-      "size_bytes": 9627,
+      "sha256": "2e57f895aac9904d1d9b5123628eb8b16db8818c6f68756ed508228f241e8c8e",
+      "size_bytes": 9506,
       "symlink_target": null,
       "tracked": true
     },
@@ -8580,8 +9413,8 @@
       "name": "ci.yml",
       "path": ".github/workflows/ci.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "c71c0e911d95a480c27256cb140983264fc8efae56c8b946264591248b726ac5",
-      "size_bytes": 24919,
+      "sha256": "86949af7e10cd9993581b4eaa16154526d0f7ac055aa3d158f9ce89269c87020",
+      "size_bytes": 27926,
       "symlink_target": null,
       "tracked": true
     },
@@ -8593,8 +9426,8 @@
       "name": "claude-code-review.yml",
       "path": ".github/workflows/claude-code-review.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "ad229c244a0f3493a980be5aa4c7cae374f8c4aa546ead1104cee46fd6770279",
-      "size_bytes": 6797,
+      "sha256": "b60ab7d810f3cb81e84ae9f105c5b9f3099759bf64074ae47b11a7076a73c5e2",
+      "size_bytes": 13991,
       "symlink_target": null,
       "tracked": true
     },
@@ -8619,8 +9452,8 @@
       "name": "docker-build-deploy.yml",
       "path": ".github/workflows/docker-build-deploy.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "b1071ba4a7954908998f61dc5c089a0a780371d8181e3d5eefd046b837834cc5",
-      "size_bytes": 8339,
+      "sha256": "9ae7de0aa36858caba55dfbaa911f4994c26e1069ea730e974608259d8b6b538",
+      "size_bytes": 11985,
       "symlink_target": null,
       "tracked": true
     },
@@ -8632,8 +9465,8 @@
       "name": "docs-freshness.yml",
       "path": ".github/workflows/docs-freshness.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "fbddeb33b7c0410e2a94d875edbc3cc2f862a5edcab8a4d34871edf692dbb323",
-      "size_bytes": 5513,
+      "sha256": "f474a69b3d3639e195b703e215bd4f93c4df2fada10a53b97cd278a9b3bce1dd",
+      "size_bytes": 11562,
       "symlink_target": null,
       "tracked": true
     },
@@ -8645,8 +9478,8 @@
       "name": "fuzz.yml",
       "path": ".github/workflows/fuzz.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "2803788fd000ac20d12ecd0cd2a7b35bcba609001f8e79a3521e61e4207cbc78",
-      "size_bytes": 3006,
+      "sha256": "e2ff1c562395135582738e773e5db1b984d190e8204fab5e4b7bffb57d9612fa",
+      "size_bytes": 3037,
       "symlink_target": null,
       "tracked": true
     },
@@ -8658,7 +9491,7 @@
       "name": "issue-label-enforcer.yml",
       "path": ".github/workflows/issue-label-enforcer.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "2361898318fad93c07a6931246b1a518e4a41126ef392e75bbc9dcc2fddb80f0",
+      "sha256": "ff4342a962c2d2395a24033abfdb5ad1d9a4f21230f120204829a78cdf474731",
       "size_bytes": 6117,
       "symlink_target": null,
       "tracked": true
@@ -8671,8 +9504,8 @@
       "name": "mcp-portability.yml",
       "path": ".github/workflows/mcp-portability.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "e64c5b9b05c7cfcd21c3a97ee329843b81f117aa80db734d1ea8a6ce8454b43e",
-      "size_bytes": 968,
+      "sha256": "312f0e0ec6c3eb9e507863dcda9dea8705a53cb9563b3913598db66bd34e058d",
+      "size_bytes": 999,
       "symlink_target": null,
       "tracked": true
     },
@@ -8710,7 +9543,7 @@
       "name": "release.yml",
       "path": ".github/workflows/release.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "1c99196a6290006d7a7166b0420907a6566d63c472f4cb5fafb094cb012375e7",
+      "sha256": "fb8847b677b17a3576f1c939fd5a3620853f991b0d2e09da12e2a60fc429506e",
       "size_bytes": 6916,
       "symlink_target": null,
       "tracked": true
@@ -8723,8 +9556,8 @@
       "name": "security-audit.yml",
       "path": ".github/workflows/security-audit.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "cbe61f3aedef61a3b63f76880d657c5619de593cdaae745cc71f518d37bc512f",
-      "size_bytes": 2788,
+      "sha256": "894847194013cff0c449ee4f35009bc269a0d2cf4cdadb718f39ea6d8cd1f998",
+      "size_bytes": 3109,
       "symlink_target": null,
       "tracked": true
     },
@@ -8749,7 +9582,7 @@
       "name": "website-deploy.yml",
       "path": ".github/workflows/website-deploy.yml",
       "role_guess": "GitHub Actions workflow",
-      "sha256": "2c47cb5036afa83ab0ecc8b9807a0e837e005e799ed905311f7d242adea8057a",
+      "sha256": "7116ea42d600c63bfeca53c37a82d9adf6c2e897e0018ff55a8e531776da892e",
       "size_bytes": 1580,
       "symlink_target": null,
       "tracked": true
@@ -8762,8 +9595,8 @@
       "name": ".gitignore",
       "path": ".gitignore",
       "role_guess": "repo configuration",
-      "sha256": "025284fe4e857eb3bec82b47319d45134e653a16be1b08ea26a9b3df0d24846b",
-      "size_bytes": 1747,
+      "sha256": "74c902a253c05fe4fa2c26cc5e56a60f4b96bdc237eebb865e0bff8952a9dc0e",
+      "size_bytes": 1838,
       "symlink_target": null,
       "tracked": true
     },
@@ -8814,8 +9647,8 @@
       "name": "AGENTS.md",
       "path": "AGENTS.md",
       "role_guess": "repo control document",
-      "sha256": "e8bf16ede1697a1835c4e5b0c9dc1c7153002076bece4a2fdc9e53fc341bd047",
-      "size_bytes": 11451,
+      "sha256": "c1975970f33c70428816f8b8f3a7120391f77a03bde7b2939ce9d6426c0bfc60",
+      "size_bytes": 16225,
       "symlink_target": null,
       "tracked": true
     },
@@ -8840,8 +9673,8 @@
       "name": "CLAUDE.md",
       "path": "CLAUDE.md",
       "role_guess": "repo control document",
-      "sha256": "10b21d87b71d522d62d9b7d5d8eafcdec424a00f9f131fb9326dfb60e5a9ade5",
-      "size_bytes": 37518,
+      "sha256": "e1dbac164c030cee7999bc0dba2108d25ccac0a2538ab689b12938b7f11cb4b1",
+      "size_bytes": 41798,
       "symlink_target": null,
       "tracked": true
     },
@@ -8912,6 +9745,19 @@
     },
     {
       "directory": "",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "LICENSING.md",
+      "path": "LICENSING.md",
+      "role_guess": "uncategorized",
+      "sha256": "83f4000d843b0618d0cc2f96784cfbdaab0f1873d24158d1807f94153c8a43a6",
+      "size_bytes": 7325,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "",
       "extension": "(none)",
       "kind": "file",
       "language": "unknown",
@@ -8931,8 +9777,21 @@
       "name": "README.md",
       "path": "README.md",
       "role_guess": "repo control document",
-      "sha256": "2a4c6d425f19efc4e44e309b4bfee9349d999065916f43f14e33ad2757c18307",
-      "size_bytes": 6784,
+      "sha256": "79041cc9b7a6f20234b413127360eae7b83e986f7bc6f86bf357b0ad17f4dadc",
+      "size_bytes": 7404,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SECURITY.md",
+      "path": "SECURITY.md",
+      "role_guess": "uncategorized",
+      "sha256": "a87798ce2c7c78fb906f89b595928baed4ea1b700bee033b31811733f30adc73",
+      "size_bytes": 3316,
       "symlink_target": null,
       "tracked": true
     },
@@ -8977,6 +9836,19 @@
     },
     {
       "directory": "apps/echo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "apps/echo/README.md",
+      "role_guess": "legacy/top-level app",
+      "sha256": "37d77850d321eeaee7b8ef773a953389643cc4c6c36554fdc58db14ae068f4f2",
+      "size_bytes": 2815,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "apps/echo",
       "extension": ".yaml",
       "kind": "file",
       "language": "YAML",
@@ -8998,396 +9870,6 @@
       "role_guess": "legacy/top-level app",
       "sha256": "6b4dc365aec61d60c423f38774fbf31a2fc96f1423121d06f0585a892020d9ca",
       "size_bytes": 8053,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/governance",
-      "extension": ".gitignore",
-      "kind": "file",
-      "language": "unknown",
-      "name": ".gitignore",
-      "path": "apps/governance/.gitignore",
-      "role_guess": "legacy/top-level app",
-      "sha256": "2ebe6cb6f5289849dce5a8a6cdd77e06b1385302c862982f8e181c4782d19214",
-      "size_bytes": 19,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/governance",
-      "extension": ".toml",
-      "kind": "file",
-      "language": "TOML",
-      "name": "Cargo.toml",
-      "path": "apps/governance/Cargo.toml",
-      "role_guess": "legacy/top-level app",
-      "sha256": "d2ef9b5e4f536b42818b133a21642d020dbc6edbd9d98dc93a933d4abb884be2",
-      "size_bytes": 974,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/governance/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "lib.rs",
-      "path": "apps/governance/src/lib.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "59d6cf75a1a80392a10abeab47c9d2b730c9c3b91b8ebca308a753b3a615dd91",
-      "size_bytes": 3573,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/governance/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "oracle.rs",
-      "path": "apps/governance/src/oracle.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "164a45a18f67a5822c4879d7e6317347ff91f114031d6a48a2de61c3e082481a",
-      "size_bytes": 6990,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/governance/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "service.rs",
-      "path": "apps/governance/src/service.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "69335632cf0f5f244618d49ccaf664d80d59fc97b8cd0066eb19a567f0dadb8a",
-      "size_bytes": 7056,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger",
-      "extension": ".gitignore",
-      "kind": "file",
-      "language": "unknown",
-      "name": ".gitignore",
-      "path": "apps/ledger/.gitignore",
-      "role_guess": "legacy/top-level app",
-      "sha256": "2ebe6cb6f5289849dce5a8a6cdd77e06b1385302c862982f8e181c4782d19214",
-      "size_bytes": 19,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger",
-      "extension": ".toml",
-      "kind": "file",
-      "language": "TOML",
-      "name": "Cargo.toml",
-      "path": "apps/ledger/Cargo.toml",
-      "role_guess": "legacy/top-level app",
-      "sha256": "6ee791cc6d2489416b9388b739b516360246d98a1b5ba52d2577a45584c81bb8",
-      "size_bytes": 1705,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger",
-      "extension": ".yaml",
-      "kind": "file",
-      "language": "YAML",
-      "name": "manifest.yaml",
-      "path": "apps/ledger/manifest.yaml",
-      "role_guess": "legacy/top-level app",
-      "sha256": "168541ad3d13f2068b16b473bc58ba18f238dafc4c2948140e7449107df4f3f6",
-      "size_bytes": 1408,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "budgets.rs",
-      "path": "apps/ledger/src/budgets.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "d107e322624fe0fdbc3035148e2a47b5ec4297e4de20938f7e859349617978be",
-      "size_bytes": 8925,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "config.rs",
-      "path": "apps/ledger/src/config.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "a88b5943ba9818fd9528398fb6aa3b13aa42aa5cfca0d92cf7b2fce2fec78746",
-      "size_bytes": 13314,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "escrow.rs",
-      "path": "apps/ledger/src/escrow.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "efa3cb851c503373dd1627461af4e76b4804175d6b2646b027c8bf026aa09162",
-      "size_bytes": 7867,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "init.rs",
-      "path": "apps/ledger/src/init.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "5c3e0751ce2ace4cee0a9b6eb390a2178a463240072fdb93343f875daf1ccb6f",
-      "size_bytes": 10497,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "lib.rs",
-      "path": "apps/ledger/src/lib.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "62f0e643753856e3cf52d32d7bd49e2ec5eb9c09052c724b127be695f86302ba",
-      "size_bytes": 3764,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "oracle.rs",
-      "path": "apps/ledger/src/oracle.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "a7db685817b45cae0584e74a0a644aa0afd5547eb3b9abd013f99710a5e4a9e4",
-      "size_bytes": 4286,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "recurring.rs",
-      "path": "apps/ledger/src/recurring.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "fc21619d848694bcb8fb3f0e59d173df915fb1631d6f3b8f7259ae48cb0d0b94",
-      "size_bytes": 8806,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/ledger/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "service.rs",
-      "path": "apps/ledger/src/service.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "fa64b50989936d54d8c7412ee94852f391b993f2e10f3b0f7df95f7355128f0e",
-      "size_bytes": 7629,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust",
-      "extension": ".gitignore",
-      "kind": "file",
-      "language": "unknown",
-      "name": ".gitignore",
-      "path": "apps/trust/.gitignore",
-      "role_guess": "legacy/top-level app",
-      "sha256": "3e503ffd2d2f0c135bc5d8c97cba5aff82676478d90cb002333ed9583b92c5a0",
-      "size_bytes": 11,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust",
-      "extension": ".toml",
-      "kind": "file",
-      "language": "TOML",
-      "name": "Cargo.toml",
-      "path": "apps/trust/Cargo.toml",
-      "role_guess": "legacy/top-level app",
-      "sha256": "a8f7dbf66bf6cc89e736250934d67c9c00f162f6e21309d00a70de79712e0ff6",
-      "size_bytes": 1467,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/benches",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "README.md",
-      "path": "apps/trust/benches/README.md",
-      "role_guess": "legacy/top-level app",
-      "sha256": "22d5c201b7b7f4ba030c106afced05d5e5b5aa94d37783594494edc9c03d2620",
-      "size_bytes": 3345,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/benches",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "trust_service_bench.rs",
-      "path": "apps/trust/benches/trust_service_bench.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "8edea6f20171b8bac6656f80e0d68b497da53de36f43e301426c571b1f5ccee8",
-      "size_bytes": 8518,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust",
-      "extension": ".yaml",
-      "kind": "file",
-      "language": "YAML",
-      "name": "manifest.yaml",
-      "path": "apps/trust/manifest.yaml",
-      "role_guess": "legacy/top-level app",
-      "sha256": "f317936db84ac6591d6eb7c696f680e2d4b7d6355760ec5dd8000272b9336f24",
-      "size_bytes": 1594,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "init.rs",
-      "path": "apps/trust/src/init.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "df618b072438ce03346f106e1b2bac69b41ab525569b336aba1690d0e0067984",
-      "size_bytes": 9174,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "lib.rs",
-      "path": "apps/trust/src/lib.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "d92f8a0f9b686dab149011439ad7dadba0fb53fb1bd0e9d51b6ec751edc7f48b",
-      "size_bytes": 4881,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "oracle.rs",
-      "path": "apps/trust/src/oracle.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "0bef203917d1e50ac7b147eacb4ecdd7d820074685b3944720c383c1a74f17a1",
-      "size_bytes": 23630,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "oracle_tokio.rs",
-      "path": "apps/trust/src/oracle_tokio.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "d9857a1bb200770f801c874067e986a42b68919753cd0c8a95964ce76b68f262",
-      "size_bytes": 8058,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "reducer.rs",
-      "path": "apps/trust/src/reducer.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "2f41d4bca777a55d3d556a04d06b9f7752b65865eb11c19efd7c46c58a5c499f",
-      "size_bytes": 23894,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "sequence.rs",
-      "path": "apps/trust/src/sequence.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "686c50e0eeffd3d16bb029ba2a345624102b7696ede94eb879fb1479747d7048",
-      "size_bytes": 11054,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "service.rs",
-      "path": "apps/trust/src/service.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "4f28347cfdea290717761f71dacd286f01c304595f23d8b57fb7594812b8528d",
-      "size_bytes": 6824,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/src",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "service_tokio.rs",
-      "path": "apps/trust/src/service_tokio.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "a57267fc74a9103d94e28eb1b89d78cdc7c4f5a17c081e0388c2ef833770edac",
-      "size_bytes": 57192,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "apps/trust/tests",
-      "extension": ".rs",
-      "kind": "file",
-      "language": "Rust",
-      "name": "cross_org_integration.rs",
-      "path": "apps/trust/tests/cross_org_integration.rs",
-      "role_guess": "legacy/top-level app",
-      "sha256": "1087d04eafa12dfa1b989f7734dc1f9c48eabfec9e86a3ca26fac2bae291d51c",
-      "size_bytes": 18302,
       "symlink_target": null,
       "tracked": true
     },
@@ -9711,8 +10193,8 @@
       "name": "RUNBOOK.md",
       "path": "demo/RUNBOOK.md",
       "role_guess": "demo",
-      "sha256": "99b94ac3d6e6a76884ea7f53866f44fab5bde6330130789bc0b8f1571ce90505",
-      "size_bytes": 11068,
+      "sha256": "31e4d38448d41ffbb2c20919319e534e8bd738c7f3452170c2ed0d2123597c4c",
+      "size_bytes": 11077,
       "symlink_target": null,
       "tracked": true
     },
@@ -9724,8 +10206,8 @@
       "name": "SELF_SERVE.md",
       "path": "demo/SELF_SERVE.md",
       "role_guess": "demo",
-      "sha256": "c2c374608bf301bef9a3b41cb632193a8a9c94cbf7ed85d13c1df6c39e9e25f1",
-      "size_bytes": 12645,
+      "sha256": "4bac20f4b7c0b25ecbbc73a17e089b66456bded30b6bc7e448ffe5e1f870a343",
+      "size_bytes": 6679,
       "symlink_target": null,
       "tracked": true
     },
@@ -9867,8 +10349,8 @@
       "name": "FEDERATION_RUNBOOK.md",
       "path": "demo/docs/FEDERATION_RUNBOOK.md",
       "role_guess": "demo",
-      "sha256": "8781226fdc73b841fb9384cb733f399a41fef01357a743eb70139cc42317f878",
-      "size_bytes": 18698,
+      "sha256": "cc4d937752e85f2aee33b0d06a5021bf437b559daa3ec51ef7f3df9642b7ce2d",
+      "size_bytes": 18707,
       "symlink_target": null,
       "tracked": true
     },
@@ -9971,8 +10453,8 @@
       "name": "flow-2-notes.md",
       "path": "demo/notes/flow-2-notes.md",
       "role_guess": "demo",
-      "sha256": "379b3a54b5818b7346afe60413cea7957636ae67b39aaf3aaa7694e3635531b5",
-      "size_bytes": 6024,
+      "sha256": "9f642f2730e8f33c783a104eda9d35ba710e51af100fe02151989ccb26eaf5f4",
+      "size_bytes": 6030,
       "symlink_target": null,
       "tracked": true
     },
@@ -9997,8 +10479,8 @@
       "name": "flow-4-notes.md",
       "path": "demo/notes/flow-4-notes.md",
       "role_guess": "demo",
-      "sha256": "852c16f3bd7f1a6d85737eb6cccc3ff9b91094b10135d5697384373ebd03711f",
-      "size_bytes": 6355,
+      "sha256": "33e12ec55bca98a99a8ba1d5f465a038476b7e8b6a2e7ce67bb24da065a374e9",
+      "size_bytes": 6357,
       "symlink_target": null,
       "tracked": true
     },
@@ -10010,8 +10492,86 @@
       "name": "flow-5-notes.md",
       "path": "demo/notes/flow-5-notes.md",
       "role_guess": "demo",
-      "sha256": "da39888039998759cb04eec4abcc333362ac20015cfe4e3e8da357f73ae74822",
-      "size_bytes": 10237,
+      "sha256": "8318f9b26183f72bb26d99502b9be7153cd7b1b4171c2a6e2910eb53f6fd1138",
+      "size_bytes": 10239,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "demo/nycn-dogfood",
+      "extension": ".gitignore",
+      "kind": "file",
+      "language": "unknown",
+      "name": ".gitignore",
+      "path": "demo/nycn-dogfood/.gitignore",
+      "role_guess": "demo",
+      "sha256": "927c64451dd71b66c6f8093e4c98d16973760d8c2fba56307a6b346f9f4aaa7a",
+      "size_bytes": 195,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "demo/nycn-dogfood",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "demo/nycn-dogfood/README.md",
+      "role_guess": "demo",
+      "sha256": "cfe80e8b2f567223b17ab4901ce2c30f725f4b16922db15dd26c8e2adc521c4f",
+      "size_bytes": 6629,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "demo/nycn-dogfood",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "make-recording.py",
+      "path": "demo/nycn-dogfood/make-recording.py",
+      "role_guess": "demo",
+      "sha256": "862b3b6f1252156fe35366e7dfe78bf0bbdd3645daa4d4124e84317b889d1408",
+      "size_bytes": 5618,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "demo/nycn-dogfood",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "run.sh",
+      "path": "demo/nycn-dogfood/run.sh",
+      "role_guess": "demo",
+      "sha256": "e556edcaeada1179c6f7e511e6fb46e7263a8e4948bd39a1770b7d512b1ec903",
+      "size_bytes": 14336,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "demo/nycn-dogfood/sample",
+      "extension": ".html",
+      "kind": "file",
+      "language": "HTML",
+      "name": "recording.html",
+      "path": "demo/nycn-dogfood/sample/recording.html",
+      "role_guess": "demo",
+      "sha256": "0ab28295240605e04131dbffdca1bb0d91b53736e1d6b5f33b88111c79897059",
+      "size_bytes": 11283,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "demo/nycn-dogfood/sample",
+      "extension": ".txt",
+      "kind": "file",
+      "language": "Text",
+      "name": "transcript.txt",
+      "path": "demo/nycn-dogfood/sample/transcript.txt",
+      "role_guess": "demo",
+      "sha256": "10e38d5fce6dbc22a440cfaf7bbff86ed179996d2da04fdfe1dd7a66741b15d7",
+      "size_bytes": 6606,
       "symlink_target": null,
       "tracked": true
     },
@@ -10036,8 +10596,8 @@
       "name": "demo-governance.py",
       "path": "demo/scripts/demo-governance.py",
       "role_guess": "demo",
-      "sha256": "7cef3652fa3010ff4f244cd6aa81e14d5d23dd24d1eeac2bd689b45f20fc34cb",
-      "size_bytes": 23957,
+      "sha256": "90472061ebfd09a45b1ec71699d986410252667d3be60894478d5dd0af1dbad0",
+      "size_bytes": 25518,
       "symlink_target": null,
       "tracked": true
     },
@@ -10153,8 +10713,8 @@
       "name": "present-governance.sh",
       "path": "demo/scripts/present-governance.sh",
       "role_guess": "demo",
-      "sha256": "0e601265c28f8402f4698e1417cd8fc039215c3bf2e4e4ad418a9f5fc0f3027d",
-      "size_bytes": 4693,
+      "sha256": "6003d21f14b526fad5204ef39b57c9081eab9a0f6539da97f905e467203c26ab",
+      "size_bytes": 4926,
       "symlink_target": null,
       "tracked": true
     },
@@ -10270,8 +10830,8 @@
       "name": "start-demo.sh",
       "path": "demo/scripts/start-demo.sh",
       "role_guess": "demo",
-      "sha256": "0b64b361664494b5d880bbe3575df2eeae2f315412f8b0e5b786ae15819e3c25",
-      "size_bytes": 2099,
+      "sha256": "a1c1365b024de0da766e07cb6f0448d74261c68153d7141d95a9b24f10f059ba",
+      "size_bytes": 2749,
       "symlink_target": null,
       "tracked": true
     },
@@ -10350,6 +10910,344 @@
       "role_guess": "deployment",
       "sha256": "a2abc547b978a59bd8bb3b0ba4e834880e89a6fc73f139d6d81ef0ec52fd7efb",
       "size_bytes": 10218,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "DEMO_QUICKSTART.md",
+      "path": "deploy/appliance/DEMO_QUICKSTART.md",
+      "role_guess": "deployment",
+      "sha256": "d898199e1eb0cf27c9fa5fedeb530ad115526bc154129be6accdf42cc9df35c1",
+      "size_bytes": 12155,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "deploy/appliance/README.md",
+      "role_guess": "deployment",
+      "sha256": "36bc3edfa59e731f7e55259fc5fb022be4025d10581dec8b592900700d8d3964",
+      "size_bytes": 20164,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "appliance.manifest.example.yaml",
+      "path": "deploy/appliance/appliance.manifest.example.yaml",
+      "role_guess": "deployment",
+      "sha256": "42ed13bf143b74118ef78a83dde52f0329f606f4e9d23df81bb9190618642470",
+      "size_bytes": 6516,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "build-image.sh",
+      "path": "deploy/appliance/build-image.sh",
+      "role_guess": "deployment",
+      "sha256": "1803e38d21e8a3dd896f5dba436c66b473ffffd0794bd3031aedd3bdd5d9ad64",
+      "size_bytes": 20506,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "check.sh",
+      "path": "deploy/appliance/check.sh",
+      "role_guess": "deployment",
+      "sha256": "40c60ed1f5997a8dcd5d3fe18e97f7ecf682564e66f82e01741aca0aa6d7b53d",
+      "size_bytes": 4209,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/roles",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "domain-host.example.yaml",
+      "path": "deploy/appliance/roles/domain-host.example.yaml",
+      "role_guess": "deployment",
+      "sha256": "f6ed40f8723cfbaa188f08d697b40047c769a7b744995e55dc4b5893671b74d5",
+      "size_bytes": 2172,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/roles",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "genesis.example.yaml",
+      "path": "deploy/appliance/roles/genesis.example.yaml",
+      "role_guess": "deployment",
+      "sha256": "5ccba9aed4c832df7fcfc53c43d640f0d1f8f90baa11f683a942cf7e7e9819bc",
+      "size_bytes": 2082,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/roles",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "sandbox.example.yaml",
+      "path": "deploy/appliance/roles/sandbox.example.yaml",
+      "role_guess": "deployment",
+      "sha256": "0309836c41c914e6f9fe80f038f93a13878b1984dedf7eb029ea28b790049bfc",
+      "size_bytes": 2282,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/roles",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "service-host.example.yaml",
+      "path": "deploy/appliance/roles/service-host.example.yaml",
+      "role_guess": "deployment",
+      "sha256": "9d573372e5cb907e182ce4ce9b8acd01f23883361c4bc62a162b19b3c07654ce",
+      "size_bytes": 2653,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/roles",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "witness-archive.example.yaml",
+      "path": "deploy/appliance/roles/witness-archive.example.yaml",
+      "role_guess": "deployment",
+      "sha256": "4d841a30b8a8508a543f5b17611d80190a049187b5c909af5e45cda6262ea104",
+      "size_bytes": 1912,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "icn-appliance-firstboot.sh",
+      "path": "deploy/appliance/scripts/icn-appliance-firstboot.sh",
+      "role_guess": "deployment",
+      "sha256": "e7643dee64897a90eea814cfcbcca4e7bfdfc72480aed8f066e5c24d998a8007",
+      "size_bytes": 16393,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "icn-demo-reset.sh",
+      "path": "deploy/appliance/scripts/icn-demo-reset.sh",
+      "role_guess": "deployment",
+      "sha256": "13da9cf73df363a4874c2ceed078b36b3f2ef178d25eab6e7b153e117c22d1f9",
+      "size_bytes": 2383,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "icn-demo-seed.sh",
+      "path": "deploy/appliance/scripts/icn-demo-seed.sh",
+      "role_guess": "deployment",
+      "sha256": "9103169e589bb8527c99bc35a015d8288a6dcb01ac9a158d15371940ff22f359",
+      "size_bytes": 8683,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "icn-demo-session.py",
+      "path": "deploy/appliance/scripts/icn-demo-session.py",
+      "role_guess": "deployment",
+      "sha256": "0ddcae89c9423726cb695637e1ecaceeebfea672dcabc7d4552567d0022cd2f9",
+      "size_bytes": 9006,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "icn-demo-verify.sh",
+      "path": "deploy/appliance/scripts/icn-demo-verify.sh",
+      "role_guess": "deployment",
+      "sha256": "b1ffb20b1b684ef914519b954b5f293784b66ec5e0167a078ab8682879cfbdfe",
+      "size_bytes": 5297,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "open-proxmox-demo.sh",
+      "path": "deploy/appliance/scripts/open-proxmox-demo.sh",
+      "role_guess": "deployment",
+      "sha256": "09e8918eb2a31bc0f7c1350db4580a3494dcab191cce6e6834b84fee156eeed1",
+      "size_bytes": 9578,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/smoke",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "deploy/appliance/smoke/README.md",
+      "role_guess": "deployment",
+      "sha256": "71b5e20311f480ff6cf6a85fbe52194f715e723efd79d988cb2f696690871316",
+      "size_bytes": 6572,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/smoke/cloud-init",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "meta-data.example.yaml",
+      "path": "deploy/appliance/smoke/cloud-init/meta-data.example.yaml",
+      "role_guess": "deployment",
+      "sha256": "9ba371a283b57c026d0e715e2f3f1f75d0e3e06d08db3f8c86c9541c8147f887",
+      "size_bytes": 471,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/smoke/cloud-init",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "user-data.example.yaml",
+      "path": "deploy/appliance/smoke/cloud-init/user-data.example.yaml",
+      "role_guess": "deployment",
+      "sha256": "27c56190467d6d983eae051791f1ae5c4328584f3f42502d96fc0c414fd6b646",
+      "size_bytes": 2998,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/smoke",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "negative-firstboot-smoke.sh",
+      "path": "deploy/appliance/smoke/negative-firstboot-smoke.sh",
+      "role_guess": "deployment",
+      "sha256": "d9cde006dcad04582d054e3b865ff82fda01b26cf03947c4334f1a866a24e2b1",
+      "size_bytes": 20044,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/smoke",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "smoke-local.sh",
+      "path": "deploy/appliance/smoke/smoke-local.sh",
+      "role_guess": "deployment",
+      "sha256": "66128b598d2a53609a5b39ee779f6946fd39b65d5e961b43b55a103ecb492334",
+      "size_bytes": 22364,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/systemd",
+      "extension": ".service",
+      "kind": "file",
+      "language": "unknown",
+      "name": "icn-appliance-firstboot.service",
+      "path": "deploy/appliance/systemd/icn-appliance-firstboot.service",
+      "role_guess": "deployment",
+      "sha256": "1c0a96d2b1eb3f78a9138ad0c0b96bcfad0bdb45c3a04989163ce3f31d949bee",
+      "size_bytes": 2281,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/systemd",
+      "extension": ".service",
+      "kind": "file",
+      "language": "unknown",
+      "name": "icn-demo-session.service",
+      "path": "deploy/appliance/systemd/icn-demo-session.service",
+      "role_guess": "deployment",
+      "sha256": "e6b4ed8c4546796144826861c43ee71185c88aa221cb98e036df60b474361c28",
+      "size_bytes": 2454,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/systemd",
+      "extension": ".service",
+      "kind": "file",
+      "language": "unknown",
+      "name": "icn-member-shell.service",
+      "path": "deploy/appliance/systemd/icn-member-shell.service",
+      "role_guess": "deployment",
+      "sha256": "1ec61b9d9223a3a55ede122655daa97347d625a1c8944514fa3abc69573ff307",
+      "size_bytes": 1494,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/systemd/icnd.service.d",
+      "extension": ".conf",
+      "kind": "file",
+      "language": "unknown",
+      "name": "10-firstboot-gate.conf",
+      "path": "deploy/appliance/systemd/icnd.service.d/10-firstboot-gate.conf",
+      "role_guess": "deployment",
+      "sha256": "214b3900158378842f2ac9bcc4248e57f92a7703d758b1f7438e60ed9a861ef7",
+      "size_bytes": 1371,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "deploy/appliance/systemd/icnd.service.d",
+      "extension": ".conf",
+      "kind": "file",
+      "language": "unknown",
+      "name": "20-demo-profile.conf",
+      "path": "deploy/appliance/systemd/icnd.service.d/20-demo-profile.conf",
+      "role_guess": "deployment",
+      "sha256": "ecadd988079158b4984c00d0bc208a450a6a2ff1f136e9fd35f5656a6abf0cd6",
+      "size_bytes": 1833,
       "symlink_target": null,
       "tracked": true
     },
@@ -10530,8 +11428,8 @@
       "name": "docker-compose.yml",
       "path": "deploy/devnet/docker-compose.yml",
       "role_guess": "deployment",
-      "sha256": "718d8480c76764b04943ac8a89509451b11986314b4b396d107e440b2308db72",
-      "size_bytes": 4735,
+      "sha256": "362da221139553c6f908a1ef0be75bc4ee99d6e79ae53285b0f3b1630bb69615",
+      "size_bytes": 5425,
       "symlink_target": null,
       "tracked": true
     },
@@ -11765,8 +12663,34 @@
       "name": "ARCHITECTURE.md",
       "path": "docs/ARCHITECTURE.md",
       "role_guess": "documentation",
-      "sha256": "651d39744c27bada749ac5cb1170653cfd43ea66b14269744226e1df7ceb5fc5",
-      "size_bytes": 55634,
+      "sha256": "c673d4e72cb2311979baa0b22c5d41cd61d584153c5fa7540e923ce849e983e1",
+      "size_bytes": 67843,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ATLAS.md",
+      "path": "docs/ATLAS.md",
+      "role_guess": "documentation",
+      "sha256": "6dc9fab6be423bb85c5b06b2199b25808f96add0e10e0611bf3d2a7c47727f49",
+      "size_bytes": 14455,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "DESIGN_PRINCIPLES.md",
+      "path": "docs/DESIGN_PRINCIPLES.md",
+      "role_guess": "documentation",
+      "sha256": "e2b07c7e87f94c308925f68dfbf729155a56d187916ef0f04256212d221cf488",
+      "size_bytes": 18709,
       "symlink_target": null,
       "tracked": true
     },
@@ -11804,7 +12728,7 @@
       "name": "DOCUMENT_REGISTRY.md",
       "path": "docs/DOCUMENT_REGISTRY.md",
       "role_guess": "documentation",
-      "sha256": "21dea92c5ae61d9dc62ae4470caa85f60f8b3eb4f0e64e7730b90472bbc89411",
+      "sha256": "3f0a751dd74654eb557520662cd74b6d2fed839444ec596b0fbad6cff8d26f78",
       "size_bytes": 4302,
       "symlink_target": null,
       "tracked": true
@@ -11843,8 +12767,8 @@
       "name": "INDEX.generated.md",
       "path": "docs/INDEX.generated.md",
       "role_guess": "documentation",
-      "sha256": "8d63820410213661e01e6014af317040efaf67612b454d500b72559b9cec4c3e",
-      "size_bytes": 50741,
+      "sha256": "0ec037af1eeec408d2b619b1fbdbb14a9335122806ada2ed61341442a425f94b",
+      "size_bytes": 99153,
       "symlink_target": null,
       "tracked": true
     },
@@ -11856,8 +12780,8 @@
       "name": "INDEX.md",
       "path": "docs/INDEX.md",
       "role_guess": "documentation",
-      "sha256": "4b7f1d5a4475b04de4c32f30b36ba70514313391909ee8ed3bff7137d3815c93",
-      "size_bytes": 31159,
+      "sha256": "cf10472b41c3bcf4c8cdb5dc89e6791359b10b19fb989817075249e1e3e9e576",
+      "size_bytes": 46794,
       "symlink_target": null,
       "tracked": true
     },
@@ -11895,8 +12819,8 @@
       "name": "PHASE_PROGRESS.md",
       "path": "docs/PHASE_PROGRESS.md",
       "role_guess": "documentation",
-      "sha256": "6a47b4f95d872138f79028e04799e4654439147b3522aabef90d09b5d8318f1b",
-      "size_bytes": 20638,
+      "sha256": "a1a5b4e070331a8ff4b4e72023f141e3275810e08ea9e37877f6eb7a9ab9e6c6",
+      "size_bytes": 93188,
       "symlink_target": null,
       "tracked": true
     },
@@ -11934,8 +12858,8 @@
       "name": "STATE.md",
       "path": "docs/STATE.md",
       "role_guess": "documentation",
-      "sha256": "8f9a5ddff9da3f6e4ef24fa53b79da7ccf1c48b4aba3c9f64e747d6ecfd8ef1e",
-      "size_bytes": 21199,
+      "sha256": "b361ad4c8c749d3278ad990ed33f0a821ade8ee2fd4fde4ce423c352836e9407",
+      "size_bytes": 167484,
       "symlink_target": null,
       "tracked": true
     },
@@ -12350,8 +13274,8 @@
       "name": "ADR-0030-compute-workload-manifest-and-authority-boundary.md",
       "path": "docs/adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md",
       "role_guess": "architecture decision record",
-      "sha256": "395d7cde58588045fe4bc409728ec9c3faf6a23936cd4c9a9f98e9e108f4e69b",
-      "size_bytes": 7680,
+      "sha256": "6cd4cae4e8c9e633240c128f32a2c8e6904ccc62f3ab0ddf3de14641f4f9aaf4",
+      "size_bytes": 8442,
       "symlink_target": null,
       "tracked": true
     },
@@ -12363,8 +13287,8 @@
       "name": "ADR-0031-commons-compute-admission-and-settlement-policy.md",
       "path": "docs/adr/ADR-0031-commons-compute-admission-and-settlement-policy.md",
       "role_guess": "architecture decision record",
-      "sha256": "1d6c311a27fe669140faf8952ef33e3086864cc6e01d3f4a37e4e403bc23d03c",
-      "size_bytes": 7183,
+      "sha256": "8b9e87f83a205c47ab994aebc01fe4e5d9e2d71486c6f6b65a68941b8edb91a7",
+      "size_bytes": 8069,
       "symlink_target": null,
       "tracked": true
     },
@@ -12404,6 +13328,19 @@
       "role_guess": "architecture decision record",
       "sha256": "bf48bdfaa77a56ae00cd70c738e9bc949ad0b3730b091800ec0617f9b74d9090",
       "size_bytes": 5371,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/adr",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ADR-0035-entity-aware-request-authorization.md",
+      "path": "docs/adr/ADR-0035-entity-aware-request-authorization.md",
+      "role_guess": "architecture decision record",
+      "sha256": "935b98bf2d991fcdb02e689313607d067e9b849ecc0eef2fd9873a5685a1fd0b",
+      "size_bytes": 9337,
       "symlink_target": null,
       "tracked": true
     },
@@ -12493,8 +13430,8 @@
       "name": "OPENAPI.md",
       "path": "docs/api/OPENAPI.md",
       "role_guess": "documentation",
-      "sha256": "c558303bf93d4cc52c39787416fdc82fcedd36cf8bd2bf9e2f5c9bb1fdd095e6",
-      "size_bytes": 7760,
+      "sha256": "8b2b5ccfbcbca4083d113aed86dad301fe100b51210d1d782e0f4cf3259a6d28",
+      "size_bytes": 7922,
       "symlink_target": null,
       "tracked": true
     },
@@ -12506,8 +13443,21 @@
       "name": "README.md",
       "path": "docs/api/README.md",
       "role_guess": "documentation",
-      "sha256": "bda4536f076eb9520f2dad4e2959f294a06771bf3e2bff4ec927b56c6a7b88e4",
-      "size_bytes": 7297,
+      "sha256": "daf258804917cd482c834b9d28aec40333e0999d1095c14f0d01255a11d838fd",
+      "size_bytes": 8384,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/api",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "check_api_doc_terms.py",
+      "path": "docs/api/check_api_doc_terms.py",
+      "role_guess": "documentation",
+      "sha256": "56ad66bf65efc16037d45b4e39e280f5e3fd4f9fab0cd7aeb61ee79cfe18ee9f",
+      "size_bytes": 7984,
       "symlink_target": null,
       "tracked": true
     },
@@ -12519,8 +13469,8 @@
       "name": "examples.sh",
       "path": "docs/api/examples.sh",
       "role_guess": "documentation",
-      "sha256": "3414cbcbc43731fabdc6913e781b29957002cf7301b055c35c7d37ccaa1d98b5",
-      "size_bytes": 4276,
+      "sha256": "a1444aede8a8648e767fdef5f66835a255f2af95fdfe329927aa71a882bd5172",
+      "size_bytes": 4638,
       "symlink_target": null,
       "tracked": true
     },
@@ -12532,8 +13482,8 @@
       "name": "openapi.generated.yaml",
       "path": "docs/api/openapi.generated.yaml",
       "role_guess": "documentation",
-      "sha256": "cec01650ea5828c239f542b89ad61fd40545032dbd1eae8000744a0bcf1a33fa",
-      "size_bytes": 45436,
+      "sha256": "f3c3d043faabc312c76011d3d2ef16345ede9306a7e96a55058d3968394b8165",
+      "size_bytes": 72121,
       "symlink_target": null,
       "tracked": true
     },
@@ -12547,6 +13497,19 @@
       "role_guess": "documentation",
       "sha256": "0de2efd30825b8b3af8ea25608fc395b22e33e75178ee5b0102bfb7b20fc9cea",
       "size_bytes": 42259,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/architecture",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ABUSE_CASE_HARDENING_STRATEGY.md",
+      "path": "docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md",
+      "role_guess": "documentation",
+      "sha256": "ff8c628630f75e9dc4b3def39e7d7f00afdab6b311017ec7b42aa7ccf6e2f7b1",
+      "size_bytes": 49857,
       "symlink_target": null,
       "tracked": true
     },
@@ -12599,6 +13562,19 @@
       "role_guess": "documentation",
       "sha256": "2b801c1d81f8eec6f18f6ba124092a208479d1abf5cf66c6f68ea234bf4ec012",
       "size_bytes": 12006,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/architecture",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ARCHITECTURE_DUE_DILIGENCE.md",
+      "path": "docs/architecture/ARCHITECTURE_DUE_DILIGENCE.md",
+      "role_guess": "documentation",
+      "sha256": "8692ca953a0eacd42b4c8f089da87b8d0e5ce47b8ee04f5b88a6573b9862ed7c",
+      "size_bytes": 26243,
       "symlink_target": null,
       "tracked": true
     },
@@ -12711,6 +13687,19 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "AUTH_BRIDGE_AND_DID_LOGIN.md",
+      "path": "docs/architecture/AUTH_BRIDGE_AND_DID_LOGIN.md",
+      "role_guess": "documentation",
+      "sha256": "9c71f5e828a585cfc7e3b472841070a145c295189d02db17ac8a2ead158420b3",
+      "size_bytes": 9133,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/architecture",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "CANONICAL_ENCODING.md",
       "path": "docs/architecture/CANONICAL_ENCODING.md",
       "role_guess": "documentation",
@@ -12740,8 +13729,8 @@
       "name": "CLIENT_MODEL.md",
       "path": "docs/architecture/CLIENT_MODEL.md",
       "role_guess": "documentation",
-      "sha256": "1cc15dfa698f7121622112697a70730908684d05117c845f394995f1953e0dd8",
-      "size_bytes": 26138,
+      "sha256": "6c9c1f86060c2cba8566c3d3c58d7cc9d6d4017bf95c1f47dfc5ae986319265c",
+      "size_bytes": 36644,
       "symlink_target": null,
       "tracked": true
     },
@@ -12802,6 +13791,19 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "DEBIAN_APPLIANCE_MODEL.md",
+      "path": "docs/architecture/DEBIAN_APPLIANCE_MODEL.md",
+      "role_guess": "documentation",
+      "sha256": "438980a258d44467900b1c7f74e9682ee4f05d7f380de2ff28bd2594330a0e54",
+      "size_bytes": 16408,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/architecture",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "DOMAIN_ROUTING_AND_DNS_BINDINGS.md",
       "path": "docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md",
       "role_guess": "documentation",
@@ -12854,6 +13856,19 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "ICN_INTEGRATED_SYSTEM_MODEL.md",
+      "path": "docs/architecture/ICN_INTEGRATED_SYSTEM_MODEL.md",
+      "role_guess": "documentation",
+      "sha256": "662f6c8acbdd33582d4d69e7127979298b83cb729d4915b044312155103ea632",
+      "size_bytes": 33032,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/architecture",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "IDENTITY_MEMBERSHIP_ARCHITECTURE.md",
       "path": "docs/architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md",
       "role_guess": "documentation",
@@ -12896,8 +13911,8 @@
       "name": "INSTITUTION_PACKAGE_BOUNDARY.md",
       "path": "docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md",
       "role_guess": "documentation",
-      "sha256": "db3d80e05b815e25fea3d30f0c059a91c4cee06ad3f30cddd13f843582a8640c",
-      "size_bytes": 27683,
+      "sha256": "892cde6a59fe30c28b9c9f47e3e58bf8df1cfd3b3c39ba29c69919e1e7fd7eee",
+      "size_bytes": 33569,
       "symlink_target": null,
       "tracked": true
     },
@@ -12909,8 +13924,8 @@
       "name": "KERNEL_APP_SEPARATION.md",
       "path": "docs/architecture/KERNEL_APP_SEPARATION.md",
       "role_guess": "documentation",
-      "sha256": "f80dea1e96ac8c1984bfc05c6d6f5833d77eeb47dd56accd9b04d14317394223",
-      "size_bytes": 51954,
+      "sha256": "546e124ed0c7a4dd2127e05734b735791a7ca7f297f70398eac523ef1cda87ab",
+      "size_bytes": 58339,
       "symlink_target": null,
       "tracked": true
     },
@@ -12945,6 +13960,19 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md",
+      "path": "docs/architecture/PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md",
+      "role_guess": "documentation",
+      "sha256": "6bbabe82208ce8b2f5ad4f48c8832f9d073ac227839883bb138ece226e0b7858",
+      "size_bytes": 10172,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/architecture",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "README.md",
       "path": "docs/architecture/README.md",
       "role_guess": "documentation",
@@ -12963,6 +13991,19 @@
       "role_guess": "documentation",
       "sha256": "cc274f2a7783c2ac80f87941c5cb3683cbb00c691177d617a0c5890b8f9a2754",
       "size_bytes": 14171,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/architecture",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SERVICE_HOSTING_MODEL.md",
+      "path": "docs/architecture/SERVICE_HOSTING_MODEL.md",
+      "role_guess": "documentation",
+      "sha256": "3f588c459247b019a3c2136a75bcb2a7cfbd875083f81c4f7e3acd0db7dff8d9",
+      "size_bytes": 11218,
       "symlink_target": null,
       "tracked": true
     },
@@ -13000,8 +14041,8 @@
       "name": "THE_COMMONS.md",
       "path": "docs/architecture/THE_COMMONS.md",
       "role_guess": "documentation",
-      "sha256": "d6afebef4c7b81c6e6ff38a1b8cb7d33f82a5df96e472223ca0f94a4cece9ad4",
-      "size_bytes": 56963,
+      "sha256": "165779984f4845300c02a1796748f28b71138b6dd744898722c6cfe1be6ed5d0",
+      "size_bytes": 56915,
       "symlink_target": null,
       "tracked": true
     },
@@ -13728,8 +14769,8 @@
       "name": "DEMO_FINAL_SESSION_SUMMARY.md",
       "path": "docs/archive/2026/demo-sessions/DEMO_FINAL_SESSION_SUMMARY.md",
       "role_guess": "documentation",
-      "sha256": "7f1cc30a75e2d7c98dad59e546272ae5ed364bfdd61ea59cf4396500d66c2b63",
-      "size_bytes": 7926,
+      "sha256": "f0e889a1d772212fd5181bf2e46b0376f70167e7a26f40e81f7bfe780ff42d6c",
+      "size_bytes": 7654,
       "symlink_target": null,
       "tracked": true
     },
@@ -13754,8 +14795,8 @@
       "name": "DEMO_FIX_LOGIN.md",
       "path": "docs/archive/2026/demo-sessions/DEMO_FIX_LOGIN.md",
       "role_guess": "documentation",
-      "sha256": "40ce8abb27fbee665ecf6a16775f02157c3539b492423dc23ef681426a18cd4b",
-      "size_bytes": 3305,
+      "sha256": "dc78b5cf144bd52bd9e13230346a7e40b6991b0ebca9190906041c7925a87680",
+      "size_bytes": 2631,
       "symlink_target": null,
       "tracked": true
     },
@@ -13858,8 +14899,8 @@
       "name": "DEMO_SERVICE_WORKER_FIX.md",
       "path": "docs/archive/2026/demo-sessions/DEMO_SERVICE_WORKER_FIX.md",
       "role_guess": "documentation",
-      "sha256": "9feb5ce8d4f8387b4a0ffcd8167b2ffed8c6672e749a599bc3eec32f580305ad",
-      "size_bytes": 4307,
+      "sha256": "1d186beab2ea8ef5d7b17c55905e6d843f691575f1303a67888c1217c1e81e74",
+      "size_bytes": 3296,
       "symlink_target": null,
       "tracked": true
     },
@@ -14066,8 +15107,34 @@
       "name": "GATE_RATCHET_PLAN.md",
       "path": "docs/ci/GATE_RATCHET_PLAN.md",
       "role_guess": "documentation",
-      "sha256": "bdda09ebcb9574b37269b42edc7ffe5df3d36f4bfe31418ee2c8a1157122ee21",
-      "size_bytes": 7311,
+      "sha256": "9debcec8b18cadb02071d2277b80ad8a040da8932c61a761a4c7751b4c9ebd98",
+      "size_bytes": 8724,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts/institution-package",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "docs/contracts/institution-package/README.md",
+      "role_guess": "documentation",
+      "sha256": "54d05a99be96955597dce088b32f261d0e4798b7e9550812386f04912e942743",
+      "size_bytes": 7597,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts/institution-package",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "action-card.example.json",
+      "path": "docs/contracts/institution-package/action-card.example.json",
+      "role_guess": "documentation",
+      "sha256": "7f9e1b55b852517dcb03c274c1d374cb182bb403ac7bcdc263062ac00a1f48e5",
+      "size_bytes": 726,
       "symlink_target": null,
       "tracked": true
     },
@@ -14079,8 +15146,138 @@
       "name": "action-card.schema.json",
       "path": "docs/contracts/institution-package/action-card.schema.json",
       "role_guess": "documentation",
-      "sha256": "b795c4dc3786de2b7bdf4b7143f26f2de21c618346e576e500e1539040b3a8b0",
-      "size_bytes": 4322,
+      "sha256": "d58485a48ab5c1f05623fc216580260bdc7505053bcfba2bcb7cc147171ab755",
+      "size_bytes": 5435,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "pending-publish-summary.example.json",
+      "path": "docs/contracts/pending-publish-summary.example.json",
+      "role_guess": "documentation",
+      "sha256": "f23264926a3d6c56122e7d489039ee35ae6f3f355c45c4c37e012d2fec514944",
+      "size_bytes": 6913,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "pending-publish-summary.md",
+      "path": "docs/contracts/pending-publish-summary.md",
+      "role_guess": "documentation",
+      "sha256": "ed7b58a46f4542497c047d00523045d8d60e0089a5bd1714eaaca672d42735c4",
+      "size_bytes": 17833,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "pending-publish-summary.schema.json",
+      "path": "docs/contracts/pending-publish-summary.schema.json",
+      "role_guess": "documentation",
+      "sha256": "025313c8a7c2e876b181a4759900b991bfa7bd028dd0580db6d51214ad57f43f",
+      "size_bytes": 21068,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "preview-review.example.json",
+      "path": "docs/contracts/preview-review.example.json",
+      "role_guess": "documentation",
+      "sha256": "3507f7da252a441b982c6836c1ea258a0b3415a166d89f918d067b25df57f270",
+      "size_bytes": 4242,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "preview-review.md",
+      "path": "docs/contracts/preview-review.md",
+      "role_guess": "documentation",
+      "sha256": "ffe6fa142ecd4ed40406194de74d2ad2d4760980a2b38d6a299c9c41bae6aaf9",
+      "size_bytes": 16648,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "preview-review.schema.json",
+      "path": "docs/contracts/preview-review.schema.json",
+      "role_guess": "documentation",
+      "sha256": "9ae77d0f93b27cc2ee026f08d27e1eb5c9955d7be5e8e0306ac9de09e0f2586c",
+      "size_bytes": 15793,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "rehearsal-evidence-export.example.json",
+      "path": "docs/contracts/rehearsal-evidence-export.example.json",
+      "role_guess": "documentation",
+      "sha256": "f4e223205d3c14c27585e090ca08d68f0b303ae60b1e29433f1ece14cb5fe970",
+      "size_bytes": 3434,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "rehearsal-evidence-export.md",
+      "path": "docs/contracts/rehearsal-evidence-export.md",
+      "role_guess": "documentation",
+      "sha256": "3fe3c4b01e5e064d74fa7b91c44b2fd173f0cf74e6536d138e3f9e23e8ef2bc5",
+      "size_bytes": 10869,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "rehearsal-evidence-export.schema.json",
+      "path": "docs/contracts/rehearsal-evidence-export.schema.json",
+      "role_guess": "documentation",
+      "sha256": "4725c4fb7be3009948cc2cf1820340bff7874bf8096888452114da62d0466083",
+      "size_bytes": 14790,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/contracts",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "schema-id-audit.md",
+      "path": "docs/contracts/schema-id-audit.md",
+      "role_guess": "documentation",
+      "sha256": "166e3c0b7521c9bd92381ce4babbfb3c17068d764acc4f2a9f81ca110b39481b",
+      "size_bytes": 13349,
       "symlink_target": null,
       "tracked": true
     },
@@ -14651,8 +15848,8 @@
       "name": "DEMO_SCRIPT.md",
       "path": "docs/demo/DEMO_SCRIPT.md",
       "role_guess": "documentation",
-      "sha256": "dc213391c48f818fd0be5f6adf32e7cbb7193eaff36750f08df2a23001779048",
-      "size_bytes": 10999,
+      "sha256": "45a4c12aee9ce5c48a0de904df85b3340c2f3479fc728225bd9cda6b76f1e7fd",
+      "size_bytes": 11055,
       "symlink_target": null,
       "tracked": true
     },
@@ -14666,6 +15863,110 @@
       "role_guess": "documentation",
       "sha256": "1fc60b75312e56dfaf11dc2bc835ee93f6c7c368f03afb3dea08c3f5cb09955e",
       "size_bytes": 8193,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/demo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "GOVERNANCE_PROPOSAL_FIXTURE_HANDOFF.md",
+      "path": "docs/demo/GOVERNANCE_PROPOSAL_FIXTURE_HANDOFF.md",
+      "role_guess": "documentation",
+      "sha256": "fb4634ecd6cc87652673d8f1fc77cba4f71b58da2fd2f363e1da49b34ef726aa",
+      "size_bytes": 8230,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/demo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ICN_SYSTEM_DEMO_READINESS_MAP.md",
+      "path": "docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md",
+      "role_guess": "documentation",
+      "sha256": "f1058c520ba16b4f6d214659a0e9bf0bf561e5a353ec338d31038c443e8e6ea5",
+      "size_bytes": 33123,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/demo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "JULY_DEMO_CANDIDATE_0.1_ACCESSIBILITY_WALKTHROUGH.md",
+      "path": "docs/demo/JULY_DEMO_CANDIDATE_0.1_ACCESSIBILITY_WALKTHROUGH.md",
+      "role_guess": "documentation",
+      "sha256": "745b5aa0bf4cf122266ad7d6d6752e767bf95de50145411913b14b74c8c7434c",
+      "size_bytes": 17962,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/demo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "JULY_DEMO_CANDIDATE_0.1_HUMAN_A11Y_VALIDATION.md",
+      "path": "docs/demo/JULY_DEMO_CANDIDATE_0.1_HUMAN_A11Y_VALIDATION.md",
+      "role_guess": "documentation",
+      "sha256": "d15b13ed871d51bb4c318b3c6e7f3fc52818e82adc8841d300c98808ede6b18a",
+      "size_bytes": 11605,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/demo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md",
+      "path": "docs/demo/JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md",
+      "role_guess": "documentation",
+      "sha256": "2780c1f687fab42208eb26bb649ba7f0598732dc105f67206d5ff84ac5c8f4bf",
+      "size_bytes": 16684,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/demo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "JULY_DEMO_CANDIDATE_0.1_RELEASE_PACKET.md",
+      "path": "docs/demo/JULY_DEMO_CANDIDATE_0.1_RELEASE_PACKET.md",
+      "role_guess": "documentation",
+      "sha256": "e0409318d78b84b34b5c769b8a9d9e224012e70f1d5480574e5b29824c03e4a6",
+      "size_bytes": 10756,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/demo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "JULY_DEMO_HANDS_ON.md",
+      "path": "docs/demo/JULY_DEMO_HANDS_ON.md",
+      "role_guess": "documentation",
+      "sha256": "fae897fbe72095b7299c74407c19c4bac5f15835884ddb5aab8ffedf077f6223",
+      "size_bytes": 24070,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/demo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "JULY_DEMO_OPERATOR_CHECKLIST.md",
+      "path": "docs/demo/JULY_DEMO_OPERATOR_CHECKLIST.md",
+      "role_guess": "documentation",
+      "sha256": "27a4d5664d9a33859949d75a556c198d2b4f6c2bc1a69ba3b798a757d83684d2",
+      "size_bytes": 4160,
       "symlink_target": null,
       "tracked": true
     },
@@ -14690,8 +15991,8 @@
       "name": "README.md",
       "path": "docs/demo/README.md",
       "role_guess": "documentation",
-      "sha256": "520686972ec7ff492e08ec59f45e4f9415033c907d529032298f28822e7f611e",
-      "size_bytes": 4194,
+      "sha256": "c5b22fba15ce0fa622a2920b4134416a07974a6887d5b448838dc0781686b19a",
+      "size_bytes": 6351,
       "symlink_target": null,
       "tracked": true
     },
@@ -14794,8 +16095,8 @@
       "name": "DEPLOY_TEST_NETWORK.md",
       "path": "docs/deployment/DEPLOY_TEST_NETWORK.md",
       "role_guess": "documentation",
-      "sha256": "013473972b1794382b459a2d8a106a0cc6b520b6cbc999ad8d5232361020b6db",
-      "size_bytes": 16300,
+      "sha256": "d109f7e11b236523a0ce6acc4acd338703e90016b17d5594fe8111f55ab10d4c",
+      "size_bytes": 16620,
       "symlink_target": null,
       "tracked": true
     },
@@ -14859,8 +16160,8 @@
       "name": "QUICK_START.md",
       "path": "docs/deployment/QUICK_START.md",
       "role_guess": "documentation",
-      "sha256": "618ba54133ecf4021abdf23fc5ab64af84f2fc023653945b211971ca55a3c894",
-      "size_bytes": 6566,
+      "sha256": "a26100c2793f0da41db6f6388c43ede97fd1d42d380039723107da51edb34789",
+      "size_bytes": 6866,
       "symlink_target": null,
       "tracked": true
     },
@@ -14872,8 +16173,8 @@
       "name": "accessibility.md",
       "path": "docs/design-language/accessibility.md",
       "role_guess": "documentation",
-      "sha256": "0f50dd68d9662a8337356eda1347fdcc41a20a9139c4615fa38d9327e3fa25f6",
-      "size_bytes": 12731,
+      "sha256": "099b6c2f84616d8591c672adda4107cafefeff093484fb51c10d190bdc67850d",
+      "size_bytes": 13906,
       "symlink_target": null,
       "tracked": true
     },
@@ -14937,8 +16238,47 @@
       "name": "CLAUDE_DESIGN_CONTEXT.md",
       "path": "docs/design/CLAUDE_DESIGN_CONTEXT.md",
       "role_guess": "documentation",
-      "sha256": "8eb4649837fdd163ef5cca5fa8eb8c20b7ea20c13700490bd854b944fd45077e",
-      "size_bytes": 3208,
+      "sha256": "cba019ac6f80d5be7c50435c5de7ad271de366e1f490c60000a394f5e75b58c5",
+      "size_bytes": 15438,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "CLAUDE_DESIGN_HANDOFF_TEMPLATE.md",
+      "path": "docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md",
+      "role_guess": "documentation",
+      "sha256": "3d1a30769efd1f589b0f40eef126de1098b318a0d4114b3e08b302697d8ae590",
+      "size_bytes": 12426,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "CLAUDE_DESIGN_REVIEW_PROTOCOL.md",
+      "path": "docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md",
+      "role_guess": "documentation",
+      "sha256": "d09cd7cdbe3817b0fa8ddf38df9fa8c0178070bf0d6257139a705cfb93317cff",
+      "size_bytes": 15072,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "CLAUDE_DESIGN_SETUP.md",
+      "path": "docs/design/CLAUDE_DESIGN_SETUP.md",
+      "role_guess": "documentation",
+      "sha256": "b7421046703bea1199474a0e380fde31fa88592dfe2b5a826b985fec8fdd365b",
+      "size_bytes": 21915,
       "symlink_target": null,
       "tracked": true
     },
@@ -14976,8 +16316,8 @@
       "name": "CONTENT_STYLE_GUIDE.md",
       "path": "docs/design/CONTENT_STYLE_GUIDE.md",
       "role_guess": "documentation",
-      "sha256": "209cadb5bf576290d69b331f4428eda0886cba447d13c60e12d5a8c60f315503",
-      "size_bytes": 5436,
+      "sha256": "0c5ba9bf6d24daa9447585cf6984ef4b41f2c97a2051b0ae04fb00902a831d20",
+      "size_bytes": 6086,
       "symlink_target": null,
       "tracked": true
     },
@@ -14999,11 +16339,24 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "FEDERATION_OPERATOR_SURFACE_CONCEPT.md",
+      "path": "docs/design/FEDERATION_OPERATOR_SURFACE_CONCEPT.md",
+      "role_guess": "documentation",
+      "sha256": "62af51ef25497f3366d4036ece757508708c62b2e5f21e788eb6fdeeb20f4a17",
+      "size_bytes": 11633,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "ICN_DESIGN_SYSTEM.md",
       "path": "docs/design/ICN_DESIGN_SYSTEM.md",
       "role_guess": "documentation",
-      "sha256": "a18d30247bfe62ad7f29238b7bf873a7ef20a6d8bd376f5444cd9cbd63d47228",
-      "size_bytes": 7605,
+      "sha256": "187d7136a3411b126423331ba9936a1f650a7fa8501e1415879f9f45894a6119",
+      "size_bytes": 16405,
       "symlink_target": null,
       "tracked": true
     },
@@ -15025,11 +16378,24 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "ICN_VISUAL_EXPLAINER_BIBLE.md",
+      "path": "docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md",
+      "role_guess": "documentation",
+      "sha256": "c3d5f6b9bf72e2f5964d0dbeff19e6c882c7dc0dd53da80595a282f5afffa5dc",
+      "size_bytes": 34797,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "ICN_VISUAL_SYSTEM.md",
       "path": "docs/design/ICN_VISUAL_SYSTEM.md",
       "role_guess": "documentation",
-      "sha256": "73e7b12a12269062e7c4136de76db5c00266bd761723ab42476ba329513caeb4",
-      "size_bytes": 12574,
+      "sha256": "3fb5727f077353fa95fd43a3335ed29f16233266e4be197a91c4879cb3b7603b",
+      "size_bytes": 13070,
       "symlink_target": null,
       "tracked": true
     },
@@ -15051,11 +16417,141 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "MUST_NOT_SHIP.md",
+      "path": "docs/design/MUST_NOT_SHIP.md",
+      "role_guess": "documentation",
+      "sha256": "447c8d9655a8cbce9db1c7dbd0448da7a71fb1a9f9485b8fb8b5a7949957d221",
+      "size_bytes": 14473,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md",
+      "path": "docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md",
+      "role_guess": "documentation",
+      "sha256": "204568910ecedbe8d4da52a2071f08b3e4a9d67ac70e6d0db3a49b6be99d71d0",
+      "size_bytes": 17265,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "README.md",
       "path": "docs/design/README.md",
       "role_guess": "documentation",
-      "sha256": "ad960da0179da832ef03754a3f1796663db1a6efd9c6a97f11b13db3877519cb",
-      "size_bytes": 3686,
+      "sha256": "da674eeed5b17d4cad608feb0a1a23d1d3e5feac1143c396d82975918553b075",
+      "size_bytes": 3853,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/assets",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ASSET_REGISTER.md",
+      "path": "docs/design/assets/ASSET_REGISTER.md",
+      "role_guess": "documentation",
+      "sha256": "31e3e7413fad0b251d95add95e219f8d69ba54eb314d875350c232d5d6628b28",
+      "size_bytes": 7078,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/assets",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "docs/design/assets/README.md",
+      "role_guess": "documentation",
+      "sha256": "4142a2cb3ce82bc9d497b1f55e666ada7d34677c1f8230b4ba50288810b8e4b4",
+      "size_bytes": 3551,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/assets",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "VISUAL_REVIEW_CHECKLIST.md",
+      "path": "docs/design/assets/VISUAL_REVIEW_CHECKLIST.md",
+      "role_guess": "documentation",
+      "sha256": "33cedda6c4088704b481169103579e1ddde3f17c80b59fc37269e23e67367f8c",
+      "size_bytes": 8128,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/assets/briefs",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "VE-001-how-icn-works-closure-loop.md",
+      "path": "docs/design/assets/briefs/VE-001-how-icn-works-closure-loop.md",
+      "role_guess": "documentation",
+      "sha256": "bc3c56b4c43e6ea27609c59b1a425840cd7a8930d47e6093ef3207db882d6c30",
+      "size_bytes": 6912,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/assets/briefs",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "VE-002-scope-model.md",
+      "path": "docs/design/assets/briefs/VE-002-scope-model.md",
+      "role_guess": "documentation",
+      "sha256": "aceeeb335a1368c71812410ae761d23be4494f1eae6f0ebcb65d4c29bdab2e3e",
+      "size_bytes": 5304,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/assets/briefs",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "VE-003-decision-to-receipt.md",
+      "path": "docs/design/assets/briefs/VE-003-decision-to-receipt.md",
+      "role_guess": "documentation",
+      "sha256": "1a737b97abe97789d8ba8220cd7e75f3e9f4070931609ae8e7db77ba21b3ba06",
+      "size_bytes": 5817,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/assets/briefs",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "VE-004-member-shell-concept.md",
+      "path": "docs/design/assets/briefs/VE-004-member-shell-concept.md",
+      "role_guess": "documentation",
+      "sha256": "448b13748eab6c7731db6498005fa9cebc3f9c6f44a922d815c9abfe317e6f9f",
+      "size_bytes": 7356,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/assets/briefs",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "VE-005-kernel-app-separation.md",
+      "path": "docs/design/assets/briefs/VE-005-kernel-app-separation.md",
+      "role_guess": "documentation",
+      "sha256": "0fa8e4622977743ac389161bf0e0cd34f625c76a2edcf589864c212f5fb72641",
+      "size_bytes": 7618,
       "symlink_target": null,
       "tracked": true
     },
@@ -15069,6 +16565,45 @@
       "role_guess": "documentation",
       "sha256": "8e7fb584d98eac35829e030c35d228e968d8acdf1335846f96a118decbdfc554",
       "size_bytes": 13493,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/claude-design-seed",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "CHANGELOG.md",
+      "path": "docs/design/claude-design-seed/CHANGELOG.md",
+      "role_guess": "documentation",
+      "sha256": "ad63f1ebbf23d650829cc2e55475f8cb314fee7b43ed4f9d35f2a774f629f8b7",
+      "size_bytes": 8464,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/claude-design-seed",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "docs/design/claude-design-seed/README.md",
+      "role_guess": "documentation",
+      "sha256": "b4de66395414a7f24ec8bc5fb345617747d0be13c40fa1013de294bc62810e88",
+      "size_bytes": 8643,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/claude-design-seed",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "REVIEW_NOTES.md",
+      "path": "docs/design/claude-design-seed/REVIEW_NOTES.md",
+      "role_guess": "documentation",
+      "sha256": "450cbe488ef88db7a54868e78977b86e1100a9db45183a4bcb38cd3225616163",
+      "size_bytes": 10568,
       "symlink_target": null,
       "tracked": true
     },
@@ -15311,6 +16846,19 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "decision-receipt-authority-and-grant-minting.md",
+      "path": "docs/design/governance/decision-receipt-authority-and-grant-minting.md",
+      "role_guess": "documentation",
+      "sha256": "d02a42bd4394a482d54123f715e83c0ca156447d77e1edb7d98a570fc5776c7b",
+      "size_bytes": 9954,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/governance",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "governance-primitives.md",
       "path": "docs/design/governance/governance-primitives.md",
       "role_guess": "documentation",
@@ -15324,11 +16872,37 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "governance-write-decomposition.md",
+      "path": "docs/design/governance/governance-write-decomposition.md",
+      "role_guess": "documentation",
+      "sha256": "262d8a24fc079405a7cf7a33dd0eae891e89f2b66d82681eaa069689bdb09332",
+      "size_bytes": 28453,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/governance",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "governance.md",
       "path": "docs/design/governance/governance.md",
       "role_guess": "documentation",
       "sha256": "9e59fe0264162e51bb5481ecba1f89b6344fbb994b9fb02880f8d8e32b5cc1df",
       "size_bytes": 29039,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/governance",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "mandate-gate-design.md",
+      "path": "docs/design/governance/mandate-gate-design.md",
+      "role_guess": "documentation",
+      "sha256": "b6a206eaa9d1e4146f1547cccac62bad2ed2771c61da4828428a63d0b61e9830",
+      "size_bytes": 18951,
       "symlink_target": null,
       "tracked": true
     },
@@ -15359,6 +16933,32 @@
       "tracked": true
     },
     {
+      "directory": "docs/design/icons",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "CANDIDATES.md",
+      "path": "docs/design/icons/CANDIDATES.md",
+      "role_guess": "documentation",
+      "sha256": "3084d298e6f6bf9b13bf4ed5f21cb67086ddfc97a4a0a5090f50eb8ce40c6c97",
+      "size_bytes": 14172,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design/icons",
+      "extension": ".svg",
+      "kind": "file",
+      "language": "unknown",
+      "name": "contact-sheet.svg",
+      "path": "docs/design/icons/contact-sheet.svg",
+      "role_guess": "documentation",
+      "sha256": "04a383ca6b7599fbf3e3596257cc0f8a747e8ee15e5f84b4e4d556c2643880ea",
+      "size_bytes": 20204,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "docs/design",
       "extension": ".md",
       "kind": "file",
@@ -15379,8 +16979,8 @@
       "name": "institutional-structure-spec.md",
       "path": "docs/design/institutional-structure-spec.md",
       "role_guess": "documentation",
-      "sha256": "3d263a4ad59691f339f03a4c01ee4079505ae21080459b081f86596409f8a6fb",
-      "size_bytes": 8541,
+      "sha256": "d0f2c3c22cec06ecdb68fb6a9b8682de998da9e152efe9465ba70182640101a8",
+      "size_bytes": 8606,
       "symlink_target": null,
       "tracked": true
     },
@@ -15420,6 +17020,19 @@
       "role_guess": "documentation",
       "sha256": "ac2a6fe15d22b3e3ce45a19813620e9266b9e4e06282c4f6dd0ebe9b240d8971",
       "size_bytes": 11493,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "passport-keyring-position-receipt.md",
+      "path": "docs/design/passport-keyring-position-receipt.md",
+      "role_guess": "documentation",
+      "sha256": "bd4df86f5afbcf1e12e95849b710fab4c539a76372048b35430a72605379c61a",
+      "size_bytes": 15627,
       "symlink_target": null,
       "tracked": true
     },
@@ -15567,6 +17180,32 @@
       "tracked": true
     },
     {
+      "directory": "docs/design",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "wallet-did-migration-boundary.md",
+      "path": "docs/design/wallet-did-migration-boundary.md",
+      "role_guess": "documentation",
+      "sha256": "f85f62b7ed559dd13f553cfe1215d07d81c01389f8ded21039da88c1599adad6",
+      "size_bytes": 16447,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "AGENT_WORKTREE_POLICY.md",
+      "path": "docs/dev/AGENT_WORKTREE_POLICY.md",
+      "role_guess": "documentation",
+      "sha256": "5df782798ee1db419445b3c8cea3709762c1f105139ca4f9f792dfc403f4e678",
+      "size_bytes": 4648,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "docs/dev",
       "extension": ".md",
       "kind": "file",
@@ -15574,34 +17213,8 @@
       "name": "HANDOFF_TEMPLATE.md",
       "path": "docs/dev/HANDOFF_TEMPLATE.md",
       "role_guess": "documentation",
-      "sha256": "5a5c324d1174ebf590aa5cd4c634956cb9c278b657d950c5c314962e3d81ae0d",
-      "size_bytes": 2705,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "docs/dev",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "NYCN_ACTION_ITEM_RECEIPT_PATH.md",
-      "path": "docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md",
-      "role_guess": "documentation",
-      "sha256": "219f9a8631573e71f7ff81a68217eb859e0c767a5feacffb961003cc60ab6545",
-      "size_bytes": 16866,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "docs/dev",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "NYCN_K3S_PROOF_PATH.md",
-      "path": "docs/dev/NYCN_K3S_PROOF_PATH.md",
-      "role_guess": "documentation",
-      "sha256": "5af096dbf78b8f1390c312988336ca4b650b3767f8a62c73fcb2182c21b20358",
-      "size_bytes": 21519,
+      "sha256": "d55f3b3f56b2ff384573619ca1310845dac54838ebb7d1cebe02e7b624492601",
+      "size_bytes": 2965,
       "symlink_target": null,
       "tracked": true
     },
@@ -15649,11 +17262,401 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "handoff-2026-05-05-b.md",
+      "path": "docs/dev/handoff-2026-05-05-b.md",
+      "role_guess": "documentation",
+      "sha256": "e5245132b6058d85a3f52542e66a4a6228af0ffdf055a7d9e2891b5cf273ae29",
+      "size_bytes": 18140,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-05-c.md",
+      "path": "docs/dev/handoff-2026-05-05-c.md",
+      "role_guess": "documentation",
+      "sha256": "1e15b735aeb274a1faa71f64f1573b24bda2af1b993e34d8e812090ff458705a",
+      "size_bytes": 21480,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-05.md",
+      "path": "docs/dev/handoff-2026-05-05.md",
+      "role_guess": "documentation",
+      "sha256": "68e3123bfd943f2e2421877977c3e970401c628ad608df63b120d471f1e9c049",
+      "size_bytes": 11930,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-07-a.md",
+      "path": "docs/dev/handoff-2026-05-07-a.md",
+      "role_guess": "documentation",
+      "sha256": "f42bdd46017cfef728d6df93b18f68f23f853b8a1f9e0adee5b053cbb0ec356d",
+      "size_bytes": 20978,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-07.md",
+      "path": "docs/dev/handoff-2026-05-07.md",
+      "role_guess": "documentation",
+      "sha256": "b108fcf19449aac59685032565a583225e6227448a083e5abcd811361b47cb50",
+      "size_bytes": 26305,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-14-artifact-registry-and-scoped-vault.md",
+      "path": "docs/dev/handoff-2026-05-14-artifact-registry-and-scoped-vault.md",
+      "role_guess": "documentation",
+      "sha256": "0c8002e1d7042cd6a3e6ba926e022a8b537ef51b5a12f221b180ba964f34f003",
+      "size_bytes": 22772,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-14-ccl-policy-registry.md",
+      "path": "docs/dev/handoff-2026-05-14-ccl-policy-registry.md",
+      "role_guess": "documentation",
+      "sha256": "1bb5e0bc2a88845df68a77760eab4e2b0c6315de637ab7c24c06135e4e07d797",
+      "size_bytes": 16484,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-14-commons-cloud-governance-spine.md",
+      "path": "docs/dev/handoff-2026-05-14-commons-cloud-governance-spine.md",
+      "role_guess": "documentation",
+      "sha256": "c73d7ab951fc18427e545d09218bd334863fba606ac207de63ff1a258e1bcc54",
+      "size_bytes": 21758,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-14-effect-dispatch-contract.md",
+      "path": "docs/dev/handoff-2026-05-14-effect-dispatch-contract.md",
+      "role_guess": "documentation",
+      "sha256": "848f7f33b299de8abe4a54eabfa01bbdc8236b889cfb9ce46bdbea02ea01ada3",
+      "size_bytes": 13054,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-14-entity-scope-vocabulary-boundary.md",
+      "path": "docs/dev/handoff-2026-05-14-entity-scope-vocabulary-boundary.md",
+      "role_guess": "documentation",
+      "sha256": "53e0c5423b2e95daf33d78e803c7feaf970f65d9b386635b299ba2b175e5f5e6",
+      "size_bytes": 26254,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-14-governed-service-binding.md",
+      "path": "docs/dev/handoff-2026-05-14-governed-service-binding.md",
+      "role_guess": "documentation",
+      "sha256": "195955f9f39edbb7df989501193bb5a18263e51c2c3e2d4530b4aab46a644a66",
+      "size_bytes": 16993,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-14-institutional-domain.md",
+      "path": "docs/dev/handoff-2026-05-14-institutional-domain.md",
+      "role_guess": "documentation",
+      "sha256": "154c9c503417404df34033bfdbfaf8d04cfd92187404190ca1cd27aeb9fff5d3",
+      "size_bytes": 14712,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-14-storage-durability-policies.md",
+      "path": "docs/dev/handoff-2026-05-14-storage-durability-policies.md",
+      "role_guess": "documentation",
+      "sha256": "f61374cf84cbd3496214dbb69f50982954ce59828f5ab4416b5807bc13bce84f",
+      "size_bytes": 18914,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-15-anti-entropy-probe-digest.md",
+      "path": "docs/dev/handoff-2026-05-15-anti-entropy-probe-digest.md",
+      "role_guess": "documentation",
+      "sha256": "5bab6cc72b709d4c9873e04d23e1fa7805def10a47547577c64eeb45e08ba38a",
+      "size_bytes": 17533,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-15-architecture-spec-sprint-wrap.md",
+      "path": "docs/dev/handoff-2026-05-15-architecture-spec-sprint-wrap.md",
+      "role_guess": "documentation",
+      "sha256": "7866a0ac820102e934c30f6b7fa368a4a69b3fe5d0e8aa29bd0aae08e461573c",
+      "size_bytes": 47566,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-15-compute-placement-policy.md",
+      "path": "docs/dev/handoff-2026-05-15-compute-placement-policy.md",
+      "role_guess": "documentation",
+      "sha256": "2b6f399c13c0b73f582669caf7ec103cef618543c6f817dc17612560edcb5a98",
+      "size_bytes": 29716,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-15-member-shell-v0.md",
+      "path": "docs/dev/handoff-2026-05-15-member-shell-v0.md",
+      "role_guess": "documentation",
+      "sha256": "9e6a61a1d1bf8bf564c49654f4a1f3e43dcfdac194001cf97501bd3979a6ead6",
+      "size_bytes": 30566,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-15-network-anti-entropy-proof-loops.md",
+      "path": "docs/dev/handoff-2026-05-15-network-anti-entropy-proof-loops.md",
+      "role_guess": "documentation",
+      "sha256": "7b25dd85f3b5aa526dbcea2ef11092fb4221ce916c161071ee5e0d822c9cdc59",
+      "size_bytes": 33933,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-15-steward-cockpit-v0.md",
+      "path": "docs/dev/handoff-2026-05-15-steward-cockpit-v0.md",
+      "role_guess": "documentation",
+      "sha256": "9ec08590b6c6a96772273ae472ee94a3313a58bd52a8ffe460888eb59db1e88b",
+      "size_bytes": 32218,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-16-abuse-case-hardening.md",
+      "path": "docs/dev/handoff-2026-05-16-abuse-case-hardening.md",
+      "role_guess": "documentation",
+      "sha256": "7aed0d1b2f0bd9596d306539c203315f1956427a47611d12c8346eb48c401ced",
+      "size_bytes": 18850,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-17-appliance-verification.md",
+      "path": "docs/dev/handoff-2026-05-17-appliance-verification.md",
+      "role_guess": "documentation",
+      "sha256": "46480a46f141e185a39530731889357141be51a30e497f3247ec287040f08913",
+      "size_bytes": 15803,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-17-thursday-meeting-prep.md",
+      "path": "docs/dev/handoff-2026-05-17-thursday-meeting-prep.md",
+      "role_guess": "documentation",
+      "sha256": "319818f51b85c5736b0bbcb7652cdd8c827c54699c1c827a6c5f89b0d48228f9",
+      "size_bytes": 9964,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-18-mackenzie-meeting-prep.md",
+      "path": "docs/dev/handoff-2026-05-18-mackenzie-meeting-prep.md",
+      "role_guess": "documentation",
+      "sha256": "b5a8823fd6d38077e08fb102b037036223a5f85cc3c1af3f062dcf0fdafb82aa",
+      "size_bytes": 7392,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-18-nycn-organizer-meeting-rehearsal.md",
+      "path": "docs/dev/handoff-2026-05-18-nycn-organizer-meeting-rehearsal.md",
+      "role_guess": "documentation",
+      "sha256": "86a50dd4c1f92981ec3ca144123c10393188e226db72293941da29fe1def3283",
+      "size_bytes": 11884,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-18-open-pr-cleanup-and-hardening-kickoff.md",
+      "path": "docs/dev/handoff-2026-05-18-open-pr-cleanup-and-hardening-kickoff.md",
+      "role_guess": "documentation",
+      "sha256": "7e56b08caaa199ecbc51c8c259dc8f5717725e36675e3fe34d8a4a609811e274",
+      "size_bytes": 9187,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-21-appliance-debian13-real-smoke.md",
+      "path": "docs/dev/handoff-2026-05-21-appliance-debian13-real-smoke.md",
+      "role_guess": "documentation",
+      "sha256": "ef57a02477f669ce3dfa398c1fd4c5da335b55f7cfd6f2f44e06cc9d932a9d05",
+      "size_bytes": 26140,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-05-22-current-state-and-next-plan.md",
+      "path": "docs/dev/handoff-2026-05-22-current-state-and-next-plan.md",
+      "role_guess": "documentation",
+      "sha256": "dc88cea6445bbf7045821f0de9a6a4097e444c09972187ffa8291e337eaccb67",
+      "size_bytes": 13629,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-06-10-appliance-negative-firstboot-smoke.md",
+      "path": "docs/dev/handoff-2026-06-10-appliance-negative-firstboot-smoke.md",
+      "role_guess": "documentation",
+      "sha256": "7e82098a5b41daab9d131f4c6471cffdf01ec8ede02322212ee522e3605eecb2",
+      "size_bytes": 11025,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "handoff-2026-06-10-truth-sync.md",
+      "path": "docs/dev/handoff-2026-06-10-truth-sync.md",
+      "role_guess": "documentation",
+      "sha256": "b98bb391eff0f009e52a0c6f4100bd236eb1cd5bc34ef3a3d1ba6ec78f301762",
+      "size_bytes": 6444,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "language-guide.md",
       "path": "docs/dev/language-guide.md",
       "role_guess": "documentation",
-      "sha256": "5a5ecd681f4766be33157e81f81c21dfd4339442c33ad22be77c6c5494ddf83f",
-      "size_bytes": 8225,
+      "sha256": "b08ded433f37a48a2d4caae72a27dded787f6b7282a15b517d02942f0ca3562c",
+      "size_bytes": 12393,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/dev",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "openapi-member-surface-gaps.md",
+      "path": "docs/dev/openapi-member-surface-gaps.md",
+      "role_guess": "documentation",
+      "sha256": "85c0d484def8bf4fe193d7ce753eda72717b62ce365e09100929f509dca5eff4",
+      "size_bytes": 6940,
       "symlink_target": null,
       "tracked": true
     },
@@ -16458,8 +18461,8 @@
       "name": "2025-12-14-session-handoff.md",
       "path": "docs/development/sessions/2025-12/2025-12-14-session-handoff.md",
       "role_guess": "documentation",
-      "sha256": "003a3e7ff8d7ef4621407071ffdde4ee82b5f827df8caf73d82df3b60e7176c9",
-      "size_bytes": 3287,
+      "sha256": "4f88ed9bb7662e557990e73705a973f21e0b8ec00ce4d8ff4b72ff1fb4ea49fe",
+      "size_bytes": 3102,
       "symlink_target": null,
       "tracked": true
     },
@@ -18239,8 +20242,8 @@
       "name": "freshness.toml",
       "path": "docs/freshness.toml",
       "role_guess": "documentation",
-      "sha256": "47aa8d396d6626733d9e10275a3776f9744c4eb8cf4e558be7d5b83f350f92b0",
-      "size_bytes": 7063,
+      "sha256": "1acdedabf33c8488b00d31f22833dce403537fe96f877c1b2fc5c4797e6a0cb5",
+      "size_bytes": 10972,
       "symlink_target": null,
       "tracked": true
     },
@@ -18265,8 +20268,8 @@
       "name": "glossary.md",
       "path": "docs/glossary.md",
       "role_guess": "documentation",
-      "sha256": "cd8dee048d5fbe26e983cafcb135d8b38bc352634f821ee9e0e3469e1c682e90",
-      "size_bytes": 19053,
+      "sha256": "2cd23a30bf8e6c4a4f1d40403d5c70d3dde6604b02523c9af8331c76c2fb284e",
+      "size_bytes": 21392,
       "symlink_target": null,
       "tracked": true
     },
@@ -18340,11 +20343,63 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "agent-context-spine-plan.md",
+      "path": "docs/guides/developer/agent-context-spine-plan.md",
+      "role_guess": "documentation",
+      "sha256": "1f63db04eaad11815428fc2ae5508ad760c65aabfec3851fce032bf3e977bafb",
+      "size_bytes": 7650,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/guides/developer",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "agent-context-spine.md",
+      "path": "docs/guides/developer/agent-context-spine.md",
+      "role_guess": "documentation",
+      "sha256": "be72a22c5b1b51c52396285861add7433183c955c6ba4005fc40fff721e1b5a8",
+      "size_bytes": 7410,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/guides/developer",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "agent-mcp-tooling.md",
+      "path": "docs/guides/developer/agent-mcp-tooling.md",
+      "role_guess": "documentation",
+      "sha256": "7d1dfb3c11e124f10e8aa23c80214b205fdb0cbeabfaed9a5bf434f2d2798e21",
+      "size_bytes": 9473,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/guides/developer",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "claude-code-plugin.md",
+      "path": "docs/guides/developer/claude-code-plugin.md",
+      "role_guess": "documentation",
+      "sha256": "e7e23f84ed8c95534bd3830234b83502c43993860e4fff5e35f4ebeb8e9f382a",
+      "size_bytes": 10794,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/guides/developer",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "cursor-mcp-setup.md",
       "path": "docs/guides/developer/cursor-mcp-setup.md",
       "role_guess": "documentation",
-      "sha256": "8b55a5168d00fa594ce1890e89a8e37e42a12ea923471434c21fe099abc91e7b",
-      "size_bytes": 3236,
+      "sha256": "75355079dccb7692cbcfbe94ba32c9ca560b2354f9222404fcfe1f10dd5c441d",
+      "size_bytes": 5091,
       "symlink_target": null,
       "tracked": true
     },
@@ -18369,8 +20424,8 @@
       "name": "institution-setup.md",
       "path": "docs/guides/institution-setup.md",
       "role_guess": "documentation",
-      "sha256": "5a95b8cb4338d51ef1f984e2cfd3180a34af838052ffa7ccf0587a28efc90f21",
-      "size_bytes": 10891,
+      "sha256": "2974ca3f2d5b2648b64c504d5c62b08725e52f710ab453cac0abc71d77dd23e6",
+      "size_bytes": 10812,
       "symlink_target": null,
       "tracked": true
     },
@@ -18713,6 +20768,19 @@
       "tracked": true
     },
     {
+      "directory": "docs/handoffs",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "open-pr-fanin-2026-05-11.md",
+      "path": "docs/handoffs/open-pr-fanin-2026-05-11.md",
+      "role_guess": "documentation",
+      "sha256": "b3abf3a79eb0ee94e11867a878d783c04a19e46180d0f24ac6a34b75ca3366d8",
+      "size_bytes": 10078,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "docs/internal",
       "extension": ".md",
       "kind": "file",
@@ -18977,6 +21045,97 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "FOUNDATIONAL_MANUAL_BASELINE_LOCK.md",
+      "path": "docs/manual/FOUNDATIONAL_MANUAL_BASELINE_LOCK.md",
+      "role_guess": "documentation",
+      "sha256": "acfa48edcf8b0d740640c15d89c380f3f9ecc3f2c73e8498f4bd3fe04ebe2364",
+      "size_bytes": 20583,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/manual",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "FOUNDATIONAL_MANUAL_BOUNDARY_TYPES.md",
+      "path": "docs/manual/FOUNDATIONAL_MANUAL_BOUNDARY_TYPES.md",
+      "role_guess": "documentation",
+      "sha256": "f80c752709935f2fadf5f0cc97f43993d2c88153c50d86737fdf3ebe4cea7a99",
+      "size_bytes": 6663,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/manual",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "FOUNDATIONAL_MANUAL_ECONOMIC_STATE_RESOLUTION.md",
+      "path": "docs/manual/FOUNDATIONAL_MANUAL_ECONOMIC_STATE_RESOLUTION.md",
+      "role_guess": "documentation",
+      "sha256": "17ec4ea0ecdc47b0cb7a02dc943ade861e1ad83ff0c8db23e8e8680330ab5d30",
+      "size_bytes": 15577,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/manual",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "FOUNDATIONAL_MANUAL_EXECUTABLE_BASELINE_LOOP.md",
+      "path": "docs/manual/FOUNDATIONAL_MANUAL_EXECUTABLE_BASELINE_LOOP.md",
+      "role_guess": "documentation",
+      "sha256": "69e5c746c467d727c5c6174da59c810f5dac0c46eadb40b0ddea88acf64ec43e",
+      "size_bytes": 19683,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/manual",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "FOUNDATIONAL_MANUAL_IDENTITY_RECOVERY_AND_CAPABILITIES.md",
+      "path": "docs/manual/FOUNDATIONAL_MANUAL_IDENTITY_RECOVERY_AND_CAPABILITIES.md",
+      "role_guess": "documentation",
+      "sha256": "419a6e3c968d071349ee78230a3bce8aafe49ba04de002045a0f4debfcc46f03",
+      "size_bytes": 21909,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/manual",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "FOUNDATIONAL_MANUAL_STATE_PROJECTION_AND_COMPACTION.md",
+      "path": "docs/manual/FOUNDATIONAL_MANUAL_STATE_PROJECTION_AND_COMPACTION.md",
+      "role_guess": "documentation",
+      "sha256": "683381ad402097ab4ea94353ee1c3bae3c124eafc90699feaa2539bea5746541",
+      "size_bytes": 14874,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/manual",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "FOUNDATIONAL_MANUAL_TRUSTLESS_CLIENT_BOUNDARY.md",
+      "path": "docs/manual/FOUNDATIONAL_MANUAL_TRUSTLESS_CLIENT_BOUNDARY.md",
+      "role_guess": "documentation",
+      "sha256": "9a410067dd672f42724df5e6805c9f21d48a5080d68e3b2ae16e8dbd50ecb30c",
+      "size_bytes": 14462,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/manual",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "ICN_USER_MANUAL.md",
       "path": "docs/manual/ICN_USER_MANUAL.md",
       "role_guess": "documentation",
@@ -19084,8 +21243,8 @@
       "name": "icn-mobile-ux-spec-v1.md",
       "path": "docs/mobile/icn-mobile-ux-spec-v1.md",
       "role_guess": "documentation",
-      "sha256": "3b3d332c97b73cb801f7b15d8388bb1faa788794c5e28089100a3cd05db889dd",
-      "size_bytes": 36093,
+      "sha256": "34cec5a05ba9244a111446704df9bc9202e8972a219d6aa0b0a50a0e115b3b25",
+      "size_bytes": 37478,
       "symlink_target": null,
       "tracked": true
     },
@@ -20020,8 +22179,8 @@
       "name": "MONITORING_VERIFICATION.md",
       "path": "docs/operations/deployment/MONITORING_VERIFICATION.md",
       "role_guess": "documentation",
-      "sha256": "3887113c72d54c29c851914df70c3f6d3bc21d611ae85bfe9a2dbb115d73e2c5",
-      "size_bytes": 13838,
+      "sha256": "3203991753da826db98f76f438f4f550840d87f8cc0dbee3626bbbe2f69942d2",
+      "size_bytes": 14215,
       "symlink_target": null,
       "tracked": true
     },
@@ -20069,11 +22228,37 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "FORGEJO_DEPLOYMENT_PLAN.md",
+      "path": "docs/ops/FORGEJO_DEPLOYMENT_PLAN.md",
+      "role_guess": "documentation",
+      "sha256": "3d488998150a68e1f5fd466efb71e3afd6730c1128ed31aa6550826303452cdf",
+      "size_bytes": 8924,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/ops",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "README.md",
       "path": "docs/ops/README.md",
       "role_guess": "documentation",
       "sha256": "7a007fc605b81d7a0d351737d77a52b911d0a6035b6e56668e0e18185b876e44",
       "size_bytes": 333,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/ops",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SERVICE_GOVERNANCE_TEMPLATE.md",
+      "path": "docs/ops/SERVICE_GOVERNANCE_TEMPLATE.md",
+      "role_guess": "documentation",
+      "sha256": "0e9752a40e2885d50821e853eb88111457b4ccf2617c67049be5e3f2b12e1a96",
+      "size_bytes": 6660,
       "symlink_target": null,
       "tracked": true
     },
@@ -20238,37 +22423,11 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
-      "name": "nycn-boundary-brief.md",
-      "path": "docs/pilots/nycn-boundary-brief.md",
+      "name": "no-cli-organizer-member-rehearsal-workflow.md",
+      "path": "docs/pilots/no-cli-organizer-member-rehearsal-workflow.md",
       "role_guess": "documentation",
-      "sha256": "92af77b3ae4d19982675d2ef207b9622ac745158ceb29388bdddce80c216a0b3",
-      "size_bytes": 9474,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "docs/pilots",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "nycn-demo-script.md",
-      "path": "docs/pilots/nycn-demo-script.md",
-      "role_guess": "documentation",
-      "sha256": "20aa726aba085e9a5851520c4bbb5f94a51b40801fad2f3be70d92705eed6f33",
-      "size_bytes": 10106,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "docs/pilots",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "nycn-organizer-asks.md",
-      "path": "docs/pilots/nycn-organizer-asks.md",
-      "role_guess": "documentation",
-      "sha256": "341197fb521b07f5219742f5665a6f45d13ec35ff8ab7d8b1cfc5ef4771b7448",
-      "size_bytes": 9601,
+      "sha256": "d8a8eb32d1b66bc9060aa50af9fb2d3f00f4b43e1656a03177834a98b58da7b8",
+      "size_bytes": 14212,
       "symlink_target": null,
       "tracked": true
     },
@@ -20319,8 +22478,8 @@
       "name": "icn-crate-reference.md",
       "path": "docs/planning/icn-crate-reference.md",
       "role_guess": "documentation",
-      "sha256": "96c871297c482393b9cbe7d81fc59debcd539b5c4a457de506525747064ac25b",
-      "size_bytes": 25176,
+      "sha256": "44278a69f1c91c5d2579bde30f37656fd50d575e2f14bd2c02c7360770a2692d",
+      "size_bytes": 25217,
       "symlink_target": null,
       "tracked": true
     },
@@ -20371,8 +22530,8 @@
       "name": "icn-vertical-slice-assessment.md",
       "path": "docs/planning/icn-vertical-slice-assessment.md",
       "role_guess": "documentation",
-      "sha256": "6e7335c35509b97f54c603b3029b20c546b3e75d880698155a9574bdbd7db514",
-      "size_bytes": 16314,
+      "sha256": "0ea0a90f205555a9745910205466fce6f90f2ddb59cfc9ec2cf824d7a78497ee",
+      "size_bytes": 16793,
       "symlink_target": null,
       "tracked": true
     },
@@ -20592,8 +22751,8 @@
       "name": "agent-teams-launch-prompt.md",
       "path": "docs/plans/agent-teams-launch-prompt.md",
       "role_guess": "documentation",
-      "sha256": "472d28d22531f71e9f85cfab52bb3da97357276029aac3a3a2dd37c6aae60d93",
-      "size_bytes": 15002,
+      "sha256": "11ef2712f116446c4752100d29a4805adf4da1cbfab6cfa5ed32de050b6fcdc3",
+      "size_bytes": 15195,
       "symlink_target": null,
       "tracked": true
     },
@@ -20774,8 +22933,21 @@
       "name": "README.md",
       "path": "docs/reference/project-index/README.md",
       "role_guess": "project index / atlas",
-      "sha256": "f0cae4c5e3e260e6c75f2460b73bfab577dd3d7432250644f71620fd7b4c37bf",
-      "size_bytes": 5834,
+      "sha256": "b2da92bf909d786ae76eacca13df4a7618f78c60699ecf33054ff09b3844d97a",
+      "size_bytes": 10895,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ccl-map.md",
+      "path": "docs/reference/project-index/ccl-map.md",
+      "role_guess": "project index / atlas",
+      "sha256": "d5a5b36ebf53ce8b185e0d23a04af55dff0d08c4e0738db66e6ab6ef2b4f984e",
+      "size_bytes": 4809,
       "symlink_target": null,
       "tracked": true
     },
@@ -20787,8 +22959,8 @@
       "name": "ci-ops-deploy-map.md",
       "path": "docs/reference/project-index/ci-ops-deploy-map.md",
       "role_guess": "project index / atlas",
-      "sha256": "f446fe85cd2e99cd566ad460eba4f6352e7fe3213132bbcd564628d9ac897566",
-      "size_bytes": 6918,
+      "sha256": "75d672049f162c4ea1b5fc205f4842d1a7d732fcec7c9b64b3486357d53133e6",
+      "size_bytes": 7404,
       "symlink_target": null,
       "tracked": true
     },
@@ -20800,8 +22972,8 @@
       "name": "current-truth-map.md",
       "path": "docs/reference/project-index/current-truth-map.md",
       "role_guess": "project index / atlas",
-      "sha256": "1788b1be52347a27f3e8beec4e50af78cc5cbca291ce292e5fc036008bf46e3e",
-      "size_bytes": 6250,
+      "sha256": "57b26f5d7ed0846ebf690db55b5dcf9fd64eae7ed09793df25f7cb21bef2c2fe",
+      "size_bytes": 6143,
       "symlink_target": null,
       "tracked": true
     },
@@ -20832,15 +23004,132 @@
       "tracked": true
     },
     {
+      "directory": "docs/reference/project-index/generated",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "agent-context-spine.json",
+      "path": "docs/reference/project-index/generated/agent-context-spine.json",
+      "role_guess": "project index / atlas",
+      "sha256": "a68345f938a12c782befa3e4fa1c597068c9911537aaaa5c599bed9d63ff6e57",
+      "size_bytes": 106372,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index/generated",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "icn-file-record.json",
+      "path": "docs/reference/project-index/generated/icn-file-record.json",
+      "role_guess": "project index / atlas",
+      "sha256": "cf7c2b7e6c389a6adec7f68dfd68cfeeb0824add14fa9e5c2656b80a49fb2f74",
+      "size_bytes": 1350034,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index/generated",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "icn-file-record.md",
+      "path": "docs/reference/project-index/generated/icn-file-record.md",
+      "role_guess": "project index / atlas",
+      "sha256": "3b9cf01f4205225e78ebfcfb81cabd6ecdb5a7457bc1205b92d71aa9b4b2c480",
+      "size_bytes": 464970,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index/generated",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "route-inventory.md",
+      "path": "docs/reference/project-index/generated/route-inventory.md",
+      "role_guess": "project index / atlas",
+      "sha256": "9298458ceb36c2a253a982be6e0136699fc9a0262fdcbfc3c0d616db828de6ae",
+      "size_bytes": 76341,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "docs/reference/project-index",
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
-      "name": "pilot-and-nycn-map.md",
-      "path": "docs/reference/project-index/pilot-and-nycn-map.md",
+      "name": "identity-crypto-map.md",
+      "path": "docs/reference/project-index/identity-crypto-map.md",
       "role_guess": "project index / atlas",
-      "sha256": "c20cd1257a54c935e291e5e964d44ebdc611231928240353bc9fb9bcb2a663da",
-      "size_bytes": 6693,
+      "sha256": "cffd912bd654b76ee514ab3a3a574e44adeec3e7a953de89e4adfcfe5ebac828",
+      "size_bytes": 5006,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "network-gossip-map.md",
+      "path": "docs/reference/project-index/network-gossip-map.md",
+      "role_guess": "project index / atlas",
+      "sha256": "2b4269277bcc2291b85f66a676eb1d382359f8d2e73b3af4c69eb32ee02ce117",
+      "size_bytes": 6833,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "pilot-ui-current-state-map.md",
+      "path": "docs/reference/project-index/pilot-ui-current-state-map.md",
+      "role_guess": "project index / atlas",
+      "sha256": "6657b47f6cddf503b39c1c0939127e7a71f5f2ddfae4385fba09081f8b35c4c1",
+      "size_bytes": 4777,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "project-coverage-matrix.md",
+      "path": "docs/reference/project-index/project-coverage-matrix.md",
+      "role_guess": "project index / atlas",
+      "sha256": "573d6ddbe32e89a6e35cf30b5ea4e151321a4a0e34af2ef1d5fe49d0897b6f07",
+      "size_bytes": 14971,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "proof-level-taxonomy-capability-matrix.md",
+      "path": "docs/reference/project-index/proof-level-taxonomy-capability-matrix.md",
+      "role_guess": "project index / atlas",
+      "sha256": "e57f919f70df3299b162b5058ebbdff7cc6dc65b4ab461ee8ca1f0a95a4307c0",
+      "size_bytes": 22249,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "remote-work-plan.md",
+      "path": "docs/reference/project-index/remote-work-plan.md",
+      "role_guess": "project index / atlas",
+      "sha256": "090c23f7c6f86b661615e6b999a11fb2584ad89b26bdfc11fde4dc12b42ccdfc",
+      "size_bytes": 1935,
       "symlink_target": null,
       "tracked": true
     },
@@ -20862,11 +23151,24 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "repository-map.md",
+      "path": "docs/reference/project-index/repository-map.md",
+      "role_guess": "project index / atlas",
+      "sha256": "364afe68002cda1520e891807dd9d650f6651112bacff214ce57f1587ed3da1f",
+      "size_bytes": 5833,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "runtime-surface-map.md",
       "path": "docs/reference/project-index/runtime-surface-map.md",
       "role_guess": "project index / atlas",
-      "sha256": "4c659b71a3aa3980aeb1c9b5431f4429caedcf84c612b374da9292b6a4259891",
-      "size_bytes": 7495,
+      "sha256": "154f524464e4cf4fda7c76f8147aae5aa9545ce6490bdfd45d3510b0278bca79",
+      "size_bytes": 11267,
       "symlink_target": null,
       "tracked": true
     },
@@ -20888,6 +23190,19 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "service-hosting-map.md",
+      "path": "docs/reference/project-index/service-hosting-map.md",
+      "role_guess": "project index / atlas",
+      "sha256": "3058ab04e6d21e55d29ea65173b333a6bc9d707d1e6ed49c2be83b01e59c8d2c",
+      "size_bytes": 5340,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "show-readiness-map.md",
       "path": "docs/reference/project-index/show-readiness-map.md",
       "role_guess": "project index / atlas",
@@ -20901,11 +23216,63 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "source-of-truth-map.md",
+      "path": "docs/reference/project-index/source-of-truth-map.md",
+      "role_guess": "project index / atlas",
+      "sha256": "86a7f1298cd6c16168508233d1e931b797f56121b803124c88dfe22bf3aa5b79",
+      "size_bytes": 9824,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "source-tree-map.md",
       "path": "docs/reference/project-index/source-tree-map.md",
       "role_guess": "project index / atlas",
-      "sha256": "5d986771d0cff362baa39053b2e448d31dabb9023ad0908e71df05e910875222",
-      "size_bytes": 6044,
+      "sha256": "3eec9a5e92948cc67093ddac43310e5bef5be3b7dbd07a28f1369ee8f7fddbd6",
+      "size_bytes": 6084,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "stale-and-archived-map.md",
+      "path": "docs/reference/project-index/stale-and-archived-map.md",
+      "role_guess": "project index / atlas",
+      "sha256": "df2487b6062c051c08afe0bbfd45c9979630dc412321b47212314aba44216320",
+      "size_bytes": 4967,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "tool-commons-map.md",
+      "path": "docs/reference/project-index/tool-commons-map.md",
+      "role_guess": "project index / atlas",
+      "sha256": "82b53c42f5b7b22e856b4f45ec0b1c78ff08ace40beedbab56e541d72c5c1d8d",
+      "size_bytes": 6015,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/reference/project-index",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "website-truth-map.md",
+      "path": "docs/reference/project-index/website-truth-map.md",
+      "role_guess": "project index / atlas",
+      "sha256": "4737cbee0ab9a1e860eb55bc0e4f344ffe750a813c490ef05843b11f1e85282d",
+      "size_bytes": 4785,
       "symlink_target": null,
       "tracked": true
     },
@@ -20917,8 +23284,8 @@
       "name": "registry.toml",
       "path": "docs/registry.toml",
       "role_guess": "documentation",
-      "sha256": "1e96df2049a5114bc58777693f091ce3d448783b8e0a8dba0be29476553a756a",
-      "size_bytes": 111804,
+      "sha256": "d583b268217bade099ba349c8c382c8697bdcb66de374b864400e1f8d76f6601",
+      "size_bytes": 167435,
       "symlink_target": null,
       "tracked": true
     },
@@ -20930,8 +23297,8 @@
       "name": "README.md",
       "path": "docs/rfcs/README.md",
       "role_guess": "request for comments",
-      "sha256": "33897ef7c0a9f03d7e5b784ca01d51db08d42606cd73d4131d073ff0f5f22e06",
-      "size_bytes": 4884,
+      "sha256": "cf109b12e3c96f1940cd8b54303c4bcba9bfc0cd705a9df83b295625947a5e37",
+      "size_bytes": 5324,
       "symlink_target": null,
       "tracked": true
     },
@@ -21005,11 +23372,24 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "RFC-0018-entity-aware-request-authorization.md",
+      "path": "docs/rfcs/RFC-0018-entity-aware-request-authorization.md",
+      "role_guess": "request for comments",
+      "sha256": "17aac64560ebced6c9ce2ea5712febff28707a3b9a4eebdaee514c3464732baa",
+      "size_bytes": 24082,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/rfcs",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "template.md",
       "path": "docs/rfcs/template.md",
       "role_guess": "request for comments",
-      "sha256": "88993eecb74db28584bfcf8a07bdb589125dbb00f026c64663a71bc7d0978d76",
-      "size_bytes": 6716,
+      "sha256": "6f7dfc65cb155b280902f70ad65eb2956d63811f8dfa0666f9f94262b8d7c917",
+      "size_bytes": 6966,
       "symlink_target": null,
       "tracked": true
     },
@@ -21062,6 +23442,71 @@
       "role_guess": "documentation",
       "sha256": "daa9e01015f6af7b8aebe94671593a54b0913134b144a7b6075c57d21d553532",
       "size_bytes": 9293,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "route_inventory.py",
+      "path": "docs/scripts/route_inventory.py",
+      "role_guess": "documentation",
+      "sha256": "c8316e636befbccfb4953eb9696fa926bf32d0742b297dbabe676c85aefbb2a8",
+      "size_bytes": 26456,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "validate-action-card.py",
+      "path": "docs/scripts/validate-action-card.py",
+      "role_guess": "documentation",
+      "sha256": "7782806b1f6c6db578dc9d8b0c0171394c05064c616db76af690d7c554e237b8",
+      "size_bytes": 5778,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "validate-preview-review.py",
+      "path": "docs/scripts/validate-preview-review.py",
+      "role_guess": "documentation",
+      "sha256": "e03079bffa878602f8a1f6fe31a2fa22b122e92a5c026a2cc67ab4451c0235bd",
+      "size_bytes": 5911,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "validate-rehearsal-evidence.py",
+      "path": "docs/scripts/validate-rehearsal-evidence.py",
+      "role_guess": "documentation",
+      "sha256": "4283d40fa78962cd70585655d91493dbf50165b377cf44c169e3aa5ae6892e81",
+      "size_bytes": 3245,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "validate-rehearsal-shell-fixtures.py",
+      "path": "docs/scripts/validate-rehearsal-shell-fixtures.py",
+      "role_guess": "documentation",
+      "sha256": "f6244bc1d9c3c748c2b4cbb8dd2ad7be5de36c73af573e9a421cd045d6e5eaa9",
+      "size_bytes": 12558,
       "symlink_target": null,
       "tracked": true
     },
@@ -21512,11 +23957,193 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "artifact-registry-and-scoped-vault.md",
+      "path": "docs/spec/artifact-registry-and-scoped-vault.md",
+      "role_guess": "documentation",
+      "sha256": "534cc1e69c4f732f80ec087b5cea9488bc4c46a42e230f2d6641a4c55536d701",
+      "size_bytes": 40946,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ccl-policy-registry.md",
+      "path": "docs/spec/ccl-policy-registry.md",
+      "role_guess": "documentation",
+      "sha256": "1ad90bfbde1d0894f8d0ae20ad5a06c46dcb9742b7d2f49230e64bfd81a1b1d0",
+      "size_bytes": 31095,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "community-proof-spine-0.1.md",
+      "path": "docs/spec/community-proof-spine-0.1.md",
+      "role_guess": "documentation",
+      "sha256": "1e1fb6a1419b322a5dd8c620efd6c1d86e1663422e89fbd6eb997b9c4296554e",
+      "size_bytes": 4248,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "compute-placement-policy.md",
+      "path": "docs/spec/compute-placement-policy.md",
+      "role_guess": "documentation",
+      "sha256": "0c2bf89b907314af12dc54ecb900be6cfb3a2e38cdabe69f5d20d7a432adf698",
+      "size_bytes": 42980,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "effect-dispatch-contract.md",
+      "path": "docs/spec/effect-dispatch-contract.md",
+      "role_guess": "documentation",
+      "sha256": "606185463032c118419bb2a66453676be573215b476e38406ba476a57faf24ab",
+      "size_bytes": 32302,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "federation-settlement-finality.md",
       "path": "docs/spec/federation-settlement-finality.md",
       "role_guess": "documentation",
       "sha256": "7185d61adca2106ff75548ce8becd1b148fa74144d500e175e1edead98d24368",
       "size_bytes": 8994,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "governed-service-binding.md",
+      "path": "docs/spec/governed-service-binding.md",
+      "role_guess": "documentation",
+      "sha256": "58cf2f6325811a8e3ec6fedf0e69de3405eb8ed0d2e897cb0cd5b709f76559bb",
+      "size_bytes": 34764,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "icn-civic-shell-v0.md",
+      "path": "docs/spec/icn-civic-shell-v0.md",
+      "role_guess": "documentation",
+      "sha256": "1fe0173f124546f8bf56065c5b72f5656792f2985e227b668d0531572fdb48d7",
+      "size_bytes": 20994,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "institutional-domain.md",
+      "path": "docs/spec/institutional-domain.md",
+      "role_guess": "documentation",
+      "sha256": "38aecb4974296b76c700dcafc856e6d3a94938e4b1b33024da706116ed563df4",
+      "size_bytes": 31503,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "member-shell-i18n-v0.md",
+      "path": "docs/spec/member-shell-i18n-v0.md",
+      "role_guess": "documentation",
+      "sha256": "bad089b0005913ccf6c76e4cecd7f957981d12f2a3586b6050acb756f7905268",
+      "size_bytes": 8575,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "member-shell-v0.md",
+      "path": "docs/spec/member-shell-v0.md",
+      "role_guess": "documentation",
+      "sha256": "6605394ad9c6cffcd41f43cc71519a840abb3d9c901681f65bbbddcedefb30b5",
+      "size_bytes": 49126,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "network-anti-entropy-proof-loops.md",
+      "path": "docs/spec/network-anti-entropy-proof-loops.md",
+      "role_guess": "documentation",
+      "sha256": "c739881e62365275fdb1a31695d838c5257bac5d8de20a751cd61f94957c98b1",
+      "size_bytes": 58756,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "private-overlay-did-activation-flow.md",
+      "path": "docs/spec/private-overlay-did-activation-flow.md",
+      "role_guess": "documentation",
+      "sha256": "e5d59ab6015933b169780d97632db4b2c41b672c13d24a80b2fc43f8e8f83ca6",
+      "size_bytes": 20791,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "steward-cockpit-v0.md",
+      "path": "docs/spec/steward-cockpit-v0.md",
+      "role_guess": "documentation",
+      "sha256": "f7443f6c0981d62c18cda3dab83981bbe6f70a74f53ef976ed8c2ef9684445f7",
+      "size_bytes": 54364,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/spec",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "storage-durability-policies.md",
+      "path": "docs/spec/storage-durability-policies.md",
+      "role_guess": "documentation",
+      "sha256": "b499973200c2b465c4e4626991daf32ffc91f3daea413e43246fa3a5c48ec2fc",
+      "size_bytes": 44481,
       "symlink_target": null,
       "tracked": true
     },
@@ -21580,8 +24207,8 @@
       "name": "status.toml",
       "path": "docs/status.toml",
       "role_guess": "documentation",
-      "sha256": "356bfbc01b6c1d8bc9103de21ab1da6d978956f45d3b1fcd7610a429a3ec386d",
-      "size_bytes": 8299,
+      "sha256": "62fedac7e7e9662d0d28613a257307db9a10189d44d13eba772038f59b97b2e5",
+      "size_bytes": 14153,
       "symlink_target": null,
       "tracked": true
     },
@@ -21668,11 +24295,154 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
+      "name": "COOPERATIVE_CODEBASE_MEETING_BRIEF_2026-06-11.md",
+      "path": "docs/strategy/COOPERATIVE_CODEBASE_MEETING_BRIEF_2026-06-11.md",
+      "role_guess": "documentation",
+      "sha256": "1dadd9cc5e1f81ff46843d71d8c06913e5d6d1d830ff530d2d46164d010fa00a",
+      "size_bytes": 9846,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
       "name": "COOPERATIVE_DEVELOPER_DISCOVERY_BRIEF.md",
       "path": "docs/strategy/COOPERATIVE_DEVELOPER_DISCOVERY_BRIEF.md",
       "role_guess": "documentation",
       "sha256": "94e8ed795d8682a7b566f58a7dec34e81ac4e199a0480d795d7252979bee2de3",
       "size_bytes": 9848,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_MEETING_PREP_2026-05-21.md",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_MEETING_PREP_2026-05-21.md",
+      "role_guess": "documentation",
+      "sha256": "360029bbac59cbe96709f5e7a014f75525b6cf61121f8a584d66b6076a3413c3",
+      "size_bytes": 17910,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".pdf",
+      "kind": "file",
+      "language": "unknown",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_MEETING_PREP_2026-05-21.pdf",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_MEETING_PREP_2026-05-21.pdf",
+      "role_guess": "documentation",
+      "sha256": "e846592f5c147c2160a885f864a95214e800087d15d5db9f9dfc122db855ebd1",
+      "size_bytes": 165389,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_ONE_PAGE_AID_2026-05-21.md",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_ONE_PAGE_AID_2026-05-21.md",
+      "role_guess": "documentation",
+      "sha256": "7f78a97233d4b1d14947c1dbbb40244fc8dc79fcf04b530ced8f2ceb68c5eb64",
+      "size_bytes": 31589,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".pdf",
+      "kind": "file",
+      "language": "unknown",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_ONE_PAGE_AID_2026-05-21.pdf",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_ONE_PAGE_AID_2026-05-21.pdf",
+      "role_guess": "documentation",
+      "sha256": "cbf34c66e5a49ddf0d27a7a4f049c04500ad8fbcd2335fec52af2a595a20ed6c",
+      "size_bytes": 242607,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".html",
+      "kind": "file",
+      "language": "HTML",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.html",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.html",
+      "role_guess": "documentation",
+      "sha256": "c5c20445e3fb4f484049830b14caa39b109e8a4757d53d59b9d2b77d829d8cd8",
+      "size_bytes": 19189,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.md",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.md",
+      "role_guess": "documentation",
+      "sha256": "bcbacb3c29084c8be91ce2fcafa0fbc32852398cd3086ee87ea06763c0eb9197",
+      "size_bytes": 11555,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".pdf",
+      "kind": "file",
+      "language": "unknown",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.pdf",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.pdf",
+      "role_guess": "documentation",
+      "sha256": "f0c3225f516d1efeea345f4b2c4217a393b9c6b676ba881faaa509cc416e503f",
+      "size_bytes": 179584,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".pptx",
+      "kind": "file",
+      "language": "unknown",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.pptx",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.pptx",
+      "role_guess": "documentation",
+      "sha256": "9ce29f3a9ddeae3e50f68b43173d404c8279d6e82f08ed19ec7559e2b521081b",
+      "size_bytes": 172986,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".html",
+      "kind": "file",
+      "language": "HTML",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_VISUAL_AID_2026-05-21.html",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_VISUAL_AID_2026-05-21.html",
+      "role_guess": "documentation",
+      "sha256": "b192fc6759b79753b8032ac711611deeaa6069e2c26247aa723e629e0a982e53",
+      "size_bytes": 24742,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".pdf",
+      "kind": "file",
+      "language": "unknown",
+      "name": "COOPERATIVE_FORMATION_PLATFORM_VISUAL_AID_2026-05-21.pdf",
+      "path": "docs/strategy/COOPERATIVE_FORMATION_PLATFORM_VISUAL_AID_2026-05-21.pdf",
+      "role_guess": "documentation",
+      "sha256": "8d434494eb2e798e9a40a9daf229b3713bb56e18ade29a8a41f042eb16727a8c",
+      "size_bytes": 275703,
       "symlink_target": null,
       "tracked": true
     },
@@ -21749,7 +24519,7 @@
       "name": "ICN-Roadmap-Live.md",
       "path": "docs/strategy/ICN-Roadmap-Live.md",
       "role_guess": "documentation",
-      "sha256": "e3b272fde76dd47720a1ec58627c4da1ffde85a618ac658bb357689a024ca29a",
+      "sha256": "87e5440fa4e8dbdcc2d2e76a71d2667be532f9ad92ed2b0d525c473d4454f1ad",
       "size_bytes": 10737,
       "symlink_target": null,
       "tracked": true
@@ -21801,8 +24571,8 @@
       "name": "ICN-Technical-Whitepaper.md",
       "path": "docs/strategy/ICN-Technical-Whitepaper.md",
       "role_guess": "documentation",
-      "sha256": "291ba9a304ae2cfd5a3b93b864c12cdd56d4813d77046c0bbdca0ad5760aeefb",
-      "size_bytes": 18885,
+      "sha256": "9e1a4c75d31d24a273e181b7b5e220027ad12566d2d9159e855fd20358b6af85",
+      "size_bytes": 19043,
       "symlink_target": null,
       "tracked": true
     },
@@ -21816,6 +24586,110 @@
       "role_guess": "documentation",
       "sha256": "18f07c593eb63c02c64311dfe32a8faa8679411bba971018227b9a10d5410a74",
       "size_bytes": 17872,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ICN_FOR_COOPERATIVE_MOVEMENT.md",
+      "path": "docs/strategy/ICN_FOR_COOPERATIVE_MOVEMENT.md",
+      "role_guess": "documentation",
+      "sha256": "676040e559e926c1c6514344b6b1ae68262f043bb1451269f8312fbf6dfce7dd",
+      "size_bytes": 22865,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ICN_FOR_EVERYONE.md",
+      "path": "docs/strategy/ICN_FOR_EVERYONE.md",
+      "role_guess": "documentation",
+      "sha256": "5a9bed8d22cef1104ef398b054119221b9595f2a5d88f6d6909e6c2f3dba3ef2",
+      "size_bytes": 18902,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ICN_HANDBILL.md",
+      "path": "docs/strategy/ICN_HANDBILL.md",
+      "role_guess": "documentation",
+      "sha256": "2f3585e6ca67d57311ebf519038c00d712f8ad2dbbebe1712760209eff1e5df7",
+      "size_bytes": 1752,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ICN_HARD_QUESTIONS.md",
+      "path": "docs/strategy/ICN_HARD_QUESTIONS.md",
+      "role_guess": "documentation",
+      "sha256": "82a0b20aedd37c1b7afe93b10a8c9ea886ef4d3e829b525dfe235bff05c10e8e",
+      "size_bytes": 13440,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ICN_INTRODUCTION_EVIDENCE_MAP.md",
+      "path": "docs/strategy/ICN_INTRODUCTION_EVIDENCE_MAP.md",
+      "role_guess": "documentation",
+      "sha256": "18eaa42e5b7068747907eb0328a97354bfa4c51fed98697b3fd12ecdcfe43b01",
+      "size_bytes": 9570,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md",
+      "path": "docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md",
+      "role_guess": "documentation",
+      "sha256": "dca97a938d2a1d259a279706989976f70e78a25abc7a7da1d420df607734c993",
+      "size_bytes": 7346,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "ICN_THURSDAY_MEETING_BRIEF_2026-05-21.md",
+      "path": "docs/strategy/ICN_THURSDAY_MEETING_BRIEF_2026-05-21.md",
+      "role_guess": "documentation",
+      "sha256": "fb708ad47186c1c325c5b9068f3c0655ba732b297b552b55c2575482eb176005",
+      "size_bytes": 26033,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "LICENSING_STRATEGY_MATRIX.md",
+      "path": "docs/strategy/LICENSING_STRATEGY_MATRIX.md",
+      "role_guess": "documentation",
+      "sha256": "116798f025909f3fc1bb1a843a89bcd3c929c81693e7b657de9cfe32908c7ff7",
+      "size_bytes": 24793,
       "symlink_target": null,
       "tracked": true
     },
@@ -21837,11 +24711,11 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
-      "name": "NYCN-Execution-Tranches.md",
-      "path": "docs/strategy/NYCN-Execution-Tranches.md",
+      "name": "NYCN_ORGANIZER_MEETING_ONE_PAGE_AID_2026-05-21.md",
+      "path": "docs/strategy/NYCN_ORGANIZER_MEETING_ONE_PAGE_AID_2026-05-21.md",
       "role_guess": "documentation",
-      "sha256": "836b2a4b7b4291decc3839347a7d097f24f5024738cca2e953fc91ce05cf9ad7",
-      "size_bytes": 22975,
+      "sha256": "c3e4f4e2a3a75536111d5f19be65d859e52b7db59d8a69994faff6821f865f9c",
+      "size_bytes": 1698,
       "symlink_target": null,
       "tracked": true
     },
@@ -21850,11 +24724,37 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
-      "name": "NYCN-Implementation-Matrix.md",
-      "path": "docs/strategy/NYCN-Implementation-Matrix.md",
+      "name": "NYCN_ORGANIZER_MEETING_PREP_2026-05-21.md",
+      "path": "docs/strategy/NYCN_ORGANIZER_MEETING_PREP_2026-05-21.md",
       "role_guess": "documentation",
-      "sha256": "bdd067270cb237eb533679eadb48d2f00cb21f5ed87f03e614d8492e481bb030",
-      "size_bytes": 33442,
+      "sha256": "d0232d7e0aeb7c0c93e1fae5ba943efa97f6a229e05c675342e9d7e0def77af4",
+      "size_bytes": 25908,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".html",
+      "kind": "file",
+      "language": "HTML",
+      "name": "NYCN_ORGANIZER_MEETING_VISUAL_AID_2026-05-21.html",
+      "path": "docs/strategy/NYCN_ORGANIZER_MEETING_VISUAL_AID_2026-05-21.html",
+      "role_guess": "documentation",
+      "sha256": "6fb13ae2b83ac9f2aa198cd3733a82da391285343edebf04012bc83c73a26f8a",
+      "size_bytes": 20194,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/strategy",
+      "extension": ".pdf",
+      "kind": "file",
+      "language": "unknown",
+      "name": "NYCN_ORGANIZER_MEETING_VISUAL_AID_2026-05-21.pdf",
+      "path": "docs/strategy/NYCN_ORGANIZER_MEETING_VISUAL_AID_2026-05-21.pdf",
+      "role_guess": "documentation",
+      "sha256": "59ce5d83c2445931970abfc7818e4a77f0727ef3884a42c45e3ee0b10ec3c233",
+      "size_bytes": 14782,
       "symlink_target": null,
       "tracked": true
     },
@@ -21863,11 +24763,11 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
-      "name": "NYCN-Implementation-Plan.md",
-      "path": "docs/strategy/NYCN-Implementation-Plan.md",
+      "name": "NYCN_SUMMIT_REFERENCE_INSTITUTION_STRATEGY.md",
+      "path": "docs/strategy/NYCN_SUMMIT_REFERENCE_INSTITUTION_STRATEGY.md",
       "role_guess": "documentation",
-      "sha256": "255028adeed75ad8cbe1501d8c1d94af1d3d0b0b5851945be0a61f44a1d24ac0",
-      "size_bytes": 16524,
+      "sha256": "6d6b630a3e1c912c5aa20d994840343e3ee42a67f583bd99e6f9068ae08f124c",
+      "size_bytes": 12899,
       "symlink_target": null,
       "tracked": true
     },
@@ -21876,50 +24776,11 @@
       "extension": ".md",
       "kind": "file",
       "language": "Markdown",
-      "name": "NYCN-Institutional-Design.md",
-      "path": "docs/strategy/NYCN-Institutional-Design.md",
+      "name": "SOVEREIGN_FORGE.md",
+      "path": "docs/strategy/SOVEREIGN_FORGE.md",
       "role_guess": "documentation",
-      "sha256": "a946f454dec0512871fb72041bfb5617827033323eac149619b5c16a34e9444e",
-      "size_bytes": 34441,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "docs/strategy",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "NYCN-Institutional-Strategy.md",
-      "path": "docs/strategy/NYCN-Institutional-Strategy.md",
-      "role_guess": "documentation",
-      "sha256": "92c08eee8e8953790b412bf460762c1d02c1a09c6351c23c0d7315fd5bbeaf72",
-      "size_bytes": 17443,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "docs/strategy",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "NYCN-Repo-Architecture-Spec.md",
-      "path": "docs/strategy/NYCN-Repo-Architecture-Spec.md",
-      "role_guess": "documentation",
-      "sha256": "d6e20f0b6e4167a18a3803fb354e8a48bfafef4d40ba7e10b9ddc06aaa785bd0",
-      "size_bytes": 54411,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "docs/strategy",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "NYCN-Sprint-Plan.md",
-      "path": "docs/strategy/NYCN-Sprint-Plan.md",
-      "role_guess": "documentation",
-      "sha256": "3b7e6eb08f29079049c5c61d84dfa7a5c057b4313589f4d4d5dc451bb79d8d9a",
-      "size_bytes": 12184,
+      "sha256": "0532f20806f4a01687d6b5974653171335b56131b359ae759ecdf8cdf6cfbd51",
+      "size_bytes": 9823,
       "symlink_target": null,
       "tracked": true
     },
@@ -22061,8 +24922,8 @@
       "name": "workshop-proposal-draft.md",
       "path": "docs/summit/workshop-proposal-draft.md",
       "role_guess": "documentation",
-      "sha256": "9e2426fb88c94bfb34553e7b758c7b4c363ae6cab7d9d7305ff818d28638829e",
-      "size_bytes": 9261,
+      "sha256": "433929518918ea2282d1f823ffc974a543cd2cf25fa966be23eecc0119df9094",
+      "size_bytes": 13525,
       "symlink_target": null,
       "tracked": true
     },
@@ -22347,8 +25208,8 @@
       "name": "COOPOS.md",
       "path": "docs/vision/COOPOS.md",
       "role_guess": "documentation",
-      "sha256": "b6a2cc706bed35485ca1c0d4fa5cbd22b76c4aab7031c5776535f6e8cd6369bb",
-      "size_bytes": 35762,
+      "sha256": "350b8e4d4a9c9e3b5a863ad2eb7ed8b5743b4e7a67c85cee12a9fd7fc5bae8c5",
+      "size_bytes": 35793,
       "symlink_target": null,
       "tracked": true
     },
@@ -22737,8 +25598,8 @@
       "name": "package-lock.json",
       "path": "examples/mobile-app/package-lock.json",
       "role_guess": "uncategorized",
-      "sha256": "70a503901edb66a4c2e487e03a97ed91597970614d12b7fe0bf2e6798bc17520",
-      "size_bytes": 452753,
+      "sha256": "182ace725ea4fc253ec6741d1f9bbcd8e0eabc0c15c1ccd5b89063ea88f094c9",
+      "size_bytes": 403126,
       "symlink_target": null,
       "tracked": true
     },
@@ -22750,8 +25611,8 @@
       "name": "package.json",
       "path": "examples/mobile-app/package.json",
       "role_guess": "uncategorized",
-      "sha256": "89835ab34958359de542f10ee0df017c69e087b269eb3e56a0c228dd977b5b4f",
-      "size_bytes": 1002,
+      "sha256": "5643343dd31d3ecbfa9a9ab9b82c8a00afef5a54bfcb0cc5ce6ebdd1c29631a0",
+      "size_bytes": 1003,
       "symlink_target": null,
       "tracked": true
     },
@@ -23023,8 +25884,8 @@
       "name": "Cargo.lock",
       "path": "icn/Cargo.lock",
       "role_guess": "uncategorized",
-      "sha256": "58a6cfc21add273fb9648c2beaec17b95cd78d575318c4c377428a8c54dffe9a",
-      "size_bytes": 212152,
+      "sha256": "2ef6b85eaea3eb592a94a0025f0658deb896495fc7db8e09b54e9fce3952aea4",
+      "size_bytes": 215694,
       "symlink_target": null,
       "tracked": true
     },
@@ -23036,8 +25897,8 @@
       "name": "Cargo.toml",
       "path": "icn/Cargo.toml",
       "role_guess": "uncategorized",
-      "sha256": "ac6adb427fa0f292c337ec502625822b43457413e1f21d0ea6bb2c1fef5042cf",
-      "size_bytes": 4557,
+      "sha256": "a9e66fc0e810ad2cc362a257b7e8d38a92f7cb9049a2569fcd95a7f1114c13d7",
+      "size_bytes": 5410,
       "symlink_target": null,
       "tracked": true
     },
@@ -23094,6 +25955,71 @@
       "tracked": true
     },
     {
+      "directory": "icn/apps/governance-app",
+      "extension": ".gitignore",
+      "kind": "file",
+      "language": "unknown",
+      "name": ".gitignore",
+      "path": "icn/apps/governance-app/.gitignore",
+      "role_guess": "runtime app crate",
+      "sha256": "2ebe6cb6f5289849dce5a8a6cdd77e06b1385302c862982f8e181c4782d19214",
+      "size_bytes": 19,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance-app",
+      "extension": ".toml",
+      "kind": "file",
+      "language": "TOML",
+      "name": "Cargo.toml",
+      "path": "icn/apps/governance-app/Cargo.toml",
+      "role_guess": "runtime app crate",
+      "sha256": "a8dad674e2cc9a584917ebc2a50d0a4732bd1c8c9aedbc84354e8b4881fcd558",
+      "size_bytes": 958,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "lib.rs",
+      "path": "icn/apps/governance-app/src/lib.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "59d6cf75a1a80392a10abeab47c9d2b730c9c3b91b8ebca308a753b3a615dd91",
+      "size_bytes": 3573,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "oracle.rs",
+      "path": "icn/apps/governance-app/src/oracle.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "164a45a18f67a5822c4879d7e6317347ff91f114031d6a48a2de61c3e082481a",
+      "size_bytes": 6990,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "service.rs",
+      "path": "icn/apps/governance-app/src/service.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "69335632cf0f5f244618d49ccaf664d80d59fc97b8cd0066eb19a567f0dadb8a",
+      "size_bytes": 7056,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "icn/apps/governance",
       "extension": ".toml",
       "kind": "file",
@@ -23101,8 +26027,8 @@
       "name": "Cargo.toml",
       "path": "icn/apps/governance/Cargo.toml",
       "role_guess": "runtime app crate",
-      "sha256": "c2037b4f4010f439c9bb20afb1d105280503a144a7b757e8a50e40658ab3b9e5",
-      "size_bytes": 2169,
+      "sha256": "b95f74f241003b8727a94a537b9b8a6f6e775445a1ccfe46b9b7ff2c89c74f94",
+      "size_bytes": 2318,
       "symlink_target": null,
       "tracked": true
     },
@@ -23114,8 +26040,8 @@
       "name": "actor.rs",
       "path": "icn/apps/governance/src/actor.rs",
       "role_guess": "runtime app crate",
-      "sha256": "a66ddc2c21712235591c1953992d29b635f96fd348ea84653fe048d010ab34d3",
-      "size_bytes": 159924,
+      "sha256": "f2105fa8fb86ada698aa66ac3867fd12372b3e020851cc1c385e79bca89a37db",
+      "size_bytes": 185427,
       "symlink_target": null,
       "tracked": true
     },
@@ -23129,6 +26055,19 @@
       "role_guess": "runtime app crate",
       "sha256": "f8bfebe41a6c259ca04034406a9addee8082c2bada13a1989636495a85753395",
       "size_bytes": 10643,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "close_journal.rs",
+      "path": "icn/apps/governance/src/close_journal.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "a64bfbcf7da30c1945bb22d387e3f348ed91964b5559d5abf1e8bd2def914bbb",
+      "size_bytes": 9747,
       "symlink_target": null,
       "tracked": true
     },
@@ -23153,8 +26092,8 @@
       "name": "dispatch_evidence_sink.rs",
       "path": "icn/apps/governance/src/dispatch_evidence_sink.rs",
       "role_guess": "runtime app crate",
-      "sha256": "5455453d599feec32dcf0b7c5f06145de64cc8a2537c3f3c2b683da77f20daf9",
-      "size_bytes": 14190,
+      "sha256": "8739897731f91a6c2e566b45850c03b2196fb491c4553ee41683cb6423d32c08",
+      "size_bytes": 19766,
       "symlink_target": null,
       "tracked": true
     },
@@ -23192,8 +26131,8 @@
       "name": "grant_minting.rs",
       "path": "icn/apps/governance/src/grant_minting.rs",
       "role_guess": "runtime app crate",
-      "sha256": "e7e1e354c76a4025444603a714b119c587f5b3c8e58e3a7ce873b9a58436d889",
-      "size_bytes": 112285,
+      "sha256": "8b11e18d371ec454e67a2295144142da2eb51bf60b5a877c865c5822806e0273",
+      "size_bytes": 121370,
       "symlink_target": null,
       "tracked": true
     },
@@ -23205,8 +26144,8 @@
       "name": "execution.rs",
       "path": "icn/apps/governance/src/handlers/execution.rs",
       "role_guess": "runtime app crate",
-      "sha256": "d4b3c6e1afb386552b2d60f9326b7169c1d53aeb21b21e0dc940441ceb47e7ab",
-      "size_bytes": 49940,
+      "sha256": "f490648dd8f3f14e13b55f29eabcfc03736d383f9208dd98f891bb2d593101ba",
+      "size_bytes": 50546,
       "symlink_target": null,
       "tracked": true
     },
@@ -23231,8 +26170,8 @@
       "name": "configure.rs",
       "path": "icn/apps/governance/src/http/configure.rs",
       "role_guess": "runtime app crate",
-      "sha256": "1bd57d7b52bd9d768fcc0e950d79eaf5b630508eae347a4f77ec4cd4449f1e53",
-      "size_bytes": 27029,
+      "sha256": "f953108a2795998cfaeaea6076d9ee1cf9fee9e29a565af9c4dfd59d059e7d03",
+      "size_bytes": 54744,
       "symlink_target": null,
       "tracked": true
     },
@@ -23244,8 +26183,8 @@
       "name": "handlers.rs",
       "path": "icn/apps/governance/src/http/handlers.rs",
       "role_guess": "runtime app crate",
-      "sha256": "70b59ff168f887749017f7ae0572f5ccff7ff30ed724539284d7873fe33e0f2f",
-      "size_bytes": 322017,
+      "sha256": "88ead143cb6a1b5566add0566bc0121f721c579d0f00f4b8d456b979764aba4a",
+      "size_bytes": 361119,
       "symlink_target": null,
       "tracked": true
     },
@@ -23257,8 +26196,8 @@
       "name": "mod.rs",
       "path": "icn/apps/governance/src/http/mod.rs",
       "role_guess": "runtime app crate",
-      "sha256": "8816c906d6b847aaf5ffeec71a9935bb765fb6aa54fc01712be87612e5305466",
-      "size_bytes": 418,
+      "sha256": "b531fa6106dc1312fe2dde1a365c35171c4cbb83d6e30dcb336ef21a0daeb38c",
+      "size_bytes": 487,
       "symlink_target": null,
       "tracked": true
     },
@@ -23270,8 +26209,8 @@
       "name": "models.rs",
       "path": "icn/apps/governance/src/http/models.rs",
       "role_guess": "runtime app crate",
-      "sha256": "a435fc7ac2dfe9a1f018ac6bcdbdc6e5a725769ddc78c4de909059d9659b1637",
-      "size_bytes": 61132,
+      "sha256": "95ee4fb2a957c0487666c08ee13c7751312329a8779e512d3a12bded223696bf",
+      "size_bytes": 62902,
       "symlink_target": null,
       "tracked": true
     },
@@ -23322,8 +26261,8 @@
       "name": "lib.rs",
       "path": "icn/apps/governance/src/lib.rs",
       "role_guess": "runtime app crate",
-      "sha256": "29404d3a02f42316bc46b72dbb98260c705c9b79fb0ac39c4c00fc12607fcdbd",
-      "size_bytes": 19186,
+      "sha256": "2144f34e912811a97df72acf3ccefe8c05e4c90d60712aa0a265c032110b0efd",
+      "size_bytes": 19619,
       "symlink_target": null,
       "tracked": true
     },
@@ -23335,8 +26274,21 @@
       "name": "manager.rs",
       "path": "icn/apps/governance/src/manager.rs",
       "role_guess": "runtime app crate",
-      "sha256": "e41f4bde568dce91e1485ba730f7b94263c9f5a28aa34789ee98faf2abfa2727",
-      "size_bytes": 347440,
+      "sha256": "14e523b233f1bf43843ae66cbae43f059b4905e2f0bd9356cbf91fce1885bc80",
+      "size_bytes": 359295,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "mandate_gate.rs",
+      "path": "icn/apps/governance/src/mandate_gate.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "6a1959ae7cb5fdc4cd73663204d539da8ef7b0ebf4955eacacd44289d4184daa",
+      "size_bytes": 55170,
       "symlink_target": null,
       "tracked": true
     },
@@ -23348,8 +26300,8 @@
       "name": "receipt_backend.rs",
       "path": "icn/apps/governance/src/receipt_backend.rs",
       "role_guess": "runtime app crate",
-      "sha256": "504bb575a47237cd0808cc350ad9d6a402459d738f4a879474779b8f75fa5bb8",
-      "size_bytes": 18781,
+      "sha256": "7e4866df3d2e9a19c0615da3196c77cd84d423d5bab72b475ce2bee8b670fe9a",
+      "size_bytes": 36470,
       "symlink_target": null,
       "tracked": true
     },
@@ -23400,8 +26352,21 @@
       "name": "state_store.rs",
       "path": "icn/apps/governance/src/state_store.rs",
       "role_guess": "runtime app crate",
-      "sha256": "4bb01a24a2b5a55f445c797b63618ae7d825e22e90b08ae22adbe94dc80e0cbe",
-      "size_bytes": 7689,
+      "sha256": "9dadb0f1d09b5cb193c64b64c8ac9a7041f51fc5a5bc0891d02d4fa1af5d9172",
+      "size_bytes": 11360,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "activity_scope_migration.rs",
+      "path": "icn/apps/governance/tests/activity_scope_migration.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "268298f317d7d6ca70435af19087ffb9573af946063f29509a42febea9d539b6",
+      "size_bytes": 6553,
       "symlink_target": null,
       "tracked": true
     },
@@ -23413,8 +26378,21 @@
       "name": "actor_acceptance_closure_atomicity.rs",
       "path": "icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs",
       "role_guess": "runtime app crate",
-      "sha256": "2a3a1d247c9694a633110a5b9b84d5355f5e75147c8adbc53b7e58730e57b2f6",
-      "size_bytes": 20649,
+      "sha256": "babfa91029b238fcff5fd9ba13f8fab725d5867f528e1e09e3909e472520cb32",
+      "size_bytes": 30240,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "actor_close_crossstore_atomicity.rs",
+      "path": "icn/apps/governance/tests/actor_close_crossstore_atomicity.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "7cdf835c739756c6e02cc79d2d6102340df255fdee09293348302e1f423569a1",
+      "size_bytes": 51921,
       "symlink_target": null,
       "tracked": true
     },
@@ -23426,8 +26404,8 @@
       "name": "actor_close_proposal_accept_parity.rs",
       "path": "icn/apps/governance/tests/actor_close_proposal_accept_parity.rs",
       "role_guess": "runtime app crate",
-      "sha256": "3741910d28354ae5370f67cc5a0c50472b25519391f594f7b49a842590f3f4d4",
-      "size_bytes": 13361,
+      "sha256": "1f12d88fb7bf39ef9eadbe4e87bfff52cefbe94cf598d6525f211ba889dc9ff6",
+      "size_bytes": 13433,
       "symlink_target": null,
       "tracked": true
     },
@@ -23439,8 +26417,8 @@
       "name": "actor_close_proposal_mandate_parity.rs",
       "path": "icn/apps/governance/tests/actor_close_proposal_mandate_parity.rs",
       "role_guess": "runtime app crate",
-      "sha256": "cd28ee42a6f14c08afcd6dc1907b68fc449ca268eb7068451ddadbda33dfd59d",
-      "size_bytes": 18815,
+      "sha256": "ff9429882c329b2d034a5ff75daa0bcce4bae8a04fba9a7a072711beea5af65f",
+      "size_bytes": 18923,
       "symlink_target": null,
       "tracked": true
     },
@@ -23452,8 +26430,8 @@
       "name": "actor_path_dispatch_evidence_sink.rs",
       "path": "icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs",
       "role_guess": "runtime app crate",
-      "sha256": "26dc50567056275d0e7501743f690e33a32291a81ef4066d18e236ad9af681a4",
-      "size_bytes": 48163,
+      "sha256": "918744bb7bcb9205d2484c4f8dab1b8796289f87bb74924348a7bbf8d3a44ab2",
+      "size_bytes": 52345,
       "symlink_target": null,
       "tracked": true
     },
@@ -23478,8 +26456,8 @@
       "name": "assign_role_authority_scope.rs",
       "path": "icn/apps/governance/tests/assign_role_authority_scope.rs",
       "role_guess": "runtime app crate",
-      "sha256": "f14fccf0721d2c6b4b8de09a46525f0cb00f2eaa647757891b024aa02cf02e96",
-      "size_bytes": 7750,
+      "sha256": "cbeb8e2ce33f3a3d55ad27b81d465027e9de662b568d5a80e79e27dc4fddb5e8",
+      "size_bytes": 7860,
       "symlink_target": null,
       "tracked": true
     },
@@ -23491,8 +26469,60 @@
       "name": "charter_activation.rs",
       "path": "icn/apps/governance/tests/charter_activation.rs",
       "role_guess": "runtime app crate",
-      "sha256": "220af2c08066d9c1c3e99f42a994706f7ef5812e2c4206c1f4805a4427116b54",
-      "size_bytes": 16284,
+      "sha256": "516309881da30b2e4379111bd2cede85873eef63aa943c93c714de2c74d24fd5",
+      "size_bytes": 19260,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "charter_scope_migration.rs",
+      "path": "icn/apps/governance/tests/charter_scope_migration.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "4f6e5bde43188cb2f4aa6a7c6018d74fd78ab7850cd48350d05a964094fd5573",
+      "size_bytes": 9299,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "comment_scope_migration.rs",
+      "path": "icn/apps/governance/tests/comment_scope_migration.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "3e8338057986320c3dae71372f4525f22274b511c101cbb6ad90f21e3b2f8351",
+      "size_bytes": 6309,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "federation_scope_migration.rs",
+      "path": "icn/apps/governance/tests/federation_scope_migration.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "472b333387330673cb2f12ecaa502183a5d9e7e645bdba7ee8c99b9282f3671a",
+      "size_bytes": 9204,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "governance_decision_receipt_v3_emission.rs",
+      "path": "icn/apps/governance/tests/governance_decision_receipt_v3_emission.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "2947afd7a492d7aab07f94dcf199eb7a2c0a74ae24e7bd8fca9aedd9bf68d820",
+      "size_bytes": 19897,
       "symlink_target": null,
       "tracked": true
     },
@@ -23504,8 +26534,8 @@
       "name": "me_action_card_receipt_chain.rs",
       "path": "icn/apps/governance/tests/me_action_card_receipt_chain.rs",
       "role_guess": "runtime app crate",
-      "sha256": "e433f00a0ebc9f2c9d25fb654f9f90952a0a658b1dd12a441197c905115948fe",
-      "size_bytes": 16027,
+      "sha256": "d9ac9da4068ffb0f2f07f020ef986eee261d5001de2367f9315a3ad20d722f5e",
+      "size_bytes": 16137,
       "symlink_target": null,
       "tracked": true
     },
@@ -23517,8 +26547,8 @@
       "name": "me_action_cards.rs",
       "path": "icn/apps/governance/tests/me_action_cards.rs",
       "role_guess": "runtime app crate",
-      "sha256": "8aa562cc0633e3a34ac986758b2e1679ce5560f305a6b6b39e6a4077dd8e4a8d",
-      "size_bytes": 12664,
+      "sha256": "6f473099f17b834ba8d9f057e7168b4d9247f12e02267e3b4b5b030aa6a6ef3e",
+      "size_bytes": 12774,
       "symlink_target": null,
       "tracked": true
     },
@@ -23530,8 +26560,8 @@
       "name": "me_action_item_receipt_chain.rs",
       "path": "icn/apps/governance/tests/me_action_item_receipt_chain.rs",
       "role_guess": "runtime app crate",
-      "sha256": "f3f033742ebb9a3b3fa6ecee94cbf518d2c585884d4e832c305516425571b1cc",
-      "size_bytes": 35727,
+      "sha256": "7e57cdc8de711606907ce301b09a097752cb81ef32af9d161efba3caa8fb5996",
+      "size_bytes": 46010,
       "symlink_target": null,
       "tracked": true
     },
@@ -23543,8 +26573,8 @@
       "name": "me_meeting_attendance_receipt_chain.rs",
       "path": "icn/apps/governance/tests/me_meeting_attendance_receipt_chain.rs",
       "role_guess": "runtime app crate",
-      "sha256": "5d3c8a70f06af824c19331be6578cd24c1cf28b95bb29d5aed09c497bd19674c",
-      "size_bytes": 21558,
+      "sha256": "c6deccdf37c33d8ea48d171e1cd04c13ebbab46bd1f20723204158e0ad6fd6d5",
+      "size_bytes": 31124,
       "symlink_target": null,
       "tracked": true
     },
@@ -23556,8 +26586,21 @@
       "name": "me_standing.rs",
       "path": "icn/apps/governance/tests/me_standing.rs",
       "role_guess": "runtime app crate",
-      "sha256": "7eafb4ea572181e0173021e47d660ca824451312ff1fc8338a131cbe1dd1a791",
-      "size_bytes": 15146,
+      "sha256": "6df51ed06cc42226a0cb230461b1fb9bbf8b37e6ea88fe6e5135ce12e40cb193",
+      "size_bytes": 15256,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "meeting_scope_migration.rs",
+      "path": "icn/apps/governance/tests/meeting_scope_migration.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "38e1c3c3a029038abde0793f119a74a99edbe165e090d1b05e15bed357835d1a",
+      "size_bytes": 6394,
       "symlink_target": null,
       "tracked": true
     },
@@ -23579,11 +26622,206 @@
       "extension": ".rs",
       "kind": "file",
       "language": "Rust",
+      "name": "process_gate_result_receipt_runtime_slice.rs",
+      "path": "icn/apps/governance/tests/process_gate_result_receipt_runtime_slice.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "884e263f26662eacabd3df0852b8c46e0fba1025d6a65d99033b40de42bf281b",
+      "size_bytes": 35240,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "proposal_scope_migration.rs",
+      "path": "icn/apps/governance/tests/proposal_scope_migration.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "92290ae6ad412c01fca635020b4c15992d74a65ab0ffbaa8c22656d303dcd157",
+      "size_bytes": 16806,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "reconciliation_status_invariants.rs",
+      "path": "icn/apps/governance/tests/reconciliation_status_invariants.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "9c9847492e6b5428626711f9781cffa3ee3db499d78f5d9a9a1389f2ddae8324",
+      "size_bytes": 19717,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
       "name": "standalone_domain_persistence.rs",
       "path": "icn/apps/governance/tests/standalone_domain_persistence.rs",
       "role_guess": "runtime app crate",
       "sha256": "f99bcaae2a73b8c8dc2e6950015c8a358613922f041714c59b26ff8a9c99b7de",
       "size_bytes": 5722,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/governance/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "steward_scope_migration.rs",
+      "path": "icn/apps/governance/tests/steward_scope_migration.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "48c9e82cf3c556b136062fed4ab205ee885401ed9f6d4f7abfd73c2d95cfa480",
+      "size_bytes": 6803,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app",
+      "extension": ".gitignore",
+      "kind": "file",
+      "language": "unknown",
+      "name": ".gitignore",
+      "path": "icn/apps/ledger-app/.gitignore",
+      "role_guess": "runtime app crate",
+      "sha256": "2ebe6cb6f5289849dce5a8a6cdd77e06b1385302c862982f8e181c4782d19214",
+      "size_bytes": 19,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app",
+      "extension": ".toml",
+      "kind": "file",
+      "language": "TOML",
+      "name": "Cargo.toml",
+      "path": "icn/apps/ledger-app/Cargo.toml",
+      "role_guess": "runtime app crate",
+      "sha256": "dbe12097c492934e1fe44bbdace72a265dddb0e8bbe43eacfdb809382fa06f52",
+      "size_bytes": 1677,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "manifest.yaml",
+      "path": "icn/apps/ledger-app/manifest.yaml",
+      "role_guess": "runtime app crate",
+      "sha256": "168541ad3d13f2068b16b473bc58ba18f238dafc4c2948140e7449107df4f3f6",
+      "size_bytes": 1408,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "budgets.rs",
+      "path": "icn/apps/ledger-app/src/budgets.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "d107e322624fe0fdbc3035148e2a47b5ec4297e4de20938f7e859349617978be",
+      "size_bytes": 8925,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "config.rs",
+      "path": "icn/apps/ledger-app/src/config.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "460589149cbbca9d6a048f1a3abc6f655763536ace6577b4cef9c6edcc1a157a",
+      "size_bytes": 13279,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "escrow.rs",
+      "path": "icn/apps/ledger-app/src/escrow.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "efa3cb851c503373dd1627461af4e76b4804175d6b2646b027c8bf026aa09162",
+      "size_bytes": 7867,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "init.rs",
+      "path": "icn/apps/ledger-app/src/init.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "5c3e0751ce2ace4cee0a9b6eb390a2178a463240072fdb93343f875daf1ccb6f",
+      "size_bytes": 10497,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "lib.rs",
+      "path": "icn/apps/ledger-app/src/lib.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "62f0e643753856e3cf52d32d7bd49e2ec5eb9c09052c724b127be695f86302ba",
+      "size_bytes": 3764,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "oracle.rs",
+      "path": "icn/apps/ledger-app/src/oracle.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "a7db685817b45cae0584e74a0a644aa0afd5547eb3b9abd013f99710a5e4a9e4",
+      "size_bytes": 4286,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "recurring.rs",
+      "path": "icn/apps/ledger-app/src/recurring.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "04f8085783c13f768aa692ba11abb73f6b713a6b1020f52509fbbb6234a532a3",
+      "size_bytes": 10522,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/ledger-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "service.rs",
+      "path": "icn/apps/ledger-app/src/service.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "fa64b50989936d54d8c7412ee94852f391b993f2e10f3b0f7df95f7355128f0e",
+      "size_bytes": 7629,
       "symlink_target": null,
       "tracked": true
     },
@@ -23686,7 +26924,7 @@
       "name": "Cargo.toml",
       "path": "icn/apps/membership/Cargo.toml",
       "role_guess": "runtime app crate",
-      "sha256": "51920f2d97b21d70b86fe490e92f469018f00ae7040ce739bbb8b40abdd4f37c",
+      "sha256": "0d5d4a817b36e34d2c929b70d1d74b6210a3e60070a5fa70f1919e07641fb857",
       "size_bytes": 1911,
       "symlink_target": null,
       "tracked": true
@@ -24134,6 +27372,188 @@
       "tracked": true
     },
     {
+      "directory": "icn/apps/trust-app",
+      "extension": ".gitignore",
+      "kind": "file",
+      "language": "unknown",
+      "name": ".gitignore",
+      "path": "icn/apps/trust-app/.gitignore",
+      "role_guess": "runtime app crate",
+      "sha256": "3e503ffd2d2f0c135bc5d8c97cba5aff82676478d90cb002333ed9583b92c5a0",
+      "size_bytes": 11,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app",
+      "extension": ".toml",
+      "kind": "file",
+      "language": "TOML",
+      "name": "Cargo.toml",
+      "path": "icn/apps/trust-app/Cargo.toml",
+      "role_guess": "runtime app crate",
+      "sha256": "dcfc146b20c7196882cb80c7c1cbeb5b750a78be264de88392e8b26596302437",
+      "size_bytes": 1439,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/benches",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "icn/apps/trust-app/benches/README.md",
+      "role_guess": "runtime app crate",
+      "sha256": "22d5c201b7b7f4ba030c106afced05d5e5b5aa94d37783594494edc9c03d2620",
+      "size_bytes": 3345,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/benches",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "trust_service_bench.rs",
+      "path": "icn/apps/trust-app/benches/trust_service_bench.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "8edea6f20171b8bac6656f80e0d68b497da53de36f43e301426c571b1f5ccee8",
+      "size_bytes": 8518,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app",
+      "extension": ".yaml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "manifest.yaml",
+      "path": "icn/apps/trust-app/manifest.yaml",
+      "role_guess": "runtime app crate",
+      "sha256": "f317936db84ac6591d6eb7c696f680e2d4b7d6355760ec5dd8000272b9336f24",
+      "size_bytes": 1594,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "init.rs",
+      "path": "icn/apps/trust-app/src/init.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "df618b072438ce03346f106e1b2bac69b41ab525569b336aba1690d0e0067984",
+      "size_bytes": 9174,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "lib.rs",
+      "path": "icn/apps/trust-app/src/lib.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "d92f8a0f9b686dab149011439ad7dadba0fb53fb1bd0e9d51b6ec751edc7f48b",
+      "size_bytes": 4881,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "oracle.rs",
+      "path": "icn/apps/trust-app/src/oracle.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "0bef203917d1e50ac7b147eacb4ecdd7d820074685b3944720c383c1a74f17a1",
+      "size_bytes": 23630,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "oracle_tokio.rs",
+      "path": "icn/apps/trust-app/src/oracle_tokio.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "d9857a1bb200770f801c874067e986a42b68919753cd0c8a95964ce76b68f262",
+      "size_bytes": 8058,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "reducer.rs",
+      "path": "icn/apps/trust-app/src/reducer.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "38997cd51b019995b2183048ede8a7073ca458b9aed95bb68877c63bde1846d2",
+      "size_bytes": 23918,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "sequence.rs",
+      "path": "icn/apps/trust-app/src/sequence.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "686c50e0eeffd3d16bb029ba2a345624102b7696ede94eb879fb1479747d7048",
+      "size_bytes": 11054,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "service.rs",
+      "path": "icn/apps/trust-app/src/service.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "4f28347cfdea290717761f71dacd286f01c304595f23d8b57fb7594812b8528d",
+      "size_bytes": 6824,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "service_tokio.rs",
+      "path": "icn/apps/trust-app/src/service_tokio.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "a57267fc74a9103d94e28eb1b89d78cdc7c4f5a17c081e0388c2ef833770edac",
+      "size_bytes": 57192,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/apps/trust-app/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "cross_org_integration.rs",
+      "path": "icn/apps/trust-app/tests/cross_org_integration.rs",
+      "role_guess": "runtime app crate",
+      "sha256": "1087d04eafa12dfa1b989f7734dc1f9c48eabfec9e86a3ca26fac2bae291d51c",
+      "size_bytes": 18302,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "icn/bins/icn-console",
       "extension": ".toml",
       "kind": "file",
@@ -24167,8 +27587,8 @@
       "name": "Cargo.toml",
       "path": "icn/bins/icnctl/Cargo.toml",
       "role_guess": "Rust binary",
-      "sha256": "b6535c62d5728d3430e3054fb001b5ad7ed45c97744b118cfe9287d8262b07fd",
-      "size_bytes": 1585,
+      "sha256": "b0ebc31e9af449497b352d25c887e66f9fe712a66c992ed460dcb790a247fd1c",
+      "size_bytes": 1750,
       "symlink_target": null,
       "tracked": true
     },
@@ -24206,8 +27626,8 @@
       "name": "institution_bootstrap.rs",
       "path": "icn/bins/icnctl/src/institution_bootstrap.rs",
       "role_guess": "Rust binary",
-      "sha256": "77d58812063ce58d79fe8b577ea3e6d14433b92be29d4a2aee40783dbcda613e",
-      "size_bytes": 101142,
+      "sha256": "c1407250f0fd7e343b77d6e698dc52e195e5722c8e849d4880100cab71bf79fa",
+      "size_bytes": 101298,
       "symlink_target": null,
       "tracked": true
     },
@@ -24219,8 +27639,8 @@
       "name": "main.rs",
       "path": "icn/bins/icnctl/src/main.rs",
       "role_guess": "Rust binary",
-      "sha256": "b2d9932cbbc6c1d99e31548bfb43f744af32e5de2250f25303dc46e01beb6ed6",
-      "size_bytes": 399852,
+      "sha256": "38c0d17929dfbddcf98b6f5df926ede6fdfdb375a962e3ab50fe9eb864bb2723",
+      "size_bytes": 415618,
       "symlink_target": null,
       "tracked": true
     },
@@ -24247,6 +27667,32 @@
       "role_guess": "Rust binary",
       "sha256": "b51e3f9adc11ef01c46091b2040ec5f20c274a18bc01caad34ea94e96c36d62d",
       "size_bytes": 13406,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/bins/icnctl/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "coop_entity_backfill_test.rs",
+      "path": "icn/bins/icnctl/tests/coop_entity_backfill_test.rs",
+      "role_guess": "Rust binary",
+      "sha256": "24ff61508ad85e34582c229c6413e86f636b812626d5bbaf61a08af7e4dde536",
+      "size_bytes": 13805,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/bins/icnctl/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "coop_entity_report_test.rs",
+      "path": "icn/bins/icnctl/tests/coop_entity_report_test.rs",
+      "role_guess": "Rust binary",
+      "sha256": "31b1e38d006f3be744821e88eed7c009f42d92c9cf20d61ab78bae5dc655b312",
+      "size_bytes": 11324,
       "symlink_target": null,
       "tracked": true
     },
@@ -24284,8 +27730,8 @@
       "name": "Cargo.toml",
       "path": "icn/bins/icnd/Cargo.toml",
       "role_guess": "Rust binary",
-      "sha256": "1bb15e1008e91e16172cf115b2c8ac1848b710af3e37a93a481041dd1f50b5f1",
-      "size_bytes": 1477,
+      "sha256": "d583baa325019b58e873cea81bac3fa258cdd1c20add77478087bc3e7a811f14",
+      "size_bytes": 1480,
       "symlink_target": null,
       "tracked": true
     },
@@ -24310,8 +27756,8 @@
       "name": "main.rs",
       "path": "icn/bins/icnd/src/main.rs",
       "role_guess": "Rust binary",
-      "sha256": "116418c334080d0855723ce396ecc804179b64d9cf815507197dd6550bb951a3",
-      "size_bytes": 29773,
+      "sha256": "bee35cab7967435478c569e809ee92f7cea377e0c12adbe3faacd973e484ca19",
+      "size_bytes": 45603,
       "symlink_target": null,
       "tracked": true
     },
@@ -24362,8 +27808,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-api/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "c950f7a6ee794a93995bce395ac2e1926d3050c9083da7866e8ec4604ba032c4",
-      "size_bytes": 874,
+      "sha256": "d5a209c25b3f03dc624b8430a016854198a423a8a644762173bdaabeee52c5a1",
+      "size_bytes": 930,
       "symlink_target": null,
       "tracked": true
     },
@@ -24427,8 +27873,8 @@
       "name": "ledger.rs",
       "path": "icn/crates/icn-api/src/ledger.rs",
       "role_guess": "Rust library crate",
-      "sha256": "f4fdc92ffd63e62dddae25a8e456794a7f424944c3f01333f4df08106a2785b1",
-      "size_bytes": 5224,
+      "sha256": "67e5c34cf4026ad22f4be08f746b6be1aab9e451d563d875a5d9a60cbc770b2e",
+      "size_bytes": 13925,
       "symlink_target": null,
       "tracked": true
     },
@@ -24453,8 +27899,8 @@
       "name": "scopes.rs",
       "path": "icn/crates/icn-api/src/scopes.rs",
       "role_guess": "Rust library crate",
-      "sha256": "71ad8e5ba3128a4bed728cc58f677a6ebd7da904d24026ddb3a40ca6357e628a",
-      "size_bytes": 4978,
+      "sha256": "57510a7cdf008d0d536968e482d2c6a122ee596832af673f63889a7d5c76e120",
+      "size_bytes": 4723,
       "symlink_target": null,
       "tracked": true
     },
@@ -24598,6 +28044,240 @@
       "role_guess": "Rust library crate",
       "sha256": "5bfa902e2f0ea4f2f06ca96904b1b4a6c637d7da2ce3456e36c41b735dc643cd",
       "size_bytes": 7533,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock-guest",
+      "extension": ".lock",
+      "kind": "file",
+      "language": "unknown",
+      "name": "Cargo.lock",
+      "path": "icn/crates/icn-baseline-lock-guest/Cargo.lock",
+      "role_guess": "Rust library crate",
+      "sha256": "20cc7fcda251bc229e3574503d2424ef6b9b83b484cf0f7570acbe0d4cb03c0b",
+      "size_bytes": 3324,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock-guest",
+      "extension": ".toml",
+      "kind": "file",
+      "language": "TOML",
+      "name": "Cargo.toml",
+      "path": "icn/crates/icn-baseline-lock-guest/Cargo.toml",
+      "role_guess": "Rust library crate",
+      "sha256": "5a0f62c866ee383da0abe70648e4d21d6e6974d2e7d749a4650d2590974a249e",
+      "size_bytes": 794,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock-guest/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "lib.rs",
+      "path": "icn/crates/icn-baseline-lock-guest/src/lib.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "c00ceb0345dd9765bf5990b4fb99154233f1d6003fe0d7317e1f6fca93aa54b1",
+      "size_bytes": 3766,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock",
+      "extension": ".toml",
+      "kind": "file",
+      "language": "TOML",
+      "name": "Cargo.toml",
+      "path": "icn/crates/icn-baseline-lock/Cargo.toml",
+      "role_guess": "Rust library crate",
+      "sha256": "fa6016b27466de6a02c987bbe8453d95c258f2db5dbed7ad7feb11b1ba1f1c9d",
+      "size_bytes": 550,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "icn/crates/icn-baseline-lock/README.md",
+      "role_guess": "Rust library crate",
+      "sha256": "10590731ca7f6700fbf3107f05d104fd177ee437c452df6812b7edc9a13ce669",
+      "size_bytes": 2143,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "capsule.rs",
+      "path": "icn/crates/icn-baseline-lock/src/capsule.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "919a46a6997f62bca1ac98e21ae84304bd53bd0d88e002720a8037818a6ed856",
+      "size_bytes": 1703,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "constants.rs",
+      "path": "icn/crates/icn-baseline-lock/src/constants.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "4292f82432ece704c36313195794e579584fd8afeb6ffeea13223925f347cdf4",
+      "size_bytes": 488,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "evidence.rs",
+      "path": "icn/crates/icn-baseline-lock/src/evidence.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "374156d0e735e75c2d14735acdaeea9bdf61e35c42ba2ff8255a99cbed05a9a6",
+      "size_bytes": 983,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "host.rs",
+      "path": "icn/crates/icn-baseline-lock/src/host.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "71f7e9eac8ad676942d803a616d3cb5c778b383014799714035fbc9eafb3ed04",
+      "size_bytes": 5838,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "lib.rs",
+      "path": "icn/crates/icn-baseline-lock/src/lib.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "c4e3f12a6392ab33a7b535b29366c765b01861e414ef24389975a3412bb1e98a",
+      "size_bytes": 980,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "projector.rs",
+      "path": "icn/crates/icn-baseline-lock/src/projector.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "f72322d102903d286eb7baa826b31b7617fe7cfaa505126a4d8ffd34477a00ff",
+      "size_bytes": 8834,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "receipt_emit.rs",
+      "path": "icn/crates/icn-baseline-lock/src/receipt_emit.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "1df267a126bda607aa84bd65975d9cb707ebb2e7f5c7eac729b460542ada5212",
+      "size_bytes": 1288,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "receipt_types.rs",
+      "path": "icn/crates/icn-baseline-lock/src/receipt_types.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "4787f7206574a39c060c4b746215bfb7e69b29278a97a6ff6434783406fb30d3",
+      "size_bytes": 12777,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "baseline_lock_loop.rs",
+      "path": "icn/crates/icn-baseline-lock/tests/baseline_lock_loop.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "18c5c0af68c7b616e5b98c72b991fac12d1b00ea0a9be4af168a2337f2941b93",
+      "size_bytes": 14034,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-baseline-lock/tests/fixtures",
+      "extension": ".wasm",
+      "kind": "file",
+      "language": "unknown",
+      "name": "icn_baseline_lock_guest.wasm",
+      "path": "icn/crates/icn-baseline-lock/tests/fixtures/icn_baseline_lock_guest.wasm",
+      "role_guess": "Rust library crate",
+      "sha256": "8f2c24ecffd69d27500ea9a54fc3969d9fdd98cb421b732e7f1367a496a42288",
+      "size_bytes": 22399,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-boundary",
+      "extension": ".toml",
+      "kind": "file",
+      "language": "TOML",
+      "name": "Cargo.toml",
+      "path": "icn/crates/icn-boundary/Cargo.toml",
+      "role_guess": "Rust library crate",
+      "sha256": "9dde7d509a8271fa39bc485459cd2529e0c1167a532091b28e80cfb96fc7a0ff",
+      "size_bytes": 742,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-boundary/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "lib.rs",
+      "path": "icn/crates/icn-boundary/src/lib.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "bd3614921d815b1181164c4c4b71c5d6383867f84ac5f0268a031db3b98548a7",
+      "size_bytes": 309,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-boundary/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "types.rs",
+      "path": "icn/crates/icn-boundary/src/types.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "fbe3de498cf3b647ab2ed01b56377ee1bdd571e66f175b186534ce7e5b775e12",
+      "size_bytes": 2997,
       "symlink_target": null,
       "tracked": true
     },
@@ -25597,7 +29277,7 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-commons/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "f7eb1ad82bb500742d0ffb835f5677bafc11aca090102ef6298a321a5131ce6e",
+      "sha256": "9796b362338196be90a75e9b426824cddc56743acf379990b73968e7dc37b6ba",
       "size_bytes": 799,
       "symlink_target": null,
       "tracked": true
@@ -25623,8 +29303,8 @@
       "name": "handle.rs",
       "path": "icn/crates/icn-commons/src/handle.rs",
       "role_guess": "Rust library crate",
-      "sha256": "b41afa0fa4568f80e5e1aa482a62040b4f93e29e38a3b95859b9b3f229ff00ad",
-      "size_bytes": 28796,
+      "sha256": "f8bb330c6b13ae64a2f33054346e558f219fc2c897a37f1946bcc6d1fd050459",
+      "size_bytes": 29513,
       "symlink_target": null,
       "tracked": true
     },
@@ -25636,8 +29316,8 @@
       "name": "inner.rs",
       "path": "icn/crates/icn-commons/src/inner.rs",
       "role_guess": "Rust library crate",
-      "sha256": "e0e0834f7346aa3a062a7a116cbc08197a64cfe1f5e89823006fe770cf66a434",
-      "size_bytes": 72142,
+      "sha256": "ecddb467766a2a13d485dd7c233fcaaa13e7cd2cdae781f51fc05bcf803e9e50",
+      "size_bytes": 73256,
       "symlink_target": null,
       "tracked": true
     },
@@ -25662,8 +29342,8 @@
       "name": "store.rs",
       "path": "icn/crates/icn-commons/src/store.rs",
       "role_guess": "Rust library crate",
-      "sha256": "eb4e8c8cf569384a9e6eb298ab04f0382f06e35a8432ea506e9d601446e64a82",
-      "size_bytes": 34854,
+      "sha256": "86f0c986bac0fdd5218b3a079ea4cb63ad760b35e8649137b8c46c658efee97d",
+      "size_bytes": 46511,
       "symlink_target": null,
       "tracked": true
     },
@@ -25896,8 +29576,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-compute/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "fddbb0112a6d39b71c4e792a94f5ca739bf0158ff163233371b5ab99e993a891",
-      "size_bytes": 1617,
+      "sha256": "65f441a9c6a377cb81a8e89704873314a56f79bea411e60588094916e4985d38",
+      "size_bytes": 1876,
       "symlink_target": null,
       "tracked": true
     },
@@ -26104,8 +29784,8 @@
       "name": "cost.rs",
       "path": "icn/crates/icn-compute/src/cost.rs",
       "role_guess": "Rust library crate",
-      "sha256": "fb40cead37adcb3ff6c2e5eec125f7a4ed67a08483620dc574db4f622af0c81e",
-      "size_bytes": 4530,
+      "sha256": "b7000e7302dabd202012e65466483b09573b9724a02a27a784f5be10987a10b8",
+      "size_bytes": 5529,
       "symlink_target": null,
       "tracked": true
     },
@@ -26247,8 +29927,8 @@
       "name": "scheduler.rs",
       "path": "icn/crates/icn-compute/src/scheduler.rs",
       "role_guess": "Rust library crate",
-      "sha256": "337ce7dc257a40b6599ab1da9c267ef975c0a26b9e69299e3f6d8cd3b25b52d6",
-      "size_bytes": 92163,
+      "sha256": "c17f206cb47318fedfdacf6f051cd3612704761238dea8b24cbbdd4f10625a55",
+      "size_bytes": 92159,
       "symlink_target": null,
       "tracked": true
     },
@@ -26351,8 +30031,8 @@
       "name": "federation_integration.rs",
       "path": "icn/crates/icn-compute/tests/federation_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "7b7a4cd1da280af37bb65ec5d74d4cb90272f0dbdb42e9594dae04bf2fd76fe5",
-      "size_bytes": 13254,
+      "sha256": "8e898938c2e66d229f12d5ca7f8348ec11813a14db4b318db708f75c99d726c4",
+      "size_bytes": 13253,
       "symlink_target": null,
       "tracked": true
     },
@@ -26377,8 +30057,8 @@
       "name": "actor.rs",
       "path": "icn/crates/icn-coop/src/actor.rs",
       "role_guess": "Rust library crate",
-      "sha256": "b24f95177ea2d06e2effd0f637532145c309f30e9cb50de63d84deaa34e7f817",
-      "size_bytes": 58135,
+      "sha256": "1bdfd9fa66d3082847e701093f8d90dafb1623fc30b3a37f1029dd5e41cb2812",
+      "size_bytes": 72400,
       "symlink_target": null,
       "tracked": true
     },
@@ -26403,8 +30083,8 @@
       "name": "lib.rs",
       "path": "icn/crates/icn-coop/src/lib.rs",
       "role_guess": "Rust library crate",
-      "sha256": "9bb51f940ab59e47eaddf2bc257beb490fa13bc72da3d8495fab4d0a2325bb66",
-      "size_bytes": 2415,
+      "sha256": "2e9a85c2c5744d455848a4a386433167abf30ced6dfe2045bd24b1339bb04dca",
+      "size_bytes": 2491,
       "symlink_target": null,
       "tracked": true
     },
@@ -26468,8 +30148,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-core/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "2287b125635d11cdfeae358eeb3dac6ca8112d4ed99408f224dc8c4c53705f5d",
-      "size_bytes": 2024,
+      "sha256": "52bb193f7a0cd14e23b5ec2aa206067bc33590d5ed3c9bc603b7995b19a61194",
+      "size_bytes": 2146,
       "symlink_target": null,
       "tracked": true
     },
@@ -26611,8 +30291,8 @@
       "name": "gateway.rs",
       "path": "icn/crates/icn-core/src/config/gateway.rs",
       "role_guess": "Rust library crate",
-      "sha256": "4fa8b2356fc6ebff86be6e9269be0e5e9cfd2de102a498d5ffbffab24fe29602",
-      "size_bytes": 2133,
+      "sha256": "8042aa0da78a8039cc2729c7fb4102e50d5589378f785f6d619f4a9b1b5980fd",
+      "size_bytes": 2997,
       "symlink_target": null,
       "tracked": true
     },
@@ -26936,8 +30616,8 @@
       "name": "resource_enforcer_actor.rs",
       "path": "icn/crates/icn-core/src/resource_enforcer_actor.rs",
       "role_guess": "Rust library crate",
-      "sha256": "52694a05bb1ca5dcb26c1695bdfee1c543955960476a2322e8106ef9e88c25c2",
-      "size_bytes": 27835,
+      "sha256": "6cc47e532dacf96a7ad5886a95469e616e51a46ef08d40365b9a59c9347308ea",
+      "size_bytes": 27831,
       "symlink_target": null,
       "tracked": true
     },
@@ -26988,8 +30668,8 @@
       "name": "federation_service.rs",
       "path": "icn/crates/icn-core/src/services/federation_service.rs",
       "role_guess": "Rust library crate",
-      "sha256": "8db0a78864ce031cb18f2ab5b6ed9a85ec4e28de494d6b7fba4105b008627f80",
-      "size_bytes": 95427,
+      "sha256": "a8720783ce807cb773026c345b9b1fe188734ec6e4586daa3ad182e1e16a3c9a",
+      "size_bytes": 100221,
       "symlink_target": null,
       "tracked": true
     },
@@ -27040,8 +30720,8 @@
       "name": "sdis_service.rs",
       "path": "icn/crates/icn-core/src/services/sdis_service.rs",
       "role_guess": "Rust library crate",
-      "sha256": "5ffc93ac4ef3068afd314615a5ad419869e753cf77c226dad9bf1808bf39ec8c",
-      "size_bytes": 56906,
+      "sha256": "3d7c3cd7f5344c43bb4c25954106dacfe1b602b4a51fa90d29d3bea98e390825",
+      "size_bytes": 63363,
       "symlink_target": null,
       "tracked": true
     },
@@ -27066,8 +30746,8 @@
       "name": "storage_challenge.rs",
       "path": "icn/crates/icn-core/src/storage_challenge.rs",
       "role_guess": "Rust library crate",
-      "sha256": "a13a580217f265ea7cc39c832774b87025dbfd4908bce8557308bec8cb7e63d5",
-      "size_bytes": 38878,
+      "sha256": "c737ea081fa0678012125411ae90aceb2569e57e47e23b099c4e6de9cc31fb38",
+      "size_bytes": 38870,
       "symlink_target": null,
       "tracked": true
     },
@@ -27079,8 +30759,8 @@
       "name": "actors.rs",
       "path": "icn/crates/icn-core/src/supervisor/actors.rs",
       "role_guess": "Rust library crate",
-      "sha256": "f804623c9c0a1d2f2b9dd80d3d8be55f6ccbbbc4c5378e815f2635b504febd19",
-      "size_bytes": 9286,
+      "sha256": "3f4abea5b37a575f1786378ef1ac6f839aea114eb7f6e98c9bda9ea46d9e744e",
+      "size_bytes": 10253,
       "symlink_target": null,
       "tracked": true
     },
@@ -27118,8 +30798,8 @@
       "name": "decision_executor.rs",
       "path": "icn/crates/icn-core/src/supervisor/decision_executor.rs",
       "role_guess": "Rust library crate",
-      "sha256": "afb829f76a1f1390cf8eed9da708efcdeb554ebe8242062a63452b263069cc71",
-      "size_bytes": 57745,
+      "sha256": "46b462242f476e5365ee72a8f492906e442a3a7c098c70f321725cce00d45e83",
+      "size_bytes": 70718,
       "symlink_target": null,
       "tracked": true
     },
@@ -27144,8 +30824,8 @@
       "name": "execution_store.rs",
       "path": "icn/crates/icn-core/src/supervisor/execution_store.rs",
       "role_guess": "Rust library crate",
-      "sha256": "62380a7922a733d71d9db367c18cbfd5d16a3c781a98cda9af23d1e315733861",
-      "size_bytes": 6831,
+      "sha256": "b24abd6aa049bedbaf986397c7ce1f73f55cba9b52af4321b682366ae5312ed3",
+      "size_bytes": 11174,
       "symlink_target": null,
       "tracked": true
     },
@@ -27222,8 +30902,8 @@
       "name": "init_coop.rs",
       "path": "icn/crates/icn-core/src/supervisor/init_coop.rs",
       "role_guess": "Rust library crate",
-      "sha256": "491342f898cefa1d779a49a874ba34d5d59b5fa4a742546fd35c346633111e34",
-      "size_bytes": 3239,
+      "sha256": "b622ddb5c3ab88b169be13ebce69b4ba596c2666a3e02a57d6585b85ede75ee0",
+      "size_bytes": 4133,
       "symlink_target": null,
       "tracked": true
     },
@@ -27261,8 +30941,8 @@
       "name": "init_gateway.rs",
       "path": "icn/crates/icn-core/src/supervisor/init_gateway.rs",
       "role_guess": "Rust library crate",
-      "sha256": "c0713d70bec53aab7b0ba1352cd6da2320d69f1daf2170fa1e092059e155cb98",
-      "size_bytes": 11023,
+      "sha256": "2a06e1e14feac571a7b119c446ff205272127a3e220b0f06ac3e97c31c855d43",
+      "size_bytes": 12537,
       "symlink_target": null,
       "tracked": true
     },
@@ -27326,8 +31006,8 @@
       "name": "init_notifications.rs",
       "path": "icn/crates/icn-core/src/supervisor/init_notifications.rs",
       "role_guess": "Rust library crate",
-      "sha256": "4e1af843ca589147e0578bc42c81a4fd0250c3e5a6b8ab7f2e80e0a9fa94dae4",
-      "size_bytes": 46776,
+      "sha256": "fea1f3cf2b967446e67226dfff49e27bf23b682acb51521d6f9d02e07fe5a714",
+      "size_bytes": 53854,
       "symlink_target": null,
       "tracked": true
     },
@@ -27404,8 +31084,8 @@
       "name": "lifecycle.rs",
       "path": "icn/crates/icn-core/src/supervisor/lifecycle.rs",
       "role_guess": "Rust library crate",
-      "sha256": "14e29afb47a63cbb7190bd98539f0eabf87ca9a72a60020ffec40135cf44ad01",
-      "size_bytes": 67718,
+      "sha256": "bb29a7e570bc09efcb1d6c0d0bab735d61721af8846fdf06bd20d9a7215ee3d9",
+      "size_bytes": 69866,
       "symlink_target": null,
       "tracked": true
     },
@@ -27609,11 +31289,24 @@
       "extension": ".rs",
       "kind": "file",
       "language": "Rust",
+      "name": "coop_entity_map_wiring.rs",
+      "path": "icn/crates/icn-core/tests/coop_entity_map_wiring.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "86b8b5dbcd14f94242bc3652e6b13aae9a09177ef945a7f36fc5e42869e8f465",
+      "size_bytes": 3445,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-core/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
       "name": "decision_executor_runtime_test.rs",
       "path": "icn/crates/icn-core/tests/decision_executor_runtime_test.rs",
       "role_guess": "Rust library crate",
-      "sha256": "6cc38d88452bc1ed326f82420bb57cd63c6b7d921d67e29b42e5d576b4d9595c",
-      "size_bytes": 54234,
+      "sha256": "00aae5d363939979bd5ae8268ef866da8cc8b20216404d6942957c1801ed0586",
+      "size_bytes": 70089,
       "symlink_target": null,
       "tracked": true
     },
@@ -27625,8 +31318,21 @@
       "name": "delegation_tally_integration.rs",
       "path": "icn/crates/icn-core/tests/delegation_tally_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "ebe7310290f74d03a3fa44fa68e96c92c932540aadfd8c39300832bb78cce635",
-      "size_bytes": 19327,
+      "sha256": "9d4c4d0a9aadc6efd5284da8a78b2c3aaa3181a23687312a1a59864544ce29f3",
+      "size_bytes": 19471,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-core/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "demo_member_standing_receipt_chain.rs",
+      "path": "icn/crates/icn-core/tests/demo_member_standing_receipt_chain.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "487885a5488dbdfcae6cf9c33d9ac58c16dda9e6c689688d16d811c016fffd66",
+      "size_bytes": 16174,
       "symlink_target": null,
       "tracked": true
     },
@@ -27690,8 +31396,8 @@
       "name": "effect_group_integration.rs",
       "path": "icn/crates/icn-core/tests/effect_group_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "8f92df8b20a6fc6a7cdf903ec5693c803274f46f7694d064aa53cc2fdb5ca5d9",
-      "size_bytes": 39567,
+      "sha256": "f59e5e4ea6ccddd09dda00688dd3a0ee31b83a481aac9f08ac41865b5b23c91c",
+      "size_bytes": 39561,
       "symlink_target": null,
       "tracked": true
     },
@@ -27755,8 +31461,8 @@
       "name": "execution_receipt_gate_integration.rs",
       "path": "icn/crates/icn-core/tests/execution_receipt_gate_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "f877238d77459235cd6c9a26d8ebd76f5b8297411992f2ceb742639ea42a06ea",
-      "size_bytes": 6909,
+      "sha256": "38cbbf38445566eae406883c5a04d80eb0bc47cc25a9cf036ebbd86496e16789",
+      "size_bytes": 6945,
       "symlink_target": null,
       "tracked": true
     },
@@ -27768,8 +31474,8 @@
       "name": "federated_two_node_pilot.rs",
       "path": "icn/crates/icn-core/tests/federated_two_node_pilot.rs",
       "role_guess": "Rust library crate",
-      "sha256": "35000aa52a096e47e4548c50681e875cc62a3ee878cfe6f96904b0964be38dfb",
-      "size_bytes": 44142,
+      "sha256": "5fc0f0d3cf382dd312ea1b8f7e3ecd20df80e9a8a9ceaa6d07de38d4cb8ad260",
+      "size_bytes": 44141,
       "symlink_target": null,
       "tracked": true
     },
@@ -28028,8 +31734,8 @@
       "name": "receipt_chain_vertical_slice.rs",
       "path": "icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs",
       "role_guess": "Rust library crate",
-      "sha256": "80aa97bab2dde18fd0fe43a93b2ecf8784ee96ecb3d12ac97bb4f01656882317",
-      "size_bytes": 11676,
+      "sha256": "fecbb6cb6ccfc39c770eff4414f947e1d759e7df173dd984a5a2c5408589c4fa",
+      "size_bytes": 11712,
       "symlink_target": null,
       "tracked": true
     },
@@ -28210,8 +31916,8 @@
       "name": "treasury_integration.rs",
       "path": "icn/crates/icn-core/tests/treasury_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "6a20d80ab018dee538a79c8ccade3dbcebf0f1ecbcfd563c77264ace85a3201f",
-      "size_bytes": 48445,
+      "sha256": "b14d8aecb3780b39baa0f2104ff8b8bd425195a82fff689718871a3f4facdf32",
+      "size_bytes": 48443,
       "symlink_target": null,
       "tracked": true
     },
@@ -28236,8 +31942,8 @@
       "name": "vertical_slice_integration.rs",
       "path": "icn/crates/icn-core/tests/vertical_slice_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "40cb97092f16f3cfd964a78d4b0ac769c83d8848ab2adf9cac134938f34bad61",
-      "size_bytes": 30448,
+      "sha256": "63d259614f9a8ddc8557c12db7d68795781f92c3d56262982aa59615080bf99a",
+      "size_bytes": 30520,
       "symlink_target": null,
       "tracked": true
     },
@@ -28262,8 +31968,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-crypto-pq/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "fc5482130369b22db2118735b35e8f11ce2b68321408c2489b16eda70ad42d23",
-      "size_bytes": 1589,
+      "sha256": "e5d911d4e11a120a99a6d86066bc25c5fd7757ab244d8faac238e16cfbf98740",
+      "size_bytes": 1734,
       "symlink_target": null,
       "tracked": true
     },
@@ -28275,8 +31981,8 @@
       "name": "blind.rs",
       "path": "icn/crates/icn-crypto-pq/src/blind.rs",
       "role_guess": "Rust library crate",
-      "sha256": "5e06f351817cda3a593cc28f3bb6518d5415e8c29ef8540d366d530c78db1490",
-      "size_bytes": 15048,
+      "sha256": "e61e21d2d3c714215812c9e10ff16fc4b577cceceae54a2667806750515864ae",
+      "size_bytes": 15055,
       "symlink_target": null,
       "tracked": true
     },
@@ -28288,8 +31994,8 @@
       "name": "hybrid.rs",
       "path": "icn/crates/icn-crypto-pq/src/hybrid.rs",
       "role_guess": "Rust library crate",
-      "sha256": "c9a966f7d69c994b9e8a833f1a31575161294bbeead5d8cf846dddf7360f7ec3",
-      "size_bytes": 18960,
+      "sha256": "7978470fddb5ea3ea0fc1870bbf29b2393aef4d66e36bcd235fb21f79b9fe22f",
+      "size_bytes": 18959,
       "symlink_target": null,
       "tracked": true
     },
@@ -28301,8 +32007,8 @@
       "name": "hybrid_kem.rs",
       "path": "icn/crates/icn-crypto-pq/src/hybrid_kem.rs",
       "role_guess": "Rust library crate",
-      "sha256": "31b75e2f4481a2036db7813b2473928a5dedc457296242f078085b68c89ce737",
-      "size_bytes": 14136,
+      "sha256": "5537d3709ced259f1bc9f49c18a1d13628621972d5017dabc8f62f97a8bf3aa4",
+      "size_bytes": 14134,
       "symlink_target": null,
       "tracked": true
     },
@@ -28340,8 +32046,8 @@
       "name": "ml_dsa.rs",
       "path": "icn/crates/icn-crypto-pq/src/ml_dsa.rs",
       "role_guess": "Rust library crate",
-      "sha256": "5c5f68ccb465b8e701e48935c178daf3e4cd1f32103b0b71f230c35c3722a75b",
-      "size_bytes": 13412,
+      "sha256": "8cac8f722576218ff3bf7967795dddb9169c9ae0c198a0c21af4e2e359d374cd",
+      "size_bytes": 13819,
       "symlink_target": null,
       "tracked": true
     },
@@ -28366,8 +32072,8 @@
       "name": "shamir.rs",
       "path": "icn/crates/icn-crypto-pq/src/shamir.rs",
       "role_guess": "Rust library crate",
-      "sha256": "53d1ed00eec1d3454dce425f39d4289fbcc4ecf65375ce2851532dbc8e86247f",
-      "size_bytes": 28389,
+      "sha256": "1ceb9342262b0a94dd95ea91623c282654be18d4ed595adadc05bc00d8f429bc",
+      "size_bytes": 28483,
       "symlink_target": null,
       "tracked": true
     },
@@ -28379,8 +32085,8 @@
       "name": "threshold.rs",
       "path": "icn/crates/icn-crypto-pq/src/threshold.rs",
       "role_guess": "Rust library crate",
-      "sha256": "6d3880bd7782674cfc9979491b09530c3c52246eb9e692ae2efcf2ddb6eeb720",
-      "size_bytes": 13510,
+      "sha256": "2ff160cc26f40ed6b231162b8c7026526193b91618707a06e3cabc7b6aba74a1",
+      "size_bytes": 13514,
       "symlink_target": null,
       "tracked": true
     },
@@ -28457,8 +32163,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-entity/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "a26685208c52a16187bd9bd2b384d3715561934068aa2a5fbfb1a6b3eb1caf55",
-      "size_bytes": 619,
+      "sha256": "2add136e6338e2c5a20e0e6ef32a351043481631c5fcb48ff21f14066915b055",
+      "size_bytes": 641,
       "symlink_target": null,
       "tracked": true
     },
@@ -28472,6 +32178,58 @@
       "role_guess": "Rust library crate",
       "sha256": "dc22556dd0de1db1b493de92a193d4ff28d0137f443213452b105259fd02ce14",
       "size_bytes": 22065,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-entity/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "coop_entity_backfill.rs",
+      "path": "icn/crates/icn-entity/src/coop_entity_backfill.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "f8e41ef4b3b45fece23e33a8913fdd7f15f098e71e42c3ada5b20f7d10dab72d",
+      "size_bytes": 39856,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-entity/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "coop_entity_inventory.rs",
+      "path": "icn/crates/icn-entity/src/coop_entity_inventory.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "60fc32fc4885ab4ae15131c7ee351dad5ceffbd23d47c92634f4d3b01029b971",
+      "size_bytes": 38771,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-entity/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "coop_entity_map.rs",
+      "path": "icn/crates/icn-entity/src/coop_entity_map.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "5178a2b92ee583c6505e7e9aea24e4449f14251bfa77fac871d5902fe3549a43",
+      "size_bytes": 41929,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-entity/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "coop_entity_surrogate.rs",
+      "path": "icn/crates/icn-entity/src/coop_entity_surrogate.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "5febf83608ad634a948da17dcd2d20c3df171f499eae7ec285b76bd179adf476",
+      "size_bytes": 10500,
       "symlink_target": null,
       "tracked": true
     },
@@ -28535,8 +32293,8 @@
       "name": "lib.rs",
       "path": "icn/crates/icn-entity/src/lib.rs",
       "role_guess": "Rust library crate",
-      "sha256": "d5b1cbc920aa4cc81c5375a5a89b4d11b53ba575c779e033f4e6a17ad7957698",
-      "size_bytes": 3697,
+      "sha256": "14d63726c85d786a2a3a149bb9eae7b75d92fae5909ec557f678ca6aa58f3c03",
+      "size_bytes": 4469,
       "symlink_target": null,
       "tracked": true
     },
@@ -28600,8 +32358,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-federation/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "9408bded7672bbdc35a8cb79a079d74c232e10752dd3481bbc47f8a4a4265a4d",
-      "size_bytes": 1217,
+      "sha256": "d8ee65a0b3f1291e54a79e3dff62aa6c5095e48aad266135f270284f622c7b65",
+      "size_bytes": 1338,
       "symlink_target": null,
       "tracked": true
     },
@@ -28678,8 +32436,8 @@
       "name": "attestation.rs",
       "path": "icn/crates/icn-federation/src/attestation.rs",
       "role_guess": "Rust library crate",
-      "sha256": "b7ff7ee83525ab4b8da4a3879ad64b19d5b420020c4efdf21c239915ee76eebd",
-      "size_bytes": 7484,
+      "sha256": "c025d515ac04b4dc95059ec53ab354ba8e7c85f4bf7b577cc2e95ee344cf85c4",
+      "size_bytes": 7548,
       "symlink_target": null,
       "tracked": true
     },
@@ -28912,8 +32670,8 @@
       "name": "federation_integration.rs",
       "path": "icn/crates/icn-federation/tests/federation_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "d273fd9d7f05a23288459f267f9c827feecfa881cd0d8620e4cec58bf0645dba",
-      "size_bytes": 29144,
+      "sha256": "2598b8f5100bded34f6477ad738089914c9b8ef9bb05ed0fd2c0551b69215c40",
+      "size_bytes": 29143,
       "symlink_target": null,
       "tracked": true
     },
@@ -28951,8 +32709,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-gateway/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "67aa43ed77710f6d709e26865d020a209e69630a988e1bc7f0b13ddcd3b59361",
-      "size_bytes": 3200,
+      "sha256": "c0eb1b6b1a895cc13ac6ae9b7c9c6e8a2dde461d9c98f6451c5a8e6b4c5ab137",
+      "size_bytes": 3520,
       "symlink_target": null,
       "tracked": true
     },
@@ -29055,8 +32813,8 @@
       "name": "auth.rs",
       "path": "icn/crates/icn-gateway/src/api/auth.rs",
       "role_guess": "Rust library crate",
-      "sha256": "d80c0b652ad34375dbbe4da4875891b25b91a011c20304b92587d2ed1ab4c04f",
-      "size_bytes": 14768,
+      "sha256": "cc43c1cbd968938a0a0e89f16a46c982fdf2134cc1cf087182591fe45ab8ee2c",
+      "size_bytes": 14894,
       "symlink_target": null,
       "tracked": true
     },
@@ -29107,8 +32865,8 @@
       "name": "mod.rs",
       "path": "icn/crates/icn-gateway/src/api/commons/mod.rs",
       "role_guess": "Rust library crate",
-      "sha256": "82dd2f3d13869321a7038a26ab41941aa036e93e32d29728607848e30bc0a789",
-      "size_bytes": 16247,
+      "sha256": "3860eea35d5075569b744420ffaff1e6be7af328b83c2952a417b16a7312371f",
+      "size_bytes": 26476,
       "symlink_target": null,
       "tracked": true
     },
@@ -29198,8 +32956,8 @@
       "name": "coops.rs",
       "path": "icn/crates/icn-gateway/src/api/coops.rs",
       "role_guess": "Rust library crate",
-      "sha256": "c7972efce78103912fee2826502a1e31866c8196e1e611e737848a3fe2a87592",
-      "size_bytes": 24430,
+      "sha256": "047571db43acd66fb0ded1f299f4a7b145b227fa1c25a941a6a9227cc1f57477",
+      "size_bytes": 24910,
       "symlink_target": null,
       "tracked": true
     },
@@ -29224,8 +32982,8 @@
       "name": "entity.rs",
       "path": "icn/crates/icn-gateway/src/api/entity.rs",
       "role_guess": "Rust library crate",
-      "sha256": "74139a12e1503df80abf84a563c6c2dd5aa2fdcbdee3acb13324440dc6f81c0a",
-      "size_bytes": 74968,
+      "sha256": "5a115aeb8d5c5b3086f17a6493367525e4143e8f9f48a5ee7426c8965fe650f9",
+      "size_bytes": 74757,
       "symlink_target": null,
       "tracked": true
     },
@@ -29237,8 +32995,8 @@
       "name": "escrow.rs",
       "path": "icn/crates/icn-gateway/src/api/escrow.rs",
       "role_guess": "Rust library crate",
-      "sha256": "9da239d085144cb3ba18c5f1681aa79e033b2c5645c7108870b13ee4e098c601",
-      "size_bytes": 12229,
+      "sha256": "c093d58a8bc60aaf9ef2bec907610ca4a4098014c5fcae7ceec6128c91464150",
+      "size_bytes": 18449,
       "symlink_target": null,
       "tracked": true
     },
@@ -29263,8 +33021,8 @@
       "name": "federation.rs",
       "path": "icn/crates/icn-gateway/src/api/federation.rs",
       "role_guess": "Rust library crate",
-      "sha256": "70819a230a127633203cf1369109adf9030113dfe94cd14134045551af84866c",
-      "size_bytes": 79360,
+      "sha256": "c585278ad43000364a2d868db2e7b715a172e7508e29f3e5d6c92525bebc2b44",
+      "size_bytes": 113754,
       "symlink_target": null,
       "tracked": true
     },
@@ -29276,8 +33034,8 @@
       "name": "flow_c.rs",
       "path": "icn/crates/icn-gateway/src/api/flow_c.rs",
       "role_guess": "Rust library crate",
-      "sha256": "af93346a4377bf6298b894892ebf2f62710c660ccc7fb273aca4ad36003e4f97",
-      "size_bytes": 8759,
+      "sha256": "1bfb954901a9933463efb37cfb7fc8cb3436fdcab1a365a769ba09e415ed6c0d",
+      "size_bytes": 11132,
       "symlink_target": null,
       "tracked": true
     },
@@ -29328,8 +33086,8 @@
       "name": "invites.rs",
       "path": "icn/crates/icn-gateway/src/api/invites.rs",
       "role_guess": "Rust library crate",
-      "sha256": "c8aa450d4d859648f6029084a6369035325efbbd2147ff44d8ca4a519a666529",
-      "size_bytes": 5860,
+      "sha256": "24f05ea807728dc17c925ac0216dabbd14223716a547cec5ea35c1090f88dcab",
+      "size_bytes": 10651,
       "symlink_target": null,
       "tracked": true
     },
@@ -29341,8 +33099,8 @@
       "name": "ledger.rs",
       "path": "icn/crates/icn-gateway/src/api/ledger.rs",
       "role_guess": "Rust library crate",
-      "sha256": "504068e419cca5bc7fb31e3b383aa43f0c5d02876c47730f8e88d3231366e7ca",
-      "size_bytes": 66642,
+      "sha256": "c63602613c82bd1ea9c0a9b12acce5053e36463952d68c9082eb99d3463aa250",
+      "size_bytes": 67782,
       "symlink_target": null,
       "tracked": true
     },
@@ -29367,8 +33125,8 @@
       "name": "members.rs",
       "path": "icn/crates/icn-gateway/src/api/members.rs",
       "role_guess": "Rust library crate",
-      "sha256": "ba66abec8450491affeba13c88e90a62181f8ee053b0dcf2b80503ec28b58a40",
-      "size_bytes": 15226,
+      "sha256": "843367d5a8b00c5e6137455b491f78498841c4c55dae88df670cbd97b825bb30",
+      "size_bytes": 15286,
       "symlink_target": null,
       "tracked": true
     },
@@ -29445,8 +33203,8 @@
       "name": "receipts.rs",
       "path": "icn/crates/icn-gateway/src/api/receipts.rs",
       "role_guess": "Rust library crate",
-      "sha256": "b41b56f09b3019da57121c7899ea78d4820dacfd8bdf946516c89c07334d0c33",
-      "size_bytes": 33028,
+      "sha256": "846f2cd36a2428453e8828c01b2eb68492d1187248cb5b910a3fdd47ee8a01bd",
+      "size_bytes": 35653,
       "symlink_target": null,
       "tracked": true
     },
@@ -29458,8 +33216,8 @@
       "name": "recurring_settlements.rs",
       "path": "icn/crates/icn-gateway/src/api/recurring_settlements.rs",
       "role_guess": "Rust library crate",
-      "sha256": "e37dbad6eb7ade304d50526560cae93cd7f40c08ac36a2bb43c17a9bc7b7da4e",
-      "size_bytes": 14063,
+      "sha256": "26423705ac48b7775a35a7f7eb308bf61a711a98c1cae8de76442ee17e87ff71",
+      "size_bytes": 20190,
       "symlink_target": null,
       "tracked": true
     },
@@ -29471,8 +33229,8 @@
       "name": "registry.rs",
       "path": "icn/crates/icn-gateway/src/api/registry.rs",
       "role_guess": "Rust library crate",
-      "sha256": "9d262c14f3aff983b697cc460474090d9be2cc6755a9858532d240073cf51e0e",
-      "size_bytes": 50940,
+      "sha256": "dcff82ce46d2b94158e036e9143d710ae1bdf4e607114f0cc88b8d26eac83f65",
+      "size_bytes": 63786,
       "symlink_target": null,
       "tracked": true
     },
@@ -29523,8 +33281,8 @@
       "name": "ephemeral.rs",
       "path": "icn/crates/icn-gateway/src/api/sdis/ephemeral.rs",
       "role_guess": "Rust library crate",
-      "sha256": "e1213a335ef1423a367bf2fc9f738fcb371fcfdc16c1e31dbc2e49d3ba8ea24c",
-      "size_bytes": 13153,
+      "sha256": "a31560a7adbd600121c6e92e056129821c22e374c07bff0f71333d1d70d0d85d",
+      "size_bytes": 13139,
       "symlink_target": null,
       "tracked": true
     },
@@ -29575,8 +33333,8 @@
       "name": "simple_enrollment.rs",
       "path": "icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs",
       "role_guess": "Rust library crate",
-      "sha256": "06085151b976f9269548be77c88723b98258e5eff8fb66d4d8820e06d56b2e7b",
-      "size_bytes": 56724,
+      "sha256": "83203eb35b72b7b79335b0a60cbf473776cf8815ab3cbc4116981188a49c74c7",
+      "size_bytes": 56716,
       "symlink_target": null,
       "tracked": true
     },
@@ -29640,8 +33398,8 @@
       "name": "treasury.rs",
       "path": "icn/crates/icn-gateway/src/api/treasury.rs",
       "role_guess": "Rust library crate",
-      "sha256": "69c0feaa1b171f7107481471788abc5e3def2a1bca14cb1cb6f00afff09dc615",
-      "size_bytes": 44067,
+      "sha256": "892a34468e8451a4e669df55d9d26c193788858aa3da08d8f30a0db5c873ca33",
+      "size_bytes": 59556,
       "symlink_target": null,
       "tracked": true
     },
@@ -29692,8 +33450,8 @@
       "name": "auth.rs",
       "path": "icn/crates/icn-gateway/src/auth.rs",
       "role_guess": "Rust library crate",
-      "sha256": "0005b4c76b0db2d6fe7e4d888a26736b2a7f8dfbffba8fa35c1cf6093170eb24",
-      "size_bytes": 16748,
+      "sha256": "d017f1ec4a3028812473593c0d62f6266653d554558233570eab4d166f953717",
+      "size_bytes": 31048,
       "symlink_target": null,
       "tracked": true
     },
@@ -29705,8 +33463,8 @@
       "name": "authority.rs",
       "path": "icn/crates/icn-gateway/src/authority.rs",
       "role_guess": "Rust library crate",
-      "sha256": "16d812350c7ae102ba556a4e5b57158ccc56cafeec009d21970a007c68a5ba6d",
-      "size_bytes": 4006,
+      "sha256": "0b0c2459b64b1608f445aabbbf223655e717d54c868e6ded0b6688f80e289437",
+      "size_bytes": 35098,
       "symlink_target": null,
       "tracked": true
     },
@@ -29806,6 +33564,19 @@
       "extension": ".rs",
       "kind": "file",
       "language": "Rust",
+      "name": "dispatch_evidence_backfill.rs",
+      "path": "icn/crates/icn-gateway/src/dispatch_evidence_backfill.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "8a855164ad33daccc76d2827cdd117a6bc76e7f5040cce92aab195072d63d740",
+      "size_bytes": 19434,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-gateway/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
       "name": "email_client.rs",
       "path": "icn/crates/icn-gateway/src/email_client.rs",
       "role_guess": "Rust library crate",
@@ -29824,6 +33595,19 @@
       "role_guess": "Rust library crate",
       "sha256": "e84f3d855a0bb1c330850fcf38ded683c7589f48ddf06bbf49be426537600bf1",
       "size_bytes": 37813,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-gateway/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "entity_map.rs",
+      "path": "icn/crates/icn-gateway/src/entity_map.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "daa10b0676215c562731348655ff4aac4f26a4c964de2680ad80bf1d241ecf57",
+      "size_bytes": 3783,
       "symlink_target": null,
       "tracked": true
     },
@@ -29939,8 +33723,8 @@
       "name": "invite.rs",
       "path": "icn/crates/icn-gateway/src/invite.rs",
       "role_guess": "Rust library crate",
-      "sha256": "f44322d312f01b6ca5dee55e8c00bbb8a9eba75e4117815cf776b1ec597fd92b",
-      "size_bytes": 7300,
+      "sha256": "fac1077d63c5938e463b6ae60efeebcc130f5fccf28ba8173052795e37edeffb",
+      "size_bytes": 7289,
       "symlink_target": null,
       "tracked": true
     },
@@ -29978,8 +33762,8 @@
       "name": "lib.rs",
       "path": "icn/crates/icn-gateway/src/lib.rs",
       "role_guess": "Rust library crate",
-      "sha256": "b735d28bd6d97e51b38cf9875dc93111db562afd1c36609da5733a4d59eea512",
-      "size_bytes": 3922,
+      "sha256": "9228d55f3df894193558a41a8a7b6a656c2a099b70f12f3d2a07328c14bdb52d",
+      "size_bytes": 4006,
       "symlink_target": null,
       "tracked": true
     },
@@ -30017,8 +33801,8 @@
       "name": "middleware.rs",
       "path": "icn/crates/icn-gateway/src/middleware.rs",
       "role_guess": "Rust library crate",
-      "sha256": "81b87c961ad57eb486720ab2ceb626fff8b839b6af7818e7e6100d837a81f691",
-      "size_bytes": 9522,
+      "sha256": "e86c07fcda523fc6200ab8380d4dd4bf514afccf12932539407e42768a97f67f",
+      "size_bytes": 20806,
       "symlink_target": null,
       "tracked": true
     },
@@ -30121,8 +33905,8 @@
       "name": "openapi.rs",
       "path": "icn/crates/icn-gateway/src/openapi.rs",
       "role_guess": "Rust library crate",
-      "sha256": "7c56884f672cfe396100b52e4eff0352a503405768eb1119744e3157467e34c3",
-      "size_bytes": 7363,
+      "sha256": "b6eba38670f110abc46440cea8e7d6fe70ce61fd87ac0210ec7deb094d783700",
+      "size_bytes": 12879,
       "symlink_target": null,
       "tracked": true
     },
@@ -30160,8 +33944,8 @@
       "name": "receipt_store.rs",
       "path": "icn/crates/icn-gateway/src/receipt_store.rs",
       "role_guess": "Rust library crate",
-      "sha256": "8ea36ce661df6c9e31f2b620508d91408e677942a0a5f4bdad0a2dad292ef419",
-      "size_bytes": 135684,
+      "sha256": "e8eca4775f3c402dfe564a6ff1fa93eefc25177d0900929f287aedc04fcf1886",
+      "size_bytes": 181810,
       "symlink_target": null,
       "tracked": true
     },
@@ -30186,8 +33970,8 @@
       "name": "server.rs",
       "path": "icn/crates/icn-gateway/src/server.rs",
       "role_guess": "Rust library crate",
-      "sha256": "a93b746f9233a48436bc4cfe3f8a5db397ae2c329d8f2b945341298ae6ffb1c4",
-      "size_bytes": 113154,
+      "sha256": "eecabb6a8162c8975229b71433e61b266a877dba77381086a75668c0dfe063bd",
+      "size_bytes": 127192,
       "symlink_target": null,
       "tracked": true
     },
@@ -30212,8 +33996,8 @@
       "name": "session.rs",
       "path": "icn/crates/icn-gateway/src/session.rs",
       "role_guess": "Rust library crate",
-      "sha256": "144e9538d4cfd0c25dc612fc7b41c62f03279ef145da69d54056f56b69d2d789",
-      "size_bytes": 12721,
+      "sha256": "01381552373578e0e31c06fd50662855590f098d1c6eb2e957e4776ddfcaaad1",
+      "size_bytes": 12710,
       "symlink_target": null,
       "tracked": true
     },
@@ -30227,6 +34011,19 @@
       "role_guess": "Rust library crate",
       "sha256": "c60bc68ece803327c65f4ae6d932c3bf4842f7d4bd26f174a6e21a9b3f5045a9",
       "size_bytes": 6527,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-gateway/src",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "token_authority.rs",
+      "path": "icn/crates/icn-gateway/src/token_authority.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "e341f222007f466aa6488d54bdf94bfbb98f9615f87bee5312d5074c7e9f444d",
+      "size_bytes": 15082,
       "symlink_target": null,
       "tracked": true
     },
@@ -30264,8 +34061,8 @@
       "name": "validation.rs",
       "path": "icn/crates/icn-gateway/src/validation.rs",
       "role_guess": "Rust library crate",
-      "sha256": "673575190284b790c0740c62520e632ab74597eb4c4e8a5bd46e2816d8f1d878",
-      "size_bytes": 39581,
+      "sha256": "4d9982b806ea91847c86d940b3755123940efccf0229ea13704cbcbb22ba678e",
+      "size_bytes": 44466,
       "symlink_target": null,
       "tracked": true
     },
@@ -30303,8 +34100,8 @@
       "name": "app.js",
       "path": "icn/crates/icn-gateway/static/app.js",
       "role_guess": "Rust library crate",
-      "sha256": "66387341ce7191276c84d02f039ac6a528c1328a88f4b0462e9a2ee075e9b883",
-      "size_bytes": 245204,
+      "sha256": "0d776af2cf0aae003839983f9f4e18168522cd0480a99fdae5e5934dae04725b",
+      "size_bytes": 245225,
       "symlink_target": null,
       "tracked": true
     },
@@ -30355,8 +34152,8 @@
       "name": "index.html",
       "path": "icn/crates/icn-gateway/static/index.html",
       "role_guess": "Rust library crate",
-      "sha256": "904304eedb4cde267b8f920495f9cfa4a9d3f5c900e3929151663e838f7168c8",
-      "size_bytes": 97197,
+      "sha256": "93c27be12136554ccdb9757a6d01d732eb6e459fa186c0bdcd3d987ca2ab9c2c",
+      "size_bytes": 97231,
       "symlink_target": null,
       "tracked": true
     },
@@ -30459,7 +34256,7 @@
       "name": "sw.js",
       "path": "icn/crates/icn-gateway/static/sw.js",
       "role_guess": "Rust library crate",
-      "sha256": "b73527af75073c667ffeecc5eb7cca7a0c84dd3097e4f740a11d899d69a37f92",
+      "sha256": "29e788d153426b4d84cfa5f7db5b8d3dc80b4071fdc1bbe65f477dc17aa88376",
       "size_bytes": 12014,
       "symlink_target": null,
       "tracked": true
@@ -30547,11 +34344,37 @@
       "extension": ".rs",
       "kind": "file",
       "language": "Rust",
+      "name": "demo_member_standing_bootstrap.rs",
+      "path": "icn/crates/icn-gateway/tests/demo_member_standing_bootstrap.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "731d39f471412e7eeaabd5117e874642dc1653f2f2ca8a980ff98fee7c457d68",
+      "size_bytes": 12003,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-gateway/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "dev_standing_bootstrap_gate.rs",
+      "path": "icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "c0169d9de9fc1c44ea4ad2384a833ce735ce23d6a4ffbbd4f207575c78f29fc2",
+      "size_bytes": 26650,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-gateway/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
       "name": "e2e_close_time_revalidation.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs",
       "role_guess": "Rust library crate",
-      "sha256": "540ddcc6b44c1b098f2134add9e28add0d0016bfe7e096bb0c4b436fc96dde72",
-      "size_bytes": 16448,
+      "sha256": "e8166f7c4cf399669ffd74225b051d4a866a228b3ce0bc3a7d8bfdcc11834443",
+      "size_bytes": 16588,
       "symlink_target": null,
       "tracked": true
     },
@@ -30563,8 +34386,8 @@
       "name": "e2e_create_delegation_gate.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs",
       "role_guess": "Rust library crate",
-      "sha256": "6afb8a1740a83892fb662412ea7b219f3f7bca4d13b77e9b1145ae3958934d44",
-      "size_bytes": 28424,
+      "sha256": "0f660977df394e227e29968df162cd79582052a5bb8a505ce7907cc0742339a4",
+      "size_bytes": 29276,
       "symlink_target": null,
       "tracked": true
     },
@@ -30576,8 +34399,8 @@
       "name": "e2e_institutional_flow.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_institutional_flow.rs",
       "role_guess": "Rust library crate",
-      "sha256": "00e1b5c6272513f8325cc5ea0ae4a8683ce58078638bf91c5ee0b2ab92d2d4a2",
-      "size_bytes": 41979,
+      "sha256": "a037eeb68413fd36e935516849dc6b3b1e672b743657708095cd998ab916c95e",
+      "size_bytes": 42871,
       "symlink_target": null,
       "tracked": true
     },
@@ -30589,8 +34412,8 @@
       "name": "e2e_ledger_freeze_enforcement.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs",
       "role_guess": "Rust library crate",
-      "sha256": "0fccbdfe3c2eca3c9d0e1b9462a64f31c5e1c8127e07b3c019b23d0705cd31e4",
-      "size_bytes": 16282,
+      "sha256": "8ceff15a32ddced7951fe5d85c5cc386267e61f75c169d2149eb0f66f8d26d71",
+      "size_bytes": 16894,
       "symlink_target": null,
       "tracked": true
     },
@@ -30602,8 +34425,8 @@
       "name": "e2e_member_standing_gate.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs",
       "role_guess": "Rust library crate",
-      "sha256": "85659d308762fce7f30acd5b666c6ee34b2f8ac487945aa04ff36de76fb9d6f3",
-      "size_bytes": 12369,
+      "sha256": "daf0db7262b306262b6070b4b2bfd6a91eef8e92e654ddeeba27fb863944be7e",
+      "size_bytes": 12509,
       "symlink_target": null,
       "tracked": true
     },
@@ -30615,8 +34438,8 @@
       "name": "e2e_open_proposal_gate.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs",
       "role_guess": "Rust library crate",
-      "sha256": "3884c0e9eeb21c60eacc59b9610fe3e1c072e85c2b1dc915493a1aade14bdbe5",
-      "size_bytes": 17915,
+      "sha256": "fe2b73b13d1363e0c69a9b6639db3010b5d9b7d28cb71fbbddbb6be2b2f291bd",
+      "size_bytes": 18527,
       "symlink_target": null,
       "tracked": true
     },
@@ -30628,8 +34451,8 @@
       "name": "e2e_proposal_submission_gate.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs",
       "role_guess": "Rust library crate",
-      "sha256": "e72cd1315f04e2e591fe50019001fd212be91160d7dae3dc0e14cb5dee2fe7f4",
-      "size_bytes": 16843,
+      "sha256": "6bd30cc6aac568fdd0c3501cb01b5ddc7734a0d841da7974ed0d843c217f7fd2",
+      "size_bytes": 17455,
       "symlink_target": null,
       "tracked": true
     },
@@ -30641,8 +34464,8 @@
       "name": "e2e_steward_standing_gate.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs",
       "role_guess": "Rust library crate",
-      "sha256": "231f3423e9e51392502ace64ab63516e47d1294bcfeeab1606c60ae197f9213f",
-      "size_bytes": 15021,
+      "sha256": "e05a92b943a2070e5a53573dc29b6858c6a97f7e191a28b8e41679cd2fe2c5c1",
+      "size_bytes": 15161,
       "symlink_target": null,
       "tracked": true
     },
@@ -30654,8 +34477,8 @@
       "name": "e2e_trust_threshold_close_time_enforcement.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs",
       "role_guess": "Rust library crate",
-      "sha256": "c87d209c84eeff21be89ad0e5a0cb8b40efb4d9c95472d0362a2e18d9968d4ad",
-      "size_bytes": 23736,
+      "sha256": "26b4925c771efe4cd99a507e751275418e1ce51db013baee00c7dc9b3997b7e6",
+      "size_bytes": 23876,
       "symlink_target": null,
       "tracked": true
     },
@@ -30667,8 +34490,8 @@
       "name": "e2e_vote_standing_gate.rs",
       "path": "icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs",
       "role_guess": "Rust library crate",
-      "sha256": "29af36396b392e73b7afd6803fcd1ed515f32766517bfb8edb21b98044f058d4",
-      "size_bytes": 17429,
+      "sha256": "ee4b5cf475d002a2de73686aaffa7d3b5b6da04ca2c9e958d24d3ed2b2e61f9a",
+      "size_bytes": 17709,
       "symlink_target": null,
       "tracked": true
     },
@@ -30680,8 +34503,8 @@
       "name": "entity_dissolution_integration.rs",
       "path": "icn/crates/icn-gateway/tests/entity_dissolution_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "b72d65070f34f5113b77b469f3ca892ed831a76ce90f30c49d30e02f476dc686",
-      "size_bytes": 34487,
+      "sha256": "f18482d730ef4a273386b8d6a999c679d72e98dafd7ab785c1ba860463564090",
+      "size_bytes": 34539,
       "symlink_target": null,
       "tracked": true
     },
@@ -30693,8 +34516,8 @@
       "name": "entity_integration.rs",
       "path": "icn/crates/icn-gateway/tests/entity_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "1f9878a99b0daa06c01246f7bc4ca8305ef5a35e806b4665dd4dee23cc264ac6",
-      "size_bytes": 35783,
+      "sha256": "8a5fececb35c9586d38f88118eef1012b5b22c1f42d28501a8ed3c88a811c400",
+      "size_bytes": 35835,
       "symlink_target": null,
       "tracked": true
     },
@@ -30745,8 +34568,8 @@
       "name": "governance_proof.rs",
       "path": "icn/crates/icn-gateway/tests/governance_proof.rs",
       "role_guess": "Rust library crate",
-      "sha256": "898a32a20c3ff53bf19ad466dd2e651ec1d0722dbca55065ad411bbc75475058",
-      "size_bytes": 18801,
+      "sha256": "3c2f0ed8b4d088f7ca541940a27113b11644e7ce9f2d6878a5e0e7f853d96ae0",
+      "size_bytes": 19111,
       "symlink_target": null,
       "tracked": true
     },
@@ -30773,6 +34596,19 @@
       "role_guess": "Rust library crate",
       "sha256": "82c88c13fa4097a3e07b6d5db9432ee7a3027f2e92dbfccb24457063ebdc7117",
       "size_bytes": 33809,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-gateway/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "mandate_gate_production_wiring.rs",
+      "path": "icn/crates/icn-gateway/tests/mandate_gate_production_wiring.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "99b8b5e2fe6be3d653f9a4c576c90c2ef57e2ee012a2a6f00244f6f01e8ea5aa",
+      "size_bytes": 4767,
       "symlink_target": null,
       "tracked": true
     },
@@ -30966,8 +34802,8 @@
       "name": "anti_entropy.rs",
       "path": "icn/crates/icn-gossip/src/anti_entropy.rs",
       "role_guess": "Rust library crate",
-      "sha256": "e53070d6364c06bbb659d61b0314113722cb1980569bbaaa24c4e099f4198801",
-      "size_bytes": 5550,
+      "sha256": "bfe386863aa062973ed6019941110d2ed86bbfb06b8f5ccf5bf957c1f8a0c55a",
+      "size_bytes": 10014,
       "symlink_target": null,
       "tracked": true
     },
@@ -31018,8 +34854,8 @@
       "name": "gossip.rs",
       "path": "icn/crates/icn-gossip/src/gossip.rs",
       "role_guess": "Rust library crate",
-      "sha256": "ac3eaf30dc9f5b2a1bd0cf595dae36ec2355c8197c97568af5e09082e3a2ee61",
-      "size_bytes": 128115,
+      "sha256": "06f38ae27d400a9eead88715b1b4eaf3aeedb6d3274cbaf006aa3f981c4ddb71",
+      "size_bytes": 128630,
       "symlink_target": null,
       "tracked": true
     },
@@ -31213,8 +35049,8 @@
       "name": "lib.rs",
       "path": "icn/crates/icn-gossip/src/lib.rs",
       "role_guess": "Rust library crate",
-      "sha256": "2f399b176c630351580aee1a4ce27ef2e8e3e638745119ebc432792556c3bc96",
-      "size_bytes": 3205,
+      "sha256": "6273bfc124077a85103b46d7a38ea36d733edae36c4444a69fc28f6421ce4874",
+      "size_bytes": 3445,
       "symlink_target": null,
       "tracked": true
     },
@@ -31395,8 +35231,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-governance/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "22539c066d91e6ba9ca1446d7f587ffc349707c1b97d23971804c1c444d24301",
-      "size_bytes": 1000,
+      "sha256": "0aa7832440af09734ca397727f1f77db55b303131c8e4e931a8f9019b974258b",
+      "size_bytes": 1048,
       "symlink_target": null,
       "tracked": true
     },
@@ -31408,8 +35244,8 @@
       "name": "action_item.rs",
       "path": "icn/crates/icn-governance/src/action_item.rs",
       "role_guess": "Rust library crate",
-      "sha256": "6ccf67b0cb7c509bbacde22649db6abedd4a2829a077bbcff2464d4ea567db9e",
-      "size_bytes": 41602,
+      "sha256": "d007ec6f142806d9f39c56b581909fb2e7dfb32511e70818dd38b996bbe4fade",
+      "size_bytes": 42374,
       "symlink_target": null,
       "tracked": true
     },
@@ -31603,8 +35439,8 @@
       "name": "handle.rs",
       "path": "icn/crates/icn-governance/src/handle.rs",
       "role_guess": "Rust library crate",
-      "sha256": "29cd7afb5950e7b3659235caa94dc3b16e7253c355201c404be1d1e04a362085",
-      "size_bytes": 9291,
+      "sha256": "d5e3d27bc5f606490c7621742f18bb6ec82c8145c2ca2a6b302f4ffdecf92e34",
+      "size_bytes": 10008,
       "symlink_target": null,
       "tracked": true
     },
@@ -31629,8 +35465,8 @@
       "name": "lib.rs",
       "path": "icn/crates/icn-governance/src/lib.rs",
       "role_guess": "Rust library crate",
-      "sha256": "90b00719d6db87b5be2b3f4c103342ff423bb5d5b14277b40b30427f9ae48abe",
-      "size_bytes": 8781,
+      "sha256": "5993050f686bbd9f75407a29c74732950fc0e6c8303940fe5dc7aa4f08570b83",
+      "size_bytes": 9223,
       "symlink_target": null,
       "tracked": true
     },
@@ -31759,8 +35595,8 @@
       "name": "proof.rs",
       "path": "icn/crates/icn-governance/src/proof.rs",
       "role_guess": "Rust library crate",
-      "sha256": "ecc8c7410152ec561b4faccb49227d8157251db932b2b1158be2807cd93a5034",
-      "size_bytes": 39307,
+      "sha256": "4cb8753a80922d12483d64741cd2eb39f04e9a044b38a469e1ad5d83342b46ba",
+      "size_bytes": 204382,
       "symlink_target": null,
       "tracked": true
     },
@@ -31772,8 +35608,8 @@
       "name": "proposal.rs",
       "path": "icn/crates/icn-governance/src/proposal.rs",
       "role_guess": "Rust library crate",
-      "sha256": "29f7001526cfa890563c268108a3319f790232b3e7818ad0c6705b3cf57e59f8",
-      "size_bytes": 102924,
+      "sha256": "bd7334ee69691a9126029143ddee21da3e1db0c5e3fe18444c16e2af2dd89a36",
+      "size_bytes": 107080,
       "symlink_target": null,
       "tracked": true
     },
@@ -31915,8 +35751,8 @@
       "name": "steward.rs",
       "path": "icn/crates/icn-governance/src/steward.rs",
       "role_guess": "Rust library crate",
-      "sha256": "967b40bd5bdc570073ad3eac78dfa45f8fc13c50e4088964edee7f5d3c3e65dd",
-      "size_bytes": 21612,
+      "sha256": "f15a8bc762d74f20634f680fcebff745749bb68e0ed1d4312331346adc176a6b",
+      "size_bytes": 24741,
       "symlink_target": null,
       "tracked": true
     },
@@ -32032,8 +35868,8 @@
       "name": "auth.rs",
       "path": "icn/crates/icn-http-kit/src/auth.rs",
       "role_guess": "Rust library crate",
-      "sha256": "bbb69e958270ec904f3b2c6811838c7cde197b79d71f33f3c64e903e8a92c7e2",
-      "size_bytes": 2790,
+      "sha256": "ea40183e30c8fd52f22b1955f7d2490be825b9a32d805bfd5ab6cf4396a7f7cf",
+      "size_bytes": 11216,
       "symlink_target": null,
       "tracked": true
     },
@@ -32123,8 +35959,8 @@
       "name": "anchor.rs",
       "path": "icn/crates/icn-identity/src/anchor.rs",
       "role_guess": "Rust library crate",
-      "sha256": "8089f13b4f2b511be8e915e88cea201578507a0e2ce0fd7620223c90c3f873cf",
-      "size_bytes": 12190,
+      "sha256": "8d79c5df2c4ff808ec089f5bf46596d3b587c6f7241c4ba062dbed9f3262263f",
+      "size_bytes": 12194,
       "symlink_target": null,
       "tracked": true
     },
@@ -32162,8 +35998,8 @@
       "name": "bundle.rs",
       "path": "icn/crates/icn-identity/src/bundle.rs",
       "role_guess": "Rust library crate",
-      "sha256": "595f5960b8eaaaabf5a5c0eb98e37d00734f5386826d5357a9ffc5eae9ef1a4c",
-      "size_bytes": 44041,
+      "sha256": "fd910c491c311b0f4d785fb3a0e0cadf56eb73ab7e8eccadc40c6dde15076cee",
+      "size_bytes": 44108,
       "symlink_target": null,
       "tracked": true
     },
@@ -32214,8 +36050,8 @@
       "name": "keybundle.rs",
       "path": "icn/crates/icn-identity/src/keybundle.rs",
       "role_guess": "Rust library crate",
-      "sha256": "efd9a4452fd612e38cdb967b6d2db97d41c6c6d72f0410e1b17f40821ef4bdac",
-      "size_bytes": 17034,
+      "sha256": "d7667a7478ea79d14999af4f6fe071c438cda67f1f78addc36158073845b1660",
+      "size_bytes": 17101,
       "symlink_target": null,
       "tracked": true
     },
@@ -32227,8 +36063,8 @@
       "name": "keystore.rs",
       "path": "icn/crates/icn-identity/src/keystore.rs",
       "role_guess": "Rust library crate",
-      "sha256": "9d5d445a795d0add4a74cf080e0c5c0661147621df93dc322493a2d7a6cca580",
-      "size_bytes": 61005,
+      "sha256": "0ba37a15a4c28ceb50ef1528c5583277131be4cd52204d67fd99a5b7fd3c917f",
+      "size_bytes": 61080,
       "symlink_target": null,
       "tracked": true
     },
@@ -32344,8 +36180,8 @@
       "name": "revocation.rs",
       "path": "icn/crates/icn-identity/src/revocation.rs",
       "role_guess": "Rust library crate",
-      "sha256": "66ab532e0f0e189d195ebb4bd518268140e25c50970455a80b8fa0d263f9b835",
-      "size_bytes": 17389,
+      "sha256": "a6d07ea8e8d31b5b3a6dc0904ad63e181ec67ef7a3580ed25b616de413301bbb",
+      "size_bytes": 17382,
       "symlink_target": null,
       "tracked": true
     },
@@ -32370,8 +36206,8 @@
       "name": "sync.rs",
       "path": "icn/crates/icn-identity/src/sync.rs",
       "role_guess": "Rust library crate",
-      "sha256": "606d44246f053d89be885c8fad2a32f25e2dbd041bb7d1579cb432ff4af88cd8",
-      "size_bytes": 18377,
+      "sha256": "2dae0cc845b0e98705144730af2a9b4ece5f509d34c91875a3e8ba1ae81735c5",
+      "size_bytes": 18578,
       "symlink_target": null,
       "tracked": true
     },
@@ -32383,8 +36219,8 @@
       "name": "vui.rs",
       "path": "icn/crates/icn-identity/src/vui.rs",
       "role_guess": "Rust library crate",
-      "sha256": "44b56daebb84d40374a1c628393cee61843284529e9a82937b991d80c5bef761",
-      "size_bytes": 9387,
+      "sha256": "ae7c1d2d50b44bfe24c5355c8a1392c2b3d47a71da6621e72118ef0cfd63a7c1",
+      "size_bytes": 9395,
       "symlink_target": null,
       "tracked": true
     },
@@ -32409,8 +36245,8 @@
       "name": "identity_sync_test.rs",
       "path": "icn/crates/icn-identity/tests/identity_sync_test.rs",
       "role_guess": "Rust library crate",
-      "sha256": "a4c40c527e1d0931bb0454204a6ea052245bb78188fb57518ac4886616b301e0",
-      "size_bytes": 9150,
+      "sha256": "26c0435f6c9fa21a56aa7a9f2f6a3a3381112bfa3126e9151fd45482b9678bb0",
+      "size_bytes": 9149,
       "symlink_target": null,
       "tracked": true
     },
@@ -32422,8 +36258,8 @@
       "name": "multi_device_integration.rs",
       "path": "icn/crates/icn-identity/tests/multi_device_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "d36ff3155ebca54e4a6e55038db19cf8e899519be73104fe605a64514588ebf6",
-      "size_bytes": 10470,
+      "sha256": "bde1970ac127ba1a5509a9e1f4f4b6c3587f11344d49ff2834fe3248cd848997",
+      "size_bytes": 10469,
       "symlink_target": null,
       "tracked": true
     },
@@ -32435,8 +36271,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-kernel-api/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "752ba9280e6303e8cfaa1bf8d1680a8d9db7f9276fc03bea1a5be96b525c84a9",
-      "size_bytes": 773,
+      "sha256": "465e8f2f5aef2d0d037a9697e1fd1dbe382dac24460b60c28f748b4d58268724",
+      "size_bytes": 1111,
       "symlink_target": null,
       "tracked": true
     },
@@ -32500,8 +36336,8 @@
       "name": "compute.rs",
       "path": "icn/crates/icn-kernel-api/src/compute.rs",
       "role_guess": "Rust library crate",
-      "sha256": "6c555be50cde3267c2711f196ad167738f5652c799734559a4d034877813017a",
-      "size_bytes": 23303,
+      "sha256": "0bac17016d88d5c8bbfef915e5b30ec8169a803a7d64449cb55a418769532682",
+      "size_bytes": 23596,
       "symlink_target": null,
       "tracked": true
     },
@@ -32552,8 +36388,8 @@
       "name": "effects.rs",
       "path": "icn/crates/icn-kernel-api/src/effects.rs",
       "role_guess": "Rust library crate",
-      "sha256": "a4edb667ae64ff0718adf9e428bd350117d28425c75c460877a3faab83e73043",
-      "size_bytes": 47527,
+      "sha256": "acc9c733f51a618e0898d45c72ad97f8de907e5ad724f3fc816c46b467fdb973",
+      "size_bytes": 50822,
       "symlink_target": null,
       "tracked": true
     },
@@ -32604,8 +36440,8 @@
       "name": "execution.rs",
       "path": "icn/crates/icn-kernel-api/src/execution.rs",
       "role_guess": "Rust library crate",
-      "sha256": "5f802e98ecc58fd37784a27d97cc1c52263ffa679abb8a746aa8d315f5490eb2",
-      "size_bytes": 13368,
+      "sha256": "c5cecf876926c7e4a1c613be53b4daab26399eb1788fa15b1ad5b027cb944d40",
+      "size_bytes": 17338,
       "symlink_target": null,
       "tracked": true
     },
@@ -32617,8 +36453,8 @@
       "name": "governance.rs",
       "path": "icn/crates/icn-kernel-api/src/governance.rs",
       "role_guess": "Rust library crate",
-      "sha256": "761fc7e241a528e293f355e070ab29de3b759aa9785f3e20e4aa8107a725d8f5",
-      "size_bytes": 29285,
+      "sha256": "9ea867ab3705436c28056f9cb08704bab0079d22ef848538eae0997d9e9fbb54",
+      "size_bytes": 32775,
       "symlink_target": null,
       "tracked": true
     },
@@ -32656,8 +36492,8 @@
       "name": "lib.rs",
       "path": "icn/crates/icn-kernel-api/src/lib.rs",
       "role_guess": "Rust library crate",
-      "sha256": "85ce686abbd798f804feb96ca090edd7e17a1918715b38b7cb666ecb93aacdba",
-      "size_bytes": 6115,
+      "sha256": "f75eaee597d2df91c0f00372a3ac7c6b3262514ef401bbeb2efa05f4e8a2e696",
+      "size_bytes": 7315,
       "symlink_target": null,
       "tracked": true
     },
@@ -32682,8 +36518,8 @@
       "name": "proofs.rs",
       "path": "icn/crates/icn-kernel-api/src/proofs.rs",
       "role_guess": "Rust library crate",
-      "sha256": "03b54fe233a4948f4bde55fee8b2f13475e0b14ee70a59d4ea4dae2aa06d7ea9",
-      "size_bytes": 8456,
+      "sha256": "7c05a7dc81672d9058f10305b82d8509c137f8ed1f6c2b26b6c7011e9a130949",
+      "size_bytes": 393150,
       "symlink_target": null,
       "tracked": true
     },
@@ -32818,6 +36654,58 @@
       "tracked": true
     },
     {
+      "directory": "icn/crates/icn-kernel-api/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "member_shell_read_only_render_slice_a.rs",
+      "path": "icn/crates/icn-kernel-api/tests/member_shell_read_only_render_slice_a.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "0248675632fcc3131aa755cb7817f567aded0d3d72a6ca07a980e75eea118d08",
+      "size_bytes": 81802,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-kernel-api/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "receipt_index_anti_entropy_slice_a.rs",
+      "path": "icn/crates/icn-kernel-api/tests/receipt_index_anti_entropy_slice_a.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "deb0714b24fed76d5c5680b3bc322e384a532f2cdb0458fa4a963f600f027e51",
+      "size_bytes": 33336,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-kernel-api/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "redundancy_proof_slice_b.rs",
+      "path": "icn/crates/icn-kernel-api/tests/redundancy_proof_slice_b.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "899179974ffdbab1cbdb1b40f3addd2d7ace6746aeeca1bc86823fc309e7567c",
+      "size_bytes": 18275,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "icn/crates/icn-kernel-api/tests",
+      "extension": ".rs",
+      "kind": "file",
+      "language": "Rust",
+      "name": "steward_cockpit_divergence_render_slice_a.rs",
+      "path": "icn/crates/icn-kernel-api/tests/steward_cockpit_divergence_render_slice_a.rs",
+      "role_guess": "Rust library crate",
+      "sha256": "8dcddd5e7903b45c4b8abb46c3f5d290860b951330cbb50a4f8dba5bc2ad079d",
+      "size_bytes": 53681,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "icn/crates/icn-ledger",
       "extension": ".toml",
       "kind": "file",
@@ -32825,8 +36713,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-ledger/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "2720de0e275eda422a4102214ff88ce05a2b07251df27c10deee6461f4f51c81",
-      "size_bytes": 986,
+      "sha256": "ab757f4e9c6fe7250be4512712ed1ab3171557159df31e183205f6d18e430292",
+      "size_bytes": 1134,
       "symlink_target": null,
       "tracked": true
     },
@@ -32838,8 +36726,8 @@
       "name": "ledger_bench.rs",
       "path": "icn/crates/icn-ledger/benches/ledger_bench.rs",
       "role_guess": "Rust library crate",
-      "sha256": "7c93b6351f10cbf3ec9ae428a0ea6f2c02d51d3aa9c31aef83dc47bc32fedeb6",
-      "size_bytes": 4365,
+      "sha256": "593c42c01ebe4d7f13306a001d71cffdbab7ba6d4c18341ee0df109af4e93d71",
+      "size_bytes": 4364,
       "symlink_target": null,
       "tracked": true
     },
@@ -33059,8 +36947,8 @@
       "name": "ledger.rs",
       "path": "icn/crates/icn-ledger/src/ledger.rs",
       "role_guess": "Rust library crate",
-      "sha256": "6d2f92e4fa42781330bced4777e69ce77dd915a016d3de27f30271cb562fe374",
-      "size_bytes": 185027,
+      "sha256": "79c522e64ecf8f1041729bafa9fc93cc2cd45682561ced5126ca51dac6ef7ace",
+      "size_bytes": 190069,
       "symlink_target": null,
       "tracked": true
     },
@@ -33085,8 +36973,8 @@
       "name": "fork_ops.rs",
       "path": "icn/crates/icn-ledger/src/ledger_impl/fork_ops.rs",
       "role_guess": "Rust library crate",
-      "sha256": "c5e9dc3ace4d61586894928dd28efac98fc532f7f860b06aae26bc4d71278fbb",
-      "size_bytes": 13501,
+      "sha256": "c42ca407891c0de25151a4923d63a90c4f01d24d2393078b1a5827b6b7d6150e",
+      "size_bytes": 16098,
       "symlink_target": null,
       "tracked": true
     },
@@ -33124,8 +37012,8 @@
       "name": "queries.rs",
       "path": "icn/crates/icn-ledger/src/ledger_impl/queries.rs",
       "role_guess": "Rust library crate",
-      "sha256": "e1cb665d8dfb779d5c2d87f5050b79875e77b1b7887f1502ad75b7cb742afbdd",
-      "size_bytes": 14592,
+      "sha256": "39ee7e89a5617262de47406fd918aa00db6885ee4a480f72f343b3f135575545",
+      "size_bytes": 24929,
       "symlink_target": null,
       "tracked": true
     },
@@ -33540,7 +37428,7 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-net/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "d593f0e507a7a2c54aa1ece01f7b740d388f6953500054666336afac5e977b2b",
+      "sha256": "4d9ab9376358f728ccc56829247f0a7012bfa85b1c69e90f341d8cb40d35b86a",
       "size_bytes": 1384,
       "symlink_target": null,
       "tracked": true
@@ -33826,8 +37714,8 @@
       "name": "protocol.rs",
       "path": "icn/crates/icn-net/src/protocol.rs",
       "role_guess": "Rust library crate",
-      "sha256": "b8c2362cba3150e4390695aea2f4fd6682e9d02756fa0ebef5fd1bde561226b4",
-      "size_bytes": 82662,
+      "sha256": "786bb0339591413c04b49b0f9af21a6e38bf0dc6d8bc15d2d0bdbfa6e47d5a70",
+      "size_bytes": 82730,
       "symlink_target": null,
       "tracked": true
     },
@@ -33852,8 +37740,8 @@
       "name": "relay_proxy.rs",
       "path": "icn/crates/icn-net/src/relay_proxy.rs",
       "role_guess": "Rust library crate",
-      "sha256": "aefcee7d173d6558b1ee6d5a1a2e03d5b121292aca502d68accdf30cafc3bea5",
-      "size_bytes": 28396,
+      "sha256": "2c2330fe17694bc64df9cacf86f74532a04c1038eda5a21c8add96651f025001",
+      "size_bytes": 28382,
       "symlink_target": null,
       "tracked": true
     },
@@ -33930,8 +37818,8 @@
       "name": "topology.rs",
       "path": "icn/crates/icn-net/src/topology.rs",
       "role_guess": "Rust library crate",
-      "sha256": "f94900ac4ca42596d19a2b730a84a16ac74863b205534b2a1fb065f067d56897",
-      "size_bytes": 29243,
+      "sha256": "4c1bfd5dbf6fa013896168315e6675bb810877337744a7feeb10f4a348297059",
+      "size_bytes": 29317,
       "symlink_target": null,
       "tracked": true
     },
@@ -33943,8 +37831,8 @@
       "name": "turn.rs",
       "path": "icn/crates/icn-net/src/turn.rs",
       "role_guess": "Rust library crate",
-      "sha256": "5da03a28bb8f8bd75d874f203d1bbb7ec01e078792c52018c6cea48b1b944963",
-      "size_bytes": 38111,
+      "sha256": "5352ea7e63ca4222a69dc2f55e4b274b67d22ff69333b97566583fbd7761710e",
+      "size_bytes": 38083,
       "symlink_target": null,
       "tracked": true
     },
@@ -34190,8 +38078,8 @@
       "name": "gateway.rs",
       "path": "icn/crates/icn-obs/src/metrics/gateway.rs",
       "role_guess": "Rust library crate",
-      "sha256": "b463be3b7a3dcad9041d67084810f57621d8635f3bea2e9fc188e86277db5af3",
-      "size_bytes": 22125,
+      "sha256": "422525e733e0d50a91a451e57545ae34e2ead4a7dfcd131f7c87467bd15f17f5",
+      "size_bytes": 23401,
       "symlink_target": null,
       "tracked": true
     },
@@ -34424,8 +38312,8 @@
       "name": "onion_routing.rs",
       "path": "icn/crates/icn-privacy/src/onion_routing.rs",
       "role_guess": "Rust library crate",
-      "sha256": "2ac63ba60961dfeeb7e9a5aa9ed36461b3de26604dd5fcf0ceaa14c1d564d648",
-      "size_bytes": 19039,
+      "sha256": "3d6aff4ae3cfdaf21dad842f013e41a32bfcb5a964afcd12c85caea38b087d30",
+      "size_bytes": 19028,
       "symlink_target": null,
       "tracked": true
     },
@@ -34437,8 +38325,8 @@
       "name": "topic_encryption.rs",
       "path": "icn/crates/icn-privacy/src/topic_encryption.rs",
       "role_guess": "Rust library crate",
-      "sha256": "4a757e2cca99c0c70658debedf9c6e6af19dad53bcfe36960d5962642ed4177e",
-      "size_bytes": 13291,
+      "sha256": "d9e9a0f0696ce7382fc454970adeedef8c15cc76242308ce2020c380fdbc18be",
+      "size_bytes": 13284,
       "symlink_target": null,
       "tracked": true
     },
@@ -34450,8 +38338,8 @@
       "name": "traffic_obfuscation.rs",
       "path": "icn/crates/icn-privacy/src/traffic_obfuscation.rs",
       "role_guess": "Rust library crate",
-      "sha256": "11a2b68c640a1867b4bd98df2ed0cea7c6ea7737269cb925b8f6b33f2b5a1864",
-      "size_bytes": 11933,
+      "sha256": "bcd4145685ae1ae8037d3ac90216ea5267fb4f83a4f9ba08c91a3d40a20f4668",
+      "size_bytes": 11917,
       "symlink_target": null,
       "tracked": true
     },
@@ -34463,8 +38351,8 @@
       "name": "privacy_integration.rs",
       "path": "icn/crates/icn-privacy/tests/privacy_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "2dfabfa8a4abcb4d077d05e8998a00d5c0f30b914ffa9664d0ce95d25b867a0b",
-      "size_bytes": 20727,
+      "sha256": "63e9dc78cedda13c550962c8b36cd12c74f56113dde139eaace7c0cc39e810e2",
+      "size_bytes": 20725,
       "symlink_target": null,
       "tracked": true
     },
@@ -34502,7 +38390,7 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-rpc/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "2707c6b255c88a439b682aa80e3f7c9768f86bd3e58c62c7214947ea91212c4f",
+      "sha256": "3fd30e2e74d46cc1b7ce148b5d5c59b0afdb85b09e65a671635fbbfbabbcec35",
       "size_bytes": 1079,
       "symlink_target": null,
       "tracked": true
@@ -34515,8 +38403,8 @@
       "name": "auth.rs",
       "path": "icn/crates/icn-rpc/src/auth.rs",
       "role_guess": "Rust library crate",
-      "sha256": "69a267233820486b7353aa1c55b0ece13ecfe50c73d801eb4d79fb75bd6df01b",
-      "size_bytes": 51169,
+      "sha256": "48ce6ecc5417011e26c7970944d387cf174cf19200cec0c433904c87d94d8590",
+      "size_bytes": 61346,
       "symlink_target": null,
       "tracked": true
     },
@@ -34632,8 +38520,8 @@
       "name": "governance.rs",
       "path": "icn/crates/icn-rpc/src/handler/governance.rs",
       "role_guess": "Rust library crate",
-      "sha256": "7d25450b42708406974dd370584b937d06540e0269d010dd4e6548e8e83c2234",
-      "size_bytes": 25404,
+      "sha256": "9f7c3dd0676488caef849f516ff88b1efb00637514aa15738f4a96bbc7e49f84",
+      "size_bytes": 25405,
       "symlink_target": null,
       "tracked": true
     },
@@ -34762,8 +38650,8 @@
       "name": "server.rs",
       "path": "icn/crates/icn-rpc/src/server.rs",
       "role_guess": "Rust library crate",
-      "sha256": "5a83e3d66bb33a9713f945a209ad6710f9949477dbeed53eb3602d13856412f8",
-      "size_bytes": 36121,
+      "sha256": "7b0ee90e7290a7e84af227b4007e6fae8f415ea5a34097c55818ca493b816866",
+      "size_bytes": 37500,
       "symlink_target": null,
       "tracked": true
     },
@@ -34788,8 +38676,8 @@
       "name": "rpc_integration.rs",
       "path": "icn/crates/icn-rpc/tests/rpc_integration.rs",
       "role_guess": "Rust library crate",
-      "sha256": "ed6ec4adb694a80b61f33023207e8cc15a0759f2eba1dbcf432fd8de5a344f89",
-      "size_bytes": 53922,
+      "sha256": "1e0a8cf32963fa1459153acb5cdb8cb344ec0e31f38b718fe9406619a1450cba",
+      "size_bytes": 57690,
       "symlink_target": null,
       "tracked": true
     },
@@ -34918,8 +38806,8 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-steward/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "4826ea65f513a94388d5bbf9c42e83804867ffcd9d6c3bad8c0218a69132007f",
-      "size_bytes": 1017,
+      "sha256": "f42ce4425dc8886c0bbf455adbe9247edddddec63c89a3a9ac58a9a7bf4ce43a",
+      "size_bytes": 1148,
       "symlink_target": null,
       "tracked": true
     },
@@ -34996,8 +38884,8 @@
       "name": "enrollment.rs",
       "path": "icn/crates/icn-steward/src/enrollment.rs",
       "role_guess": "Rust library crate",
-      "sha256": "9bed6f988bf0a9c22f5e37c03dba9083247623b212be56ae044442e5f6f44e72",
-      "size_bytes": 23714,
+      "sha256": "e369f927ba15f0579baca3856d6719625ea6931a1cdb496350b7d5703631eb55",
+      "size_bytes": 23718,
       "symlink_target": null,
       "tracked": true
     },
@@ -35074,8 +38962,8 @@
       "name": "token.rs",
       "path": "icn/crates/icn-steward/src/token.rs",
       "role_guess": "Rust library crate",
-      "sha256": "13489a342dd241f81e1759d53b53e54ca91b040502edb363ba9aed69fd1bf114",
-      "size_bytes": 9578,
+      "sha256": "383d00d79c29b441940a9ba0f4618c74940f1c8fad4c11de8f1cec445bdd94a4",
+      "size_bytes": 9582,
       "symlink_target": null,
       "tracked": true
     },
@@ -35152,8 +39040,8 @@
       "name": "lib.rs",
       "path": "icn/crates/icn-store/src/lib.rs",
       "role_guess": "Rust library crate",
-      "sha256": "bd4a202777c246fdc28ba92449c9719c6c11d4f891ef26786e73a794a455ef3b",
-      "size_bytes": 63061,
+      "sha256": "f56b29610b715335bb96d33f53485a554404998bff82ea180bcb22855ece13b5",
+      "size_bytes": 67837,
       "symlink_target": null,
       "tracked": true
     },
@@ -35373,8 +39261,8 @@
       "name": "sync.rs",
       "path": "icn/crates/icn-time/src/sync.rs",
       "role_guess": "Rust library crate",
-      "sha256": "a7cd691602e912fe0a96b05d5f4a67f3c42e5f8b6417c8d2229c623e99004f73",
-      "size_bytes": 18483,
+      "sha256": "da935294b1a712bafcde92307e4ef1ad0fa548e81114698a669bd8fc8aba2030",
+      "size_bytes": 18491,
       "symlink_target": null,
       "tracked": true
     },
@@ -35412,7 +39300,7 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-trust/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "0f809fedf494221604cd9637c91413e7899ea7327d4e36d7e52c5b7b5f376410",
+      "sha256": "d4e2bbf9cf62a19fd71d09d37c0ee989704a992d21ba49b283b38adf9ef0b27f",
       "size_bytes": 770,
       "symlink_target": null,
       "tracked": true
@@ -35425,7 +39313,7 @@
       "name": "trust_bench.rs",
       "path": "icn/crates/icn-trust/benches/trust_bench.rs",
       "role_guess": "Rust library crate",
-      "sha256": "9bdc8586b450307df35a9f6fd884bfda6c1367db6b18165223f8a2bec5f1adfc",
+      "sha256": "e326b9d31608fa752a80aef06976430d44530562776e6f3984cddba156bae98b",
       "size_bytes": 9208,
       "symlink_target": null,
       "tracked": true
@@ -35672,7 +39560,7 @@
       "name": "Cargo.toml",
       "path": "icn/crates/icn-zkp/Cargo.toml",
       "role_guess": "Rust library crate",
-      "sha256": "edb01fa3e06bf8c2000e45c539857ab2a04e1cfe2e183355e6da2587e4b65305",
+      "sha256": "3428a7507928ded08ae6e3abbdbd11d11552d1c23db70b92fcb64d149b3096a6",
       "size_bytes": 1719,
       "symlink_target": null,
       "tracked": true
@@ -35698,8 +39586,8 @@
       "name": "age.rs",
       "path": "icn/crates/icn-zkp/src/circuit/age.rs",
       "role_guess": "Rust library crate",
-      "sha256": "4ae2cd1a09d089501aa1b94529d2dead9a3e57a2cb04c5c2777d2df561a69820",
-      "size_bytes": 12094,
+      "sha256": "d0e9fa49203453f75f47467c766b79f2aa16cf49835d947961f9295c2df4450a",
+      "size_bytes": 12080,
       "symlink_target": null,
       "tracked": true
     },
@@ -35711,8 +39599,8 @@
       "name": "citizenship.rs",
       "path": "icn/crates/icn-zkp/src/circuit/citizenship.rs",
       "role_guess": "Rust library crate",
-      "sha256": "310e296592dca598b67325ecf9594237713f7cea0b2d0df14c3394cba0077fd2",
-      "size_bytes": 9736,
+      "sha256": "007d24f00fa56c3f1317632a6897eeadc5edeb25e68468b1ecd90d6183508eeb",
+      "size_bytes": 9729,
       "symlink_target": null,
       "tracked": true
     },
@@ -35724,8 +39612,8 @@
       "name": "membership.rs",
       "path": "icn/crates/icn-zkp/src/circuit/membership.rs",
       "role_guess": "Rust library crate",
-      "sha256": "cfcb382a08fe145154289073cb24044a35e61dbb69761d4ca0edc3dd24ea2aa6",
-      "size_bytes": 10770,
+      "sha256": "40a9fbe6b92cc1d8e4d1826793711feee145ac48ba882341dd24d3ccf3851485",
+      "size_bytes": 10763,
       "symlink_target": null,
       "tracked": true
     },
@@ -35750,8 +39638,8 @@
       "name": "non_revocation.rs",
       "path": "icn/crates/icn-zkp/src/circuit/non_revocation.rs",
       "role_guess": "Rust library crate",
-      "sha256": "dda8c3f3cd58b2a6d6218a4e57e612b59e185a18361d156c05761725103e6e92",
-      "size_bytes": 17365,
+      "sha256": "87804672029f4ffbdef3d0fe693db5d08fe603deaf222fd6541f230fa71d66b5",
+      "size_bytes": 17358,
       "symlink_target": null,
       "tracked": true
     },
@@ -35880,8 +39768,8 @@
       "name": "types.rs",
       "path": "icn/crates/icn-zkp/src/types.rs",
       "role_guess": "Rust library crate",
-      "sha256": "abee609f1bed85265a41766472b29324f102b8cd51d84dfefe274069b3fe744a",
-      "size_bytes": 11534,
+      "sha256": "e9520f21abd75ee84ae9d9292b8d54fdc811782114cbb9b6e4a583435902bafd",
+      "size_bytes": 11527,
       "symlink_target": null,
       "tracked": true
     },
@@ -35906,8 +39794,8 @@
       "name": "deny.toml",
       "path": "icn/deny.toml",
       "role_guess": "uncategorized",
-      "sha256": "0f446608233298c8cb0e3e43452468c197def97e5fddadb95c7818fec1646160",
-      "size_bytes": 3606,
+      "sha256": "cf2297330a7e38a0c1eb360a7ee38c5b65bd2c42a791ba34435d778509c52993",
+      "size_bytes": 5081,
       "symlink_target": null,
       "tracked": true
     },
@@ -35997,8 +39885,8 @@
       "name": "README.md",
       "path": "institutions/nycn/README.md",
       "role_guess": "institution package",
-      "sha256": "af6012e20a4bd51878e302240dc05b01cd499a599674c0523c396b44acd19eeb",
-      "size_bytes": 3330,
+      "sha256": "cfbd9468b85de46c1ee69ec910ca1198ba23375a0bd1a89595f9b79f2c191786",
+      "size_bytes": 3364,
       "symlink_target": null,
       "tracked": true
     },
@@ -36322,8 +40210,8 @@
       "name": "workshop-proposal-draft.md",
       "path": "institutions/nycn/summit/docs/workshop-proposal-draft.md",
       "role_guess": "institution package",
-      "sha256": "9e2426fb88c94bfb34553e7b758c7b4c363ae6cab7d9d7305ff818d28638829e",
-      "size_bytes": 9261,
+      "sha256": "433929518918ea2282d1f823ffc974a543cd2cf25fa966be23eecc0119df9094",
+      "size_bytes": 13525,
       "symlink_target": null,
       "tracked": true
     },
@@ -36517,8 +40405,8 @@
       "name": "kernel_surface.toml",
       "path": "kernel_surface.toml",
       "role_guess": "uncategorized",
-      "sha256": "6317c2a58c3af1d4e3fa3e501e1ac9bad5211f6c9ef66e74186913740f59bb8e",
-      "size_bytes": 25208,
+      "sha256": "0bc4faf030b0cdfb21c1afed3b6717b43b2deb99aed8fa163eec5bb5e2790bee",
+      "size_bytes": 25640,
       "symlink_target": null,
       "tracked": true
     },
@@ -36829,8 +40717,60 @@
       "name": "README.md",
       "path": "ops/ideas/README.md",
       "role_guess": "operations / coordination",
-      "sha256": "a9d662cb37ee1d2be5ffc85fbacbb9ddaff61d6784347d3e660bb8425fe04528",
-      "size_bytes": 9257,
+      "sha256": "b997ce60d85d7287e542b7c53613acd43cd952a0937858cdfc5c8e301490b125",
+      "size_bytes": 10593,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/ideas/dogfood",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "democratic-authority-primitives-mvp.md",
+      "path": "ops/ideas/dogfood/democratic-authority-primitives-mvp.md",
+      "role_guess": "operations / coordination",
+      "sha256": "e3062c4a0268e56f4ba818b99884158de8a666490348661af29bf2bcc2c07207",
+      "size_bytes": 38374,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/ideas/dogfood",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "institutional-process-substrate-mvp.md",
+      "path": "ops/ideas/dogfood/institutional-process-substrate-mvp.md",
+      "role_guess": "operations / coordination",
+      "sha256": "253fabaf690d8135f1577e2da2903241a566c1dd317e04dfc9d3921afa618c28",
+      "size_bytes": 32511,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/ideas/framing",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "democratic-authority-primitives.md",
+      "path": "ops/ideas/framing/democratic-authority-primitives.md",
+      "role_guess": "operations / coordination",
+      "sha256": "8635027a9245657c486693f56a15d0386471f00d6a2f9afac9c8865aa5c4951c",
+      "size_bytes": 57767,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/ideas/framing",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "institutional-process-substrate.md",
+      "path": "ops/ideas/framing/institutional-process-substrate.md",
+      "role_guess": "operations / coordination",
+      "sha256": "b4836c7345bc5e2aeb4c2f79bff27dfa2400184cd0c544ad8769cb97f12ee0b4",
+      "size_bytes": 31218,
       "symlink_target": null,
       "tracked": true
     },
@@ -36855,8 +40795,8 @@
       "name": "ideas.yaml",
       "path": "ops/ideas/ideas.yaml",
       "role_guess": "operations / coordination",
-      "sha256": "09862c024341f7034d85961921b5b2a472fb8569d5b4dec0dc6747eb854513b3",
-      "size_bytes": 36944,
+      "sha256": "1d308bcc25f911d17f485ddfe9e4f516caeb33c9d71738983a243e14c03c3649",
+      "size_bytes": 54573,
       "symlink_target": null,
       "tracked": true
     },
@@ -36946,8 +40886,8 @@
       "name": "package-lock.json",
       "path": "ops/mcp/package-lock.json",
       "role_guess": "operations / coordination",
-      "sha256": "2379db1a91826bfd6d35bcbfd74b147bfd60abe83e0dbaf5896c12d092cbe8a2",
-      "size_bytes": 112506,
+      "sha256": "4d0407a8581d4cdbeb6bbd232b6fb9be686ec9a02fa351515840d4eed76cc2ab",
+      "size_bytes": 106746,
       "symlink_target": null,
       "tracked": true
     },
@@ -36959,8 +40899,151 @@
       "name": "package.json",
       "path": "ops/mcp/package.json",
       "role_guess": "operations / coordination",
-      "sha256": "7c46ba65abee31dd621f22d061c82eb1cacad2c86d52f95355970fb1439433e1",
-      "size_bytes": 781,
+      "sha256": "8914b169f20cb5cd316bc753fca0b7e2dfdc341ed925288abac812b447fdd3d6",
+      "size_bytes": 872,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "agent-brief.ts",
+      "path": "ops/mcp/src/diagnostics/agent-brief.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "28f586f3502f5489ee8496e8065dcb64381cb2b885f09393c656c1eb254b540c",
+      "size_bytes": 3246,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "agent-context-spine.ts",
+      "path": "ops/mcp/src/diagnostics/agent-context-spine.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "d399a51a51303cf5d7444d10d04b666e44bcb1624bb34bb6e489c9b66702bbdd",
+      "size_bytes": 12693,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "command-catalog.ts",
+      "path": "ops/mcp/src/diagnostics/command-catalog.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "b10090eb447f0e94977ffd0c2bdf9ffcc12ee3cc273a936b058d21a22d47d6d8",
+      "size_bytes": 7273,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "doctor.ts",
+      "path": "ops/mcp/src/diagnostics/doctor.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "3d10827226481d42b6b15538a2102bbadcf9ccdc00e4d5d63a9ec2e03076b6e3",
+      "size_bytes": 7614,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "environment-report.ts",
+      "path": "ops/mcp/src/diagnostics/environment-report.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "e411506ef4560d3fbf8f2661717e844a20651c7c4844a3e020a839b9d3ecfdac",
+      "size_bytes": 8053,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "mcp-config.ts",
+      "path": "ops/mcp/src/diagnostics/mcp-config.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "0a2c212ecc638891e0e3b4c637a909258fd0b8aa57bc35be94e1ec0e6ede0f42",
+      "size_bytes": 2597,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "next-steps.ts",
+      "path": "ops/mcp/src/diagnostics/next-steps.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "5f0666177bcf508a4287bc8d0a16d4b0801169a18466d300e7548af0cf8159a6",
+      "size_bytes": 9509,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "repo-map.ts",
+      "path": "ops/mcp/src/diagnostics/repo-map.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "44ab45efba40eebc91e98003a6d3cf9c86c739c0cc6546c0cdc6b679437a1e7b",
+      "size_bytes": 2810,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "safe-json.ts",
+      "path": "ops/mcp/src/diagnostics/safe-json.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "336f47dad678d4a04847b966cb79f55ad5fed8c883546e2488706c3b2b2ce848",
+      "size_bytes": 632,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "state-index.ts",
+      "path": "ops/mcp/src/diagnostics/state-index.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "c1e3521cb27bf94bde54d229779cdc2c160a2058a948b1859d85a5ae922cc11c",
+      "size_bytes": 2102,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/diagnostics",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "verification-plan.ts",
+      "path": "ops/mcp/src/diagnostics/verification-plan.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "43156b4d09beccd5a651b2ad3c70360373ebbdfd099950cb4353023db44f623e",
+      "size_bytes": 8703,
       "symlink_target": null,
       "tracked": true
     },
@@ -36972,8 +41055,8 @@
       "name": "index.ts",
       "path": "ops/mcp/src/index.ts",
       "role_guess": "operations / coordination",
-      "sha256": "c3a2afaebf84870ae114329d13f7f55fa82e81be1500e8b0119218f1010375b4",
-      "size_bytes": 3254,
+      "sha256": "085108b41f966b4c5c2212e444989ad6cd65f680bf7e9b597caac4aeb40f39c8",
+      "size_bytes": 6363,
       "symlink_target": null,
       "tracked": true
     },
@@ -36998,8 +41081,8 @@
       "name": "builds.ts",
       "path": "ops/mcp/src/polling/builds.ts",
       "role_guess": "operations / coordination",
-      "sha256": "5c72a214028ca3a22ba7001338498ab7317a6da8da8f9dc345a34bd66f1c5847",
-      "size_bytes": 1034,
+      "sha256": "f566f494b8ebbd600bc51efdef04d1e644c66625be24639fb9b557c41648ef1f",
+      "size_bytes": 1487,
       "symlink_target": null,
       "tracked": true
     },
@@ -37011,8 +41094,8 @@
       "name": "cluster.ts",
       "path": "ops/mcp/src/polling/cluster.ts",
       "role_guess": "operations / coordination",
-      "sha256": "f9c2a9dd18ccaa37bfc29f82523a58045e2a53ff6a9e6e338353cad1b8e04062",
-      "size_bytes": 2184,
+      "sha256": "794c8f8813fdb3c1278d16ce5dbcfb81f07c249d2ac64e9833b586b9f062aa58",
+      "size_bytes": 2867,
       "symlink_target": null,
       "tracked": true
     },
@@ -37024,8 +41107,8 @@
       "name": "git.ts",
       "path": "ops/mcp/src/polling/git.ts",
       "role_guess": "operations / coordination",
-      "sha256": "33e397f53a8c50197342f3d34be1072d46c898cd634bd79bea9e546b902c3089",
-      "size_bytes": 2597,
+      "sha256": "85c70986d0b3251f55f5d9a18c343ee6c3d0c705fd3be8987f9ad0cd6abcd859",
+      "size_bytes": 3530,
       "symlink_target": null,
       "tracked": true
     },
@@ -37050,8 +41133,8 @@
       "name": "db.ts",
       "path": "ops/mcp/src/state/db.ts",
       "role_guess": "operations / coordination",
-      "sha256": "aa52735f36e7f04635e90f103f626a41f10f7d716a39f0296d7902d71c356aa2",
-      "size_bytes": 3651,
+      "sha256": "173b0f63328228d4dda2498fce22158cb26e7330257e7fc743bf0625eead5cd5",
+      "size_bytes": 3721,
       "symlink_target": null,
       "tracked": true
     },
@@ -37078,6 +41161,45 @@
       "role_guess": "operations / coordination",
       "sha256": "8af4f666783ddb19c17df3ee57cac648ea53c2f0e01bd5667cef153ffa3610ea",
       "size_bytes": 946,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/tests",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "agent-context-spine.test.ts",
+      "path": "ops/mcp/src/tests/agent-context-spine.test.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "d589c757afaea3083e5210b766a46ab3573dea7fa0b97f88018ad45076a85370",
+      "size_bytes": 13360,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/tests",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "agent-diagnostics.test.ts",
+      "path": "ops/mcp/src/tests/agent-diagnostics.test.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "d0dfb67314c48334300c483063108c8b9ca80b5b2c136e5f060315742bee9621",
+      "size_bytes": 5432,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/tests",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "commands.test.ts",
+      "path": "ops/mcp/src/tests/commands.test.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "05a378f39279eecede13a54d4bf9c61c851b5c83e04a4d9e8fb4e9c73c652087",
+      "size_bytes": 3193,
       "symlink_target": null,
       "tracked": true
     },
@@ -37134,6 +41256,32 @@
       "tracked": true
     },
     {
+      "directory": "ops/mcp/src/tests",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "workflow-guidance.test.ts",
+      "path": "ops/mcp/src/tests/workflow-guidance.test.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "e6ccb10d08a3c02d791c9d238917e94daecc8be122c0b1eb4a979bd7a48c6d42",
+      "size_bytes": 5968,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/tools",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "agent-ops.ts",
+      "path": "ops/mcp/src/tools/agent-ops.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "bcee92066c3a0dc1dc0475f26302fea4fe92a0df0a2012d50b590a5beb30c36b",
+      "size_bytes": 6759,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "ops/mcp/src/tools",
       "extension": ".ts",
       "kind": "file",
@@ -37180,8 +41328,8 @@
       "name": "health.ts",
       "path": "ops/mcp/src/tools/health.ts",
       "role_guess": "operations / coordination",
-      "sha256": "b2eed4585765bc54a100d0a13e6caba0c2cf92ead56ceeb2e16652f1776c14d9",
-      "size_bytes": 3691,
+      "sha256": "4652edee1d344720656a8441545b17c9872fe4fcf61c4bd377b637b489d4d673",
+      "size_bytes": 4258,
       "symlink_target": null,
       "tracked": true
     },
@@ -37193,8 +41341,8 @@
       "name": "repos.ts",
       "path": "ops/mcp/src/tools/repos.ts",
       "role_guess": "operations / coordination",
-      "sha256": "9d490b97a6277b057a30195633f64535eafac2ced55c8f9ba526c69dc022c62f",
-      "size_bytes": 5715,
+      "sha256": "f18682eabbcbff5f954402eb711f7f827b1bd490b421cec4b6186c9abb936caf",
+      "size_bytes": 7164,
       "symlink_target": null,
       "tracked": true
     },
@@ -37234,6 +41382,32 @@
       "role_guess": "operations / coordination",
       "sha256": "8d04a5ab0417f4bcdfe9e3b7793ac12d49d57050fd0c75a4b9f6b22483527f72",
       "size_bytes": 2447,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/utils",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "commands.ts",
+      "path": "ops/mcp/src/utils/commands.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "c0bc49379085f3b98322f6585911367be36052fc39ea0d1e5fefbea5dc56e1e7",
+      "size_bytes": 4677,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "ops/mcp/src/utils",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "kubectl-pods.ts",
+      "path": "ops/mcp/src/utils/kubectl-pods.ts",
+      "role_guess": "operations / coordination",
+      "sha256": "5ec808d967ec0c7e5f6fae6de343e0ea4a70521596a947e8dfb03d625296102c",
+      "size_bytes": 1496,
       "symlink_target": null,
       "tracked": true
     },
@@ -37355,6 +41529,19 @@
       "tracked": true
     },
     {
+      "directory": "ops/state",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "ecosystem.json",
+      "path": "ops/state/ecosystem.json",
+      "role_guess": "operations / coordination",
+      "sha256": "bd54104ae7eeffd161e8366c813ec7acb3d64ab19973e901ee1adea450b5bd70",
+      "size_bytes": 10720,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "ops/state/sprint",
       "extension": ".json",
       "kind": "file",
@@ -37427,8 +41614,8 @@
       "name": "agents.json",
       "path": "ops/state/truth/agents.json",
       "role_guess": "operations / coordination",
-      "sha256": "ca54ceac316763ce8952286a160d78ea2a7367a84c3b240559bf842253fe7e2e",
-      "size_bytes": 4996,
+      "sha256": "5c6c262fa59b46d1be89654f1ec35460e30e08c149fb653132a60c8c903263ae",
+      "size_bytes": 5537,
       "symlink_target": null,
       "tracked": true
     },
@@ -37453,8 +41640,8 @@
       "name": "skills.json",
       "path": "ops/state/truth/skills.json",
       "role_guess": "operations / coordination",
-      "sha256": "34243baadb2f1c90998bc2c989b40f7fccb9f03354891ddfb87518a0ec5284e8",
-      "size_bytes": 2554,
+      "sha256": "0ae946f96b5e0c503edbfcf0f900a6c35118343a325c5f5538052a1b03a82173",
+      "size_bytes": 2567,
       "symlink_target": null,
       "tracked": true
     },
@@ -37466,8 +41653,8 @@
       "name": "sources.json",
       "path": "ops/state/truth/sources.json",
       "role_guess": "operations / coordination",
-      "sha256": "1fb2b398f624bfaf0a4d2b4260be3c55f4f6dab8ff3aefabd0718455526ad2a9",
-      "size_bytes": 3389,
+      "sha256": "d566fba11595dcf11abe5777865db2e2dab25d731d6e01eb42c66ee1708ce8f5",
+      "size_bytes": 3783,
       "symlink_target": null,
       "tracked": true
     },
@@ -37492,8 +41679,73 @@
       "name": "bootstrap.sh",
       "path": "scripts/bootstrap.sh",
       "role_guess": "script",
-      "sha256": "5a98f874959054a11b4f7d7e7acb526946af11bd5c45adca3ce28f9757c4188e",
-      "size_bytes": 5030,
+      "sha256": "a1c0b819119a1a725d59b00311917f3b8886cfe2110c1c7bcd59a8944c3c75ba",
+      "size_bytes": 10321,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "build-baseline-lock-guest.sh",
+      "path": "scripts/build-baseline-lock-guest.sh",
+      "role_guess": "script",
+      "sha256": "cf35c794e76e43cf45de3a7f1f64c67a0fc2546ef640d223594848345bb5ac92",
+      "size_bytes": 649,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
+      "extension": ".js",
+      "kind": "file",
+      "language": "JavaScript",
+      "name": "build-launch-deck-pptx.js",
+      "path": "scripts/build-launch-deck-pptx.js",
+      "role_guess": "script",
+      "sha256": "5b8474169409afdcbc88d744ed48380aa04313c326d222285deeadc0999d66bf",
+      "size_bytes": 26527,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "check-agent-context-spine.py",
+      "path": "scripts/check-agent-context-spine.py",
+      "role_guess": "script",
+      "sha256": "916390849fbe93fdeff243dda48d1ce3565b21e02edbc4fdf01d1489eba6e17d",
+      "size_bytes": 7950,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "check-claude-plugin-root-resolution.py",
+      "path": "scripts/check-claude-plugin-root-resolution.py",
+      "role_guess": "script",
+      "sha256": "793a9cbc7c9d83af268babf6b3b00daa613267ea977794ca1763618143d5519c",
+      "size_bytes": 6522,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "check-claude-plugin.py",
+      "path": "scripts/check-claude-plugin.py",
+      "role_guess": "script",
+      "sha256": "3584e1132c559d923e9feffb341235d7b19f4568238736f89a416f097db0b03b",
+      "size_bytes": 16681,
       "symlink_target": null,
       "tracked": true
     },
@@ -37505,8 +41757,8 @@
       "name": "check-mcp-portability.py",
       "path": "scripts/check-mcp-portability.py",
       "role_guess": "script",
-      "sha256": "bf0f1a6ed515a2e6bca552059d3ee9a5592ed49be3315e91f19306516e7f0d93",
-      "size_bytes": 3020,
+      "sha256": "842d1996988a65649bc6bd515f9368bc53ddfaeae20586479ee5786e55994f75",
+      "size_bytes": 3031,
       "symlink_target": null,
       "tracked": true
     },
@@ -37694,6 +41946,19 @@
     },
     {
       "directory": "scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "generate-agent-context-spine.py",
+      "path": "scripts/generate-agent-context-spine.py",
+      "role_guess": "script",
+      "sha256": "e6a3ae3d2042febc9754d6a6fa6ec8c6d27dddbefde12fea9c6b84824e352dbd",
+      "size_bytes": 39619,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
       "extension": ".sh",
       "kind": "file",
       "language": "Shell",
@@ -37754,6 +42019,58 @@
       "role_guess": "script",
       "sha256": "9f453776a7a9b96944c42a1b3ced4434e8ccae5cb97280a9a1c064c2ae1f25a0",
       "size_bytes": 14015,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "local_audit_verify_auth_demo.sh",
+      "path": "scripts/local_audit_verify_auth_demo.sh",
+      "role_guess": "script",
+      "sha256": "8b9e9d2835424145f908a316faca958a93436762a452a6318fa42dd957984d44",
+      "size_bytes": 9308,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "local_economic_receipt_chain_demo.sh",
+      "path": "scripts/local_economic_receipt_chain_demo.sh",
+      "role_guess": "script",
+      "sha256": "5e2afca36b3f0bc3a3491fdae04f003c3af7d47f1e7a5f2dbeff0dfc0b0b3781",
+      "size_bytes": 13540,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "local_receipt_chain_13of13_rehearsal.sh",
+      "path": "scripts/local_receipt_chain_13of13_rehearsal.sh",
+      "role_guess": "script",
+      "sha256": "c43f5065dcae6d5b3b72d4fe8a03eeb9eeb351db4a6a19158801f3cb0f2bcab0",
+      "size_bytes": 11701,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "md-to-pdf.py",
+      "path": "scripts/md-to-pdf.py",
+      "role_guess": "script",
+      "sha256": "c9b55cdce02fa7470f49f7a41f695e5c411490b37243d21657944b8921fd7375",
+      "size_bytes": 6130,
       "symlink_target": null,
       "tracked": true
     },
@@ -38064,8 +42381,8 @@
       "name": "README.md",
       "path": "sdk/react-native/README.md",
       "role_guess": "React Native SDK",
-      "sha256": "1d500c3a3209ad21d1ecbb4af20f87b7ff1a0cb716b94933d19ddbee58ba1410",
-      "size_bytes": 18471,
+      "sha256": "b3b4bf2b8e536aa30d322660c29ef5dbcdf86f6a765d812916d075da41f39a27",
+      "size_bytes": 20302,
       "symlink_target": null,
       "tracked": true
     },
@@ -38116,8 +42433,8 @@
       "name": "App.tsx",
       "path": "sdk/react-native/examples/CoopWallet/App.tsx",
       "role_guess": "React Native SDK",
-      "sha256": "15af095da0d48501b7336a4a6a2c5c400292457423214217dd949ccdc741d75c",
-      "size_bytes": 110329,
+      "sha256": "90c421aba7236abeb2cb04321f2c939ab76a57724a9b15be2c45e31ade492e03",
+      "size_bytes": 114927,
       "symlink_target": null,
       "tracked": true
     },
@@ -38129,8 +42446,8 @@
       "name": "README.md",
       "path": "sdk/react-native/examples/CoopWallet/README.md",
       "role_guess": "React Native SDK",
-      "sha256": "df943f30ae14324bd9c4e71d8575b4f4d38cc725e5edeb33f68a444845e680eb",
-      "size_bytes": 5439,
+      "sha256": "953679e17c5ba16a576d7dba1bed5c9c5005e1355d086dc7d7b3daf02636c1d7",
+      "size_bytes": 5841,
       "symlink_target": null,
       "tracked": true
     },
@@ -38792,8 +43109,8 @@
       "name": "package-lock.json",
       "path": "sdk/react-native/examples/CoopWallet/package-lock.json",
       "role_guess": "React Native SDK",
-      "sha256": "afa6207763c83015dfb702cf8b15d021cad914cf3094067eb41898168527053c",
-      "size_bytes": 333093,
+      "sha256": "4606e6c9a37cb7060cdabf2811788bd6924abfd03fc8646cbd5c5a5d939f031c",
+      "size_bytes": 335783,
       "symlink_target": null,
       "tracked": true
     },
@@ -38818,8 +43135,8 @@
       "name": "client.ts",
       "path": "sdk/react-native/examples/CoopWallet/src/client.ts",
       "role_guess": "React Native SDK",
-      "sha256": "1e94b826b0d4f7137a97bee9243ada153914dab81928891da74259a733c81604",
-      "size_bytes": 7267,
+      "sha256": "8c7c07ecb9b093e4aaa5ba701d8b3148b640da699439e01bf4970ea6cd924432",
+      "size_bytes": 11129,
       "symlink_target": null,
       "tracked": true
     },
@@ -39351,8 +43668,8 @@
       "name": "package-lock.json",
       "path": "sdk/react-native/package-lock.json",
       "role_guess": "React Native SDK",
-      "sha256": "b92aa7745285ae6cdee1f8e660d3c110ef244002baf257e6ffc0e2430edb1076",
-      "size_bytes": 300269,
+      "sha256": "f7ca266767a99b324f5d2e83ee292671e955235810511f21cf5c49269a5d25c9",
+      "size_bytes": 470760,
       "symlink_target": null,
       "tracked": true
     },
@@ -39429,8 +43746,8 @@
       "name": "client.test.ts",
       "path": "sdk/react-native/src/client.test.ts",
       "role_guess": "React Native SDK",
-      "sha256": "a1ff6396dc428fbac1298c21319d5482a107c1761d750d602d0a761763c31ab6",
-      "size_bytes": 7951,
+      "sha256": "a439fe8d5d8c573b2a6815baf6812df32817235645c6b9e56f47d2fa97cf6719",
+      "size_bytes": 38608,
       "symlink_target": null,
       "tracked": true
     },
@@ -39442,8 +43759,8 @@
       "name": "client.ts",
       "path": "sdk/react-native/src/client.ts",
       "role_guess": "React Native SDK",
-      "sha256": "abea270489bd82f9881fd1af7a077a71b4621bab7086b75b386ca2416c2ef8e1",
-      "size_bytes": 83756,
+      "sha256": "49e3c72f8f7a289a57b922b03ccde4e324f7252cfff73db33aa7766422882f0b",
+      "size_bytes": 98112,
       "symlink_target": null,
       "tracked": true
     },
@@ -39455,8 +43772,8 @@
       "name": "constitutional-hooks.ts",
       "path": "sdk/react-native/src/constitutional-hooks.ts",
       "role_guess": "React Native SDK",
-      "sha256": "3b107f51a5e0cf6833526bc3b87132d16b378907f4a9811a7a239224bd9dce24",
-      "size_bytes": 22511,
+      "sha256": "326c0ec8ed96a014a6bc94a8129562ec566298445f0969fa03200a0b3f9ac596",
+      "size_bytes": 22975,
       "symlink_target": null,
       "tracked": true
     },
@@ -39468,8 +43785,8 @@
       "name": "constitutional-types.ts",
       "path": "sdk/react-native/src/constitutional-types.ts",
       "role_guess": "React Native SDK",
-      "sha256": "afefa8901f5e0b3d523126b7692073d0b87565789bd83d6206150de2426fcf8d",
-      "size_bytes": 5813,
+      "sha256": "61d4692346308a3dc45bd99ca86ff81fb7d77f6e53c1a3f50e5d435aad0c61e8",
+      "size_bytes": 2872,
       "symlink_target": null,
       "tracked": true
     },
@@ -39533,8 +43850,8 @@
       "name": "hooks.ts",
       "path": "sdk/react-native/src/hooks.ts",
       "role_guess": "React Native SDK",
-      "sha256": "817e075a3db856bf71071529c22577cc823da8a839adf2b21f3cd305c3dc9895",
-      "size_bytes": 22528,
+      "sha256": "16780b9aaed295672d0a35805af0446555aef43226aebb16e0dbcb4a4d4daa82",
+      "size_bytes": 22544,
       "symlink_target": null,
       "tracked": true
     },
@@ -39572,8 +43889,8 @@
       "name": "hybrid-wallet.test.ts",
       "path": "sdk/react-native/src/hybrid-wallet.test.ts",
       "role_guess": "React Native SDK",
-      "sha256": "c5300603101b46d81ad8351e7c88494f3354eb1a3719b908aa6edc9be9675723",
-      "size_bytes": 12384,
+      "sha256": "3cbcedd16ce450f57718b725f394865c17357347484319c3e82a2e1d4d8cbf71",
+      "size_bytes": 14726,
       "symlink_target": null,
       "tracked": true
     },
@@ -39585,8 +43902,8 @@
       "name": "hybrid-wallet.ts",
       "path": "sdk/react-native/src/hybrid-wallet.ts",
       "role_guess": "React Native SDK",
-      "sha256": "fbeddf29e52129dc9e8e5524d85efc094dd4946eb17228b75dcac0853b2ae6d7",
-      "size_bytes": 14934,
+      "sha256": "b895ef09261683d11cbee738cf63b2ed5c3f6d173c03185ab196334c4ae99aa0",
+      "size_bytes": 17329,
       "symlink_target": null,
       "tracked": true
     },
@@ -39598,8 +43915,21 @@
       "name": "index.ts",
       "path": "sdk/react-native/src/index.ts",
       "role_guess": "React Native SDK",
-      "sha256": "c5e9eed9a9fbbfd11b537255a5dfbeb8c08ddafa4502b645b73a2e883d8153c2",
-      "size_bytes": 5797,
+      "sha256": "7a722c3531ad6d3fb5ee51d0d3a1301f3b9f3f906b47c775b867b3171179abf9",
+      "size_bytes": 7183,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "sdk/react-native/src",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
+      "name": "keyring-aliases.test.ts",
+      "path": "sdk/react-native/src/keyring-aliases.test.ts",
+      "role_guess": "React Native SDK",
+      "sha256": "ca5960c77123010570f3f782ef805dc35354a670322ef86c4d3f5dd7500359b6",
+      "size_bytes": 3808,
       "symlink_target": null,
       "tracked": true
     },
@@ -39673,11 +44003,24 @@
       "extension": ".ts",
       "kind": "file",
       "language": "TypeScript",
+      "name": "queue-manager.test.ts",
+      "path": "sdk/react-native/src/queue-manager.test.ts",
+      "role_guess": "React Native SDK",
+      "sha256": "3f4daae40aa7d91d961ae53b6388e815c1a1dff2d19e49272244e16934f26c80",
+      "size_bytes": 5548,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "sdk/react-native/src",
+      "extension": ".ts",
+      "kind": "file",
+      "language": "TypeScript",
       "name": "queue-manager.ts",
       "path": "sdk/react-native/src/queue-manager.ts",
       "role_guess": "React Native SDK",
-      "sha256": "cf898660a03a73d34b5c35f3111269bc642750e342f2067d92663502d7007869",
-      "size_bytes": 4221,
+      "sha256": "44a463390a67655a813a73657131895e151b6cbb1df0be5e849270cd6d94e322",
+      "size_bytes": 7446,
       "symlink_target": null,
       "tracked": true
     },
@@ -39780,8 +44123,8 @@
       "name": "types.ts",
       "path": "sdk/react-native/src/types.ts",
       "role_guess": "React Native SDK",
-      "sha256": "1523f97fc68e07f99db52fa0c27acbb4455f8c244155130675e8d44045529710",
-      "size_bytes": 4237,
+      "sha256": "7b6b2c3e9c57b58c09b690417d7b58b50cfa0d377090aee801b067bdfaa2ab4d",
+      "size_bytes": 5388,
       "symlink_target": null,
       "tracked": true
     },
@@ -39793,8 +44136,8 @@
       "name": "wallet.test.ts",
       "path": "sdk/react-native/src/wallet.test.ts",
       "role_guess": "React Native SDK",
-      "sha256": "9c9dc2984ffc1930717a5c47a48adbc2c4be046561c491eab9fda7c86826ceb9",
-      "size_bytes": 6798,
+      "sha256": "5d22fec978496a50beaf2740c1245ed7e67ad20c8e9f7807fb1012a4515793b8",
+      "size_bytes": 9277,
       "symlink_target": null,
       "tracked": true
     },
@@ -39806,8 +44149,8 @@
       "name": "wallet.ts",
       "path": "sdk/react-native/src/wallet.ts",
       "role_guess": "React Native SDK",
-      "sha256": "b7c8690a88623068ec920beb81643695e220647b28663e847f4fbc698c0561ec",
-      "size_bytes": 7117,
+      "sha256": "6d3bd0b50716c2ab6ea3e2adc92e8a93a625f08c9ff853afb511520a26425475",
+      "size_bytes": 10075,
       "symlink_target": null,
       "tracked": true
     },
@@ -39819,8 +44162,8 @@
       "name": "tsconfig.json",
       "path": "sdk/react-native/tsconfig.json",
       "role_guess": "React Native SDK",
-      "sha256": "eab0e7240385c1822b5b0cec6fd53ec71cfc23b241c01b0fc6ad6605066e2e18",
-      "size_bytes": 564,
+      "sha256": "21cc8271da73d997dccec6ee4dd160606b4212d23f5be7a2e21699bf85e44bcc",
+      "size_bytes": 567,
       "symlink_target": null,
       "tracked": true
     },
@@ -39845,8 +44188,21 @@
       "name": "README.md",
       "path": "sdk/typescript/README.md",
       "role_guess": "TypeScript SDK",
-      "sha256": "48c48fc94be85d901192baca14efcc1683808bf320c4f0b38a604ba25fe3890e",
-      "size_bytes": 18292,
+      "sha256": "3d5e365d5a70fee26c6d854f6f49c126c91fb66d3d57ef830675af56602132c2",
+      "size_bytes": 20282,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "sdk/typescript",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "check_sdk_doc_terms.py",
+      "path": "sdk/typescript/check_sdk_doc_terms.py",
+      "role_guess": "TypeScript SDK",
+      "sha256": "408104e75bce99ee5c7e5704b0e85b7a0bcfabc2878e3112e37d5d8e1fbe44b2",
+      "size_bytes": 11936,
       "symlink_target": null,
       "tracked": true
     },
@@ -39871,8 +44227,8 @@
       "name": "README.md",
       "path": "sdk/typescript/examples/README.md",
       "role_guess": "TypeScript SDK",
-      "sha256": "1f55fbd2c792004bef7ad83b05a83d70bedb0c6790d1de5881a605df58665feb",
-      "size_bytes": 9069,
+      "sha256": "bc7736e8edeeaa57eb1bb9d7ed0d4bb383040aeb98599fd1f5c67fd0e270cfdb",
+      "size_bytes": 10369,
       "symlink_target": null,
       "tracked": true
     },
@@ -39884,8 +44240,8 @@
       "name": "basic-auth.ts",
       "path": "sdk/typescript/examples/basic-auth.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "d19f215e3a46194f8c86e03f0bf028e253255f4d1fc04a0986fbee26eb653bb6",
-      "size_bytes": 2584,
+      "sha256": "866b3da0ecd7c2f1c01bbad2f0040980ac137dfecceaec2e4287080d0d3c3c13",
+      "size_bytes": 3480,
       "symlink_target": null,
       "tracked": true
     },
@@ -39897,8 +44253,8 @@
       "name": "batch-operations.ts",
       "path": "sdk/typescript/examples/batch-operations.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "8b45537ea1940da0327193b250f5f977cd72ad29ae3d7f05a0e25d61f981d940",
-      "size_bytes": 3173,
+      "sha256": "dc96939f08f512efb9bd7d5275aed23e2017d180b57c8242578b726f3a7145ae",
+      "size_bytes": 3209,
       "symlink_target": null,
       "tracked": true
     },
@@ -39923,8 +44279,8 @@
       "name": "compute.ts",
       "path": "sdk/typescript/examples/compute.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "5d8c1fc5bb015ed2b2e6ff957a4f799a645d50e7ed4d117161544012b1fbcd0d",
-      "size_bytes": 6260,
+      "sha256": "1c8f9c219fbeef49594eeee3f6be83c889e50b6f2d8da2e12144d63afd7d29f5",
+      "size_bytes": 6263,
       "symlink_target": null,
       "tracked": true
     },
@@ -39949,8 +44305,8 @@
       "name": "query-builder.ts",
       "path": "sdk/typescript/examples/query-builder.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "c8d205617a0c462484873b55eaecafd05a709384ce36b44739a94a9a834ecba5",
-      "size_bytes": 3426,
+      "sha256": "f1361c9d5a38e5a4fb72d05ae5d70f71f61a4af9a8d06a3897ea652017e74776",
+      "size_bytes": 3422,
       "symlink_target": null,
       "tracked": true
     },
@@ -39962,8 +44318,8 @@
       "name": "seed-demo-data.ts",
       "path": "sdk/typescript/examples/seed-demo-data.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "d721d70b76c731cd41727619257553484f81c6af99a9d431c37a4063ec302ece",
-      "size_bytes": 8679,
+      "sha256": "6b083febf668dfd59a8be0ed825f548440caacf2b36a15ef13140172d1eb1768",
+      "size_bytes": 8677,
       "symlink_target": null,
       "tracked": true
     },
@@ -39975,8 +44331,8 @@
       "name": "timebank.ts",
       "path": "sdk/typescript/examples/timebank.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "f57661b5014e8b3178dd6ac477de22a56459c30f09b92ced878437edb545fba1",
-      "size_bytes": 4898,
+      "sha256": "01d8f162c653d3afc2a2f52b8008bc9ffaaa4019760ce6bee451b36f561f0c0b",
+      "size_bytes": 4869,
       "symlink_target": null,
       "tracked": true
     },
@@ -39988,8 +44344,8 @@
       "name": "websocket-events.ts",
       "path": "sdk/typescript/examples/websocket-events.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "ed3398259b93d742812b941354f8f9267a479b964c4a006d24412471b240024d",
-      "size_bytes": 12016,
+      "sha256": "ba441947626d2d9ed356fe7b8ac35d4150d968317eed5dcfe2987a06a0c4147f",
+      "size_bytes": 11970,
       "symlink_target": null,
       "tracked": true
     },
@@ -40027,8 +44383,8 @@
       "name": "package-lock.json",
       "path": "sdk/typescript/package-lock.json",
       "role_guess": "TypeScript SDK",
-      "sha256": "a1486982b6e3aa0c0ea16f332dd74b5764474208aaabfc5f12e042c9bfa9a41a",
-      "size_bytes": 224856,
+      "sha256": "e10389cd39c645476478d7592b1bf12c892e87805eada84ebd2717605f6a183c",
+      "size_bytes": 225376,
       "symlink_target": null,
       "tracked": true
     },
@@ -40040,8 +44396,8 @@
       "name": "package.json",
       "path": "sdk/typescript/package.json",
       "role_guess": "TypeScript SDK",
-      "sha256": "3cb3f719cbbbc792e4da91ae0d25c516f1d28b931974bae40fc4deb338901e50",
-      "size_bytes": 1361,
+      "sha256": "fe0dbbcf4e52899acf825ff8ffc647475bb0617b903b7e125e127d7bba58c073",
+      "size_bytes": 1430,
       "symlink_target": null,
       "tracked": true
     },
@@ -40066,8 +44422,8 @@
       "name": "api-types.ts",
       "path": "sdk/typescript/src/generated/api-types.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "d15c5821f4a21c11d658f7e8907addf9008871133ac6c705f639887b2768fe9a",
-      "size_bytes": 31417,
+      "sha256": "aad84ec5a6fd569394e7dba0d5aac3abff6e1a06788253a55a8712e87104c638",
+      "size_bytes": 61644,
       "symlink_target": null,
       "tracked": true
     },
@@ -40079,8 +44435,8 @@
       "name": "index.test.ts",
       "path": "sdk/typescript/src/index.test.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "7bc72b4d635bfe0e401653e5f9ae6148e348c0bb7e461d38ab202cc9ec72e8a5",
-      "size_bytes": 83392,
+      "sha256": "dc9960da37ee955d9f13376520e7365b6eabb372aa3c258b888d050407a12a16",
+      "size_bytes": 90322,
       "symlink_target": null,
       "tracked": true
     },
@@ -40092,8 +44448,8 @@
       "name": "index.ts",
       "path": "sdk/typescript/src/index.ts",
       "role_guess": "TypeScript SDK",
-      "sha256": "804280a561b6d18f3c44d1ad84662630919685509f8c1a42baa2dccb655208c8",
-      "size_bytes": 82862,
+      "sha256": "59341ae472af9a7d1803804b782c995cefefc646fb401e281c78624e62259f87",
+      "size_bytes": 86123,
       "symlink_target": null,
       "tracked": true
     },
@@ -40159,6 +44515,19 @@
       "role_guess": "TypeScript SDK",
       "sha256": "a52dcbb428dfa5693f144b5ba03dbba1776e6a4ea3ecf10436151e326c3098d7",
       "size_bytes": 8168,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "sdk/typescript",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "tsconfig.examples.json",
+      "path": "sdk/typescript/tsconfig.examples.json",
+      "role_guess": "TypeScript SDK",
+      "sha256": "28d81511446566fd7be660c7c65a405fbeb24b2820794e54c969b94341baf0cb",
+      "size_bytes": 606,
       "symlink_target": null,
       "tracked": true
     },
@@ -40462,6 +44831,344 @@
       "tracked": true
     },
     {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/.claude-plugin",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "plugin.json",
+      "path": "tools/claude-code/plugins/icn-agent-pack/.claude-plugin/plugin.json",
+      "role_guess": "uncategorized",
+      "sha256": "f22a5c9136dccad354ec9b0195ae84875c0b8ce811e44b71a284c9fe586b841d",
+      "size_bytes": 670,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": ".lsp.json",
+      "path": "tools/claude-code/plugins/icn-agent-pack/.lsp.json",
+      "role_guess": "uncategorized",
+      "sha256": "ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356",
+      "size_bytes": 3,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": ".mcp.json",
+      "path": "tools/claude-code/plugins/icn-agent-pack/.mcp.json",
+      "role_guess": "uncategorized",
+      "sha256": "890d02c326250550cace2dfc48c098ce9881848dcfb9723f2b1ce06c4e7b934c",
+      "size_bytes": 106,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/README.md",
+      "role_guess": "uncategorized",
+      "sha256": "a7519610bfaecf7f709d7c0ffa0eebebd69b00c28acd922c90ad9ff1f8db4793",
+      "size_bytes": 13410,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/agents",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "icn-architect.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/agents/icn-architect.md",
+      "role_guess": "uncategorized",
+      "sha256": "f0d9fe7e09ff59d72ee378ec9e710f60534c790446de0e1ab6364ea4170f36c2",
+      "size_bytes": 4778,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/agents",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "icn-code-reviewer.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/agents/icn-code-reviewer.md",
+      "role_guess": "uncategorized",
+      "sha256": "e87093d9a24186ca03ae23fadcc71b263a8bb6cbb86c0a622c244451cb7b35a4",
+      "size_bytes": 4666,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/agents",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "icn-docs-truth-auditor.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/agents/icn-docs-truth-auditor.md",
+      "role_guess": "uncategorized",
+      "sha256": "4df2386e8acabe94d05dafab67f81bf304f5938733dcacc41c46b414be532ff5",
+      "size_bytes": 3795,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/agents",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "icn-economist.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/agents/icn-economist.md",
+      "role_guess": "uncategorized",
+      "sha256": "2a19f74eaa027191339d57afb659cf3db8bdaf8f800963080beba0389f8ba733",
+      "size_bytes": 4564,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/agents",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "icn-navigator.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/agents/icn-navigator.md",
+      "role_guess": "uncategorized",
+      "sha256": "85ea5c28b4983038e5213376434ab36528b4e246631607c3b3180124c3593126",
+      "size_bytes": 4522,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/agents",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "icn-ops.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/agents/icn-ops.md",
+      "role_guess": "uncategorized",
+      "sha256": "be65bef1023474663a74b522c2a58cf8108353779974cc8a6554b38d5af1e09c",
+      "size_bytes": 4369,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/bin",
+      "extension": "(none)",
+      "kind": "file",
+      "language": "unknown",
+      "name": "icn-find-root",
+      "path": "tools/claude-code/plugins/icn-agent-pack/bin/icn-find-root",
+      "role_guess": "uncategorized",
+      "sha256": "20aab2e3aa607818a02264228f0918a1039f6ee80bef2311c8178dd185facb1a",
+      "size_bytes": 6231,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/bin",
+      "extension": "(none)",
+      "kind": "file",
+      "language": "unknown",
+      "name": "icn-ops-mcp",
+      "path": "tools/claude-code/plugins/icn-agent-pack/bin/icn-ops-mcp",
+      "role_guess": "uncategorized",
+      "sha256": "ee8ab0837cc942c0d2a99d0e5bc407b63dd7ed7d30e9f9c37357cb4faadee21a",
+      "size_bytes": 2650,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/bin",
+      "extension": "(none)",
+      "kind": "file",
+      "language": "unknown",
+      "name": "icn-route-impact-hint",
+      "path": "tools/claude-code/plugins/icn-agent-pack/bin/icn-route-impact-hint",
+      "role_guess": "uncategorized",
+      "sha256": "d6ea892d607e28617ca1e19355e0bd90fbc6f70def11c120c09adc42cc42e7e9",
+      "size_bytes": 1593,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/bin",
+      "extension": "(none)",
+      "kind": "file",
+      "language": "unknown",
+      "name": "icn-session-context",
+      "path": "tools/claude-code/plugins/icn-agent-pack/bin/icn-session-context",
+      "role_guess": "uncategorized",
+      "sha256": "930b4a4cbbde989294f846065b1cc9a71418d23012d765e5fcfcae47f815bb61",
+      "size_bytes": 1144,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/bin",
+      "extension": "(none)",
+      "kind": "file",
+      "language": "unknown",
+      "name": "icn-truth-sync-hint",
+      "path": "tools/claude-code/plugins/icn-agent-pack/bin/icn-truth-sync-hint",
+      "role_guess": "uncategorized",
+      "sha256": "59ce2bc2a0c15afb96ba7f2bbf2e9dc2e846d2c4eaaa3e4859b4406ae843fae6",
+      "size_bytes": 1175,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/hooks",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "hooks.json",
+      "path": "tools/claude-code/plugins/icn-agent-pack/hooks/hooks.json",
+      "role_guess": "uncategorized",
+      "sha256": "19ec87c6487af74dcb61331923aa43f66b75223f5ace352f4c124372695dd5c4",
+      "size_bytes": 937,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/authority-spine",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SKILL.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/authority-spine/SKILL.md",
+      "role_guess": "uncategorized",
+      "sha256": "082479fbda7cb9a8b7e5fce27683d62c71cf5263a6e35a3fc1f575f24660824c",
+      "size_bytes": 3631,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/authority-spine",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "reference.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/authority-spine/reference.md",
+      "role_guess": "uncategorized",
+      "sha256": "5fdc71119fb9ec7ddeb31c013016bf1dc2437f632fc61eef6426f431c1afe831",
+      "size_bytes": 3365,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/doctor",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SKILL.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/doctor/SKILL.md",
+      "role_guess": "uncategorized",
+      "sha256": "f2a4d2aa4f069d12bb6f7aba19464703863c32dd3570b32290e79411ff622078",
+      "size_bytes": 3167,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/navigator",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SKILL.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/navigator/SKILL.md",
+      "role_guess": "uncategorized",
+      "sha256": "05ed1280a4c2a62551201daf58bd4da3028dd96e8b38f379a4a4177c9a53d2d6",
+      "size_bytes": 4102,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/navigator",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "reference.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/navigator/reference.md",
+      "role_guess": "uncategorized",
+      "sha256": "e0e789473ad7623faaa497d83636b7b5863fcd58c98a6ca171e358493e42a546",
+      "size_bytes": 3500,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/preflight",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SKILL.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/preflight/SKILL.md",
+      "role_guess": "uncategorized",
+      "sha256": "1b6fa063b261175d86aae48321adfc9fb187d8ac9f0b5838e3caf21c39253602",
+      "size_bytes": 2605,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/route-impact",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SKILL.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/route-impact/SKILL.md",
+      "role_guess": "uncategorized",
+      "sha256": "9bfb268c41e5c1ec98a0254aea26a9ce7cd74ef89657a83846a10a9840e7cf7d",
+      "size_bytes": 3171,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/route-impact",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "reference.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/route-impact/reference.md",
+      "role_guess": "uncategorized",
+      "sha256": "f760ff25218cc7faccb1124f7cb6ff54f05994ffc0a234a201f30c84d4a673ec",
+      "size_bytes": 3162,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/truth-sync",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "SKILL.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/truth-sync/SKILL.md",
+      "role_guess": "uncategorized",
+      "sha256": "4f685ac367100aaa2846317465c291462ebe496721791f83e82df5e5b548ca51",
+      "size_bytes": 3050,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "tools/claude-code/plugins/icn-agent-pack/skills/truth-sync",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "reference.md",
+      "path": "tools/claude-code/plugins/icn-agent-pack/skills/truth-sync/reference.md",
+      "role_guess": "uncategorized",
+      "sha256": "c26a56e635e6efbf4088f3d7d2351c17302ae60e36db2eed41a8862646b3524c",
+      "size_bytes": 4541,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
       "directory": "web/api-docs",
       "extension": "(none)",
       "kind": "file",
@@ -40614,6 +45321,136 @@
       "role_guess": "dashboard UI",
       "sha256": "5863d0c101ed64919455936205c48d9c93fcf954cdb5097464da2d2a22135c83",
       "size_bytes": 9876,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "web/member-shell/README.md",
+      "role_guess": "uncategorized",
+      "sha256": "5745bdbd6da7958c131276aec1d09754c88525fd522d0591e0c98c4b441b89d2",
+      "size_bytes": 13587,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell",
+      "extension": ".cjs",
+      "kind": "file",
+      "language": "unknown",
+      "name": "a11y-walkthrough.cjs",
+      "path": "web/member-shell/a11y-walkthrough.cjs",
+      "role_guess": "uncategorized",
+      "sha256": "7ed8c5a5d2cc763b0e2ce7c46394f1f4002fe077fc06b0bbf2b266ba05745e53",
+      "size_bytes": 8198,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell/fixtures",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "community-action-cards.json",
+      "path": "web/member-shell/fixtures/community-action-cards.json",
+      "role_guess": "uncategorized",
+      "sha256": "b5e9121f89feafb1afc795930ca1f22d15dc97fd6d95cab113b36a1d71975b09",
+      "size_bytes": 989,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell/fixtures",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "community-completion-receipt.json",
+      "path": "web/member-shell/fixtures/community-completion-receipt.json",
+      "role_guess": "uncategorized",
+      "sha256": "b1971fc0eee367fda565ff0e13756b9e05f0df01485286587d70fa1d942c97ac",
+      "size_bytes": 407,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell/fixtures",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "community-standing.json",
+      "path": "web/member-shell/fixtures/community-standing.json",
+      "role_guess": "uncategorized",
+      "sha256": "e8b3ea60153e7ca58771b2ccc7f0d9f9b9f0de470c09639630ce6cb438d92e84",
+      "size_bytes": 839,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell/fixtures",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "demo-completion-receipt.json",
+      "path": "web/member-shell/fixtures/demo-completion-receipt.json",
+      "role_guess": "uncategorized",
+      "sha256": "5e4650ed6b7526ad5f0f2dbad38ba70fc77808823f8886eec131b043fb70a0ad",
+      "size_bytes": 371,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell",
+      "extension": ".js",
+      "kind": "file",
+      "language": "JavaScript",
+      "name": "i18n.js",
+      "path": "web/member-shell/i18n.js",
+      "role_guess": "uncategorized",
+      "sha256": "83ffb9f51ca4e41d980ad5557eca3a7b02bb4a97bfe336764d921fe735480651",
+      "size_bytes": 23656,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell",
+      "extension": ".html",
+      "kind": "file",
+      "language": "HTML",
+      "name": "index.html",
+      "path": "web/member-shell/index.html",
+      "role_guess": "uncategorized",
+      "sha256": "d77b6e95118835fe31907d081a1c2e27ffea404e612965f2c751caad665cc1f1",
+      "size_bytes": 9422,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell",
+      "extension": ".css",
+      "kind": "file",
+      "language": "CSS",
+      "name": "shell.css",
+      "path": "web/member-shell/shell.css",
+      "role_guess": "uncategorized",
+      "sha256": "be9a03ce5785583c847b2a95078aa349bd88ac732874b9655dfb18c0669e4308",
+      "size_bytes": 6899,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/member-shell",
+      "extension": ".js",
+      "kind": "file",
+      "language": "JavaScript",
+      "name": "shell.js",
+      "path": "web/member-shell/shell.js",
+      "role_guess": "uncategorized",
+      "sha256": "2e03d356255e23f10cf57ca8c19ee64b3e93ecaefbae988c472cdb1933aa1989",
+      "size_bytes": 41952,
       "symlink_target": null,
       "tracked": true
     },
@@ -40859,8 +45696,8 @@
       "name": "README.md",
       "path": "web/pilot-ui/README.md",
       "role_guess": "pilot UI",
-      "sha256": "f50401cb8229993889c9fa5e2f7327afc76f4b7f1d20d7d12cca9c72e7fe09d8",
-      "size_bytes": 12475,
+      "sha256": "d1cf718cd1e4d661871f993109fa06bac5f7c2b661856eec7785b7553190418c",
+      "size_bytes": 4971,
       "symlink_target": null,
       "tracked": true
     },
@@ -40911,8 +45748,8 @@
       "name": "app.js",
       "path": "web/pilot-ui/app.js",
       "role_guess": "pilot UI",
-      "sha256": "f954a3c0d259cef3a273ecd55a686496b10f4bf1f455d9c81574d998ce47b9b2",
-      "size_bytes": 288193,
+      "sha256": "97f78f13c3fe1a09afe2c341a0490392ed26626e0512a67f96eeb3b7e54e6cb0",
+      "size_bytes": 316161,
       "symlink_target": null,
       "tracked": true
     },
@@ -40952,6 +45789,71 @@
       "role_guess": "pilot UI",
       "sha256": "73c2101fbf998323ab21da56265e61dc209fa86acda9bc5596f08a362de382a9",
       "size_bytes": 5078,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/pilot-ui/fixtures/icn-organizer-demo",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "README.md",
+      "path": "web/pilot-ui/fixtures/icn-organizer-demo/README.md",
+      "role_guess": "pilot UI",
+      "sha256": "39b968ab144a17608f575c53938b91bbfbb347dbdb782e57cbdcaff0dfad195e",
+      "size_bytes": 8858,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/pilot-ui/fixtures/icn-organizer-demo",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "action-cards.json",
+      "path": "web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json",
+      "role_guess": "pilot UI",
+      "sha256": "34f3d94423aca6c110f9ac012f38683f731eabfd4362fe5ae9e2dd0a91326ff0",
+      "size_bytes": 2467,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/pilot-ui/fixtures/icn-organizer-demo",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "preview-review.pending-publish-summary.json",
+      "path": "web/pilot-ui/fixtures/icn-organizer-demo/preview-review.pending-publish-summary.json",
+      "role_guess": "pilot UI",
+      "sha256": "8ba45540aba23852e8e6519c934873123af1f40d1a990e0e3e2973feb0997546",
+      "size_bytes": 4399,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/pilot-ui/fixtures/icn-organizer-demo",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "rehearsal-shell.manifest.json",
+      "path": "web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json",
+      "role_guess": "pilot UI",
+      "sha256": "3b9050b58355fd9758e257ebebfad9751fcce6bf2fcc1d5867cfbbe39beb88ff",
+      "size_bytes": 4409,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/pilot-ui/fixtures/icn-organizer-demo",
+      "extension": ".json",
+      "kind": "file",
+      "language": "JSON",
+      "name": "standing.json",
+      "path": "web/pilot-ui/fixtures/icn-organizer-demo/standing.json",
+      "role_guess": "pilot UI",
+      "sha256": "0c6a34ca2d6e8bd8ecb3335dbe426142ed7f205ba059ad0164c392a3db452fa7",
+      "size_bytes": 1320,
       "symlink_target": null,
       "tracked": true
     },
@@ -41119,8 +46021,8 @@
       "name": "index.html",
       "path": "web/pilot-ui/index.html",
       "role_guess": "pilot UI",
-      "sha256": "d8baffdaecf467b0afcfa15f2701b6df97904a640f9d4cbe7ac277d4effa30e2",
-      "size_bytes": 116405,
+      "sha256": "872d5f3efb8f814eda769a9236cfa3262da11bc97d5cf8bb999cab70cb3ff354",
+      "size_bytes": 129907,
       "symlink_target": null,
       "tracked": true
     },
@@ -41197,8 +46099,8 @@
       "name": "package-lock.json",
       "path": "web/pilot-ui/package-lock.json",
       "role_guess": "pilot UI",
-      "sha256": "9121f187ac845fa3975969989d0c7c87f7e81577fb4a6270a675a94edccc6b62",
-      "size_bytes": 199913,
+      "sha256": "63d327d12bdcebbc72335065eaf73717a090e30f9256efe86fbb2dd5f2873e4a",
+      "size_bytes": 197039,
       "symlink_target": null,
       "tracked": true
     },
@@ -41210,8 +46112,8 @@
       "name": "package.json",
       "path": "web/pilot-ui/package.json",
       "role_guess": "pilot UI",
-      "sha256": "59353ccc0769b8e43f255364f222b9af4074de8540990e081c54931642b7778f",
-      "size_bytes": 1473,
+      "sha256": "5499f03064f328159ad5b3cd9cee40dac76b32352801810882930afbdbcfe7dd",
+      "size_bytes": 1516,
       "symlink_target": null,
       "tracked": true
     },
@@ -41236,8 +46138,8 @@
       "name": "receipts.js",
       "path": "web/pilot-ui/receipts.js",
       "role_guess": "pilot UI",
-      "sha256": "474f8ba1ce8f8046d8f972e89f900717284160223dbe8cd9e14c0afd79790879",
-      "size_bytes": 17641,
+      "sha256": "9b081cfaa2da27684ece19f0f51674ea7228656e8bb3f9d397310f2379213373",
+      "size_bytes": 26534,
       "symlink_target": null,
       "tracked": true
     },
@@ -41457,8 +46359,8 @@
       "name": "style.css",
       "path": "web/pilot-ui/style.css",
       "role_guess": "pilot UI",
-      "sha256": "8d04387f13502d725a64dc142be9470dca77f0a042b4e83183a9b8a6290a623d",
-      "size_bytes": 111250,
+      "sha256": "44e0d1ef7c31bd11738fbbcaedaebb6a7508d2d93595842e938bcbf6b21cc43e",
+      "size_bytes": 149509,
       "symlink_target": null,
       "tracked": true
     },
@@ -41470,8 +46372,8 @@
       "name": "sw.js",
       "path": "web/pilot-ui/sw.js",
       "role_guess": "pilot UI",
-      "sha256": "b73527af75073c667ffeecc5eb7cca7a0c84dd3097e4f740a11d899d69a37f92",
-      "size_bytes": 12014,
+      "sha256": "af2715c7f57cd78e790bdd49ce828d7fb0351fcbfced2d158b45fccd146bc9e0",
+      "size_bytes": 12339,
       "symlink_target": null,
       "tracked": true
     },
@@ -41483,8 +46385,8 @@
       "name": "test-api.html",
       "path": "web/pilot-ui/test-api.html",
       "role_guess": "pilot UI",
-      "sha256": "7fcd4ebb5302a5362b015cc06a916ecc00e5b20e7618fc4cdc6aa4f6ae73096f",
-      "size_bytes": 2274,
+      "sha256": "b5a1b66d9b6bdd89b17f5c891e86eabc50f894993404eac23864f26147d34e19",
+      "size_bytes": 2155,
       "symlink_target": null,
       "tracked": true
     },
@@ -41532,6 +46434,32 @@
       "extension": ".js",
       "kind": "file",
       "language": "JavaScript",
+      "name": "demo-fixture-preload.spec.js",
+      "path": "web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js",
+      "role_guess": "pilot UI",
+      "sha256": "13b8ec6ecd59d084368b10a1cb13dc69a286e5fe643eaf7d67745c48742292fc",
+      "size_bytes": 7638,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/pilot-ui/tests/e2e",
+      "extension": ".js",
+      "kind": "file",
+      "language": "JavaScript",
+      "name": "demo-mode.spec.js",
+      "path": "web/pilot-ui/tests/e2e/demo-mode.spec.js",
+      "role_guess": "pilot UI",
+      "sha256": "df13170324ebdb678a5cae002f32e00b38beb576bb1d2d40ada066d1ada9b61d",
+      "size_bytes": 11777,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/pilot-ui/tests/e2e",
+      "extension": ".js",
+      "kind": "file",
+      "language": "JavaScript",
       "name": "login.spec.js",
       "path": "web/pilot-ui/tests/e2e/login.spec.js",
       "role_guess": "pilot UI",
@@ -41550,6 +46478,32 @@
       "role_guess": "pilot UI",
       "sha256": "11f0f00b7a4d28af339368adb5fc755a64ba68e1faa769727d266a88346ce021",
       "size_bytes": 15755,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/pilot-ui/tests/e2e",
+      "extension": ".js",
+      "kind": "file",
+      "language": "JavaScript",
+      "name": "receipt-plain-language.spec.js",
+      "path": "web/pilot-ui/tests/e2e/receipt-plain-language.spec.js",
+      "role_guess": "pilot UI",
+      "sha256": "4bd9750f931cdcc589e7126e74d8afae06aa2d73b7859f300578c626349bf2f8",
+      "size_bytes": 4152,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "web/pilot-ui/tests/e2e",
+      "extension": ".js",
+      "kind": "file",
+      "language": "JavaScript",
+      "name": "standing-action-cards.spec.js",
+      "path": "web/pilot-ui/tests/e2e/standing-action-cards.spec.js",
+      "role_guess": "pilot UI",
+      "sha256": "43a6784c28c4016382b338057c094313773dda66138d95295e6532032626fb05",
+      "size_bytes": 4926,
       "symlink_target": null,
       "tracked": true
     },
@@ -41704,8 +46658,8 @@
       "name": "README.md",
       "path": "website/README.md",
       "role_guess": "public website",
-      "sha256": "aa8b54a417f25923980eabe8d0f1274cca0a2f972b9ddc27279e7d701135a5e0",
-      "size_bytes": 5071,
+      "sha256": "d8e71141096916c21f5d39d03ddb276d7152f713e2905a93bad8e3fba1a0fe73",
+      "size_bytes": 6952,
       "symlink_target": null,
       "tracked": true
     },
@@ -41717,8 +46671,8 @@
       "name": "astro.config.mjs",
       "path": "website/astro.config.mjs",
       "role_guess": "public website",
-      "sha256": "90a2c3c74b5de239c4324dc2b0eb394867897064204d2466bf6dc6845cdefaf6",
-      "size_bytes": 341,
+      "sha256": "80a2edc96bb226d67d8e083abe4601f1243ae9d856d2baa526c4c40901a28dfb",
+      "size_bytes": 696,
       "symlink_target": null,
       "tracked": true
     },
@@ -41743,8 +46697,21 @@
       "name": "package.json",
       "path": "website/package.json",
       "role_guess": "public website",
-      "sha256": "3e5fdd8d471fa68d737d516ecea2565a70250d74b82e515ac61ab05385150b00",
-      "size_bytes": 725,
+      "sha256": "2aa38ff05df6f9c47cf6a6f1472cc9c6d0fce20c2f287dddb10ae5f44724e529",
+      "size_bytes": 793,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "website/public/.well-known/matrix",
+      "extension": "(none)",
+      "kind": "file",
+      "language": "unknown",
+      "name": "client",
+      "path": "website/public/.well-known/matrix/client",
+      "role_guess": "public website",
+      "sha256": "fd416be1dfe50edd5a5d6d6fce33a812231a7ed4cbc644abe04b13855bd49f02",
+      "size_bytes": 86,
       "symlink_target": null,
       "tracked": true
     },
@@ -41841,6 +46808,19 @@
     },
     {
       "directory": "website/scripts",
+      "extension": ".sh",
+      "kind": "file",
+      "language": "Shell",
+      "name": "format-check-changed.sh",
+      "path": "website/scripts/format-check-changed.sh",
+      "role_guess": "public website",
+      "sha256": "44f3ffbda7bff0962eaebaf97ff6afa34ccad5caa0d92d647bdb531c16ee7b4d",
+      "size_bytes": 1742,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "website/scripts",
       "extension": ".mjs",
       "kind": "file",
       "language": "JavaScript",
@@ -41860,8 +46840,21 @@
       "name": "ClosureLoop.astro",
       "path": "website/src/components/ClosureLoop.astro",
       "role_guess": "public website",
-      "sha256": "36035084a84fd382973f1e0383eeb7ac5c76ad05d1664d3f365c00549844ff1a",
-      "size_bytes": 9441,
+      "sha256": "ed8fa455c127f89ba1d88f0758be68d10901844cdcbf72306e21d80dc04e5cbc",
+      "size_bytes": 11692,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "website/src/components",
+      "extension": ".astro",
+      "kind": "file",
+      "language": "Astro",
+      "name": "HowIcnWorksExplainer.astro",
+      "path": "website/src/components/HowIcnWorksExplainer.astro",
+      "role_guess": "public website",
+      "sha256": "293123303cfc3a4fd66bc6a6fed114a2d9c36e8c3f28d1250df4d88bad7587cc",
+      "size_bytes": 10972,
       "symlink_target": null,
       "tracked": true
     },
@@ -41925,8 +46918,8 @@
       "name": "MemberSurface.astro",
       "path": "website/src/components/MemberSurface.astro",
       "role_guess": "public website",
-      "sha256": "a59e6ca0ba8deac877bc22043da55ac60a6680beaad8a8a401ce59893f5801d9",
-      "size_bytes": 13746,
+      "sha256": "42f77099220f229f26fe27945f3c14ba4011de541bf2ea7117402ed3d707bab8",
+      "size_bytes": 16534,
       "symlink_target": null,
       "tracked": true
     },
@@ -41938,8 +46931,8 @@
       "name": "ProvenanceTrail.astro",
       "path": "website/src/components/ProvenanceTrail.astro",
       "role_guess": "public website",
-      "sha256": "c005b5d483b21d8632496716b09c4bd8299f92b38558e72c5777e18b97119f35",
-      "size_bytes": 7537,
+      "sha256": "b1e9716cfccf4b215e24235ae307fbbd95ece10605abb5b64de891a08cbf7839",
+      "size_bytes": 9737,
       "symlink_target": null,
       "tracked": true
     },
@@ -41964,8 +46957,8 @@
       "name": "ScopeModel.astro",
       "path": "website/src/components/ScopeModel.astro",
       "role_guess": "public website",
-      "sha256": "de17128ef0a0f5fefe5eeb60a114d456a3e7215d339fc65596e6a8cd8d4a9690",
-      "size_bytes": 6524,
+      "sha256": "c1ce5d6d654b2a130c2027743612fe78e3daca0caa1f306eeee8d543024cd0ef",
+      "size_bytes": 8724,
       "symlink_target": null,
       "tracked": true
     },
@@ -42003,8 +46996,8 @@
       "name": "content.config.ts",
       "path": "website/src/content.config.ts",
       "role_guess": "public website",
-      "sha256": "e85d5683b804f1f833516425c5ffc09012b7bbec06c4c4082c2ad1f690a13989",
-      "size_bytes": 755,
+      "sha256": "dde9ed63842dc627c75281b0e29c577fccab4c8c6e56ca848eb522723901cebd",
+      "size_bytes": 468,
       "symlink_target": null,
       "tracked": true
     },
@@ -42016,8 +47009,8 @@
       "name": "institution-in-a-box.md",
       "path": "website/src/content/blog/institution-in-a-box.md",
       "role_guess": "public website",
-      "sha256": "5eeed650603ad3de55fff925c6e6e11e205323214eb51e4614c27dbfefec3ffe",
-      "size_bytes": 4314,
+      "sha256": "f634503d0e39e8ccb5293b17ac2a612b0303e9673e5264e88a12d4498db483f6",
+      "size_bytes": 4253,
       "symlink_target": null,
       "tracked": true
     },
@@ -42068,8 +47061,8 @@
       "name": "what-icn-is-and-isnt.md",
       "path": "website/src/content/blog/what-icn-is-and-isnt.md",
       "role_guess": "public website",
-      "sha256": "ac59ccb5f367eb3448b49d83067b96a29d8c761e8034c486c9e6cedc86b2d1ec",
-      "size_bytes": 4608,
+      "sha256": "99a0ebf12d1c48a8e0f21f94e60fd927baafdfec2db51ba82c5ab4822009f71d",
+      "size_bytes": 4582,
       "symlink_target": null,
       "tracked": true
     },
@@ -42083,32 +47076,6 @@
       "role_guess": "public website",
       "sha256": "83a703c70f205beec237c5f6ce9f296e6b3423c9b7b86576ae2ae6b66b87c177",
       "size_bytes": 382,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "website/src/content/docs",
-      "extension": ".gitkeep",
-      "kind": "file",
-      "language": "unknown",
-      "name": ".gitkeep",
-      "path": "website/src/content/docs/.gitkeep",
-      "role_guess": "public website",
-      "sha256": "36a9e7f1c95b82ffb99743e0c5c4ce95d83c9a430aac59f84ef3cbfab6145068",
-      "size_bytes": 1,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "website/src/content/docs",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "README.md",
-      "path": "website/src/content/docs/README.md",
-      "role_guess": "public website",
-      "sha256": "72ed6be34a8e4bcdd8d71c321fb3898334039716b0e6f403f953f5c1ab8a94f5",
-      "size_bytes": 7290,
       "symlink_target": null,
       "tracked": true
     },
@@ -42159,8 +47126,8 @@
       "name": "README.md",
       "path": "website/src/design/README.md",
       "role_guess": "public website",
-      "sha256": "2a2e226816766f9fa8308742ad737334a3473789bfb68ca52ef12ed3b0411281",
-      "size_bytes": 1721,
+      "sha256": "2b6ebfb2bea1eb50ba3ef8330fe6031a6b60bf469cd05889ff2e30e8916bc777",
+      "size_bytes": 3426,
       "symlink_target": null,
       "tracked": true
     },
@@ -42211,8 +47178,8 @@
       "name": "markdown.ts",
       "path": "website/src/lib/markdown.ts",
       "role_guess": "public website",
-      "sha256": "456b3bee85425de556b71bd2322025912f22af755f2bcbce61ae84449521bd89",
-      "size_bytes": 2408,
+      "sha256": "06ab9de42061991be88c5b997d27898d186adc85eab07b115aa04671fb4acbf6",
+      "size_bytes": 3326,
       "symlink_target": null,
       "tracked": true
     },
@@ -42354,8 +47321,8 @@
       "name": "for-cooperatives.astro",
       "path": "website/src/pages/for-cooperatives.astro",
       "role_guess": "public website",
-      "sha256": "e8f89470fb693d6c235dc65e14e8b8a84f5912d141545f87027da1f88aa02f57",
-      "size_bytes": 15564,
+      "sha256": "ce4fb9893e3694616681d539035522b45933992821f11b1fd6960759686c7125",
+      "size_bytes": 15318,
       "symlink_target": null,
       "tracked": true
     },
@@ -42367,8 +47334,8 @@
       "name": "for-developers.astro",
       "path": "website/src/pages/for-developers.astro",
       "role_guess": "public website",
-      "sha256": "5c376f5176ce325763e6c50657da0b0fe1d2d9cb200d7e060f74c4e04e9af3aa",
-      "size_bytes": 18247,
+      "sha256": "eca7c8bf8a47ce50401ea8d33370c98cb1c5985f7e20f1dc9c00bc1668236bf4",
+      "size_bytes": 18200,
       "symlink_target": null,
       "tracked": true
     },
@@ -42380,8 +47347,8 @@
       "name": "get-involved.astro",
       "path": "website/src/pages/get-involved.astro",
       "role_guess": "public website",
-      "sha256": "81cf5c503123252a933061ffbb792b7d6bb7310a04227e38c47a7c9aa99ebda4",
-      "size_bytes": 30284,
+      "sha256": "17d4c83e1049013ae1618b430265301d80fab4bd4bcb6c11cf2b023eb354c7de",
+      "size_bytes": 29870,
       "symlink_target": null,
       "tracked": true
     },
@@ -42393,8 +47360,8 @@
       "name": "how-it-works.astro",
       "path": "website/src/pages/how-it-works.astro",
       "role_guess": "public website",
-      "sha256": "5c5a8f446d56b8e4cd5e3d6424638523019148b2f72bfe03ed3c9e6297e59c44",
-      "size_bytes": 16850,
+      "sha256": "1e533189aed22cf126276a28b11e55d0f6c98c23f833f54d1688562ed9ffdf1d",
+      "size_bytes": 17410,
       "symlink_target": null,
       "tracked": true
     },
@@ -42406,8 +47373,8 @@
       "name": "index.astro",
       "path": "website/src/pages/index.astro",
       "role_guess": "public website",
-      "sha256": "fb6f486adc1c9ed5bef4f15feaf576fa0dd140db00b377aaa0ffcfb2f8ba2840",
-      "size_bytes": 27962,
+      "sha256": "af4d53545e81df9d60a649e9eba6b541fd8b73b32421fe2aea4c8facddfadf0f",
+      "size_bytes": 27984,
       "symlink_target": null,
       "tracked": true
     },
@@ -42419,8 +47386,8 @@
       "name": "roadmap.astro",
       "path": "website/src/pages/roadmap.astro",
       "role_guess": "public website",
-      "sha256": "d86139d629c626773ef4c20658f3213a8955ba3ea69641950dc8416342b2c96a",
-      "size_bytes": 6484,
+      "sha256": "cc39ab40f66970e38c140d749f8cfc9c8e528f1fc440b125afa653c20a5aedd9",
+      "size_bytes": 6453,
       "symlink_target": null,
       "tracked": true
     },
@@ -42445,8 +47412,8 @@
       "name": "what-is-icn.astro",
       "path": "website/src/pages/what-is-icn.astro",
       "role_guess": "public website",
-      "sha256": "56bbf64f339f5e769648b20612bc73cbe801bbfe36ab62f9cd77f1ebf692e49c",
-      "size_bytes": 8430,
+      "sha256": "2459defd4b88e83e14c06b89fc32b200a80501f3e4d607812135d5655bf85d6c",
+      "size_bytes": 8469,
       "symlink_target": null,
       "tracked": true
     },
@@ -42458,8 +47425,8 @@
       "name": "whats-real-now.astro",
       "path": "website/src/pages/whats-real-now.astro",
       "role_guess": "public website",
-      "sha256": "63dfed156c7b4c2aab10ea0bac0343657943f727c8eab4768b2d91ea551926a1",
-      "size_bytes": 12451,
+      "sha256": "5cd5fbb048ebb858a82af2652ef403528aa13c0c765bca55850c75979cd6278b",
+      "size_bytes": 9997,
       "symlink_target": null,
       "tracked": true
     },
@@ -42471,8 +47438,8 @@
       "name": "why-icn.astro",
       "path": "website/src/pages/why-icn.astro",
       "role_guess": "public website",
-      "sha256": "608afaeb844de55fe7a3bf625ad9f9356695c21a9aca57284c1079c883366593",
-      "size_bytes": 8803,
+      "sha256": "daa78b938138c515df8f506f81d1eca2cb07f58fdce23d0254996f519188985c",
+      "size_bytes": 8822,
       "symlink_target": null,
       "tracked": true
     },
@@ -42503,95 +47470,98 @@
       "tracked": true
     }
   ],
-  "generated_at": "2026-05-01T14:42:25.255265+00:00",
-  "head": "9af1d6c68ea064b78165006c7ba6f1a3b3f467f8",
+  "generated_at": "2026-06-21T14:23:11.642134+00:00",
+  "head": "41c7082b330a6249bead068d641c6e4e495d2075",
   "include_untracked": false,
   "repo": "icn",
   "schema": "icn.repo_record.v1",
   "summary": {
-    "directory_count": 558,
+    "directory_count": 610,
     "extensions": {
-      "(none)": 13,
-      ".astro": 30,
+      "(none)": 19,
+      ".astro": 31,
       ".bat": 1,
-      ".conf": 2,
-      ".css": 9,
+      ".cjs": 1,
+      ".conf": 4,
+      ".css": 10,
       ".dockerignore": 4,
       ".example": 10,
       ".fast": 1,
       ".gitattributes": 1,
-      ".gitignore": 15,
-      ".gitkeep": 1,
+      ".gitignore": 16,
       ".gradle": 3,
-      ".html": 14,
+      ".html": 19,
       ".hurl": 1,
       ".icnd": 1,
       ".icnd-fast": 1,
       ".ipynb": 1,
       ".jar": 1,
-      ".js": 36,
-      ".json": 131,
+      ".js": 43,
+      ".json": 154,
       ".keystore": 1,
       ".kt": 2,
-      ".lock": 2,
+      ".lock": 3,
       ".log": 1,
-      ".md": 1004,
+      ".md": 1168,
       ".mermaid": 1,
       ".mjs": 2,
+      ".pdf": 5,
       ".png": 24,
+      ".pptx": 1,
       ".pro": 1,
       ".properties": 2,
-      ".py": 24,
-      ".rs": 897,
-      ".service": 1,
-      ".sh": 104,
-      ".svg": 4,
+      ".py": 40,
+      ".rs": 940,
+      ".service": 4,
+      ".sh": 119,
+      ".svg": 5,
       ".test": 1,
-      ".toml": 109,
+      ".toml": 112,
       ".tpl": 1,
-      ".ts": 92,
+      ".ts": 112,
       ".tsx": 43,
-      ".txt": 4,
+      ".txt": 5,
+      ".wasm": 1,
       ".webp": 15,
       ".xml": 11,
-      ".yaml": 84,
-      ".yml": 54
+      ".yaml": 92,
+      ".yml": 59
     },
-    "file_count": 2760,
+    "file_count": 3093,
     "kinds": {
-      "file": 2760
+      "file": 3093
     },
     "roles": {
       "GitHub Actions workflow": 17,
-      "React Native SDK": 137,
-      "Rust binary": 14,
-      "Rust library crate": 888,
-      "TypeScript SDK": 27,
+      "React Native SDK": 139,
+      "Rust binary": 16,
+      "Rust library crate": 922,
+      "TypeScript SDK": 29,
       "agent definition": 22,
-      "architecture decision record": 35,
+      "architecture decision record": 36,
       "contract template": 12,
       "dashboard UI": 7,
-      "demo": 47,
-      "deployment": 104,
-      "documentation": 764,
+      "demo": 53,
+      "deployment": 130,
+      "documentation": 897,
       "institution package": 40,
-      "legacy/top-level app": 34,
+      "legacy/top-level app": 5,
       "monitoring": 9,
-      "operations / coordination": 64,
-      "pilot UI": 75,
-      "project index / atlas": 11,
-      "public website": 70,
-      "repo configuration": 129,
+      "operations / coordination": 87,
+      "pilot UI": 84,
+      "project index / atlas": 27,
+      "public website": 71,
+      "repo configuration": 144,
       "repo control document": 4,
-      "request for comments": 7,
-      "runtime app crate": 83,
-      "script": 43,
-      "uncategorized": 117
+      "request for comments": 8,
+      "runtime app crate": 126,
+      "script": 53,
+      "uncategorized": 155
     },
     "skipped_paths": [],
-    "total_size_bytes": 39151683,
-    "tracked_file_count": 2760,
-    "tracked_total_size_bytes": 39151683,
+    "total_size_bytes": 48274562,
+    "tracked_file_count": 3093,
+    "tracked_total_size_bytes": 48274562,
     "untracked_file_count": 0,
     "untracked_total_size_bytes": 0
   },

--- a/docs/reference/project-index/generated/icn-file-record.md
+++ b/docs/reference/project-index/generated/icn-file-record.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-05-01T14:42:25.281015+00:00
+Generated: 2026-06-21T14:23:11.702360+00:00
 ---
 
 # Full Repository Record — `icn`
@@ -11,84 +11,86 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 ## Snapshot
 
 - Repo: `icn`
-- Branch: `docs/generated-repo-record-snapshot`
-- HEAD: `9af1d6c68ea064b78165006c7ba6f1a3b3f467f8`
+- Branch: `docs/record-refresh-2126`
+- HEAD: `41c7082b330a6249bead068d641c6e4e495d2075`
 - Working tree: `clean (no uncommitted changes against HEAD)`
 - SHA source: `working tree bytes (may differ from HEAD blob bytes when .gitattributes filters apply, e.g. CRLF normalization)`
-- Files recorded: `2760`
-- Tracked files recorded: `2760`
-- Directories recorded: `558`
-- Total recorded bytes: `39151683`
-- Total tracked bytes: `39151683`
-- Entry kinds: `file: 2760`
+- Files recorded: `3093`
+- Tracked files recorded: `3093`
+- Directories recorded: `610`
+- Total recorded bytes: `48274562`
+- Total tracked bytes: `48274562`
+- Entry kinds: `file: 3093`
 
 ## Role summary
 
 | Role guess | Files |
 |---|---:|
-| Rust library crate | 888 |
-| documentation | 764 |
-| React Native SDK | 137 |
-| repo configuration | 129 |
-| uncategorized | 117 |
-| deployment | 104 |
-| runtime app crate | 83 |
-| pilot UI | 75 |
-| public website | 70 |
-| operations / coordination | 64 |
-| demo | 47 |
-| script | 43 |
+| Rust library crate | 922 |
+| documentation | 897 |
+| uncategorized | 155 |
+| repo configuration | 144 |
+| React Native SDK | 139 |
+| deployment | 130 |
+| runtime app crate | 126 |
+| operations / coordination | 87 |
+| pilot UI | 84 |
+| public website | 71 |
+| demo | 53 |
+| script | 53 |
 | institution package | 40 |
-| architecture decision record | 35 |
-| legacy/top-level app | 34 |
-| TypeScript SDK | 27 |
+| architecture decision record | 36 |
+| TypeScript SDK | 29 |
+| project index / atlas | 27 |
 | agent definition | 22 |
 | GitHub Actions workflow | 17 |
-| Rust binary | 14 |
+| Rust binary | 16 |
 | contract template | 12 |
-| project index / atlas | 11 |
 | monitoring | 9 |
+| request for comments | 8 |
 | dashboard UI | 7 |
-| request for comments | 7 |
+| legacy/top-level app | 5 |
 | repo control document | 4 |
 
 ## Extension summary
 
 | Extension | Files |
 |---|---:|
-| `.md` | 1004 |
-| `.rs` | 897 |
-| `.json` | 131 |
-| `.toml` | 109 |
-| `.sh` | 104 |
-| `.ts` | 92 |
-| `.yaml` | 84 |
-| `.yml` | 54 |
+| `.md` | 1168 |
+| `.rs` | 940 |
+| `.json` | 154 |
+| `.sh` | 119 |
+| `.toml` | 112 |
+| `.ts` | 112 |
+| `.yaml` | 92 |
+| `.yml` | 59 |
+| `.js` | 43 |
 | `.tsx` | 43 |
-| `.js` | 36 |
-| `.astro` | 30 |
+| `.py` | 40 |
+| `.astro` | 31 |
 | `.png` | 24 |
-| `.py` | 24 |
-| `.gitignore` | 15 |
+| `(none)` | 19 |
+| `.html` | 19 |
+| `.gitignore` | 16 |
 | `.webp` | 15 |
-| `.html` | 14 |
-| `(none)` | 13 |
 | `.xml` | 11 |
+| `.css` | 10 |
 | `.example` | 10 |
-| `.css` | 9 |
+| `.pdf` | 5 |
+| `.svg` | 5 |
+| `.txt` | 5 |
+| `.conf` | 4 |
 | `.dockerignore` | 4 |
-| `.svg` | 4 |
-| `.txt` | 4 |
+| `.service` | 4 |
 | `.gradle` | 3 |
-| `.conf` | 2 |
+| `.lock` | 3 |
 | `.kt` | 2 |
-| `.lock` | 2 |
 | `.mjs` | 2 |
 | `.properties` | 2 |
 | `.bat` | 1 |
+| `.cjs` | 1 |
 | `.fast` | 1 |
 | `.gitattributes` | 1 |
-| `.gitkeep` | 1 |
 | `.hurl` | 1 |
 | `.icnd` | 1 |
 | `.icnd-fast` | 1 |
@@ -97,158 +99,163 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.keystore` | 1 |
 | `.log` | 1 |
 | `.mermaid` | 1 |
+| `.pptx` | 1 |
 | `.pro` | 1 |
-| `.service` | 1 |
 | `.test` | 1 |
 | `.tpl` | 1 |
+| `.wasm` | 1 |
 
 ## Directory record
 
 | Directory | Depth | Files under directory | Child dirs | Size bytes | Role guess |
 |---|---:|---:|---:|---:|---|
-| `.` | 0 | 2760 | 24 | 39151683 | repo root |
-| `.agents` | 1 | 24 | 1 | 66504 | repo configuration |
-| `.claude` | 1 | 61 | 5 | 192712 | repo configuration |
+| `.` | 0 | 3093 | 25 | 48274562 | repo root |
+| `.agents` | 1 | 25 | 1 | 71663 | repo configuration |
+| `.claude` | 1 | 65 | 5 | 228531 | repo configuration |
 | `.codex` | 1 | 16 | 2 | 19783 | repo configuration |
-| `.cursor` | 1 | 1 | 0 | 132 | repo configuration |
-| `.devcontainer` | 1 | 1 | 0 | 1320 | repo configuration |
-| `.github` | 1 | 58 | 6 | 234091 | repo configuration |
+| `.cursor` | 1 | 1 | 0 | 135 | repo configuration |
+| `.devcontainer` | 1 | 1 | 0 | 1307 | repo configuration |
+| `.github` | 1 | 68 | 6 | 284056 | repo configuration |
 | `.opencode` | 1 | 2 | 1 | 1837 | repo configuration |
-| `apps` | 1 | 34 | 4 | 273802 | legacy/top-level app |
+| `apps` | 1 | 5 | 1 | 11841 | legacy/top-level app |
 | `config` | 1 | 11 | 0 | 34536 | uncategorized |
 | `contracts` | 1 | 12 | 3 | 98869 | contract template |
-| `demo` | 1 | 47 | 5 | 471677 | demo |
-| `deploy` | 1 | 104 | 9 | 383265 | deployment |
+| `demo` | 1 | 53 | 6 | 512850 | demo |
+| `deploy` | 1 | 130 | 10 | 571828 | deployment |
 | `docker` | 1 | 6 | 0 | 17165 | uncategorized |
-| `docs` | 1 | 817 | 45 | 9982723 | documentation |
-| `examples` | 1 | 43 | 5 | 612341 | uncategorized |
-| `icn` | 1 | 1002 | 9 | 19698385 | uncategorized |
-| `institutions` | 1 | 40 | 1 | 97783 | institution package |
+| `docs` | 1 | 968 | 46 | 15760928 | documentation |
+| `examples` | 1 | 43 | 5 | 562715 | uncategorized |
+| `icn` | 1 | 1081 | 9 | 21916668 | uncategorized |
+| `institutions` | 1 | 40 | 1 | 102081 | institution package |
 | `monitoring` | 1 | 9 | 0 | 67029 | monitoring |
-| `ops` | 1 | 64 | 8 | 545508 | operations / coordination |
-| `scripts` | 1 | 43 | 0 | 279218 | script |
-| `sdk` | 1 | 164 | 2 | 2214796 | uncategorized |
+| `ops` | 1 | 87 | 8 | 843723 | operations / coordination |
+| `scripts` | 1 | 53 | 0 | 423147 | script |
+| `sdk` | 1 | 168 | 2 | 2524210 | uncategorized |
 | `sims` | 1 | 19 | 1 | 92514 | uncategorized |
-| `web` | 1 | 87 | 3 | 1433099 | uncategorized |
-| `website` | 1 | 70 | 6 | 1893195 | public website |
-| `.agents/skills` | 2 | 24 | 24 | 66504 | repo configuration |
-| `.claude/agents` | 2 | 15 | 0 | 69783 | repo configuration |
+| `tools` | 1 | 26 | 1 | 88907 | uncategorized |
+| `web` | 1 | 106 | 4 | 1667858 | uncategorized |
+| `website` | 1 | 71 | 6 | 1910144 | public website |
+| `.agents/skills` | 2 | 25 | 25 | 71663 | repo configuration |
+| `.claude/agents` | 2 | 16 | 0 | 82164 | repo configuration |
 | `.claude/commands` | 2 | 4 | 0 | 11351 | repo configuration |
-| `.claude/hooks` | 2 | 12 | 0 | 19357 | repo configuration |
-| `.claude/rules` | 2 | 4 | 0 | 5713 | repo configuration |
-| `.claude/skills` | 2 | 24 | 24 | 79871 | repo configuration |
+| `.claude/hooks` | 2 | 12 | 0 | 20657 | repo configuration |
+| `.claude/rules` | 2 | 5 | 0 | 9922 | repo configuration |
+| `.claude/skills` | 2 | 26 | 26 | 97800 | repo configuration |
 | `.codex/mcp` | 2 | 1 | 0 | 751 | repo configuration |
 | `.codex/skills` | 2 | 15 | 7 | 19032 | repo configuration |
-| `.github/ISSUE_TEMPLATE` | 2 | 4 | 0 | 4015 | repo configuration |
+| `.github/ISSUE_TEMPLATE` | 2 | 9 | 0 | 15085 | repo configuration |
 | `.github/actions` | 2 | 2 | 2 | 3265 | repo configuration |
-| `.github/agents` | 2 | 22 | 0 | 58675 | agent definition |
-| `.github/instructions` | 2 | 5 | 0 | 28655 | repo configuration |
-| `.github/scripts` | 2 | 3 | 0 | 22628 | repo configuration |
-| `.github/workflows` | 2 | 17 | 0 | 88198 | GitHub Actions workflow |
+| `.github/agents` | 2 | 22 | 0 | 59062 | agent definition |
+| `.github/instructions` | 2 | 5 | 0 | 28980 | repo configuration |
+| `.github/scripts` | 2 | 8 | 1 | 39349 | repo configuration |
+| `.github/workflows` | 2 | 17 | 0 | 108418 | GitHub Actions workflow |
 | `.opencode/commands` | 2 | 1 | 0 | 409 | repo configuration |
-| `apps/echo` | 2 | 4 | 1 | 9026 | legacy/top-level app |
-| `apps/governance` | 2 | 5 | 1 | 18612 | legacy/top-level app |
-| `apps/ledger` | 2 | 11 | 1 | 68220 | legacy/top-level app |
-| `apps/trust` | 2 | 14 | 3 | 177944 | legacy/top-level app |
+| `apps/echo` | 2 | 5 | 1 | 11841 | legacy/top-level app |
 | `contracts/governance` | 2 | 5 | 0 | 69912 | contract template |
 | `contracts/protocol` | 2 | 2 | 0 | 18846 | contract template |
 | `contracts/templates` | 2 | 5 | 0 | 10111 | contract template |
 | `demo/configs` | 2 | 1 | 0 | 401 | demo |
 | `demo/data` | 2 | 8 | 0 | 15595 | demo |
-| `demo/docs` | 2 | 7 | 1 | 85878 | demo |
-| `demo/notes` | 2 | 5 | 0 | 33969 | demo |
-| `demo/scripts` | 2 | 21 | 0 | 290211 | demo |
+| `demo/docs` | 2 | 7 | 1 | 85887 | demo |
+| `demo/notes` | 2 | 5 | 0 | 33979 | demo |
+| `demo/nycn-dogfood` | 2 | 6 | 1 | 44667 | demo |
+| `demo/scripts` | 2 | 21 | 0 | 292655 | demo |
+| `deploy/appliance` | 2 | 26 | 4 | 187873 | deployment |
 | `deploy/ci-runner` | 2 | 2 | 0 | 7871 | deployment |
 | `deploy/compose` | 2 | 4 | 0 | 5785 | deployment |
 | `deploy/config` | 2 | 6 | 1 | 34463 | deployment |
-| `deploy/devnet` | 2 | 8 | 1 | 20249 | deployment |
+| `deploy/devnet` | 2 | 8 | 1 | 20939 | deployment |
 | `deploy/grafana` | 2 | 1 | 0 | 8724 | deployment |
 | `deploy/helm` | 2 | 9 | 1 | 8970 | deployment |
 | `deploy/k8s` | 2 | 51 | 5 | 235397 | deployment |
 | `deploy/kubernetes` | 2 | 12 | 0 | 25850 | deployment |
 | `deploy/prometheus` | 2 | 1 | 0 | 4149 | deployment |
-| `docs/adr` | 2 | 35 | 0 | 289086 | architecture decision record |
+| `docs/adr` | 2 | 36 | 0 | 300071 | architecture decision record |
 | `docs/ai` | 2 | 5 | 0 | 21008 | documentation |
-| `docs/api` | 2 | 5 | 0 | 107028 | documentation |
-| `docs/architecture` | 2 | 36 | 0 | 1062755 | documentation |
-| `docs/archive` | 2 | 78 | 2 | 1052773 | documentation |
-| `docs/ci` | 2 | 3 | 0 | 12404 | documentation |
-| `docs/contracts` | 2 | 1 | 1 | 4322 | documentation |
+| `docs/api` | 2 | 6 | 0 | 143308 | documentation |
+| `docs/architecture` | 2 | 43 | 0 | 1241547 | documentation |
+| `docs/archive` | 2 | 78 | 2 | 1050816 | documentation |
+| `docs/ci` | 2 | 3 | 0 | 13817 | documentation |
+| `docs/contracts` | 2 | 13 | 1 | 138697 | documentation |
 | `docs/crate-manifests` | 2 | 42 | 0 | 46904 | documentation |
-| `docs/demo` | 2 | 6 | 0 | 62929 | documentation |
-| `docs/deployment` | 2 | 12 | 0 | 109523 | documentation |
-| `docs/design` | 2 | 51 | 3 | 778243 | documentation |
-| `docs/design-language` | 2 | 3 | 0 | 38437 | documentation |
-| `docs/dev` | 2 | 7 | 0 | 77044 | documentation |
-| `docs/development` | 2 | 189 | 3 | 2245202 | documentation |
+| `docs/demo` | 2 | 14 | 0 | 191732 | documentation |
+| `docs/deployment` | 2 | 12 | 0 | 110143 | documentation |
+| `docs/design` | 2 | 76 | 6 | 1131479 | documentation |
+| `docs/design-language` | 2 | 3 | 0 | 39612 | documentation |
+| `docs/dev` | 2 | 36 | 0 | 626299 | documentation |
+| `docs/development` | 2 | 189 | 3 | 2245017 | documentation |
 | `docs/examples` | 2 | 7 | 1 | 11596 | documentation |
 | `docs/features` | 2 | 2 | 0 | 50031 | documentation |
-| `docs/guides` | 2 | 34 | 3 | 247024 | documentation |
+| `docs/guides` | 2 | 38 | 3 | 284127 | documentation |
+| `docs/handoffs` | 2 | 1 | 0 | 10078 | documentation |
 | `docs/internal` | 2 | 19 | 3 | 296737 | documentation |
 | `docs/maintenance` | 2 | 1 | 0 | 7296 | documentation |
-| `docs/manual` | 2 | 1 | 0 | 41675 | documentation |
+| `docs/manual` | 2 | 8 | 0 | 155426 | documentation |
 | `docs/migration-guides` | 2 | 2 | 0 | 17471 | documentation |
-| `docs/mobile` | 2 | 6 | 1 | 72777 | documentation |
+| `docs/mobile` | 2 | 6 | 1 | 74162 | documentation |
 | `docs/observability` | 2 | 2 | 0 | 12156 | documentation |
 | `docs/onboarding` | 2 | 67 | 6 | 559495 | documentation |
-| `docs/operations` | 2 | 6 | 1 | 78722 | documentation |
-| `docs/ops` | 2 | 3 | 1 | 7517 | documentation |
+| `docs/operations` | 2 | 6 | 1 | 79099 | documentation |
+| `docs/ops` | 2 | 5 | 1 | 23101 | documentation |
 | `docs/performance` | 2 | 7 | 0 | 41495 | documentation |
 | `docs/phases` | 2 | 1 | 0 | 3801 | documentation |
-| `docs/pilots` | 2 | 6 | 0 | 53808 | documentation |
-| `docs/planning` | 2 | 7 | 0 | 101764 | documentation |
-| `docs/plans` | 2 | 17 | 1 | 414822 | documentation |
-| `docs/reference` | 2 | 24 | 3 | 192710 | documentation |
-| `docs/rfcs` | 2 | 7 | 0 | 152136 | request for comments |
-| `docs/scripts` | 2 | 4 | 0 | 51791 | documentation |
+| `docs/pilots` | 2 | 4 | 0 | 38839 | documentation |
+| `docs/planning` | 2 | 7 | 0 | 102284 | documentation |
+| `docs/plans` | 2 | 17 | 1 | 415015 | documentation |
+| `docs/reference` | 2 | 40 | 3 | 2290330 | documentation |
+| `docs/rfcs` | 2 | 8 | 0 | 176908 | request for comments |
+| `docs/scripts` | 2 | 9 | 0 | 105739 | documentation |
 | `docs/sdis` | 2 | 13 | 0 | 161014 | documentation |
 | `docs/security` | 2 | 20 | 0 | 279869 | documentation |
-| `docs/spec` | 2 | 2 | 0 | 52569 | documentation |
+| `docs/spec` | 2 | 16 | 0 | 527494 | documentation |
 | `docs/state` | 2 | 4 | 0 | 32902 | documentation |
 | `docs/status` | 2 | 5 | 0 | 28327 | documentation |
-| `docs/strategy` | 2 | 31 | 1 | 453732 | documentation |
-| `docs/summit` | 2 | 1 | 0 | 9261 | documentation |
+| `docs/strategy` | 2 | 49 | 1 | 1623575 | documentation |
+| `docs/summit` | 2 | 1 | 0 | 13525 | documentation |
 | `docs/superpowers` | 2 | 8 | 2 | 112413 | documentation |
 | `docs/templates` | 2 | 8 | 0 | 9820 | documentation |
 | `docs/testing` | 2 | 4 | 0 | 21851 | documentation |
-| `docs/vision` | 2 | 3 | 0 | 48885 | documentation |
+| `docs/vision` | 2 | 3 | 0 | 48916 | documentation |
 | `examples/01-quickstart` | 2 | 2 | 0 | 15554 | uncategorized |
 | `examples/contracts` | 2 | 7 | 0 | 9523 | uncategorized |
 | `examples/governance-api` | 2 | 3 | 0 | 24351 | uncategorized |
-| `examples/mobile-app` | 2 | 27 | 2 | 552052 | uncategorized |
+| `examples/mobile-app` | 2 | 27 | 2 | 502426 | uncategorized |
 | `examples/wasm-compute` | 2 | 3 | 1 | 6409 | uncategorized |
 | `icn/.cargo` | 2 | 3 | 0 | 1519 | uncategorized |
 | `icn/.config` | 2 | 1 | 0 | 779 | uncategorized |
-| `icn/apps` | 2 | 83 | 4 | 2141681 | runtime app crate |
-| `icn/bins` | 2 | 14 | 3 | 655701 | Rust binary |
+| `icn/apps` | 2 | 126 | 7 | 2841591 | runtime app crate |
+| `icn/bins` | 2 | 16 | 3 | 712750 | Rust binary |
 | `icn/config` | 2 | 1 | 0 | 8247 | uncategorized |
-| `icn/crates` | 2 | 888 | 35 | 16640221 | Rust library crate |
+| `icn/crates` | 2 | 922 | 38 | 18095675 | Rust library crate |
 | `icn/docs` | 2 | 1 | 0 | 10540 | uncategorized |
 | `icn/examples` | 2 | 1 | 0 | 4866 | uncategorized |
 | `icn/scripts` | 2 | 1 | 0 | 7253 | uncategorized |
-| `institutions/nycn` | 2 | 39 | 9 | 97254 | institution package |
+| `institutions/nycn` | 2 | 39 | 9 | 101552 | institution package |
 | `ops/.github` | 2 | 1 | 1 | 1087 | operations / coordination |
 | `ops/automation` | 2 | 3 | 1 | 8671 | operations / coordination |
 | `ops/coordination` | 2 | 5 | 0 | 136117 | operations / coordination |
 | `ops/docs` | 2 | 2 | 1 | 45626 | operations / coordination |
-| `ops/ideas` | 2 | 9 | 2 | 97487 | operations / coordination |
-| `ops/mcp` | 2 | 25 | 1 | 189028 | operations / coordination |
+| `ops/ideas` | 2 | 13 | 3 | 276322 | operations / coordination |
+| `ops/mcp` | 2 | 43 | 1 | 296740 | operations / coordination |
 | `ops/scripts` | 2 | 3 | 0 | 24198 | operations / coordination |
-| `ops/state` | 2 | 13 | 5 | 35981 | operations / coordination |
-| `sdk/react-native` | 2 | 137 | 3 | 1577732 | React Native SDK |
-| `sdk/typescript` | 2 | 27 | 2 | 637064 | TypeScript SDK |
+| `ops/state` | 2 | 14 | 5 | 47649 | operations / coordination |
+| `sdk/react-native` | 2 | 139 | 3 | 1829453 | React Native SDK |
+| `sdk/typescript` | 2 | 29 | 2 | 694757 | TypeScript SDK |
 | `sims/mutual-credit` | 2 | 19 | 2 | 92514 | uncategorized |
+| `tools/claude-code` | 2 | 26 | 1 | 88907 | uncategorized |
 | `web/api-docs` | 2 | 5 | 0 | 51150 | uncategorized |
 | `web/dashboard` | 2 | 7 | 0 | 53602 | dashboard UI |
-| `web/pilot-ui` | 2 | 75 | 4 | 1328347 | pilot UI |
+| `web/member-shell` | 2 | 10 | 1 | 106320 | uncategorized |
+| `web/pilot-ui` | 2 | 84 | 5 | 1456786 | pilot UI |
 | `website/.claude` | 2 | 2 | 1 | 3418 | public website |
 | `website/.github` | 2 | 1 | 1 | 1004 | public website |
 | `website/.vscode` | 2 | 2 | 0 | 294 | public website |
-| `website/public` | 2 | 7 | 1 | 1256597 | public website |
-| `website/scripts` | 2 | 1 | 0 | 3707 | public website |
-| `website/src` | 2 | 49 | 8 | 374149 | public website |
+| `website/public` | 2 | 8 | 2 | 1256683 | public website |
+| `website/scripts` | 2 | 2 | 0 | 5449 | public website |
+| `website/src` | 2 | 48 | 8 | 386966 | public website |
 | `.agents/skills/bench` | 3 | 1 | 0 | 2237 | repo configuration |
 | `.agents/skills/changelog` | 3 | 1 | 0 | 2594 | repo configuration |
+| `.agents/skills/ci-status` | 3 | 1 | 0 | 5159 | repo configuration |
 | `.agents/skills/demo-validate` | 3 | 1 | 0 | 1024 | repo configuration |
 | `.agents/skills/devnet` | 3 | 1 | 0 | 1588 | repo configuration |
 | `.agents/skills/diag-infra` | 3 | 1 | 0 | 960 | repo configuration |
@@ -273,6 +280,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.agents/skills/watch-ci-and-advance` | 3 | 1 | 0 | 5321 | repo configuration |
 | `.claude/skills/bench` | 3 | 1 | 0 | 2237 | repo configuration |
 | `.claude/skills/changelog` | 3 | 1 | 0 | 2594 | repo configuration |
+| `.claude/skills/ci-status` | 3 | 1 | 0 | 5159 | repo configuration |
 | `.claude/skills/demo-validate` | 3 | 1 | 0 | 1473 | repo configuration |
 | `.claude/skills/devnet` | 3 | 1 | 0 | 1867 | repo configuration |
 | `.claude/skills/diag-infra` | 3 | 1 | 0 | 1376 | repo configuration |
@@ -280,6 +288,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.claude/skills/fix-ci` | 3 | 1 | 0 | 2525 | repo configuration |
 | `.claude/skills/fix-rust-lints` | 3 | 1 | 0 | 5781 | repo configuration |
 | `.claude/skills/handoff` | 3 | 1 | 0 | 2857 | repo configuration |
+| `.claude/skills/icn-commons-design` | 3 | 1 | 0 | 12770 | repo configuration |
 | `.claude/skills/icn-dev` | 3 | 1 | 0 | 6560 | repo configuration |
 | `.claude/skills/icn-preflight` | 3 | 1 | 0 | 2609 | repo configuration |
 | `.claude/skills/integrate-pr-stack` | 3 | 1 | 0 | 6314 | repo configuration |
@@ -304,13 +313,14 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.codex/skills/icn-shipping` | 3 | 1 | 0 | 1657 | repo configuration |
 | `.github/actions/free-disk-space` | 3 | 1 | 0 | 2717 | repo configuration |
 | `.github/actions/install-build-tools` | 3 | 1 | 0 | 548 | repo configuration |
+| `.github/scripts/fixtures` | 3 | 3 | 1 | 803 | repo configuration |
 | `apps/echo/src` | 3 | 1 | 0 | 8053 | legacy/top-level app |
-| `apps/governance/src` | 3 | 3 | 0 | 17619 | legacy/top-level app |
-| `apps/ledger/src` | 3 | 8 | 0 | 65088 | legacy/top-level app |
-| `apps/trust/benches` | 3 | 2 | 0 | 11863 | legacy/top-level app |
-| `apps/trust/src` | 3 | 8 | 0 | 144707 | legacy/top-level app |
-| `apps/trust/tests` | 3 | 1 | 0 | 18302 | legacy/top-level app |
 | `demo/docs/plans` | 3 | 2 | 0 | 39539 | demo |
+| `demo/nycn-dogfood/sample` | 3 | 2 | 0 | 17889 | demo |
+| `deploy/appliance/roles` | 3 | 5 | 0 | 11101 | deployment |
+| `deploy/appliance/scripts` | 3 | 6 | 0 | 51340 | deployment |
+| `deploy/appliance/smoke` | 3 | 5 | 1 | 52449 | deployment |
+| `deploy/appliance/systemd` | 3 | 5 | 1 | 9433 | deployment |
 | `deploy/config/grafana` | 3 | 3 | 1 | 31405 | deployment |
 | `deploy/devnet/monitoring` | 3 | 4 | 1 | 10698 | deployment |
 | `deploy/helm/icn` | 3 | 9 | 1 | 8970 | deployment |
@@ -320,16 +330,19 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `deploy/k8s/scripts` | 3 | 10 | 0 | 40866 | deployment |
 | `deploy/k8s/self-hosted-runner` | 3 | 3 | 0 | 13789 | deployment |
 | `docs/archive/2025` | 3 | 45 | 0 | 645034 | documentation |
-| `docs/archive/2026` | 3 | 32 | 2 | 406815 | documentation |
-| `docs/contracts/institution-package` | 3 | 1 | 0 | 4322 | documentation |
+| `docs/archive/2026` | 3 | 32 | 2 | 404858 | documentation |
+| `docs/contracts/institution-package` | 3 | 3 | 0 | 13758 | documentation |
+| `docs/design/assets` | 3 | 8 | 1 | 51764 | documentation |
+| `docs/design/claude-design-seed` | 3 | 3 | 0 | 27675 | documentation |
 | `docs/design/economics` | 3 | 9 | 0 | 189718 | documentation |
-| `docs/design/governance` | 3 | 6 | 0 | 77508 | documentation |
+| `docs/design/governance` | 3 | 9 | 0 | 134866 | documentation |
+| `docs/design/icons` | 3 | 2 | 0 | 34376 | documentation |
 | `docs/design/sdis` | 3 | 2 | 0 | 21313 | documentation |
-| `docs/development/sessions` | 3 | 159 | 7 | 1985413 | documentation |
+| `docs/development/sessions` | 3 | 159 | 7 | 1985228 | documentation |
 | `docs/development/sprints` | 3 | 4 | 0 | 15626 | documentation |
 | `docs/development/testing` | 3 | 11 | 0 | 105370 | documentation |
 | `docs/examples/policies` | 3 | 7 | 0 | 11596 | documentation |
-| `docs/guides/developer` | 3 | 5 | 0 | 19977 | documentation |
+| `docs/guides/developer` | 3 | 9 | 0 | 57159 | documentation |
 | `docs/guides/operations` | 3 | 21 | 1 | 169239 | documentation |
 | `docs/guides/user` | 3 | 4 | 0 | 20386 | documentation |
 | `docs/internal/documentation-control-system` | 3 | 7 | 0 | 14990 | documentation |
@@ -342,12 +355,12 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/onboarding/resources` | 3 | 1 | 0 | 271 | documentation |
 | `docs/onboarding/tracks` | 3 | 3 | 0 | 14637 | documentation |
 | `docs/onboarding/workshops` | 3 | 15 | 0 | 96505 | documentation |
-| `docs/operations/deployment` | 3 | 5 | 0 | 77036 | documentation |
+| `docs/operations/deployment` | 3 | 5 | 0 | 77413 | documentation |
 | `docs/ops/runbooks` | 3 | 1 | 0 | 293 | documentation |
 | `docs/plans/.scratch` | 3 | 1 | 0 | 1229 | documentation |
 | `docs/reference/api` | 3 | 5 | 0 | 52497 | documentation |
 | `docs/reference/config` | 3 | 4 | 0 | 24982 | documentation |
-| `docs/reference/project-index` | 3 | 11 | 0 | 74703 | project index / atlas |
+| `docs/reference/project-index` | 3 | 27 | 1 | 2172323 | project index / atlas |
 | `docs/strategy/grants` | 3 | 7 | 0 | 32301 | documentation |
 | `docs/superpowers/plans` | 3 | 1 | 0 | 42648 | documentation |
 | `docs/superpowers/specs` | 3 | 7 | 0 | 69765 | documentation |
@@ -355,88 +368,99 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `examples/mobile-app/src` | 3 | 10 | 3 | 39760 | uncategorized |
 | `examples/wasm-compute/src` | 3 | 1 | 0 | 3089 | uncategorized |
 | `icn/apps/charter` | 3 | 3 | 1 | 16833 | runtime app crate |
-| `icn/apps/governance` | 3 | 38 | 2 | 1495230 | runtime app crate |
+| `icn/apps/governance` | 3 | 51 | 2 | 1928731 | runtime app crate |
+| `icn/apps/governance-app` | 3 | 5 | 1 | 18596 | runtime app crate |
 | `icn/apps/ledger` | 3 | 7 | 2 | 26000 | runtime app crate |
+| `icn/apps/ledger-app` | 3 | 11 | 1 | 69873 | runtime app crate |
 | `icn/apps/membership` | 3 | 35 | 1 | 603618 | runtime app crate |
+| `icn/apps/trust-app` | 3 | 14 | 3 | 177940 | runtime app crate |
 | `icn/bins/icn-console` | 3 | 2 | 1 | 35842 | Rust binary |
-| `icn/bins/icnctl` | 3 | 9 | 3 | 569816 | Rust binary |
-| `icn/bins/icnd` | 3 | 3 | 1 | 50043 | Rust binary |
-| `icn/crates/icn-api` | 3 | 8 | 1 | 57465 | Rust library crate |
+| `icn/bins/icnctl` | 3 | 11 | 3 | 611032 | Rust binary |
+| `icn/bins/icnd` | 3 | 3 | 1 | 65876 | Rust binary |
+| `icn/crates/icn-api` | 3 | 8 | 1 | 65967 | Rust library crate |
 | `icn/crates/icn-authz` | 3 | 11 | 2 | 48635 | Rust library crate |
+| `icn/crates/icn-baseline-lock` | 3 | 12 | 2 | 72017 | Rust library crate |
+| `icn/crates/icn-baseline-lock-guest` | 3 | 3 | 1 | 7884 | Rust library crate |
+| `icn/crates/icn-boundary` | 3 | 3 | 1 | 4048 | Rust library crate |
 | `icn/crates/icn-ccl` | 3 | 76 | 4 | 925986 | Rust library crate |
-| `icn/crates/icn-commons` | 3 | 10 | 2 | 178380 | Rust library crate |
+| `icn/crates/icn-commons` | 3 | 10 | 2 | 191868 | Rust library crate |
 | `icn/crates/icn-community` | 3 | 13 | 2 | 131502 | Rust library crate |
-| `icn/crates/icn-compute` | 3 | 36 | 4 | 1041041 | Rust library crate |
-| `icn/crates/icn-coop` | 3 | 8 | 1 | 182967 | Rust library crate |
-| `icn/crates/icn-core` | 3 | 138 | 2 | 2532599 | Rust library crate |
+| `icn/crates/icn-compute` | 3 | 36 | 4 | 1042294 | Rust library crate |
+| `icn/crates/icn-coop` | 3 | 8 | 1 | 197308 | Rust library crate |
+| `icn/crates/icn-core` | 3 | 140 | 2 | 2610494 | Rust library crate |
 | `icn/crates/icn-crypto` | 3 | 2 | 1 | 1737 | Rust library crate |
-| `icn/crates/icn-crypto-pq` | 3 | 11 | 2 | 148568 | Rust library crate |
+| `icn/crates/icn-crypto-pq` | 3 | 11 | 2 | 149222 | Rust library crate |
 | `icn/crates/icn-encoding` | 3 | 2 | 1 | 4341 | Rust library crate |
-| `icn/crates/icn-entity` | 3 | 11 | 1 | 252990 | Rust library crate |
-| `icn/crates/icn-federation` | 3 | 27 | 2 | 549383 | Rust library crate |
-| `icn/crates/icn-gateway` | 3 | 152 | 5 | 3491740 | Rust library crate |
-| `icn/crates/icn-gossip` | 3 | 36 | 3 | 609707 | Rust library crate |
-| `icn/crates/icn-governance` | 3 | 48 | 2 | 1099898 | Rust library crate |
-| `icn/crates/icn-http-kit` | 3 | 6 | 1 | 30588 | Rust library crate |
-| `icn/crates/icn-identity` | 3 | 26 | 3 | 518202 | Rust library crate |
-| `icn/crates/icn-kernel-api` | 3 | 30 | 1 | 587941 | Rust library crate |
-| `icn/crates/icn-ledger` | 3 | 53 | 4 | 1123750 | Rust library crate |
+| `icn/crates/icn-entity` | 3 | 15 | 1 | 384840 | Rust library crate |
+| `icn/crates/icn-federation` | 3 | 27 | 2 | 549567 | Rust library crate |
+| `icn/crates/icn-gateway` | 3 | 158 | 5 | 3802638 | Rust library crate |
+| `icn/crates/icn-gossip` | 3 | 36 | 3 | 614926 | Rust library crate |
+| `icn/crates/icn-governance` | 3 | 48 | 2 | 1274237 | Rust library crate |
+| `icn/crates/icn-http-kit` | 3 | 6 | 1 | 39014 | Rust library crate |
+| `icn/crates/icn-identity` | 3 | 26 | 3 | 518615 | Rust library crate |
+| `icn/crates/icn-kernel-api` | 3 | 34 | 2 | 1172315 | Rust library crate |
+| `icn/crates/icn-ledger` | 3 | 53 | 4 | 1141873 | Rust library crate |
 | `icn/crates/icn-naming` | 3 | 2 | 1 | 29980 | Rust library crate |
-| `icn/crates/icn-net` | 3 | 41 | 3 | 848164 | Rust library crate |
-| `icn/crates/icn-obs` | 3 | 24 | 2 | 413932 | Rust library crate |
-| `icn/crates/icn-privacy` | 3 | 7 | 2 | 68900 | Rust library crate |
+| `icn/crates/icn-net` | 3 | 41 | 3 | 848264 | Rust library crate |
+| `icn/crates/icn-obs` | 3 | 24 | 2 | 415208 | Rust library crate |
+| `icn/crates/icn-privacy` | 3 | 7 | 2 | 68864 | Rust library crate |
 | `icn/crates/icn-protocol` | 3 | 2 | 1 | 1731 | Rust library crate |
-| `icn/crates/icn-rpc` | 3 | 23 | 2 | 402031 | Rust library crate |
+| `icn/crates/icn-rpc` | 3 | 23 | 2 | 417356 | Rust library crate |
 | `icn/crates/icn-security` | 3 | 3 | 1 | 74333 | Rust library crate |
 | `icn/crates/icn-services` | 3 | 2 | 1 | 2051 | Rust library crate |
 | `icn/crates/icn-snapshot` | 3 | 4 | 1 | 97784 | Rust library crate |
-| `icn/crates/icn-steward` | 3 | 16 | 2 | 231521 | Rust library crate |
-| `icn/crates/icn-store` | 3 | 7 | 2 | 160420 | Rust library crate |
+| `icn/crates/icn-steward` | 3 | 16 | 2 | 231660 | Rust library crate |
+| `icn/crates/icn-store` | 3 | 7 | 2 | 165196 | Rust library crate |
 | `icn/crates/icn-testkit` | 3 | 9 | 2 | 84825 | Rust library crate |
-| `icn/crates/icn-time` | 3 | 6 | 2 | 41421 | Rust library crate |
+| `icn/crates/icn-time` | 3 | 6 | 2 | 41429 | Rust library crate |
 | `icn/crates/icn-trust` | 3 | 20 | 3 | 477034 | Rust library crate |
-| `icn/crates/icn-zkp` | 3 | 18 | 1 | 188674 | Rust library crate |
+| `icn/crates/icn-zkp` | 3 | 18 | 1 | 188632 | Rust library crate |
 | `institutions/nycn/charter` | 3 | 1 | 0 | 11711 | institution package |
 | `institutions/nycn/config` | 3 | 1 | 0 | 757 | institution package |
 | `institutions/nycn/definitions` | 3 | 5 | 0 | 1719 | institution package |
 | `institutions/nycn/docs` | 3 | 4 | 0 | 59202 | institution package |
 | `institutions/nycn/migrations` | 3 | 3 | 0 | 707 | institution package |
 | `institutions/nycn/seed` | 3 | 8 | 0 | 6010 | institution package |
-| `institutions/nycn/summit` | 3 | 5 | 2 | 10641 | institution package |
+| `institutions/nycn/summit` | 3 | 5 | 2 | 14905 | institution package |
 | `institutions/nycn/views` | 3 | 5 | 1 | 1102 | institution package |
 | `institutions/nycn/workflows` | 3 | 5 | 0 | 1326 | institution package |
 | `ops/.github/workflows` | 3 | 1 | 0 | 1087 | operations / coordination |
 | `ops/automation/skills` | 3 | 3 | 3 | 8671 | operations / coordination |
 | `ops/docs/plans` | 3 | 2 | 0 | 45626 | operations / coordination |
-| `ops/ideas/framing` | 3 | 1 | 0 | 17682 | operations / coordination |
+| `ops/ideas/dogfood` | 3 | 2 | 0 | 70885 | operations / coordination |
+| `ops/ideas/framing` | 3 | 3 | 0 | 106667 | operations / coordination |
 | `ops/ideas/templates` | 3 | 5 | 0 | 20805 | operations / coordination |
-| `ops/mcp/src` | 3 | 21 | 4 | 75148 | operations / coordination |
+| `ops/mcp/src` | 3 | 39 | 6 | 188529 | operations / coordination |
 | `ops/state/config` | 3 | 1 | 0 | 2124 | operations / coordination |
 | `ops/state/decisions` | 3 | 1 | 0 | 1081 | operations / coordination |
 | `ops/state/deferrals` | 3 | 1 | 0 | 844 | operations / coordination |
 | `ops/state/sprint` | 3 | 5 | 1 | 15630 | operations / coordination |
-| `ops/state/truth` | 3 | 4 | 0 | 13934 | operations / coordination |
+| `ops/state/truth` | 3 | 4 | 0 | 14882 | operations / coordination |
 | `sdk/react-native/docs` | 3 | 1 | 0 | 15079 | React Native SDK |
-| `sdk/react-native/examples` | 3 | 94 | 1 | 856592 | React Native SDK |
-| `sdk/react-native/src` | 3 | 34 | 1 | 382000 | React Native SDK |
-| `sdk/typescript/examples` | 3 | 11 | 0 | 73414 | TypeScript SDK |
-| `sdk/typescript/src` | 3 | 9 | 1 | 317361 | TypeScript SDK |
+| `sdk/react-native/examples` | 3 | 94 | 1 | 868144 | React Native SDK |
+| `sdk/react-native/src` | 3 | 36 | 1 | 449844 | React Native SDK |
+| `sdk/typescript/examples` | 3 | 11 | 0 | 75568 | TypeScript SDK |
+| `sdk/typescript/src` | 3 | 9 | 1 | 357779 | TypeScript SDK |
 | `sims/mutual-credit/analysis` | 3 | 1 | 0 | 11430 | uncategorized |
 | `sims/mutual-credit/scenarios` | 3 | 5 | 0 | 5395 | uncategorized |
+| `tools/claude-code/plugins` | 3 | 26 | 1 | 88907 | uncategorized |
+| `web/member-shell/fixtures` | 3 | 4 | 0 | 2606 | uncategorized |
 | `web/pilot-ui/components` | 3 | 1 | 0 | 11066 | pilot UI |
+| `web/pilot-ui/fixtures` | 3 | 5 | 1 | 21453 | pilot UI |
 | `web/pilot-ui/icons` | 3 | 11 | 0 | 16172 | pilot UI |
 | `web/pilot-ui/locales` | 3 | 2 | 0 | 9489 | pilot UI |
-| `web/pilot-ui/tests` | 3 | 8 | 1 | 72711 | pilot UI |
+| `web/pilot-ui/tests` | 3 | 12 | 1 | 101204 | pilot UI |
 | `website/.claude/rules` | 3 | 1 | 0 | 2423 | public website |
 | `website/.github/workflows` | 3 | 1 | 0 | 1004 | public website |
+| `website/public/.well-known` | 3 | 1 | 1 | 86 | public website |
 | `website/public/images` | 3 | 4 | 0 | 1255979 | public website |
-| `website/src/components` | 3 | 11 | 0 | 67748 | public website |
-| `website/src/content` | 3 | 8 | 2 | 25897 | public website |
+| `website/src/components` | 3 | 12 | 0 | 88159 | public website |
+| `website/src/content` | 3 | 6 | 1 | 18519 | public website |
 | `website/src/data` | 3 | 3 | 0 | 14860 | public website |
-| `website/src/design` | 3 | 1 | 0 | 1721 | public website |
+| `website/src/design` | 3 | 1 | 0 | 3426 | public website |
 | `website/src/layouts` | 3 | 1 | 0 | 11604 | public website |
-| `website/src/lib` | 3 | 3 | 0 | 3365 | public website |
-| `website/src/pages` | 3 | 19 | 2 | 217389 | public website |
+| `website/src/lib` | 3 | 3 | 0 | 4283 | public website |
+| `website/src/pages` | 3 | 19 | 2 | 214837 | public website |
 | `website/src/styles` | 3 | 1 | 0 | 30764 | public website |
 | `.codex/skills/icn-ci-failure-triage/agents` | 4 | 1 | 0 | 226 | repo configuration |
 | `.codex/skills/icn-docs-reality-sync/agents` | 4 | 1 | 0 | 256 | repo configuration |
@@ -445,14 +469,18 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.codex/skills/icn-gateway-openapi-sync/agents` | 4 | 1 | 0 | 234 | repo configuration |
 | `.codex/skills/icn-invariants-review/agents` | 4 | 1 | 0 | 241 | repo configuration |
 | `.codex/skills/icn-kernel-app-separation-extraction/agents` | 4 | 1 | 0 | 269 | repo configuration |
+| `.github/scripts/fixtures/readiness` | 4 | 3 | 0 | 803 | repo configuration |
+| `deploy/appliance/smoke/cloud-init` | 4 | 2 | 0 | 3469 | deployment |
+| `deploy/appliance/systemd/icnd.service.d` | 4 | 2 | 0 | 3204 | deployment |
 | `deploy/config/grafana/provisioning` | 4 | 3 | 2 | 31405 | deployment |
 | `deploy/devnet/monitoring/grafana` | 4 | 3 | 2 | 10172 | deployment |
 | `deploy/helm/icn/templates` | 4 | 6 | 0 | 6095 | deployment |
 | `deploy/k8s/multi-node/scripts` | 4 | 5 | 0 | 32387 | deployment |
-| `docs/archive/2026/demo-sessions` | 4 | 20 | 0 | 151044 | documentation |
+| `docs/archive/2026/demo-sessions` | 4 | 20 | 0 | 149087 | documentation |
 | `docs/archive/2026/plans-scratch` | 4 | 7 | 0 | 180770 | documentation |
+| `docs/design/assets/briefs` | 4 | 5 | 0 | 33007 | documentation |
 | `docs/development/sessions/2025-11` | 4 | 45 | 0 | 873032 | documentation |
-| `docs/development/sessions/2025-12` | 4 | 37 | 0 | 312202 | documentation |
+| `docs/development/sessions/2025-12` | 4 | 37 | 0 | 312017 | documentation |
 | `docs/development/sessions/2026-01` | 4 | 12 | 0 | 176879 | documentation |
 | `docs/development/sessions/2026-02` | 4 | 1 | 0 | 7924 | documentation |
 | `docs/development/sessions/2026-03` | 4 | 1 | 0 | 5119 | documentation |
@@ -471,107 +499,122 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/onboarding/path/phase-2-architecture` | 4 | 4 | 0 | 36895 | documentation |
 | `docs/onboarding/path/phase-3-systems` | 4 | 4 | 0 | 15550 | documentation |
 | `docs/onboarding/path/phase-4-ownership` | 4 | 3 | 0 | 9932 | documentation |
+| `docs/reference/project-index/generated` | 4 | 4 | 0 | 1997717 | project index / atlas |
 | `examples/mobile-app/src/contexts` | 4 | 1 | 0 | 673 | uncategorized |
 | `examples/mobile-app/src/screens` | 4 | 7 | 0 | 27991 | uncategorized |
 | `examples/mobile-app/src/services` | 4 | 2 | 0 | 11096 | uncategorized |
 | `icn/apps/charter/src` | 4 | 2 | 0 | 16217 | runtime app crate |
-| `icn/apps/governance/src` | 4 | 23 | 4 | 1236571 | runtime app crate |
-| `icn/apps/governance/tests` | 4 | 14 | 0 | 256490 | runtime app crate |
+| `icn/apps/governance-app/src` | 4 | 3 | 0 | 17619 | runtime app crate |
+| `icn/apps/governance/src` | 4 | 25 | 4 | 1444562 | runtime app crate |
+| `icn/apps/governance/tests` | 4 | 25 | 0 | 481851 | runtime app crate |
+| `icn/apps/ledger-app/src` | 4 | 8 | 0 | 66769 | runtime app crate |
 | `icn/apps/ledger/src` | 4 | 5 | 0 | 20308 | runtime app crate |
 | `icn/apps/ledger/tests` | 4 | 1 | 0 | 5065 | runtime app crate |
 | `icn/apps/membership/src` | 4 | 32 | 3 | 596329 | runtime app crate |
+| `icn/apps/trust-app/benches` | 4 | 2 | 0 | 11863 | runtime app crate |
+| `icn/apps/trust-app/src` | 4 | 8 | 0 | 144731 | runtime app crate |
+| `icn/apps/trust-app/tests` | 4 | 1 | 0 | 18302 | runtime app crate |
 | `icn/bins/icn-console/src` | 4 | 1 | 0 | 34935 | Rust binary |
 | `icn/bins/icnctl/locales` | 4 | 2 | 0 | 17044 | Rust binary |
-| `icn/bins/icnctl/src` | 4 | 2 | 0 | 500994 | Rust binary |
-| `icn/bins/icnctl/tests` | 4 | 4 | 0 | 50193 | Rust binary |
-| `icn/bins/icnd/src` | 4 | 2 | 0 | 48566 | Rust binary |
-| `icn/crates/icn-api/src` | 4 | 6 | 0 | 47927 | Rust library crate |
+| `icn/bins/icnctl/src` | 4 | 2 | 0 | 516916 | Rust binary |
+| `icn/bins/icnctl/tests` | 4 | 6 | 0 | 75322 | Rust binary |
+| `icn/bins/icnd/src` | 4 | 2 | 0 | 64396 | Rust binary |
+| `icn/crates/icn-api/src` | 4 | 6 | 0 | 56373 | Rust library crate |
 | `icn/crates/icn-authz/src` | 4 | 9 | 3 | 40747 | Rust library crate |
 | `icn/crates/icn-authz/tests` | 4 | 1 | 0 | 7533 | Rust library crate |
+| `icn/crates/icn-baseline-lock-guest/src` | 4 | 1 | 0 | 3766 | Rust library crate |
+| `icn/crates/icn-baseline-lock/src` | 4 | 8 | 0 | 32891 | Rust library crate |
+| `icn/crates/icn-baseline-lock/tests` | 4 | 2 | 1 | 36433 | Rust library crate |
+| `icn/crates/icn-boundary/src` | 4 | 2 | 0 | 3306 | Rust library crate |
 | `icn/crates/icn-ccl/examples` | 4 | 1 | 0 | 5842 | Rust library crate |
 | `icn/crates/icn-ccl/fuzz` | 4 | 45 | 2 | 356361 | Rust library crate |
 | `icn/crates/icn-ccl/src` | 4 | 26 | 2 | 506602 | Rust library crate |
 | `icn/crates/icn-ccl/tests` | 4 | 3 | 0 | 56465 | Rust library crate |
-| `icn/crates/icn-commons/src` | 4 | 5 | 1 | 140774 | Rust library crate |
+| `icn/crates/icn-commons/src` | 4 | 5 | 1 | 154262 | Rust library crate |
 | `icn/crates/icn-commons/tests` | 4 | 4 | 0 | 36807 | Rust library crate |
 | `icn/crates/icn-community/src` | 4 | 9 | 0 | 116660 | Rust library crate |
 | `icn/crates/icn-community/tests` | 4 | 3 | 0 | 14167 | Rust library crate |
 | `icn/crates/icn-compute/benches` | 4 | 1 | 0 | 9737 | Rust library crate |
 | `icn/crates/icn-compute/examples` | 4 | 1 | 0 | 6242 | Rust library crate |
-| `icn/crates/icn-compute/src` | 4 | 29 | 1 | 929116 | Rust library crate |
-| `icn/crates/icn-compute/tests` | 4 | 4 | 0 | 94329 | Rust library crate |
-| `icn/crates/icn-coop/src` | 4 | 7 | 0 | 181964 | Rust library crate |
-| `icn/crates/icn-core/src` | 4 | 79 | 6 | 1463579 | Rust library crate |
-| `icn/crates/icn-core/tests` | 4 | 58 | 0 | 1066996 | Rust library crate |
-| `icn/crates/icn-crypto-pq/src` | 4 | 9 | 0 | 123586 | Rust library crate |
+| `icn/crates/icn-compute/src` | 4 | 29 | 1 | 930111 | Rust library crate |
+| `icn/crates/icn-compute/tests` | 4 | 4 | 0 | 94328 | Rust library crate |
+| `icn/crates/icn-coop/src` | 4 | 7 | 0 | 196305 | Rust library crate |
+| `icn/crates/icn-core/src` | 4 | 79 | 6 | 1505599 | Rust library crate |
+| `icn/crates/icn-core/tests` | 4 | 60 | 0 | 1102749 | Rust library crate |
+| `icn/crates/icn-crypto-pq/src` | 4 | 9 | 0 | 124095 | Rust library crate |
 | `icn/crates/icn-crypto-pq/tests` | 4 | 1 | 0 | 23393 | Rust library crate |
 | `icn/crates/icn-crypto/src` | 4 | 1 | 0 | 1279 | Rust library crate |
 | `icn/crates/icn-encoding/src` | 4 | 1 | 0 | 3935 | Rust library crate |
-| `icn/crates/icn-entity/src` | 4 | 10 | 0 | 252371 | Rust library crate |
-| `icn/crates/icn-federation/src` | 4 | 21 | 1 | 397063 | Rust library crate |
-| `icn/crates/icn-federation/tests` | 4 | 5 | 0 | 151103 | Rust library crate |
+| `icn/crates/icn-entity/src` | 4 | 14 | 0 | 384199 | Rust library crate |
+| `icn/crates/icn-federation/src` | 4 | 21 | 1 | 397127 | Rust library crate |
+| `icn/crates/icn-federation/tests` | 4 | 5 | 0 | 151102 | Rust library crate |
 | `icn/crates/icn-gateway/benches` | 4 | 1 | 0 | 6965 | Rust library crate |
 | `icn/crates/icn-gateway/locales` | 4 | 2 | 0 | 4338 | Rust library crate |
-| `icn/crates/icn-gateway/src` | 4 | 96 | 1 | 2307285 | Rust library crate |
-| `icn/crates/icn-gateway/static` | 4 | 14 | 1 | 551597 | Rust library crate |
-| `icn/crates/icn-gateway/tests` | 4 | 35 | 0 | 595852 | Rust library crate |
+| `icn/crates/icn-gateway/src` | 4 | 99 | 1 | 2569554 | Rust library crate |
+| `icn/crates/icn-gateway/static` | 4 | 14 | 1 | 551652 | Rust library crate |
+| `icn/crates/icn-gateway/tests` | 4 | 38 | 0 | 644106 | Rust library crate |
 | `icn/crates/icn-gossip/benches` | 4 | 1 | 0 | 4548 | Rust library crate |
-| `icn/crates/icn-gossip/src` | 4 | 29 | 2 | 527868 | Rust library crate |
+| `icn/crates/icn-gossip/src` | 4 | 29 | 2 | 533087 | Rust library crate |
 | `icn/crates/icn-gossip/tests` | 4 | 4 | 0 | 68952 | Rust library crate |
-| `icn/crates/icn-governance/src` | 4 | 45 | 1 | 1054616 | Rust library crate |
+| `icn/crates/icn-governance/src` | 4 | 45 | 1 | 1228907 | Rust library crate |
 | `icn/crates/icn-governance/tests` | 4 | 2 | 0 | 44282 | Rust library crate |
-| `icn/crates/icn-http-kit/src` | 4 | 5 | 0 | 30163 | Rust library crate |
+| `icn/crates/icn-http-kit/src` | 4 | 5 | 0 | 38589 | Rust library crate |
 | `icn/crates/icn-identity/examples` | 4 | 1 | 0 | 4573 | Rust library crate |
-| `icn/crates/icn-identity/src` | 4 | 21 | 0 | 490111 | Rust library crate |
-| `icn/crates/icn-identity/tests` | 4 | 3 | 0 | 22386 | Rust library crate |
-| `icn/crates/icn-kernel-api/src` | 4 | 29 | 0 | 587168 | Rust library crate |
-| `icn/crates/icn-ledger/benches` | 4 | 1 | 0 | 4365 | Rust library crate |
+| `icn/crates/icn-identity/src` | 4 | 21 | 0 | 490526 | Rust library crate |
+| `icn/crates/icn-identity/tests` | 4 | 3 | 0 | 22384 | Rust library crate |
+| `icn/crates/icn-kernel-api/src` | 4 | 29 | 0 | 984110 | Rust library crate |
+| `icn/crates/icn-kernel-api/tests` | 4 | 4 | 0 | 187094 | Rust library crate |
+| `icn/crates/icn-ledger/benches` | 4 | 1 | 0 | 4364 | Rust library crate |
 | `icn/crates/icn-ledger/examples` | 4 | 1 | 0 | 9759 | Rust library crate |
-| `icn/crates/icn-ledger/src` | 4 | 45 | 3 | 1031624 | Rust library crate |
+| `icn/crates/icn-ledger/src` | 4 | 45 | 3 | 1049600 | Rust library crate |
 | `icn/crates/icn-ledger/tests` | 4 | 5 | 0 | 77016 | Rust library crate |
 | `icn/crates/icn-naming/src` | 4 | 1 | 0 | 29546 | Rust library crate |
 | `icn/crates/icn-net/benches` | 4 | 1 | 0 | 7879 | Rust library crate |
-| `icn/crates/icn-net/src` | 4 | 31 | 2 | 729007 | Rust library crate |
+| `icn/crates/icn-net/src` | 4 | 31 | 2 | 729107 | Rust library crate |
 | `icn/crates/icn-net/tests` | 4 | 8 | 0 | 109894 | Rust library crate |
-| `icn/crates/icn-obs/src` | 4 | 22 | 1 | 397109 | Rust library crate |
+| `icn/crates/icn-obs/src` | 4 | 22 | 1 | 398385 | Rust library crate |
 | `icn/crates/icn-obs/static` | 4 | 1 | 0 | 16244 | Rust library crate |
-| `icn/crates/icn-privacy/src` | 4 | 5 | 0 | 47517 | Rust library crate |
-| `icn/crates/icn-privacy/tests` | 4 | 1 | 0 | 20727 | Rust library crate |
+| `icn/crates/icn-privacy/src` | 4 | 5 | 0 | 47483 | Rust library crate |
+| `icn/crates/icn-privacy/tests` | 4 | 1 | 0 | 20725 | Rust library crate |
 | `icn/crates/icn-protocol/src` | 4 | 1 | 0 | 1367 | Rust library crate |
-| `icn/crates/icn-rpc/src` | 4 | 21 | 1 | 347030 | Rust library crate |
-| `icn/crates/icn-rpc/tests` | 4 | 1 | 0 | 53922 | Rust library crate |
+| `icn/crates/icn-rpc/src` | 4 | 21 | 1 | 358587 | Rust library crate |
+| `icn/crates/icn-rpc/tests` | 4 | 1 | 0 | 57690 | Rust library crate |
 | `icn/crates/icn-security/src` | 4 | 2 | 0 | 73819 | Rust library crate |
 | `icn/crates/icn-services/src` | 4 | 1 | 0 | 1657 | Rust library crate |
 | `icn/crates/icn-snapshot/src` | 4 | 3 | 0 | 97279 | Rust library crate |
-| `icn/crates/icn-steward/src` | 4 | 13 | 1 | 194415 | Rust library crate |
+| `icn/crates/icn-steward/src` | 4 | 13 | 1 | 194423 | Rust library crate |
 | `icn/crates/icn-steward/tests` | 4 | 2 | 0 | 36089 | Rust library crate |
-| `icn/crates/icn-store/src` | 4 | 5 | 0 | 148455 | Rust library crate |
+| `icn/crates/icn-store/src` | 4 | 5 | 0 | 153231 | Rust library crate |
 | `icn/crates/icn-store/tests` | 4 | 1 | 0 | 11336 | Rust library crate |
 | `icn/crates/icn-testkit/src` | 4 | 6 | 0 | 67274 | Rust library crate |
 | `icn/crates/icn-testkit/tests` | 4 | 2 | 0 | 16809 | Rust library crate |
-| `icn/crates/icn-time/src` | 4 | 4 | 0 | 26204 | Rust library crate |
+| `icn/crates/icn-time/src` | 4 | 4 | 0 | 26212 | Rust library crate |
 | `icn/crates/icn-time/tests` | 4 | 1 | 0 | 14828 | Rust library crate |
 | `icn/crates/icn-trust/benches` | 4 | 1 | 0 | 9208 | Rust library crate |
 | `icn/crates/icn-trust/src` | 4 | 16 | 1 | 411557 | Rust library crate |
 | `icn/crates/icn-trust/tests` | 4 | 2 | 0 | 55499 | Rust library crate |
-| `icn/crates/icn-zkp/src` | 4 | 17 | 2 | 186955 | Rust library crate |
-| `institutions/nycn/summit/docs` | 4 | 1 | 0 | 9261 | institution package |
+| `icn/crates/icn-zkp/src` | 4 | 17 | 2 | 186913 | Rust library crate |
+| `institutions/nycn/summit/docs` | 4 | 1 | 0 | 13525 | institution package |
 | `institutions/nycn/summit/templates` | 4 | 3 | 0 | 1086 | institution package |
 | `institutions/nycn/views/dashboards` | 4 | 3 | 0 | 669 | institution package |
 | `ops/automation/skills/status` | 4 | 1 | 0 | 2906 | operations / coordination |
 | `ops/automation/skills/sync-and-build` | 4 | 1 | 0 | 2007 | operations / coordination |
 | `ops/automation/skills/worktree` | 4 | 1 | 0 | 3758 | operations / coordination |
-| `ops/mcp/src/polling` | 4 | 4 | 0 | 7656 | operations / coordination |
-| `ops/mcp/src/state` | 4 | 3 | 0 | 6704 | operations / coordination |
-| `ops/mcp/src/tests` | 4 | 4 | 1 | 10838 | operations / coordination |
-| `ops/mcp/src/tools` | 4 | 8 | 0 | 46007 | operations / coordination |
+| `ops/mcp/src/diagnostics` | 4 | 11 | 0 | 65232 | operations / coordination |
+| `ops/mcp/src/polling` | 4 | 4 | 0 | 9725 | operations / coordination |
+| `ops/mcp/src/state` | 4 | 3 | 0 | 6774 | operations / coordination |
+| `ops/mcp/src/tests` | 4 | 8 | 1 | 38791 | operations / coordination |
+| `ops/mcp/src/tools` | 4 | 9 | 0 | 54782 | operations / coordination |
+| `ops/mcp/src/utils` | 4 | 2 | 0 | 6173 | operations / coordination |
 | `ops/state/sprint/history` | 4 | 2 | 0 | 6311 | operations / coordination |
-| `sdk/react-native/examples/CoopWallet` | 4 | 94 | 3 | 856592 | React Native SDK |
+| `sdk/react-native/examples/CoopWallet` | 4 | 94 | 3 | 868144 | React Native SDK |
 | `sdk/react-native/src/__mocks__` | 4 | 2 | 0 | 2265 | React Native SDK |
-| `sdk/typescript/src/generated` | 4 | 1 | 0 | 31417 | TypeScript SDK |
-| `web/pilot-ui/tests/e2e` | 4 | 4 | 0 | 47215 | pilot UI |
-| `website/src/content/blog` | 4 | 5 | 0 | 18224 | public website |
-| `website/src/content/docs` | 4 | 2 | 0 | 7291 | public website |
+| `sdk/typescript/src/generated` | 4 | 1 | 0 | 61644 | TypeScript SDK |
+| `tools/claude-code/plugins/icn-agent-pack` | 4 | 26 | 5 | 88907 | uncategorized |
+| `web/pilot-ui/fixtures/icn-organizer-demo` | 4 | 5 | 0 | 21453 | pilot UI |
+| `web/pilot-ui/tests/e2e` | 4 | 8 | 0 | 75708 | pilot UI |
+| `website/public/.well-known/matrix` | 4 | 1 | 0 | 86 | public website |
+| `website/src/content/blog` | 4 | 5 | 0 | 18137 | public website |
 | `website/src/pages/blog` | 4 | 2 | 0 | 4089 | public website |
 | `website/src/pages/docs` | 4 | 3 | 0 | 33636 | public website |
 | `deploy/config/grafana/provisioning/dashboards` | 5 | 2 | 0 | 31225 | deployment |
@@ -579,8 +622,8 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `deploy/devnet/monitoring/grafana/dashboards` | 5 | 1 | 0 | 9699 | deployment |
 | `deploy/devnet/monitoring/grafana/provisioning` | 5 | 2 | 2 | 473 | deployment |
 | `icn/apps/governance/src/bin` | 5 | 1 | 0 | 10643 | runtime app crate |
-| `icn/apps/governance/src/handlers` | 5 | 2 | 0 | 50207 | runtime app crate |
-| `icn/apps/governance/src/http` | 5 | 5 | 0 | 428496 | runtime app crate |
+| `icn/apps/governance/src/handlers` | 5 | 2 | 0 | 50813 | runtime app crate |
+| `icn/apps/governance/src/http` | 5 | 5 | 0 | 497152 | runtime app crate |
 | `icn/apps/governance/src/registry` | 5 | 3 | 0 | 23205 | runtime app crate |
 | `icn/apps/membership/src/community_core` | 5 | 9 | 0 | 116000 | runtime app crate |
 | `icn/apps/membership/src/coop_core` | 5 | 8 | 0 | 180981 | runtime app crate |
@@ -588,6 +631,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-authz/src/adapters` | 5 | 1 | 0 | 73 | Rust library crate |
 | `icn/crates/icn-authz/src/graph` | 5 | 2 | 0 | 7171 | Rust library crate |
 | `icn/crates/icn-authz/src/model` | 5 | 4 | 0 | 32319 | Rust library crate |
+| `icn/crates/icn-baseline-lock/tests/fixtures` | 5 | 1 | 0 | 22399 | Rust library crate |
 | `icn/crates/icn-ccl/fuzz/corpus` | 5 | 39 | 3 | 251898 | Rust library crate |
 | `icn/crates/icn-ccl/fuzz/fuzz_targets` | 5 | 3 | 0 | 7933 | Rust library crate |
 | `icn/crates/icn-ccl/src/registry_actor` | 5 | 4 | 0 | 55065 | Rust library crate |
@@ -596,41 +640,46 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-compute/src/actor` | 5 | 9 | 0 | 295857 | Rust library crate |
 | `icn/crates/icn-core/src/apps` | 5 | 5 | 0 | 101408 | Rust library crate |
 | `icn/crates/icn-core/src/bin` | 5 | 1 | 0 | 7964 | Rust library crate |
-| `icn/crates/icn-core/src/config` | 5 | 17 | 0 | 173091 | Rust library crate |
+| `icn/crates/icn-core/src/config` | 5 | 17 | 0 | 173955 | Rust library crate |
 | `icn/crates/icn-core/src/replication` | 5 | 3 | 0 | 45643 | Rust library crate |
-| `icn/crates/icn-core/src/services` | 5 | 7 | 0 | 277091 | Rust library crate |
-| `icn/crates/icn-core/src/supervisor` | 5 | 30 | 0 | 603799 | Rust library crate |
+| `icn/crates/icn-core/src/services` | 5 | 7 | 0 | 288342 | Rust library crate |
+| `icn/crates/icn-core/src/supervisor` | 5 | 30 | 0 | 633716 | Rust library crate |
 | `icn/crates/icn-federation/src/agreement` | 5 | 5 | 0 | 127390 | Rust library crate |
-| `icn/crates/icn-gateway/src/api` | 5 | 49 | 6 | 1101537 | Rust library crate |
+| `icn/crates/icn-gateway/src/api` | 5 | 49 | 6 | 1198204 | Rust library crate |
 | `icn/crates/icn-gateway/static/locales` | 5 | 2 | 0 | 9489 | Rust library crate |
 | `icn/crates/icn-gossip/src/bin` | 5 | 1 | 0 | 7639 | Rust library crate |
 | `icn/crates/icn-gossip/src/handlers` | 5 | 12 | 0 | 161306 | Rust library crate |
 | `icn/crates/icn-governance/src/protocol_store` | 5 | 4 | 0 | 96877 | Rust library crate |
-| `icn/crates/icn-ledger/src/ledger_impl` | 5 | 6 | 0 | 60766 | Rust library crate |
+| `icn/crates/icn-ledger/src/ledger_impl` | 5 | 6 | 0 | 73700 | Rust library crate |
 | `icn/crates/icn-ledger/src/oracle` | 5 | 8 | 1 | 81626 | Rust library crate |
 | `icn/crates/icn-ledger/src/treasury` | 5 | 3 | 0 | 36733 | Rust library crate |
 | `icn/crates/icn-net/src/actor` | 5 | 3 | 0 | 117351 | Rust library crate |
 | `icn/crates/icn-net/src/handlers` | 5 | 7 | 0 | 93885 | Rust library crate |
-| `icn/crates/icn-obs/src/metrics` | 5 | 16 | 0 | 122018 | Rust library crate |
-| `icn/crates/icn-rpc/src/handler` | 5 | 12 | 0 | 163336 | Rust library crate |
+| `icn/crates/icn-obs/src/metrics` | 5 | 16 | 0 | 123294 | Rust library crate |
+| `icn/crates/icn-rpc/src/handler` | 5 | 12 | 0 | 163337 | Rust library crate |
 | `icn/crates/icn-steward/src/ceremony` | 5 | 3 | 0 | 32006 | Rust library crate |
 | `icn/crates/icn-trust/src/bin` | 5 | 1 | 0 | 6169 | Rust library crate |
-| `icn/crates/icn-zkp/src/circuit` | 5 | 5 | 0 | 52833 | Rust library crate |
+| `icn/crates/icn-zkp/src/circuit` | 5 | 5 | 0 | 52798 | Rust library crate |
 | `icn/crates/icn-zkp/src/stark` | 5 | 6 | 0 | 51440 | Rust library crate |
 | `ops/mcp/src/tests/fixtures` | 5 | 1 | 0 | 287 | operations / coordination |
 | `sdk/react-native/examples/CoopWallet/android` | 5 | 44 | 2 | 111245 | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/assets` | 5 | 3 | 0 | 210 | React Native SDK |
-| `sdk/react-native/examples/CoopWallet/src` | 5 | 37 | 4 | 291022 | React Native SDK |
+| `sdk/react-native/examples/CoopWallet/src` | 5 | 37 | 4 | 294884 | React Native SDK |
+| `tools/claude-code/plugins/icn-agent-pack/.claude-plugin` | 5 | 1 | 0 | 670 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/agents` | 5 | 6 | 0 | 26694 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/bin` | 5 | 5 | 0 | 12793 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/hooks` | 5 | 1 | 0 | 937 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills` | 5 | 10 | 6 | 34294 | uncategorized |
 | `deploy/devnet/monitoring/grafana/provisioning/dashboards` | 6 | 1 | 0 | 232 | deployment |
 | `deploy/devnet/monitoring/grafana/provisioning/datasources` | 6 | 1 | 0 | 241 | deployment |
 | `icn/crates/icn-ccl/fuzz/corpus/fuzz_contract_json` | 6 | 13 | 0 | 83966 | Rust library crate |
 | `icn/crates/icn-ccl/fuzz/corpus/fuzz_contract_validate` | 6 | 13 | 0 | 83966 | Rust library crate |
 | `icn/crates/icn-ccl/fuzz/corpus/fuzz_interpreter` | 6 | 13 | 0 | 83966 | Rust library crate |
 | `icn/crates/icn-gateway/src/api/charter` | 6 | 1 | 0 | 20691 | Rust library crate |
-| `icn/crates/icn-gateway/src/api/commons` | 6 | 2 | 0 | 28301 | Rust library crate |
+| `icn/crates/icn-gateway/src/api/commons` | 6 | 2 | 0 | 38530 | Rust library crate |
 | `icn/crates/icn-gateway/src/api/constitutional` | 6 | 3 | 0 | 84881 | Rust library crate |
 | `icn/crates/icn-gateway/src/api/membership` | 6 | 1 | 0 | 26716 | Rust library crate |
-| `icn/crates/icn-gateway/src/api/sdis` | 6 | 8 | 0 | 156080 | Rust library crate |
+| `icn/crates/icn-gateway/src/api/sdis` | 6 | 8 | 0 | 156058 | Rust library crate |
 | `icn/crates/icn-gateway/src/api/steward` | 6 | 1 | 0 | 26765 | Rust library crate |
 | `icn/crates/icn-ledger/src/oracle/sources` | 6 | 3 | 0 | 22914 | Rust library crate |
 | `sdk/react-native/examples/CoopWallet/android/app` | 6 | 36 | 1 | 50762 | React Native SDK |
@@ -639,6 +688,12 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `sdk/react-native/examples/CoopWallet/src/contexts` | 6 | 2 | 0 | 4700 | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/src/i18n` | 6 | 3 | 1 | 15765 | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/src/screens` | 6 | 21 | 0 | 229887 | React Native SDK |
+| `tools/claude-code/plugins/icn-agent-pack/skills/authority-spine` | 6 | 2 | 0 | 6996 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/doctor` | 6 | 1 | 0 | 3167 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/navigator` | 6 | 2 | 0 | 7602 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/preflight` | 6 | 1 | 0 | 2605 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/route-impact` | 6 | 2 | 0 | 6333 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/truth-sync` | 6 | 2 | 0 | 7591 | uncategorized |
 | `sdk/react-native/examples/CoopWallet/android/app/src` | 7 | 33 | 3 | 39802 | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/android/gradle/wrapper` | 7 | 2 | 0 | 44017 | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/src/i18n/locales` | 7 | 2 | 0 | 12972 | React Native SDK |
@@ -671,6 +726,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 |---|---:|---|---|---|
 | `.agents/skills/bench/SKILL.md` | 2237 | `648a8a6670e14c19a9adf5dcc0bb72f850e97c5fa5a1823a3bf1c56b718e3c51` | Markdown | repo configuration |
 | `.agents/skills/changelog/SKILL.md` | 2594 | `2eb0b991dd71a81843415754c9a5686953cc0483296cf82f816c98df46972974` | Markdown | repo configuration |
+| `.agents/skills/ci-status/SKILL.md` | 5159 | `ad03d16aacfe2e71af576d5720650ee49e496e42ae90859a268d910d1d11efa8` | Markdown | repo configuration |
 | `.agents/skills/demo-validate/SKILL.md` | 1024 | `50924e50c49e95dc898436c470df3be3cbded26788c01fb53899c41ee6b9537a` | Markdown | repo configuration |
 | `.agents/skills/devnet/SKILL.md` | 1588 | `ecd774fb4d95fd88850ce6789105181e49c57f8ddd83dba9220c7613ad7590ba` | Markdown | repo configuration |
 | `.agents/skills/diag-infra/SKILL.md` | 960 | `7e78a105e3d86236f990b2c0c6797c4f98372b93152c709abb057c9ebedfc422` | Markdown | repo configuration |
@@ -695,6 +751,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.agents/skills/watch-ci-and-advance/SKILL.md` | 5321 | `855932a98205efd341124ef352616137419c5c2085165b70f1600919d7d768a9` | Markdown | repo configuration |
 | `.claude/agents/icn-architect.md` | 4764 | `6edd6d649141f5124e223606103d1778f75d4d0058d199ec6241c91bb3d136ee` | Markdown | repo configuration |
 | `.claude/agents/icn-code-reviewer.md` | 3415 | `b661a2885f1eb6a2fd3ff45a6bf032fc4aa3b57bf86a3bc1d8897773b61fb5ce` | Markdown | repo configuration |
+| `.claude/agents/icn-design-advisor.md` | 12381 | `b1d17479515ed381f47e2e7043c748958195a5c467622bc90d10aade9353b433` | Markdown | repo configuration |
 | `.claude/agents/icn-economics-advisor.md` | 5225 | `dd62e761e3f496dcabebbd033ac12af96da5e19d79df05252cff6628757ca06c` | Markdown | repo configuration |
 | `.claude/agents/icn-economist.md` | 5612 | `c215c9135990f7d922ca34842143ae564ee5db4724c6279b80bca5883d7e6446` | Markdown | repo configuration |
 | `.claude/agents/icn-gossip-net.md` | 3608 | `1e322b6bdfd518dad82ff0da457870113157f21b86b3e0cb02425728ffef69fd` | Markdown | repo configuration |
@@ -723,15 +780,17 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.claude/hooks/pre-bash-guard.py` | 306 | `57010c579b2ec7f752404fff4c3eeadcd1e30740067611bb3e9de8bb5c37db82` | Python | repo configuration |
 | `.claude/hooks/pre-tool-guard.py` | 1084 | `ae342322afeb6f9c70bbdc2f7652f48362fc6258791a1955561ca5cdcf3ee79a` | Python | repo configuration |
 | `.claude/hooks/scope-guard.sh` | 2795 | `21d3c5a1f0fb149505b35f09c030ff91302ebffd0e46f25e514d8806d37793e7` | Shell | repo configuration |
-| `.claude/hooks/todo-guard.sh` | 1369 | `3385d52cc168bfb5728ca12c4138484e742de236c97c9b5bca1760ac537c4af8` | Shell | repo configuration |
+| `.claude/hooks/todo-guard.sh` | 2669 | `ea793bc48b1dcb32721c58fcf028c6113ff6aabe0bf56b4f363a086df4211332` | Shell | repo configuration |
 | `.claude/project_rules.md` | 1334 | `ddddd92635bc187783d5fb60c6b1ddc11ad6e932dfdceec097c484a928821295` | Markdown | repo configuration |
 | `.claude/rules/deploy.md` | 1004 | `3d733bb62cdb0bf1aefccea1dc20083efc72be1477de445a17aad98c3902743f` | Markdown | repo configuration |
+| `.claude/rules/design.md` | 4209 | `e1421e3c65bc4b6c2879a22898335fa66830222ff70d8e2b7a463785be0cabf9` | Markdown | repo configuration |
 | `.claude/rules/gateway.md` | 1318 | `03fdc6ecbabedcae1d730478991ab3650cb6d836d7a9c33e7e83d318eebea6c0` | Markdown | repo configuration |
 | `.claude/rules/kernel-boundary.md` | 1450 | `73af1943b74f0868c014379675f193477e44a9f305b1f8f0917e7520ede8e666` | Markdown | repo configuration |
 | `.claude/rules/rust-core.md` | 1941 | `5f04882bb03f0a91cf54060e466e726d206accff2311e44d8e280ce63fec9342` | Markdown | repo configuration |
 | `.claude/settings.json` | 5303 | `263e7b2b398b3584947b1625c1af3a3b961159f62871c6ec60c69ff4020522ab` | JSON | repo configuration |
 | `.claude/skills/bench/SKILL.md` | 2237 | `648a8a6670e14c19a9adf5dcc0bb72f850e97c5fa5a1823a3bf1c56b718e3c51` | Markdown | repo configuration |
 | `.claude/skills/changelog/SKILL.md` | 2594 | `2eb0b991dd71a81843415754c9a5686953cc0483296cf82f816c98df46972974` | Markdown | repo configuration |
+| `.claude/skills/ci-status/SKILL.md` | 5159 | `ad03d16aacfe2e71af576d5720650ee49e496e42ae90859a268d910d1d11efa8` | Markdown | repo configuration |
 | `.claude/skills/demo-validate/SKILL.md` | 1473 | `77a18c36fb1b64334e43d4348d1b0fe8323619ded0e583be95e3d59ceeac6d18` | Markdown | repo configuration |
 | `.claude/skills/devnet/SKILL.md` | 1867 | `47b793a35eca3f06ce55f6bfc713067aed09e9d0485d3527fba7d54875e93fee` | Markdown | repo configuration |
 | `.claude/skills/diag-infra/SKILL.md` | 1376 | `d0154d490466f2a7c88a04cec1cf0287a287d0b29081a302c91d9a83f75fd988` | Markdown | repo configuration |
@@ -739,6 +798,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.claude/skills/fix-ci/SKILL.md` | 2525 | `6503610a139ca838e037d1bdced60b38784367698b19fd89c40b55c3b884d244` | Markdown | repo configuration |
 | `.claude/skills/fix-rust-lints/SKILL.md` | 5781 | `bd94b65faca81c1330c65539664212fa00615da7c58d8278fc7df64daceec211` | Markdown | repo configuration |
 | `.claude/skills/handoff/SKILL.md` | 2857 | `b8afca3245006544abcc7d5a3e1a1879e36c16822969165180213bad831509b9` | Markdown | repo configuration |
+| `.claude/skills/icn-commons-design/SKILL.md` | 12770 | `6d5f05beeecbc567e7f3c6be71e89b8c56b608372b4b0e49b5b8b0f298578cb1` | Markdown | repo configuration |
 | `.claude/skills/icn-dev/SKILL.md` | 6560 | `06de048e8e942e11f3328f359716b7141b4cfa3735633849a8d9ba0e4f051153` | Markdown | repo configuration |
 | `.claude/skills/icn-preflight/SKILL.md` | 2609 | `403a9cf7c8b783d9a87e64900885e9d7f882eb2ecda68b852d7fb10236889098` | Markdown | repo configuration |
 | `.claude/skills/integrate-pr-stack/SKILL.md` | 6314 | `ed63f2afd3991fce53d68d6128de81454eb64f4ee2518bfc0eda825f3b010873` | Markdown | repo configuration |
@@ -771,15 +831,20 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.codex/skills/icn-kernel-app-separation-extraction/agents/openai.yaml` | 269 | `838516e84ed5550853aef1d2af5da3d1b3a0fd5c4dbc247b8e1d528f42134b5d` | YAML | repo configuration |
 | `.codex/skills/icn-orchestrator/SKILL.md` | 1263 | `8eabaa0c887aa81ebcba0e9aa409deb3fd01d227fd23414ac0506df1a6927f25` | Markdown | repo configuration |
 | `.codex/skills/icn-shipping/SKILL.md` | 1657 | `2c6a4b20fa8b86a7469c976f00b33865ddb9879391d032d85c3162b707827f43` | Markdown | repo configuration |
-| `.cursor/mcp.json` | 132 | `f773c33f8b03630a014ddebaae8087d04ded6d0ec08aace31db58576ac6affe6` | JSON | repo configuration |
-| `.devcontainer/devcontainer.json` | 1320 | `51035dc4e08e34d8edd4da2708e0c4cf3855024df0e3b3af1ed10f46aa5ee63c` | JSON | repo configuration |
+| `.cursor/mcp.json` | 135 | `1e365a870be91c6c154b88a439da630a535e67e28524c84b5afc8102262a1f3a` | JSON | repo configuration |
+| `.devcontainer/devcontainer.json` | 1307 | `7efa47ecdce13f7067d31be4f6aa0eb0f110428b88762dc718acd2bb73900b97` | JSON | repo configuration |
 | `.dockerignore` | 230 | `80df1ab08f9a715f99427254d77117660ef831c36a21c6b39c72714c45c28957` | unknown | repo configuration |
 | `.gitattributes` | 395 | `b493b6f2d0260f2da13e712350bae5e824c6db5b7978b96ab529875ce4d0e959` | unknown | repo configuration |
 | `.github/FUNDING.yml` | 141 | `124e380ed58c931234e85b8dcf88f0b6122aba9dc588caba3035c0bf50c096b6` | YAML | repo configuration |
 | `.github/ISSUE_POLICY.md` | 3643 | `0cc86cdbeb29db23bed07ed8ec8d6bccef0bbad96d91f6b206017cbf2bad8d26` | Markdown | repo configuration |
 | `.github/ISSUE_TEMPLATE/bug_report.yml` | 1138 | `024a315509736f16a70ccae472018d138ebc8bc26023dabb3379bc0fa8116f55` | YAML | repo configuration |
 | `.github/ISSUE_TEMPLATE/config.yml` | 28 | `1f103c6a9dd07cd13a9a6f17ace6b813f47747eb9cb7e00488cb2073caaf91bb` | YAML | repo configuration |
+| `.github/ISSUE_TEMPLATE/design_accessibility.yml` | 2398 | `00409836445ba7b574330de7db0dd964b2bb9969ec8dd50854e09ea39fd86bf0` | YAML | repo configuration |
 | `.github/ISSUE_TEMPLATE/documentation-system-migration.md` | 962 | `279c134b429daa375072262689b90e19ded2d65691e42f0a2be92ed9a609366c` | Markdown | repo configuration |
+| `.github/ISSUE_TEMPLATE/documentation_issue.yml` | 1947 | `624b3213eabad756ad7b1b158a4364d12d9cf5f3e680735427e452d47a1fe6da` | YAML | repo configuration |
+| `.github/ISSUE_TEMPLATE/governance_process.yml` | 2230 | `6740051a62983da1458533d459cdc6a6356296ba4fcb64906ec6b27f012459cf` | YAML | repo configuration |
+| `.github/ISSUE_TEMPLATE/rfc_proposal.yml` | 2891 | `e122de048b8187556ad0b9de39f0f30ec3d9bc69e3c79cb6a7f329b0529bca0d` | YAML | repo configuration |
+| `.github/ISSUE_TEMPLATE/security_redirect.yml` | 1604 | `ae0d88d116ba80f36fc6488c4f909ad0649e2e29bce32e374ee94cbd12ab86c9` | YAML | repo configuration |
 | `.github/ISSUE_TEMPLATE/work_item.yml` | 1887 | `a1335ccd12233faabe0c357ffd86cc891dcf07e3dd064a33169bf26b06c24184` | YAML | repo configuration |
 | `.github/actions/free-disk-space/action.yml` | 2717 | `a8949293b37efd1a2ca52b5f558f68fda6026e402a91749edc4601d3e7ec9ce5` | YAML | repo configuration |
 | `.github/actions/install-build-tools/action.yml` | 548 | `8eb6895e6663a403136f65bb396a29acfc647bdbdcb6203118760ea8392dfce9` | YAML | repo configuration |
@@ -788,12 +853,12 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.github/agents/icn-ci-reliability.md` | 2413 | `ef736aee19fc077d2bd9ab65ae1776617e3d6239791191af39eee6efc634fc78` | Markdown | agent definition |
 | `.github/agents/icn-code-reviewer.md` | 2094 | `fc21d1f30adab30b47e84a4a2aee8d77eaafc0e3ca5fabeb7e19e4251e94d269` | Markdown | agent definition |
 | `.github/agents/icn-devnet-deploy.md` | 3010 | `e669b314c2a7c4f2415e66e80a8e3edf3a5728a921a7cfbf55c9716ab1dd5bde` | Markdown | agent definition |
-| `.github/agents/icn-docs-spec.md` | 2690 | `ef86d471bfafa73b6b46d61dd50a0743befbc52a094971994183f9497004995c` | Markdown | agent definition |
+| `.github/agents/icn-docs-spec.md` | 2989 | `5994902ae827be47979be35a2964c838a426057923e19d7bece1e8d1d2fad8c9` | Markdown | agent definition |
 | `.github/agents/icn-docs-synchronizer.md` | 1689 | `2933181075c693b8ce36863a44e3586e2d815665500519b1477d16beddbb5dbd` | Markdown | agent definition |
 | `.github/agents/icn-gateway-api.md` | 2940 | `0f39b15f9ef0a3d33bc4f068ad58d4028644361141c0f62cf4851699d06b7af6` | Markdown | agent definition |
 | `.github/agents/icn-gossip-net.md` | 2896 | `f1b47fa1a537a89e0f5ca2e3b174a64188fcea8bc0d8ca0d460050d0793be1a4` | Markdown | agent definition |
 | `.github/agents/icn-governance-ccl.md` | 2633 | `c825ec5f7b87e8e3e657ee6fbba493089458d809fe581aa11cf20fb01d6672b3` | Markdown | agent definition |
-| `.github/agents/icn-homelab-infra.md` | 3400 | `5269876f52a7ac511e6aab91e35334730556d3f4b15de330b25139971100ebe8` | Markdown | agent definition |
+| `.github/agents/icn-homelab-infra.md` | 3488 | `b43ef08b4506537da7f6b04b4076e11d66ff4bb457aedbb9541cadda03d116a0` | Markdown | agent definition |
 | `.github/agents/icn-invariants-guardian.md` | 2578 | `8821aa345d2f45b2f0a270e9897208d69ce81beb9e3e72daf64a7ce348a96546` | Markdown | agent definition |
 | `.github/agents/icn-ledger-econ.md` | 2616 | `4dc449ac8aeb93966a3cc1d048ba86b9cafdc0ce0bef16e675796835ab69a83d` | Markdown | agent definition |
 | `.github/agents/icn-monitoring.md` | 3073 | `30a5c25623ab7d4754fcb169537973d4b121ca841e44b9b5073ccd168098c1f4` | Markdown | agent definition |
@@ -805,83 +870,61 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `.github/agents/icn-sdk-web.md` | 2393 | `b403064bd58f0ace10a75d8b260b62868cd8a604fadd0ac1e2f40e9d0267d98f` | Markdown | agent definition |
 | `.github/agents/icn-security-auditor.md` | 2445 | `bd80883b8616265a84d2aff28c521b1a048e0777943bbbbec019740d714d1d5e` | Markdown | agent definition |
 | `.github/agents/icn-trust-identity.md` | 2741 | `76e1cebb15206bb14aa1efa549555353c86e4df922c967091c843306e94728f9` | Markdown | agent definition |
-| `.github/copilot-instructions.md` | 18528 | `ba5420e1477883be636422b2d7ea4dba35116c0080ce2fd2e51888e302acbbdd` | Markdown | repo configuration |
+| `.github/copilot-instructions.md` | 18867 | `abad52452b378e3fc34478614b7891427c7c975d4b7b198cfe904491d810f3d2` | Markdown | repo configuration |
 | `.github/dependabot.yml` | 2794 | `3f02595bc3e202d723bf9604fda9179993254d0c5d3591b08d9f78e1c6cb3527` | YAML | repo configuration |
 | `.github/instructions/README.md` | 5304 | `f01a0e174a660449f3a9dfd48e5e869f38a28c2a15d81c04fe955ca32066b991` | Markdown | repo configuration |
-| `.github/instructions/documentation.md` | 5587 | `0242c94cad67eb9660d2a2b7c3fb86e8d6bbff487f4fcb9d3b0cd6b47f9045e8` | Markdown | repo configuration |
+| `.github/instructions/documentation.md` | 5912 | `36e61c1f45af49a4a504aab18d7f8ffe3b4269aae81834bbf705a5fb434dcb76` | Markdown | repo configuration |
 | `.github/instructions/rust-core.md` | 9031 | `f66300bf4e18e89484d0cbe7504213be8161fa205796415a483dd50c6d19310f` | Markdown | repo configuration |
 | `.github/instructions/sdk.md` | 4929 | `58545abc5735eafb6abaa3ab62f7352fbebd2830e109966289b892cf4cbf62d1` | Markdown | repo configuration |
 | `.github/instructions/web-ui.md` | 3804 | `3ac78f3f8dc1c424bb74ff246b4e268cba99776f5238d1f623b671e1c075dc64` | Markdown | repo configuration |
-| `.github/pull_request_template.md` | 3549 | `b0adff9d42cd27bb8f6afae2be5294a4df1bb33d558ad921a648e41197f2633e` | Markdown | repo configuration |
+| `.github/pull_request_template.md` | 4452 | `b13accb67f7167524ccbde7c733048bacc3af561b33ca6cb4a4b1d3844ad538e` | Markdown | repo configuration |
 | `.github/scripts/README.md` | 5712 | `468b8b8ba744afa5836742d32527b866fc58f1dcfba052e3d19486c0b192152d` | Markdown | repo configuration |
 | `.github/scripts/compliance_linter.py` | 9045 | `fd758f7f089e3d715d0ea0aab7c08068483f60cfda0a0a9c56ac6546b15b37e4` | Python | repo configuration |
 | `.github/scripts/firewall_denylist.py` | 7871 | `4ac2356f6716c8f2aabb8cba668f73b1f485460753281c998b1dd62fefe7e1ba` | Python | repo configuration |
-| `.github/workflows/agent-drift-check.yml` | 1252 | `280fe210fb018c052b38fec92b36302a9ab9088a6e48a17ab15c389501b77325` | YAML | GitHub Actions workflow |
-| `.github/workflows/api-types.yml` | 2895 | `d53ed06da41563e07beb730a7dbdb630318910475ebc040bc9f6bdbff6464c5e` | YAML | GitHub Actions workflow |
-| `.github/workflows/benchmark.yml` | 9627 | `b2dee746e63f50a56f7f9e23bf65935ce41626ffc31725a5525d13e1fb97b6e9` | YAML | GitHub Actions workflow |
-| `.github/workflows/ci.yml` | 24919 | `c71c0e911d95a480c27256cb140983264fc8efae56c8b946264591248b726ac5` | YAML | GitHub Actions workflow |
-| `.github/workflows/claude-code-review.yml` | 6797 | `ad229c244a0f3493a980be5aa4c7cae374f8c4aa546ead1104cee46fd6770279` | YAML | GitHub Actions workflow |
+| `.github/scripts/fixtures/readiness/bad_unbannered.md` | 155 | `d4f271f3c7df8a39542c739da3f878b098db09d96b87c75038789a74b6e687f9` | Markdown | repo configuration |
+| `.github/scripts/fixtures/readiness/good_bannered.md` | 344 | `d827689652701930f71d9aaa75d5965fa55cac13d069f43468c8bebfbb8594e6` | Markdown | repo configuration |
+| `.github/scripts/fixtures/readiness/good_negated.md` | 304 | `c2db26885c5078e7fffe517d1d3936aac4a5943f70faaaee2e74359b344b9bc6` | Markdown | repo configuration |
+| `.github/scripts/readiness_overclaim_linter.py` | 10688 | `ff439735a3b33f68c526bfd4b7962aa49b70ba318e8ec3247d0c8e5e7c063735` | Python | repo configuration |
+| `.github/scripts/test_readiness_overclaim_linter.py` | 5230 | `f88e203dabe3fa9b5e27e4f9a179061595ea66e5c951d27c94a1e1221bf10dd3` | Python | repo configuration |
+| `.github/workflows/agent-drift-check.yml` | 1283 | `77a32c55b27ed37405bd3c8b53f4732c47a24e326405c47227ec881118cc4224` | YAML | GitHub Actions workflow |
+| `.github/workflows/api-types.yml` | 2926 | `21ff932b492fade8f11b02751fbf6693e5dcb23e52d9df405cefee0f989acf6d` | YAML | GitHub Actions workflow |
+| `.github/workflows/benchmark.yml` | 9506 | `2e57f895aac9904d1d9b5123628eb8b16db8818c6f68756ed508228f241e8c8e` | YAML | GitHub Actions workflow |
+| `.github/workflows/ci.yml` | 27926 | `86949af7e10cd9993581b4eaa16154526d0f7ac055aa3d158f9ce89269c87020` | YAML | GitHub Actions workflow |
+| `.github/workflows/claude-code-review.yml` | 13991 | `b60ab7d810f3cb81e84ae9f105c5b9f3099759bf64074ae47b11a7076a73c5e2` | YAML | GitHub Actions workflow |
 | `.github/workflows/claude.yml` | 3058 | `cdc7f225666a3dc6510fdbb61ba4208cc5936219e0cc940bc823fb6e6d6e4174` | YAML | GitHub Actions workflow |
-| `.github/workflows/docker-build-deploy.yml` | 8339 | `b1071ba4a7954908998f61dc5c089a0a780371d8181e3d5eefd046b837834cc5` | YAML | GitHub Actions workflow |
-| `.github/workflows/docs-freshness.yml` | 5513 | `fbddeb33b7c0410e2a94d875edbc3cc2f862a5edcab8a4d34871edf692dbb323` | YAML | GitHub Actions workflow |
-| `.github/workflows/fuzz.yml` | 3006 | `2803788fd000ac20d12ecd0cd2a7b35bcba609001f8e79a3521e61e4207cbc78` | YAML | GitHub Actions workflow |
-| `.github/workflows/issue-label-enforcer.yml` | 6117 | `2361898318fad93c07a6931246b1a518e4a41126ef392e75bbc9dcc2fddb80f0` | YAML | GitHub Actions workflow |
-| `.github/workflows/mcp-portability.yml` | 968 | `e64c5b9b05c7cfcd21c3a97ee329843b81f117aa80db734d1ea8a6ce8454b43e` | YAML | GitHub Actions workflow |
+| `.github/workflows/docker-build-deploy.yml` | 11985 | `9ae7de0aa36858caba55dfbaa911f4994c26e1069ea730e974608259d8b6b538` | YAML | GitHub Actions workflow |
+| `.github/workflows/docs-freshness.yml` | 11562 | `f474a69b3d3639e195b703e215bd4f93c4df2fada10a53b97cd278a9b3bce1dd` | YAML | GitHub Actions workflow |
+| `.github/workflows/fuzz.yml` | 3037 | `e2ff1c562395135582738e773e5db1b984d190e8204fab5e4b7bffb57d9612fa` | YAML | GitHub Actions workflow |
+| `.github/workflows/issue-label-enforcer.yml` | 6117 | `ff4342a962c2d2395a24033abfdb5ad1d9a4f21230f120204829a78cdf474731` | YAML | GitHub Actions workflow |
+| `.github/workflows/mcp-portability.yml` | 999 | `312f0e0ec6c3eb9e507863dcda9dea8705a53cb9563b3913598db66bd34e058d` | YAML | GitHub Actions workflow |
 | `.github/workflows/npm-publish.yml` | 2107 | `cc0712289070cc9b08630b359acb6b296174e3df6749750ffe7fd98afefd5db1` | YAML | GitHub Actions workflow |
 | `.github/workflows/opencode.yml` | 819 | `56ffc1b78090e98a3fed7c6c0aa5b098cb189119677acec0899f9656188550cc` | YAML | GitHub Actions workflow |
-| `.github/workflows/release.yml` | 6916 | `1c99196a6290006d7a7166b0420907a6566d63c472f4cb5fafb094cb012375e7` | YAML | GitHub Actions workflow |
-| `.github/workflows/security-audit.yml` | 2788 | `cbe61f3aedef61a3b63f76880d657c5619de593cdaae745cc71f518d37bc512f` | YAML | GitHub Actions workflow |
+| `.github/workflows/release.yml` | 6916 | `fb8847b677b17a3576f1c939fd5a3620853f991b0d2e09da12e2a60fc429506e` | YAML | GitHub Actions workflow |
+| `.github/workflows/security-audit.yml` | 3109 | `894847194013cff0c449ee4f35009bc269a0d2cf4cdadb718f39ea6d8cd1f998` | YAML | GitHub Actions workflow |
 | `.github/workflows/sync-stats.yml` | 1497 | `2f0d383bd6ca462bae51c3815adf65b8f72c929b593315d9119f106b2981c7d2` | YAML | GitHub Actions workflow |
-| `.github/workflows/website-deploy.yml` | 1580 | `2c47cb5036afa83ab0ecc8b9807a0e837e005e799ed905311f7d242adea8057a` | YAML | GitHub Actions workflow |
-| `.gitignore` | 1747 | `025284fe4e857eb3bec82b47319d45134e653a16be1b08ea26a9b3df0d24846b` | unknown | repo configuration |
+| `.github/workflows/website-deploy.yml` | 1580 | `7116ea42d600c63bfeca53c37a82d9adf6c2e897e0018ff55a8e531776da892e` | YAML | GitHub Actions workflow |
+| `.gitignore` | 1838 | `74c902a253c05fe4fa2c26cc5e56a60f4b96bdc237eebb865e0bff8952a9dc0e` | unknown | repo configuration |
 | `.mcp.json` | 135 | `1e365a870be91c6c154b88a439da630a535e67e28524c84b5afc8102262a1f3a` | JSON | repo configuration |
 | `.opencode/commands/checkpoint.md` | 409 | `b106821e24824534a9ec3a409040a0f5db1ee5a809032cda1e0571b0e6bdb361` | Markdown | repo configuration |
 | `.opencode/opencode.json` | 1428 | `67abd881122905dc0f8f8f389aa44512ffc462202b22c4304389ab51bb94973d` | JSON | repo configuration |
-| `AGENTS.md` | 11451 | `e8bf16ede1697a1835c4e5b0c9dc1c7153002076bece4a2fdc9e53fc341bd047` | Markdown | repo control document |
+| `AGENTS.md` | 16225 | `c1975970f33c70428816f8b8f3a7120391f77a03bde7b2939ce9d6426c0bfc60` | Markdown | repo control document |
 | `CHANGELOG.md` | 271554 | `a67df62eeff9bf3e62b9bf2e74ec3f9547b0e49feee47730dfb2eba604238da1` | Markdown | uncategorized |
-| `CLAUDE.md` | 37518 | `10b21d87b71d522d62d9b7d5d8eafcdec424a00f9f131fb9326dfb60e5a9ade5` | Markdown | repo control document |
+| `CLAUDE.md` | 41798 | `e1dbac164c030cee7999bc0dba2108d25ccac0a2538ab689b12938b7f11cb4b1` | Markdown | repo control document |
 | `CODE_OF_CONDUCT.md` | 5489 | `ea5dc671c7def95591ab73b1b8152125af1451100c095734c01ecb40e1f387e5` | Markdown | uncategorized |
 | `CONTRIBUTING.md` | 6960 | `73c4e7211da049d5c7f8d7de53baec19a5aeaab75ace72e19eac391c35ee729b` | Markdown | repo control document |
 | `Dockerfile` | 1955 | `a772218ce7c43875e4b3621b2dcd41f77fd02efdedbda0bbb3ac3ab402c21e3a` | unknown | uncategorized |
 | `Dockerfile.fast` | 426 | `4b1e224b21397694e9b5eed41b0a11bfeac7fc4253c844200e46db7ab2b8912a` | unknown | uncategorized |
 | `LICENSE` | 34523 | `0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0` | unknown | uncategorized |
+| `LICENSING.md` | 7325 | `83f4000d843b0618d0cc2f96784cfbdaab0f1873d24158d1807f94153c8a43a6` | Markdown | uncategorized |
 | `Makefile` | 474 | `c87d52935fe266089e3108e4e61906d6d6dec892c3e5cebdf9df383e009d9a11` | unknown | uncategorized |
-| `README.md` | 6784 | `2a4c6d425f19efc4e44e309b4bfee9349d999065916f43f14e33ad2757c18307` | Markdown | repo control document |
+| `README.md` | 7404 | `79041cc9b7a6f20234b413127360eae7b83e986f7bc6f86bf357b0ad17f4dadc` | Markdown | repo control document |
+| `SECURITY.md` | 3316 | `a87798ce2c7c78fb906f89b595928baed4ea1b700bee033b31811733f30adc73` | Markdown | uncategorized |
 | `VISION.md` | 2945 | `77332ad57c02b2c3c30e7b8fbc431a91bbb6344356affe2a69a8960819742493` | Markdown | uncategorized |
 | `apps/echo/.gitignore` | 11 | `3e503ffd2d2f0c135bc5d8c97cba5aff82676478d90cb002333ed9583b92c5a0` | unknown | legacy/top-level app |
 | `apps/echo/Cargo.toml` | 504 | `0e0c9c37a0aa3ee074144c1dc7fe0801c2d2843c253b3c773bbceed52f9218c0` | TOML | legacy/top-level app |
+| `apps/echo/README.md` | 2815 | `37d77850d321eeaee7b8ef773a953389643cc4c6c36554fdc58db14ae068f4f2` | Markdown | legacy/top-level app |
 | `apps/echo/manifest.yaml` | 458 | `95e1b890e97e18f9b4ee35fdd9d6fad8363d61111339b3c8636c734d4e8d17ee` | YAML | legacy/top-level app |
 | `apps/echo/src/lib.rs` | 8053 | `6b4dc365aec61d60c423f38774fbf31a2fc96f1423121d06f0585a892020d9ca` | Rust | legacy/top-level app |
-| `apps/governance/.gitignore` | 19 | `2ebe6cb6f5289849dce5a8a6cdd77e06b1385302c862982f8e181c4782d19214` | unknown | legacy/top-level app |
-| `apps/governance/Cargo.toml` | 974 | `d2ef9b5e4f536b42818b133a21642d020dbc6edbd9d98dc93a933d4abb884be2` | TOML | legacy/top-level app |
-| `apps/governance/src/lib.rs` | 3573 | `59d6cf75a1a80392a10abeab47c9d2b730c9c3b91b8ebca308a753b3a615dd91` | Rust | legacy/top-level app |
-| `apps/governance/src/oracle.rs` | 6990 | `164a45a18f67a5822c4879d7e6317347ff91f114031d6a48a2de61c3e082481a` | Rust | legacy/top-level app |
-| `apps/governance/src/service.rs` | 7056 | `69335632cf0f5f244618d49ccaf664d80d59fc97b8cd0066eb19a567f0dadb8a` | Rust | legacy/top-level app |
-| `apps/ledger/.gitignore` | 19 | `2ebe6cb6f5289849dce5a8a6cdd77e06b1385302c862982f8e181c4782d19214` | unknown | legacy/top-level app |
-| `apps/ledger/Cargo.toml` | 1705 | `6ee791cc6d2489416b9388b739b516360246d98a1b5ba52d2577a45584c81bb8` | TOML | legacy/top-level app |
-| `apps/ledger/manifest.yaml` | 1408 | `168541ad3d13f2068b16b473bc58ba18f238dafc4c2948140e7449107df4f3f6` | YAML | legacy/top-level app |
-| `apps/ledger/src/budgets.rs` | 8925 | `d107e322624fe0fdbc3035148e2a47b5ec4297e4de20938f7e859349617978be` | Rust | legacy/top-level app |
-| `apps/ledger/src/config.rs` | 13314 | `a88b5943ba9818fd9528398fb6aa3b13aa42aa5cfca0d92cf7b2fce2fec78746` | Rust | legacy/top-level app |
-| `apps/ledger/src/escrow.rs` | 7867 | `efa3cb851c503373dd1627461af4e76b4804175d6b2646b027c8bf026aa09162` | Rust | legacy/top-level app |
-| `apps/ledger/src/init.rs` | 10497 | `5c3e0751ce2ace4cee0a9b6eb390a2178a463240072fdb93343f875daf1ccb6f` | Rust | legacy/top-level app |
-| `apps/ledger/src/lib.rs` | 3764 | `62f0e643753856e3cf52d32d7bd49e2ec5eb9c09052c724b127be695f86302ba` | Rust | legacy/top-level app |
-| `apps/ledger/src/oracle.rs` | 4286 | `a7db685817b45cae0584e74a0a644aa0afd5547eb3b9abd013f99710a5e4a9e4` | Rust | legacy/top-level app |
-| `apps/ledger/src/recurring.rs` | 8806 | `fc21619d848694bcb8fb3f0e59d173df915fb1631d6f3b8f7259ae48cb0d0b94` | Rust | legacy/top-level app |
-| `apps/ledger/src/service.rs` | 7629 | `fa64b50989936d54d8c7412ee94852f391b993f2e10f3b0f7df95f7355128f0e` | Rust | legacy/top-level app |
-| `apps/trust/.gitignore` | 11 | `3e503ffd2d2f0c135bc5d8c97cba5aff82676478d90cb002333ed9583b92c5a0` | unknown | legacy/top-level app |
-| `apps/trust/Cargo.toml` | 1467 | `a8f7dbf66bf6cc89e736250934d67c9c00f162f6e21309d00a70de79712e0ff6` | TOML | legacy/top-level app |
-| `apps/trust/benches/README.md` | 3345 | `22d5c201b7b7f4ba030c106afced05d5e5b5aa94d37783594494edc9c03d2620` | Markdown | legacy/top-level app |
-| `apps/trust/benches/trust_service_bench.rs` | 8518 | `8edea6f20171b8bac6656f80e0d68b497da53de36f43e301426c571b1f5ccee8` | Rust | legacy/top-level app |
-| `apps/trust/manifest.yaml` | 1594 | `f317936db84ac6591d6eb7c696f680e2d4b7d6355760ec5dd8000272b9336f24` | YAML | legacy/top-level app |
-| `apps/trust/src/init.rs` | 9174 | `df618b072438ce03346f106e1b2bac69b41ab525569b336aba1690d0e0067984` | Rust | legacy/top-level app |
-| `apps/trust/src/lib.rs` | 4881 | `d92f8a0f9b686dab149011439ad7dadba0fb53fb1bd0e9d51b6ec751edc7f48b` | Rust | legacy/top-level app |
-| `apps/trust/src/oracle.rs` | 23630 | `0bef203917d1e50ac7b147eacb4ecdd7d820074685b3944720c383c1a74f17a1` | Rust | legacy/top-level app |
-| `apps/trust/src/oracle_tokio.rs` | 8058 | `d9857a1bb200770f801c874067e986a42b68919753cd0c8a95964ce76b68f262` | Rust | legacy/top-level app |
-| `apps/trust/src/reducer.rs` | 23894 | `2f41d4bca777a55d3d556a04d06b9f7752b65865eb11c19efd7c46c58a5c499f` | Rust | legacy/top-level app |
-| `apps/trust/src/sequence.rs` | 11054 | `686c50e0eeffd3d16bb029ba2a345624102b7696ede94eb879fb1479747d7048` | Rust | legacy/top-level app |
-| `apps/trust/src/service.rs` | 6824 | `4f28347cfdea290717761f71dacd286f01c304595f23d8b57fb7594812b8528d` | Rust | legacy/top-level app |
-| `apps/trust/src/service_tokio.rs` | 57192 | `a57267fc74a9103d94e28eb1b89d78cdc7c4f5a17c081e0388c2ef833770edac` | Rust | legacy/top-level app |
-| `apps/trust/tests/cross_org_integration.rs` | 18302 | `1087d04eafa12dfa1b989f7734dc1f9c48eabfec9e86a3ca26fac2bae291d51c` | Rust | legacy/top-level app |
 | `config/README.md` | 3929 | `5cfdd5485edf834f132061779049a432fe0c64d9f0cb18bd6d220e2f1b020a8f` | Markdown | uncategorized |
 | `config/icn-alpha.toml` | 1109 | `d9eda8f5db70e49b31056aa3cf7ed0f9c3c70e5903acb810336a5b8da7404a8d` | TOML | uncategorized |
 | `config/icn-beta.toml` | 1106 | `dd9f05f00be4bfeb769a8b803467d8faf4df34d2e4f01ecebc61d7209327f729` | TOML | uncategorized |
@@ -906,8 +949,8 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `contracts/templates/housing-coop.yaml` | 1937 | `ecbc0926a6e36ed2643374d13e00b05789d4eecee5865d51e925e965a5678183` | YAML | contract template |
 | `contracts/templates/worker-coop.yaml` | 2168 | `eee7cc68a9d8bd01cc2c868017eed771b56ab8163bc6d43088227ca81aaecb91` | YAML | contract template |
 | `demo/README.md` | 9769 | `b6b0520cb3428bf7d70fe63a3bd4465352d68cf541e75cca4944b53570417b69` | Markdown | demo |
-| `demo/RUNBOOK.md` | 11068 | `99b94ac3d6e6a76884ea7f53866f44fab5bde6330130789bc0b8f1571ce90505` | Markdown | demo |
-| `demo/SELF_SERVE.md` | 12645 | `c2c374608bf301bef9a3b41cb632193a8a9c94cbf7ed85d13c1df6c39e9e25f1` | Markdown | demo |
+| `demo/RUNBOOK.md` | 11077 | `31e4d38448d41ffbb2c20919319e534e8bd738c7f3452170c2ed0d2123597c4c` | Markdown | demo |
+| `demo/SELF_SERVE.md` | 6679 | `4bac20f4b7c0b25ecbbc73a17e089b66456bded30b6bc7e448ffe5e1f870a343` | Markdown | demo |
 | `demo/configs/tool-library.toml` | 401 | `85622c40304326f4f2d35229cfe1f84e5ff98e78f4d8c184ce5df95121a52a68` | TOML | demo |
 | `demo/data/brightworks-members.json` | 1320 | `011532d1fbf93a43f4018aae4892e5862daef2fc55b64c6b0e893c8233cc7a26` | JSON | demo |
 | `demo/data/federation-history.json` | 2117 | `5466821f7ef8517f30b4feb8cca823dc3f51f6f3ac024c8df53579e5ced7d84e` | JSON | demo |
@@ -918,7 +961,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `demo/data/tool-library-history.json` | 2146 | `de611bbb66b5333418094f76c84a521e9dd564a9e617712467ed31cdb8801796` | JSON | demo |
 | `demo/data/tool-library-members.json` | 2821 | `a0cd59c309a2dd5845639e67c43a1392fe1d3d5b2f646b29d4b1694c4e5deb33` | JSON | demo |
 | `demo/docs/API_INTEGRATION.md` | 1494 | `f215cfa3a47f559c8650a3df938ded7ac894c01a3df229b8b17475236fe7c923` | Markdown | demo |
-| `demo/docs/FEDERATION_RUNBOOK.md` | 18698 | `8781226fdc73b841fb9384cb733f399a41fef01357a743eb70139cc42317f878` | Markdown | demo |
+| `demo/docs/FEDERATION_RUNBOOK.md` | 18707 | `cc4d937752e85f2aee33b0d06a5021bf437b559daa3ec51ef7f3df9642b7ce2d` | Markdown | demo |
 | `demo/docs/UI_FIXES_APPLIED.md` | 729 | `5d910abf1f4e685a0393533402fee777ec679b540d675d43bb22c7bd2ba7207b` | Markdown | demo |
 | `demo/docs/api-map.md` | 20859 | `a4975cfaf2cb64a31b2810b19d4134cb27085e65d2e7bd77357b37258f907e03` | Markdown | demo |
 | `demo/docs/gateway-secrets.md` | 4559 | `f0eee0f9d7177b460b1577bceee48618f95c8260a1fa015d5b02afde381257e0` | Markdown | demo |
@@ -926,12 +969,18 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `demo/docs/plans/2026-03-09-terminal-presenter-mode-plan.md` | 31400 | `c0d6bc8fccb2edace53a6f44dd410a508b96e31e5ec4876ccc4858c5a340b167` | Markdown | demo |
 | `demo/flow-c-treasury-governance.sh` | 5831 | `d26fd134b18c362825484765b801748cc28f24dd7b6b663cfb76f53655a7267c` | Shell | demo |
 | `demo/notes/flow-1-notes.md` | 6119 | `a0e07a41b5ee47d2a5d885b83a8b81020d6ab638fdd7862a11e0545a38cf9841` | Markdown | demo |
-| `demo/notes/flow-2-notes.md` | 6024 | `379b3a54b5818b7346afe60413cea7957636ae67b39aaf3aaa7694e3635531b5` | Markdown | demo |
+| `demo/notes/flow-2-notes.md` | 6030 | `9f642f2730e8f33c783a104eda9d35ba710e51af100fe02151989ccb26eaf5f4` | Markdown | demo |
 | `demo/notes/flow-3-notes.md` | 5234 | `7096b4cfb1ef35f9052315e1b56d9ec417743a630e0d82251db16c72450fdd84` | Markdown | demo |
-| `demo/notes/flow-4-notes.md` | 6355 | `852c16f3bd7f1a6d85737eb6cccc3ff9b91094b10135d5697384373ebd03711f` | Markdown | demo |
-| `demo/notes/flow-5-notes.md` | 10237 | `da39888039998759cb04eec4abcc333362ac20015cfe4e3e8da357f73ae74822` | Markdown | demo |
+| `demo/notes/flow-4-notes.md` | 6357 | `33e12ec55bca98a99a8ba1d5f465a038476b7e8b6a2e7ce67bb24da065a374e9` | Markdown | demo |
+| `demo/notes/flow-5-notes.md` | 10239 | `8318f9b26183f72bb26d99502b9be7153cd7b1b4171c2a6e2910eb53f6fd1138` | Markdown | demo |
+| `demo/nycn-dogfood/.gitignore` | 195 | `927c64451dd71b66c6f8093e4c98d16973760d8c2fba56307a6b346f9f4aaa7a` | unknown | demo |
+| `demo/nycn-dogfood/README.md` | 6629 | `cfe80e8b2f567223b17ab4901ce2c30f725f4b16922db15dd26c8e2adc521c4f` | Markdown | demo |
+| `demo/nycn-dogfood/make-recording.py` | 5618 | `862b3b6f1252156fe35366e7dfe78bf0bbdd3645daa4d4124e84317b889d1408` | Python | demo |
+| `demo/nycn-dogfood/run.sh` | 14336 | `e556edcaeada1179c6f7e511e6fb46e7263a8e4948bd39a1770b7d512b1ec903` | Shell | demo |
+| `demo/nycn-dogfood/sample/recording.html` | 11283 | `0ab28295240605e04131dbffdca1bb0d91b53736e1d6b5f33b88111c79897059` | HTML | demo |
+| `demo/nycn-dogfood/sample/transcript.txt` | 6606 | `10e38d5fce6dbc22a440cfaf7bbff86ed179996d2da04fdfe1dd7a66741b15d7` | Text | demo |
 | `demo/run-all.sh` | 6310 | `d603a99fa91a418b6c741cbb24620b832e79e6b95924832d9cc94f106266e8bb` | Shell | demo |
-| `demo/scripts/demo-governance.py` | 23957 | `7cef3652fa3010ff4f244cd6aa81e14d5d23dd24d1eeac2bd689b45f20fc34cb` | Python | demo |
+| `demo/scripts/demo-governance.py` | 25518 | `90472061ebfd09a45b1ec71699d986410252667d3be60894478d5dd0af1dbad0` | Python | demo |
 | `demo/scripts/flow-1-governance.sh` | 21212 | `89c4607999f88be7c7931dc35aff171d223a3a046345c6a8272256b5455a2ccb` | Shell | demo |
 | `demo/scripts/flow-2-patronage.sh` | 34329 | `08d1ca4067bc122b9cbc49844c16a27d0ad14705652c190de1ca176458cefb96` | Shell | demo |
 | `demo/scripts/flow-3-federation.sh` | 28981 | `2f5a480ef39dbdd61d46a3ed169181a99948e0b8978f4803e12aea85d438f7b4` | Shell | demo |
@@ -940,7 +989,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `demo/scripts/lib-demo-ports.sh` | 23218 | `66cc67eeeed46221d6ae793557ec01b3f5e25a8dac71fbe6afcf64c3c1ab4d76` | Shell | demo |
 | `demo/scripts/lib-demo-ports.sh.test` | 7834 | `7b941d351635c944f34be3487da73e2bca3447b8e4ea55dc522ee0307424c91d` | unknown | demo |
 | `demo/scripts/load-sample-data.sh` | 4354 | `a057dc6af30ce8d49c08a8a21273239a59c92be59027d72569e8821d814199d8` | Shell | demo |
-| `demo/scripts/present-governance.sh` | 4693 | `0e601265c28f8402f4698e1417cd8fc039215c3bf2e4e4ad418a9f5fc0f3027d` | Shell | demo |
+| `demo/scripts/present-governance.sh` | 4926 | `6003d21f14b526fad5204ef39b57c9081eab9a0f6539da97f905e467203c26ab` | Shell | demo |
 | `demo/scripts/present.sh` | 3693 | `15a5d05c2f6c6354467ce2792e05392eddb2e5956201e927dfe502f209a8862e` | Shell | demo |
 | `demo/scripts/quick-test.sh` | 5193 | `9a8f832af7270d38828825deb42a573f512ecec321d1ad48f1d66c93b131e072` | Shell | demo |
 | `demo/scripts/record-demo.sh` | 1613 | `bab6b0e6ad8a7fa8584ad6f7c4cf5be212737c3febe63e62a7fe3909b12084c1` | Shell | demo |
@@ -949,13 +998,39 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `demo/scripts/reset-demo.sh` | 4356 | `eabbbc13784d227494ac9213a1f813b5d3ee880f84872153dccf93bf2b26dadd` | Shell | demo |
 | `demo/scripts/run-tool-library-demo.sh` | 18108 | `74cccadca669a2cbf335e62f39e9aa004410da9923ae9eac35b231f392e560a5` | Shell | demo |
 | `demo/scripts/setup-demo-env.sh` | 1044 | `2588e80e03a97c01e0451f6ccfdaa00ecf2c70c43e6a06ea3c904b20e81830fe` | Shell | demo |
-| `demo/scripts/start-demo.sh` | 2099 | `0b64b361664494b5d880bbe3575df2eeae2f315412f8b0e5b786ae15819e3c25` | Shell | demo |
+| `demo/scripts/start-demo.sh` | 2749 | `a1c1365b024de0da766e07cb6f0448d74261c68153d7141d95a9b24f10f059ba` | Shell | demo |
 | `demo/scripts/test-ui-integration.sh` | 1459 | `926cdd4326de15a5cdda398e1944867a4c88e6d7f5b86f5d0446caf8a68de15b` | Shell | demo |
 | `demo/scripts/verify-demo.sh` | 2897 | `ab6ba79e888814f519ee20d534ef6c88f47d494c5b3468d712edaa3fc4619ab7` | Shell | demo |
 | `deploy/.env.example` | 420 | `23d77f4ae19ffac25bdd221223a3603eec214e28ef810bb6de83e16f7c6c7137` | unknown | deployment |
 | `deploy/Dockerfile.icnd` | 1753 | `c10ff8600c5e551e05d57f3fee284de2a3c21b33ce52c466826c805e0e05f557` | unknown | deployment |
 | `deploy/Dockerfile.icnd-fast` | 467 | `d9ea0f4c92bb8b6edf3a775a619a10148264814848a5791cf36bf87fe87fc00a` | unknown | deployment |
 | `deploy/README.md` | 10218 | `a2abc547b978a59bd8bb3b0ba4e834880e89a6fc73f139d6d81ef0ec52fd7efb` | Markdown | deployment |
+| `deploy/appliance/DEMO_QUICKSTART.md` | 12155 | `d898199e1eb0cf27c9fa5fedeb530ad115526bc154129be6accdf42cc9df35c1` | Markdown | deployment |
+| `deploy/appliance/README.md` | 20164 | `36bc3edfa59e731f7e55259fc5fb022be4025d10581dec8b592900700d8d3964` | Markdown | deployment |
+| `deploy/appliance/appliance.manifest.example.yaml` | 6516 | `42ed13bf143b74118ef78a83dde52f0329f606f4e9d23df81bb9190618642470` | YAML | deployment |
+| `deploy/appliance/build-image.sh` | 20506 | `1803e38d21e8a3dd896f5dba436c66b473ffffd0794bd3031aedd3bdd5d9ad64` | Shell | deployment |
+| `deploy/appliance/check.sh` | 4209 | `40c60ed1f5997a8dcd5d3fe18e97f7ecf682564e66f82e01741aca0aa6d7b53d` | Shell | deployment |
+| `deploy/appliance/roles/domain-host.example.yaml` | 2172 | `f6ed40f8723cfbaa188f08d697b40047c769a7b744995e55dc4b5893671b74d5` | YAML | deployment |
+| `deploy/appliance/roles/genesis.example.yaml` | 2082 | `5ccba9aed4c832df7fcfc53c43d640f0d1f8f90baa11f683a942cf7e7e9819bc` | YAML | deployment |
+| `deploy/appliance/roles/sandbox.example.yaml` | 2282 | `0309836c41c914e6f9fe80f038f93a13878b1984dedf7eb029ea28b790049bfc` | YAML | deployment |
+| `deploy/appliance/roles/service-host.example.yaml` | 2653 | `9d573372e5cb907e182ce4ce9b8acd01f23883361c4bc62a162b19b3c07654ce` | YAML | deployment |
+| `deploy/appliance/roles/witness-archive.example.yaml` | 1912 | `4d841a30b8a8508a543f5b17611d80190a049187b5c909af5e45cda6262ea104` | YAML | deployment |
+| `deploy/appliance/scripts/icn-appliance-firstboot.sh` | 16393 | `e7643dee64897a90eea814cfcbcca4e7bfdfc72480aed8f066e5c24d998a8007` | Shell | deployment |
+| `deploy/appliance/scripts/icn-demo-reset.sh` | 2383 | `13da9cf73df363a4874c2ceed078b36b3f2ef178d25eab6e7b153e117c22d1f9` | Shell | deployment |
+| `deploy/appliance/scripts/icn-demo-seed.sh` | 8683 | `9103169e589bb8527c99bc35a015d8288a6dcb01ac9a158d15371940ff22f359` | Shell | deployment |
+| `deploy/appliance/scripts/icn-demo-session.py` | 9006 | `0ddcae89c9423726cb695637e1ecaceeebfea672dcabc7d4552567d0022cd2f9` | Python | deployment |
+| `deploy/appliance/scripts/icn-demo-verify.sh` | 5297 | `b1ffb20b1b684ef914519b954b5f293784b66ec5e0167a078ab8682879cfbdfe` | Shell | deployment |
+| `deploy/appliance/scripts/open-proxmox-demo.sh` | 9578 | `09e8918eb2a31bc0f7c1350db4580a3494dcab191cce6e6834b84fee156eeed1` | Shell | deployment |
+| `deploy/appliance/smoke/README.md` | 6572 | `71b5e20311f480ff6cf6a85fbe52194f715e723efd79d988cb2f696690871316` | Markdown | deployment |
+| `deploy/appliance/smoke/cloud-init/meta-data.example.yaml` | 471 | `9ba371a283b57c026d0e715e2f3f1f75d0e3e06d08db3f8c86c9541c8147f887` | YAML | deployment |
+| `deploy/appliance/smoke/cloud-init/user-data.example.yaml` | 2998 | `27c56190467d6d983eae051791f1ae5c4328584f3f42502d96fc0c414fd6b646` | YAML | deployment |
+| `deploy/appliance/smoke/negative-firstboot-smoke.sh` | 20044 | `d9cde006dcad04582d054e3b865ff82fda01b26cf03947c4334f1a866a24e2b1` | Shell | deployment |
+| `deploy/appliance/smoke/smoke-local.sh` | 22364 | `66128b598d2a53609a5b39ee779f6946fd39b65d5e961b43b55a103ecb492334` | Shell | deployment |
+| `deploy/appliance/systemd/icn-appliance-firstboot.service` | 2281 | `1c0a96d2b1eb3f78a9138ad0c0b96bcfad0bdb45c3a04989163ce3f31d949bee` | unknown | deployment |
+| `deploy/appliance/systemd/icn-demo-session.service` | 2454 | `e6b4ed8c4546796144826861c43ee71185c88aa221cb98e036df60b474361c28` | unknown | deployment |
+| `deploy/appliance/systemd/icn-member-shell.service` | 1494 | `1ec61b9d9223a3a55ede122655daa97347d625a1c8944514fa3abc69573ff307` | unknown | deployment |
+| `deploy/appliance/systemd/icnd.service.d/10-firstboot-gate.conf` | 1371 | `214b3900158378842f2ac9bcc4248e57f92a7703d758b1f7438e60ed9a861ef7` | unknown | deployment |
+| `deploy/appliance/systemd/icnd.service.d/20-demo-profile.conf` | 1833 | `ecadd988079158b4984c00d0bc208a450a6a2ff1f136e9fd35f5656a6abf0cd6` | unknown | deployment |
 | `deploy/ci-runner/README.md` | 3196 | `3d83d4ef9519a3d60f24729bd36319cef86dc0d3f67a1e131392d8e754ed8da7` | Markdown | deployment |
 | `deploy/ci-runner/atlas-sccache-setup.sh` | 4675 | `ea1e4d25b3c9fe527956bb2eae637a9de8cc9e4df463b292c21b9ea80ccbaff4` | Shell | deployment |
 | `deploy/compose/README.md` | 2643 | `ba53193dc7438bb68b8caa387345c0edad07326fa9552ead5f7e4484f73ceb6a` | Markdown | deployment |
@@ -969,7 +1044,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `deploy/config/nginx.conf` | 767 | `56076f14caed51946f80dd009a0f5f02a261b68b5b0be0f2f27854c5c5d42b93` | unknown | deployment |
 | `deploy/config/prometheus.yml` | 195 | `48182cc0f04ca448b28d51cde4b5509289fe6e4c814e3c4517b23ef381ed1963` | YAML | deployment |
 | `deploy/devnet/Makefile` | 1760 | `c2aecb610779fcdc860ed8387a10a2eb896b3da402ece724f1cb61539e522ae8` | unknown | deployment |
-| `deploy/devnet/docker-compose.yml` | 4735 | `718d8480c76764b04943ac8a89509451b11986314b4b396d107e440b2308db72` | YAML | deployment |
+| `deploy/devnet/docker-compose.yml` | 5425 | `362da221139553c6f908a1ef0be75bc4ee99d6e79ae53285b0f3b1630bb69615` | YAML | deployment |
 | `deploy/devnet/entrypoint.sh` | 2932 | `c04776ead440db100fab4b84d74b23d4a1f58de48f1708e4c426388853e12d12` | Shell | deployment |
 | `deploy/devnet/genesis.json` | 124 | `5ca86a42976e355e5adbf29d7a69bff2de39f8553cb13f1e64b5a1a17c35a86c` | JSON | deployment |
 | `deploy/devnet/monitoring/grafana/dashboards/icn-devnet.json` | 9699 | `8805967097dd76d18a2820a0ae063f90ea36ebcc9f94e5e692dd4c8017043802` | JSON | deployment |
@@ -1064,20 +1139,22 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docker/docker-compose.dev.yml` | 2069 | `6d6f886289bedce325ad0569ba6264d3a09e51e51c3656b092e9b86b36a9412e` | YAML | uncategorized |
 | `docker/docker-compose.yml` | 4190 | `78497084696009b6c0e8b833dbc1700610f2ceb4a858228bac648973f175006e` | YAML | uncategorized |
 | `docker/prometheus.yml` | 853 | `c96ed6db391790cc1c6a69b9ef02fd67e268db84b51443af37bc4689848d9db3` | YAML | uncategorized |
-| `docs/ARCHITECTURE.md` | 55634 | `651d39744c27bada749ac5cb1170653cfd43ea66b14269744226e1df7ceb5fc5` | Markdown | documentation |
+| `docs/ARCHITECTURE.md` | 67843 | `c673d4e72cb2311979baa0b22c5d41cd61d584153c5fa7540e923ce849e983e1` | Markdown | documentation |
+| `docs/ATLAS.md` | 14455 | `6dc9fab6be423bb85c5b06b2199b25808f96add0e10e0611bf3d2a7c47727f49` | Markdown | documentation |
+| `docs/DESIGN_PRINCIPLES.md` | 18709 | `e2b07c7e87f94c308925f68dfbf729155a56d187916ef0f04256212d221cf488` | Markdown | documentation |
 | `docs/DOCUMENTATION_CONTROL_SYSTEM.md` | 18211 | `492ba28857b9cbe27b6ac5d78e8b9298b781757b8e5612eb2e50614d91198adf` | Markdown | documentation |
 | `docs/DOCUMENTATION_MAINTENANCE.md` | 17600 | `1334cbbc9f7423ad72a758bf772c1f144322485eb78ff190b60516226cf33d3a` | Markdown | documentation |
-| `docs/DOCUMENT_REGISTRY.md` | 4302 | `21dea92c5ae61d9dc62ae4470caa85f60f8b3eb4f0e64e7730b90472bbc89411` | Markdown | documentation |
+| `docs/DOCUMENT_REGISTRY.md` | 4302 | `3f0a751dd74654eb557520662cd74b6d2fed839444ec596b0fbad6cff8d26f78` | Markdown | documentation |
 | `docs/GETTING_STARTED.md` | 6309 | `a0ec4a52c2f835cc7432957eaa69bb53b83884ced4395deaad1dfb4c0d306a57` | Markdown | documentation |
 | `docs/GOLDEN_PROMPT.md` | 768 | `fb9c7a045d7d84219f83eba32b8b20e81a23adf613c1cdcefc9ed447d8b74fa2` | Markdown | documentation |
-| `docs/INDEX.generated.md` | 50741 | `8d63820410213661e01e6014af317040efaf67612b454d500b72559b9cec4c3e` | Markdown | documentation |
-| `docs/INDEX.md` | 31159 | `4b7f1d5a4475b04de4c32f30b36ba70514313391909ee8ed3bff7137d3815c93` | Markdown | documentation |
+| `docs/INDEX.generated.md` | 99153 | `0ec037af1eeec408d2b619b1fbdbb14a9335122806ada2ed61341442a425f94b` | Markdown | documentation |
+| `docs/INDEX.md` | 46794 | `cf10472b41c3bcf4c8cdb5dc89e6791359b10b19fb989817075249e1e3e9e576` | Markdown | documentation |
 | `docs/OVERVIEW.md` | 17180 | `b48fe3ac1aa3ef7ea1f82ae9b1908c5e4c4181313f2a1de2ff06b8f2f339d584` | Markdown | documentation |
 | `docs/PHASE_HISTORY.md` | 17368 | `9d19e4f8030fa1067b4d599cc77f2464d0a588a6d1dc013f1040dca0088b84b9` | Markdown | documentation |
-| `docs/PHASE_PROGRESS.md` | 20638 | `6a47b4f95d872138f79028e04799e4654439147b3522aabef90d09b5d8318f1b` | Markdown | documentation |
+| `docs/PHASE_PROGRESS.md` | 93188 | `a1a5b4e070331a8ff4b4e72023f141e3275810e08ea9e37877f6eb7a9ab9e6c6` | Markdown | documentation |
 | `docs/README.md` | 7313 | `69e37fc3e652339beb53fd24cb1b66abf3e834ec838560780d1efafd5e6dcc86` | Markdown | documentation |
 | `docs/REORGANIZATION_2026.md` | 14226 | `13e0c6c9d3ae339ec1ea833c75af153978e9606171fa9e28304e760471b3d755` | Markdown | documentation |
-| `docs/STATE.md` | 21199 | `8f9a5ddff9da3f6e4ef24fa53b79da7ccf1c48b4aba3c9f64e747d6ecfd8ef1e` | Markdown | documentation |
+| `docs/STATE.md` | 167484 | `b361ad4c8c749d3278ad990ed33f0a821ade8ee2fd4fde4ce423c352836e9407` | Markdown | documentation |
 | `docs/SYNC_LOG.md` | 1361 | `914569d96c0daa94f35b7868c1500e42520803cef5d09b3aea2b149398e71756` | Markdown | documentation |
 | `docs/TODO.md` | 1668 | `12723cd9c98ebaa2e72dcf45c64f55b44e3f2c8301e1d51be4889e6cfabf4150` | Markdown | documentation |
 | `docs/adr/ADR-0001-orchestration-plane-architecture.md` | 4405 | `c8578ec4bc28e42dd4d77df95a89872ae2fd234b7910dfdc52541d47d75b55dd` | Markdown | architecture decision record |
@@ -1109,26 +1186,30 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/adr/ADR-0027-action-card-contract.md` | 7714 | `7922ce5ed7e8e99c3d2c6dd37c5ade3b1d310896f56072eff283e5b73612e925` | Markdown | architecture decision record |
 | `docs/adr/ADR-0028-accessibility-baseline-for-member-interfaces.md` | 7560 | `232b6f4e2ab03d10f4c57dadd48e93fa8be2fea2d039bb53fa29bd08dc31343b` | Markdown | architecture decision record |
 | `docs/adr/ADR-0029-conflict-resolution-object-model.md` | 7130 | `7a11af16da54015032fd88cc6f01de90d39b5c78a0f155828785632c856dd940` | Markdown | architecture decision record |
-| `docs/adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md` | 7680 | `395d7cde58588045fe4bc409728ec9c3faf6a23936cd4c9a9f98e9e108f4e69b` | Markdown | architecture decision record |
-| `docs/adr/ADR-0031-commons-compute-admission-and-settlement-policy.md` | 7183 | `1d6c311a27fe669140faf8952ef33e3086864cc6e01d3f4a37e4e403bc23d03c` | Markdown | architecture decision record |
+| `docs/adr/ADR-0030-compute-workload-manifest-and-authority-boundary.md` | 8442 | `6cd4cae4e8c9e633240c128f32a2c8e6904ccc62f3ab0ddf3de14641f4f9aaf4` | Markdown | architecture decision record |
+| `docs/adr/ADR-0031-commons-compute-admission-and-settlement-policy.md` | 8069 | `8b9e87f83a205c47ab994aebc01fe4e5d9e2d71486c6f6b65a68941b8edb91a7` | Markdown | architecture decision record |
 | `docs/adr/ADR-0032-website-truth-boundary.md` | 6296 | `e87f92b3336d1b59efeb9b6c0c1e0675da244c39ad553d10a410f20be6d9bcb2` | Markdown | architecture decision record |
 | `docs/adr/ADR-0033-public-maturity-claims-and-evidence-links.md` | 4385 | `e97bb5a305319eb39e66e5b10b4a0e8c6a019845fb8c254fed364f30b86943a1` | Markdown | architecture decision record |
 | `docs/adr/ADR-0034-adr-candidate-registry-as-architectural-memory.md` | 5371 | `bf48bdfaa77a56ae00cd70c738e9bc949ad0b3730b091800ec0617f9b74d9090` | Markdown | architecture decision record |
+| `docs/adr/ADR-0035-entity-aware-request-authorization.md` | 9337 | `935b98bf2d991fcdb02e689313607d067e9b849ecc0eef2fd9873a5685a1fd0b` | Markdown | architecture decision record |
 | `docs/adr/template.md` | 2116 | `93da786ffa4d64a75f1df8f7e4bd7f393e7b6d2ec7c26001c8d9220405c6c211` | Markdown | architecture decision record |
 | `docs/ai/CODEX_WORKFLOW.md` | 3221 | `a60b6df40d2cc7e46d0408b2cc9f590ac43fb2f472e2204a72f193dfb1548b27` | Markdown | documentation |
 | `docs/ai/ICN_CONSTITUTIONAL_CORE.md` | 10280 | `d8139c260917ea8d3d9775ea4d5ca0f934be9d560522b78bb08b7f34a7a267db` | Markdown | documentation |
 | `docs/ai/ICN_LIVE_STATE_OVERLAY_TEMPLATE.md` | 2748 | `6af52b6ee876dad633c6fe8265da357daf17535092db20dc4a4736d8e28e2ddd` | Markdown | documentation |
 | `docs/ai/ICN_SESSION_FRAME_TEMPLATE.md` | 1934 | `a78fabbc162396b4ff26c49112ab0dd0da48b131a896a29bb9a4b392fc73bcf5` | Markdown | documentation |
 | `docs/ai/WORKFLOW_ARCHITECTURE.md` | 2825 | `adfa98a30d85a672d1181b2922824dd0cd342b8fceb1d31115c055ce4f85f0c1` | Markdown | documentation |
-| `docs/api/OPENAPI.md` | 7760 | `c558303bf93d4cc52c39787416fdc82fcedd36cf8bd2bf9e2f5c9bb1fdd095e6` | Markdown | documentation |
-| `docs/api/README.md` | 7297 | `bda4536f076eb9520f2dad4e2959f294a06771bf3e2bff4ec927b56c6a7b88e4` | Markdown | documentation |
-| `docs/api/examples.sh` | 4276 | `3414cbcbc43731fabdc6913e781b29957002cf7301b055c35c7d37ccaa1d98b5` | Shell | documentation |
-| `docs/api/openapi.generated.yaml` | 45436 | `cec01650ea5828c239f542b89ad61fd40545032dbd1eae8000744a0bcf1a33fa` | YAML | documentation |
+| `docs/api/OPENAPI.md` | 7922 | `8b2b5ccfbcbca4083d113aed86dad301fe100b51210d1d782e0f4cf3259a6d28` | Markdown | documentation |
+| `docs/api/README.md` | 8384 | `daf258804917cd482c834b9d28aec40333e0999d1095c14f0d01255a11d838fd` | Markdown | documentation |
+| `docs/api/check_api_doc_terms.py` | 7984 | `56ad66bf65efc16037d45b4e39e280f5e3fd4f9fab0cd7aeb61ee79cfe18ee9f` | Python | documentation |
+| `docs/api/examples.sh` | 4638 | `a1444aede8a8648e767fdef5f66835a255f2af95fdfe329927aa71a882bd5172` | Shell | documentation |
+| `docs/api/openapi.generated.yaml` | 72121 | `f3c3d043faabc312c76011d3d2ef16345ede9306a7e96a55058d3968394b8165` | YAML | documentation |
 | `docs/api/openapi.yaml` | 42259 | `0de2efd30825b8b3af8ea25608fc395b22e33e75178ee5b0102bfb7b20fc9cea` | YAML | documentation |
+| `docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md` | 49857 | `ff8c628630f75e9dc4b3def39e7d7f00afdab6b311017ec7b42aa7ccf6e2f7b1` | Markdown | documentation |
 | `docs/architecture/ARCHITECTURAL_GAPS_AND_FIXES.md` | 24257 | `263708455dd7e77b23702db4253516a183d22b22fb994698b70775249120650c` | Markdown | documentation |
 | `docs/architecture/ARCHITECTURE_AUDIT_2025-12-17.md` | 20675 | `829e6655b163fd3e6491ed91b530d32f59072813902b118780573d3a9b25e61d` | Markdown | documentation |
 | `docs/architecture/ARCHITECTURE_COMPLETE_CHECKLIST.md` | 11422 | `b11927ad350ff7d095e5499601abafbba431a5d3adae24976a74ee74acbcfe9c` | Markdown | documentation |
 | `docs/architecture/ARCHITECTURE_COMPLETION_STATUS_OLD.md` | 12006 | `2b801c1d81f8eec6f18f6ba124092a208479d1abf5cf66c6f68ea234bf4ec012` | Markdown | documentation |
+| `docs/architecture/ARCHITECTURE_DUE_DILIGENCE.md` | 26243 | `8692ca953a0eacd42b4c8f089da87b8d0e5ce47b8ee04f5b88a6573b9862ed7c` | Markdown | documentation |
 | `docs/architecture/ARCHITECTURE_INDEX.md` | 18247 | `dfb63cabdb74d59b26c073991cf6d36ea3473a252149e290a1b10987bef5c63c` | Markdown | documentation |
 | `docs/architecture/ARCHITECTURE_MAP.md` | 197361 | `de76d62386211559e9778465acc493f2b0cd12e1413f49e264174dd7d4b2077b` | Markdown | documentation |
 | `docs/architecture/ARCHITECTURE_QUICK_REF.md` | 6477 | `61db50e5b11f59036861909c39216b6356f9a06a02ededc3e7b1a3b78feb178c` | Markdown | documentation |
@@ -1137,29 +1218,34 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/architecture/ARCHITECTURE_UPDATE_2025-12-17.md` | 8666 | `2d50d5fde08219e336691b822226df44a4ef1383707de45c5ae8c67e15e93c62` | Markdown | documentation |
 | `docs/architecture/ARCHITECTURE_VISUAL.md` | 44127 | `0ab38203e49e37d2c73efc7aea9fb45b541093946b2edc47cb91fc50a9e4864e` | Markdown | documentation |
 | `docs/architecture/ARCHITECTURE_WIRING_AUDIT.md` | 3851 | `09f4bc3cde9373eb5fb12362bbf6b88e14e794c2a7573d1b9b52a93a1da76626` | Markdown | documentation |
+| `docs/architecture/AUTH_BRIDGE_AND_DID_LOGIN.md` | 9133 | `9c71f5e828a585cfc7e3b472841070a145c295189d02db17ac8a2ead158420b3` | Markdown | documentation |
 | `docs/architecture/CANONICAL_ENCODING.md` | 25634 | `1e0b5014205a3c25b4a9117ab640c95ed6aec7ff593aba3f1897ef69ac677e9a` | Markdown | documentation |
 | `docs/architecture/CELLS_AND_SCOPES.md` | 40147 | `452f9f43eaf24676d4c85b2dbfb53de1a3893df676f8d0b8bce9743969c9e1ca` | Markdown | documentation |
-| `docs/architecture/CLIENT_MODEL.md` | 26138 | `1cc15dfa698f7121622112697a70730908684d05117c845f394995f1953e0dd8` | Markdown | documentation |
+| `docs/architecture/CLIENT_MODEL.md` | 36644 | `6c9c1f86060c2cba8566c3d3c58d7cc9d6d4017bf95c1f47dfc5ae986319265c` | Markdown | documentation |
 | `docs/architecture/COMPLETE_ARCHITECTURE_AUDIT_2025-12-17.md` | 25267 | `238b09f8f3dac4b5db48423d2da097c537c25754d25f25732c1d554ec0a26ddc` | Markdown | documentation |
 | `docs/architecture/COMPREHENSIVE_ARCHITECTURE_REVIEW_2025-12-17.md` | 39378 | `9e14a5e4f8ecd2bf5380b233bb0e31c75b6af266c10e0cf9893db2b7098b7aea` | Markdown | documentation |
 | `docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md` | 27256 | `cbbd6a49163891eef01d22d127f7575a50cbe7ac0d982fbe3d7064de2b1cc729` | Markdown | documentation |
 | `docs/architecture/COOPERATIVE_TOOL_COMMONS.md` | 13196 | `3d356d30ddcce597303bcdeda118c7b4de857e7086d875b37a857d34f89e5a77` | Markdown | documentation |
+| `docs/architecture/DEBIAN_APPLIANCE_MODEL.md` | 16408 | `438980a258d44467900b1c7f74e9682ee4f05d7f380de2ff28bd2594330a0e54` | Markdown | documentation |
 | `docs/architecture/DOMAIN_ROUTING_AND_DNS_BINDINGS.md` | 10986 | `df41e80585025fab723551b69849a0a68c1576dd26a9a4347229975bf7481d15` | Markdown | documentation |
 | `docs/architecture/FEDERATION_ACTIONS.md` | 25723 | `84d14d02ef3b377a6f2dca7dacff8cefff3a5af37a198e8b512b33d041a67e39` | Markdown | documentation |
 | `docs/architecture/FEDERATION_INTEROP_CONTRACT.md` | 35946 | `13564182a65bf66892d4fac907de700725fc400642a5c9417fd3ccf5b9148566` | Markdown | documentation |
 | `docs/architecture/GOVERNANCE_STATE_MACHINE.md` | 29287 | `da529698f05396d8b184c8c3edd5183f7d976f1ce9f12010bc728a98b1575117` | Markdown | documentation |
+| `docs/architecture/ICN_INTEGRATED_SYSTEM_MODEL.md` | 33032 | `662f6c8acbdd33582d4d69e7127979298b83cb729d4915b044312155103ea632` | Markdown | documentation |
 | `docs/architecture/IDENTITY_MEMBERSHIP_ARCHITECTURE.md` | 41091 | `192d5451eca0d7889af82df03ff72a9d44489c1bf7da266f136435f8b8eaac32` | Markdown | documentation |
 | `docs/architecture/IMPLEMENTATION_GAP_ANALYSIS.md` | 30467 | `c981209dbb2e0bd396977d763086f800333e46d739d00eb5a746846793077180` | Markdown | documentation |
 | `docs/architecture/INSTITUTIONAL_FEEDBACK_AND_SUPPORT_PRIMITIVES.md` | 33692 | `3c7785bc80bf8a4cfb627028e5db39649bb3d291f408d2ddf17d4b397a6b2d77` | Markdown | documentation |
-| `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md` | 27683 | `db3d80e05b815e25fea3d30f0c059a91c4cee06ad3f30cddd13f843582a8640c` | Markdown | documentation |
-| `docs/architecture/KERNEL_APP_SEPARATION.md` | 51954 | `f80dea1e96ac8c1984bfc05c6d6f5833d77eeb47dd56accd9b04d14317394223` | Markdown | documentation |
+| `docs/architecture/INSTITUTION_PACKAGE_BOUNDARY.md` | 33569 | `892cde6a59fe30c28b9c9f47e3e58bf8df1cfd3b3c39ba29c69919e1e7fd7eee` | Markdown | documentation |
+| `docs/architecture/KERNEL_APP_SEPARATION.md` | 58339 | `546e124ed0c7a4dd2127e05734b735791a7ca7f297f70398eac523ef1cda87ab` | Markdown | documentation |
 | `docs/architecture/MEMBER_STANDING.md` | 74741 | `a337d6874960f95a08f3e60ff92d6ab3b156bf1f772608c4143ffcd9fa3514a9` | Markdown | documentation |
 | `docs/architecture/MODEL_WORKLOADS_AND_DELIBERATION.md` | 9957 | `cc89b1195f7d969508e70f5c9246b4134627b614643a55d593dfeedadd2ed368` | Markdown | documentation |
+| `docs/architecture/PROTOCOL_SELECTION_FOR_MEMBER_SERVICES.md` | 10172 | `6bbabe82208ce8b2f5ad4f48c8832f9d073ac227839883bb138ece226e0b7858` | Markdown | documentation |
 | `docs/architecture/README.md` | 6803 | `757583802c0a14b536b8e46e0c70fc567e37c9db4b9829ef92a88ca535ee7443` | Markdown | documentation |
 | `docs/architecture/SCOPE_BOUNDED_TRUST.md` | 14171 | `cc274f2a7783c2ac80f87941c5cb3683cbb00c691177d617a0c5890b8f9a2754` | Markdown | documentation |
+| `docs/architecture/SERVICE_HOSTING_MODEL.md` | 11218 | `3f588c459247b019a3c2136a75bcb2a7cfbd875083f81c4f7e3acd0db7dff8d9` | Markdown | documentation |
 | `docs/architecture/SESSION_SUMMARY_2025-12-17_ARCHITECTURE.md` | 9380 | `f4863774245716429cbe5caeab2a1f2e36ff40857135d038d4c6ca6e44a8b6d3` | Markdown | documentation |
 | `docs/architecture/SESSION_SUMMARY_2025-12-17_ARCHITECTURE_AUDIT.md` | 8470 | `993d3c34fb442ec9d76fbc4a3a7b3747153bf886b3a3c59447053cd55e527efe` | Markdown | documentation |
-| `docs/architecture/THE_COMMONS.md` | 56963 | `d6afebef4c7b81c6e6ff38a1b8cb7d33f82a5df96e472223ca0f94a4cece9ad4` | Markdown | documentation |
+| `docs/architecture/THE_COMMONS.md` | 56915 | `165779984f4845300c02a1796748f28b71138b6dd744898722c6cfe1be6ed5d0` | Markdown | documentation |
 | `docs/architecture/meaning-firewall-audit.md` | 16487 | `540e55f8ddb9372197abf71831332cb76a4a04959880a72837c03d034c6c22df` | Markdown | documentation |
 | `docs/archive/2025/2025-12-25-sprint-status.md` | 1601 | `eeb357de831613d541cdccae5fb9c77d333f1eb951fa54ceb2610d3f8f81c598` | Markdown | documentation |
 | `docs/archive/2025/CODE_REVIEW_COMPLETE.md` | 23621 | `c7fe91fd23259507c4acb1c6fc5a738475e1e637616d2f84f3669741c93993b2` | Markdown | documentation |
@@ -1215,9 +1301,9 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/archive/2026/demo-sessions/DEMO_AUDIT.md` | 13734 | `523b33b7476ed884304b91a4786603583ee9132633096ef9e24590bee1e5fd66` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_BUG_FOUND.md` | 5128 | `02c29466cc51b888b75946f20615776e917ec69b6cebb8eb37d69b8739176892` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_CURRENT_STATUS.md` | 11128 | `9c95bf0bc3bdddc2ec67f65e76fe0bb2cac4b178ec7c4678c6fc151784c0d2c3` | Markdown | documentation |
-| `docs/archive/2026/demo-sessions/DEMO_FINAL_SESSION_SUMMARY.md` | 7926 | `7f1cc30a75e2d7c98dad59e546272ae5ed364bfdd61ea59cf4396500d66c2b63` | Markdown | documentation |
+| `docs/archive/2026/demo-sessions/DEMO_FINAL_SESSION_SUMMARY.md` | 7654 | `f0e889a1d772212fd5181bf2e46b0376f70167e7a26f40e81f7bfe780ff42d6c` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_FINAL_STATUS.md` | 12454 | `8529b1196424168b36d1e3380e84bbd9f923859762e4f1b4cc27e0369db1f4f2` | Markdown | documentation |
-| `docs/archive/2026/demo-sessions/DEMO_FIX_LOGIN.md` | 3305 | `40ce8abb27fbee665ecf6a16775f02157c3539b492423dc23ef681426a18cd4b` | Markdown | documentation |
+| `docs/archive/2026/demo-sessions/DEMO_FIX_LOGIN.md` | 2631 | `dc78b5cf144bd52bd9e13230346a7e40b6991b0ebca9190906041c7925a87680` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_INFRASTRUCTURE_COMPLETE.md` | 9652 | `aa6dd8ae2c752aeaf488032caed0c603e0098115cedfec88e9201b0ce634867d` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_LOGIN_INFO.md` | 3006 | `13474a366395a7fb75a1aca99fe64d02aee8cec321a7d0c1489bd7d505f9e567` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_NEXT_IMMEDIATE_STEPS.md` | 4313 | `b72372ee1c191c69a0bce5d67044e18df7a1e1158f5ba3173fd3772e4b677449` | Markdown | documentation |
@@ -1225,7 +1311,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/archive/2026/demo-sessions/DEMO_PROGRESS_UPDATE.md` | 8339 | `8132a2904c0f1d63986ca9e1188f4888ec4e31b986d7df79aa0036858ccb2d21` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_QUICK_START.md` | 3886 | `ae462da4f84635cfc59907d7413c11ca573c2aec218ef6dc8b0dcb41232ae04c` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_README.md` | 10601 | `5f78fd8a63472a2849f4d580aefb18d1a63f29049b16a6e9c3135d34c220b1e3` | Markdown | documentation |
-| `docs/archive/2026/demo-sessions/DEMO_SERVICE_WORKER_FIX.md` | 4307 | `9feb5ce8d4f8387b4a0ffcd8167b2ffed8c6672e749a599bc3eec32f580305ad` | Markdown | documentation |
+| `docs/archive/2026/demo-sessions/DEMO_SERVICE_WORKER_FIX.md` | 3296 | `1d186beab2ea8ef5d7b17c55905e6d843f691575f1303a67888c1217c1e81e74` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_SESSION_1_SUMMARY.md` | 4804 | `2816380b91375fe9bbcd988a0908fbb84d55ddb072eb50684bcb21d503273c4d` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_SESSION_COMPLETE.md` | 8677 | `0bdbd8d6d7bea7d5fc0117900112f44d8852b7a2338d69cd8290dbb2fcf0fe08` | Markdown | documentation |
 | `docs/archive/2026/demo-sessions/DEMO_STATUS_SUMMARY.md` | 10325 | `42e024a49221cf414364d06a35206ac60d0cc9bcd31de1d527ea07ab2cfe2a59` | Markdown | documentation |
@@ -1241,8 +1327,20 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/archive/README.md` | 924 | `485797a166626c1e4bb221980ac5fb0ef8efa21c1662f23f9d48b93f81bb202f` | Markdown | documentation |
 | `docs/ci/CI_ALL_GREEN_REPORT.md` | 3384 | `1c5b85e4f9f8270c282d602d11514fdf7df52b687ab8d44ab5f8940fb0f81528` | Markdown | documentation |
 | `docs/ci/CI_CURRENT_STATUS.md` | 1709 | `3212b15b6adbb956eb5a42e2c1660928af6418c1697d94cd6eeccdb0e3ab09fb` | Markdown | documentation |
-| `docs/ci/GATE_RATCHET_PLAN.md` | 7311 | `bdda09ebcb9574b37269b42edc7ffe5df3d36f4bfe31418ee2c8a1157122ee21` | Markdown | documentation |
-| `docs/contracts/institution-package/action-card.schema.json` | 4322 | `b795c4dc3786de2b7bdf4b7143f26f2de21c618346e576e500e1539040b3a8b0` | JSON | documentation |
+| `docs/ci/GATE_RATCHET_PLAN.md` | 8724 | `9debcec8b18cadb02071d2277b80ad8a040da8932c61a761a4c7751b4c9ebd98` | Markdown | documentation |
+| `docs/contracts/institution-package/README.md` | 7597 | `54d05a99be96955597dce088b32f261d0e4798b7e9550812386f04912e942743` | Markdown | documentation |
+| `docs/contracts/institution-package/action-card.example.json` | 726 | `7f9e1b55b852517dcb03c274c1d374cb182bb403ac7bcdc263062ac00a1f48e5` | JSON | documentation |
+| `docs/contracts/institution-package/action-card.schema.json` | 5435 | `d58485a48ab5c1f05623fc216580260bdc7505053bcfba2bcb7cc147171ab755` | JSON | documentation |
+| `docs/contracts/pending-publish-summary.example.json` | 6913 | `f23264926a3d6c56122e7d489039ee35ae6f3f355c45c4c37e012d2fec514944` | JSON | documentation |
+| `docs/contracts/pending-publish-summary.md` | 17833 | `ed7b58a46f4542497c047d00523045d8d60e0089a5bd1714eaaca672d42735c4` | Markdown | documentation |
+| `docs/contracts/pending-publish-summary.schema.json` | 21068 | `025313c8a7c2e876b181a4759900b991bfa7bd028dd0580db6d51214ad57f43f` | JSON | documentation |
+| `docs/contracts/preview-review.example.json` | 4242 | `3507f7da252a441b982c6836c1ea258a0b3415a166d89f918d067b25df57f270` | JSON | documentation |
+| `docs/contracts/preview-review.md` | 16648 | `ffe6fa142ecd4ed40406194de74d2ad2d4760980a2b38d6a299c9c41bae6aaf9` | Markdown | documentation |
+| `docs/contracts/preview-review.schema.json` | 15793 | `9ae77d0f93b27cc2ee026f08d27e1eb5c9955d7be5e8e0306ac9de09e0f2586c` | JSON | documentation |
+| `docs/contracts/rehearsal-evidence-export.example.json` | 3434 | `f4e223205d3c14c27585e090ca08d68f0b303ae60b1e29433f1ece14cb5fe970` | JSON | documentation |
+| `docs/contracts/rehearsal-evidence-export.md` | 10869 | `3fe3c4b01e5e064d74fa7b91c44b2fd173f0cf74e6536d138e3f9e23e8ef2bc5` | Markdown | documentation |
+| `docs/contracts/rehearsal-evidence-export.schema.json` | 14790 | `4725c4fb7be3009948cc2cf1820340bff7874bf8096888452114da62d0466083` | JSON | documentation |
+| `docs/contracts/schema-id-audit.md` | 13349 | `166e3c0b7521c9bd92381ce4babbfb3c17068d764acc4f2a9f81ca110b39481b` | Markdown | documentation |
 | `docs/crate-manifests/charter-app.toml` | 931 | `d22b5a20317ec7e09d0f085ccc9e4de324ecfc7e4d1181086858c8919febeb08` | TOML | documentation |
 | `docs/crate-manifests/doc-template.toml` | 1969 | `34ddba9b87a56134f6e9307010b7abf1475064f31e628955883e6069c827b570` | TOML | documentation |
 | `docs/crate-manifests/governance-app.toml` | 1200 | `bdb5542235ae80cc287003e71041d2e3cbf4fe4d7de5d96f23ec4eba64af2628` | TOML | documentation |
@@ -1286,10 +1384,18 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/crate-manifests/ledger-app.toml` | 936 | `6cff3742418d7e827ccf208722d54766dcdd1cc010d308b0f08b131a6994afab` | TOML | documentation |
 | `docs/crate-manifests/membership-app.toml` | 1186 | `4478e15842b2cdaec1d600c90bbf425a6ccf60be6a51e12cc3b7e9e3d7f4aba1` | TOML | documentation |
 | `docs/demo/ARCHITECTURE_OVERVIEW.md` | 19424 | `52b9c72162f71f1dcff59dbdc82c551336310805cde31e3d2efc36a4aa4869b0` | Markdown | documentation |
-| `docs/demo/DEMO_SCRIPT.md` | 10999 | `dc213391c48f818fd0be5f6adf32e7cbb7193eaff36750f08df2a23001779048` | Markdown | documentation |
+| `docs/demo/DEMO_SCRIPT.md` | 11055 | `45a4c12aee9ce5c48a0de904df85b3340c2f3479fc728225bd9cda6b76f1e7fd` | Markdown | documentation |
 | `docs/demo/FAQ.md` | 8193 | `1fc60b75312e56dfaf11dc2bc835ee93f6c7c368f03afb3dea08c3f5cb09955e` | Markdown | documentation |
+| `docs/demo/GOVERNANCE_PROPOSAL_FIXTURE_HANDOFF.md` | 8230 | `fb4634ecd6cc87652673d8f1fc77cba4f71b58da2fd2f363e1da49b34ef726aa` | Markdown | documentation |
+| `docs/demo/ICN_SYSTEM_DEMO_READINESS_MAP.md` | 33123 | `f1058c520ba16b4f6d214659a0e9bf0bf561e5a353ec338d31038c443e8e6ea5` | Markdown | documentation |
+| `docs/demo/JULY_DEMO_CANDIDATE_0.1_ACCESSIBILITY_WALKTHROUGH.md` | 17962 | `745b5aa0bf4cf122266ad7d6d6752e767bf95de50145411913b14b74c8c7434c` | Markdown | documentation |
+| `docs/demo/JULY_DEMO_CANDIDATE_0.1_HUMAN_A11Y_VALIDATION.md` | 11605 | `d15b13ed871d51bb4c318b3c6e7f3fc52818e82adc8841d300c98808ede6b18a` | Markdown | documentation |
+| `docs/demo/JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md` | 16684 | `2780c1f687fab42208eb26bb649ba7f0598732dc105f67206d5ff84ac5c8f4bf` | Markdown | documentation |
+| `docs/demo/JULY_DEMO_CANDIDATE_0.1_RELEASE_PACKET.md` | 10756 | `e0409318d78b84b34b5c769b8a9d9e224012e70f1d5480574e5b29824c03e4a6` | Markdown | documentation |
+| `docs/demo/JULY_DEMO_HANDS_ON.md` | 24070 | `fae897fbe72095b7299c74407c19c4bac5f15835884ddb5aab8ffedf077f6223` | Markdown | documentation |
+| `docs/demo/JULY_DEMO_OPERATOR_CHECKLIST.md` | 4160 | `27a4d5664d9a33859949d75a556c198d2b4f6c2bc1a69ba3b798a757d83684d2` | Markdown | documentation |
 | `docs/demo/QUICK_START.md` | 3263 | `a45f409e0ecc776695443a5af2cd56ee1b28f7cb37467179e83f82cccef11d19` | Markdown | documentation |
-| `docs/demo/README.md` | 4194 | `520686972ec7ff492e08ec59f45e4f9415033c907d529032298f28822e7f611e` | Markdown | documentation |
+| `docs/demo/README.md` | 6351 | `c5b22fba15ce0fa622a2920b4134416a07974a6887d5b448838dc0781686b19a` | Markdown | documentation |
 | `docs/demo/WALKTHROUGH.md` | 16856 | `f796acd9ffe8325ee2405b89f1859ec12d75c1e8ab8887d54b5932bbaa495ce9` | Markdown | documentation |
 | `docs/deployment/DEPLOYMENT_ACTIVE.md` | 6921 | `536a6f15faf87b732d33a945fcc605a6a13df54e6c961c646617f9538e1bcd5b` | Markdown | documentation |
 | `docs/deployment/DEPLOYMENT_COMPLETE.md` | 12198 | `f696088a77768977435784c323e49c4d741e7b811eac66e232787facfa2c0f28` | Markdown | documentation |
@@ -1297,28 +1403,46 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/deployment/DEPLOYMENT_INVITE_SYSTEM.md` | 6456 | `a6082d3476e19712ff83a4eb9209fcc83bfab5b769555b41738c6e2317ab4f35` | Markdown | documentation |
 | `docs/deployment/DEPLOYMENT_READY.md` | 11463 | `23555348bf9d4de9862e03e64fe04ff726f08a583968c850a37f2cce862c8724` | Markdown | documentation |
 | `docs/deployment/DEPLOYMENT_STATUS_2025-12-12.md` | 6100 | `5da4b13d01aa4a9888fbea2663b1dbfc2bdd24bf282abb78da2546b1295938b7` | Markdown | documentation |
-| `docs/deployment/DEPLOY_TEST_NETWORK.md` | 16300 | `013473972b1794382b459a2d8a106a0cc6b520b6cbc999ad8d5232361020b6db` | Markdown | documentation |
+| `docs/deployment/DEPLOY_TEST_NETWORK.md` | 16620 | `d109f7e11b236523a0ce6acc4acd338703e90016b17d5594fe8111f55ab10d4c` | Markdown | documentation |
 | `docs/deployment/DEPLOY_TO_K3S.md` | 10169 | `2be50eaf670bed8cfd9a4bd1f60885cbafe2f97aefe5aa3b2910a65615d842f5` | Markdown | documentation |
 | `docs/deployment/FULL_STACK_DEPLOY.md` | 12657 | `0a1119e1b40e22e1e3ae3a90e5bc9861efa3f18ccc56b31446e664f353a4d621` | Markdown | documentation |
 | `docs/deployment/ICN_ZONE_ROUTING.md` | 3366 | `d4d9fca0a420fef810f70e605ef841f3e961ae6553b30a48336e13a9ee1f28a8` | Markdown | documentation |
 | `docs/deployment/QUICK_DEPLOY.md` | 4558 | `58da4eeb63394d840d15ce71fafcbd05141e0530a722a49af6468256bff128d0` | Markdown | documentation |
-| `docs/deployment/QUICK_START.md` | 6566 | `618ba54133ecf4021abdf23fc5ab64af84f2fc023653945b211971ca55a3c894` | Markdown | documentation |
-| `docs/design-language/accessibility.md` | 12731 | `0f50dd68d9662a8337356eda1347fdcc41a20a9139c4615fa38d9327e3fa25f6` | Markdown | documentation |
+| `docs/deployment/QUICK_START.md` | 6866 | `a26100c2793f0da41db6f6388c43ede97fd1d42d380039723107da51edb34789` | Markdown | documentation |
+| `docs/design-language/accessibility.md` | 13906 | `099b6c2f84616d8591c672adda4107cafefeff093484fb51c10d190bdc67850d` | Markdown | documentation |
 | `docs/design-language/brief-v0.md` | 13406 | `ed930a9ede4aab75246ced29ecebb445ad03998ead0fdb4b12e96127f2859d2c` | Markdown | documentation |
 | `docs/design-language/concept-map.md` | 12300 | `ab1c77ae864994b742704ccc86e8a543272175cff745996160b00547821ea815` | Markdown | documentation |
 | `docs/design/ACCESSIBILITY_BASELINE.md` | 6128 | `4a317b96fcaf75dd49fdba528ffbe3e146c04e5c4949e82ee130113d6618dd7d` | Markdown | documentation |
 | `docs/design/AGENT_HANDOFF.md` | 6746 | `b59cea9e8fa7084de37cb33bf137137129808c449f15f23724a504cb8068bfd7` | Markdown | documentation |
-| `docs/design/CLAUDE_DESIGN_CONTEXT.md` | 3208 | `8eb4649837fdd163ef5cca5fa8eb8c20b7ea20c13700490bd854b944fd45077e` | Markdown | documentation |
+| `docs/design/CLAUDE_DESIGN_CONTEXT.md` | 15438 | `cba019ac6f80d5be7c50435c5de7ad271de366e1f490c60000a394f5e75b58c5` | Markdown | documentation |
+| `docs/design/CLAUDE_DESIGN_HANDOFF_TEMPLATE.md` | 12426 | `3d1a30769efd1f589b0f40eef126de1098b318a0d4114b3e08b302697d8ae590` | Markdown | documentation |
+| `docs/design/CLAUDE_DESIGN_REVIEW_PROTOCOL.md` | 15072 | `d09cd7cdbe3817b0fa8ddf38df9fa8c0178070bf0d6257139a705cfb93317cff` | Markdown | documentation |
+| `docs/design/CLAUDE_DESIGN_SETUP.md` | 21915 | `b7421046703bea1199474a0e380fde31fa88592dfe2b5a826b985fec8fdd365b` | Markdown | documentation |
 | `docs/design/COMMONS_EVOLUTION.md` | 26103 | `7fffb01bc0f98f12094777ef7569cd3c8bae4acf1a354075221443d0ab030e3d` | Markdown | documentation |
 | `docs/design/COMPUTE_SUBSTRATE_STATUS.md` | 9608 | `a1ac9ddb73a7e3e327c30fb499bbde44e198563386fbf9575f58ea279eea6e17` | Markdown | documentation |
-| `docs/design/CONTENT_STYLE_GUIDE.md` | 5436 | `209cadb5bf576290d69b331f4428eda0886cba447d13c60e12d5a8c60f315503` | Markdown | documentation |
+| `docs/design/CONTENT_STYLE_GUIDE.md` | 6086 | `0c5ba9bf6d24daa9447585cf6984ef4b41f2c97a2051b0ae04fb00902a831d20` | Markdown | documentation |
 | `docs/design/DETERMINISTIC_COMPUTE_SPRINT.md` | 28583 | `83397fbf3054e92fd287654d5eadd1bed949828868a4b5030a525728613e2ef1` | Markdown | documentation |
-| `docs/design/ICN_DESIGN_SYSTEM.md` | 7605 | `a18d30247bfe62ad7f29238b7bf873a7ef20a6d8bd376f5444cd9cbd63d47228` | Markdown | documentation |
+| `docs/design/FEDERATION_OPERATOR_SURFACE_CONCEPT.md` | 11633 | `62af51ef25497f3366d4036ece757508708c62b2e5f21e788eb6fdeeb20f4a17` | Markdown | documentation |
+| `docs/design/ICN_DESIGN_SYSTEM.md` | 16405 | `187d7136a3411b126423331ba9936a1f650a7fa8501e1415879f9f45894a6119` | Markdown | documentation |
 | `docs/design/ICN_PROMPT_LIBRARY.md` | 8936 | `f37fdece08bdcdb64e7b0bc8abf4a1cf1a4b1f9c2d3da1c30d82e4398762701b` | Markdown | documentation |
-| `docs/design/ICN_VISUAL_SYSTEM.md` | 12574 | `73e7b12a12269062e7c4136de76db5c00266bd761723ab42476ba329513caeb4` | Markdown | documentation |
+| `docs/design/ICN_VISUAL_EXPLAINER_BIBLE.md` | 34797 | `c3d5f6b9bf72e2f5964d0dbeff19e6c882c7dc0dd53da80595a282f5afffa5dc` | Markdown | documentation |
+| `docs/design/ICN_VISUAL_SYSTEM.md` | 13070 | `3fb5727f077353fa95fd43a3335ed29f16233266e4be197a91c4879cb3b7603b` | Markdown | documentation |
 | `docs/design/MINIMAL-VIABLE-COOP.md` | 14736 | `451d4e587d1b33847f108f22ce6244fa36d47bdccfd981d488280e21d87c038b` | Markdown | documentation |
-| `docs/design/README.md` | 3686 | `ad960da0179da832ef03754a3f1796663db1a6efd9c6a97f11b13db3877519cb` | Markdown | documentation |
+| `docs/design/MUST_NOT_SHIP.md` | 14473 | `447c8d9655a8cbce9db1c7dbd0448da7a71fb1a9f9485b8fb8b5a7949957d221` | Markdown | documentation |
+| `docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md` | 17265 | `204568910ecedbe8d4da52a2071f08b3e4a9d67ac70e6d0db3a49b6be99d71d0` | Markdown | documentation |
+| `docs/design/README.md` | 3853 | `da674eeed5b17d4cad608feb0a1a23d1d3e5feac1143c396d82975918553b075` | Markdown | documentation |
+| `docs/design/assets/ASSET_REGISTER.md` | 7078 | `31e3e7413fad0b251d95add95e219f8d69ba54eb314d875350c232d5d6628b28` | Markdown | documentation |
+| `docs/design/assets/README.md` | 3551 | `4142a2cb3ce82bc9d497b1f55e666ada7d34677c1f8230b4ba50288810b8e4b4` | Markdown | documentation |
+| `docs/design/assets/VISUAL_REVIEW_CHECKLIST.md` | 8128 | `33cedda6c4088704b481169103579e1ddde3f17c80b59fc37269e23e67367f8c` | Markdown | documentation |
+| `docs/design/assets/briefs/VE-001-how-icn-works-closure-loop.md` | 6912 | `bc3c56b4c43e6ea27609c59b1a425840cd7a8930d47e6093ef3207db882d6c30` | Markdown | documentation |
+| `docs/design/assets/briefs/VE-002-scope-model.md` | 5304 | `aceeeb335a1368c71812410ae761d23be4494f1eae6f0ebcb65d4c29bdab2e3e` | Markdown | documentation |
+| `docs/design/assets/briefs/VE-003-decision-to-receipt.md` | 5817 | `1a737b97abe97789d8ba8220cd7e75f3e9f4070931609ae8e7db77ba21b3ba06` | Markdown | documentation |
+| `docs/design/assets/briefs/VE-004-member-shell-concept.md` | 7356 | `448b13748eab6c7731db6498005fa9cebc3f9c6f44a922d815c9abfe317e6f9f` | Markdown | documentation |
+| `docs/design/assets/briefs/VE-005-kernel-app-separation.md` | 7618 | `0fa8e4622977743ac389161bf0e0cd34f625c76a2edcf589864c212f5fb72641` | Markdown | documentation |
 | `docs/design/capability-based-features.md` | 13493 | `8e7fb584d98eac35829e030c35d228e968d8acdf1335846f96a118decbdfc554` | Markdown | documentation |
+| `docs/design/claude-design-seed/CHANGELOG.md` | 8464 | `ad63f1ebbf23d650829cc2e55475f8cb314fee7b43ed4f9d35f2a774f629f8b7` | Markdown | documentation |
+| `docs/design/claude-design-seed/README.md` | 8643 | `b4de66395414a7f24ec8bc5fb345617747d0be13c40fa1013de294bc62810e88` | Markdown | documentation |
+| `docs/design/claude-design-seed/REVIEW_NOTES.md` | 10568 | `450cbe488ef88db7a54868e78977b86e1100a9db45183a4bcb38cd3225616163` | Markdown | documentation |
 | `docs/design/compute-classes.md` | 6295 | `264a51e31f615f5c561a60d2784f044257577f5466b85ac7da314fda9d0868a0` | Markdown | documentation |
 | `docs/design/compute-substrate-design.md` | 43337 | `fd9a9e25459d78bb7eff839e79f2cb48549116b65dd229354c61abf2a1aaf231` | Markdown | documentation |
 | `docs/design/deterministic-core.md` | 11971 | `d3c9811d87c257186b6469995f45ab246a9d77d331478b2542b3913f8e8e4da9` | Markdown | documentation |
@@ -1337,15 +1461,21 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/design/execution-bridge-spec.md` | 24871 | `b9080287f3b305f55756697d6d5b6c06b3c9e19082240c02512d0d405fb170dd` | Markdown | documentation |
 | `docs/design/governance/PROJECT_GOVERNANCE.md` | 11125 | `1e650aef5a85f335ea6ead3a5fcfa4bcd09088a83fe51a0c17cc1a9606abc39b` | Markdown | documentation |
 | `docs/design/governance/README.md` | 778 | `229bdeb72540704e2fd4fde0732bd237e89df1787074410ffed06f759da2ee11` | Markdown | documentation |
+| `docs/design/governance/decision-receipt-authority-and-grant-minting.md` | 9954 | `d02a42bd4394a482d54123f715e83c0ca156447d77e1edb7d98a570fc5776c7b` | Markdown | documentation |
 | `docs/design/governance/governance-primitives.md` | 10664 | `c4e6f68cb2f61115a5f7f55c2fe89a72e4c0f3f5b5df7c07aeb1b8a7e2f66f97` | Markdown | documentation |
+| `docs/design/governance/governance-write-decomposition.md` | 28453 | `262d8a24fc079405a7cf7a33dd0eae891e89f2b66d82681eaa069689bdb09332` | Markdown | documentation |
 | `docs/design/governance/governance.md` | 29039 | `9e59fe0264162e51bb5481ecba1f89b6344fbb994b9fb02880f8d8e32b5cc1df` | Markdown | documentation |
+| `docs/design/governance/mandate-gate-design.md` | 18951 | `b6a206eaa9d1e4146f1547cccac62bad2ed2771c61da4828428a63d0b61e9830` | Markdown | documentation |
 | `docs/design/governance/model-validation.md` | 17395 | `04f4217737d65c5d2188f6815cc9259008221d220fe779922a799720915d12d9` | Markdown | documentation |
 | `docs/design/governance/witness-trust-validation.md` | 8507 | `4ebc9897823aecf4eefbb84e251b789cf73202f664734b535f9bf3ff6b879a08` | Markdown | documentation |
+| `docs/design/icons/CANDIDATES.md` | 14172 | `3084d298e6f6bf9b13bf4ed5f21cb67086ddfc97a4a0a5090f50eb8ce40c6c97` | Markdown | documentation |
+| `docs/design/icons/contact-sheet.svg` | 20204 | `04a383ca6b7599fbf3e3596257cc0f8a747e8ee15e5f84b4e4d556c2643880ea` | unknown | documentation |
 | `docs/design/institution-in-a-box.md` | 1393 | `6f991d3e25a7c3d23d1909b68f126c989b476a2c6722b421825dd74ba63c45e6` | Markdown | documentation |
-| `docs/design/institutional-structure-spec.md` | 8541 | `3d263a4ad59691f339f03a4c01ee4079505ae21080459b081f86596409f8a6fb` | Markdown | documentation |
+| `docs/design/institutional-structure-spec.md` | 8606 | `d0f2c3c22cec06ecdb68fb6a9b8682de998da9e152efe9465ba70182640101a8` | Markdown | documentation |
 | `docs/design/ipv6-endpoint-sets-design.md` | 11763 | `7d03f4d74f3cce3302bc4b7a46b6c48ece0a8e4f8162e297cf68298fcefb586b` | Markdown | documentation |
 | `docs/design/multi-device-identity-design.md` | 22486 | `33919f4b5c3d7aa3de073e36dde36388820b7adede81cd93dd0cbcce4c7c06a7` | Markdown | documentation |
 | `docs/design/nat-traversal-design.md` | 11493 | `ac2a6fe15d22b3e3ce45a19813620e9266b9e4e06282c4f6dd0ebe9b240d8971` | Markdown | documentation |
+| `docs/design/passport-keyring-position-receipt.md` | 15627 | `bd4df86f5afbcf1e12e95849b710fab4c539a76372048b35430a72605379c61a` | Markdown | documentation |
 | `docs/design/platform-layer-design.md` | 23514 | `676817ede6b96fdf9ac8b7735d7aad36623a1fc9f645ddb4173c78f9712f3ba7` | Markdown | documentation |
 | `docs/design/post-quantum-crypto.md` | 14982 | `99dc39e8f8d796ef4a6e03903cf47a5305c38101fcabba1bedc5dc1c639a8941` | Markdown | documentation |
 | `docs/design/razeto-integration-design.md` | 28919 | `e386b6458a13acb2d070cfa642da43ec3f319b3d3d1f08d005b6c04e646d42ab` | Markdown | documentation |
@@ -1357,13 +1487,43 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/design/sdis/social-recovery.md` | 20835 | `92228c2e942746d89cd39cf020bb16aab019dc17b09a65cd0a1741b57401ba07` | Markdown | documentation |
 | `docs/design/session-handoff-2026-02-17.md` | 14514 | `78dca21b4c18ea0cbefb4cd04fb37ecd5c1923b9c3f48b7c73b79242e240671b` | Markdown | documentation |
 | `docs/design/social-recovery-design.md` | 13685 | `26fcf76031884844ce3bcfb3cf8b384d56b33ed9a9b9fc0548223736cdecfc86` | Markdown | documentation |
-| `docs/dev/HANDOFF_TEMPLATE.md` | 2705 | `5a5c324d1174ebf590aa5cd4c634956cb9c278b657d950c5c314962e3d81ae0d` | Markdown | documentation |
-| `docs/dev/NYCN_ACTION_ITEM_RECEIPT_PATH.md` | 16866 | `219f9a8631573e71f7ff81a68217eb859e0c767a5feacffb961003cc60ab6545` | Markdown | documentation |
-| `docs/dev/NYCN_K3S_PROOF_PATH.md` | 21519 | `5af096dbf78b8f1390c312988336ca4b650b3767f8a62c73fcb2182c21b20358` | Markdown | documentation |
+| `docs/design/wallet-did-migration-boundary.md` | 16447 | `f85f62b7ed559dd13f553cfe1215d07d81c01389f8ded21039da88c1599adad6` | Markdown | documentation |
+| `docs/dev/AGENT_WORKTREE_POLICY.md` | 4648 | `5df782798ee1db419445b3c8cea3709762c1f105139ca4f9f792dfc403f4e678` | Markdown | documentation |
+| `docs/dev/HANDOFF_TEMPLATE.md` | 2965 | `d55f3b3f56b2ff384573619ca1310845dac54838ebb7d1cebe02e7b624492601` | Markdown | documentation |
 | `docs/dev/WORKTREES.md` | 4932 | `f039f5268333954507ce39cd378ce09719477815e3df0badc9cb10e86d4d5d42` | Markdown | documentation |
 | `docs/dev/handoff-2026-04-10.md` | 4485 | `e68b778beb14c4dc1b179cbbff973f43d569d5af07c4aabcf226571a81e8ce8f` | Markdown | documentation |
 | `docs/dev/handoff-2026-04-15.md` | 18312 | `b7fb7ad611a39cff0bc7435feb5763f155750a7842106922b9cacd5ac5c7e696` | Markdown | documentation |
-| `docs/dev/language-guide.md` | 8225 | `5a5ecd681f4766be33157e81f81c21dfd4339442c33ad22be77c6c5494ddf83f` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-05-b.md` | 18140 | `e5245132b6058d85a3f52542e66a4a6228af0ffdf055a7d9e2891b5cf273ae29` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-05-c.md` | 21480 | `1e15b735aeb274a1faa71f64f1573b24bda2af1b993e34d8e812090ff458705a` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-05.md` | 11930 | `68e3123bfd943f2e2421877977c3e970401c628ad608df63b120d471f1e9c049` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-07-a.md` | 20978 | `f42bdd46017cfef728d6df93b18f68f23f853b8a1f9e0adee5b053cbb0ec356d` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-07.md` | 26305 | `b108fcf19449aac59685032565a583225e6227448a083e5abcd811361b47cb50` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-14-artifact-registry-and-scoped-vault.md` | 22772 | `0c8002e1d7042cd6a3e6ba926e022a8b537ef51b5a12f221b180ba964f34f003` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-14-ccl-policy-registry.md` | 16484 | `1bb5e0bc2a88845df68a77760eab4e2b0c6315de637ab7c24c06135e4e07d797` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-14-commons-cloud-governance-spine.md` | 21758 | `c73d7ab951fc18427e545d09218bd334863fba606ac207de63ff1a258e1bcc54` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-14-effect-dispatch-contract.md` | 13054 | `848f7f33b299de8abe4a54eabfa01bbdc8236b889cfb9ce46bdbea02ea01ada3` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-14-entity-scope-vocabulary-boundary.md` | 26254 | `53e0c5423b2e95daf33d78e803c7feaf970f65d9b386635b299ba2b175e5f5e6` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-14-governed-service-binding.md` | 16993 | `195955f9f39edbb7df989501193bb5a18263e51c2c3e2d4530b4aab46a644a66` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-14-institutional-domain.md` | 14712 | `154c9c503417404df34033bfdbfaf8d04cfd92187404190ca1cd27aeb9fff5d3` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-14-storage-durability-policies.md` | 18914 | `f61374cf84cbd3496214dbb69f50982954ce59828f5ab4416b5807bc13bce84f` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-15-anti-entropy-probe-digest.md` | 17533 | `5bab6cc72b709d4c9873e04d23e1fa7805def10a47547577c64eeb45e08ba38a` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-15-architecture-spec-sprint-wrap.md` | 47566 | `7866a0ac820102e934c30f6b7fa368a4a69b3fe5d0e8aa29bd0aae08e461573c` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-15-compute-placement-policy.md` | 29716 | `2b6f399c13c0b73f582669caf7ec103cef618543c6f817dc17612560edcb5a98` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-15-member-shell-v0.md` | 30566 | `9e6a61a1d1bf8bf564c49654f4a1f3e43dcfdac194001cf97501bd3979a6ead6` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-15-network-anti-entropy-proof-loops.md` | 33933 | `7b25dd85f3b5aa526dbcea2ef11092fb4221ce916c161071ee5e0d822c9cdc59` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-15-steward-cockpit-v0.md` | 32218 | `9ec08590b6c6a96772273ae472ee94a3313a58bd52a8ffe460888eb59db1e88b` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-16-abuse-case-hardening.md` | 18850 | `7aed0d1b2f0bd9596d306539c203315f1956427a47611d12c8346eb48c401ced` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-17-appliance-verification.md` | 15803 | `46480a46f141e185a39530731889357141be51a30e497f3247ec287040f08913` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-17-thursday-meeting-prep.md` | 9964 | `319818f51b85c5736b0bbcb7652cdd8c827c54699c1c827a6c5f89b0d48228f9` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-18-mackenzie-meeting-prep.md` | 7392 | `b5a8823fd6d38077e08fb102b037036223a5f85cc3c1af3f062dcf0fdafb82aa` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-18-nycn-organizer-meeting-rehearsal.md` | 11884 | `86a50dd4c1f92981ec3ca144123c10393188e226db72293941da29fe1def3283` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-18-open-pr-cleanup-and-hardening-kickoff.md` | 9187 | `7e56b08caaa199ecbc51c8c259dc8f5717725e36675e3fe34d8a4a609811e274` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-21-appliance-debian13-real-smoke.md` | 26140 | `ef57a02477f669ce3dfa398c1fd4c5da335b55f7cfd6f2f44e06cc9d932a9d05` | Markdown | documentation |
+| `docs/dev/handoff-2026-05-22-current-state-and-next-plan.md` | 13629 | `dc88cea6445bbf7045821f0de9a6a4097e444c09972187ffa8291e337eaccb67` | Markdown | documentation |
+| `docs/dev/handoff-2026-06-10-appliance-negative-firstboot-smoke.md` | 11025 | `7e82098a5b41daab9d131f4c6471cffdf01ec8ede02322212ee522e3605eecb2` | Markdown | documentation |
+| `docs/dev/handoff-2026-06-10-truth-sync.md` | 6444 | `b98bb391eff0f009e52a0c6f4100bd236eb1cd5bc34ef3a3d1ba6ec78f301762` | Markdown | documentation |
+| `docs/dev/language-guide.md` | 12393 | `b08ded433f37a48a2d4caae72a27dded787f6b7282a15b517d02942f0ca3562c` | Markdown | documentation |
+| `docs/dev/openapi-member-surface-gaps.md` | 6940 | `85c0d484def8bf4fe193d7ce753eda72717b62ce365e09100929f509dca5eff4` | Markdown | documentation |
 | `docs/development/README.md` | 1680 | `bec067d96213deb35cc794d3a1f50cddcb81f4e833f880e1ec70a31f9719bede` | Markdown | documentation |
 | `docs/development/RELEASE_PROCESS.md` | 10591 | `1b1a8566af5a9a127a5101c39732e280d94602722ce921c447664af5848c9c29` | Markdown | documentation |
 | `docs/development/SPRINT_RECEIPTS_STAGES_3_7.md` | 5908 | `da30fe9bb45aaa6429fb8835c03408e8db5be3ddf8c0946f22808d475d5c0c19` | Markdown | documentation |
@@ -1425,7 +1585,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/development/sessions/2025-11/2025-11-24-phase-16e-week1-3-policy-implementation.md` | 42617 | `1ea692a3d48d9b6915b7fcc46f12cc2e5ba1c2877583a79132ea4d755cf4c2c9` | Markdown | documentation |
 | `docs/development/sessions/2025-12/2025-12-04-internal-testing-infrastructure.md` | 9313 | `0d5d6a4de3f1407f464f20237ecef61b586c832c83ed0bcb8b31698466263baf` | Markdown | documentation |
 | `docs/development/sessions/2025-12/2025-12-13-phase4-nat-traversal-supervisor-modularization.md` | 10767 | `6ac570c07233a579b7000678ac6e9f9a29abc7e13e8dd2fe6003fd4ebb154760` | Markdown | documentation |
-| `docs/development/sessions/2025-12/2025-12-14-session-handoff.md` | 3287 | `003a3e7ff8d7ef4621407071ffdde4ee82b5f827df8caf73d82df3b60e7176c9` | Markdown | documentation |
+| `docs/development/sessions/2025-12/2025-12-14-session-handoff.md` | 3102 | `4f88ed9bb7662e557990e73705a973f21e0b8ec00ce4d8ff4b72ff1fb4ea49fe` | Markdown | documentation |
 | `docs/development/sessions/2025-12/FINAL-SESSION-SUMMARY-2025-12-14.md` | 13233 | `415f5d31b3b18eaea6b443b7a899da0c59f856777f2536e4af80bc02debcafb5` | Markdown | documentation |
 | `docs/development/sessions/2025-12/FINAL_SESSION_SUMMARY.md` | 4859 | `ad2fbc378f65499e317af4aa84654b873d4d6c4f22035e4228cab698f31eacb1` | Markdown | documentation |
 | `docs/development/sessions/2025-12/FINAL_STATUS_20251212.md` | 13968 | `f5549e0dde03f7c17cf1cd47443bebb2739f30c758ab93971db87aa368383545` | Markdown | documentation |
@@ -1562,17 +1722,21 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/examples/policies/time-restricted.json` | 730 | `0668a90103c0d66105a2641f3a6e3560e648bdf8b158024018196e62b919610c` | JSON | documentation |
 | `docs/features/ACTION_ITEMS_EXCHANGE.md` | 17110 | `0838939908999c7bdd9d35c2a46555e2a07f4d34041b0042ae87d2d1e31dd281` | Markdown | documentation |
 | `docs/features/witness-signature-best-practices.md` | 32921 | `83555dbdf62da72d479eb029ef690983c9033f248a8a67444c1684efe65bf9a7` | Markdown | documentation |
-| `docs/freshness.toml` | 7063 | `47aa8d396d6626733d9e10275a3776f9744c4eb8cf4e558be7d5b83f350f92b0` | TOML | documentation |
+| `docs/freshness.toml` | 10972 | `1acdedabf33c8488b00d31f22833dce403537fe96f877c1b2fc5c4797e6a0cb5` | TOML | documentation |
 | `docs/genesis.md` | 16232 | `190ddb217ba2b2790ff31d5f57d7156f26f9e0a2ecc0673497ddf493f718e291` | Markdown | documentation |
-| `docs/glossary.md` | 19053 | `cd8dee048d5fbe26e983cafcb135d8b38bc352634f821ee9e0e3469e1c682e90` | Markdown | documentation |
+| `docs/glossary.md` | 21392 | `2cd23a30bf8e6c4a4f1d40403d5c70d3dde6604b02523c9af8331c76c2fb284e` | Markdown | documentation |
 | `docs/guides/FAQ.md` | 13567 | `232715f7701b5055cb97b4b2c729e2dff38126ece65ce4d6ba07059f4c679f9f` | Markdown | documentation |
 | `docs/guides/QUICK_REFERENCE.md` | 4216 | `08640837f1acf4b443347c3469d5cc5441b049b1984cb30504b43d477cae3585` | Markdown | documentation |
 | `docs/guides/developer/DEV_ENVIRONMENT.md` | 2529 | `13a23b392f6578ce84befec4e198433edfa623c4df30b5be3f15defce53acebf` | Markdown | documentation |
 | `docs/guides/developer/DOCUMENTATION_STYLE.md` | 4359 | `b5a402434979f2c07883bf13d8a3021f32ea1085a36e7b9adb52073f9e898567` | Markdown | documentation |
 | `docs/guides/developer/README.md` | 491 | `dd9fa1a130e6b5d09f8f2c3b571e3f8c8316b77fa615c1c6a68e6783cc011b53` | Markdown | documentation |
-| `docs/guides/developer/cursor-mcp-setup.md` | 3236 | `8b55a5168d00fa594ce1890e89a8e37e42a12ea923471434c21fe099abc91e7b` | Markdown | documentation |
+| `docs/guides/developer/agent-context-spine-plan.md` | 7650 | `1f63db04eaad11815428fc2ae5508ad760c65aabfec3851fce032bf3e977bafb` | Markdown | documentation |
+| `docs/guides/developer/agent-context-spine.md` | 7410 | `be72a22c5b1b51c52396285861add7433183c955c6ba4005fc40fff721e1b5a8` | Markdown | documentation |
+| `docs/guides/developer/agent-mcp-tooling.md` | 9473 | `7d1dfb3c11e124f10e8aa23c80214b205fdb0cbeabfaed9a5bf434f2d2798e21` | Markdown | documentation |
+| `docs/guides/developer/claude-code-plugin.md` | 10794 | `e7e23f84ed8c95534bd3830234b83502c43993860e4fff5e35f4ebeb8e9f382a` | Markdown | documentation |
+| `docs/guides/developer/cursor-mcp-setup.md` | 5091 | `75355079dccb7692cbcfbe94ba32c9ca560b2354f9222404fcfe1f10dd5c441d` | Markdown | documentation |
 | `docs/guides/developer/i18n-guide.md` | 9362 | `0a30ba895a8636b97f7ccffc53119c6d913cce6631e5479a3cdfb25483bf79d8` | Markdown | documentation |
-| `docs/guides/institution-setup.md` | 10891 | `5a95b8cb4338d51ef1f984e2cfd3180a34af838052ffa7ccf0587a28efc90f21` | Markdown | documentation |
+| `docs/guides/institution-setup.md` | 10812 | `2974ca3f2d5b2648b64c504d5c62b08725e52f710ab453cac0abc71d77dd23e6` | Markdown | documentation |
 | `docs/guides/onboarding-runbook.md` | 8748 | `f6411638c7900ef2d32c7c8100cbc645bf4231d20bded5f2c22582244e76685f` | Markdown | documentation |
 | `docs/guides/operations/PILOT_RUNBOOK.md` | 12558 | `608bcd82638d22095bee243feb2aa0cf105709046c479aab09922d47ea648475` | Markdown | documentation |
 | `docs/guides/operations/README.md` | 597 | `86fe0515afe115693afc575d3b2fb8341e5cc9bc5c63265d9f7806cd4c9ad0a1` | Markdown | documentation |
@@ -1599,6 +1763,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/guides/user/WHY_ICN_HANDOUT.md` | 4026 | `d34c2058bbde6801fd019f20ad2fbee82a6f0da49b563fcaffb74b4dd6772f41` | Markdown | documentation |
 | `docs/guides/user/cooperative-setup-guide.md` | 8568 | `11d2d7ee78fcd4d15ea2aa3cbf43307c39355f3ddd225592b5b341839edb97a9` | Markdown | documentation |
 | `docs/guides/user/summit-demo.md` | 7343 | `0b672865d83265fe94dccb1ecf77cb55538756d116d0c6e170289e20585a86a4` | Markdown | documentation |
+| `docs/handoffs/open-pr-fanin-2026-05-11.md` | 10078 | `b3abf3a79eb0ee94e11867a878d783c04a19e46180d0f24ac6a34b75ca3366d8` | Markdown | documentation |
 | `docs/internal/README.md` | 1570 | `8086345214d767a369cf6d4d300a7cf89d702b0c08763539059c741d38fce287` | Markdown | documentation |
 | `docs/internal/documentation-control-system/00_CONTEXT_PACK_README.md` | 1530 | `cc3eb6d40bd5fc9aa47ef038049f5c9ba683d73f01d0a3eb9faf90568208b854` | Markdown | documentation |
 | `docs/internal/documentation-control-system/02_DOCUMENT_REGISTRY_SPEC.md` | 2949 | `7a8825496221b3d0e60a52b19b6ec96e167fc5e9ce25cc13ae7f3207f1ccdef2` | Markdown | documentation |
@@ -1619,6 +1784,13 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/internal/status/strategic-gap-analysis.md` | 16930 | `7308609cc17191ff34b505a26ba80176edeb68f769a86cc40373ed5a7b48c687` | Markdown | documentation |
 | `docs/internal/status/vision-implementation-gap.md` | 14142 | `85f0e82b998ad841dd3551b2186e013e23f6fcf9b9840f2aa8050224df761c9b` | Markdown | documentation |
 | `docs/maintenance/spring-cleaning-2026-02-23.md` | 7296 | `c562f29f54d1d1f7566e9d9618ca36d06845155fdc5e415139b2eeb52797e895` | Markdown | documentation |
+| `docs/manual/FOUNDATIONAL_MANUAL_BASELINE_LOCK.md` | 20583 | `acfa48edcf8b0d740640c15d89c380f3f9ecc3f2c73e8498f4bd3fe04ebe2364` | Markdown | documentation |
+| `docs/manual/FOUNDATIONAL_MANUAL_BOUNDARY_TYPES.md` | 6663 | `f80c752709935f2fadf5f0cc97f43993d2c88153c50d86737fdf3ebe4cea7a99` | Markdown | documentation |
+| `docs/manual/FOUNDATIONAL_MANUAL_ECONOMIC_STATE_RESOLUTION.md` | 15577 | `17ec4ea0ecdc47b0cb7a02dc943ade861e1ad83ff0c8db23e8e8680330ab5d30` | Markdown | documentation |
+| `docs/manual/FOUNDATIONAL_MANUAL_EXECUTABLE_BASELINE_LOOP.md` | 19683 | `69e5c746c467d727c5c6174da59c810f5dac0c46eadb40b0ddea88acf64ec43e` | Markdown | documentation |
+| `docs/manual/FOUNDATIONAL_MANUAL_IDENTITY_RECOVERY_AND_CAPABILITIES.md` | 21909 | `419a6e3c968d071349ee78230a3bce8aafe49ba04de002045a0f4debfcc46f03` | Markdown | documentation |
+| `docs/manual/FOUNDATIONAL_MANUAL_STATE_PROJECTION_AND_COMPACTION.md` | 14874 | `683381ad402097ab4ea94353ee1c3bae3c124eafc90699feaa2539bea5746541` | Markdown | documentation |
+| `docs/manual/FOUNDATIONAL_MANUAL_TRUSTLESS_CLIENT_BOUNDARY.md` | 14462 | `9a410067dd672f42724df5e6805c9f21d48a5080d68e3b2ae16e8dbd50ecb30c` | Markdown | documentation |
 | `docs/manual/ICN_USER_MANUAL.md` | 41675 | `9aa637d8d46ed7e19e1713d21b38e08dc752675dbc202bc45697e3da7e8e92e0` | Markdown | documentation |
 | `docs/migration-guides/keystore-versions.md` | 7484 | `2b60ce666b2940e57b1b4daa78a7dce6164b1351fb7acea87e49f4f067e39dea` | Markdown | documentation |
 | `docs/migration-guides/version-upgrades.md` | 9987 | `96578d4cdfd718d76f092315e673e9a97338799e1ed7c64b291b6cc93917dd62` | Markdown | documentation |
@@ -1627,7 +1799,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/mobile/archive/MOBILE_TODO.md` | 5852 | `9352964cf2b615c0de430c6c8821f64e23caef083b3875d6500da0e3390a4f5b` | Markdown | documentation |
 | `docs/mobile/archive/MOBILE_TRUST_INTEGRATION.md` | 4650 | `e18e5532d83880776c1dff59b2b49ff928c57807a5f605a71c72ee6d1998ed04` | Markdown | documentation |
 | `docs/mobile/archive/MOBILE_WALLET_INTEGRATION.md` | 8297 | `358cd820d7cfd05810307a9e578c3f59673829665dc9db9b4b62519330ae458c` | Markdown | documentation |
-| `docs/mobile/icn-mobile-ux-spec-v1.md` | 36093 | `3b3d332c97b73cb801f7b15d8388bb1faa788794c5e28089100a3cd05db889dd` | Markdown | documentation |
+| `docs/mobile/icn-mobile-ux-spec-v1.md` | 37478 | `34cec5a05ba9244a111446704df9bc9202e8972a219d6aa0b0a50a0e115b3b25` | Markdown | documentation |
 | `docs/observability/storage-metrics.md` | 4011 | `885eb2fec179d8b97ecd0c3b30aa672076dd6e7fec919dfcae4a69a10b7a8b4c` | Markdown | documentation |
 | `docs/observability/tail-based-sampling.md` | 8145 | `1c9f08dfb12fc25666e0fbcd18accad5276c60e5e16fb1af69ebcb87518a953c` | Markdown | documentation |
 | `docs/onboarding/README.md` | 8108 | `a9eca13c77399f163f2a0fdba095ac3ecc58c66a89aea48f8493c59f3180dbf6` | Markdown | documentation |
@@ -1699,11 +1871,13 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/onboarding/workshops/workshop-14-governance-ccl.md` | 2126 | `385fbb8038f4cfc7305c6713022fb9cdecad05d2b064fdbd5381ffc5067b06b7` | Markdown | documentation |
 | `docs/operations/README.md` | 1686 | `ddbc6331be647b099043278a93b5a8de4bee5689d140558cafe2a444a289cc6d` | Markdown | documentation |
 | `docs/operations/deployment/HOMELAB_DEPLOYMENT.md` | 7587 | `593a0abed9500bfc7e8b3217931eaf157e7ef3cfc94e782513f78ba3ce1ce02f` | Markdown | documentation |
-| `docs/operations/deployment/MONITORING_VERIFICATION.md` | 13838 | `3887113c72d54c29c851914df70c3f6d3bc21d611ae85bfe9a2dbb115d73e2c5` | Markdown | documentation |
+| `docs/operations/deployment/MONITORING_VERIFICATION.md` | 14215 | `3203991753da826db98f76f438f4f550840d87f8cc0dbee3626bbbe2f69942d2` | Markdown | documentation |
 | `docs/operations/deployment/deployment-guide.md` | 13417 | `38379604e0ba299dee309fc542834d59967a91913c1f84fb42454146088ae70a` | Markdown | documentation |
 | `docs/operations/deployment/distributed-tracing.md` | 7804 | `d90a73d2bb81b0e660fa4989220e1de92c0d8539eac9895cad114556e84e5802` | Markdown | documentation |
 | `docs/operations/deployment/incident-response.md` | 34390 | `3965734fbcafadce6e9e408c6d84d19f63f7170bba9cacc2c0c037097c507f87` | Markdown | documentation |
+| `docs/ops/FORGEJO_DEPLOYMENT_PLAN.md` | 8924 | `3d488998150a68e1f5fd466efb71e3afd6730c1128ed31aa6550826303452cdf` | Markdown | documentation |
 | `docs/ops/README.md` | 333 | `7a007fc605b81d7a0d351737d77a52b911d0a6035b6e56668e0e18185b876e44` | Markdown | documentation |
+| `docs/ops/SERVICE_GOVERNANCE_TEMPLATE.md` | 6660 | `0e9752a40e2885d50821e853eb88111457b4ccf2617c67049be5e3f2b12e1a96` | Markdown | documentation |
 | `docs/ops/SLO.md` | 6891 | `5a7579c2e4d1c913578e0b95dc6ff9d4deef9fe9c6e6153574624e8693d86070` | Markdown | documentation |
 | `docs/ops/runbooks/README.md` | 293 | `1633d707952cbe841046135e4ba7aa0c805ed7173ed7be2d514274bf9190129e` | Markdown | documentation |
 | `docs/performance/BENCHMARKS.md` | 10248 | `f923deea090d59233220edf2e4d18b630dcb147a59a8fda5e952bdf5274f3615` | Markdown | documentation |
@@ -1716,17 +1890,15 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/phases/phase-6-crate-consolidation.md` | 3801 | `35f17761c0032e7df3f8a83c7ccd83abd6c72f92d23cc0ef850c2109299c1dbe` | Markdown | documentation |
 | `docs/pilots/decision_registry_treasury_vote.md` | 10649 | `14043a3bae9dbef91d53d75d142354e1c2edea3b1285493b059b169002e3b2f0` | Markdown | documentation |
 | `docs/pilots/hosted-approach.md` | 7291 | `bb4ed4066cc3fa8282ac6f70f8b50370cba827b06d55e279ad3312690248e8d4` | Markdown | documentation |
-| `docs/pilots/nycn-boundary-brief.md` | 9474 | `92af77b3ae4d19982675d2ef207b9622ac745158ceb29388bdddce80c216a0b3` | Markdown | documentation |
-| `docs/pilots/nycn-demo-script.md` | 10106 | `20aa726aba085e9a5851520c4bbb5f94a51b40801fad2f3be70d92705eed6f33` | Markdown | documentation |
-| `docs/pilots/nycn-organizer-asks.md` | 9601 | `341197fb521b07f5219742f5665a6f45d13ec35ff8ab7d8b1cfc5ef4771b7448` | Markdown | documentation |
+| `docs/pilots/no-cli-organizer-member-rehearsal-workflow.md` | 14212 | `d8a8eb32d1b66bc9060aa50af9fb2d3f00f4b43e1656a03177834a98b58da7b8` | Markdown | documentation |
 | `docs/pilots/pilot-proposal-template.md` | 6687 | `3fc4ef30cb9c851a242b365594c6c82e220dfedfde1fe5e6baaaffca77902a33` | Markdown | documentation |
 | `docs/planning/agent-knowledge-architecture.md` | 18309 | `f060caf881db274d12898a944e710e1936600d89c81f02e71404575eb0e5dbc9` | Markdown | documentation |
 | `docs/planning/documentation-namespace-resolution.md` | 4585 | `a8b9829c1435edf8216484cbfa346aa4f4b76b89937a62065ab4287f27275e95` | Markdown | documentation |
-| `docs/planning/icn-crate-reference.md` | 25176 | `96c871297c482393b9cbe7d81fc59debcd539b5c4a457de506525747064ac25b` | Markdown | documentation |
+| `docs/planning/icn-crate-reference.md` | 25217 | `44278a69f1c91c5d2579bde30f37656fd50d575e2f14bd2c02c7360770a2692d` | Markdown | documentation |
 | `docs/planning/icn-demo-one-pager.md` | 7378 | `8dcb4f43bb2148a4b3122d5920069fbe4621ab82c30b32d704b8d49bcbd2206b` | Markdown | documentation |
 | `docs/planning/icn-demo-presentation-prompt.md` | 8319 | `0a4f6fb652f6bfb79f70fad12076745a7312b7aa1744dd243f76bed343466186` | Markdown | documentation |
 | `docs/planning/icn-ecosystem-map.md` | 21683 | `206554c51ad01cce3616a17a4f246ab225a1f92a42fadb6d94eec6dd31ab1db6` | Markdown | documentation |
-| `docs/planning/icn-vertical-slice-assessment.md` | 16314 | `6e7335c35509b97f54c603b3029b20c546b3e75d880698155a9574bdbd7db514` | Markdown | documentation |
+| `docs/planning/icn-vertical-slice-assessment.md` | 16793 | `0ea0a90f205555a9745910205466fce6f90f2ddb59cfc9ec2cf824d7a78497ee` | Markdown | documentation |
 | `docs/plans/.scratch/README.md` | 1229 | `406f7478fa2d159da719f58738d5adf75452855a11da3635dc08bed808f63e2b` | Markdown | documentation |
 | `docs/plans/2026-02-13-ui-polish-design.md` | 24687 | `6ff66e6a37660a66319fbb4fbb7d69b7dbffe987b4e1a8000fa6018a8e3a58e4` | Markdown | documentation |
 | `docs/plans/2026-02-14-icn-consensus-stack-a-to-b.md` | 63883 | `e806cb9ac22f238ddd18a416a751790cb5524abe71faf44be4a95181dad727b9` | Markdown | documentation |
@@ -1743,7 +1915,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/plans/2026-03-07-demo-system-design.md` | 15723 | `81f8e4483b92f8fac29e0abe0463ae17092e61f75d02f9b8ca60845993d7e5e2` | Markdown | documentation |
 | `docs/plans/2026-03-07-demo-system-implementation.md` | 34111 | `eec06b801b2084458338a2064bd371847df5fa4563a95076ac9740662e4a2587` | Markdown | documentation |
 | `docs/plans/2026-03-21-sprint-21-meaning-firewall-policy-extraction.md` | 24825 | `0c8d34f95efb9c0c77d26a78eea93390f3156ac46a7b3a74e8b40101381c0273` | Markdown | documentation |
-| `docs/plans/agent-teams-launch-prompt.md` | 15002 | `472d28d22531f71e9f85cfab52bb3da97357276029aac3a3a2dd37c6aae60d93` | Markdown | documentation |
+| `docs/plans/agent-teams-launch-prompt.md` | 15195 | `11ef2712f116446c4752100d29a4805adf4da1cbfab6cfa5ed32de050b6fcdc3` | Markdown | documentation |
 | `docs/reference/api/API_REFERENCE.md` | 7438 | `0fadf58b9007ac78d2a0432cefeb3705fff74556a817248c597e14e530cd1675` | Markdown | documentation |
 | `docs/reference/api/README.md` | 460 | `53b9712e38db1c8ccdcb8d3d9a8901489e5c456504cfce75c40f130986bd40b0` | Markdown | documentation |
 | `docs/reference/api/api-versioning.md` | 13258 | `7da8b162371b25b8b6be1b6934ec55df68d6fbe94b463623fce8cc98e34b98c0` | Markdown | documentation |
@@ -1757,29 +1929,51 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/reference/entity-topology-patterns.md` | 8297 | `9440c2dcb73e814e44a0fcd7601d9415700f29064b8b03453edc9998f418e28b` | Markdown | documentation |
 | `docs/reference/governance-playbook.md` | 9914 | `7cf8d6b194326e5e169068748da27ca3f29ae5c73a0ad84ed7e60984a730dde5` | Markdown | documentation |
 | `docs/reference/institution-package-bootstrap.md` | 4876 | `607b4dbc13267b91d381ea84242bc5a2e137450bd44739856a9ff5a9b41dd14f` | Markdown | documentation |
-| `docs/reference/project-index/README.md` | 5834 | `f0cae4c5e3e260e6c75f2460b73bfab577dd3d7432250644f71620fd7b4c37bf` | Markdown | project index / atlas |
-| `docs/reference/project-index/ci-ops-deploy-map.md` | 6918 | `f446fe85cd2e99cd566ad460eba4f6352e7fe3213132bbcd564628d9ac897566` | Markdown | project index / atlas |
-| `docs/reference/project-index/current-truth-map.md` | 6250 | `1788b1be52347a27f3e8beec4e50af78cc5cbca291ce292e5fc036008bf46e3e` | Markdown | project index / atlas |
+| `docs/reference/project-index/README.md` | 10895 | `b2da92bf909d786ae76eacca13df4a7618f78c60699ecf33054ff09b3844d97a` | Markdown | project index / atlas |
+| `docs/reference/project-index/ccl-map.md` | 4809 | `d5a5b36ebf53ce8b185e0d23a04af55dff0d08c4e0738db66e6ab6ef2b4f984e` | Markdown | project index / atlas |
+| `docs/reference/project-index/ci-ops-deploy-map.md` | 7404 | `75d672049f162c4ea1b5fc205f4842d1a7d732fcec7c9b64b3486357d53133e6` | Markdown | project index / atlas |
+| `docs/reference/project-index/current-truth-map.md` | 6143 | `57b26f5d7ed0846ebf690db55b5dcf9fd64eae7ed09793df25f7cb21bef2c2fe` | Markdown | project index / atlas |
 | `docs/reference/project-index/docs-control-map.md` | 7227 | `41469ea307fb54c0466e6d20feaa8449b7bc643c45790574683237f030987c7c` | Markdown | project index / atlas |
 | `docs/reference/project-index/full-repo-record.md` | 7597 | `56a3be5e123f70aaf8fce07505f6143d486e04951ea35a94b8f5b0b7dd4d7730` | Markdown | project index / atlas |
-| `docs/reference/project-index/pilot-and-nycn-map.md` | 6693 | `c20cd1257a54c935e291e5e964d44ebdc611231928240353bc9fb9bcb2a663da` | Markdown | project index / atlas |
+| `docs/reference/project-index/generated/agent-context-spine.json` | 106372 | `a68345f938a12c782befa3e4fa1c597068c9911537aaaa5c599bed9d63ff6e57` | JSON | project index / atlas |
+| `docs/reference/project-index/generated/icn-file-record.json` | 1350034 | `cf7c2b7e6c389a6adec7f68dfd68cfeeb0824add14fa9e5c2656b80a49fb2f74` | JSON | project index / atlas |
+| `docs/reference/project-index/generated/icn-file-record.md` | 464970 | `3b9cf01f4205225e78ebfcfb81cabd6ecdb5a7457bc1205b92d71aa9b4b2c480` | Markdown | project index / atlas |
+| `docs/reference/project-index/generated/route-inventory.md` | 76341 | `9298458ceb36c2a253a982be6e0136699fc9a0262fdcbfc3c0d616db828de6ae` | Markdown | project index / atlas |
+| `docs/reference/project-index/identity-crypto-map.md` | 5006 | `cffd912bd654b76ee514ab3a3a574e44adeec3e7a953de89e4adfcfe5ebac828` | Markdown | project index / atlas |
+| `docs/reference/project-index/network-gossip-map.md` | 6833 | `2b4269277bcc2291b85f66a676eb1d382359f8d2e73b3af4c69eb32ee02ce117` | Markdown | project index / atlas |
+| `docs/reference/project-index/pilot-ui-current-state-map.md` | 4777 | `6657b47f6cddf503b39c1c0939127e7a71f5f2ddfae4385fba09081f8b35c4c1` | Markdown | project index / atlas |
+| `docs/reference/project-index/project-coverage-matrix.md` | 14971 | `573d6ddbe32e89a6e35cf30b5ea4e151321a4a0e34af2ef1d5fe49d0897b6f07` | Markdown | project index / atlas |
+| `docs/reference/project-index/proof-level-taxonomy-capability-matrix.md` | 22249 | `e57f919f70df3299b162b5058ebbdff7cc6dc65b4ab461ee8ca1f0a95a4307c0` | Markdown | project index / atlas |
+| `docs/reference/project-index/remote-work-plan.md` | 1935 | `090c23f7c6f86b661615e6b999a11fb2584ad89b26bdfc11fde4dc12b42ccdfc` | Markdown | project index / atlas |
 | `docs/reference/project-index/repo-atlas.md` | 5616 | `b4720b3ccb32ea97cf67e3e142cfe7af5adcf0a2f6735ce2065c12b922f63c50` | Markdown | project index / atlas |
-| `docs/reference/project-index/runtime-surface-map.md` | 7495 | `4c659b71a3aa3980aeb1c9b5431f4429caedcf84c612b374da9292b6a4259891` | Markdown | project index / atlas |
+| `docs/reference/project-index/repository-map.md` | 5833 | `364afe68002cda1520e891807dd9d650f6651112bacff214ce57f1587ed3da1f` | Markdown | project index / atlas |
+| `docs/reference/project-index/runtime-surface-map.md` | 11267 | `154f524464e4cf4fda7c76f8147aae5aa9545ce6490bdfd45d3510b0278bca79` | Markdown | project index / atlas |
 | `docs/reference/project-index/rust-workspace-map.md` | 6194 | `ee344929ee477539372971b4f1f44375a324cd3dffcccaa5cb57fe6cb26d3eb4` | Markdown | project index / atlas |
+| `docs/reference/project-index/service-hosting-map.md` | 5340 | `3058ab04e6d21e55d29ea65173b333a6bc9d707d1e6ed49c2be83b01e59c8d2c` | Markdown | project index / atlas |
 | `docs/reference/project-index/show-readiness-map.md` | 8835 | `1efd2c3450fc98cd0e3187dfa18366beba54779cd33383dc1daf5af856c8250e` | Markdown | project index / atlas |
-| `docs/reference/project-index/source-tree-map.md` | 6044 | `5d986771d0cff362baa39053b2e448d31dabb9023ad0908e71df05e910875222` | Markdown | project index / atlas |
-| `docs/registry.toml` | 111804 | `1e96df2049a5114bc58777693f091ce3d448783b8e0a8dba0be29476553a756a` | TOML | documentation |
-| `docs/rfcs/README.md` | 4884 | `33897ef7c0a9f03d7e5b784ca01d51db08d42606cd73d4131d073ff0f5f22e06` | Markdown | request for comments |
+| `docs/reference/project-index/source-of-truth-map.md` | 9824 | `86a7f1298cd6c16168508233d1e931b797f56121b803124c88dfe22bf3aa5b79` | Markdown | project index / atlas |
+| `docs/reference/project-index/source-tree-map.md` | 6084 | `3eec9a5e92948cc67093ddac43310e5bef5be3b7dbd07a28f1369ee8f7fddbd6` | Markdown | project index / atlas |
+| `docs/reference/project-index/stale-and-archived-map.md` | 4967 | `df2487b6062c051c08afe0bbfd45c9979630dc412321b47212314aba44216320` | Markdown | project index / atlas |
+| `docs/reference/project-index/tool-commons-map.md` | 6015 | `82b53c42f5b7b22e856b4f45ec0b1c78ff08ace40beedbab56e541d72c5c1d8d` | Markdown | project index / atlas |
+| `docs/reference/project-index/website-truth-map.md` | 4785 | `4737cbee0ab9a1e860eb55bc0e4f344ffe750a813c490ef05843b11f1e85282d` | Markdown | project index / atlas |
+| `docs/registry.toml` | 167435 | `d583b268217bade099ba349c8c382c8697bdcb66de374b864400e1f8d76f6601` | TOML | documentation |
+| `docs/rfcs/README.md` | 5324 | `cf109b12e3c96f1940cd8b54303c4bcba9bfc0cd705a9df83b295625947a5e37` | Markdown | request for comments |
 | `docs/rfcs/RFC-0000-rfc-process.md` | 12207 | `ccb99a67bc4c412e39114596f3c97ae496cff46bd29010aa2f80f292b27d432f` | Markdown | request for comments |
 | `docs/rfcs/RFC-0001-obligation-allocation-settlement-primitives.md` | 34160 | `643b05a55e58bb4b2b7b97e92a9110456c49dd929e190452d445fe8284111ba1` | Markdown | request for comments |
 | `docs/rfcs/RFC-0015-public-surface-and-learning-repo-architecture.md` | 21922 | `46761a839d0cbe79343b56f4ece02d41b6994f033908c5c6a58c1b004bf2a7b7` | Markdown | request for comments |
 | `docs/rfcs/RFC-0016-relationship-surface.md` | 14532 | `5c21a9fd7e0526560a78d0d08522fb194fb26eed1ac0bc0371ff1b71389d7d77` | Markdown | request for comments |
 | `docs/rfcs/RFC-0017-tool-install-infrastructure.md` | 57715 | `9d3e3c48e234dafdb56e98491f476d69fb3e848d14c5e97c65dc3f97fe1e1a89` | Markdown | request for comments |
-| `docs/rfcs/template.md` | 6716 | `88993eecb74db28584bfcf8a07bdb589125dbb00f026c64663a71bc7d0978d76` | Markdown | request for comments |
+| `docs/rfcs/RFC-0018-entity-aware-request-authorization.md` | 24082 | `17aac64560ebced6c9ce2ea5712febff28707a3b9a4eebdaee514c3464732baa` | Markdown | request for comments |
+| `docs/rfcs/template.md` | 6966 | `6f7dfc65cb155b280902f70ad65eb2956d63811f8dfa0666f9f94262b8d7c917` | Markdown | request for comments |
 | `docs/scripts/doc_control_check.py` | 28650 | `0c36890093b788ebc2654383b65b92bcd105f7a79a6d691130af7cfbf4199f76` | Python | documentation |
 | `docs/scripts/freshness-check.py` | 7140 | `1a7ac460b96309ee97dd7f069415b849ad518631cd69b69352b2f7d87cf6b15e` | Python | documentation |
 | `docs/scripts/generate-index.py` | 6708 | `2245c66bf47ff62c7c468238e2c3984f6423ea27585fc9a5d339521f1119c225` | Python | documentation |
 | `docs/scripts/lint-arch.py` | 9293 | `daa9e01015f6af7b8aebe94671593a54b0913134b144a7b6075c57d21d553532` | Python | documentation |
+| `docs/scripts/route_inventory.py` | 26456 | `c8316e636befbccfb4953eb9696fa926bf32d0742b297dbabe676c85aefbb2a8` | Python | documentation |
+| `docs/scripts/validate-action-card.py` | 5778 | `7782806b1f6c6db578dc9d8b0c0171394c05064c616db76af690d7c554e237b8` | Python | documentation |
+| `docs/scripts/validate-preview-review.py` | 5911 | `e03079bffa878602f8a1f6fe31a2fa22b122e92a5c026a2cc67ab4451c0235bd` | Python | documentation |
+| `docs/scripts/validate-rehearsal-evidence.py` | 3245 | `4283d40fa78962cd70585655d91493dbf50165b377cf44c169e3aa5ae6892e81` | Python | documentation |
+| `docs/scripts/validate-rehearsal-shell-fixtures.py` | 12558 | `f6244bc1d9c3c748c2b4cbb8dd2ad7be5de36c73af573e9a421cd045d6e5eaa9` | Python | documentation |
 | `docs/sdis/SDIS_API_GUIDE.md` | 9395 | `d18e4b629ac49345790b907280d632db65db0afb4856a1f80500b4456c43663a` | Markdown | documentation |
 | `docs/sdis/SDIS_BUILD_PLAN.md` | 9038 | `694acab2e41ba8ff473dcea546e773d55cef649b4dd5dbc65ac8fc9c8809895d` | Markdown | documentation |
 | `docs/sdis/SDIS_DEPLOYMENT_STATUS.md` | 6944 | `8442305558f500756a3169556c9071f95e24b9471bd0b0a427289bf0451f18bf` | Markdown | documentation |
@@ -1814,38 +2008,70 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/security/security-roadmap.md` | 67546 | `6f70f730bca871c41b3c329bcfc7b8dd6c2496ccaf661006bae9e2ff06bd52c7` | Markdown | documentation |
 | `docs/security/threat-model.md` | 42915 | `0c65b48fb8af06cb38fca524cfdb30db00d8a550741073f856dee26edd01de0a` | Markdown | documentation |
 | `docs/spec/KERNEL_CONTRACTS.md` | 43575 | `f155ea33758b4ae17b596fb6258280a9b59197c9e58288237857c0c19d7e9d9e` | Markdown | documentation |
+| `docs/spec/artifact-registry-and-scoped-vault.md` | 40946 | `534cc1e69c4f732f80ec087b5cea9488bc4c46a42e230f2d6641a4c55536d701` | Markdown | documentation |
+| `docs/spec/ccl-policy-registry.md` | 31095 | `1ad90bfbde1d0894f8d0ae20ad5a06c46dcb9742b7d2f49230e64bfd81a1b1d0` | Markdown | documentation |
+| `docs/spec/community-proof-spine-0.1.md` | 4248 | `1e1fb6a1419b322a5dd8c620efd6c1d86e1663422e89fbd6eb997b9c4296554e` | Markdown | documentation |
+| `docs/spec/compute-placement-policy.md` | 42980 | `0c2bf89b907314af12dc54ecb900be6cfb3a2e38cdabe69f5d20d7a432adf698` | Markdown | documentation |
+| `docs/spec/effect-dispatch-contract.md` | 32302 | `606185463032c118419bb2a66453676be573215b476e38406ba476a57faf24ab` | Markdown | documentation |
 | `docs/spec/federation-settlement-finality.md` | 8994 | `7185d61adca2106ff75548ce8becd1b148fa74144d500e175e1edead98d24368` | Markdown | documentation |
+| `docs/spec/governed-service-binding.md` | 34764 | `58cf2f6325811a8e3ec6fedf0e69de3405eb8ed0d2e897cb0cd5b709f76559bb` | Markdown | documentation |
+| `docs/spec/icn-civic-shell-v0.md` | 20994 | `1fe0173f124546f8bf56065c5b72f5656792f2985e227b668d0531572fdb48d7` | Markdown | documentation |
+| `docs/spec/institutional-domain.md` | 31503 | `38aecb4974296b76c700dcafc856e6d3a94938e4b1b33024da706116ed563df4` | Markdown | documentation |
+| `docs/spec/member-shell-i18n-v0.md` | 8575 | `bad089b0005913ccf6c76e4cecd7f957981d12f2a3586b6050acb756f7905268` | Markdown | documentation |
+| `docs/spec/member-shell-v0.md` | 49126 | `6605394ad9c6cffcd41f43cc71519a840abb3d9c901681f65bbbddcedefb30b5` | Markdown | documentation |
+| `docs/spec/network-anti-entropy-proof-loops.md` | 58756 | `c739881e62365275fdb1a31695d838c5257bac5d8de20a751cd61f94957c98b1` | Markdown | documentation |
+| `docs/spec/private-overlay-did-activation-flow.md` | 20791 | `e5d59ab6015933b169780d97632db4b2c41b672c13d24a80b2fc43f8e8f83ca6` | Markdown | documentation |
+| `docs/spec/steward-cockpit-v0.md` | 54364 | `f7443f6c0981d62c18cda3dab83981bbe6f70a74f53ef976ed8c2ef9684445f7` | Markdown | documentation |
+| `docs/spec/storage-durability-policies.md` | 44481 | `b499973200c2b465c4e4626991daf32ffc91f3daea413e43246fa3a5c48ec2fc` | Markdown | documentation |
 | `docs/state/ICN-Platform-Baseline-2026-03.md` | 10597 | `e43abb5e5e6fa30338bb013b07b0e40cdcf8f2a6b2d4a610261544a72557a26e` | Markdown | documentation |
 | `docs/state/README.md` | 316 | `60c875c35c649d74f4d469fc2fe0b5ecfc0e07bf4082c1e5b04a44fd93830d59` | Markdown | documentation |
 | `docs/state/demo-path-2026-03.md` | 14599 | `d9953baa438c4171537265685ede2a1bc97c21b0bbb4dc7da5e4043a0d8680f1` | Markdown | documentation |
 | `docs/state/storage-governance-spec.md` | 7390 | `3fad1d9ebd10d1b851e87ba109a02e906e5815fbd6d73db5a9c41846454e8332` | Markdown | documentation |
-| `docs/status.toml` | 8299 | `356bfbc01b6c1d8bc9103de21ab1da6d978956f45d3b1fcd7610a429a3ec386d` | TOML | documentation |
+| `docs/status.toml` | 14153 | `62fedac7e7e9662d0d28613a257307db9a10189d44d13eba772038f59b97b2e5` | TOML | documentation |
 | `docs/status/DEPLOYMENT_VERIFICATION.md` | 9068 | `47216764806d4cc7dac534773ed1a0d0644077e397f4143ed3b19851e6b7256a` | Markdown | documentation |
 | `docs/status/MOBILE_APP_DEMO.md` | 3575 | `b1401f93332ca8e1b9b69e4ac2a425c08104ee4a635df2ce84f20e0cf4a63411` | Markdown | documentation |
 | `docs/status/demo-audit-2026-03-19-flow3-verified.md` | 1638 | `faa07d359d607cbe8be43ba80b167b5e006ca11bb9e768e3951fa28bffdb5ae1` | Markdown | documentation |
 | `docs/status/demo-audit-2026-03-19.md` | 8116 | `952bcab2bdb178249aff5cdd528c9732eb4860bc381dbe3e18a7a52c0c71576a` | Markdown | documentation |
 | `docs/status/icn-status-march-2026.md` | 5930 | `b561b05405d2479d8bd7d1cb7e9e62433e73bddbe906d0e433c3ec29c291d6b0` | Markdown | documentation |
 | `docs/strategy/ADR-001-What-ICN-Is.md` | 11300 | `2de20cd82ab3120328064ae38a52306f1fded556640d4586d05337bae93c5e33` | Markdown | documentation |
+| `docs/strategy/COOPERATIVE_CODEBASE_MEETING_BRIEF_2026-06-11.md` | 9846 | `1dadd9cc5e1f81ff46843d71d8c06913e5d6d1d830ff530d2d46164d010fa00a` | Markdown | documentation |
 | `docs/strategy/COOPERATIVE_DEVELOPER_DISCOVERY_BRIEF.md` | 9848 | `94e8ed795d8682a7b566f58a7dec34e81ac4e199a0480d795d7252979bee2de3` | Markdown | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_MEETING_PREP_2026-05-21.md` | 17910 | `360029bbac59cbe96709f5e7a014f75525b6cf61121f8a584d66b6076a3413c3` | Markdown | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_MEETING_PREP_2026-05-21.pdf` | 165389 | `e846592f5c147c2160a885f864a95214e800087d15d5db9f9dfc122db855ebd1` | unknown | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_ONE_PAGE_AID_2026-05-21.md` | 31589 | `7f78a97233d4b1d14947c1dbbb40244fc8dc79fcf04b530ced8f2ceb68c5eb64` | Markdown | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_ONE_PAGE_AID_2026-05-21.pdf` | 242607 | `cbf34c66e5a49ddf0d27a7a4f049c04500ad8fbcd2335fec52af2a595a20ed6c` | unknown | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.html` | 19189 | `c5c20445e3fb4f484049830b14caa39b109e8a4757d53d59b9d2b77d829d8cd8` | HTML | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.md` | 11555 | `bcbacb3c29084c8be91ce2fcafa0fbc32852398cd3086ee87ea06763c0eb9197` | Markdown | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.pdf` | 179584 | `f0c3225f516d1efeea345f4b2c4217a393b9c6b676ba881faaa509cc416e503f` | unknown | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_SCREEN_DECK_2026-05-21.pptx` | 172986 | `9ce29f3a9ddeae3e50f68b43173d404c8279d6e82f08ed19ec7559e2b521081b` | unknown | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_VISUAL_AID_2026-05-21.html` | 24742 | `b192fc6759b79753b8032ac711611deeaa6069e2c26247aa723e629e0a982e53` | HTML | documentation |
+| `docs/strategy/COOPERATIVE_FORMATION_PLATFORM_VISUAL_AID_2026-05-21.pdf` | 275703 | `8d434494eb2e798e9a40a9daf229b3713bb56e18ade29a8a41f042eb16727a8c` | unknown | documentation |
 | `docs/strategy/ICN-Definition.md` | 19525 | `19c043c27537aed32b9a29a2cc469e2730aed34432bd68303486482d7915a9d0` | Markdown | documentation |
 | `docs/strategy/ICN-Evolution-Arc.md` | 15612 | `cf3f02a4eff538c0d455295fea4a676c3bf0f320ed5117f0f00616ce7f8e60ef` | Markdown | documentation |
 | `docs/strategy/ICN-Gap-Analysis-March-2026.md` | 27156 | `767f2300f8744b52ff8992b6d33d0c67b3449fd455a729ca9540b371468379bd` | Markdown | documentation |
 | `docs/strategy/ICN-Institutional-Operability-Roadmap.md` | 10602 | `a4433896dec67a7d5a0613694f6ce8e08bb4b4b4cf4ba6459fb87941ff8a3e9c` | Markdown | documentation |
 | `docs/strategy/ICN-Pitch.md` | 7299 | `b194cf7abdb6ad95f28fca2cb8b8a9d20c99e43c4cb81895431d78a3faa73cca` | Markdown | documentation |
-| `docs/strategy/ICN-Roadmap-Live.md` | 10737 | `e3b272fde76dd47720a1ec58627c4da1ffde85a618ac658bb357689a024ca29a` | Markdown | documentation |
+| `docs/strategy/ICN-Roadmap-Live.md` | 10737 | `87e5440fa4e8dbdcc2d2e76a71d2667be532f9ad92ed2b0d525c473d4454f1ad` | Markdown | documentation |
 | `docs/strategy/ICN-Roadmap-Strategy.md` | 15719 | `5b5d8368b11d4741b8fc0279541a61d4f7652793353047f82ba52ab426d05873` | Markdown | documentation |
 | `docs/strategy/ICN-Scenarios.md` | 16029 | `f479903369ffd5c2cc8b9c351c900ee21b707a11f005751e237ca3da6cc291c9` | Markdown | documentation |
 | `docs/strategy/ICN-Sprint-March17.md` | 10094 | `a00e74f95515da1d4ee6d0f576bb200348200f0123faa48f95a98a44113a3865` | Markdown | documentation |
-| `docs/strategy/ICN-Technical-Whitepaper.md` | 18885 | `291ba9a304ae2cfd5a3b93b864c12cdd56d4813d77046c0bbdca0ad5760aeefb` | Markdown | documentation |
+| `docs/strategy/ICN-Technical-Whitepaper.md` | 19043 | `9e1a4c75d31d24a273e181b7b5e220027ad12566d2d9159e855fd20358b6af85` | Markdown | documentation |
 | `docs/strategy/ICN_CONSTITUTIONAL_ROADMAP.md` | 17872 | `18f07c593eb63c02c64311dfe32a8faa8679411bba971018227b9a10d5410a74` | Markdown | documentation |
+| `docs/strategy/ICN_FOR_COOPERATIVE_MOVEMENT.md` | 22865 | `676040e559e926c1c6514344b6b1ae68262f043bb1451269f8312fbf6dfce7dd` | Markdown | documentation |
+| `docs/strategy/ICN_FOR_EVERYONE.md` | 18902 | `5a9bed8d22cef1104ef398b054119221b9595f2a5d88f6d6909e6c2f3dba3ef2` | Markdown | documentation |
+| `docs/strategy/ICN_HANDBILL.md` | 1752 | `2f3585e6ca67d57311ebf519038c00d712f8ad2dbbebe1712760209eff1e5df7` | Markdown | documentation |
+| `docs/strategy/ICN_HARD_QUESTIONS.md` | 13440 | `82a0b20aedd37c1b7afe93b10a8c9ea886ef4d3e829b525dfe235bff05c10e8e` | Markdown | documentation |
+| `docs/strategy/ICN_INTRODUCTION_EVIDENCE_MAP.md` | 9570 | `18eaa42e5b7068747907eb0328a97354bfa4c51fed98697b3fd12ecdcfe43b01` | Markdown | documentation |
+| `docs/strategy/ICN_NYCN_INSTITUTION_PACKAGE_BOUNDARY.md` | 7346 | `dca97a938d2a1d259a279706989976f70e78a25abc7a7da1d420df607734c993` | Markdown | documentation |
+| `docs/strategy/ICN_THURSDAY_MEETING_BRIEF_2026-05-21.md` | 26033 | `fb708ad47186c1c325c5b9068f3c0655ba732b297b552b55c2575482eb176005` | Markdown | documentation |
+| `docs/strategy/LICENSING_STRATEGY_MATRIX.md` | 24793 | `116798f025909f3fc1bb1a843a89bcd3c929c81693e7b657de9cfe32908c7ff7` | Markdown | documentation |
 | `docs/strategy/NYCN-Charter-Draft.yaml` | 11862 | `41691a31793301a30a26dca2cafec395a94370bce94768f6fad5896d8bdd8a89` | YAML | documentation |
-| `docs/strategy/NYCN-Execution-Tranches.md` | 22975 | `836b2a4b7b4291decc3839347a7d097f24f5024738cca2e953fc91ce05cf9ad7` | Markdown | documentation |
-| `docs/strategy/NYCN-Implementation-Matrix.md` | 33442 | `bdd067270cb237eb533679eadb48d2f00cb21f5ed87f03e614d8492e481bb030` | Markdown | documentation |
-| `docs/strategy/NYCN-Implementation-Plan.md` | 16524 | `255028adeed75ad8cbe1501d8c1d94af1d3d0b0b5851945be0a61f44a1d24ac0` | Markdown | documentation |
-| `docs/strategy/NYCN-Institutional-Design.md` | 34441 | `a946f454dec0512871fb72041bfb5617827033323eac149619b5c16a34e9444e` | Markdown | documentation |
-| `docs/strategy/NYCN-Institutional-Strategy.md` | 17443 | `92c08eee8e8953790b412bf460762c1d02c1a09c6351c23c0d7315fd5bbeaf72` | Markdown | documentation |
-| `docs/strategy/NYCN-Repo-Architecture-Spec.md` | 54411 | `d6e20f0b6e4167a18a3803fb354e8a48bfafef4d40ba7e10b9ddc06aaa785bd0` | Markdown | documentation |
-| `docs/strategy/NYCN-Sprint-Plan.md` | 12184 | `3b7e6eb08f29079049c5c61d84dfa7a5c057b4313589f4d4d5dc451bb79d8d9a` | Markdown | documentation |
+| `docs/strategy/NYCN_ORGANIZER_MEETING_ONE_PAGE_AID_2026-05-21.md` | 1698 | `c3e4f4e2a3a75536111d5f19be65d859e52b7db59d8a69994faff6821f865f9c` | Markdown | documentation |
+| `docs/strategy/NYCN_ORGANIZER_MEETING_PREP_2026-05-21.md` | 25908 | `d0232d7e0aeb7c0c93e1fae5ba943efa97f6a229e05c675342e9d7e0def77af4` | Markdown | documentation |
+| `docs/strategy/NYCN_ORGANIZER_MEETING_VISUAL_AID_2026-05-21.html` | 20194 | `6fb13ae2b83ac9f2aa198cd3733a82da391285343edebf04012bc83c73a26f8a` | HTML | documentation |
+| `docs/strategy/NYCN_ORGANIZER_MEETING_VISUAL_AID_2026-05-21.pdf` | 14782 | `59ce5d83c2445931970abfc7818e4a77f0727ef3884a42c45e3ee0b10ec3c233` | unknown | documentation |
+| `docs/strategy/NYCN_SUMMIT_REFERENCE_INSTITUTION_STRATEGY.md` | 12899 | `6d6b630a3e1c912c5aa20d994840343e3ee42a67f583bd99e6f9068ae08f124c` | Markdown | documentation |
+| `docs/strategy/SOVEREIGN_FORGE.md` | 9823 | `0532f20806f4a01687d6b5974653171335b56131b359ae759ecdf8cdf6cfbd51` | Markdown | documentation |
 | `docs/strategy/grants/README.md` | 2161 | `cc5ff8aa1e7d85bbe2f86f98a0b9f41804a270c1a37e338fa38443d59413097f` | Markdown | documentation |
 | `docs/strategy/grants/budget-skeleton.md` | 3627 | `ccb326237b6395d89f0811934bba2589fafec2fa16ce004fa0ee13d98f962c06` | Markdown | documentation |
 | `docs/strategy/grants/compliance-architecture.md` | 5502 | `64356030b96100048d1e18b780eb7dcca4e7495ed304ca857caeccccff1786b0` | Markdown | documentation |
@@ -1856,7 +2082,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/strategy/institutional-ecosystem-arc.md` | 14290 | `835accdc4788047e2488a156a14ef3fdb35c441a2fab0b99b5350139840396dc` | Markdown | documentation |
 | `docs/strategy/operability-audit-2026-03-25.md` | 9573 | `d177bcb3cb1b661693d0bc4a98037be0722fb8080ee9966b15504418bbe1da07` | Markdown | documentation |
 | `docs/strategy/sprint-24-close.md` | 3608 | `0e12d4488c317036cf4efeefd062c1dcdb8a8e27cab5d8afb4e90f6fa519692d` | Markdown | documentation |
-| `docs/summit/workshop-proposal-draft.md` | 9261 | `9e2426fb88c94bfb34553e7b758c7b4c363ae6cab7d9d7305ff818d28638829e` | Markdown | documentation |
+| `docs/summit/workshop-proposal-draft.md` | 13525 | `433929518918ea2282d1f823ffc974a543cd2cf25fa966be23eecc0119df9094` | Markdown | documentation |
 | `docs/superpowers/plans/2026-03-22-sprint-23-baseline-lock.md` | 42648 | `cd3eb43dae7db4e28739436ba951a5bb56f52f891b14d0bf0399328702baf4c6` | Markdown | documentation |
 | `docs/superpowers/specs/2026-03-22-coverage-ci-decision.md` | 11226 | `c7f9253ef5d1284d3041b589649a4d32b1b3b3c6ee1494081fb6ff80cfd120fe` | Markdown | documentation |
 | `docs/superpowers/specs/2026-03-22-flow2-repair-checklist.md` | 7772 | `9f11d4b7d1382084459a4d18a82c4515f814ba08a1ef1648ecc7313d93958d7f` | Markdown | documentation |
@@ -1878,7 +2104,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `docs/testing/QUICK_MOBILE_TEST.md` | 2594 | `653077ad438af08758ba55c8d8d7ea119f73a42dce89bfda448d5fd18401f36a` | Markdown | documentation |
 | `docs/testing/TESTING_SUMMARY.md` | 6259 | `6390bcee56d12382084caaac16dac3d522b992244ff52e183ae638a9cb3893cd` | Markdown | documentation |
 | `docs/trust_policy_oracle_sequence.mermaid` | 1470 | `48340a9da3c6d363047de4d4a8f4995b5f1a25116fd648794b74e6ae91bc0ffa` | unknown | documentation |
-| `docs/vision/COOPOS.md` | 35762 | `b6a2cc706bed35485ca1c0d4fa5cbd22b76c4aab7031c5776535f6e8cd6369bb` | Markdown | documentation |
+| `docs/vision/COOPOS.md` | 35793 | `350b8e4d4a9c9e3b5a863ad2eb7ed8b5743b4e7a67c85cee12a9fd7fc5bae8c5` | Markdown | documentation |
 | `docs/vision/FUTURE_WORK.md` | 11924 | `015aee459ef8429cf3a1586551e0e7b31a404e71356a3328a9499c7918c2542c` | Markdown | documentation |
 | `docs/vision/README.md` | 1199 | `1cf049157eab22bf4c2c28cea197eb87acb9468924f75f6d1ae35a67736cbb4f` | Markdown | documentation |
 | `examples/01-quickstart/README.md` | 7714 | `793d81fc9259e3e77e9fc22edfb7b04b1ec48d9bf6ed79255855cb7379bd7824` | Markdown | uncategorized |
@@ -1908,8 +2134,8 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `examples/mobile-app/assets/icon.png` | 0 | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` | unknown | uncategorized |
 | `examples/mobile-app/assets/splash.png` | 0 | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` | unknown | uncategorized |
 | `examples/mobile-app/babel.config.js` | 163 | `3972ce4348d08515c3e3eed50f66025cb042c3d6a6149d1092917eec6eb8c7e8` | JavaScript | uncategorized |
-| `examples/mobile-app/package-lock.json` | 452753 | `70a503901edb66a4c2e487e03a97ed91597970614d12b7fe0bf2e6798bc17520` | JSON | uncategorized |
-| `examples/mobile-app/package.json` | 1002 | `89835ab34958359de542f10ee0df017c69e087b269eb3e56a0c228dd977b5b4f` | JSON | uncategorized |
+| `examples/mobile-app/package-lock.json` | 403126 | `182ace725ea4fc253ec6741d1f9bbcd8e0eabc0c15c1ccd5b89063ea88f094c9` | JSON | uncategorized |
+| `examples/mobile-app/package.json` | 1003 | `5643343dd31d3ecbfa9a9ab9b82c8a00afef5a54bfcb0cc5ce6ebdd1c29631a0` | JSON | uncategorized |
 | `examples/mobile-app/src/contexts/AuthContext.ts` | 673 | `c8a1bf9a2ed1fc9403c3d43fba22d283a8ad863ffdaa41b8396ae3e1af231791` | TypeScript | uncategorized |
 | `examples/mobile-app/src/screens/CooperativesScreen.tsx` | 1014 | `08d55b1efd43a0a72ae10636ca13d0eefd0dace73aa0c8c1ea4cf12615b619a7` | TypeScript/React | uncategorized |
 | `examples/mobile-app/src/screens/GovernanceScreen.tsx` | 1000 | `239553714a0c33957e9bc34ce7c9aaac7cc852a3f361d22ee1266f34f6bd98ec` | TypeScript/React | uncategorized |
@@ -1930,50 +2156,79 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/.cargo/config.user.toml.example` | 624 | `dea544add56c74402e7d57d3005b8b643504dda9996eb5ce250d16887e128a27` | unknown | uncategorized |
 | `icn/.config/nextest.toml` | 779 | `f431e3fb17e3b1d97eab6e165b64ccb07a21092711e4366fc4bb19f5f3cdfe50` | TOML | uncategorized |
 | `icn/.dockerignore` | 373 | `c4f2cbd8ea971b3446568181e2f54ae5362226ed63b54193f2b1dfa44b6526e1` | unknown | uncategorized |
-| `icn/Cargo.lock` | 212152 | `58a6cfc21add273fb9648c2beaec17b95cd78d575318c4c377428a8c54dffe9a` | unknown | uncategorized |
-| `icn/Cargo.toml` | 4557 | `ac6adb427fa0f292c337ec502625822b43457413e1f21d0ea6bb2c1fef5042cf` | TOML | uncategorized |
+| `icn/Cargo.lock` | 215694 | `2ef6b85eaea3eb592a94a0025f0658deb896495fc7db8e09b54e9fce3952aea4` | unknown | uncategorized |
+| `icn/Cargo.toml` | 5410 | `a9e66fc0e810ad2cc362a257b7e8d38a92f7cb9049a2569fcd95a7f1114c13d7` | TOML | uncategorized |
 | `icn/QUICKSTART.md` | 2433 | `90b080229730e010533bc3ac0d43fe4d73bc180674d68521e0ca5194b5b7bc9b` | Markdown | uncategorized |
 | `icn/apps/charter/Cargo.toml` | 616 | `a033fa8a465db37f269e4e02e2e9936b35f07fbaa37199ef6ed9a204b6c96aba` | TOML | runtime app crate |
 | `icn/apps/charter/src/lib.rs` | 2358 | `34649e4f002bdb6c5a20f629f9d546ecaa99eb18e455604ff546b56e19cc037d` | Rust | runtime app crate |
 | `icn/apps/charter/src/oracle.rs` | 13859 | `90809842de41002300ba88198e2acd7c79bb13a54344cdc36c94d434ccad0ee9` | Rust | runtime app crate |
-| `icn/apps/governance/Cargo.toml` | 2169 | `c2037b4f4010f439c9bb20afb1d105280503a144a7b757e8a50e40658ab3b9e5` | TOML | runtime app crate |
-| `icn/apps/governance/src/actor.rs` | 159924 | `a66ddc2c21712235591c1953992d29b635f96fd348ea84653fe048d010ab34d3` | Rust | runtime app crate |
+| `icn/apps/governance-app/.gitignore` | 19 | `2ebe6cb6f5289849dce5a8a6cdd77e06b1385302c862982f8e181c4782d19214` | unknown | runtime app crate |
+| `icn/apps/governance-app/Cargo.toml` | 958 | `a8dad674e2cc9a584917ebc2a50d0a4732bd1c8c9aedbc84354e8b4881fcd558` | TOML | runtime app crate |
+| `icn/apps/governance-app/src/lib.rs` | 3573 | `59d6cf75a1a80392a10abeab47c9d2b730c9c3b91b8ebca308a753b3a615dd91` | Rust | runtime app crate |
+| `icn/apps/governance-app/src/oracle.rs` | 6990 | `164a45a18f67a5822c4879d7e6317347ff91f114031d6a48a2de61c3e082481a` | Rust | runtime app crate |
+| `icn/apps/governance-app/src/service.rs` | 7056 | `69335632cf0f5f244618d49ccaf664d80d59fc97b8cd0066eb19a567f0dadb8a` | Rust | runtime app crate |
+| `icn/apps/governance/Cargo.toml` | 2318 | `b95f74f241003b8727a94a537b9b8a6f6e775445a1ccfe46b9b7ff2c89c74f94` | TOML | runtime app crate |
+| `icn/apps/governance/src/actor.rs` | 185427 | `f2105fa8fb86ada698aa66ac3867fd12372b3e020851cc1c385e79bca89a37db` | Rust | runtime app crate |
 | `icn/apps/governance/src/bin/governance_restart_helper.rs` | 10643 | `f8bfebe41a6c259ca04034406a9addee8082c2bada13a1989636495a85753395` | Rust | runtime app crate |
+| `icn/apps/governance/src/close_journal.rs` | 9747 | `a64bfbcf7da30c1945bb22d387e3f348ed91964b5559d5abf1e8bd2def914bbb` | Rust | runtime app crate |
 | `icn/apps/governance/src/dispatch_evidence.rs` | 11501 | `7842019581d81f636af4495af6b8bea83cb801ba803bd807acfd019804b71a61` | Rust | runtime app crate |
-| `icn/apps/governance/src/dispatch_evidence_sink.rs` | 14190 | `5455453d599feec32dcf0b7c5f06145de64cc8a2537c3f3c2b683da77f20daf9` | Rust | runtime app crate |
+| `icn/apps/governance/src/dispatch_evidence_sink.rs` | 19766 | `8739897731f91a6c2e566b45850c03b2196fb491c4553ee41683cb6423d32c08` | Rust | runtime app crate |
 | `icn/apps/governance/src/events.rs` | 3075 | `0a6e7d2324f1dffc4e0f85be826ad34216ae41fb718559f40bfd4fd9e7f6cfe0` | Rust | runtime app crate |
 | `icn/apps/governance/src/executor.rs` | 4947 | `dc0aee4a6cd9de7d9bca48181385070df1b03d39002b113df3b9f4f6f6e6c91b` | Rust | runtime app crate |
-| `icn/apps/governance/src/grant_minting.rs` | 112285 | `e7e1e354c76a4025444603a714b119c587f5b3c8e58e3a7ce873b9a58436d889` | Rust | runtime app crate |
-| `icn/apps/governance/src/handlers/execution.rs` | 49940 | `d4b3c6e1afb386552b2d60f9326b7169c1d53aeb21b21e0dc940441ceb47e7ab` | Rust | runtime app crate |
+| `icn/apps/governance/src/grant_minting.rs` | 121370 | `8b11e18d371ec454e67a2295144142da2eb51bf60b5a877c865c5822806e0273` | Rust | runtime app crate |
+| `icn/apps/governance/src/handlers/execution.rs` | 50546 | `f490648dd8f3f14e13b55f29eabcfc03736d383f9208dd98f891bb2d593101ba` | Rust | runtime app crate |
 | `icn/apps/governance/src/handlers/mod.rs` | 267 | `259f33bccc0c4b395fe63c5ad65e67834360044e5289274f9faa98cb58d81294` | Rust | runtime app crate |
-| `icn/apps/governance/src/http/configure.rs` | 27029 | `1bd57d7b52bd9d768fcc0e950d79eaf5b630508eae347a4f77ec4cd4449f1e53` | Rust | runtime app crate |
-| `icn/apps/governance/src/http/handlers.rs` | 322017 | `70b59ff168f887749017f7ae0572f5ccff7ff30ed724539284d7873fe33e0f2f` | Rust | runtime app crate |
-| `icn/apps/governance/src/http/mod.rs` | 418 | `8816c906d6b847aaf5ffeec71a9935bb765fb6aa54fc01712be87612e5305466` | Rust | runtime app crate |
-| `icn/apps/governance/src/http/models.rs` | 61132 | `a435fc7ac2dfe9a1f018ac6bcdbdc6e5a725769ddc78c4de909059d9659b1637` | Rust | runtime app crate |
+| `icn/apps/governance/src/http/configure.rs` | 54744 | `f953108a2795998cfaeaea6076d9ee1cf9fee9e29a565af9c4dfd59d059e7d03` | Rust | runtime app crate |
+| `icn/apps/governance/src/http/handlers.rs` | 361119 | `88ead143cb6a1b5566add0566bc0121f721c579d0f00f4b8d456b979764aba4a` | Rust | runtime app crate |
+| `icn/apps/governance/src/http/mod.rs` | 487 | `b531fa6106dc1312fe2dde1a365c35171c4cbb83d6e30dcb336ef21a0daeb38c` | Rust | runtime app crate |
+| `icn/apps/governance/src/http/models.rs` | 62902 | `95ee4fb2a957c0487666c08ee13c7751312329a8779e512d3a12bded223696bf` | Rust | runtime app crate |
 | `icn/apps/governance/src/http/validation.rs` | 17900 | `425cffb608ae11d966ee67b7a5e0544a03d70bce8749734f97a2fa5f80bdff3f` | Rust | runtime app crate |
 | `icn/apps/governance/src/init.rs` | 4699 | `c9b8aea21e6a3fd9d4ccd77d5905f4e3e5513de3f85429ff205eb7f3ed5fae12` | Rust | runtime app crate |
 | `icn/apps/governance/src/institutional_effect.rs` | 20303 | `395c5b373daea2f7156443ca4bc1180a65c9d08ceeee3b6d99b38b8182c9468b` | Rust | runtime app crate |
-| `icn/apps/governance/src/lib.rs` | 19186 | `29404d3a02f42316bc46b72dbb98260c705c9b79fb0ac39c4c00fc12607fcdbd` | Rust | runtime app crate |
-| `icn/apps/governance/src/manager.rs` | 347440 | `e41f4bde568dce91e1485ba730f7b94263c9f5a28aa34789ee98faf2abfa2727` | Rust | runtime app crate |
-| `icn/apps/governance/src/receipt_backend.rs` | 18781 | `504bb575a47237cd0808cc350ad9d6a402459d738f4a879474779b8f75fa5bb8` | Rust | runtime app crate |
+| `icn/apps/governance/src/lib.rs` | 19619 | `2144f34e912811a97df72acf3ccefe8c05e4c90d60712aa0a265c032110b0efd` | Rust | runtime app crate |
+| `icn/apps/governance/src/manager.rs` | 359295 | `14e523b233f1bf43843ae66cbae43f059b4905e2f0bd9356cbf91fce1885bc80` | Rust | runtime app crate |
+| `icn/apps/governance/src/mandate_gate.rs` | 55170 | `6a1959ae7cb5fdc4cd73663204d539da8ef7b0ebf4955eacacd44289d4184daa` | Rust | runtime app crate |
+| `icn/apps/governance/src/receipt_backend.rs` | 36470 | `7e4866df3d2e9a19c0615da3196c77cd84d423d5bab72b475ce2bee8b670fe9a` | Rust | runtime app crate |
 | `icn/apps/governance/src/registry/mod.rs` | 2184 | `b270a29b4d42ed783d04149b90fbd6568fc9aba672d8bc4b64a23a3de922d777` | Rust | runtime app crate |
 | `icn/apps/governance/src/registry/models.rs` | 9127 | `d5631e6ae640f7f9a2337ec8cc52303717310a3b94f3da0a1e6df8ac21b63009` | Rust | runtime app crate |
 | `icn/apps/governance/src/registry/store.rs` | 11894 | `d5fc9a2bfa02371d4576f92c7c397551bc54e9987c50a54d57e7f9ca7242f83e` | Rust | runtime app crate |
-| `icn/apps/governance/src/state_store.rs` | 7689 | `4bb01a24a2b5a55f445c797b63618ae7d825e22e90b08ae22adbe94dc80e0cbe` | Rust | runtime app crate |
-| `icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs` | 20649 | `2a3a1d247c9694a633110a5b9b84d5355f5e75147c8adbc53b7e58730e57b2f6` | Rust | runtime app crate |
-| `icn/apps/governance/tests/actor_close_proposal_accept_parity.rs` | 13361 | `3741910d28354ae5370f67cc5a0c50472b25519391f594f7b49a842590f3f4d4` | Rust | runtime app crate |
-| `icn/apps/governance/tests/actor_close_proposal_mandate_parity.rs` | 18815 | `cd28ee42a6f14c08afcd6dc1907b68fc449ca268eb7068451ddadbda33dfd59d` | Rust | runtime app crate |
-| `icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs` | 48163 | `26dc50567056275d0e7501743f690e33a32291a81ef4066d18e236ad9af681a4` | Rust | runtime app crate |
+| `icn/apps/governance/src/state_store.rs` | 11360 | `9dadb0f1d09b5cb193c64b64c8ac9a7041f51fc5a5bc0891d02d4fa1af5d9172` | Rust | runtime app crate |
+| `icn/apps/governance/tests/activity_scope_migration.rs` | 6553 | `268298f317d7d6ca70435af19087ffb9573af946063f29509a42febea9d539b6` | Rust | runtime app crate |
+| `icn/apps/governance/tests/actor_acceptance_closure_atomicity.rs` | 30240 | `babfa91029b238fcff5fd9ba13f8fab725d5867f528e1e09e3909e472520cb32` | Rust | runtime app crate |
+| `icn/apps/governance/tests/actor_close_crossstore_atomicity.rs` | 51921 | `7cdf835c739756c6e02cc79d2d6102340df255fdee09293348302e1f423569a1` | Rust | runtime app crate |
+| `icn/apps/governance/tests/actor_close_proposal_accept_parity.rs` | 13433 | `1f12d88fb7bf39ef9eadbe4e87bfff52cefbe94cf598d6525f211ba889dc9ff6` | Rust | runtime app crate |
+| `icn/apps/governance/tests/actor_close_proposal_mandate_parity.rs` | 18923 | `ff9429882c329b2d034a5ff75daa0bcce4bae8a04fba9a7a072711beea5af65f` | Rust | runtime app crate |
+| `icn/apps/governance/tests/actor_path_dispatch_evidence_sink.rs` | 52345 | `918744bb7bcb9205d2484c4f8dab1b8796289f87bb74924348a7bbf8d3a44ab2` | Rust | runtime app crate |
 | `icn/apps/governance/tests/actor_receipt_store_parity.rs` | 14313 | `9005f84e28582c406d7441949e2382d61e51e09ef4a3ad22d16c09c2d4469bb9` | Rust | runtime app crate |
-| `icn/apps/governance/tests/assign_role_authority_scope.rs` | 7750 | `f14fccf0721d2c6b4b8de09a46525f0cb00f2eaa647757891b024aa02cf02e96` | Rust | runtime app crate |
-| `icn/apps/governance/tests/charter_activation.rs` | 16284 | `220af2c08066d9c1c3e99f42a994706f7ef5812e2c4206c1f4805a4427116b54` | Rust | runtime app crate |
-| `icn/apps/governance/tests/me_action_card_receipt_chain.rs` | 16027 | `e433f00a0ebc9f2c9d25fb654f9f90952a0a658b1dd12a441197c905115948fe` | Rust | runtime app crate |
-| `icn/apps/governance/tests/me_action_cards.rs` | 12664 | `8aa562cc0633e3a34ac986758b2e1679ce5560f305a6b6b39e6a4077dd8e4a8d` | Rust | runtime app crate |
-| `icn/apps/governance/tests/me_action_item_receipt_chain.rs` | 35727 | `f3f033742ebb9a3b3fa6ecee94cbf518d2c585884d4e832c305516425571b1cc` | Rust | runtime app crate |
-| `icn/apps/governance/tests/me_meeting_attendance_receipt_chain.rs` | 21558 | `5d3c8a70f06af824c19331be6578cd24c1cf28b95bb29d5aed09c497bd19674c` | Rust | runtime app crate |
-| `icn/apps/governance/tests/me_standing.rs` | 15146 | `7eafb4ea572181e0173021e47d660ca824451312ff1fc8338a131cbe1dd1a791` | Rust | runtime app crate |
+| `icn/apps/governance/tests/assign_role_authority_scope.rs` | 7860 | `cbeb8e2ce33f3a3d55ad27b81d465027e9de662b568d5a80e79e27dc4fddb5e8` | Rust | runtime app crate |
+| `icn/apps/governance/tests/charter_activation.rs` | 19260 | `516309881da30b2e4379111bd2cede85873eef63aa943c93c714de2c74d24fd5` | Rust | runtime app crate |
+| `icn/apps/governance/tests/charter_scope_migration.rs` | 9299 | `4f6e5bde43188cb2f4aa6a7c6018d74fd78ab7850cd48350d05a964094fd5573` | Rust | runtime app crate |
+| `icn/apps/governance/tests/comment_scope_migration.rs` | 6309 | `3e8338057986320c3dae71372f4525f22274b511c101cbb6ad90f21e3b2f8351` | Rust | runtime app crate |
+| `icn/apps/governance/tests/federation_scope_migration.rs` | 9204 | `472b333387330673cb2f12ecaa502183a5d9e7e645bdba7ee8c99b9282f3671a` | Rust | runtime app crate |
+| `icn/apps/governance/tests/governance_decision_receipt_v3_emission.rs` | 19897 | `2947afd7a492d7aab07f94dcf199eb7a2c0a74ae24e7bd8fca9aedd9bf68d820` | Rust | runtime app crate |
+| `icn/apps/governance/tests/me_action_card_receipt_chain.rs` | 16137 | `d9ac9da4068ffb0f2f07f020ef986eee261d5001de2367f9315a3ad20d722f5e` | Rust | runtime app crate |
+| `icn/apps/governance/tests/me_action_cards.rs` | 12774 | `6f473099f17b834ba8d9f057e7168b4d9247f12e02267e3b4b5b030aa6a6ef3e` | Rust | runtime app crate |
+| `icn/apps/governance/tests/me_action_item_receipt_chain.rs` | 46010 | `7e57cdc8de711606907ce301b09a097752cb81ef32af9d161efba3caa8fb5996` | Rust | runtime app crate |
+| `icn/apps/governance/tests/me_meeting_attendance_receipt_chain.rs` | 31124 | `c6deccdf37c33d8ea48d171e1cd04c13ebbab46bd1f20723204158e0ad6fd6d5` | Rust | runtime app crate |
+| `icn/apps/governance/tests/me_standing.rs` | 15256 | `6df51ed06cc42226a0cb230461b1fb9bbf8b37e6ea88fe6e5135ce12e40cb193` | Rust | runtime app crate |
+| `icn/apps/governance/tests/meeting_scope_migration.rs` | 6394 | `38e1c3c3a029038abde0793f119a74a99edbe165e090d1b05e15bed357835d1a` | Rust | runtime app crate |
 | `icn/apps/governance/tests/persistence_proof.rs` | 10311 | `798bf89471bfe77e9456fdc69bfd7efefb2e23af3c1ba76c82643087d3eca42e` | Rust | runtime app crate |
+| `icn/apps/governance/tests/process_gate_result_receipt_runtime_slice.rs` | 35240 | `884e263f26662eacabd3df0852b8c46e0fba1025d6a65d99033b40de42bf281b` | Rust | runtime app crate |
+| `icn/apps/governance/tests/proposal_scope_migration.rs` | 16806 | `92290ae6ad412c01fca635020b4c15992d74a65ab0ffbaa8c22656d303dcd157` | Rust | runtime app crate |
+| `icn/apps/governance/tests/reconciliation_status_invariants.rs` | 19717 | `9c9847492e6b5428626711f9781cffa3ee3db499d78f5d9a9a1389f2ddae8324` | Rust | runtime app crate |
 | `icn/apps/governance/tests/standalone_domain_persistence.rs` | 5722 | `f99bcaae2a73b8c8dc2e6950015c8a358613922f041714c59b26ff8a9c99b7de` | Rust | runtime app crate |
+| `icn/apps/governance/tests/steward_scope_migration.rs` | 6803 | `48c9e82cf3c556b136062fed4ab205ee885401ed9f6d4f7abfd73c2d95cfa480` | Rust | runtime app crate |
+| `icn/apps/ledger-app/.gitignore` | 19 | `2ebe6cb6f5289849dce5a8a6cdd77e06b1385302c862982f8e181c4782d19214` | unknown | runtime app crate |
+| `icn/apps/ledger-app/Cargo.toml` | 1677 | `dbe12097c492934e1fe44bbdace72a265dddb0e8bbe43eacfdb809382fa06f52` | TOML | runtime app crate |
+| `icn/apps/ledger-app/manifest.yaml` | 1408 | `168541ad3d13f2068b16b473bc58ba18f238dafc4c2948140e7449107df4f3f6` | YAML | runtime app crate |
+| `icn/apps/ledger-app/src/budgets.rs` | 8925 | `d107e322624fe0fdbc3035148e2a47b5ec4297e4de20938f7e859349617978be` | Rust | runtime app crate |
+| `icn/apps/ledger-app/src/config.rs` | 13279 | `460589149cbbca9d6a048f1a3abc6f655763536ace6577b4cef9c6edcc1a157a` | Rust | runtime app crate |
+| `icn/apps/ledger-app/src/escrow.rs` | 7867 | `efa3cb851c503373dd1627461af4e76b4804175d6b2646b027c8bf026aa09162` | Rust | runtime app crate |
+| `icn/apps/ledger-app/src/init.rs` | 10497 | `5c3e0751ce2ace4cee0a9b6eb390a2178a463240072fdb93343f875daf1ccb6f` | Rust | runtime app crate |
+| `icn/apps/ledger-app/src/lib.rs` | 3764 | `62f0e643753856e3cf52d32d7bd49e2ec5eb9c09052c724b127be695f86302ba` | Rust | runtime app crate |
+| `icn/apps/ledger-app/src/oracle.rs` | 4286 | `a7db685817b45cae0584e74a0a644aa0afd5547eb3b9abd013f99710a5e4a9e4` | Rust | runtime app crate |
+| `icn/apps/ledger-app/src/recurring.rs` | 10522 | `04f8085783c13f768aa692ba11abb73f6b713a6b1020f52509fbbb6234a532a3` | Rust | runtime app crate |
+| `icn/apps/ledger-app/src/service.rs` | 7629 | `fa64b50989936d54d8c7412ee94852f391b993f2e10f3b0f7df95f7355128f0e` | Rust | runtime app crate |
 | `icn/apps/ledger/Cargo.toml` | 627 | `a94ca962a20a8502ca3ac0b78e2cef19318f8f67135b82585b9349cbf1712a2c` | TOML | runtime app crate |
 | `icn/apps/ledger/src/budget.rs` | 5479 | `81db4c29e343f0ef1fe2cb05d43fcc28de2b093a01338d329e39f2f8ca7e7357` | Rust | runtime app crate |
 | `icn/apps/ledger/src/escrow.rs` | 5024 | `b5fedf614925bdd62ffca68b200dd5b15ff5fdd404cf0af6b04b7463c4b4f92b` | Rust | runtime app crate |
@@ -1981,7 +2236,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/apps/ledger/src/lib.rs` | 285 | `64d00d68df9cd32f378891d358e3fbfd0c4b228ab195105f74ee6f2c8029de61` | Rust | runtime app crate |
 | `icn/apps/ledger/src/resource_access.rs` | 7325 | `78dca210e64bc194ca846fccf89661148d2964cf378089028cd273f08de3c988` | Rust | runtime app crate |
 | `icn/apps/ledger/tests/actor_persistence_proof.rs` | 5065 | `075ee61f6ecbb8f4c4dd10e34ac87f30f1587a0317d3e573738d36b369f97a18` | Rust | runtime app crate |
-| `icn/apps/membership/Cargo.toml` | 1911 | `51920f2d97b21d70b86fe490e92f469018f00ae7040ce739bbb8b40abdd4f37c` | TOML | runtime app crate |
+| `icn/apps/membership/Cargo.toml` | 1911 | `0d5d4a817b36e34d2c929b70d1d74b6210a3e60070a5fa70f1919e07641fb857` | TOML | runtime app crate |
 | `icn/apps/membership/README.md` | 2141 | `e5994f94d2cb8b09548f6d1e05af11852ef3f4ad78613ec227caada3b4f5a083` | Markdown | runtime app crate |
 | `icn/apps/membership/manifest.yaml` | 3237 | `4c72caa0fb1a6dd20dbf7b0563e732970243ebb9bfb2d66fe9ea43e1612f2b7f` | YAML | runtime app crate |
 | `icn/apps/membership/src/community.rs` | 9408 | `92aa2e44ac8f30d0f8ed1ade33fa593689f143121101eb114aee8cb7d896ecf3` | Rust | runtime app crate |
@@ -2016,31 +2271,47 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/apps/membership/src/entity_core/sled_registry.rs` | 56559 | `836fb31c5d9a3ce8b379aecb1a37818669fc1942f602d98d649812db90145215` | Rust | runtime app crate |
 | `icn/apps/membership/src/lib.rs` | 6135 | `7153b0242e647c28ac12feac300b0e32c8c79c7cee2e83ffbea6a432af301791` | Rust | runtime app crate |
 | `icn/apps/membership/src/membership.rs` | 20234 | `737e3ab5fa98b818c55afc9b506dc716e3dc8ebf2554ee3a22830ce52108fc34` | Rust | runtime app crate |
+| `icn/apps/trust-app/.gitignore` | 11 | `3e503ffd2d2f0c135bc5d8c97cba5aff82676478d90cb002333ed9583b92c5a0` | unknown | runtime app crate |
+| `icn/apps/trust-app/Cargo.toml` | 1439 | `dcfc146b20c7196882cb80c7c1cbeb5b750a78be264de88392e8b26596302437` | TOML | runtime app crate |
+| `icn/apps/trust-app/benches/README.md` | 3345 | `22d5c201b7b7f4ba030c106afced05d5e5b5aa94d37783594494edc9c03d2620` | Markdown | runtime app crate |
+| `icn/apps/trust-app/benches/trust_service_bench.rs` | 8518 | `8edea6f20171b8bac6656f80e0d68b497da53de36f43e301426c571b1f5ccee8` | Rust | runtime app crate |
+| `icn/apps/trust-app/manifest.yaml` | 1594 | `f317936db84ac6591d6eb7c696f680e2d4b7d6355760ec5dd8000272b9336f24` | YAML | runtime app crate |
+| `icn/apps/trust-app/src/init.rs` | 9174 | `df618b072438ce03346f106e1b2bac69b41ab525569b336aba1690d0e0067984` | Rust | runtime app crate |
+| `icn/apps/trust-app/src/lib.rs` | 4881 | `d92f8a0f9b686dab149011439ad7dadba0fb53fb1bd0e9d51b6ec751edc7f48b` | Rust | runtime app crate |
+| `icn/apps/trust-app/src/oracle.rs` | 23630 | `0bef203917d1e50ac7b147eacb4ecdd7d820074685b3944720c383c1a74f17a1` | Rust | runtime app crate |
+| `icn/apps/trust-app/src/oracle_tokio.rs` | 8058 | `d9857a1bb200770f801c874067e986a42b68919753cd0c8a95964ce76b68f262` | Rust | runtime app crate |
+| `icn/apps/trust-app/src/reducer.rs` | 23918 | `38997cd51b019995b2183048ede8a7073ca458b9aed95bb68877c63bde1846d2` | Rust | runtime app crate |
+| `icn/apps/trust-app/src/sequence.rs` | 11054 | `686c50e0eeffd3d16bb029ba2a345624102b7696ede94eb879fb1479747d7048` | Rust | runtime app crate |
+| `icn/apps/trust-app/src/service.rs` | 6824 | `4f28347cfdea290717761f71dacd286f01c304595f23d8b57fb7594812b8528d` | Rust | runtime app crate |
+| `icn/apps/trust-app/src/service_tokio.rs` | 57192 | `a57267fc74a9103d94e28eb1b89d78cdc7c4f5a17c081e0388c2ef833770edac` | Rust | runtime app crate |
+| `icn/apps/trust-app/tests/cross_org_integration.rs` | 18302 | `1087d04eafa12dfa1b989f7734dc1f9c48eabfec9e86a3ca26fac2bae291d51c` | Rust | runtime app crate |
 | `icn/bins/icn-console/Cargo.toml` | 907 | `a0b0e253ed652451103acbb173e365d059b3fe657e818cbb5f7438ac7b4e3f78` | TOML | Rust binary |
 | `icn/bins/icn-console/src/main.rs` | 34935 | `219577f8fa06dbac75828eaef36a43a3517254cde77fae5753b00bef3dbb941f` | Rust | Rust binary |
-| `icn/bins/icnctl/Cargo.toml` | 1585 | `b6535c62d5728d3430e3054fb001b5ad7ed45c97744b118cfe9287d8262b07fd` | TOML | Rust binary |
+| `icn/bins/icnctl/Cargo.toml` | 1750 | `b0ebc31e9af449497b352d25c887e66f9fe712a66c992ed460dcb790a247fd1c` | TOML | Rust binary |
 | `icn/bins/icnctl/locales/en.yaml` | 8064 | `550d4f6ded48f250ff48f30ae719e2cf2513c836bbac6d0d2ad44dc031cf5490` | YAML | Rust binary |
 | `icn/bins/icnctl/locales/es.yaml` | 8980 | `68da9c4a75e0d76c4693ab72ca310285bb5b50cc7403ac9fc7574d5737f08809` | YAML | Rust binary |
-| `icn/bins/icnctl/src/institution_bootstrap.rs` | 101142 | `77d58812063ce58d79fe8b577ea3e6d14433b92be29d4a2aee40783dbcda613e` | Rust | Rust binary |
-| `icn/bins/icnctl/src/main.rs` | 399852 | `b2d9932cbbc6c1d99e31548bfb43f744af32e5de2250f25303dc46e01beb6ed6` | Rust | Rust binary |
+| `icn/bins/icnctl/src/institution_bootstrap.rs` | 101298 | `c1407250f0fd7e343b77d6e698dc52e195e5722c8e849d4880100cab71bf79fa` | Rust | Rust binary |
+| `icn/bins/icnctl/src/main.rs` | 415618 | `38c0d17929dfbddcf98b6f5df926ede6fdfdb375a962e3ab50fe9eb864bb2723` | Rust | Rust binary |
 | `icn/bins/icnctl/tests/audit_verify_test.rs` | 15668 | `3e5c21ef0ae71f99868ee9fcd924a5d1ae641217e4f859f5a7c662d6fc34c4a7` | Rust | Rust binary |
 | `icn/bins/icnctl/tests/backup_restore_test.rs` | 13406 | `b51e3f9adc11ef01c46091b2040ec5f20c274a18bc01caad34ea94e96c36d62d` | Rust | Rust binary |
+| `icn/bins/icnctl/tests/coop_entity_backfill_test.rs` | 13805 | `24ff61508ad85e34582c229c6413e86f636b812626d5bbaf61a08af7e4dde536` | Rust | Rust binary |
+| `icn/bins/icnctl/tests/coop_entity_report_test.rs` | 11324 | `31b1e38d006f3be744821e88eed7c009f42d92c9cf20d61ab78bae5dc655b312` | Rust | Rust binary |
 | `icn/bins/icnctl/tests/i18n_test.rs` | 10780 | `52ad320e99abfe45d3320ea5064b723df2b6bcd0b3f77a217d5dba9b899d999b` | Rust | Rust binary |
 | `icn/bins/icnctl/tests/qr_code_test.rs` | 10339 | `75cfd40bb0e6bfc17114aa32a53ca8b48d0b15baa162a08a480641be8def3a8b` | Rust | Rust binary |
-| `icn/bins/icnd/Cargo.toml` | 1477 | `1bb15e1008e91e16172cf115b2c8ac1848b710af3e37a93a481041dd1f50b5f1` | TOML | Rust binary |
+| `icn/bins/icnd/Cargo.toml` | 1480 | `d583baa325019b58e873cea81bac3fa258cdd1c20add77478087bc3e7a811f14` | TOML | Rust binary |
 | `icn/bins/icnd/src/compute_wiring.rs` | 18793 | `ddce7c3a89f562e44006803f2ef4dc1042316d96a98afccf51835a49fdde64ab` | Rust | Rust binary |
-| `icn/bins/icnd/src/main.rs` | 29773 | `116418c334080d0855723ce396ecc804179b64d9cf815507197dd6550bb951a3` | Rust | Rust binary |
+| `icn/bins/icnd/src/main.rs` | 45603 | `bee35cab7967435478c569e809ee92f7cea377e0c12adbe3faacd973e484ca19` | Rust | Rust binary |
 | `icn/check_output_2.txt` | 2183 | `34a29e2a89a5bec3d2981b68131102fb79d56c33dbf2ab2fb526352138d571c5` | Text | uncategorized |
 | `icn/clippy.toml` | 621 | `2ea68cc8456a5fdb4769fcb81a07c86f0bd396a46a61010414db7bd1762c8e32` | TOML | uncategorized |
 | `icn/config/icn.toml.example` | 8247 | `65660cbaca66d6338ab48964001dfdbfccbaa6a919f3e7b9149b1e03865ce903` | unknown | uncategorized |
-| `icn/crates/icn-api/Cargo.toml` | 874 | `c950f7a6ee794a93995bce395ac2e1926d3050c9083da7866e8ec4604ba032c4` | TOML | Rust library crate |
+| `icn/crates/icn-api/Cargo.toml` | 930 | `d5a209c25b3f03dc624b8430a016854198a423a8a644762173bdaabeee52c5a1` | TOML | Rust library crate |
 | `icn/crates/icn-api/README.md` | 8664 | `1e226c9b8ee2e49c622ff04a2ad6aaae3aa9d3a8c813c7553eb227aa2d264562` | Markdown | Rust library crate |
 | `icn/crates/icn-api/src/compute.rs` | 31878 | `a380d2d34b23dd8126e9b4a47328b145d262ed412f45b0a51301e8692d44184e` | Rust | Rust library crate |
 | `icn/crates/icn-api/src/error.rs` | 1480 | `0c3ff3a87bbcc771d6fe3299084a9120f28618b3ccba1aaebba1425d0a1bd213` | Rust | Rust library crate |
 | `icn/crates/icn-api/src/governance.rs` | 1779 | `b6134ace8abe93ad95bfaa9e888799309b4897245a3a68f69e373e0ac96da03f` | Rust | Rust library crate |
-| `icn/crates/icn-api/src/ledger.rs` | 5224 | `f4fdc92ffd63e62dddae25a8e456794a7f424944c3f01333f4df08106a2785b1` | Rust | Rust library crate |
+| `icn/crates/icn-api/src/ledger.rs` | 13925 | `67e5c34cf4026ad22f4be08f746b6be1aab9e451d563d875a5d9a60cbc770b2e` | Rust | Rust library crate |
 | `icn/crates/icn-api/src/lib.rs` | 2588 | `3d3fb0cf158a37627ea860fcfe1b0c83745b906b772920faabdfa3f55c257301` | Rust | Rust library crate |
-| `icn/crates/icn-api/src/scopes.rs` | 4978 | `71ad8e5ba3128a4bed728cc58f677a6ebd7da904d24026ddb3a40ca6357e628a` | Rust | Rust library crate |
+| `icn/crates/icn-api/src/scopes.rs` | 4723 | `57510a7cdf008d0d536968e482d2c6a122ee596832af673f63889a7d5c76e120` | Rust | Rust library crate |
 | `icn/crates/icn-authz/Cargo.toml` | 355 | `ca8b379039759bcfb5d761594268937aa3ab552e6931f3a7c89a41a985da607e` | TOML | Rust library crate |
 | `icn/crates/icn-authz/src/adapters/mod.rs` | 73 | `b41a49a6f2cddbdafdb2eb4c2f2fc48157fd6f7f9e7877c70b037cc0a7ea72e6` | Rust | Rust library crate |
 | `icn/crates/icn-authz/src/error.rs` | 260 | `a42c43dd0ae7eaec972e9b423313f2660c518894dd255b80a8ea30dd3172981d` | Rust | Rust library crate |
@@ -2052,6 +2323,24 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-authz/src/model/ids.rs` | 11266 | `9c1f3d4301b23eec9fb2dbd191039db2a488b4b08b8db4077d965a7738477a4b` | Rust | Rust library crate |
 | `icn/crates/icn-authz/src/model/mod.rs` | 198 | `c7ddb8b24f811d6f83cdacacf3003b5eba8727227f0d52c2d79b5eeb0122681d` | Rust | Rust library crate |
 | `icn/crates/icn-authz/tests/capability_graph_integration.rs` | 7533 | `5bfa902e2f0ea4f2f06ca96904b1b4a6c637d7da2ce3456e36c41b735dc643cd` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock-guest/Cargo.lock` | 3324 | `20cc7fcda251bc229e3574503d2424ef6b9b83b484cf0f7570acbe0d4cb03c0b` | unknown | Rust library crate |
+| `icn/crates/icn-baseline-lock-guest/Cargo.toml` | 794 | `5a0f62c866ee383da0abe70648e4d21d6e6974d2e7d749a4650d2590974a249e` | TOML | Rust library crate |
+| `icn/crates/icn-baseline-lock-guest/src/lib.rs` | 3766 | `c00ceb0345dd9765bf5990b4fb99154233f1d6003fe0d7317e1f6fca93aa54b1` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/Cargo.toml` | 550 | `fa6016b27466de6a02c987bbe8453d95c258f2db5dbed7ad7feb11b1ba1f1c9d` | TOML | Rust library crate |
+| `icn/crates/icn-baseline-lock/README.md` | 2143 | `10590731ca7f6700fbf3107f05d104fd177ee437c452df6812b7edc9a13ce669` | Markdown | Rust library crate |
+| `icn/crates/icn-baseline-lock/src/capsule.rs` | 1703 | `919a46a6997f62bca1ac98e21ae84304bd53bd0d88e002720a8037818a6ed856` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/src/constants.rs` | 488 | `4292f82432ece704c36313195794e579584fd8afeb6ffeea13223925f347cdf4` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/src/evidence.rs` | 983 | `374156d0e735e75c2d14735acdaeea9bdf61e35c42ba2ff8255a99cbed05a9a6` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/src/host.rs` | 5838 | `71f7e9eac8ad676942d803a616d3cb5c778b383014799714035fbc9eafb3ed04` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/src/lib.rs` | 980 | `c4e3f12a6392ab33a7b535b29366c765b01861e414ef24389975a3412bb1e98a` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/src/projector.rs` | 8834 | `f72322d102903d286eb7baa826b31b7617fe7cfaa505126a4d8ffd34477a00ff` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/src/receipt_emit.rs` | 1288 | `1df267a126bda607aa84bd65975d9cb707ebb2e7f5c7eac729b460542ada5212` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/src/receipt_types.rs` | 12777 | `4787f7206574a39c060c4b746215bfb7e69b29278a97a6ff6434783406fb30d3` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/tests/baseline_lock_loop.rs` | 14034 | `18c5c0af68c7b616e5b98c72b991fac12d1b00ea0a9be4af168a2337f2941b93` | Rust | Rust library crate |
+| `icn/crates/icn-baseline-lock/tests/fixtures/icn_baseline_lock_guest.wasm` | 22399 | `8f2c24ecffd69d27500ea9a54fc3969d9fdd98cb421b732e7f1367a496a42288` | unknown | Rust library crate |
+| `icn/crates/icn-boundary/Cargo.toml` | 742 | `9dde7d509a8271fa39bc485459cd2529e0c1167a532091b28e80cfb96fc7a0ff` | TOML | Rust library crate |
+| `icn/crates/icn-boundary/src/lib.rs` | 309 | `bd3614921d815b1181164c4c4b71c5d6383867f84ac5f0268a031db3b98548a7` | Rust | Rust library crate |
+| `icn/crates/icn-boundary/src/types.rs` | 2997 | `fbe3de498cf3b647ab2ed01b56377ee1bdd571e66f175b186534ce7e5b775e12` | Rust | Rust library crate |
 | `icn/crates/icn-ccl/Cargo.toml` | 716 | `3f78c5af1cc0b07cac8012ee5829a70306291cd5889ccf0ff37a3d82d31e7925` | TOML | Rust library crate |
 | `icn/crates/icn-ccl/examples/timebank.rs` | 5842 | `e9a582516efb09e26f140eca542821b1159d0fa90b1864f429916f706671bfe0` | Rust | Rust library crate |
 | `icn/crates/icn-ccl/fuzz/Cargo.lock` | 93417 | `f232fb7c0929fa25e8bc599d1d3a91fc608cf6bfc19e02f89548f342648d6510` | unknown | Rust library crate |
@@ -2128,12 +2417,12 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-ccl/tests/charter_bridge_integration.rs` | 13710 | `ff17f6c079462a605346e589375a6f924ef4fbe59ebab0475e9a47309f0bb694` | Rust | Rust library crate |
 | `icn/crates/icn-ccl/tests/contract_integration.rs` | 36598 | `fdb6eefe4f2598c7d6d639a9136052ec3eda1e321338b3f1a89ea0912399f6de` | Rust | Rust library crate |
 | `icn/crates/icn-ccl/tests/dispute_actor_integration.rs` | 6157 | `d8b1b5f935f1139ed44ae13a9e716ea2e5ca6731ba9da821cb26f2e0c842d210` | Rust | Rust library crate |
-| `icn/crates/icn-commons/Cargo.toml` | 799 | `f7eb1ad82bb500742d0ffb835f5677bafc11aca090102ef6298a321a5131ce6e` | TOML | Rust library crate |
+| `icn/crates/icn-commons/Cargo.toml` | 799 | `9796b362338196be90a75e9b426824cddc56743acf379990b73968e7dc37b6ba` | TOML | Rust library crate |
 | `icn/crates/icn-commons/src/bin/commons_restart_helper.rs` | 4783 | `670a0dff25dd7c5a925296b73c96b7449fb226ecb2c2dd6b52f4f299acd7c7cd` | Rust | Rust library crate |
-| `icn/crates/icn-commons/src/handle.rs` | 28796 | `b41afa0fa4568f80e5e1aa482a62040b4f93e29e38a3b95859b9b3f229ff00ad` | Rust | Rust library crate |
-| `icn/crates/icn-commons/src/inner.rs` | 72142 | `e0e0834f7346aa3a062a7a116cbc08197a64cfe1f5e89823006fe770cf66a434` | Rust | Rust library crate |
+| `icn/crates/icn-commons/src/handle.rs` | 29513 | `f8bb330c6b13ae64a2f33054346e558f219fc2c897a37f1946bcc6d1fd050459` | Rust | Rust library crate |
+| `icn/crates/icn-commons/src/inner.rs` | 73256 | `ecddb467766a2a13d485dd7c233fcaaa13e7cd2cdae781f51fc05bcf803e9e50` | Rust | Rust library crate |
 | `icn/crates/icn-commons/src/lib.rs` | 199 | `28b3ebf839e2cca0ef51251d80649a830bcd9fc4f53a2675f12041896f2cf5e9` | Rust | Rust library crate |
-| `icn/crates/icn-commons/src/store.rs` | 34854 | `eb4e8c8cf569384a9e6eb298ab04f0382f06e35a8432ea506e9d601446e64a82` | Rust | Rust library crate |
+| `icn/crates/icn-commons/src/store.rs` | 46511 | `86f0c986bac0fdd5218b3a079ea4cb63ad760b35e8649137b8c46c658efee97d` | Rust | Rust library crate |
 | `icn/crates/icn-commons/tests/commons_persistence.rs` | 9952 | `124079d0c4b3460cde1f1ae8a83c6f7f75b34e2ef92405599fd9c2252ad5c8bf` | Rust | Rust library crate |
 | `icn/crates/icn-commons/tests/domain_isolation.rs` | 8475 | `678bef07b7d492349bbed73c821375692da2cc6294d6f870ec339463c2defcf1` | Rust | Rust library crate |
 | `icn/crates/icn-commons/tests/scope_enforcement.rs` | 13498 | `9000e2e0a346f21488baf66601129aa1a97993f1bca6ad2e2f79d090b46b86bc` | Rust | Rust library crate |
@@ -2151,7 +2440,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-community/tests/integration.rs` | 5594 | `d296255c6c6dae23b061ea11632c0f5b2f31742d19ce3d6f515d0d0711624411` | Rust | Rust library crate |
 | `icn/crates/icn-community/tests/lifecycle_tests.rs` | 4167 | `54ec47af3f14ed83113591348781c05cce40e4ab99c12d2728330b9191f8f184` | Rust | Rust library crate |
 | `icn/crates/icn-community/tests/membership_tests.rs` | 4406 | `f4e27faf2280570507da1c9d0d9dc1e5f2ef47ed0865a923b91bf8cc98437c9f` | Rust | Rust library crate |
-| `icn/crates/icn-compute/Cargo.toml` | 1617 | `fddbb0112a6d39b71c4e792a94f5ca739bf0158ff163233371b5ab99e993a891` | TOML | Rust library crate |
+| `icn/crates/icn-compute/Cargo.toml` | 1876 | `65f441a9c6a377cb81a8e89704873314a56f79bea411e60588094916e4985d38` | TOML | Rust library crate |
 | `icn/crates/icn-compute/benches/compute_bench.rs` | 9737 | `a046ecac2978d42b3e581ca2aff052ab52fd46b3231ef2798dc6caaf04dc99d1` | Rust | Rust library crate |
 | `icn/crates/icn-compute/examples/scheduler_demo.rs` | 6242 | `27341cc7f0281f14dc561981458b75e72591fcc92f94be4ab5b91a4524f6d938` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/actor/command.rs` | 2218 | `28ea43b507cf2bd6e330acf4824d217f4faa1d08589c0b940689a32119617cd0` | Rust | Rust library crate |
@@ -2167,7 +2456,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-compute/src/actor_runtime.rs` | 28551 | `e89d514396c339b1577c28a4e8c66bb69b16636f112a43084341081423ce87cb` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/checkpoint_store.rs` | 19834 | `301fcfcecc1263e4297fc46c7b726405847a0b0486cffe9e99f7a4fbb00cfdb3` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/commons_pool.rs` | 23275 | `48d5b9190374c98c5205d2833ea030b47d018f033588759ad217a5ba4b8412cb` | Rust | Rust library crate |
-| `icn/crates/icn-compute/src/cost.rs` | 4530 | `fb40cead37adcb3ff6c2e5eec125f7a4ed67a08483620dc574db4f622af0c81e` | Rust | Rust library crate |
+| `icn/crates/icn-compute/src/cost.rs` | 5529 | `b7000e7302dabd202012e65466483b09573b9724a02a27a784f5be10987a10b8` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/dispute.rs` | 20316 | `956c14a59a0bf4bf976959f74ab4d139b0729c07bfd3b8b3000b11f49c987793` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/error.rs` | 3015 | `3952f8912066f08cd15fda58233c98d9593e728e52e0d85753f4ee30bb570625` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/executor.rs` | 22968 | `eda65486fe96843ef706cfb330711050677dac403964cce65476511e54df2290` | Rust | Rust library crate |
@@ -2178,7 +2467,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-compute/src/policy.rs` | 66625 | `4bf0ece71219a0424bd9a32b207553bc946b7006ac6604d11ac78e645a489199` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/receipt.rs` | 61163 | `40ecfc9bf9dc2668b9985150531d02d265cddbe7eb57edf58b1e6bc9694ead0f` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/result_quorum.rs` | 32378 | `ea677700949a2b573546c99954c2ec849b26577eb68243448c8bbac937603ca8` | Rust | Rust library crate |
-| `icn/crates/icn-compute/src/scheduler.rs` | 92163 | `337ce7dc257a40b6599ab1da9c267ef975c0a26b9e69299e3f6d8cd3b25b52d6` | Rust | Rust library crate |
+| `icn/crates/icn-compute/src/scheduler.rs` | 92159 | `c17f206cb47318fedfdacf6f051cd3612704761238dea8b24cbbdd4f10625a55` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/task.rs` | 15167 | `fc2aaf201764893203b2d4f07122470b6235f5e5fdeff1a1eab089f89baef85d` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/types.rs` | 45606 | `3e9bececff11db59670c34624e2834c119684e7d17b06eb0160d21c5b3d9a405` | Rust | Rust library crate |
 | `icn/crates/icn-compute/src/wasm_executor.rs` | 50978 | `2084b42fd825d217a684ca9bf2b00125bf4d8cfb5c56542d8607df000d4ec961` | Rust | Rust library crate |
@@ -2186,16 +2475,16 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-compute/tests/commons_integration.rs` | 46672 | `220322eb8379da107107da39ded7469747a6987cfd2efec37ed09befdb52c805` | Rust | Rust library crate |
 | `icn/crates/icn-compute/tests/commons_settlement_integration.rs` | 11186 | `f9a3d4164fd8b39796ff4a00b4ac34dac086fb94b69d95f96c292ed640aacda8` | Rust | Rust library crate |
 | `icn/crates/icn-compute/tests/compute_integration.rs` | 23217 | `59e16f4268b3a39137ed77754110f01ea5cbb54606bf0dc3de5611243930ce2b` | Rust | Rust library crate |
-| `icn/crates/icn-compute/tests/federation_integration.rs` | 13254 | `7b7a4cd1da280af37bb65ec5d74d4cb90272f0dbdb42e9594dae04bf2fd76fe5` | Rust | Rust library crate |
+| `icn/crates/icn-compute/tests/federation_integration.rs` | 13253 | `8e898938c2e66d229f12d5ca7f8348ec11813a14db4b318db708f75c99d726c4` | Rust | Rust library crate |
 | `icn/crates/icn-coop/Cargo.toml` | 1003 | `e228d8ba8ab2456b6a0799cac9c2c8a06fac11161cc7c546dd25e1cec4f5508b` | TOML | Rust library crate |
-| `icn/crates/icn-coop/src/actor.rs` | 58135 | `b24f95177ea2d06e2effd0f637532145c309f30e9cb50de63d84deaa34e7f817` | Rust | Rust library crate |
+| `icn/crates/icn-coop/src/actor.rs` | 72400 | `1bdfd9fa66d3082847e701093f8d90dafb1623fc30b3a37f1029dd5e41cb2812` | Rust | Rust library crate |
 | `icn/crates/icn-coop/src/handle.rs` | 10398 | `3b6bf02e6677231bdc2e5fe21163fb136fe802f81aace101c07f46ff74ca3c93` | Rust | Rust library crate |
-| `icn/crates/icn-coop/src/lib.rs` | 2415 | `9bb51f940ab59e47eaddf2bc257beb490fa13bc72da3d8495fab4d0a2325bb66` | Rust | Rust library crate |
+| `icn/crates/icn-coop/src/lib.rs` | 2491 | `2e9a85c2c5744d455848a4a386433167abf30ced6dfe2045bd24b1339bb04dca` | Rust | Rust library crate |
 | `icn/crates/icn-coop/src/lifecycle.rs` | 23315 | `9a9bfc9f1e1e00c9bdc87a1fd85ebb09b2e4012297dc43b160ec626a99edd4b1` | Rust | Rust library crate |
 | `icn/crates/icn-coop/src/membership.rs` | 19218 | `d9dedd60ba5ec81ab68f5142d01d7476873eb3fc62e8b98bdb1fcf76b079d8a7` | Rust | Rust library crate |
 | `icn/crates/icn-coop/src/store.rs` | 29624 | `1794136baf374ca0de44dd63e605ae9daa510b5d8990d4e2ab6d751acd39de08` | Rust | Rust library crate |
 | `icn/crates/icn-coop/src/types.rs` | 38859 | `a01795de73341c3f6eafbc48fcef1266c9c892be824ad3b0ccab212c428f2cc4` | Rust | Rust library crate |
-| `icn/crates/icn-core/Cargo.toml` | 2024 | `2287b125635d11cdfeae358eeb3dac6ca8112d4ed99408f224dc8c4c53705f5d` | TOML | Rust library crate |
+| `icn/crates/icn-core/Cargo.toml` | 2146 | `52bb193f7a0cd14e23b5ec2aa206067bc33590d5ed3c9bc603b7995b19a61194` | TOML | Rust library crate |
 | `icn/crates/icn-core/src/anti_entropy.rs` | 4242 | `bdf3f7f7859972fec67a9146951f65f60aebb55a283ac869798966780ca212cb` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/apps/dispatcher.rs` | 26978 | `87809aebabb7222f8b07792cda2cb0e9da628c25a558213aa3c5b578a7df84fc` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/apps/manifest.rs` | 19640 | `bc76511488ab6ccb1f7b2273e07cf163b5472d41a981014634b159a45cc1301a` | Rust | Rust library crate |
@@ -2206,7 +2495,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-core/src/config/compute.rs` | 14183 | `e4d0f29a580887d76534d20800b7e42a7d212670c99204465c48d410c4cf6956` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/config/cooperative.rs` | 752 | `94901d65b751b451265dc2da02a34c2687f0bd466e69a391ccb79b4dfe2c9a2b` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/config/federation.rs` | 3976 | `ba4a9fba1c90819bd4ee1879d4e532d0510bdb5a4f6f0120ec0046b469e4341f` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/config/gateway.rs` | 2133 | `4fa8b2356fc6ebff86be6e9269be0e5e9cfd2de102a498d5ffbffab24fe29602` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/config/gateway.rs` | 2997 | `8042aa0da78a8039cc2729c7fb4102e50d5589378f785f6d619f4a9b1b5980fd` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/config/genesis.rs` | 10981 | `04d7a15ff35e844eef7933de54d70a11a719d83b840bfe3cb0bce338e8ebd73d` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/config/gossip.rs` | 10098 | `cee495676dd3c40b6a9a190d27cff17a4c971ed45da332535612d89ea526eba1` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/config/identity.rs` | 8886 | `4a662d6595ac2717d7095e6b891cbf3eaba17131a13422b5a0d99ccbb06a838c` | Rust | Rust library crate |
@@ -2231,43 +2520,43 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-core/src/replication/adjuster.rs` | 15980 | `ec127b69e7b140372eec9651901ca5636f1230f57fe6c27de8145c6f6094afbf` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/replication/manager.rs` | 29346 | `919d2634a52e33b021d06d7a0982e8e4c17f4809ded99dff6daa099ef23e8447` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/replication/mod.rs` | 317 | `c78d6ec95372c9b921a081b85836182f73a32de023b922762169d9de407d8eaf` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/resource_enforcer_actor.rs` | 27835 | `52694a05bb1ca5dcb26c1695bdfee1c543955960476a2322e8106ef9e88c25c2` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/resource_enforcer_actor.rs` | 27831 | `6cc47e532dacf96a7ad5886a95469e616e51a46ef08d40365b9a59c9347308ea` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/restart.rs` | 9951 | `8d7f00fcd0a83f303d04d1ea03c8ba26273d0ce851c8c163c98f6457d7d175a0` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/runtime.rs` | 3623 | `572961194390a893a993223bcb3ef7d7814d8c6b7499b98936595c5b22a32507` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/services/control_service.rs` | 12174 | `3624e770564d0fbe80c8a188d11d93269fb265f7900ea4253c43994138042036` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/services/federation_service.rs` | 95427 | `8db0a78864ce031cb18f2ab5b6ed9a85ec4e28de494d6b7fba4105b008627f80` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/services/federation_service.rs` | 100221 | `a8720783ce807cb773026c345b9b1fe188734ec6e4586daa3ad182e1e16a3c9a` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/services/ledger_service.rs` | 46364 | `362424651f1fd3d2ec4bca151526ee95551d5e3b5796af50154cc7bb84a891a2` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/services/membership_service.rs` | 47298 | `52eea183599dd51ce261eb4f7d6d9ba71d8ffaecc1e8aa080f1fff9235f91eb9` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/services/mod.rs` | 1170 | `4ea56e05c19da37e060705fecece894dc86907125028ca5a90384e981934f6a9` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/services/sdis_service.rs` | 56906 | `5ffc93ac4ef3068afd314615a5ad419869e753cf77c226dad9bf1808bf39ec8c` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/services/sdis_service.rs` | 63363 | `3d7c3cd7f5344c43bb4c25954106dacfe1b602b4a51fa90d29d3bea98e390825` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/services/state_hash.rs` | 17752 | `0b15e3996f88a2c1baa203b8df32a751d7d9a55352472ab529c38064d044ada5` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/storage_challenge.rs` | 38878 | `a13a580217f265ea7cc39c832774b87025dbfd4908bce8557308bec8cb7e63d5` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/supervisor/actors.rs` | 9286 | `f804623c9c0a1d2f2b9dd80d3d8be55f6ccbbbc4c5378e815f2635b504febd19` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/storage_challenge.rs` | 38870 | `c737ea081fa0678012125411ae90aceb2569e57e47e23b099c4e6de9cc31fb38` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/supervisor/actors.rs` | 10253 | `3f4abea5b37a575f1786378ef1ac6f839aea114eb7f6e98c9bda9ea46d9e744e` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/background_tasks.rs` | 37638 | `de2054b557c55f2d0915c8061f538fa93bbb8678f6e69b00169647e50b12a57f` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/bridge.rs` | 12291 | `9e932192da5beadb1e1a6e4ae35d60722b102b008a3615c17c2d033d0a816825` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/supervisor/decision_executor.rs` | 57745 | `afb829f76a1f1390cf8eed9da708efcdeb554ebe8242062a63452b263069cc71` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/supervisor/decision_executor.rs` | 70718 | `46b462242f476e5365ee72a8f492906e442a3a7c098c70f321725cce00d45e83` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/effect_dispatcher.rs` | 24849 | `3985badd5be84d6dd326bd367afbd96710bbb3326694c40ae1ffae4e13678e22` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/supervisor/execution_store.rs` | 6831 | `62380a7922a733d71d9db367c18cbfd5d16a3c781a98cda9af23d1e315733861` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/supervisor/execution_store.rs` | 11174 | `b24abd6aa049bedbaf986397c7ce1f73f55cba9b52af4321b682366ae5312ed3` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/governance_executor.rs` | 152571 | `5e467b0308b3efdb76164a36bfeceb0bb132eee50a3a4711c314a0f5ea9e17d2` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_bootstrap.rs` | 9082 | `e6b88b3715ea2caabb929882432a38e75b152586fa811934ed3c95bc3068f145` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_community.rs` | 3033 | `0b0a62beb0ed99b149fbd51183a5fbdc1c37cfbe03fa3ccef152e2044c723097` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_compute.rs` | 21622 | `54d785846695659e49f184e9f99837cfb0e751270fcc79aa3b02ab38660e885b` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_contract_registry.rs` | 5213 | `5d2d96937c9db4c414f11611d69e3628ec6faee8bb30ea522e4aebb8c1b3c1d9` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/supervisor/init_coop.rs` | 3239 | `491342f898cefa1d779a49a874ba34d5d59b5fa4a742546fd35c346633111e34` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/supervisor/init_coop.rs` | 4133 | `b622ddb5c3ab88b169be13ebce69b4ba596c2666a3e02a57d6585b85ede75ee0` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_entity.rs` | 7231 | `65e6b91da8a7d37b16edad10e5bb92f4b4b5ae1586b7d11e8b97152acd37d45b` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_federation.rs` | 19288 | `708a440229024f0a6d261eb8f9a42efe0e3b678e2f453aac7d519b9453f237e8` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/supervisor/init_gateway.rs` | 11023 | `c0713d70bec53aab7b0ba1352cd6da2320d69f1daf2170fa1e092059e155cb98` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/supervisor/init_gateway.rs` | 12537 | `2a06e1e14feac571a7b119c446ff205272127a3e220b0f06ac3e97c31c855d43` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_gossip.rs` | 15157 | `77d2b20c691c7508b6c59b2162a8237e234599e158ed85f6ab7e8d1035498a3d` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_governance.rs` | 6380 | `852141ef1814800f7b4a34a5ee0861aacfe74ee71eb7e0942c73bde05e0e6552` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_naming.rs` | 704 | `874b4129243693946bdcff26096e9077a2214b2d450db522f3f1ae08dffd274a` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_network.rs` | 16356 | `e358de8627db572ca76c84189a1b146ffa598c6c948eff7f04e8cf3e764a39a9` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/supervisor/init_notifications.rs` | 46776 | `4e1af843ca589147e0578bc42c81a4fd0250c3e5a6b8ab7f2e80e0a9fa94dae4` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/supervisor/init_notifications.rs` | 53854 | `fea1f3cf2b967446e67226dfff49e27bf23b682acb51521d6f9d02e07fe5a714` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_resource_enforcer.rs` | 2828 | `cdae1394bf0813306d627458cce411c0b95714dca0b12a2df6ff55e5e1641562` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_rpc.rs` | 8681 | `dcd7984cc201dbce46b7c84890e961a35c2c03da32e5405775149b0153a001ce` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_send_callback.rs` | 11976 | `e1917eb3138fe4ec4ea39196d83289e8d3464e65d28f17317673b746fa4f7875` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_snapshot.rs` | 561 | `e041c4028d2867d1592f6b3a250304a697b768e0b99637f1b447cc32c6d16456` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/init_steward.rs` | 6880 | `8f516146ac36ce690abffe169b9dbbf870a73e2b0cc0678d705b5ba44740af60` | Rust | Rust library crate |
-| `icn/crates/icn-core/src/supervisor/lifecycle.rs` | 67718 | `14e29afb47a63cbb7190bd98539f0eabf87ca9a72a60020ffec40135cf44ad01` | Rust | Rust library crate |
+| `icn/crates/icn-core/src/supervisor/lifecycle.rs` | 69866 | `bb29a7e570bc09efcb1d6c0d0bab735d61721af8846fdf06bd20d9a7215ee3d9` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/mod.rs` | 2915 | `c5b1239fe916438fde1219d7878b923fb4c5f2c0b725273d95049f20b645ebae` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/nat_dial.rs` | 17853 | `fb54f48aef019db898833a5fa9098027bd6c941594cb8a8cc9b09568ce0ebe9c` | Rust | Rust library crate |
 | `icn/crates/icn-core/src/supervisor/shutdown.rs` | 6939 | `e431e219c01435689c651cf7e077ec63e55c372f468cb62c7dc364eacd718a3b` | Rust | Rust library crate |
@@ -2283,19 +2572,21 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-core/tests/charter_enforcement_integration.rs` | 8444 | `edc0615fffec9fd2559cbf5a6875a86d440e1ae4ff4c3dbb25e2d0f1e0f1e986` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/commons_multinode_integration.rs` | 10457 | `2bbcfccb85e8220a602c0456b096881b5f75229c35d2a49108dbbbc7dff1a49a` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/contract_deployment_integration.rs` | 54045 | `9f723d61eb146328c30b4bddf37457b819754b9a58147ae83d2f47ca3aef1557` | Rust | Rust library crate |
-| `icn/crates/icn-core/tests/decision_executor_runtime_test.rs` | 54234 | `6cc38d88452bc1ed326f82420bb57cd63c6b7d921d67e29b42e5d576b4d9595c` | Rust | Rust library crate |
-| `icn/crates/icn-core/tests/delegation_tally_integration.rs` | 19327 | `ebe7310290f74d03a3fa44fa68e96c92c932540aadfd8c39300832bb78cce635` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/coop_entity_map_wiring.rs` | 3445 | `86b8b5dbcd14f94242bc3652e6b13aae9a09177ef945a7f36fc5e42869e8f465` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/decision_executor_runtime_test.rs` | 70089 | `00aae5d363939979bd5ae8268ef866da8cc8b20216404d6942957c1801ed0586` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/delegation_tally_integration.rs` | 19471 | `9d4c4d0a9aadc6efd5284da8a78b2c3aaa3181a23687312a1a59864544ce29f3` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/demo_member_standing_receipt_chain.rs` | 16174 | `487885a5488dbdfcae6cf9c33d9ac58c16dda9e6c689688d16d811c016fffd66` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/devnet_integration.rs` | 24567 | `7d7869da8cdc34d1c5b35392d76459c48c136478e0c0edd91dee40676f78c9d9` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/devnet_smoke.rs` | 5587 | `db8ae152842608d53d25db954f5380114af20cbcc0c0ae1c863abee64f33ed93` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/economic_chain_two_node.rs` | 21478 | `8ed464009a9803b5f218d15decf5ac066275310a215f7d7d4b3f05fb1fec7b86` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/economic_safety_integration.rs` | 19277 | `1c783430b49029cea8b3fd861ac3eba7fa7f082653f1b6bec42fc49b2e488c25` | Rust | Rust library crate |
-| `icn/crates/icn-core/tests/effect_group_integration.rs` | 39567 | `8f92df8b20a6fc6a7cdf903ec5693c803274f46f7694d064aa53cc2fdb5ca5d9` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/effect_group_integration.rs` | 39561 | `f59e5e4ea6ccddd09dda00688dd3a0ee31b83a481aac9f08ac41865b5b23c91c` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/effect_path_tripwire.rs` | 16327 | `9476a990f2dda0572f882daf31bf9e011cb1d273eac76da07679d604c705cf0f` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/emitted_surface_contract.rs` | 9738 | `eb65764c7e5db6c32ede2b5077af36b4f1a1e0d2076c567ff8c4872f4bf99edc` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/entity_gossip_convergence.rs` | 21581 | `468e773d877535409d12226e4e20e0e034b855d5fb9c2b5f1539819227fe870f` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/escrow_release_integration.rs` | 18697 | `39003736a601b1eae6fa132c6ad5a1082bb41da35b60addc71faec13ab2540a9` | Rust | Rust library crate |
-| `icn/crates/icn-core/tests/execution_receipt_gate_integration.rs` | 6909 | `f877238d77459235cd6c9a26d8ebd76f5b8297411992f2ceb742639ea42a06ea` | Rust | Rust library crate |
-| `icn/crates/icn-core/tests/federated_two_node_pilot.rs` | 44142 | `35000aa52a096e47e4548c50681e875cc62a3ee878cfe6f96904b0964be38dfb` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/execution_receipt_gate_integration.rs` | 6945 | `38cbbf38445566eae406883c5a04d80eb0bc47cc25a9cf036ebbd86496e16789` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/federated_two_node_pilot.rs` | 44141 | `5fc0f0d3cf382dd312ea1b8f7e3ecd20df80e9a8a9ceaa6d07de38d4cb8ad260` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/federation_bridge_integration.rs` | 14748 | `f1ff705aa3d13865f81828d078bbecc2987b97b6bcc38e2ece8f39fbf6b86a8f` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/fork_resolution_integration.rs` | 20062 | `22072ddfb83a99419e11055ef3a46096bdf37f94d1e9308a29d29449922fdf08` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/freeze_unfreeze_governance_integration.rs` | 18357 | `f3d00be188b8787a7e29753bd9ac36572332e0bfbd0ea7fd264270bc970d0567` | Rust | Rust library crate |
@@ -2315,7 +2606,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-core/tests/partition_healing_multistate_integration.rs` | 19015 | `007cb52d06c96bd34938e00e6cf8ade43b9c233999eaaa99836d72f083f622c6` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/partition_integration.rs` | 13445 | `e75ea26a31efee0f014422f0af6c07fce12dc515208f5a7abb71f98aa64631c1` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/protocol_governance_integration.rs` | 33288 | `96cf657f4fa9444d6adfcaf68a053817a7bb169f6d76f1b8bb84e1c7e94f8af8` | Rust | Rust library crate |
-| `icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs` | 11676 | `80aa97bab2dde18fd0fe43a93b2ecf8784ee96ecb3d12ac97bb4f01656882317` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs` | 11712 | `fecbb6cb6ccfc39c770eff4414f947e1d759e7df173dd984a5a2c5408589c4fa` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/receipt_persistence_e2e.rs` | 14821 | `50933db7d3d8105447db386adf60978cf9cf68c2dcaa49d442a8f1104a85ddae` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/recovery_integration.rs` | 27990 | `c930243592892619caf9e5125be5f1a1cc806856c67b342e35079c74a4e623ed` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/remove_member_governance_integration.rs` | 11085 | `f881d8431af03706a1feaccb8f99e88daef8264e3cab1c5fc7d6f918a5e40730` | Rust | Rust library crate |
@@ -2329,43 +2620,47 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-core/tests/subscription_integration.rs` | 12832 | `5a7ee15a273c7da9cdb245ce3e3f0d881aaad578477a0243bf1e0431e2a652cf` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/topology_integration.rs` | 22468 | `88fe840f8220a73a2bd8d8c58ebaf050606496dc1458e373874180c3cbab6ab1` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/treasury_governance_integration.rs` | 18516 | `60c94fd51839333ac3e215843164cec86348e07ff6067040b9722ad4c877109b` | Rust | Rust library crate |
-| `icn/crates/icn-core/tests/treasury_integration.rs` | 48445 | `6a20d80ab018dee538a79c8ccade3dbcebf0f1ecbcfd563c77264ace85a3201f` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/treasury_integration.rs` | 48443 | `b14d8aecb3780b39baa0f2104ff8b8bd425195a82fff689718871a3f4facdf32` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/treasury_spend_governance_provenance.rs` | 16952 | `3bb2dc4e5848ba1142c62f979133bb39c8cf2ddd481b4a3344e3457ac38dd198` | Rust | Rust library crate |
-| `icn/crates/icn-core/tests/vertical_slice_integration.rs` | 30448 | `40cb97092f16f3cfd964a78d4b0ac769c83d8848ab2adf9cac134938f34bad61` | Rust | Rust library crate |
+| `icn/crates/icn-core/tests/vertical_slice_integration.rs` | 30520 | `63d259614f9a8ddc8557c12db7d68795781f92c3d56262982aa59615080bf99a` | Rust | Rust library crate |
 | `icn/crates/icn-core/tests/witness_integration.rs` | 14315 | `9a206b58ef9f63e198ffb18ecc3e870709b774564b4df7ccb00ac455a2e15df2` | Rust | Rust library crate |
-| `icn/crates/icn-crypto-pq/Cargo.toml` | 1589 | `fc5482130369b22db2118735b35e8f11ce2b68321408c2489b16eda70ad42d23` | TOML | Rust library crate |
-| `icn/crates/icn-crypto-pq/src/blind.rs` | 15048 | `5e06f351817cda3a593cc28f3bb6518d5415e8c29ef8540d366d530c78db1490` | Rust | Rust library crate |
-| `icn/crates/icn-crypto-pq/src/hybrid.rs` | 18960 | `c9a966f7d69c994b9e8a833f1a31575161294bbeead5d8cf846dddf7360f7ec3` | Rust | Rust library crate |
-| `icn/crates/icn-crypto-pq/src/hybrid_kem.rs` | 14136 | `31b75e2f4481a2036db7813b2473928a5dedc457296242f078085b68c89ce737` | Rust | Rust library crate |
+| `icn/crates/icn-crypto-pq/Cargo.toml` | 1734 | `e5d911d4e11a120a99a6d86066bc25c5fd7757ab244d8faac238e16cfbf98740` | TOML | Rust library crate |
+| `icn/crates/icn-crypto-pq/src/blind.rs` | 15055 | `e61e21d2d3c714215812c9e10ff16fc4b577cceceae54a2667806750515864ae` | Rust | Rust library crate |
+| `icn/crates/icn-crypto-pq/src/hybrid.rs` | 18959 | `7978470fddb5ea3ea0fc1870bbf29b2393aef4d66e36bcd235fb21f79b9fe22f` | Rust | Rust library crate |
+| `icn/crates/icn-crypto-pq/src/hybrid_kem.rs` | 14134 | `5537d3709ced259f1bc9f49c18a1d13628621972d5017dabc8f62f97a8bf3aa4` | Rust | Rust library crate |
 | `icn/crates/icn-crypto-pq/src/kdf.rs` | 7290 | `584f76372121bb28b47614711ce4a9eac4d2fed944400e9baaf9693e4fa41af1` | Rust | Rust library crate |
 | `icn/crates/icn-crypto-pq/src/lib.rs` | 4028 | `8d28be3eb2d62a103d69cf01ec71ed43c73f21fb36cfdf1b8d3262205e14ba66` | Rust | Rust library crate |
-| `icn/crates/icn-crypto-pq/src/ml_dsa.rs` | 13412 | `5c5f68ccb465b8e701e48935c178daf3e4cd1f32103b0b71f230c35c3722a75b` | Rust | Rust library crate |
+| `icn/crates/icn-crypto-pq/src/ml_dsa.rs` | 13819 | `8cac8f722576218ff3bf7967795dddb9169c9ae0c198a0c21af4e2e359d374cd` | Rust | Rust library crate |
 | `icn/crates/icn-crypto-pq/src/ml_kem.rs` | 8813 | `a6f5041539fa1bad8458f20dc27bf3f7f424a44ecd4336b8a94157b76b2b963e` | Rust | Rust library crate |
-| `icn/crates/icn-crypto-pq/src/shamir.rs` | 28389 | `53d1ed00eec1d3454dce425f39d4289fbcc4ecf65375ce2851532dbc8e86247f` | Rust | Rust library crate |
-| `icn/crates/icn-crypto-pq/src/threshold.rs` | 13510 | `6d3880bd7782674cfc9979491b09530c3c52246eb9e692ae2efcf2ddb6eeb720` | Rust | Rust library crate |
+| `icn/crates/icn-crypto-pq/src/shamir.rs` | 28483 | `1ceb9342262b0a94dd95ea91623c282654be18d4ed595adadc05bc00d8f429bc` | Rust | Rust library crate |
+| `icn/crates/icn-crypto-pq/src/threshold.rs` | 13514 | `2ff160cc26f40ed6b231162b8c7026526193b91618707a06e3cabc7b6aba74a1` | Rust | Rust library crate |
 | `icn/crates/icn-crypto-pq/tests/pq_crypto_integration.rs` | 23393 | `e0b04c67811a24bf0c50ad2744bcae52633026d39a4d052fd52dab5829933161` | Rust | Rust library crate |
 | `icn/crates/icn-crypto/Cargo.toml` | 458 | `e5f5cb0d03452ec36fe7f2239892b47904db4a05fb3783079a88c63a7197123e` | TOML | Rust library crate |
 | `icn/crates/icn-crypto/src/lib.rs` | 1279 | `11a95311c49203f8dc5011208e12a72d7046cd422e69f64df7801dcaaf6efe6d` | Rust | Rust library crate |
 | `icn/crates/icn-encoding/Cargo.toml` | 406 | `1b22c72bd510f0edd95bb9f1e857effc42ad83322b04480c0eb9b2a36738949f` | TOML | Rust library crate |
 | `icn/crates/icn-encoding/src/lib.rs` | 3935 | `6c8b0d069b4cef6476449630f3759b007e1e4e3d81c2163312a00b33a0322bc7` | Rust | Rust library crate |
-| `icn/crates/icn-entity/Cargo.toml` | 619 | `a26685208c52a16187bd9bd2b384d3715561934068aa2a5fbfb1a6b3eb1caf55` | TOML | Rust library crate |
+| `icn/crates/icn-entity/Cargo.toml` | 641 | `2add136e6338e2c5a20e0e6ef32a351043481631c5fcb48ff21f14066915b055` | TOML | Rust library crate |
 | `icn/crates/icn-entity/src/actor.rs` | 22065 | `dc22556dd0de1db1b493de92a193d4ff28d0137f443213452b105259fd02ce14` | Rust | Rust library crate |
+| `icn/crates/icn-entity/src/coop_entity_backfill.rs` | 39856 | `f8e41ef4b3b45fece23e33a8913fdd7f15f098e71e42c3ada5b20f7d10dab72d` | Rust | Rust library crate |
+| `icn/crates/icn-entity/src/coop_entity_inventory.rs` | 38771 | `60fc32fc4885ab4ae15131c7ee351dad5ceffbd23d47c92634f4d3b01029b971` | Rust | Rust library crate |
+| `icn/crates/icn-entity/src/coop_entity_map.rs` | 41929 | `5178a2b92ee583c6505e7e9aea24e4449f14251bfa77fac871d5902fe3549a43` | Rust | Rust library crate |
+| `icn/crates/icn-entity/src/coop_entity_surrogate.rs` | 10500 | `5febf83608ad634a948da17dcd2d20c3df171f499eae7ec285b76bd179adf476` | Rust | Rust library crate |
 | `icn/crates/icn-entity/src/entity.rs` | 48976 | `1ed065ba5d0d5a338c4b867cd6b9d272dc8e57681cb73627e59b2183067c1477` | Rust | Rust library crate |
 | `icn/crates/icn-entity/src/error.rs` | 2369 | `aa123ca045a6bd62246061e8210960475654b98c7def5d790ddeead13b2a201a` | Rust | Rust library crate |
 | `icn/crates/icn-entity/src/handle.rs` | 7306 | `65995581079716c4ce70b21b74dbba736885e86736f91ee5a7e3c401560e2c55` | Rust | Rust library crate |
 | `icn/crates/icn-entity/src/labor_exchange.rs` | 13279 | `b41e65a7bd8ddf6f00343a962b0da6e37706db6208936399dbb7923776e2383b` | Rust | Rust library crate |
-| `icn/crates/icn-entity/src/lib.rs` | 3697 | `d5b1cbc920aa4cc81c5375a5a89b4d11b53ba575c779e033f4e6a17ad7957698` | Rust | Rust library crate |
+| `icn/crates/icn-entity/src/lib.rs` | 4469 | `14d63726c85d786a2a3a149bb9eae7b75d92fae5909ec557f678ca6aa58f3c03` | Rust | Rust library crate |
 | `icn/crates/icn-entity/src/lifecycle.rs` | 17967 | `e5014c4254122d62b7ddbc327648e647d750d40ccdfdc240778af7024ca32f24` | Rust | Rust library crate |
 | `icn/crates/icn-entity/src/membership.rs` | 46588 | `29fd745c5c22593da3b0475f3aed340e9e7633258984bc8a1e786d5613cd1dbd` | Rust | Rust library crate |
 | `icn/crates/icn-entity/src/registry.rs` | 33604 | `b3c5d7a52379c46a7b0a5f1102268b4107b68aab2fcdc4a584482213edc41ce8` | Rust | Rust library crate |
 | `icn/crates/icn-entity/src/sled_registry.rs` | 56520 | `dc78179b5a5881968dbfdab1a7a827ed3dfbc327187337cc10e4ed9732b61d56` | Rust | Rust library crate |
-| `icn/crates/icn-federation/Cargo.toml` | 1217 | `9408bded7672bbdc35a8cb79a079d74c232e10752dd3481bbc47f8a4a4265a4d` | TOML | Rust library crate |
+| `icn/crates/icn-federation/Cargo.toml` | 1338 | `d8ee65a0b3f1291e54a79e3dff62aa6c5095e48aad266135f270284f622c7b65` | TOML | Rust library crate |
 | `icn/crates/icn-federation/src/agreement/gossip.rs` | 20740 | `6bf8a371450bc389670df793d707a79c361f2d0fb91670bc607607849c46190b` | Rust | Rust library crate |
 | `icn/crates/icn-federation/src/agreement/manager.rs` | 33158 | `32801179eb10febfbd16728e252d80df36a6c801bd10a23c48de93348bd50b52` | Rust | Rust library crate |
 | `icn/crates/icn-federation/src/agreement/mod.rs` | 2544 | `0c5d6719f47562018609a3d085b2de0858c54a98e7abc3791d7bd7b72e85986d` | Rust | Rust library crate |
 | `icn/crates/icn-federation/src/agreement/store.rs` | 26909 | `20582e6c495936459741c9cd563e2d44c2e19afce9280455770db15f25c9ffcc` | Rust | Rust library crate |
 | `icn/crates/icn-federation/src/agreement/types.rs` | 44039 | `d17c717eb4501ce313c514b613ee822dcbc3fd8ef8d0020f0111e6c910f70ecf` | Rust | Rust library crate |
-| `icn/crates/icn-federation/src/attestation.rs` | 7484 | `b7ff7ee83525ab4b8da4a3879ad64b19d5b420020c4efdf21c239915ee76eebd` | Rust | Rust library crate |
+| `icn/crates/icn-federation/src/attestation.rs` | 7548 | `c025d515ac04b4dc95059ec53ab354ba8e7c85f4bf7b577cc2e95ee344cf85c4` | Rust | Rust library crate |
 | `icn/crates/icn-federation/src/attestation_store.rs` | 7894 | `576bd4bbee747c4544f4072e5c7537959f04133346837e9e503a5327b6a26ea9` | Rust | Rust library crate |
 | `icn/crates/icn-federation/src/channel.rs` | 4997 | `fdffebc7009e9125096919862446a702980ad1611f51aeffc8bd3f5559d8d08e` | Rust | Rust library crate |
 | `icn/crates/icn-federation/src/clearing.rs` | 9418 | `fdf0aa16609a1add7d7bfd95206bedffeffe252f4da3393c9049a58d2e28ebcd` | Rust | Rust library crate |
@@ -2383,10 +2678,10 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-federation/src/types.rs` | 31408 | `97ab2d0a44e7d6fafa7f240b25e303fb3956a12ed19b81031946c6e553ebd15c` | Rust | Rust library crate |
 | `icn/crates/icn-federation/tests/agreement_concurrent_ops.rs` | 52704 | `74b160d5f0d85d8738c7dbc67bca9ae012ae09dab2dd2fb81a108f5ea04fefce` | Rust | Rust library crate |
 | `icn/crates/icn-federation/tests/agreement_integration.rs` | 39694 | `20a5ff31a112db96b96e6de2ac107f6503727ccce12d9fdf70dbb2cfdc261d58` | Rust | Rust library crate |
-| `icn/crates/icn-federation/tests/federation_integration.rs` | 29144 | `d273fd9d7f05a23288459f267f9c827feecfa881cd0d8620e4cec58bf0645dba` | Rust | Rust library crate |
+| `icn/crates/icn-federation/tests/federation_integration.rs` | 29143 | `2598b8f5100bded34f6477ad738089914c9b8ef9bb05ed0fd2c0551b69215c40` | Rust | Rust library crate |
 | `icn/crates/icn-federation/tests/integration.rs` | 5602 | `15b354985ea1cfc0c8622bf0648a1f3eb5007e36c8e531bbd85c2fcd03d11006` | Rust | Rust library crate |
 | `icn/crates/icn-federation/tests/store_isolation_clearing_adoption.rs` | 23959 | `b4f14d776f8230acf1cc41a207ee0d810823fbba16bf3e9d270956620a7099a3` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/Cargo.toml` | 3200 | `67aa43ed77710f6d709e26865d020a209e69630a988e1bc7f0b13ddcd3b59361` | TOML | Rust library crate |
+| `icn/crates/icn-gateway/Cargo.toml` | 3520 | `c0eb1b6b1a895cc13ac6ae9b7c9c6e8a2dde461d9c98f6451c5a8e6b4c5ab137` | TOML | Rust library crate |
 | `icn/crates/icn-gateway/README.md` | 14865 | `6102a57c0591b5287f7b3b712ee7304ba3c48a1b357131db72b8113fcdff9267` | Markdown | Rust library crate |
 | `icn/crates/icn-gateway/benches/commons_bench.rs` | 6965 | `070f0b17b0f038b144602475e9da91d906ad49db873dd7eb125d98f337146ec9` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/grafana-dashboard.json` | 3627 | `c1db6e9ff41bafd07d81067a4d4bb4bc28801aa1761aad7224f388aea67f40c8` | JSON | Rust library crate |
@@ -2394,57 +2689,57 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-gateway/locales/es.yaml` | 2218 | `5bd07d2f61f9d3d8effd624ac2e83b38b6ac19a302cc2b0728c447c3fadce32d` | YAML | Rust library crate |
 | `icn/crates/icn-gateway/prometheus-alerts.yml` | 4011 | `588683a333fe5ac09de388a8914f99f103f72885ab008387e25474c10d1c6681` | YAML | Rust library crate |
 | `icn/crates/icn-gateway/src/api/agreements.rs` | 50247 | `f23c064db8547126fe6ef5df27857a226e2f89ae9fdb7ec95a9402a3750e6bd7` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/auth.rs` | 14768 | `d80c0b652ad34375dbbe4da4875891b25b91a011c20304b92587d2ed1ab4c04f` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/auth.rs` | 14894 | `cc43c1cbd968938a0a0e89f16a46c982fdf2134cc1cf087182591fe45ab8ee2c` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/budgets.rs` | 8138 | `108e517162d6442a76857f8e9d06f23668e5ae88aac976b8b44bd87188eae040` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/charter/mod.rs` | 20691 | `a3b173ed27288da087981aba3dcd26fe2f382718ed4acf357434b89edb2d2f08` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/commons/anchor.rs` | 12054 | `a1a58f3b83188b5137559b9c612521e96696c842788cca79f25cdd2875e2895c` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/commons/mod.rs` | 16247 | `82dd2f3d13869321a7038a26ab41941aa036e93e32d29728607848e30bc0a789` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/commons/mod.rs` | 26476 | `3860eea35d5075569b744420ffaff1e6be7af328b83c2952a417b16a7312371f` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/communities.rs` | 12558 | `88ddec17a791849e66269751f258510c4f8f0ad946298749e74c5af41afd11d6` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/compute.rs` | 24207 | `7a920d4571749934191a952f15356a6dd84b8b9860e3b407a30b0f6972f231fb` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/constitutional/appeals_ui.rs` | 18269 | `158ed3d5b589a636479b1e3d6d00654b708aaf01a11c84dc3a3ff358a4c59082` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/constitutional/mod.rs` | 50482 | `dd42258e1a733e6020d72400a65d46e8a7dd57c23bf15653c71b931451e75f0f` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/constitutional/voting.rs` | 16130 | `303ab32a71aae78ad4bb188339b5d66d0e4853d2e17331bc3228c3cde0d352be` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/contracts.rs` | 25467 | `c984199818a8248ebe8a17bd032952426ec374d4a477f17e9d584bdcbaf94b37` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/coops.rs` | 24430 | `c7972efce78103912fee2826502a1e31866c8196e1e611e737848a3fe2a87592` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/coops.rs` | 24910 | `047571db43acd66fb0ded1f299f4a7b145b227fa1c25a941a6a9227cc1f57477` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/devices.rs` | 9583 | `0131d44fcf29e8ee705753f07089eb2b0d79915b4b2107d2974567d7615101ec` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/entity.rs` | 74968 | `74139a12e1503df80abf84a563c6c2dd5aa2fdcbdee3acb13324440dc6f81c0a` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/escrow.rs` | 12229 | `9da239d085144cb3ba18c5f1681aa79e033b2c5645c7108870b13ee4e098c601` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/entity.rs` | 74757 | `5a115aeb8d5c5b3086f17a6493367525e4143e8f9f48a5ee7426c8965fe650f9` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/escrow.rs` | 18449 | `c093d58a8bc60aaf9ef2bec907610ca4a4098014c5fcae7ceec6128c91464150` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/execution.rs` | 7810 | `bb046c587b95151b82c2be7ad5db5551d343a306fa88ed7fbfbd464613195332` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/federation.rs` | 79360 | `70819a230a127633203cf1369109adf9030113dfe94cd14134045551af84866c` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/flow_c.rs` | 8759 | `af93346a4377bf6298b894892ebf2f62710c660ccc7fb273aca4ad36003e4f97` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/federation.rs` | 113754 | `c585278ad43000364a2d868db2e7b715a172e7508e29f3e5d6c92525bebc2b44` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/flow_c.rs` | 11132 | `1bfb954901a9933463efb37cfb7fc8cb3436fdcab1a365a769ba09e415ed6c0d` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/governance_dashboard.rs` | 1412 | `14c9f31a2768efba7a1e57d775379ea73cb14244ffb99a7e3a3b1ab052d5f1cc` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/health.rs` | 20136 | `6651997d05c6b8e673b245a9ab3f0c2f86183734e688b0f61b74a13cb096ded7` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/identity.rs` | 6538 | `7ef3cd51c0dec83e012a400352cdf0bfb0ebbdfc6c855a9a7270942dde49c561` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/invites.rs` | 5860 | `c8aa450d4d859648f6029084a6369035325efbbd2147ff44d8ca4a519a666529` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/ledger.rs` | 66642 | `504068e419cca5bc7fb31e3b383aa43f0c5d02876c47730f8e88d3231366e7ca` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/invites.rs` | 10651 | `24f05ea807728dc17c925ac0216dabbd14223716a547cec5ea35c1090f88dcab` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/ledger.rs` | 67782 | `c63602613c82bd1ea9c0a9b12acce5053e36463952d68c9082eb99d3463aa250` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/listings.rs` | 46290 | `14ce3216ce3006f6704b07e74244849069e417ef8faf5cde44817b58d4f68bcb` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/members.rs` | 15226 | `ba66abec8450491affeba13c88e90a62181f8ee053b0dcf2b80503ec28b58a40` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/members.rs` | 15286 | `843367d5a8b00c5e6137455b491f78498841c4c55dae88df670cbd97b825bb30` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/membership/mod.rs` | 26716 | `9dabbd48d3ece3665264bb45bf0098aa50e6a993b48456e4c74ce8832f9ee64a` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/mod.rs` | 719 | `2da773bce228c3a3beadf903db91818f3009e87332b027859d8ab40edcbad2ad` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/names.rs` | 10801 | `f5c0fab950c68b122a71f7ccc7343ce66ee883b80863636ff16dbbf77ffb7f4e` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/notifications.rs` | 22117 | `d684d283574cec6aec76813276bc5ca350b302f077a8f1b6ee27b7132bf71afb` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/oracle.rs` | 16350 | `f6b8ea2dd33d292678b14c9c92518aeb1e8541c686606b981ecbbb6cc24adab9` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/receipts.rs` | 33028 | `b41b56f09b3019da57121c7899ea78d4820dacfd8bdf946516c89c07334d0c33` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/recurring_settlements.rs` | 14063 | `e37dbad6eb7ade304d50526560cae93cd7f40c08ac36a2bb43c17a9bc7b7da4e` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/registry.rs` | 50940 | `9d262c14f3aff983b697cc460474090d9be2cc6755a9858532d240073cf51e0e` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/receipts.rs` | 35653 | `846f2cd36a2428453e8828c01b2eb68492d1187248cb5b910a3fdd47ee8a01bd` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/recurring_settlements.rs` | 20190 | `26423705ac48b7775a35a7f7eb308bf61a711a98c1cae8de76442ee17e87ff71` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/registry.rs` | 63786 | `dcff82ce46d2b94158e036e9143d710ae1bdf4e607114f0cc88b8d26eac83f65` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/rights.rs` | 679 | `604e4f9aca65f8371cbaccaf707190b0225bdaadf1a017fbbb4ea2404bf5b8e5` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/sdis/anchor.rs` | 15335 | `8a84b36165c5961ab3f6ab017c7714ba692146247e50377cffc1855a7bfd1bc7` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs` | 16784 | `5459da4a485f64e9c7f7a97edde6dcb08711efdf4b533b557ec0cf358c09cee1` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/sdis/ephemeral.rs` | 13153 | `e1213a335ef1423a367bf2fc9f738fcb371fcfdc16c1e31dbc2e49d3ba8ea24c` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/sdis/ephemeral.rs` | 13139 | `a31560a7adbd600121c6e92e056129821c22e374c07bff0f71333d1d70d0d85d` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/sdis/mod.rs` | 16715 | `297cab45a6b3631f624fbe2f06dcc8ff27a3cd93aeb01e6192349a9e2be3e268` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/sdis/qr.rs` | 8872 | `b6dcd405419b6168fbcd9e981f3cdfe30642b818fe85dbdaa10cc56aaa5231ad` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/sdis/recovery.rs` | 15755 | `3a91c8337e1ae61e750232468d8bbb4377397e8a66a98511dda48b38d4133c65` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs` | 56724 | `06085151b976f9269548be77c88723b98258e5eff8fb66d4d8820e06d56b2e7b` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs` | 56716 | `83203eb35b72b7b79335b0a60cbf473776cf8815ab3cbc4116981188a49c74c7` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/sdis/verify.rs` | 12742 | `271e506dfc6a3334a548c4483d16415d1bf043b0dc77042ddcf9473910bd043c` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/services.rs` | 25251 | `0171730b711372b2c66ed91463d7561d9aa45da338dd7d3bf977b340588fc256` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/sessions.rs` | 16215 | `086bcf329215deabef5a86a36d5bd60e9d6acbd7dd9f645463c9e71d8ec83ab0` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/steward/mod.rs` | 26765 | `e88824cd66fb37842522a2033843c355baf949830531315615d43dd6158d8c82` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/api/treasury.rs` | 44067 | `69c0feaa1b171f7107481471788abc5e3def2a1bca14cb1cb6f00afff09dc615` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/api/treasury.rs` | 59556 | `892a34468e8451a4e669df55d9d26c193788858aa3da08d8f30a0db5c873ca33` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/trust.rs` | 7595 | `6f5d31f92f3f2de27aabefd10f3799654c850972e485d147047c9f8a36dcf299` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/api/websocket.rs` | 1650 | `e9baa5eea0cb2064f1677a4406b6fffa597f395d566ccc431bc00f6a9e2c7386` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/audit.rs` | 7364 | `e97e1b522c765eecd98f27f56654a0f0f7c0cc9a944a7624cafb955e5c19a32b` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/auth.rs` | 16748 | `0005b4c76b0db2d6fe7e4d888a26736b2a7f8dfbffba8fa35c1cf6093170eb24` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/authority.rs` | 4006 | `16d812350c7ae102ba556a4e5b57158ccc56cafeec009d21970a007c68a5ba6d` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/auth.rs` | 31048 | `d017f1ec4a3028812473593c0d62f6266653d554558233570eab4d166f953717` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/authority.rs` | 35098 | `0b0c2459b64b1608f445aabbbf223655e717d54c868e6ded0b6688f80e289437` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/commons_mgr.rs` | 37781 | `cb981f120c2d36bcc49817aceeb1a6f6c10c92668434d83e85302c51c3b78106` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/commons_store.rs` | 54274 | `48747a89bd85d2cfa6a94489e15128d3f28979836a1fe6c72fb8e3d7b00167af` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/community_mgr.rs` | 4626 | `3cdf183ac686c6cfd4a0ddf3a8a90e923fe9294fd35e3652dcfa5d1fc4e5cb55` | Rust | Rust library crate |
@@ -2452,8 +2747,10 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-gateway/src/compute_mgr.rs` | 16589 | `61e50b0fdc7560f7c98fbdef2ca22268805f22be2a603b84f629b8fd240e6e14` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/coop.rs` | 28299 | `a1c075e304844abaa077de69fbafe3d0c15ffa8756e04462e9066c1619f78d4f` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/coop_actor_adapter.rs` | 8595 | `d94c72a52a6df883a0211bffb734440f9e6426f4be7896010b3fa99cffdd132d` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/dispatch_evidence_backfill.rs` | 19434 | `8a855164ad33daccc76d2827cdd117a6bc76e7f5040cce92aab195072d63d740` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/email_client.rs` | 30562 | `f21c89a9e8f0d0567fbcdf2319c4ee1dc6ccaff60659800e8cfe3ac7e2cdc880` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/entity_audit.rs` | 37813 | `e84f3d855a0bb1c330850fcf38ded683c7589f48ddf06bbf49be426537600bf1` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/entity_map.rs` | 3783 | `daa10b0676215c562731348655ff4aac4f26a4c964de2680ad80bf1d241ecf57` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/entity_mgr.rs` | 14502 | `e4d55888c86b0583c2bf03d23cd87f7551e298613d8c62c5fa67ae2b6d53d8c3` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/error.rs` | 11553 | `81f131353ec50b2741424d7cf77a3930411c9dee482744d0a978a617bb690ba7` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/events.rs` | 29475 | `928ce8396ad501d116644d27bc84095ce43c7e70610c3ca7bc29f700c20e4ca1` | Rust | Rust library crate |
@@ -2462,13 +2759,13 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-gateway/src/governance_adapter.rs` | 7032 | `ce10342928ad9fdff0fcc9c5a71804c9509c767ae2eb43c6ac5c9373319cf732` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/governance_mgr.rs` | 353 | `83adf608a862fadb1253b8d6b85355e686fe0e46b417db3305b208f4ef79e4aa` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/identity_mgr.rs` | 19076 | `4df28a7e3e4b39ef9355e0c7ff5b2698643bf95c6338eacd92069cea62bb1cd9` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/invite.rs` | 7300 | `f44322d312f01b6ca5dee55e8c00bbb8a9eba75e4117815cf776b1ec597fd92b` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/invite.rs` | 7289 | `fac1077d63c5938e463b6ae60efeebcc130f5fccf28ba8173052795e37edeffb` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/ledger_events.rs` | 16744 | `769d9264ecd64f30517606d72470d9f589f466391a78f2d4650a2eda6fb2e4f5` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/ledger_mgr.rs` | 29245 | `5f8a6e6bc7e82123bcead70bfdb619b0b7c32efadcb5a1aa6945c39d24105bdf` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/lib.rs` | 3922 | `b735d28bd6d97e51b38cf9875dc93111db562afd1c36609da5733a4d59eea512` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/lib.rs` | 4006 | `9228d55f3df894193558a41a8a7b6a656c2a099b70f12f3d2a07328c14bdb52d` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/listings_mgr.rs` | 65412 | `1a72f06d7b34a178e339a135cd36ccf2dcc9ca3f071ac74de43cde1296b73aec` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/logging.rs` | 1942 | `54438b96d3c3f367219bf3858305866914120ad59322b81f259dff375c5130e2` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/middleware.rs` | 9522 | `81b87c961ad57eb486720ab2ceb626fff8b839b6af7818e7e6100d837a81f691` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/middleware.rs` | 20806 | `e86c07fcda523fc6200ab8380d4dd4bf514afccf12932539407e42768a97f67f` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/models.rs` | 41380 | `33eb1f786c2ecb07fdd88cc78972d0d31711c03cd88706982acf97804cfd5059` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/notification_listener.rs` | 6598 | `3bd2cf683f548e859a148ff19f5142416be679638e5ce350e6e7ed5e396d9413` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/notification_processor.rs` | 32228 | `04b3d666d1f435e8eb32f4221014b1ec0e6bc84ef3873b630c059722a39db0e4` | Rust | Rust library crate |
@@ -2476,25 +2773,26 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-gateway/src/notification_store.rs` | 14227 | `d2b00106118ef10abda933abff4598426ad1dc6ffde9c5360f4bc67a03275149` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/notification_triggers.rs` | 19145 | `bca8aff322999141f2bc16840fca55f5b42a9edaf79b00fce82d7771e6b33c3d` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/notifications.rs` | 9630 | `c3c483caa6ae7e05d0237acdd5da230c292ae09e77e3da2dc27330e28d4dfd84` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/openapi.rs` | 7363 | `7c56884f672cfe396100b52e4eff0352a503405768eb1119744e3157467e34c3` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/openapi.rs` | 12879 | `b6eba38670f110abc46440cea8e7d6fe70ce61fd87ac0210ec7deb094d783700` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/pagination.rs` | 299 | `488a3ff766f54526fab7178a52a7e0093c536ec1ed3f7204f093356c986b6c9c` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/rate_limit.rs` | 42323 | `99ef5ae492d0ad59ed2478de9911d63d1005004cdd020432fa35d25102b29249` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/receipt_store.rs` | 135684 | `8ea36ce661df6c9e31f2b620508d91408e677942a0a5f4bdad0a2dad292ef419` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/receipt_store.rs` | 181810 | `e8eca4775f3c402dfe564a6ff1fa93eefc25177d0900929f287aedc04fcf1886` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/security.rs` | 23916 | `fceb52c469718b4c9383431fc4b4f7fe42b7a76a75003550a8918e05b649956e` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/server.rs` | 113154 | `a93b746f9233a48436bc4cfe3f8a5db397ae2c329d8f2b945341298ae6ffb1c4` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/server.rs` | 127192 | `eecabb6a8162c8975229b71433e61b266a877dba77381086a75668c0dfe063bd` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/service_discovery_mgr.rs` | 64619 | `40938231cea9657837cb558249a94db919fc84f4ea84919f44cd9e2a92f23244` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/session.rs` | 12721 | `144e9538d4cfd0c25dc612fc7b41c62f03279ef145da69d54056f56b69d2d789` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/session.rs` | 12710 | `01381552373578e0e31c06fd50662855590f098d1c6eb2e957e4776ddfcaaad1` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/steward_mgr.rs` | 6527 | `c60bc68ece803327c65f4ae6d932c3bf4842f7d4bd26f174a6e21a9b3f5045a9` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/token_authority.rs` | 15082 | `e341f222007f466aa6488d54bdf94bfbb98f9615f87bee5312d5074c7e9f444d` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/treasury_mgr.rs` | 18702 | `8665ec75d514ca02984a90709f2534d443192d0d039e091f192afde161fa9c4c` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/trust_mgr.rs` | 76216 | `35bc7a29ef8f0ea9a125852c96a012524fa35725ce832f9b66aa09430568dad9` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/src/validation.rs` | 39581 | `673575190284b790c0740c62520e632ab74597eb4c4e8a5bd46e2816d8f1d878` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/src/validation.rs` | 44466 | `4d9982b806ea91847c86d940b3755123940efccf0229ea13704cbcbb22ba678e` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/src/websocket.rs` | 17494 | `da5c45f1a6358956eda9c4566e31f042a4bfe27d92dc82d168520e82e81955b2` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/static/README.md` | 4340 | `f2ff17daf9f618424f4b8c7800bfa887996afac7fb33ff002836c28eae665f8e` | Markdown | Rust library crate |
-| `icn/crates/icn-gateway/static/app.js` | 245204 | `66387341ce7191276c84d02f039ac6a528c1328a88f4b0462e9a2ee075e9b883` | JavaScript | Rust library crate |
+| `icn/crates/icn-gateway/static/app.js` | 245225 | `0d776af2cf0aae003839983f9f4e18168522cd0480a99fdae5e5934dae04725b` | JavaScript | Rust library crate |
 | `icn/crates/icn-gateway/static/demo.html` | 9940 | `555d53dc21cde129297e22a5f7367c12df116a187fabeb784e1a50bac65eef23` | HTML | Rust library crate |
 | `icn/crates/icn-gateway/static/demo.js` | 23780 | `5d87e8c6d027b2e8ea22f1c38fabc33e230e1e4bd311203845ba0d2da3497603` | JavaScript | Rust library crate |
 | `icn/crates/icn-gateway/static/i18n.js` | 5039 | `68f06459707f062c10b46fdb02d2ec6d84ba2e05076cc6f53bd4b00139b6b000` | JavaScript | Rust library crate |
-| `icn/crates/icn-gateway/static/index.html` | 97197 | `904304eedb4cde267b8f920495f9cfa4a9d3f5c900e3929151663e838f7168c8` | HTML | Rust library crate |
+| `icn/crates/icn-gateway/static/index.html` | 97231 | `93c27be12136554ccdb9757a6d01d732eb6e459fa186c0bdcd3d987ca2ab9c2c` | HTML | Rust library crate |
 | `icn/crates/icn-gateway/static/locales/en.json` | 4560 | `48f6b22dfe864487a0568a1198bed0bc957fe06b16f55c9a582ac89729edc24a` | JSON | Rust library crate |
 | `icn/crates/icn-gateway/static/locales/es.json` | 4929 | `11cccced8cc34f684c874e23f1a0a5ad0153a08a64b1e199fa0bf5c214e463a4` | JSON | Rust library crate |
 | `icn/crates/icn-gateway/static/manifest.json` | 2898 | `339396c3ba9f3eceb7529e3677c11f45428c43ced7b5b4013091c256095ecf4b` | JSON | Rust library crate |
@@ -2502,31 +2800,34 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-gateway/static/offline.html` | 5735 | `15458d79294fc6ca649b82d51914d3601f80115a6ffbde9df4f07edc0757fc57` | HTML | Rust library crate |
 | `icn/crates/icn-gateway/static/receipts.js` | 17641 | `474f8ba1ce8f8046d8f972e89f900717284160223dbe8cd9e14c0afd79790879` | JavaScript | Rust library crate |
 | `icn/crates/icn-gateway/static/style.css` | 106463 | `1c20aad951912be7cd59cf3b703ad1d971545167268f89f0bb2e1ea6bb26f70a` | CSS | Rust library crate |
-| `icn/crates/icn-gateway/static/sw.js` | 12014 | `b73527af75073c667ffeecc5eb7cca7a0c84dd3097e4f740a11d899d69a37f92` | JavaScript | Rust library crate |
+| `icn/crates/icn-gateway/static/sw.js` | 12014 | `29e788d153426b4d84cfa5f7db5b8d3dc80b4071fdc1bbe65f477dc17aa88376` | JavaScript | Rust library crate |
 | `icn/crates/icn-gateway/tests/authority_enforcement_integration.rs` | 26081 | `ec61ed66ac4b8293bf4de9e3b5c98d91d8d2fb3c84702b2ed7967fa0b20362df` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/boundary_scope_integration.rs` | 8849 | `596fb61856d75a7cbba460c49f4a48f44cc0053f33c7127151f385415d0c43ce` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/budget_integration.rs` | 3329 | `641aa2e04c53a2ab4642f5c0f34e8fdf4e328e7d95629a9c593432ddd3d40679` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/commons_integration.rs` | 21494 | `4dcfea113c98fc3df09cc2636e4cd7eb71b5dadbfc1967f66784afdd7d788812` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/compute_events_integration.rs` | 12991 | `d03d45970961e56302610977c2a01ea210f3d2c0b6999a444446af668c5f5b9f` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/constitutional_integration.rs` | 19883 | `6fa8f227ab5813cb412ee75215c1dc965b36ee64cb64e5ea50a1caea9d6eb1ea` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs` | 16448 | `540ddcc6b44c1b098f2134add9e28add0d0016bfe7e096bb0c4b436fc96dde72` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs` | 28424 | `6afb8a1740a83892fb662412ea7b219f3f7bca4d13b77e9b1145ae3958934d44` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_institutional_flow.rs` | 41979 | `00e1b5c6272513f8325cc5ea0ae4a8683ce58078638bf91c5ee0b2ab92d2d4a2` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs` | 16282 | `0fccbdfe3c2eca3c9d0e1b9462a64f31c5e1c8127e07b3c019b23d0705cd31e4` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs` | 12369 | `85659d308762fce7f30acd5b666c6ee34b2f8ac487945aa04ff36de76fb9d6f3` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs` | 17915 | `3884c0e9eeb21c60eacc59b9610fe3e1c072e85c2b1dc915493a1aade14bdbe5` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs` | 16843 | `e72cd1315f04e2e591fe50019001fd212be91160d7dae3dc0e14cb5dee2fe7f4` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs` | 15021 | `231f3423e9e51392502ace64ab63516e47d1294bcfeeab1606c60ae197f9213f` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs` | 23736 | `c87d209c84eeff21be89ad0e5a0cb8b40efb4d9c95472d0362a2e18d9968d4ad` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs` | 17429 | `29af36396b392e73b7afd6803fcd1ed515f32766517bfb8edb21b98044f058d4` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/entity_dissolution_integration.rs` | 34487 | `b72d65070f34f5113b77b469f3ca892ed831a76ce90f30c49d30e02f476dc686` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/entity_integration.rs` | 35783 | `1f9878a99b0daa06c01246f7bc4ca8305ef5a35e806b4665dd4dee23cc264ac6` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/demo_member_standing_bootstrap.rs` | 12003 | `731d39f471412e7eeaabd5117e874642dc1653f2f2ca8a980ff98fee7c457d68` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs` | 26650 | `c0169d9de9fc1c44ea4ad2384a833ce735ce23d6a4ffbbd4f207575c78f29fc2` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs` | 16588 | `e8166f7c4cf399669ffd74225b051d4a866a228b3ce0bc3a7d8bfdcc11834443` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs` | 29276 | `0f660977df394e227e29968df162cd79582052a5bb8a505ce7907cc0742339a4` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_institutional_flow.rs` | 42871 | `a037eeb68413fd36e935516849dc6b3b1e672b743657708095cd998ab916c95e` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs` | 16894 | `8ceff15a32ddced7951fe5d85c5cc386267e61f75c169d2149eb0f66f8d26d71` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs` | 12509 | `daf0db7262b306262b6070b4b2bfd6a91eef8e92e654ddeeba27fb863944be7e` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs` | 18527 | `fe2b73b13d1363e0c69a9b6639db3010b5d9b7d28cb71fbbddbb6be2b2f291bd` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs` | 17455 | `6bd30cc6aac568fdd0c3501cb01b5ddc7734a0d841da7974ed0d843c217f7fd2` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs` | 15161 | `e05a92b943a2070e5a53573dc29b6858c6a97f7e191a28b8e41679cd2fe2c5c1` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs` | 23876 | `26b4925c771efe4cd99a507e751275418e1ce51db013baee00c7dc9b3997b7e6` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs` | 17709 | `ee4b5cf475d002a2de73686aaffa7d3b5b6da04ca2c9e958d24d3ed2b2e61f9a` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/entity_dissolution_integration.rs` | 34539 | `f18482d730ef4a273386b8d6a999c679d72e98dafd7ab785c1ba860463564090` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/entity_integration.rs` | 35835 | `8a5fececb35c9586d38f88118eef1012b5b22c1f42d28501a8ed3c88a811c400` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/escrow_integration.rs` | 5357 | `05cb6df6a2270d6d92631864b4b07d85ceaa029881691ca2eefcad50947b1e27` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/federation_endpoints.hurl` | 6275 | `712b37cb5106b42b752754fa24547bfd4b6fcb0be9060a69f01c9c2d4f080b11` | unknown | Rust library crate |
 | `icn/crates/icn-gateway/tests/governance_flows_integration.rs` | 22149 | `c33ae07db900186b14f0dc9e036040d42c03dbb8827a58d018f568c08ddd084a` | Rust | Rust library crate |
-| `icn/crates/icn-gateway/tests/governance_proof.rs` | 18801 | `898a32a20c3ff53bf19ad466dd2e651ec1d0722dbca55065ad411bbc75475058` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/governance_proof.rs` | 19111 | `3c2f0ed8b4d088f7ca541940a27113b11644e7ce9f2d6878a5e0e7f853d96ae0` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/i18n_error_test.rs` | 8079 | `a99e7f9d79c5ab940ba4d9407b8d02a973ba6bf8797a3e154a71e72cfa9dd11f` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/listings_integration.rs` | 33809 | `82c88c13fa4097a3e07b6d5db9432ee7a3027f2e92dbfccb24457063ebdc7117` | Rust | Rust library crate |
+| `icn/crates/icn-gateway/tests/mandate_gate_production_wiring.rs` | 4767 | `99b8b5e2fe6be3d653f9a4c576c90c2ef57e2ee012a2a6f00244f6f01e8ea5aa` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/metrics_integration.rs` | 1254 | `eb13736334e985e284e00605a5608f6f27a77114bde1725e4c336998f1234ed5` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/pilot_features_integration.rs` | 10422 | `ad8b1d3073edb994ef42e85d366a6ca38f89ccf7de85798b1a71974098d95c41` | Rust | Rust library crate |
 | `icn/crates/icn-gateway/tests/recurring_payments_integration.rs` | 3027 | `1f1b2d13a9e5ad34ed9a13920b2439ae578eb4cbfb26bf80ed7a02b6638d094d` | Rust | Rust library crate |
@@ -2541,11 +2842,11 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-gossip/Cargo.toml` | 937 | `8772aa52fd03c6f0dc1042b7314a32cea32a2eb65f7ec49d39a5e1cb8323c5bb` | TOML | Rust library crate |
 | `icn/crates/icn-gossip/PULL_PROTOCOL.md` | 7402 | `7c698df1cec99365f2877231059dd7a6fcf9d81af52310af4a3d30d4ce9bd715` | Markdown | Rust library crate |
 | `icn/crates/icn-gossip/benches/gossip_bench.rs` | 4548 | `b5fce90a2208de890f3a0380a21b1b27bb79f7535c73978b5ab5bdabb39e3010` | Rust | Rust library crate |
-| `icn/crates/icn-gossip/src/anti_entropy.rs` | 5550 | `e53070d6364c06bbb659d61b0314113722cb1980569bbaaa24c4e099f4198801` | Rust | Rust library crate |
+| `icn/crates/icn-gossip/src/anti_entropy.rs` | 10014 | `bfe386863aa062973ed6019941110d2ed86bbfb06b8f5ccf5bf957c1f8a0c55a` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/bin/gossip_restart_helper.rs` | 7639 | `ee500f38cb490169ace9dee02b2313df7425628a721f4ebd24e6a3bc35a52559` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/bloom.rs` | 18524 | `51d975b370b8cd3f0f555e9fb1511845756c3ed783a87dee89fae1cfd762b29f` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/error.rs` | 1572 | `9b57f9599a7dbab5766e3a82c682e8b930a621a6e566df8ddc0b01a5e1261de2` | Rust | Rust library crate |
-| `icn/crates/icn-gossip/src/gossip.rs` | 128115 | `ac3eaf30dc9f5b2a1bd0cf595dae36ec2355c8197c97568af5e09082e3a2ee61` | Rust | Rust library crate |
+| `icn/crates/icn-gossip/src/gossip.rs` | 128630 | `06f38ae27d400a9eead88715b1b4eaf3aeedb6d3274cbaf006aa3f981c4ddb71` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/handlers/blob_nonce_guard.rs` | 10556 | `31d4e8f37979dd5e758de24734cbe178182925dce420b8633cb254c1894ece09` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/handlers/blob_transfer.rs` | 38916 | `123b182034950ff298069f5d6fca0f2ba649987239a2ecaf53230cc70d460e55` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/handlers/blob_transfer_state.rs` | 28890 | `f1ff6d4b8639cc4ef061a05404466354c80ce98dc69d23ef424b0f499924566f` | Rust | Rust library crate |
@@ -2560,7 +2861,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-gossip/src/handlers/storage_challenge.rs` | 14287 | `6da445064b42f34eb0d650d2ff085e30a01361a8f23416b92d87f75f65ccbb64` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/key_rotation.rs` | 11775 | `bc7d08619b70842c830b1089822e461e5dcac720a9a6b0b950088eb398d58a57` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/labor_shares.rs` | 8898 | `a04dfb3802ca39ce17097959cb4d9b61ca4d7a49c15bfee89426e23c412dbb74` | Rust | Rust library crate |
-| `icn/crates/icn-gossip/src/lib.rs` | 3205 | `2f399b176c630351580aee1a4ce27ef2e8e3e638745119ebc432792556c3bc96` | Rust | Rust library crate |
+| `icn/crates/icn-gossip/src/lib.rs` | 3445 | `6273bfc124077a85103b46d7a38ea36d733edae36c4444a69fc28f6421ce4874` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/partition.rs` | 26145 | `a161821fb8051a84603858f48a6dd9c8d144aec1cc441b6c7ad62e5082073137` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/protocol.rs` | 4446 | `01241348ebd160c9fa15d284fc83b7bae295e8d2c5ae2f03ce5b32af9291878d` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/src/quotas.rs` | 18640 | `ab262048c7bc46075dea9bc9df88d72a36c15d188130f732bd83c2505250f95e` | Rust | Rust library crate |
@@ -2574,8 +2875,8 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-gossip/tests/gossip_persistence.rs` | 17056 | `830fc4cd2ab62c92b2e087d4c1e0935e28e567714da6282c1861ed649cd95d4c` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/tests/service_discovery_auth_boundary.rs` | 23901 | `2657d45473845667bad6b11c9dcf58fc3d59056b6a86159ad5c7207189e2424a` | Rust | Rust library crate |
 | `icn/crates/icn-gossip/tests/service_discovery_integration.rs` | 9225 | `0028a271dc1be8bcad22a5ebca9d8338ce687a03d08166f801ab3c84eef2395e` | Rust | Rust library crate |
-| `icn/crates/icn-governance/Cargo.toml` | 1000 | `22539c066d91e6ba9ca1446d7f587ffc349707c1b97d23971804c1c444d24301` | TOML | Rust library crate |
-| `icn/crates/icn-governance/src/action_item.rs` | 41602 | `6ccf67b0cb7c509bbacde22649db6abedd4a2829a077bbcff2464d4ea567db9e` | Rust | Rust library crate |
+| `icn/crates/icn-governance/Cargo.toml` | 1048 | `0aa7832440af09734ca397727f1f77db55b303131c8e4e931a8f9019b974258b` | TOML | Rust library crate |
+| `icn/crates/icn-governance/src/action_item.rs` | 42374 | `d007ec6f142806d9f39c56b581909fb2e7dfb32511e70818dd38b996bbe4fade` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/activity.rs` | 15298 | `f5ecc4cd1f171fcc2a5eac0f9133d6926ba6105a32aa3bc5d2441c79fce59fe0` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/amendment.rs` | 41331 | `c31d3ae2c24913516c1e59be7c5f9957a92f88b0c9161edc9071fd330b0b2fb5` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/appeal.rs` | 33295 | `631f75db7eeff9c20ef1ddd75e713bc7a89b8c72dd55a5993c03b4d84f6459d1` | Rust | Rust library crate |
@@ -2590,9 +2891,9 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-governance/src/effect_manifest.rs` | 10139 | `306896c3e6c6ceb0125376ae7ab2594ffc9c634bc7bc94f7cd8f3f29b7374d00` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/error.rs` | 2333 | `2cec0e76fc73b54f3b8f7f4e6d5067bb0d0f4cf09de64f8f8fa5e812ec03dc19` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/gate.rs` | 6508 | `eb6b92da13c5fecf3d2fc9657d9bcc2e5a987e462fb78a028f6a2ae59d050717` | Rust | Rust library crate |
-| `icn/crates/icn-governance/src/handle.rs` | 9291 | `29cd7afb5950e7b3659235caa94dc3b16e7253c355201c404be1d1e04a362085` | Rust | Rust library crate |
+| `icn/crates/icn-governance/src/handle.rs` | 10008 | `d5e3d27bc5f606490c7621742f18bb6ec82c8145c2ca2a6b302f4ffdecf92e34` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/invariant_gate.rs` | 18063 | `31bba0bd30f4c53c4c23dd56807ecad791f3555907656df0392409febda93dea` | Rust | Rust library crate |
-| `icn/crates/icn-governance/src/lib.rs` | 8781 | `90b00719d6db87b5be2b3f4c103342ff423bb5d5b14277b40b30427f9ae48abe` | Rust | Rust library crate |
+| `icn/crates/icn-governance/src/lib.rs` | 9223 | `5993050f686bbd9f75407a29c74732950fc0e6c8303940fe5dc7aa4f08570b83` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/mandate.rs` | 15868 | `544616a587bf8503d7b6a5682424b66447c49ff115805b865463dd5dbd50db0f` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/meeting.rs` | 24304 | `871de21ad9223f500a4144c97e17acbb34e88c03cc8d71b4c1c871f29147f1ee` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/membership.rs` | 2600 | `1b0691bf661b68d88de5fa27c7ad9cd060676bc4782e11b8a063fe19c47ea73d` | Rust | Rust library crate |
@@ -2602,8 +2903,8 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-governance/src/power_diff.rs` | 8281 | `3f1a65dc4e16c89d20a9a3bd2556f613bf5dc6548e72faa79edd01da77cd15a6` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/profile.rs` | 14694 | `f2428c7f070e5c59867fec91807f15fa68504e74aefc9f592867596a26fadfac` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/program.rs` | 24840 | `f63d285cdc4cad9350db4f82f47e0829f6c79fd53e3f4a01d18c28467cfddfd0` | Rust | Rust library crate |
-| `icn/crates/icn-governance/src/proof.rs` | 39307 | `ecc8c7410152ec561b4faccb49227d8157251db932b2b1158be2807cd93a5034` | Rust | Rust library crate |
-| `icn/crates/icn-governance/src/proposal.rs` | 102924 | `29f7001526cfa890563c268108a3319f790232b3e7818ad0c6705b3cf57e59f8` | Rust | Rust library crate |
+| `icn/crates/icn-governance/src/proof.rs` | 204382 | `4cb8753a80922d12483d64741cd2eb39f04e9a044b38a469e1ad5d83342b46ba` | Rust | Rust library crate |
+| `icn/crates/icn-governance/src/proposal.rs` | 107080 | `bd7334ee69691a9126029143ddee21da3e1db0c5e3fe18444c16e2af2dd89a36` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/proposal_cleanup.rs` | 27163 | `28aa8d28369097931a2f590147f5769c2ec5b52b0d10ff29d820487077764076` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/protocol.rs` | 26580 | `26b3c6a42b8cf10ee2e06c9a5b3ded3efd3139a419c26a4483677a0f2ba0656f` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/protocol_defaults.rs` | 31845 | `84d29e508ea20205cd382dc7b1ffdcd40f4ae25768f734cd4f3fed7bbf8564a9` | Rust | Rust library crate |
@@ -2614,7 +2915,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-governance/src/protocol_validation.rs` | 10933 | `f938a28058ed811fff2d15f2519433d67a6b2167d3a0e2857860167cc603e852` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/resolver.rs` | 19142 | `5588da27f0a4ccc2d65565bc2096666c373d5695824a161df887fab4e1fcb9ab` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/sdis.rs` | 20965 | `ca651675bc2d0b09febcf3d9a512966c946efa801682bdc2550e94424f8f6f79` | Rust | Rust library crate |
-| `icn/crates/icn-governance/src/steward.rs` | 21612 | `967b40bd5bdc570073ad3eac78dfa45f8fc13c50e4088964edee7f5d3c3e65dd` | Rust | Rust library crate |
+| `icn/crates/icn-governance/src/steward.rs` | 24741 | `f15a8bc762d74f20634f680fcebff745749bb68e0ed1d4312331346adc176a6b` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/steward_store.rs` | 31803 | `ce7063612a9f9e3b72ab7d9e765585ec22da3d40e6fd5ef80299f6c922261418` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/store.rs` | 36446 | `d776a9325ac14bd40a03740604e09c87d2dd33e8c149f240946770554774ca90` | Rust | Rust library crate |
 | `icn/crates/icn-governance/src/structure.rs` | 21179 | `8ee059e88cf664dc9f863ebe41a13b1b60a05a75a37b54e2c5fb5d32b7506acc` | Rust | Rust library crate |
@@ -2623,22 +2924,22 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-governance/tests/governance_integration.rs` | 39019 | `9248ce92861910163cea1548ea603917da08a0fb701b0955e4f7ebb5ad25140b` | Rust | Rust library crate |
 | `icn/crates/icn-governance/tests/governance_safety_integration.rs` | 5263 | `0820a8698c2982bdfda47109bd8c0fc248201b0f1b0e34be149a17b931de5556` | Rust | Rust library crate |
 | `icn/crates/icn-http-kit/Cargo.toml` | 425 | `821788cac398c0114ddeed4e6a710ac8b736ac00bfdbf619ff14201d32564347` | TOML | Rust library crate |
-| `icn/crates/icn-http-kit/src/auth.rs` | 2790 | `bbb69e958270ec904f3b2c6811838c7cde197b79d71f33f3c64e903e8a92c7e2` | Rust | Rust library crate |
+| `icn/crates/icn-http-kit/src/auth.rs` | 11216 | `ea40183e30c8fd52f22b1955f7d2490be825b9a32d805bfd5ab6cf4396a7f7cf` | Rust | Rust library crate |
 | `icn/crates/icn-http-kit/src/error.rs` | 2087 | `43384b1b29d6912e9e978fef7eeeccb348045de16b15d6da53b0894645f57393` | Rust | Rust library crate |
 | `icn/crates/icn-http-kit/src/lib.rs` | 691 | `4c79f32b5fd758a43b245b4952ab1719e7f89819b58881bdcb4d4f257d6f1d49` | Rust | Rust library crate |
 | `icn/crates/icn-http-kit/src/pagination.rs` | 22965 | `cb190336961a8bd219e542d5594aedd485a473164290a038e85f2eb6a186db49` | Rust | Rust library crate |
 | `icn/crates/icn-http-kit/src/validation.rs` | 1630 | `cbd1bbdcd6420e142508766cd430ffe2bd0a812378a6eaaa2f2fe39bf20e5b0a` | Rust | Rust library crate |
 | `icn/crates/icn-identity/Cargo.toml` | 1132 | `2dc063c3c9b4ac2e04e02a7396e225848d0e213a02d415ddf51d61d2bc9c294a` | TOML | Rust library crate |
 | `icn/crates/icn-identity/examples/tpm_identity.rs` | 4573 | `d54054fb9f8ade993502b0e4f0a7006d88c274552e26d81498b85fdfb6abd6ba` | Rust | Rust library crate |
-| `icn/crates/icn-identity/src/anchor.rs` | 12190 | `8089f13b4f2b511be8e915e88cea201578507a0e2ce0fd7620223c90c3f873cf` | Rust | Rust library crate |
+| `icn/crates/icn-identity/src/anchor.rs` | 12194 | `8d79c5df2c4ff808ec089f5bf46596d3b587c6f7241c4ba062dbed9f3262263f` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/backend_factory.rs` | 6043 | `baa6baa86d553010d5ff351219b8afc1f54a3169b9f7953f10d1c79957539c9a` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/batch_verify.rs` | 14184 | `161d501c406d6e5250cfe67ccc9ff56e234737b78db7ab9d19805bcf8c5da265` | Rust | Rust library crate |
-| `icn/crates/icn-identity/src/bundle.rs` | 44041 | `595f5960b8eaaaabf5a5c0eb98e37d00734f5386826d5357a9ffc5eae9ef1a4c` | Rust | Rust library crate |
+| `icn/crates/icn-identity/src/bundle.rs` | 44108 | `fd910c491c311b0f4d785fb3a0e0cadf56eb73ab7e8eccadc40c6dde15076cee` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/commons.rs` | 36635 | `49f9a404e8e8c5c259beeac1f49d540076cf257db852ad0632b9bcb2b0bb9598` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/commons_store.rs` | 28563 | `0fb47ceeb4327b5748a24bd8b18393f84893c3dc08edf0e61c8d4eaa9513de14` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/did_signer.rs` | 9904 | `31bdc9c3aa97e3277be4bc6be4f7a37a1b2a17ab932065abddc05ed25e1bd171` | Rust | Rust library crate |
-| `icn/crates/icn-identity/src/keybundle.rs` | 17034 | `efd9a4452fd612e38cdb967b6d2db97d41c6c6d72f0410e1b17f40821ef4bdac` | Rust | Rust library crate |
-| `icn/crates/icn-identity/src/keystore.rs` | 61005 | `9d5d445a795d0add4a74cf080e0c5c0661147621df93dc322493a2d7a6cca580` | Rust | Rust library crate |
+| `icn/crates/icn-identity/src/keybundle.rs` | 17101 | `d7667a7478ea79d14999af4f6fe071c438cda67f1f78addc36158073845b1660` | Rust | Rust library crate |
+| `icn/crates/icn-identity/src/keystore.rs` | 61080 | `0ba37a15a4c28ceb50ef1528c5583277131be4cd52204d67fd99a5b7fd3c917f` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/keystore_backend.rs` | 5104 | `5e7c68284ede1e487cf1341c8db2e1b64806e310cc7d4fb7f2473832ea83869a` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/keystore_pkcs11.rs` | 5138 | `361889d10125f5bfa72359d41ad07e3ffdd70027f2ba956f18fd6a31b089f096` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/keystore_tpm.rs` | 52674 | `879d264e907066e4b44798a7196fb3e60728354454751cd052e7dbd82bd98d30` | Rust | Rust library crate |
@@ -2647,33 +2948,33 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-identity/src/personhood.rs` | 28563 | `3944e90f0c89e5e57474aa1b9daa36d80721355ac60b9dbe8bdfcdaa510a3490` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/personhood_store.rs` | 29310 | `7af632bbdaa55488a94ca592cbb01614c1fbd60f5d694bc20f4fb5d55c2b5b01` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/recovery.rs` | 26948 | `ef34c60799b44d0595e012fbdc1653937e53e7d282895142dc243d65223adf2e` | Rust | Rust library crate |
-| `icn/crates/icn-identity/src/revocation.rs` | 17389 | `66ab532e0f0e189d195ebb4bd518268140e25c50970455a80b8fa0d263f9b835` | Rust | Rust library crate |
+| `icn/crates/icn-identity/src/revocation.rs` | 17382 | `a6d07ea8e8d31b5b3a6dc0904ad63e181ec67ef7a3580ed25b616de413301bbb` | Rust | Rust library crate |
 | `icn/crates/icn-identity/src/revocation_store.rs` | 18907 | `faa6ed2c217e9357814c17432f4bc1804b9a77b69fb85f6df6031005f0cd0587` | Rust | Rust library crate |
-| `icn/crates/icn-identity/src/sync.rs` | 18377 | `606d44246f053d89be885c8fad2a32f25e2dbd041bb7d1579cb432ff4af88cd8` | Rust | Rust library crate |
-| `icn/crates/icn-identity/src/vui.rs` | 9387 | `44b56daebb84d40374a1c628393cee61843284529e9a82937b991d80c5bef761` | Rust | Rust library crate |
+| `icn/crates/icn-identity/src/sync.rs` | 18578 | `2dae0cc845b0e98705144730af2a9b4ece5f509d34c91875a3e8ba1ae81735c5` | Rust | Rust library crate |
+| `icn/crates/icn-identity/src/vui.rs` | 9395 | `ae7c1d2d50b44bfe24c5355c8a1392c2b3d47a71da6621e72118ef0cfd63a7c1` | Rust | Rust library crate |
 | `icn/crates/icn-identity/tests/backend_abstraction_test.rs` | 2766 | `b455d78dae0a25ec3e0e4af4b6f286ad6699ac2d96d6f38ee574ee716af63666` | Rust | Rust library crate |
-| `icn/crates/icn-identity/tests/identity_sync_test.rs` | 9150 | `a4c40c527e1d0931bb0454204a6ea052245bb78188fb57518ac4886616b301e0` | Rust | Rust library crate |
-| `icn/crates/icn-identity/tests/multi_device_integration.rs` | 10470 | `d36ff3155ebca54e4a6e55038db19cf8e899519be73104fe605a64514588ebf6` | Rust | Rust library crate |
-| `icn/crates/icn-kernel-api/Cargo.toml` | 773 | `752ba9280e6303e8cfaa1bf8d1680a8d9db7f9276fc03bea1a5be96b525c84a9` | TOML | Rust library crate |
+| `icn/crates/icn-identity/tests/identity_sync_test.rs` | 9149 | `26c0435f6c9fa21a56aa7a9f2f6a3a3381112bfa3126e9151fd45482b9678bb0` | Rust | Rust library crate |
+| `icn/crates/icn-identity/tests/multi_device_integration.rs` | 10469 | `bde1970ac127ba1a5509a9e1f4f4b6c3587f11344d49ff2834fe3248cd848997` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/Cargo.toml` | 1111 | `465e8f2f5aef2d0d037a9697e1fd1dbe382dac24460b60c28f748b4d58268724` | TOML | Rust library crate |
 | `icn/crates/icn-kernel-api/src/authz.rs` | 34565 | `75559557c96d0eb332d30d50d5abca92f8a368905ed8c748ade194e7cf8f45b8` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/bootstrap.rs` | 38992 | `2845da0a8545c00384b017434b7af98df2fc5d045953c9ecb3cc369938b03ef1` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/budget.rs` | 12747 | `0f959a6b028322721fd337700b1a1ce6e9b6bed20ea32947fbaee58bec7a5a8a` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/comms.rs` | 7487 | `3d6458e1dfc34e7473ff871bbf60e48694a7bdf97b142bf888132a210e23b1f7` | Rust | Rust library crate |
-| `icn/crates/icn-kernel-api/src/compute.rs` | 23303 | `6c555be50cde3267c2711f196ad167738f5652c799734559a4d034877813017a` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/src/compute.rs` | 23596 | `0bac17016d88d5c8bbfef915e5b30ec8169a803a7d64449cb55a418769532682` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/container.rs` | 5130 | `349a286c8908b94ffdcfa3188534e6878a8a8dd4bff1c42ae32d58ca33f9eb13` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/coord.rs` | 8918 | `a7e9e648928ebc13434dc89c17df18906ab6f8c07682e7078e992db390ff9f61` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/economics.rs` | 21386 | `352712a674d4ebc5b4c3681d1c94450290c0df8b11aed43032e3222488046198` | Rust | Rust library crate |
-| `icn/crates/icn-kernel-api/src/effects.rs` | 47527 | `a4edb667ae64ff0718adf9e428bd350117d28425c75c460877a3faab83e73043` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/src/effects.rs` | 50822 | `acc9c733f51a618e0898d45c72ad97f8de907e5ad724f3fc816c46b467fdb973` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/error.rs` | 9060 | `5394c9f3b3530f7554950c4db23f806b0af3f25870a8db4ca4b58544191d727a` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/escrow.rs` | 16744 | `d1bf5daec853f3aa4d27f8dfd09529fba512e98c32dc6d9aab3d16a70850a1ae` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/events.rs` | 5284 | `48cdc4ce9ac0ddc18b1a36ac843763129c67ce2eedc3fb23ea82eaf96d744e1b` | Rust | Rust library crate |
-| `icn/crates/icn-kernel-api/src/execution.rs` | 13368 | `5f802e98ecc58fd37784a27d97cc1c52263ffa679abb8a746aa8d315f5490eb2` | Rust | Rust library crate |
-| `icn/crates/icn-kernel-api/src/governance.rs` | 29285 | `761fc7e241a528e293f355e070ab29de3b759aa9785f3e20e4aa8107a725d8f5` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/src/execution.rs` | 17338 | `c5cecf876926c7e4a1c613be53b4daab26399eb1788fa15b1ad5b027cb944d40` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/src/governance.rs` | 32775 | `9ea867ab3705436c28056f9cb08704bab0079d22ef848538eae0997d9e9fbb54` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/identity.rs` | 7496 | `45001d0237a6d1d450ea3027ae577c6f1af510659d9319381c8c27249e1f9af5` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/invariants.rs` | 7910 | `e249811ab1856bf5ee3eb32fd9d36f8f008ee36c390c92f5cecb04703c3582d6` | Rust | Rust library crate |
-| `icn/crates/icn-kernel-api/src/lib.rs` | 6115 | `85ce686abbd798f804feb96ca090edd7e17a1918715b38b7cb666ecb93aacdba` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/src/lib.rs` | 7315 | `f75eaee597d2df91c0f00372a3ac7c6b3262514ef401bbeb2efa05f4e8a2e696` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/naming.rs` | 28527 | `82c6316153fac115fa7e1ea93d66ca40cc9e1bdf20b75f1ddfe0b4f70729374d` | Rust | Rust library crate |
-| `icn/crates/icn-kernel-api/src/proofs.rs` | 8456 | `03b54fe233a4948f4bde55fee8b2f13475e0b14ee70a59d4ea4dae2aa06d7ea9` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/src/proofs.rs` | 393150 | `7c05a7dc81672d9058f10305b82d8509c137f8ed1f6c2b26b6c7011e9a130949` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/protocol_params.rs` | 42754 | `b76aac0f83e990fac9bcef2b57394b725470e44329a79172c061ce0de27267f1` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/receipts.rs` | 21473 | `77fa40bb7e9896465b410419520df40d9f3afc8da6f976c6231e96f31f1e36c8` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/resource.rs` | 3029 | `6dcd07b7141e2f101d1568e5290274c26ebcf2320c74bc2662e03e530944c1dd` | Rust | Rust library crate |
@@ -2684,8 +2985,12 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-kernel-api/src/time.rs` | 9428 | `e69ae303466f866f550f415305733695edc5589a88ba3da93ca08162b92d3bb6` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/types.rs` | 8291 | `58201df710b39bddb4bc8fd67e58977d78a7e65909ffbbc636be3f7ba2380116` | Rust | Rust library crate |
 | `icn/crates/icn-kernel-api/src/version.rs` | 3574 | `06dc8e16412e016c83f3458bef6eab2acaf8f1783e0313339801a7d903f87ba9` | Rust | Rust library crate |
-| `icn/crates/icn-ledger/Cargo.toml` | 986 | `2720de0e275eda422a4102214ff88ce05a2b07251df27c10deee6461f4f51c81` | TOML | Rust library crate |
-| `icn/crates/icn-ledger/benches/ledger_bench.rs` | 4365 | `7c93b6351f10cbf3ec9ae428a0ea6f2c02d51d3aa9c31aef83dc47bc32fedeb6` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/tests/member_shell_read_only_render_slice_a.rs` | 81802 | `0248675632fcc3131aa755cb7817f567aded0d3d72a6ca07a980e75eea118d08` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/tests/receipt_index_anti_entropy_slice_a.rs` | 33336 | `deb0714b24fed76d5c5680b3bc322e384a532f2cdb0458fa4a963f600f027e51` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/tests/redundancy_proof_slice_b.rs` | 18275 | `899179974ffdbab1cbdb1b40f3addd2d7ace6746aeeca1bc86823fc309e7567c` | Rust | Rust library crate |
+| `icn/crates/icn-kernel-api/tests/steward_cockpit_divergence_render_slice_a.rs` | 53681 | `8dcddd5e7903b45c4b8abb46c3f5d290860b951330cbb50a4f8dba5bc2ad079d` | Rust | Rust library crate |
+| `icn/crates/icn-ledger/Cargo.toml` | 1134 | `ab757f4e9c6fe7250be4512712ed1ab3171557159df31e183205f6d18e430292` | TOML | Rust library crate |
+| `icn/crates/icn-ledger/benches/ledger_bench.rs` | 4364 | `593c42c01ebe4d7f13306a001d71cffdbab7ba6d4c18341ee0df109af4e93d71` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/examples/multi_node_sync.rs` | 9759 | `ba3f7c627e1d83a6cec250ce35f40e4d85c8aadc5760e250e8c42127d36ce288` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/allocations.rs` | 4982 | `83e3aa7b84720fc7b182a93cf645eb395536a1ec3a93323a6d34bfac11b13738` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/asset_types.rs` | 18645 | `ef11ed69476b16b2b63d13823d1579f62a6a6fbf24a8df4d116f9f1b756d95b3` | Rust | Rust library crate |
@@ -2702,12 +3007,12 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-ledger/src/fx.rs` | 51493 | `8b9332f72eb0f9af81b00c334cd995f59d88405cfb5008737d448d7f58c31c89` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/hash.rs` | 6186 | `732c4881174e4b524dc4a2d658e32a7333cc0367c4ddf47126a339d91d91459a` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/labor_shares.rs` | 33338 | `5424cadb57c2838a6c233c7742b865a83d8d5e1d09489860ffc3c6f62deaeaff` | Rust | Rust library crate |
-| `icn/crates/icn-ledger/src/ledger.rs` | 185027 | `6d2f92e4fa42781330bced4777e69ce77dd915a016d3de27f30271cb562fe374` | Rust | Rust library crate |
+| `icn/crates/icn-ledger/src/ledger.rs` | 190069 | `79c522e64ecf8f1041729bafa9fc93cc2cd45682561ced5126ca51dac6ef7ace` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/ledger_impl/balances.rs` | 10492 | `3e5d551680adaacc933c50525bc706bba06201b3cee7d425591ab8962d1658fa` | Rust | Rust library crate |
-| `icn/crates/icn-ledger/src/ledger_impl/fork_ops.rs` | 13501 | `c5e9dc3ace4d61586894928dd28efac98fc532f7f860b06aae26bc4d71278fbb` | Rust | Rust library crate |
+| `icn/crates/icn-ledger/src/ledger_impl/fork_ops.rs` | 16098 | `c42ca407891c0de25151a4923d63a90c4f01d24d2393078b1a5827b6b7d6150e` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/ledger_impl/freeze_ops.rs` | 8490 | `0deaccd89ddc62cecac8b063aaad69b0fae96489c0538305fee4abb8336fe3af` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/ledger_impl/mod.rs` | 284 | `76568ae5fdc180313fd8387774fd866ebd9c66c6605e1562bf75552b981b28b8` | Rust | Rust library crate |
-| `icn/crates/icn-ledger/src/ledger_impl/queries.rs` | 14592 | `e1cb665d8dfb779d5c2d87f5050b79875e77b1b7887f1502ad75b7cb742afbdd` | Rust | Rust library crate |
+| `icn/crates/icn-ledger/src/ledger_impl/queries.rs` | 24929 | `39ee7e89a5617262de47406fd918aa00db6885ee4a480f72f343b3f135575545` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/ledger_impl/witness_ops.rs` | 13407 | `dc48fe2dd09413fc68bc6d6b932bc35a1350914fbb655fd0c09162a2f38147da` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/lib.rs` | 6074 | `0859604b51388a8ac332bc291038bdd803f2d54b5077e4e6d15ebfd5278eedd9` | Rust | Rust library crate |
 | `icn/crates/icn-ledger/src/membership.rs` | 6977 | `a5fe84c78be32ef145db0c1b8037728403ba6b55f9e6755cfca7a85712820558` | Rust | Rust library crate |
@@ -2739,7 +3044,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-ledger/tests/witness_trust.rs` | 19626 | `72cdfad0736cc72bb2b0bf8eac33aa5da9c0cfcf943cbf68fc55633513165799` | Rust | Rust library crate |
 | `icn/crates/icn-naming/Cargo.toml` | 434 | `3e5afe3506ea241ff435c7e4cf82a5698d89267963b5dd8da6c3da7a3d8820c9` | TOML | Rust library crate |
 | `icn/crates/icn-naming/src/lib.rs` | 29546 | `6647800a9c64df6fd23cbd194fc51a04204225f3cb5b3cfc55ac261dca514b5a` | Rust | Rust library crate |
-| `icn/crates/icn-net/Cargo.toml` | 1384 | `d593f0e507a7a2c54aa1ece01f7b740d388f6953500054666336afac5e977b2b` | TOML | Rust library crate |
+| `icn/crates/icn-net/Cargo.toml` | 1384 | `4d9ab9376358f728ccc56829247f0a7012bfa85b1c69e90f341d8cb40d35b86a` | TOML | Rust library crate |
 | `icn/crates/icn-net/benches/net_bench.rs` | 7879 | `85b5987d71ff471d8282bc9d08115743ca768ab0709b63705db4482f3ceaaef1` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/actor/connection.rs` | 17690 | `b29d2d3e333b308cdd1f9e360222a15931ef0f5963a5dcd9c4e67b45700b836b` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/actor/messages.rs` | 22143 | `27ce96c8175a2c82cd3226c395aa0d058904f5f473a307b6be6bef32bde569fc` | Rust | Rust library crate |
@@ -2761,16 +3066,16 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-net/src/handlers/signed.rs` | 29139 | `62a9724182510ccab8916066a630424d553b221c97558da74492e7edc7a72337` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/lib.rs` | 2295 | `fe04230d776c6f0f4de6091e4e126d85c6753962e57f3c5ffe9afb97bd23528f` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/nat.rs` | 13654 | `8f854bc75723ad76e622b46bd5d4a4f8d09ebd98281f55182f6024d2fc47a92f` | Rust | Rust library crate |
-| `icn/crates/icn-net/src/protocol.rs` | 82662 | `b8c2362cba3150e4390695aea2f4fd6682e9d02756fa0ebef5fd1bde561226b4` | Rust | Rust library crate |
+| `icn/crates/icn-net/src/protocol.rs` | 82730 | `786bb0339591413c04b49b0f9af21a6e38bf0dc6d8bc15d2d0bdbfa6e47d5a70` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/rate_limit.rs` | 45810 | `abbe36144f30cb6ce1dd9d3fdaf640da5875828f8653d4f6361ee2e53e0196f2` | Rust | Rust library crate |
-| `icn/crates/icn-net/src/relay_proxy.rs` | 28396 | `aefcee7d173d6558b1ee6d5a1a2e03d5b121292aca502d68accdf30cafc3bea5` | Rust | Rust library crate |
+| `icn/crates/icn-net/src/relay_proxy.rs` | 28382 | `2c2330fe17694bc64df9cacf86f74532a04c1038eda5a21c8add96651f025001` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/replay_guard.rs` | 49524 | `7608581a8c93f371e5697b1abdda2c7337bcc69aa147f66c92b2837dd9164dae` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/sequence_tracker.rs` | 36197 | `e2d0d373d9fdb25f47690023e206c4e250aee6c7c563bb9383571a8f235d98fa` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/session.rs` | 31311 | `0f41ddeca4d006c6a3420821faacb825501d805768d5a8123db3c0e8b53ef0df` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/stun.rs` | 14338 | `5c8d090d861fc11c7039a3bc1a2a7e7283b17fac3b4ad8404b670896e9addfe9` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/tls.rs` | 14894 | `40dab33fa1ab3ec0cfb3cea88878c64bf665a48b2872d63e45d6edf956764a9e` | Rust | Rust library crate |
-| `icn/crates/icn-net/src/topology.rs` | 29243 | `f94900ac4ca42596d19a2b730a84a16ac74863b205534b2a1fb065f067d56897` | Rust | Rust library crate |
-| `icn/crates/icn-net/src/turn.rs` | 38111 | `5da03a28bb8f8bd75d874f203d1bbb7ec01e078792c52018c6cea48b1b944963` | Rust | Rust library crate |
+| `icn/crates/icn-net/src/topology.rs` | 29317 | `4c1bfd5dbf6fa013896168315e6675bb810877337744a7feeb10f4a348297059` | Rust | Rust library crate |
+| `icn/crates/icn-net/src/turn.rs` | 38083 | `5352ea7e63ca4222a69dc2f55e4b274b67d22ff69333b97566583fbd7761710e` | Rust | Rust library crate |
 | `icn/crates/icn-net/src/version.rs` | 15921 | `acbd96ce5db8a96d22dcdf490201ba0e50c278d9a33a6d6bc2cca538735ff2df` | Rust | Rust library crate |
 | `icn/crates/icn-net/tests/client_cert_verification_integration.rs` | 17126 | `78477b2bc6d86166ac6da84d18e1e584e39919aaf8cc0a2120335e778a582e31` | Rust | Rust library crate |
 | `icn/crates/icn-net/tests/did_tls_binding_integration.rs` | 13469 | `d8a576d4dd9b7ae2ed9f2aa2c3539f34776c0f12f3a1ad22244de4a40d734329` | Rust | Rust library crate |
@@ -2789,7 +3094,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-obs/src/metrics/agreement.rs` | 6443 | `25da591ee40a940bb362e3a63ab18ce856768ba6526425db0e2eb9f74d440d84` | Rust | Rust library crate |
 | `icn/crates/icn-obs/src/metrics/apps.rs` | 5557 | `07ed60363aa9832d16fd7e634f09adbf274e0557496ae119c62aa6fa8e2f7383` | Rust | Rust library crate |
 | `icn/crates/icn-obs/src/metrics/exchange.rs` | 5401 | `e16f1a624ed40ad5d3892ddc10b13c34fc430293744d03d3864d87e006c98028` | Rust | Rust library crate |
-| `icn/crates/icn-obs/src/metrics/gateway.rs` | 22125 | `b463be3b7a3dcad9041d67084810f57621d8635f3bea2e9fc188e86277db5af3` | Rust | Rust library crate |
+| `icn/crates/icn-obs/src/metrics/gateway.rs` | 23401 | `422525e733e0d50a91a451e57545ae34e2ead4a7dfcd131f7c87467bd15f17f5` | Rust | Rust library crate |
 | `icn/crates/icn-obs/src/metrics/governance.rs` | 11844 | `2b6e82d321fa9fd682a60ca99f9893459114e3455a74b136672a822411afd2fe` | Rust | Rust library crate |
 | `icn/crates/icn-obs/src/metrics/ledger.rs` | 11142 | `6f5a6836078550316014b1798c5829a091bcb6bce97e0f76dfe29d57c198759a` | Rust | Rust library crate |
 | `icn/crates/icn-obs/src/metrics/macros.rs` | 9845 | `3ec49a264ed0e5580fff2966bc9f420e07aafb4de7382d3999dc610e5800b57b` | Rust | Rust library crate |
@@ -2807,14 +3112,14 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-privacy/Cargo.toml` | 656 | `ee2e5b495fa7ec6f48a4898e86ad1d79fe4d77a6aa5a1af1e7cb0f53902bfd29` | TOML | Rust library crate |
 | `icn/crates/icn-privacy/src/error.rs` | 803 | `44675ef206539b6eabd856ed5ea03e66c4e4cfeaeb9ebc153e502a6ce9d73cfa` | Rust | Rust library crate |
 | `icn/crates/icn-privacy/src/lib.rs` | 2451 | `4a42b9e9072cc4a802de79c99024f2dee6396e3ab8a4b58c28dc6ad198c9767e` | Rust | Rust library crate |
-| `icn/crates/icn-privacy/src/onion_routing.rs` | 19039 | `2ac63ba60961dfeeb7e9a5aa9ed36461b3de26604dd5fcf0ceaa14c1d564d648` | Rust | Rust library crate |
-| `icn/crates/icn-privacy/src/topic_encryption.rs` | 13291 | `4a757e2cca99c0c70658debedf9c6e6af19dad53bcfe36960d5962642ed4177e` | Rust | Rust library crate |
-| `icn/crates/icn-privacy/src/traffic_obfuscation.rs` | 11933 | `11a2b68c640a1867b4bd98df2ed0cea7c6ea7737269cb925b8f6b33f2b5a1864` | Rust | Rust library crate |
-| `icn/crates/icn-privacy/tests/privacy_integration.rs` | 20727 | `2dfabfa8a4abcb4d077d05e8998a00d5c0f30b914ffa9664d0ce95d25b867a0b` | Rust | Rust library crate |
+| `icn/crates/icn-privacy/src/onion_routing.rs` | 19028 | `3d6aff4ae3cfdaf21dad842f013e41a32bfcb5a964afcd12c85caea38b087d30` | Rust | Rust library crate |
+| `icn/crates/icn-privacy/src/topic_encryption.rs` | 13284 | `d9e9a0f0696ce7382fc454970adeedef8c15cc76242308ce2020c380fdbc18be` | Rust | Rust library crate |
+| `icn/crates/icn-privacy/src/traffic_obfuscation.rs` | 11917 | `bcd4145685ae1ae8037d3ac90216ea5267fb4f83a4f9ba08c91a3d40a20f4668` | Rust | Rust library crate |
+| `icn/crates/icn-privacy/tests/privacy_integration.rs` | 20725 | `63e9dc78cedda13c550962c8b36cd12c74f56113dde139eaace7c0cc39e810e2` | Rust | Rust library crate |
 | `icn/crates/icn-protocol/Cargo.toml` | 364 | `f057dfaddab5669838d7016d03a9819603e3bc5e1df88d51f9b95d229154d7d7` | TOML | Rust library crate |
 | `icn/crates/icn-protocol/src/lib.rs` | 1367 | `472aba069c69030afa195ce3f367d9f7cbb239e5e24972d4e44afb21339d6267` | Rust | Rust library crate |
-| `icn/crates/icn-rpc/Cargo.toml` | 1079 | `2707c6b255c88a439b682aa80e3f7c9768f86bd3e58c62c7214947ea91212c4f` | TOML | Rust library crate |
-| `icn/crates/icn-rpc/src/auth.rs` | 51169 | `69a267233820486b7353aa1c55b0ece13ecfe50c73d801eb4d79fb75bd6df01b` | Rust | Rust library crate |
+| `icn/crates/icn-rpc/Cargo.toml` | 1079 | `3fd30e2e74d46cc1b7ce148b5d5c59b0afdb85b09e65a671635fbbfbabbcec35` | TOML | Rust library crate |
+| `icn/crates/icn-rpc/src/auth.rs` | 61346 | `48ce6ecc5417011e26c7970944d387cf174cf19200cec0c433904c87d94d8590` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/client.rs` | 30172 | `d024810960765a601905ed32669ba8e4ef4291fcf7780b67f65cefd496055c85` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/context.rs` | 5725 | `1d614bc2d6854f183ab874cab8f4a8af57e514613045d56bcfaeebf5ec01667d` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/error_codes.rs` | 11249 | `a68fe090a89c1eba682e27cd3036fb61c2bda8c36b48c00efbcf7ac31f924265` | Rust | Rust library crate |
@@ -2823,7 +3128,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-rpc/src/handler/contract.rs` | 11100 | `0b5a7cc9fc75d10d05961ee328efe3fd94fb17b1853b2bfff6ecaf693e4e304b` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/handler/dispute.rs` | 17254 | `01088834a4abc4cc37e30faf4d637dcef2ad4f6d430ea6aa01c781bddf941eac` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/handler/federation.rs` | 31393 | `c4168d399c5abb0563e2a344096033acc3e02f9441a08a130538067776f055e7` | Rust | Rust library crate |
-| `icn/crates/icn-rpc/src/handler/governance.rs` | 25404 | `7d25450b42708406974dd370584b937d06540e0269d010dd4e6548e8e83c2234` | Rust | Rust library crate |
+| `icn/crates/icn-rpc/src/handler/governance.rs` | 25405 | `9f7c3dd0676488caef849f516ff88b1efb00637514aa15738f4a96bbc7e49f84` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/handler/ledger.rs` | 21612 | `1751c097ba255c78b33ebf2e5ecc24e4c679dd85c640fc1bd59dd676dc2bafa9` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/handler/mod.rs` | 287 | `786ca7121b6630cb19db9b734e6843da23d0459def7f2bb0b67d0158bb814254` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/handler/network.rs` | 5261 | `4d23e50124ec2adbf60fb310be4df9c69ae67a0ad7c6e5188b33a6c5af058415` | Rust | Rust library crate |
@@ -2833,9 +3138,9 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-rpc/src/lib.rs` | 1678 | `ecc0674be6a22bc6bc454130214056fc597ab61dd8cca98729dfb83f2ab23efe` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/pagination.rs` | 11229 | `ee172c8bf020b15cc87f7dafb6699e214f07729ece251cd3cf64ab7734eaa523` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/receipt.rs` | 11871 | `5ed89655d7c5e85834c78372b8f45215aafc28e5d531fda6ef6e4bd55a7789aa` | Rust | Rust library crate |
-| `icn/crates/icn-rpc/src/server.rs` | 36121 | `5a83e3d66bb33a9713f945a209ad6710f9949477dbeed53eb3602d13856412f8` | Rust | Rust library crate |
+| `icn/crates/icn-rpc/src/server.rs` | 37500 | `7b0ee90e7290a7e84af227b4007e6fae8f415ea5a34097c55818ca493b816866` | Rust | Rust library crate |
 | `icn/crates/icn-rpc/src/types.rs` | 24480 | `10a9a4c750d7f1cae9432df701112a92a74a09ff28509f3cfab158b309e53601` | Rust | Rust library crate |
-| `icn/crates/icn-rpc/tests/rpc_integration.rs` | 53922 | `ed6ec4adb694a80b61f33023207e8cc15a0759f2eba1dbcf432fd8de5a344f89` | Rust | Rust library crate |
+| `icn/crates/icn-rpc/tests/rpc_integration.rs` | 57690 | `1e0a8cf32963fa1459153acb5cdb8cb344ec0e31f38b718fe9406619a1450cba` | Rust | Rust library crate |
 | `icn/crates/icn-security/Cargo.toml` | 514 | `15a31ec51fe6560efdb3de11f6ea2cb6e9585d64a49938379487fb572f0749ef` | TOML | Rust library crate |
 | `icn/crates/icn-security/src/lib.rs` | 593 | `57d8b9fbdea2fbcba4a5c55ca0d18889180ba61d63743ddbf27d41ea3f30a5e1` | Rust | Rust library crate |
 | `icn/crates/icn-security/src/misbehavior.rs` | 73226 | `0cce08b44b1eb7ec82b1a6f090824a957e65c2b55b63abfbabd8cae0e68763e2` | Rust | Rust library crate |
@@ -2845,25 +3150,25 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-snapshot/src/coordinator.rs` | 20880 | `a8deab8a27b4ce952ab12d6c106ac18ad6fdf61274f9bc6cb80a9a8e74c38b35` | Rust | Rust library crate |
 | `icn/crates/icn-snapshot/src/lib.rs` | 66019 | `9c557db11a4a12052442e66b06b8e49c909c8ada9c1827445884a19763017c13` | Rust | Rust library crate |
 | `icn/crates/icn-snapshot/src/protocol.rs` | 10380 | `f2ac1a149285e505a341cbe51e807f22429c5b178574b9b83e2f9932f8c33f45` | Rust | Rust library crate |
-| `icn/crates/icn-steward/Cargo.toml` | 1017 | `4826ea65f513a94388d5bbf9c42e83804867ffcd9d6c3bad8c0218a69132007f` | TOML | Rust library crate |
+| `icn/crates/icn-steward/Cargo.toml` | 1148 | `f42ce4425dc8886c0bbf455adbe9247edddddec63c89a3a9ac58a9a7bf4ce43a` | TOML | Rust library crate |
 | `icn/crates/icn-steward/src/actor.rs` | 38379 | `4ab216b1d08c24a40dbbf2db061576a0c03051cfe00163f3ed60113ef57b4960` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/ceremony/enrollment.rs` | 12784 | `018cd03c5926f9103edd24e58078d6159ab89788c175b2c7b8d933c966d73e3d` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/ceremony/mod.rs` | 4959 | `824f71099b050b6ece7867b5ac796946572e0e39e6e4ecc53ce16471996c6785` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/ceremony/recovery.rs` | 14263 | `dbeb1b9d81b3ab3efd820c8bbcdfa633b0baa2be55390341dfc0b96134ffb91b` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/config.rs` | 5217 | `df5615c0ce170d048893e36e8bd027e8441c5b4f31e08dd1a24eb6a2acc8df9c` | Rust | Rust library crate |
-| `icn/crates/icn-steward/src/enrollment.rs` | 23714 | `9bed6f988bf0a9c22f5e37c03dba9083247623b212be56ae044442e5f6f44e72` | Rust | Rust library crate |
+| `icn/crates/icn-steward/src/enrollment.rs` | 23718 | `e369f927ba15f0579baca3856d6719625ea6931a1cdb496350b7d5703631eb55` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/gossip.rs` | 20973 | `a1bbf39885411b2bb95f11922262b9e979378a6353cd5d538e8257b3b1fa5822` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/handle.rs` | 13219 | `ac88bf64458b46cf41a5b7f1c74b7339df746fcbea2e468b597822ba431e1911` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/lib.rs` | 5240 | `4a9116f3bdf40958e4da62d4076e80b100a43244dce12bd30e9746545c7f11dd` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/profile.rs` | 13870 | `cd237af2b16b260a0c7fa4d5fe8e20c16648cc09909f5a8fc92ba8526c52be6a` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/recovery.rs` | 21797 | `76210064b11de834b4dd765b46ae647c1a788ba97d2b9afbb6e824e2d2274052` | Rust | Rust library crate |
-| `icn/crates/icn-steward/src/token.rs` | 9578 | `13489a342dd241f81e1759d53b53e54ca91b040502edb363ba9aed69fd1bf114` | Rust | Rust library crate |
+| `icn/crates/icn-steward/src/token.rs` | 9582 | `383d00d79c29b441940a9ba0f4618c74940f1c8fad4c11de8f1cec445bdd94a4` | Rust | Rust library crate |
 | `icn/crates/icn-steward/src/vui_registry.rs` | 10422 | `d0297875450940ec8491c8293b95ce9ebdba349c19159107192efd5538d063ac` | Rust | Rust library crate |
 | `icn/crates/icn-steward/tests/enrollment_integration.rs` | 19879 | `cfd44a80f0ab01a0221989196c8905326d8e873bd8cc5acbfe45105cc717ab30` | Rust | Rust library crate |
 | `icn/crates/icn-steward/tests/recovery_integration.rs` | 16210 | `d940969c05f70c624e1e799103236efc542acba1a3287faf2b5e92236c4957ca` | Rust | Rust library crate |
 | `icn/crates/icn-store/Cargo.toml` | 629 | `26d6367116013dcea37d746ade56889bd6aaeb1fad8a5e11fc9ea1b3a8f0e40d` | TOML | Rust library crate |
 | `icn/crates/icn-store/src/blob_store.rs` | 18109 | `b059030c0cecbae9f160c062afef3710e3b8d39aa76c0c678bb4aa0afa593b0c` | Rust | Rust library crate |
-| `icn/crates/icn-store/src/lib.rs` | 63061 | `bd4a202777c246fdc28ba92449c9719c6c11d4f891ef26786e73a794a455ef3b` | Rust | Rust library crate |
+| `icn/crates/icn-store/src/lib.rs` | 67837 | `f56b29610b715335bb96d33f53485a554404998bff82ea180bcb22855ece13b5` | Rust | Rust library crate |
 | `icn/crates/icn-store/src/maintenance.rs` | 12485 | `671eb5e72dcc1971bda3db34eb5a3111f6e1823e168b9fa76b06efb7d1b0b2af` | Rust | Rust library crate |
 | `icn/crates/icn-store/src/peer_cache.rs` | 15482 | `676ff862647618f3736c29cf3e958c3beecbc4bbe49720b77eeb04e60e0e453a` | Rust | Rust library crate |
 | `icn/crates/icn-store/src/pos.rs` | 39318 | `16f4daca12f5ed6f50356b98ab130879f137bbb4627b841650f001d354ab8d80` | Rust | Rust library crate |
@@ -2880,11 +3185,11 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-time/Cargo.toml` | 389 | `0c981bd97999bfb4effd22cf38691086eeb754c013a60eba6a5ef51d35a54e4c` | TOML | Rust library crate |
 | `icn/crates/icn-time/src/error.rs` | 947 | `210a320044dceb8ea1ea73bf9d214fe97242e0ab0f780744c96aa2010c811439` | Rust | Rust library crate |
 | `icn/crates/icn-time/src/lib.rs` | 1429 | `8fd87cdd3d4c484c40fa373c821ef74939210523a04440d89e81897b40fcb0b2` | Rust | Rust library crate |
-| `icn/crates/icn-time/src/sync.rs` | 18483 | `a7cd691602e912fe0a96b05d5f4a67f3c42e5f8b6417c8d2229c623e99004f73` | Rust | Rust library crate |
+| `icn/crates/icn-time/src/sync.rs` | 18491 | `da935294b1a712bafcde92307e4ef1ad0fa548e81114698a669bd8fc8aba2030` | Rust | Rust library crate |
 | `icn/crates/icn-time/src/timestamp.rs` | 5345 | `2ac30e3468fdf7e306b3b8021b915a6f5c58de612e7bab1b542a6ff956e64c31` | Rust | Rust library crate |
 | `icn/crates/icn-time/tests/time_integration.rs` | 14828 | `4c1b0779c9c22f131176f36dd198bc60a95b9e8da384547d552c0ef5efd46413` | Rust | Rust library crate |
-| `icn/crates/icn-trust/Cargo.toml` | 770 | `0f809fedf494221604cd9637c91413e7899ea7327d4e36d7e52c5b7b5f376410` | TOML | Rust library crate |
-| `icn/crates/icn-trust/benches/trust_bench.rs` | 9208 | `9bdc8586b450307df35a9f6fd884bfda6c1367db6b18165223f8a2bec5f1adfc` | Rust | Rust library crate |
+| `icn/crates/icn-trust/Cargo.toml` | 770 | `d4e2bbf9cf62a19fd71d09d37c0ee989704a992d21ba49b283b38adf9ef0b27f` | TOML | Rust library crate |
+| `icn/crates/icn-trust/benches/trust_bench.rs` | 9208 | `e326b9d31608fa752a80aef06976430d44530562776e6f3984cddba156bae98b` | Rust | Rust library crate |
 | `icn/crates/icn-trust/src/anomaly.rs` | 39110 | `80af4a589f209e1b34a0b45f6d37c013d11a97ae58c47f2a64703d5a624d813d` | Rust | Rust library crate |
 | `icn/crates/icn-trust/src/attestation.rs` | 63146 | `7a80780d0601cfc59ca80f6bb7bea10fc5a3d25ed4abc5b650dec08c80a09387` | Rust | Rust library crate |
 | `icn/crates/icn-trust/src/bin/trust_restart_helper.rs` | 6169 | `69c6fd9ad0b8e90dbc4f3cb2baa13f21f14fea41d389094f0a986edbb72e3e6d` | Rust | Rust library crate |
@@ -2903,13 +3208,13 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-trust/src/types.rs` | 35554 | `ffe5c32aeefd0a4b1ac4a8a1c9eb5623ddc85e072ee94ea4d2be65a1eb1e9003` | Rust | Rust library crate |
 | `icn/crates/icn-trust/tests/trust_integration.rs` | 40610 | `269881fa4f6ec382de55a477cae313eb0220fd0ad9366b593a0e734bf6b6644b` | Rust | Rust library crate |
 | `icn/crates/icn-trust/tests/trust_persistence.rs` | 14889 | `2638037b64557d63cf29c14f9b2449c0bd0e5d1d0f78a4a906b0dbd5ed4f649e` | Rust | Rust library crate |
-| `icn/crates/icn-zkp/Cargo.toml` | 1719 | `edb01fa3e06bf8c2000e45c539857ab2a04e1cfe2e183355e6da2587e4b65305` | TOML | Rust library crate |
+| `icn/crates/icn-zkp/Cargo.toml` | 1719 | `3428a7507928ded08ae6e3abbdbd11d11552d1c23db70b92fcb64d149b3096a6` | TOML | Rust library crate |
 | `icn/crates/icn-zkp/src/accumulator.rs` | 11518 | `5e4e4ca1f102ece903fa54fd88abd20fe58f6bab99fa94b768704d6e5c1d823a` | Rust | Rust library crate |
-| `icn/crates/icn-zkp/src/circuit/age.rs` | 12094 | `4ae2cd1a09d089501aa1b94529d2dead9a3e57a2cb04c5c2777d2df561a69820` | Rust | Rust library crate |
-| `icn/crates/icn-zkp/src/circuit/citizenship.rs` | 9736 | `310e296592dca598b67325ecf9594237713f7cea0b2d0df14c3394cba0077fd2` | Rust | Rust library crate |
-| `icn/crates/icn-zkp/src/circuit/membership.rs` | 10770 | `cfcb382a08fe145154289073cb24044a35e61dbb69761d4ca0edc3dd24ea2aa6` | Rust | Rust library crate |
+| `icn/crates/icn-zkp/src/circuit/age.rs` | 12080 | `d0e9fa49203453f75f47467c766b79f2aa16cf49835d947961f9295c2df4450a` | Rust | Rust library crate |
+| `icn/crates/icn-zkp/src/circuit/citizenship.rs` | 9729 | `007d24f00fa56c3f1317632a6897eeadc5edeb25e68468b1ecd90d6183508eeb` | Rust | Rust library crate |
+| `icn/crates/icn-zkp/src/circuit/membership.rs` | 10763 | `40a9fbe6b92cc1d8e4d1826793711feee145ac48ba882341dd24d3ccf3851485` | Rust | Rust library crate |
 | `icn/crates/icn-zkp/src/circuit/mod.rs` | 2868 | `d124f37b69e0efe16ce1205bdf504137728e21e311d59614c541f09e52bc96a4` | Rust | Rust library crate |
-| `icn/crates/icn-zkp/src/circuit/non_revocation.rs` | 17365 | `dda8c3f3cd58b2a6d6218a4e57e612b59e185a18361d156c05761725103e6e92` | Rust | Rust library crate |
+| `icn/crates/icn-zkp/src/circuit/non_revocation.rs` | 17358 | `87804672029f4ffbdef3d0fe693db5d08fe603deaf222fd6541f230fa71d66b5` | Rust | Rust library crate |
 | `icn/crates/icn-zkp/src/lib.rs` | 14799 | `a243f927a956341ae81818a3f51939456f9be241e6b40f7a15563dcf09528e41` | Rust | Rust library crate |
 | `icn/crates/icn-zkp/src/merkle_accumulator.rs` | 19474 | `b2eac462f204d505895e4a3d67b9975ed8eaad691b66c01bcb798c2a617765b8` | Rust | Rust library crate |
 | `icn/crates/icn-zkp/src/prover.rs` | 11790 | `b34ddde57b0d0c4f475b66eb27dfc29be507ed269e961e93162002a90b350ec1` | Rust | Rust library crate |
@@ -2919,16 +3224,16 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `icn/crates/icn-zkp/src/stark/membership.rs` | 9538 | `e9750a8cb145bfe1f3d14a6c869379ee43e337e0370e50b272f9144974b2fe70` | Rust | Rust library crate |
 | `icn/crates/icn-zkp/src/stark/mod.rs` | 789 | `6b4cb3989fedd038586d9539a9ad373f7b5fe22b5265cfa3b51ba6149ac52dfc` | Rust | Rust library crate |
 | `icn/crates/icn-zkp/src/stark/non_revocation.rs` | 8614 | `0121c09c4617461e7ed1192d9029e8f45b50f5490fb388a2549c7e4d4c884cf3` | Rust | Rust library crate |
-| `icn/crates/icn-zkp/src/types.rs` | 11534 | `abee609f1bed85265a41766472b29324f102b8cd51d84dfefe274069b3fe744a` | Rust | Rust library crate |
+| `icn/crates/icn-zkp/src/types.rs` | 11527 | `e9520f21abd75ee84ae9d9292b8d54fdc811782114cbb9b6e4a583435902bafd` | Rust | Rust library crate |
 | `icn/crates/icn-zkp/src/verifier.rs` | 13567 | `ea341f3aca695479ccc5b599f469f341ca2fd0fcbfaf5c3dc386892507d44258` | Rust | Rust library crate |
-| `icn/deny.toml` | 3606 | `0f446608233298c8cb0e3e43452468c197def97e5fddadb95c7818fec1646160` | TOML | uncategorized |
+| `icn/deny.toml` | 5081 | `cf2297330a7e38a0c1eb360a7ee38c5b65bd2c42a791ba34435d778509c52993` | TOML | uncategorized |
 | `icn/docs/version-negotiation-design.md` | 10540 | `f28fcc3262472e5a020d6a8e33368cfa0a8c6dbde9d1e075d457b18389d69f3c` | Markdown | uncategorized |
 | `icn/examples/signed_messages_demo.rs` | 4866 | `bbb3fada4ba2485b63ed42f0c06e0020f779b43be34cb73f468c8ce71bc2c59a` | Rust | uncategorized |
 | `icn/rust-toolchain.toml` | 98 | `f67a6121ba015b1fce969255c2cdda4ec0b6e6416d7248b9947e08e4a18eafe5` | TOML | uncategorized |
 | `icn/scripts/test-federation-api.sh` | 7253 | `59d31138e58fa08291de23e25166fc2d50edc576be35beb7c420b1f8f949ba8b` | Shell | uncategorized |
 | `icn/start-gateway.sh` | 1555 | `dfcb51a245888fe1e0fb367c30e74e8fce6190463f3738776b8dd9e22c6b26b5` | Shell | uncategorized |
 | `institutions/README.md` | 529 | `c1b171156f02cdc8be4de0d86def7be7b068595c3be98aeb64ae10cdf593b900` | Markdown | institution package |
-| `institutions/nycn/README.md` | 3330 | `af6012e20a4bd51878e302240dc05b01cd499a599674c0523c396b44acd19eeb` | Markdown | institution package |
+| `institutions/nycn/README.md` | 3364 | `cfbd9468b85de46c1ee69ec910ca1198ba23375a0bd1a89595f9b79f2c191786` | Markdown | institution package |
 | `institutions/nycn/bootstrap.yaml` | 749 | `fa118119cb18f527bdb55c2f914843b7a00a4ddafc350f2bf0c07deadb313489` | YAML | institution package |
 | `institutions/nycn/charter/nycn-federation.charter.yaml` | 11711 | `4a264a397356fd8ff03fc8a96a61d7cb4bd3350ac52893d4b405affaf2684568` | YAML | institution package |
 | `institutions/nycn/config/package.yaml` | 757 | `1b526cd18316e653a49175c446e96b684170b06d1444de6fc196906f284a7e7a` | YAML | institution package |
@@ -2953,7 +3258,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `institutions/nycn/seed/05-role-assignment.seed.yaml` | 1091 | `b4d1478355af333ff89b2f5f230569e1072ecfbfc8a79d2f15621209b26e1432` | YAML | institution package |
 | `institutions/nycn/seed/README.md` | 988 | `821119bc0af8d6b2faf7b820d6b68d909126d1b1f2ae0e64886ce73af67125a0` | Markdown | institution package |
 | `institutions/nycn/summit/README.md` | 294 | `78136996d672c51e0a666aec33f11954570d3bb4d9e03d8935204889bcc14994` | Markdown | institution package |
-| `institutions/nycn/summit/docs/workshop-proposal-draft.md` | 9261 | `9e2426fb88c94bfb34553e7b758c7b4c363ae6cab7d9d7305ff818d28638829e` | Markdown | institution package |
+| `institutions/nycn/summit/docs/workshop-proposal-draft.md` | 13525 | `433929518918ea2282d1f823ffc974a543cd2cf25fa966be23eecc0119df9094` | Markdown | institution package |
 | `institutions/nycn/summit/templates/registration-form.template.yaml` | 378 | `8e01e43eaa6f3f6e4ba6b3d4bbd1c41c4bb5cdd0d3398c7176f92a7dd90a59e1` | YAML | institution package |
 | `institutions/nycn/summit/templates/session-catalog.template.yaml` | 366 | `7ee16d8cc83727070ce0714fd2182997934ca3aa1b6571572aec6c68a2a240e2` | YAML | institution package |
 | `institutions/nycn/summit/templates/sponsor-commitment.template.yaml` | 342 | `7bbf2ad3f38e1bc875503e2aca7ac9b2655d114ad92fda308502098d4caab50b` | YAML | institution package |
@@ -2968,7 +3273,7 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `institutions/nycn/workflows/sponsor-commitment.workflow.md` | 355 | `3e373f0d32b4a7d07e933e3a0d68b2a1fa2f86ad74cfb306b96d429f6afea4b6` | Markdown | institution package |
 | `institutions/nycn/workflows/venue-selection.workflow.md` | 280 | `c4d00e77a2f84e363ded33ab1fec7a5f55ecad9f776eefebf95623b9fc59fde8` | Markdown | institution package |
 | `justfile` | 3565 | `44893c69c458b58b0dfd43a8a0d32e47dc4c197e2f3209f9bfd9bcb61bdeb8cc` | unknown | uncategorized |
-| `kernel_surface.toml` | 25208 | `6317c2a58c3af1d4e3fa3e501e1ac9bad5211f6c9ef66e74186913740f59bb8e` | TOML | uncategorized |
+| `kernel_surface.toml` | 25640 | `0bc4faf030b0cdfb21c1afed3b6717b43b2deb99aed8fa163eec5bb5e2790bee` | TOML | uncategorized |
 | `monitoring/README.md` | 5354 | `f5744dd110c9b68a37208764ff164e51ddd6fbdac61100ee9227b20bf2ed3f70` | Markdown | monitoring |
 | `monitoring/alert_rules.yml` | 9432 | `c23c01106da1d9154496905f0262d82580e4a7d30f7a172f67811bdc9e79e33e` | YAML | monitoring |
 | `monitoring/alertmanager.yml` | 2707 | `30d5fe0e776cc04aa12027f17464d56e28844843cd3c4f12b729919ebfe328fc` | YAML | monitoring |
@@ -2992,38 +3297,60 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `ops/coordination/rfc_candidates.yaml` | 62741 | `ea550992f0d33ab1633006e19a3cac599894aee6fe87dab0cda597bbaecb0cc5` | YAML | operations / coordination |
 | `ops/docs/plans/2026-02-19-icn-ops-design.md` | 15386 | `982de6d335c3b84593ebfc807991b59113bb5bfb250a71c47d904b6ed36c9827` | Markdown | operations / coordination |
 | `ops/docs/plans/2026-02-19-icn-ops-phases-2-6.md` | 30240 | `9d1643a018959ad8b3e07ec505cb18cdfef3dcd0fb37a23c740f2feaf9918a34` | Markdown | operations / coordination |
-| `ops/ideas/README.md` | 9257 | `a9d662cb37ee1d2be5ffc85fbacbb9ddaff61d6784347d3e660bb8425fe04528` | Markdown | operations / coordination |
+| `ops/ideas/README.md` | 10593 | `b997ce60d85d7287e542b7c53613acd43cd952a0937858cdfc5c8e301490b125` | Markdown | operations / coordination |
+| `ops/ideas/dogfood/democratic-authority-primitives-mvp.md` | 38374 | `e3062c4a0268e56f4ba818b99884158de8a666490348661af29bf2bcc2c07207` | Markdown | operations / coordination |
+| `ops/ideas/dogfood/institutional-process-substrate-mvp.md` | 32511 | `253fabaf690d8135f1577e2da2903241a566c1dd317e04dfc9d3921afa618c28` | Markdown | operations / coordination |
+| `ops/ideas/framing/democratic-authority-primitives.md` | 57767 | `8635027a9245657c486693f56a15d0386471f00d6a2f9afac9c8865aa5c4951c` | Markdown | operations / coordination |
+| `ops/ideas/framing/institutional-process-substrate.md` | 31218 | `b4836c7345bc5e2aeb4c2f79bff27dfa2400184cd0c544ad8769cb97f12ee0b4` | Markdown | operations / coordination |
 | `ops/ideas/framing/institutional-rule-authoring.md` | 17682 | `27f3305ee72c77357ad6eecd8f7b4b46f7f630fe6119c9d7240be9583d9a4281` | Markdown | operations / coordination |
-| `ops/ideas/ideas.yaml` | 36944 | `09862c024341f7034d85961921b5b2a472fb8569d5b4dec0dc6747eb854513b3` | YAML | operations / coordination |
+| `ops/ideas/ideas.yaml` | 54573 | `1d308bcc25f911d17f485ddfe9e4f516caeb33c9d71738983a243e14c03c3649` | YAML | operations / coordination |
 | `ops/ideas/templates/dogfood-slice.md` | 3833 | `990bafe7f29750f969122d6129509f26fa1ffc2c606be961c2433ce0a0b8c817` | Markdown | operations / coordination |
 | `ops/ideas/templates/framing-brief.md` | 3156 | `4a345a972b88eeed7bf8e2f613e0481d9c38eeb25c4f04c886c35913ab07d273` | Markdown | operations / coordination |
 | `ops/ideas/templates/idea-card.md` | 5203 | `6df6ac000e9092f581971171f796c2bd2768517d0d39027fdb0735d42a837050` | Markdown | operations / coordination |
 | `ops/ideas/templates/promotion-review.md` | 4551 | `bfdd15faf593374078d13da35fdcc527f562ef3753a5532b2e848d3a7a02f646` | Markdown | operations / coordination |
 | `ops/ideas/templates/source-review.md` | 4062 | `7c7df51a806638558ccccee0992f89cc780ac4339254a79dfa3bc5613ce5c5e0` | Markdown | operations / coordination |
 | `ops/ideas/validate_ideas.py` | 12799 | `8b2294098c5b30ff95d98ef97ac6c37657a7a912c0ba946548ceca8f223ef4fc` | Python | operations / coordination |
-| `ops/mcp/package-lock.json` | 112506 | `2379db1a91826bfd6d35bcbfd74b147bfd60abe83e0dbaf5896c12d092cbe8a2` | JSON | operations / coordination |
-| `ops/mcp/package.json` | 781 | `7c46ba65abee31dd621f22d061c82eb1cacad2c86d52f95355970fb1439433e1` | JSON | operations / coordination |
-| `ops/mcp/src/index.ts` | 3254 | `c3a2afaebf84870ae114329d13f7f55fa82e81be1500e8b0119218f1010375b4` | TypeScript | operations / coordination |
+| `ops/mcp/package-lock.json` | 106746 | `4d0407a8581d4cdbeb6bbd232b6fb9be686ec9a02fa351515840d4eed76cc2ab` | JSON | operations / coordination |
+| `ops/mcp/package.json` | 872 | `8914b169f20cb5cd316bc753fca0b7e2dfdc341ed925288abac812b447fdd3d6` | JSON | operations / coordination |
+| `ops/mcp/src/diagnostics/agent-brief.ts` | 3246 | `28f586f3502f5489ee8496e8065dcb64381cb2b885f09393c656c1eb254b540c` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/agent-context-spine.ts` | 12693 | `d399a51a51303cf5d7444d10d04b666e44bcb1624bb34bb6e489c9b66702bbdd` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/command-catalog.ts` | 7273 | `b10090eb447f0e94977ffd0c2bdf9ffcc12ee3cc273a936b058d21a22d47d6d8` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/doctor.ts` | 7614 | `3d10827226481d42b6b15538a2102bbadcf9ccdc00e4d5d63a9ec2e03076b6e3` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/environment-report.ts` | 8053 | `e411506ef4560d3fbf8f2661717e844a20651c7c4844a3e020a839b9d3ecfdac` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/mcp-config.ts` | 2597 | `0a2c212ecc638891e0e3b4c637a909258fd0b8aa57bc35be94e1ec0e6ede0f42` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/next-steps.ts` | 9509 | `5f0666177bcf508a4287bc8d0a16d4b0801169a18466d300e7548af0cf8159a6` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/repo-map.ts` | 2810 | `44ab45efba40eebc91e98003a6d3cf9c86c739c0cc6546c0cdc6b679437a1e7b` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/safe-json.ts` | 632 | `336f47dad678d4a04847b966cb79f55ad5fed8c883546e2488706c3b2b2ce848` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/state-index.ts` | 2102 | `c1e3521cb27bf94bde54d229779cdc2c160a2058a948b1859d85a5ae922cc11c` | TypeScript | operations / coordination |
+| `ops/mcp/src/diagnostics/verification-plan.ts` | 8703 | `43156b4d09beccd5a651b2ad3c70360373ebbdfd099950cb4353023db44f623e` | TypeScript | operations / coordination |
+| `ops/mcp/src/index.ts` | 6363 | `085108b41f966b4c5c2212e444989ad6cd65f680bf7e9b597caac4aeb40f39c8` | TypeScript | operations / coordination |
 | `ops/mcp/src/paths.ts` | 689 | `35fdc89252ccc25d4ac2c897675b4bc4f125b472fe6b70173b0ecf43cb6e6ed2` | TypeScript | operations / coordination |
-| `ops/mcp/src/polling/builds.ts` | 1034 | `5c72a214028ca3a22ba7001338498ab7317a6da8da8f9dc345a34bd66f1c5847` | TypeScript | operations / coordination |
-| `ops/mcp/src/polling/cluster.ts` | 2184 | `f9c2a9dd18ccaa37bfc29f82523a58045e2a53ff6a9e6e338353cad1b8e04062` | TypeScript | operations / coordination |
-| `ops/mcp/src/polling/git.ts` | 2597 | `33e397f53a8c50197342f3d34be1072d46c898cd634bd79bea9e546b902c3089` | TypeScript | operations / coordination |
+| `ops/mcp/src/polling/builds.ts` | 1487 | `f566f494b8ebbd600bc51efdef04d1e644c66625be24639fb9b557c41648ef1f` | TypeScript | operations / coordination |
+| `ops/mcp/src/polling/cluster.ts` | 2867 | `794c8f8813fdb3c1278d16ce5dbcfb81f07c249d2ac64e9833b586b9f062aa58` | TypeScript | operations / coordination |
+| `ops/mcp/src/polling/git.ts` | 3530 | `85c70986d0b3251f55f5d9a18c343ee6c3d0c705fd3be8987f9ad0cd6abcd859` | TypeScript | operations / coordination |
 | `ops/mcp/src/polling/processes.ts` | 1841 | `aaefe73b7e0d06f9a90a9282169071d5e21bd2509cb4eb4a710268a08ca07529` | TypeScript | operations / coordination |
-| `ops/mcp/src/state/db.ts` | 3651 | `aa52735f36e7f04635e90f103f626a41f10f7d716a39f0296d7902d71c356aa2` | TypeScript | operations / coordination |
+| `ops/mcp/src/state/db.ts` | 3721 | `173b0f63328228d4dda2498fce22158cb26e7330257e7fc743bf0625eead5cd5` | TypeScript | operations / coordination |
 | `ops/mcp/src/state/events.ts` | 2107 | `1a6dcc3cf25bac09b7e31ca50fa34ffd789103be4bef82225134003e05a69ec3` | TypeScript | operations / coordination |
 | `ops/mcp/src/state/schemas.ts` | 946 | `8af4f666783ddb19c17df3ee57cac648ea53c2f0e01bd5667cef153ffa3610ea` | TypeScript | operations / coordination |
+| `ops/mcp/src/tests/agent-context-spine.test.ts` | 13360 | `d589c757afaea3083e5210b766a46ab3573dea7fa0b97f88018ad45076a85370` | TypeScript | operations / coordination |
+| `ops/mcp/src/tests/agent-diagnostics.test.ts` | 5432 | `d0dfb67314c48334300c483063108c8b9ca80b5b2c136e5f060315742bee9621` | TypeScript | operations / coordination |
+| `ops/mcp/src/tests/commands.test.ts` | 3193 | `05a378f39279eecede13a54d4bf9c61c851b5c83e04a4d9e8fb4e9c73c652087` | TypeScript | operations / coordination |
 | `ops/mcp/src/tests/decisions.test.ts` | 6642 | `a8d0d21bcb246cbde42fef48edf0f2e0ba2e1194f6c7beab1f05b8860d29893b` | TypeScript | operations / coordination |
 | `ops/mcp/src/tests/fixtures/sprint.json` | 287 | `f94135ff2fab0dde2d0776776c0d031ab49c5e98e147c095cba9746a72764c90` | JSON | operations / coordination |
 | `ops/mcp/src/tests/sessions.test.ts` | 1909 | `ec79762b28e8bd431dff81d5c36265ae254f890ce659487a083664237162e4db` | TypeScript | operations / coordination |
 | `ops/mcp/src/tests/tasks.test.ts` | 2000 | `d164211810df7d376aeeea5626d9b367a7b2ba085523430d98d54919680f6e8c` | TypeScript | operations / coordination |
+| `ops/mcp/src/tests/workflow-guidance.test.ts` | 5968 | `e6ccb10d08a3c02d791c9d238917e94daecc8be122c0b1eb4a979bd7a48c6d42` | TypeScript | operations / coordination |
+| `ops/mcp/src/tools/agent-ops.ts` | 6759 | `bcee92066c3a0dc1dc0475f26302fea4fe92a0df0a2012d50b590a5beb30c36b` | TypeScript | operations / coordination |
 | `ops/mcp/src/tools/comms.ts` | 4494 | `92cb4159a9a3f9b8cea19f3844b3d4a341772e6885ffec4e1fddae132c70a00d` | TypeScript | operations / coordination |
 | `ops/mcp/src/tools/decisions.ts` | 14665 | `5068a702878f85bcf16481c99a81d756ecfc12e2a832e1da974106ef68416324` | TypeScript | operations / coordination |
 | `ops/mcp/src/tools/events.ts` | 2381 | `3e7caccbf3b30fcf778394342e2577dd28cfa875035a45aa56fc4521a374f787` | TypeScript | operations / coordination |
-| `ops/mcp/src/tools/health.ts` | 3691 | `b2eed4585765bc54a100d0a13e6caba0c2cf92ead56ceeb2e16652f1776c14d9` | TypeScript | operations / coordination |
-| `ops/mcp/src/tools/repos.ts` | 5715 | `9d490b97a6277b057a30195633f64535eafac2ced55c8f9ba526c69dc022c62f` | TypeScript | operations / coordination |
+| `ops/mcp/src/tools/health.ts` | 4258 | `4652edee1d344720656a8441545b17c9872fe4fcf61c4bd377b637b489d4d673` | TypeScript | operations / coordination |
+| `ops/mcp/src/tools/repos.ts` | 7164 | `f18682eabbcbff5f954402eb711f7f827b1bd490b421cec4b6186c9abb936caf` | TypeScript | operations / coordination |
 | `ops/mcp/src/tools/sessions.ts` | 5830 | `1758e32f7cbf5a2951437164c81ab05b21f0dd1e513b1d4b56e4acd454039f7b` | TypeScript | operations / coordination |
 | `ops/mcp/src/tools/tasks.ts` | 6784 | `c0673eaa8d519752e273c8e04df9d17bc005aa0ba0622f29df4cc6a84f0a79ce` | TypeScript | operations / coordination |
 | `ops/mcp/src/tools/watchers.ts` | 2447 | `8d04a5ab0417f4bcdfe9e3b7793ac12d49d57050fd0c75a4b9f6b22483527f72` | TypeScript | operations / coordination |
+| `ops/mcp/src/utils/commands.ts` | 4677 | `c0bc49379085f3b98322f6585911367be36052fc39ea0d1e5fefbea5dc56e1e7` | TypeScript | operations / coordination |
+| `ops/mcp/src/utils/kubectl-pods.ts` | 1496 | `5ec808d967ec0c7e5f6fae6de343e0ea4a70521596a947e8dfb03d625296102c` | TypeScript | operations / coordination |
 | `ops/mcp/tsconfig.json` | 431 | `7f9e6246e1a0f89c95eb959fbc0460a42e2b8de1b13540d740aca476aab1bf07` | JSON | operations / coordination |
 | `ops/mcp/vitest.config.ts` | 162 | `a6bb99fe95f6fa7eb6367ecdcd514aacc317a30421721599775a2bbf3c63b96d` | TypeScript | operations / coordination |
 | `ops/scripts/drift-check.sh` | 11654 | `13a155edae292fe14bae1c64e3fa9a9b9741ad78f800ff814a0994d973270b7b` | Shell | operations / coordination |
@@ -3033,18 +3360,24 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `ops/state/config/repo-map.json` | 2124 | `92912a8579626cc92b33979ed97ad19a8831eccb072d5835c043ce54ed5f8b3a` | JSON | operations / coordination |
 | `ops/state/decisions/README.md` | 1081 | `98180aa6dd010d95afca82813901ebd716effe85f26bd2566aae275699694b13` | Markdown | operations / coordination |
 | `ops/state/deferrals/s23-t5-crdt-deferral.md` | 844 | `e40e71b5aa31691027de4b7596fb872cb1709d425ac99f9c566cd39e603456bc` | Markdown | operations / coordination |
+| `ops/state/ecosystem.json` | 10720 | `bd54104ae7eeffd161e8366c813ec7acb3d64ab19973e901ee1adea450b5bd70` | JSON | operations / coordination |
 | `ops/state/sprint/current.json` | 3487 | `0d702e106e1e669ebc5fb439dadcc8204fded13387227d23c5ddcc3153c95705` | JSON | operations / coordination |
 | `ops/state/sprint/history/sprint-15.json` | 4532 | `86ecf493085be8bd5390d5d8fae152667ae46e81a79afe8c59c6995c14277a7c` | JSON | operations / coordination |
 | `ops/state/sprint/history/sprint-8.json` | 1779 | `35f7f76dff5d741f4f59324cff2ea5cfa435ff874313f5fc5dc717da36f061ae` | JSON | operations / coordination |
 | `ops/state/sprint/sprint-22-closed.json` | 2047 | `5d0eae8795c55d082d69ba17211c9227dce683b4a66702c6d7ccb9bea201dc8f` | JSON | operations / coordination |
 | `ops/state/sprint/sprint-23-closed.json` | 3785 | `4a45ab28707a75f6f2e67f50a5bfcc018ffbd01d6112e39e94b35b92ad052a91` | JSON | operations / coordination |
-| `ops/state/truth/agents.json` | 4996 | `ca54ceac316763ce8952286a160d78ea2a7367a84c3b240559bf842253fe7e2e` | JSON | operations / coordination |
+| `ops/state/truth/agents.json` | 5537 | `5c6c262fa59b46d1be89654f1ec35460e30e08c149fb653132a60c8c903263ae` | JSON | operations / coordination |
 | `ops/state/truth/policy.json` | 2995 | `c8822f116e9c6f0b518e8500c9197b2ec1150072c559ac1c3a982efcc62e838d` | JSON | operations / coordination |
-| `ops/state/truth/skills.json` | 2554 | `34243baadb2f1c90998bc2c989b40f7fccb9f03354891ddfb87518a0ec5284e8` | JSON | operations / coordination |
-| `ops/state/truth/sources.json` | 3389 | `1fb2b398f624bfaf0a4d2b4260be3c55f4f6dab8ff3aefabd0718455526ad2a9` | JSON | operations / coordination |
+| `ops/state/truth/skills.json` | 2567 | `0ae946f96b5e0c503edbfcf0f900a6c35118343a325c5f5538052a1b03a82173` | JSON | operations / coordination |
+| `ops/state/truth/sources.json` | 3783 | `d566fba11595dcf11abe5777865db2e2dab25d731d6e01eb42c66ee1708ce8f5` | JSON | operations / coordination |
 | `package-lock.json` | 82 | `76c01bc1204f03b745a731b495bf227f6c6848ec93305a4e61f8d7319584df13` | JSON | uncategorized |
-| `scripts/bootstrap.sh` | 5030 | `5a98f874959054a11b4f7d7e7acb526946af11bd5c45adca3ce28f9757c4188e` | Shell | script |
-| `scripts/check-mcp-portability.py` | 3020 | `bf0f1a6ed515a2e6bca552059d3ee9a5592ed49be3315e91f19306516e7f0d93` | Python | script |
+| `scripts/bootstrap.sh` | 10321 | `a1c0b819119a1a725d59b00311917f3b8886cfe2110c1c7bcd59a8944c3c75ba` | Shell | script |
+| `scripts/build-baseline-lock-guest.sh` | 649 | `cf35c794e76e43cf45de3a7f1f64c67a0fc2546ef640d223594848345bb5ac92` | Shell | script |
+| `scripts/build-launch-deck-pptx.js` | 26527 | `5b8474169409afdcbc88d744ed48380aa04313c326d222285deeadc0999d66bf` | JavaScript | script |
+| `scripts/check-agent-context-spine.py` | 7950 | `916390849fbe93fdeff243dda48d1ce3565b21e02edbc4fdf01d1489eba6e17d` | Python | script |
+| `scripts/check-claude-plugin-root-resolution.py` | 6522 | `793a9cbc7c9d83af268babf6b3b00daa613267ea977794ca1763618143d5519c` | Python | script |
+| `scripts/check-claude-plugin.py` | 16681 | `3584e1132c559d923e9feffb341235d7b19f4568238736f89a416f097db0b03b` | Python | script |
+| `scripts/check-mcp-portability.py` | 3031 | `842d1996988a65649bc6bd515f9368bc53ddfaeae20586479ee5786e55994f75` | Python | script |
 | `scripts/check-meaning-firewall.sh` | 1866 | `232811f6567c5b9764ea199e604e43f90a8acec38e481209584888fc1df8bd4c` | Shell | script |
 | `scripts/check-onboarding-maps.sh` | 1443 | `0620d80def2cee542a9e38b26bbfaa2bbdd58074639dbfe445a04204fe761217` | Shell | script |
 | `scripts/demo-flow-a.sh` | 2841 | `985de4c7fe0e2efb984ece328075e942095cb81d1141326f9a65c2eede128935` | Shell | script |
@@ -3059,11 +3392,16 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `scripts/dev-setup.sh` | 3231 | `2e03f559d58bcda7e01b13e12cfad0824a5eba02d87425c47945876ab3eea13e` | Shell | script |
 | `scripts/federated-governance-demo.sh` | 12412 | `913fc025cbead401c35727ba64114e7ca818bb1f2a5ac706e2a9e992e141427a` | Shell | script |
 | `scripts/forbidden-deps-allowlist.txt` | 737 | `e3acf72c847044428dc42af1cc9a11c78e5c68a8b6cf731d63b5fcef1454d11d` | Text | script |
+| `scripts/generate-agent-context-spine.py` | 39619 | `e6a3ae3d2042febc9754d6a6fa6ec8c6d27dddbefde12fea9c6b84824e352dbd` | Python | script |
 | `scripts/generate-test-token.sh` | 1581 | `bea751d5058b9d0ab6b841980e143acd23356ec207ad2da886afc3680b0b8714` | Shell | script |
 | `scripts/generate_repo_record.py` | 21852 | `fd4ae442a188064be1d5699548ddc045413ac7268180732249778af228d4f96d` | Python | script |
 | `scripts/governance-demo.sh` | 9746 | `d9db1799692b5323e8a0cf2bf51ebdada86bf616bd14699e6316a4af80159d20` | Shell | script |
 | `scripts/icn-preflight.sh` | 2129 | `3d69b9f78b307bd5cda606d8844a58c7d0c299f49c5356883e324da3bc4d121d` | Shell | script |
 | `scripts/install.sh` | 14015 | `9f453776a7a9b96944c42a1b3ced4434e8ccae5cb97280a9a1c064c2ae1f25a0` | Shell | script |
+| `scripts/local_audit_verify_auth_demo.sh` | 9308 | `8b9e9d2835424145f908a316faca958a93436762a452a6318fa42dd957984d44` | Shell | script |
+| `scripts/local_economic_receipt_chain_demo.sh` | 13540 | `5e2afca36b3f0bc3a3491fdae04f003c3af7d47f1e7a5f2dbeff0dfc0b0b3781` | Shell | script |
+| `scripts/local_receipt_chain_13of13_rehearsal.sh` | 11701 | `c43f5065dcae6d5b3b72d4fe8a03eeb9eeb351db4a6a19158801f3cb0f2bcab0` | Shell | script |
+| `scripts/md-to-pdf.py` | 6130 | `c9b55cdce02fa7470f49f7a41f695e5c411490b37243d21657944b8921fd7375` | Python | script |
 | `scripts/pilot_chain_demo.sh` | 9116 | `2f955e52efe057fc725018b5352c68845d582e9438c588ec057f1e852de4f619` | Shell | script |
 | `scripts/pilot_economics_demo.sh` | 5498 | `c28b66b68609129eb0ac6de26772af9a49683595d2dc2b1233e7b615e12286bf` | Shell | script |
 | `scripts/pilot_receipt_chain_demo.sh` | 8694 | `c6a490492effd24bf8936b3b11391aba7d6ebef4f3fa78d29e8d2fe696ad5dcf` | Shell | script |
@@ -3087,12 +3425,12 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `scripts/worktree_sanity.sh` | 3105 | `70a3e6575c86e47638c27e76c8ecd11888e14d221874fda99710c20e3da6cf23` | Shell | script |
 | `scripts/worktrees.sh` | 3596 | `7c95cf0a66f587198df968e3a91c0a239298514f859d48db02eae2a09b9f6747` | Shell | script |
 | `sdk/react-native/.gitignore` | 26 | `e8bc935ce727f1809c792f4c5d26c5fc75ba2b7df7fc9390c56c8892f6a6007f` | unknown | React Native SDK |
-| `sdk/react-native/README.md` | 18471 | `1d500c3a3209ad21d1ecbb4af20f87b7ff1a0cb716b94933d19ddbee58ba1410` | Markdown | React Native SDK |
+| `sdk/react-native/README.md` | 20302 | `b3b4bf2b8e536aa30d322660c29ef5dbcdf86f6a765d812916d075da41f39a27` | Markdown | React Native SDK |
 | `sdk/react-native/babel.config.js` | 133 | `508b0dabfabcb143ffe906789f62593774271bd762e0fa54f926eb76ed19c0b4` | JavaScript | React Native SDK |
 | `sdk/react-native/docs/offline-first.md` | 15079 | `85bca47a2da4d7838a0716a79ca62594149b2fdde6e6988ee24df6406c5140d6` | Markdown | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/.gitignore` | 44 | `5cac5f0abcc564232abf886e7897fbccf2ab17c7a7ba856c4081cb527f23bd64` | unknown | React Native SDK |
-| `sdk/react-native/examples/CoopWallet/App.tsx` | 110329 | `15af095da0d48501b7336a4a6a2c5c400292457423214217dd949ccdc741d75c` | TypeScript/React | React Native SDK |
-| `sdk/react-native/examples/CoopWallet/README.md` | 5439 | `df943f30ae14324bd9c4e71d8575b4f4d38cc725e5edeb33f68a444845e680eb` | Markdown | React Native SDK |
+| `sdk/react-native/examples/CoopWallet/App.tsx` | 114927 | `90c421aba7236abeb2cb04321f2c939ab76a57724a9b15be2c45e31ade492e03` | TypeScript/React | React Native SDK |
+| `sdk/react-native/examples/CoopWallet/README.md` | 5841 | `953679e17c5ba16a576d7dba1bed5c9c5005e1355d086dc7d7b3daf02636c1d7` | Markdown | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/android/.gitignore` | 129 | `03263c9a1436e264a87c6e0547007488dc980efb2326724b5a85c0835bac34a7` | unknown | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/android/app/build.gradle` | 8141 | `85f67189256c4bcb316a6c0cb30242c726471a9e695f368def8c7f59a1bdeac0` | unknown | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/android/app/debug.keystore` | 2257 | `221e0a3106aa4c3ccc154e0a418b55020b3f9ea6e84f92e8749cd9e2f39f5e58` | unknown | React Native SDK |
@@ -3143,9 +3481,9 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `sdk/react-native/examples/CoopWallet/assets/splash.png` | 70 | `497790947d4666760ce38f3c00e852c71fdb66cae849bae8e9ede352719e1581` | unknown | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/eas.json` | 516 | `acd22ac472e9fe0cea61b93994968ca7f66564f058775f79d4169091506687bb` | JSON | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/metro.config.js` | 897 | `375c5926aa60b7e4b7f146363ec2c3a3a183173037296775d553f700fb1ebde7` | JavaScript | React Native SDK |
-| `sdk/react-native/examples/CoopWallet/package-lock.json` | 333093 | `afa6207763c83015dfb702cf8b15d021cad914cf3094067eb41898168527053c` | JSON | React Native SDK |
+| `sdk/react-native/examples/CoopWallet/package-lock.json` | 335783 | `4606e6c9a37cb7060cdabf2811788bd6924abfd03fc8646cbd5c5a5d939f031c` | JSON | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/package.json` | 1496 | `5f6e69710a66112ab83b1e73c0ab9805ea038a29d3ead67685aa60dd93ac7654` | JSON | React Native SDK |
-| `sdk/react-native/examples/CoopWallet/src/client.ts` | 7267 | `1e94b826b0d4f7137a97bee9243ada153914dab81928891da74259a733c81604` | TypeScript | React Native SDK |
+| `sdk/react-native/examples/CoopWallet/src/client.ts` | 11129 | `8c7c07ecb9b093e4aaa5ba701d8b3148b640da699439e01bf4970ea6cd924432` | TypeScript | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/src/components/BottomNavBar.tsx` | 4188 | `49621d32ebef98f79b8c25ed87920720fb6bf2f3783f8c32a568c251ea526acd` | TypeScript/React | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/src/components/EmptyState.tsx` | 2164 | `16b71202fd37db60dd52c665619c8abfe48374eb72b01e2876b5262ec9352ef8` | TypeScript/React | React Native SDK |
 | `sdk/react-native/examples/CoopWallet/src/components/ErrorState.tsx` | 2038 | `700b80b63e38d44d41fd5a16e979f62dbe1518dcfd85f1862442531b8aa9b93f` | TypeScript/React | React Native SDK |
@@ -3186,32 +3524,34 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `sdk/react-native/examples/CoopWallet/webpack.config.js` | 1125 | `84a8eac1d6bdb3e0fc894c16b70cd0920637fd890f51bcad2600374a282c8438` | JavaScript | React Native SDK |
 | `sdk/react-native/jest-resolver.js` | 2121 | `b4ce50dc0143495a60c0779357ac4ffc9617f477d34983151b47cfacfa7f2190` | JavaScript | React Native SDK |
 | `sdk/react-native/jest.config.js` | 933 | `5a27b5f256d5134911995fdd5edac1e730ab421b3e0850c87eb8c4e141b2ad5c` | JavaScript | React Native SDK |
-| `sdk/react-native/package-lock.json` | 300269 | `b92aa7745285ae6cdee1f8e660d3c110ef244002baf257e6ffc0e2430edb1076` | JSON | React Native SDK |
+| `sdk/react-native/package-lock.json` | 470760 | `f7ca266767a99b324f5d2e83ee292671e955235810511f21cf5c49269a5d25c9` | JSON | React Native SDK |
 | `sdk/react-native/package.json` | 1544 | `8ebaf8dd565629ac0958a2162832c05baef0cc2bbd09138ffdc643dfea2d39e8` | JSON | React Native SDK |
 | `sdk/react-native/src/__mocks__/react.ts` | 1416 | `b638d387c14cf1755f6f626bbbe96a05e5b6768074ac0e75add9653a27cba2ff` | TypeScript | React Native SDK |
 | `sdk/react-native/src/__mocks__/setup.ts` | 849 | `c21fadea8e9a68e7b62ea1bb3733d517d3abc77dda979a9a8c68712369ccef8c` | TypeScript | React Native SDK |
 | `sdk/react-native/src/charter-hooks.ts` | 9248 | `f1dde2290bb2f997688b46a291dd0bd508b754d24ea9fc37cfeb63dc9ad2cd94` | TypeScript | React Native SDK |
 | `sdk/react-native/src/charter-types.ts` | 1687 | `d6785dc4a57f1cb3d6fc5fe68af85e9172d2c22305e9732fb1c2d8e9e2067ffa` | TypeScript | React Native SDK |
-| `sdk/react-native/src/client.test.ts` | 7951 | `a1ff6396dc428fbac1298c21319d5482a107c1761d750d602d0a761763c31ab6` | TypeScript | React Native SDK |
-| `sdk/react-native/src/client.ts` | 83756 | `abea270489bd82f9881fd1af7a077a71b4621bab7086b75b386ca2416c2ef8e1` | TypeScript | React Native SDK |
-| `sdk/react-native/src/constitutional-hooks.ts` | 22511 | `3b107f51a5e0cf6833526bc3b87132d16b378907f4a9811a7a239224bd9dce24` | TypeScript | React Native SDK |
-| `sdk/react-native/src/constitutional-types.ts` | 5813 | `afefa8901f5e0b3d523126b7692073d0b87565789bd83d6206150de2426fcf8d` | TypeScript | React Native SDK |
+| `sdk/react-native/src/client.test.ts` | 38608 | `a439fe8d5d8c573b2a6815baf6812df32817235645c6b9e56f47d2fa97cf6719` | TypeScript | React Native SDK |
+| `sdk/react-native/src/client.ts` | 98112 | `49e3c72f8f7a289a57b922b03ccde4e324f7252cfff73db33aa7766422882f0b` | TypeScript | React Native SDK |
+| `sdk/react-native/src/constitutional-hooks.ts` | 22975 | `326c0ec8ed96a014a6bc94a8129562ec566298445f0969fa03200a0b3f9ac596` | TypeScript | React Native SDK |
+| `sdk/react-native/src/constitutional-types.ts` | 2872 | `61d4692346308a3dc45bd99ca86ff81fb7d77f6e53c1a3f50e5d435aad0c61e8` | TypeScript | React Native SDK |
 | `sdk/react-native/src/device-hooks.ts` | 12732 | `2f7db9d17d7a98181c81fb9db12f063b4492866f7d2c28a26a5d2706bad08cd2` | TypeScript | React Native SDK |
 | `sdk/react-native/src/economic-hooks.ts` | 23178 | `83fada8b62506edd8178577993ba90b0eeaf524bc152343b4421e27668bbf162` | TypeScript | React Native SDK |
 | `sdk/react-native/src/error-utils.ts` | 4019 | `a50a202c75c2597d0138892d433e3b856b682d5689f49584b9f3ff1db73d7aea` | TypeScript | React Native SDK |
 | `sdk/react-native/src/governance-dashboard-hooks.ts` | 8920 | `b15a6b025b23dec602b81292c62731d1956e96c88c7eb41e71c3cd4dd43c5f64` | TypeScript | React Native SDK |
-| `sdk/react-native/src/hooks.ts` | 22528 | `817e075a3db856bf71071529c22577cc823da8a839adf2b21f3cd305c3dc9895` | TypeScript | React Native SDK |
+| `sdk/react-native/src/hooks.ts` | 22544 | `16780b9aaed295672d0a35805af0446555aef43226aebb16e0dbcb4a4d4daa82` | TypeScript | React Native SDK |
 | `sdk/react-native/src/hybrid-crypto.test.ts` | 9107 | `26f47f9351ee0dbccb98a3ea04f1dda73a2f2917a567739e2afd704f9ffd52c9` | TypeScript | React Native SDK |
 | `sdk/react-native/src/hybrid-crypto.ts` | 16284 | `10b3685ca803c5ef95101fd163b2a914e2c4886519ee38cb1ad8d49e137b2862` | TypeScript | React Native SDK |
-| `sdk/react-native/src/hybrid-wallet.test.ts` | 12384 | `c5300603101b46d81ad8351e7c88494f3354eb1a3719b908aa6edc9be9675723` | TypeScript | React Native SDK |
-| `sdk/react-native/src/hybrid-wallet.ts` | 14934 | `fbeddf29e52129dc9e8e5524d85efc094dd4946eb17228b75dcac0853b2ae6d7` | TypeScript | React Native SDK |
-| `sdk/react-native/src/index.ts` | 5797 | `c5e9eed9a9fbbfd11b537255a5dfbeb8c08ddafa4502b645b73a2e883d8153c2` | TypeScript | React Native SDK |
+| `sdk/react-native/src/hybrid-wallet.test.ts` | 14726 | `3cbcedd16ce450f57718b725f394865c17357347484319c3e82a2e1d4d8cbf71` | TypeScript | React Native SDK |
+| `sdk/react-native/src/hybrid-wallet.ts` | 17329 | `b895ef09261683d11cbee738cf63b2ed5c3f6d173c03185ab196334c4ae99aa0` | TypeScript | React Native SDK |
+| `sdk/react-native/src/index.ts` | 7183 | `7a722c3531ad6d3fb5ee51d0d3a1301f3b9f3f906b47c775b867b3171179abf9` | TypeScript | React Native SDK |
+| `sdk/react-native/src/keyring-aliases.test.ts` | 3808 | `ca5960c77123010570f3f782ef805dc35354a670322ef86c4d3f5dd7500359b6` | TypeScript | React Native SDK |
 | `sdk/react-native/src/membership-hooks.ts` | 12384 | `8fa0ffab9802f38db12263784a39c2a3030e069fb7e586ad765b2686920c1e82` | TypeScript | React Native SDK |
 | `sdk/react-native/src/membership-types.ts` | 2272 | `ce95f9f83e705a2000812b93d78fb0eea2df4db6491b689fbf7ad25a48771018` | TypeScript | React Native SDK |
 | `sdk/react-native/src/notification-hooks.ts` | 10384 | `bfa9c49d6f02f5010973221971c38385cf045514669ca18b3fa4149eae4ad2f5` | TypeScript | React Native SDK |
 | `sdk/react-native/src/qr.test.ts` | 17212 | `b66a128d9fc625abcea7f5e9d541830854c8d903da021007302522d4466d8f02` | TypeScript | React Native SDK |
 | `sdk/react-native/src/qr.ts` | 10700 | `81587966ce596261f2deef7666f6e3473b3f640888396a23de2bf19ca2d0c112` | TypeScript | React Native SDK |
-| `sdk/react-native/src/queue-manager.ts` | 4221 | `cf898660a03a73d34b5c35f3111269bc642750e342f2067d92663502d7007869` | TypeScript | React Native SDK |
+| `sdk/react-native/src/queue-manager.test.ts` | 5548 | `3f4daae40aa7d91d961ae53b6388e815c1a1dff2d19e49272244e16934f26c80` | TypeScript | React Native SDK |
+| `sdk/react-native/src/queue-manager.ts` | 7446 | `44a463390a67655a813a73657131895e151b6cbb1df0be5e849270cd6d94e322` | TypeScript | React Native SDK |
 | `sdk/react-native/src/sdis-hooks.ts` | 10410 | `d916b4e73c6c2ab5c305cf21702cdb7a8be2380368a02ab783f0bfdb4e4abf3a` | TypeScript | React Native SDK |
 | `sdk/react-native/src/sdis-qr.test.ts` | 5161 | `00f039f8472a1d06bb30ef3bb881b5519b35fcfc3d346e60b2fc091a0960b1fb` | TypeScript | React Native SDK |
 | `sdk/react-native/src/sdis-qr.ts` | 6084 | `c241c8052ee193993153b1276b953eb9f40ecc068aca106943dc0ec572aaba50` | TypeScript | React Native SDK |
@@ -3219,36 +3559,38 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `sdk/react-native/src/sdis-types.ts` | 4920 | `34a32c0ef37c33ad6fd82c52593af931df915f4422b0d5ef63c4bfe4ec139ce4` | TypeScript | React Native SDK |
 | `sdk/react-native/src/steward-hooks.ts` | 9357 | `e2140365d679d72e005d1fd2ac2b2f495d256d96d4f2f4d493efe55db76a2c7f` | TypeScript | React Native SDK |
 | `sdk/react-native/src/steward-types.ts` | 3622 | `e3458d0842baeebf4782585d81066a68be3d25ecbd3646913167b6de7a0bcdb5` | TypeScript | React Native SDK |
-| `sdk/react-native/src/types.ts` | 4237 | `1523f97fc68e07f99db52fa0c27acbb4455f8c244155130675e8d44045529710` | TypeScript | React Native SDK |
-| `sdk/react-native/src/wallet.test.ts` | 6798 | `9c9dc2984ffc1930717a5c47a48adbc2c4be046561c491eab9fda7c86826ceb9` | TypeScript | React Native SDK |
-| `sdk/react-native/src/wallet.ts` | 7117 | `b7c8690a88623068ec920beb81643695e220647b28663e847f4fbc698c0561ec` | TypeScript | React Native SDK |
-| `sdk/react-native/tsconfig.json` | 564 | `eab0e7240385c1822b5b0cec6fd53ec71cfc23b241c01b0fc6ad6605066e2e18` | JSON | React Native SDK |
+| `sdk/react-native/src/types.ts` | 5388 | `7b6b2c3e9c57b58c09b690417d7b58b50cfa0d377090aee801b067bdfaa2ab4d` | TypeScript | React Native SDK |
+| `sdk/react-native/src/wallet.test.ts` | 9277 | `5d22fec978496a50beaf2740c1245ed7e67ad20c8e9f7807fb1012a4515793b8` | TypeScript | React Native SDK |
+| `sdk/react-native/src/wallet.ts` | 10075 | `6d3bd0b50716c2ab6ea3e2adc92e8a93a625f08c9ff853afb511520a26425475` | TypeScript | React Native SDK |
+| `sdk/react-native/tsconfig.json` | 567 | `21cc8271da73d997dccec6ee4dd160606b4212d23f5be7a2e21699bf85e44bcc` | JSON | React Native SDK |
 | `sdk/typescript/.gitignore` | 112 | `cc85e603762afb5a35f016eaf3197e7b8f1ebcf20fef52c058dd39613b438911` | unknown | TypeScript SDK |
-| `sdk/typescript/README.md` | 18292 | `48c48fc94be85d901192baca14efcc1683808bf320c4f0b38a604ba25fe3890e` | Markdown | TypeScript SDK |
+| `sdk/typescript/README.md` | 20282 | `3d5e365d5a70fee26c6d854f6f49c126c91fb66d3d57ef830675af56602132c2` | Markdown | TypeScript SDK |
+| `sdk/typescript/check_sdk_doc_terms.py` | 11936 | `408104e75bce99ee5c7e5704b0e85b7a0bcfabc2878e3112e37d5d8e1fbe44b2` | Python | TypeScript SDK |
 | `sdk/typescript/eslint.config.js` | 471 | `831035d5380eaea06b2557493d0b4fec844296246fe9935937bbe86509dedd14` | JavaScript | TypeScript SDK |
-| `sdk/typescript/examples/README.md` | 9069 | `1f55fbd2c792004bef7ad83b05a83d70bedb0c6790d1de5881a605df58665feb` | Markdown | TypeScript SDK |
-| `sdk/typescript/examples/basic-auth.ts` | 2584 | `d19f215e3a46194f8c86e03f0bf028e253255f4d1fc04a0986fbee26eb653bb6` | TypeScript | TypeScript SDK |
-| `sdk/typescript/examples/batch-operations.ts` | 3173 | `8b45537ea1940da0327193b250f5f977cd72ad29ae3d7f05a0e25d61f981d940` | TypeScript | TypeScript SDK |
+| `sdk/typescript/examples/README.md` | 10369 | `bc7736e8edeeaa57eb1bb9d7ed0d4bb383040aeb98599fd1f5c67fd0e270cfdb` | Markdown | TypeScript SDK |
+| `sdk/typescript/examples/basic-auth.ts` | 3480 | `866b3da0ecd7c2f1c01bbad2f0040980ac137dfecceaec2e4287080d0d3c3c13` | TypeScript | TypeScript SDK |
+| `sdk/typescript/examples/batch-operations.ts` | 3209 | `dc96939f08f512efb9bd7d5275aed23e2017d180b57c8242578b726f3a7145ae` | TypeScript | TypeScript SDK |
 | `sdk/typescript/examples/commons-evolution.ts` | 12025 | `72176d238651fd1bcee82fe00547d54c4a9df462747643be3206e13b360dac2d` | TypeScript | TypeScript SDK |
-| `sdk/typescript/examples/compute.ts` | 6260 | `5d8c1fc5bb015ed2b2e6ff957a4f799a645d50e7ed4d117161544012b1fbcd0d` | TypeScript | TypeScript SDK |
+| `sdk/typescript/examples/compute.ts` | 6263 | `1c8f9c219fbeef49594eeee3f6be83c889e50b6f2d8da2e12144d63afd7d29f5` | TypeScript | TypeScript SDK |
 | `sdk/typescript/examples/governance.ts` | 5738 | `844c5d523d81658ea4769ce97e3dae576ea5dad48592d8f2c72d124f0e590a85` | TypeScript | TypeScript SDK |
-| `sdk/typescript/examples/query-builder.ts` | 3426 | `c8d205617a0c462484873b55eaecafd05a709384ce36b44739a94a9a834ecba5` | TypeScript | TypeScript SDK |
-| `sdk/typescript/examples/seed-demo-data.ts` | 8679 | `d721d70b76c731cd41727619257553484f81c6af99a9d431c37a4063ec302ece` | TypeScript | TypeScript SDK |
-| `sdk/typescript/examples/timebank.ts` | 4898 | `f57661b5014e8b3178dd6ac477de22a56459c30f09b92ced878437edb545fba1` | TypeScript | TypeScript SDK |
-| `sdk/typescript/examples/websocket-events.ts` | 12016 | `ed3398259b93d742812b941354f8f9267a479b964c4a006d24412471b240024d` | TypeScript | TypeScript SDK |
+| `sdk/typescript/examples/query-builder.ts` | 3422 | `f1361c9d5a38e5a4fb72d05ae5d70f71f61a4af9a8d06a3897ea652017e74776` | TypeScript | TypeScript SDK |
+| `sdk/typescript/examples/seed-demo-data.ts` | 8677 | `6b083febf668dfd59a8be0ed825f548440caacf2b36a15ef13140172d1eb1768` | TypeScript | TypeScript SDK |
+| `sdk/typescript/examples/timebank.ts` | 4869 | `01d8f162c653d3afc2a2f52b8008bc9ffaaa4019760ce6bee451b36f561f0c0b` | TypeScript | TypeScript SDK |
+| `sdk/typescript/examples/websocket-events.ts` | 11970 | `ba441947626d2d9ed356fe7b8ac35d4150d968317eed5dcfe2987a06a0c4147f` | TypeScript | TypeScript SDK |
 | `sdk/typescript/examples/websocket-filters.ts` | 5546 | `e2e9bfef924bf9562b3323c8f1c411c1c114a30bbac95eadca36db09b97fd13a` | TypeScript | TypeScript SDK |
 | `sdk/typescript/jest.config.js` | 437 | `9c2b7d7a632066d77755ee17836d90ba2d635c0babde87b0d435178dcaaa941f` | JavaScript | TypeScript SDK |
-| `sdk/typescript/package-lock.json` | 224856 | `a1486982b6e3aa0c0ea16f332dd74b5764474208aaabfc5f12e042c9bfa9a41a` | JSON | TypeScript SDK |
-| `sdk/typescript/package.json` | 1361 | `3cb3f719cbbbc792e4da91ae0d25c516f1d28b931974bae40fc4deb338901e50` | JSON | TypeScript SDK |
+| `sdk/typescript/package-lock.json` | 225376 | `e10389cd39c645476478d7592b1bf12c892e87805eada84ebd2717605f6a183c` | JSON | TypeScript SDK |
+| `sdk/typescript/package.json` | 1430 | `fe0dbbcf4e52899acf825ff8ffc647475bb0617b903b7e125e127d7bba58c073` | JSON | TypeScript SDK |
 | `sdk/typescript/src/api-types.ts` | 48041 | `322a9c21a11e96de374713ceebc8b1c76b233d832adb1f98202b746db238c40e` | TypeScript | TypeScript SDK |
-| `sdk/typescript/src/generated/api-types.ts` | 31417 | `d15c5821f4a21c11d658f7e8907addf9008871133ac6c705f639887b2768fe9a` | TypeScript | TypeScript SDK |
-| `sdk/typescript/src/index.test.ts` | 83392 | `7bc72b4d635bfe0e401653e5f9ae6148e348c0bb7e461d38ab202cc9ec72e8a5` | TypeScript | TypeScript SDK |
-| `sdk/typescript/src/index.ts` | 82862 | `804280a561b6d18f3c44d1ad84662630919685509f8c1a42baa2dccb655208c8` | TypeScript | TypeScript SDK |
+| `sdk/typescript/src/generated/api-types.ts` | 61644 | `aad84ec5a6fd569394e7dba0d5aac3abff6e1a06788253a55a8712e87104c638` | TypeScript | TypeScript SDK |
+| `sdk/typescript/src/index.test.ts` | 90322 | `dc9960da37ee955d9f13376520e7365b6eabb372aa3c258b888d050407a12a16` | TypeScript | TypeScript SDK |
+| `sdk/typescript/src/index.ts` | 86123 | `59341ae472af9a7d1803804b782c995cefefc646fb401e281c78624e62259f87` | TypeScript | TypeScript SDK |
 | `sdk/typescript/src/typed_error_mapping.test.ts` | 4617 | `0c8854ba1242451f10fc9c2132315870fc3b01467344058addfed296381692b2` | TypeScript | TypeScript SDK |
 | `sdk/typescript/src/types.ts` | 51683 | `cad31fb2191f09f6c34de15dc5f612db234decdbe7c338374c2c5dda0c5f79b1` | TypeScript | TypeScript SDK |
 | `sdk/typescript/src/wasm.deploy.test.ts` | 3654 | `dcce3c4d632a2ff0ee0a18b8dbb59494ee595d56ab1300abbea3bbc18f73fe41` | TypeScript | TypeScript SDK |
 | `sdk/typescript/src/wasm.list.test.ts` | 3527 | `47e7aa0d4671281c5476a58d4bfaaf7452596293a7ca884de5caaf13a937b9ea` | TypeScript | TypeScript SDK |
 | `sdk/typescript/src/wasm.ts` | 8168 | `a52dcbb428dfa5693f144b5ba03dbba1776e6a4ea3ecf10436151e326c3098d7` | TypeScript | TypeScript SDK |
+| `sdk/typescript/tsconfig.examples.json` | 606 | `28d81511446566fd7be660c7c65a405fbeb24b2820794e54c969b94341baf0cb` | JSON | TypeScript SDK |
 | `sdk/typescript/tsconfig.json` | 760 | `a6b91b6c155393264d48261a268f0740df83ba05c00e1b736c1a7f0e4af61012` | JSON | TypeScript SDK |
 | `sims/mutual-credit/README.md` | 4492 | `5e42e2ecc40fb64e25fc7f0c9180f339bee66365fe1c2ada8119bfb9e66fee2d` | Markdown | uncategorized |
 | `sims/mutual-credit/RESULTS_SUMMARY.md` | 5414 | `9153ac4c4bcabac8e9acd7f3e7a2c0ab3e23116ad9db71631ed5f72fc91d0f54` | Markdown | uncategorized |
@@ -3272,6 +3614,32 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `start-gateway-test.sh` | 1180 | `f18a6947e12d1f6e27cf8c03d2e0a111f8ed77a743e807c41a2f1b3781344aa5` | Shell | uncategorized |
 | `start-gateway.sh` | 1124 | `d731af0a371f33bba7e9bec4d6c239e27db9161194737bc581d4d8d87b170039` | Shell | uncategorized |
 | `test_coop_integration.sh` | 4761 | `3eaed535884efa69089cc36601915820572b110741de7b1155216d5b58339a6d` | Shell | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/.claude-plugin/plugin.json` | 670 | `f22a5c9136dccad354ec9b0195ae84875c0b8ce811e44b71a284c9fe586b841d` | JSON | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/.lsp.json` | 3 | `ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356` | JSON | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/.mcp.json` | 106 | `890d02c326250550cace2dfc48c098ce9881848dcfb9723f2b1ce06c4e7b934c` | JSON | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/README.md` | 13410 | `a7519610bfaecf7f709d7c0ffa0eebebd69b00c28acd922c90ad9ff1f8db4793` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/agents/icn-architect.md` | 4778 | `f0d9fe7e09ff59d72ee378ec9e710f60534c790446de0e1ab6364ea4170f36c2` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/agents/icn-code-reviewer.md` | 4666 | `e87093d9a24186ca03ae23fadcc71b263a8bb6cbb86c0a622c244451cb7b35a4` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/agents/icn-docs-truth-auditor.md` | 3795 | `4df2386e8acabe94d05dafab67f81bf304f5938733dcacc41c46b414be532ff5` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/agents/icn-economist.md` | 4564 | `2a19f74eaa027191339d57afb659cf3db8bdaf8f800963080beba0389f8ba733` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/agents/icn-navigator.md` | 4522 | `85ea5c28b4983038e5213376434ab36528b4e246631607c3b3180124c3593126` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/agents/icn-ops.md` | 4369 | `be65bef1023474663a74b522c2a58cf8108353779974cc8a6554b38d5af1e09c` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/bin/icn-find-root` | 6231 | `20aab2e3aa607818a02264228f0918a1039f6ee80bef2311c8178dd185facb1a` | unknown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/bin/icn-ops-mcp` | 2650 | `ee8ab0837cc942c0d2a99d0e5bc407b63dd7ed7d30e9f9c37357cb4faadee21a` | unknown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/bin/icn-route-impact-hint` | 1593 | `d6ea892d607e28617ca1e19355e0bd90fbc6f70def11c120c09adc42cc42e7e9` | unknown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/bin/icn-session-context` | 1144 | `930b4a4cbbde989294f846065b1cc9a71418d23012d765e5fcfcae47f815bb61` | unknown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/bin/icn-truth-sync-hint` | 1175 | `59ce2bc2a0c15afb96ba7f2bbf2e9dc2e846d2c4eaaa3e4859b4406ae843fae6` | unknown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/hooks/hooks.json` | 937 | `19ec87c6487af74dcb61331923aa43f66b75223f5ace352f4c124372695dd5c4` | JSON | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/authority-spine/SKILL.md` | 3631 | `082479fbda7cb9a8b7e5fce27683d62c71cf5263a6e35a3fc1f575f24660824c` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/authority-spine/reference.md` | 3365 | `5fdc71119fb9ec7ddeb31c013016bf1dc2437f632fc61eef6426f431c1afe831` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/doctor/SKILL.md` | 3167 | `f2a4d2aa4f069d12bb6f7aba19464703863c32dd3570b32290e79411ff622078` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/navigator/SKILL.md` | 4102 | `05ed1280a4c2a62551201daf58bd4da3028dd96e8b38f379a4a4177c9a53d2d6` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/navigator/reference.md` | 3500 | `e0e789473ad7623faaa497d83636b7b5863fcd58c98a6ca171e358493e42a546` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/preflight/SKILL.md` | 2605 | `1b6fa063b261175d86aae48321adfc9fb187d8ac9f0b5838e3caf21c39253602` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/route-impact/SKILL.md` | 3171 | `9bfb268c41e5c1ec98a0254aea26a9ce7cd74ef89657a83846a10a9840e7cf7d` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/route-impact/reference.md` | 3162 | `f760ff25218cc7faccb1124f7cb6ff54f05994ffc0a234a201f30c84d4a673ec` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/truth-sync/SKILL.md` | 3050 | `4f685ac367100aaa2846317465c291462ebe496721791f83e82df5e5b548ca51` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/truth-sync/reference.md` | 4541 | `c26a56e635e6efbf4088f3d7d2351c17302ae60e36db2eed41a8862646b3524c` | Markdown | uncategorized |
 | `web/api-docs/Dockerfile` | 246 | `db5e9a9a3b5ca91b1fd4a0e7134acf90e2383b1c16398931621f9e962c58dd1b` | unknown | uncategorized |
 | `web/api-docs/README.md` | 6486 | `3b697c5907e8ca7b6c7bc4fd806db9c7ef92c4bcb4f2b1742fb822dc6398bac8` | Markdown | uncategorized |
 | `web/api-docs/deploy.sh` | 1433 | `34a02e58247e909f9e93601236a4c69e34236dea610b2be1130a3df97888f2a8` | Shell | uncategorized |
@@ -3284,6 +3652,16 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `web/dashboard/index.html` | 12090 | `b7f106bd428c5db5a00f6e2009930f63b4e1763dccb20ee0f0d9c2ec9d762531` | HTML | dashboard UI |
 | `web/dashboard/package.json` | 441 | `a760bd223c19c2d0e674b67ced3822436ca23f3f1ab9cd5ab2e1af7824f1f2ba` | JSON | dashboard UI |
 | `web/dashboard/style.css` | 9876 | `5863d0c101ed64919455936205c48d9c93fcf954cdb5097464da2d2a22135c83` | CSS | dashboard UI |
+| `web/member-shell/README.md` | 13587 | `5745bdbd6da7958c131276aec1d09754c88525fd522d0591e0c98c4b441b89d2` | Markdown | uncategorized |
+| `web/member-shell/a11y-walkthrough.cjs` | 8198 | `7ed8c5a5d2cc763b0e2ce7c46394f1f4002fe077fc06b0bbf2b266ba05745e53` | unknown | uncategorized |
+| `web/member-shell/fixtures/community-action-cards.json` | 989 | `b5e9121f89feafb1afc795930ca1f22d15dc97fd6d95cab113b36a1d71975b09` | JSON | uncategorized |
+| `web/member-shell/fixtures/community-completion-receipt.json` | 407 | `b1971fc0eee367fda565ff0e13756b9e05f0df01485286587d70fa1d942c97ac` | JSON | uncategorized |
+| `web/member-shell/fixtures/community-standing.json` | 839 | `e8b3ea60153e7ca58771b2ccc7f0d9f9b9f0de470c09639630ce6cb438d92e84` | JSON | uncategorized |
+| `web/member-shell/fixtures/demo-completion-receipt.json` | 371 | `5e4650ed6b7526ad5f0f2dbad38ba70fc77808823f8886eec131b043fb70a0ad` | JSON | uncategorized |
+| `web/member-shell/i18n.js` | 23656 | `83ffb9f51ca4e41d980ad5557eca3a7b02bb4a97bfe336764d921fe735480651` | JavaScript | uncategorized |
+| `web/member-shell/index.html` | 9422 | `d77b6e95118835fe31907d081a1c2e27ffea404e612965f2c751caad665cc1f1` | HTML | uncategorized |
+| `web/member-shell/shell.css` | 6899 | `be9a03ce5785583c847b2a95078aa349bd88ac732874b9655dfb18c0669e4308` | CSS | uncategorized |
+| `web/member-shell/shell.js` | 41952 | `2e03d356255e23f10cf57ca8c19ee64b3e93ecaefbae988c472cdb1933aa1989` | JavaScript | uncategorized |
 | `web/pilot-ui/.dockerignore` | 113 | `f021484efeaff436204178f6627e9bd1e20018f94ffdb2892f6741427612e591` | unknown | pilot UI |
 | `web/pilot-ui/.gitignore` | 290 | `7e31fe23f687440a1f96848b2f7ab227956ffc9ddaecaf70a6218c58931f18d8` | unknown | pilot UI |
 | `web/pilot-ui/ADMIN-GUIDE.md` | 25423 | `d2fc73108bc141b20ab398decd425910c73d4a989e13a124218d43efbe713165` | Markdown | pilot UI |
@@ -3302,14 +3680,19 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `web/pilot-ui/PRODUCTION-DEPLOY.md` | 17162 | `85a1f3ddcba93e7930f09a62dfcf1c4c710a6736a5d2ef536896d649df612589` | Markdown | pilot UI |
 | `web/pilot-ui/PWA-ICON-GUIDE.md` | 4903 | `50cea5915675a148f6595f47359614687e1c4029c2e7a7ff2c5eddc306adf66f` | Markdown | pilot UI |
 | `web/pilot-ui/QUICK-START.md` | 6752 | `739392fa681a5e68f653da10bc93fb63ab0685be2dc58dfe711a7c00e69dcfdc` | Markdown | pilot UI |
-| `web/pilot-ui/README.md` | 12475 | `f50401cb8229993889c9fa5e2f7327afc76f4b7f1d20d7d12cca9c72e7fe09d8` | Markdown | pilot UI |
+| `web/pilot-ui/README.md` | 4971 | `d1cf718cd1e4d661871f993109fa06bac5f7c2b661856eec7785b7553190418c` | Markdown | pilot UI |
 | `web/pilot-ui/SUMMARY.md` | 12658 | `07b8fec19394310a090de6807f81d941aee2bd7328c95ec083e74dda9a5feb52` | Markdown | pilot UI |
 | `web/pilot-ui/TRANSACTION-FILTERING.md` | 9463 | `02783f33f9990207d4169e4ab1cfb55304a06b9e398adda6cc26204375b54588` | Markdown | pilot UI |
 | `web/pilot-ui/TREASURER-GUIDE.md` | 16416 | `98521265a7160ae0d0f057fa7c38a930a880c034fc12de73e03ea618dd5ea535` | Markdown | pilot UI |
-| `web/pilot-ui/app.js` | 288193 | `f954a3c0d259cef3a273ecd55a686496b10f4bf1f455d9c81574d998ce47b9b2` | JavaScript | pilot UI |
+| `web/pilot-ui/app.js` | 316161 | `97f78f13c3fe1a09afe2c341a0490392ed26626e0512a67f96eeb3b7e54e6cb0` | JavaScript | pilot UI |
 | `web/pilot-ui/components/anchor-manager.js` | 11066 | `2b5665723bcdfc657c7497d60625edc1afa7d21b9d75b6730e082a2f2ad0c98f` | JavaScript | pilot UI |
 | `web/pilot-ui/crypto.js` | 9889 | `b79b91d579f78633426c568fa102800f32e4f7c6aa7d485422bc72de0e29fa41` | JavaScript | pilot UI |
 | `web/pilot-ui/deploy-ui.sh` | 5078 | `73c2101fbf998323ab21da56265e61dc209fa86acda9bc5596f08a362de382a9` | Shell | pilot UI |
+| `web/pilot-ui/fixtures/icn-organizer-demo/README.md` | 8858 | `39b968ab144a17608f575c53938b91bbfbb347dbdb782e57cbdcaff0dfad195e` | Markdown | pilot UI |
+| `web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json` | 2467 | `34f3d94423aca6c110f9ac012f38683f731eabfd4362fe5ae9e2dd0a91326ff0` | JSON | pilot UI |
+| `web/pilot-ui/fixtures/icn-organizer-demo/preview-review.pending-publish-summary.json` | 4399 | `8ba45540aba23852e8e6519c934873123af1f40d1a990e0e3e2973feb0997546` | JSON | pilot UI |
+| `web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json` | 4409 | `3b9050b58355fd9758e257ebebfad9751fcce6bf2fcc1d5867cfbbe39beb88ff` | JSON | pilot UI |
+| `web/pilot-ui/fixtures/icn-organizer-demo/standing.json` | 1320 | `0c6a34ca2d6e8bd8ecb3335dbe426142ed7f205ba059ad0164c392a3db452fa7` | JSON | pilot UI |
 | `web/pilot-ui/i18n.js` | 5039 | `68f06459707f062c10b46fdb02d2ec6d84ba2e05076cc6f53bd4b00139b6b000` | JavaScript | pilot UI |
 | `web/pilot-ui/icons/icon-128x128.png` | 940 | `c77a0c9f6f39ff1811a9d9de492e500e29987b73fc7b2026c41d20d8fdfd2334` | unknown | pilot UI |
 | `web/pilot-ui/icons/icon-144x144.png` | 1046 | `e6932dc7c0cf0ebd32f7526af2179dd41cbac9ac235c08b772fa1e7fb859ff6f` | unknown | pilot UI |
@@ -3322,16 +3705,16 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `web/pilot-ui/icons/shortcut-history.png` | 671 | `1a20e1a26bb6d48ccbe9faf81877590456ab04502397bd7398f66a5d96bda79a` | unknown | pilot UI |
 | `web/pilot-ui/icons/shortcut-log.png` | 671 | `1a20e1a26bb6d48ccbe9faf81877590456ab04502397bd7398f66a5d96bda79a` | unknown | pilot UI |
 | `web/pilot-ui/icons/shortcut-vote.png` | 671 | `1a20e1a26bb6d48ccbe9faf81877590456ab04502397bd7398f66a5d96bda79a` | unknown | pilot UI |
-| `web/pilot-ui/index.html` | 116405 | `d8baffdaecf467b0afcfa15f2701b6df97904a640f9d4cbe7ac277d4effa30e2` | HTML | pilot UI |
+| `web/pilot-ui/index.html` | 129907 | `872d5f3efb8f814eda769a9236cfa3262da11bc97d5cf8bb999cab70cb3ff354` | HTML | pilot UI |
 | `web/pilot-ui/locales/en.json` | 4560 | `48f6b22dfe864487a0568a1198bed0bc957fe06b16f55c9a582ac89729edc24a` | JSON | pilot UI |
 | `web/pilot-ui/locales/es.json` | 4929 | `11cccced8cc34f684c874e23f1a0a5ad0153a08a64b1e199fa0bf5c214e463a4` | JSON | pilot UI |
 | `web/pilot-ui/manifest.json` | 2898 | `339396c3ba9f3eceb7529e3677c11f45428c43ced7b5b4013091c256095ecf4b` | JSON | pilot UI |
 | `web/pilot-ui/offline-storage.js` | 11857 | `576a0a2f62d77afe420adaed96033a6acc941750db81347cc5a58fb5816380e1` | JavaScript | pilot UI |
 | `web/pilot-ui/offline.html` | 5735 | `15458d79294fc6ca649b82d51914d3601f80115a6ffbde9df4f07edc0757fc57` | HTML | pilot UI |
-| `web/pilot-ui/package-lock.json` | 199913 | `9121f187ac845fa3975969989d0c7c87f7e81577fb4a6270a675a94edccc6b62` | JSON | pilot UI |
-| `web/pilot-ui/package.json` | 1473 | `59353ccc0769b8e43f255364f222b9af4074de8540990e081c54931642b7778f` | JSON | pilot UI |
+| `web/pilot-ui/package-lock.json` | 197039 | `63d327d12bdcebbc72335065eaf73717a090e30f9256efe86fbb2dd5f2873e4a` | JSON | pilot UI |
+| `web/pilot-ui/package.json` | 1516 | `5499f03064f328159ad5b3cd9cee40dac76b32352801810882930afbdbcfe7dd` | JSON | pilot UI |
 | `web/pilot-ui/playwright.config.js` | 1810 | `4cda5274e38337431010a92d3c09f2689e05d24b0eafae1007a96f4ae41b52c2` | JavaScript | pilot UI |
-| `web/pilot-ui/receipts.js` | 17641 | `474f8ba1ce8f8046d8f972e89f900717284160223dbe8cd9e14c0afd79790879` | JavaScript | pilot UI |
+| `web/pilot-ui/receipts.js` | 26534 | `9b081cfaa2da27684ece19f0f51674ea7228656e8bb3f9d397310f2379213373` | JavaScript | pilot UI |
 | `web/pilot-ui/sdis-enrollment.css` | 8508 | `b2fdffe0ea25cbcb3aea947bebf8ea084e5b8798be0146e174ac8b554d62345a` | CSS | pilot UI |
 | `web/pilot-ui/sdis-enrollment.html` | 9054 | `07b4811f8b5f5c808797d60d1123aef4fb54ec79af870c52ca907f60f6824090` | HTML | pilot UI |
 | `web/pilot-ui/sdis-enrollment.js` | 18260 | `f9239b0f14e80dc30537ac93c2e7085fcf6596819c212501d8c32d11424b9a28` | JavaScript | pilot UI |
@@ -3348,14 +3731,18 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `web/pilot-ui/steward-dashboard.css` | 10359 | `f7d68addf93b9682263fa9a1f9099ae6ac6fa44146ba022ce833118bb450b3ed` | CSS | pilot UI |
 | `web/pilot-ui/steward-dashboard.html` | 6281 | `15bfcd98cb0193fb0753343477749d13f5897c86003257a58ef4ff174f5d318a` | HTML | pilot UI |
 | `web/pilot-ui/steward-dashboard.js` | 23128 | `31d3afcdfa7cfdde41ab749dac0d83086343b18b124f653ce37a9c9e6bc469ad` | JavaScript | pilot UI |
-| `web/pilot-ui/style.css` | 111250 | `8d04387f13502d725a64dc142be9470dca77f0a042b4e83183a9b8a6290a623d` | CSS | pilot UI |
-| `web/pilot-ui/sw.js` | 12014 | `b73527af75073c667ffeecc5eb7cca7a0c84dd3097e4f740a11d899d69a37f92` | JavaScript | pilot UI |
-| `web/pilot-ui/test-api.html` | 2274 | `7fcd4ebb5302a5362b015cc06a916ecc00e5b20e7618fc4cdc6aa4f6ae73096f` | HTML | pilot UI |
+| `web/pilot-ui/style.css` | 149509 | `44e0d1ef7c31bd11738fbbcaedaebb6a7508d2d93595842e938bcbf6b21cc43e` | CSS | pilot UI |
+| `web/pilot-ui/sw.js` | 12339 | `af2715c7f57cd78e790bdd49ce828d7fb0351fcbfced2d158b45fccd146bc9e0` | JavaScript | pilot UI |
+| `web/pilot-ui/test-api.html` | 2155 | `b5a1b66d9b6bdd89b17f5c891e86eabc50f894993404eac23864f26147d34e19` | HTML | pilot UI |
 | `web/pilot-ui/tests/README.md` | 8229 | `ac71637bda5c3bff8591435bc0385a628ce793dd2a8f1cf72604b37c7303ed02` | Markdown | pilot UI |
 | `web/pilot-ui/tests/e2e/accessibility.spec.js` | 10755 | `36c2efcad0f9c08105ce7fdc31943835596698029b4006337a42131941bec869` | JavaScript | pilot UI |
 | `web/pilot-ui/tests/e2e/dashboard.spec.js` | 12472 | `5ededbe91dc893e55c2d4fbffe52238ad6efdcc05bdb7a017de00545e79c30a5` | JavaScript | pilot UI |
+| `web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js` | 7638 | `13b8ec6ecd59d084368b10a1cb13dc69a286e5fe643eaf7d67745c48742292fc` | JavaScript | pilot UI |
+| `web/pilot-ui/tests/e2e/demo-mode.spec.js` | 11777 | `df13170324ebdb678a5cae002f32e00b38beb576bb1d2d40ada066d1ada9b61d` | JavaScript | pilot UI |
 | `web/pilot-ui/tests/e2e/login.spec.js` | 8233 | `e528b19976ea9381ae931923f25e4830b3162b0df17fdca43a09d169a2045113` | JavaScript | pilot UI |
 | `web/pilot-ui/tests/e2e/phase8-features.spec.js` | 15755 | `11f0f00b7a4d28af339368adb5fc755a64ba68e1faa769727d266a88346ce021` | JavaScript | pilot UI |
+| `web/pilot-ui/tests/e2e/receipt-plain-language.spec.js` | 4152 | `4bd9750f931cdcc589e7126e74d8afae06aa2d73b7859f300578c626349bf2f8` | JavaScript | pilot UI |
+| `web/pilot-ui/tests/e2e/standing-action-cards.spec.js` | 4926 | `43a6784c28c4016382b338057c094313773dda66138d95295e6532032626fb05` | JavaScript | pilot UI |
 | `web/pilot-ui/tests/setup.js` | 1192 | `fc1d02b9e561cdb4a50bb7554a72b223c2c35513e14d708f6bad7414eec4cc31` | JavaScript | pilot UI |
 | `web/pilot-ui/tests/steward-gateway-url.test.js` | 2309 | `36d7f2efcae08af2fbf604ac7b6809f8fb1e10febf5df8762b289f70d96e2529` | JavaScript | pilot UI |
 | `web/pilot-ui/tests/utils.test.js` | 13766 | `adf6b96bdd57fed404869f558fed24cbfc8f72d2f560caf84d4a5db1b984f120` | JavaScript | pilot UI |
@@ -3367,10 +3754,11 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `website/.vscode/launch.json` | 207 | `461accad2f8d7604a8470fb4705b84768bcf24791b0974d49cba0d96c3fea857` | JSON | public website |
 | `website/CLAUDE.md` | 3108 | `de3990536a60e30cac32e2e98899aeaa2b2212811e1eb89eb7777959758185fc` | Markdown | public website |
 | `website/CNAME` | 24 | `0a98c16143b1bd9dda704a1564767acbdd9844784727015594653371554f00ab` | unknown | public website |
-| `website/README.md` | 5071 | `aa8b54a417f25923980eabe8d0f1274cca0a2f972b9ddc27279e7d701135a5e0` | Markdown | public website |
-| `website/astro.config.mjs` | 341 | `90a2c3c74b5de239c4324dc2b0eb394867897064204d2466bf6dc6845cdefaf6` | JavaScript | public website |
+| `website/README.md` | 6952 | `d8e71141096916c21f5d39d03ddb276d7152f713e2905a93bad8e3fba1a0fe73` | Markdown | public website |
+| `website/astro.config.mjs` | 696 | `80a2edc96bb226d67d8e083abe4601f1243ae9d856d2baa526c4c40901a28dfb` | JavaScript | public website |
 | `website/package-lock.json` | 244221 | `91b77172cfa152e045095ecce2e7db2645ebfc35985d4d4d57925fc2eab5ff75` | JSON | public website |
-| `website/package.json` | 725 | `3e5fdd8d471fa68d737d516ecea2565a70250d74b82e515ac61ab05385150b00` | JSON | public website |
+| `website/package.json` | 793 | `2aa38ff05df6f9c47cf6a6f1472cc9c6d0fce20c2f287dddb10ae5f44724e529` | JSON | public website |
+| `website/public/.well-known/matrix/client` | 86 | `fd416be1dfe50edd5a5d6d6fce33a812231a7ed4cbc644abe04b13855bd49f02` | unknown | public website |
 | `website/public/CNAME` | 24 | `0a98c16143b1bd9dda704a1564767acbdd9844784727015594653371554f00ab` | unknown | public website |
 | `website/public/favicon.svg` | 510 | `674b2b10e3e98ec126ee01482a815976f6f4a757612939680f170626645abbc2` | unknown | public website |
 | `website/public/images/grid-pattern.svg` | 354 | `0f8ac84ebeda145e856ca4e88b69119d8bf04cda8d27287fe20ffc84fcf50148` | unknown | public website |
@@ -3378,35 +3766,35 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `website/public/images/hero-network.svg` | 5621 | `5d4f0b9758301331ac1a4800eb5c47e23f044043ee99d667bf861c9dffc7331c` | unknown | public website |
 | `website/public/images/pattern-dots.svg` | 327 | `f100a25d96dfde75c332de3646e65c7d8030c7fd0d1b6af38422bc8d8859d85d` | unknown | public website |
 | `website/public/robots.txt` | 84 | `9d882a3235bb3ceb71587b884c1279f997c7752d3b53ccb914f9613edd5d5459` | Text | public website |
+| `website/scripts/format-check-changed.sh` | 1742 | `44f3ffbda7bff0962eaebaf97ff6afa34ccad5caa0d92d647bdb531c16ee7b4d` | Shell | public website |
 | `website/scripts/gen-stats.mjs` | 3707 | `84beb9f4384ad76020ed3bae37b06aed058bf0be8a553ea83860248228937302` | JavaScript | public website |
-| `website/src/components/ClosureLoop.astro` | 9441 | `36035084a84fd382973f1e0383eeb7ac5c76ad05d1664d3f365c00549844ff1a` | Astro | public website |
+| `website/src/components/ClosureLoop.astro` | 11692 | `ed8fa455c127f89ba1d88f0758be68d10901844cdcbf72306e21d80dc04e5cbc` | Astro | public website |
+| `website/src/components/HowIcnWorksExplainer.astro` | 10972 | `293123303cfc3a4fd66bc6a6fed114a2d9c36e8c3f28d1250df4d88bad7587cc` | Astro | public website |
 | `website/src/components/Icon.astro` | 2678 | `6a5d27333817bba06942906bb6191e64fadaadbc533e4626c6974d819e9a1640` | Astro | public website |
 | `website/src/components/MaturityBadge.astro` | 2315 | `b899d948558b33988d53939b268249fb75525306669af013fc2ad2a087c33f5a` | Astro | public website |
 | `website/src/components/MaturityCard.astro` | 2178 | `3483d0e8b3a6b45ec198f098da1268cd1e1f7e54b23f64c385de2d6ccc495cfe` | Astro | public website |
 | `website/src/components/MaturityGrid.astro` | 583 | `69e8f2b12047e0eb2bcb37d974a13967e4766fb7c81dbdc9d93c15e6fa70371c` | Astro | public website |
-| `website/src/components/MemberSurface.astro` | 13746 | `a59e6ca0ba8deac877bc22043da55ac60a6680beaad8a8a401ce59893f5801d9` | Astro | public website |
-| `website/src/components/ProvenanceTrail.astro` | 7537 | `c005b5d483b21d8632496716b09c4bd8299f92b38558e72c5777e18b97119f35` | Astro | public website |
+| `website/src/components/MemberSurface.astro` | 16534 | `42f77099220f229f26fe27945f3c14ba4011de541bf2ea7117402ed3d707bab8` | Astro | public website |
+| `website/src/components/ProvenanceTrail.astro` | 9737 | `b1e9716cfccf4b215e24235ae307fbbd95ece10605abb5b64de891a08cbf7839` | Astro | public website |
 | `website/src/components/ReadingLadder.astro` | 12671 | `cc667f85835b32c7bbe83d5551da29ed2046d5105e4a7244bcc362fae4c73a08` | Astro | public website |
-| `website/src/components/ScopeModel.astro` | 6524 | `de17128ef0a0f5fefe5eeb60a114d456a3e7215d339fc65596e6a8cd8d4a9690` | Astro | public website |
+| `website/src/components/ScopeModel.astro` | 8724 | `c1ce5d6d654b2a130c2027743612fe78e3daca0caa1f306eeee8d543024cd0ef` | Astro | public website |
 | `website/src/components/Search.astro` | 7810 | `6fcaf0b58c58acd5ac0e78917eeab326e3655fb514622f28b149bfd65277481b` | Astro | public website |
 | `website/src/components/ThemeToggle.astro` | 2265 | `043fc2eaaae111b2f1ee79de4f222d730b8e972bf114b64c2dd004e8f1f2ddb6` | Astro | public website |
-| `website/src/content.config.ts` | 755 | `e85d5683b804f1f833516425c5ffc09012b7bbec06c4c4082c2ad1f690a13989` | TypeScript | public website |
-| `website/src/content/blog/institution-in-a-box.md` | 4314 | `5eeed650603ad3de55fff925c6e6e11e205323214eb51e4614c27dbfefec3ffe` | Markdown | public website |
+| `website/src/content.config.ts` | 468 | `dde9ed63842dc627c75281b0e29c577fccab4c8c6e56ca848eb522723901cebd` | TypeScript | public website |
+| `website/src/content/blog/institution-in-a-box.md` | 4253 | `f634503d0e39e8ccb5293b17ac2a612b0303e9673e5264e88a12d4498db483f6` | Markdown | public website |
 | `website/src/content/blog/regulatory-safety-by-architecture.md` | 4486 | `8969331dd071a034dc6dc3235c1d56c127abd4ee66cafdb90ced38bfba989670` | Markdown | public website |
 | `website/src/content/blog/sprint-14-closing-the-economic-loop.md` | 4308 | `df9409b62f6ec1bafacb052a5eeddba685fc07094513d8cd1a133afea8eaac62` | Markdown | public website |
 | `website/src/content/blog/welcome.md` | 508 | `bc38864add37d7c5c5bd30e2d3b5b4c5e5be7d9e92fb227be53ac651eacc7663` | Markdown | public website |
-| `website/src/content/blog/what-icn-is-and-isnt.md` | 4608 | `ac59ccb5f367eb3448b49d83067b96a29d8c761e8034c486c9e6cedc86b2d1ec` | Markdown | public website |
+| `website/src/content/blog/what-icn-is-and-isnt.md` | 4582 | `99a0ebf12d1c48a8e0f21f94e60fd927baafdfec2db51ba82c5ab4822009f71d` | Markdown | public website |
 | `website/src/content/config.ts` | 382 | `83a703c70f205beec237c5f6ce9f296e6b3423c9b7b86576ae2ae6b66b87c177` | TypeScript | public website |
-| `website/src/content/docs/.gitkeep` | 1 | `36a9e7f1c95b82ffb99743e0c5c4ce95d83c9a430aac59f84ef3cbfab6145068` | unknown | public website |
-| `website/src/content/docs/README.md` | 7290 | `72ed6be34a8e4bcdd8d71c321fb3898334039716b0e6f403f953f5c1ab8a94f5` | Markdown | public website |
 | `website/src/data/icons.ts` | 8280 | `4c30e5b71f98256c6caf06125f81b0caaf7ff13c69b62839d7ebf624d13a8d09` | TypeScript | public website |
 | `website/src/data/readingOrder.ts` | 3326 | `7be78a8973294d251204be4220d0627caac20f29574c99f70760db561c2cfbf4` | TypeScript | public website |
 | `website/src/data/roadmap.json` | 3254 | `3f278dc502b47753c9bdc5cb9e53e85cdd3feed7c2a867b7970a53b4b6b7e1a0` | JSON | public website |
-| `website/src/design/README.md` | 1721 | `2a2e226816766f9fa8308742ad737334a3473789bfb68ca52ef12ed3b0411281` | Markdown | public website |
+| `website/src/design/README.md` | 3426 | `2b6ebfb2bea1eb50ba3ef8330fe6031a6b60bf469cd05889ff2e30e8916bc777` | Markdown | public website |
 | `website/src/env.d.ts` | 46 | `1f46bd6c18afa396328159483b1c9016c788de553eeef99c806c3d1ba591aec8` | TypeScript | public website |
 | `website/src/layouts/Layout.astro` | 11604 | `d6c9d63e069dad1d280c1984d5130b4031796ea81fcf895853e4af2242249176` | Astro | public website |
 | `website/src/lib/blog-slug.ts` | 89 | `1b1b91f2a7e6ee41ee5c869149f13096d890a747e762d4fb4ed9aced955ff9c0` | TypeScript | public website |
-| `website/src/lib/markdown.ts` | 2408 | `456b3bee85425de556b71bd2322025912f22af755f2bcbce61ae84449521bd89` | TypeScript | public website |
+| `website/src/lib/markdown.ts` | 3326 | `06ab9de42061991be88c5b997d27898d186adc85eab07b115aa04671fb4acbf6` | TypeScript | public website |
 | `website/src/lib/paths.ts` | 868 | `97af61feac562be4814d3d44ee17a048a09fddbf7b30a6b2ca4530cabfeae2be` | TypeScript | public website |
 | `website/src/pages/about.astro` | 8781 | `d98bafe924e80781a6c8a2760203a439cc89b3f0041bd38007d175a09472f730` | Astro | public website |
 | `website/src/pages/architecture.astro` | 5502 | `01d47a7691564f94109e3648976b3ebf819554b7bc26b73e3f52ba595e910e58` | Astro | public website |
@@ -3417,15 +3805,15 @@ Generated: 2026-05-01T14:42:25.281015+00:00
 | `website/src/pages/docs/[...slug].astro` | 3467 | `85a5968e9828a282507e53ac071e42be3f99bb2dcc7bac03c74256d3b3d58095` | Astro | public website |
 | `website/src/pages/docs/demo.astro` | 13135 | `3438415162ff91978b8b95494dddf3266ec90b8de0e39bf1de29f6c4dc3eb7f4` | Astro | public website |
 | `website/src/pages/docs/index.astro` | 17034 | `75f8d4da27accb7e59dee8d41f14751e07bbd1692aa6a3693ae17c337dec1be7` | Astro | public website |
-| `website/src/pages/for-cooperatives.astro` | 15564 | `e8f89470fb693d6c235dc65e14e8b8a84f5912d141545f87027da1f88aa02f57` | Astro | public website |
-| `website/src/pages/for-developers.astro` | 18247 | `5c376f5176ce325763e6c50657da0b0fe1d2d9cb200d7e060f74c4e04e9af3aa` | Astro | public website |
-| `website/src/pages/get-involved.astro` | 30284 | `81cf5c503123252a933061ffbb792b7d6bb7310a04227e38c47a7c9aa99ebda4` | Astro | public website |
-| `website/src/pages/how-it-works.astro` | 16850 | `5c5a8f446d56b8e4cd5e3d6424638523019148b2f72bfe03ed3c9e6297e59c44` | Astro | public website |
-| `website/src/pages/index.astro` | 27962 | `fb6f486adc1c9ed5bef4f15feaf576fa0dd140db00b377aaa0ffcfb2f8ba2840` | Astro | public website |
-| `website/src/pages/roadmap.astro` | 6484 | `d86139d629c626773ef4c20658f3213a8955ba3ea69641950dc8416342b2c96a` | Astro | public website |
+| `website/src/pages/for-cooperatives.astro` | 15318 | `ce4fb9893e3694616681d539035522b45933992821f11b1fd6960759686c7125` | Astro | public website |
+| `website/src/pages/for-developers.astro` | 18200 | `eca7c8bf8a47ce50401ea8d33370c98cb1c5985f7e20f1dc9c00bc1668236bf4` | Astro | public website |
+| `website/src/pages/get-involved.astro` | 29870 | `17d4c83e1049013ae1618b430265301d80fab4bd4bcb6c11cf2b023eb354c7de` | Astro | public website |
+| `website/src/pages/how-it-works.astro` | 17410 | `1e533189aed22cf126276a28b11e55d0f6c98c23f833f54d1688562ed9ffdf1d` | Astro | public website |
+| `website/src/pages/index.astro` | 27984 | `af4d53545e81df9d60a649e9eba6b541fd8b73b32421fe2aea4c8facddfadf0f` | Astro | public website |
+| `website/src/pages/roadmap.astro` | 6453 | `cc39ab40f66970e38c140d749f8cfc9c8e528f1fc440b125afa653c20a5aedd9` | Astro | public website |
 | `website/src/pages/rss.xml.ts` | 539 | `cae87a7b959a8338bc36cfb2f6ee3cc935ac98463ece21e82d2266c94c2dd309` | TypeScript | public website |
-| `website/src/pages/what-is-icn.astro` | 8430 | `56bbf64f339f5e769648b20612bc73cbe801bbfe36ab62f9cd77f1ebf692e49c` | Astro | public website |
-| `website/src/pages/whats-real-now.astro` | 12451 | `63dfed156c7b4c2aab10ea0bac0343657943f727c8eab4768b2d91ea551926a1` | Astro | public website |
-| `website/src/pages/why-icn.astro` | 8803 | `608afaeb844de55fe7a3bf625ad9f9356695c21a9aca57284c1079c883366593` | Astro | public website |
+| `website/src/pages/what-is-icn.astro` | 8469 | `2459defd4b88e83e14c06b89fc32b200a80501f3e4d607812135d5655bf85d6c` | Astro | public website |
+| `website/src/pages/whats-real-now.astro` | 9997 | `5cd5fbb048ebb858a82af2652ef403528aa13c0c765bca55850c75979cd6278b` | Astro | public website |
+| `website/src/pages/why-icn.astro` | 8822 | `daa78b938138c515df8f506f81d1eca2cb07f58fdce23d0254996f519188985c` | Astro | public website |
 | `website/src/styles/global.css` | 30764 | `9fc916ef3d241cd3cd5d565b6fabcc9801932024234c5d68244de04b78cabb3f` | CSS | public website |
 | `website/tsconfig.json` | 109 | `b5b0a5b04a14cddd7713c5e1c82e86c79c17c2f86b170e26e9b170b3d5e01cd9` | JSON | public website |


### PR DESCRIPTION
## Summary

- Regenerates the generated repo file-record snapshot for `icn`.
- Removes stale `website/src/content/docs` entries left after #2124 / #2125 (the obsolete Astro docs mirror) — these generated files were the last place the old path survived. Refs #2126.

## Generator command

```bash
python3 scripts/generate_repo_record.py --repo icn=. --out docs/reference/project-index/generated
```

- **Source commit:** `41c7082b330a6249bead068d641c6e4e495d2075` (current `main`)
- **Files changed:** only the two generated artifacts —
  - `docs/reference/project-index/generated/icn-file-record.json`
  - `docs/reference/project-index/generated/icn-file-record.md`

## Diff shape (large but mechanical)

- 2 files, ~ +7737 / −2379. Pure `git ls-files` + filesystem-metadata regeneration — **no hand-edits** (header: "Do not hand-edit generated sections; rerun `scripts/generate_repo_record.py`").
- Header source HEAD `9af1d6c6` → `41c7082b`; files recorded `2760` → `3093` (~7 weeks of file-inventory churn).
- Stale `src/content/docs` references: md `3 → 0`, json `5 → 0`.

## Scope / non-goals

- Generated-only maintenance for #2126. `--repo icn=.` only — no NYCN/private material recorded.
- No public-copy / runtime / route-inventory / OpenAPI / registry / truth-sync changes.
- Does not touch `.claude/`, root `.mcp.json`, `.cursor/mcp.json`, or `ops/state/truth/`.
- Isolated per the issue: not mixed with the #2124 / #2125 / #1779 lane.

## Validation

- Regenerated by the documented generator (above); exactly the 2 generated files changed; 0 untracked.
- `grep src/content/docs` → 0 in both files; generated header reflects HEAD `41c7082b`.
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` → exit 0, 65 enforcement warnings (baseline; none reference the file-record).
- The generator has no `--check` mode and there is no separate repo-record CI/checker; validation is mechanical (regenerate → confirm scope → confirm stale path gone → confirm header source commit).
