### PR TITLE
docs(pilots): add Summit Ops registration fixture shape

### DIFF
--- a/docs/pilots/summit-ops-registration-action-card-proof-loop.md
+++ b/docs/pilots/summit-ops-registration-action-card-proof-loop.md
@@ -169,6 +169,7 @@ Never committed: real attendee names; real registration roll; real emails; phone
 | You want… | Read |
 |---|---|
 | The event-day run-stage facilitator path (parent) | [`summit-ops-run-stage-facilitator-path.md`](summit-ops-run-stage-facilitator-path.md) |
+| The exact fixture shape to commit so this lane becomes fixture-backed | [`summit-ops-registration-fixture-shape.md`](summit-ops-registration-fixture-shape.md) |
 | The full event lifecycle map | [`summit-ops-lifecycle-package-map.md`](summit-ops-lifecycle-package-map.md) |
 | Recorded proof per capability | [`proof-level-taxonomy-capability-matrix.md`](../reference/project-index/proof-level-taxonomy-capability-matrix.md) |
 | Real runtime surfaces (action cards, receipts) | [`runtime-surface-map.md`](../reference/project-index/runtime-surface-map.md) |

--- a/docs/pilots/summit-ops-registration-fixture-shape.md
+++ b/docs/pilots/summit-ops-registration-fixture-shape.md
@@ -16,7 +16,7 @@ The [registration proof-loop map](summit-ops-registration-action-card-proof-loop
 
 The fixture *schema* is unambiguous, but the **render/validation path is not fully runnable from a docs change**:
 
-- The action-cards fixture is loaded by the no-CLI rehearsal shell and exercised by a **Playwright e2e** (`web/pilot-ui/tests/e2e/standing-action-cards.spec.js`) and the **"Rehearsal Fixture Bundle"** CI gate. A committed fixture change should be verified against those, which need a browser/npm environment.
+- The action-cards fixture's **content** is exercised by a **Playwright e2e** — `web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js`, which fetches `action-cards.json` and asserts the `{did, cards, generated_at}` wrapper plus **per-card required fields** and the `scope` / `risk_level` enums — and by the **"Rehearsal Fixture Bundle"** CI gate. (`standing-action-cards.spec.js` covers the Action-Cards-list **DOM wiring**, not fixture contents.) A committed fixture change should be verified against those, which need a browser/npm environment.
 - The Python bundle validator ([`docs/scripts/validate-rehearsal-shell-fixtures.py`](../scripts/validate-rehearsal-shell-fixtures.py)) checks the action-cards read-model **shape-only** (`did`, `cards`, `generated_at`) — it does **not** per-card schema-validate, so passing it is necessary but not sufficient.
 
 So this doc specifies the shape and the full validation path; **committing the fixture + running the e2e/bundle gate is the next slice** (and the moment the lane may be called fixture-backed).
@@ -28,7 +28,7 @@ The organizer-demo rehearsal-shell bundle:
 - **Fixture file to extend:** [`web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json`](../../web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json) — wrapper `{ "did": …, "cards": [ … ], "generated_at": … }`. A registration card is appended to `cards`.
 - **Manifest read-model:** `member_action_cards` in [`rehearsal-shell.manifest.json`](../../web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json) (surface `GET /v1/gov/me/action-cards`, `validate: shape_only`). No manifest change is required to add a card.
 - **Per-card contract:** [`docs/contracts/institution-package/action-card.schema.json`](../contracts/institution-package/action-card.schema.json).
-- **Validators / tests:** `docs/scripts/validate-rehearsal-shell-fixtures.py` (shape), `web/pilot-ui/tests/e2e/standing-action-cards.spec.js` (render).
+- **Validators / tests:** `docs/scripts/validate-rehearsal-shell-fixtures.py` (bundle shape-only for action-cards), `web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js` (fetches `action-cards.json`; asserts wrapper + per-card required fields + `scope`/`risk_level` enums), `web/pilot-ui/tests/e2e/standing-action-cards.spec.js` (Action-Cards-list DOM wiring).
 
 ## The exact registration card shape
 
@@ -68,7 +68,7 @@ From the monorepo root, after appending the card to `action-cards.json`:
 
 1. `python3 docs/scripts/validate-rehearsal-shell-fixtures.py` — must stay `PASS` (action-cards read-model is shape-only: wrapper keys unchanged).
 2. The **per-card schema check** against `action-card.schema.json` (e.g. validate the appended object with `jsonschema`).
-3. The **Playwright e2e** `web/pilot-ui/tests/e2e/standing-action-cards.spec.js` and the **"Rehearsal Fixture Bundle"** CI gate — confirm the shell still renders the Action Cards list (the current spec asserts structure, not a fixed card count, but re-run to be sure).
+3. The **fixture-content Playwright e2e** `web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js` — it fetches `action-cards.json` and asserts the wrapper + per-card required fields + `scope`/`risk_level` enums (it checks `cards.length > 0`, not a fixed count, so appending a card is fine) — plus the **"Rehearsal Fixture Bundle"** CI gate; `standing-action-cards.spec.js` additionally covers the Action-Cards-list DOM wiring. Re-run these to be sure.
 4. `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml`, `bash ops/scripts/drift-check.sh`, `python3 scripts/check-state-lag.py`, `git diff --check`.
 
 Only when the fixture is committed **and** those pass may the [registration proof-loop map](summit-ops-registration-action-card-proof-loop.md) be updated from *fixture-ready* to *fixture-backed*.

--- a/docs/pilots/summit-ops-registration-fixture-shape.md
+++ b/docs/pilots/summit-ops-registration-fixture-shape.md
@@ -1,0 +1,104 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-06-26
+---
+
+# Summit Ops Registration Fixture Shape (generic ICN)
+
+> For current project truth, defer to [`docs/STATE.md`](../STATE.md) and [`docs/PHASE_PROGRESS.md`](../PHASE_PROGRESS.md). This is a **docs-only fixture-shape map**: it specifies the exact, schema-valid JSON a future contributor would commit so the [Registration Desk proof loop](summit-ops-registration-action-card-proof-loop.md) can move from **fixture-ready** to genuinely **fixture-backed**. It commits **no runtime fixture** itself, syncs no Google surface, mutates no partner repo, and uses no real attendee data.
+
+## Purpose
+
+The [registration proof-loop map](summit-ops-registration-action-card-proof-loop.md) is **fixture-ready, not fixture-backed**: the shell's fixture pack has no registration-lane rows, so a steward cannot rehearse this lane from committed fixtures today. This doc closes that gap on paper — it pins the precise fixture shape, the file it belongs in, and the validation a contributor must pass — without committing the fixture here (so it can't break the shell's e2e bundle from an environment that can't run it).
+
+## Why docs-only (Option A) rather than committing the fixture now
+
+The fixture *schema* is unambiguous, but the **render/validation path is not fully runnable from a docs change**:
+
+- The action-cards fixture is loaded by the no-CLI rehearsal shell and exercised by a **Playwright e2e** (`web/pilot-ui/tests/e2e/standing-action-cards.spec.js`) and the **"Rehearsal Fixture Bundle"** CI gate. A committed fixture change should be verified against those, which need a browser/npm environment.
+- The Python bundle validator ([`docs/scripts/validate-rehearsal-shell-fixtures.py`](../scripts/validate-rehearsal-shell-fixtures.py)) checks the action-cards read-model **shape-only** (`did`, `cards`, `generated_at`) — it does **not** per-card schema-validate, so passing it is necessary but not sufficient.
+
+So this doc specifies the shape and the full validation path; **committing the fixture + running the e2e/bundle gate is the next slice** (and the moment the lane may be called fixture-backed).
+
+## Where the fixture lives
+
+The organizer-demo rehearsal-shell bundle:
+
+- **Fixture file to extend:** [`web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json`](../../web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json) — wrapper `{ "did": …, "cards": [ … ], "generated_at": … }`. A registration card is appended to `cards`.
+- **Manifest read-model:** `member_action_cards` in [`rehearsal-shell.manifest.json`](../../web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json) (surface `GET /v1/gov/me/action-cards`, `validate: shape_only`). No manifest change is required to add a card.
+- **Per-card contract:** [`docs/contracts/institution-package/action-card.schema.json`](../contracts/institution-package/action-card.schema.json).
+- **Validators / tests:** `docs/scripts/validate-rehearsal-shell-fixtures.py` (shape), `web/pilot-ui/tests/e2e/standing-action-cards.spec.js` (render).
+
+## The exact registration card shape
+
+Schema-valid (`source_kind: action_item`, `action_kind: complete`, `scope: structure`), fictional ids only, matching the existing accessibility card's field set. Append this object to the `cards` array:
+
+```json
+{
+  "id": "demo-card-action-item-complete-registration-001",
+  "source_kind": "action_item",
+  "action_kind": "complete",
+  "scope": "structure",
+  "title": "Mark a registration-desk step complete (badge-packet check)",
+  "summary": "A day-of registration-desk step is assigned to the logistics committee role. Marking it complete produces a completion receipt. Fictional demo data; no real attendee information.",
+  "authority_basis": "Logistics Committee role (demo role)",
+  "required_authority_scope": ["registration_desk"],
+  "deadline": 1730500000,
+  "risk_level": "normal",
+  "accessibility_hint": "Plain-language step summary before structured fields; status read in order; no color-only signaling.",
+  "receipt_expected": true,
+  "source_id": "demo-action-item-registration-001",
+  "domain_id": "demo.coop.organizing"
+}
+```
+
+**Field discipline:**
+
+- `source_kind` / `action_kind` — the only emitted, schema-valid day-of pair: `action_item` / `complete`. **Do not** use `committee_log` or `program_milestone` (not in the closed `source_kind` enum) or invent new source kinds; any richer source-kind is a future schema change (separate ADR/RFC + `action-card.schema.json` update).
+- `scope` — `structure` (the logistics `Structure` that owns the registration-desk work); must be one of `entity` / `structure` / `individual`.
+- `id` / `source_id` — fictional, deterministic, prefixed `demo-…`. Carries ids, not contact info.
+- All required fields present: `id, source_kind, action_kind, scope, title, summary, authority_basis, required_authority_scope, risk_level, accessibility_hint, receipt_expected, source_id` (`deadline`, `domain_id` optional).
+
+The fictional, categorical registration steps the lane models (`registration-desk-opened`, `badge-packet-check-complete`, `walk-in-question-escalated`, `attendance-count-category-updated`, `late-arrival-support-needed`, `registration-desk-closed`) map onto one or more such `action_item/complete` cards — each a step a logistics role marks complete. Attendance stays a **count category**, never a roll.
+
+## Validation a contributor must pass before claiming fixture-backed
+
+From the monorepo root, after appending the card to `action-cards.json`:
+
+1. `python3 docs/scripts/validate-rehearsal-shell-fixtures.py` — must stay `PASS` (action-cards read-model is shape-only: wrapper keys unchanged).
+2. The **per-card schema check** against `action-card.schema.json` (e.g. validate the appended object with `jsonschema`).
+3. The **Playwright e2e** `web/pilot-ui/tests/e2e/standing-action-cards.spec.js` and the **"Rehearsal Fixture Bundle"** CI gate — confirm the shell still renders the Action Cards list (the current spec asserts structure, not a fixed card count, but re-run to be sure).
+4. `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml`, `bash ops/scripts/drift-check.sh`, `python3 scripts/check-state-lag.py`, `git diff --check`.
+
+Only when the fixture is committed **and** those pass may the [registration proof-loop map](summit-ops-registration-action-card-proof-loop.md) be updated from *fixture-ready* to *fixture-backed*.
+
+## Privacy boundaries
+
+Fictional / categorical only. Never commit: real attendee names, registration lists, emails, phone numbers, medical/accessibility details, actual attendance rolls, private Drive URLs, raw Google Sheet rows, or financial/payment details. Registration is `attendee-restricted`; rehearsal privacy is by exclusion.
+
+## Nonclaims
+
+- Does not commit a runtime fixture (docs-only); does not make the lane fixture-backed yet.
+- Does not claim live summit registration or a real attendee workflow exists.
+- Does not sync Google data; does not mutate the NYCN repo.
+- Does not commit private attendee, sponsor, accessibility, volunteer, incident, registration, or payment data.
+- Does not claim organizer readiness, a formal NYCN pilot, production readiness, live federation, or Phase 2 completion.
+- Does not change route behavior, `icnctl` behavior, authn/authz, or OpenAPI; does not regenerate SDK types.
+- Does not affect [#2082](https://github.com/InterCooperative-Network/icn/issues/2082); does not start A2e.
+
+## Next slices
+
+1. Commit the registration card above into `action-cards.json`; run the validators + e2e + Rehearsal Fixture Bundle gate; flip the lane to **fixture-backed** in the proof-loop map.
+2. Wire / confirm the shell renders the registration action register from the committed fixture.
+3. Add a second lane's fixture shape (room monitors or closing/cleanup) the same way.
+
+## Where to read deeper
+
+| You want… | Read |
+|---|---|
+| The registration proof-loop map (parent) | [`summit-ops-registration-action-card-proof-loop.md`](summit-ops-registration-action-card-proof-loop.md) |
+| The run-stage facilitator path | [`summit-ops-run-stage-facilitator-path.md`](summit-ops-run-stage-facilitator-path.md) |
+| The ActionCard contract | [`docs/contracts/institution-package/action-card.schema.json`](../contracts/institution-package/action-card.schema.json) |
+| Recorded proof per capability | [`proof-level-taxonomy-capability-matrix.md`](../reference/project-index/proof-level-taxonomy-capability-matrix.md) |
+| The milestone + spine | [#1746](https://github.com/InterCooperative-Network/icn/issues/1746) · [#2141](https://github.com/InterCooperative-Network/icn/issues/2141) |

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -3591,6 +3591,22 @@ domain_tags = ["pilot", "nycn", "summit", "action-cards", "proof-loop"]
 recommended_action = "keep"
 last_reviewed = "2026-06-26"
 
+[docs."docs/pilots/summit-ops-registration-fixture-shape.md"]
+category = "reference"
+status = "living"
+title = "Summit Ops Registration Fixture Shape (generic ICN)"
+description = "Docs-only fixture-shape map specifying the exact schema-valid (action_item/complete, scope structure, fictional ids) registration ActionCard JSON to commit later into web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json, plus the validation path (validate-rehearsal-shell-fixtures.py + the Playwright e2e + Rehearsal Fixture Bundle gate), so the Registration Desk lane can move from fixture-ready to fixture-backed. Commits no runtime fixture; no real attendee data; docs-only."
+last_updated = "2026-06-26"
+owner = "matt"
+audiences = ["team", "organizers"]
+truth_class = "descriptive"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["pilot", "nycn", "summit", "action-cards", "fixture"]
+recommended_action = "keep"
+last_reviewed = "2026-06-26"
+
 [docs."docs/contracts/institution-package/README.md"]
 category = "reference"
 status = "living"


### PR DESCRIPTION
## Summary

A **docs-only fixture-shape map** (Option A) and the next child of #2207: it specifies the exact, schema-valid registration ActionCard JSON a contributor would commit so the [Registration Desk proof loop](https://github.com/InterCooperative-Network/icn/blob/main/docs/pilots/summit-ops-registration-action-card-proof-loop.md) can move from **fixture-ready** to genuinely **fixture-backed** — while committing **no runtime fixture** here.

## #2207 status

**Merged.** PR #2207 (`docs(pilots): map Summit Ops registration action-card proof loop`) squash-merged non-admin (merge commit `012c34ec`, on `origin/main`). This branch is based on that `main`. #2207 ended fixture-ready (no lane fixtures committed); this PR pins exactly what to commit to close that gap.

## Why this follows #2207

#2207 established the proof-loop on fiction but is **fixture-ready, not fixture-backed**: the shell's fixture pack has no registration rows. This PR is the bridge — it removes the ambiguity about *what* to commit and *how* to validate it, so the actual fixture commit (the slice after this) is mechanical and safe.

## Fixture-ready vs fixture-backed distinction

The lane stays **fixture-ready** after this PR: it commits a *map of the shape*, not the fixture. The lane becomes **fixture-backed** only when the specified card is committed into `web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json` **and** the render/validation path passes (the doc enumerates it).

## Why Option A (docs-only) rather than Option B (commit the fixture now)

The fixture *schema* is unambiguous, but the render/validation path is **not fully runnable from a docs change**: the action-cards fixture is exercised by a **Playwright e2e** (`web/pilot-ui/tests/e2e/demo-fixture-preload.spec.js`, the fixture-content gate; `standing-action-cards.spec.js` covers DOM wiring) and the **"Rehearsal Fixture Bundle"** CI gate (browser/npm env), and the Python bundle validator (`validate-rehearsal-shell-fixtures.py`) checks the action-cards read-model **shape-only** — necessary but not sufficient. Committing an untestable-here fixture risks a CI break, so per the task's guidance (prefer Option A under UI-loader/validation-path uncertainty) this PR specifies the shape + the full validation path instead.

## What files changed

- `docs/pilots/summit-ops-registration-fixture-shape.md` (new — the fixture-shape map)
- `docs/registry.toml` (+1 explicit registry row, `truth_class = descriptive`)
- `docs/pilots/summit-ops-registration-action-card-proof-loop.md` (+1 discoverability pointer)

## Whether a committed lane fixture now exists

**No.** This PR commits no runtime fixture. The Registration Desk lane remains **fixture-ready**. The doc specifies the exact card to add later and the validation gate that, once green, lets the lane be called fixture-backed.

## Schema / action-card discipline

The specified card uses the only emitted, schema-valid day-of pair — `source_kind: action_item`, `action_kind: complete`, `scope: structure` — per `docs/contracts/institution-package/action-card.schema.json` (closed `source_kind` taxonomy; `scope ∈ {entity,structure,individual}`), with all required fields and fictional `demo-…` ids. No `committee_log`, no `program_milestone`, no invented source kinds; any richer source-kind is explicitly a future schema change.

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — **passed** (895 docs, 66 enforcement warnings; the explicit registry row preempts the `docs/pilots/` prefix `yaml-mismatch`).
- `bash ops/scripts/drift-check.sh` — PASS (0 errors, 0 warnings).
- `python3 scripts/check-state-lag.py` — OK.
- `git diff --check` — clean.
- (Context) `python3 docs/scripts/validate-rehearsal-shell-fixtures.py` currently `PASS` (5 read models) on `main` — the bundle the future fixture would join.
- No Rust/OpenAPI/SDK changed; no `web/` fixture committed; no generated artifacts modified.

## Follow-ups

- **Next slice:** commit the specified registration card into `action-cards.json`; run the bundle validator + the Playwright e2e + the "Rehearsal Fixture Bundle" gate; then flip the proof-loop map from *fixture-ready* to *fixture-backed*.
- Wire / confirm the shell renders the registration action register from the committed fixture.
- Add a second lane's fixture shape (room monitors or closing/cleanup) the same way.

## Nonclaims

- Does not commit a runtime fixture (docs-only); does not make the lane fixture-backed yet.
- Does not claim live summit registration exists or a real attendee workflow.
- Does not sync Google data; does not mutate the NYCN repo.
- Does not commit private attendee, sponsor, accessibility, volunteer, incident, registration, or payment data.
- Does not claim organizer readiness, a formal NYCN pilot, production readiness, live federation, or Phase 2 completion.
- Does not change route behavior, `icnctl` behavior, authn/authz, or OpenAPI; does not regenerate SDK types.
- Does not affect #2082; does not start A2e.

Refs #1746
Refs #2141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

