### PR TITLE
feat(governance): expose domain policy adoption route

### DIFF
--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-22T18:19:04+00:00
+Generated: 2026-06-23T14:58:18+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -17,7 +17,7 @@ Generated: 2026-06-22T18:19:04+00:00
 
 ## Snapshot
 
-- Source commit: `7c7158c8a9b32d8a73c41f6570a50977eaf6d386`
+- Source commit: `72b9d86b42d254d0b8943eafb565be1cdcf5bcec`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -29,7 +29,7 @@ Generated: 2026-06-22T18:19:04+00:00
 - Not matched to OpenAPI (best-effort): 285 (~99% of discovered)
 - Documented share of discovered routes: ~0.7%
 - **OpenAPI operations (method + path) not matched to a discovered gateway route: 3** (see section below)
-- **Governance app route-registration candidates (separate surface, not gateway macros): 81** (see section below)
+- **Governance app route-registration candidates (separate surface, not gateway macros): 82** (see section below)
 
 > The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside the gateway crate and are not captured by this macro scan — so the documented/undocumented counts here are a best-effort comparison, while the two headline counts (discovered macros, OpenAPI paths) are the robust measured facts.
 
@@ -40,8 +40,8 @@ These OpenAPI-documented paths did **not** mechanically match any discovered gat
 | Method | OpenAPI path | Matched gateway route | Governance registration candidate | Status | Claim safety |
 |---|---|---|---|---|---|
 | GET | `/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | no | `get_action_item_completion_receipt` @ `icn/apps/governance/src/http/configure.rs`:682 | unknown / needs local verification | needs review |
-| GET | `/gov/me/action-cards` | no | `get_my_action_cards` @ `icn/apps/governance/src/http/configure.rs`:839 | unknown / needs local verification | needs review |
-| GET | `/gov/me/standing` | no | `get_my_standing` @ `icn/apps/governance/src/http/configure.rs`:835 | unknown / needs local verification | needs review |
+| GET | `/gov/me/action-cards` | no | `get_my_action_cards` @ `icn/apps/governance/src/http/configure.rs`:844 | unknown / needs local verification | needs review |
+| GET | `/gov/me/standing` | no | `get_my_standing` @ `icn/apps/governance/src/http/configure.rs`:840 | unknown / needs local verification | needs review |
 
 ## Governance app route-registration candidates
 
@@ -49,12 +49,12 @@ The governance app (`icn-governance-actor` = `icn/apps/governance`) registers it
 
 | Method | Path (relative, under `/gov`) | Source | Handler | OpenAPI documented | Status | Claim safety |
 |---|---|---|---|---|---|---|
-| GET | `/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:712 | `get_activity` | no | unknown / needs local verification | needs review |
+| GET | `/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:717 | `get_activity` | no | unknown / needs local verification | needs review |
 | POST | `/charters` | `icn/apps/governance/src/http/configure.rs`:587 | `activate_charter` | no | unknown / needs local verification | needs review |
 | GET | `/delegations` | `icn/apps/governance/src/http/configure.rs`:654 | `list_delegations` | no | unknown / needs local verification | needs review |
 | POST | `/delegations` | `icn/apps/governance/src/http/configure.rs`:653 | `create_delegation` | no | unknown / needs local verification | needs review |
 | DELETE | `/delegations/{delegation_id}` | `icn/apps/governance/src/http/configure.rs`:658 | `revoke_delegation` | no | unknown / needs local verification | needs review |
-| GET | `/digest` | `icn/apps/governance/src/http/configure.rs`:832 | `get_digest` | no | unknown / needs local verification | needs review |
+| GET | `/digest` | `icn/apps/governance/src/http/configure.rs`:837 | `get_digest` | no | unknown / needs local verification | needs review |
 | GET | `/domains` | `icn/apps/governance/src/http/configure.rs`:576 | `list_domains` | no | unknown / needs local verification | needs review |
 | POST | `/domains` | `icn/apps/governance/src/http/configure.rs`:575 | `create_domain` | no | unknown / needs local verification | needs review |
 | GET | `/domains/{domain_id}` | `icn/apps/governance/src/http/configure.rs`:579 | `get_domain` | no | unknown / needs local verification | needs review |
@@ -66,51 +66,52 @@ The governance app (`icn-governance-actor` = `icn/apps/governance`) registers it
 | GET | `/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `icn/apps/governance/src/http/configure.rs`:682 | `get_action_item_completion_receipt` | yes | unknown / needs local verification | needs review |
 | POST | `/domains/{domain_id}/action-items/{item_id}/notes` | `icn/apps/governance/src/http/configure.rs`:678 | `add_action_item_note` | no | unknown / needs local verification | needs review |
 | PUT | `/domains/{domain_id}/action-items/{item_id}/status` | `icn/apps/governance/src/http/configure.rs`:674 | `update_action_item_status` | no | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:763 | `list_meetings` | no | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:762 | `create_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/domain-policy/adopt` | `icn/apps/governance/src/http/configure.rs`:692 | `adopt_domain_policy` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:768 | `list_meetings` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:767 | `create_meeting` | no | unknown / needs local verification | needs review |
 | DELETE | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:584 | `remove_domain_member` | no | unknown / needs local verification | needs review |
 | POST | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:583 | `add_domain_member` | no | unknown / needs local verification | needs review |
 | POST | `/domains/{domain_id}/process-sessions/{session_id}/gate-results` | `icn/apps/governance/src/http/configure.rs`:687 | `record_process_gate_result` | no | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:718 | `list_programs_by_domain` | no | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:717 | `create_program` | no | unknown / needs local verification | needs review |
-| GET | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:708 | `list_activities` | no | unknown / needs local verification | needs review |
-| POST | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:707 | `create_activity` | no | unknown / needs local verification | needs review |
-| GET | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:693 | `list_structures` | no | unknown / needs local verification | needs review |
-| POST | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:692 | `create_structure` | no | unknown / needs local verification | needs review |
-| GET | `/me/action-cards` | `icn/apps/governance/src/http/configure.rs`:839 | `get_my_action_cards` | yes | unknown / needs local verification | needs review |
-| GET | `/me/scopes` | `icn/apps/governance/src/http/configure.rs`:834 | `get_my_scopes` | no | unknown / needs local verification | needs review |
-| GET | `/me/standing` | `icn/apps/governance/src/http/configure.rs`:835 | `get_my_standing` | yes | unknown / needs local verification | needs review |
-| GET | `/me/work` | `icn/apps/governance/src/http/configure.rs`:836 | `get_my_work` | no | unknown / needs local verification | needs review |
-| GET | `/meetings/{meeting_id}` | `icn/apps/governance/src/http/configure.rs`:767 | `get_meeting` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/agenda` | `icn/apps/governance/src/http/configure.rs`:787 | `add_agenda_item` | no | unknown / needs local verification | needs review |
-| PUT | `/meetings/{meeting_id}/agenda/{item_id}` | `icn/apps/governance/src/http/configure.rs`:791 | `update_agenda_item` | no | unknown / needs local verification | needs review |
-| PUT | `/meetings/{meeting_id}/attendance` | `icn/apps/governance/src/http/configure.rs`:783 | `mark_attendance` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/attendees` | `icn/apps/governance/src/http/configure.rs`:779 | `add_attendee` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/end` | `icn/apps/governance/src/http/configure.rs`:775 | `end_meeting` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/start` | `icn/apps/governance/src/http/configure.rs`:771 | `start_meeting` | no | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:748 | `get_milestone` | no | unknown / needs local verification | needs review |
-| PATCH | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:749 | `update_milestone_status` | no | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}/history` | `icn/apps/governance/src/http/configure.rs`:757 | `get_milestone_history` | no | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}/preview` | `icn/apps/governance/src/http/configure.rs`:753 | `preview_milestone` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}` | `icn/apps/governance/src/http/configure.rs`:722 | `get_program` | no | unknown / needs local verification | needs review |
-| DELETE | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:744 | `unlink_activity_from_program` | no | unknown / needs local verification | needs review |
-| PUT | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:743 | `link_activity_to_program` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/dashboard` | `icn/apps/governance/src/http/configure.rs`:730 | `get_program_dashboard` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:739 | `list_milestones_by_program` | no | unknown / needs local verification | needs review |
-| POST | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:738 | `create_milestone` | no | unknown / needs local verification | needs review |
-| PATCH | `/programs/{program_id}/status` | `icn/apps/governance/src/http/configure.rs`:726 | `update_program_status` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/summary` | `icn/apps/governance/src/http/configure.rs`:734 | `get_program_summary` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:723 | `list_programs_by_domain` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:722 | `create_program` | no | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:713 | `list_activities` | no | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:712 | `create_activity` | no | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:698 | `list_structures` | no | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:697 | `create_structure` | no | unknown / needs local verification | needs review |
+| GET | `/me/action-cards` | `icn/apps/governance/src/http/configure.rs`:844 | `get_my_action_cards` | yes | unknown / needs local verification | needs review |
+| GET | `/me/scopes` | `icn/apps/governance/src/http/configure.rs`:839 | `get_my_scopes` | no | unknown / needs local verification | needs review |
+| GET | `/me/standing` | `icn/apps/governance/src/http/configure.rs`:840 | `get_my_standing` | yes | unknown / needs local verification | needs review |
+| GET | `/me/work` | `icn/apps/governance/src/http/configure.rs`:841 | `get_my_work` | no | unknown / needs local verification | needs review |
+| GET | `/meetings/{meeting_id}` | `icn/apps/governance/src/http/configure.rs`:772 | `get_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/agenda` | `icn/apps/governance/src/http/configure.rs`:792 | `add_agenda_item` | no | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/agenda/{item_id}` | `icn/apps/governance/src/http/configure.rs`:796 | `update_agenda_item` | no | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/attendance` | `icn/apps/governance/src/http/configure.rs`:788 | `mark_attendance` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/attendees` | `icn/apps/governance/src/http/configure.rs`:784 | `add_attendee` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/end` | `icn/apps/governance/src/http/configure.rs`:780 | `end_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/start` | `icn/apps/governance/src/http/configure.rs`:776 | `start_meeting` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:753 | `get_milestone` | no | unknown / needs local verification | needs review |
+| PATCH | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:754 | `update_milestone_status` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/history` | `icn/apps/governance/src/http/configure.rs`:762 | `get_milestone_history` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/preview` | `icn/apps/governance/src/http/configure.rs`:758 | `preview_milestone` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}` | `icn/apps/governance/src/http/configure.rs`:727 | `get_program` | no | unknown / needs local verification | needs review |
+| DELETE | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:749 | `unlink_activity_from_program` | no | unknown / needs local verification | needs review |
+| PUT | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:748 | `link_activity_to_program` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/dashboard` | `icn/apps/governance/src/http/configure.rs`:735 | `get_program_dashboard` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:744 | `list_milestones_by_program` | no | unknown / needs local verification | needs review |
+| POST | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:743 | `create_milestone` | no | unknown / needs local verification | needs review |
+| PATCH | `/programs/{program_id}/status` | `icn/apps/governance/src/http/configure.rs`:731 | `update_program_status` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/summary` | `icn/apps/governance/src/http/configure.rs`:739 | `get_program_summary` | no | unknown / needs local verification | needs review |
 | GET | `/proposals` | `icn/apps/governance/src/http/configure.rs`:592 | `list_proposals` | no | unknown / needs local verification | needs review |
 | POST | `/proposals` | `icn/apps/governance/src/http/configure.rs`:591 | `create_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/clearing/establish` | `icn/apps/governance/src/http/configure.rs`:804 | `create_establish_clearing_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/clearing/terminate` | `icn/apps/governance/src/http/configure.rs`:808 | `create_terminate_clearing_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/join` | `icn/apps/governance/src/http/configure.rs`:796 | `create_join_federation_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/leave` | `icn/apps/governance/src/http/configure.rs`:800 | `create_leave_federation_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/policy` | `icn/apps/governance/src/http/configure.rs`:820 | `create_update_federation_policy_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/vouch` | `icn/apps/governance/src/http/configure.rs`:812 | `create_vouch_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/vouch/revoke` | `icn/apps/governance/src/http/configure.rs`:816 | `create_revoke_vouch_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/sdis/appoint-steward` | `icn/apps/governance/src/http/configure.rs`:825 | `create_appoint_steward_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/sdis/remove-steward` | `icn/apps/governance/src/http/configure.rs`:829 | `create_remove_steward_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/establish` | `icn/apps/governance/src/http/configure.rs`:809 | `create_establish_clearing_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/terminate` | `icn/apps/governance/src/http/configure.rs`:813 | `create_terminate_clearing_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/join` | `icn/apps/governance/src/http/configure.rs`:801 | `create_join_federation_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/leave` | `icn/apps/governance/src/http/configure.rs`:805 | `create_leave_federation_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/policy` | `icn/apps/governance/src/http/configure.rs`:825 | `create_update_federation_policy_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch` | `icn/apps/governance/src/http/configure.rs`:817 | `create_vouch_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch/revoke` | `icn/apps/governance/src/http/configure.rs`:821 | `create_revoke_vouch_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/appoint-steward` | `icn/apps/governance/src/http/configure.rs`:830 | `create_appoint_steward_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/remove-steward` | `icn/apps/governance/src/http/configure.rs`:834 | `create_remove_steward_proposal` | no | unknown / needs local verification | needs review |
 | GET | `/proposals/{proposal_id}` | `icn/apps/governance/src/http/configure.rs`:596 | `get_proposal` | no | unknown / needs local verification | needs review |
 | GET | `/proposals/{proposal_id}/chain` | `icn/apps/governance/src/http/configure.rs`:620 | `get_chain` | no | unknown / needs local verification | needs review |
 | POST | `/proposals/{proposal_id}/close` | `icn/apps/governance/src/http/configure.rs`:604 | `close_proposal` | no | unknown / needs local verification | needs review |
@@ -127,9 +128,9 @@ The governance app (`icn-governance-actor` = `icn/apps/governance`) registers it
 | GET | `/proposals/{proposal_id}/proof` | `icn/apps/governance/src/http/configure.rs`:616 | `get_proof` | no | unknown / needs local verification | needs review |
 | GET | `/proposals/{proposal_id}/tally` | `icn/apps/governance/src/http/configure.rs`:612 | `get_vote_tally` | no | unknown / needs local verification | needs review |
 | POST | `/proposals/{proposal_id}/vote` | `icn/apps/governance/src/http/configure.rs`:608 | `cast_vote` | no | unknown / needs local verification | needs review |
-| GET | `/structures/{structure_id}` | `icn/apps/governance/src/http/configure.rs`:697 | `get_structure` | no | unknown / needs local verification | needs review |
-| GET | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:702 | `list_roles` | no | unknown / needs local verification | needs review |
-| POST | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:701 | `assign_role` | no | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}` | `icn/apps/governance/src/http/configure.rs`:702 | `get_structure` | no | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:707 | `list_roles` | no | unknown / needs local verification | needs review |
+| POST | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:706 | `assign_role` | no | unknown / needs local verification | needs review |
 
 ## Limitations
 

--- a/icn/apps/governance/src/domain_policy_adoption.rs
+++ b/icn/apps/governance/src/domain_policy_adoption.rs
@@ -281,17 +281,19 @@ impl crate::manager::GovernanceManager {
     ///
     /// # Concurrency
     ///
-    /// The `load → mutate → save` sequence is **not atomic** and has no
-    /// per-domain serialization. With the current callers (in-process tests;
-    /// **no HTTP route or concurrent caller exists yet** — that is the deferred
-    /// next lane, see `docs/spec/institutional-domain.md`) there is no
-    /// concurrent access, so no update can be lost. **Before** this seam is
-    /// exposed to concurrent callers (an HTTP adoption route), the route lane
-    /// must add per-domain serialization (an in-process lock keyed by
-    /// `GovernanceDomainId`) and/or an atomic store primitive
-    /// (e.g. a transactional `get`+`put`), or two concurrent adoptions could
-    /// last-writer-win and drop an intervening `current_policy` update. This is
-    /// recorded as a prerequisite for the route lane, not fixed here.
+    /// The `load → mutate → save` sequence is serialized **per domain** by an
+    /// in-process lock keyed by `GovernanceDomainId`
+    /// ([`crate::manager::GovernanceManager::domain_adoption_lock`]), so two
+    /// concurrent adoptions for the same domain cannot interleave their
+    /// load→save and last-writer-win, dropping an intervening `current_policy`
+    /// update. Adoptions for *different* domains take distinct locks and run
+    /// concurrently. The guarded section is fully synchronous, so the lock is
+    /// never held across an `.await`.
+    ///
+    /// This is the in-process (single-node) guarantee the #2142 HTTP adoption
+    /// route relies on. It is **not** a cross-process / multi-writer guarantee:
+    /// a transactional store primitive (atomic compare-and-swap `get`+`put`)
+    /// for multi-writer deployments remains later work.
     pub fn adopt_domain_policy_persisted(
         &self,
         domain_id: &GovernanceDomainId,
@@ -302,6 +304,17 @@ impl crate::manager::GovernanceManager {
         let store = self
             .domain_state_store()
             .ok_or(InstitutionalDomainStoreError::MissingDomainStore)?;
+
+        // Serialize the load→adopt→save critical section per domain so two
+        // concurrent adoptions for the *same* domain cannot interleave and
+        // last-writer-win, dropping an intervening `current_policy` update.
+        // Different domains take distinct locks and proceed concurrently. The
+        // whole section below is synchronous (no `.await`), so holding this
+        // guard across it never blocks an async executor on a held lock.
+        let domain_lock = self.domain_adoption_lock(domain_id);
+        let _adopt_guard = domain_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         let mut domain = store
             .get_institutional_domain(domain_id)
@@ -963,5 +976,65 @@ mod tests {
                 AdoptDomainPolicyError::Core(InstitutionalDomainError::PolicyForOtherDomain)
             ))
         ));
+    }
+
+    #[test]
+    fn adopt_persisted_serializes_concurrent_same_domain_adoptions() {
+        // Eight threads race the same per-domain `load → adopt → save` critical
+        // section. The per-domain lock must serialize them: every contending
+        // adoption succeeds with the same ref, and the final persisted state is
+        // exactly that policy — no panic, no torn read/modify/write, no lost
+        // update. This exercises the lock path under real contention.
+        use std::thread;
+
+        let actor = did(1);
+        let (backend,) = live_adopt_fixture(&actor, "coop-alpha");
+        let mgr = Arc::new(manager_with_stores(backend));
+        mgr.declare_institutional_domain(
+            domain_id("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .unwrap();
+
+        let policy = DomainPolicy::new(domain_id("coop-alpha"), b"policy v1");
+        let expected = policy.policy_ref();
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let mgr = Arc::clone(&mgr);
+                let policy = policy.clone();
+                let actor = actor.clone();
+                thread::spawn(move || {
+                    mgr.adopt_domain_policy_persisted(
+                        &domain_id("coop-alpha"),
+                        &policy,
+                        &actor,
+                        100,
+                    )
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|h| h.join().expect("adoption thread did not panic"))
+            .collect();
+
+        assert_eq!(results.len(), 8);
+        for r in &results {
+            assert_eq!(
+                r.as_ref().expect("each concurrent adoption succeeds"),
+                &expected
+            );
+        }
+
+        // Final persisted state is exactly the adopted policy (no lost update).
+        let store = mgr.domain_state_store().unwrap();
+        let reloaded = store
+            .get_institutional_domain(&domain_id("coop-alpha"))
+            .unwrap()
+            .expect("persisted");
+        assert_eq!(reloaded.current_policy(), Some(&expected));
     }
 }

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -686,6 +686,11 @@ where
             web::resource("/domains/{domain_id}/process-sessions/{session_id}/gate-results")
                 .route(web::post().to(handlers::record_process_gate_result::<E>)),
         )
+        // ── Institutional domain policy adoption (#2142 — gated adoption) ──
+        .service(
+            web::resource("/domains/{domain_id}/domain-policy/adopt")
+                .route(web::post().to(handlers::adopt_domain_policy::<E>)),
+        )
         // ── Structure endpoints ──────────────────────────────────────────
         .service(
             web::resource("/entities/{entity_id}/structures")

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -9,7 +9,7 @@ use icn_federation::SettlementInterval;
 use icn_governance::{
     ActionItemFilter, ActionItemId, ActionItemPriority, ActionItemStatus, ActivityId, ActivityKind,
     ActivityStatus, AttendanceStatus, DataSharingLevel, Delegation, DelegationId, DelegationScope,
-    DisputeResolutionMethod, FederationProposal, FederationTerms, GovernanceDomain,
+    DisputeResolutionMethod, DomainPolicy, FederationProposal, FederationTerms, GovernanceDomain,
     GovernanceDomainId, GovernanceParams, MeetingId, MeetingRole, MeetingStatus, MembershipAction,
     MembershipConfig, MilestoneId, MilestoneStatus, ProgramId, ProgramKind, ProposalId,
     ProposalPayload, ProposalScope, StructureId, StructureKind, StructureStatus, VoteChoice,
@@ -24,6 +24,9 @@ use icn_identity::Did;
 use super::configure::{DispatchEvidenceSpec, GovernanceContext, GovernanceEffect};
 use super::models::*;
 use super::validation as val;
+use crate::domain_policy_adoption::{
+    AdoptDomainPolicyError, DomainPolicyAdoptionError, InstitutionalDomainStoreError,
+};
 use crate::events::GovernanceEventEmitter;
 
 // ============================================================================
@@ -3135,6 +3138,104 @@ pub async fn record_process_gate_result<E: GovernanceEventEmitter + Clone + 'sta
         .map_err(anyhow_to_api)?;
 
     Ok(HttpResponse::Ok().json(receipt))
+}
+
+/// Map the persisted domain-policy adoption seam error onto the governance
+/// HTTP error taxonomy. Fail-closed: only a clearly-authorization or
+/// clearly-client problem maps to 403/404; everything else (missing store,
+/// backend read/write failure, unreachable `AlreadyDeclared`) surfaces as 500.
+fn institutional_domain_store_err_to_api(e: InstitutionalDomainStoreError) -> ApiError {
+    use AdoptDomainPolicyError as Gate;
+    use DomainPolicyAdoptionError as Adopt;
+    use InstitutionalDomainStoreError as Store;
+    let msg = e.to_string();
+    match e {
+        // No `InstitutionalDomain` declared for this domain id.
+        Store::NotDeclared => err_not_found(msg),
+        // Authority refusal — the gate denied the actor/domain/act/lifecycle,
+        // or the pure-core structural commit rejected the adoption.
+        Store::Adopt(Adopt::Gated(Gate::Unauthorized(_) | Gate::Core(_))) => err_forbidden(msg),
+        // Misconfiguration or backend failure. `AlreadyDeclared` is unreachable
+        // on the adopt path; fail closed to 500 if it ever surfaces.
+        Store::MissingDomainStore
+        | Store::AlreadyDeclared
+        | Store::Store(_)
+        | Store::Adopt(Adopt::MissingReceiptBackend)
+        | Store::Adopt(Adopt::Gated(Gate::Backend(_))) => err_internal(msg),
+    }
+}
+
+/// POST /gov/domains/{domain_id}/domain-policy/adopt
+/// — Adopt a `DomainPolicy` as the persisted `InstitutionalDomain`'s current
+/// policy, gated by the app-side `DefaultMandateGate` (issue #2142).
+///
+/// Drives the existing persisted adoption seam end-to-end over HTTP:
+///
+/// ```text
+/// POST → governance:write scope + domain-membership gate
+///      → GovernanceManager::adopt_domain_policy_persisted
+///        → load InstitutionalDomain
+///        → DefaultMandateGate authority resolution (actor → active grants →
+///          domain-scoped Execution `domain_policy:adopt` grant + live mandate)
+///        → pure-core InstitutionalDomain::adopt_policy() (defense-in-depth)
+///        → save InstitutionalDomain
+///      → adopted DomainPolicyRef
+/// ```
+///
+/// The adopting actor is the authenticated caller (`sub`), never a body field.
+/// The candidate policy is content-addressed server-side from `policy_content`
+/// and bound to the path `domain_id`, so the policy↔domain identity is correct
+/// by construction (the pure-core `PolicyForOtherDomain` rejection is therefore
+/// unreachable from this route). The manager seam serializes concurrent
+/// same-domain adoptions through a per-domain critical section.
+///
+/// This adds **no** declare/create route — declaring a governed domain is not
+/// mandate-gated yet, so exposing it would be an authority bypass — and no CCL
+/// runtime, policy registry, service-binding runtime, or auth-model change.
+///
+/// Returns:
+/// - 200 with the adopted policy ref projection (`{policy_id, domain_id}`).
+/// - 400 when `policy_content` is empty/whitespace, or the body/DID is malformed.
+/// - 401 when the bearer token is missing/invalid.
+/// - 403 when the token lacks `governance:write`, the caller is not a domain
+///   member, or the `DefaultMandateGate` refuses adoption authority.
+/// - 404 when no `InstitutionalDomain` is declared for `domain_id` (or the
+///   `GovernanceDomain` membership target does not exist).
+/// - 500 when no domain/receipt store is wired, or a backend read/write fails.
+pub async fn adopt_domain_policy<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<String>,
+    req: web::Json<AdoptDomainPolicyRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let actor = parse_did(&claims.sub, "Invalid DID in token")?;
+
+    if req.policy_content.trim().is_empty() {
+        return Err(err_bad("policy_content must be a non-empty string"));
+    }
+    let domain = GovernanceDomainId(path.into_inner());
+
+    // Reuse the existing coarse domain-membership gate (the same gate the rest
+    // of the domain-scoped write surface uses). The authoritative adopt check
+    // is the DefaultMandateGate inside the manager seam below; membership is
+    // strictly additive and fail-closed, not a substitute for it.
+    check_domain_membership(&ctx, &domain, &actor).await?;
+
+    // Content-address the candidate policy server-side and bind it to the path
+    // domain, so the adopted ref can neither mismatch its id nor target a
+    // foreign domain.
+    let policy = DomainPolicy::new(domain.clone(), req.policy_content.as_bytes());
+
+    let policy_ref = ctx
+        .manager
+        .adopt_domain_policy_persisted(&domain, &policy, &actor, current_time_secs())
+        .map_err(institutional_domain_store_err_to_api)?;
+
+    Ok(HttpResponse::Ok().json(AdoptDomainPolicyResponse {
+        policy_id: policy_ref.id.to_hex(),
+        domain_id: policy_ref.domain_id.0,
+    }))
 }
 
 // ============================================================================

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3195,7 +3195,8 @@ fn institutional_domain_store_err_to_api(e: InstitutionalDomainStoreError) -> Ap
 ///
 /// Returns:
 /// - 200 with the adopted policy ref projection (`{policy_id, domain_id}`).
-/// - 400 when `policy_content` is empty/whitespace, or the body/DID is malformed.
+/// - 400 when `policy_content` is empty/whitespace or exceeds
+///   `MAX_DOMAIN_POLICY_CONTENT_BYTES`, or the body/DID is malformed.
 /// - 401 when the bearer token is missing/invalid.
 /// - 403 when the token lacks `governance:write`, the caller is not a domain
 ///   member, or the `DefaultMandateGate` refuses adoption authority.
@@ -3211,9 +3212,9 @@ pub async fn adopt_domain_policy<E: GovernanceEventEmitter + Clone + 'static>(
     let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
     let actor = parse_did(&claims.sub, "Invalid DID in token")?;
 
-    if req.policy_content.trim().is_empty() {
-        return Err(err_bad("policy_content must be a non-empty string"));
-    }
+    // Reject empty/whitespace and oversize bodies before content-addressing
+    // (blake3-hashing) the candidate — an unbounded body is a DoS vector.
+    val::validate_domain_policy_content(&req.policy_content)?;
     let domain = GovernanceDomainId(path.into_inner());
 
     // Reuse the existing coarse domain-membership gate (the same gate the rest

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -69,6 +69,41 @@ pub struct RecordProcessGateResultRequest {
 }
 
 // ============================================================================
+// Institutional domain policy adoption (#2142 — gated DomainPolicy adoption)
+// ============================================================================
+
+/// Request body for `POST /gov/domains/{domain_id}/domain-policy/adopt`.
+///
+/// Carries only the policy *content* to adopt. The server content-addresses it
+/// (blake3) into a `DomainPolicyId` and binds it to the path `domain_id`, so the
+/// adopted `DomainPolicyRef` is correct by construction: a client cannot assert
+/// a mismatched id or author the policy for a foreign domain. The adopting
+/// actor is the authenticated caller (token `sub`) — never a body field — and
+/// the authority to adopt is resolved server-side through the
+/// `DefaultMandateGate`, not asserted here.
+///
+/// The MVP `DomainPolicy` stores no CCL text (#1817); `policy_content` is the
+/// opaque bytes the content-addressed id commits to. Only the adopted
+/// `DomainPolicyRef` is persisted in the `InstitutionalDomain`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdoptDomainPolicyRequest {
+    /// Opaque policy content the adopted `DomainPolicyId` is the blake3 hash of.
+    pub policy_content: String,
+}
+
+/// Response body for a successful domain-policy adoption.
+///
+/// The legible projection of the adopted [`icn_governance::DomainPolicyRef`]:
+/// the content-addressed policy id (hex) and the domain it was adopted for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdoptDomainPolicyResponse {
+    /// Hex-encoded content-addressed id of the adopted policy version.
+    pub policy_id: String,
+    /// The governance domain the policy was adopted for.
+    pub domain_id: String,
+}
+
+// ============================================================================
 // Charter activation
 // ============================================================================
 

--- a/icn/apps/governance/src/http/validation.rs
+++ b/icn/apps/governance/src/http/validation.rs
@@ -21,6 +21,10 @@ pub const MAX_CHARTER_ID_LEN: usize = 128;
 ///
 /// If the gateway-wide JSON limit ever moves, this constant must move with it.
 pub const MAX_CHARTER_YAML_BYTES: usize = 262_144;
+/// Upper bound on a domain-policy adoption candidate's content. The adoption
+/// route content-addresses (blake3-hashes) the whole body, so an unbounded
+/// payload is a DoS vector; this caps it like the charter YAML payload above.
+pub const MAX_DOMAIN_POLICY_CONTENT_BYTES: usize = 262_144;
 pub const MAX_DOMAIN_NAME_LEN: usize = 256;
 pub const MAX_GOVERNANCE_MODEL_LEN: usize = 64;
 pub const MAX_PROPOSAL_TITLE_LEN: usize = 256;
@@ -97,6 +101,23 @@ pub fn validate_charter_yaml(yaml: &str) -> Result<(), ApiError> {
     if yaml.len() > MAX_CHARTER_YAML_BYTES {
         return Err(ApiError::BadRequest(format!(
             "Charter YAML exceeds maximum size of {MAX_CHARTER_YAML_BYTES} bytes"
+        )));
+    }
+    Ok(())
+}
+
+/// Bound a domain-policy adoption candidate's content. Empty/whitespace input
+/// is rejected with a clear message; oversize input is rejected as a DoS guard
+/// before the handler content-addresses (blake3-hashes) it.
+pub fn validate_domain_policy_content(content: &str) -> Result<(), ApiError> {
+    if content.is_empty() || content.trim().is_empty() {
+        return Err(ApiError::BadRequest(
+            "policy_content cannot be empty or whitespace-only".into(),
+        ));
+    }
+    if content.len() > MAX_DOMAIN_POLICY_CONTENT_BYTES {
+        return Err(ApiError::BadRequest(format!(
+            "policy_content exceeds maximum size of {MAX_DOMAIN_POLICY_CONTENT_BYTES} bytes"
         )));
     }
     Ok(())

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -33,7 +33,7 @@ use icn_identity::Did;
 use icn_kernel_api::{AllocationReceipt, ScopeLevel, SettlementIntent};
 use icn_store::SledStore;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use tracing::debug;
 
 // ============================================================================
@@ -2756,6 +2756,20 @@ pub struct GovernanceManager {
     /// `None` in tests and standalone mode. Set by sled-backed constructors so
     /// production deployments record every status change.
     program_event_log: Option<Arc<dyn ProgramEventLogBackend>>,
+    /// Per-`GovernanceDomainId` serialization for the persisted
+    /// `InstitutionalDomain` `load → adopt → save` critical section
+    /// (`adopt_domain_policy_persisted`, #2142 route lane).
+    ///
+    /// That seam is a read-modify-write on a single domain record. Two
+    /// concurrent adoptions for the *same* domain (the #2142 HTTP adoption
+    /// route admits concurrent callers) could otherwise interleave their
+    /// load→save and last-writer-win, dropping an intervening `current_policy`
+    /// update. This map hands out one `Arc<Mutex<()>>` per domain id so same-
+    /// domain adoptions serialize while different domains stay concurrent. The
+    /// outer mutex is held only to look up / create the per-domain lock, never
+    /// across the critical section. In-process only (single-node); a
+    /// multi-writer / transactional store remains later work.
+    domain_adoption_locks: Mutex<HashMap<GovernanceDomainId, Arc<Mutex<()>>>>,
 }
 
 impl GovernanceManager {
@@ -2782,6 +2796,7 @@ impl GovernanceManager {
             receipt_store: None,
             milestone_event_log: None,
             program_event_log: None,
+            domain_adoption_locks: Mutex::new(HashMap::new()),
         }
     }
 
@@ -2821,6 +2836,7 @@ impl GovernanceManager {
             receipt_store: None,
             milestone_event_log: None,
             program_event_log: None,
+            domain_adoption_locks: Mutex::new(HashMap::new()),
         }
     }
 
@@ -2871,6 +2887,26 @@ impl GovernanceManager {
     /// callers must fail closed in that case.
     pub(crate) fn domain_state_store(&self) -> Option<Arc<dyn GovernanceStateStore>> {
         self.domain_store.clone()
+    }
+
+    /// Acquire (creating on first use) the per-domain serialization lock for
+    /// `domain_id`'s `InstitutionalDomain` `load → adopt → save` critical
+    /// section. See [`Self::domain_adoption_locks`].
+    ///
+    /// The returned `Arc<Mutex<()>>` is the serialization point: same-domain
+    /// adoptions contend on it, different domains get distinct locks. The outer
+    /// map mutex is held only for the lookup/insert here, never across the
+    /// critical section. Recovers from a poisoned lock rather than panicking —
+    /// a poisoned `()` guard carries no state to corrupt.
+    pub(crate) fn domain_adoption_lock(&self, domain_id: &GovernanceDomainId) -> Arc<Mutex<()>> {
+        let mut locks = self
+            .domain_adoption_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks
+            .entry(domain_id.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
     }
 
     /// Replace the structure store backend.
@@ -2961,6 +2997,7 @@ impl GovernanceManager {
             domain_store: None,
             milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db.clone()))),
             program_event_log: Some(Arc::new(SledProgramEventLog::new(db))),
+            domain_adoption_locks: Mutex::new(HashMap::new()),
         }
     }
 
@@ -3020,6 +3057,7 @@ impl GovernanceManager {
             receipt_store: None,
             milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db.clone()))),
             program_event_log: Some(Arc::new(SledProgramEventLog::new(db))),
+            domain_adoption_locks: Mutex::new(HashMap::new()),
         }
     }
 

--- a/icn/apps/governance/tests/domain_policy_adoption_http_route.rs
+++ b/icn/apps/governance/tests/domain_policy_adoption_http_route.rs
@@ -533,3 +533,48 @@ async fn adopt_route_rejects_empty_policy_content() {
         "an empty/whitespace policy_content must be a 400"
     );
 }
+
+#[actix_web::test]
+async fn adopt_route_rejects_oversize_policy_content() {
+    // The handler content-addresses (blake3-hashes) the whole body, so an
+    // unbounded payload is a DoS vector. A body over the configured cap must be
+    // rejected with 400 before any hashing/persistence, and nothing adopted.
+    use icn_governance_actor::http::validation::MAX_DOMAIN_POLICY_CONTENT_BYTES;
+
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = adopt_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+    seed_governance_domain(&h.ctx.manager, &caller, "coop-alpha").await;
+    h.ctx
+        .manager
+        .declare_institutional_domain(
+            GovernanceDomainId::new("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .expect("declare");
+
+    let oversize = "a".repeat(MAX_DOMAIN_POLICY_CONTENT_BYTES + 1);
+    let app = gov_app!(h.ctx.clone(), &caller, Some("governance:write".to_string()));
+    let req = test::TestRequest::post()
+        .uri(&adopt_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "policy_content": oversize }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a policy_content over the byte cap must be a 400"
+    );
+    let reloaded = h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .unwrap();
+    assert!(
+        reloaded.current_policy().is_none(),
+        "nothing may be adopted when the body is rejected"
+    );
+}

--- a/icn/apps/governance/tests/domain_policy_adoption_http_route.rs
+++ b/icn/apps/governance/tests/domain_policy_adoption_http_route.rs
@@ -1,0 +1,535 @@
+//! HTTP route proof for gated, persisted `DomainPolicy` adoption — issue #2142.
+//!
+//! The adoption machinery already exists and is proven at the manager layer
+//! (`domain_policy_adoption.rs` unit tests): the pure-core structural commit
+//! (`icn-governance`), the app-side `DefaultMandateGate` authority resolution,
+//! and the persisted `GovernanceManager::adopt_domain_policy_persisted`
+//! (`load → gate → adopt → save`, #2170). This test pins the missing surface:
+//! **one governance HTTP route that drives that persisted, gated path end to
+//! end**:
+//!
+//!   `POST /gov/domains/{domain_id}/domain-policy/adopt`
+//!     → governance:write scope + domain-membership gate
+//!     → GovernanceManager::adopt_domain_policy_persisted
+//!       → load InstitutionalDomain → DefaultMandateGate → pure-core adopt
+//!       → save InstitutionalDomain
+//!     → adopted DomainPolicyRef projection ({policy_id, domain_id})
+//!
+//! It adds NO declare/create route (declaring a governed domain is not
+//! mandate-gated yet), no CCL runtime, no policy registry, and no auth change.
+//!
+//! Pins:
+//!
+//! 1. The route is mounted and reachable (not 404) and succeeds with an
+//!    active, domain-scoped adopt grant.
+//! 2. The adoption persists `current_policy` and survives a reload from the
+//!    `InstitutionalDomain` store.
+//! 3. The route requires the existing `governance:write` write guard.
+//! 4. A non-member is rejected by the existing domain-membership gate (403).
+//! 5. An undeclared `InstitutionalDomain` returns 404 (not found).
+//! 6. The wrong actor is rejected through the `DefaultMandateGate` (403),
+//!    leaving state unchanged.
+//! 7. A revoked backing mandate is rejected through the gate (403).
+//! 8. An empty `policy_content` is a 400.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{body::to_bytes, http::StatusCode, test, App};
+use icn_governance::{
+    AuthorityClass, AuthorityGrant, AuthorityGrantId, BootstrapEntityType, DecisionProvenance,
+    DomainPolicy, GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, Grantee,
+    GrantorEntityId, Mandate, MandateStatus, MembershipConfig, MembershipSource, Timestamp,
+    TypedScope,
+};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
+    GovernanceStateStore, NoopEventEmitter, SledGovernanceStateStore,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+
+// ============================================================================
+// Gate-serving receipt backend: serves the grants + mandates the
+// DefaultMandateGate reads. Mirrors `domain_policy_adoption::tests::TestBackend`.
+// ============================================================================
+
+struct TestBackend {
+    mandates: Vec<Mandate>,
+    grants: Vec<AuthorityGrant>,
+}
+
+impl TestBackend {
+    fn new(mandates: Vec<Mandate>, grants: Vec<AuthorityGrant>) -> Arc<Self> {
+        Arc::new(Self { mandates, grants })
+    }
+}
+
+impl GovernanceReceiptBackend for TestBackend {
+    fn put_governance(&self, _: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn list_mandates_by_decision(&self, decision_hash: &Hash) -> Result<Vec<Mandate>, String> {
+        Ok(self
+            .mandates
+            .iter()
+            .filter(|m| &m.decision.decision_hash == decision_hash)
+            .cloned()
+            .collect())
+    }
+    fn get_authority_grant(
+        &self,
+        grant_id: &AuthorityGrantId,
+    ) -> Result<Option<AuthorityGrant>, String> {
+        Ok(self.grants.iter().find(|g| &g.id == grant_id).cloned())
+    }
+    fn list_active_authority_grants_by_grantee(
+        &self,
+        grantee: &Grantee,
+        now: Timestamp,
+    ) -> Result<Vec<AuthorityGrant>, String> {
+        Ok(self
+            .grants
+            .iter()
+            .filter(|g| &g.grantee == grantee && g.is_active_at(now))
+            .cloned()
+            .collect())
+    }
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn decision() -> DecisionProvenance {
+    DecisionProvenance {
+        proposal_id: "prop-1".into(),
+        decision_hash: [7u8; 32],
+    }
+}
+
+/// An Execution grant for `actor`, bound to `dom`, carrying the
+/// `domain_policy:adopt` act token, provenance-linked to `decision()`.
+///
+/// `valid_until: None` so the grant is active at wall-clock `now` (the handler
+/// resolves authority at `current_time_secs()`, not a fixed test timestamp).
+fn adopt_grant(actor: Did, dom: &str, grant_id: AuthorityGrantId) -> AuthorityGrant {
+    AuthorityGrant {
+        id: grant_id,
+        class: AuthorityClass::Execution,
+        grantor: GrantorEntityId("coop:alpha".into()),
+        grantee: Grantee::Person(actor),
+        scope: TypedScope {
+            domain: Some(GovernanceDomainId::new(dom)),
+            action_kind: vec!["domain_policy:adopt".into()],
+            ..TypedScope::default()
+        },
+        granted_by: Some(decision()),
+        valid_from: 0,
+        valid_until: None,
+        revoked_at: None,
+    }
+}
+
+/// A live mandate backing `grant_id` (no deadline → live at any time).
+fn backing_mandate(grant_id: AuthorityGrantId) -> Mandate {
+    Mandate::new(decision(), [9u8; 32], vec![grant_id], None, None, 0)
+        .expect("grant-bearing mandate is valid")
+}
+
+struct Harness {
+    ctx: GovernanceContext<NoopEventEmitter>,
+    store: Arc<dyn GovernanceStateStore>,
+}
+
+/// Build a manager wired with the gate backend + a temp Sled
+/// `InstitutionalDomain` store, then return a `Test`-mode context.
+fn make_harness(backend: Arc<TestBackend>) -> Harness {
+    let store: Arc<dyn GovernanceStateStore> = Arc::new(SledGovernanceStateStore::new(Arc::new(
+        icn_store::SledStore::temporary().expect("temp sled"),
+    )));
+    let manager = GovernanceManager::new()
+        .with_receipt_store(backend as Arc<dyn GovernanceReceiptBackend>)
+        .with_domain_store(store.clone());
+    let ctx = GovernanceContext {
+        manager: Arc::new(manager),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        mandate_gate: None,
+        build_mode: http::GovernanceContextBuildMode::Test,
+    };
+    Harness { ctx, store }
+}
+
+/// Seed the in-memory `GovernanceDomain` (for the membership gate) with `member`
+/// as a static-list member.
+async fn seed_governance_domain(mgr: &GovernanceManager, member: &Did, domain_id: &str) {
+    mgr.create_domain(
+        GovernanceDomainId::new(domain_id),
+        "Test Coop".to_string(),
+        "default".to_string(),
+        GovernanceParams {
+            quorum_percentage: 1,
+            approval_threshold_percentage: 51,
+            voting_period_seconds: 86_400,
+            require_deliberation: false,
+            ..GovernanceParams::default()
+        },
+        MembershipConfig {
+            source: MembershipSource::StaticList(vec![member.clone()]),
+        },
+    )
+    .await
+    .expect("create_domain");
+}
+
+/// Build an actix app for the governance routes, injecting `BasicClaims` for
+/// `caller` with `scope`.
+macro_rules! gov_app {
+    ($ctx:expr, $caller:expr, $scope:expr) => {{
+        use actix_web::dev::Service as _;
+        use actix_web::HttpMessage as _;
+        let caller = $caller.to_string();
+        let scope: Option<String> = $scope;
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: scope.clone(),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+fn adopt_uri(domain_id: &str) -> String {
+    format!("/domains/{domain_id}/domain-policy/adopt")
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[actix_web::test]
+async fn adopt_route_persists_current_policy_and_survives_reload() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = adopt_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    seed_governance_domain(&h.ctx.manager, &caller, "coop-alpha").await;
+    h.ctx
+        .manager
+        .declare_institutional_domain(
+            GovernanceDomainId::new("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .expect("declare InstitutionalDomain");
+
+    let app = gov_app!(h.ctx.clone(), &caller, Some("governance:write".to_string()));
+    let req = test::TestRequest::post()
+        .uri(&adopt_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "policy_content": "policy v1" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "POST adopt must mount and succeed; body: {}",
+        String::from_utf8_lossy(&bytes)
+    );
+
+    // The response is the adopted policy ref projection, content-addressed
+    // server-side from the request content + bound to the path domain.
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+    let expected = DomainPolicy::new(GovernanceDomainId::new("coop-alpha"), b"policy v1");
+    assert_eq!(body["domain_id"], "coop-alpha");
+    assert_eq!(body["policy_id"], expected.id.to_hex());
+
+    // current_policy survives reload from the InstitutionalDomain store.
+    let reloaded = h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .expect("load")
+        .expect("persisted");
+    assert_eq!(reloaded.current_policy(), Some(&expected.policy_ref()));
+}
+
+#[actix_web::test]
+async fn adopt_route_requires_governance_write_scope() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = adopt_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+    seed_governance_domain(&h.ctx.manager, &caller, "coop-alpha").await;
+    h.ctx
+        .manager
+        .declare_institutional_domain(
+            GovernanceDomainId::new("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .expect("declare");
+
+    // Token carries only the read scope — the write guard must reject it.
+    let app = gov_app!(h.ctx.clone(), &caller, Some("governance:read".to_string()));
+    let req = test::TestRequest::post()
+        .uri(&adopt_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "policy_content": "policy v1" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "missing governance:write scope must be rejected"
+    );
+
+    // Nothing was adopted.
+    let reloaded = h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .unwrap();
+    assert!(reloaded.current_policy().is_none());
+}
+
+#[actix_web::test]
+async fn adopt_route_rejects_non_member() {
+    let member = fresh_did();
+    let outsider = fresh_did();
+    assert_ne!(member, outsider);
+    // The outsider even *holds* an adopt grant, but is not a domain member: the
+    // coarse membership gate must still reject before the adopt seam runs.
+    let gid = AuthorityGrantId::new();
+    let grant = adopt_grant(outsider.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+    seed_governance_domain(&h.ctx.manager, &member, "coop-alpha").await;
+    h.ctx
+        .manager
+        .declare_institutional_domain(
+            GovernanceDomainId::new("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .expect("declare");
+
+    let app = gov_app!(
+        h.ctx.clone(),
+        &outsider,
+        Some("governance:write".to_string())
+    );
+    let req = test::TestRequest::post()
+        .uri(&adopt_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "policy_content": "policy v1" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-member must be rejected by the membership gate"
+    );
+    let reloaded = h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .unwrap();
+    assert!(reloaded.current_policy().is_none());
+}
+
+#[actix_web::test]
+async fn adopt_route_undeclared_institutional_domain_is_not_found() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = adopt_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+    // GovernanceDomain exists (membership passes), but the InstitutionalDomain
+    // is never declared.
+    seed_governance_domain(&h.ctx.manager, &caller, "coop-alpha").await;
+
+    let app = gov_app!(h.ctx.clone(), &caller, Some("governance:write".to_string()));
+    let req = test::TestRequest::post()
+        .uri(&adopt_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "policy_content": "policy v1" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "adoption on an undeclared InstitutionalDomain must be 404"
+    );
+}
+
+#[actix_web::test]
+async fn adopt_route_rejects_wrong_actor_via_gate() {
+    // The grant is for the domain member, but a *different* member is the
+    // authenticated caller and holds no grant of their own.
+    let member_a = fresh_did();
+    let member_b = fresh_did();
+    assert_ne!(member_a, member_b);
+    let gid = AuthorityGrantId::new();
+    let grant = adopt_grant(member_a.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+    // Both are members so the membership gate passes; the gate must still
+    // reject member_b for lack of an authorizing grant.
+    h.ctx
+        .manager
+        .create_domain(
+            GovernanceDomainId::new("coop-alpha"),
+            "Test Coop".to_string(),
+            "default".to_string(),
+            GovernanceParams::default(),
+            MembershipConfig {
+                source: MembershipSource::StaticList(vec![member_a.clone(), member_b.clone()]),
+            },
+        )
+        .await
+        .expect("create_domain");
+    h.ctx
+        .manager
+        .declare_institutional_domain(
+            GovernanceDomainId::new("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .expect("declare");
+
+    let app = gov_app!(
+        h.ctx.clone(),
+        &member_b,
+        Some("governance:write".to_string())
+    );
+    let req = test::TestRequest::post()
+        .uri(&adopt_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "policy_content": "policy v1" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "an actor with no authorizing grant must be rejected by the gate"
+    );
+    let reloaded = h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .unwrap();
+    assert!(
+        reloaded.current_policy().is_none(),
+        "state must be unchanged on a gate rejection"
+    );
+}
+
+#[actix_web::test]
+async fn adopt_route_rejects_revoked_authority_via_gate() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = adopt_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mut mandate = backing_mandate(gid);
+    mandate.status = MandateStatus::Revoked; // grant active, mandate dead
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+    seed_governance_domain(&h.ctx.manager, &caller, "coop-alpha").await;
+    h.ctx
+        .manager
+        .declare_institutional_domain(
+            GovernanceDomainId::new("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .expect("declare");
+
+    let app = gov_app!(h.ctx.clone(), &caller, Some("governance:write".to_string()));
+    let req = test::TestRequest::post()
+        .uri(&adopt_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "policy_content": "policy v1" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a revoked backing mandate must be rejected by the gate"
+    );
+    let reloaded = h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .unwrap();
+    assert!(reloaded.current_policy().is_none());
+}
+
+#[actix_web::test]
+async fn adopt_route_rejects_empty_policy_content() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = adopt_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+    seed_governance_domain(&h.ctx.manager, &caller, "coop-alpha").await;
+    h.ctx
+        .manager
+        .declare_institutional_domain(
+            GovernanceDomainId::new("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+        )
+        .expect("declare");
+
+    let app = gov_app!(h.ctx.clone(), &caller, Some("governance:write".to_string()));
+    let req = test::TestRequest::post()
+        .uri(&adopt_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "policy_content": "   " }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "an empty/whitespace policy_content must be a 400"
+    );
+}


### PR DESCRIPTION
## What

Adds a thin governance HTTP route for persisted, gated `DomainPolicy` adoption:

```
POST /gov/domains/{domain_id}/domain-policy/adopt
```

The route calls `GovernanceManager::adopt_domain_policy_persisted(...)`, which loads the `InstitutionalDomain`, resolves authority through `DefaultMandateGate`, applies the pure-core `InstitutionalDomain::adopt_policy()` structural commit, saves the updated domain, and returns the adopted policy ref projection (`{policy_id, domain_id}`).

The adopting actor is the authenticated caller (token `sub`), never a body field. The candidate policy is content-addressed server-side from `policy_content` and bound to the path `domain_id`, so the policy↔domain identity is correct by construction (the pure-core `PolicyForOtherDomain` rejection is unreachable from this route). The route reuses the existing `governance:write` scope and domain-membership guards; the `DefaultMandateGate` is the authoritative adopt check.

## Why

#2170 landed the `InstitutionalDomain` persistence seam (`load → gate → adopt → save`) required for an honest route-level adoption surface. This PR exposes that path without adding a declare route or any broad lifecycle subsystem.

## Concurrency

The seam's documented prerequisite for a concurrent caller is now satisfied: `adopt_domain_policy_persisted` serializes its `load → mutate → save` critical section **per domain** via an in-process lock keyed by `GovernanceDomainId` (`GovernanceManager::domain_adoption_lock`). Two concurrent adoptions for the same domain can no longer interleave and last-writer-win, dropping an intervening `current_policy` update; adoptions for different domains take distinct locks and stay concurrent. The guarded section is fully synchronous, so the lock is never held across an `.await`. This is the in-process (single-node) guarantee; a transactional / multi-writer store primitive remains later work, and the seam doc records that.

No declare/create route is added: `declare_institutional_domain(...)` is not mandate-gated yet, so exposing it would be an authority bypass — out of scope here.

## Non-claims

This does not complete #2142, add a declare route, implement CCL runtime, implement a policy evaluator/registry, implement service binding runtime, perform an auth-model change, perform entity-aware auth cutover, activate institution packages, or imply production / pilot / organizer / federation readiness. The `DomainPolicy` MVP stores no CCL text; only the adopted `DomainPolicyRef` is persisted.

## Tests

New HTTP integration test `apps/governance/tests/domain_policy_adoption_http_route.rs` (7 tests): route mounted + succeeds with active domain-scoped authority; persists `current_policy` and survives reload; requires `governance:write`; non-member 403; undeclared `InstitutionalDomain` 404; wrong actor rejected via gate (state unchanged); revoked mandate rejected via gate; empty `policy_content` 400. New unit test proving the per-domain lock path under contention (8 threads, same domain).

```text
cargo fmt --all --check                                          # clean
cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings  # clean
cargo test -p icn-governance-actor --lib domain_policy           # 22 passed
cargo test -p icn-governance-actor --test domain_policy_adoption_http_route  # 7 passed
cargo test -p icn-governance-actor mandate_gate                  # 25 passed
cargo test -p icn-governance-actor --test process_gate_result_http_route  # 5 passed (no regression)
cargo test -p icn-governance institutional_domain               # 14 passed
cargo check --workspace                                          # ok
python3 docs/scripts/route_inventory.py --check                 # OK (route present, 82 governance candidates)
python3 docs/scripts/doc_control_check.py                       # OK (65 pre-existing warnings)
ops/scripts/drift-check.sh                                       # PASS (0 errors)
```

Refs #2142.