### PR TITLE
docs(terminology): clarify commons settlement language

### DIFF
--- a/docs/adr/ADR-0031-commons-compute-admission-and-settlement-policy.md
+++ b/docs/adr/ADR-0031-commons-compute-admission-and-settlement-policy.md
@@ -28,7 +28,7 @@ references:
 
 ## Context
 
-ICN's commons compute is the shared-infrastructure layer: members and federated peers contribute compute capacity to a pool, and consumers draw from it under a trust-gated admission policy. Settlement runs on mutual credit, balanced earn/spend journal entries (ADR-0005), and is regulatory-safe in vocabulary (ADR-0004).
+ICN's commons compute is the shared-infrastructure layer: members and federated peers contribute compute capacity to a pool, and consumers draw from it under a trust-gated admission policy. Settlement runs on mutual credit, balanced contribution/allocation journal entries (ADR-0005), and is regulatory-safe in vocabulary (ADR-0004).
 
 The pool, admission policy, and settlement engine have been implemented and tested for some time. The pieces:
 

--- a/docs/rfcs/RFC-0001-obligation-allocation-settlement-primitives.md
+++ b/docs/rfcs/RFC-0001-obligation-allocation-settlement-primitives.md
@@ -70,7 +70,7 @@ ICN's existing decisions about economic coordination:
 - [ADR-0007: Commons Resource Policy — CCL Formula Extraction](../adr/ADR-0007-commons-resource-policy-ccl-formula-extraction.md) — CCL bridge for resource-policy formulas.
 - [ADR-0013: Federation Clearing Adoption Contract](../adr/ADR-0013-federation-clearing-adoption-contract.md) — dual-path clearing model with store isolation now proven by `crates/icn-federation/tests/store_isolation_clearing_adoption.rs` (PR #1650).
 - [ADR-0026: Receipt and Provenance Proof Envelope](../adr/ADR-0026-receipt-and-provenance-proof-envelope.md) — the layered envelope this RFC's bridge receipts plug into.
-- [ADR-0031: Commons Compute Admission and Settlement Policy](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md) — back-fill of the settlement engine producing balanced earn/spend journal entries.
+- [ADR-0031: Commons Compute Admission and Settlement Policy](../adr/ADR-0031-commons-compute-admission-and-settlement-policy.md) — back-fill of the settlement engine producing balanced contribution/allocation journal entries.
 
 Open issues this RFC informs:
 

--- a/icn/bins/icnd/src/compute_wiring.rs
+++ b/icn/bins/icnd/src/compute_wiring.rs
@@ -71,9 +71,10 @@ pub fn create_balance_callback(ledger: LedgerHandle) -> icn_compute::BalanceCall
         match ledger.try_read() {
             Ok(guard) => {
                 // The ICN ledger uses net_change = debit - credit, so `credit` entries
-                // (which record earnings) produce a NEGATIVE raw balance. Negate to convert
-                // "earned credit balance" → "spendable capacity" (positive = can spend).
-                // Example: earn 1000 → raw balance = -1000 → capacity = +1000.
+                // (which record recognized contributions) produce a NEGATIVE raw balance.
+                // Negate to convert "recognized-contribution balance" → "drawable capacity"
+                // (positive = capacity available to draw).
+                // Example: recognize 1000 → raw balance = -1000 → capacity = +1000.
                 -guard.get_balance(&did, icn_ledger::commons_credits::COMMONS_CREDIT_CURRENCY)
             }
             Err(_) => {
@@ -219,7 +220,7 @@ pub fn create_payment_callback(
 /// 1. Fetches the consumer's current commons credit balance (for the balance-floor invariant).
 /// 2. Converts the compute-layer `CommonsPaymentRequest` into a ledger-layer
 ///    `CommonsSettlementRequest` and runs it through `SettlementEngine::settle_commons_receipt()`.
-/// 3. Appends the resulting `(earn_entry, spend_entry)` to the ledger.
+/// 3. Appends the resulting contribution/allocation pair (`earn_entry`, `spend_entry`) to the ledger.
 ///
 /// `engine` must be pre-created by the caller. Use `build_settlement_engine()` for
 /// restart-safe idempotence.
@@ -235,7 +236,7 @@ pub fn create_commons_settlement_callback(
         let engine = engine.clone();
 
         tokio::spawn(async move {
-            // 1. Parse contributor DID (executor — earns credits)
+            // 1. Parse contributor DID (executor — contribution recognized / credited)
             let contributor: icn_identity::Did = match req.contributor.parse() {
                 Ok(d) => d,
                 Err(e) => {
@@ -247,7 +248,7 @@ pub fn create_commons_settlement_callback(
                 }
             };
 
-            // 2. Parse consumer DID (submitter — spends credits)
+            // 2. Parse consumer DID (submitter — allocation drawn / debited)
             let consumer: icn_identity::Did = match req.consumer.parse() {
                 Ok(d) => d,
                 Err(e) => {
@@ -261,7 +262,7 @@ pub fn create_commons_settlement_callback(
 
             // 3. Fetch consumer balance for the balance-floor invariant.
             //    Negate: ledger credit entries give negative raw balance; negate to get
-            //    spendable capacity (positive = can spend). Matches BalanceCallback convention.
+            //    drawable capacity (positive = capacity available). Matches BalanceCallback convention.
             let consumer_balance = {
                 let guard = ledger.read().await;
                 -guard.get_balance(
@@ -317,7 +318,7 @@ pub fn create_commons_settlement_callback(
                 }
             };
 
-            // 7. Append both legs (earn + spend) via the ledger's pre-validating batch
+            // 7. Append both legs (contribution + allocation) via the ledger's pre-validating batch
             //    append. Both entries are validated before either is written, so a leg that
             //    fails validation can no longer leave the other leg committed one-sidedly.
             //    This is NOT a full transaction: a lower-level append/store failure between
@@ -361,8 +362,8 @@ mod tests {
     /// This test closes the durability gap identified in the settlement path trace:
     /// `CommonsSettlementCallback` was wired to `None` in the daemon, so completed commons
     /// tasks produced no ledger consequence. After this fix, the callback fires
-    /// `SettlementEngine::settle_commons_receipt()` and appends both earn/spend journal
-    /// entries to the ledger — making the economic consequence auditable.
+    /// `SettlementEngine::settle_commons_receipt()` and appends both contribution/allocation
+    /// journal entries to the ledger — making the economic consequence auditable.
     ///
     /// Flow exercised:
     ///   CommonsPaymentRequest → create_commons_settlement_callback → SettlementEngine

--- a/icn/crates/icn-compute/src/actor/types.rs
+++ b/icn/crates/icn-compute/src/actor/types.rs
@@ -184,9 +184,9 @@ pub type CommonsRequiredCreditsCallback =
 /// journal entries to the ledger.
 #[derive(Debug, Clone)]
 pub struct CommonsPaymentRequest {
-    /// DID of the contributor (executor — earns commons credits from the mint).
+    /// DID of the contributor (executor — contribution recognized; credited by the mint).
     pub contributor: String,
-    /// DID of the consumer (submitter — spends commons credits to the mint).
+    /// DID of the consumer (submitter — allocation drawn; debited by the mint).
     pub consumer: String,
     /// Amount of commons credits to settle (already computed by the actor).
     pub amount: u64,

--- a/icn/crates/icn-compute/src/actor/types.rs
+++ b/icn/crates/icn-compute/src/actor/types.rs
@@ -202,7 +202,7 @@ pub struct CommonsPaymentRequest {
 /// `SettlementEngine`. The callback is responsible for:
 /// 1. Fetching the consumer's current commons credit balance.
 /// 2. Constructing a `CommonsSettlementRequest` and calling `settle_commons_receipt()`.
-/// 3. Appending the resulting earn/spend entries to the ledger.
+/// 3. Appending the resulting contribution/allocation entries to the ledger.
 ///
 /// **Settlement semantics change with reservation (#1404):** once `CommonsReserveCallback`
 /// is configured, the app-layer implementation of this callback must reconcile against

--- a/icn/crates/icn-core/tests/commons_multinode_integration.rs
+++ b/icn/crates/icn-core/tests/commons_multinode_integration.rs
@@ -2,7 +2,7 @@
 //! Multi-node commons contribution integration test (issue #949).
 //!
 //! Proves that:
-//! 1. `settle_commons_receipt()` produces a balanced earn/spend pair for a
+//! 1. `settle_commons_receipt()` produces a balanced contribution/allocation pair for a
 //!    `ScopeLevel::Commons` task.
 //! 2. After the entries are appended to one node's ledger and replicated to a
 //!    second node via `handle_sync_message`, both nodes agree on the final

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1231,8 +1231,8 @@ impl Ledger {
     /// Every entry is validated against the current (pre-batch) ledger state *before any
     /// entry is appended*. If any entry fails that up-front validation, none are appended.
     /// This closes the **validation-rejection** one-sided-entry window for a settlement
-    /// expressed as independent legs (e.g. the commons earn + spend pair, which touch
-    /// different accounts): a later leg that validation would reject can no longer leave an
+    /// expressed as independent legs (e.g. the commons contribution/allocation pair, which
+    /// touch different accounts): a later leg that validation would reject can no longer leave an
     /// earlier leg committed. Entries are appended in input order once all pass; the
     /// returned hashes are in the same order.
     ///

--- a/icn/crates/icn-ledger/src/ledger.rs
+++ b/icn/crates/icn-ledger/src/ledger.rs
@@ -1247,8 +1247,8 @@ impl Ledger {
     ///    earlier entries in the same batch. Entries that each pass the up-front check
     ///    against the pre-batch state but *interact* (e.g. two debits that individually fit
     ///    a credit limit but collectively exceed it) can still fail mid-batch, after an
-    ///    earlier entry was appended. The intended caller (the commons earn/spend pair)
-    ///    touches independent accounts, so its legs do not interact this way.
+    ///    earlier entry was appended. The intended caller (the commons contribution/allocation
+    ///    pair) touches independent accounts, so its legs do not interact this way.
     /// 2. **Store I/O between writes.** The durable writes are not wrapped in one storage
     ///    transaction, so a store I/O failure *between* per-entry appends can leave a
     ///    partial journal — inherent to the ledger's non-transactional append (an

--- a/icn/crates/icn-ledger/src/types.rs
+++ b/icn/crates/icn-ledger/src/types.rs
@@ -112,11 +112,11 @@ pub struct JournalEntry {
     /// When present, the nonce is included in the content hash computation,
     /// ensuring that entries with identical amounts/accounts/timestamps
     /// produce distinct hashes. This prevents silent deduplication of
-    /// legitimate repeat transactions (e.g., two separate earn events
+    /// legitimate repeat transactions (e.g., two separate contribution events
     /// for the same amount).
     ///
     /// For commons credit entries, this should be set to the `receipt_id`
-    /// of the `ExecutionReceipt` that triggered the earn/spend.
+    /// of the `ExecutionReceipt` that triggered the contribution/allocation settlement.
     ///
     /// Note: Do NOT use `skip_serializing_if` here — while the ledger
     /// currently uses serde_json (which tolerates missing fields),


### PR DESCRIPTION
## Summary

Narrow ICN terminology cleanup: replace market-coded **"earn/spend"** framing for **commons compute settlement** with ICN-native **contribution/allocation** vocabulary, in **docs prose and code comments only**.

No identifiers, string literals, function signatures, serialized schemas, public APIs, metrics names, provenance strings, or runtime logic are changed.

## Audit findings

The previous audit found three categories of `earn/spend` language:

1. Reader-facing docs prose in ADR-0031 and RFC-0001 — changed where safe.
2. Code comments explaining commons settlement flow — changed where safe.
3. Compatibility/API names such as `build_earn_entry`, `build_spend_entry`, `EarningTracker`, metrics names, and provenance strings — intentionally left unchanged.

## What changed

- ADR-0031 and RFC-0001 now describe the commons settlement pair as contribution/allocation journal entries.
- `compute_wiring.rs` comments now describe the executor side as contribution recognized / credited and the submitter side as allocation drawn / debited.
- `ledger.rs`, `types.rs`, `icn-compute` actor docs, and the commons multinode integration test module comment now use contribution/allocation language where they previously described commons settlement as earn/spend.

## What intentionally did not change

- No Rust identifiers renamed.
- No public API or serialized schema changed.
- No metrics names changed.
- No provenance strings changed.
- No runtime behavior changed.
- No settlement semantics changed.
- No broader economics refactor attempted.

Compatibility names like `build_earn_entry`, `build_spend_entry`, `EarningTracker`, and `commons_credits_earned_*` remain in place until a deliberate compatibility/deprecation plan exists.

## Validation

- `cargo fmt --all --check`
- `cargo check -p icn-ledger -p icn-compute -p icnd`
- `cargo check -p icn-core --test commons_multinode_integration`
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml`
- `bash ops/scripts/drift-check.sh`
- `python3 scripts/check-state-lag.py`

## Nonclaims

- Does not change runtime settlement behavior.
- Does not change ledger accounting semantics.
- Does not change public APIs or serialized schemas.
- Does not rename exported helper APIs.
- Does not change metrics names.
- Does not change provenance strings.
- Does not introduce payment/wallet/currency framing.
- Does not alter entity-aware authorization.
- Does not enable enforcement.
- Does not affect #2082.
- Does not claim production readiness.
- Does not claim pilot readiness.
- Does not claim live federation.
- Does not claim Phase 2 completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
