### PR TITLE
feat(authz): wire store-backed coop entity resolver for treasury observation

### DIFF
--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -26,6 +26,10 @@ pub struct GatewayActorHandles {
     pub treasury: Option<icn_gateway::TreasuryHandle>,
     pub ledger: Option<icn_gateway::LedgerHandle>,
     pub entity: Option<icn_entity::EntityHandle>,
+    /// Canonical, provenance-aware coop_id↔EntityId name-binding store (#2082/#2190).
+    /// Threaded to the gateway so observe-mode treasury classification can consult a
+    /// trusted, fail-closed `StoreBackedCoopEntityResolver` (A2c). Observe-only.
+    pub coop_entity_map: Option<icn_coop::CoopEntityMapHandle>,
     pub steward: Option<icn_steward::StewardHandle>,
     pub agreement_manager: Option<icn_federation::agreement::AgreementManagerHandle>,
     pub service_discovery_manager:

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -45,6 +45,10 @@ pub struct GatewayHandles {
     pub ledger: Option<icn_gateway::LedgerHandle>,
     /// Entity handle for entity management
     pub entity: Option<icn_entity::EntityHandle>,
+    /// Canonical, provenance-aware coop_id↔EntityId name-binding store (#2082/#2190).
+    /// When present, the gateway builds a trusted, fail-closed
+    /// `StoreBackedCoopEntityResolver` for observe-mode treasury classification (A2c).
+    pub coop_entity_map: Option<icn_coop::CoopEntityMapHandle>,
     /// Steward handle for SDIS ceremonies
     pub steward: Option<icn_steward::StewardHandle>,
     /// Agreement manager for inter-cooperative agreements
@@ -138,6 +142,7 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let treasury_handle = handles.treasury;
     let ledger_handle = handles.ledger;
     let entity_handle = handles.entity;
+    let coop_entity_map_handle = handles.coop_entity_map;
     let steward_handle = handles.steward;
     let agreement_manager_handle = handles.agreement_manager;
     let service_discovery_manager = handles.service_discovery_manager;
@@ -214,6 +219,10 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
 
             if let Some(handle) = entity_handle {
                 gateway_server = gateway_server.with_entity_handle(handle);
+            }
+
+            if let Some(handle) = coop_entity_map_handle {
+                gateway_server = gateway_server.with_coop_entity_map_handle(handle);
             }
 
             if let Some(handle) = steward_handle {

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -167,6 +167,7 @@ pub async fn run_supervisor(
             treasury: gateway_handles.treasury,
             ledger: gateway_handles.ledger,
             entity: gateway_handles.entity,
+            coop_entity_map: gateway_handles.coop_entity_map,
             steward: gateway_handles.steward,
             agreement_manager: gateway_handles.agreement_manager,
             service_discovery_manager: gateway_handles.service_discovery_manager,
@@ -507,6 +508,10 @@ async fn spawn_actors_with_identity(
     gateway_handles.community = Some(community_services.community_handle);
     gateway_handles.trust_service = trust_service_from_registry.clone();
     gateway_handles.entity = Some(entity_services.entity_handle);
+    // A2c: hand the canonical, provenance-aware coop_id↔EntityId store to the gateway
+    // so observe-mode treasury classification can use a trusted, fail-closed
+    // StoreBackedCoopEntityResolver. Observe-only; no authorization change.
+    gateway_handles.coop_entity_map = Some(coop_entity_map.clone());
     gateway_handles.service_discovery_manager = service_discovery_mgr.clone();
     gateway_handles.naming_service = match super::init_naming::init_naming_service(config) {
         Ok(service) => Some(service),

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -25,6 +25,9 @@ use tracing::info;
 
 use crate::auth::TokenClaims;
 use crate::authority::{observe_treasury_entity_access, EntityAction};
+use crate::coop_entity_resolver::{
+    CoopEntityResolver, ObserveCoopEntityResolver, UnwiredCoopEntityResolver,
+};
 use crate::entity_mgr::EntityManager;
 use crate::error::{GatewayError, Result};
 use crate::governance_mgr::GovernanceManager;
@@ -323,13 +326,35 @@ async fn observe_treasury(
     // strictly off the request path — it can affect neither the response nor its
     // latency. (RFC-0018 observe mode, ADR-0035.)
     let entity_mgr = entity_mgr.get_ref().clone();
+    let resolver = observe_coop_entity_resolver(req);
     let target = treasury_entity_id.cloned();
     let coop_id = coop_id.to_string();
     actix_web::rt::spawn(async move {
-        let _ =
-            observe_treasury_entity_access(&entity_mgr, &caller, target.as_ref(), &coop_id, action)
-                .await;
+        let _ = observe_treasury_entity_access(
+            resolver.as_ref(),
+            &entity_mgr,
+            &caller,
+            target.as_ref(),
+            &coop_id,
+            action,
+        )
+        .await;
     });
+}
+
+/// Fetch the observe-mode `coop_id → EntityId` resolver from gateway app state (A2c).
+///
+/// The gateway registers exactly one [`ObserveCoopEntityResolver`] as shared
+/// `web::Data` — a `StoreBackedCoopEntityResolver` when a trusted, provenance-aware
+/// `CoopEntityMap` handle is wired, otherwise the fail-closed
+/// [`UnwiredCoopEntityResolver`]. When none is registered (e.g. a standalone or test
+/// app), this falls back to the fail-closed default, so the observe path never trusts
+/// a resolution it cannot verify. The resolver is consulted observe-only and changes
+/// no authorization outcome.
+fn observe_coop_entity_resolver(req: &HttpRequest) -> Arc<dyn CoopEntityResolver> {
+    req.app_data::<web::Data<ObserveCoopEntityResolver>>()
+        .map(|d| d.get_ref().0.clone())
+        .unwrap_or_else(|| Arc::new(UnwiredCoopEntityResolver))
 }
 
 /// Like [`observe_treasury`], but keyed by the **owning treasury's `treasury_did`**
@@ -359,6 +384,7 @@ async fn observe_treasury_by_did(
     let entity_mgr = entity_mgr.get_ref().clone();
     let treasury_mgr = treasury_mgr.get_ref().clone();
     let treasury_did = treasury_did.clone();
+    let resolver = observe_coop_entity_resolver(req);
     actix_web::rt::spawn(async move {
         // Resolve the budget's owning treasury off the hot path; observe against
         // its stored entity_id (and its own coop_id for the fallback projection).
@@ -366,9 +392,15 @@ async fn observe_treasury_by_did(
             Ok(Some(t)) => (t.entity_id().cloned(), t.coop_id.clone()),
             _ => (None, String::new()),
         };
-        let _ =
-            observe_treasury_entity_access(&entity_mgr, &caller, target.as_ref(), &coop_id, action)
-                .await;
+        let _ = observe_treasury_entity_access(
+            resolver.as_ref(),
+            &entity_mgr,
+            &caller,
+            target.as_ref(),
+            &coop_id,
+            action,
+        )
+        .await;
     });
 }
 

--- a/icn/crates/icn-gateway/src/authority.rs
+++ b/icn/crates/icn-gateway/src/authority.rs
@@ -17,7 +17,7 @@
 
 use crate::commons_mgr::CommonsManager;
 use crate::coop_entity_resolver::{
-    CoopEntityResolution, CoopEntityResolver, ResolutionUnavailable, UnwiredCoopEntityResolver,
+    CoopEntityResolution, CoopEntityResolver, ResolutionUnavailable,
 };
 use crate::entity_map::legacy_coop_id_to_entity_id_fallback;
 use crate::entity_mgr::EntityManager;
@@ -302,6 +302,7 @@ impl EntityAccessObservation {
 /// `treasury_entity_id` is the treasury's stored `EntityId` (`treasury.entity_id()`);
 /// `coop_id` is the path coop id used only as a best-effort fallback target.
 pub(crate) async fn observe_treasury_entity_access(
+    resolver: &dyn CoopEntityResolver,
     entity_mgr: &EntityManager,
     caller: &EntityId,
     treasury_entity_id: Option<&EntityId>,
@@ -356,13 +357,14 @@ pub(crate) async fn observe_treasury_entity_access(
         }
     }
 
-    // A2b: observe-only `coop_id → EntityId` resolution discrepancy. Consults the
-    // fail-closed resolver seam (#2188) and logs how it compares to the legacy
-    // projection the observe path already uses. Uses the default
-    // `UnwiredCoopEntityResolver` until a trusted source is wired (A2c), so today it
-    // reports "resolver unavailable" — it never affects this observation, the flat
-    // guard, or any authorization decision.
-    let _ = observe_coop_entity_resolution(&UnwiredCoopEntityResolver, coop_id).await;
+    // A2b/A2c: observe-only `coop_id → EntityId` resolution discrepancy. Consults the
+    // governed resolver seam (#2188) and logs how it compares to the legacy projection
+    // the observe path already uses. The resolver is injected by the caller (A2c): the
+    // gateway wires a trusted, provenance-gated `StoreBackedCoopEntityResolver` when a
+    // `CoopEntityMap` handle is configured, and otherwise the fail-closed
+    // `UnwiredCoopEntityResolver`. Either way this never affects this observation, the
+    // flat guard, or any authorization decision.
+    let _ = observe_coop_entity_resolution(resolver, coop_id).await;
 
     observation
 }
@@ -539,7 +541,11 @@ async fn compute_treasury_observation(
 #[allow(clippy::unwrap_used)]
 mod entity_access_tests {
     use super::*;
-    use icn_entity::{CooperativeEntity, MembershipCapability, MembershipStatus};
+    use crate::coop_entity_resolver::{StoreBackedCoopEntityResolver, UnwiredCoopEntityResolver};
+    use icn_entity::{
+        CoopEntityBindingProvenance, CoopEntityMap, CooperativeEntity, InMemoryCoopEntityMap,
+        MembershipCapability, MembershipStatus,
+    };
     use icn_identity::KeyPair;
 
     /// Register a fresh in-memory coop entity; return the manager and its EntityId.
@@ -705,6 +711,7 @@ mod entity_access_tests {
         let (mgr, target) = setup().await;
         let caller = add_active_member(&mgr, &target, MembershipRole::Founder).await;
         let obs = observe_treasury_entity_access(
+            &UnwiredCoopEntityResolver,
             &mgr,
             &caller,
             Some(&target),
@@ -726,6 +733,7 @@ mod entity_access_tests {
         let kp = KeyPair::generate().unwrap();
         let outsider = EntityId::from_did(kp.did());
         let obs = observe_treasury_entity_access(
+            &UnwiredCoopEntityResolver,
             &mgr,
             &outsider,
             Some(&target),
@@ -745,6 +753,7 @@ mod entity_access_tests {
         let kp = KeyPair::generate().unwrap();
         let caller = EntityId::from_did(kp.did());
         let obs = observe_treasury_entity_access(
+            &UnwiredCoopEntityResolver,
             &mgr,
             &caller,
             Some(&target),
@@ -765,6 +774,7 @@ mod entity_access_tests {
         let kp = KeyPair::generate().unwrap();
         let caller = EntityId::from_did(kp.did());
         let obs = observe_treasury_entity_access(
+            &UnwiredCoopEntityResolver,
             &mgr,
             &caller,
             None,
@@ -785,6 +795,7 @@ mod entity_access_tests {
         let (mgr, target) = setup().await;
         let caller = add_active_member(&mgr, &target, MembershipRole::Founder).await;
         let obs = observe_treasury_entity_access(
+            &UnwiredCoopEntityResolver,
             &mgr,
             &caller,
             None,
@@ -793,6 +804,66 @@ mod entity_access_tests {
         )
         .await;
         assert_eq!(obs, EntityAccessObservation::AgreesAllow);
+    }
+
+    // A2c: the KEY safety property — with a fully-resolving, trusted store-backed
+    // resolver wired, the treasury `EntityAccessObservation` (and therefore every
+    // route outcome) is computed purely from the entity-membership path: byte-
+    // identical to the unwired result. The resolver is observe-only and never an
+    // authorization input.
+    #[tokio::test]
+    async fn store_backed_resolver_does_not_change_treasury_observation() {
+        let (mgr, target) = setup().await;
+        let caller = add_active_member(&mgr, &target, MembershipRole::Founder).await;
+        let map = InMemoryCoopEntityMap::new();
+        let entity = EntityId::cooperative("treasury-coop").expect("valid coop slug");
+        map.bind_resolved_with_provenance(
+            "treasury-coop",
+            &entity,
+            CoopEntityBindingProvenance::Activation,
+        )
+        .expect("seed trusted binding");
+        let store_backed = StoreBackedCoopEntityResolver::new(std::sync::Arc::new(map));
+
+        // A founder is a member: AgreesAllow with EITHER resolver, byte-identical.
+        let with_store = observe_treasury_entity_access(
+            &store_backed,
+            &mgr,
+            &caller,
+            Some(&target),
+            "treasury-coop",
+            EntityAction::TreasuryWrite,
+        )
+        .await;
+        let with_unwired = observe_treasury_entity_access(
+            &UnwiredCoopEntityResolver,
+            &mgr,
+            &caller,
+            Some(&target),
+            "treasury-coop",
+            EntityAction::TreasuryWrite,
+        )
+        .await;
+        assert_eq!(with_store, EntityAccessObservation::AgreesAllow);
+        assert_eq!(with_store, with_unwired);
+
+        // A non-member still observes EntityDeny with the trusted resolver wired —
+        // resolving a coop_id→EntityId binding never upgrades a non-member to allow.
+        let kp = KeyPair::generate().unwrap();
+        let outsider = EntityId::from_did(kp.did());
+        let deny = observe_treasury_entity_access(
+            &store_backed,
+            &mgr,
+            &outsider,
+            Some(&target),
+            "treasury-coop",
+            EntityAction::TreasuryRead,
+        )
+        .await;
+        assert_eq!(
+            deny,
+            EntityAccessObservation::EntityDeny(DenyReason::NonMember)
+        );
     }
 }
 
@@ -1130,5 +1201,123 @@ mod coop_resolution_observe_tests {
                 "unwired resolver must never yield a resolver-trusting outcome for {coop_id:?}, got {out:?}"
             );
         }
+    }
+
+    // ----------------------------------------------------------------------
+    // A2c: observe-mode wiring of the trusted, store-backed resolver.
+    //
+    // These prove the observe path consults a real `StoreBackedCoopEntityResolver`
+    // when one is wired — producing genuine Agree / ResolverOnly / LegacyOnly
+    // classifications from trusted provenance — while the entity-membership
+    // observation (and therefore every treasury route outcome) is UNCHANGED.
+    // The default (no store) path is proven by the `default_resolver_*` tests above.
+    // ----------------------------------------------------------------------
+    use crate::coop_entity_resolver::{StoreBackedCoopEntityResolver, UnwiredCoopEntityResolver};
+    use icn_entity::{
+        CoopEntityBindingProvenance, CoopEntityMap, CoopEntityMapError, InMemoryCoopEntityMap,
+    };
+
+    fn store_backed_for(
+        map: impl CoopEntityMap + Send + Sync + 'static,
+    ) -> StoreBackedCoopEntityResolver {
+        StoreBackedCoopEntityResolver::new(std::sync::Arc::new(map))
+    }
+
+    // (B) Trusted Activation binding: `food-coop` legacy-projects to
+    // `EntityId::cooperative("food-coop")`, and a trusted binding records the same
+    // EntityId, so the observation agrees.
+    #[tokio::test]
+    async fn store_backed_observe_activation_binding_is_agree() {
+        let map = InMemoryCoopEntityMap::new();
+        let entity = EntityId::cooperative("food-coop").expect("valid coop slug");
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &entity,
+            CoopEntityBindingProvenance::Activation,
+        )
+        .expect("seed trusted activation binding");
+        let out = observe_coop_entity_resolution(&store_backed_for(map), "food-coop").await;
+        assert_eq!(out, CoopResolutionObservation::Agree);
+    }
+
+    // (C) Trusted OperatorBackfill surrogate: a non-mappable default `coop:<uuid>`
+    // (the legacy projection rejects it) bound to its cooperative surrogate with
+    // OperatorBackfill provenance resolves through the existing trust gate — so the
+    // resolver produces an EntityId the legacy path cannot: ResolverOnly.
+    #[tokio::test]
+    async fn store_backed_observe_operator_backfill_surrogate_is_resolver_only() {
+        let map = InMemoryCoopEntityMap::new();
+        let surrogate = EntityId::cooperative("coop-legacy-abc123").expect("valid coop slug");
+        map.bind_resolved_with_provenance(
+            "coop:7f3a2b",
+            &surrogate,
+            CoopEntityBindingProvenance::OperatorBackfill,
+        )
+        .expect("seed operator-backfill binding");
+        let out = observe_coop_entity_resolution(&store_backed_for(map), "coop:7f3a2b").await;
+        assert_eq!(out, CoopResolutionObservation::ResolverOnly);
+    }
+
+    // (D) UnknownLegacy: an unprovenanced binding (plain `bind_resolved`) is the
+    // fail-closed sentinel — it must never resolve. The observation is
+    // LegacyOnly(UnverifiedProvenance), never Agree.
+    #[tokio::test]
+    async fn store_backed_observe_unknown_legacy_is_not_trusted() {
+        let map = InMemoryCoopEntityMap::new();
+        let entity = EntityId::cooperative("food-coop").expect("valid coop slug");
+        map.bind_resolved("food-coop", &entity)
+            .expect("seed unprovenanced (UnknownLegacy) binding");
+        let out = observe_coop_entity_resolution(&store_backed_for(map), "food-coop").await;
+        assert_eq!(
+            out,
+            CoopResolutionObservation::LegacyOnly(ResolutionUnavailable::UnverifiedProvenance)
+        );
+        assert!(!matches!(out, CoopResolutionObservation::Agree));
+    }
+
+    /// A `CoopEntityMap` whose reads always fail — proves observe fails closed on a
+    /// backend error (never a trusted agreement).
+    struct FailingObserveMap;
+    // NOTE: `Result` in this module is the gateway's `crate::error::Result`
+    // (GatewayError) alias, so the `CoopEntityMap` trait methods are spelled with
+    // fully-qualified `std::result::Result<_, CoopEntityMapError>`.
+    impl CoopEntityMap for FailingObserveMap {
+        fn bind_resolved(
+            &self,
+            _c: &str,
+            _e: &EntityId,
+        ) -> std::result::Result<(), CoopEntityMapError> {
+            Ok(())
+        }
+        fn entity_for_coop(
+            &self,
+            _c: &str,
+        ) -> std::result::Result<Option<EntityId>, CoopEntityMapError> {
+            Err(CoopEntityMapError::Storage(
+                "simulated backend failure".into(),
+            ))
+        }
+        fn coop_for_entity(
+            &self,
+            _e: &EntityId,
+        ) -> std::result::Result<Option<String>, CoopEntityMapError> {
+            Err(CoopEntityMapError::Storage(
+                "simulated backend failure".into(),
+            ))
+        }
+    }
+
+    // (E) Backend error fails closed: `food-coop` legacy-projects, but the store
+    // errors, so the resolver is SourceUnavailable → LegacyOnly(SourceUnavailable),
+    // never a trusted Agree. (Ambiguous / entity-type-mismatch fail-closed cases are
+    // proven at the resolver layer in `coop_entity_resolver.rs`.)
+    #[tokio::test]
+    async fn store_backed_observe_backend_error_fails_closed() {
+        let out =
+            observe_coop_entity_resolution(&store_backed_for(FailingObserveMap), "food-coop").await;
+        assert_eq!(
+            out,
+            CoopResolutionObservation::LegacyOnly(ResolutionUnavailable::SourceUnavailable)
+        );
     }
 }

--- a/icn/crates/icn-gateway/src/coop_entity_resolver.rs
+++ b/icn/crates/icn-gateway/src/coop_entity_resolver.rs
@@ -204,6 +204,25 @@ impl StoreBackedCoopEntityResolver {
     }
 }
 
+/// App-state holder for the observe-mode `coop_id → EntityId` resolver (A2c wiring).
+///
+/// The gateway registers exactly one of these as shared `web::Data`. It defaults to
+/// the fail-closed [`UnwiredCoopEntityResolver`] (via [`Self::unwired`]); the gateway
+/// builder installs a [`StoreBackedCoopEntityResolver`] instead when a trusted,
+/// provenance-aware [`CoopEntityMap`] handle is wired
+/// (`GatewayServer::with_coop_entity_map_handle`). It is consulted only by the
+/// observe-mode treasury path: it changes no route outcome, denies nothing, and a
+/// resolved binding grants no authority.
+#[derive(Clone)]
+pub(crate) struct ObserveCoopEntityResolver(pub(crate) Arc<dyn CoopEntityResolver>);
+
+impl ObserveCoopEntityResolver {
+    /// The fail-closed default: resolves nothing until a trusted store is wired.
+    pub(crate) fn unwired() -> Self {
+        Self(Arc::new(UnwiredCoopEntityResolver))
+    }
+}
+
 /// Whether a binding's recorded provenance is trusted enough to resolve a *name*
 /// (never authority).
 ///

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -113,6 +113,12 @@ pub struct GatewayServer {
     ledger_handle: Option<LedgerHandle>,
     /// Optional handle to daemon's EntityRegistry (for entity management)
     entity_handle: Option<EntityHandle>,
+    /// Optional handle to the daemon's canonical, provenance-aware coop_id↔EntityId
+    /// name-binding store (#2082/#2190). When present, the gateway builds a trusted,
+    /// fail-closed `StoreBackedCoopEntityResolver` for observe-mode treasury
+    /// classification (A2c); when absent, the observe path uses the fail-closed
+    /// `UnwiredCoopEntityResolver`. Observe-only — never an authorization input.
+    coop_entity_map_handle: Option<icn_coop::CoopEntityMapHandle>,
     /// Optional handle to daemon's CommunityActor (for civic engine)
     community_handle: Option<icn_community::CommunityHandle>,
     /// Optional handle to daemon's StewardActor (for SDIS ceremonies)
@@ -200,6 +206,7 @@ impl GatewayServer {
             treasury_handle: None,
             ledger_handle: None,
             entity_handle: None,
+            coop_entity_map_handle: None,
             community_handle: None,
             steward_handle: None,
             agreement_manager_handle: None,
@@ -251,6 +258,7 @@ impl GatewayServer {
             treasury_handle: None,
             ledger_handle: None,
             entity_handle: None,
+            coop_entity_map_handle: None,
             community_handle: None,
             steward_handle: None,
             agreement_manager_handle: None,
@@ -303,6 +311,7 @@ impl GatewayServer {
             treasury_handle: None,
             ledger_handle: None,
             entity_handle: None,
+            coop_entity_map_handle: None,
             community_handle: None,
             steward_handle: None,
             agreement_manager_handle: None,
@@ -494,6 +503,20 @@ impl GatewayServer {
     /// EntityRegistry, ensuring persistence and consistent state.
     pub fn with_entity_handle(mut self, handle: EntityHandle) -> Self {
         self.entity_handle = Some(handle);
+        self
+    }
+
+    /// Set the canonical, provenance-aware coop_id↔EntityId name-binding store
+    /// handle (#2082/#2190).
+    ///
+    /// When set, the gateway builds a trusted, fail-closed
+    /// `StoreBackedCoopEntityResolver` over this store and consults it in
+    /// observe-mode treasury classification (A2c). It is observe-only: it resolves
+    /// only bindings with trusted provenance, never changes a route outcome, and a
+    /// resolved binding grants no authority. When unset, the observe path uses the
+    /// fail-closed `UnwiredCoopEntityResolver`.
+    pub fn with_coop_entity_map_handle(mut self, handle: icn_coop::CoopEntityMapHandle) -> Self {
+        self.coop_entity_map_handle = Some(handle);
         self
     }
 
@@ -1142,6 +1165,25 @@ impl GatewayServer {
         } else {
             warn!("Entity manager running standalone (in-memory only)");
             Arc::new(EntityManager::new())
+        };
+
+        // A2c observe-mode coop_id→EntityId resolver. When the daemon wires the
+        // canonical, provenance-aware CoopEntityMap, build a trusted, fail-closed
+        // StoreBackedCoopEntityResolver; otherwise fall back to the fail-closed
+        // UnwiredCoopEntityResolver. This resolver is consulted ONLY by observe-mode
+        // treasury classification (RFC-0018, ADR-0035): it resolves only bindings with
+        // trusted provenance, changes no route outcome, and grants no authority.
+        let observe_coop_entity_resolver = match self.coop_entity_map_handle {
+            Some(map) => {
+                info!("Coop-entity resolver: store-backed (trusted, observe-only) — A2c wired");
+                crate::coop_entity_resolver::ObserveCoopEntityResolver(std::sync::Arc::new(
+                    crate::coop_entity_resolver::StoreBackedCoopEntityResolver::new(map),
+                ))
+            }
+            None => {
+                info!("Coop-entity resolver: unwired (fail-closed default)");
+                crate::coop_entity_resolver::ObserveCoopEntityResolver::unwired()
+            }
         };
 
         // Create treasury manager (uses handle if available, otherwise in-memory)
@@ -1900,6 +1942,7 @@ impl GatewayServer {
                 .app_data(web::Data::new(federation_service_for_routes.clone()))
                 .app_data(web::Data::new(commons_manager.clone()))
                 .app_data(web::Data::new(entity_manager.clone()))
+                .app_data(web::Data::new(observe_coop_entity_resolver.clone()))
                 .app_data(web::Data::new(entity_audit_manager.clone()))
                 .app_data(web::Data::new(treasury_manager.clone()))
                 .app_data(web::Data::new(ledger_manager.clone()))


### PR DESCRIPTION
## Summary

Make the A2c provenance lane observable in a **real runtime path**: treasury observe-mode classification now consults a trusted, fail-closed `StoreBackedCoopEntityResolver` when the daemon provides the canonical, provenance-aware `CoopEntityMap`, instead of always using the unwired default. **Observe-only — it changes no authorization outcome.**

## What changed

**Gateway (`icn-gateway`):**
- `observe_treasury_entity_access` now takes `resolver: &dyn CoopEntityResolver` instead of hardcoding `UnwiredCoopEntityResolver`. The resolver feeds **only** the discarded (`let _ =`) discrepancy log/metric; the `EntityAccessObservation` is still computed exactly as before from the entity-membership path.
- The treasury observe helpers (`observe_treasury` / `observe_treasury_by_did`) fetch an `ObserveCoopEntityResolver` from app state via `req.app_data()` (falling back to the fail-closed `UnwiredCoopEntityResolver` when none is registered) and pass it into the detached observation task. No route-handler signatures change.
- `GatewayServer::with_coop_entity_map_handle(...)` builds a `StoreBackedCoopEntityResolver` over the provided `CoopEntityMap` when present, else `UnwiredCoopEntityResolver`, and registers it as shared `web::Data` (new `ObserveCoopEntityResolver` holder).

**Daemon (`icn-core`):** threads the canonical `coop_entity_map` handle through `GatewayActorHandles` → `init_gateway::GatewayHandles` → `.with_coop_entity_map_handle(...)`, mirroring the existing `entity` handle path (same `gateway_handles` instance declared in `run_supervisor`, populated in `spawn_actors_with_identity`, consumed by `spawn_gateway`).

Trust policy is **unchanged**: only trusted provenance (`Activation` / `OperatorBackfill` / `Surrogate` / `GovernanceReceipt`) resolves; `UnknownLegacy`, missing, ambiguous, entity-type-mismatch, and backend-error all fail closed. Gossip-mirror / unprovenanced rows stay `UnknownLegacy` and never resolve.

## Why this is the next A2c step after #2195

After the substrate (#2190), the fail-closed store-backed resolver *source* (#2192), the observe-only treasury *classification* (#2189), and the trusted *producers* (#2193 activation, #2194 operator backfill), the resolver source was built but **not yet wired into any live app-state/handler**. This slice connects the daemon's real, provenance-aware store to the treasury observe path so the classification (`Agree` / `ResolverOnly` / `LegacyOnly` / `Disagree`) becomes meaningful in production — still strictly observe-only, one step before any per-route-family enforcement gating.

## Validation

- `cargo fmt --all --check` — clean
- `cargo test -p icn-gateway --lib` — **647 passed, 0 failed**
- `cargo build -p icn-core` — builds (daemon handle threading compiles)
- `cargo clippy -p icn-gateway --all-targets --all-features -- -D warnings` — clean
- `cargo clippy -p icn-core --all-targets --all-features -- -D warnings` — clean
- `ops/scripts/drift-check.sh` — PASS

**New tests (TDD):**
- **A (default / no store):** existing `default_resolver_*` tests + the `req.app_data` fallback prove the unwired default never yields a trusted resolution; route outcome unchanged.
- **B (Activation):** `store_backed_observe_activation_binding_is_agree` — `Activation` provenance resolves; legacy+resolver agreement → `Agree`.
- **C (OperatorBackfill):** `store_backed_observe_operator_backfill_surrogate_is_resolver_only` — a backfilled surrogate resolves through the existing trust gate → `ResolverOnly`.
- **D (UnknownLegacy):** `store_backed_observe_unknown_legacy_is_not_trusted` — an unprovenanced binding → `LegacyOnly(UnverifiedProvenance)`, never `Agree`.
- **E (backend error):** `store_backed_observe_backend_error_fails_closed` — store error → `LegacyOnly(SourceUnavailable)`; no authority granted.
- **F (treasury safety):** `store_backed_resolver_does_not_change_treasury_observation` — with a fully-resolving trusted resolver wired, the treasury `EntityAccessObservation` (allow/deny) is **byte-identical** to the unwired result, and a non-member still observes `EntityDeny`.

## Nonclaims

This change does **not**: enforce entity-aware authorization · change any route outcome · cut treasury over to `require_entity_access` · issue positive `entity_id`/`entity_type` token claims · treat `CoopEntityMap` as authority · trust `UnknownLegacy` · trust gossip-originated mappings · upgrade pre-existing legacy rows · complete all of #2082 · claim production / pilot / live-federation / Phase-2 readiness.

## Relationship to #2187–#2195 and #2082

- #2187 resolver-seam design · #2188 `CoopEntityResolver` trait + fail-closed `UnwiredCoopEntityResolver` · #2189 observe-only treasury classification · #2190 provenance substrate · #2191 institutional-powers spec · #2192 `StoreBackedCoopEntityResolver` source · #2193 `Activation` producer · #2194 `OperatorBackfill` producer · #2195 docs truth-sync.
- **This PR** wires #2192's source into #2189's observe path, consuming the #2193/#2194 producers' rows through #2190's substrate — observe-only.
- **#2082 (the `coop_id ↔ EntityId` store/mapping tracker) remains OPEN** and is not completed by this slice.

Refs #2082
