### PR TITLE
feat(governance): gate institutional domain declaration

### DIFF
--- a/icn/apps/governance/src/domain_policy_adoption.rs
+++ b/icn/apps/governance/src/domain_policy_adoption.rs
@@ -37,7 +37,8 @@ use icn_governance::{
 use icn_identity::Did;
 
 use crate::mandate_gate::{
-    DefaultMandateGate, MandateAct, MandateGate, MandateGateError, MandateRequest, MandateTarget,
+    DefaultMandateGate, MandateAct, MandateGate, MandateGateError, MandateRejection,
+    MandateRequest, MandateTarget,
 };
 use crate::receipt_backend::GovernanceReceiptBackend;
 
@@ -211,10 +212,16 @@ pub enum DeclareInstitutionalDomainError {
     /// cannot be resolved. Fail closed — a manager that cannot resolve authority
     /// must never declare a governed domain.
     MissingReceiptBackend,
-    /// The app-side [`MandateGate`] refused authority: no authorizing grant, or
-    /// a wrong actor / domain / act / class, or an expired or revoked grant or
-    /// mandate.
-    Unauthorized(MandateGateError),
+    /// The app-side [`MandateGate`] **refused** authority: no authorizing grant,
+    /// or a wrong actor / domain / act / class, or an expired or revoked grant
+    /// or mandate. An authorization denial (→ 403), kept distinct from a backend
+    /// fault so a surface never renders an infra error as "unauthorized".
+    Unauthorized(MandateRejection),
+    /// A backend read failed while the gate resolved authority; the gate fails
+    /// closed. An **infrastructure** failure (→ 5xx), not an authorization
+    /// denial — separated from [`Self::Unauthorized`] at the type level so the
+    /// gate's `Rejected`/`Backend` split survives into this seam's error.
+    Backend(String),
     /// Authority resolved, but the underlying persisted declaration failed (no
     /// domain store wired, already declared, or a backend write error).
     Store(InstitutionalDomainStoreError),
@@ -229,6 +236,9 @@ impl std::fmt::Display for DeclareInstitutionalDomainError {
             ),
             Self::Unauthorized(e) => {
                 write!(f, "institutional domain declaration unauthorized: {e}")
+            }
+            Self::Backend(e) => {
+                write!(f, "institutional domain declaration backend error: {e}")
             }
             Self::Store(e) => write!(f, "{e}"),
         }
@@ -325,12 +335,14 @@ impl crate::manager::GovernanceManager {
     /// resolver logic is duplicated and no new authority primitive is added.
     ///
     /// Fails closed: [`DeclareInstitutionalDomainError::MissingReceiptBackend`]
-    /// (no backend wired), [`DeclareInstitutionalDomainError::Unauthorized`] on
-    /// any gate rejection (wrong actor / domain / act / class, expired or revoked
-    /// authority), and [`DeclareInstitutionalDomainError::Store`] when authority
-    /// resolves but the persisted declaration fails (no domain store, already
-    /// declared, or a backend write error). Authority is resolved **before** any
-    /// store write, so an unauthorized caller never mutates state.
+    /// (no backend wired), [`DeclareInstitutionalDomainError::Unauthorized`] on a
+    /// gate **rejection** (wrong actor / domain / act / class, expired or revoked
+    /// authority — a 403-class denial), [`DeclareInstitutionalDomainError::Backend`]
+    /// when the gate's own backend read fails (a 5xx-class infrastructure fault,
+    /// kept distinct from a denial), and [`DeclareInstitutionalDomainError::Store`]
+    /// when authority resolves but the persisted declaration fails (no domain
+    /// store, already declared, or a backend write error). Authority is resolved
+    /// **before** any store write, so an unauthorized caller never mutates state.
     ///
     /// [`Execution`]: icn_governance::AuthorityClass::Execution
     pub fn declare_institutional_domain_gated(
@@ -357,8 +369,15 @@ impl crate::manager::GovernanceManager {
             target: MandateTarget::Domain(domain_id.clone()),
             at: now,
         };
-        gate.require(&req)
-            .map_err(DeclareInstitutionalDomainError::Unauthorized)?;
+        // Preserve the gate's Rejected/Backend split: an authorization denial is
+        // a 403-class `Unauthorized`, a backend read failure is a 5xx-class
+        // `Backend` — never conflated.
+        gate.require(&req).map_err(|e| match e {
+            MandateGateError::Rejected(rejection) => {
+                DeclareInstitutionalDomainError::Unauthorized(rejection)
+            }
+            MandateGateError::Backend(msg) => DeclareInstitutionalDomainError::Backend(msg),
+        })?;
 
         self.declare_institutional_domain(domain_id, owning_entity_class, charter_ref)
             .map_err(DeclareInstitutionalDomainError::Store)
@@ -437,7 +456,6 @@ mod tests {
 
     use super::*;
     use crate::manager::GovernanceManager;
-    use crate::mandate_gate::MandateRejection;
     use icn_governance::{
         AuthorityClass, AuthorityGrant, AuthorityGrantId, BootstrapEntityType, DecisionProvenance,
         GovernanceDecisionReceipt, GovernanceDomainId, Grantee, GrantorEntityId, Mandate,
@@ -1226,9 +1244,7 @@ mod tests {
             .expect_err("an actor with no authorizing grant must be refused");
         assert!(matches!(
             err,
-            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
-                MandateRejection::NoMandate
-            ))
+            DeclareInstitutionalDomainError::Unauthorized(MandateRejection::NoMandate)
         ));
         // Nothing persisted on a gate rejection.
         let store = mgr.domain_state_store().unwrap();
@@ -1254,9 +1270,7 @@ mod tests {
             .expect_err("a grant scoped to another domain must be refused");
         assert!(matches!(
             err,
-            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
-                MandateRejection::WrongTarget
-            ))
+            DeclareInstitutionalDomainError::Unauthorized(MandateRejection::WrongTarget)
         ));
     }
 
@@ -1278,9 +1292,7 @@ mod tests {
             .expect_err("a grant that does not bind the declare act must be refused");
         assert!(matches!(
             err,
-            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
-                MandateRejection::WrongTarget
-            ))
+            DeclareInstitutionalDomainError::Unauthorized(MandateRejection::WrongTarget)
         ));
     }
 
@@ -1303,9 +1315,7 @@ mod tests {
             .expect_err("an expired grant must be refused");
         assert!(matches!(
             err,
-            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
-                MandateRejection::NoMandate
-            ))
+            DeclareInstitutionalDomainError::Unauthorized(MandateRejection::NoMandate)
         ));
     }
 
@@ -1328,9 +1338,7 @@ mod tests {
             .expect_err("a revoked backing mandate must be refused");
         assert!(matches!(
             err,
-            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
-                MandateRejection::Revoked
-            ))
+            DeclareInstitutionalDomainError::Unauthorized(MandateRejection::Revoked)
         ));
     }
 
@@ -1361,6 +1369,73 @@ mod tests {
             err,
             DeclareInstitutionalDomainError::Store(InstitutionalDomainStoreError::AlreadyDeclared)
         ));
+    }
+
+    /// A receipt backend whose grant lookup always fails — drives the gate's
+    /// `MandateGateError::Backend` path (infrastructure failure, fail-closed).
+    struct FailingGrantBackend;
+
+    impl GovernanceReceiptBackend for FailingGrantBackend {
+        fn put_governance(&self, _: &GovernanceDecisionReceipt) -> Result<(), String> {
+            Ok(())
+        }
+        fn get_governance_by_proposal(
+            &self,
+            _: &str,
+        ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+            Ok(None)
+        }
+        fn put_allocation(&self, _: &AllocationReceipt) -> Result<Hash, String> {
+            Ok([0u8; 32])
+        }
+        fn get_governance_by_decision(
+            &self,
+            _: &Hash,
+        ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+            Ok(None)
+        }
+        fn list_allocations_by_decision(&self, _: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+            Ok(vec![])
+        }
+        fn list_active_authority_grants_by_grantee(
+            &self,
+            _: &Grantee,
+            _: Timestamp,
+        ) -> Result<Vec<AuthorityGrant>, String> {
+            Err("backend offline".into())
+        }
+    }
+
+    #[test]
+    fn gated_declare_surfaces_gate_backend_failure_as_backend_not_unauthorized() {
+        // A backend read failure during gate resolution is infrastructure, not a
+        // denial: it must surface as `Backend` (5xx-class), never `Unauthorized`
+        // (403). This pins the Rejected/Backend split through the seam.
+        let domain_store = Arc::new(SledGovernanceStateStore::new(Arc::new(
+            icn_store::SledStore::temporary().expect("temp sled"),
+        )));
+        let mgr = GovernanceManager::new()
+            .with_receipt_store(Arc::new(FailingGrantBackend) as Arc<dyn GovernanceReceiptBackend>)
+            .with_domain_store(domain_store);
+        let err = mgr
+            .declare_institutional_domain_gated(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+                &did(1),
+                100,
+            )
+            .expect_err("a gate backend read failure must not be silently authorized");
+        assert!(
+            matches!(err, DeclareInstitutionalDomainError::Backend(_)),
+            "gate backend failure must be Backend, not Unauthorized: {err:?}"
+        );
+        // Nothing persisted when authority could not be resolved.
+        let store = mgr.domain_state_store().unwrap();
+        assert!(store
+            .get_institutional_domain(&domain_id("coop-alpha"))
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/icn/apps/governance/src/domain_policy_adoption.rs
+++ b/icn/apps/governance/src/domain_policy_adoption.rs
@@ -197,6 +197,46 @@ impl std::fmt::Display for InstitutionalDomainStoreError {
 
 impl std::error::Error for InstitutionalDomainStoreError {}
 
+/// Error from the **gated** `InstitutionalDomain` declaration seam
+/// ([`crate::manager::GovernanceManager::declare_institutional_domain_gated`]).
+///
+/// Declaring a governed domain is an authority-bearing act (ADR-0083): this
+/// seam resolves that authority through the app-side [`DefaultMandateGate`]
+/// before delegating to the bootstrap/in-process
+/// [`crate::manager::GovernanceManager::declare_institutional_domain`]. Every
+/// variant is fail-closed — nothing is persisted unless authority resolves.
+#[derive(Debug)]
+pub enum DeclareInstitutionalDomainError {
+    /// The manager has no receipt/grant backend wired, so declaration authority
+    /// cannot be resolved. Fail closed — a manager that cannot resolve authority
+    /// must never declare a governed domain.
+    MissingReceiptBackend,
+    /// The app-side [`MandateGate`] refused authority: no authorizing grant, or
+    /// a wrong actor / domain / act / class, or an expired or revoked grant or
+    /// mandate.
+    Unauthorized(MandateGateError),
+    /// Authority resolved, but the underlying persisted declaration failed (no
+    /// domain store wired, already declared, or a backend write error).
+    Store(InstitutionalDomainStoreError),
+}
+
+impl std::fmt::Display for DeclareInstitutionalDomainError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingReceiptBackend => write!(
+                f,
+                "institutional domain declaration fail-closed: no receipt backend wired"
+            ),
+            Self::Unauthorized(e) => {
+                write!(f, "institutional domain declaration unauthorized: {e}")
+            }
+            Self::Store(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for DeclareInstitutionalDomainError {}
+
 impl crate::manager::GovernanceManager {
     /// Adopt `policy` as `domain`'s current policy, resolving authority through
     /// this manager's wired [`GovernanceReceiptBackend`] and the app-side
@@ -234,11 +274,14 @@ impl crate::manager::GovernanceManager {
     /// when a record already exists for `domain_id`. The declared domain is
     /// unbound (`current_policy == None`) until a later adoption.
     ///
-    /// **Authority note:** declaring a governed domain is itself an
-    /// authority-bearing act. This MVP seam does **not** yet mandate-gate
-    /// `declare` (a flagged sub-question in the ADR-0083 persistence addendum);
-    /// it must not be exposed on a routable surface until that gate lands. No
-    /// HTTP route is added here.
+    /// **Authority note — bootstrap / in-process only.** Declaring a governed
+    /// domain is itself an authority-bearing act, and this seam does **not**
+    /// resolve that authority: it persists unconditionally. It must **never** be
+    /// wired to a routable surface. Any HTTP/network declare path must call the
+    /// gate-resolving [`Self::declare_institutional_domain_gated`] instead;
+    /// this ungated form is for bootstrap and in-process callers (including
+    /// tests) where authority is established out of band. No HTTP route is added
+    /// here.
     pub fn declare_institutional_domain(
         &self,
         domain_id: GovernanceDomainId,
@@ -265,6 +308,60 @@ impl crate::manager::GovernanceManager {
             .save_institutional_domain(&domain)
             .map_err(|e| InstitutionalDomainStoreError::Store(e.to_string()))?;
         Ok(domain)
+    }
+
+    /// Declare and persist a new [`InstitutionalDomain`], **gated** by the
+    /// app-side [`DefaultMandateGate`] over this manager's wired
+    /// [`GovernanceReceiptBackend`].
+    ///
+    /// Declaring a governed domain is an authority-bearing act (ADR-0083): this
+    /// is the authorization-resolving wrapper a routable surface (a future
+    /// declare/create HTTP route) must call instead of the bootstrap-only
+    /// [`Self::declare_institutional_domain`]. It resolves whether `actor` holds
+    /// an active, domain-scoped [`Execution`] grant binding the
+    /// `institutional_domain:declare` act — via the **real** gate resolver, the
+    /// same machinery [`Self::adopt_domain_policy`] uses — then delegates to
+    /// [`Self::declare_institutional_domain`] for the persisted create. No
+    /// resolver logic is duplicated and no new authority primitive is added.
+    ///
+    /// Fails closed: [`DeclareInstitutionalDomainError::MissingReceiptBackend`]
+    /// (no backend wired), [`DeclareInstitutionalDomainError::Unauthorized`] on
+    /// any gate rejection (wrong actor / domain / act / class, expired or revoked
+    /// authority), and [`DeclareInstitutionalDomainError::Store`] when authority
+    /// resolves but the persisted declaration fails (no domain store, already
+    /// declared, or a backend write error). Authority is resolved **before** any
+    /// store write, so an unauthorized caller never mutates state.
+    ///
+    /// [`Execution`]: icn_governance::AuthorityClass::Execution
+    pub fn declare_institutional_domain_gated(
+        &self,
+        domain_id: GovernanceDomainId,
+        owning_entity_class: BootstrapEntityType,
+        charter_ref: Option<CharterId>,
+        actor: &Did,
+        now: Timestamp,
+    ) -> Result<InstitutionalDomain, DeclareInstitutionalDomainError> {
+        let backend = self
+            .receipt_backend()
+            .ok_or(DeclareInstitutionalDomainError::MissingReceiptBackend)?;
+
+        // Resolve declaration authority through the real gate BEFORE any store
+        // write, so an unauthorized caller never creates a domain. Mirrors the
+        // adoption seam: actor → active grants → TypedScope.domain + Execution
+        // class + `institutional_domain:declare` act token + mandate lifecycle.
+        let gate = DefaultMandateGate::new(backend);
+        let req = MandateRequest {
+            actor: actor.clone(),
+            domain: domain_id.clone(),
+            act: MandateAct::DeclareInstitutionalDomain,
+            target: MandateTarget::Domain(domain_id.clone()),
+            at: now,
+        };
+        gate.require(&req)
+            .map_err(DeclareInstitutionalDomainError::Unauthorized)?;
+
+        self.declare_institutional_domain(domain_id, owning_entity_class, charter_ref)
+            .map_err(DeclareInstitutionalDomainError::Store)
     }
 
     /// Adopt `policy` as the current policy of a **persisted**
@@ -1036,5 +1133,253 @@ mod tests {
             .unwrap()
             .expect("persisted");
         assert_eq!(reloaded.current_policy(), Some(&expected));
+    }
+
+    // ----- gated declaration tests (#2142 declare-gate lane) ----------------
+
+    /// An Execution grant for `actor`, bound to `dom`, carrying the
+    /// `institutional_domain:declare` act token — the declare analogue of
+    /// [`adopt_grant`].
+    fn declare_grant(actor: Did, dom: &str, grant_id: AuthorityGrantId) -> AuthorityGrant {
+        AuthorityGrant {
+            id: grant_id,
+            class: AuthorityClass::Execution,
+            grantor: GrantorEntityId("coop:alpha".into()),
+            grantee: Grantee::Person(actor),
+            scope: TypedScope {
+                domain: Some(domain_id(dom)),
+                action_kind: vec!["institutional_domain:declare".into()],
+                ..TypedScope::default()
+            },
+            granted_by: Some(decision()),
+            valid_from: 0,
+            valid_until: Some(1000),
+            revoked_at: None,
+        }
+    }
+
+    fn live_declare_fixture(actor: &Did, dom: &str) -> Arc<TestBackend> {
+        let gid = AuthorityGrantId::new();
+        let grant = declare_grant(actor.clone(), dom, gid.clone());
+        let mandate = backing_mandate(gid);
+        TestBackend::new(vec![mandate], vec![grant])
+    }
+
+    #[test]
+    fn gated_declare_succeeds_with_active_declare_grant() {
+        let actor = did(1);
+        let mgr = manager_with_stores(live_declare_fixture(&actor, "coop-alpha"));
+        let declared = mgr
+            .declare_institutional_domain_gated(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+                &actor,
+                100,
+            )
+            .expect("an active domain-scoped declare grant authorizes declaration");
+        assert_eq!(declared.domain_id, domain_id("coop-alpha"));
+        assert!(declared.current_policy().is_none());
+
+        // The gated declaration is persisted, identical to the ungated path.
+        let store = mgr.domain_state_store().unwrap();
+        let loaded = store
+            .get_institutional_domain(&domain_id("coop-alpha"))
+            .unwrap()
+            .expect("persisted");
+        assert_eq!(loaded, declared);
+    }
+
+    #[test]
+    fn gated_declare_fails_closed_without_receipt_backend() {
+        // No receipt backend → declaration authority cannot be resolved. The
+        // backend check precedes any store access, so this fails closed even
+        // with no domain store wired.
+        let mgr = GovernanceManager::new();
+        let err = mgr
+            .declare_institutional_domain_gated(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+                &did(1),
+                100,
+            )
+            .expect_err("a manager with no receipt backend must fail closed");
+        assert!(matches!(
+            err,
+            DeclareInstitutionalDomainError::MissingReceiptBackend
+        ));
+    }
+
+    #[test]
+    fn gated_declare_rejects_wrong_actor() {
+        // Grant is for did(1); did(2) attempts the declaration with no grant.
+        let mgr = manager_with_stores(live_declare_fixture(&did(1), "coop-alpha"));
+        let err = mgr
+            .declare_institutional_domain_gated(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+                &did(2),
+                100,
+            )
+            .expect_err("an actor with no authorizing grant must be refused");
+        assert!(matches!(
+            err,
+            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
+                MandateRejection::NoMandate
+            ))
+        ));
+        // Nothing persisted on a gate rejection.
+        let store = mgr.domain_state_store().unwrap();
+        assert!(store
+            .get_institutional_domain(&domain_id("coop-alpha"))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn gated_declare_rejects_wrong_domain() {
+        // Grant scoped to coop-beta; the declaration target is coop-alpha.
+        let actor = did(1);
+        let mgr = manager_with_stores(live_declare_fixture(&actor, "coop-beta"));
+        let err = mgr
+            .declare_institutional_domain_gated(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+                &actor,
+                100,
+            )
+            .expect_err("a grant scoped to another domain must be refused");
+        assert!(matches!(
+            err,
+            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
+                MandateRejection::WrongTarget
+            ))
+        ));
+    }
+
+    #[test]
+    fn gated_declare_rejects_wrong_act_token() {
+        // Right actor / domain / Execution class, but the grant authorizes
+        // adoption (`domain_policy:adopt`), not declaration — the declare act
+        // token / class is absent, so the gate refuses.
+        let actor = did(1);
+        let mgr = manager_with_stores(live_adopt_fixture(&actor, "coop-alpha").0);
+        let err = mgr
+            .declare_institutional_domain_gated(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+                &actor,
+                100,
+            )
+            .expect_err("a grant that does not bind the declare act must be refused");
+        assert!(matches!(
+            err,
+            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
+                MandateRejection::WrongTarget
+            ))
+        ));
+    }
+
+    #[test]
+    fn gated_declare_rejects_expired_grant() {
+        let actor = did(1);
+        let gid = AuthorityGrantId::new();
+        let mut grant = declare_grant(actor.clone(), "coop-alpha", gid.clone());
+        grant.valid_until = Some(50); // expired well before `at = 100`
+        let mandate = backing_mandate(gid);
+        let mgr = manager_with_stores(TestBackend::new(vec![mandate], vec![grant]));
+        let err = mgr
+            .declare_institutional_domain_gated(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+                &actor,
+                100,
+            )
+            .expect_err("an expired grant must be refused");
+        assert!(matches!(
+            err,
+            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
+                MandateRejection::NoMandate
+            ))
+        ));
+    }
+
+    #[test]
+    fn gated_declare_rejects_revoked_mandate() {
+        let actor = did(1);
+        let gid = AuthorityGrantId::new();
+        let grant = declare_grant(actor.clone(), "coop-alpha", gid.clone());
+        let mut mandate = backing_mandate(gid);
+        mandate.status = MandateStatus::Revoked; // grant active, mandate dead
+        let mgr = manager_with_stores(TestBackend::new(vec![mandate], vec![grant]));
+        let err = mgr
+            .declare_institutional_domain_gated(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+                &actor,
+                100,
+            )
+            .expect_err("a revoked backing mandate must be refused");
+        assert!(matches!(
+            err,
+            DeclareInstitutionalDomainError::Unauthorized(MandateGateError::Rejected(
+                MandateRejection::Revoked
+            ))
+        ));
+    }
+
+    #[test]
+    fn gated_declare_still_refuses_duplicate() {
+        // Authority resolves, but a record already exists → the underlying
+        // store refusal surfaces as Store(AlreadyDeclared).
+        let actor = did(1);
+        let mgr = manager_with_stores(live_declare_fixture(&actor, "coop-alpha"));
+        mgr.declare_institutional_domain_gated(
+            domain_id("coop-alpha"),
+            BootstrapEntityType::Cooperative,
+            None,
+            &actor,
+            100,
+        )
+        .expect("first gated declare succeeds");
+        let err = mgr
+            .declare_institutional_domain_gated(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+                &actor,
+                100,
+            )
+            .expect_err("a second gated declare must fail");
+        assert!(matches!(
+            err,
+            DeclareInstitutionalDomainError::Store(InstitutionalDomainStoreError::AlreadyDeclared)
+        ));
+    }
+
+    #[test]
+    fn ungated_declare_works_without_receipt_backend() {
+        // The bootstrap/in-process seam needs no authority resolver: it persists
+        // with only a domain store wired (no receipt backend), proving it is a
+        // distinct, deliberately-ungated path from the gated seam above.
+        let domain_store = Arc::new(SledGovernanceStateStore::new(Arc::new(
+            icn_store::SledStore::temporary().expect("temp sled"),
+        )));
+        let mgr = GovernanceManager::new().with_domain_store(domain_store);
+        let declared = mgr
+            .declare_institutional_domain(
+                domain_id("coop-alpha"),
+                BootstrapEntityType::Cooperative,
+                None,
+            )
+            .expect("ungated declare persists without any authority resolution");
+        assert_eq!(declared.domain_id, domain_id("coop-alpha"));
+        assert!(declared.current_policy().is_none());
     }
 }

--- a/icn/apps/governance/src/mandate_gate.rs
+++ b/icn/apps/governance/src/mandate_gate.rs
@@ -1244,6 +1244,8 @@ mod tests {
         // map to a unique snake_case token. Adding a MandateAct variant
         // without updating as_wire_token() is the failure mode this
         // guards.
+        // Every MandateAct variant must be listed here — this is the manual
+        // enumeration that guards `as_wire_token()` coverage.
         let acts = [
             MandateAct::ActivateCharter,
             MandateAct::AddDomainMember,
@@ -1254,6 +1256,8 @@ mod tests {
             MandateAct::RemoveSteward,
             MandateAct::JoinFederation,
             MandateAct::LeaveFederation,
+            MandateAct::AdoptDomainPolicy,
+            MandateAct::DeclareInstitutionalDomain,
         ];
         let mut seen = std::collections::HashSet::new();
         for act in acts {

--- a/icn/apps/governance/src/mandate_gate.rs
+++ b/icn/apps/governance/src/mandate_gate.rs
@@ -112,6 +112,8 @@ pub enum MandateAct {
     LeaveFederation,
     /// Adopt (or change) a governed domain's current `DomainPolicy`.
     AdoptDomainPolicy,
+    /// Declare (create) a governed `InstitutionalDomain`.
+    DeclareInstitutionalDomain,
 }
 
 /// The subject an act operates on.
@@ -196,6 +198,7 @@ impl MandateAct {
             MandateAct::JoinFederation => "join_federation",
             MandateAct::LeaveFederation => "leave_federation",
             MandateAct::AdoptDomainPolicy => "adopt_domain_policy",
+            MandateAct::DeclareInstitutionalDomain => "declare_institutional_domain",
         }
     }
 }
@@ -348,7 +351,8 @@ fn expected_class(act: &MandateAct) -> AuthorityClass {
         | MandateAct::RemoveSteward
         | MandateAct::JoinFederation
         | MandateAct::LeaveFederation
-        | MandateAct::AdoptDomainPolicy => AuthorityClass::Execution,
+        | MandateAct::AdoptDomainPolicy
+        | MandateAct::DeclareInstitutionalDomain => AuthorityClass::Execution,
     }
 }
 
@@ -376,6 +380,10 @@ fn expected_act_tokens(act: &MandateAct) -> (Option<&'static str>, Option<&'stat
         MandateAct::JoinFederation => (Some("federation:join"), Some("Federation")),
         MandateAct::LeaveFederation => (Some("federation:leave"), Some("Federation")),
         MandateAct::AdoptDomainPolicy => (Some("domain_policy:adopt"), Some("DomainPolicy")),
+        MandateAct::DeclareInstitutionalDomain => (
+            Some("institutional_domain:declare"),
+            Some("InstitutionalDomain"),
+        ),
     }
 }
 


### PR DESCRIPTION
## What

Adds a mandate-gated manager seam for declaring `InstitutionalDomain` records: `GovernanceManager::declare_institutional_domain_gated(...)`.

It resolves authority through the existing app-side `DefaultMandateGate` **before** any store write, then delegates to the existing persisted `declare_institutional_domain`. The existing ungated `declare_institutional_domain` stays as an explicit bootstrap/in-process seam, documented as never-routable.

## Why

ADR-0083 flags declaration as an authority-bearing act and explicitly defers the gating decision to the implementation lane: "declaring a governed domain is itself an authority-bearing act — whether `declare` must be mandate-gated or may be a bootstrap-time seam should be settled when the path lands; it must not silently permit unauthorized domain creation on a routable surface." Now that adoption is routable (#2172), declaration must be gate-resolved before any declare/create HTTP route can exist.

## Details

- Adds `MandateAct::DeclareInstitutionalDomain` — Execution class; act token `institutional_domain:declare` / proposal-class `InstitutionalDomain`; wire token `declare_institutional_domain`. Reuses `MandateTarget::Domain`; no resolver logic duplicated (mirrors `AdoptDomainPolicy`).
- `declare_institutional_domain_gated(domain_id, owning_entity_class, charter_ref, actor, now)` → `DeclareInstitutionalDomainError`:
  - `MissingReceiptBackend` when no receipt/grant backend is wired (fail-closed);
  - `Unauthorized(MandateGateError)` on any gate rejection (wrong actor / domain / act / class, expired or revoked authority);
  - `Store(InstitutionalDomainStoreError)` when authority resolves but the persisted declaration fails (no domain store, already declared, backend write error).
  - Authority is resolved **before** any store write, so an unauthorized caller never mutates state.
- The ungated `declare_institutional_domain` doc is updated to "bootstrap / in-process only — never wire to a routable surface; use the gated seam."

## Concurrency

Unchanged. Declaration is a single store write guarded by `AlreadyDeclared`; the per-domain adoption lock from #2172 is not involved. Cross-process / multi-writer transactional safety remains future work.

## Non-claims

This does not complete #2142, add a declare/create HTTP route (that is the next rung, after this gating is reviewed), implement CCL runtime, implement a policy registry/evaluator, implement a service-binding runtime, perform an auth-model change, perform entity-aware auth enforcement, activate institution packages, provide cross-process/multi-writer transactional safety, or imply production / pilot / organizer / federation readiness.

## Tests

9 new unit tests in `domain_policy_adoption.rs` (mirroring the adoption gate tests, reusing `TestBackend` + `DefaultMandateGate`):

```text
cargo fmt --all --check                                                       # clean
cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings  # clean
cargo test -p icn-governance-actor --lib domain_policy   # 31 passed (incl. 8 gated + 1 ungated declare)
cargo test -p icn-governance-actor mandate_gate          # 25 passed
cargo test -p icn-governance institutional_domain        # 14 passed
cargo check --workspace                                  # ok
python3 docs/scripts/route_inventory.py --check          # OK (unchanged — no route added)
python3 docs/scripts/doc_control_check.py                # OK (65 pre-existing warnings)
ops/scripts/drift-check.sh                               # PASS (0 errors)
firewall / meaning-firewall checks                       # no NEW violations
```

Refs #2142.