### PR TITLE
feat(authz): add treasury entity gate scaffold

### DIFF
--- a/icn/crates/icn-gateway/src/authority.rs
+++ b/icn/crates/icn-gateway/src/authority.rs
@@ -294,6 +294,195 @@ impl EntityAccessObservation {
     }
 }
 
+// ===========================================================================
+// A2d: treasury entity-authorization gate scaffold (observe → measure → gate).
+//
+// This is the explicit, testable seam that decides what to do with the now-real
+// treasury resolver observation. The shipped mode is `ObserveOnly` — it NEVER alters
+// a route outcome. `EnforceTrustedResolver` is a decision-only mode exercised solely
+// by `decide_treasury_gate` and its tests; this slice wires it to NO route and NO
+// production config. A later, deliberate cutover would set the mode from an
+// operator-gated, off-by-default knob and consume the decision at the route layer.
+// ===========================================================================
+
+/// The treasury route family's entity-authorization **mode** (A2d).
+///
+/// `ObserveOnly` is the default and the only mode the gateway ships *wired* — it never
+/// changes a route outcome. `EnforceTrustedResolver` exists for the pure
+/// [`decide_treasury_gate`] decision function and its tests; it is **not** reachable
+/// from any production config in this slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum TreasuryEntityAuthMode {
+    /// Record/measure only; the flat `require_coop_access` guard stays authoritative.
+    #[default]
+    ObserveOnly,
+    /// Trusted-resolver enforcement *semantics* (decision-only; never wired to a route
+    /// here).
+    EnforceTrustedResolver,
+}
+
+/// The active treasury entity-auth mode the gateway runs with. Hardcoded to the
+/// fail-safe default — this slice ships **no** path that sets it to enforcement.
+pub(crate) const ACTIVE_TREASURY_ENTITY_AUTH_MODE: TreasuryEntityAuthMode =
+    TreasuryEntityAuthMode::ObserveOnly;
+
+/// What the A2d gate decides for a treasury request that has ALREADY passed the flat
+/// `require_coop_access` guard.
+///
+/// `ProceedUnchanged` leaves the route outcome exactly as the flat guard decided.
+/// `WouldDeny` is produced **only** under
+/// [`TreasuryEntityAuthMode::EnforceTrustedResolver`] and is **not** acted on in this
+/// slice — it is measured/logged for a future cutover.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TreasuryGateDecision {
+    /// Route proceeds as the flat guard decided (every `ObserveOnly` decision, and the
+    /// allow case under enforcement).
+    ProceedUnchanged,
+    /// Under enforcement, this request would be denied (carries a stable reason). Never
+    /// produced under `ObserveOnly`.
+    WouldDeny(TreasuryGateDenyReason),
+}
+
+/// Stable reason a trusted-resolver enforcement decision would deny.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TreasuryGateDenyReason {
+    /// The entity-membership observation says the caller is not an (active) member.
+    NotMember,
+    /// No trusted `coop_id → EntityId` basis: the resolver was unavailable, the binding
+    /// was unprovenanced (`UnknownLegacy`, incl. gossip-originated rows), ambiguous,
+    /// entity-type-mismatched, or the store errored. A name binding is never authority,
+    /// and an untrusted one is never a basis for enforcement.
+    UntrustedResolution,
+    /// The legacy projection and the trusted resolver DISAGREE on the `EntityId` — a
+    /// migration collision; fail closed.
+    ResolverConflict,
+    /// A trusted basis exists but the entity-membership observation is indeterminate (a
+    /// data gap); fail closed.
+    IndeterminateMembership,
+    /// The entity-membership observation errored; fail closed.
+    ObservationError,
+}
+
+impl TreasuryGateDecision {
+    /// Stable, lowercase outcome label for logs / future metrics.
+    fn outcome_label(self) -> &'static str {
+        match self {
+            TreasuryGateDecision::ProceedUnchanged => "proceed_unchanged",
+            TreasuryGateDecision::WouldDeny(_) => "would_deny",
+        }
+    }
+}
+
+impl TreasuryGateDenyReason {
+    /// Stable, lowercase reason label for logs / future metrics.
+    fn label(self) -> &'static str {
+        match self {
+            TreasuryGateDenyReason::NotMember => "not_member",
+            TreasuryGateDenyReason::UntrustedResolution => "untrusted_resolution",
+            TreasuryGateDenyReason::ResolverConflict => "resolver_conflict",
+            TreasuryGateDenyReason::IndeterminateMembership => "indeterminate_membership",
+            TreasuryGateDenyReason::ObservationError => "observation_error",
+        }
+    }
+}
+
+/// Pure A2d gate decision for a treasury request (no side effects).
+///
+/// Inputs are the two already-computed observe-mode signals — the entity-membership
+/// `observation` and the `coop_id → EntityId` `resolution` classification — plus the
+/// `mode`. The function NEVER consults a mapping as authority: under enforcement the
+/// `resolution` is used only as a *trust qualifier* (is there a trusted basis at all?),
+/// and the actual allow/deny signal is the entity-membership `observation`.
+///
+/// - [`TreasuryEntityAuthMode::ObserveOnly`] (the shipped default) ALWAYS returns
+///   [`TreasuryGateDecision::ProceedUnchanged`]: byte-identical to the flat guard,
+///   regardless of the observation or resolution.
+/// - [`TreasuryEntityAuthMode::EnforceTrustedResolver`] (decision-only; not wired to any
+///   route here) requires a trusted basis first, then defers to membership:
+///   - `Agree` / `ResolverOnly` → trusted basis established;
+///   - `Disagree` → `WouldDeny(ResolverConflict)` (migration collision; fail closed);
+///   - `LegacyOnly(_)` / `NeitherResolved(_)` → `WouldDeny(UntrustedResolution)` — covers
+///     `UnknownLegacy`, gossip-originated/unprovenanced rows, ambiguous bindings,
+///     entity-type mismatch, and backend/source errors (all fail closed);
+///   - with a trusted basis: `AgreesAllow` → `ProceedUnchanged`; `EntityDeny` →
+///     `WouldDeny(NotMember)`; `Indeterminate` → `WouldDeny(IndeterminateMembership)`;
+///     `Error` → `WouldDeny(ObservationError)`.
+pub(crate) fn decide_treasury_gate(
+    mode: TreasuryEntityAuthMode,
+    observation: &EntityAccessObservation,
+    resolution: &CoopResolutionObservation,
+) -> TreasuryGateDecision {
+    match mode {
+        // Default, shipped behavior: never alter the route.
+        TreasuryEntityAuthMode::ObserveOnly => TreasuryGateDecision::ProceedUnchanged,
+        TreasuryEntityAuthMode::EnforceTrustedResolver => {
+            // (1) A trusted coop→EntityId basis is required before any enforcement.
+            //     An untrusted/unavailable/ambiguous mapping fails closed BEFORE the
+            //     membership signal is even consulted — you cannot trust the membership
+            //     target if you cannot trust the coop→entity mapping that named it.
+            match resolution {
+                CoopResolutionObservation::Agree | CoopResolutionObservation::ResolverOnly => {}
+                CoopResolutionObservation::Disagree => {
+                    return TreasuryGateDecision::WouldDeny(
+                        TreasuryGateDenyReason::ResolverConflict,
+                    );
+                }
+                CoopResolutionObservation::LegacyOnly(_)
+                | CoopResolutionObservation::NeitherResolved(_) => {
+                    return TreasuryGateDecision::WouldDeny(
+                        TreasuryGateDenyReason::UntrustedResolution,
+                    );
+                }
+            }
+            // (2) With a trusted basis, the entity-membership observation decides.
+            match observation {
+                EntityAccessObservation::AgreesAllow => TreasuryGateDecision::ProceedUnchanged,
+                EntityAccessObservation::EntityDeny(_) => {
+                    TreasuryGateDecision::WouldDeny(TreasuryGateDenyReason::NotMember)
+                }
+                EntityAccessObservation::Indeterminate(_) => {
+                    TreasuryGateDecision::WouldDeny(TreasuryGateDenyReason::IndeterminateMembership)
+                }
+                EntityAccessObservation::Error(_) => {
+                    TreasuryGateDecision::WouldDeny(TreasuryGateDenyReason::ObservationError)
+                }
+            }
+        }
+    }
+}
+
+/// Record (observe-only) the A2d treasury gate decision for cutover-readiness
+/// telemetry. `active` is the decision under the shipped
+/// [`ACTIVE_TREASURY_ENTITY_AUTH_MODE`] (always `ProceedUnchanged` today);
+/// `would_enforce` is the hypothetical [`TreasuryEntityAuthMode::EnforceTrustedResolver`]
+/// decision. Logging only — this denies nothing and changes no route outcome.
+fn record_treasury_gate(
+    caller: &EntityId,
+    action: EntityAction,
+    active: TreasuryGateDecision,
+    would_enforce: TreasuryGateDecision,
+) {
+    match would_enforce {
+        TreasuryGateDecision::WouldDeny(reason) => warn!(
+            target: "entity_authz_gate",
+            caller = %caller,
+            action = action.metric_label(),
+            active = active.outcome_label(),
+            would_enforce = would_enforce.outcome_label(),
+            reason = reason.label(),
+            "treasury entity gate WOULD DENY under enforcement (observe-only; flat coop guard remains authoritative)"
+        ),
+        TreasuryGateDecision::ProceedUnchanged => debug!(
+            target: "entity_authz_gate",
+            caller = %caller,
+            action = action.metric_label(),
+            active = active.outcome_label(),
+            would_enforce = would_enforce.outcome_label(),
+            "treasury entity gate would proceed under enforcement (observe-only)"
+        ),
+    }
+}
+
 /// Compute, record, and return the entity-aware authorization observation for a
 /// treasury request that has ALREADY passed the flat `require_coop_access` guard.
 ///
@@ -358,13 +547,28 @@ pub(crate) async fn observe_treasury_entity_access(
     }
 
     // A2b/A2c: observe-only `coop_id → EntityId` resolution discrepancy. Consults the
-    // governed resolver seam (#2188) and logs how it compares to the legacy projection
-    // the observe path already uses. The resolver is injected by the caller (A2c): the
-    // gateway wires a trusted, provenance-gated `StoreBackedCoopEntityResolver` when a
-    // `CoopEntityMap` handle is configured, and otherwise the fail-closed
+    // governed resolver seam (#2188) and classifies how it compares to the legacy
+    // projection the observe path already uses. The resolver is injected by the caller
+    // (A2c): the gateway wires a trusted, provenance-gated `StoreBackedCoopEntityResolver`
+    // when a `CoopEntityMap` handle is configured, and otherwise the fail-closed
     // `UnwiredCoopEntityResolver`. Either way this never affects this observation, the
     // flat guard, or any authorization decision.
-    let _ = observe_coop_entity_resolution(resolver, coop_id).await;
+    let resolution = observe_coop_entity_resolution(resolver, coop_id).await;
+
+    // A2d: observe → MEASURE the treasury entity-auth gate. The active gate runs under
+    // `ACTIVE_TREASURY_ENTITY_AUTH_MODE` (the shipped fail-safe default `ObserveOnly`),
+    // so its decision is always `ProceedUnchanged` and the route is NEVER altered here —
+    // this function stays observe-only and its return value is still discarded by the
+    // caller. We additionally evaluate what `EnforceTrustedResolver` WOULD decide and
+    // record it, so a future cutover can be measured first. Neither path denies anything.
+    let active_gate =
+        decide_treasury_gate(ACTIVE_TREASURY_ENTITY_AUTH_MODE, &observation, &resolution);
+    let would_enforce_gate = decide_treasury_gate(
+        TreasuryEntityAuthMode::EnforceTrustedResolver,
+        &observation,
+        &resolution,
+    );
+    record_treasury_gate(caller, action, active_gate, would_enforce_gate);
 
     observation
 }
@@ -1319,5 +1523,177 @@ mod coop_resolution_observe_tests {
             out,
             CoopResolutionObservation::LegacyOnly(ResolutionUnavailable::SourceUnavailable)
         );
+    }
+
+    // ----------------------------------------------------------------------
+    // A2d: treasury entity-auth gate decision (pure). The shipped default
+    // (ObserveOnly) never alters a route; EnforceTrustedResolver fails closed unless a
+    // TRUSTED coop→EntityId basis AND an affirmative membership both hold. Route safety
+    // (observe_treasury_entity_access returns the unchanged observation) is proven by
+    // `entity_access_tests::store_backed_resolver_does_not_change_treasury_observation`.
+    // ----------------------------------------------------------------------
+    use TreasuryEntityAuthMode::{EnforceTrustedResolver, ObserveOnly};
+    use TreasuryGateDecision::{ProceedUnchanged, WouldDeny};
+    use TreasuryGateDenyReason::{
+        IndeterminateMembership, NotMember, ObservationError, ResolverConflict, UntrustedResolution,
+    };
+
+    fn allow() -> EntityAccessObservation {
+        EntityAccessObservation::AgreesAllow
+    }
+    fn deny() -> EntityAccessObservation {
+        EntityAccessObservation::EntityDeny(DenyReason::NonMember)
+    }
+    fn indeterminate() -> EntityAccessObservation {
+        EntityAccessObservation::Indeterminate(IndeterminateReason::NoMemberships)
+    }
+    fn errored() -> EntityAccessObservation {
+        EntityAccessObservation::Error("entity manager unavailable".into())
+    }
+    /// UnknownLegacy / unprovenanced rows (incl. gossip-originated) read back as
+    /// `UnverifiedProvenance` → the resolver is unavailable → `LegacyOnly`.
+    fn untrusted() -> CoopResolutionObservation {
+        CoopResolutionObservation::LegacyOnly(ResolutionUnavailable::UnverifiedProvenance)
+    }
+
+    // (A) ObserveOnly (the shipped default) NEVER denies, for every observation ×
+    // resolution combination — byte-identical route behavior.
+    #[test]
+    fn gate_observe_only_always_proceeds_unchanged() {
+        let observations = [allow(), deny(), indeterminate(), errored()];
+        let resolutions = [
+            CoopResolutionObservation::Agree,
+            CoopResolutionObservation::Disagree,
+            CoopResolutionObservation::ResolverOnly,
+            untrusted(),
+            CoopResolutionObservation::LegacyOnly(ResolutionUnavailable::SourceUnavailable),
+            CoopResolutionObservation::NeitherResolved(ResolutionUnavailable::NoTrustedSourceWired),
+        ];
+        for o in &observations {
+            for r in &resolutions {
+                assert_eq!(
+                    decide_treasury_gate(ObserveOnly, o, r),
+                    ProceedUnchanged,
+                    "ObserveOnly must never deny: observation={o:?} resolution={r:?}"
+                );
+            }
+        }
+    }
+
+    // (B) Enforcement: trusted agreement allows.
+    #[test]
+    fn gate_enforce_trusted_agreement_allows() {
+        assert_eq!(
+            decide_treasury_gate(
+                EnforceTrustedResolver,
+                &allow(),
+                &CoopResolutionObservation::Agree
+            ),
+            ProceedUnchanged
+        );
+    }
+
+    // (B) Enforcement: a trusted resolver-only basis (an activation/backfill surrogate
+    // the legacy projection can't produce) still allows an affirmative member —
+    // intentionally-documented policy.
+    #[test]
+    fn gate_enforce_trusted_resolver_only_allows_member() {
+        assert_eq!(
+            decide_treasury_gate(
+                EnforceTrustedResolver,
+                &allow(),
+                &CoopResolutionObservation::ResolverOnly
+            ),
+            ProceedUnchanged
+        );
+    }
+
+    // (B,D) Enforcement: legacy-only / untrusted provenance (UnknownLegacy, gossip rows)
+    // is NOT a trusted basis — fail closed even for an affirmative member.
+    #[test]
+    fn gate_enforce_untrusted_resolution_denies_even_for_member() {
+        assert_eq!(
+            decide_treasury_gate(EnforceTrustedResolver, &allow(), &untrusted()),
+            WouldDeny(UntrustedResolution)
+        );
+    }
+
+    // (B) Enforcement: resolver/legacy DISAGREE (migration collision) fails closed.
+    #[test]
+    fn gate_enforce_disagreement_denies() {
+        assert_eq!(
+            decide_treasury_gate(
+                EnforceTrustedResolver,
+                &allow(),
+                &CoopResolutionObservation::Disagree
+            ),
+            WouldDeny(ResolverConflict)
+        );
+    }
+
+    // (B,E) Enforcement: source-unavailable / backend-error fails closed (both the
+    // LegacyOnly and NeitherResolved carriers).
+    #[test]
+    fn gate_enforce_source_unavailable_denies() {
+        for r in [
+            CoopResolutionObservation::LegacyOnly(ResolutionUnavailable::SourceUnavailable),
+            CoopResolutionObservation::NeitherResolved(ResolutionUnavailable::SourceUnavailable),
+        ] {
+            assert_eq!(
+                decide_treasury_gate(EnforceTrustedResolver, &allow(), &r),
+                WouldDeny(UntrustedResolution),
+                "source-unavailable must fail closed under enforcement: {r:?}"
+            );
+        }
+    }
+
+    // (C) Enforcement with a trusted basis: a non-member is denied via the EXISTING
+    // entity-membership signal (the gate adds no new allow path).
+    #[test]
+    fn gate_enforce_trusted_basis_non_member_denies() {
+        assert_eq!(
+            decide_treasury_gate(
+                EnforceTrustedResolver,
+                &deny(),
+                &CoopResolutionObservation::Agree
+            ),
+            WouldDeny(NotMember)
+        );
+    }
+
+    // (C) Enforcement with a trusted basis: indeterminate membership (data gap) and a
+    // membership error both fail closed.
+    #[test]
+    fn gate_enforce_trusted_basis_membership_gaps_fail_closed() {
+        assert_eq!(
+            decide_treasury_gate(
+                EnforceTrustedResolver,
+                &indeterminate(),
+                &CoopResolutionObservation::Agree
+            ),
+            WouldDeny(IndeterminateMembership)
+        );
+        assert_eq!(
+            decide_treasury_gate(
+                EnforceTrustedResolver,
+                &errored(),
+                &CoopResolutionObservation::ResolverOnly
+            ),
+            WouldDeny(ObservationError)
+        );
+    }
+
+    // (D) Trust precedence / no mapping-as-authority: an untrusted resolution fails
+    // closed REGARDLESS of the membership signal — the gate never treats a mapping as
+    // authority, and never lets an untrusted basis through on a member.
+    #[test]
+    fn gate_enforce_untrusted_resolution_precedes_membership() {
+        for obs in [allow(), deny(), indeterminate(), errored()] {
+            assert_eq!(
+                decide_treasury_gate(EnforceTrustedResolver, &obs, &untrusted()),
+                WouldDeny(UntrustedResolution),
+                "untrusted resolution must fail closed before membership: {obs:?}"
+            );
+        }
     }
 }

--- a/icn/crates/icn-gateway/src/authority.rs
+++ b/icn/crates/icn-gateway/src/authority.rs
@@ -356,6 +356,12 @@ pub(crate) enum TreasuryGateDenyReason {
     /// The legacy projection and the trusted resolver DISAGREE on the `EntityId` — a
     /// migration collision; fail closed.
     ResolverConflict,
+    /// The resolver produced a trusted `EntityId` the legacy projection could NOT
+    /// (`ResolverOnly`), but the entity-membership observation was computed against
+    /// `treasury.entity_id()` / the legacy projection — NOT against that resolved
+    /// target. Until a follow-up carries the resolved target into membership
+    /// evaluation, `ResolverOnly` is measured but **not enforceable**; fail closed.
+    ResolverOnlyTargetUnverified,
     /// A trusted basis exists but the entity-membership observation is indeterminate (a
     /// data gap); fail closed.
     IndeterminateMembership,
@@ -380,6 +386,9 @@ impl TreasuryGateDenyReason {
             TreasuryGateDenyReason::NotMember => "not_member",
             TreasuryGateDenyReason::UntrustedResolution => "untrusted_resolution",
             TreasuryGateDenyReason::ResolverConflict => "resolver_conflict",
+            TreasuryGateDenyReason::ResolverOnlyTargetUnverified => {
+                "resolver_only_target_unverified"
+            }
             TreasuryGateDenyReason::IndeterminateMembership => "indeterminate_membership",
             TreasuryGateDenyReason::ObservationError => "observation_error",
         }
@@ -398,15 +407,23 @@ impl TreasuryGateDenyReason {
 ///   [`TreasuryGateDecision::ProceedUnchanged`]: byte-identical to the flat guard,
 ///   regardless of the observation or resolution.
 /// - [`TreasuryEntityAuthMode::EnforceTrustedResolver`] (decision-only; not wired to any
-///   route here) requires a trusted basis first, then defers to membership:
-///   - `Agree` / `ResolverOnly` → trusted basis established;
+///   route here) requires an *enforceable* trusted basis first, then defers to
+///   membership:
+///   - `Agree` → enforceable basis: the legacy projection and the resolver agree on the
+///     SAME `EntityId`, which is also the target the membership observation was computed
+///     against;
+///   - `ResolverOnly` → `WouldDeny(ResolverOnlyTargetUnverified)`: the resolver produced
+///     a target the legacy projection could not, so the membership observation
+///     (`treasury.entity_id()` / legacy projection) was never checked against it.
+///     Measured but **not enforceable** until a follow-up carries the resolved target
+///     into membership evaluation — fail closed;
 ///   - `Disagree` → `WouldDeny(ResolverConflict)` (migration collision; fail closed);
 ///   - `LegacyOnly(_)` / `NeitherResolved(_)` → `WouldDeny(UntrustedResolution)` — covers
 ///     `UnknownLegacy`, gossip-originated/unprovenanced rows, ambiguous bindings,
 ///     entity-type mismatch, and backend/source errors (all fail closed);
-///   - with a trusted basis: `AgreesAllow` → `ProceedUnchanged`; `EntityDeny` →
-///     `WouldDeny(NotMember)`; `Indeterminate` → `WouldDeny(IndeterminateMembership)`;
-///     `Error` → `WouldDeny(ObservationError)`.
+///   - with an enforceable basis (`Agree`): `AgreesAllow` → `ProceedUnchanged`;
+///     `EntityDeny` → `WouldDeny(NotMember)`; `Indeterminate` →
+///     `WouldDeny(IndeterminateMembership)`; `Error` → `WouldDeny(ObservationError)`.
 pub(crate) fn decide_treasury_gate(
     mode: TreasuryEntityAuthMode,
     observation: &EntityAccessObservation,
@@ -416,12 +433,26 @@ pub(crate) fn decide_treasury_gate(
         // Default, shipped behavior: never alter the route.
         TreasuryEntityAuthMode::ObserveOnly => TreasuryGateDecision::ProceedUnchanged,
         TreasuryEntityAuthMode::EnforceTrustedResolver => {
-            // (1) A trusted coop→EntityId basis is required before any enforcement.
-            //     An untrusted/unavailable/ambiguous mapping fails closed BEFORE the
-            //     membership signal is even consulted — you cannot trust the membership
-            //     target if you cannot trust the coop→entity mapping that named it.
+            // (1) An *enforceable* trusted coop→EntityId basis is required before any
+            //     enforcement. Anything untrusted/unavailable/ambiguous/unverified-target
+            //     fails closed BEFORE the membership signal is consulted — you cannot
+            //     enforce on a membership target whose coop→entity mapping you cannot
+            //     trust, or that the observation never actually checked.
             match resolution {
-                CoopResolutionObservation::Agree | CoopResolutionObservation::ResolverOnly => {}
+                // Only `Agree` is enforceable: legacy projection and resolver agree on
+                // the SAME `EntityId`, which is also the target the membership
+                // observation was computed against.
+                CoopResolutionObservation::Agree => {}
+                // `ResolverOnly` is a real, useful observation, but the resolver's target
+                // was never checked for membership (the observation used
+                // `treasury.entity_id()` / the legacy projection, which produced no target
+                // for this `coop_id`). Conservatively NOT enforceable yet — fail closed
+                // until a follow-up carries the resolved target into membership.
+                CoopResolutionObservation::ResolverOnly => {
+                    return TreasuryGateDecision::WouldDeny(
+                        TreasuryGateDenyReason::ResolverOnlyTargetUnverified,
+                    );
+                }
                 CoopResolutionObservation::Disagree => {
                     return TreasuryGateDecision::WouldDeny(
                         TreasuryGateDenyReason::ResolverConflict,
@@ -463,14 +494,29 @@ fn record_treasury_gate(
     would_enforce: TreasuryGateDecision,
 ) {
     match would_enforce {
-        TreasuryGateDecision::WouldDeny(reason) => warn!(
+        // Reserve `warn!` for the high-signal migration collision (a true
+        // resolver/legacy `EntityId` disagreement). Ordinary hypothetical denies
+        // (unverified-target/untrusted resolution, non-member, data gaps) are expected to
+        // be common in observe-only mode — especially while the resolver is unwired or
+        // most coops still classify as `LegacyOnly`/`NeitherResolved` — so they stay
+        // low-noise `debug!` measurement rather than alert-worthy warnings.
+        TreasuryGateDecision::WouldDeny(TreasuryGateDenyReason::ResolverConflict) => warn!(
+            target: "entity_authz_gate",
+            caller = %caller,
+            action = action.metric_label(),
+            active = active.outcome_label(),
+            would_enforce = would_enforce.outcome_label(),
+            reason = TreasuryGateDenyReason::ResolverConflict.label(),
+            "treasury entity gate WOULD DENY under enforcement on a resolver/legacy collision (observe-only; flat coop guard remains authoritative)"
+        ),
+        TreasuryGateDecision::WouldDeny(reason) => debug!(
             target: "entity_authz_gate",
             caller = %caller,
             action = action.metric_label(),
             active = active.outcome_label(),
             would_enforce = would_enforce.outcome_label(),
             reason = reason.label(),
-            "treasury entity gate WOULD DENY under enforcement (observe-only; flat coop guard remains authoritative)"
+            "treasury entity gate would deny under enforcement (observe-only measurement)"
         ),
         TreasuryGateDecision::ProceedUnchanged => debug!(
             target: "entity_authz_gate",
@@ -1535,7 +1581,8 @@ mod coop_resolution_observe_tests {
     use TreasuryEntityAuthMode::{EnforceTrustedResolver, ObserveOnly};
     use TreasuryGateDecision::{ProceedUnchanged, WouldDeny};
     use TreasuryGateDenyReason::{
-        IndeterminateMembership, NotMember, ObservationError, ResolverConflict, UntrustedResolution,
+        IndeterminateMembership, NotMember, ObservationError, ResolverConflict,
+        ResolverOnlyTargetUnverified, UntrustedResolution,
     };
 
     fn allow() -> EntityAccessObservation {
@@ -1593,19 +1640,24 @@ mod coop_resolution_observe_tests {
         );
     }
 
-    // (B) Enforcement: a trusted resolver-only basis (an activation/backfill surrogate
-    // the legacy projection can't produce) still allows an affirmative member —
-    // intentionally-documented policy.
+    // (B,D) Enforcement: `ResolverOnly` is NOT enforceable yet. The resolver produced a
+    // target the legacy projection could not, so the membership observation was never
+    // checked against it — fail closed REGARDLESS of the membership signal (even for an
+    // affirmative member). It stays a useful observation; enforceability is deferred to a
+    // follow-up that carries the resolved target into membership evaluation.
     #[test]
-    fn gate_enforce_trusted_resolver_only_allows_member() {
-        assert_eq!(
-            decide_treasury_gate(
-                EnforceTrustedResolver,
-                &allow(),
-                &CoopResolutionObservation::ResolverOnly
-            ),
-            ProceedUnchanged
-        );
+    fn gate_enforce_resolver_only_is_not_enforceable_yet() {
+        for obs in [allow(), deny(), indeterminate(), errored()] {
+            assert_eq!(
+                decide_treasury_gate(
+                    EnforceTrustedResolver,
+                    &obs,
+                    &CoopResolutionObservation::ResolverOnly
+                ),
+                WouldDeny(ResolverOnlyTargetUnverified),
+                "ResolverOnly must fail closed (unverified target) under enforcement: {obs:?}"
+            );
+        }
     }
 
     // (B,D) Enforcement: legacy-only / untrusted provenance (UnknownLegacy, gossip rows)
@@ -1677,7 +1729,7 @@ mod coop_resolution_observe_tests {
             decide_treasury_gate(
                 EnforceTrustedResolver,
                 &errored(),
-                &CoopResolutionObservation::ResolverOnly
+                &CoopResolutionObservation::Agree
             ),
             WouldDeny(ObservationError)
         );

--- a/icn/crates/icn-gateway/src/authority.rs
+++ b/icn/crates/icn-gateway/src/authority.rs
@@ -362,6 +362,15 @@ pub(crate) enum TreasuryGateDenyReason {
     /// target. Until a follow-up carries the resolved target into membership
     /// evaluation, `ResolverOnly` is measured but **not enforceable**; fail closed.
     ResolverOnlyTargetUnverified,
+    /// The legacy projection and the resolver AGREE on the path `coop_id`'s `EntityId`,
+    /// but that agreement does NOT prove the treasury's stored `entity_id` — the target
+    /// the entity-membership observation was actually computed against — equals that
+    /// agreed target. An affirmative-member allow would otherwise be granted against a
+    /// target the agreement never verified. Until a follow-up carries the agreed target
+    /// into membership evaluation, an `Agree`-based allow is measured but **not
+    /// enforceable**; fail closed. (Membership *denies* still surface via the existing
+    /// signal — denying never trusts an unverified target.)
+    AgreeTargetUnverified,
     /// A trusted basis exists but the entity-membership observation is indeterminate (a
     /// data gap); fail closed.
     IndeterminateMembership,
@@ -389,6 +398,7 @@ impl TreasuryGateDenyReason {
             TreasuryGateDenyReason::ResolverOnlyTargetUnverified => {
                 "resolver_only_target_unverified"
             }
+            TreasuryGateDenyReason::AgreeTargetUnverified => "agree_target_unverified",
             TreasuryGateDenyReason::IndeterminateMembership => "indeterminate_membership",
             TreasuryGateDenyReason::ObservationError => "observation_error",
         }
@@ -409,9 +419,10 @@ impl TreasuryGateDenyReason {
 /// - [`TreasuryEntityAuthMode::EnforceTrustedResolver`] (decision-only; not wired to any
 ///   route here) requires an *enforceable* trusted basis first, then defers to
 ///   membership:
-///   - `Agree` → enforceable basis: the legacy projection and the resolver agree on the
-///     SAME `EntityId`, which is also the target the membership observation was computed
-///     against;
+///   - `Agree` → strongest basis (the legacy projection and the resolver agree on the
+///     SAME `EntityId` for the path `coop_id`), but agreement does NOT prove the
+///     treasury's stored `entity_id` equals that target — so its would-allow path still
+///     fails closed (see below);
 ///   - `ResolverOnly` → `WouldDeny(ResolverOnlyTargetUnverified)`: the resolver produced
 ///     a target the legacy projection could not, so the membership observation
 ///     (`treasury.entity_id()` / legacy projection) was never checked against it.
@@ -421,9 +432,13 @@ impl TreasuryGateDenyReason {
 ///   - `LegacyOnly(_)` / `NeitherResolved(_)` → `WouldDeny(UntrustedResolution)` — covers
 ///     `UnknownLegacy`, gossip-originated/unprovenanced rows, ambiguous bindings,
 ///     entity-type mismatch, and backend/source errors (all fail closed);
-///   - with an enforceable basis (`Agree`): `AgreesAllow` → `ProceedUnchanged`;
-///     `EntityDeny` → `WouldDeny(NotMember)`; `Indeterminate` →
-///     `WouldDeny(IndeterminateMembership)`; `Error` → `WouldDeny(ObservationError)`.
+///   - with an `Agree` basis the membership signal decides, except the would-allow path:
+///     `AgreesAllow` → `WouldDeny(AgreeTargetUnverified)` (the agreed target was never
+///     verified against `treasury.entity_id()`; measured but not enforceable until a
+///     follow-up carries it through); `EntityDeny` → `WouldDeny(NotMember)`;
+///     `Indeterminate` → `WouldDeny(IndeterminateMembership)`; `Error` →
+///     `WouldDeny(ObservationError)`. No resolution yields `ProceedUnchanged` under
+///     enforcement today — every path is measured fail-closed pending that follow-up.
 pub(crate) fn decide_treasury_gate(
     mode: TreasuryEntityAuthMode,
     observation: &EntityAccessObservation,
@@ -439,9 +454,10 @@ pub(crate) fn decide_treasury_gate(
             //     enforce on a membership target whose coop→entity mapping you cannot
             //     trust, or that the observation never actually checked.
             match resolution {
-                // Only `Agree` is enforceable: legacy projection and resolver agree on
-                // the SAME `EntityId`, which is also the target the membership
-                // observation was computed against.
+                // `Agree` is the strongest basis (legacy projection and resolver agree on
+                // the SAME `EntityId` for the path `coop_id`), but agreement on the path
+                // does NOT prove the treasury's stored `entity_id` equals that target —
+                // see the would-allow handling in (2). Fall through to membership.
                 CoopResolutionObservation::Agree => {}
                 // `ResolverOnly` is a real, useful observation, but the resolver's target
                 // was never checked for membership (the observation used
@@ -465,9 +481,18 @@ pub(crate) fn decide_treasury_gate(
                     );
                 }
             }
-            // (2) With a trusted basis, the entity-membership observation decides.
+            // (2) With a trusted basis, the entity-membership observation decides — except
+            // the would-allow path. `Agree` (the only resolution reaching here) proves the
+            // resolver matches the legacy projection for the path `coop_id`, NOT that the
+            // treasury's stored `entity_id` — the target this observation was computed
+            // against — equals that agreed target. An allow would therefore trust an
+            // unverified target: fail closed until a follow-up carries the agreed target
+            // into membership evaluation. Membership DENIES still surface unchanged —
+            // denying never trusts an unverified target.
             match observation {
-                EntityAccessObservation::AgreesAllow => TreasuryGateDecision::ProceedUnchanged,
+                EntityAccessObservation::AgreesAllow => {
+                    TreasuryGateDecision::WouldDeny(TreasuryGateDenyReason::AgreeTargetUnverified)
+                }
                 EntityAccessObservation::EntityDeny(_) => {
                     TreasuryGateDecision::WouldDeny(TreasuryGateDenyReason::NotMember)
                 }
@@ -1581,8 +1606,8 @@ mod coop_resolution_observe_tests {
     use TreasuryEntityAuthMode::{EnforceTrustedResolver, ObserveOnly};
     use TreasuryGateDecision::{ProceedUnchanged, WouldDeny};
     use TreasuryGateDenyReason::{
-        IndeterminateMembership, NotMember, ObservationError, ResolverConflict,
-        ResolverOnlyTargetUnverified, UntrustedResolution,
+        AgreeTargetUnverified, IndeterminateMembership, NotMember, ObservationError,
+        ResolverConflict, ResolverOnlyTargetUnverified, UntrustedResolution,
     };
 
     fn allow() -> EntityAccessObservation {
@@ -1627,16 +1652,21 @@ mod coop_resolution_observe_tests {
         }
     }
 
-    // (B) Enforcement: trusted agreement allows.
+    // (B) Enforcement: `Agree` proves the resolver and legacy projection match on the
+    // path `coop_id`, but NOT that the treasury's stored `entity_id` (the target the
+    // membership observation was computed against) equals that agreed target. An
+    // affirmative-member ALLOW is therefore target-unverified and fails closed until a
+    // follow-up carries the agreed target into membership evaluation. (Membership denies
+    // still surface — see the non-member / gap tests below.)
     #[test]
-    fn gate_enforce_trusted_agreement_allows() {
+    fn gate_enforce_trusted_agreement_allow_is_target_unverified() {
         assert_eq!(
             decide_treasury_gate(
                 EnforceTrustedResolver,
                 &allow(),
                 &CoopResolutionObservation::Agree
             ),
-            ProceedUnchanged
+            WouldDeny(AgreeTargetUnverified)
         );
     }
 


### PR DESCRIPTION
## Summary

A2d (**observe → measure → gate**) for the **treasury route family only**: turn the now-real resolver observation (#2196) from "fire-and-forget classification exists" into an **explicit, testable gate seam** that ships **observe-only by default** and can later be switched to enforcement under a deliberate, operator-gated flag. **Default route behavior is byte-identical; nothing is enforced.**

## What changed

A single-file change in `icn/crates/icn-gateway/src/authority.rs`:

- **`TreasuryEntityAuthMode { ObserveOnly (default), EnforceTrustedResolver }`** + `ACTIVE_TREASURY_ENTITY_AUTH_MODE = ObserveOnly` — the only mode shipped *wired*.
- **`decide_treasury_gate(mode, observation, resolution) -> TreasuryGateDecision`** (pure; `ProceedUnchanged` | `WouldDeny(reason)`):
  - `ObserveOnly` **always** returns `ProceedUnchanged` → route outcome identical to the flat `require_coop_access` guard, for every observation × resolution.
  - `EnforceTrustedResolver` (decision-only; **not** wired to any route or config) requires a **trusted** `coop_id → EntityId` basis first, then defers to the existing entity-membership observation:
    - `Agree`/`ResolverOnly` → trusted basis; `Disagree` → `WouldDeny(ResolverConflict)`; `LegacyOnly(_)`/`NeitherResolved(_)` → `WouldDeny(UntrustedResolution)` (covers `UnknownLegacy`, gossip/unprovenanced rows, ambiguous, entity-type-mismatch, backend/source error — **all fail closed**);
    - with a trusted basis: `AgreesAllow` → proceed; `EntityDeny` → `WouldDeny(NotMember)`; `Indeterminate` → `WouldDeny(IndeterminateMembership)`; `Error` → `WouldDeny(ObservationError)`.
- **Measure wiring:** `observe_treasury_entity_access` now captures the resolution and records (observe-only log) the active decision plus what `EnforceTrustedResolver` *would* decide. It still returns the unchanged observation; the caller still discards it.

The resolution is used **only as a trust qualifier** (is there a trusted basis?), never as authority; the allow/deny signal stays the entity-membership observation. An untrusted resolution **fails closed before** membership is even consulted.

## Why this is the next A2d step after #2196

#2196 made treasury observation consult the real store-backed resolver. This adds the **explicit gate scaffold** that decides what to do with that observation — the "measure → gate-later" rung of `observe → measure → enforce`. It deliberately stops at a *tested, switchable* seam rather than enforcing: there is no route consultation, no config knob, no token issuance.

## Validation

- `cargo fmt --all --check` — clean
- `cargo test -p icn-gateway --lib` — **656 passed, 0 failed** (9 new gate tests)
- `cargo clippy -p icn-gateway --all-targets --all-features -- -D warnings` — clean
- `ops/scripts/drift-check.sh` — PASS
- Diff: **1 file** (`authority.rs`, +381/−5); icn-core untouched.

**New tests (TDD):**
- **A (ObserveOnly):** `gate_observe_only_always_proceeds_unchanged` — never denies across all observation × resolution combos.
- **B (enforcement):** trusted agreement allows; trusted resolver-only allows a member; untrusted/disagreement/source-unavailable/backend-error fail closed.
- **C (route safety):** non-member denied via the existing membership signal; indeterminate/error fail closed; route-outcome-unchanged proven by the existing #2196 `store_backed_resolver_does_not_change_treasury_observation` test.
- **D (trust boundaries):** `UnknownLegacy`/gossip rows cannot satisfy enforcement; untrusted resolution fails closed **before** membership (no mapping-as-authority).

## Nonclaims

This change does **not**: enable entity-aware authorization enforcement by default · change default route outcomes · cut treasury over to `require_entity_access` · issue positive `entity_id`/`entity_type` token claims · treat `CoopEntityMap` as authority · trust `UnknownLegacy` · trust gossip-originated mappings · upgrade pre-existing legacy rows · complete #2082 · claim production / pilot / live-federation / Phase-2 readiness.

## Relationship to #2187–#2196 and #2082

- #2187 resolver-seam design · #2188 trait + fail-closed `Unwired` · #2189 observe-only treasury classification · #2190 provenance substrate · #2191 institutional-powers spec · #2192 `StoreBackedCoopEntityResolver` source · #2193 `Activation` producer · #2194 `OperatorBackfill` producer · #2195 docs truth-sync · #2196 wired the resolver into treasury observation.
- **This PR** adds the A2d gate scaffold over #2196's observation — observe-only, decision-tested, enforcement reachable only via the pure function and never wired to a route.
- **#2082 (the `coop_id ↔ EntityId` store/mapping tracker) remains OPEN** and is not completed by this slice.

> NOTE: a `docs/STATE.md` / `docs/PHASE_PROGRESS.md` truth-sync for this slice is intentionally deferred to the separate docs-sync lane (consistent with prior A2 PRs).

Refs #2082

---

## Review update (commit `c1b83388`)

Addressed two review threads:

- **Codex (P2) — ResolverOnly basis:** `EnforceTrustedResolver` no longer treats `ResolverOnly` as an enforceable trusted basis. The membership observation is computed against `treasury.entity_id()` / the legacy projection — **not** the resolver's resolved target — so a non-mappable, operator-backfilled `coop_id` was never checked for membership against the resolved entity. Conservative fix: only **`Agree`** (legacy == resolver target == membership target) is enforceable; `ResolverOnly` now **fails closed** under enforcement with a new explicit `ResolverOnlyTargetUnverified` reason. **`ResolverOnly` remains a useful observation but is not enforceable** until a follow-up carries the resolved target into membership evaluation. (Decision-only; active mode is still `ObserveOnly`, so no route outcome changes.)
- **Copilot — log noise:** `record_treasury_gate` now reserves `warn!` for the high-signal `ResolverConflict` (a true resolver/legacy collision); ordinary hypothetical denies (`ResolverOnlyTargetUnverified`, `UntrustedResolution`, `NotMember`, data gaps) — expected to be common in observe-only mode — log at `debug!`. Measurement preserved.

Re-validated: `cargo fmt --all --check` clean · `cargo test -p icn-gateway --lib` 656/0 · `cargo clippy -p icn-gateway --all-targets --all-features -- -D warnings` clean · `ops/scripts/drift-check.sh` PASS.

## Review update (commit `8301ccfb`)

Addressed a follow-up review thread:

- **Codex (P2) — `Agree` target unverified:** under `EnforceTrustedResolver`, the `Agree` **would-allow** path (`AgreesAllow → ProceedUnchanged`) now **fails closed** with a new explicit `AgreeTargetUnverified` reason. `Agree` proves the resolver matches the legacy projection for the path `coop_id`, but **not** that the treasury's stored `entity_id` (the target the membership observation was computed against) equals that agreed target — so allowing there would trust an unverified target. Mirrors the `ResolverOnly` resolution: **measured but not enforceable** until a follow-up carries the agreed target into membership evaluation and compares it against `treasury.entity_id()`. Membership **denies** still surface unchanged (`NotMember` / `IndeterminateMembership` / `ObservationError`); denying never trusts an unverified target. `AgreeTargetUnverified` logs at `debug!` (only `ResolverConflict` warns). Decision-only; active mode is still `ObserveOnly`, so **no route outcome changes** — under enforcement, **no resolution now yields `ProceedUnchanged`** (every path is measured fail-closed pending the target-carrying follow-up).

Re-validated: `cargo fmt --all --check` clean · `cargo test -p icn-gateway --lib` 656/0 (`gate_` 14/0) · `cargo clippy -p icn-gateway --all-targets --all-features -- -D warnings` clean · `ops/scripts/drift-check.sh` PASS.
