### PR TITLE
docs(cli): classify additional icnctl gateway command statuses

### DIFF
--- a/docs/reference/project-index/generated/icnctl-command-inventory.md
+++ b/docs/reference/project-index/generated/icnctl-command-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-26T13:27:08+00:00
+Generated: 2026-06-26T13:43:48+00:00
 ---
 
 # `icnctl` Command Inventory (generated)
@@ -19,7 +19,7 @@ Generated: 2026-06-26T13:27:08+00:00
 
 ## Snapshot
 
-- Source commit: `439d3b18053d77b6bf9a015b12bcf66d47055b09`
+- Source commit: `31c39e3ab8f8fd98ed283fc179995253adf5405c`
 - Source scanned: `icn/bins/icnctl/src/**` (clap `#[derive(Subcommand)]` / `#[derive(Parser)]` tree)
 
 ## Summary
@@ -27,7 +27,7 @@ Generated: 2026-06-26T13:27:08+00:00
 - **Total leaf commands (default build): 162**
 - Top-level command groups: 33
 - By role (curated, needs review): organizer 53 · operator 64 · developer 43 · maintainer 2
-- By status (curated, see section below): live 10 · partial 2 · planned 7 · unknown / needs local verification 143
+- By status (curated, see section below): live 10 · partial 6 · planned 7 · unknown / needs local verification 139
 - Proof level: every command is `L1` (declaration exists in source).
 - **Feature-gated commands (NOT in the default build, excluded from the counts above): 1** (see section below).
 - Unparsed / unresolved candidates: 0 (see section below).
@@ -142,7 +142,7 @@ Role is the **curated** top-level-group heuristic (needs review). `status` is a 
 | `icnctl snapshot delete` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1350 |
 | `icnctl snapshot list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1341 |
 | `icnctl snapshot verify` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1344 |
-| `icnctl status` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:51 |
+| `icnctl status` | partial | L1 | `icn/bins/icnctl/src/main.rs`:51 |
 | `icnctl steward attesters` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1458 |
 | `icnctl steward check-vui` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1496 |
 | `icnctl steward config` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1433 |
@@ -197,9 +197,9 @@ Role is the **curated** top-level-group heuristic (needs review). `status` is a 
 | `icnctl ledger quarantine list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:752 |
 | `icnctl ledger quarantine purge` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:773 |
 | `icnctl ledger quarantine release` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:761 |
-| `icnctl receipts allocation` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:299 |
-| `icnctl receipts chain` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:281 |
-| `icnctl receipts intent` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:313 |
+| `icnctl receipts allocation` | partial | L1 | `icn/bins/icnctl/src/main.rs`:299 |
+| `icnctl receipts chain` | partial | L1 | `icn/bins/icnctl/src/main.rs`:281 |
+| `icnctl receipts intent` | partial | L1 | `icn/bins/icnctl/src/main.rs`:313 |
 | `icnctl recovery attest` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:656 |
 | `icnctl recovery cancel` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:681 |
 | `icnctl recovery config` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:647 |
@@ -243,12 +243,12 @@ Status is a **curated** classification (issue #2113), defaulting to `unknown / n
 | Status | Count |
 |---|---|
 | live | 10 |
-| partial | 2 |
+| partial | 6 |
 | fixture-demo | 0 |
 | planned | 7 |
-| unknown / needs local verification | 143 |
+| unknown / needs local verification | 139 |
 
-### Classified commands (19)
+### Classified commands (23)
 
 Every non-`unknown` command, with its evidence basis. (All other default-build commands carry `unknown / needs local verification`.)
 
@@ -266,6 +266,10 @@ Every non-`unknown` command, with its evidence basis. (All other default-build c
 | `icnctl verify-backup` | live | local backup verification; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:114 |
 | `icnctl audit verify` | partial | concrete gateway client `GET /v1/receipts/chain/{hash}` (`icn/bins/icnctl/src/main.rs` AuditCommands::Verify); chain-verification algorithm covered by `icn/bins/icnctl/tests/audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested | `icn/bins/icnctl/src/main.rs`:330 |
 | `icnctl preflight` | partial | runs real local health checks (data-dir, keystore open via `AgeKeyStore`) in `handle_preflight_command`; the gateway-connectivity check requires a running gateway; not integration-tested | `icn/bins/icnctl/src/main.rs`:203 |
+| `icnctl receipts allocation` | partial | concrete gateway client `reqwest GET {gateway}/v1/receipts/allocations/{hash}` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` ReceiptCommands::Allocation); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/main.rs`:299 |
+| `icnctl receipts chain` | partial | concrete gateway client `reqwest GET {gateway}/v1/receipts/chain/{decision_hash}` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` ReceiptCommands::Chain); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/main.rs`:281 |
+| `icnctl receipts intent` | partial | concrete gateway client `reqwest GET {gateway}/v1/receipts/intents/{hash}` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` ReceiptCommands::Intent); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/main.rs`:313 |
+| `icnctl status` | partial | RPC client to the daemon (`create_rpc_client` + `client.get_status()`) in `handle_status_command` (`icn/bins/icnctl/src/main.rs` Commands::Status); prints local config and fails gracefully when no daemon; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:51 |
 | `icnctl charter deploy` | planned | handler validates the CCL doc locally, then prints "Not yet implemented — charter deployment requires gateway integration" (`icn/bins/icnctl/src/main.rs` CharterCommands::Deploy) | `icn/bins/icnctl/src/main.rs`:1718 |
 | `icnctl steward check-vui` | planned | placeholder; validates input then prints "VUI registry check requires running steward daemon" (`icn/bins/icnctl/src/main.rs` StewardCommands::CheckVui) | `icn/bins/icnctl/src/main.rs`:1496 |
 | `icnctl steward enrollment-status` | planned | placeholder; ceremony status check requires a running steward daemon (`icn/bins/icnctl/src/main.rs` StewardCommands::EnrollmentStatus) | `icn/bins/icnctl/src/main.rs`:1513 |

--- a/docs/scripts/icnctl_command_inventory.py
+++ b/docs/scripts/icnctl_command_inventory.py
@@ -142,6 +142,13 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     # partial — real work, but depends on incomplete/unproven runtime; not integration-tested end-to-end.
     "audit verify": (STATUS_PARTIAL, "concrete gateway client `GET /v1/receipts/chain/{hash}` (`icn/bins/icnctl/src/main.rs` AuditCommands::Verify); chain-verification algorithm covered by `icn/bins/icnctl/tests/audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested"),
     "preflight": (STATUS_PARTIAL, "runs real local health checks (data-dir, keystore open via `AgeKeyStore`) in `handle_preflight_command`; the gateway-connectivity check requires a running gateway; not integration-tested"),
+    # partial (pass 2, issue #2113) — `status` + `receipts` gateway/daemon-client group: each
+    # handler makes a real client call to a route present in generated/route-inventory.md, but
+    # depends on a running daemon/gateway and has no binary-spawning e2e test.
+    "status": (STATUS_PARTIAL, "RPC client to the daemon (`create_rpc_client` + `client.get_status()`) in `handle_status_command` (`icn/bins/icnctl/src/main.rs` Commands::Status); prints local config and fails gracefully when no daemon; requires a running daemon, not integration-tested"),
+    "receipts chain": (STATUS_PARTIAL, "concrete gateway client `reqwest GET {gateway}/v1/receipts/chain/{decision_hash}` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` ReceiptCommands::Chain); requires a running gateway, not integration-tested"),
+    "receipts allocation": (STATUS_PARTIAL, "concrete gateway client `reqwest GET {gateway}/v1/receipts/allocations/{hash}` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` ReceiptCommands::Allocation); requires a running gateway, not integration-tested"),
+    "receipts intent": (STATUS_PARTIAL, "concrete gateway client `reqwest GET {gateway}/v1/receipts/intents/{hash}` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` ReceiptCommands::Intent); requires a running gateway, not integration-tested"),
     # planned — handler is an explicit placeholder / prints "not yet implemented".
     "charter deploy": (STATUS_PLANNED, "handler validates the CCL doc locally, then prints \"Not yet implemented — charter deployment requires gateway integration\" (`icn/bins/icnctl/src/main.rs` CharterCommands::Deploy)"),
     "steward check-vui": (STATUS_PLANNED, "placeholder; validates input then prints \"VUI registry check requires running steward daemon\" (`icn/bins/icnctl/src/main.rs` StewardCommands::CheckVui)"),


### PR DESCRIPTION
## Summary

Second #2113 classification pass: classifies one compact gateway/daemon-client command group — **`status` (1) + `receipts` (3)** — in the curated `STATUS_BY_COMMAND` map of the inventory generator. All four were `unknown`; each is now `partial`, with a source/test evidence basis. Generator + regenerated artifact only; no `icnctl` behavior change, no Rust.

## #2213 status

**Merged** (squash `31c39e3a`, on `origin/main`). #2213 added the curated status dimension (live 10 / partial 2 / planned 7 / unknown 143). This PR builds directly on it.

## #2113 status after #2213

Still **OPEN** and stays open — #2213 classified 19 of 162 default-build commands; this PR classifies 4 more (23 total), leaving 139 `unknown`. The full acceptance criterion (all default-build commands distinguished) is not met, so no closing keyword.

## Command group inspected

`status` and the `receipts` group (`receipts chain`, `receipts allocation`, `receipts intent`) — a coherent, compact gateway/daemon-client group, the same family as the already-classified `audit verify`. Every handler was read directly:

- **`status`** → `handle_status_command` builds an RPC client to the daemon (`create_rpc_client` + `client.get_status()`), prints local config, and fails gracefully ("Daemon Connection: FAILED") when no daemon is reachable.
- **`receipts chain`** → `reqwest GET {gateway}/v1/receipts/chain/{decision_hash}` (+ optional ledger query).
- **`receipts allocation`** → `reqwest GET {gateway}/v1/receipts/allocations/{hash}`.
- **`receipts intent`** → `reqwest GET {gateway}/v1/receipts/intents/{hash}`.

All three receipts routes are present in [`generated/route-inventory.md`](https://github.com/InterCooperative-Network/icn/blob/main/docs/reference/project-index/generated/route-inventory.md), and no `icnctl` integration test spawns the binary for any of these commands.

## Counts before / after (default build, total 162)

| Status | Before (#2213) | After |
|---|---|---|
| live | 10 | 10 |
| partial | 2 | **6** |
| planned | 7 | 7 |
| fixture-demo | 0 | 0 |
| unknown / needs local verification | 143 | **139** |

Classified: 19 → **23**. Only the 4 newly-classified commands changed; role assignments, command set, counts, and feature gating (`id upgrade-pq` still excluded) are unchanged.

## Exact commands newly classified and why

All four → **`partial`**: handler performs real work (concrete daemon RPC / gateway HTTP client call to a route that exists in the route inventory) but depends on a running daemon/gateway and has **no binary-spawning or runtime e2e test**, so it is wired-but-not-proven — never `live`. This matches the basis already used for `audit verify`.

- `status` — daemon RPC client (`get_status()`), graceful on no daemon.
- `receipts chain` — gateway client, `/v1/receipts/chain/{decision_hash}`.
- `receipts allocation` — gateway client, `/v1/receipts/allocations/{hash}`.
- `receipts intent` — gateway client, `/v1/receipts/intents/{hash}`.

## Commands inspected but left unknown

None in this group — all 4 of the chosen group's commands were classifiable as `partial`. The other 139 `unknown` commands (gov, federation, network, trust, ledger, compute, etc.) are out of this narrow pass.

## Validation

- `python3 docs/scripts/icnctl_command_inventory.py --check` — **OK** (162 default-build + 1 feature-gated, 0 unparsed).
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — **passed** (897 docs, 65 enforcement warnings, unchanged baseline).
- `bash ops/scripts/drift-check.sh` — **PASS** (0/0).
- `python3 scripts/check-state-lag.py` — **OK**.
- `git diff --check` — clean.
- No cargo: no Rust/Cargo files touched (generator + generated markdown only).

## Follow-ups

- Keep classifying remaining `unknown` groups (network 4, quota 2, registry 2, then the larger gov/federation/ledger groups — most likely `partial` after per-handler reads).
- Consider a CI drift gate for `icnctl_command_inventory.py --check` (route_inventory has one in `docs-freshness.yml`; the icnctl inventory still has none — pre-existing gap, out of scope here).
- Avoid Summit Ops / pilot-UI fixture commits until #2099 is handled.

## Nonclaims

- Does not change `icnctl` behavior; does not add commands.
- Does not change route behavior, authn/authz, or OpenAPI; does not regenerate SDK types.
- A `partial`/`live` status is **not** a production-readiness claim; the static inventory is not runtime execution proof except where a basis cites a test (these four cite source + route inventory, not a passing e2e).
- Does not claim organizer readiness, a formal NYCN pilot, live federation, or Phase 2 completion.
- Does not sync Google; does not mutate the NYCN repo; does not commit private attendee/sponsor/accessibility/volunteer/incident/registration/payment data.
- Does not affect #2082; does not start A2e.
- `Refs #2113` only (no closing keyword): 139 commands remain unknown.

Refs #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
