### PR TITLE
fix(project-index): make file-record check convergent

### DIFF
--- a/docs/reference/project-index/generated/icn-file-record.json
+++ b/docs/reference/project-index/generated/icn-file-record.json
@@ -1,5 +1,5 @@
 {
-  "branch": "docs/record-refresh-2126",
+  "branch": "fix/file-record-exclude-self",
   "directories": [
     {
       "child_directory_count": 25,
@@ -24,7 +24,7 @@
         ".ipynb": 1,
         ".jar": 1,
         ".js": 43,
-        ".json": 154,
+        ".json": 153,
         ".keystore": 1,
         ".kt": 2,
         ".lock": 3,
@@ -37,7 +37,7 @@
         ".pptx": 1,
         ".pro": 1,
         ".properties": 2,
-        ".py": 40,
+        ".py": 41,
         ".rs": 940,
         ".service": 4,
         ".sh": 119,
@@ -52,12 +52,12 @@
         ".webp": 15,
         ".xml": 11,
         ".yaml": 92,
-        ".yml": 59
+        ".yml": 60
       },
-      "file_count": 3093,
+      "file_count": 3094,
       "path": ".",
       "role_guess": "repo root",
-      "total_size_bytes": 48274562
+      "total_size_bytes": 46534125
     },
     {
       "child_directory_count": 1,
@@ -127,12 +127,12 @@
       "extensions": {
         ".md": 35,
         ".py": 4,
-        ".yml": 29
+        ".yml": 30
       },
-      "file_count": 68,
+      "file_count": 69,
       "path": ".github",
       "role_guess": "repo configuration",
-      "total_size_bytes": 284056
+      "total_size_bytes": 289482
     },
     {
       "child_directory_count": 1,
@@ -253,7 +253,7 @@
       "depth": 1,
       "extensions": {
         ".html": 3,
-        ".json": 16,
+        ".json": 15,
         ".md": 881,
         ".mermaid": 1,
         ".pdf": 5,
@@ -264,10 +264,10 @@
         ".toml": 45,
         ".yaml": 4
       },
-      "file_count": 968,
+      "file_count": 967,
       "path": "docs",
       "role_guess": "documentation",
-      "total_size_bytes": 15760928
+      "total_size_bytes": 13955313
     },
     {
       "child_directory_count": 5,
@@ -364,14 +364,14 @@
       "depth": 1,
       "extensions": {
         ".js": 1,
-        ".py": 9,
+        ".py": 10,
         ".sh": 42,
         ".txt": 1
       },
-      "file_count": 53,
+      "file_count": 54,
       "path": "scripts",
       "role_guess": "script",
-      "total_size_bytes": 423147
+      "total_size_bytes": 481807
     },
     {
       "child_directory_count": 2,
@@ -428,7 +428,7 @@
       "file_count": 26,
       "path": "tools",
       "role_guess": "uncategorized",
-      "total_size_bytes": 88907
+      "total_size_bytes": 89999
     },
     {
       "child_directory_count": 4,
@@ -629,12 +629,12 @@
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".yml": 17
+        ".yml": 18
       },
-      "file_count": 17,
+      "file_count": 18,
       "path": ".github/workflows",
       "role_guess": "GitHub Actions workflow",
-      "total_size_bytes": 108418
+      "total_size_bytes": 113844
     },
     {
       "child_directory_count": 0,
@@ -926,7 +926,7 @@
       "file_count": 5,
       "path": "docs/ai",
       "role_guess": "documentation",
-      "total_size_bytes": 21008
+      "total_size_bytes": 26161
     },
     {
       "child_directory_count": 0,
@@ -968,12 +968,12 @@
       "child_directory_count": 0,
       "depth": 2,
       "extensions": {
-        ".md": 3
+        ".md": 4
       },
-      "file_count": 3,
+      "file_count": 4,
       "path": "docs/ci",
       "role_guess": "documentation",
-      "total_size_bytes": 13817
+      "total_size_bytes": 18053
     },
     {
       "child_directory_count": 1,
@@ -1268,14 +1268,14 @@
       "child_directory_count": 3,
       "depth": 2,
       "extensions": {
-        ".json": 2,
-        ".md": 37,
+        ".json": 1,
+        ".md": 36,
         ".yaml": 1
       },
-      "file_count": 40,
+      "file_count": 38,
       "path": "docs/reference",
       "role_guess": "documentation",
-      "total_size_bytes": 2290330
+      "total_size_bytes": 475326
     },
     {
       "child_directory_count": 0,
@@ -1783,7 +1783,7 @@
       "file_count": 26,
       "path": "tools/claude-code",
       "role_guess": "uncategorized",
-      "total_size_bytes": 88907
+      "total_size_bytes": 89999
     },
     {
       "child_directory_count": 0,
@@ -3135,13 +3135,13 @@
       "child_directory_count": 1,
       "depth": 3,
       "extensions": {
-        ".json": 2,
-        ".md": 25
+        ".json": 1,
+        ".md": 24
       },
-      "file_count": 27,
+      "file_count": 25,
       "path": "docs/reference/project-index",
       "role_guess": "project index / atlas",
-      "total_size_bytes": 2172323
+      "total_size_bytes": 357319
     },
     {
       "child_directory_count": 0,
@@ -4155,7 +4155,7 @@
       "file_count": 26,
       "path": "tools/claude-code/plugins",
       "role_guess": "uncategorized",
-      "total_size_bytes": 88907
+      "total_size_bytes": 89999
     },
     {
       "child_directory_count": 0,
@@ -4776,13 +4776,13 @@
       "child_directory_count": 0,
       "depth": 4,
       "extensions": {
-        ".json": 2,
-        ".md": 2
+        ".json": 1,
+        ".md": 1
       },
-      "file_count": 4,
+      "file_count": 2,
       "path": "docs/reference/project-index/generated",
       "role_guess": "project index / atlas",
-      "total_size_bytes": 1997717
+      "total_size_bytes": 182713
     },
     {
       "child_directory_count": 0,
@@ -6034,7 +6034,7 @@
       "file_count": 26,
       "path": "tools/claude-code/plugins/icn-agent-pack",
       "role_guess": "uncategorized",
-      "total_size_bytes": 88907
+      "total_size_bytes": 89999
     },
     {
       "child_directory_count": 0,
@@ -6698,7 +6698,7 @@
       "file_count": 10,
       "path": "tools/claude-code/plugins/icn-agent-pack/skills",
       "role_guess": "uncategorized",
-      "total_size_bytes": 34294
+      "total_size_bytes": 35386
     },
     {
       "child_directory_count": 0,
@@ -6950,7 +6950,7 @@
       "file_count": 1,
       "path": "tools/claude-code/plugins/icn-agent-pack/skills/preflight",
       "role_guess": "uncategorized",
-      "total_size_bytes": 2605
+      "total_size_bytes": 3697
     },
     {
       "child_directory_count": 0,
@@ -9480,6 +9480,19 @@
       "role_guess": "GitHub Actions workflow",
       "sha256": "e2ff1c562395135582738e773e5db1b984d190e8204fab5e4b7bffb57d9612fa",
       "size_bytes": 3037,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": ".github/workflows",
+      "extension": ".yml",
+      "kind": "file",
+      "language": "YAML",
+      "name": "generated-truth.yml",
+      "path": ".github/workflows/generated-truth.yml",
+      "role_guess": "GitHub Actions workflow",
+      "sha256": "cf03e607fbfac884f97a1301c6fe40f53f6d4aa1403beaa9e7d00e1ec5f1c3d9",
+      "size_bytes": 5426,
       "symlink_target": null,
       "tracked": true
     },
@@ -13391,8 +13404,8 @@
       "name": "ICN_LIVE_STATE_OVERLAY_TEMPLATE.md",
       "path": "docs/ai/ICN_LIVE_STATE_OVERLAY_TEMPLATE.md",
       "role_guess": "documentation",
-      "sha256": "6af52b6ee876dad633c6fe8265da357daf17535092db20dc4a4736d8e28e2ddd",
-      "size_bytes": 2748,
+      "sha256": "00421d4642a229ef027df1ccaacc4ba49cbc44c6861e99a86ad47e4064e324e8",
+      "size_bytes": 7901,
       "symlink_target": null,
       "tracked": true
     },
@@ -15109,6 +15122,19 @@
       "role_guess": "documentation",
       "sha256": "9debcec8b18cadb02071d2277b80ad8a040da8932c61a761a4c7751b4c9ebd98",
       "size_bytes": 8724,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "docs/ci",
+      "extension": ".md",
+      "kind": "file",
+      "language": "Markdown",
+      "name": "GENERATED_TRUTH_DRIFT.md",
+      "path": "docs/ci/GENERATED_TRUTH_DRIFT.md",
+      "role_guess": "documentation",
+      "sha256": "46753d3d2baf4c0c709efc771a7a8b304bd4477ebf4d66fea06fcdc0e20e7085",
+      "size_bytes": 4236,
       "symlink_target": null,
       "tracked": true
     },
@@ -23013,32 +23039,6 @@
       "role_guess": "project index / atlas",
       "sha256": "a68345f938a12c782befa3e4fa1c597068c9911537aaaa5c599bed9d63ff6e57",
       "size_bytes": 106372,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "docs/reference/project-index/generated",
-      "extension": ".json",
-      "kind": "file",
-      "language": "JSON",
-      "name": "icn-file-record.json",
-      "path": "docs/reference/project-index/generated/icn-file-record.json",
-      "role_guess": "project index / atlas",
-      "sha256": "cf7c2b7e6c389a6adec7f68dfd68cfeeb0824add14fa9e5c2656b80a49fb2f74",
-      "size_bytes": 1350034,
-      "symlink_target": null,
-      "tracked": true
-    },
-    {
-      "directory": "docs/reference/project-index/generated",
-      "extension": ".md",
-      "kind": "file",
-      "language": "Markdown",
-      "name": "icn-file-record.md",
-      "path": "docs/reference/project-index/generated/icn-file-record.md",
-      "role_guess": "project index / atlas",
-      "sha256": "3b9cf01f4205225e78ebfcfb81cabd6ecdb5a7457bc1205b92d71aa9b4b2c480",
-      "size_bytes": 464970,
       "symlink_target": null,
       "tracked": true
     },
@@ -41959,6 +41959,19 @@
     },
     {
       "directory": "scripts",
+      "extension": ".py",
+      "kind": "file",
+      "language": "Python",
+      "name": "generate-live-state-overlay.py",
+      "path": "scripts/generate-live-state-overlay.py",
+      "role_guess": "script",
+      "sha256": "04398e0a68e0c8a4293f82a881aaaacb77eae0d90a36a00bc2690069532fe61f",
+      "size_bytes": 50165,
+      "symlink_target": null,
+      "tracked": true
+    },
+    {
+      "directory": "scripts",
       "extension": ".sh",
       "kind": "file",
       "language": "Shell",
@@ -41978,8 +41991,8 @@
       "name": "generate_repo_record.py",
       "path": "scripts/generate_repo_record.py",
       "role_guess": "script",
-      "sha256": "fd4ae442a188064be1d5699548ddc045413ac7268180732249778af228d4f96d",
-      "size_bytes": 21852,
+      "sha256": "1b7f9aec71df765a4df383b254cecdde81a46b011998123dd1a30b23f66f83ff",
+      "size_bytes": 30347,
       "symlink_target": null,
       "tracked": true
     },
@@ -45111,8 +45124,8 @@
       "name": "SKILL.md",
       "path": "tools/claude-code/plugins/icn-agent-pack/skills/preflight/SKILL.md",
       "role_guess": "uncategorized",
-      "sha256": "1b6fa063b261175d86aae48321adfc9fb187d8ac9f0b5838e3caf21c39253602",
-      "size_bytes": 2605,
+      "sha256": "cf2c29ef43dd689c46c3c877d38693c719ba7dc6895ba899810da5a13e43a386",
+      "size_bytes": 3697,
       "symlink_target": null,
       "tracked": true
     },
@@ -47470,8 +47483,8 @@
       "tracked": true
     }
   ],
-  "generated_at": "2026-06-21T14:23:11.642134+00:00",
-  "head": "41c7082b330a6249bead068d641c6e4e495d2075",
+  "generated_at": "2026-06-21T21:21:29.736718+00:00",
+  "head": "fa819b47fbf774296400b42ca6f7c7c8630004af",
   "include_untracked": false,
   "repo": "icn",
   "schema": "icn.repo_record.v1",
@@ -47497,7 +47510,7 @@
       ".ipynb": 1,
       ".jar": 1,
       ".js": 43,
-      ".json": 154,
+      ".json": 153,
       ".keystore": 1,
       ".kt": 2,
       ".lock": 3,
@@ -47510,7 +47523,7 @@
       ".pptx": 1,
       ".pro": 1,
       ".properties": 2,
-      ".py": 40,
+      ".py": 41,
       ".rs": 940,
       ".service": 4,
       ".sh": 119,
@@ -47525,14 +47538,14 @@
       ".webp": 15,
       ".xml": 11,
       ".yaml": 92,
-      ".yml": 59
+      ".yml": 60
     },
-    "file_count": 3093,
+    "file_count": 3094,
     "kinds": {
-      "file": 3093
+      "file": 3094
     },
     "roles": {
-      "GitHub Actions workflow": 17,
+      "GitHub Actions workflow": 18,
       "React Native SDK": 139,
       "Rust binary": 16,
       "Rust library crate": 922,
@@ -47543,25 +47556,25 @@
       "dashboard UI": 7,
       "demo": 53,
       "deployment": 130,
-      "documentation": 897,
+      "documentation": 898,
       "institution package": 40,
       "legacy/top-level app": 5,
       "monitoring": 9,
       "operations / coordination": 87,
       "pilot UI": 84,
-      "project index / atlas": 27,
+      "project index / atlas": 25,
       "public website": 71,
       "repo configuration": 144,
       "repo control document": 4,
       "request for comments": 8,
       "runtime app crate": 126,
-      "script": 53,
+      "script": 54,
       "uncategorized": 155
     },
     "skipped_paths": [],
-    "total_size_bytes": 48274562,
-    "tracked_file_count": 3093,
-    "tracked_total_size_bytes": 48274562,
+    "total_size_bytes": 46534125,
+    "tracked_file_count": 3094,
+    "tracked_total_size_bytes": 46534125,
     "untracked_file_count": 0,
     "untracked_total_size_bytes": 0
   },

--- a/docs/reference/project-index/generated/icn-file-record.md
+++ b/docs/reference/project-index/generated/icn-file-record.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-21T14:23:11.702360+00:00
+Generated: 2026-06-21T21:21:29.799055+00:00
 ---
 
 # Full Repository Record — `icn`
@@ -11,23 +11,23 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 ## Snapshot
 
 - Repo: `icn`
-- Branch: `docs/record-refresh-2126`
-- HEAD: `41c7082b330a6249bead068d641c6e4e495d2075`
+- Branch: `fix/file-record-exclude-self`
+- HEAD: `fa819b47fbf774296400b42ca6f7c7c8630004af`
 - Working tree: `clean (no uncommitted changes against HEAD)`
 - SHA source: `working tree bytes (may differ from HEAD blob bytes when .gitattributes filters apply, e.g. CRLF normalization)`
-- Files recorded: `3093`
-- Tracked files recorded: `3093`
+- Files recorded: `3094`
+- Tracked files recorded: `3094`
 - Directories recorded: `610`
-- Total recorded bytes: `48274562`
-- Total tracked bytes: `48274562`
-- Entry kinds: `file: 3093`
+- Total recorded bytes: `46534125`
+- Total tracked bytes: `46534125`
+- Entry kinds: `file: 3094`
 
 ## Role summary
 
 | Role guess | Files |
 |---|---:|
 | Rust library crate | 922 |
-| documentation | 897 |
+| documentation | 898 |
 | uncategorized | 155 |
 | repo configuration | 144 |
 | React Native SDK | 139 |
@@ -36,14 +36,14 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | operations / coordination | 87 |
 | pilot UI | 84 |
 | public website | 71 |
+| script | 54 |
 | demo | 53 |
-| script | 53 |
 | institution package | 40 |
 | architecture decision record | 36 |
 | TypeScript SDK | 29 |
-| project index / atlas | 27 |
+| project index / atlas | 25 |
 | agent definition | 22 |
-| GitHub Actions workflow | 17 |
+| GitHub Actions workflow | 18 |
 | Rust binary | 16 |
 | contract template | 12 |
 | monitoring | 9 |
@@ -58,15 +58,15 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 |---|---:|
 | `.md` | 1168 |
 | `.rs` | 940 |
-| `.json` | 154 |
+| `.json` | 153 |
 | `.sh` | 119 |
 | `.toml` | 112 |
 | `.ts` | 112 |
 | `.yaml` | 92 |
-| `.yml` | 59 |
+| `.yml` | 60 |
 | `.js` | 43 |
 | `.tsx` | 43 |
-| `.py` | 40 |
+| `.py` | 41 |
 | `.astro` | 31 |
 | `.png` | 24 |
 | `(none)` | 19 |
@@ -109,13 +109,13 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 
 | Directory | Depth | Files under directory | Child dirs | Size bytes | Role guess |
 |---|---:|---:|---:|---:|---|
-| `.` | 0 | 3093 | 25 | 48274562 | repo root |
+| `.` | 0 | 3094 | 25 | 46534125 | repo root |
 | `.agents` | 1 | 25 | 1 | 71663 | repo configuration |
 | `.claude` | 1 | 65 | 5 | 228531 | repo configuration |
 | `.codex` | 1 | 16 | 2 | 19783 | repo configuration |
 | `.cursor` | 1 | 1 | 0 | 135 | repo configuration |
 | `.devcontainer` | 1 | 1 | 0 | 1307 | repo configuration |
-| `.github` | 1 | 68 | 6 | 284056 | repo configuration |
+| `.github` | 1 | 69 | 6 | 289482 | repo configuration |
 | `.opencode` | 1 | 2 | 1 | 1837 | repo configuration |
 | `apps` | 1 | 5 | 1 | 11841 | legacy/top-level app |
 | `config` | 1 | 11 | 0 | 34536 | uncategorized |
@@ -123,16 +123,16 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `demo` | 1 | 53 | 6 | 512850 | demo |
 | `deploy` | 1 | 130 | 10 | 571828 | deployment |
 | `docker` | 1 | 6 | 0 | 17165 | uncategorized |
-| `docs` | 1 | 968 | 46 | 15760928 | documentation |
+| `docs` | 1 | 967 | 46 | 13955313 | documentation |
 | `examples` | 1 | 43 | 5 | 562715 | uncategorized |
 | `icn` | 1 | 1081 | 9 | 21916668 | uncategorized |
 | `institutions` | 1 | 40 | 1 | 102081 | institution package |
 | `monitoring` | 1 | 9 | 0 | 67029 | monitoring |
 | `ops` | 1 | 87 | 8 | 843723 | operations / coordination |
-| `scripts` | 1 | 53 | 0 | 423147 | script |
+| `scripts` | 1 | 54 | 0 | 481807 | script |
 | `sdk` | 1 | 168 | 2 | 2524210 | uncategorized |
 | `sims` | 1 | 19 | 1 | 92514 | uncategorized |
-| `tools` | 1 | 26 | 1 | 88907 | uncategorized |
+| `tools` | 1 | 26 | 1 | 89999 | uncategorized |
 | `web` | 1 | 106 | 4 | 1667858 | uncategorized |
 | `website` | 1 | 71 | 6 | 1910144 | public website |
 | `.agents/skills` | 2 | 25 | 25 | 71663 | repo configuration |
@@ -148,7 +148,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `.github/agents` | 2 | 22 | 0 | 59062 | agent definition |
 | `.github/instructions` | 2 | 5 | 0 | 28980 | repo configuration |
 | `.github/scripts` | 2 | 8 | 1 | 39349 | repo configuration |
-| `.github/workflows` | 2 | 17 | 0 | 108418 | GitHub Actions workflow |
+| `.github/workflows` | 2 | 18 | 0 | 113844 | GitHub Actions workflow |
 | `.opencode/commands` | 2 | 1 | 0 | 409 | repo configuration |
 | `apps/echo` | 2 | 5 | 1 | 11841 | legacy/top-level app |
 | `contracts/governance` | 2 | 5 | 0 | 69912 | contract template |
@@ -171,11 +171,11 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `deploy/kubernetes` | 2 | 12 | 0 | 25850 | deployment |
 | `deploy/prometheus` | 2 | 1 | 0 | 4149 | deployment |
 | `docs/adr` | 2 | 36 | 0 | 300071 | architecture decision record |
-| `docs/ai` | 2 | 5 | 0 | 21008 | documentation |
+| `docs/ai` | 2 | 5 | 0 | 26161 | documentation |
 | `docs/api` | 2 | 6 | 0 | 143308 | documentation |
 | `docs/architecture` | 2 | 43 | 0 | 1241547 | documentation |
 | `docs/archive` | 2 | 78 | 2 | 1050816 | documentation |
-| `docs/ci` | 2 | 3 | 0 | 13817 | documentation |
+| `docs/ci` | 2 | 4 | 0 | 18053 | documentation |
 | `docs/contracts` | 2 | 13 | 1 | 138697 | documentation |
 | `docs/crate-manifests` | 2 | 42 | 0 | 46904 | documentation |
 | `docs/demo` | 2 | 14 | 0 | 191732 | documentation |
@@ -202,7 +202,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `docs/pilots` | 2 | 4 | 0 | 38839 | documentation |
 | `docs/planning` | 2 | 7 | 0 | 102284 | documentation |
 | `docs/plans` | 2 | 17 | 1 | 415015 | documentation |
-| `docs/reference` | 2 | 40 | 3 | 2290330 | documentation |
+| `docs/reference` | 2 | 38 | 3 | 475326 | documentation |
 | `docs/rfcs` | 2 | 8 | 0 | 176908 | request for comments |
 | `docs/scripts` | 2 | 9 | 0 | 105739 | documentation |
 | `docs/sdis` | 2 | 13 | 0 | 161014 | documentation |
@@ -242,7 +242,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `sdk/react-native` | 2 | 139 | 3 | 1829453 | React Native SDK |
 | `sdk/typescript` | 2 | 29 | 2 | 694757 | TypeScript SDK |
 | `sims/mutual-credit` | 2 | 19 | 2 | 92514 | uncategorized |
-| `tools/claude-code` | 2 | 26 | 1 | 88907 | uncategorized |
+| `tools/claude-code` | 2 | 26 | 1 | 89999 | uncategorized |
 | `web/api-docs` | 2 | 5 | 0 | 51150 | uncategorized |
 | `web/dashboard` | 2 | 7 | 0 | 53602 | dashboard UI |
 | `web/member-shell` | 2 | 10 | 1 | 106320 | uncategorized |
@@ -360,7 +360,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `docs/plans/.scratch` | 3 | 1 | 0 | 1229 | documentation |
 | `docs/reference/api` | 3 | 5 | 0 | 52497 | documentation |
 | `docs/reference/config` | 3 | 4 | 0 | 24982 | documentation |
-| `docs/reference/project-index` | 3 | 27 | 1 | 2172323 | project index / atlas |
+| `docs/reference/project-index` | 3 | 25 | 1 | 357319 | project index / atlas |
 | `docs/strategy/grants` | 3 | 7 | 0 | 32301 | documentation |
 | `docs/superpowers/plans` | 3 | 1 | 0 | 42648 | documentation |
 | `docs/superpowers/specs` | 3 | 7 | 0 | 69765 | documentation |
@@ -443,7 +443,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `sdk/typescript/src` | 3 | 9 | 1 | 357779 | TypeScript SDK |
 | `sims/mutual-credit/analysis` | 3 | 1 | 0 | 11430 | uncategorized |
 | `sims/mutual-credit/scenarios` | 3 | 5 | 0 | 5395 | uncategorized |
-| `tools/claude-code/plugins` | 3 | 26 | 1 | 88907 | uncategorized |
+| `tools/claude-code/plugins` | 3 | 26 | 1 | 89999 | uncategorized |
 | `web/member-shell/fixtures` | 3 | 4 | 0 | 2606 | uncategorized |
 | `web/pilot-ui/components` | 3 | 1 | 0 | 11066 | pilot UI |
 | `web/pilot-ui/fixtures` | 3 | 5 | 1 | 21453 | pilot UI |
@@ -499,7 +499,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `docs/onboarding/path/phase-2-architecture` | 4 | 4 | 0 | 36895 | documentation |
 | `docs/onboarding/path/phase-3-systems` | 4 | 4 | 0 | 15550 | documentation |
 | `docs/onboarding/path/phase-4-ownership` | 4 | 3 | 0 | 9932 | documentation |
-| `docs/reference/project-index/generated` | 4 | 4 | 0 | 1997717 | project index / atlas |
+| `docs/reference/project-index/generated` | 4 | 2 | 0 | 182713 | project index / atlas |
 | `examples/mobile-app/src/contexts` | 4 | 1 | 0 | 673 | uncategorized |
 | `examples/mobile-app/src/screens` | 4 | 7 | 0 | 27991 | uncategorized |
 | `examples/mobile-app/src/services` | 4 | 2 | 0 | 11096 | uncategorized |
@@ -610,7 +610,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `sdk/react-native/examples/CoopWallet` | 4 | 94 | 3 | 868144 | React Native SDK |
 | `sdk/react-native/src/__mocks__` | 4 | 2 | 0 | 2265 | React Native SDK |
 | `sdk/typescript/src/generated` | 4 | 1 | 0 | 61644 | TypeScript SDK |
-| `tools/claude-code/plugins/icn-agent-pack` | 4 | 26 | 5 | 88907 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack` | 4 | 26 | 5 | 89999 | uncategorized |
 | `web/pilot-ui/fixtures/icn-organizer-demo` | 4 | 5 | 0 | 21453 | pilot UI |
 | `web/pilot-ui/tests/e2e` | 4 | 8 | 0 | 75708 | pilot UI |
 | `website/public/.well-known/matrix` | 4 | 1 | 0 | 86 | public website |
@@ -669,7 +669,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `tools/claude-code/plugins/icn-agent-pack/agents` | 5 | 6 | 0 | 26694 | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/bin` | 5 | 5 | 0 | 12793 | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/hooks` | 5 | 1 | 0 | 937 | uncategorized |
-| `tools/claude-code/plugins/icn-agent-pack/skills` | 5 | 10 | 6 | 34294 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills` | 5 | 10 | 6 | 35386 | uncategorized |
 | `deploy/devnet/monitoring/grafana/provisioning/dashboards` | 6 | 1 | 0 | 232 | deployment |
 | `deploy/devnet/monitoring/grafana/provisioning/datasources` | 6 | 1 | 0 | 241 | deployment |
 | `icn/crates/icn-ccl/fuzz/corpus/fuzz_contract_json` | 6 | 13 | 0 | 83966 | Rust library crate |
@@ -691,7 +691,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `tools/claude-code/plugins/icn-agent-pack/skills/authority-spine` | 6 | 2 | 0 | 6996 | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/skills/doctor` | 6 | 1 | 0 | 3167 | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/skills/navigator` | 6 | 2 | 0 | 7602 | uncategorized |
-| `tools/claude-code/plugins/icn-agent-pack/skills/preflight` | 6 | 1 | 0 | 2605 | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/preflight` | 6 | 1 | 0 | 3697 | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/skills/route-impact` | 6 | 2 | 0 | 6333 | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/skills/truth-sync` | 6 | 2 | 0 | 7591 | uncategorized |
 | `sdk/react-native/examples/CoopWallet/android/app/src` | 7 | 33 | 3 | 39802 | React Native SDK |
@@ -895,6 +895,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `.github/workflows/docker-build-deploy.yml` | 11985 | `9ae7de0aa36858caba55dfbaa911f4994c26e1069ea730e974608259d8b6b538` | YAML | GitHub Actions workflow |
 | `.github/workflows/docs-freshness.yml` | 11562 | `f474a69b3d3639e195b703e215bd4f93c4df2fada10a53b97cd278a9b3bce1dd` | YAML | GitHub Actions workflow |
 | `.github/workflows/fuzz.yml` | 3037 | `e2ff1c562395135582738e773e5db1b984d190e8204fab5e4b7bffb57d9612fa` | YAML | GitHub Actions workflow |
+| `.github/workflows/generated-truth.yml` | 5426 | `cf03e607fbfac884f97a1301c6fe40f53f6d4aa1403beaa9e7d00e1ec5f1c3d9` | YAML | GitHub Actions workflow |
 | `.github/workflows/issue-label-enforcer.yml` | 6117 | `ff4342a962c2d2395a24033abfdb5ad1d9a4f21230f120204829a78cdf474731` | YAML | GitHub Actions workflow |
 | `.github/workflows/mcp-portability.yml` | 999 | `312f0e0ec6c3eb9e507863dcda9dea8705a53cb9563b3913598db66bd34e058d` | YAML | GitHub Actions workflow |
 | `.github/workflows/npm-publish.yml` | 2107 | `cc0712289070cc9b08630b359acb6b296174e3df6749750ffe7fd98afefd5db1` | YAML | GitHub Actions workflow |
@@ -1195,7 +1196,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `docs/adr/template.md` | 2116 | `93da786ffa4d64a75f1df8f7e4bd7f393e7b6d2ec7c26001c8d9220405c6c211` | Markdown | architecture decision record |
 | `docs/ai/CODEX_WORKFLOW.md` | 3221 | `a60b6df40d2cc7e46d0408b2cc9f590ac43fb2f472e2204a72f193dfb1548b27` | Markdown | documentation |
 | `docs/ai/ICN_CONSTITUTIONAL_CORE.md` | 10280 | `d8139c260917ea8d3d9775ea4d5ca0f934be9d560522b78bb08b7f34a7a267db` | Markdown | documentation |
-| `docs/ai/ICN_LIVE_STATE_OVERLAY_TEMPLATE.md` | 2748 | `6af52b6ee876dad633c6fe8265da357daf17535092db20dc4a4736d8e28e2ddd` | Markdown | documentation |
+| `docs/ai/ICN_LIVE_STATE_OVERLAY_TEMPLATE.md` | 7901 | `00421d4642a229ef027df1ccaacc4ba49cbc44c6861e99a86ad47e4064e324e8` | Markdown | documentation |
 | `docs/ai/ICN_SESSION_FRAME_TEMPLATE.md` | 1934 | `a78fabbc162396b4ff26c49112ab0dd0da48b131a896a29bb9a4b392fc73bcf5` | Markdown | documentation |
 | `docs/ai/WORKFLOW_ARCHITECTURE.md` | 2825 | `adfa98a30d85a672d1181b2922824dd0cd342b8fceb1d31115c055ce4f85f0c1` | Markdown | documentation |
 | `docs/api/OPENAPI.md` | 7922 | `8b2b5ccfbcbca4083d113aed86dad301fe100b51210d1d782e0f4cf3259a6d28` | Markdown | documentation |
@@ -1328,6 +1329,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `docs/ci/CI_ALL_GREEN_REPORT.md` | 3384 | `1c5b85e4f9f8270c282d602d11514fdf7df52b687ab8d44ab5f8940fb0f81528` | Markdown | documentation |
 | `docs/ci/CI_CURRENT_STATUS.md` | 1709 | `3212b15b6adbb956eb5a42e2c1660928af6418c1697d94cd6eeccdb0e3ab09fb` | Markdown | documentation |
 | `docs/ci/GATE_RATCHET_PLAN.md` | 8724 | `9debcec8b18cadb02071d2277b80ad8a040da8932c61a761a4c7751b4c9ebd98` | Markdown | documentation |
+| `docs/ci/GENERATED_TRUTH_DRIFT.md` | 4236 | `46753d3d2baf4c0c709efc771a7a8b304bd4477ebf4d66fea06fcdc0e20e7085` | Markdown | documentation |
 | `docs/contracts/institution-package/README.md` | 7597 | `54d05a99be96955597dce088b32f261d0e4798b7e9550812386f04912e942743` | Markdown | documentation |
 | `docs/contracts/institution-package/action-card.example.json` | 726 | `7f9e1b55b852517dcb03c274c1d374cb182bb403ac7bcdc263062ac00a1f48e5` | JSON | documentation |
 | `docs/contracts/institution-package/action-card.schema.json` | 5435 | `d58485a48ab5c1f05623fc216580260bdc7505053bcfba2bcb7cc147171ab755` | JSON | documentation |
@@ -1936,8 +1938,6 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `docs/reference/project-index/docs-control-map.md` | 7227 | `41469ea307fb54c0466e6d20feaa8449b7bc643c45790574683237f030987c7c` | Markdown | project index / atlas |
 | `docs/reference/project-index/full-repo-record.md` | 7597 | `56a3be5e123f70aaf8fce07505f6143d486e04951ea35a94b8f5b0b7dd4d7730` | Markdown | project index / atlas |
 | `docs/reference/project-index/generated/agent-context-spine.json` | 106372 | `a68345f938a12c782befa3e4fa1c597068c9911537aaaa5c599bed9d63ff6e57` | JSON | project index / atlas |
-| `docs/reference/project-index/generated/icn-file-record.json` | 1350034 | `cf7c2b7e6c389a6adec7f68dfd68cfeeb0824add14fa9e5c2656b80a49fb2f74` | JSON | project index / atlas |
-| `docs/reference/project-index/generated/icn-file-record.md` | 464970 | `3b9cf01f4205225e78ebfcfb81cabd6ecdb5a7457bc1205b92d71aa9b4b2c480` | Markdown | project index / atlas |
 | `docs/reference/project-index/generated/route-inventory.md` | 76341 | `9298458ceb36c2a253a982be6e0136699fc9a0262fdcbfc3c0d616db828de6ae` | Markdown | project index / atlas |
 | `docs/reference/project-index/identity-crypto-map.md` | 5006 | `cffd912bd654b76ee514ab3a3a574e44adeec3e7a953de89e4adfcfe5ebac828` | Markdown | project index / atlas |
 | `docs/reference/project-index/network-gossip-map.md` | 6833 | `2b4269277bcc2291b85f66a676eb1d382359f8d2e73b3af4c69eb32ee02ce117` | Markdown | project index / atlas |
@@ -3393,8 +3393,9 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `scripts/federated-governance-demo.sh` | 12412 | `913fc025cbead401c35727ba64114e7ca818bb1f2a5ac706e2a9e992e141427a` | Shell | script |
 | `scripts/forbidden-deps-allowlist.txt` | 737 | `e3acf72c847044428dc42af1cc9a11c78e5c68a8b6cf731d63b5fcef1454d11d` | Text | script |
 | `scripts/generate-agent-context-spine.py` | 39619 | `e6a3ae3d2042febc9754d6a6fa6ec8c6d27dddbefde12fea9c6b84824e352dbd` | Python | script |
+| `scripts/generate-live-state-overlay.py` | 50165 | `04398e0a68e0c8a4293f82a881aaaacb77eae0d90a36a00bc2690069532fe61f` | Python | script |
 | `scripts/generate-test-token.sh` | 1581 | `bea751d5058b9d0ab6b841980e143acd23356ec207ad2da886afc3680b0b8714` | Shell | script |
-| `scripts/generate_repo_record.py` | 21852 | `fd4ae442a188064be1d5699548ddc045413ac7268180732249778af228d4f96d` | Python | script |
+| `scripts/generate_repo_record.py` | 30347 | `1b7f9aec71df765a4df383b254cecdde81a46b011998123dd1a30b23f66f83ff` | Python | script |
 | `scripts/governance-demo.sh` | 9746 | `d9db1799692b5323e8a0cf2bf51ebdada86bf616bd14699e6316a4af80159d20` | Shell | script |
 | `scripts/icn-preflight.sh` | 2129 | `3d69b9f78b307bd5cda606d8844a58c7d0c299f49c5356883e324da3bc4d121d` | Shell | script |
 | `scripts/install.sh` | 14015 | `9f453776a7a9b96944c42a1b3ced4434e8ccae5cb97280a9a1c064c2ae1f25a0` | Shell | script |
@@ -3635,7 +3636,7 @@ Generated: 2026-06-21T14:23:11.702360+00:00
 | `tools/claude-code/plugins/icn-agent-pack/skills/doctor/SKILL.md` | 3167 | `f2a4d2aa4f069d12bb6f7aba19464703863c32dd3570b32290e79411ff622078` | Markdown | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/skills/navigator/SKILL.md` | 4102 | `05ed1280a4c2a62551201daf58bd4da3028dd96e8b38f379a4a4177c9a53d2d6` | Markdown | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/skills/navigator/reference.md` | 3500 | `e0e789473ad7623faaa497d83636b7b5863fcd58c98a6ca171e358493e42a546` | Markdown | uncategorized |
-| `tools/claude-code/plugins/icn-agent-pack/skills/preflight/SKILL.md` | 2605 | `1b6fa063b261175d86aae48321adfc9fb187d8ac9f0b5838e3caf21c39253602` | Markdown | uncategorized |
+| `tools/claude-code/plugins/icn-agent-pack/skills/preflight/SKILL.md` | 3697 | `cf2c29ef43dd689c46c3c877d38693c719ba7dc6895ba899810da5a13e43a386` | Markdown | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/skills/route-impact/SKILL.md` | 3171 | `9bfb268c41e5c1ec98a0254aea26a9ce7cd74ef89657a83846a10a9840e7cf7d` | Markdown | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/skills/route-impact/reference.md` | 3162 | `f760ff25218cc7faccb1124f7cb6ff54f05994ffc0a234a201f30c84d4a673ec` | Markdown | uncategorized |
 | `tools/claude-code/plugins/icn-agent-pack/skills/truth-sync/SKILL.md` | 3050 | `4f685ac367100aaa2846317465c291462ebe496721791f83e82df5e5b548ca51` | Markdown | uncategorized |

--- a/scripts/generate_repo_record.py
+++ b/scripts/generate_repo_record.py
@@ -472,6 +472,24 @@ def generate_for_repo(
     if include_untracked:
         all_paths.extend((path, False) for path in git_untracked(resolved_path))
 
+    # Exclude THIS generator's own committed outputs from the inventory (and
+    # therefore from SHA/size, directory size rollups, file_count, and
+    # total_size_bytes). The file-record is committed at the canonical
+    # project-index location; if it inventoried itself it would have to record
+    # its own post-write SHA/size — an impossible fixed point — so
+    # `--check` would report drift forever, even immediately after a clean
+    # regeneration. The exclusion is keyed to the CANONICAL committed paths, not
+    # `out_dir` (which is a temp dir during `--check`), so a temp-dir
+    # regeneration and the committed artifact exclude the same entries and thus
+    # converge. This is specific to this generator's own `<repo>-file-record.*`
+    # outputs; other generated artifacts (route-inventory, agent-context-spine,
+    # live-state overlay, etc.) are intentionally NOT excluded.
+    self_outputs = {
+        f"docs/reference/project-index/generated/{repo_name}-file-record.json",
+        f"docs/reference/project-index/generated/{repo_name}-file-record.md",
+    }
+    all_paths = [(path, tracked) for path, tracked in all_paths if path not in self_outputs]
+
     files: list[FileRecord] = []
     skipped: list[str] = []
     for path, tracked in all_paths:
@@ -543,27 +561,45 @@ def parse_repo_arg(value: str) -> tuple[str, Path]:
 
 
 def _normalize_record(text: str, ext: str) -> str:
-    """Strip incidental, non-content fields so --check compares the snapshot
-    payload (file inventory, sizes, SHAs, head) rather than the generation
-    timestamp or the branch the snapshot happened to be taken on.
+    """Strip generation-moment metadata so --check compares the snapshot's
+    repository inventory (file paths, SHAs, sizes, counts, directory rollups)
+    rather than metadata that records WHEN/WHERE/HOW the snapshot was taken.
 
-    Normalized out:
-      - JSON `generated_at` (changes every run) and `branch` (incidental: a
-        refresh on any branch is equivalent).
-      - Markdown `Generated:` front-matter line and the `- Branch:` line.
-    `head` and the file inventory are intentionally KEPT — a head/inventory
-    difference is real snapshot staleness, which is exactly what --check reports.
+    A committed file-record can never satisfy a naive equality check on its own
+    generation metadata. The artifact records the commit it was generated at
+    (`head`), but the commit that *contains* the committed artifact is
+    necessarily a later commit — so a committed artifact can never record its own
+    containing commit SHA. `head` is therefore structurally unmatchable for any
+    committed snapshot, exactly like the self-inventory fixed point the
+    self-output exclusion solves in `generate_for_repo`. The same holds for
+    `generated_at` (a fresh run is a new instant), `branch` (a refresh on any
+    branch is equivalent), and `working_tree_dirty` (it reports the porcelain
+    state at generation time, not repository content).
+
+    Normalized out (generation-moment metadata only):
+      - JSON: `generated_at`, `branch`, `head`, `working_tree_dirty`.
+      - Markdown: `Generated:` front-matter, `- Branch:`, `- HEAD:`, and the
+        `- Working tree:` clean/dirty line.
+    Everything that encodes repository CONTENT is intentionally KEPT and fully
+    compared: the per-file inventory (paths, SHA256, sizes, kinds), directory
+    rollups, `file_count`, `total_size_bytes`, `include_untracked`, and the
+    role/extension/kind summaries. Real content drift is still detected. The only
+    inventory adjustment is the self-output exclusion applied during generation
+    (see `generate_for_repo`), not a comparison-time filter here.
     """
     if ext == "json":
         data = json.loads(text)
-        data.pop("generated_at", None)
-        data["branch"] = "<normalized>"
+        for key in ("generated_at", "branch", "head", "working_tree_dirty"):
+            data.pop(key, None)
         return json.dumps(data, indent=2, sort_keys=True)
     # markdown
     kept = [
         line
         for line in text.splitlines()
-        if not line.startswith("Generated:") and not line.startswith("- Branch:")
+        if not line.startswith("Generated:")
+        and not line.startswith("- Branch:")
+        and not line.startswith("- HEAD:")
+        and not line.startswith("- Working tree:")
     ]
     return "\n".join(kept)
 
@@ -577,12 +613,15 @@ def check_repos(
     committed artifact under `out_dir`, ignoring the volatile fields above.
 
     Exit contract:
-      0  every committed record matches the working tree (modulo timestamp/branch)
+      0  every committed record matches the working tree (modulo generation-moment metadata)
       1  drift — a committed record is stale or missing
       2  checker error — regeneration or comparison itself failed (e.g. a repo
          path is not a git checkout, git failed, or a committed artifact is
-         unreadable/invalid JSON/MD). Kept distinct from drift so CI can fail on
-         real breakage while only warning on staleness.
+         unreadable/invalid JSON/MD). Kept distinct from drift (1) so a caller
+         can map the two codes differently. This function always RETURNS the
+         exit code; it never warns or suppresses on its own. The observational
+         generated-truth workflow is what treats a checker error (>=2) as a hard
+         CI failure while only emitting a warning on staleness (1).
     Never writes to `out_dir`.
     """
 
@@ -615,15 +654,18 @@ def check_repos(
                         drift = True
                         print(f"DRIFT: {committed} differs from a fresh generation.")
                         if ext == "json":
-                            c = json.loads(committed.read_text(encoding="utf-8"))
-                            f = json.loads(fresh.read_text(encoding="utf-8"))
+                            # `head` is generation-moment metadata and is NOT
+                            # compared (see _normalize_record), so report the
+                            # content signals that actually drive drift instead.
+                            c = json.loads(committed.read_text(encoding="utf-8")).get("summary", {})
+                            f = json.loads(fresh.read_text(encoding="utf-8")).get("summary", {})
                             print(
-                                f"  committed head={c.get('head', '?')[:12]} "
-                                f"file_count={c.get('summary', {}).get('file_count')}"
+                                f"  committed file_count={c.get('file_count')} "
+                                f"total_size_bytes={c.get('total_size_bytes')}"
                             )
                             print(
-                                f"  working   head={f.get('head', '?')[:12]} "
-                                f"file_count={f.get('summary', {}).get('file_count')}"
+                                f"  working   file_count={f.get('file_count')} "
+                                f"total_size_bytes={f.get('total_size_bytes')}"
                             )
     except SystemExit as exc:
         # generate_for_repo raises SystemExit (with a message) on a real
@@ -641,7 +683,7 @@ def check_repos(
     if drift:
         print(f"\nRegenerate with:\n  {_regenerate_command()}", file=sys.stderr)
         return 1
-    print("OK: repo file-record matches the working tree (timestamp/branch ignored).")
+    print("OK: repo file-record matches the working tree (generation-moment metadata ignored).")
     return 0
 
 
@@ -665,8 +707,9 @@ def main() -> None:
         action="store_true",
         help=(
             "Do not write. Regenerate each record into a temp dir and compare "
-            "it against the committed artifact under --out, ignoring the "
-            "generation timestamp and branch. Exit 0 if current, 1 on drift "
+            "it against the committed artifact under --out, ignoring "
+            "generation-moment metadata (timestamp, branch, head, "
+            "working-tree-dirty state). Exit 0 if current, 1 on drift "
             "(stale or missing snapshot), 2 on checker error."
         ),
     )


### PR DESCRIPTION
## What

Fixes the repo file-record generator/check path so `generate_repo_record.py --check` can converge to exit `0`.

Two narrow changes:

1. **Self-output exclusion** (`generate_for_repo`): excludes the generator's own committed outputs from the file inventory and all SHA/size/count/directory rollups:
   - `docs/reference/project-index/generated/icn-file-record.json`
   - `docs/reference/project-index/generated/icn-file-record.md`

2. **Generation-moment normalization** (`_normalize_record`, used only by `--check`): ignores `generated_at`, `branch`, `head`, and `working_tree_dirty` when comparing the committed record against a fresh regeneration. The Markdown comparator drops the matching `Generated:`, `- Branch:`, `- HEAD:`, and `- Working tree:` lines.

The generated file-record snapshot is regenerated after the fix.

## Why

After the observational generated-truth drift gate landed, the file-record check exposed **two fixed-point self-references** that made `--check` report drift even immediately after a clean regeneration:

- the artifact inventoried its own generated outputs, including their post-write SHA/size; and
- the artifact records the commit it was generated at (`head`), but a committed artifact necessarily lands in a *later* commit, so it can never record the SHA of the commit that contains it. `head` is therefore structurally unmatchable for any committed snapshot (as are `generated_at`, `branch`, and the generation-time `working_tree_dirty` flag).

The fix makes `--check` compare the meaningful repository **content** — paths, file SHA256, file sizes, `file_count`, `total_size_bytes`, directory rollups, `include_untracked`, and the role/extension/kind summaries — while ignoring generation-moment metadata that is structurally unmatchable. `--check` keeps its hard `0`/`1`/`2` exit contract (it is **not** made warning-only).

## Validation

- `python3 -c "import ast; ast.parse(open('scripts/generate_repo_record.py').read())"` — parses
- `python3 scripts/generate_repo_record.py --repo icn=. --check` → exit **0**
- `icn-file-record.{json,md}` no longer list themselves as inventory entries (`self_entries=[]`); `file_count` 3096→3094
- Second regeneration is a **content** no-op: re-running the generator changes only generation-moment fields (`generated_at`, `head`); the file inventory/sizes/counts are byte-identical, and `--check` still exits 0. (A raw `git diff --exit-code` is non-zero solely because `generated_at` is wall-clock and `head` is the generation commit — precisely the fields `--check` normalizes.)
- Drift is still detected: tampering a single `files[].size_bytes` flips `--check` to exit **1**; tampering only `head`/`working_tree_dirty` stays exit **0**.
- `python3 scripts/check-agent-context-spine.py` — exit 0
- `python3 scripts/check-claude-plugin.py` — exit 0
- `python3 scripts/check-claude-plugin-root-resolution.py` — 9/9
- `python3 scripts/generate-live-state-overlay.py --check --no-gh` — exit 0
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — exit 0, 65-warning baseline unchanged
- `python3 docs/scripts/route_inventory.py --check` — exit 0 (287 routes)
- `.github/workflows/generated-truth.yml` parses

## Risk

Low and narrow:

- one generator/check script change + the generated file-record refresh
- no Rust runtime changes
- no gateway behavior changes
- no canonical truth-root changes
- no NYCN / Summit / infra changes

## Notes

This does not address pre-existing ARCHITECTURE freshness warnings or related docs drift.