### PR TITLE
feat(coop): record Activation provenance on coop-entity name bindings

### DIFF
--- a/icn/crates/icn-coop/src/actor.rs
+++ b/icn/crates/icn-coop/src/actor.rs
@@ -52,30 +52,66 @@ pub enum EntityMapBindOutcome {
     StorageError(String),
 }
 
-/// Attempt a non-authoritative `coop_id → EntityId` name binding, recording
-/// [`CoopEntityBindingProvenance::Activation`] provenance.
+/// Map a `coop_id → EntityId` bind result to the non-fatal [`EntityMapBindOutcome`].
 ///
-/// Returns the [`EntityMapBindOutcome`] without ever propagating an error: a
-/// mapping bind is an observability side effect and must not fail activation.
-/// Used by both cooperative activation and the gossip coop-update sync path (which
-/// mirrors the origin node's activation-time bind for activated cooperatives only),
-/// so a binding is recorded deterministically on every node that accepts an
-/// activated cooperative.
+/// Shared by both bind entry points: a mapping bind never propagates an error
+/// (it is an observability side effect and must not fail activation), so every
+/// `Result` is folded into an outcome variant.
+fn bind_outcome(result: std::result::Result<EntityId, CoopEntityMapError>) -> EntityMapBindOutcome {
+    match result {
+        Ok(entity_id) => EntityMapBindOutcome::Mapped(entity_id),
+        Err(CoopEntityMapError::NotMappable(reason)) => EntityMapBindOutcome::NotMappable(reason),
+        Err(CoopEntityMapError::Conflict(reason)) => EntityMapBindOutcome::Conflict(reason),
+        Err(e) => EntityMapBindOutcome::StorageError(e.to_string()),
+    }
+}
+
+/// Record a non-authoritative `coop_id → EntityId` name binding with **no trusted
+/// provenance** (it reads back as the fail-closed
+/// [`CoopEntityBindingProvenance::UnknownLegacy`] sentinel).
 ///
-/// The write is reject-not-normalize: a non-mappable `coop_id` (e.g. the default
-/// `coop:<uuid>` shape) yields [`EntityMapBindOutcome::NotMappable`] and writes
-/// nothing. A mappable id is bound with `Activation` provenance via
-/// [`CoopEntityMap::bind_resolved_with_provenance`], so the row reads back as a
-/// trusted activation binding (not the fail-closed `UnknownLegacy` that a plain
-/// `bind_projected`/`bind_resolved` leaves). Re-binding the identical pair with the
-/// same provenance is idempotent; a pre-provenance (`UnknownLegacy`) row from an
-/// older binary is upgraded in place. A binding still grants no authority.
+/// This is the bind for **untrusted** sources — specifically the gossip
+/// coop-update mirror, which replicates an unauthenticated `coop:updates` payload
+/// (its `status` field is not an activation proof and the entry author is not
+/// verified). Recording trusted `Activation` provenance here would let any topic
+/// publisher poison the durable map with a row a future store-backed resolver
+/// would treat as trusted, so this path deliberately leaves the row untrusted.
+/// Use [`bind_coop_entity_map_activation`] only from a path that authoritatively
+/// performed the activation.
+///
+/// Reject-not-normalize: a non-mappable `coop_id` (e.g. the default `coop:<uuid>`
+/// shape) yields [`EntityMapBindOutcome::NotMappable`] and writes nothing. Idempotent
+/// for an identical pair. A binding grants no authority.
 pub fn bind_coop_entity_map(
     map: &(dyn CoopEntityMap + Send + Sync),
     coop_id: &str,
 ) -> EntityMapBindOutcome {
-    // Reject-not-normalize projection (the same gate the previous `bind_projected`
-    // applied) followed by a provenance-aware write recording `Activation`.
+    // `bind_projected` records no provenance, so the row reads back as
+    // `UnknownLegacy` (untrusted) — correct for an unverified gossip-sourced bind.
+    bind_outcome(map.bind_projected(coop_id))
+}
+
+/// Record a `coop_id → EntityId` name binding with trusted
+/// [`CoopEntityBindingProvenance::Activation`] provenance.
+///
+/// Call this **only** from a path that authoritatively performed (or witnessed)
+/// the cooperative's activation — i.e. the local activation handler. The trusted
+/// `Activation` provenance is what lets the merged `StoreBackedCoopEntityResolver`
+/// (#2192) resolve the row; it must never be written for a binding derived from an
+/// unauthenticated source (see [`bind_coop_entity_map`] for the gossip mirror).
+///
+/// Returns the [`EntityMapBindOutcome`] without ever propagating an error — a
+/// mapping bind must not fail activation. Reject-not-normalize: a non-mappable
+/// `coop_id` yields [`EntityMapBindOutcome::NotMappable`] and writes nothing.
+/// Re-binding the identical pair with `Activation` is idempotent; a pre-provenance
+/// (`UnknownLegacy`) row from an older binary or the gossip mirror is upgraded in
+/// place. A binding still grants no authority.
+pub fn bind_coop_entity_map_activation(
+    map: &(dyn CoopEntityMap + Send + Sync),
+    coop_id: &str,
+) -> EntityMapBindOutcome {
+    // Reject-not-normalize projection (the same gate `bind_projected` applies),
+    // then a provenance-aware write recording trusted `Activation`.
     let result = project_coop_id(coop_id).and_then(|entity_id| {
         map.bind_resolved_with_provenance(
             coop_id,
@@ -84,12 +120,7 @@ pub fn bind_coop_entity_map(
         )
         .map(|()| entity_id)
     });
-    match result {
-        Ok(entity_id) => EntityMapBindOutcome::Mapped(entity_id),
-        Err(CoopEntityMapError::NotMappable(reason)) => EntityMapBindOutcome::NotMappable(reason),
-        Err(CoopEntityMapError::Conflict(reason)) => EntityMapBindOutcome::Conflict(reason),
-        Err(e) => EntityMapBindOutcome::StorageError(e.to_string()),
-    }
+    bind_outcome(result)
 }
 
 pub struct CoopActor {
@@ -488,7 +519,7 @@ impl CoopActor {
         // authority, and a bind failure — including the common NotMappable case
         // for default `coop:<uuid>` ids — is reported but never fails activation.
         if let Some(ref map) = self.coop_entity_map {
-            match bind_coop_entity_map(map.as_ref(), &coop_id) {
+            match bind_coop_entity_map_activation(map.as_ref(), &coop_id) {
                 EntityMapBindOutcome::Mapped(entity_id) => tracing::info!(
                     target: "coop_entity_bind",
                     coop_id = %coop_id,
@@ -2166,7 +2197,7 @@ mod tests {
     #[test]
     fn test_bind_outcome_records_activation_provenance() {
         let map = InMemoryCoopEntityMap::new();
-        let outcome = bind_coop_entity_map(&map, "good-coop");
+        let outcome = bind_coop_entity_map_activation(&map, "good-coop");
         assert_eq!(
             outcome,
             EntityMapBindOutcome::Mapped(EntityId::cooperative("good-coop").unwrap())
@@ -2183,8 +2214,8 @@ mod tests {
     #[test]
     fn test_bind_outcome_idempotent_keeps_activation_provenance() {
         let map = InMemoryCoopEntityMap::new();
-        let first = bind_coop_entity_map(&map, "good-coop");
-        let second = bind_coop_entity_map(&map, "good-coop");
+        let first = bind_coop_entity_map_activation(&map, "good-coop");
+        let second = bind_coop_entity_map_activation(&map, "good-coop");
         assert_eq!(first, second);
         assert_eq!(
             second,
@@ -2203,7 +2234,7 @@ mod tests {
     // propagated — the activation contract (bind is non-fatal) is preserved.
     #[test]
     fn test_bind_outcome_storage_error_is_reported_not_propagated() {
-        let outcome = bind_coop_entity_map(&FailingCoopEntityMap, "good-coop");
+        let outcome = bind_coop_entity_map_activation(&FailingCoopEntityMap, "good-coop");
         assert!(
             matches!(outcome, EntityMapBindOutcome::StorageError(_)),
             "expected StorageError, got {outcome:?}"
@@ -2219,7 +2250,7 @@ mod tests {
     fn test_activation_binding_satisfies_resolver_trust_gates() {
         let map = InMemoryCoopEntityMap::new();
         assert!(matches!(
-            bind_coop_entity_map(&map, "good-coop"),
+            bind_coop_entity_map_activation(&map, "good-coop"),
             EntityMapBindOutcome::Mapped(_)
         ));
         let entity = EntityId::cooperative("good-coop").unwrap();
@@ -2232,6 +2263,30 @@ mod tests {
         assert_eq!(
             map.coop_for_entity(&entity).unwrap(),
             Some("good-coop".to_string())
+        );
+    }
+
+    // T6e: the gossip/untrusted bind (`bind_coop_entity_map`) records NO trusted
+    // provenance — it reads back as `UnknownLegacy`, never `Activation`. This guards
+    // the trust boundary: an unauthenticated `coop:updates` payload must not be able
+    // to write a row the store-backed resolver would treat as trusted. Only
+    // `bind_coop_entity_map_activation` (the local authoritative path) records trust.
+    #[test]
+    fn test_gossip_bind_records_untrusted_unknown_legacy_provenance() {
+        let map = InMemoryCoopEntityMap::new();
+        let outcome = bind_coop_entity_map(&map, "good-coop");
+        assert_eq!(
+            outcome,
+            EntityMapBindOutcome::Mapped(EntityId::cooperative("good-coop").unwrap())
+        );
+        let binding = map
+            .binding_for_coop("good-coop")
+            .unwrap()
+            .expect("name binding present after gossip-mirror bind");
+        assert_eq!(
+            binding.provenance,
+            CoopEntityBindingProvenance::UnknownLegacy,
+            "gossip-sourced bind must NOT record trusted Activation provenance"
         );
     }
 }

--- a/icn/crates/icn-coop/src/actor.rs
+++ b/icn/crates/icn-coop/src/actor.rs
@@ -2,7 +2,9 @@ use crate::{
     AssetDistributionPlan, CoopStore, CoopType, Cooperative, FormationRequest, LifecycleEvent,
     LifecycleManager, Member, MemberRole, MembershipManager, Result,
 };
-use icn_entity::{CoopEntityMap, CoopEntityMapError, EntityId};
+use icn_entity::{
+    project_coop_id, CoopEntityBindingProvenance, CoopEntityMap, CoopEntityMapError, EntityId,
+};
 use icn_gossip::GossipActor;
 use icn_governance::charter::FounderSignature;
 use icn_identity::Did;
@@ -50,19 +52,39 @@ pub enum EntityMapBindOutcome {
     StorageError(String),
 }
 
-/// Attempt a non-authoritative `coop_id → EntityId` name binding.
+/// Attempt a non-authoritative `coop_id → EntityId` name binding, recording
+/// [`CoopEntityBindingProvenance::Activation`] provenance.
 ///
 /// Returns the [`EntityMapBindOutcome`] without ever propagating an error: a
 /// mapping bind is an observability side effect and must not fail activation.
-/// `bind_projected` is idempotent for an identical pair, so repeated binds are
-/// safe. Used by both cooperative activation and the gossip coop-update sync
-/// path so a binding is recorded deterministically on every node that accepts an
+/// Used by both cooperative activation and the gossip coop-update sync path (which
+/// mirrors the origin node's activation-time bind for activated cooperatives only),
+/// so a binding is recorded deterministically on every node that accepts an
 /// activated cooperative.
+///
+/// The write is reject-not-normalize: a non-mappable `coop_id` (e.g. the default
+/// `coop:<uuid>` shape) yields [`EntityMapBindOutcome::NotMappable`] and writes
+/// nothing. A mappable id is bound with `Activation` provenance via
+/// [`CoopEntityMap::bind_resolved_with_provenance`], so the row reads back as a
+/// trusted activation binding (not the fail-closed `UnknownLegacy` that a plain
+/// `bind_projected`/`bind_resolved` leaves). Re-binding the identical pair with the
+/// same provenance is idempotent; a pre-provenance (`UnknownLegacy`) row from an
+/// older binary is upgraded in place. A binding still grants no authority.
 pub fn bind_coop_entity_map(
     map: &(dyn CoopEntityMap + Send + Sync),
     coop_id: &str,
 ) -> EntityMapBindOutcome {
-    match map.bind_projected(coop_id) {
+    // Reject-not-normalize projection (the same gate the previous `bind_projected`
+    // applied) followed by a provenance-aware write recording `Activation`.
+    let result = project_coop_id(coop_id).and_then(|entity_id| {
+        map.bind_resolved_with_provenance(
+            coop_id,
+            &entity_id,
+            CoopEntityBindingProvenance::Activation,
+        )
+        .map(|()| entity_id)
+    });
+    match result {
         Ok(entity_id) => EntityMapBindOutcome::Mapped(entity_id),
         Err(CoopEntityMapError::NotMappable(reason)) => EntityMapBindOutcome::NotMappable(reason),
         Err(CoopEntityMapError::Conflict(reason)) => EntityMapBindOutcome::Conflict(reason),
@@ -2105,6 +2127,111 @@ mod tests {
             map.coop_for_entity(&EntityId::cooperative("good-coop").unwrap())
                 .unwrap(),
             None
+        );
+    }
+
+    // === A2c: activation bindings record real `Activation` provenance ===
+
+    /// A `CoopEntityMap` whose writes always fail, to prove a storage error during
+    /// the provenance-aware activation bind is reported (`StorageError`) and never
+    /// propagated — a mapping bind must not fail activation.
+    struct FailingCoopEntityMap;
+
+    impl CoopEntityMap for FailingCoopEntityMap {
+        fn bind_resolved(
+            &self,
+            _coop_id: &str,
+            _entity_id: &EntityId,
+        ) -> std::result::Result<(), CoopEntityMapError> {
+            Err(CoopEntityMapError::Storage(
+                "simulated backend failure".into(),
+            ))
+        }
+        fn entity_for_coop(
+            &self,
+            _coop_id: &str,
+        ) -> std::result::Result<Option<EntityId>, CoopEntityMapError> {
+            Ok(None)
+        }
+        fn coop_for_entity(
+            &self,
+            _entity_id: &EntityId,
+        ) -> std::result::Result<Option<String>, CoopEntityMapError> {
+            Ok(None)
+        }
+    }
+
+    // T6a: a mappable activation bind records `Activation` provenance (not the
+    // fail-closed `UnknownLegacy` that the old plain `bind_projected` left behind).
+    #[test]
+    fn test_bind_outcome_records_activation_provenance() {
+        let map = InMemoryCoopEntityMap::new();
+        let outcome = bind_coop_entity_map(&map, "good-coop");
+        assert_eq!(
+            outcome,
+            EntityMapBindOutcome::Mapped(EntityId::cooperative("good-coop").unwrap())
+        );
+        let binding = map
+            .binding_for_coop("good-coop")
+            .unwrap()
+            .expect("binding present after activation bind");
+        assert_eq!(binding.provenance, CoopEntityBindingProvenance::Activation);
+    }
+
+    // T6b: repeating the identical activation bind is idempotent and keeps the
+    // `Activation` provenance (re-recording the same provenance is not a Conflict).
+    #[test]
+    fn test_bind_outcome_idempotent_keeps_activation_provenance() {
+        let map = InMemoryCoopEntityMap::new();
+        let first = bind_coop_entity_map(&map, "good-coop");
+        let second = bind_coop_entity_map(&map, "good-coop");
+        assert_eq!(first, second);
+        assert_eq!(
+            second,
+            EntityMapBindOutcome::Mapped(EntityId::cooperative("good-coop").unwrap())
+        );
+        assert_eq!(
+            map.binding_for_coop("good-coop")
+                .unwrap()
+                .unwrap()
+                .provenance,
+            CoopEntityBindingProvenance::Activation
+        );
+    }
+
+    // T6c: a storage error during the bind is reported as `StorageError` and never
+    // propagated — the activation contract (bind is non-fatal) is preserved.
+    #[test]
+    fn test_bind_outcome_storage_error_is_reported_not_propagated() {
+        let outcome = bind_coop_entity_map(&FailingCoopEntityMap, "good-coop");
+        assert!(
+            matches!(outcome, EntityMapBindOutcome::StorageError(_)),
+            "expected StorageError, got {outcome:?}"
+        );
+    }
+
+    // T6d: the activation-written binding satisfies every trust gate the merged
+    // `StoreBackedCoopEntityResolver` (#2192) requires to resolve — trusted
+    // `Activation` provenance, a cooperative target, and a consistent reverse index.
+    // (The resolver actually resolving such a binding is covered by the icn-gateway
+    // test `store_backed_resolves_binding_with_trusted_provenance`.)
+    #[test]
+    fn test_activation_binding_satisfies_resolver_trust_gates() {
+        let map = InMemoryCoopEntityMap::new();
+        assert!(matches!(
+            bind_coop_entity_map(&map, "good-coop"),
+            EntityMapBindOutcome::Mapped(_)
+        ));
+        let entity = EntityId::cooperative("good-coop").unwrap();
+        let binding = map.binding_for_coop("good-coop").unwrap().unwrap();
+        // (1) trusted provenance
+        assert_eq!(binding.provenance, CoopEntityBindingProvenance::Activation);
+        // (2) cooperative target
+        assert!(binding.entity_id.is_cooperative());
+        // (3) reverse index consistent: entity -> good-coop
+        assert_eq!(
+            map.coop_for_entity(&entity).unwrap(),
+            Some("good-coop".to_string())
         );
     }
 }

--- a/icn/crates/icn-coop/src/lib.rs
+++ b/icn/crates/icn-coop/src/lib.rs
@@ -18,8 +18,8 @@ pub mod store;
 pub mod types;
 
 pub use actor::{
-    bind_coop_entity_map, CoopActor, CoopEntityMapHandle, CoopMessage, EntityMapBindOutcome,
-    GossipHandle, TreasuryManagerHandle, COOP_TOPIC,
+    bind_coop_entity_map, bind_coop_entity_map_activation, CoopActor, CoopEntityMapHandle,
+    CoopMessage, EntityMapBindOutcome, GossipHandle, TreasuryManagerHandle, COOP_TOPIC,
 };
 pub use handle::CoopHandle;
 pub use lifecycle::{


### PR DESCRIPTION
## What changed

The coop-entity name-binding write in `icn-coop/src/actor.rs` is **split by trust
level**, so trusted `CoopEntityBindingProvenance::Activation` is recorded only by
the authoritative local activation path — never from an unauthenticated gossip
payload:

- **`bind_coop_entity_map_activation`** (new) — projects the `coop_id`
  (reject-not-normalize) and writes via
  `CoopEntityMap::bind_resolved_with_provenance(..., Activation)`. Called **only**
  from the local `CoopActor` activation handler (immediately after
  `save_cooperative`), which authoritatively performed the activation. This is the
  trusted row the merged `StoreBackedCoopEntityResolver` (#2192) can resolve.
- **`bind_coop_entity_map`** (existing, unchanged signature) — a no-provenance write
  that reads back as the fail-closed `UnknownLegacy` sentinel. Used by the **gossip
  coop-update mirror** (`handle_coop_update` in `icn-core`), which binds for `Active`
  `coop:updates` payloads **without** verifying the entry author or an activation
  proof. Leaving these rows untrusted prevents a topic publisher from poisoning the
  durable map with a row the resolver would trust. The icn-core call site is
  unchanged.

Both share a private `bind_outcome` mapper and return the same `EntityMapBindOutcome`
(`Mapped` / `NotMappable` / `Conflict` / `StorageError`). A gossip-seeded
`UnknownLegacy` row is still upgraded in place if the node later locally activates
the same cooperative.

> The split (and the gossip-stays-untrusted decision) was made in response to a
> Codex P1 review on the initial single-helper approach; see commit `3446ef9b`.

## Why this is the next A2c step after #2192

#2192 merged `StoreBackedCoopEntityResolver`, which resolves a `coop_id` only when
the binding carries **trusted** provenance — `UnknownLegacy` is fail-closed. Until
now every activation binding was written as `UnknownLegacy`, so the resolver could
never resolve a real row. This slice upgrades the **local activation** producer
path so live activation rows are trusted `Activation` bindings (gossip-mirrored
rows stay `UnknownLegacy` / untrusted), making the activation rows resolvable when
observe-only resolver wiring is added in a later slice.

## Scope

- One crate, two files: `icn/crates/icn-coop/src/actor.rs` and `.../lib.rs`
  (new `bind_coop_entity_map_activation` re-export).
- The `EntityMapBindOutcome` enum is unchanged; the icn-core gossip call site is
  unchanged (it keeps calling `bind_coop_entity_map`).
- **No backfill path touched.** The existing `icnctl coop entity-backfill-surrogates`
  is a separate command; recording `Surrogate` / `OperatorBackfill` provenance there
  is the next slice, deliberately left out here.

## Non-claims

- Does **not** enforce entity-aware authorization.
- Does **not** change any route authorization outcome.
- Does **not** cut over treasury routes, and does not touch `require_entity_access`
  or `require_coop_access`.
- Does **not** issue positive `entity_id` / `entity_type` token claims.
- Does **not** wire `StoreBackedCoopEntityResolver` into any handler or app state.
- Does **not** treat `CoopEntityMap` as authority; a binding is a name binding only.
- Does **not** trust `UnknownLegacy` or make missing provenance look trusted — it
  only changes what the **local activation producer writes** (now real `Activation`
  provenance); gossip-mirrored rows stay `UnknownLegacy` / untrusted.

The activation contract is preserved: the mapping bind is a non-authoritative,
non-fatal side effect — `Conflict` / `StorageError` are reported (logged at the
call sites), never propagated, and activation is never failed; a non-mappable
`coop:<uuid>` id still yields `NotMappable` and writes nothing.

## Validation

- `cargo fmt --all --check` — clean.
- `cargo test -p icn-coop --lib` — **153 passed / 0 failed**, including 5 new tests:
  - local activation bind records `Activation` provenance for a mappable id;
  - repeated identical activation bind is idempotent and keeps `Activation`;
  - a storage error is reported as `StorageError`, never propagated (activation
    non-fatal);
  - the activation-written binding satisfies every `StoreBackedCoopEntityResolver`
    trust gate (trusted `Activation` provenance, cooperative target, consistent
    reverse index);
  - **the gossip helper records `UnknownLegacy`, never `Activation`** (trust-boundary
    guard).
- `cargo check -p icn-core` — the gossip consumer still compiles.
- `cargo clippy -p icn-coop --all-targets -- -D warnings` — clean.
- `ops/scripts/drift-check.sh` — PASS (0 errors / 0 warnings).

Developed test-first: the two provenance assertions were observed failing on
`UnknownLegacy` vs `Activation` (runtime RED), then the helper was switched to the
provenance-aware write (GREEN). The resolver actually resolving an `Activation`
binding is independently covered by the merged icn-gateway test
`store_backed_resolves_binding_with_trusted_provenance` (#2192).

## Relationship to prior work

- `#2187` (design) / `#2188` (resolver seam) / `#2189` (observe wiring) — establish
  the fail-closed `coop_id → EntityId` resolver. Unchanged here.
- `#2190` (provenance substrate) — added `bind_resolved_with_provenance` +
  `CoopEntityBindingProvenance`; this PR is the first **producer** to record real
  `Activation` provenance through that API.
- `#2191` (institutional powers spec) — "a mapping is not authority" still holds:
  this records provenance on a name binding, not authority.
- `#2192` (store-backed resolver) — consumes trusted provenance; this PR makes live
  activation rows trusted so the resolver has real rows to resolve later.

## Explicit statement

This PR **records provenance on name bindings**; it **does not** enforce
entity-aware authorization, **does not** change route outcomes, **does not** issue
token claims, **does not** treat mappings as authority, and **does not** trust
legacy/unprovenanced (`UnknownLegacy`) rows.

Refs #2187, #2188, #2189, #2190, #2191, #2192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

