### PR TITLE
feat(kernel-api): wire storage access validation

### DIFF
--- a/docs/state/storage-governance-spec.md
+++ b/docs/state/storage-governance-spec.md
@@ -1,7 +1,7 @@
 # Storage is Governance — ICN Storage Specification
 
 **Issue**: [#1131](https://github.com/InterCooperative-Network/icn/issues/1131)
-**Status**: Core types implemented; StorageSpec and validate_storage_access() not yet present
+**Status**: Implemented — `StorageClass`, `DataLocality`, `StorageSpec`, and `validate_storage_access()` are present; the canonical-output rule is enforced at the compute task-validation boundary (#2143)
 **Date**: 2026-03-22
 
 ## Thesis
@@ -83,21 +83,27 @@ Three error variants encode the governance violations the system can detect:
   `CellLocal` data accessed by a `FederationMirrored` task. This is the highest-risk
   locality violation (federation-scope task reaching into local-only data).
 
-### Implementation Gap (as of Sprint 23)
+### Enforcement Layer (#2143)
 
-The task brief for s23-t7 anticipated two additional types:
+Two callable items complete the enforcement path in `storage.rs`:
 
-- `StorageSpec` — A composite struct combining `StorageClass` and `DataLocality` into a
-  single constraint that could be attached to compute tasks.
-- `validate_storage_access()` — A free function to enforce storage governance at the
-  kernel boundary, returning `Result<(), StorageValidationError>`.
+- `StorageSpec` — A composite struct pairing `StorageClass` and `DataLocality`. A generic
+  custody/runtime policy shape with no domain meaning.
+- `validate_storage_access(task: StorageSpec, data: StorageSpec, canonical_output: bool)
+  -> Result<(), StorageValidationError>` — the free function that enforces storage
+  governance at the kernel boundary, mapping violations onto the existing error variants:
+  - `canonical_output` with a non-canonical `task.class` → `CanonicalTaskNonCanonicalStorage`
+  - `task.locality` cannot access `data.locality` → `LocalityAccessViolation`, with the
+    `FederationMirrored`-task / `CellLocal`-data case reported as `CellLocalFederationViolation`.
 
-Neither is present in the current `storage.rs`. The error variants exist but are not
-wired to any enforcement function. This means the error taxonomy is defined but not
-yet callable at the kernel boundary.
-
-**Required follow-up**: Implement `StorageSpec` and `validate_storage_access()` to
-complete the enforcement path. The error types and semantics are already correct.
+The error taxonomy is now callable. The first runtime caller is `ComputeTask::validate()`
+(`icn-compute`), which builds a `StorageSpec` from the task's declared `storage_class` /
+`data_locality` and rejects a Canonical-determinism task that declares a non-Canonical
+storage class — reached live through `ComputeActor::handle_submit`. On that self-validation
+path `task` and `data` are the same spec, so the locality check is the degenerate
+equal-spec case and only the canonical-output rule fires; the cross-locality access rules
+(`LocalityAccessViolation` / `CellLocalFederationViolation`) are enforced wherever a caller
+supplies a task spec and a distinct data spec, and are covered by the kernel unit tests.
 
 ## Governance Semantics
 
@@ -126,17 +132,17 @@ coop-internal state.
 
 ## Relationship to P0 Completion
 
-This spec closes the documentation gap for issue #1131. The `StorageClass` and
-`DataLocality` types were implemented as part of the Meaning Firewall arc (Sprints
-19-22). The `StorageSpec` and `validate_storage_access()` function referenced in the
-original issue acceptance criteria are not yet implemented — they are a remaining
-follow-up. This document provides the written specification that makes the existing
-implementation's governance intent legible, and identifies the outstanding gap.
+This spec documents issue #1131. The `StorageClass` and `DataLocality` types were
+implemented as part of the Meaning Firewall arc (Sprints 19-22). The `StorageSpec` and
+`validate_storage_access()` function referenced in the original issue acceptance criteria
+are now implemented (#2143) and callable, with the canonical-output rule enforced on the
+compute task-validation path.
 
 ## Sprint 23 Notes
 
 This task (s23-t7) is independent of s23-t5 (CRDT) and s23-t6 (ContainerRuntime).
-The `StorageClass` and `DataLocality` implementation is complete with full test coverage
-(21 tests covering ordering, access rules, serde roundtrips, and error display).
-`StorageSpec` and `validate_storage_access()` remain to be implemented to complete
-the acceptance criteria from the original issue.
+The `StorageClass` and `DataLocality` implementation is complete with full test coverage.
+`StorageSpec` and `validate_storage_access()` are now implemented (#2143) with unit tests
+covering the default spec, serde roundtrip, and all three `StorageValidationError`
+variants, plus compute-side tests proving the canonical-output rule rejects through
+`ComputeTask::validate()` and the live `handle_submit` path.

--- a/icn/crates/icn-compute/src/actor/tests.rs
+++ b/icn/crates/icn-compute/src/actor/tests.rs
@@ -86,6 +86,30 @@ async fn test_submit_low_trust_rejected() {
 }
 
 #[tokio::test]
+async fn test_submit_rejects_canonical_task_with_non_canonical_storage() {
+    use icn_kernel_api::storage::StorageClass;
+    // Trust is above the submit threshold, so the only rejection reason is
+    // storage validation at the live handle_submit chokepoint (#2143).
+    let trust_cb: TrustCallback = Arc::new(|_| 0.5);
+    let actor = ComputeActor::new("did:icn:executor".into(), trust_cb);
+    let handle = actor.spawn();
+
+    let mut task = make_task("task-storage-canonical", "did:icn:alice");
+    // Canonical determinism (default) writing outputs to non-Canonical storage.
+    task.storage_class = Some(StorageClass::ServiceState);
+
+    let err = handle.submit(task).await.unwrap_err();
+    assert!(
+        matches!(err, ComputeError::InvalidCode(_)),
+        "expected InvalidCode, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("Canonical"),
+        "submit must reject with the canonical-storage rule: {err}"
+    );
+}
+
+#[tokio::test]
 async fn test_gossip_message_handling() {
     let trust_cb: TrustCallback = Arc::new(|_| 0.5);
     let mut actor = ComputeActor::new("did:icn:executor".into(), trust_cb);

--- a/icn/crates/icn-compute/src/types.rs
+++ b/icn/crates/icn-compute/src/types.rs
@@ -315,8 +315,9 @@ impl ComputeTask {
         // class that can hold canonical output. Enforced through the generic
         // kernel helper `validate_storage_access`. We only check when a
         // storage_class is explicitly declared; an unset (None) class is left
-        // to placement-time defaulting, preserving prior behavior. The task
-        // validates its own declared storage, so the locality check is the
+        // unchecked here, preserving prior behavior (no enforcement on the
+        // None case). The task validates its own declared storage, so the
+        // locality check is the
         // degenerate equal-spec case here — only the canonical-output rule
         // can fire (cross-locality data access is validated where a task spec
         // is compared against a distinct data spec).

--- a/icn/crates/icn-compute/src/types.rs
+++ b/icn/crates/icn-compute/src/types.rs
@@ -310,15 +310,25 @@ impl ComputeTask {
             }
         }
 
-        // Validate storage specification fields (E4)
-        // Canonical tasks producing outputs SHOULD use StorageClass::Canonical
-        if self.determinism_class == DeterminismClass::Canonical {
-            if let Some(storage_class) = &self.storage_class {
-                if !storage_class.can_hold_canonical_output() {
-                    // This is a SHOULD, not a MUST - log warning but don't reject
-                    // The scheduler may apply stricter enforcement
-                }
-            }
+        // Validate storage specification fields (E4 / #2143).
+        // A Canonical-determinism task producing outputs MUST use a storage
+        // class that can hold canonical output. Enforced through the generic
+        // kernel helper `validate_storage_access`. We only check when a
+        // storage_class is explicitly declared; an unset (None) class is left
+        // to placement-time defaulting, preserving prior behavior. The task
+        // validates its own declared storage, so the locality check is the
+        // degenerate equal-spec case here — only the canonical-output rule
+        // can fire (cross-locality data access is validated where a task spec
+        // is compared against a distinct data spec).
+        if let Some(storage_class) = self.storage_class {
+            let spec = icn_kernel_api::storage::StorageSpec::new(
+                storage_class,
+                self.data_locality
+                    .unwrap_or(icn_kernel_api::storage::DataLocality::CellLocal),
+            );
+            let canonical_output = self.determinism_class == DeterminismClass::Canonical;
+            icn_kernel_api::storage::validate_storage_access(spec, spec, canonical_output)
+                .map_err(|e| crate::error::ComputeError::InvalidCode(e.to_string()))?;
         }
 
         // CellLocal data cannot be accessed by tasks with FederationMirrored locality
@@ -1193,9 +1203,32 @@ mod tests {
     fn test_task_with_all_storage_fields() {
         use icn_kernel_api::storage::{DataLocality, StorageClass};
         let mut task = valid_task();
+        // Advisory output may use a non-Canonical storage class (#2143:
+        // only Canonical-output tasks are constrained to Canonical storage).
+        task.determinism_class = DeterminismClass::Advisory;
         task.storage_class = Some(StorageClass::ServiceState);
         task.data_locality = Some(DataLocality::CoopReplicated);
         assert!(task.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_canonical_task_rejects_non_canonical_storage() {
+        use icn_kernel_api::storage::StorageClass;
+        // A Canonical-determinism task (the default) that declares a
+        // non-Canonical storage class for its outputs must be rejected.
+        // Previously this was a SHOULD-only no-op (#2143).
+        let mut task = valid_task();
+        assert_eq!(task.determinism_class, DeterminismClass::Canonical);
+        task.storage_class = Some(StorageClass::ServiceState);
+        let err = task.validate().unwrap_err();
+        assert!(
+            matches!(err, crate::error::ComputeError::InvalidCode(_)),
+            "expected InvalidCode, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("Canonical"),
+            "error must reference the canonical-storage rule: {err}"
+        );
     }
 
     #[test]

--- a/icn/crates/icn-kernel-api/src/lib.rs
+++ b/icn/crates/icn-kernel-api/src/lib.rs
@@ -148,7 +148,9 @@ pub use state::{
     BlobService, KvService, LogService, ObjectReplication, ReplicationPolicy, StateBackend,
     StateKey, StateOp, StateScope, StateValue,
 };
-pub use storage::{DataLocality, StorageClass, StorageValidationError};
+pub use storage::{
+    validate_storage_access, DataLocality, StorageClass, StorageSpec, StorageValidationError,
+};
 pub use time::TimeService;
 pub use version::Version;
 

--- a/icn/crates/icn-kernel-api/src/storage.rs
+++ b/icn/crates/icn-kernel-api/src/storage.rs
@@ -292,6 +292,77 @@ pub enum StorageValidationError {
 }
 
 // ============================================================================
+// Storage Specification + Access Validation (E4 / #2143)
+// ============================================================================
+
+/// A unit of storage's class and data locality, paired.
+///
+/// `StorageSpec` is the generic custody/runtime policy shape the kernel
+/// enforces. It carries no domain meaning: an app decides *why* a given
+/// class/locality applies (regulatory tier, sensitivity, replication
+/// budget); the kernel only checks the resulting generic constraints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct StorageSpec {
+    /// Storage class — mutability and replication requirements.
+    pub class: StorageClass,
+    /// Data locality — placement and access scope.
+    pub locality: DataLocality,
+}
+
+impl StorageSpec {
+    /// Construct a spec from a class and locality.
+    pub const fn new(class: StorageClass, locality: DataLocality) -> Self {
+        Self { class, locality }
+    }
+}
+
+/// Validate that a task with storage spec `task` may produce/access data
+/// with storage spec `data`.
+///
+/// Enforces the two generic storage-governance rules:
+///
+/// 1. **Canonical output ⇒ canonical storage.** A task that produces
+///    canonical output (`canonical_output == true`) must use a storage
+///    class that can hold it (`StorageClass::can_hold_canonical_output`),
+///    else [`StorageValidationError::CanonicalTaskNonCanonicalStorage`].
+/// 2. **Locality access.** A task may only access data at its own locality
+///    or wider (`task.locality.can_access(data.locality)`). The
+///    `FederationMirrored`-task / `CellLocal`-data case is reported with
+///    the dedicated [`StorageValidationError::CellLocalFederationViolation`];
+///    every other access violation is
+///    [`StorageValidationError::LocalityAccessViolation`].
+///
+/// `canonical_output` is supplied by the caller — the kernel does not infer
+/// it from any domain concept. When `task` and `data` are the same spec
+/// (a task validating its own declared storage), the locality check is the
+/// degenerate `can_access(self) == true` case and only rule 1 can fire.
+pub fn validate_storage_access(
+    task: StorageSpec,
+    data: StorageSpec,
+    canonical_output: bool,
+) -> Result<(), StorageValidationError> {
+    if canonical_output && !task.class.can_hold_canonical_output() {
+        return Err(StorageValidationError::CanonicalTaskNonCanonicalStorage {
+            actual: task.class,
+        });
+    }
+
+    if !task.locality.can_access(data.locality) {
+        if task.locality == DataLocality::FederationMirrored
+            && data.locality == DataLocality::CellLocal
+        {
+            return Err(StorageValidationError::CellLocalFederationViolation);
+        }
+        return Err(StorageValidationError::LocalityAccessViolation {
+            task_locality: task.locality,
+            data_locality: data.locality,
+        });
+    }
+
+    Ok(())
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -559,5 +630,71 @@ mod tests {
         let err = StorageValidationError::CellLocalFederationViolation;
         assert!(err.to_string().contains("CellLocal"));
         assert!(err.to_string().contains("FederationMirrored"));
+    }
+
+    // --- StorageSpec + validate_storage_access tests (#2143) ---
+
+    #[test]
+    fn test_storage_spec_default() {
+        let spec = StorageSpec::default();
+        assert_eq!(spec.class, StorageClass::ServiceState);
+        assert_eq!(spec.locality, DataLocality::CellLocal);
+    }
+
+    #[test]
+    fn test_storage_spec_serde_roundtrip() {
+        let spec = StorageSpec::new(StorageClass::Canonical, DataLocality::CoopReplicated);
+        let json = serde_json::to_string(&spec).unwrap();
+        let parsed: StorageSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, spec);
+    }
+
+    #[test]
+    fn test_validate_storage_access_ok() {
+        // Canonical output into Canonical storage, equal locality -> ok.
+        let spec = StorageSpec::new(StorageClass::Canonical, DataLocality::CellLocal);
+        assert_eq!(validate_storage_access(spec, spec, true), Ok(()));
+
+        // Non-canonical output; a narrower task may access wider data -> ok.
+        let task = StorageSpec::new(StorageClass::ServiceState, DataLocality::CellLocal);
+        let data = StorageSpec::new(StorageClass::ServiceState, DataLocality::CommonsPublic);
+        assert_eq!(validate_storage_access(task, data, false), Ok(()));
+    }
+
+    #[test]
+    fn test_validate_storage_access_rejects_canonical_output_non_canonical_storage() {
+        let task = StorageSpec::new(StorageClass::ServiceState, DataLocality::CellLocal);
+        let err = validate_storage_access(task, task, true).unwrap_err();
+        assert_eq!(
+            err,
+            StorageValidationError::CanonicalTaskNonCanonicalStorage {
+                actual: StorageClass::ServiceState,
+            }
+        );
+    }
+
+    #[test]
+    fn test_validate_storage_access_rejects_locality_access_violation() {
+        // A CoopReplicated task cannot access narrower CellLocal data.
+        let task = StorageSpec::new(StorageClass::ServiceState, DataLocality::CoopReplicated);
+        let data = StorageSpec::new(StorageClass::ServiceState, DataLocality::CellLocal);
+        let err = validate_storage_access(task, data, false).unwrap_err();
+        assert_eq!(
+            err,
+            StorageValidationError::LocalityAccessViolation {
+                task_locality: DataLocality::CoopReplicated,
+                data_locality: DataLocality::CellLocal,
+            }
+        );
+    }
+
+    #[test]
+    fn test_validate_storage_access_federation_task_cell_local_data_is_specific_variant() {
+        // A FederationMirrored task accessing CellLocal data uses the
+        // dedicated variant, not the generic LocalityAccessViolation.
+        let task = StorageSpec::new(StorageClass::ServiceState, DataLocality::FederationMirrored);
+        let data = StorageSpec::new(StorageClass::ServiceState, DataLocality::CellLocal);
+        let err = validate_storage_access(task, data, false).unwrap_err();
+        assert_eq!(err, StorageValidationError::CellLocalFederationViolation);
     }
 }


### PR DESCRIPTION
## What

Implements the storage-governance enforcement slice from #2143:

- adds `StorageSpec` (a composite `{ class, locality }` — generic custody/runtime policy shape)
- adds `validate_storage_access(task, data, canonical_output) -> Result<(), StorageValidationError>`
- wires validation into the existing compute task-validation path (`ComputeTask::validate()`, reached live via `ComputeActor::handle_submit`)
- makes the canonical/non-canonical and locality violations reachable through the existing `StorageValidationError` variants
- updates the storage-governance spec status

## Why

`StorageClass`, `DataLocality`, and `StorageValidationError` existed, but `docs/state/storage-governance-spec.md` (#1131) named `StorageSpec` and `validate_storage_access()` as the missing **callable** enforcement layer — the error taxonomy was defined but not reachable. This turns that taxonomy into an actual boundary check, and turns the previous canonical-output **SHOULD-only no-op** in `ComputeTask::validate()` into a real, fail-closed rejection.

## How / scope

- `icn-kernel-api/src/storage.rs`: `StorageSpec` + `validate_storage_access()`; re-exported from `lib.rs`.
- `icn-compute/src/types.rs`: `validate()` builds a `StorageSpec` from the task's declared `storage_class`/`data_locality` and enforces the canonical-output rule. Fires **only when `storage_class` is explicitly declared**, preserving the prior `None`-default behavior. On this self-validation path `task == data`, so the locality check is the degenerate equal-spec case and only the canonical rule fires.
- The cross-locality access rules (`LocalityAccessViolation` / `CellLocalFederationViolation`) apply wherever a caller supplies a task spec and a **distinct** data spec; they are covered by the kernel unit tests.

## Meaning firewall

`canonical_output` is **caller-supplied**, not inferred from any domain concept. No domain types or thresholds enter `icn-kernel-api`. The kernel enforces generic constraints blindly.

## Non-claims

Does not redesign storage, implement encrypted/distributed/backup/archive storage, ArtifactRegistry, ScopedVault, federation/commons compute rollout, change auth, implement InstitutionalDomain/DomainPolicy, or imply production/pilot readiness. `docs/STATE.md` / `docs/PHASE_PROGRESS.md` are intentionally not edited (post-merge truth-sync artifacts).

## Tests

```
cargo fmt -p icn-kernel-api -p icn-compute -- --check        # clean
cargo test -p icn-kernel-api --lib                            # 615 passed (incl. 28 storage)
cargo test -p icn-compute                                     # 364 unit + 60 integration, 0 failed
cargo clippy -p icn-kernel-api -p icn-compute --all-targets -- -D warnings   # 0 warnings
cargo check --workspace                                       # Finished
```

New tests: kernel unit tests make all three `StorageValidationError` variants reachable through `validate_storage_access`; an `icn-compute` unit test and an actor-submit test prove the canonical-output rule rejects through `ComputeTask::validate()` and the live `handle_submit` path.

Closes #2143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)