### PR TITLE
fix(compute): make commons settlement append atomic

### DIFF
--- a/icn/bins/icnd/src/compute_wiring.rs
+++ b/icn/bins/icnd/src/compute_wiring.rs
@@ -253,9 +253,9 @@ pub fn create_commons_settlement_callback(
             //
             // Dedup is recorded inside settle_commons_receipt() before the ledger append
             // below. If the append is rejected the receipt is already marked settled and
-            // retries return DuplicateEntry — but the append is now all-or-nothing on
-            // validation (step 7), so a rejected settlement leaves NO ledger effect rather
-            // than a one-sided one.
+            // retries return DuplicateEntry. The append (step 7) pre-validates both legs
+            // before writing either, so a settlement rejected at validation leaves no
+            // ledger effect — but it is not a full transaction (see step 7 for residuals).
             let (earn_entry, spend_entry) = match engine.settle_commons_receipt(&settlement_req) {
                 Ok(entries) => entries,
                 Err(icn_ledger::LedgerError::DuplicateEntry(_)) => {
@@ -272,12 +272,12 @@ pub fn create_commons_settlement_callback(
                 }
             };
 
-            // 7. Append both legs (earn + spend) via the ledger's all-or-nothing
-            //    validation batch. Both entries are validated before either is written, so
-            //    an invalid spend leg can no longer leave the earn leg committed one-sidedly.
-            //    Residual: a store I/O failure *between* the two journal writes (inherent to
-            //    the ledger's non-transactional append) — reconcilable, since the journal is
-            //    authoritative and balances are recomputable from it.
+            // 7. Append both legs (earn + spend) via the ledger's pre-validating batch
+            //    append. Both entries are validated before either is written, so a leg that
+            //    fails validation can no longer leave the other leg committed one-sidedly.
+            //    This is NOT a full transaction: a lower-level append/store failure between
+            //    the two writes can still require reconciliation (the ledger is not fully
+            //    transactional; the journal is authoritative and balances are recomputable).
             let mut ledger = ledger.write().await;
             match ledger.append_entries(vec![earn_entry, spend_entry]).await {
                 Ok(_) => {
@@ -288,12 +288,15 @@ pub fn create_commons_settlement_callback(
                     );
                 }
                 Err(e) => {
-                    // Settlement rejected at validation — neither leg committed (no partial
-                    // state). Dedup is already recorded, so this receipt will not retry;
-                    // surface loudly for audit.
+                    // A validation rejection commits nothing; a mid-batch append/store
+                    // failure may instead leave a partial journal needing reconciliation.
+                    // Dedup is already recorded, so this receipt will not retry; surface
+                    // loudly for audit.
                     warn!(
-                        "commons_settlement: settlement rejected for task {} \
-                         (no partial commit): {} — receipt {} will not retry; check audit logs",
+                        "commons_settlement: settlement not fully committed for task {} \
+                         (validation rejection commits nothing; a mid-batch append failure \
+                         may need reconciliation): {} — receipt {} will not retry; \
+                         check audit logs",
                         req.task_id,
                         e,
                         hex::encode(req.receipt_hash),

--- a/icn/bins/icnd/src/compute_wiring.rs
+++ b/icn/bins/icnd/src/compute_wiring.rs
@@ -251,16 +251,15 @@ pub fn create_commons_settlement_callback(
 
             // 6. Run through settlement engine (dedup + invariant checks).
             //
-            // KNOWN LIMITATION: dedup is recorded inside settle_commons_receipt() before
-            // the ledger appends below complete. If append_entry() fails after this point,
-            // the receipt is permanently marked settled and retries will return DuplicateEntry.
-            // True atomicity requires batch-append support in the ledger (not yet available).
-            // On partial failure (earn ok, spend fails), manual recovery is required.
+            // Dedup is recorded inside settle_commons_receipt() before the ledger append
+            // below. If the append is rejected the receipt is already marked settled and
+            // retries return DuplicateEntry — but the append is now all-or-nothing on
+            // validation (step 7), so a rejected settlement leaves NO ledger effect rather
+            // than a one-sided one.
             let (earn_entry, spend_entry) = match engine.settle_commons_receipt(&settlement_req) {
                 Ok(entries) => entries,
                 Err(icn_ledger::LedgerError::DuplicateEntry(_)) => {
-                    // Idempotent — receipt already settled (or a prior partial settlement
-                    // recorded dedup before ledger appends completed — check audit logs).
+                    // Idempotent — receipt already settled.
                     return;
                 }
                 Err(e) => {
@@ -273,19 +272,14 @@ pub fn create_commons_settlement_callback(
                 }
             };
 
-            // 7. Append both entries to the ledger (double-entry: earn + spend).
-            //    These two appends are NOT atomic. If spend fails after earn succeeds,
-            //    the ledger has a one-sided entry and the receipt dedup is already committed.
-            //    This constitutes a partial settlement requiring manual operator intervention.
+            // 7. Append both legs (earn + spend) via the ledger's all-or-nothing
+            //    validation batch. Both entries are validated before either is written, so
+            //    an invalid spend leg can no longer leave the earn leg committed one-sidedly.
+            //    Residual: a store I/O failure *between* the two journal writes (inherent to
+            //    the ledger's non-transactional append) — reconcilable, since the journal is
+            //    authoritative and balances are recomputable from it.
             let mut ledger = ledger.write().await;
-            if let Err(e) = ledger.append_entry(earn_entry).await {
-                warn!(
-                    "commons_settlement: failed to append earn entry for task {}: {}",
-                    req.task_id, e
-                );
-                return;
-            }
-            match ledger.append_entry(spend_entry).await {
+            match ledger.append_entries(vec![earn_entry, spend_entry]).await {
                 Ok(_) => {
                     info!(
                         "commons_settlement: settled {} credits, consumer='{}', \
@@ -294,14 +288,12 @@ pub fn create_commons_settlement_callback(
                     );
                 }
                 Err(e) => {
-                    // Earn entry committed but spend entry failed — PARTIAL SETTLEMENT.
-                    // Dedup is already recorded; retries will be silently ignored.
-                    // Manual operator recovery required: inspect receipt {} and
-                    // task {} in audit logs.
+                    // Settlement rejected at validation — neither leg committed (no partial
+                    // state). Dedup is already recorded, so this receipt will not retry;
+                    // surface loudly for audit.
                     warn!(
-                        "commons_settlement: PARTIAL SETTLEMENT for task {} \
-                         (earn committed, spend failed): {} — receipt {} will not retry; \
-                         manual recovery required",
+                        "commons_settlement: settlement rejected for task {} \
+                         (no partial commit): {} — receipt {} will not retry; check audit logs",
                         req.task_id,
                         e,
                         hex::encode(req.receipt_hash),

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1226,6 +1226,44 @@ impl Ledger {
         self.append_entry_internal(entry, false).await
     }
 
+    /// Append multiple journal entries with all-or-nothing **validation**.
+    ///
+    /// Every entry is validated against current ledger state *before any entry is
+    /// appended*. If any entry fails validation, none are appended. This is the
+    /// guarantee a settlement expressed as multiple legs relies on (e.g. the commons
+    /// earn + spend pair): if a later leg would be rejected, an earlier leg is never
+    /// committed one-sidedly. Entries are appended in input order once all pass; the
+    /// returned hashes are in the same order.
+    ///
+    /// # Atomicity scope
+    ///
+    /// This closes the *validation*-induced partial-commit window — the realistic
+    /// failure mode, where a balance / credit-limit / freeze rejection on a later leg
+    /// previously left the earlier leg committed. It does **not** wrap the durable writes
+    /// in a single storage transaction, so a store I/O failure *between* the per-entry
+    /// appends could still leave a partial journal. That residual is inherent to the
+    /// ledger's current non-transactional append (an individual [`append_entry`] already
+    /// performs its journal write and cached-balance save as separate operations). The
+    /// journal is the authoritative source and balances are recomputable from it, so such
+    /// a state is reconcilable.
+    ///
+    /// [`append_entry`]: Self::append_entry
+    pub async fn append_entries(&mut self, entries: Vec<JournalEntry>) -> Result<Vec<ContentHash>> {
+        // Phase 1 — validate every entry up front (read-only; no durable mutation).
+        // Returning here, before any append, guarantees no partial state lands when a
+        // later entry is invalid.
+        for entry in &entries {
+            self.validate_entry(entry)?;
+        }
+
+        // Phase 2 — all entries validated; append them in order.
+        let mut hashes = Vec::with_capacity(entries.len());
+        for entry in entries {
+            hashes.push(self.append_entry_internal(entry, true).await?);
+        }
+        Ok(hashes)
+    }
+
     /// Append a witnessed entry with signature validation
     ///
     /// This method validates witness signatures before appending. Use this when
@@ -3184,6 +3222,90 @@ mod tests {
 
         assert_eq!(ledger.get_balance(&alice, "hours"), 15);
         assert_eq!(ledger.get_balance(&bob, "hours"), -15);
+    }
+
+    #[tokio::test]
+    async fn test_append_entries_commits_all_on_success() {
+        let (mut ledger, _temp) = create_test_ledger();
+
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+
+        let earn = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("test-earn")
+            .build()
+            .unwrap();
+        let spend = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 4)
+            .credit(bob.clone(), "hours".to_string(), 4)
+            .with_system_provenance("test-spend")
+            .build()
+            .unwrap();
+
+        let hashes = ledger
+            .append_entries(vec![earn, spend])
+            .await
+            .expect("both valid entries should commit");
+
+        assert_eq!(hashes.len(), 2, "both entries should be appended");
+        assert_eq!(ledger.get_all_entries().unwrap().len(), 2);
+        assert_eq!(ledger.get_balance(&alice, "hours"), 14);
+        assert_eq!(ledger.get_balance(&bob, "hours"), -14);
+    }
+
+    /// B2 regression: a settlement expressed as multiple legs must be all-or-nothing on
+    /// validation. If a later leg is invalid (here: its author is frozen), the earlier
+    /// leg must NOT be left committed one-sidedly.
+    #[tokio::test]
+    async fn test_append_entries_rejects_all_when_a_later_entry_is_invalid() {
+        let (mut ledger, _temp) = create_test_ledger();
+
+        let alice = KeyPair::generate().unwrap().did().clone();
+        let bob = KeyPair::generate().unwrap().did().clone();
+        let frozen = KeyPair::generate().unwrap().did().clone();
+
+        // First leg is valid on its own.
+        let good = JournalEntryBuilder::new(alice.clone())
+            .debit(alice.clone(), "hours".to_string(), 10)
+            .credit(bob.clone(), "hours".to_string(), 10)
+            .with_system_provenance("good-leg")
+            .build()
+            .unwrap();
+
+        // Second leg is balanced but authored by a frozen DID, so `validate_entry`
+        // rejects it. `freeze_member` records a freeze (not a journal entry).
+        ledger.freeze_member(frozen.clone(), "test freeze".to_string(), None);
+        let bad = JournalEntryBuilder::new(frozen.clone())
+            .debit(frozen.clone(), "hours".to_string(), 5)
+            .credit(bob.clone(), "hours".to_string(), 5)
+            .with_system_provenance("bad-leg")
+            .build()
+            .unwrap();
+
+        let result = ledger.append_entries(vec![good, bad]).await;
+        assert!(
+            result.is_err(),
+            "a batch containing an invalid leg must be rejected"
+        );
+
+        // The valid first leg must NOT have been committed — no one-sided state.
+        assert_eq!(
+            ledger.get_all_entries().unwrap().len(),
+            0,
+            "no entry may be committed when a later leg fails validation"
+        );
+        assert_eq!(
+            ledger.get_balance(&alice, "hours"),
+            0,
+            "first leg must not have been applied"
+        );
+        assert_eq!(
+            ledger.get_balance(&bob, "hours"),
+            0,
+            "first leg must not have been applied"
+        );
     }
 
     #[tokio::test]

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1226,32 +1226,45 @@ impl Ledger {
         self.append_entry_internal(entry, false).await
     }
 
-    /// Append multiple journal entries with all-or-nothing **validation**.
+    /// Append multiple journal entries, pre-validating all of them before appending any.
     ///
-    /// Every entry is validated against current ledger state *before any entry is
-    /// appended*. If any entry fails validation, none are appended. This is the
-    /// guarantee a settlement expressed as multiple legs relies on (e.g. the commons
-    /// earn + spend pair): if a later leg would be rejected, an earlier leg is never
-    /// committed one-sidedly. Entries are appended in input order once all pass; the
+    /// Every entry is validated against the current (pre-batch) ledger state *before any
+    /// entry is appended*. If any entry fails that up-front validation, none are appended.
+    /// This closes the **validation-rejection** one-sided-entry window for a settlement
+    /// expressed as independent legs (e.g. the commons earn + spend pair, which touch
+    /// different accounts): a later leg that validation would reject can no longer leave an
+    /// earlier leg committed. Entries are appended in input order once all pass; the
     /// returned hashes are in the same order.
     ///
-    /// # Atomicity scope
+    /// # This is NOT a full transaction
     ///
-    /// This closes the *validation*-induced partial-commit window — the realistic
-    /// failure mode, where a balance / credit-limit / freeze rejection on a later leg
-    /// previously left the earlier leg committed. It does **not** wrap the durable writes
-    /// in a single storage transaction, so a store I/O failure *between* the per-entry
-    /// appends could still leave a partial journal. That residual is inherent to the
-    /// ledger's current non-transactional append (an individual [`append_entry`] already
-    /// performs its journal write and cached-balance save as separate operations). The
-    /// journal is the authoritative source and balances are recomputable from it, so such
-    /// a state is reconcilable.
+    /// Up-front validation prevents the *validation-rejection* partial commit, but two
+    /// residuals remain — callers must treat a returned `Err` as "may need reconciliation",
+    /// not "nothing was written":
+    ///
+    /// 1. **Re-validation against mutated state.** Each entry is re-validated inside
+    ///    `append_entry_internal` as it is applied, against state already mutated by
+    ///    earlier entries in the same batch. Entries that each pass the up-front check
+    ///    against the pre-batch state but *interact* (e.g. two debits that individually fit
+    ///    a credit limit but collectively exceed it) can still fail mid-batch, after an
+    ///    earlier entry was appended. The intended caller (the commons earn/spend pair)
+    ///    touches independent accounts, so its legs do not interact this way.
+    /// 2. **Store I/O between writes.** The durable writes are not wrapped in one storage
+    ///    transaction, so a store I/O failure *between* per-entry appends can leave a
+    ///    partial journal — inherent to the ledger's non-transactional append (an
+    ///    individual [`append_entry`] already performs its journal write and cached-balance
+    ///    save as separate operations).
+    ///
+    /// In both residual cases the journal is the authoritative source and balances are
+    /// recomputable from it, so the state is reconcilable rather than silently wrong. A
+    /// fully transactional batch append is tracked as a follow-up.
     ///
     /// [`append_entry`]: Self::append_entry
     pub async fn append_entries(&mut self, entries: Vec<JournalEntry>) -> Result<Vec<ContentHash>> {
         // Phase 1 — validate every entry up front (read-only; no durable mutation).
-        // Returning here, before any append, guarantees no partial state lands when a
-        // later entry is invalid.
+        // Returning here, before any append, prevents a one-sided commit when a later
+        // entry fails validation against the pre-batch state. (It does not cover the
+        // re-validation / store-I/O residuals documented on this method.)
         for entry in &entries {
             self.validate_entry(entry)?;
         }


### PR DESCRIPTION
## Summary
- Makes the commons earn/spend settlement append **all-or-nothing on validation**, eliminating the one-sided-entry window where the earn leg committed but the spend leg was then rejected.
- Adds `Ledger::append_entries(Vec<JournalEntry>)`: validates every entry against current ledger state **before appending any**, then appends in order. If any leg is invalid, none are appended.
- The commons settlement callback now appends the earn+spend pair through `append_entries` instead of two separate `append_entry` calls.
- Preserves existing successful commons settlement behavior and the existing dedup/idempotency contract.

## How
`validate_entry` is read-only (checks empty-accounts, frozen members, the double-entry balance invariant, and credit limits — the realistic spend-leg failure modes; it records no usage and persists nothing). The two legs touch independent accounts, so pre-validating both has no durable side effects and neither validation depends on the other being applied first. This closes the **validation-induced** partial-commit window — the documented realistic failure.

**Residual (documented, not introduced here):** `append_entries` does not wrap the durable writes in a single storage transaction, so a store I/O failure *between* the per-entry appends could still leave a partial journal. This is inherent to the ledger's current non-transactional append — a single `append_entry` already performs its journal write and balance-cache save as separate operations. The journal is the authoritative source and balances are recomputable from it (`recompute_balances`), so such a state is reconcilable. A fully-transactional ledger append is a larger follow-up beyond this fix's "no broad ledger rewrites" scope.

## Scope
- runtime code + tests only
- no docs
- no auth/entity resolver changes
- no treasury/entity observe-mode changes
- no network/federation changes
- the B1 bilateral payment callback (PR #2185, not yet merged) is untouched; `create_payment_callback` is not modified here, so B1's routing through `SettlementEngine` stands independently

## Tests
- `cargo fmt --all --check` → OK
- `cargo test -p icn-ledger` → all pass, incl. two new tests:
  - `test_append_entries_rejects_all_when_a_later_entry_is_invalid` — a batch whose 2nd leg has a frozen author is rejected and the valid 1st leg is **not** committed (`get_all_entries().len() == 0`, balances unchanged) — proves no one-sided commit
  - `test_append_entries_commits_all_on_success` — a valid batch commits both legs
- `cargo test -p icnd compute_wiring` → `test_commons_settlement_callback_posts_ledger_entries` passes (callback now uses `append_entries`)
- `cargo clippy -p icn-ledger --all-targets -- -D warnings` → clean
- `cargo clippy -p icnd --all-targets -- -D warnings` → clean

## Risk
Low–moderate (ledger append path). New method is additive; the commons callback swaps two `append_entry` calls for one `append_entries`. No change to settlement scope semantics, dedup keys, or the earn/spend-via-mint accounting model.