### PR TITLE
feat(authz): add fail-closed coop entity resolver seam

### DIFF
--- a/icn/crates/icn-gateway/src/coop_entity_resolver.rs
+++ b/icn/crates/icn-gateway/src/coop_entity_resolver.rs
@@ -1,0 +1,248 @@
+//! Fail-closed governed `coop_id → EntityId` resolver seam (A2a).
+//!
+//! Design: `docs/design/coop-id-entity-resolver.md` (#2187), companion to the
+//! entity-aware authorization control map (`docs/design/entity-aware-auth-control-map.md`).
+//!
+//! This is the **route / observe-side** analogue of the issuance-side
+//! [`crate::token_authority::TokenAuthoritySource`] seam. Where that seam answers
+//! *"may this subject receive a token binding a typed entity?"*, this one answers
+//! *"what trusted [`EntityId`] does a legacy flat `coop_id` denote?"*. Both are
+//! fail-closed by construction and are designed to read the same governed,
+//! membership-grounded source once it is wired.
+//!
+//! ## What this slice (A2a) is — and is not
+//!
+//! This defines only the **seam**: a trait, a by-value result type, and the
+//! fail-closed default that resolves nothing. It deliberately does **not**:
+//! - consume the `icn-entity` `CoopEntityMap` store (#2082) — per-binding provenance
+//!   retrieval is an A2c prerequisite (see the design doc); this slice adds no
+//!   dependency on the store,
+//! - wire any route, change the flat `require_coop_access` guard, or enforce the
+//!   entity-aware `require_entity_access` check anywhere new,
+//! - issue positive `entity_id` / `entity_type` token claims.
+//!
+//! ## Core invariants (shared across the auth migration)
+//!
+//! - **A mapping is not authority.** Resolving `coop_id → EntityId` says only which
+//!   entity an identifier denotes, never what a caller may do. Authority still flows
+//!   from memberships, standing, mandates, and decision receipts.
+//! - **Fail closed.** Anything other than a trusted, unambiguous resolution is a
+//!   first-class [`CoopEntityResolution::Unavailable`] *value* — never an `Err` a
+//!   caller might treat as success — and the shipped default resolves nothing.
+//! - **Reject, never project.** The default does not fall back to the lossy
+//!   `legacy_coop_id_to_entity_id_fallback` projection; an unwired source yields no
+//!   identity at all.
+
+use icn_entity::EntityId;
+
+/// Why a [`CoopEntityResolver`] could not return a trusted [`EntityId`].
+///
+/// Stable, machine-readable reasons (see [`ResolutionUnavailable::label`]) so the
+/// outcome can flow into logs/metrics without leaking internals. These enumerate the
+/// fail-closed failure modes from the design doc (§5); only a future store-backed,
+/// provenance-aware source (A2c) produces most of them. The shipped default
+/// ([`UnwiredCoopEntityResolver`]) only ever returns
+/// [`ResolutionUnavailable::NoTrustedSourceWired`].
+///
+/// Note: subject-bound mismatches are intentionally absent here — the A2a seam keys
+/// resolution on `coop_id` alone; a subject input (and its mismatch reason) arrives
+/// with the observe-mode wiring (A2b) per the design doc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolutionUnavailable {
+    /// No trusted resolver source is wired — the fail-closed default for this slice.
+    NoTrustedSourceWired,
+    /// No binding exists for the `coop_id`.
+    Unmapped,
+    /// More than one candidate binding, or a forward/reverse conflict.
+    Ambiguous,
+    /// A binding exists but the target entity is revoked / retired.
+    Revoked,
+    /// The backing source could not answer (I/O, lock, backend failure).
+    SourceUnavailable,
+    /// A binding exists but its provenance is stale or cannot be verified.
+    UnverifiedProvenance,
+    /// The bound entity is not a cooperative (a flat `coop_id` denotes a cooperative).
+    EntityTypeMismatch,
+}
+
+impl ResolutionUnavailable {
+    /// Stable, lowercase label for logs / metrics.
+    #[must_use]
+    pub fn label(&self) -> &'static str {
+        match self {
+            ResolutionUnavailable::NoTrustedSourceWired => "no_trusted_source_wired",
+            ResolutionUnavailable::Unmapped => "unmapped",
+            ResolutionUnavailable::Ambiguous => "ambiguous",
+            ResolutionUnavailable::Revoked => "revoked",
+            ResolutionUnavailable::SourceUnavailable => "source_unavailable",
+            ResolutionUnavailable::UnverifiedProvenance => "unverified_provenance",
+            ResolutionUnavailable::EntityTypeMismatch => "entity_type_mismatch",
+        }
+    }
+}
+
+/// The outcome of resolving a legacy flat `coop_id` to a typed [`EntityId`].
+///
+/// Returned **by value** (never a `Result`): an unavailable resolution — including
+/// an unwired or unhealthy source mapped to [`CoopEntityResolution::Unavailable`] —
+/// must never be confusable with a successful resolution. A resolved binding is a
+/// name binding only and confers no authority.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use = "a coop->entity resolution must be acted on (resolved vs unavailable)"]
+pub enum CoopEntityResolution {
+    /// A trusted, typed cooperative [`EntityId`] for the `coop_id`.
+    ///
+    /// Provenance is intentionally absent in A2a; a provenance-tagged resolution
+    /// arrives in A2c, once the store can return per-binding provenance (see the
+    /// design doc — provenance is decisive for `Enforce` / `Issue`).
+    Resolved {
+        /// The cooperative entity the `coop_id` denotes.
+        entity_id: EntityId,
+    },
+    /// No trusted [`EntityId`] could be returned; carries a machine-readable reason.
+    Unavailable {
+        /// Why resolution failed closed.
+        reason: ResolutionUnavailable,
+    },
+}
+
+impl CoopEntityResolution {
+    /// `true` only for [`CoopEntityResolution::Resolved`].
+    #[must_use]
+    pub fn is_resolved(&self) -> bool {
+        matches!(self, CoopEntityResolution::Resolved { .. })
+    }
+
+    /// The resolved [`EntityId`], or `None` for any
+    /// [`CoopEntityResolution::Unavailable`]. Never fabricates a value.
+    #[must_use]
+    pub fn resolved_entity_id(&self) -> Option<&EntityId> {
+        match self {
+            CoopEntityResolution::Resolved { entity_id } => Some(entity_id),
+            CoopEntityResolution::Unavailable { .. } => None,
+        }
+    }
+}
+
+/// The trust boundary a caller consults to resolve a legacy flat `coop_id` to a
+/// trusted cooperative [`EntityId`].
+///
+/// The method is `async` because a real source resolves from a persisted store (the
+/// same async shape as [`crate::token_authority::TokenAuthoritySource`]); the
+/// fail-closed default resolves without I/O. Returning the outcome by value (rather
+/// than `Result`) is deliberate — see [`CoopEntityResolution`].
+#[async_trait::async_trait]
+pub trait CoopEntityResolver: Send + Sync {
+    /// Resolve `coop_id` to a trusted cooperative [`EntityId`], or report why not.
+    /// Implementations must never project, normalize, or fabricate an identity.
+    async fn resolve_coop_entity(&self, coop_id: &str) -> CoopEntityResolution;
+}
+
+/// The fail-closed default [`CoopEntityResolver`]: resolves nothing.
+///
+/// Until a trusted, provenance-aware source is wired (A2c), this is the only
+/// resolver the gateway ships. It always returns
+/// [`ResolutionUnavailable::NoTrustedSourceWired`] and reads none of its input — no
+/// `coop_id`, however well-formed, can produce a [`CoopEntityResolution::Resolved`].
+/// It is the resolver-side counterpart of
+/// [`crate::token_authority::DenyUntilWired`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UnwiredCoopEntityResolver;
+
+#[async_trait::async_trait]
+impl CoopEntityResolver for UnwiredCoopEntityResolver {
+    async fn resolve_coop_entity(&self, _coop_id: &str) -> CoopEntityResolution {
+        CoopEntityResolution::Unavailable {
+            reason: ResolutionUnavailable::NoTrustedSourceWired,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `coop_id` that is itself a valid cooperative [`EntityId`] slug — used to
+    /// prove the default does NOT fall back to projecting it.
+    const MAPPABLE_SLUG: &str = "food-coop";
+
+    /// Ids the projection bridge would reject anyway (uppercase, underscore, unicode,
+    /// too short, empty, non-slug uuid form).
+    const NON_MAPPABLE: &[&str] = &["coop_A", "FoodCoop", "café-coop", "abc", "", "coop:7f3a2b"];
+
+    #[tokio::test]
+    async fn unwired_resolver_resolves_nothing_for_any_coop_id() {
+        let resolver = UnwiredCoopEntityResolver;
+        for coop_id in NON_MAPPABLE.iter().copied().chain([MAPPABLE_SLUG]) {
+            let out = resolver.resolve_coop_entity(coop_id).await;
+            assert_eq!(
+                out,
+                CoopEntityResolution::Unavailable {
+                    reason: ResolutionUnavailable::NoTrustedSourceWired
+                },
+                "coop_id {coop_id:?} must resolve to NoTrustedSourceWired"
+            );
+            assert!(!out.is_resolved());
+            assert_eq!(out.resolved_entity_id(), None);
+        }
+    }
+
+    #[tokio::test]
+    async fn unwired_resolver_never_fabricates_entity_id_even_for_valid_slug() {
+        // `food-coop` IS a valid cooperative EntityId slug, so a naive resolver might
+        // be tempted to project it. The fail-closed default must not.
+        assert!(
+            EntityId::cooperative(MAPPABLE_SLUG).is_ok(),
+            "test premise: {MAPPABLE_SLUG} is a valid cooperative slug"
+        );
+        let out = UnwiredCoopEntityResolver
+            .resolve_coop_entity(MAPPABLE_SLUG)
+            .await;
+        assert!(!out.is_resolved());
+        assert_eq!(out.resolved_entity_id(), None);
+    }
+
+    #[tokio::test]
+    async fn unwired_resolution_cannot_be_mistaken_for_success() {
+        let out = UnwiredCoopEntityResolver
+            .resolve_coop_entity("anything")
+            .await;
+        match out {
+            CoopEntityResolution::Resolved { .. } => panic!("default must never resolve"),
+            CoopEntityResolution::Unavailable { reason } => {
+                assert_eq!(reason, ResolutionUnavailable::NoTrustedSourceWired);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn unwired_resolver_is_deterministic() {
+        let resolver = UnwiredCoopEntityResolver;
+        let first = resolver.resolve_coop_entity(MAPPABLE_SLUG).await;
+        let second = resolver.resolve_coop_entity(MAPPABLE_SLUG).await;
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn unavailable_reason_labels_are_stable() {
+        assert_eq!(
+            ResolutionUnavailable::NoTrustedSourceWired.label(),
+            "no_trusted_source_wired"
+        );
+        assert_eq!(ResolutionUnavailable::Unmapped.label(), "unmapped");
+        assert_eq!(ResolutionUnavailable::Ambiguous.label(), "ambiguous");
+        assert_eq!(ResolutionUnavailable::Revoked.label(), "revoked");
+        assert_eq!(
+            ResolutionUnavailable::SourceUnavailable.label(),
+            "source_unavailable"
+        );
+        assert_eq!(
+            ResolutionUnavailable::UnverifiedProvenance.label(),
+            "unverified_provenance"
+        );
+        assert_eq!(
+            ResolutionUnavailable::EntityTypeMismatch.label(),
+            "entity_type_mismatch"
+        );
+    }
+}

--- a/icn/crates/icn-gateway/src/lib.rs
+++ b/icn/crates/icn-gateway/src/lib.rs
@@ -31,6 +31,7 @@ pub mod community_mgr;
 pub mod compute_events;
 pub mod compute_mgr;
 pub mod coop;
+pub mod coop_entity_resolver;
 mod dispatch_evidence_backfill;
 pub mod email_client;
 pub mod entity_audit;


### PR DESCRIPTION
## What

Adds the **A2a resolver seam** in `icn-gateway`:
- `CoopEntityResolver` trait (`async fn resolve_coop_entity(&self, coop_id: &str) -> CoopEntityResolution`).
- A by-value `CoopEntityResolution` outcome — `Resolved { entity_id }` | `Unavailable { reason }` — that **cannot be confused with a successful `EntityId`** (not a `Result`; an unavailable outcome can't be `?`-propagated or unwrapped into a phantom success).
- A machine-readable `ResolutionUnavailable` reason enum (the design's §5 fail-closed modes).
- A fail-closed default `UnwiredCoopEntityResolver` — always returns `Unavailable { NoTrustedSourceWired }`, reads none of its input, and never fabricates an `EntityId`. The route/observe-side analogue of `token_authority::DenyUntilWired`.
- 5 focused unit tests.

## Why

- #2187 defined the governed `coop_id → EntityId` resolver **design seam**.
- This PR adds the first **code** seam — the trait, outcome type, and fail-closed default — with no route wiring and no behavior change, so later slices have a stable, fail-closed interface to build on.

## Scope

- `icn-gateway` seam only (new `coop_entity_resolver.rs` + one `pub mod` line in `lib.rs`).
- No runtime auth behavior change.
- No route wiring.
- No token issuance changes.
- No `CoopEntityMap` consumption yet (referenced only in comments).
- No provenance persistence yet.

## Non-claims

- Does not implement A2b / A2c / A2d / A2e.
- Does not enforce `require_entity_access` on any new route.
- Does not remove or change `require_coop_access`.
- Does not issue trusted positive `entity_id` / `entity_type` token claims.
- Does not treat existing `CoopEntityMap` rows as authoritative (provenance is an A2c prerequisite, per #2187).
- Does not complete #2061, #2080, #1868, or #2082.
- Does not claim production, pilot, live-federation, NYCN, or complete-API readiness.

## Validation

Run from `icn/` on branch `feat/a2a-coop-entity-resolver-seam`:

```
cargo fmt --all --check                                  # exit 0
cargo test -p icn-gateway coop_entity_resolver           # exit 0 — test result: ok. 5 passed; 0 failed
cargo clippy -p icn-gateway --all-targets -- -D warnings # exit 0 — no warnings
```

The 5 unit tests prove the default resolver: fails closed for any `coop_id` (including ids the projection bridge would reject), never fabricates an `EntityId` even for a valid cooperative slug, cannot be mistaken for success, and is deterministic; plus stable reason labels.

Docs were not touched, so docs/control checks were not run.

## Relationship

- Refs #2187
- Refs #2061
- Refs #2080
- Refs #1868
- Refs #2082
