### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -5757,9 +5757,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What
Bump `quinn-proto` 0.11.14 → 0.11.15 (`Cargo.lock`-only).

## Why
Resolves **RUSTSEC-2026-0185** (CVSS 7.5, high) — remote memory exhaustion in
`quinn-proto` from unbounded out-of-order stream reassembly, a remotely
triggerable DoS in the QUIC stack. This is a genuine vulnerability, distinct
from the accepted-risk *unmaintained* advisories intentionally ignored per #1983.

`quinn-proto` is pulled in transitively via `quinn 0.11.9` (QUIC transport in
`icn-net`, and also via `reqwest`). `0.11.15` is a semver-compatible patch
release; `quinn 0.11.9` and `quinn-udp 0.5.14` are unchanged.

Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0185

## How
`cargo update -p quinn-proto --precise 0.11.15`, applied as a surgical
version+checksum edit to the `quinn-proto` lock entry so only that package
changes — avoids unrelated multi-version re-resolution churn (windows-sys/syn)
that a full re-resolve introduced. No `Cargo.toml` change, no toolchain change
(pinned 1.95.0).

## Risk
Low. Patch-level bump internal to quinn-proto's stream reassembly; no public API
change. Single-version, semver-compatible reverse-dep tree.

## Test plan (pinned toolchain 1.95.0)
- `cargo audit`: exit 0, RUSTSEC-2026-0185 cleared (only pre-existing unmaintained warnings remain)
- `cargo fmt --all --check`: pass
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: pass (0 warnings)
- `cargo test -p icn-net --locked`: 293 passed, 0 failed (28 network-gated ignored)
- Full workspace tests not run; all workspace targets compiled clean via `clippy --all-targets`.

`Security Audit` is a non-required check (not merge-blocking), but the
quinn-proto advisory is a real vuln worth resolving rather than carrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
