### PR TITLE
feat(coop): record OperatorBackfill provenance on surrogate backfill bindings

### DIFF
--- a/icn/bins/icnctl/tests/coop_entity_backfill_test.rs
+++ b/icn/bins/icnctl/tests/coop_entity_backfill_test.rs
@@ -13,7 +13,7 @@ use std::process::{Command, Output};
 use std::sync::Arc;
 
 use icn_coop::{CoopStore, CoopType, Cooperative};
-use icn_entity::{CoopEntityMap, SledCoopEntityMap};
+use icn_entity::{CoopEntityBindingProvenance, CoopEntityMap, SledCoopEntityMap};
 use icn_store::SledStore;
 use serde_json::Value;
 use tempfile::TempDir;
@@ -186,6 +186,31 @@ fn apply_binds_default_coop_to_deterministic_surrogate_and_preserves_coop_id() {
     );
     // The mappable coop was NOT bound by the surrogate path.
     assert_eq!(map.entity_for_coop("real-coop").unwrap(), None);
+}
+
+#[test]
+fn apply_records_operator_backfill_provenance_durably() {
+    // End-to-end: after `--apply`, the durable Sled binding carries the
+    // OperatorBackfill provenance (not the fail-closed UnknownLegacy a plain
+    // bind_resolved would leave), so a later store-backed resolver could trust it.
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    let default_id = seed_two_cooperatives(&data_dir);
+
+    assert!(run(&data_dir, &["--apply", "--json"]).status.success());
+
+    let surrogate = icn_entity::propose_surrogate_entity_id(&default_id).unwrap();
+    let (_store, map) = open_map(&data_dir);
+    let binding = map
+        .binding_for_coop(&default_id)
+        .unwrap()
+        .expect("default coop is now bound");
+    assert_eq!(binding.coop_id, default_id);
+    assert_eq!(binding.entity_id, surrogate);
+    assert_eq!(
+        binding.provenance,
+        CoopEntityBindingProvenance::OperatorBackfill
+    );
 }
 
 #[test]

--- a/icn/crates/icn-entity/src/coop_entity_backfill.rs
+++ b/icn/crates/icn-entity/src/coop_entity_backfill.rs
@@ -11,16 +11,17 @@
 //!   PR3),
 //! - deterministic surrogate proposal
 //!   ([`propose_surrogate_entity_id`](crate::propose_surrogate_entity_id), PR4),
-//! - the reversible write primitive
-//!   ([`CoopEntityMap::bind_resolved`](crate::CoopEntityMap::bind_resolved),
-//!   PR5).
+//! - the reversible, provenance-recording write primitive
+//!   ([`CoopEntityMap::bind_resolved_with_provenance`](crate::CoopEntityMap::bind_resolved_with_provenance),
+//!   PR5 + A2c).
 //!
 //! Given a set of flat `coop_id`s and the canonical map, it selects the *safe,
 //! non-mappable* entries (a default `coop:<uuid>` cannot project to a valid
 //! cooperative slug), proposes each one's deterministic surrogate, and — only
 //! under an explicit [`SurrogateBackfillMode::Apply`] — binds the pair with
-//! `bind_resolved`. [`SurrogateBackfillMode::DryRun`] is the default and writes
-//! nothing.
+//! `bind_resolved_with_provenance`, recording
+//! [`CoopEntityBindingProvenance::OperatorBackfill`](crate::CoopEntityBindingProvenance::OperatorBackfill).
+//! [`SurrogateBackfillMode::DryRun`] is the default and writes nothing.
 //!
 //! # A mapping is NOT authority
 //!
@@ -48,7 +49,7 @@
 //!   leave an ambiguous partial result).
 
 use crate::coop_entity_inventory::{classify_coop_ids, CoopEntityClass, CoopEntityInventoryEntry};
-use crate::coop_entity_map::{CoopEntityMap, CoopEntityMapError};
+use crate::coop_entity_map::{CoopEntityBindingProvenance, CoopEntityMap, CoopEntityMapError};
 use crate::coop_entity_surrogate::propose_surrogate_entity_id;
 use crate::entity::EntityId;
 use serde::{Deserialize, Serialize};
@@ -64,7 +65,9 @@ pub enum SurrogateBackfillMode {
     /// Compute and report the plan; bind nothing.
     DryRun,
     /// Bind each eligible, collision-free non-mappable `coop_id` to its
-    /// deterministic surrogate via [`CoopEntityMap::bind_resolved`].
+    /// deterministic surrogate via
+    /// [`CoopEntityMap::bind_resolved_with_provenance`], recording
+    /// [`CoopEntityBindingProvenance::OperatorBackfill`].
     Apply,
 }
 
@@ -235,8 +238,9 @@ impl CoopSurrogateBackfill {
 /// performs only read operations and binds nothing; in
 /// [`SurrogateBackfillMode::Apply`] it binds each eligible, collision-free
 /// non-mappable `coop_id` to its deterministic surrogate via
-/// [`CoopEntityMap::bind_resolved`], preserving the original `coop_id`
-/// byte-for-byte. A binding confers no authority.
+/// [`CoopEntityMap::bind_resolved_with_provenance`] — recording
+/// [`CoopEntityBindingProvenance::OperatorBackfill`] — preserving the original
+/// `coop_id` byte-for-byte. A binding confers no authority.
 pub fn backfill_coop_surrogates(
     coop_ids: impl IntoIterator<Item = String>,
     map: &dyn CoopEntityMap,
@@ -284,10 +288,13 @@ pub fn backfill_coop_surrogates(
 }
 
 /// Decide the backfill action for one classified entry — and, in `Apply` mode,
-/// perform the `bind_resolved` write for a collision-free non-mappable entry.
+/// perform the `bind_resolved_with_provenance` write for a collision-free
+/// non-mappable entry.
 ///
 /// Pure for every non-`NonMappable` class and for collisions/storage errors; the
-/// only write is `bind_resolved` on an eligible entry in `Apply` mode.
+/// only write is `bind_resolved_with_provenance` (recording
+/// [`CoopEntityBindingProvenance::OperatorBackfill`]) on an eligible entry in
+/// `Apply` mode.
 fn plan_entry(
     entry: &CoopEntityInventoryEntry,
     surrogate: Option<EntityId>,
@@ -414,7 +421,19 @@ fn plan_entry(
                     None,
                 ),
                 SurrogateBackfillMode::Apply => {
-                    match map.bind_resolved(&entry.coop_id, &surrogate) {
+                    // Record OperatorBackfill provenance: this is an operator-run
+                    // backfill (the `OperatorBackfill` variant's doc names this exact
+                    // command). The surrogate nature of the target is already evident
+                    // from its `coop-legacy-<hash>` slug, so provenance records HOW the
+                    // binding was established. A recorded provenance is what lets the
+                    // store-backed A2c resolver treat the binding as trusted; absent it,
+                    // the row reads back as the fail-closed UnknownLegacy sentinel.
+                    // A binding still confers no authority (see the module docs).
+                    match map.bind_resolved_with_provenance(
+                        &entry.coop_id,
+                        &surrogate,
+                        CoopEntityBindingProvenance::OperatorBackfill,
+                    ) {
                         Ok(()) => make(
                             SurrogateBackfillAction::Bound,
                             Some(surrogate.clone()),
@@ -899,6 +918,100 @@ mod tests {
         assert_eq!(entry["action"].as_str(), Some("would_bind"));
         assert_eq!(entry["proposed_entity_id"].as_str(), Some(UUID_SURROGATE));
         assert!(entry["reason"].as_str().is_some());
+    }
+
+    // ------------------------------------------------------------------
+    // Provenance recording (A2c): apply records OperatorBackfill provenance on
+    // the surrogate name binding; dry-run and refused entries record nothing.
+    // ------------------------------------------------------------------
+
+    use crate::coop_entity_map::CoopEntityBindingProvenance;
+
+    #[test]
+    fn apply_records_operator_backfill_provenance_on_surrogate_binding() {
+        let map = InMemoryCoopEntityMap::new();
+        let report =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(report.applied, 1);
+
+        // The binding carries the operator-backfill provenance, not the
+        // fail-closed UnknownLegacy sentinel a plain bind_resolved would leave.
+        let binding = map.binding_for_coop(UUID_COOP).unwrap().unwrap();
+        assert_eq!(binding.entity_id.as_str(), UUID_SURROGATE);
+        assert_eq!(
+            binding.provenance,
+            CoopEntityBindingProvenance::OperatorBackfill
+        );
+        // The reverse binding records the same provenance.
+        let by_entity = map
+            .binding_for_entity(&coop_eid("coop-legacy-edf6152975301bd80c13"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            by_entity.provenance,
+            CoopEntityBindingProvenance::OperatorBackfill
+        );
+    }
+
+    #[test]
+    fn apply_rerun_keeps_operator_backfill_provenance() {
+        let map = InMemoryCoopEntityMap::new();
+        backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        // Rerun: the id is AlreadyBound, so it is skipped (not re-bound) and the
+        // recorded provenance is unchanged.
+        let second =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(second.applied, 0);
+        assert_eq!(second.skipped_already_bound, 1);
+        assert_eq!(
+            map.binding_for_coop(UUID_COOP).unwrap().unwrap().provenance,
+            CoopEntityBindingProvenance::OperatorBackfill
+        );
+    }
+
+    #[test]
+    fn dry_run_records_no_binding_or_provenance() {
+        let map = InMemoryCoopEntityMap::new();
+        backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::DryRun);
+        // Dry-run writes nothing: no binding at all (and therefore no provenance).
+        assert_eq!(map.binding_for_coop(UUID_COOP).unwrap(), None);
+    }
+
+    #[test]
+    fn collision_records_no_provenance_and_leaves_occupant_untouched() {
+        // A different coop already occupies the surrogate target, so the
+        // non-mappable id collides and is never bound — no provenance is written
+        // for it, and the occupant's (provenance-less) binding is untouched.
+        let map = InMemoryCoopEntityMap::new();
+        let surrogate = propose_surrogate_entity_id(UUID_COOP).unwrap();
+        map.bind_exact("alpha-coop", &surrogate).unwrap();
+
+        let report =
+            backfill_coop_surrogates(ids(&[UUID_COOP]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(report.surrogate_collision, 1);
+        assert_eq!(report.applied, 0);
+
+        // The collided non-mappable id has no binding/provenance of its own.
+        assert_eq!(map.binding_for_coop(UUID_COOP).unwrap(), None);
+        // The occupant binding is unchanged (bind_exact records no provenance).
+        let occupant = map.binding_for_entity(&surrogate).unwrap().unwrap();
+        assert_eq!(occupant.coop_id, "alpha-coop");
+        assert_eq!(
+            occupant.provenance,
+            CoopEntityBindingProvenance::UnknownLegacy
+        );
+    }
+
+    #[test]
+    fn apply_leaves_mappable_unbound_id_without_binding_or_provenance() {
+        // A mappable coop resolves by projection; the surrogate backfill must not
+        // bind it, so it has no binding (and thus no provenance) afterward.
+        let map = InMemoryCoopEntityMap::new();
+        let report =
+            backfill_coop_surrogates(ids(&["food-coop"]), &map, SurrogateBackfillMode::Apply);
+        assert_eq!(report.skipped_mappable_unbound, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(map.binding_for_coop("food-coop").unwrap(), None);
     }
 
     #[test]

--- a/icn/crates/icn-entity/src/coop_entity_backfill.rs
+++ b/icn/crates/icn-entity/src/coop_entity_backfill.rs
@@ -100,10 +100,11 @@ pub enum SurrogateBackfillAction {
     /// already reverse-bound to a different `coop_id`, or claimed by another
     /// `coop_id` in this same batch. Reported, never bound.
     SurrogateCollision,
-    /// Apply: `bind_resolved` rejected the surrogate as a forward/reverse
-    /// mapping conflict (a real concurrent-state change between plan and write).
+    /// Apply: `bind_resolved_with_provenance` rejected the surrogate as a
+    /// forward/reverse mapping conflict (a real concurrent-state change between
+    /// plan and write).
     BindConflict,
-    /// Apply: `bind_resolved` failed with a storage/other error.
+    /// Apply: `bind_resolved_with_provenance` failed with a storage/other error.
     BindError,
 }
 
@@ -162,11 +163,11 @@ pub struct CoopSurrogateBackfill {
     pub skipped_storage_error: usize,
     /// Non-mappable entries whose proposed surrogate would collide on bind.
     pub surrogate_collision: usize,
-    /// Eligible entries whose `bind_resolved` was rejected as a conflict
-    /// (`Apply` only).
+    /// Eligible entries whose `bind_resolved_with_provenance` was rejected as a
+    /// conflict (`Apply` only).
     pub bind_conflict: usize,
-    /// Eligible entries whose `bind_resolved` failed with a storage/other error
-    /// (`Apply` only).
+    /// Eligible entries whose `bind_resolved_with_provenance` failed with a
+    /// storage/other error (`Apply` only).
     pub bind_error: usize,
     /// Per-`coop_id` detail, in input order.
     pub entries: Vec<SurrogateBackfillEntry>,
@@ -443,14 +444,14 @@ fn plan_entry(
                         Err(CoopEntityMapError::Conflict(msg)) => make(
                             SurrogateBackfillAction::BindConflict,
                             Some(surrogate.clone()),
-                            "bind_resolved rejected the surrogate as a forward/reverse conflict"
+                            "bind_resolved_with_provenance rejected the surrogate as a forward/reverse conflict"
                                 .into(),
                             Some(msg),
                         ),
                         Err(e) => make(
                             SurrogateBackfillAction::BindError,
                             Some(surrogate.clone()),
-                            "bind_resolved failed".into(),
+                            "bind_resolved_with_provenance failed".into(),
                             Some(e.to_string()),
                         ),
                     }

--- a/icn/crates/icn-gateway/src/coop_entity_resolver.rs
+++ b/icn/crates/icn-gateway/src/coop_entity_resolver.rs
@@ -528,6 +528,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn store_backed_resolves_surrogate_written_by_operator_backfill() {
+        // Interop: a non-mappable default `coop:<uuid>` backfilled to its
+        // deterministic surrogate (recording OperatorBackfill provenance) resolves
+        // through the store-backed resolver — proving the provenance the backfill
+        // records passes the resolver's existing trust gate. No resolver-trust
+        // broadening: OperatorBackfill is already trusted.
+        use icn_entity::{
+            backfill_coop_surrogates, propose_surrogate_entity_id, SurrogateBackfillMode,
+        };
+        const UUID_COOP: &str = "coop:550e8400-e29b-41d4-a716-446655440000";
+
+        let map = InMemoryCoopEntityMap::new();
+        let report =
+            backfill_coop_surrogates([UUID_COOP.to_string()], &map, SurrogateBackfillMode::Apply);
+        assert_eq!(report.applied, 1, "backfill bound exactly one surrogate");
+        let surrogate = propose_surrogate_entity_id(UUID_COOP).unwrap();
+
+        let out = store_backed(map).resolve_coop_entity(UUID_COOP).await;
+        assert_eq!(
+            out,
+            CoopEntityResolution::Resolved {
+                entity_id: surrogate
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn store_backed_resolves_governance_receipt_provenance() {
         let map = InMemoryCoopEntityMap::new();
         let entity = coop_entity();


### PR DESCRIPTION
## What changed

The `icnctl coop entity-backfill-surrogates` **apply** path now writes its
surrogate name bindings with provenance instead of as unprovenanced rows. The
single Apply-mode write in `backfill_coop_surrogates` / `plan_entry`
(`icn-entity/src/coop_entity_backfill.rs`) switches from
`CoopEntityMap::bind_resolved` to `bind_resolved_with_provenance`, recording
`CoopEntityBindingProvenance::OperatorBackfill`. Module/function doc comments are
updated to match. No counters, report shape, CLI flags, or dry-run behavior
change.

## Why this is the next A2c step (after #2192, #2193)

A2c is about making `coop_id → EntityId` bindings *trustable* by a store-backed
resolver, which keys trust on recorded provenance. #2193 made the
**activation-time** producer record `Activation` provenance. This PR closes the
analogous gap for the other live producer of bindings — the operator-run
surrogate backfill — so backfilled rows are no longer written as the fail-closed
`UnknownLegacy` sentinel. It is producer-side only and remains observe/record,
not enforcement.

## Scope

- Producer-side write change in one crate (`icn-entity`), plus tests in
  `icn-entity`, `icnctl`, and `icn-gateway`.
- Dry-run unchanged (writes nothing). Collision / storage-error paths unchanged
  (write no provenance). Original `coop_id` preserved byte-for-byte. Already-bound
  rows skipped unchanged. A mapping confers no authority.

## Chosen provenance variant and why

**`OperatorBackfill`.** Rationale:
1. That variant's own doc comment names this exact command: *"Bound by an
   operator-run backfill (e.g. `icnctl coop entity-backfill-surrogates`)"* — the
   strongest established-semantics signal in code/comments.
2. The surrogate nature of the target is not lost: it is already self-evident
   from the `entity:icn:cooperative:coop-legacy-<hash>` slug, so provenance is
   free to record *how* the binding was established (an operator backfill).
3. `OperatorBackfill` is already a trusted variant in the gateway resolver's
   `provenance_is_trusted_for_resolution` (alongside `Surrogate`, `Activation`,
   `GovernanceReceipt`), so this PR needs **no** resolver-trust broadening.

`Surrogate` was the runner-up (it equally describes the target), but the
`OperatorBackfill` doc citing this command by name is decisive; choosing
`Surrogate` would leave `OperatorBackfill`'s example pointing at a command that
never produces it.

## Non-claims / what this PR does NOT do

- Does **not** enforce entity-aware authorization.
- Does **not** change any route authorization outcome.
- Does **not** cut over treasury routes or touch `require_entity_access` /
  `require_coop_access`.
- Does **not** issue positive `entity_id` / `entity_type` token claims.
- Does **not** wire `StoreBackedCoopEntityResolver` into handlers / app state.
- Does **not** treat `CoopEntityMap` as authority.
- Does **not** trust `UnknownLegacy` or gossip-originated mappings, and does
  **not** alter the gossip/activation trust split from #2193.
- Does **not** upgrade pre-existing legacy (`UnknownLegacy`) rows — backfill
  still skips already-bound rows unchanged; legacy upgrade is a later repair slice.
- Does **not** broaden backfill into a general migration framework.

## Validation

- `cargo fmt --all --check` — clean
- `cargo test -p icn-entity --lib` — 247 passed
- `cargo test -p icnctl --test coop_entity_backfill_test` — 11 passed (incl. new
  `apply_records_operator_backfill_provenance_durably`)
- `cargo test -p icn-gateway --lib coop_entity_resolver` — 15 passed (incl. new
  `store_backed_resolves_surrogate_written_by_operator_backfill`; the existing
  `store_backed_does_not_resolve_missing_provenance` still fails closed)
- `cargo clippy -p icn-entity -p icnctl -p icn-gateway --all-targets --all-features -- -D warnings` — clean
- `ops/scripts/drift-check.sh` — PASS

New tests prove: apply records `OperatorBackfill`; rerun stays idempotent with
the same provenance; dry-run / collision / mappable-unbound write no provenance;
the durable Sled binding carries `OperatorBackfill` after `--apply`; and a
backfilled surrogate resolves through `StoreBackedCoopEntityResolver` only
because its provenance passes the resolver's existing trust gate.

## Relationship to the A2c lane

- **#2187** — A2c resolver/source design seam (governed `coop_id → EntityId`).
- **#2188** — `CoopEntityResolver` trait + fail-closed `UnwiredCoopEntityResolver`.
- **#2189** — observe-only wiring into treasury access classification.
- **#2190** — provenance substrate (`CoopEntityBindingProvenance`,
  `bind_resolved_with_provenance`, fail-closed `UnknownLegacy`).
- **#2191** — institutional-powers doctrine (docs).
- **#2192 / #2193** — first provenance producers (activation path recording
  `Activation`).
- **This PR** — the operator-backfill producer recording `OperatorBackfill`, so
  the second live binding producer also emits trustable provenance.

This PR records provenance on surrogate backfill name bindings; it does not
enforce entity-aware authorization, does not change route outcomes, does not
issue token claims, does not treat mappings as authority, does not trust
legacy/unprovenanced rows, and does not alter the gossip/activation trust split
from #2193.

Refs #2082
