### PR TITLE
ci(docs): add observational drift gate for generated-truth artifacts

### DIFF
--- a/.github/workflows/generated-truth.yml
+++ b/.github/workflows/generated-truth.yml
@@ -1,0 +1,120 @@
+name: Generated-truth drift
+
+# Observational drift guard for the repo's generated orientation/truth artifacts
+# and the agent/plugin validation tooling (#2128 spine, #2130 file-record, #2127
+# Claude agent pack, #2131 live-state overlay). These artifacts are
+# "Canonical: no" — orientation/reference layers, NOT truth roots (canonical
+# state is docs/STATE.md + docs/PHASE_PROGRESS.md). Drift here is therefore a
+# WARNING, not a merge blocker, mirroring the route-inventory guard in
+# docs-freshness.yml. The job only FAILS if a checker itself errors (not on
+# drift). Promote individual checks to blocking only after a clean CI baseline
+# is proven and they are added to branch protection.
+#
+# See docs/ci/GENERATED_TRUTH_DRIFT.md for what is gated, what is advisory, and
+# the regenerate commands.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/generate-agent-context-spine.py'
+      - 'scripts/check-agent-context-spine.py'
+      - 'scripts/generate_repo_record.py'
+      - 'scripts/check-claude-plugin.py'
+      - 'scripts/check-claude-plugin-root-resolution.py'
+      - 'scripts/generate-live-state-overlay.py'
+      - 'docs/reference/project-index/generated/**'
+      - 'docs/ai/ICN_LIVE_STATE_OVERLAY_TEMPLATE.md'
+      - 'tools/claude-code/plugins/**'
+      - '.github/workflows/generated-truth.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/generate-agent-context-spine.py'
+      - 'scripts/check-agent-context-spine.py'
+      - 'scripts/generate_repo_record.py'
+      - 'scripts/check-claude-plugin.py'
+      - 'scripts/check-claude-plugin-root-resolution.py'
+      - 'scripts/generate-live-state-overlay.py'
+      - 'docs/reference/project-index/generated/**'
+      - 'docs/ai/ICN_LIVE_STATE_OVERLAY_TEMPLATE.md'
+      - 'tools/claude-code/plugins/**'
+      - '.github/workflows/generated-truth.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generated-truth:
+    name: Generated-truth drift (observational)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      # Spine: structural validation + freshness vs a fresh generation
+      # (check-agent-context-spine.py runs generate-agent-context-spine.py --check).
+      # Currently green on main; observational here. exit 0 = current.
+      - name: Agent context spine — valid + fresh
+        run: |
+          python3 scripts/check-agent-context-spine.py && rc=0 || rc=$?
+          if [ "${rc:-0}" = "0" ]; then
+            echo "Agent context spine is valid and current."
+          else
+            echo "::warning::agent-context-spine drift/validation issue (exit $rc). Regenerate: python3 scripts/generate-agent-context-spine.py --write"
+          fi
+
+      # Claude agent pack: portable skeleton + repo-root resolution. Currently
+      # green on main; observational here.
+      - name: Claude plugin skeleton portability
+        run: |
+          python3 scripts/check-claude-plugin.py && rc=0 || rc=$?
+          if [ "${rc:-0}" = "0" ]; then
+            echo "Claude plugin skeleton OK."
+          else
+            echo "::warning::check-claude-plugin.py reported an issue (exit $rc)."
+          fi
+
+      - name: Claude plugin root resolution
+        run: |
+          python3 scripts/check-claude-plugin-root-resolution.py && rc=0 || rc=$?
+          if [ "${rc:-0}" = "0" ]; then
+            echo "Claude plugin root-resolution OK."
+          else
+            echo "::warning::check-claude-plugin-root-resolution.py reported an issue (exit $rc)."
+          fi
+
+      # Live-state overlay generator is on-demand with NO committed snapshot, so
+      # there is nothing to drift-check; this is a runnable-smoke (--check
+      # self-validates the 13 sections). --no-gh keeps it offline/deterministic.
+      - name: Live-state overlay generator smoke (--check, offline)
+        run: |
+          python3 scripts/generate-live-state-overlay.py --check --no-gh && rc=0 || rc=$?
+          if [ "${rc:-0}" = "0" ]; then
+            echo "Live-state overlay generator self-check passed."
+          else
+            echo "::warning::generate-live-state-overlay.py --check failed (exit $rc) — generator regression."
+          fi
+
+      # Repo file-record is a periodic snapshot (Canonical: no). It legitimately
+      # lags main between refreshes, so drift is a WARNING (refresh is a separate
+      # generated-only commit). Mirrors the route-inventory guard:
+      #   exit 0 = current  -> pass
+      #   exit 1 = stale     -> ::warning:: (regenerate); job still succeeds
+      #   exit >=2 = checker errored -> fail (real breakage, not staleness)
+      - name: Repo file-record snapshot drift (warn on stale)
+        run: |
+          python3 scripts/generate_repo_record.py --repo icn=. --check && rc=0 || rc=$?
+          if [ "${rc:-0}" = "0" ]; then
+            echo "Repo file-record snapshot is current."
+          elif [ "${rc:-0}" = "1" ]; then
+            echo "::warning::docs/reference/project-index/generated/icn-file-record.{json,md} is stale vs the working tree. Regenerate (generated-only commit): python3 scripts/generate_repo_record.py --repo icn=. --out docs/reference/project-index/generated"
+          else
+            echo "::error::generate_repo_record.py --check errored (exit $rc) — checker error, not a staleness signal."
+            exit "$rc"
+          fi

--- a/docs/ci/GENERATED_TRUTH_DRIFT.md
+++ b/docs/ci/GENERATED_TRUTH_DRIFT.md
@@ -1,0 +1,70 @@
+# Generated-truth drift gate
+
+**Status Type**: Operational reference (not a canonical truth source)
+**Workflow**: [`.github/workflows/generated-truth.yml`](../../.github/workflows/generated-truth.yml)
+
+## Purpose
+
+ICN's generated **orientation / truth-layer** artifacts (the agent context spine,
+the repo file-record snapshot, the Claude agent pack, and the live-state overlay
+generator) are reference aids that agents and developers navigate by. They are
+**`Canonical: no`** — they are NOT truth roots. The canonical project state
+remains [`docs/STATE.md`](../STATE.md) + [`docs/PHASE_PROGRESS.md`](../PHASE_PROGRESS.md);
+everything below orients toward those and must not exceed them.
+
+Because these artifacts are generated, they can silently diverge from source
+between manual regenerations. This gate makes that drift **visible** in CI. It
+mirrors the existing route-inventory guard in
+[`docs-freshness.yml`](../../.github/workflows/docs-freshness.yml): drift is a
+**warning**, not a merge blocker.
+
+## What is checked
+
+| Check (script) | Artifact / invariant | Regenerate | Current posture |
+|---|---|---|---|
+| `scripts/check-agent-context-spine.py` | `docs/reference/project-index/generated/agent-context-spine.json` is structurally valid and matches a fresh generation | `python3 scripts/generate-agent-context-spine.py --write` | green on main |
+| `scripts/generate_repo_record.py --repo icn=. --check` | `docs/reference/project-index/generated/icn-file-record.{json,md}` matches the working tree (timestamp/branch ignored) | `python3 scripts/generate_repo_record.py --repo icn=. --out docs/reference/project-index/generated` | **stale-warn** (periodic snapshot; see below) |
+| `scripts/check-claude-plugin.py` | Claude agent pack skeleton is portable (no machine paths) | n/a (validation only) | green on main |
+| `scripts/check-claude-plugin-root-resolution.py` | Agent-pack repo-root resolver behaves across worktree layouts | n/a (validation only) | green on main |
+| `scripts/generate-live-state-overlay.py --check --no-gh` | Live-state overlay generator self-check (13 sections, claim discipline). The overlay is **on-demand with NO committed snapshot**, so this is a runnable-smoke, not a drift check. | n/a (never committed) | green on main |
+
+## Blocking vs observational
+
+**All checks are observational** in this gate (v1). The job emits `::warning::`
+on drift and **succeeds**; it only **fails** if a checker itself errors (e.g.
+`generate_repo_record.py --check` exits ≥2, distinct from `1`=stale). The
+workflow is not a branch-protection–required check, so it does not block merge.
+
+This conservative start matches the repo convention for orientation artifacts
+(route-inventory is warn-only — issue #2112). See
+[`GATE_RATCHET_PLAN.md`](GATE_RATCHET_PLAN.md) for how observational checks
+graduate to enforceable gates.
+
+## Regenerating artifacts
+
+```bash
+# Agent context spine
+python3 scripts/generate-agent-context-spine.py --write
+
+# Repo file-record snapshot (generated-only commit; do not hand-edit)
+python3 scripts/generate_repo_record.py --repo icn=. --out docs/reference/project-index/generated
+
+# Live-state overlay — on-demand only, NEVER commit a snapshot
+python3 scripts/generate-live-state-overlay.py            # markdown to stdout
+```
+
+## Known follow-ups (out of scope for the gate itself)
+
+- **File-record snapshot is periodically stale.** It is a point-in-time
+  snapshot refreshed by a dedicated generated-only commit (e.g. #2126/#2130),
+  not on every PR. The observational check flags when it lags `main`; refreshing
+  it is a separate commit, intentionally not bundled here.
+- **Spine subsystem coverage is partial.** The agent-context-spine currently
+  derives crate→subsystem membership for ~7 of the ~14 subsystems the live-state
+  overlay lists (the rest are curated v0 with no spine `owned_by_subsystem`
+  node). Completing that derivation is a separate lane.
+- **Promotion candidates.** `check-agent-context-spine.py`,
+  `check-claude-plugin.py`, and `check-claude-plugin-root-resolution.py` are
+  green-on-main and deterministic; they are candidates to graduate from
+  observational to blocking once a clean CI baseline is confirmed and they are
+  added to branch protection.

--- a/scripts/generate_repo_record.py
+++ b/scripts/generate_repo_record.py
@@ -21,10 +21,13 @@ without review.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime as dt
 import hashlib
 import json
 import subprocess
+import sys
+import tempfile
 from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -539,6 +542,88 @@ def parse_repo_arg(value: str) -> tuple[str, Path]:
     return name, Path(path)
 
 
+def _normalize_record(text: str, ext: str) -> str:
+    """Strip incidental, non-content fields so --check compares the snapshot
+    payload (file inventory, sizes, SHAs, head) rather than the generation
+    timestamp or the branch the snapshot happened to be taken on.
+
+    Normalized out:
+      - JSON `generated_at` (changes every run) and `branch` (incidental: a
+        refresh on any branch is equivalent).
+      - Markdown `Generated:` front-matter line and the `- Branch:` line.
+    `head` and the file inventory are intentionally KEPT — a head/inventory
+    difference is real snapshot staleness, which is exactly what --check reports.
+    """
+    if ext == "json":
+        data = json.loads(text)
+        data.pop("generated_at", None)
+        data["branch"] = "<normalized>"
+        return json.dumps(data, indent=2, sort_keys=True)
+    # markdown
+    kept = [
+        line
+        for line in text.splitlines()
+        if not line.startswith("Generated:") and not line.startswith("- Branch:")
+    ]
+    return "\n".join(kept)
+
+
+def check_repos(
+    repos: list[tuple[str, Path]],
+    out_dir: Path,
+    include_untracked: bool,
+) -> int:
+    """Regenerate each repo record into a temp dir and compare it against the
+    committed artifact under `out_dir`, ignoring the volatile fields above.
+
+    Returns 0 when every committed record matches the working tree, 1 on drift
+    or a missing committed artifact. Never writes to `out_dir`.
+    """
+    drift = False
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        for repo_name, repo_path in repos:
+            # allow_dirty=True: --check compares against the current working
+            # tree (it must not refuse on a dirty checkout); it never persists
+            # a misleading artifact because it only writes into the temp dir.
+            with contextlib.redirect_stdout(sys.stderr):
+                generate_for_repo(repo_name, repo_path, tmp_dir, include_untracked, True)
+            for ext in ("json", "md"):
+                committed = out_dir / f"{repo_name}-file-record.{ext}"
+                fresh = tmp_dir / f"{repo_name}-file-record.{ext}"
+                if not committed.exists():
+                    print(f"DRIFT: committed artifact missing: {committed}")
+                    drift = True
+                    continue
+                if _normalize_record(committed.read_text(encoding="utf-8"), ext) != _normalize_record(
+                    fresh.read_text(encoding="utf-8"), ext
+                ):
+                    drift = True
+                    print(f"DRIFT: {committed} differs from a fresh generation.")
+                    if ext == "json":
+                        c = json.loads(committed.read_text(encoding="utf-8"))
+                        f = json.loads(fresh.read_text(encoding="utf-8"))
+                        print(
+                            f"  committed head={c.get('head', '?')[:12]} "
+                            f"file_count={c.get('summary', {}).get('file_count')}"
+                        )
+                        print(
+                            f"  working   head={f.get('head', '?')[:12]} "
+                            f"file_count={f.get('summary', {}).get('file_count')}"
+                        )
+    if drift:
+        out_disp = out_dir if str(out_dir) != "." else "docs/reference/project-index/generated"
+        print(
+            "\nRegenerate with:\n"
+            f"  python3 scripts/generate_repo_record.py "
+            f"--repo {repos[0][0]}={repos[0][1]} --out {out_disp}",
+            file=sys.stderr,
+        )
+        return 1
+    print("OK: repo file-record matches the working tree (timestamp/branch ignored).")
+    return 0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -553,6 +638,16 @@ def main() -> None:
         type=Path,
         default=Path("docs/reference/project-index/generated"),
         help="Output directory for generated JSON and Markdown records.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Do not write. Regenerate each record into a temp dir and compare "
+            "it against the committed artifact under --out, ignoring the "
+            "generation timestamp and branch. Exit 0 if current, 1 on drift "
+            "(stale snapshot) or a missing committed artifact."
+        ),
     )
     parser.add_argument(
         "--include-untracked",
@@ -570,6 +665,9 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+
+    if args.check:
+        raise SystemExit(check_repos(args.repo, args.out, args.include_untracked))
 
     for repo_name, repo_path in args.repo:
         generate_for_repo(

--- a/scripts/generate_repo_record.py
+++ b/scripts/generate_repo_record.py
@@ -576,49 +576,70 @@ def check_repos(
     """Regenerate each repo record into a temp dir and compare it against the
     committed artifact under `out_dir`, ignoring the volatile fields above.
 
-    Returns 0 when every committed record matches the working tree, 1 on drift
-    or a missing committed artifact. Never writes to `out_dir`.
+    Exit contract:
+      0  every committed record matches the working tree (modulo timestamp/branch)
+      1  drift — a committed record is stale or missing
+      2  checker error — regeneration or comparison itself failed (e.g. a repo
+         path is not a git checkout, git failed, or a committed artifact is
+         unreadable/invalid JSON/MD). Kept distinct from drift so CI can fail on
+         real breakage while only warning on staleness.
+    Never writes to `out_dir`.
     """
+
+    def _regenerate_command() -> str:
+        # Reconstruct the actual command (every --repo entry + the real --out),
+        # not just the first repo / a hard-coded path.
+        repo_args = " ".join(f"--repo {name}={path}" for name, path in repos)
+        return f"python3 scripts/generate_repo_record.py {repo_args} --out {out_dir}"
+
     drift = False
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp_dir = Path(tmp)
-        for repo_name, repo_path in repos:
-            # allow_dirty=True: --check compares against the current working
-            # tree (it must not refuse on a dirty checkout); it never persists
-            # a misleading artifact because it only writes into the temp dir.
-            with contextlib.redirect_stdout(sys.stderr):
-                generate_for_repo(repo_name, repo_path, tmp_dir, include_untracked, True)
-            for ext in ("json", "md"):
-                committed = out_dir / f"{repo_name}-file-record.{ext}"
-                fresh = tmp_dir / f"{repo_name}-file-record.{ext}"
-                if not committed.exists():
-                    print(f"DRIFT: committed artifact missing: {committed}")
-                    drift = True
-                    continue
-                if _normalize_record(committed.read_text(encoding="utf-8"), ext) != _normalize_record(
-                    fresh.read_text(encoding="utf-8"), ext
-                ):
-                    drift = True
-                    print(f"DRIFT: {committed} differs from a fresh generation.")
-                    if ext == "json":
-                        c = json.loads(committed.read_text(encoding="utf-8"))
-                        f = json.loads(fresh.read_text(encoding="utf-8"))
-                        print(
-                            f"  committed head={c.get('head', '?')[:12]} "
-                            f"file_count={c.get('summary', {}).get('file_count')}"
-                        )
-                        print(
-                            f"  working   head={f.get('head', '?')[:12]} "
-                            f"file_count={f.get('summary', {}).get('file_count')}"
-                        )
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            for repo_name, repo_path in repos:
+                # allow_dirty=True: --check compares against the current working
+                # tree (it must not refuse on a dirty checkout); it never persists
+                # a misleading artifact because it only writes into the temp dir.
+                with contextlib.redirect_stdout(sys.stderr):
+                    generate_for_repo(repo_name, repo_path, tmp_dir, include_untracked, True)
+                for ext in ("json", "md"):
+                    committed = out_dir / f"{repo_name}-file-record.{ext}"
+                    fresh = tmp_dir / f"{repo_name}-file-record.{ext}"
+                    if not committed.exists():
+                        print(f"DRIFT: committed artifact missing: {committed}")
+                        drift = True
+                        continue
+                    if _normalize_record(committed.read_text(encoding="utf-8"), ext) != _normalize_record(
+                        fresh.read_text(encoding="utf-8"), ext
+                    ):
+                        drift = True
+                        print(f"DRIFT: {committed} differs from a fresh generation.")
+                        if ext == "json":
+                            c = json.loads(committed.read_text(encoding="utf-8"))
+                            f = json.loads(fresh.read_text(encoding="utf-8"))
+                            print(
+                                f"  committed head={c.get('head', '?')[:12]} "
+                                f"file_count={c.get('summary', {}).get('file_count')}"
+                            )
+                            print(
+                                f"  working   head={f.get('head', '?')[:12]} "
+                                f"file_count={f.get('summary', {}).get('file_count')}"
+                            )
+    except SystemExit as exc:
+        # generate_for_repo raises SystemExit (with a message) on a real
+        # regeneration failure (path is not a git repo, git failure, etc.).
+        # Map it to a checker error (>=2) so CI fails rather than mistaking it
+        # for drift (rc=1).
+        print(f"CHECKER ERROR: repo file-record regeneration failed: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        # Any other unexpected failure (e.g. an unreadable/invalid committed
+        # JSON/MD artifact) is a checker error (>=2), not staleness (rc=1).
+        print(f"CHECKER ERROR: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
     if drift:
-        out_disp = out_dir if str(out_dir) != "." else "docs/reference/project-index/generated"
-        print(
-            "\nRegenerate with:\n"
-            f"  python3 scripts/generate_repo_record.py "
-            f"--repo {repos[0][0]}={repos[0][1]} --out {out_disp}",
-            file=sys.stderr,
-        )
+        print(f"\nRegenerate with:\n  {_regenerate_command()}", file=sys.stderr)
         return 1
     print("OK: repo file-record matches the working tree (timestamp/branch ignored).")
     return 0
@@ -646,7 +667,7 @@ def main() -> None:
             "Do not write. Regenerate each record into a temp dir and compare "
             "it against the committed artifact under --out, ignoring the "
             "generation timestamp and branch. Exit 0 if current, 1 on drift "
-            "(stale snapshot) or a missing committed artifact."
+            "(stale or missing snapshot), 2 on checker error."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## What

Adds an observational CI drift gate for ICN's generated orientation / truth-layer artifacts.

This PR includes:

- `scripts/generate_repo_record.py --check`
  - regenerates repo file-record output into a temp directory
  - normalizes volatile timestamp / branch fields
  - compares committed `docs/reference/project-index/generated/icn-file-record.{json,md}` against fresh output
  - exits `0` when current, `1` when stale, and `>=2` for checker errors

- `.github/workflows/generated-truth.yml`
  - new path-filtered / manual workflow
  - runs:
    - `check-agent-context-spine.py`
    - `generate_repo_record.py --repo icn=. --check`
    - `check-claude-plugin.py`
    - `check-claude-plugin-root-resolution.py`
    - `generate-live-state-overlay.py --check --no-gh`
  - reports drift as `::warning::`
  - stays observational / non-blocking
  - fails only on checker errors

- `docs/ci/GENERATED_TRUTH_DRIFT.md`
  - documents what is gated
  - clarifies canonical truth roots vs generated orientation artifacts
  - records regenerate commands and follow-up posture

## Why

The repo now relies on generated/on-demand orientation artifacts for agent and developer navigation, but several validators were not wired into CI. Without a drift gate, those maps can silently rot.

Canonical truth roots remain:

- `docs/STATE.md`
- `docs/PHASE_PROGRESS.md`

These generated artifacts remain `Canonical: no`; they orient toward truth, they do not become truth roots.

## Validation

Local validation (re-run against current `origin/main` = `80a18c24`):

- `check-agent-context-spine.py` exits `0`
- `check-claude-plugin.py` exits `0`
- `check-claude-plugin-root-resolution.py` exits `0`
- `generate-live-state-overlay.py --check --no-gh` exits `0`
- `generate_repo_record.py --repo icn=. --check` exits `1` — expected stale-warn (committed snapshot `head=41c7082b` `file_count=3093` vs working `80a18c24` `3094`; the +1 file is the `#2131` overlay generator), NOT a checker error. Proven exit `0` against a fresh temp baseline.
- `doc_control_check.py --repo . --registry docs/registry.toml` passes (882 docs, 65-warning baseline, no new warnings)
- `route_inventory.py --check` passes
- workflow YAML parses
- no untrusted `github.event.*` interpolation in workflow `run:` blocks

## Risk

Low. This is CI/docs/script-only:

- no Rust runtime changes
- no entity-auth changes
- no gateway behavior changes
- no generated file refresh in this PR
- no new truth root
- workflow is observational, not branch-protection blocking

## Follow-ups

- Refresh `docs/reference/project-index/generated/icn-file-record.{json,md}` in a separate generated-only PR (clears the standing file-record warning).
- Consider promoting deterministic checks such as agent-context-spine and Claude plugin validation from observational to blocking after a clean CI baseline.
