### PR TITLE
docs(arch): add source-linked invariants catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ If a change might impact any invariant:
 - Add tests proving the invariant still holds
 - Update the relevant docs/specs
 
+For the full source-linked index of all four invariant families (operational, firewall-contract, frozen-core, regulatory), see [`docs/reference/project-index/invariants-catalog.md`](docs/reference/project-index/invariants-catalog.md). That catalog indexes canonical sources; it does not define new invariants.
+
 ---
 
 ## Repo layout (critical)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -240,6 +240,7 @@ Show-ready orientation layer — routes outside readers, contributors, and agent
 - [ci-ops-deploy-map.md](reference/project-index/ci-ops-deploy-map.md) - Workflows, deploy paths, K3s smoke runbooks
 - [show-readiness-map.md](reference/project-index/show-readiness-map.md) - What can be shown now, what should not be shown as finished, red lines
 - [proof-level-taxonomy-capability-matrix.md](reference/project-index/proof-level-taxonomy-capability-matrix.md) - Proof-level taxonomy (L0-L8) and a capability matrix for the organizer-rehearsal path
+- [invariants-catalog.md](reference/project-index/invariants-catalog.md) - Source-linked index of the four canonical invariant families (index only; canonical sources authoritative); machine-readable companion `invariants-catalog.toml`
 
 ---
 

--- a/docs/reference/project-index/README.md
+++ b/docs/reference/project-index/README.md
@@ -38,6 +38,7 @@ ICN already has several truth- and freshness-tracking systems. **This index does
 | What is safe to show / claim publicly? | [`show-readiness-map.md`](show-readiness-map.md) + [`website-truth-map.md`](website-truth-map.md) |
 | What routes does the gateway actually expose, and which reach OpenAPI? | [`generated/route-inventory.md`](generated/route-inventory.md) — mechanical scan, regenerate with `docs/scripts/route_inventory.py` ([#2112](https://github.com/InterCooperative-Network/icn/issues/2112)) |
 | Given a path/crate, what subsystem/docs/tests/invariants/claims/skills apply? (orientation, non-canonical) | [`generated/agent-context-spine.json`](generated/agent-context-spine.json) — generated, evidence-grounded; see [`docs/guides/developer/agent-context-spine.md`](../../guides/developer/agent-context-spine.md). Regenerate with `scripts/generate-agent-context-spine.py` |
+| Which invariants exist, and where are they canonically defined? | [`invariants-catalog.md`](invariants-catalog.md) (+ [`invariants-catalog.toml`](invariants-catalog.toml)) — indexes the four canonical families; index only, canonical sources remain authoritative ([#2114](https://github.com/InterCooperative-Network/icn/issues/2114)) |
 
 **Discipline (for humans and agents):**
 
@@ -74,6 +75,7 @@ ICN already has several truth- and freshness-tracking systems. **This index does
 | [`show-readiness-map.md`](show-readiness-map.md) | What can be shown now, what should not be shown as finished, the suggested demo narrative, and red lines. |
 | [`project-coverage-matrix.md`](project-coverage-matrix.md) | Coverage-style matrix: subsystem → anchors → drift and show risks. |
 | [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md) | Proof-level taxonomy (L0–L8) as shared claim-boundary vocabulary, plus a capability matrix for the current organizer-rehearsal path. Supports #1746, narrows #1796. |
+| [`invariants-catalog.md`](invariants-catalog.md) | Source-linked index of the four canonical invariant families (operational / firewall-contract / frozen-core / regulatory, 28 total). Index only; canonical sources remain authoritative. Machine-readable: [`invariants-catalog.toml`](invariants-catalog.toml). |
 | [`identity-crypto-map.md`](identity-crypto-map.md) | Identity, keys, DIDs, signing — where code and docs live. |
 | [`network-gossip-map.md`](network-gossip-map.md) | QUIC, gossip, discovery — runtime surfaces and overclaim guardrails. |
 | [`ccl-map.md`](ccl-map.md) | Cooperative Contract Language interpreter and governance wiring. |

--- a/docs/reference/project-index/invariants-catalog.md
+++ b/docs/reference/project-index/invariants-catalog.md
@@ -1,0 +1,120 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-06-22
+---
+
+# ICN Invariants Catalog
+
+> This catalog indexes invariants. It does not define them. The canonical source listed for each entry remains authoritative.
+
+ICN's invariants are real but scattered across four canonical sources in different formats, so the
+families get conflated or miscounted. This page is a single searchable enumeration that links each
+invariant back to where it is actually defined. The machine-readable form is
+[`invariants-catalog.toml`](invariants-catalog.toml).
+
+**This is an orientation/index layer (`Canonical: no`), not a truth root.** It restates nothing; it
+only points. The numbers below are the live source counts (verified 2026-06-22) and they match the
+counts in [#2114](https://github.com/InterCooperative-Network/icn/issues/2114): 5 + 6 + 10 + 7 = **28**.
+
+## Non-goals
+
+- Not new invariants or doctrine — this page invents nothing.
+- Not a redefinition — definitions live in the canonical sources; only one-line labels appear here.
+- Not a competing source of truth — when this page and a canonical source disagree, the canonical
+  source wins. The full precedence ladder is in [`source-of-truth-map.md`](source-of-truth-map.md).
+
+## How to read an entry
+
+Each entry carries: family, a stable id, a one-line label (mirroring the source's own wording), the
+canonical source path, a stable **anchor** (a section heading, Rust enum variant name, or bold
+label — not a line number, which drifts), source type (doc/code), and whether the source states it
+normatively.
+
+---
+
+## 1. Operational invariants (tier 1)
+
+Canonical source: [`docs/DESIGN_PRINCIPLES.md`](../../DESIGN_PRINCIPLES.md) §1 · 5 invariants · doc
+
+| ID | Invariant | Anchor | Normative |
+|----|-----------|--------|-----------|
+| `adversarial_by_default` | Every peer is untrusted until verifiable participation establishes trust. | §1.1 Adversarial-by-default | yes |
+| `determinism` | Same inputs produce same outputs; no floating point in consensus paths. | §1.2 Determinism | yes |
+| `canonical_encodings` | One valid byte representation per value (definite-length CBOR). | §1.3 Canonical encodings | yes |
+| `no_panics_in_protocol_paths` | Protocol/network/actor paths return `Result`, never panic on bad input. | §1.4 No panics in protocol paths | yes |
+| `kernel_app_boundary_inviolable` | The dependency graph forbids domain crates inside kernel crates. | §1.5 Kernel/app boundary is inviolable | yes |
+
+> `kernel_app_boundary_inviolable` is the tier-1 statement of the tier-2 firewall contract below —
+> the same rule, decomposed into six mechanically checkable sub-rules.
+
+## 2. Firewall contract (tier 2)
+
+Canonical source: [`docs/architecture/KERNEL_APP_SEPARATION.md`](../../architecture/KERNEL_APP_SEPARATION.md) · 6 invariants · doc · mechanically enforced via CI
+
+| ID | Invariant | Anchor | Normative |
+|----|-----------|--------|-----------|
+| `kernel_no_domain_imports` | Kernel must not import domain crates. | Invariant 1 | yes |
+| `kernel_pure_data_types` | Kernel only accepts pure data types at its entrypoints. | Invariant 2 | yes |
+| `semantic_lookup_in_policy_oracle` | All semantic lookup is confined to `PolicyOracle`. | Invariant 3 | yes |
+| `no_pattern_match_constraintset_custom` | Kernel must not pattern-match on `ConstraintSet.custom` keys. | Invariant 4 | yes |
+| `mechanism_not_policy` | Kernel contains enforcement mechanisms, not policy decisions. | Invariant 5 | yes |
+| `opaque_receipt_storage` | Kernel stores app-generated receipts opaquely (never parses the body). | Invariant 6 | yes |
+
+## 3. Frozen-core invariants (tier 3)
+
+Canonical source: [`icn/crates/icn-kernel-api/src/invariants.rs`](../../../icn/crates/icn-kernel-api/src/invariants.rs) (`enum InvariantId`) · 10 invariants · code
+
+The count is asserted in-crate by `test_all_invariants_returns_10`. Anchors are the enum variant names.
+
+| ID | Invariant | Variant | Domain | Normative |
+|----|-----------|---------|--------|-----------|
+| `right_of_exit` | No rule can prevent an identity from leaving an entity. | `RightOfExit` | SovereigntyCore | yes |
+| `no_retroactive_obligations` | Rules only apply to actions after activation block. | `NoRetroactiveObligations` | SovereigntyCore | yes |
+| `explicit_cryptographic_entry` | Adding an identity requires their cryptographic signature. | `ExplicitCryptographicEntry` | SovereigntyCore | yes |
+| `no_silent_power_changes` | Authz changes must include a computable capability delta. | `NoSilentPowerChanges` | AntiCaptureCore | yes |
+| `bounded_authority` | No wildcard capabilities across all resources. | `BoundedAuthority` | AntiCaptureCore | yes |
+| `mandatory_execution_delay` | Economic/capability changes require timelock delay. | `MandatoryExecutionDelay` | AntiCaptureCore | yes |
+| `capability_conservation` | Cannot delegate capabilities you don't possess. | `CapabilityConservation` | AntiCaptureCore | yes |
+| `mutual_credit_conservation` | Mutual credit loops must net to zero. | `MutualCreditConservation` | EconomicCore | yes |
+| `sovereign_signature_requirement` | Funds move only via owner signature or pre-consented dispute hook. | `SovereignSignatureRequirement` | EconomicCore | yes |
+| `universal_receipt_generation` | Every state transition emits an immutable receipt. | `UniversalReceiptGeneration` | EconomicCore | yes |
+
+## 4. Regulatory invariants (tier 4)
+
+Canonical source: [`docs/ARCHITECTURE.md`](../../ARCHITECTURE.md) §5 ("Seven regulatory invariants") · 7 invariants · doc
+
+| ID | Invariant | Anchor | Normative |
+|----|-----------|--------|-----------|
+| `user_signed_transitions_only` | No transition without the user's cryptographic signature. | User-signed transitions only | yes |
+| `no_hosted_positions` | ICN holds no balances on behalf of users. | No hosted positions | yes |
+| `no_operator_routing_of_value` | Units move directly debtor → creditor, not through an operator account. | No operator routing of value | yes |
+| `derived_views_not_primitives` | A balance is a computed view, not enforced protocol state. | Derived views are not protocol primitives | no (descriptive) |
+| `no_embedded_convertibility` | Cross-coop settlement requires explicit trust agreements + governance approval. | No embedded convertibility | yes |
+| `matching_market_opt_in` | Marketplace features are opt-in, scoped, governance-authorized (a CCL contract, not a platform feature). | Matching/market features are opt-in, scoped, governance-authorized | yes |
+| `execution_receipts_close_loop` | Every state transition produces a cryptographically signed receipt. | Execution receipts close the loop | yes |
+
+> Cross-reference: `execution_receipts_close_loop` (regulatory) and `universal_receipt_generation`
+> (frozen-core) are the same receipt-universality property seen from two tiers. The catalog records
+> the link via `related_to`; it does not merge them.
+
+---
+
+## Related enumerations (NOT indexed here)
+
+The four families above are exactly the ones #2114 names. The repo contains other invariant-shaped
+lists that are deliberately **out of scope** for this catalog, to avoid double-counting and taxonomy
+sprawl:
+
+- [`AGENTS.md`](../../../AGENTS.md) restates the five operational invariants as a PR-review gate for
+  the `icn-invariants-guardian`. That is the same family 1, not a fifth family — `docs/DESIGN_PRINCIPLES.md`
+  remains its canonical source. `AGENTS.md` points here for the broader source-linked index.
+- [`docs/genesis.md`](../../genesis.md) describes "hard mechanisms" and "meta-invariants" under a
+  different framing. Indexing those would require separate scoping; they are not part of #2114.
+
+## Orientation discipline
+
+This page lives in the project-index orientation layer. Like every map here it is `Canonical: no`:
+defer to code/tests first, then [`docs/STATE.md`](../../STATE.md) and
+[`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), then accepted ADRs/RFCs. Generated project-index
+artifacts (under `generated/`) and these hand-maintained maps are navigation, not state.

--- a/docs/reference/project-index/invariants-catalog.toml
+++ b/docs/reference/project-index/invariants-catalog.toml
@@ -1,0 +1,383 @@
+# ICN Invariants Catalog (machine-readable index)
+#
+# This catalog INDEXES invariants. It does not define them. The canonical source
+# listed for each entry remains authoritative. See invariants-catalog.md for the
+# human-facing view and the claim-discipline note.
+#
+# Hand-curated (not generated). Anchors are stable identifiers — section headings,
+# Rust enum variant names, or bold list labels — NOT line numbers, which drift.
+# Each `source_anchor` is a verbatim substring of its `source_path` (see the
+# anchor-sanity check in invariants-catalog.md).
+
+[meta]
+title = "ICN Invariants Catalog"
+issue = "https://github.com/InterCooperative-Network/icn/issues/2114"
+status = "descriptive"
+canonical = false
+indexes_not_defines = true
+generated_by = "hand-curated"
+last_reviewed = "2026-06-22"
+disclaimer = "This catalog indexes invariants. It does not define them. The canonical source listed for each entry remains authoritative."
+canonical_sources = [
+  "docs/DESIGN_PRINCIPLES.md",
+  "docs/architecture/KERNEL_APP_SEPARATION.md",
+  "icn/crates/icn-kernel-api/src/invariants.rs",
+  "docs/ARCHITECTURE.md",
+]
+
+# Family roll-up. Counts are the live source counts (verified 2026-06-22); they
+# match #2114's stated 5 / 6 / 10 / 7.
+[[family]]
+key = "operational"
+title = "Operational invariants (tier 1)"
+count = 5
+canonical_source = "docs/DESIGN_PRINCIPLES.md"
+source_type = "doc"
+
+[[family]]
+key = "firewall_contract"
+title = "Firewall contract (tier 2)"
+count = 6
+canonical_source = "docs/architecture/KERNEL_APP_SEPARATION.md"
+source_type = "doc"
+
+[[family]]
+key = "frozen_core"
+title = "Frozen-core invariants (tier 3)"
+count = 10
+canonical_source = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_type = "code"
+
+[[family]]
+key = "regulatory"
+title = "Regulatory invariants (tier 4)"
+count = 7
+canonical_source = "docs/ARCHITECTURE.md"
+source_type = "doc"
+
+# ---------------------------------------------------------------------------
+# Family 1 — Operational invariants (tier 1)
+# Canonical source: docs/DESIGN_PRINCIPLES.md §1
+# ---------------------------------------------------------------------------
+
+[[invariant]]
+family = "operational"
+id = "adversarial_by_default"
+label = "Adversarial-by-default: every peer is untrusted until verifiable participation establishes trust."
+source_path = "docs/DESIGN_PRINCIPLES.md"
+source_anchor = "1.1 Adversarial-by-default"
+source_type = "doc"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "operational"
+id = "determinism"
+label = "Determinism: same inputs produce same outputs; no floating point in consensus paths."
+source_path = "docs/DESIGN_PRINCIPLES.md"
+source_anchor = "1.2 Determinism"
+source_type = "doc"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "operational"
+id = "canonical_encodings"
+label = "Canonical encodings: one valid byte representation per value (definite-length CBOR)."
+source_path = "docs/DESIGN_PRINCIPLES.md"
+source_anchor = "1.3 Canonical encodings"
+source_type = "doc"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "operational"
+id = "no_panics_in_protocol_paths"
+label = "No panics in protocol paths: protocol/network/actor paths return Result, never panic on bad input."
+source_path = "docs/DESIGN_PRINCIPLES.md"
+source_anchor = "1.4 No panics in protocol paths"
+source_type = "doc"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "operational"
+id = "kernel_app_boundary_inviolable"
+label = "Kernel/app boundary is inviolable: the dependency graph forbids domain crates inside kernel crates."
+source_path = "docs/DESIGN_PRINCIPLES.md"
+source_anchor = "1.5 Kernel/app boundary is inviolable"
+source_type = "doc"
+normative = true
+related_to = ["kernel_no_domain_imports"]
+notes = "Tier-1 statement of the tier-2 firewall contract; decomposed into the six firewall_contract sub-rules."
+
+# ---------------------------------------------------------------------------
+# Family 2 — Firewall contract (tier 2)
+# Canonical source: docs/architecture/KERNEL_APP_SEPARATION.md
+# ---------------------------------------------------------------------------
+
+[[invariant]]
+family = "firewall_contract"
+id = "kernel_no_domain_imports"
+label = "Kernel must not import domain crates."
+source_path = "docs/architecture/KERNEL_APP_SEPARATION.md"
+source_anchor = "Invariant 1: Kernel Must Not Import Domain Crates"
+source_type = "doc"
+normative = true
+notes = "Index entry only; mechanically enforced via CI. Canonical source authoritative."
+
+[[invariant]]
+family = "firewall_contract"
+id = "kernel_pure_data_types"
+label = "Kernel only accepts pure data types at its entrypoints."
+source_path = "docs/architecture/KERNEL_APP_SEPARATION.md"
+source_anchor = "Invariant 2: Kernel Only Accepts Pure Data Types"
+source_type = "doc"
+normative = true
+notes = "Index entry only; mechanically enforced via CI. Canonical source authoritative."
+
+[[invariant]]
+family = "firewall_contract"
+id = "semantic_lookup_in_policy_oracle"
+label = "All semantic lookup is confined to PolicyOracle."
+source_path = "docs/architecture/KERNEL_APP_SEPARATION.md"
+source_anchor = "Invariant 3: All Semantic Lookup Confined to PolicyOracle"
+source_type = "doc"
+normative = true
+notes = "Index entry only; mechanically enforced via CI. Canonical source authoritative."
+
+[[invariant]]
+family = "firewall_contract"
+id = "no_pattern_match_constraintset_custom"
+label = "Kernel must not pattern-match on ConstraintSet.custom keys."
+source_path = "docs/architecture/KERNEL_APP_SEPARATION.md"
+source_anchor = "Invariant 4: Kernel Must Not Pattern-Match on"
+source_type = "doc"
+normative = true
+notes = "Anchor truncated before a backticked term so it stays a verbatim substring. Canonical source authoritative."
+
+[[invariant]]
+family = "firewall_contract"
+id = "mechanism_not_policy"
+label = "Kernel contains enforcement mechanisms, not policy decisions."
+source_path = "docs/architecture/KERNEL_APP_SEPARATION.md"
+source_anchor = "Invariant 5: Kernel Contains Enforcement Mechanisms, Not Policy Decisions"
+source_type = "doc"
+normative = true
+notes = "Index entry only; mechanically enforced via CI. Canonical source authoritative."
+
+[[invariant]]
+family = "firewall_contract"
+id = "opaque_receipt_storage"
+label = "Kernel stores app-generated receipts opaquely (never parses the body)."
+source_path = "docs/architecture/KERNEL_APP_SEPARATION.md"
+source_anchor = "Invariant 6: Kernel Stores App-Generated Receipts Opaquely"
+source_type = "doc"
+normative = true
+notes = "Index entry only; mechanically enforced via CI. Canonical source authoritative."
+
+# ---------------------------------------------------------------------------
+# Family 3 — Frozen-core invariants (tier 3)
+# Canonical source: icn/crates/icn-kernel-api/src/invariants.rs (enum InvariantId)
+# Anchors are the Rust enum variant names. source_symbol gives the full path.
+# ---------------------------------------------------------------------------
+
+[[invariant]]
+family = "frozen_core"
+id = "right_of_exit"
+label = "No rule can prevent an identity from leaving an entity."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "RightOfExit"
+source_symbol = "InvariantId::RightOfExit"
+source_type = "code"
+domain = "SovereigntyCore"
+normative = true
+notes = "Index entry only; canonical source authoritative. Count asserted by test_all_invariants_returns_10."
+
+[[invariant]]
+family = "frozen_core"
+id = "no_retroactive_obligations"
+label = "Rules only apply to actions after activation block."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "NoRetroactiveObligations"
+source_symbol = "InvariantId::NoRetroactiveObligations"
+source_type = "code"
+domain = "SovereigntyCore"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "frozen_core"
+id = "explicit_cryptographic_entry"
+label = "Adding an identity requires their cryptographic signature."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "ExplicitCryptographicEntry"
+source_symbol = "InvariantId::ExplicitCryptographicEntry"
+source_type = "code"
+domain = "SovereigntyCore"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "frozen_core"
+id = "no_silent_power_changes"
+label = "Authz changes must include a computable capability delta."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "NoSilentPowerChanges"
+source_symbol = "InvariantId::NoSilentPowerChanges"
+source_type = "code"
+domain = "AntiCaptureCore"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "frozen_core"
+id = "bounded_authority"
+label = "No wildcard capabilities across all resources."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "BoundedAuthority"
+source_symbol = "InvariantId::BoundedAuthority"
+source_type = "code"
+domain = "AntiCaptureCore"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "frozen_core"
+id = "mandatory_execution_delay"
+label = "Economic/capability changes require timelock delay."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "MandatoryExecutionDelay"
+source_symbol = "InvariantId::MandatoryExecutionDelay"
+source_type = "code"
+domain = "AntiCaptureCore"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "frozen_core"
+id = "capability_conservation"
+label = "Cannot delegate capabilities you don't possess."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "CapabilityConservation"
+source_symbol = "InvariantId::CapabilityConservation"
+source_type = "code"
+domain = "AntiCaptureCore"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "frozen_core"
+id = "mutual_credit_conservation"
+label = "Mutual credit loops must net to zero."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "MutualCreditConservation"
+source_symbol = "InvariantId::MutualCreditConservation"
+source_type = "code"
+domain = "EconomicCore"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "frozen_core"
+id = "sovereign_signature_requirement"
+label = "Funds move only via owner signature or pre-consented dispute hook."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "SovereignSignatureRequirement"
+source_symbol = "InvariantId::SovereignSignatureRequirement"
+source_type = "code"
+domain = "EconomicCore"
+normative = true
+related_to = ["user_signed_transitions_only"]
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "frozen_core"
+id = "universal_receipt_generation"
+label = "Every state transition emits an immutable receipt."
+source_path = "icn/crates/icn-kernel-api/src/invariants.rs"
+source_anchor = "UniversalReceiptGeneration"
+source_symbol = "InvariantId::UniversalReceiptGeneration"
+source_type = "code"
+domain = "EconomicCore"
+normative = true
+related_to = ["execution_receipts_close_loop"]
+notes = "Index entry only; canonical source authoritative. DESIGN_PRINCIPLES.md §A2 notes it is structurally a tier-1 invariant."
+
+# ---------------------------------------------------------------------------
+# Family 4 — Regulatory invariants (tier 4)
+# Canonical source: docs/ARCHITECTURE.md §5 ("Seven regulatory invariants")
+# Anchors are the bold list labels.
+# ---------------------------------------------------------------------------
+
+[[invariant]]
+family = "regulatory"
+id = "user_signed_transitions_only"
+label = "User-signed transitions only: no transition without the user's cryptographic signature."
+source_path = "docs/ARCHITECTURE.md"
+source_anchor = "User-signed transitions only."
+source_type = "doc"
+normative = true
+related_to = ["sovereign_signature_requirement"]
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "regulatory"
+id = "no_hosted_positions"
+label = "No hosted positions: ICN holds no balances on behalf of users."
+source_path = "docs/ARCHITECTURE.md"
+source_anchor = "No hosted positions."
+source_type = "doc"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "regulatory"
+id = "no_operator_routing_of_value"
+label = "No operator routing of value: units move directly debtor to creditor, not through an operator account."
+source_path = "docs/ARCHITECTURE.md"
+source_anchor = "No operator routing of value."
+source_type = "doc"
+normative = true
+notes = "Index entry only; canonical source authoritative. Foundational to the software-provider regulatory framing."
+
+[[invariant]]
+family = "regulatory"
+id = "derived_views_not_primitives"
+label = "Derived views are not protocol primitives: a balance is a computed view, not enforced protocol state."
+source_path = "docs/ARCHITECTURE.md"
+source_anchor = "Derived views are not protocol primitives."
+source_type = "doc"
+normative = false
+notes = "Descriptive in the source: the protocol does not enforce balance invariants; governance may. Canonical source authoritative."
+
+[[invariant]]
+family = "regulatory"
+id = "no_embedded_convertibility"
+label = "No embedded convertibility: cross-coop settlement requires explicit trust agreements and governance approval."
+source_path = "docs/ARCHITECTURE.md"
+source_anchor = "No embedded convertibility."
+source_type = "doc"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "regulatory"
+id = "matching_market_opt_in"
+label = "Matching/market features are opt-in, scoped, governance-authorized (a CCL contract, not a platform feature)."
+source_path = "docs/ARCHITECTURE.md"
+source_anchor = "Matching/market features are opt-in, scoped, governance-authorized."
+source_type = "doc"
+normative = true
+notes = "Index entry only; canonical source authoritative."
+
+[[invariant]]
+family = "regulatory"
+id = "execution_receipts_close_loop"
+label = "Execution receipts close the loop: every state transition produces a cryptographically signed receipt."
+source_path = "docs/ARCHITECTURE.md"
+source_anchor = "Execution receipts close the loop."
+source_type = "doc"
+normative = true
+related_to = ["universal_receipt_generation"]
+notes = "Index entry only; canonical source authoritative."

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -2520,6 +2520,22 @@ domain_tags = ["project-index", "navigation", "proof-level", "rehearsal", "show-
 recommended_action = "keep"
 last_reviewed = "2026-06-09"
 
+[docs."docs/reference/project-index/invariants-catalog.md"]
+category = "reference"
+status = "living"
+title = "ICN Invariants Catalog"
+description = "Source-linked index of the four canonical ICN invariant families (5 operational / 6 firewall-contract / 10 frozen-core / 7 regulatory = 28), each linked to its canonical source with a stable anchor. Indexes only; it does not define invariants, and the canonical sources remain authoritative. Machine-readable companion: invariants-catalog.toml. Implements the #2114 deliverable."
+last_updated = "2026-06-22"
+owner = "matt"
+audiences = ["all", "team"]
+truth_class = "descriptive"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["project-index", "navigation", "invariants", "architecture"]
+recommended_action = "keep"
+last_reviewed = "2026-06-22"
+
 [docs."docs/glossary.md"]
 category = "reference"
 status = "living"


### PR DESCRIPTION
## What
Adds one source-linked **index** of ICN's invariant families:
- `docs/reference/project-index/invariants-catalog.toml` — machine-readable (28 `[[invariant]]` entries + family roll-up)
- `docs/reference/project-index/invariants-catalog.md` — thin human-facing pointer
- Discoverability: project-index `README.md` (All-maps + truth-layer rows), a `docs/registry.toml` entry, and one `AGENTS.md` pointer line

## Why
Tracking issue: #2114. ICN's invariants are real but scattered across four canonical sources in different formats, so the families get conflated/miscounted. Reviewers and `icn-invariants-guardian` need one authoritative enumeration that links each invariant to where it is actually defined.

## How
Hand-curated (not generated). Indexes exactly the four families #2114 names:

| Family | Canonical source | Count |
|---|---|---|
| Operational | `docs/DESIGN_PRINCIPLES.md` §1 | 5 |
| Firewall-contract | `docs/architecture/KERNEL_APP_SEPARATION.md` | 6 |
| Frozen-core | `icn/crates/icn-kernel-api/src/invariants.rs` (`enum InvariantId`) | 10 |
| Regulatory | `docs/ARCHITECTURE.md` §5 | 7 |

Total **28** — matches the issue's counts, verified against the live sources. Each entry carries family, a stable id, a one-line label, the canonical source path, a **stable anchor** (section heading / Rust enum variant / bold label — never a line number, which drifts), source type, and whether the source states it normatively. Anchors are verbatim substrings of their sources, so the catalog is self-checking.

## Claim discipline
- **Indexes only — does not define.** The `.md` carries verbatim: *"This catalog indexes invariants. It does not define them. The canonical source listed for each entry remains authoritative."*
- **No new invariants**, no doctrine, no restated definitions.
- **Not a competing source of truth** (`Canonical: no`); defers to the canonical sources and the source-of-truth ladder.
- Related-but-out-of-scope enumerations (`AGENTS.md`'s restatement of family 1; `genesis.md` hard mechanisms / meta-invariants) are noted, not double-counted.
- **No runtime changes**; no Rust touched. No production / pilot / live-federation / Phase 2 / entity-auth claims.

## Risk
Docs / control-plane only (523 insertions, 0 deletions). No canonical source files edited; nothing under `generated/` touched. Low risk.

## Test plan / validation (run on this branch)
- `doc_control_check.py --repo . --registry docs/registry.toml` → exit 0; **65-warning enforcement baseline unchanged** (md file count 883 → 884, no new warnings)
- `check-state-lag.py` → exit 0
- `generate-live-state-overlay.py --check --no-gh` → exit 0 (14 sections)
- `freshness-check.py` → exit 0 (all fresh)
- `cargo fmt --all --check` → exit 0; agent-tooling drift-check PASS
- TOML parse + count sanity → 28 entries (5/6/10/7), family roll-up matches
- Anchor sanity → all 28 `source_anchor` values resolve as verbatim substrings of their sources
- Link check → all 10 relative links in the catalog resolve

Tracking: #2114 (left open; I will comment to close after review if acceptance is confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
