### PR TITLE
docs(cli): classify icnctl command implementation status

### DIFF
--- a/docs/reference/project-index/generated/icnctl-command-inventory.md
+++ b/docs/reference/project-index/generated/icnctl-command-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-26T02:17:04+00:00
+Generated: 2026-06-26T13:17:35+00:00
 ---
 
 # `icnctl` Command Inventory (generated)
@@ -14,12 +14,12 @@ Generated: 2026-06-26T02:17:04+00:00
 - **Proves:** these `icnctl` command declarations exist in the clap command tree under `icn/bins/icnctl/src/**` at the snapshot commit (proof level **L1**).
 - **Does NOT prove:** that a command works, is safe for organizers, is production-ready, is wired to a live gateway, has correct auth/permissions, is part of a supported pilot flow, or is appropriate for non-technical users.
 - **`role` is a curated navigation heuristic** (top-level command group -> role), **not** mechanically derived from clap and **needs review**. It says "where might I look first", never "this user may safely run this".
-- **`status` is uniformly `unknown / needs local verification`** by construction: a static clap scan proves a command is *declared*, not whether it is `implemented` / `implemented but partial` / `fixture-backed` / `gateway-backed` / `docs-only / design-direction` / `planned`. Assigning those per command is a human/runtime follow-up — so nothing here is presented as live.
+- **`status` is a curated, evidence-pointer classification** (issue #2113): `live` / `partial` / `fixture-demo` / `planned`, defaulting to `unknown / needs local verification` for any command not explicitly classified. It is curated from source/test evidence (a static clap scan proves a command is *declared*, not how far its handler is implemented), so it is **never** inferred from a declaration. `live` is asserted only with concrete-handler + (integration test | local-only no-network) evidence and is **not** a production-readiness claim; demo/dev-gated commands are never presented as live. See the [Implementation status](#implementation-status-classification) section.
 - Defer to canonical truth/precedence: [`source-of-truth-map.md`](../source-of-truth-map.md) and proof levels in [`proof-level-taxonomy-capability-matrix.md`](../proof-level-taxonomy-capability-matrix.md). Orientation artifact (`Canonical: no`); companion to [`generated/route-inventory.md`](route-inventory.md).
 
 ## Snapshot
 
-- Source commit: `1b9576e06a74658a45242ac19c7a934149bf5c08`
+- Source commit: `f06d5b0305ddb22551e0ec07b97185601df559ce`
 - Source scanned: `icn/bins/icnctl/src/**` (clap `#[derive(Subcommand)]` / `#[derive(Parser)]` tree)
 
 ## Summary
@@ -27,7 +27,7 @@ Generated: 2026-06-26T02:17:04+00:00
 - **Total leaf commands (default build): 162**
 - Top-level command groups: 33
 - By role (curated, needs review): organizer 53 · operator 64 · developer 43 · maintainer 2
-- By status: every default-build command is `unknown / needs local verification` (162) — see note above.
+- By status (curated, see section below): live 10 · partial 2 · planned 7 · unknown / needs local verification 143
 - Proof level: every command is `L1` (declaration exists in source).
 - **Feature-gated commands (NOT in the default build, excluded from the counts above): 1** (see section below).
 - Unparsed / unresolved candidates: 0 (see section below).
@@ -55,7 +55,7 @@ Role is the **curated** top-level-group heuristic (needs review). `status` and `
 | `icnctl appeal show` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1962 |
 | `icnctl appeal withdraw` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:2024 |
 | `icnctl charter create` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1614 |
-| `icnctl charter deploy` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1718 |
+| `icnctl charter deploy` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1718 |
 | `icnctl charter inspect` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1704 |
 | `icnctl charter list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1651 |
 | `icnctl charter ratify` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1684 |
@@ -98,8 +98,8 @@ Role is the **curated** top-level-group heuristic (needs review). `status` and `
 
 | Command | Status | Proof | Source |
 |---|---|---|---|
-| `icnctl audit verify` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:330 |
-| `icnctl backup` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:98 |
+| `icnctl audit verify` | partial | L1 | `icn/bins/icnctl/src/main.rs`:330 |
+| `icnctl backup` | live | L1 | `icn/bins/icnctl/src/main.rs`:98 |
 | `icnctl federation add` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:862 |
 | `icnctl federation attestation from` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1022 |
 | `icnctl federation attestation issue` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1028 |
@@ -133,10 +133,10 @@ Role is the **curated** top-level-group heuristic (needs review). `status` and `
 | `icnctl policy remove` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:534 |
 | `icnctl policy set` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:513 |
 | `icnctl policy show` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:524 |
-| `icnctl preflight` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:203 |
+| `icnctl preflight` | partial | L1 | `icn/bins/icnctl/src/main.rs`:203 |
 | `icnctl quota list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:555 |
 | `icnctl quota show` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:544 |
-| `icnctl restore` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:104 |
+| `icnctl restore` | live | L1 | `icn/bins/icnctl/src/main.rs`:104 |
 | `icnctl snapshot cleanup` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1356 |
 | `icnctl snapshot create` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1338 |
 | `icnctl snapshot delete` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1350 |
@@ -144,32 +144,32 @@ Role is the **curated** top-level-group heuristic (needs review). `status` and `
 | `icnctl snapshot verify` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1344 |
 | `icnctl status` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:51 |
 | `icnctl steward attesters` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1458 |
-| `icnctl steward check-vui` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1496 |
+| `icnctl steward check-vui` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1496 |
 | `icnctl steward config` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1433 |
-| `icnctl steward enrollment-status` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1513 |
+| `icnctl steward enrollment-status` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1513 |
 | `icnctl steward info` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1436 |
-| `icnctl steward issue-token` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1544 |
+| `icnctl steward issue-token` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1544 |
 | `icnctl steward list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1445 |
-| `icnctl steward recovery-status` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1538 |
+| `icnctl steward recovery-status` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1538 |
 | `icnctl steward register` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1465 |
 | `icnctl steward retire` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1487 |
-| `icnctl steward start-enrollment` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1502 |
-| `icnctl steward start-recovery` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1519 |
+| `icnctl steward start-enrollment` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1502 |
+| `icnctl steward start-recovery` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1519 |
 | `icnctl steward status` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1430 |
 | `icnctl steward topics` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1555 |
 | `icnctl trust add` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:694 |
 | `icnctl trust list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:707 |
 | `icnctl trust remove` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:716 |
 | `icnctl trust show` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:710 |
-| `icnctl verify-backup` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:114 |
+| `icnctl verify-backup` | live | L1 | `icn/bins/icnctl/src/main.rs`:114 |
 
 ### developer (43)
 
 | Command | Status | Proof | Source |
 |---|---|---|---|
-| `icnctl api export-openapi` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:267 |
+| `icnctl api export-openapi` | live | L1 | `icn/bins/icnctl/src/main.rs`:267 |
 | `icnctl auth token` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:410 |
-| `icnctl completions` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:214 |
+| `icnctl completions` | live | L1 | `icn/bins/icnctl/src/main.rs`:214 |
 | `icnctl compute cancel` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:500 |
 | `icnctl compute status` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:494 |
 | `icnctl compute submit` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:432 |
@@ -180,15 +180,15 @@ Role is the **curated** top-level-group heuristic (needs review). `status` and `
 | `icnctl contract list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:828 |
 | `icnctl contract prepare` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:786 |
 | `icnctl contract sign` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:796 |
-| `icnctl device add` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:600 |
+| `icnctl device add` | live | L1 | `icn/bins/icnctl/src/main.rs`:600 |
 | `icnctl device approve` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:614 |
 | `icnctl device list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:597 |
 | `icnctl device revoke` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:620 |
 | `icnctl id export` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:582 |
 | `icnctl id import` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:588 |
-| `icnctl id init` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:565 |
+| `icnctl id init` | live | L1 | `icn/bins/icnctl/src/main.rs`:565 |
 | `icnctl id rotate` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:571 |
-| `icnctl id show` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:568 |
+| `icnctl id show` | live | L1 | `icn/bins/icnctl/src/main.rs`:568 |
 | `icnctl ledger balance` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:728 |
 | `icnctl ledger head` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:725 |
 | `icnctl ledger history` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:738 |
@@ -215,8 +215,8 @@ Role is the **curated** top-level-group heuristic (needs review). `status` and `
 
 | Command | Status | Proof | Source |
 |---|---|---|---|
-| `icnctl coop entity-backfill-surrogates` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:249 |
-| `icnctl coop entity-report` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:230 |
+| `icnctl coop entity-backfill-surrogates` | live | L1 | `icn/bins/icnctl/src/main.rs`:249 |
+| `icnctl coop entity-report` | live | L1 | `icn/bins/icnctl/src/main.rs`:230 |
 
 ## Feature-gated commands (not in the default build)
 
@@ -226,9 +226,60 @@ These commands are guarded by a Cargo `#[cfg(feature = …)]` and are **absent f
 |---|---|---|---|---|
 | `icnctl id upgrade-pq` | `cfg(feature = "post-quantum")` | developer | L1 | `icn/bins/icnctl/src/main.rs`:579 |
 
-## Commands by status
+## Implementation status classification
 
-All 162 default-build commands carry the conservative status `unknown / needs local verification`. The static clap scan cannot mechanically distinguish `implemented` / `implemented but partial` / `fixture-backed` / `gateway-backed` / `docs-only / design-direction` / `planned`; that per-command classification is a human/runtime verification follow-up (so demo/dev-gated commands are never presented here as live).
+Status is a **curated** classification (issue #2113), defaulting to `unknown / needs local verification`. It is curated from source/test evidence — a static clap scan proves a command is *declared*, not how far its handler is implemented — so it is never inferred from a declaration. This is a deliberately **narrow, defensible first pass**: only commands with clear evidence are classified; the rest stay `unknown` (honest, not a failure).
+
+### Vocabulary
+
+- **`live`** — compiled in the default build, calls a concrete client/runtime path, and has evidence it works: an integration test that spawns the binary and asserts success, OR a local-only operation with no network dependency. **Not** asserted because a clap subcommand exists; **not** a production-readiness claim.
+- **`partial`** — the handler does real work but depends on incomplete/unproven runtime support (e.g. a live gateway) and is not integration-tested end-to-end.
+- **`fixture-demo`** — a demo / fixture / rehearsal-only path, exercisable without live network/service; must not be implied as live operational use.
+- **`planned`** — declared but the handler is a placeholder / TODO / prints "not yet implemented" (or the feature is unavailable in the default build).
+- **`unknown / needs local verification`** — status not established from source/tests/docs in this pass; the conservative default.
+
+### Counts by status (default build)
+
+| Status | Count |
+|---|---|
+| live | 10 |
+| partial | 2 |
+| fixture-demo | 0 |
+| planned | 7 |
+| unknown / needs local verification | 143 |
+
+### Classified commands (19)
+
+Every non-`unknown` command, with its evidence basis. (All other default-build commands carry `unknown / needs local verification`.)
+
+| Command | Status | Basis (source/test evidence) | Source |
+|---|---|---|---|
+| `icnctl api export-openapi` | live | serializes the embedded `icn_gateway::openapi::ApiDoc` to file/stdout; local-only, no gateway (`main.rs` ApiCommands::ExportOpenapi) | `icn/bins/icnctl/src/main.rs`:267 |
+| `icnctl backup` | live | local data-dir backup; integration-tested (`backup_restore_test.rs` asserts success + tarball created) | `icn/bins/icnctl/src/main.rs`:98 |
+| `icnctl completions` | live | shell-completion generation via `clap_complete::generate`; local-only, no network (`main.rs` Commands::Completions) | `icn/bins/icnctl/src/main.rs`:214 |
+| `icnctl coop entity-backfill-surrogates` | live | local coop-store surrogate backfill; integration-tested (`coop_entity_backfill_test.rs` asserts success) | `icn/bins/icnctl/src/main.rs`:249 |
+| `icnctl coop entity-report` | live | read-only local coop-store report; integration-tested (`coop_entity_report_test.rs`, `coop_entity_backfill_test.rs` assert success + JSON) | `icn/bins/icnctl/src/main.rs`:230 |
+| `icnctl device add` | live | local keystore device add; integration-tested (`qr_code_test.rs` asserts success) | `icn/bins/icnctl/src/main.rs`:600 |
+| `icnctl id init` | live | local keystore init; integration-tested (`bins/icnctl/tests/backup_restore_test.rs`, `qr_code_test.rs` spawn the binary, assert success) | `icn/bins/icnctl/src/main.rs`:565 |
+| `icnctl id show` | live | local keystore read; integration-tested (`backup_restore_test.rs`, `qr_code_test.rs`) | `icn/bins/icnctl/src/main.rs`:568 |
+| `icnctl restore` | live | local data-dir restore; integration-tested (`backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:104 |
+| `icnctl verify-backup` | live | local backup verification; integration-tested (`backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:114 |
+| `icnctl audit verify` | partial | concrete gateway client `GET /v1/receipts/chain/{hash}` (`main.rs` AuditCommands::Verify); chain-verification algorithm covered by `audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested | `icn/bins/icnctl/src/main.rs`:330 |
+| `icnctl preflight` | partial | runs real local health checks (data-dir, keystore open via `AgeKeyStore`) in `handle_preflight_command`; the gateway-connectivity check requires a running gateway; not integration-tested | `icn/bins/icnctl/src/main.rs`:203 |
+| `icnctl charter deploy` | planned | handler validates the CCL doc locally, then prints "Not yet implemented — charter deployment requires gateway integration" (`main.rs` CharterCommands::Deploy) | `icn/bins/icnctl/src/main.rs`:1718 |
+| `icnctl steward check-vui` | planned | placeholder; validates input then prints "VUI registry check requires running steward daemon" (`main.rs` StewardCommands::CheckVui) | `icn/bins/icnctl/src/main.rs`:1496 |
+| `icnctl steward enrollment-status` | planned | placeholder; ceremony status check requires a running steward daemon (`main.rs` StewardCommands::EnrollmentStatus) | `icn/bins/icnctl/src/main.rs`:1513 |
+| `icnctl steward issue-token` | planned | placeholder for the full SDIS token issuance flow; requires a running steward daemon (`main.rs` StewardCommands::IssueToken) | `icn/bins/icnctl/src/main.rs`:1544 |
+| `icnctl steward recovery-status` | planned | placeholder; ceremony status check requires a running steward daemon (`main.rs` StewardCommands::RecoveryStatus) | `icn/bins/icnctl/src/main.rs`:1538 |
+| `icnctl steward start-enrollment` | planned | placeholder for the full SDIS enrollment flow; requires a running steward daemon (`main.rs` StewardCommands::StartEnrollment) | `icn/bins/icnctl/src/main.rs`:1502 |
+| `icnctl steward start-recovery` | planned | placeholder for the full SDIS recovery flow; requires a running steward daemon (`main.rs` StewardCommands::StartRecovery) | `icn/bins/icnctl/src/main.rs`:1519 |
+
+### Status non-claims
+
+- A command marked `live` is **not** a production-readiness claim — only that it runs and does real work per the cited local/test evidence.
+- This generated static inventory is **not** runtime execution proof except where a basis cites a test; proof level stays `L1` (declaration) regardless of status.
+- A default `unknown / needs local verification` is an honest "not yet verified", not a failure or a defect.
+- Feature-gated commands remain **excluded** from the default-build counts and are left unclassified.
 
 ## Unparsed / unknown candidates
 

--- a/docs/reference/project-index/generated/icnctl-command-inventory.md
+++ b/docs/reference/project-index/generated/icnctl-command-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-26T13:17:35+00:00
+Generated: 2026-06-26T13:27:08+00:00
 ---
 
 # `icnctl` Command Inventory (generated)
@@ -19,7 +19,7 @@ Generated: 2026-06-26T13:17:35+00:00
 
 ## Snapshot
 
-- Source commit: `f06d5b0305ddb22551e0ec07b97185601df559ce`
+- Source commit: `439d3b18053d77b6bf9a015b12bcf66d47055b09`
 - Source scanned: `icn/bins/icnctl/src/**` (clap `#[derive(Subcommand)]` / `#[derive(Parser)]` tree)
 
 ## Summary
@@ -34,7 +34,7 @@ Generated: 2026-06-26T13:17:35+00:00
 
 ## Commands by role
 
-Role is the **curated** top-level-group heuristic (needs review). `status` and `proof` are uniform by construction (see the note above).
+Role is the **curated** top-level-group heuristic (needs review). `status` is a **curated, per-command** classification (see the [Implementation status](#implementation-status-classification) section); `proof` is uniform at `L1` (declaration scan).
 
 ### organizer (53)
 
@@ -235,7 +235,7 @@ Status is a **curated** classification (issue #2113), defaulting to `unknown / n
 - **`live`** — compiled in the default build, calls a concrete client/runtime path, and has evidence it works: an integration test that spawns the binary and asserts success, OR a local-only operation with no network dependency. **Not** asserted because a clap subcommand exists; **not** a production-readiness claim.
 - **`partial`** — the handler does real work but depends on incomplete/unproven runtime support (e.g. a live gateway) and is not integration-tested end-to-end.
 - **`fixture-demo`** — a demo / fixture / rehearsal-only path, exercisable without live network/service; must not be implied as live operational use.
-- **`planned`** — declared but the handler is a placeholder / TODO / prints "not yet implemented" (or the feature is unavailable in the default build).
+- **`planned`** — declared but the handler is a placeholder / TODO / prints "not yet implemented".
 - **`unknown / needs local verification`** — status not established from source/tests/docs in this pass; the conservative default.
 
 ### Counts by status (default build)
@@ -254,25 +254,25 @@ Every non-`unknown` command, with its evidence basis. (All other default-build c
 
 | Command | Status | Basis (source/test evidence) | Source |
 |---|---|---|---|
-| `icnctl api export-openapi` | live | serializes the embedded `icn_gateway::openapi::ApiDoc` to file/stdout; local-only, no gateway (`main.rs` ApiCommands::ExportOpenapi) | `icn/bins/icnctl/src/main.rs`:267 |
-| `icnctl backup` | live | local data-dir backup; integration-tested (`backup_restore_test.rs` asserts success + tarball created) | `icn/bins/icnctl/src/main.rs`:98 |
-| `icnctl completions` | live | shell-completion generation via `clap_complete::generate`; local-only, no network (`main.rs` Commands::Completions) | `icn/bins/icnctl/src/main.rs`:214 |
-| `icnctl coop entity-backfill-surrogates` | live | local coop-store surrogate backfill; integration-tested (`coop_entity_backfill_test.rs` asserts success) | `icn/bins/icnctl/src/main.rs`:249 |
-| `icnctl coop entity-report` | live | read-only local coop-store report; integration-tested (`coop_entity_report_test.rs`, `coop_entity_backfill_test.rs` assert success + JSON) | `icn/bins/icnctl/src/main.rs`:230 |
-| `icnctl device add` | live | local keystore device add; integration-tested (`qr_code_test.rs` asserts success) | `icn/bins/icnctl/src/main.rs`:600 |
-| `icnctl id init` | live | local keystore init; integration-tested (`bins/icnctl/tests/backup_restore_test.rs`, `qr_code_test.rs` spawn the binary, assert success) | `icn/bins/icnctl/src/main.rs`:565 |
-| `icnctl id show` | live | local keystore read; integration-tested (`backup_restore_test.rs`, `qr_code_test.rs`) | `icn/bins/icnctl/src/main.rs`:568 |
-| `icnctl restore` | live | local data-dir restore; integration-tested (`backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:104 |
-| `icnctl verify-backup` | live | local backup verification; integration-tested (`backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:114 |
-| `icnctl audit verify` | partial | concrete gateway client `GET /v1/receipts/chain/{hash}` (`main.rs` AuditCommands::Verify); chain-verification algorithm covered by `audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested | `icn/bins/icnctl/src/main.rs`:330 |
+| `icnctl api export-openapi` | live | serializes the embedded `icn_gateway::openapi::ApiDoc` to file/stdout; local-only, no gateway (`icn/bins/icnctl/src/main.rs` ApiCommands::ExportOpenapi) | `icn/bins/icnctl/src/main.rs`:267 |
+| `icnctl backup` | live | local data-dir backup; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs` asserts success + tarball created) | `icn/bins/icnctl/src/main.rs`:98 |
+| `icnctl completions` | live | shell-completion generation via `clap_complete::generate`; local-only, no network (`icn/bins/icnctl/src/main.rs` Commands::Completions) | `icn/bins/icnctl/src/main.rs`:214 |
+| `icnctl coop entity-backfill-surrogates` | live | local coop-store surrogate backfill; integration-tested (`icn/bins/icnctl/tests/coop_entity_backfill_test.rs` asserts success) | `icn/bins/icnctl/src/main.rs`:249 |
+| `icnctl coop entity-report` | live | read-only local coop-store report; integration-tested (`icn/bins/icnctl/tests/coop_entity_report_test.rs`, `icn/bins/icnctl/tests/coop_entity_backfill_test.rs` assert success + JSON) | `icn/bins/icnctl/src/main.rs`:230 |
+| `icnctl device add` | live | local keystore device add; integration-tested (`icn/bins/icnctl/tests/qr_code_test.rs` asserts success) | `icn/bins/icnctl/src/main.rs`:600 |
+| `icnctl id init` | live | local keystore init; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`, `icn/bins/icnctl/tests/qr_code_test.rs` spawn the binary, assert success) | `icn/bins/icnctl/src/main.rs`:565 |
+| `icnctl id show` | live | local keystore read; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`, `icn/bins/icnctl/tests/qr_code_test.rs`) | `icn/bins/icnctl/src/main.rs`:568 |
+| `icnctl restore` | live | local data-dir restore; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:104 |
+| `icnctl verify-backup` | live | local backup verification; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:114 |
+| `icnctl audit verify` | partial | concrete gateway client `GET /v1/receipts/chain/{hash}` (`icn/bins/icnctl/src/main.rs` AuditCommands::Verify); chain-verification algorithm covered by `icn/bins/icnctl/tests/audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested | `icn/bins/icnctl/src/main.rs`:330 |
 | `icnctl preflight` | partial | runs real local health checks (data-dir, keystore open via `AgeKeyStore`) in `handle_preflight_command`; the gateway-connectivity check requires a running gateway; not integration-tested | `icn/bins/icnctl/src/main.rs`:203 |
-| `icnctl charter deploy` | planned | handler validates the CCL doc locally, then prints "Not yet implemented — charter deployment requires gateway integration" (`main.rs` CharterCommands::Deploy) | `icn/bins/icnctl/src/main.rs`:1718 |
-| `icnctl steward check-vui` | planned | placeholder; validates input then prints "VUI registry check requires running steward daemon" (`main.rs` StewardCommands::CheckVui) | `icn/bins/icnctl/src/main.rs`:1496 |
-| `icnctl steward enrollment-status` | planned | placeholder; ceremony status check requires a running steward daemon (`main.rs` StewardCommands::EnrollmentStatus) | `icn/bins/icnctl/src/main.rs`:1513 |
-| `icnctl steward issue-token` | planned | placeholder for the full SDIS token issuance flow; requires a running steward daemon (`main.rs` StewardCommands::IssueToken) | `icn/bins/icnctl/src/main.rs`:1544 |
-| `icnctl steward recovery-status` | planned | placeholder; ceremony status check requires a running steward daemon (`main.rs` StewardCommands::RecoveryStatus) | `icn/bins/icnctl/src/main.rs`:1538 |
-| `icnctl steward start-enrollment` | planned | placeholder for the full SDIS enrollment flow; requires a running steward daemon (`main.rs` StewardCommands::StartEnrollment) | `icn/bins/icnctl/src/main.rs`:1502 |
-| `icnctl steward start-recovery` | planned | placeholder for the full SDIS recovery flow; requires a running steward daemon (`main.rs` StewardCommands::StartRecovery) | `icn/bins/icnctl/src/main.rs`:1519 |
+| `icnctl charter deploy` | planned | handler validates the CCL doc locally, then prints "Not yet implemented — charter deployment requires gateway integration" (`icn/bins/icnctl/src/main.rs` CharterCommands::Deploy) | `icn/bins/icnctl/src/main.rs`:1718 |
+| `icnctl steward check-vui` | planned | placeholder; validates input then prints "VUI registry check requires running steward daemon" (`icn/bins/icnctl/src/main.rs` StewardCommands::CheckVui) | `icn/bins/icnctl/src/main.rs`:1496 |
+| `icnctl steward enrollment-status` | planned | placeholder; ceremony status check requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::EnrollmentStatus) | `icn/bins/icnctl/src/main.rs`:1513 |
+| `icnctl steward issue-token` | planned | placeholder for the full SDIS token issuance flow; requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::IssueToken) | `icn/bins/icnctl/src/main.rs`:1544 |
+| `icnctl steward recovery-status` | planned | placeholder; ceremony status check requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::RecoveryStatus) | `icn/bins/icnctl/src/main.rs`:1538 |
+| `icnctl steward start-enrollment` | planned | placeholder for the full SDIS enrollment flow; requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::StartEnrollment) | `icn/bins/icnctl/src/main.rs`:1502 |
+| `icnctl steward start-recovery` | planned | placeholder for the full SDIS recovery flow; requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::StartRecovery) | `icn/bins/icnctl/src/main.rs`:1519 |
 
 ### Status non-claims
 

--- a/docs/scripts/icnctl_command_inventory.py
+++ b/docs/scripts/icnctl_command_inventory.py
@@ -129,27 +129,27 @@ STATUS_ORDER = [STATUS_LIVE, STATUS_PARTIAL, STATUS_FIXTURE_DEMO, STATUS_PLANNED
 STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     # live — concrete handler + integration test (binary spawned, success asserted) or a
     # local-only, no-network operation.
-    "id init": (STATUS_LIVE, "local keystore init; integration-tested (`bins/icnctl/tests/backup_restore_test.rs`, `qr_code_test.rs` spawn the binary, assert success)"),
-    "id show": (STATUS_LIVE, "local keystore read; integration-tested (`backup_restore_test.rs`, `qr_code_test.rs`)"),
-    "backup": (STATUS_LIVE, "local data-dir backup; integration-tested (`backup_restore_test.rs` asserts success + tarball created)"),
-    "restore": (STATUS_LIVE, "local data-dir restore; integration-tested (`backup_restore_test.rs`)"),
-    "verify-backup": (STATUS_LIVE, "local backup verification; integration-tested (`backup_restore_test.rs`)"),
-    "coop entity-report": (STATUS_LIVE, "read-only local coop-store report; integration-tested (`coop_entity_report_test.rs`, `coop_entity_backfill_test.rs` assert success + JSON)"),
-    "coop entity-backfill-surrogates": (STATUS_LIVE, "local coop-store surrogate backfill; integration-tested (`coop_entity_backfill_test.rs` asserts success)"),
-    "device add": (STATUS_LIVE, "local keystore device add; integration-tested (`qr_code_test.rs` asserts success)"),
-    "completions": (STATUS_LIVE, "shell-completion generation via `clap_complete::generate`; local-only, no network (`main.rs` Commands::Completions)"),
-    "api export-openapi": (STATUS_LIVE, "serializes the embedded `icn_gateway::openapi::ApiDoc` to file/stdout; local-only, no gateway (`main.rs` ApiCommands::ExportOpenapi)"),
+    "id init": (STATUS_LIVE, "local keystore init; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`, `icn/bins/icnctl/tests/qr_code_test.rs` spawn the binary, assert success)"),
+    "id show": (STATUS_LIVE, "local keystore read; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`, `icn/bins/icnctl/tests/qr_code_test.rs`)"),
+    "backup": (STATUS_LIVE, "local data-dir backup; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs` asserts success + tarball created)"),
+    "restore": (STATUS_LIVE, "local data-dir restore; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`)"),
+    "verify-backup": (STATUS_LIVE, "local backup verification; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`)"),
+    "coop entity-report": (STATUS_LIVE, "read-only local coop-store report; integration-tested (`icn/bins/icnctl/tests/coop_entity_report_test.rs`, `icn/bins/icnctl/tests/coop_entity_backfill_test.rs` assert success + JSON)"),
+    "coop entity-backfill-surrogates": (STATUS_LIVE, "local coop-store surrogate backfill; integration-tested (`icn/bins/icnctl/tests/coop_entity_backfill_test.rs` asserts success)"),
+    "device add": (STATUS_LIVE, "local keystore device add; integration-tested (`icn/bins/icnctl/tests/qr_code_test.rs` asserts success)"),
+    "completions": (STATUS_LIVE, "shell-completion generation via `clap_complete::generate`; local-only, no network (`icn/bins/icnctl/src/main.rs` Commands::Completions)"),
+    "api export-openapi": (STATUS_LIVE, "serializes the embedded `icn_gateway::openapi::ApiDoc` to file/stdout; local-only, no gateway (`icn/bins/icnctl/src/main.rs` ApiCommands::ExportOpenapi)"),
     # partial — real work, but depends on incomplete/unproven runtime; not integration-tested end-to-end.
-    "audit verify": (STATUS_PARTIAL, "concrete gateway client `GET /v1/receipts/chain/{hash}` (`main.rs` AuditCommands::Verify); chain-verification algorithm covered by `audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested"),
+    "audit verify": (STATUS_PARTIAL, "concrete gateway client `GET /v1/receipts/chain/{hash}` (`icn/bins/icnctl/src/main.rs` AuditCommands::Verify); chain-verification algorithm covered by `icn/bins/icnctl/tests/audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested"),
     "preflight": (STATUS_PARTIAL, "runs real local health checks (data-dir, keystore open via `AgeKeyStore`) in `handle_preflight_command`; the gateway-connectivity check requires a running gateway; not integration-tested"),
     # planned — handler is an explicit placeholder / prints "not yet implemented".
-    "charter deploy": (STATUS_PLANNED, "handler validates the CCL doc locally, then prints \"Not yet implemented — charter deployment requires gateway integration\" (`main.rs` CharterCommands::Deploy)"),
-    "steward check-vui": (STATUS_PLANNED, "placeholder; validates input then prints \"VUI registry check requires running steward daemon\" (`main.rs` StewardCommands::CheckVui)"),
-    "steward start-enrollment": (STATUS_PLANNED, "placeholder for the full SDIS enrollment flow; requires a running steward daemon (`main.rs` StewardCommands::StartEnrollment)"),
-    "steward enrollment-status": (STATUS_PLANNED, "placeholder; ceremony status check requires a running steward daemon (`main.rs` StewardCommands::EnrollmentStatus)"),
-    "steward start-recovery": (STATUS_PLANNED, "placeholder for the full SDIS recovery flow; requires a running steward daemon (`main.rs` StewardCommands::StartRecovery)"),
-    "steward recovery-status": (STATUS_PLANNED, "placeholder; ceremony status check requires a running steward daemon (`main.rs` StewardCommands::RecoveryStatus)"),
-    "steward issue-token": (STATUS_PLANNED, "placeholder for the full SDIS token issuance flow; requires a running steward daemon (`main.rs` StewardCommands::IssueToken)"),
+    "charter deploy": (STATUS_PLANNED, "handler validates the CCL doc locally, then prints \"Not yet implemented — charter deployment requires gateway integration\" (`icn/bins/icnctl/src/main.rs` CharterCommands::Deploy)"),
+    "steward check-vui": (STATUS_PLANNED, "placeholder; validates input then prints \"VUI registry check requires running steward daemon\" (`icn/bins/icnctl/src/main.rs` StewardCommands::CheckVui)"),
+    "steward start-enrollment": (STATUS_PLANNED, "placeholder for the full SDIS enrollment flow; requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::StartEnrollment)"),
+    "steward enrollment-status": (STATUS_PLANNED, "placeholder; ceremony status check requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::EnrollmentStatus)"),
+    "steward start-recovery": (STATUS_PLANNED, "placeholder for the full SDIS recovery flow; requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::StartRecovery)"),
+    "steward recovery-status": (STATUS_PLANNED, "placeholder; ceremony status check requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::RecoveryStatus)"),
+    "steward issue-token": (STATUS_PLANNED, "placeholder for the full SDIS token issuance flow; requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::IssueToken)"),
 }
 
 CFG_RE = re.compile(r"^\s*#\[cfg\((.+)\)\]\s*$")
@@ -342,6 +342,20 @@ def render(leaves: list[dict], unparsed: list[str], commit: str) -> str:
             "STATUS_BY_COMMAND keys not found among default-build commands "
             f"(renamed/removed?): {stale_keys}"
         )
+    # Validate values too, so a typo'd status or empty basis fails explicitly here rather
+    # than later during rendering/sorting. Curated entries must use one of the non-default
+    # statuses and carry a non-empty evidence basis.
+    valid_statuses = {STATUS_LIVE, STATUS_PARTIAL, STATUS_FIXTURE_DEMO, STATUS_PLANNED}
+    bad_values = sorted(
+        f"{k} (status={status!r}, basis={'empty' if not basis.strip() else 'ok'})"
+        for k, (status, basis) in STATUS_BY_COMMAND.items()
+        if status not in valid_statuses or not basis.strip()
+    )
+    if bad_values:
+        raise ValueError(
+            f"STATUS_BY_COMMAND values invalid (status must be one of {sorted(valid_statuses)} "
+            f"and basis must be non-empty): {bad_values}"
+        )
 
     by_role: dict[str, list[dict]] = {}
     role_counts: dict[str, int] = {}
@@ -427,8 +441,10 @@ def render(leaves: list[dict], unparsed: list[str], commit: str) -> str:
     o.append("")
     o.append("## Commands by role")
     o.append("")
-    o.append("Role is the **curated** top-level-group heuristic (needs review). `status` and "
-             "`proof` are uniform by construction (see the note above).")
+    o.append("Role is the **curated** top-level-group heuristic (needs review). `status` is a "
+             "**curated, per-command** classification (see the "
+             "[Implementation status](#implementation-status-classification) section); `proof` "
+             "is uniform at `L1` (declaration scan).")
     o.append("")
     for role in role_order:
         cmds = sorted(by_role.get(role, []), key=lambda x: x["path"])
@@ -481,7 +497,7 @@ def render(leaves: list[dict], unparsed: list[str], commit: str) -> str:
     o.append("- **`fixture-demo`** — a demo / fixture / rehearsal-only path, exercisable "
              "without live network/service; must not be implied as live operational use.")
     o.append("- **`planned`** — declared but the handler is a placeholder / TODO / prints "
-             "\"not yet implemented\" (or the feature is unavailable in the default build).")
+             "\"not yet implemented\".")
     o.append(f"- **`{UNIFORM_STATUS}`** — status not established from source/tests/docs in "
              "this pass; the conservative default.")
     o.append("")

--- a/docs/scripts/icnctl_command_inventory.py
+++ b/docs/scripts/icnctl_command_inventory.py
@@ -10,12 +10,16 @@ What is mechanical (drift-checked) vs curated:
   derived from the clap enums. Counts never hand-maintained.
 - **Curated (needs review):** the `role` column is a small, explicit top-level-group ->
   role map (a navigation heuristic, NOT derived from clap and asserting no usability or
-  safety). The `status` column is uniformly `unknown / needs local verification`: a
-  static scan proves a command is **declared**, not that it is implemented / wired to a
-  live gateway / fixture-only / production-ready. Distinguishing
-  live/partial/fixture/planned per command is a human/runtime follow-up.
+  safety). The `status` column is a curated, evidence-pointer classification
+  (`STATUS_BY_COMMAND`, issue #2113): live / partial / fixture-demo / planned, defaulting
+  to `unknown / needs local verification` for any command not explicitly classified. A
+  static scan proves a command is **declared**, not how far its handler is implemented, so
+  status is curated from source/test evidence — never mechanically inferred from clap, and
+  `live` is **never** asserted merely because a subcommand exists.
 - **Proof level** is capped at **L1** (a command declaration exists in source) per
-  `proof-level-taxonomy-capability-matrix.md`. A static scan cannot assert higher.
+  `proof-level-taxonomy-capability-matrix.md`. A static scan cannot assert higher; the
+  `status` column carries the implementation classification separately from proof level
+  (a `live` status is NOT a higher proof level and NOT a production-readiness claim).
 
 Usage:
     python3 docs/scripts/icnctl_command_inventory.py --write    # regenerate artifact
@@ -95,6 +99,58 @@ ROLE_BY_GROUP: dict[str, str] = {
 
 UNIFORM_STATUS = "unknown / needs local verification"
 PROOF_LEVEL = "L1"
+
+# Implementation-status vocabulary (issue #2113 acceptance criterion).
+STATUS_LIVE = "live"
+STATUS_PARTIAL = "partial"
+STATUS_FIXTURE_DEMO = "fixture-demo"
+STATUS_PLANNED = "planned"
+STATUS_ORDER = [STATUS_LIVE, STATUS_PARTIAL, STATUS_FIXTURE_DEMO, STATUS_PLANNED, UNIFORM_STATUS]
+
+# Curated implementation-status classification (issue #2113). Like ROLE_BY_GROUP this is
+# NOT mechanically derivable from the clap tree: a static scan proves a command is
+# *declared*, not how far its handler is implemented. Each entry is keyed by the EXACT
+# command path (as rendered, without the leading `icnctl `) and carries (status, basis),
+# where basis is a concise source/test evidence pointer. Every key is validated against the
+# default-build command set at generation time (a renamed/removed command fails generation
+# loudly), so the classification cannot silently rot. Any command NOT listed here defaults
+# to `unknown / needs local verification` — an honest "not yet verified", not a failure.
+#
+# Discipline (issue #2113 "do not present demo/dev-gated as live"):
+# - `live` is asserted ONLY with concrete-handler evidence AND either an integration test
+#   that spawns the binary and asserts success, or a local-only operation with no network
+#   dependency. It is never inferred from a clap declaration and is NOT a production claim.
+# - `partial` = the handler does real work but depends on incomplete/unproven runtime
+#   (e.g. a live gateway) and is not integration-tested end-to-end.
+# - `planned` = the handler is an explicit placeholder / prints "not yet implemented".
+# - `fixture-demo` = a demo/fixture/rehearsal-only path. (None today: `icnctl` has no
+#   demo-only commands; the Summit Ops demo fixtures live in `web/pilot-ui`, not the CLI.)
+# This is a deliberately NARROW, defensible first pass; most commands remain `unknown`.
+STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
+    # live — concrete handler + integration test (binary spawned, success asserted) or a
+    # local-only, no-network operation.
+    "id init": (STATUS_LIVE, "local keystore init; integration-tested (`bins/icnctl/tests/backup_restore_test.rs`, `qr_code_test.rs` spawn the binary, assert success)"),
+    "id show": (STATUS_LIVE, "local keystore read; integration-tested (`backup_restore_test.rs`, `qr_code_test.rs`)"),
+    "backup": (STATUS_LIVE, "local data-dir backup; integration-tested (`backup_restore_test.rs` asserts success + tarball created)"),
+    "restore": (STATUS_LIVE, "local data-dir restore; integration-tested (`backup_restore_test.rs`)"),
+    "verify-backup": (STATUS_LIVE, "local backup verification; integration-tested (`backup_restore_test.rs`)"),
+    "coop entity-report": (STATUS_LIVE, "read-only local coop-store report; integration-tested (`coop_entity_report_test.rs`, `coop_entity_backfill_test.rs` assert success + JSON)"),
+    "coop entity-backfill-surrogates": (STATUS_LIVE, "local coop-store surrogate backfill; integration-tested (`coop_entity_backfill_test.rs` asserts success)"),
+    "device add": (STATUS_LIVE, "local keystore device add; integration-tested (`qr_code_test.rs` asserts success)"),
+    "completions": (STATUS_LIVE, "shell-completion generation via `clap_complete::generate`; local-only, no network (`main.rs` Commands::Completions)"),
+    "api export-openapi": (STATUS_LIVE, "serializes the embedded `icn_gateway::openapi::ApiDoc` to file/stdout; local-only, no gateway (`main.rs` ApiCommands::ExportOpenapi)"),
+    # partial — real work, but depends on incomplete/unproven runtime; not integration-tested end-to-end.
+    "audit verify": (STATUS_PARTIAL, "concrete gateway client `GET /v1/receipts/chain/{hash}` (`main.rs` AuditCommands::Verify); chain-verification algorithm covered by `audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested"),
+    "preflight": (STATUS_PARTIAL, "runs real local health checks (data-dir, keystore open via `AgeKeyStore`) in `handle_preflight_command`; the gateway-connectivity check requires a running gateway; not integration-tested"),
+    # planned — handler is an explicit placeholder / prints "not yet implemented".
+    "charter deploy": (STATUS_PLANNED, "handler validates the CCL doc locally, then prints \"Not yet implemented — charter deployment requires gateway integration\" (`main.rs` CharterCommands::Deploy)"),
+    "steward check-vui": (STATUS_PLANNED, "placeholder; validates input then prints \"VUI registry check requires running steward daemon\" (`main.rs` StewardCommands::CheckVui)"),
+    "steward start-enrollment": (STATUS_PLANNED, "placeholder for the full SDIS enrollment flow; requires a running steward daemon (`main.rs` StewardCommands::StartEnrollment)"),
+    "steward enrollment-status": (STATUS_PLANNED, "placeholder; ceremony status check requires a running steward daemon (`main.rs` StewardCommands::EnrollmentStatus)"),
+    "steward start-recovery": (STATUS_PLANNED, "placeholder for the full SDIS recovery flow; requires a running steward daemon (`main.rs` StewardCommands::StartRecovery)"),
+    "steward recovery-status": (STATUS_PLANNED, "placeholder; ceremony status check requires a running steward daemon (`main.rs` StewardCommands::RecoveryStatus)"),
+    "steward issue-token": (STATUS_PLANNED, "placeholder for the full SDIS token issuance flow; requires a running steward daemon (`main.rs` StewardCommands::IssueToken)"),
+}
 
 CFG_RE = re.compile(r"^\s*#\[cfg\((.+)\)\]\s*$")
 ENUM_RE = re.compile(r"#\[derive\([^)]*\bSubcommand\b[^)]*\)\]")
@@ -277,17 +333,38 @@ def render(leaves: list[dict], unparsed: list[str], commit: str) -> str:
     default_cmds = [c for c in leaves if not c.get("cfg")]
     gated_cmds = [c for c in leaves if c.get("cfg")]
 
+    # Anti-drift: every curated status key must match a real default-build command path,
+    # else a rename/removal would silently drop the classification. Fail generation loudly.
+    default_paths = {c["path"] for c in default_cmds}
+    stale_keys = sorted(k for k in STATUS_BY_COMMAND if k not in default_paths)
+    if stale_keys:
+        raise ValueError(
+            "STATUS_BY_COMMAND keys not found among default-build commands "
+            f"(renamed/removed?): {stale_keys}"
+        )
+
     by_role: dict[str, list[dict]] = {}
     role_counts: dict[str, int] = {}
+    status_counts: dict[str, int] = {}
+    classified: list[dict] = []
     group_set = set()
     for c in default_cmds:
         role = ROLE_BY_GROUP.get(c["group"], "unknown")
         c["role"] = role
+        status, basis = STATUS_BY_COMMAND.get(c["path"], (UNIFORM_STATUS, ""))
+        c["status"] = status
+        c["status_basis"] = basis
+        if status != UNIFORM_STATUS:
+            classified.append(c)
         by_role.setdefault(role, []).append(c)
         role_counts[role] = role_counts.get(role, 0) + 1
+        status_counts[status] = status_counts.get(status, 0) + 1
         group_set.add(c["group"])
     for c in gated_cmds:
         c["role"] = ROLE_BY_GROUP.get(c["group"], "unknown")
+        # Feature-gated commands stay unclassified (and excluded from default-build counts).
+        c["status"] = UNIFORM_STATUS
+        c["status_basis"] = ""
         group_set.add(c["group"])
 
     now = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
@@ -317,11 +394,15 @@ def render(leaves: list[dict], unparsed: list[str], commit: str) -> str:
     o.append("- **`role` is a curated navigation heuristic** (top-level command group -> role), "
              "**not** mechanically derived from clap and **needs review**. It says \"where might I "
              "look first\", never \"this user may safely run this\".")
-    o.append("- **`status` is uniformly `" + UNIFORM_STATUS + "`** by construction: a static clap "
-             "scan proves a command is *declared*, not whether it is `implemented` / "
-             "`implemented but partial` / `fixture-backed` / `gateway-backed` / "
-             "`docs-only / design-direction` / `planned`. Assigning those per command is a "
-             "human/runtime follow-up — so nothing here is presented as live.")
+    o.append("- **`status` is a curated, evidence-pointer classification** (issue #2113): "
+             "`live` / `partial` / `fixture-demo` / `planned`, defaulting to "
+             f"`{UNIFORM_STATUS}` for any command not explicitly classified. It is curated "
+             "from source/test evidence (a static clap scan proves a command is *declared*, "
+             "not how far its handler is implemented), so it is **never** inferred from a "
+             "declaration. `live` is asserted only with concrete-handler + (integration "
+             "test | local-only no-network) evidence and is **not** a production-readiness "
+             "claim; demo/dev-gated commands are never presented as live. See the "
+             "[Implementation status](#implementation-status-classification) section.")
     o.append("- Defer to canonical truth/precedence: [`source-of-truth-map.md`](../source-of-truth-map.md) "
              "and proof levels in [`proof-level-taxonomy-capability-matrix.md`](../proof-level-taxonomy-capability-matrix.md). "
              "Orientation artifact (`Canonical: no`); companion to [`generated/route-inventory.md`](route-inventory.md).")
@@ -337,7 +418,8 @@ def render(leaves: list[dict], unparsed: list[str], commit: str) -> str:
     o.append(f"- Top-level command groups: {len(group_set)}")
     o.append("- By role (curated, needs review): "
              + " · ".join(f"{r} {role_counts.get(r, 0)}" for r in role_order if role_counts.get(r, 0)))
-    o.append(f"- By status: every default-build command is `{UNIFORM_STATUS}` ({total}) — see note above.")
+    o.append("- By status (curated, see section below): "
+             + " · ".join(f"{s} {status_counts.get(s, 0)}" for s in STATUS_ORDER if status_counts.get(s, 0)))
     o.append(f"- Proof level: every command is `{PROOF_LEVEL}` (declaration exists in source).")
     o.append(f"- **Feature-gated commands (NOT in the default build, excluded from the counts "
              f"above): {len(gated_cmds)}** (see section below).")
@@ -357,7 +439,7 @@ def render(leaves: list[dict], unparsed: list[str], commit: str) -> str:
         o.append("| Command | Status | Proof | Source |")
         o.append("|---|---|---|---|")
         for c in cmds:
-            o.append(f"| `icnctl {md_escape(c['path'])}` | {UNIFORM_STATUS} | {PROOF_LEVEL} | "
+            o.append(f"| `icnctl {md_escape(c['path'])}` | {md_escape(c['status'])} | {PROOF_LEVEL} | "
                      f"`{c['file']}`:{c['line']} |")
         o.append("")
 
@@ -379,14 +461,62 @@ def render(leaves: list[dict], unparsed: list[str], commit: str) -> str:
         o.append("- None: every discovered command is present in the default build.")
         o.append("")
 
-    o.append("## Commands by status")
+    o.append("## Implementation status classification")
     o.append("")
-    o.append(f"All {total} default-build commands carry the conservative status "
-             f"`{UNIFORM_STATUS}`. The static clap scan cannot mechanically distinguish "
-             "`implemented` / `implemented but partial` / `fixture-backed` / `gateway-backed` / "
-             "`docs-only / design-direction` / `planned`; that per-command classification is a "
-             "human/runtime verification follow-up (so demo/dev-gated commands are never "
-             "presented here as live).")
+    o.append("Status is a **curated** classification (issue #2113), defaulting to "
+             f"`{UNIFORM_STATUS}`. It is curated from source/test evidence — a static clap "
+             "scan proves a command is *declared*, not how far its handler is implemented — "
+             "so it is never inferred from a declaration. This is a deliberately **narrow, "
+             "defensible first pass**: only commands with clear evidence are classified; the "
+             "rest stay `unknown` (honest, not a failure).")
+    o.append("")
+    o.append("### Vocabulary")
+    o.append("")
+    o.append("- **`live`** — compiled in the default build, calls a concrete client/runtime "
+             "path, and has evidence it works: an integration test that spawns the binary and "
+             "asserts success, OR a local-only operation with no network dependency. **Not** "
+             "asserted because a clap subcommand exists; **not** a production-readiness claim.")
+    o.append("- **`partial`** — the handler does real work but depends on incomplete/unproven "
+             "runtime support (e.g. a live gateway) and is not integration-tested end-to-end.")
+    o.append("- **`fixture-demo`** — a demo / fixture / rehearsal-only path, exercisable "
+             "without live network/service; must not be implied as live operational use.")
+    o.append("- **`planned`** — declared but the handler is a placeholder / TODO / prints "
+             "\"not yet implemented\" (or the feature is unavailable in the default build).")
+    o.append(f"- **`{UNIFORM_STATUS}`** — status not established from source/tests/docs in "
+             "this pass; the conservative default.")
+    o.append("")
+    o.append("### Counts by status (default build)")
+    o.append("")
+    o.append("| Status | Count |")
+    o.append("|---|---|")
+    for s in STATUS_ORDER:
+        o.append(f"| {s} | {status_counts.get(s, 0)} |")
+    o.append("")
+    o.append(f"### Classified commands ({len(classified)})")
+    o.append("")
+    o.append("Every non-`unknown` command, with its evidence basis. (All other default-build "
+             f"commands carry `{UNIFORM_STATUS}`.)")
+    o.append("")
+    if classified:
+        o.append("| Command | Status | Basis (source/test evidence) | Source |")
+        o.append("|---|---|---|---|")
+        for c in sorted(classified, key=lambda x: (STATUS_ORDER.index(x["status"]), x["path"])):
+            o.append(f"| `icnctl {md_escape(c['path'])}` | {md_escape(c['status'])} | "
+                     f"{md_escape(c['status_basis'])} | `{c['file']}`:{c['line']} |")
+        o.append("")
+    else:
+        o.append(f"- None classified yet — every command carries `{UNIFORM_STATUS}`.")
+        o.append("")
+    o.append("### Status non-claims")
+    o.append("")
+    o.append("- A command marked `live` is **not** a production-readiness claim — only that "
+             "it runs and does real work per the cited local/test evidence.")
+    o.append("- This generated static inventory is **not** runtime execution proof except "
+             "where a basis cites a test; proof level stays `L1` (declaration) regardless of status.")
+    o.append(f"- A default `{UNIFORM_STATUS}` is an honest \"not yet verified\", not a failure "
+             "or a defect.")
+    o.append("- Feature-gated commands remain **excluded** from the default-build counts and "
+             "are left unclassified.")
     o.append("")
 
     o.append("## Unparsed / unknown candidates")


### PR DESCRIPTION
## Summary

Advances **#2113** by giving the generated `icnctl` command inventory a **curated, reproducible implementation-status classification** so commands are no longer uniformly `unknown / needs local verification`. The classification lives in the generator ([`docs/scripts/icnctl_command_inventory.py`](https://github.com/InterCooperative-Network/icn/blob/main/docs/scripts/icnctl_command_inventory.py)) as a `STATUS_BY_COMMAND` map — mirroring the existing curated `ROLE_BY_GROUP` — keyed by exact command path with a concise source/test evidence basis. The clap command set, counts, and source `file:line` stay 100% mechanically derived; only the status (like role) is curated, and curated **only from source/test evidence** — never inferred from a clap declaration. This is a deliberately **narrow, defensible first pass**: most commands stay `unknown` (honest, not a failure).

This does **not** change `icnctl` behavior, add commands, change routes/auth/OpenAPI, or touch Rust — only the generator + its regenerated artifact.

## #2212 status

**Merged** (squash `f06d5b03`, on `origin/main`). This PR is the pivot off Summit Ops fixture work: committing the recap fixture would expand `web/pilot-ui` surface, which #2099 gates, so I switched to the open, claim-discipline-aligned #2113 instead.

## #2113 status before this PR

#2203 delivered the mechanically-generated, role-bucketed inventory, but every command carried the uniform `unknown / needs local verification` status — the acceptance criterion "distinguishes live / partial / fixture-demo / planned" was **unmet**. This PR begins meeting it.

## Classification vocabulary

- **`live`** — compiled in the default build, calls a concrete client/runtime path, with evidence it works: an integration test that spawns the binary and asserts success, OR a local-only operation with no network dependency. Never asserted because a clap subcommand exists; **not** a production-readiness claim.
- **`partial`** — handler does real work but depends on incomplete/unproven runtime support (e.g. a live gateway) and is not integration-tested end-to-end.
- **`fixture-demo`** — a demo / fixture / rehearsal-only path.
- **`planned`** — declared but the handler is a placeholder / prints "not yet implemented".
- **`unknown / needs local verification`** — status not established from source/tests/docs in this pass (the conservative default).

## Counts by status (default build)

| Status | Count |
|---|---|
| live | 10 |
| partial | 2 |
| planned | 7 |
| fixture-demo | 0 |
| unknown / needs local verification | 143 |

**19 of 162** default-build commands classified; 143 remain `unknown`.

## Counts by role / build visibility (unchanged from #2203)

- **Total leaf commands (default build): 162** — unchanged.
- **Feature-gated (excluded from default-build counts): 1** — `icnctl id upgrade-pq` (`cfg(feature = "post-quantum")`). Total 163. Unchanged.
- By role (curated): organizer 53 · operator 64 · developer 43 · maintainer 2 · agent 0 — unchanged.
- Source unchanged → counts unchanged; this PR adds a status dimension only.

## What was classified, what remains unknown

**live (10)** — local-only, no-network ops or commands with binary-spawning integration tests asserting success:
`completions` (clap_complete), `api export-openapi` (serializes embedded `icn_gateway::openapi::ApiDoc`), `id init`, `id show`, `backup`, `restore`, `verify-backup`, `coop entity-report`, `coop entity-backfill-surrogates`, `device add`.

**partial (2)** — real work, unproven runtime / not e2e-tested:
`audit verify` (gateway client `GET /v1/receipts/chain/{hash}`; verification algorithm covered by `audit_verify_test.rs` via an inlined copy, but the binary's gateway path is not integration-tested), `preflight` (real local checks — data-dir, keystore open via `AgeKeyStore` — plus a gateway-connectivity check).

**planned (7)** — explicit placeholders:
`charter deploy` ("Not yet implemented — charter deployment requires gateway integration"), and 6 `steward` SDIS flows (`check-vui`, `start-enrollment`, `enrollment-status`, `start-recovery`, `recovery-status`, `issue-token`) that validate input then print "placeholder … requires running steward daemon".

**fixture-demo (0)** — honest finding: `icnctl` has **no** demo-only commands; the Summit Ops demo fixtures live in `web/pilot-ui`, not the CLI. (I did not force Summit Ops into the CLI without command-source evidence.)

**unknown (143)** — gateway/runtime-dependent groups (status, gov, federation, network, trust, ledger, compute, etc.) whose end-to-end behavior I couldn't prove from source/tests in this pass. Each carries the honest default.

Every non-`unknown` command appears with its evidence basis + source `file:line` in the new **Implementation status classification** section of the artifact.

## Validation

- `python3 docs/scripts/icnctl_command_inventory.py --check` — **OK** (committed artifact == fresh scan; counts 162 default-build + 1 feature-gated, 0 unparsed).
- Anti-drift guard verified: a `STATUS_BY_COMMAND` key not matching a default-build command path raises at generation time (a renamed/removed command fails loudly, never silently drops its classification).
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — **passed** (897 docs, 65 enforcement warnings, unchanged baseline).
- `bash ops/scripts/drift-check.sh` — **PASS** (0 errors, 0 warnings).
- `python3 scripts/check-state-lag.py` — **OK**.
- `git diff --check` — clean.
- No cargo run: no Rust/Cargo files touched (generator + generated markdown only).

## Follow-ups

- Classify more of the 143 `unknown` commands (gateway-client groups: status / gov / federation / network / trust / ledger — most are likely `partial`, needing per-handler reading + runtime verification).
- Consider a CI drift gate for `icnctl_command_inventory.py --check` — `route_inventory.py` has one in `docs-freshness.yml`; the icnctl inventory currently has none (pre-existing gap; out of scope here).
- `contract deploy` does real local validation + keystore signing — a `partial` candidate not classified here pending a full handler read.

## Nonclaims

- Does not change `icnctl` behavior; does not add commands.
- Does not change route behavior, authn/authz, or OpenAPI; does not regenerate SDK types.
- A `live` status is **not** a production-readiness claim; proof level stays `L1` (declaration scan) regardless of status; the static inventory is not runtime execution proof except where a basis cites a test.
- Does not claim organizer readiness, a formal NYCN pilot, live federation, or Phase 2 completion.
- Does not sync Google; does not mutate the NYCN repo; does not commit private attendee/sponsor/accessibility/volunteer/incident/registration/payment data.
- Does not affect #2082; does not start A2e.
- `Refs #2113` only (no closing keyword): this is a narrow first pass, not full classification across all 162 commands.

Refs #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
