### PR TITLE
feat(governance): persist institutional domain state

### DIFF
--- a/icn/apps/governance/src/domain_policy_adoption.rs
+++ b/icn/apps/governance/src/domain_policy_adoption.rs
@@ -155,7 +155,7 @@ impl std::error::Error for DomainPolicyAdoptionError {}
 /// (`declare_institutional_domain` / `adopt_domain_policy_persisted`).
 #[derive(Debug)]
 pub enum InstitutionalDomainStoreError {
-    /// No [`GovernanceStateStore`] is wired, so the `InstitutionalDomain` record
+    /// No [`crate::GovernanceStateStore`] is wired, so the `InstitutionalDomain` record
     /// cannot be loaded or persisted. Fail closed.
     MissingDomainStore,
     /// `declare`: an `InstitutionalDomain` is already declared for this
@@ -227,7 +227,7 @@ impl crate::manager::GovernanceManager {
     }
 
     /// Declare and persist a new [`InstitutionalDomain`] authority record for an
-    /// existing `GovernanceDomainId`, via the wired [`GovernanceStateStore`].
+    /// existing `GovernanceDomainId`, via the wired [`crate::GovernanceStateStore`].
     ///
     /// Fails closed with [`InstitutionalDomainStoreError::MissingDomainStore`]
     /// when no store is wired, and with [`InstitutionalDomainStoreError::AlreadyDeclared`]
@@ -278,6 +278,20 @@ impl crate::manager::GovernanceManager {
     /// declared), [`InstitutionalDomainStoreError::Adopt`] (gate/structural
     /// rejection — state left unchanged, nothing saved), or
     /// [`InstitutionalDomainStoreError::Store`] (backend read/write error).
+    ///
+    /// # Concurrency
+    ///
+    /// The `load → mutate → save` sequence is **not atomic** and has no
+    /// per-domain serialization. With the current callers (in-process tests;
+    /// **no HTTP route or concurrent caller exists yet** — that is the deferred
+    /// next lane, see `docs/spec/institutional-domain.md`) there is no
+    /// concurrent access, so no update can be lost. **Before** this seam is
+    /// exposed to concurrent callers (an HTTP adoption route), the route lane
+    /// must add per-domain serialization (an in-process lock keyed by
+    /// `GovernanceDomainId`) and/or an atomic store primitive
+    /// (e.g. a transactional `get`+`put`), or two concurrent adoptions could
+    /// last-writer-win and drop an intervening `current_policy` update. This is
+    /// recorded as a prerequisite for the route lane, not fixed here.
     pub fn adopt_domain_policy_persisted(
         &self,
         domain_id: &GovernanceDomainId,

--- a/icn/apps/governance/src/domain_policy_adoption.rs
+++ b/icn/apps/governance/src/domain_policy_adoption.rs
@@ -31,7 +31,8 @@ use std::sync::Arc;
 
 use icn_governance::Timestamp;
 use icn_governance::{
-    DomainPolicy, DomainPolicyRef, InstitutionalDomain, InstitutionalDomainError,
+    BootstrapEntityType, CharterId, DomainPolicy, DomainPolicyRef, GovernanceDomainId,
+    InstitutionalDomain, InstitutionalDomainError,
 };
 use icn_identity::Did;
 
@@ -150,6 +151,52 @@ impl std::fmt::Display for DomainPolicyAdoptionError {
 
 impl std::error::Error for DomainPolicyAdoptionError {}
 
+/// Error from the persisted `InstitutionalDomain` manager operations
+/// (`declare_institutional_domain` / `adopt_domain_policy_persisted`).
+#[derive(Debug)]
+pub enum InstitutionalDomainStoreError {
+    /// No [`GovernanceStateStore`] is wired, so the `InstitutionalDomain` record
+    /// cannot be loaded or persisted. Fail closed.
+    MissingDomainStore,
+    /// `declare`: an `InstitutionalDomain` is already declared for this
+    /// `GovernanceDomainId`.
+    AlreadyDeclared,
+    /// `adopt`: no `InstitutionalDomain` has been declared for this
+    /// `GovernanceDomainId`.
+    NotDeclared,
+    /// The backing store returned an error — including the fail-closed default
+    /// for a `GovernanceStateStore` that does not implement institutional-domain
+    /// persistence.
+    Store(String),
+    /// The gated adoption itself was refused (delegated to
+    /// [`crate::manager::GovernanceManager::adopt_domain_policy`]).
+    Adopt(DomainPolicyAdoptionError),
+}
+
+impl std::fmt::Display for InstitutionalDomainStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingDomainStore => write!(
+                f,
+                "institutional domain persistence fail-closed: no governance state store wired"
+            ),
+            Self::AlreadyDeclared => {
+                write!(
+                    f,
+                    "institutional domain already declared for this domain id"
+                )
+            }
+            Self::NotDeclared => {
+                write!(f, "no institutional domain declared for this domain id")
+            }
+            Self::Store(e) => write!(f, "institutional domain store error: {e}"),
+            Self::Adopt(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for InstitutionalDomainStoreError {}
+
 impl crate::manager::GovernanceManager {
     /// Adopt `policy` as `domain`'s current policy, resolving authority through
     /// this manager's wired [`GovernanceReceiptBackend`] and the app-side
@@ -177,6 +224,86 @@ impl crate::manager::GovernanceManager {
             .ok_or(DomainPolicyAdoptionError::MissingReceiptBackend)?;
         adopt_domain_policy_gated(backend, domain, policy, actor, now)
             .map_err(DomainPolicyAdoptionError::Gated)
+    }
+
+    /// Declare and persist a new [`InstitutionalDomain`] authority record for an
+    /// existing `GovernanceDomainId`, via the wired [`GovernanceStateStore`].
+    ///
+    /// Fails closed with [`InstitutionalDomainStoreError::MissingDomainStore`]
+    /// when no store is wired, and with [`InstitutionalDomainStoreError::AlreadyDeclared`]
+    /// when a record already exists for `domain_id`. The declared domain is
+    /// unbound (`current_policy == None`) until a later adoption.
+    ///
+    /// **Authority note:** declaring a governed domain is itself an
+    /// authority-bearing act. This MVP seam does **not** yet mandate-gate
+    /// `declare` (a flagged sub-question in the ADR-0083 persistence addendum);
+    /// it must not be exposed on a routable surface until that gate lands. No
+    /// HTTP route is added here.
+    pub fn declare_institutional_domain(
+        &self,
+        domain_id: GovernanceDomainId,
+        owning_entity_class: BootstrapEntityType,
+        charter_ref: Option<CharterId>,
+    ) -> Result<InstitutionalDomain, InstitutionalDomainStoreError> {
+        let store = self
+            .domain_state_store()
+            .ok_or(InstitutionalDomainStoreError::MissingDomainStore)?;
+
+        if store
+            .get_institutional_domain(&domain_id)
+            .map_err(|e| InstitutionalDomainStoreError::Store(e.to_string()))?
+            .is_some()
+        {
+            return Err(InstitutionalDomainStoreError::AlreadyDeclared);
+        }
+
+        let mut domain = InstitutionalDomain::declare(domain_id, owning_entity_class);
+        if let Some(charter) = charter_ref {
+            domain = domain.with_charter(charter);
+        }
+        store
+            .save_institutional_domain(&domain)
+            .map_err(|e| InstitutionalDomainStoreError::Store(e.to_string()))?;
+        Ok(domain)
+    }
+
+    /// Adopt `policy` as the current policy of a **persisted**
+    /// [`InstitutionalDomain`], loading it by `domain_id`, resolving authority
+    /// through the existing gate, and saving the mutated record on success.
+    ///
+    /// Composes the existing pieces — it does **not** bypass the gate:
+    /// `load → adopt_domain_policy (real DefaultMandateGate + pure-core commit)
+    /// → save`. Fails closed with [`InstitutionalDomainStoreError::MissingDomainStore`]
+    /// (no store), [`InstitutionalDomainStoreError::NotDeclared`] (domain never
+    /// declared), [`InstitutionalDomainStoreError::Adopt`] (gate/structural
+    /// rejection — state left unchanged, nothing saved), or
+    /// [`InstitutionalDomainStoreError::Store`] (backend read/write error).
+    pub fn adopt_domain_policy_persisted(
+        &self,
+        domain_id: &GovernanceDomainId,
+        policy: &DomainPolicy,
+        actor: &Did,
+        now: Timestamp,
+    ) -> Result<DomainPolicyRef, InstitutionalDomainStoreError> {
+        let store = self
+            .domain_state_store()
+            .ok_or(InstitutionalDomainStoreError::MissingDomainStore)?;
+
+        let mut domain = store
+            .get_institutional_domain(domain_id)
+            .map_err(|e| InstitutionalDomainStoreError::Store(e.to_string()))?
+            .ok_or(InstitutionalDomainStoreError::NotDeclared)?;
+
+        // Real gate resolution + pure-core structural commit. On rejection the
+        // in-memory `domain` is left unchanged and nothing is persisted.
+        let policy_ref = self
+            .adopt_domain_policy(&mut domain, policy, actor, now)
+            .map_err(InstitutionalDomainStoreError::Adopt)?;
+
+        store
+            .save_institutional_domain(&domain)
+            .map_err(|e| InstitutionalDomainStoreError::Store(e.to_string()))?;
+        Ok(policy_ref)
     }
 }
 
@@ -601,5 +728,226 @@ mod tests {
             ))
         ));
         assert!(domain.current_policy().is_none());
+    }
+
+    // ----- persisted (store-backed) manager tests --------------------------
+
+    use crate::state_store::SledGovernanceStateStore;
+
+    /// A manager wired with both a receipt backend (for the gate) and a
+    /// temporary sled-backed `GovernanceStateStore` (for InstitutionalDomain
+    /// persistence — exercises the real `SledGovernanceStateStore` impl).
+    fn manager_with_stores(backend: Arc<TestBackend>) -> GovernanceManager {
+        let domain_store = Arc::new(SledGovernanceStateStore::new(Arc::new(
+            icn_store::SledStore::temporary().expect("temp sled"),
+        )));
+        GovernanceManager::new()
+            .with_receipt_store(backend)
+            .with_domain_store(domain_store)
+    }
+
+    fn live_adopt_fixture(actor: &Did, dom: &str) -> (Arc<TestBackend>,) {
+        let gid = AuthorityGrantId::new();
+        let grant = adopt_grant(actor.clone(), dom, gid.clone());
+        let mandate = backing_mandate(gid);
+        (TestBackend::new(vec![mandate], vec![grant]),)
+    }
+
+    #[test]
+    fn declare_persists_and_round_trips() {
+        let mgr = manager_with_stores(TestBackend::new(vec![], vec![]));
+        let declared = mgr
+            .declare_institutional_domain(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+            )
+            .expect("declare succeeds");
+        assert_eq!(declared.domain_id, domain_id("coop-alpha"));
+        assert!(declared.current_policy().is_none());
+
+        let store = mgr.domain_state_store().unwrap();
+        let loaded = store
+            .get_institutional_domain(&domain_id("coop-alpha"))
+            .unwrap()
+            .expect("persisted");
+        assert_eq!(loaded, declared);
+    }
+
+    #[test]
+    fn declare_twice_fails() {
+        let mgr = manager_with_stores(TestBackend::new(vec![], vec![]));
+        mgr.declare_institutional_domain(
+            domain_id("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .unwrap();
+        let err = mgr
+            .declare_institutional_domain(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+            )
+            .expect_err("second declare must fail");
+        assert!(matches!(
+            err,
+            InstitutionalDomainStoreError::AlreadyDeclared
+        ));
+    }
+
+    #[test]
+    fn adopt_persisted_loads_adopts_saves_and_survives_reload() {
+        let actor = did(1);
+        let (backend,) = live_adopt_fixture(&actor, "coop-alpha");
+        let mgr = manager_with_stores(backend);
+        mgr.declare_institutional_domain(
+            domain_id("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .unwrap();
+
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+        let adopted = mgr
+            .adopt_domain_policy_persisted(&domain_id("coop-alpha"), &policy, &actor, 100)
+            .expect("persisted adoption succeeds");
+        assert_eq!(adopted, policy.policy_ref());
+
+        // current_policy survives reload from the store.
+        let store = mgr.domain_state_store().unwrap();
+        let reloaded = store
+            .get_institutional_domain(&domain_id("coop-alpha"))
+            .unwrap()
+            .expect("persisted");
+        assert_eq!(reloaded.current_policy(), Some(&policy.policy_ref()));
+    }
+
+    #[test]
+    fn adopt_persisted_fails_when_not_declared() {
+        let actor = did(1);
+        let (backend,) = live_adopt_fixture(&actor, "coop-alpha");
+        let mgr = manager_with_stores(backend);
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+        let err = mgr
+            .adopt_domain_policy_persisted(&domain_id("coop-alpha"), &policy, &actor, 100)
+            .expect_err("adoption on an undeclared domain must fail");
+        assert!(matches!(err, InstitutionalDomainStoreError::NotDeclared));
+    }
+
+    #[test]
+    fn persisted_ops_fail_closed_without_domain_store() {
+        // Receipt store wired, but NO domain store.
+        let mgr = GovernanceManager::new().with_receipt_store(TestBackend::new(vec![], vec![]));
+        let declare_err = mgr
+            .declare_institutional_domain(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+            )
+            .expect_err("declare must fail closed without a store");
+        assert!(matches!(
+            declare_err,
+            InstitutionalDomainStoreError::MissingDomainStore
+        ));
+
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+        let adopt_err = mgr
+            .adopt_domain_policy_persisted(&domain_id("coop-alpha"), &policy, &did(1), 100)
+            .expect_err("persisted adoption must fail closed without a store");
+        assert!(matches!(
+            adopt_err,
+            InstitutionalDomainStoreError::MissingDomainStore
+        ));
+    }
+
+    #[test]
+    fn adopt_persisted_rejects_wrong_actor_via_gate() {
+        // Grant is for did(1); the actor attempting adoption is did(2).
+        let (backend,) = live_adopt_fixture(&did(1), "coop-alpha");
+        let mgr = manager_with_stores(backend);
+        mgr.declare_institutional_domain(
+            domain_id("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .unwrap();
+
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+        let err = mgr
+            .adopt_domain_policy_persisted(&domain_id("coop-alpha"), &policy, &did(2), 100)
+            .expect_err("wrong actor must be refused by the gate");
+        assert!(matches!(
+            err,
+            InstitutionalDomainStoreError::Adopt(DomainPolicyAdoptionError::Gated(
+                AdoptDomainPolicyError::Unauthorized(MandateGateError::Rejected(
+                    MandateRejection::NoMandate
+                ))
+            ))
+        ));
+
+        // State unchanged on rejection: current_policy stays None after reload.
+        let store = mgr.domain_state_store().unwrap();
+        assert!(store
+            .get_institutional_domain(&domain_id("coop-alpha"))
+            .unwrap()
+            .unwrap()
+            .current_policy()
+            .is_none());
+    }
+
+    #[test]
+    fn adopt_persisted_rejects_revoked_authority_via_gate() {
+        let actor = did(1);
+        let gid = AuthorityGrantId::new();
+        let grant = adopt_grant(actor.clone(), "coop-alpha", gid.clone());
+        let mut mandate = backing_mandate(gid);
+        mandate.status = MandateStatus::Revoked;
+        let mgr = manager_with_stores(TestBackend::new(vec![mandate], vec![grant]));
+        mgr.declare_institutional_domain(
+            domain_id("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .unwrap();
+
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+        let err = mgr
+            .adopt_domain_policy_persisted(&domain_id("coop-alpha"), &policy, &actor, 100)
+            .expect_err("a revoked backing mandate must be refused by the gate");
+        assert!(matches!(
+            err,
+            InstitutionalDomainStoreError::Adopt(DomainPolicyAdoptionError::Gated(
+                AdoptDomainPolicyError::Unauthorized(MandateGateError::Rejected(
+                    MandateRejection::Revoked
+                ))
+            ))
+        ));
+    }
+
+    #[test]
+    fn adopt_persisted_preserves_pure_core_defense_in_depth() {
+        // Gate authorizes the actor for coop-alpha, but the policy is authored
+        // for coop-beta: the pure-core structural check must still reject it.
+        let actor = did(1);
+        let (backend,) = live_adopt_fixture(&actor, "coop-alpha");
+        let mgr = manager_with_stores(backend);
+        mgr.declare_institutional_domain(
+            domain_id("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .unwrap();
+
+        let foreign = DomainPolicy::new(domain_id("coop-beta"), b"policy v1");
+        let err = mgr
+            .adopt_domain_policy_persisted(&domain_id("coop-alpha"), &foreign, &actor, 100)
+            .expect_err("a policy for another domain must be refused by the core check");
+        assert!(matches!(
+            err,
+            InstitutionalDomainStoreError::Adopt(DomainPolicyAdoptionError::Gated(
+                AdoptDomainPolicyError::Core(InstitutionalDomainError::PolicyForOtherDomain)
+            ))
+        ));
     }
 }

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -2851,6 +2851,28 @@ impl GovernanceManager {
         self.receipt_store.clone()
     }
 
+    /// Attach a [`GovernanceStateStore`] for governance-domain and
+    /// `InstitutionalDomain` persistence.
+    ///
+    /// Symmetric with [`Self::with_receipt_store`]. Used by the persisted
+    /// domain-policy adoption path ([`crate::domain_policy_adoption`]) to
+    /// load/save `InstitutionalDomain` records. Unlike [`Self::new_with_sled`],
+    /// this does **not** seed the in-memory `GovernanceDomain` cache — it only
+    /// wires the store (the institutional-domain key space is separate).
+    pub fn with_domain_store(mut self, store: Arc<dyn GovernanceStateStore>) -> Self {
+        self.domain_store = Some(store);
+        self
+    }
+
+    /// Clone the attached [`GovernanceStateStore`], if one is wired.
+    ///
+    /// Used by the persisted domain-policy adoption seam to load/save
+    /// `InstitutionalDomain` records. Returns `None` when no store is wired —
+    /// callers must fail closed in that case.
+    pub(crate) fn domain_state_store(&self) -> Option<Arc<dyn GovernanceStateStore>> {
+        self.domain_store.clone()
+    }
+
     /// Replace the structure store backend.
     ///
     /// Use this to configure Sled-backed persistent storage for structures.

--- a/icn/apps/governance/src/state_store.rs
+++ b/icn/apps/governance/src/state_store.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use std::sync::Arc;
 
 use icn_governance::{
-    Delegation, DelegationId, GovernanceDomain, GovernanceDomainId, Proposal, ProposalId,
-    Timestamp, Vote,
+    Delegation, DelegationId, GovernanceDomain, GovernanceDomainId, InstitutionalDomain, Proposal,
+    ProposalId, Timestamp, Vote,
 };
 use icn_identity::Did;
 use icn_store::Store;
@@ -123,6 +123,37 @@ pub trait GovernanceStateStore: Send + Sync {
     fn flush(&self) -> Result<()> {
         Ok(())
     }
+
+    // --- Institutional domains (ADR-0083 persistence addendum, #2142) ---
+
+    /// Load the [`InstitutionalDomain`] authority record for `id`, if one has
+    /// been declared. Keyed by the **existing** `GovernanceDomainId` and stored
+    /// as a **separate sibling record** from `GovernanceDomain` (a distinct key
+    /// space); it carries only the adopted `current_policy: DomainPolicyRef`
+    /// pointer, never the `DomainPolicy` body (#1817).
+    ///
+    /// **Default impl FAILS CLOSED** (returns `Err`): a store that does not
+    /// implement institutional-domain persistence must not masquerade as
+    /// "no domain declared". Callers (declare / persisted-adopt) treat the error
+    /// as a wiring fault, not as absence. The sled-backed store overrides this.
+    fn get_institutional_domain(
+        &self,
+        _id: &GovernanceDomainId,
+    ) -> Result<Option<InstitutionalDomain>> {
+        anyhow::bail!(
+            "institutional_domain persistence not implemented by this GovernanceStateStore"
+        )
+    }
+
+    /// Persist an [`InstitutionalDomain`] authority record (insert or overwrite),
+    /// keyed by its `domain_id`. **Default impl FAILS CLOSED** for the same
+    /// reason as [`Self::get_institutional_domain`]; the sled-backed store
+    /// overrides this.
+    fn save_institutional_domain(&self, _domain: &InstitutionalDomain) -> Result<()> {
+        anyhow::bail!(
+            "institutional_domain persistence not implemented by this GovernanceStateStore"
+        )
+    }
 }
 
 // ---- Key helpers ----
@@ -133,6 +164,12 @@ fn domain_key(id: &GovernanceDomainId) -> Vec<u8> {
 
 fn domain_key_prefix() -> &'static [u8] {
     b"gov:domain:"
+}
+
+fn institutional_domain_key(id: &GovernanceDomainId) -> Vec<u8> {
+    // Distinct key space from `gov:domain:` (GovernanceDomain) — the
+    // InstitutionalDomain authority record is a sibling, not a replacement.
+    format!("gov:institutional-domain:{}", id.0).into_bytes()
 }
 
 fn proposal_key(id: &ProposalId) -> Vec<u8> {
@@ -223,6 +260,22 @@ impl GovernanceStateStore for SledGovernanceStateStore {
         rows.into_iter()
             .map(|(_k, v)| Ok(serde_json::from_slice::<GovernanceDomain>(&v)?))
             .collect()
+    }
+
+    // --- Institutional domains ---
+
+    fn get_institutional_domain(
+        &self,
+        id: &GovernanceDomainId,
+    ) -> Result<Option<InstitutionalDomain>> {
+        load_json(self.store.as_ref(), &institutional_domain_key(id))
+    }
+
+    fn save_institutional_domain(&self, domain: &InstitutionalDomain) -> Result<()> {
+        self.store.put(
+            &institutional_domain_key(&domain.domain_id),
+            &serde_json::to_vec(domain)?,
+        )
     }
 
     // --- Proposals ---
@@ -337,5 +390,106 @@ impl GovernanceStateStore for SledGovernanceStateStore {
             Some(bytes) => Ok(Some(serde_json::from_slice::<CloseJournalEntry>(&bytes)?)),
             None => Ok(None),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use icn_governance::BootstrapEntityType;
+    use icn_store::SledStore;
+
+    fn temp_store() -> SledGovernanceStateStore {
+        SledGovernanceStateStore::new(Arc::new(SledStore::temporary().expect("temp sled")))
+    }
+
+    #[test]
+    fn institutional_domain_round_trips() {
+        let store = temp_store();
+        let id = GovernanceDomainId::new("coop-alpha");
+        assert!(store.get_institutional_domain(&id).unwrap().is_none());
+
+        let domain = InstitutionalDomain::declare(id.clone(), BootstrapEntityType::Cooperative);
+        store.save_institutional_domain(&domain).unwrap();
+
+        let loaded = store
+            .get_institutional_domain(&id)
+            .unwrap()
+            .expect("present after save");
+        assert_eq!(loaded, domain);
+
+        // Distinct key space: the GovernanceDomain get for the same id is
+        // unaffected by the institutional-domain write.
+        assert!(store.get_domain(&id).unwrap().is_none());
+    }
+
+    /// A `GovernanceStateStore` that does NOT override the institutional-domain
+    /// methods must hit the fail-closed defaults (`Err`), never silent
+    /// `Ok`/`None`. All other (required) methods are unreachable in this test.
+    struct NoInstitutionalDomainStore;
+
+    impl GovernanceStateStore for NoInstitutionalDomainStore {
+        fn get_domain(&self, _: &GovernanceDomainId) -> Result<Option<GovernanceDomain>> {
+            unimplemented!()
+        }
+        fn save_domain(&self, _: &GovernanceDomain) -> Result<()> {
+            unimplemented!()
+        }
+        fn list_domains(&self) -> Result<Vec<GovernanceDomain>> {
+            unimplemented!()
+        }
+        fn get_proposal(&self, _: &ProposalId) -> Result<Option<Proposal>> {
+            unimplemented!()
+        }
+        fn save_proposal(&self, _: &Proposal) -> Result<()> {
+            unimplemented!()
+        }
+        fn list_proposals(&self) -> Result<Vec<Proposal>> {
+            unimplemented!()
+        }
+        fn get_vote(&self, _: &ProposalId, _: &Did) -> Result<Option<Vote>> {
+            unimplemented!()
+        }
+        fn save_vote(&self, _: &ProposalId, _: &Vote) -> Result<()> {
+            unimplemented!()
+        }
+        fn list_votes(&self, _: &ProposalId) -> Result<Vec<Vote>> {
+            unimplemented!()
+        }
+        fn get_delegation(&self, _: &DelegationId) -> Result<Option<Delegation>> {
+            unimplemented!()
+        }
+        fn save_delegation(&self, _: &Delegation) -> Result<()> {
+            unimplemented!()
+        }
+        fn list_all_delegations(&self) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+            unimplemented!()
+        }
+        fn save_revoked_delegation(&self, _: &Delegation, _: Timestamp) -> Result<()> {
+            unimplemented!()
+        }
+        fn get_proof_bytes(&self, _: &ProposalId) -> Result<Option<Vec<u8>>> {
+            unimplemented!()
+        }
+        fn save_proof_bytes(&self, _: &ProposalId, _: &[u8]) -> Result<()> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn default_institutional_domain_methods_fail_closed() {
+        let store = NoInstitutionalDomainStore;
+        let id = GovernanceDomainId::new("coop-alpha");
+        assert!(
+            store.get_institutional_domain(&id).is_err(),
+            "default get must fail closed, not return Ok(None)"
+        );
+        let domain = InstitutionalDomain::declare(id, BootstrapEntityType::Cooperative);
+        assert!(
+            store.save_institutional_domain(&domain).is_err(),
+            "default save must fail closed, not silently succeed"
+        );
     }
 }


### PR DESCRIPTION
## What

Implements the minimal `InstitutionalDomain` persistence seam from the **ADR-0083 persistence addendum** (#2169). App-side only; `icn-governance` pure-core unchanged; **no HTTP route** (still the lane after this).

- **`GovernanceStateStore`** gains `get_institutional_domain` / `save_institutional_domain` as **default-implemented, fail-closed** methods (`anyhow::bail!`) — a store that doesn't implement them must never masquerade as "no domain declared". `SledGovernanceStateStore` overrides both, keyed by the existing `GovernanceDomainId` under a **distinct `gov:institutional-domain:` key space** (sibling to `gov:domain:`, not embedded). Persists the `InstitutionalDomain` record incl. its adopted `current_policy: DomainPolicyRef` only — no `DomainPolicy` body (#1817).
- **`GovernanceManager`**: `with_domain_store` builder + `pub(crate) domain_state_store()` accessor (mirror `with_receipt_store`/`receipt_backend`).
- **`declare_institutional_domain`**: persists a freshly declared domain; `AlreadyDeclared` on duplicate; **fails closed** (`MissingDomainStore`) without a store. Declare-authority gating is left as the ADR-flagged sub-question (no HTTP exposure).
- **`adopt_domain_policy_persisted`**: `load → existing gated adopt_domain_policy (real DefaultMandateGate + pure-core commit) → save`; state unchanged on rejection. `InstitutionalDomainStoreError { MissingDomainStore, AlreadyDeclared, NotDeclared, Store, Adopt }`.

## Why

The domain-policy adoption HTTP route was blocked (#2168) because `GovernanceManager::adopt_domain_policy` (#2166) takes a caller-held `&mut InstitutionalDomain` and there was no load/save/declare path. This lands that seam per the persistence model decided in #2169 — without a broad CRUD subsystem (two default trait methods, one builder/accessor, two manager methods).

## Non-claims

This does not add an HTTP route, complete #2142, implement durable `DomainPolicy` body storage, implement CCL runtime / policy registry / evaluator selection, implement a service-binding runtime, mandate-gate the declare act, perform an auth cutover or entity-aware auth enforcement, activate institution packages, or imply production/pilot/organizer/federation readiness.

## Tests

```
cargo test -p icn-governance-actor            # lib 297 passed; 0 failed (+ all integration binaries green)
cargo test -p icn-governance institutional_domain   # 14 passed; 0 failed (pure-core regression)
cargo fmt --all --check                       # rc=0
cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings   # rc=0
cargo check --workspace                       # rc=0
python3 .github/scripts/firewall_denylist.py  # No NEW firewall violations
python3 docs/scripts/doc_control_check.py     # OK (886 docs)
python3 docs/scripts/route_inventory.py --check   # OK (no new routes)
ops/scripts/drift-check.sh                     # PASS
```

New tests: `state_store` (institutional-domain round-trip; distinct key space; fail-closed default trait methods via a non-overriding store double) + `domain_policy_adoption` persisted-manager tests (declare round-trip; declare-twice → AlreadyDeclared; persisted adopt loads/adopts/saves + survives reload; not-declared → NotDeclared; missing-store fail-closed; wrong-actor & revoked rejected through the real `DefaultMandateGate`; wrong-domain policy rejected by pure-core defense-in-depth).

Refs #2142.
