### PR TITLE
feat(governance): expose institutional domain declaration route

### DIFF
--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-23T14:58:18+00:00
+Generated: 2026-06-23T17:55:59+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -17,7 +17,7 @@ Generated: 2026-06-23T14:58:18+00:00
 
 ## Snapshot
 
-- Source commit: `72b9d86b42d254d0b8943eafb565be1cdcf5bcec`
+- Source commit: `16593e3fe42209422093aabd80c4073116d4457f`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -29,7 +29,7 @@ Generated: 2026-06-23T14:58:18+00:00
 - Not matched to OpenAPI (best-effort): 285 (~99% of discovered)
 - Documented share of discovered routes: ~0.7%
 - **OpenAPI operations (method + path) not matched to a discovered gateway route: 3** (see section below)
-- **Governance app route-registration candidates (separate surface, not gateway macros): 82** (see section below)
+- **Governance app route-registration candidates (separate surface, not gateway macros): 83** (see section below)
 
 > The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside the gateway crate and are not captured by this macro scan — so the documented/undocumented counts here are a best-effort comparison, while the two headline counts (discovered macros, OpenAPI paths) are the robust measured facts.
 
@@ -40,8 +40,8 @@ These OpenAPI-documented paths did **not** mechanically match any discovered gat
 | Method | OpenAPI path | Matched gateway route | Governance registration candidate | Status | Claim safety |
 |---|---|---|---|---|---|
 | GET | `/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | no | `get_action_item_completion_receipt` @ `icn/apps/governance/src/http/configure.rs`:682 | unknown / needs local verification | needs review |
-| GET | `/gov/me/action-cards` | no | `get_my_action_cards` @ `icn/apps/governance/src/http/configure.rs`:844 | unknown / needs local verification | needs review |
-| GET | `/gov/me/standing` | no | `get_my_standing` @ `icn/apps/governance/src/http/configure.rs`:840 | unknown / needs local verification | needs review |
+| GET | `/gov/me/action-cards` | no | `get_my_action_cards` @ `icn/apps/governance/src/http/configure.rs`:849 | unknown / needs local verification | needs review |
+| GET | `/gov/me/standing` | no | `get_my_standing` @ `icn/apps/governance/src/http/configure.rs`:845 | unknown / needs local verification | needs review |
 
 ## Governance app route-registration candidates
 
@@ -49,12 +49,12 @@ The governance app (`icn-governance-actor` = `icn/apps/governance`) registers it
 
 | Method | Path (relative, under `/gov`) | Source | Handler | OpenAPI documented | Status | Claim safety |
 |---|---|---|---|---|---|---|
-| GET | `/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:717 | `get_activity` | no | unknown / needs local verification | needs review |
+| GET | `/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:722 | `get_activity` | no | unknown / needs local verification | needs review |
 | POST | `/charters` | `icn/apps/governance/src/http/configure.rs`:587 | `activate_charter` | no | unknown / needs local verification | needs review |
 | GET | `/delegations` | `icn/apps/governance/src/http/configure.rs`:654 | `list_delegations` | no | unknown / needs local verification | needs review |
 | POST | `/delegations` | `icn/apps/governance/src/http/configure.rs`:653 | `create_delegation` | no | unknown / needs local verification | needs review |
 | DELETE | `/delegations/{delegation_id}` | `icn/apps/governance/src/http/configure.rs`:658 | `revoke_delegation` | no | unknown / needs local verification | needs review |
-| GET | `/digest` | `icn/apps/governance/src/http/configure.rs`:837 | `get_digest` | no | unknown / needs local verification | needs review |
+| GET | `/digest` | `icn/apps/governance/src/http/configure.rs`:842 | `get_digest` | no | unknown / needs local verification | needs review |
 | GET | `/domains` | `icn/apps/governance/src/http/configure.rs`:576 | `list_domains` | no | unknown / needs local verification | needs review |
 | POST | `/domains` | `icn/apps/governance/src/http/configure.rs`:575 | `create_domain` | no | unknown / needs local verification | needs review |
 | GET | `/domains/{domain_id}` | `icn/apps/governance/src/http/configure.rs`:579 | `get_domain` | no | unknown / needs local verification | needs review |
@@ -67,51 +67,52 @@ The governance app (`icn-governance-actor` = `icn/apps/governance`) registers it
 | POST | `/domains/{domain_id}/action-items/{item_id}/notes` | `icn/apps/governance/src/http/configure.rs`:678 | `add_action_item_note` | no | unknown / needs local verification | needs review |
 | PUT | `/domains/{domain_id}/action-items/{item_id}/status` | `icn/apps/governance/src/http/configure.rs`:674 | `update_action_item_status` | no | unknown / needs local verification | needs review |
 | POST | `/domains/{domain_id}/domain-policy/adopt` | `icn/apps/governance/src/http/configure.rs`:692 | `adopt_domain_policy` | no | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:768 | `list_meetings` | no | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:767 | `create_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/institutional-domain/declare` | `icn/apps/governance/src/http/configure.rs`:697 | `declare_institutional_domain` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:773 | `list_meetings` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:772 | `create_meeting` | no | unknown / needs local verification | needs review |
 | DELETE | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:584 | `remove_domain_member` | no | unknown / needs local verification | needs review |
 | POST | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:583 | `add_domain_member` | no | unknown / needs local verification | needs review |
 | POST | `/domains/{domain_id}/process-sessions/{session_id}/gate-results` | `icn/apps/governance/src/http/configure.rs`:687 | `record_process_gate_result` | no | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:723 | `list_programs_by_domain` | no | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:722 | `create_program` | no | unknown / needs local verification | needs review |
-| GET | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:713 | `list_activities` | no | unknown / needs local verification | needs review |
-| POST | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:712 | `create_activity` | no | unknown / needs local verification | needs review |
-| GET | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:698 | `list_structures` | no | unknown / needs local verification | needs review |
-| POST | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:697 | `create_structure` | no | unknown / needs local verification | needs review |
-| GET | `/me/action-cards` | `icn/apps/governance/src/http/configure.rs`:844 | `get_my_action_cards` | yes | unknown / needs local verification | needs review |
-| GET | `/me/scopes` | `icn/apps/governance/src/http/configure.rs`:839 | `get_my_scopes` | no | unknown / needs local verification | needs review |
-| GET | `/me/standing` | `icn/apps/governance/src/http/configure.rs`:840 | `get_my_standing` | yes | unknown / needs local verification | needs review |
-| GET | `/me/work` | `icn/apps/governance/src/http/configure.rs`:841 | `get_my_work` | no | unknown / needs local verification | needs review |
-| GET | `/meetings/{meeting_id}` | `icn/apps/governance/src/http/configure.rs`:772 | `get_meeting` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/agenda` | `icn/apps/governance/src/http/configure.rs`:792 | `add_agenda_item` | no | unknown / needs local verification | needs review |
-| PUT | `/meetings/{meeting_id}/agenda/{item_id}` | `icn/apps/governance/src/http/configure.rs`:796 | `update_agenda_item` | no | unknown / needs local verification | needs review |
-| PUT | `/meetings/{meeting_id}/attendance` | `icn/apps/governance/src/http/configure.rs`:788 | `mark_attendance` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/attendees` | `icn/apps/governance/src/http/configure.rs`:784 | `add_attendee` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/end` | `icn/apps/governance/src/http/configure.rs`:780 | `end_meeting` | no | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/start` | `icn/apps/governance/src/http/configure.rs`:776 | `start_meeting` | no | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:753 | `get_milestone` | no | unknown / needs local verification | needs review |
-| PATCH | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:754 | `update_milestone_status` | no | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}/history` | `icn/apps/governance/src/http/configure.rs`:762 | `get_milestone_history` | no | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}/preview` | `icn/apps/governance/src/http/configure.rs`:758 | `preview_milestone` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}` | `icn/apps/governance/src/http/configure.rs`:727 | `get_program` | no | unknown / needs local verification | needs review |
-| DELETE | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:749 | `unlink_activity_from_program` | no | unknown / needs local verification | needs review |
-| PUT | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:748 | `link_activity_to_program` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/dashboard` | `icn/apps/governance/src/http/configure.rs`:735 | `get_program_dashboard` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:744 | `list_milestones_by_program` | no | unknown / needs local verification | needs review |
-| POST | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:743 | `create_milestone` | no | unknown / needs local verification | needs review |
-| PATCH | `/programs/{program_id}/status` | `icn/apps/governance/src/http/configure.rs`:731 | `update_program_status` | no | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/summary` | `icn/apps/governance/src/http/configure.rs`:739 | `get_program_summary` | no | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:728 | `list_programs_by_domain` | no | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:727 | `create_program` | no | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:718 | `list_activities` | no | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:717 | `create_activity` | no | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:703 | `list_structures` | no | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:702 | `create_structure` | no | unknown / needs local verification | needs review |
+| GET | `/me/action-cards` | `icn/apps/governance/src/http/configure.rs`:849 | `get_my_action_cards` | yes | unknown / needs local verification | needs review |
+| GET | `/me/scopes` | `icn/apps/governance/src/http/configure.rs`:844 | `get_my_scopes` | no | unknown / needs local verification | needs review |
+| GET | `/me/standing` | `icn/apps/governance/src/http/configure.rs`:845 | `get_my_standing` | yes | unknown / needs local verification | needs review |
+| GET | `/me/work` | `icn/apps/governance/src/http/configure.rs`:846 | `get_my_work` | no | unknown / needs local verification | needs review |
+| GET | `/meetings/{meeting_id}` | `icn/apps/governance/src/http/configure.rs`:777 | `get_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/agenda` | `icn/apps/governance/src/http/configure.rs`:797 | `add_agenda_item` | no | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/agenda/{item_id}` | `icn/apps/governance/src/http/configure.rs`:801 | `update_agenda_item` | no | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/attendance` | `icn/apps/governance/src/http/configure.rs`:793 | `mark_attendance` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/attendees` | `icn/apps/governance/src/http/configure.rs`:789 | `add_attendee` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/end` | `icn/apps/governance/src/http/configure.rs`:785 | `end_meeting` | no | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/start` | `icn/apps/governance/src/http/configure.rs`:781 | `start_meeting` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:758 | `get_milestone` | no | unknown / needs local verification | needs review |
+| PATCH | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:759 | `update_milestone_status` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/history` | `icn/apps/governance/src/http/configure.rs`:767 | `get_milestone_history` | no | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/preview` | `icn/apps/governance/src/http/configure.rs`:763 | `preview_milestone` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}` | `icn/apps/governance/src/http/configure.rs`:732 | `get_program` | no | unknown / needs local verification | needs review |
+| DELETE | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:754 | `unlink_activity_from_program` | no | unknown / needs local verification | needs review |
+| PUT | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:753 | `link_activity_to_program` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/dashboard` | `icn/apps/governance/src/http/configure.rs`:740 | `get_program_dashboard` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:749 | `list_milestones_by_program` | no | unknown / needs local verification | needs review |
+| POST | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:748 | `create_milestone` | no | unknown / needs local verification | needs review |
+| PATCH | `/programs/{program_id}/status` | `icn/apps/governance/src/http/configure.rs`:736 | `update_program_status` | no | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/summary` | `icn/apps/governance/src/http/configure.rs`:744 | `get_program_summary` | no | unknown / needs local verification | needs review |
 | GET | `/proposals` | `icn/apps/governance/src/http/configure.rs`:592 | `list_proposals` | no | unknown / needs local verification | needs review |
 | POST | `/proposals` | `icn/apps/governance/src/http/configure.rs`:591 | `create_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/clearing/establish` | `icn/apps/governance/src/http/configure.rs`:809 | `create_establish_clearing_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/clearing/terminate` | `icn/apps/governance/src/http/configure.rs`:813 | `create_terminate_clearing_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/join` | `icn/apps/governance/src/http/configure.rs`:801 | `create_join_federation_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/leave` | `icn/apps/governance/src/http/configure.rs`:805 | `create_leave_federation_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/policy` | `icn/apps/governance/src/http/configure.rs`:825 | `create_update_federation_policy_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/vouch` | `icn/apps/governance/src/http/configure.rs`:817 | `create_vouch_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/vouch/revoke` | `icn/apps/governance/src/http/configure.rs`:821 | `create_revoke_vouch_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/sdis/appoint-steward` | `icn/apps/governance/src/http/configure.rs`:830 | `create_appoint_steward_proposal` | no | unknown / needs local verification | needs review |
-| POST | `/proposals/sdis/remove-steward` | `icn/apps/governance/src/http/configure.rs`:834 | `create_remove_steward_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/establish` | `icn/apps/governance/src/http/configure.rs`:814 | `create_establish_clearing_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/terminate` | `icn/apps/governance/src/http/configure.rs`:818 | `create_terminate_clearing_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/join` | `icn/apps/governance/src/http/configure.rs`:806 | `create_join_federation_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/leave` | `icn/apps/governance/src/http/configure.rs`:810 | `create_leave_federation_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/policy` | `icn/apps/governance/src/http/configure.rs`:830 | `create_update_federation_policy_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch` | `icn/apps/governance/src/http/configure.rs`:822 | `create_vouch_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch/revoke` | `icn/apps/governance/src/http/configure.rs`:826 | `create_revoke_vouch_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/appoint-steward` | `icn/apps/governance/src/http/configure.rs`:835 | `create_appoint_steward_proposal` | no | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/remove-steward` | `icn/apps/governance/src/http/configure.rs`:839 | `create_remove_steward_proposal` | no | unknown / needs local verification | needs review |
 | GET | `/proposals/{proposal_id}` | `icn/apps/governance/src/http/configure.rs`:596 | `get_proposal` | no | unknown / needs local verification | needs review |
 | GET | `/proposals/{proposal_id}/chain` | `icn/apps/governance/src/http/configure.rs`:620 | `get_chain` | no | unknown / needs local verification | needs review |
 | POST | `/proposals/{proposal_id}/close` | `icn/apps/governance/src/http/configure.rs`:604 | `close_proposal` | no | unknown / needs local verification | needs review |
@@ -128,9 +129,9 @@ The governance app (`icn-governance-actor` = `icn/apps/governance`) registers it
 | GET | `/proposals/{proposal_id}/proof` | `icn/apps/governance/src/http/configure.rs`:616 | `get_proof` | no | unknown / needs local verification | needs review |
 | GET | `/proposals/{proposal_id}/tally` | `icn/apps/governance/src/http/configure.rs`:612 | `get_vote_tally` | no | unknown / needs local verification | needs review |
 | POST | `/proposals/{proposal_id}/vote` | `icn/apps/governance/src/http/configure.rs`:608 | `cast_vote` | no | unknown / needs local verification | needs review |
-| GET | `/structures/{structure_id}` | `icn/apps/governance/src/http/configure.rs`:702 | `get_structure` | no | unknown / needs local verification | needs review |
-| GET | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:707 | `list_roles` | no | unknown / needs local verification | needs review |
-| POST | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:706 | `assign_role` | no | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}` | `icn/apps/governance/src/http/configure.rs`:707 | `get_structure` | no | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:712 | `list_roles` | no | unknown / needs local verification | needs review |
+| POST | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:711 | `assign_role` | no | unknown / needs local verification | needs review |
 
 ## Limitations
 

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -691,6 +691,11 @@ where
             web::resource("/domains/{domain_id}/domain-policy/adopt")
                 .route(web::post().to(handlers::adopt_domain_policy::<E>)),
         )
+        // ── Institutional domain declaration (#2142 — gated declare) ──────
+        .service(
+            web::resource("/domains/{domain_id}/institutional-domain/declare")
+                .route(web::post().to(handlers::declare_institutional_domain::<E>)),
+        )
         // ── Structure endpoints ──────────────────────────────────────────
         .service(
             web::resource("/entities/{entity_id}/structures")

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -8,11 +8,12 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use icn_federation::SettlementInterval;
 use icn_governance::{
     ActionItemFilter, ActionItemId, ActionItemPriority, ActionItemStatus, ActivityId, ActivityKind,
-    ActivityStatus, AttendanceStatus, DataSharingLevel, Delegation, DelegationId, DelegationScope,
-    DisputeResolutionMethod, DomainPolicy, FederationProposal, FederationTerms, GovernanceDomain,
-    GovernanceDomainId, GovernanceParams, MeetingId, MeetingRole, MeetingStatus, MembershipAction,
-    MembershipConfig, MilestoneId, MilestoneStatus, ProgramId, ProgramKind, ProposalId,
-    ProposalPayload, ProposalScope, StructureId, StructureKind, StructureStatus, VoteChoice,
+    ActivityStatus, AttendanceStatus, CharterId, DataSharingLevel, Delegation, DelegationId,
+    DelegationScope, DisputeResolutionMethod, DomainPolicy, FederationProposal, FederationTerms,
+    GovernanceDomain, GovernanceDomainId, GovernanceParams, MeetingId, MeetingRole, MeetingStatus,
+    MembershipAction, MembershipConfig, MilestoneId, MilestoneStatus, ProgramId, ProgramKind,
+    ProposalId, ProposalPayload, ProposalScope, StructureId, StructureKind, StructureStatus,
+    VoteChoice,
 };
 use icn_http_kit::{
     auth::{require_any_scope, require_any_scope_matched, require_scope, BasicClaims},
@@ -25,7 +26,8 @@ use super::configure::{DispatchEvidenceSpec, GovernanceContext, GovernanceEffect
 use super::models::*;
 use super::validation as val;
 use crate::domain_policy_adoption::{
-    AdoptDomainPolicyError, DomainPolicyAdoptionError, InstitutionalDomainStoreError,
+    AdoptDomainPolicyError, DeclareInstitutionalDomainError, DomainPolicyAdoptionError,
+    InstitutionalDomainStoreError,
 };
 use crate::events::GovernanceEventEmitter;
 
@@ -3236,6 +3238,122 @@ pub async fn adopt_domain_policy<E: GovernanceEventEmitter + Clone + 'static>(
     Ok(HttpResponse::Ok().json(AdoptDomainPolicyResponse {
         policy_id: policy_ref.id.to_hex(),
         domain_id: policy_ref.domain_id.0,
+    }))
+}
+
+/// Parse the optional hex `charter_id` request field into a [`CharterId`].
+/// `None` stays `None`; a present value must be exactly 32 bytes (64 hex chars).
+fn parse_optional_charter_id(charter_id: &Option<String>) -> Result<Option<CharterId>, ApiError> {
+    let Some(s) = charter_id.as_ref() else {
+        return Ok(None);
+    };
+    let bytes = hex::decode(s.trim())
+        .map_err(|e| err_bad(format!("charter_id must be hex-encoded: {e}")))?;
+    let arr: [u8; 32] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| err_bad("charter_id must be 32 bytes (64 hex characters)"))?;
+    Ok(Some(CharterId::new(arr)))
+}
+
+/// Map the gated-declaration seam error onto the governance HTTP error
+/// taxonomy. Fail-closed: only a clearly-authorization or already-declared
+/// problem maps to 403/409; everything else (missing backend/store, gate
+/// backend fault, unreachable variants) surfaces as 500.
+fn declare_institutional_domain_err_to_api(e: DeclareInstitutionalDomainError) -> ApiError {
+    use DeclareInstitutionalDomainError as D;
+    use InstitutionalDomainStoreError as S;
+    let msg = e.to_string();
+    match e {
+        // Gate denial (wrong actor/domain/act/class, expired/revoked) → 403.
+        D::Unauthorized(_) => err_forbidden(msg),
+        // A record already exists for this domain id → conflict.
+        D::Store(S::AlreadyDeclared) => ApiError::Conflict(msg),
+        // Misconfiguration / infrastructure faults → 500. `NotDeclared` and
+        // `Adopt(_)` are unreachable on the declare path; fail closed to 500.
+        D::MissingReceiptBackend
+        | D::Backend(_)
+        | D::Store(S::MissingDomainStore)
+        | D::Store(S::Store(_))
+        | D::Store(S::NotDeclared)
+        | D::Store(S::Adopt(_)) => err_internal(msg),
+    }
+}
+
+/// POST /gov/domains/{domain_id}/institutional-domain/declare
+/// — Declare the `InstitutionalDomain` authority record for an existing
+/// `GovernanceDomainId`, gated by the app-side `DefaultMandateGate` (issue
+/// #2142).
+///
+/// Drives the mandate-gated declaration seam end-to-end over HTTP:
+///
+/// ```text
+/// POST → governance:write scope
+///      → GovernanceManager::declare_institutional_domain_gated
+///        → DefaultMandateGate authority resolution (actor → active grants →
+///          domain-scoped Execution `institutional_domain:declare` grant +
+///          live mandate)
+///        → (only on pass) persist a freshly-declared InstitutionalDomain
+///      → declared-domain projection
+/// ```
+///
+/// The declaring actor is the authenticated caller (`sub`), never a body field.
+/// The route calls the **gated** seam, never the ungated bootstrap
+/// `declare_institutional_domain` — authority is resolved before any store
+/// write, so an unauthorized caller persists nothing and cannot learn whether a
+/// domain already exists (the gate refuses before the duplicate check).
+///
+/// **Membership gate intentionally omitted.** Unlike the domain-scoped *write*
+/// surface (which reuses `check_domain_membership`), declaration must not
+/// require prior membership: the actor authorized to *establish* a governed
+/// domain (by a domain-scoped declare grant) may not yet be a member of it, so a
+/// membership precondition could wrongly block the first authorized declaration.
+/// The `DefaultMandateGate` declare grant is the authoritative — and strictly
+/// stronger — authority check here.
+///
+/// This adds no new authority primitive, no CCL runtime, no policy registry, and
+/// no auth-model change.
+///
+/// Returns:
+/// - 200 with the declared-domain projection.
+/// - 400 when `entity_type` is out of taxonomy, `charter_id` is malformed, or
+///   the body/DID is malformed.
+/// - 401 when the bearer token is missing/invalid.
+/// - 403 when the token lacks `governance:write` or the `DefaultMandateGate`
+///   refuses declaration authority.
+/// - 409 when an `InstitutionalDomain` is already declared for `domain_id`.
+/// - 500 when no receipt/domain store is wired, or a backend read/write fails.
+pub async fn declare_institutional_domain<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<String>,
+    req: web::Json<DeclareInstitutionalDomainRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let actor = parse_did(&claims.sub, "Invalid DID in token")?;
+
+    let domain = GovernanceDomainId(path.into_inner());
+    let charter_ref = parse_optional_charter_id(&req.charter_id)?;
+
+    // Authoritative check is the DefaultMandateGate inside the gated seam, which
+    // resolves authority BEFORE any store write. The ungated bootstrap seam is
+    // never reached from this route.
+    let declared = ctx
+        .manager
+        .declare_institutional_domain_gated(
+            domain,
+            req.entity_type,
+            charter_ref,
+            &actor,
+            current_time_secs(),
+        )
+        .map_err(declare_institutional_domain_err_to_api)?;
+
+    Ok(HttpResponse::Ok().json(DeclareInstitutionalDomainResponse {
+        domain_id: declared.domain_id.0,
+        owning_entity_class: declared.owning_entity_class,
+        charter_id: declared.charter_ref.map(|c| c.to_hex()),
+        current_policy_id: declared.current_policy.map(|p| p.id.to_hex()),
     }))
 }
 

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3247,7 +3247,16 @@ fn parse_optional_charter_id(charter_id: &Option<String>) -> Result<Option<Chart
     let Some(s) = charter_id.as_ref() else {
         return Ok(None);
     };
-    let bytes = hex::decode(s.trim())
+    let trimmed = s.trim();
+    // A `CharterId` is exactly 32 bytes (64 hex chars). Validate length BEFORE
+    // decoding so an oversize body is never hex-decoded, and a wrong-length
+    // value gets a precise 400 rather than a generic decode error.
+    if trimmed.len() != 64 {
+        return Err(err_bad(
+            "charter_id must be exactly 64 hex characters (32 bytes)",
+        ));
+    }
+    let bytes = hex::decode(trimmed)
         .map_err(|e| err_bad(format!("charter_id must be hex-encoded: {e}")))?;
     let arr: [u8; 32] = bytes
         .as_slice()

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -7,7 +7,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use icn_governance::{ProcessGateKind, ProcessGateResult};
+use icn_governance::{BootstrapEntityType, ProcessGateKind, ProcessGateResult};
 
 // ============================================================================
 // Domain
@@ -101,6 +101,47 @@ pub struct AdoptDomainPolicyResponse {
     pub policy_id: String,
     /// The governance domain the policy was adopted for.
     pub domain_id: String,
+}
+
+// ============================================================================
+// Institutional domain declaration (#2142 — gated declare/create)
+// ============================================================================
+
+/// Request body for `POST /gov/domains/{domain_id}/institutional-domain/declare`.
+///
+/// Declares the `InstitutionalDomain` authority record for the existing
+/// `GovernanceDomainId` carried in the path. The declaring actor is the
+/// authenticated caller (token `sub`), never a body field, and the authority to
+/// declare is resolved server-side through the `DefaultMandateGate` — not
+/// asserted here. `entity_type` is the closed [`BootstrapEntityType`] taxonomy
+/// (`"federation"` | `"cooperative"` | `"community"` | `"individual"`); an
+/// out-of-taxonomy value is rejected by JSON deserialization (400). `charter_id`
+/// is the optional hex (64-char) id of the domain's founding charter; omit it
+/// to declare a charter-less domain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeclareInstitutionalDomainRequest {
+    /// The governed entity taxonomy the domain is owned by.
+    pub entity_type: BootstrapEntityType,
+    /// Optional hex (64-char) id of the domain's founding `CharterId`.
+    #[serde(default)]
+    pub charter_id: Option<String>,
+}
+
+/// Response body for a successful `InstitutionalDomain` declaration.
+///
+/// A legible projection of the freshly-declared
+/// [`icn_governance::InstitutionalDomain`]. A freshly-declared domain is
+/// unbound, so `current_policy_id` is always `null` here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeclareInstitutionalDomainResponse {
+    /// The governance domain the institutional-domain record is keyed by.
+    pub domain_id: String,
+    /// The owning entity taxonomy.
+    pub owning_entity_class: BootstrapEntityType,
+    /// Hex id of the adopted founding charter, if any.
+    pub charter_id: Option<String>,
+    /// Hex id of the current adopted policy — `null` for a fresh declaration.
+    pub current_policy_id: Option<String>,
 }
 
 // ============================================================================

--- a/icn/apps/governance/tests/institutional_domain_declare_http_route.rs
+++ b/icn/apps/governance/tests/institutional_domain_declare_http_route.rs
@@ -1,0 +1,513 @@
+//! HTTP route proof for gated `InstitutionalDomain` declaration — issue #2142.
+//!
+//! The gated declaration seam already exists and is proven at the manager layer
+//! (`domain_policy_adoption.rs` unit tests): `MandateAct::DeclareInstitutionalDomain`,
+//! `GovernanceManager::declare_institutional_domain_gated` (`gate → persist`,
+//! gate-before-write), and the ungated bootstrap `declare_institutional_domain`.
+//! This test pins the missing surface: **one governance HTTP route that drives
+//! the gated seam end-to-end**:
+//!
+//!   `POST /gov/domains/{domain_id}/institutional-domain/declare`
+//!     → governance:write scope
+//!     → GovernanceManager::declare_institutional_domain_gated
+//!       → DefaultMandateGate (domain-scoped `institutional_domain:declare` grant)
+//!       → persist InstitutionalDomain (only after the gate passes)
+//!     → declared-domain projection
+//!
+//! It adds NO new authority primitive and NEVER calls the ungated bootstrap
+//! `declare_institutional_domain` seam.
+//!
+//! Pins:
+//!
+//! 1. The route is mounted and succeeds with an active domain-scoped declare grant.
+//! 2. The declared `InstitutionalDomain` persists and reloads from the store.
+//! 3. The route requires the existing `governance:write` write guard.
+//! 4. The acting DID is the authenticated token subject (the grant is bound to
+//!    that DID; a request with a different token subject is refused).
+//! 5. A wrong actor is rejected via the gate (403) and persists nothing.
+//! 6. A wrong-domain grant is rejected via the gate (403).
+//! 7. A revoked backing mandate is rejected via the gate (403).
+//! 8. Duplicate declaration (by the authorized actor) returns 409.
+//! 9. **Gate-before-write / no existence leak**: an unauthorized actor declaring
+//!    an already-declared domain gets 403 (the gate refuses), NOT 409.
+//!    This is also the proof the route does not bypass the gate into the
+//!    ungated seam — an ungated path would have persisted/succeeded.
+//! 10. A malformed `charter_id` (non-hex / wrong length) is a 400.
+//! 11. An out-of-taxonomy `entity_type` is a 400.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{body::to_bytes, http::StatusCode, test, App};
+use icn_governance::{
+    AuthorityClass, AuthorityGrant, AuthorityGrantId, BootstrapEntityType, DecisionProvenance,
+    GovernanceDecisionReceipt, GovernanceDomainId, Grantee, GrantorEntityId, Mandate,
+    MandateStatus, Timestamp, TypedScope,
+};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
+    GovernanceStateStore, NoopEventEmitter, SledGovernanceStateStore,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+
+// ============================================================================
+// Gate-serving receipt backend (mirrors the adoption route test).
+// ============================================================================
+
+struct TestBackend {
+    mandates: Vec<Mandate>,
+    grants: Vec<AuthorityGrant>,
+}
+
+impl TestBackend {
+    fn new(mandates: Vec<Mandate>, grants: Vec<AuthorityGrant>) -> Arc<Self> {
+        Arc::new(Self { mandates, grants })
+    }
+}
+
+impl GovernanceReceiptBackend for TestBackend {
+    fn put_governance(&self, _: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn list_mandates_by_decision(&self, decision_hash: &Hash) -> Result<Vec<Mandate>, String> {
+        Ok(self
+            .mandates
+            .iter()
+            .filter(|m| &m.decision.decision_hash == decision_hash)
+            .cloned()
+            .collect())
+    }
+    fn get_authority_grant(
+        &self,
+        grant_id: &AuthorityGrantId,
+    ) -> Result<Option<AuthorityGrant>, String> {
+        Ok(self.grants.iter().find(|g| &g.id == grant_id).cloned())
+    }
+    fn list_active_authority_grants_by_grantee(
+        &self,
+        grantee: &Grantee,
+        now: Timestamp,
+    ) -> Result<Vec<AuthorityGrant>, String> {
+        Ok(self
+            .grants
+            .iter()
+            .filter(|g| &g.grantee == grantee && g.is_active_at(now))
+            .cloned()
+            .collect())
+    }
+}
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn decision() -> DecisionProvenance {
+    DecisionProvenance {
+        proposal_id: "prop-1".into(),
+        decision_hash: [7u8; 32],
+    }
+}
+
+/// An Execution grant for `actor`, bound to `dom`, carrying the
+/// `institutional_domain:declare` act token. `valid_until: None` so it is active
+/// at wall-clock `now` (the handler resolves authority at `current_time_secs()`).
+fn declare_grant(actor: Did, dom: &str, grant_id: AuthorityGrantId) -> AuthorityGrant {
+    AuthorityGrant {
+        id: grant_id,
+        class: AuthorityClass::Execution,
+        grantor: GrantorEntityId("coop:alpha".into()),
+        grantee: Grantee::Person(actor),
+        scope: TypedScope {
+            domain: Some(GovernanceDomainId::new(dom)),
+            action_kind: vec!["institutional_domain:declare".into()],
+            ..TypedScope::default()
+        },
+        granted_by: Some(decision()),
+        valid_from: 0,
+        valid_until: None,
+        revoked_at: None,
+    }
+}
+
+fn backing_mandate(grant_id: AuthorityGrantId) -> Mandate {
+    Mandate::new(decision(), [9u8; 32], vec![grant_id], None, None, 0)
+        .expect("grant-bearing mandate is valid")
+}
+
+struct Harness {
+    ctx: GovernanceContext<NoopEventEmitter>,
+    store: Arc<dyn GovernanceStateStore>,
+}
+
+/// Manager wired with the gate backend + a temp Sled `InstitutionalDomain`
+/// store, in `Test`-mode context. No `GovernanceDomain` is seeded: the declare
+/// route does not apply the membership gate (see the handler docs).
+fn make_harness(backend: Arc<TestBackend>) -> Harness {
+    let store: Arc<dyn GovernanceStateStore> = Arc::new(SledGovernanceStateStore::new(Arc::new(
+        icn_store::SledStore::temporary().expect("temp sled"),
+    )));
+    let manager = GovernanceManager::new()
+        .with_receipt_store(backend as Arc<dyn GovernanceReceiptBackend>)
+        .with_domain_store(store.clone());
+    let ctx = GovernanceContext {
+        manager: Arc::new(manager),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        mandate_gate: None,
+        build_mode: http::GovernanceContextBuildMode::Test,
+    };
+    Harness { ctx, store }
+}
+
+macro_rules! gov_app {
+    ($ctx:expr, $caller:expr, $scope:expr) => {{
+        use actix_web::dev::Service as _;
+        use actix_web::HttpMessage as _;
+        let caller = $caller.to_string();
+        let scope: Option<String> = $scope;
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: scope.clone(),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+fn declare_uri(domain_id: &str) -> String {
+    format!("/domains/{domain_id}/institutional-domain/declare")
+}
+
+fn write_scope() -> Option<String> {
+    Some("governance:write".to_string())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[actix_web::test]
+async fn declare_route_succeeds_persists_and_reloads() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let app = gov_app!(h.ctx.clone(), &caller, write_scope());
+    let req = test::TestRequest::post()
+        .uri(&declare_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "entity_type": "cooperative" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "POST declare must mount and succeed; body: {}",
+        String::from_utf8_lossy(&bytes)
+    );
+
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("json body");
+    assert_eq!(body["domain_id"], "coop-alpha");
+    assert_eq!(body["owning_entity_class"], "cooperative");
+    assert!(body["charter_id"].is_null());
+    assert!(body["current_policy_id"].is_null());
+
+    // Persisted and reloadable, declared-but-unbound.
+    let loaded = h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .expect("load")
+        .expect("persisted");
+    assert_eq!(loaded.domain_id, GovernanceDomainId::new("coop-alpha"));
+    assert_eq!(loaded.owning_entity_class, BootstrapEntityType::Cooperative);
+    assert!(loaded.current_policy().is_none());
+}
+
+#[actix_web::test]
+async fn declare_route_requires_governance_write_scope() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    // Read scope only — the write guard must reject.
+    let app = gov_app!(h.ctx.clone(), &caller, Some("governance:read".to_string()));
+    let req = test::TestRequest::post()
+        .uri(&declare_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "entity_type": "cooperative" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert!(h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .is_none());
+}
+
+#[actix_web::test]
+async fn declare_route_actor_is_token_subject_not_body() {
+    // The grant is bound to `granted_did`. A request authenticated as a
+    // DIFFERENT token subject must be refused — proving the acting DID is the
+    // token subject (there is no actor body field to override it).
+    let granted_did = fresh_did();
+    let other_did = fresh_did();
+    assert_ne!(granted_did, other_did);
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(granted_did, "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let app = gov_app!(h.ctx.clone(), &other_did, write_scope());
+    let req = test::TestRequest::post()
+        .uri(&declare_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "entity_type": "cooperative" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "the acting DID is the token subject; a non-grantee subject must be refused"
+    );
+    assert!(h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .is_none());
+}
+
+#[actix_web::test]
+async fn declare_route_rejects_wrong_domain_via_gate() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    // Grant scoped to coop-beta; declaring coop-alpha.
+    let grant = declare_grant(caller.clone(), "coop-beta", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let app = gov_app!(h.ctx.clone(), &caller, write_scope());
+    let req = test::TestRequest::post()
+        .uri(&declare_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "entity_type": "cooperative" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert!(h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .is_none());
+}
+
+#[actix_web::test]
+async fn declare_route_rejects_revoked_authority_via_gate() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mut mandate = backing_mandate(gid);
+    mandate.status = MandateStatus::Revoked;
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let app = gov_app!(h.ctx.clone(), &caller, write_scope());
+    let req = test::TestRequest::post()
+        .uri(&declare_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "entity_type": "cooperative" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert!(h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .is_none());
+}
+
+#[actix_web::test]
+async fn declare_route_duplicate_returns_conflict() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let app = gov_app!(h.ctx.clone(), &caller, write_scope());
+    let mk = || {
+        test::TestRequest::post()
+            .uri(&declare_uri("coop-alpha"))
+            .set_json(serde_json::json!({ "entity_type": "cooperative" }))
+            .to_request()
+    };
+    let first = test::call_service(&app, mk()).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let second = test::call_service(&app, mk()).await;
+    assert_eq!(
+        second.status(),
+        StatusCode::CONFLICT,
+        "a second declaration by the authorized actor must be a 409"
+    );
+}
+
+#[actix_web::test]
+async fn declare_route_unauthorized_on_existing_is_forbidden_not_conflict() {
+    // Gate-before-write / no existence leak: declare once with the authorized
+    // actor, then a DIFFERENT actor (no grant) declares the same domain. The
+    // gate refuses first → 403, NOT 409 — so existence is not leaked, and the
+    // route is provably not bypassing the gate into the ungated seam.
+    let authorized = fresh_did();
+    let outsider = fresh_did();
+    assert_ne!(authorized, outsider);
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(authorized.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let app_ok = gov_app!(h.ctx.clone(), &authorized, write_scope());
+    let first = test::call_service(
+        &app_ok,
+        test::TestRequest::post()
+            .uri(&declare_uri("coop-alpha"))
+            .set_json(serde_json::json!({ "entity_type": "cooperative" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK);
+
+    let app_outsider = gov_app!(h.ctx.clone(), &outsider, write_scope());
+    let second = test::call_service(
+        &app_outsider,
+        test::TestRequest::post()
+            .uri(&declare_uri("coop-alpha"))
+            .set_json(serde_json::json!({ "entity_type": "cooperative" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        second.status(),
+        StatusCode::FORBIDDEN,
+        "unauthorized declare on an existing domain must be 403 (gate first), not 409"
+    );
+}
+
+#[actix_web::test]
+async fn declare_route_rejects_malformed_charter_id() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let app = gov_app!(h.ctx.clone(), &caller, write_scope());
+    let req = test::TestRequest::post()
+        .uri(&declare_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "entity_type": "cooperative", "charter_id": "not-hex!!" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a non-hex charter_id must be a 400"
+    );
+    assert!(h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .is_none());
+}
+
+#[actix_web::test]
+async fn declare_route_rejects_unknown_entity_type() {
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let app = gov_app!(h.ctx.clone(), &caller, write_scope());
+    let req = test::TestRequest::post()
+        .uri(&declare_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "entity_type": "not_a_real_entity" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "an out-of-taxonomy entity_type must be a 400, not coerced"
+    );
+}
+
+#[actix_web::test]
+async fn declare_route_accepts_valid_charter_id() {
+    // A well-formed 64-hex charter_id is parsed and echoed back as the stored
+    // charter_ref (the seam stores the reference; no charter-existence check).
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let charter_hex = "ab".repeat(32); // 64 hex chars = 32 bytes
+    let app = gov_app!(h.ctx.clone(), &caller, write_scope());
+    let req = test::TestRequest::post()
+        .uri(&declare_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "entity_type": "community", "charter_id": charter_hex }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body()).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a valid charter_id must be accepted; body: {}",
+        String::from_utf8_lossy(&bytes)
+    );
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["owning_entity_class"], "community");
+    assert_eq!(body["charter_id"], charter_hex);
+}

--- a/icn/apps/governance/tests/institutional_domain_declare_http_route.rs
+++ b/icn/apps/governance/tests/institutional_domain_declare_http_route.rs
@@ -436,23 +436,55 @@ async fn declare_route_unauthorized_on_existing_is_forbidden_not_conflict() {
 }
 
 #[actix_web::test]
-async fn declare_route_rejects_malformed_charter_id() {
+async fn declare_route_rejects_non_hex_charter_id() {
+    // Correct length (64 chars) but non-hex content → rejected by hex decoding,
+    // after the length check, with a 400.
     let caller = fresh_did();
     let gid = AuthorityGrantId::new();
     let grant = declare_grant(caller.clone(), "coop-alpha", gid.clone());
     let mandate = backing_mandate(gid);
     let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
 
+    let non_hex = "z".repeat(64); // 64 chars, but 'z' is not a hex digit
     let app = gov_app!(h.ctx.clone(), &caller, write_scope());
     let req = test::TestRequest::post()
         .uri(&declare_uri("coop-alpha"))
-        .set_json(serde_json::json!({ "entity_type": "cooperative", "charter_id": "not-hex!!" }))
+        .set_json(serde_json::json!({ "entity_type": "cooperative", "charter_id": non_hex }))
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(
         resp.status(),
         StatusCode::BAD_REQUEST,
         "a non-hex charter_id must be a 400"
+    );
+    assert!(h
+        .store
+        .get_institutional_domain(&GovernanceDomainId::new("coop-alpha"))
+        .unwrap()
+        .is_none());
+}
+
+#[actix_web::test]
+async fn declare_route_rejects_wrong_length_charter_id() {
+    // Valid hex but the wrong length → rejected by the length check BEFORE any
+    // hex decoding (an oversize body is never decoded), with a 400.
+    let caller = fresh_did();
+    let gid = AuthorityGrantId::new();
+    let grant = declare_grant(caller.clone(), "coop-alpha", gid.clone());
+    let mandate = backing_mandate(gid);
+    let h = make_harness(TestBackend::new(vec![mandate], vec![grant]));
+
+    let short_hex = "ab".repeat(20); // 40 hex chars = 20 bytes, not 32
+    let app = gov_app!(h.ctx.clone(), &caller, write_scope());
+    let req = test::TestRequest::post()
+        .uri(&declare_uri("coop-alpha"))
+        .set_json(serde_json::json!({ "entity_type": "cooperative", "charter_id": short_hex }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a wrong-length charter_id must be a 400"
     );
     assert!(h
         .store


### PR DESCRIPTION
## What

Adds a thin governance HTTP route for mandate-gated `InstitutionalDomain` declaration:

```
POST /gov/domains/{domain_id}/institutional-domain/declare
```

The route calls `GovernanceManager::declare_institutional_domain_gated(...)`, derives the actor from the authenticated token subject, resolves declaration authority through `DefaultMandateGate`, and only writes the `InstitutionalDomain` after the gate passes. `entity_type` is the closed `BootstrapEntityType` taxonomy; `charter_id` is an optional 64-char hex `CharterId`. Returns a small declared-domain projection.

## Why

#2174 made declaration an authority-checked manager operation (`declare_institutional_domain_gated`). This PR exposes that path through the HTTP layer without wiring the ungated bootstrap seam to a routable surface.

## Security

- the HTTP route never calls the ungated bootstrap `declare_institutional_domain(...)` seam
- gate-before-write ordering is preserved — unauthorized attempts persist nothing
- an unauthorized attempt on an already-declared domain returns **403** (the gate refuses first), not 409 — no existence leak
- an authorized duplicate declaration returns **409**
- the actor is derived from the token subject, never the request body

## Authorization design

This route intentionally does **not** apply `check_domain_membership` (unlike the domain-scoped write surface). Declaration may be the act that *establishes* the governed domain, so requiring prior membership could wrongly block the first authorized declaration. The `DefaultMandateGate` declare grant (domain-scoped, `institutional_domain:declare`) is the decisive and strictly-stronger authority check. This is documented in the handler.

## Non-claims

This does not complete #2142, implement CCL runtime, implement a policy registry/evaluator, implement a service-binding runtime, perform an auth-model change, perform entity-aware auth enforcement, activate institution packages, provide cross-process / multi-writer transactional store safety, or imply production / pilot / organizer / federation readiness.

## Tests

New `apps/governance/tests/institutional_domain_declare_http_route.rs` (10 tests): mounted + succeeds; persists + reloads; requires `governance:write`; actor is token subject (non-grantee subject refused); wrong domain / revoked authority rejected via gate; duplicate → 409; unauthorized-on-existing → 403 not 409 (no existence leak, proves the gate is not bypassed); malformed `charter_id` → 400; out-of-taxonomy `entity_type` → 400; valid hex `charter_id` accepted + echoed.

```text
cargo fmt --all --check                                                       # clean
cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings  # clean
cargo test -p icn-governance-actor --test institutional_domain_declare_http_route  # 10 passed
cargo test -p icn-governance-actor --test domain_policy_adoption_http_route   # 8 passed (no regression)
cargo test -p icn-governance-actor --lib domain_policy                        # 32 passed
cargo test -p icn-governance-actor mandate_gate                              # 25 passed
cargo test -p icn-governance institutional_domain                           # 14 passed
cargo check --workspace                                                      # ok
python3 docs/scripts/route_inventory.py --check                             # OK (new route present, 83 gov candidates)
python3 docs/scripts/doc_control_check.py                                   # OK (65 pre-existing warnings)
ops/scripts/drift-check.sh                                                  # PASS (0 errors)
firewall / meaning-firewall checks                                          # no NEW violations
```

Refs #2142.