### PR TITLE
feat(governance): add domain policy adoption manager seam

### DIFF
--- a/icn/apps/governance/src/domain_policy_adoption.rs
+++ b/icn/apps/governance/src/domain_policy_adoption.rs
@@ -123,11 +123,69 @@ pub fn adopt_domain_policy_gated(
         .map_err(AdoptDomainPolicyError::Core)
 }
 
+/// Error from the [`GovernanceManager`](crate::manager::GovernanceManager)
+/// domain-policy adoption seam.
+#[derive(Debug)]
+pub enum DomainPolicyAdoptionError {
+    /// The manager has no receipt/grant backend wired, so authority cannot be
+    /// resolved. Fail closed — a manager that cannot resolve authority must
+    /// never allow adoption.
+    MissingReceiptBackend,
+    /// The gated adoption was refused (unauthorized, backend read failure, or
+    /// pure-core structural rejection).
+    Gated(AdoptDomainPolicyError),
+}
+
+impl std::fmt::Display for DomainPolicyAdoptionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingReceiptBackend => write!(
+                f,
+                "domain policy adoption fail-closed: no receipt backend wired"
+            ),
+            Self::Gated(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for DomainPolicyAdoptionError {}
+
+impl crate::manager::GovernanceManager {
+    /// Adopt `policy` as `domain`'s current policy, resolving authority through
+    /// this manager's wired [`GovernanceReceiptBackend`] and the app-side
+    /// [`DefaultMandateGate`].
+    ///
+    /// Fails closed with [`DomainPolicyAdoptionError::MissingReceiptBackend`]
+    /// when no backend is wired; otherwise delegates to
+    /// [`adopt_domain_policy_gated`], mutating the caller-held `domain` only on
+    /// success and returning the adopted [`DomainPolicyRef`].
+    ///
+    /// **Persistence note:** there is no `InstitutionalDomain` store yet, so
+    /// this seam operates on a caller-held domain; durable persistence of the
+    /// adopted policy is a later manager/domain-store lane. This method adds no
+    /// HTTP surface and changes no auth model — it composes the existing gate
+    /// and the pure-core structural commit behind the governance-app boundary.
+    pub fn adopt_domain_policy(
+        &self,
+        domain: &mut InstitutionalDomain,
+        policy: &DomainPolicy,
+        actor: &Did,
+        now: Timestamp,
+    ) -> Result<DomainPolicyRef, DomainPolicyAdoptionError> {
+        let backend = self
+            .receipt_backend()
+            .ok_or(DomainPolicyAdoptionError::MissingReceiptBackend)?;
+        adopt_domain_policy_gated(backend, domain, policy, actor, now)
+            .map_err(DomainPolicyAdoptionError::Gated)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
 
     use super::*;
+    use crate::manager::GovernanceManager;
     use crate::mandate_gate::MandateRejection;
     use icn_governance::{
         AuthorityClass, AuthorityGrant, AuthorityGrantId, BootstrapEntityType, DecisionProvenance,
@@ -405,6 +463,142 @@ mod tests {
         assert!(matches!(
             err,
             AdoptDomainPolicyError::Core(InstitutionalDomainError::PolicyForOtherDomain)
+        ));
+        assert!(domain.current_policy().is_none());
+    }
+
+    // ----- GovernanceManager seam tests -------------------------------------
+
+    fn manager_with(backend: Arc<TestBackend>) -> GovernanceManager {
+        GovernanceManager::new().with_receipt_store(backend)
+    }
+
+    #[test]
+    fn manager_adoption_succeeds_with_active_grant() {
+        let actor = did(1);
+        let gid = AuthorityGrantId::new();
+        let grant = adopt_grant(actor.clone(), "coop-alpha", gid.clone());
+        let mandate = backing_mandate(gid);
+        let manager = manager_with(TestBackend::new(vec![mandate], vec![grant]));
+
+        let mut domain = coop_alpha();
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+
+        let adopted = manager
+            .adopt_domain_policy(&mut domain, &policy, &actor, 100)
+            .expect("an active domain-scoped grant authorizes adoption via the manager");
+        assert_eq!(adopted, policy.policy_ref());
+        assert_eq!(domain.current_policy(), Some(&policy.policy_ref()));
+    }
+
+    #[test]
+    fn manager_adoption_fails_closed_without_receipt_backend() {
+        // A manager that cannot resolve authority must never silently allow.
+        let manager = GovernanceManager::new();
+        let mut domain = coop_alpha();
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+
+        let err = manager
+            .adopt_domain_policy(&mut domain, &policy, &did(1), 100)
+            .expect_err("a manager with no receipt backend must fail closed");
+        assert!(matches!(
+            err,
+            DomainPolicyAdoptionError::MissingReceiptBackend
+        ));
+        assert!(domain.current_policy().is_none());
+    }
+
+    #[test]
+    fn manager_adoption_rejects_wrong_actor() {
+        let gid = AuthorityGrantId::new();
+        let grant = adopt_grant(did(1), "coop-alpha", gid.clone());
+        let mandate = backing_mandate(gid);
+        let manager = manager_with(TestBackend::new(vec![mandate], vec![grant]));
+
+        let mut domain = coop_alpha();
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+
+        let err = manager
+            .adopt_domain_policy(&mut domain, &policy, &did(2), 100)
+            .expect_err("an actor with no authorizing grant must be refused");
+        assert!(matches!(
+            err,
+            DomainPolicyAdoptionError::Gated(AdoptDomainPolicyError::Unauthorized(
+                MandateGateError::Rejected(MandateRejection::NoMandate)
+            ))
+        ));
+        assert!(domain.current_policy().is_none());
+    }
+
+    #[test]
+    fn manager_adoption_rejects_wrong_domain() {
+        let actor = did(1);
+        let gid = AuthorityGrantId::new();
+        // Grant bound to coop-beta; adoption target is coop-alpha.
+        let grant = adopt_grant(actor.clone(), "coop-beta", gid.clone());
+        let mandate = backing_mandate(gid);
+        let manager = manager_with(TestBackend::new(vec![mandate], vec![grant]));
+
+        let mut domain = coop_alpha();
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+
+        let err = manager
+            .adopt_domain_policy(&mut domain, &policy, &actor, 100)
+            .expect_err("a grant scoped to another domain must be refused");
+        assert!(matches!(
+            err,
+            DomainPolicyAdoptionError::Gated(AdoptDomainPolicyError::Unauthorized(
+                MandateGateError::Rejected(MandateRejection::WrongTarget)
+            ))
+        ));
+        assert!(domain.current_policy().is_none());
+    }
+
+    #[test]
+    fn manager_adoption_rejects_revoked_authority() {
+        let actor = did(1);
+        let gid = AuthorityGrantId::new();
+        let grant = adopt_grant(actor.clone(), "coop-alpha", gid.clone());
+        let mut mandate = backing_mandate(gid);
+        mandate.status = MandateStatus::Revoked;
+        let manager = manager_with(TestBackend::new(vec![mandate], vec![grant]));
+
+        let mut domain = coop_alpha();
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+
+        let err = manager
+            .adopt_domain_policy(&mut domain, &policy, &actor, 100)
+            .expect_err("a revoked backing mandate must be refused");
+        assert!(matches!(
+            err,
+            DomainPolicyAdoptionError::Gated(AdoptDomainPolicyError::Unauthorized(
+                MandateGateError::Rejected(MandateRejection::Revoked)
+            ))
+        ));
+        assert!(domain.current_policy().is_none());
+    }
+
+    #[test]
+    fn manager_adoption_preserves_pure_core_defense_in_depth() {
+        // Gate authorizes the actor for coop-alpha, but the policy is authored
+        // for coop-beta: the pure-core structural check must still reject it.
+        let actor = did(1);
+        let gid = AuthorityGrantId::new();
+        let grant = adopt_grant(actor.clone(), "coop-alpha", gid.clone());
+        let mandate = backing_mandate(gid);
+        let manager = manager_with(TestBackend::new(vec![mandate], vec![grant]));
+
+        let mut domain = coop_alpha();
+        let foreign_policy = DomainPolicy::new(domain_id("coop-beta"), b"policy v1");
+
+        let err = manager
+            .adopt_domain_policy(&mut domain, &foreign_policy, &actor, 100)
+            .expect_err("a policy authored for another domain must be refused by the core check");
+        assert!(matches!(
+            err,
+            DomainPolicyAdoptionError::Gated(AdoptDomainPolicyError::Core(
+                InstitutionalDomainError::PolicyForOtherDomain
+            ))
         ));
         assert!(domain.current_policy().is_none());
     }

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -2841,6 +2841,16 @@ impl GovernanceManager {
         self
     }
 
+    /// Clone the attached receipt/grant backend, if one is wired.
+    ///
+    /// Used by the domain-policy adoption seam
+    /// ([`crate::domain_policy_adoption`]) to resolve authority through
+    /// `DefaultMandateGate`. Returns `None` when no backend is wired — callers
+    /// that resolve authority must fail closed in that case.
+    pub(crate) fn receipt_backend(&self) -> Option<Arc<dyn GovernanceReceiptBackend>> {
+        self.receipt_store.clone()
+    }
+
     /// Replace the structure store backend.
     ///
     /// Use this to configure Sled-backed persistent storage for structures.


### PR DESCRIPTION
## What

Adds a `GovernanceManager` seam for gated `DomainPolicy` adoption — the app-boundary entry point for the authority-resolved adoption added in #2164. **No HTTP route** (that is the next lane).

- `GovernanceManager::adopt_domain_policy(&self, &mut InstitutionalDomain, &DomainPolicy, &Did, now)` resolves authority through this manager's wired `GovernanceReceiptBackend` + the **real** `DefaultMandateGate` (via `adopt_domain_policy_gated`), then commits through pure-core `InstitutionalDomain::adopt_policy` as defense-in-depth.
- **Fails closed** with `DomainPolicyAdoptionError::MissingReceiptBackend` when no backend is wired — a manager that cannot resolve authority must never allow adoption; otherwise wraps the gated outcome in `DomainPolicyAdoptionError::Gated`.
- Adds a tiny `pub(crate)` `GovernanceManager::receipt_backend()` accessor.

## Why

The #2142 step after #2164 is to connect the pure `InstitutionalDomain` / `DomainPolicy` root and the app-side MandateGate resolver to the governance application boundary. This keeps HTTP routing separate and lets the manager behavior be tested first.

## Details

- calls `adopt_domain_policy_gated(...)` (no resolver logic duplicated)
- fails closed when the receipt/grant authority resolver is not wired
- preserves pure-core `InstitutionalDomain::adopt_policy()` as defense-in-depth
- does not add a route; `icn-governance` pure-core unchanged

**Persistence note:** there is no `InstitutionalDomain` store yet, so the seam operates on a caller-held domain (`&mut InstitutionalDomain`); durable persistence of the adopted policy is a later manager/domain-store lane.

## Non-claims

This does not complete #2142, add an HTTP surface, wire durable `InstitutionalDomain` persistence, implement CCL runtime, implement a full policy registry, implement a service-binding runtime, perform an auth cutover, perform entity-aware auth enforcement, activate institution packages, or imply production / pilot / organizer / federation readiness.

## Tests

```
cargo test -p icn-governance-actor domain_policy_adoption   # 13 passed; 0 failed (7 helper + 6 manager-seam)
cargo test -p icn-governance-actor mandate_gate             # 25 passed; 0 failed (regression)
cargo test -p icn-governance institutional_domain           # 14 passed; 0 failed (pure-core regression)
cargo fmt --all --check                                     # rc=0
cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings  # rc=0
cargo check --workspace                                     # rc=0
python3 .github/scripts/firewall_denylist.py                # No NEW firewall violations
python3 docs/scripts/doc_control_check.py                   # OK (886 docs)
python3 docs/scripts/route_inventory.py --check             # OK (no new routes)
ops/scripts/drift-check.sh                                   # PASS
```

The 6 manager-seam tests run over the real `DefaultMandateGate` + a seeded backend: success with an active domain-scoped adopt grant; fail-closed with no receipt backend; rejection for wrong actor and wrong domain; rejection for a revoked backing mandate; and pure-core defense-in-depth (gate authorizes, but the policy targets a different domain).

Refs #2142.
