### PR TITLE
docs(registry): refresh generated document registry after #2135

### DIFF
--- a/docs/DOCUMENT_REGISTRY.md
+++ b/docs/DOCUMENT_REGISTRY.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-06-09
+Last Reviewed: 2026-06-22
 ---
 
 # ICN Document Registry (human summary)
@@ -41,13 +41,13 @@ python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml
 
 ## Corpus coverage
 
-- **Markdown files under docs/**: 862
+- **Markdown files under docs/**: 884
 - **By truth_class (merged):**
-  - `descriptive`: 501
-  - `draft`: 43
+  - `descriptive`: 509
+  - `draft`: 44
   - `historical`: 79
-  - `normative`: 75
-  - `operational`: 164
+  - `normative`: 78
+  - `operational`: 174
 
 ## Schema and policy
 
@@ -76,5 +76,5 @@ What fails in CI, what warns, what `--strict` adds, and when to promote strict t
 
 ## Registry coverage (this snapshot)
 
-- **Files scanned:** 862 Markdown files under `docs/`
-- **Explicit `[docs."…"]` rows under `docs/`:** 302 (remaining files rely on `[[doc_path_defaults]]` only)
+- **Files scanned:** 884 Markdown files under `docs/`
+- **Explicit `[docs."…"]` rows under `docs/`:** 304 (remaining files rely on `[[doc_path_defaults]]` only)

--- a/docs/INDEX.generated.md
+++ b/docs/INDEX.generated.md
@@ -1246,7 +1246,7 @@ Release notes and version history
 
 Guidance for Claude Code sessions working with ICN codebase
 
-**For:** `agents`, `developers` | **Updated:** 2026-03-21
+**For:** `agents`, `developers` | **Updated:** 2026-06-17
 
 ### 🔒 **Canonical** [Code of Conduct](/CODE_OF_CONDUCT.md)
 
@@ -1260,6 +1260,12 @@ Main project README with overview, quick start, and CI/CD status badge
 
 **For:** `contributors`, `public` | **Updated:** 2026-03-10
 
+### 📝 **Living** [ICN Ecosystem Atlas](/docs/ATLAS.md)
+
+Top-level front door composing the project-index map family and the truth spine; cross-repo map (incl. private ops/provider repos), boundary/claims guardrail, and agent preflight. Index, not a source of truth.
+
+**For:** `all`, `agents` | **Updated:** 2026-06-16
+
 ### 🔒 **Canonical** [ICN Documentation Control System](/docs/DOCUMENTATION_CONTROL_SYSTEM.md)
 
 Normative development control plane: discovery vs delivery, artifact routing, and documentation governance
@@ -1270,7 +1276,7 @@ Normative development control plane: discovery vs delivery, artifact routing, an
 
 Auto-generated summary companion to registry.toml; run doc_control_check.py to refresh
 
-**For:** `contributors`, `agents` | **Updated:** 2026-06-09
+**For:** `contributors`, `agents` | **Updated:** 2026-06-22
 
 ### 📝 **Living** [ICN Golden Development Prompt](/docs/GOLDEN_PROMPT.md)
 
@@ -1574,9 +1580,9 @@ Trust score threshold configuration guide
 
 ### 📝 **Living** [ICN Project Index](/docs/reference/project-index/README.md)
 
-Show-ready orientation layer — routes outside readers, contributors, and agents to the right canonical doc, source tree, or external URL. Defers to STATE.md and PHASE_PROGRESS.md for current truth.
+Show-ready orientation layer — routes outside readers, contributors, and agents to the right canonical doc, source tree, or external URL. Defers to STATE.md and PHASE_PROGRESS.md for current truth. Includes the Truth Layer / Claim Discipline section cross-linking the existing truth systems.
 
-**For:** `all` | **Updated:** 2026-05-11
+**For:** `all` | **Updated:** 2026-06-20
 
 ### 📝 **Living** [CI / Ops / Deploy Map](/docs/reference/project-index/ci-ops-deploy-map.md)
 
@@ -1601,6 +1607,12 @@ How INDEX.md, registry.toml, DOCUMENT_REGISTRY.md, and doc_control_check.py rela
 Protocol for recording every tracked file and directory across InterCooperative-Network/icn (and adjacent repos) as a mechanical record plus an interpretive atlas. Defines outputs, generator, classification vocabulary, and privacy boundary.
 
 **For:** `contributors`, `architects` | **Updated:** 2026-05-01
+
+### 📝 **Living** [ICN Invariants Catalog](/docs/reference/project-index/invariants-catalog.md)
+
+Source-linked index of the four canonical ICN invariant families (5 operational / 6 firewall-contract / 10 frozen-core / 7 regulatory = 28), each linked to its canonical source with a stable anchor. Indexes only; it does not define invariants, and the canonical sources remain authoritative. Machine-readable companion: invariants-catalog.toml. Implements the #2114 deliverable.
+
+**For:** `all`, `team` | **Updated:** 2026-06-22
 
 ### 📝 **Living** [Proof-Level Taxonomy and Capability Matrix](/docs/reference/project-index/proof-level-taxonomy-capability-matrix.md)
 
@@ -1738,7 +1750,7 @@ Comprehensive threat model covering attack vectors, adversary capabilities, and 
 
 Living snapshot of repo layout, decisions, constraints, and current engineering status
 
-**For:** `developers`, `agents` | **Updated:** 2026-06-10
+**For:** `developers`, `agents` | **Updated:** 2026-06-21
 
 
 ## Strategy
@@ -1898,9 +1910,9 @@ Assessment of pilot readiness and gaps
 
 ## Summary
 
-**Total documents:** 309
+**Total documents:** 311
 
 **By status:**
 - Canonical: 40
 - Draft: 72
-- Living: 197
+- Living: 199

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -714,7 +714,7 @@ category = "reference"
 status = "living"
 title = "ICN Document Registry (human summary)"
 description = "Auto-generated summary companion to registry.toml; run doc_control_check.py to refresh"
-last_updated = "2026-06-09"
+last_updated = "2026-06-22"
 owner = "matt"
 audiences = ["contributors", "agents"]
 truth_class = "descriptive"
@@ -723,7 +723,7 @@ canonical = "no"
 freshness = "current"
 domain_tags = ["registry", "documentation-control"]
 recommended_action = "keep"
-last_reviewed = "2026-06-09"
+last_reviewed = "2026-06-22"
 
 [docs."docs/planning/documentation-namespace-resolution.md"]
 category = "strategy"


### PR DESCRIPTION
## What

Refreshes generated documentation registry/index artifacts after #2135 added the source-linked invariants catalog.

- `docs/DOCUMENT_REGISTRY.md` — regenerated via `doc_control_check.py --write-document-registry` (corpus/registry counts now current; corpus 862 → 884).
- `docs/INDEX.generated.md` — regenerated via `generate-index.py --registry docs/registry.toml` (now matches generator output; clears the docs-freshness "INDEX.generated.md out of date" warning).
- `docs/registry.toml` — **required mechanical correction only**: bump the `docs/DOCUMENT_REGISTRY.md` row `last_updated`/`last_reviewed` `2026-06-09 → 2026-06-22` so the regenerated frontmatter date matches its registry row (otherwise `doc_control_check` raises a Last-Reviewed yaml-mismatch, moving the baseline 65 → 66).

## Why

#2135 added a new explicit `docs/registry.toml` entry for `docs/reference/project-index/invariants-catalog.md`. The generated whole-corpus summaries (`DOCUMENT_REGISTRY.md`, `INDEX.generated.md`) were last regenerated at corpus=862 and had since drifted; this brings them back in sync. This was deliberately deferred out of #2135 (a hand-authored PR) per generated-commit hygiene.

## Scope

Generated-doc refresh only, plus the single mechanically-entailed registry date bump. The `docs/registry.toml` change is exactly two lines on the `DOCUMENT_REGISTRY.md` row.

## Non-goals

- No runtime changes; no Rust touched.
- No hand-authored truth/canonical changes.
- No new invariants.
- No production / pilot / live-federation / Phase 2 / entity-auth / `/auth/verify` / private-data / OpenAPI claims.
- The whole-repo `icn-file-record.*` snapshot is a separate generated artifact with its own refresh lane and is intentionally left untouched.
- Does not start #2080, #2081, #2112, #2113, #2041, or #1703.

## Validation (on this branch)

- `doc_control_check.py --repo . --registry docs/registry.toml` → exit 0, **65-warning baseline restored** (no Last-Reviewed mismatch)
- `check-state-lag.py` → exit 0
- `generate-live-state-overlay.py --check --no-gh` → exit 0 (14 sections)
- `freshness-check.py` → exit 0
- Both regens idempotent (a second regen produces no further diff)
- generated-truth checkers: overlay + agent-context-spine `--check` exit 0
- `cargo fmt --all --check` → exit 0; drift-check PASS
