### PR TITLE
docs(cli): classify remaining small icnctl command groups

### DIFF
--- a/docs/reference/project-index/generated/icnctl-command-inventory.md
+++ b/docs/reference/project-index/generated/icnctl-command-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-26T13:58:19+00:00
+Generated: 2026-06-26T14:07:40+00:00
 ---
 
 # `icnctl` Command Inventory (generated)
@@ -19,7 +19,7 @@ Generated: 2026-06-26T13:58:19+00:00
 
 ## Snapshot
 
-- Source commit: `300801c029480f5d6bf66d87568d929d7d1e7acf`
+- Source commit: `21314803cf6d9b254b90f39f119bff546eb3d84d`
 - Source scanned: `icn/bins/icnctl/src/**` (clap `#[derive(Subcommand)]` / `#[derive(Parser)]` tree)
 
 ## Summary
@@ -27,7 +27,7 @@ Generated: 2026-06-26T13:58:19+00:00
 - **Total leaf commands (default build): 162**
 - Top-level command groups: 33
 - By role (curated, needs review): organizer 53 · operator 64 · developer 43 · maintainer 2
-- By status (curated, see section below): live 10 · partial 14 · planned 7 · unknown / needs local verification 131
+- By status (curated, see section below): live 21 · partial 15 · planned 7 · unknown / needs local verification 119
 - Proof level: every command is `L1` (declaration exists in source).
 - **Feature-gated commands (NOT in the default build, excluded from the counts above): 1** (see section below).
 - Unparsed / unresolved candidates: 0 (see section below).
@@ -137,11 +137,11 @@ Role is the **curated** top-level-group heuristic (needs review). `status` is a 
 | `icnctl quota list` | partial | L1 | `icn/bins/icnctl/src/main.rs`:555 |
 | `icnctl quota show` | partial | L1 | `icn/bins/icnctl/src/main.rs`:544 |
 | `icnctl restore` | live | L1 | `icn/bins/icnctl/src/main.rs`:104 |
-| `icnctl snapshot cleanup` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1356 |
-| `icnctl snapshot create` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1338 |
-| `icnctl snapshot delete` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1350 |
-| `icnctl snapshot list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1341 |
-| `icnctl snapshot verify` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1344 |
+| `icnctl snapshot cleanup` | live | L1 | `icn/bins/icnctl/src/main.rs`:1356 |
+| `icnctl snapshot create` | live | L1 | `icn/bins/icnctl/src/main.rs`:1338 |
+| `icnctl snapshot delete` | live | L1 | `icn/bins/icnctl/src/main.rs`:1350 |
+| `icnctl snapshot list` | live | L1 | `icn/bins/icnctl/src/main.rs`:1341 |
+| `icnctl snapshot verify` | live | L1 | `icn/bins/icnctl/src/main.rs`:1344 |
 | `icnctl status` | partial | L1 | `icn/bins/icnctl/src/main.rs`:51 |
 | `icnctl steward attesters` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1458 |
 | `icnctl steward check-vui` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1496 |
@@ -168,7 +168,7 @@ Role is the **curated** top-level-group heuristic (needs review). `status` is a 
 | Command | Status | Proof | Source |
 |---|---|---|---|
 | `icnctl api export-openapi` | live | L1 | `icn/bins/icnctl/src/main.rs`:267 |
-| `icnctl auth token` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:410 |
+| `icnctl auth token` | partial | L1 | `icn/bins/icnctl/src/main.rs`:410 |
 | `icnctl completions` | live | L1 | `icn/bins/icnctl/src/main.rs`:214 |
 | `icnctl compute cancel` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:500 |
 | `icnctl compute status` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:494 |
@@ -181,13 +181,13 @@ Role is the **curated** top-level-group heuristic (needs review). `status` is a 
 | `icnctl contract prepare` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:786 |
 | `icnctl contract sign` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:796 |
 | `icnctl device add` | live | L1 | `icn/bins/icnctl/src/main.rs`:600 |
-| `icnctl device approve` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:614 |
-| `icnctl device list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:597 |
-| `icnctl device revoke` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:620 |
-| `icnctl id export` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:582 |
-| `icnctl id import` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:588 |
+| `icnctl device approve` | live | L1 | `icn/bins/icnctl/src/main.rs`:614 |
+| `icnctl device list` | live | L1 | `icn/bins/icnctl/src/main.rs`:597 |
+| `icnctl device revoke` | live | L1 | `icn/bins/icnctl/src/main.rs`:620 |
+| `icnctl id export` | live | L1 | `icn/bins/icnctl/src/main.rs`:582 |
+| `icnctl id import` | live | L1 | `icn/bins/icnctl/src/main.rs`:588 |
 | `icnctl id init` | live | L1 | `icn/bins/icnctl/src/main.rs`:565 |
-| `icnctl id rotate` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:571 |
+| `icnctl id rotate` | live | L1 | `icn/bins/icnctl/src/main.rs`:571 |
 | `icnctl id show` | live | L1 | `icn/bins/icnctl/src/main.rs`:568 |
 | `icnctl ledger balance` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:728 |
 | `icnctl ledger head` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:725 |
@@ -242,13 +242,13 @@ Status is a **curated** classification (issue #2113), defaulting to `unknown / n
 
 | Status | Count |
 |---|---|
-| live | 10 |
-| partial | 14 |
+| live | 21 |
+| partial | 15 |
 | fixture-demo | 0 |
 | planned | 7 |
-| unknown / needs local verification | 131 |
+| unknown / needs local verification | 119 |
 
-### Classified commands (31)
+### Classified commands (43)
 
 Every non-`unknown` command, with its evidence basis. (All other default-build commands carry `unknown / needs local verification`.)
 
@@ -260,11 +260,23 @@ Every non-`unknown` command, with its evidence basis. (All other default-build c
 | `icnctl coop entity-backfill-surrogates` | live | local coop-store surrogate backfill; integration-tested (`icn/bins/icnctl/tests/coop_entity_backfill_test.rs` asserts success) | `icn/bins/icnctl/src/main.rs`:249 |
 | `icnctl coop entity-report` | live | read-only local coop-store report; integration-tested (`icn/bins/icnctl/tests/coop_entity_report_test.rs`, `icn/bins/icnctl/tests/coop_entity_backfill_test.rs` assert success + JSON) | `icn/bins/icnctl/src/main.rs`:230 |
 | `icnctl device add` | live | local keystore device add; integration-tested (`icn/bins/icnctl/tests/qr_code_test.rs` asserts success) | `icn/bins/icnctl/src/main.rs`:600 |
+| `icnctl device approve` | live | local keystore device-approval from a request file via `AgeKeyStore` in `handle_device_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` DeviceCommands::Approve) | `icn/bins/icnctl/src/main.rs`:614 |
+| `icnctl device list` | live | local keystore device listing (`AgeKeyStore::get_did_document`/`get_device_id`) in `handle_device_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` DeviceCommands::List) | `icn/bins/icnctl/src/main.rs`:597 |
+| `icnctl device revoke` | live | local keystore device revocation via `AgeKeyStore` in `handle_device_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` DeviceCommands::Revoke) | `icn/bins/icnctl/src/main.rs`:620 |
+| `icnctl id export` | live | local passphrase-gated keystore export via `AgeKeyStore` in `handle_id_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` IdCommands::Export) | `icn/bins/icnctl/src/main.rs`:582 |
+| `icnctl id import` | live | local keystore import via `AgeKeyStore` in `handle_id_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` IdCommands::Import) | `icn/bins/icnctl/src/main.rs`:588 |
 | `icnctl id init` | live | local keystore init; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`, `icn/bins/icnctl/tests/qr_code_test.rs` spawn the binary, assert success) | `icn/bins/icnctl/src/main.rs`:565 |
+| `icnctl id rotate` | live | local keystore rotation `AgeKeyStore::rotate` in `handle_id_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` IdCommands::Rotate) | `icn/bins/icnctl/src/main.rs`:571 |
 | `icnctl id show` | live | local keystore read; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`, `icn/bins/icnctl/tests/qr_code_test.rs`) | `icn/bins/icnctl/src/main.rs`:568 |
 | `icnctl restore` | live | local data-dir restore; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:104 |
+| `icnctl snapshot cleanup` | live | local snapshot cleanup `icn_snapshot::cleanup_old_snapshots` in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Cleanup) | `icn/bins/icnctl/src/main.rs`:1356 |
+| `icnctl snapshot create` | live | local snapshot creation via `icn_snapshot` on the store dir in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Create) | `icn/bins/icnctl/src/main.rs`:1338 |
+| `icnctl snapshot delete` | live | local snapshot deletion (`std::fs::remove_file`) in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Delete) | `icn/bins/icnctl/src/main.rs`:1350 |
+| `icnctl snapshot list` | live | local snapshot listing via `icn_snapshot` in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::List) | `icn/bins/icnctl/src/main.rs`:1341 |
+| `icnctl snapshot verify` | live | local snapshot integrity check `icn_snapshot::verify_snapshot`/`verify_timestamped_snapshot` in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Verify) | `icn/bins/icnctl/src/main.rs`:1344 |
 | `icnctl verify-backup` | live | local backup verification; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:114 |
 | `icnctl audit verify` | partial | concrete gateway client `GET /v1/receipts/chain/{hash}` (`icn/bins/icnctl/src/main.rs` AuditCommands::Verify); chain-verification algorithm covered by `icn/bins/icnctl/tests/audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested | `icn/bins/icnctl/src/main.rs`:330 |
+| `icnctl auth token` | partial | gateway auth client: signs a keystore challenge then `reqwest POST {gateway}/v1/auth/challenge` + `/v1/auth/verify` (routes in `docs/reference/project-index/generated/route-inventory.md`) in `handle_auth_command` (`icn/bins/icnctl/src/main.rs` AuthCommands::Token); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/main.rs`:410 |
 | `icnctl network dial` | partial | daemon RPC client `client.dial(did, addr)` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` NetworkCommands::Dial); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:837 |
 | `icnctl network peers` | partial | daemon RPC client `client.get_peers()` via `create_rpc_client` in `handle_network_command` (`icn/bins/icnctl/src/main.rs` NetworkCommands::Peers); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:834 |
 | `icnctl network stats` | partial | daemon RPC client `client.get_stats()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` NetworkCommands::Stats); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:847 |

--- a/docs/scripts/icnctl_command_inventory.py
+++ b/docs/scripts/icnctl_command_inventory.py
@@ -139,6 +139,23 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     "device add": (STATUS_LIVE, "local keystore device add; integration-tested (`icn/bins/icnctl/tests/qr_code_test.rs` asserts success)"),
     "completions": (STATUS_LIVE, "shell-completion generation via `clap_complete::generate`; local-only, no network (`icn/bins/icnctl/src/main.rs` Commands::Completions)"),
     "api export-openapi": (STATUS_LIVE, "serializes the embedded `icn_gateway::openapi::ApiDoc` to file/stdout; local-only, no gateway (`icn/bins/icnctl/src/main.rs` ApiCommands::ExportOpenapi)"),
+    # live (pass 4, issue #2113) — local-only `id` / `device` / `snapshot` ops. Each handler
+    # (handle_id_command / handle_device_command / handle_snapshot_command) is a SYNCHRONOUS fn
+    # that receives only `data_dir` (no endpoint) and contains zero network markers
+    # (reqwest / create_rpc_client / RpcClient), so it is structurally local-only with no
+    # network dependency — the published `live` criterion. Same local keystore/snapshot
+    # machinery as the integration-tested `id init`/`id show`/`device add`.
+    "id rotate": (STATUS_LIVE, "local keystore rotation `AgeKeyStore::rotate` in `handle_id_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` IdCommands::Rotate)"),
+    "id export": (STATUS_LIVE, "local passphrase-gated keystore export via `AgeKeyStore` in `handle_id_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` IdCommands::Export)"),
+    "id import": (STATUS_LIVE, "local keystore import via `AgeKeyStore` in `handle_id_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` IdCommands::Import)"),
+    "device list": (STATUS_LIVE, "local keystore device listing (`AgeKeyStore::get_did_document`/`get_device_id`) in `handle_device_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` DeviceCommands::List)"),
+    "device approve": (STATUS_LIVE, "local keystore device-approval from a request file via `AgeKeyStore` in `handle_device_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` DeviceCommands::Approve)"),
+    "device revoke": (STATUS_LIVE, "local keystore device revocation via `AgeKeyStore` in `handle_device_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` DeviceCommands::Revoke)"),
+    "snapshot create": (STATUS_LIVE, "local snapshot creation via `icn_snapshot` on the store dir in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Create)"),
+    "snapshot list": (STATUS_LIVE, "local snapshot listing via `icn_snapshot` in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::List)"),
+    "snapshot verify": (STATUS_LIVE, "local snapshot integrity check `icn_snapshot::verify_snapshot`/`verify_timestamped_snapshot` in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Verify)"),
+    "snapshot delete": (STATUS_LIVE, "local snapshot deletion (`std::fs::remove_file`) in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Delete)"),
+    "snapshot cleanup": (STATUS_LIVE, "local snapshot cleanup `icn_snapshot::cleanup_old_snapshots` in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Cleanup)"),
     # partial — real work, but depends on incomplete/unproven runtime; not integration-tested end-to-end.
     "audit verify": (STATUS_PARTIAL, "concrete gateway client `GET /v1/receipts/chain/{hash}` (`icn/bins/icnctl/src/main.rs` AuditCommands::Verify); chain-verification algorithm covered by `icn/bins/icnctl/tests/audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested"),
     "preflight": (STATUS_PARTIAL, "runs real local health checks (data-dir, keystore open via `AgeKeyStore`) in `handle_preflight_command`; the gateway-connectivity check requires a running gateway; not integration-tested"),
@@ -161,6 +178,9 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     "quota list": (STATUS_PARTIAL, "authenticated daemon RPC `client.call(\"quota.list\", ...)` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` QuotaCommands::List); requires a running daemon, not integration-tested"),
     "registry list": (STATUS_PARTIAL, "concrete gateway client `reqwest GET {gateway}/v1/registry/decisions` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` RegistryCommands::List); requires a running gateway, not integration-tested"),
     "registry trace": (STATUS_PARTIAL, "concrete gateway client `reqwest GET {gateway}/v1/registry/decisions/{receipt_id}/trace` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` RegistryCommands::Trace); requires a running gateway, not integration-tested"),
+    # partial (pass 4, issue #2113) — `auth token` does local keystore work (open/unlock/sign)
+    # then a gateway challenge-response, so it depends on a running gateway.
+    "auth token": (STATUS_PARTIAL, "gateway auth client: signs a keystore challenge then `reqwest POST {gateway}/v1/auth/challenge` + `/v1/auth/verify` (routes in `docs/reference/project-index/generated/route-inventory.md`) in `handle_auth_command` (`icn/bins/icnctl/src/main.rs` AuthCommands::Token); requires a running gateway, not integration-tested"),
     # planned — handler is an explicit placeholder / prints "not yet implemented".
     "charter deploy": (STATUS_PLANNED, "handler validates the CCL doc locally, then prints \"Not yet implemented — charter deployment requires gateway integration\" (`icn/bins/icnctl/src/main.rs` CharterCommands::Deploy)"),
     "steward check-vui": (STATUS_PLANNED, "placeholder; validates input then prints \"VUI registry check requires running steward daemon\" (`icn/bins/icnctl/src/main.rs` StewardCommands::CheckVui)"),


### PR DESCRIPTION
## Summary

Fourth #2113 classification pass: classifies the small **`auth` (1) + `id` (3 remaining) + `device` (3 remaining) + `snapshot` (5)** groups — 12 commands — in the curated `STATUS_BY_COMMAND` map. 11 become `live` (local-only) and 1 (`auth token`) becomes `partial` (gateway client). Generator + regenerated artifact only; no `icnctl` behavior change, no Rust.

## #2215 status

**Merged** (squash `21314803`, on `origin/main`). #2215 (pass 3) classified `network` + `quota` + `registry` → partial (counts live 10 / partial 14 / planned 7 / unknown 131). This PR builds directly on it.

## #2113 status after #2215

Still **OPEN** and stays open — through #2215, 31 of 162 default-build commands were classified; this PR classifies 12 more (43 total), leaving 119 `unknown`. The full acceptance criterion (all default-build commands distinguished) is not met, so no closing keyword.

## Command groups inspected

`auth` (`token`), remaining `id` (`rotate`, `export`, `import`), remaining `device` (`list`, `approve`, `revoke`), `snapshot` (`create`, `list`, `verify`, `delete`, `cleanup`). Every handler was read directly. Key structural finding: `handle_id_command`, `handle_device_command`, and `handle_snapshot_command` are each a **synchronous `fn` taking only `data_dir` (no `endpoint`)** and contain **zero network markers** (verified: no `reqwest` / `create_rpc_client` / `RpcClient` in any of the three function bodies) → structurally local-only with no network dependency. `handle_auth_command` is async and the `Token` arm constructs a `reqwest` client to `{gateway}`.

## Counts before / after (default build, total 162)

| Status | Before (#2215) | After |
|---|---|---|
| live | 10 | **21** |
| partial | 14 | **15** |
| planned | 7 | 7 |
| fixture-demo | 0 | 0 |
| unknown / needs local verification | 131 | **119** |

Classified: 31 → **43**. Only the 12 newly-classified commands changed; role assignments, command set, counts, and feature gating (`id upgrade-pq` still excluded) are unchanged.

## Exact commands newly classified and why

**live (11)** — local-only, no network (the published `live` criterion: "a local-only operation with no network dependency", matching the merged `completions` / `api export-openapi`, and the same keystore/snapshot machinery exercised by the integration-tested `id init` / `id show` / `device add`):

- `id rotate` — `AgeKeyStore::rotate`.
- `id export` — passphrase-gated keystore export via `AgeKeyStore`.
- `id import` — keystore import via `AgeKeyStore`.
- `device list` — `AgeKeyStore::get_did_document` / `get_device_id`.
- `device approve` — local keystore device-approval from a request file.
- `device revoke` — local keystore device revocation.
- `snapshot create` / `list` / `verify` / `delete` / `cleanup` — `icn_snapshot` / `std::fs` ops on the local store dir.

**partial (1)** — gateway-dependent, no e2e test:

- `auth token` — signs a keystore challenge, then `reqwest POST {gateway}/v1/auth/challenge` + `/v1/auth/verify` (both routes present in [`generated/route-inventory.md`](https://github.com/InterCooperative-Network/icn/blob/main/docs/reference/project-index/generated/route-inventory.md)); depends on a running gateway.

## Commands inspected but left unknown

None in these four groups — all 12 were classifiable from source. The other 119 `unknown` commands (gov, federation, ledger, trust, compute, contract, commons, dispute, amendment, appeal, charter, recovery, steward-remainder, institution) are out of this narrow pass.

## Validation

- `python3 docs/scripts/icnctl_command_inventory.py --check` — **OK** (162 default-build + 1 feature-gated, 0 unparsed).
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — **passed** (897 docs, 65 enforcement warnings, unchanged baseline).
- `bash ops/scripts/drift-check.sh` — **PASS** (0/0).
- `python3 scripts/check-state-lag.py` — **OK**.
- `git diff --check` — clean.
- No cargo: no Rust/Cargo files touched (generator + generated markdown only).

## Follow-ups

- Keep classifying remaining `unknown` groups — next candidates are the larger gateway/daemon-client groups (gov 15, federation 25, ledger 8, trust 4, compute 4, contract 6, commons 6, dispute 6, amendment 8, appeal 6, charter 7-remaining, recovery 8, institution 3, steward 8-remaining) — most likely `partial`/`planned` after per-handler reads.
- Consider a CI drift gate for `icnctl_command_inventory.py --check` (route_inventory has one in `docs-freshness.yml`; the icnctl inventory still has none — pre-existing gap, out of scope here).
- Avoid Summit Ops / pilot-UI fixture commits until #2099 is handled.

## Nonclaims

- Does not change `icnctl` behavior; does not add commands.
- Does not change route behavior, authn/authz, or OpenAPI; does not regenerate SDK types.
- A `live`/`partial` status is **not** a production-readiness claim; the static inventory is not runtime execution proof except where a basis cites a test (these 12 cite source structure + route inventory, not a passing e2e — the `live` ones are local-only by handler structure, not integration-tested per command).
- Does not claim organizer readiness, a formal NYCN pilot, live federation, or Phase 2 completion.
- Does not sync Google; does not mutate the NYCN repo; does not commit private attendee/sponsor/accessibility/volunteer/incident/registration/payment data.
- Does not affect #2082; does not start A2e.
- `Refs #2113` only (no closing keyword): 119 commands remain unknown.

Refs #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
