### PR TITLE
feat(process): mount ProcessGateResultReceipt over HTTP

### DIFF
--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-20T16:19:03+00:00
+Generated: 2026-06-22T18:19:04+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -17,7 +17,7 @@ Generated: 2026-06-20T16:19:03+00:00
 
 ## Snapshot
 
-- Source commit: `4b47261a3fb9b2c7bd7c979d6556e3fb06bb0ce2`
+- Source commit: `7c7158c8a9b32d8a73c41f6570a50977eaf6d386`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -29,7 +29,7 @@ Generated: 2026-06-20T16:19:03+00:00
 - Not matched to OpenAPI (best-effort): 285 (~99% of discovered)
 - Documented share of discovered routes: ~0.7%
 - **OpenAPI operations (method + path) not matched to a discovered gateway route: 3** (see section below)
-- **Governance app route-registration candidates (separate surface, not gateway macros): 80** (see section below)
+- **Governance app route-registration candidates (separate surface, not gateway macros): 81** (see section below)
 
 > The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside the gateway crate and are not captured by this macro scan — so the documented/undocumented counts here are a best-effort comparison, while the two headline counts (discovered macros, OpenAPI paths) are the robust measured facts.
 
@@ -40,8 +40,8 @@ These OpenAPI-documented paths did **not** mechanically match any discovered gat
 | Method | OpenAPI path | Matched gateway route | Governance registration candidate | Status | Claim safety |
 |---|---|---|---|---|---|
 | GET | `/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | no | `get_action_item_completion_receipt` @ `icn/apps/governance/src/http/configure.rs`:682 | unknown / needs local verification | needs review |
-| GET | `/gov/me/action-cards` | no | `get_my_action_cards` @ `icn/apps/governance/src/http/configure.rs`:834 | unknown / needs local verification | needs review |
-| GET | `/gov/me/standing` | no | `get_my_standing` @ `icn/apps/governance/src/http/configure.rs`:830 | unknown / needs local verification | needs review |
+| GET | `/gov/me/action-cards` | no | `get_my_action_cards` @ `icn/apps/governance/src/http/configure.rs`:839 | unknown / needs local verification | needs review |
+| GET | `/gov/me/standing` | no | `get_my_standing` @ `icn/apps/governance/src/http/configure.rs`:835 | unknown / needs local verification | needs review |
 
 ## Governance app route-registration candidates
 
@@ -49,12 +49,12 @@ The governance app (`icn-governance-actor` = `icn/apps/governance`) registers it
 
 | Method | Path (relative, under `/gov`) | Source | Handler | OpenAPI documented | Status | Claim safety |
 |---|---|---|---|---|---|---|
-| GET | `/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:707 | `get_activity` | no | unknown / needs local verification | needs review |
+| GET | `/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:712 | `get_activity` | no | unknown / needs local verification | needs review |
 | POST | `/charters` | `icn/apps/governance/src/http/configure.rs`:587 | `activate_charter` | no | unknown / needs local verification | needs review |
 | GET | `/delegations` | `icn/apps/governance/src/http/configure.rs`:654 | `list_delegations` | no | unknown / needs local verification | needs review |
 | POST | `/delegations` | `icn/apps/governance/src/http/configure.rs`:653 | `create_delegation` | no | unknown / needs local verification | needs review |
 | DELETE | `/delegations/{delegation_id}` | `icn/apps/governance/src/http/configure.rs`:658 | `revoke_delegation` | no | unknown / needs local verification | needs review |
-| GET | `/digest` | `icn/apps/governance/src/http/configure.rs`:827 | `get_digest` | no | unknown / needs local verification | needs review |
+| GET | `/digest` | `icn/apps/governance/src/http/configure.rs`:832 | `get_digest` | no | unknown / needs local verification | needs review |
 | GET | `/domains` | `icn/apps/governance/src/http/configure.rs`:576 | `list_domains` | no | unknown / needs local verification | needs review |
 | POST | `/domains` | `icn/apps/governance/src/http/configure.rs`:575 | `create_domain` | no | unknown / needs local verification | needs review |
 | GET | `/domains/{domain_id}` | `icn/apps/governance/src/http/configure.rs`:579 | `get_domain` | no | unknown / needs local verification | needs review |
@@ -66,50 +66,51 @@ The governance app (`icn-governance-actor` = `icn/apps/governance`) registers it
 | GET | `/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `icn/apps/governance/src/http/configure.rs`:682 | `get_action_item_completion_receipt` | yes | unknown / needs local verification | needs review |
 | POST | `/domains/{domain_id}/action-items/{item_id}/notes` | `icn/apps/governance/src/http/configure.rs`:678 | `add_action_item_note` | no | unknown / needs local verification | needs review |
 | PUT | `/domains/{domain_id}/action-items/{item_id}/status` | `icn/apps/governance/src/http/configure.rs`:674 | `update_action_item_status` | no | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:758 | `list_meetings` | no | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:757 | `create_meeting` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:763 | `list_meetings` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:762 | `create_meeting` | no | unknown / needs local verification | needs review |
 | DELETE | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:584 | `remove_domain_member` | no | unknown / needs local verification | needs review |
 | POST | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:583 | `add_domain_member` | no | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:713 | `list_programs_by_domain` | no | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:712 | `create_program` | no | unknown / needs local verification | needs review |
-| GET | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:703 | `list_activities` | no | unknown / needs local verification | needs review |
-| POST | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:702 | `create_activity` | no | unknown / needs local verification | needs review |
-| GET | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:688 | `list_structures` | no | unknown / needs local verification | needs review |
-| POST | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:687 | `create_structure` | no | unknown / needs local verification | needs review |
-| GET | `/me/action-cards` | `icn/apps/governance/src/http/configure.rs`:834 | `get_my_action_cards` | yes | unknown / needs local verification | needs review |
-| GET | `/me/scopes` | `icn/apps/governance/src/http/configure.rs`:829 | `get_my_scopes` | no | unknown / needs local verification | needs review |
-| GET | `/me/standing` | `icn/apps/governance/src/http/configure.rs`:830 | `get_my_standing` | yes | unknown / needs local verification | needs review |
-| GET | `/me/work` | `icn/apps/governance/src/http/configure.rs`:831 | `get_my_work` | no | unknown / needs local verification | needs review |
-| GET | `/meetings/{meeting_id}` | `icn/apps/governance/src/http/configure.rs`:762 | `get_meeting` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/agenda` | `icn/apps/governance/src/http/configure.rs`:782 | `add_agenda_item` | no | unknown / needs local verification | needs review |
-| PUT | `/meetings/{meeting_id}/agenda/{item_id}` | `icn/apps/governance/src/http/configure.rs`:786 | `update_agenda_item` | no | unknown / needs local verification | needs review |
-| PUT | `/meetings/{meeting_id}/attendance` | `icn/apps/governance/src/http/configure.rs`:778 | `mark_attendance` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/attendees` | `icn/apps/governance/src/http/configure.rs`:774 | `add_attendee` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/end` | `icn/apps/governance/src/http/configure.rs`:770 | `end_meeting` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/start` | `icn/apps/governance/src/http/configure.rs`:766 | `start_meeting` | no | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:743 | `get_milestone` | no | unknown / needs local verification | needs review |
-| PATCH | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:744 | `update_milestone_status` | no | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}/history` | `icn/apps/governance/src/http/configure.rs`:752 | `get_milestone_history` | no | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}/preview` | `icn/apps/governance/src/http/configure.rs`:748 | `preview_milestone` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}` | `icn/apps/governance/src/http/configure.rs`:717 | `get_program` | no | unknown / needs local verification | needs review |
-| DELETE | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:739 | `unlink_activity_from_program` | no | unknown / needs local verification | needs review |
-| PUT | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:738 | `link_activity_to_program` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/dashboard` | `icn/apps/governance/src/http/configure.rs`:725 | `get_program_dashboard` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:734 | `list_milestones_by_program` | no | unknown / needs local verification | needs review |
-| POST | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:733 | `create_milestone` | no | unknown / needs local verification | needs review |
-| PATCH | `/programs/{program_id}/status` | `icn/apps/governance/src/http/configure.rs`:721 | `update_program_status` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/summary` | `icn/apps/governance/src/http/configure.rs`:729 | `get_program_summary` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/process-sessions/{session_id}/gate-results` | `icn/apps/governance/src/http/configure.rs`:687 | `record_process_gate_result` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:718 | `list_programs_by_domain` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:717 | `create_program` | no | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:708 | `list_activities` | no | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:707 | `create_activity` | no | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:693 | `list_structures` | no | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:692 | `create_structure` | no | unknown / needs local verification | needs review |
+| GET | `/me/action-cards` | `icn/apps/governance/src/http/configure.rs`:839 | `get_my_action_cards` | yes | unknown / needs local verification | needs review |
+| GET | `/me/scopes` | `icn/apps/governance/src/http/configure.rs`:834 | `get_my_scopes` | no | unknown / needs local verification | needs review |
+| GET | `/me/standing` | `icn/apps/governance/src/http/configure.rs`:835 | `get_my_standing` | yes | unknown / needs local verification | needs review |
+| GET | `/me/work` | `icn/apps/governance/src/http/configure.rs`:836 | `get_my_work` | no | unknown / needs local verification | needs review |
+| GET | `/meetings/{meeting_id}` | `icn/apps/governance/src/http/configure.rs`:767 | `get_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/agenda` | `icn/apps/governance/src/http/configure.rs`:787 | `add_agenda_item` | no | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/agenda/{item_id}` | `icn/apps/governance/src/http/configure.rs`:791 | `update_agenda_item` | no | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/attendance` | `icn/apps/governance/src/http/configure.rs`:783 | `mark_attendance` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/attendees` | `icn/apps/governance/src/http/configure.rs`:779 | `add_attendee` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/end` | `icn/apps/governance/src/http/configure.rs`:775 | `end_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/start` | `icn/apps/governance/src/http/configure.rs`:771 | `start_meeting` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:748 | `get_milestone` | no | unknown / needs local verification | needs review |
+| PATCH | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:749 | `update_milestone_status` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/history` | `icn/apps/governance/src/http/configure.rs`:757 | `get_milestone_history` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/preview` | `icn/apps/governance/src/http/configure.rs`:753 | `preview_milestone` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}` | `icn/apps/governance/src/http/configure.rs`:722 | `get_program` | no | unknown / needs local verification | needs review |
+| DELETE | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:744 | `unlink_activity_from_program` | no | unknown / needs local verification | needs review |
+| PUT | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:743 | `link_activity_to_program` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/dashboard` | `icn/apps/governance/src/http/configure.rs`:730 | `get_program_dashboard` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:739 | `list_milestones_by_program` | no | unknown / needs local verification | needs review |
+| POST | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:738 | `create_milestone` | no | unknown / needs local verification | needs review |
+| PATCH | `/programs/{program_id}/status` | `icn/apps/governance/src/http/configure.rs`:726 | `update_program_status` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/summary` | `icn/apps/governance/src/http/configure.rs`:734 | `get_program_summary` | no | unknown / needs local verification | needs review |
 | GET | `/proposals` | `icn/apps/governance/src/http/configure.rs`:592 | `list_proposals` | no | unknown / needs local verification | needs review |
 | POST | `/proposals` | `icn/apps/governance/src/http/configure.rs`:591 | `create_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/clearing/establish` | `icn/apps/governance/src/http/configure.rs`:799 | `create_establish_clearing_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/clearing/terminate` | `icn/apps/governance/src/http/configure.rs`:803 | `create_terminate_clearing_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/join` | `icn/apps/governance/src/http/configure.rs`:791 | `create_join_federation_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/leave` | `icn/apps/governance/src/http/configure.rs`:795 | `create_leave_federation_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/policy` | `icn/apps/governance/src/http/configure.rs`:815 | `create_update_federation_policy_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/vouch` | `icn/apps/governance/src/http/configure.rs`:807 | `create_vouch_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/vouch/revoke` | `icn/apps/governance/src/http/configure.rs`:811 | `create_revoke_vouch_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/sdis/appoint-steward` | `icn/apps/governance/src/http/configure.rs`:820 | `create_appoint_steward_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/sdis/remove-steward` | `icn/apps/governance/src/http/configure.rs`:824 | `create_remove_steward_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/establish` | `icn/apps/governance/src/http/configure.rs`:804 | `create_establish_clearing_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/terminate` | `icn/apps/governance/src/http/configure.rs`:808 | `create_terminate_clearing_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/join` | `icn/apps/governance/src/http/configure.rs`:796 | `create_join_federation_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/leave` | `icn/apps/governance/src/http/configure.rs`:800 | `create_leave_federation_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/policy` | `icn/apps/governance/src/http/configure.rs`:820 | `create_update_federation_policy_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch` | `icn/apps/governance/src/http/configure.rs`:812 | `create_vouch_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch/revoke` | `icn/apps/governance/src/http/configure.rs`:816 | `create_revoke_vouch_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/appoint-steward` | `icn/apps/governance/src/http/configure.rs`:825 | `create_appoint_steward_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/remove-steward` | `icn/apps/governance/src/http/configure.rs`:829 | `create_remove_steward_proposal` | no | unknown / needs local verification | needs review |
 | GET | `/proposals/{proposal_id}` | `icn/apps/governance/src/http/configure.rs`:596 | `get_proposal` | no | unknown / needs local verification | needs review |
 | GET | `/proposals/{proposal_id}/chain` | `icn/apps/governance/src/http/configure.rs`:620 | `get_chain` | no | unknown / needs local verification | needs review |
 | POST | `/proposals/{proposal_id}/close` | `icn/apps/governance/src/http/configure.rs`:604 | `close_proposal` | no | unknown / needs local verification | needs review |
@@ -126,9 +127,9 @@ The governance app (`icn-governance-actor` = `icn/apps/governance`) registers it
 | GET | `/proposals/{proposal_id}/proof` | `icn/apps/governance/src/http/configure.rs`:616 | `get_proof` | no | unknown / needs local verification | needs review |
 | GET | `/proposals/{proposal_id}/tally` | `icn/apps/governance/src/http/configure.rs`:612 | `get_vote_tally` | no | unknown / needs local verification | needs review |
 | POST | `/proposals/{proposal_id}/vote` | `icn/apps/governance/src/http/configure.rs`:608 | `cast_vote` | no | unknown / needs local verification | needs review |
-| GET | `/structures/{structure_id}` | `icn/apps/governance/src/http/configure.rs`:692 | `get_structure` | no | unknown / needs local verification | needs review |
-| GET | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:697 | `list_roles` | no | unknown / needs local verification | needs review |
-| POST | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:696 | `assign_role` | no | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}` | `icn/apps/governance/src/http/configure.rs`:697 | `get_structure` | no | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:702 | `list_roles` | no | unknown / needs local verification | needs review |
+| POST | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:701 | `assign_role` | no | unknown / needs local verification | needs review |
 
 ## Limitations
 

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -681,6 +681,11 @@ where
             web::resource("/domains/{domain_id}/action-items/{item_id}/completion-receipt")
                 .route(web::get().to(handlers::get_action_item_completion_receipt::<E>)),
         )
+        // ── Process gate results (#2144 — first ProcessTransitionReceipt) ──
+        .service(
+            web::resource("/domains/{domain_id}/process-sessions/{session_id}/gate-results")
+                .route(web::post().to(handlers::record_process_gate_result::<E>)),
+        )
         // ── Structure endpoints ──────────────────────────────────────────
         .service(
             web::resource("/entities/{entity_id}/structures")

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3077,6 +3077,66 @@ pub async fn get_action_item_completion_receipt<E: GovernanceEventEmitter + Clon
     Ok(HttpResponse::Ok().json(receipt))
 }
 
+/// POST /gov/domains/{domain_id}/process-sessions/{session_id}/gate-results
+/// — Record one process-gate result and return its persisted
+/// [`icn_governance::ProcessGateResultReceipt`] (issue #2144).
+///
+/// Mounts the existing `GovernanceManager::record_process_gate_result`
+/// runtime slice — the first `ProcessTransitionReceipt` class for the
+/// `idea-0019` Institutional Process Substrate (ADR-0026 Layer 2) — over
+/// HTTP. The manager constructs a deterministic blake3 receipt and persists
+/// it through the receipt backend *before* returning, so the response body
+/// carries the persisted receipt and its `record_hash` is the verification
+/// evidence. This adds no new receipt type and no process runtime.
+///
+/// Authorization mirrors the action-item write surface: the existing
+/// `governance:write` scope plus domain membership for the caller. This
+/// handler composes those existing gates and changes no authorization
+/// decision. The manager performs no authority check itself — charter
+/// enforcement of "who may record a gate result for this domain/session"
+/// is upstream of this slice.
+///
+/// Returns:
+/// - 200 with the persisted `ProcessGateResultReceipt` JSON.
+/// - 400 when `result`/`gate_kind` is outside its closed taxonomy
+///   (deserialization) or `session_id` is empty/whitespace.
+/// - 401 when the bearer token is missing/invalid.
+/// - 403 when the token lacks `governance:write` or the caller is not a
+///   member of the domain.
+/// - 404 when the domain does not exist.
+pub async fn record_process_gate_result<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+    req: web::Json<RecordProcessGateResultRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let recorded_by = parse_did(&claims.sub, "Invalid DID in token")?;
+
+    let (domain_id, session_id) = path.into_inner();
+    if session_id.trim().is_empty() {
+        return Err(err_bad("session_id must be a non-empty path segment"));
+    }
+    let domain = GovernanceDomainId(domain_id);
+
+    // Reuse the existing domain-membership gate; do not introduce a new
+    // authorization regime.
+    check_domain_membership(&ctx, &domain, &recorded_by).await?;
+
+    let receipt = ctx
+        .manager
+        .record_process_gate_result(
+            &domain,
+            &session_id,
+            req.gate_kind,
+            req.result,
+            &recorded_by,
+        )
+        .map_err(anyhow_to_api)?;
+
+    Ok(HttpResponse::Ok().json(receipt))
+}
+
 // ============================================================================
 // Notification digest handler
 // ============================================================================

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -7,6 +7,8 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use icn_governance::{ProcessGateKind, ProcessGateResult};
+
 // ============================================================================
 // Domain
 // ============================================================================
@@ -45,6 +47,25 @@ pub struct AddDomainMemberRequest {
 
 fn default_weight() -> f64 {
     1.0
+}
+
+// ============================================================================
+// Process gate results (#2144 — first ProcessTransitionReceipt class)
+// ============================================================================
+
+/// Request body for `POST /gov/domains/{domain_id}/process-sessions/{session_id}/gate-results`.
+///
+/// `gate_kind` and `result` are the closed `icn_governance` taxonomies
+/// ([`ProcessGateKind`], [`ProcessGateResult`]); an out-of-taxonomy value is
+/// rejected by JSON deserialization (400) rather than silently coerced. The
+/// `session_id` and `domain_id` come from the path, and the recording actor
+/// comes from the authenticated token — not the body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordProcessGateResultRequest {
+    /// Closed-taxonomy gate kind being recorded (e.g. `"privacy_review"`).
+    pub gate_kind: ProcessGateKind,
+    /// Pass/fail result of the gate evaluation (`"pass"` | `"fail"`).
+    pub result: ProcessGateResult,
 }
 
 // ============================================================================

--- a/icn/apps/governance/tests/process_gate_result_http_route.rs
+++ b/icn/apps/governance/tests/process_gate_result_http_route.rs
@@ -328,3 +328,57 @@ async fn record_process_gate_result_route_rejects_unknown_result() {
     let _ = to_bytes(resp.into_body()).await.unwrap();
     assert_eq!(h.receipts.total_count(), 0);
 }
+
+#[actix_web::test]
+async fn record_process_gate_result_route_rejects_whitespace_session_id() {
+    // The handler's `session_id.trim().is_empty()` guard must reject a
+    // whitespace-only session id (`%20`, which actix percent-decodes to a
+    // single space) with 400 and persist nothing.
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&h.ctx.manager, &caller, "test-coop").await;
+
+    let app = gate_app!(h.ctx.clone(), &caller);
+    let req = test::TestRequest::post()
+        .uri(&gate_results_uri(&domain.0, "%20"))
+        .set_json(serde_json::json!({
+            "gate_kind": "privacy_review",
+            "result": "pass",
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a whitespace-only session_id must be rejected with 400"
+    );
+    let _ = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(h.receipts.total_count(), 0);
+}
+
+#[actix_web::test]
+async fn record_process_gate_result_route_rejects_unknown_gate_kind() {
+    // Symmetric to the unknown-`result` case: an out-of-taxonomy
+    // `gate_kind` must be rejected by JSON deserialization (400), never
+    // coerced -- the gate-kind taxonomy is closed.
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&h.ctx.manager, &caller, "test-coop").await;
+
+    let app = gate_app!(h.ctx.clone(), &caller);
+    let req = test::TestRequest::post()
+        .uri(&gate_results_uri(&domain.0, "session-http-400-gate"))
+        .set_json(serde_json::json!({
+            "gate_kind": "not_a_real_gate",
+            "result": "pass",
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "an out-of-taxonomy gate_kind must be a 400, not silently accepted"
+    );
+    let _ = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(h.receipts.total_count(), 0);
+}

--- a/icn/apps/governance/tests/process_gate_result_http_route.rs
+++ b/icn/apps/governance/tests/process_gate_result_http_route.rs
@@ -1,0 +1,330 @@
+//! HTTP route proof for the first `ProcessTransitionReceipt` class
+//! ([`ProcessGateResultReceipt`]) — issue #2144.
+//!
+//! The receipt machinery (type, `GovernanceManager::record_process_gate_result`,
+//! and the receipt-store record kind) already exists and is proven at the
+//! manager layer by `process_gate_result_receipt_runtime_slice.rs`. This
+//! test pins the missing surface: **one governance HTTP route that drives
+//! that existing path end-to-end**:
+//!
+//!   `POST /gov/domains/{domain_id}/process-sessions/{session_id}/gate-results`
+//!     → governance handler
+//!     → GovernanceManager::record_process_gate_result
+//!     → persisted ProcessGateResultReceipt
+//!     → response body carries the persisted receipt (deterministic record_hash)
+//!
+//! It does NOT add a new receipt type, a process runtime, or a read-back
+//! manager getter. The POST response IS the retrieval/verification surface.
+//!
+//! Pins:
+//!
+//! 1. The route is mounted and reachable (not 404).
+//! 2. The handler calls `record_process_gate_result` and returns the
+//!    persisted receipt: returned fields match the request, `recorded_by`
+//!    is the authenticated caller, and `record_hash` is a real blake3
+//!    binding (not a zero placeholder) that matches
+//!    `ProcessGateResultReceipt::compute_record_hash` for the returned
+//!    fields (deterministic).
+//! 3. The receipt is actually persisted through the HTTP path — the wired
+//!    backend captures it and a `(session_id, gate_kind)` lookup returns
+//!    the same `record_hash`.
+//! 4. Authorization reuses the existing action-item write surface gate:
+//!    a caller who is not a member of the domain receives 403 and no
+//!    receipt is persisted (auth decisions are unchanged by this slice).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex};
+
+use actix_web::{body::to_bytes, http::StatusCode, test, App};
+use icn_governance::{
+    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    MembershipSource, ProcessGateKind, ProcessGateResult, ProcessGateResultReceipt,
+};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+
+// ============================================================================
+// Test receipt backend — captures ProcessGateResultReceipt writes + lookups.
+// Mirrors the minimal backend in process_gate_result_receipt_runtime_slice.rs:
+// overrides only the methods that have no trait default plus the three
+// process-gate methods.
+// ============================================================================
+
+#[derive(Default)]
+struct TestReceiptStore {
+    persisted: Mutex<Vec<ProcessGateResultReceipt>>,
+}
+
+impl GovernanceReceiptBackend for TestReceiptStore {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+
+    fn put_process_gate_result(&self, receipt: &ProcessGateResultReceipt) -> Result<(), String> {
+        self.persisted.lock().unwrap().push(receipt.clone());
+        Ok(())
+    }
+
+    fn get_latest_process_gate_result(
+        &self,
+        session_id: &str,
+        gate_kind: ProcessGateKind,
+    ) -> Result<Option<ProcessGateResultReceipt>, String> {
+        Ok(self
+            .persisted
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.session_id == session_id && r.gate_kind == gate_kind)
+            .max_by_key(|r| r.recorded_at)
+            .cloned())
+    }
+}
+
+impl TestReceiptStore {
+    fn total_count(&self) -> usize {
+        self.persisted.lock().unwrap().len()
+    }
+}
+
+// ============================================================================
+// Scaffolding (mirrors me_action_item_receipt_chain.rs)
+// ============================================================================
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+struct Harness {
+    ctx: GovernanceContext<NoopEventEmitter>,
+    receipts: Arc<TestReceiptStore>,
+}
+
+fn make_harness() -> Harness {
+    let receipts = Arc::new(TestReceiptStore::default());
+    let manager = GovernanceManager::new()
+        .with_receipt_store(receipts.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let ctx = GovernanceContext {
+        manager: Arc::new(manager),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        mandate_gate: None,
+        build_mode: http::GovernanceContextBuildMode::Test,
+    };
+    Harness { ctx, receipts }
+}
+
+async fn seed_domain_with_member(
+    mgr: &GovernanceManager,
+    member: &Did,
+    domain_id: &str,
+) -> GovernanceDomainId {
+    let domain = GovernanceDomainId::new(domain_id);
+    mgr.create_domain(
+        domain.clone(),
+        "Test Coop".to_string(),
+        "default".to_string(),
+        GovernanceParams {
+            quorum_percentage: 1,
+            approval_threshold_percentage: 51,
+            voting_period_seconds: 86_400,
+            require_deliberation: false,
+            ..GovernanceParams::default()
+        },
+        MembershipConfig {
+            source: MembershipSource::StaticList(vec![member.clone()]),
+        },
+    )
+    .await
+    .expect("create_domain");
+    domain
+}
+
+/// Build an actix app for the governance routes, injecting `BasicClaims`
+/// for `caller` with the `governance:write` scope (the same scope the
+/// action-item write surface requires).
+macro_rules! gate_app {
+    ($ctx:expr, $caller:expr) => {{
+        use actix_web::dev::Service as _;
+        use actix_web::HttpMessage as _;
+        let caller = $caller.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some("governance:write".to_string()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+fn gate_results_uri(domain_id: &str, session_id: &str) -> String {
+    format!("/domains/{domain_id}/process-sessions/{session_id}/gate-results")
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[actix_web::test]
+async fn record_process_gate_result_route_persists_and_returns_receipt() {
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&h.ctx.manager, &caller, "test-coop").await;
+    let session_id = "session-http-001";
+
+    let app = gate_app!(h.ctx.clone(), &caller);
+    let req = test::TestRequest::post()
+        .uri(&gate_results_uri(&domain.0, session_id))
+        .set_json(serde_json::json!({
+            "gate_kind": "privacy_review",
+            "result": "pass",
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "POST gate-results must mount and succeed; body: {}",
+        String::from_utf8_lossy(&bytes)
+    );
+
+    let receipt: ProcessGateResultReceipt =
+        serde_json::from_slice(&bytes).expect("response body is a ProcessGateResultReceipt");
+
+    // Returned fields match the request + authenticated caller.
+    assert_eq!(receipt.session_id, session_id);
+    assert_eq!(receipt.domain_id, domain.0);
+    assert_eq!(receipt.gate_kind, ProcessGateKind::PrivacyReview);
+    assert_eq!(receipt.result, ProcessGateResult::Pass);
+    assert_eq!(receipt.recorded_by, caller.to_string());
+    assert_ne!(
+        receipt.record_hash, [0u8; 32],
+        "record_hash must be a real blake3 binding, not a zero placeholder"
+    );
+
+    // Deterministic: the returned record_hash binds exactly the returned fields.
+    let expected = ProcessGateResultReceipt::compute_record_hash(
+        &receipt.session_id,
+        &receipt.domain_id,
+        receipt.gate_kind,
+        receipt.result,
+        &receipt.recorded_by,
+        receipt.recorded_at,
+    );
+    assert_eq!(
+        receipt.record_hash, expected,
+        "record_hash must equal compute_record_hash over the returned fields"
+    );
+
+    // Persisted through the HTTP path: the wired backend captured it and a
+    // (session_id, gate_kind) lookup returns the same receipt.
+    let latest = h
+        .receipts
+        .get_latest_process_gate_result(session_id, ProcessGateKind::PrivacyReview)
+        .expect("lookup")
+        .expect("a receipt must be persisted before the route responds");
+    assert_eq!(latest.record_hash, receipt.record_hash);
+}
+
+#[actix_web::test]
+async fn record_process_gate_result_route_rejects_non_member() {
+    // The domain exists and has a member, but the authenticated caller is
+    // NOT that member. The route must reuse the existing domain-membership
+    // gate and return 403 without persisting a receipt.
+    let h = make_harness();
+    let member = fresh_did();
+    let outsider = fresh_did();
+    assert_ne!(member, outsider);
+    let domain = seed_domain_with_member(&h.ctx.manager, &member, "test-coop").await;
+
+    let app = gate_app!(h.ctx.clone(), &outsider);
+    let req = test::TestRequest::post()
+        .uri(&gate_results_uri(&domain.0, "session-http-403"))
+        .set_json(serde_json::json!({
+            "gate_kind": "scope_confirmation",
+            "result": "pass",
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-member must be rejected by the existing domain-membership gate"
+    );
+    assert_eq!(
+        h.receipts.total_count(),
+        0,
+        "no receipt may be persisted when authorization fails"
+    );
+}
+
+#[actix_web::test]
+async fn record_process_gate_result_route_rejects_unknown_result() {
+    // A malformed `result` value must be rejected by JSON deserialization
+    // (400), never coerced — the result taxonomy is closed.
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&h.ctx.manager, &caller, "test-coop").await;
+
+    let app = gate_app!(h.ctx.clone(), &caller);
+    let req = test::TestRequest::post()
+        .uri(&gate_results_uri(&domain.0, "session-http-400"))
+        .set_json(serde_json::json!({
+            "gate_kind": "privacy_review",
+            "result": "maybe",
+        }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "an out-of-taxonomy result must be a 400, not silently accepted"
+    );
+    let _ = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(h.receipts.total_count(), 0);
+}


### PR DESCRIPTION
## What

Mounts the existing `ProcessGateResultReceipt` runtime slice over one governance HTTP route:

```
POST /gov/domains/{domain_id}/process-sessions/{session_id}/gate-results
body: { "gate_kind": "...", "result": "pass" | "fail" }
```

The handler records a typed process gate result through `GovernanceManager::record_process_gate_result` and returns the persisted receipt (whose deterministic blake3 `record_hash` is the verification evidence).

## Why

#2144 asked for the smallest runtime path from a process gate result to verifiable receipt evidence. The receipt type (`ProcessGateResultReceipt`, ADR-0026 Layer 2), the manager method, and the receipt-store `"process_gate_result"` record kind already existed and are proven at the manager layer (`process_gate_result_receipt_runtime_slice.rs`). The missing piece was an HTTP surface that actually drives it.

## Scope

- Adds `RecordProcessGateResultRequest` (typed `icn_governance` enums; out-of-taxonomy values rejected by deserialization → 400)
- Adds the `record_process_gate_result` HTTP handler — composes the **existing** `governance:write` scope + `check_domain_membership` gates (no authorization decision changed)
- Mounts one governance route
- Adds an integration test proving route → manager → persisted receipt (happy path 200 + deterministic `record_hash`; non-member → 403; bad result → 400)
- Regenerates the route inventory (`--check` converges; governance candidates 80 → 81)

Route shape uses `process-sessions/{session_id}` because the manager keys results by `(session_id, gate_kind)` where `gate_kind` is a closed enum — not a free-form id.

## Non-claims

This does **not** implement a workflow engine, complete the Institutional Process Substrate, change auth decisions, implement `InstitutionalDomain`/`DomainPolicy` (#2142), implement storage governance (#2143), or imply production / pilot / organizer / federation readiness.

`docs/STATE.md` and `docs/PHASE_PROGRESS.md` are intentionally not edited here — their sync blocks are post-merge truth-sync artifacts written against `origin/main`.

## Issue link — Refs #2144 (not a close)

Satisfies #2144 acceptance criteria 1, 2, 4 (a runtime transition emits a verifiable, ADR-0026-compatible receipt; the response is repo-safe; tests demonstrate the slice). The one residual is the scope's `→ EvidencePacket export` step: this slice returns the receipt **inline** in the HTTP response rather than producing a distinct EvidencePacket-export artifact. Linked as `Refs` so the maintainer can decide whether the inline repo-safe receipt response closes #2144 or whether a follow-up EvidencePacket-export slice is wanted.

## Tests

```
cargo test -p icn-governance-actor --test process_gate_result_http_route   # 3 passed
cargo fmt -p icn-governance-actor -- --check                               # clean
cargo clippy -p icn-governance-actor --all-targets -- -D warnings          # 0 warnings
cargo test -p icn-governance-actor                                         # 29 suites ok, 0 failed
cargo check --workspace                                                     # gateway/daemon compile
python3 docs/scripts/route_inventory.py --check                             # converges
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)