### PR TITLE
fix(gateway): fail closed on entity member read errors

### DIFF
--- a/icn/crates/icn-gateway/src/api/entity.rs
+++ b/icn/crates/icn-gateway/src/api/entity.rs
@@ -472,7 +472,10 @@ pub async fn register_entity(
         )));
     }
 
-    let members = entity_mgr.get_members(&entity_id).await.unwrap_or_default();
+    let members = entity_mgr
+        .get_members(&entity_id)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get members: {e}")))?;
     let response = entity_to_response(&entity, members.len());
 
     Ok(HttpResponse::Created().json(response))
@@ -503,7 +506,10 @@ pub async fn get_entity(
         )));
     };
 
-    let members = entity_mgr.get_members(&entity_id).await.unwrap_or_default();
+    let members = entity_mgr
+        .get_members(&entity_id)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get members: {e}")))?;
     let response = entity_to_response(&entity, members.len());
 
     Ok(HttpResponse::Ok().json(response))
@@ -571,7 +577,10 @@ pub async fn update_entity(
 
     // Skip no-op updates - return early if no changes were requested
     if changed_fields.is_empty() {
-        let members = entity_mgr.get_members(&entity_id).await.unwrap_or_default();
+        let members = entity_mgr
+            .get_members(&entity_id)
+            .await
+            .map_err(|e| GatewayError::InternalError(format!("Failed to get members: {e}")))?;
         let response = entity_to_response(&entity, members.len());
         return Ok(HttpResponse::Ok().json(response));
     }
@@ -622,7 +631,10 @@ pub async fn update_entity(
         )));
     }
 
-    let members = entity_mgr.get_members(&entity_id).await.unwrap_or_default();
+    let members = entity_mgr
+        .get_members(&entity_id)
+        .await
+        .map_err(|e| GatewayError::InternalError(format!("Failed to get members: {e}")))?;
     let response = entity_to_response(&entity, members.len());
 
     Ok(HttpResponse::Ok().json(response))

--- a/icn/crates/icn-gateway/tests/entity_integration.rs
+++ b/icn/crates/icn-gateway/tests/entity_integration.rs
@@ -1081,3 +1081,69 @@ async fn test_audit_stats_admin_only() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), 403);
 }
+
+// ============================================================================
+// Read-path fail-closed regression (C2)
+// ============================================================================
+
+/// Regression: a membership-lookup error on the entity read path must FAIL CLOSED
+/// (return a server error), not silently degrade to a successful zero-member response.
+///
+/// The handler is backed by an `EntityManager` whose actor answers `Get` (so the
+/// handler gets past entity resolution and reaches the member read) but returns an
+/// error for `GetMembers`. Before the fix, `get_members(..).await.unwrap_or_default()`
+/// swallowed that error and returned `200 OK` with `member_count = 0`; now it
+/// propagates as a `GatewayError::InternalError` (5xx).
+#[actix_web::test]
+async fn get_entity_fails_closed_when_member_lookup_errors() {
+    use icn_entity::actor::EntityMessage;
+    use icn_entity::{CooperativeEntity, EntityError, EntityHandle};
+    use tokio::sync::mpsc;
+
+    init_logging();
+
+    // Mock entity actor: `Get` -> Ok(entity); `GetMembers` -> Err (simulated lookup failure).
+    let (tx, mut rx) = mpsc::channel::<EntityMessage>(16);
+    tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                EntityMessage::Get { reply, .. } => {
+                    let entity = CooperativeEntity::cooperative("lookup-fail", "Lookup Fail Coop")
+                        .expect("valid test coop");
+                    let _ = reply.send(Ok(Some(entity)));
+                }
+                EntityMessage::GetMembers { reply, .. } => {
+                    let _ = reply.send(Err(EntityError::MembershipError(
+                        "simulated membership lookup failure".to_string(),
+                    )));
+                }
+                // get_entity only issues Get + GetMembers; other variants are unused here.
+                _ => {}
+            }
+        }
+    });
+
+    let entity_mgr = Arc::new(EntityManager::with_handle(EntityHandle::new(tx)));
+    let store = Arc::new(SledStore::temporary().unwrap());
+    let audit_mgr = Arc::new(EntityAuditManager::new(store));
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(entity_mgr.clone()))
+            .app_data(web::Data::new(audit_mgr.clone()))
+            .service(web::scope("/entities").configure(entity::configure)),
+    )
+    .await;
+
+    let claims = create_test_claims("did:icn:c2tester", vec!["entity:read"]);
+    let req = test::TestRequest::get()
+        .uri("/entities/entity:icn:cooperative:lookup-fail")
+        .to_request();
+    req.extensions_mut().insert(claims);
+
+    let resp = test::call_service(&app, req).await;
+    assert!(
+        resp.status().is_server_error(),
+        "member lookup error must fail closed (5xx), got {}",
+        resp.status()
+    );
+}


### PR DESCRIPTION
## Summary
- Replaces read-path `get_members(..).await.unwrap_or_default()` handling in the entity API (4 sites in `icn-gateway/src/api/entity.rs`: register/get/update responses).
- Preserves real empty-membership behavior (`Ok(vec![])` → `member_count = 0` as before).
- Returns an explicit gateway error (`GatewayError::InternalError`, `?`) when membership resolution fails, instead of silently degrading to a successful zero-member response.

Uses the crate's existing idiom — identical to the already-correct `get_members` call sites elsewhere in the same file (e.g. `list_members`, `remove_membership`, `delete_entity`).

## Scope
- runtime code + tests only
- no auth model changes (authorization semantics unchanged; only error handling)
- no docs
- no resolver / token-issuance / treasury / ledger / compute / federation / route-inventory changes

## Tests
- `cargo fmt --all --check` → OK
- `cargo test -p icn-gateway --test entity_integration` → **31 passed; 0 failed** (incl. new `get_entity_fails_closed_when_member_lookup_errors`, plus existing register/get/update/membership happy paths unchanged)
- `cargo clippy -p icn-gateway --all-targets -- -D warnings` → clean

The new regression test wires an `EntityManager` to a mock entity actor that answers `Get` (so the handler reaches the member read) but returns `Err` on `GetMembers`, asserting the read path returns 5xx rather than a zero-member 200. Before the fix this test would have returned 200.

## Risk
Low. Internal error-handling only; no route, request/response schema, or success-path status-code change (no OpenAPI/SDK regen needed). The only behavior change is that a previously-swallowed membership lookup error now surfaces as a 5xx.