### PR TITLE
docs(cli): classify remaining icnctl recovery and ledger statuses

### DIFF
--- a/docs/reference/project-index/generated/icnctl-command-inventory.md
+++ b/docs/reference/project-index/generated/icnctl-command-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-26T19:16:01+00:00
+Generated: 2026-06-26T19:25:52+00:00
 ---
 
 # `icnctl` Command Inventory (generated)
@@ -19,7 +19,7 @@ Generated: 2026-06-26T19:16:01+00:00
 
 ## Snapshot
 
-- Source commit: `4e9b0be4fdfd23547b11ee87478c08c35600e3df`
+- Source commit: `73cceb1c28dee9dde0d92476876e57a3c0842280`
 - Source scanned: `icn/bins/icnctl/src/**` (clap `#[derive(Subcommand)]` / `#[derive(Parser)]` tree)
 
 ## Summary
@@ -27,7 +27,7 @@ Generated: 2026-06-26T19:16:01+00:00
 - **Total leaf commands (default build): 162**
 - Top-level command groups: 33
 - By role (curated, needs review): organizer 53 · operator 64 · developer 43 · maintainer 2
-- By status (curated, see section below): live 32 · partial 59 · planned 10 · unknown / needs local verification 61
+- By status (curated, see section below): live 34 · partial 73 · planned 10 · unknown / needs local verification 45
 - Proof level: every command is `L1` (declaration exists in source).
 - **Feature-gated commands (NOT in the default build, excluded from the counts above): 1** (see section below).
 - Unparsed / unresolved candidates: 0 (see section below).
@@ -189,25 +189,25 @@ Role is the **curated** top-level-group heuristic (needs review). `status` is a 
 | `icnctl id init` | live | L1 | `icn/bins/icnctl/src/main.rs`:565 |
 | `icnctl id rotate` | live | L1 | `icn/bins/icnctl/src/main.rs`:571 |
 | `icnctl id show` | live | L1 | `icn/bins/icnctl/src/main.rs`:568 |
-| `icnctl ledger balance` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:728 |
-| `icnctl ledger head` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:725 |
-| `icnctl ledger history` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:738 |
-| `icnctl ledger quarantine drop` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:767 |
-| `icnctl ledger quarantine get` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:755 |
-| `icnctl ledger quarantine list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:752 |
-| `icnctl ledger quarantine purge` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:773 |
-| `icnctl ledger quarantine release` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:761 |
+| `icnctl ledger balance` | partial | L1 | `icn/bins/icnctl/src/main.rs`:728 |
+| `icnctl ledger head` | partial | L1 | `icn/bins/icnctl/src/main.rs`:725 |
+| `icnctl ledger history` | partial | L1 | `icn/bins/icnctl/src/main.rs`:738 |
+| `icnctl ledger quarantine drop` | partial | L1 | `icn/bins/icnctl/src/main.rs`:767 |
+| `icnctl ledger quarantine get` | partial | L1 | `icn/bins/icnctl/src/main.rs`:755 |
+| `icnctl ledger quarantine list` | partial | L1 | `icn/bins/icnctl/src/main.rs`:752 |
+| `icnctl ledger quarantine purge` | partial | L1 | `icn/bins/icnctl/src/main.rs`:773 |
+| `icnctl ledger quarantine release` | partial | L1 | `icn/bins/icnctl/src/main.rs`:761 |
 | `icnctl receipts allocation` | partial | L1 | `icn/bins/icnctl/src/main.rs`:299 |
 | `icnctl receipts chain` | partial | L1 | `icn/bins/icnctl/src/main.rs`:281 |
 | `icnctl receipts intent` | partial | L1 | `icn/bins/icnctl/src/main.rs`:313 |
-| `icnctl recovery attest` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:656 |
-| `icnctl recovery cancel` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:681 |
-| `icnctl recovery config` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:647 |
-| `icnctl recovery finalize` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:675 |
-| `icnctl recovery initiate` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:650 |
-| `icnctl recovery list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:666 |
-| `icnctl recovery setup` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:633 |
-| `icnctl recovery status` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:669 |
+| `icnctl recovery attest` | partial | L1 | `icn/bins/icnctl/src/main.rs`:656 |
+| `icnctl recovery cancel` | partial | L1 | `icn/bins/icnctl/src/main.rs`:681 |
+| `icnctl recovery config` | live | L1 | `icn/bins/icnctl/src/main.rs`:647 |
+| `icnctl recovery finalize` | partial | L1 | `icn/bins/icnctl/src/main.rs`:675 |
+| `icnctl recovery initiate` | partial | L1 | `icn/bins/icnctl/src/main.rs`:650 |
+| `icnctl recovery list` | partial | L1 | `icn/bins/icnctl/src/main.rs`:666 |
+| `icnctl recovery setup` | live | L1 | `icn/bins/icnctl/src/main.rs`:633 |
+| `icnctl recovery status` | partial | L1 | `icn/bins/icnctl/src/main.rs`:669 |
 | `icnctl registry list` | partial | L1 | `icn/bins/icnctl/src/main.rs`:366 |
 | `icnctl registry trace` | partial | L1 | `icn/bins/icnctl/src/main.rs`:389 |
 
@@ -242,13 +242,13 @@ Status is a **curated** classification (issue #2113), defaulting to `unknown / n
 
 | Status | Count |
 |---|---|
-| live | 32 |
-| partial | 59 |
+| live | 34 |
+| partial | 73 |
 | fixture-demo | 0 |
 | planned | 10 |
-| unknown / needs local verification | 61 |
+| unknown / needs local verification | 45 |
 
-### Classified commands (101)
+### Classified commands (117)
 
 Every non-`unknown` command, with its evidence basis. (All other default-build commands carry `unknown / needs local verification`.)
 
@@ -277,6 +277,8 @@ Every non-`unknown` command, with its evidence basis. (All other default-build c
 | `icnctl id show` | live | local keystore read; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`, `icn/bins/icnctl/tests/qr_code_test.rs`) | `icn/bins/icnctl/src/main.rs`:568 |
 | `icnctl institution bootstrap plan` | live | local bootstrap plan report `build_plan_report` (sync `pub fn`, no network) (`icn/bins/icnctl/src/institution_bootstrap.rs` InstitutionCommands::Bootstrap -> InstitutionBootstrapCommands::Plan) | `icn/bins/icnctl/src/institution_bootstrap.rs`:38 |
 | `icnctl institution bootstrap validate` | live | local package validation `validate_package` (sync `pub fn`, reads the package dir, no network) (`icn/bins/icnctl/src/institution_bootstrap.rs` InstitutionCommands::Bootstrap -> InstitutionBootstrapCommands::Validate) | `icn/bins/icnctl/src/institution_bootstrap.rs`:27 |
+| `icnctl recovery config` | live | local keystore read: opens+unlocks `AgeKeyStore` and prints the DID document's recovery config; no client/network (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Config) | `icn/bins/icnctl/src/main.rs`:647 |
+| `icnctl recovery setup` | live | local keystore op: opens+unlocks `AgeKeyStore` and writes the social-recovery config into the DID document via `update_did_document`; no client/network (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Setup) | `icn/bins/icnctl/src/main.rs`:633 |
 | `icnctl restore` | live | local data-dir restore; integration-tested (`icn/bins/icnctl/tests/backup_restore_test.rs`) | `icn/bins/icnctl/src/main.rs`:104 |
 | `icnctl snapshot cleanup` | live | local snapshot cleanup `icn_snapshot::cleanup_old_snapshots` in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Cleanup) | `icn/bins/icnctl/src/main.rs`:1356 |
 | `icnctl snapshot create` | live | local snapshot creation via `icn_snapshot` on the store dir in `handle_snapshot_command` (sync, no endpoint, no network) (`icn/bins/icnctl/src/main.rs` SnapshotCommands::Create) | `icn/bins/icnctl/src/main.rs`:1338 |
@@ -322,6 +324,14 @@ Every non-`unknown` command, with its evidence basis. (All other default-build c
 | `icnctl dispute list` | partial | daemon RPC `client.dispute_list()` (`icn/bins/icnctl/src/main.rs` DisputeCommands::List); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:1377 |
 | `icnctl dispute resolve` | partial | daemon RPC `client.dispute_resolve()` (`icn/bins/icnctl/src/main.rs` DisputeCommands::Resolve); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:1416 |
 | `icnctl institution bootstrap apply` | partial | async `apply_package` posts the package to the gateway via `reqwest::Client` (`icn/bins/icnctl/src/institution_bootstrap.rs` InstitutionCommands::Bootstrap -> InstitutionBootstrapCommands::Apply); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/institution_bootstrap.rs`:49 |
+| `icnctl ledger balance` | partial | daemon RPC client `client.get_ledger_balance()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Balance); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:728 |
+| `icnctl ledger head` | partial | daemon RPC client `client.get_ledger_head()` via `create_rpc_client` in `handle_ledger_command` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Head); "Is icnd running?"; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:725 |
+| `icnctl ledger history` | partial | daemon RPC client `client.get_ledger_history()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::History); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:738 |
+| `icnctl ledger quarantine drop` | partial | daemon RPC client `client.quarantine_drop()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::Drop); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:767 |
+| `icnctl ledger quarantine get` | partial | daemon RPC client `client.quarantine_get()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::Get); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:755 |
+| `icnctl ledger quarantine list` | partial | daemon RPC client `client.quarantine_list()` via `create_rpc_client` in `handle_quarantine_command` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::List); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:752 |
+| `icnctl ledger quarantine purge` | partial | daemon RPC client `client.quarantine_purge()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::Purge); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:773 |
+| `icnctl ledger quarantine release` | partial | daemon RPC client `client.quarantine_release()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::Release); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:761 |
 | `icnctl network dial` | partial | daemon RPC client `client.dial(did, addr)` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` NetworkCommands::Dial); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:837 |
 | `icnctl network peers` | partial | daemon RPC client `client.get_peers()` via `create_rpc_client` in `handle_network_command` (`icn/bins/icnctl/src/main.rs` NetworkCommands::Peers); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:834 |
 | `icnctl network stats` | partial | daemon RPC client `client.get_stats()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` NetworkCommands::Stats); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:847 |
@@ -332,6 +342,12 @@ Every non-`unknown` command, with its evidence basis. (All other default-build c
 | `icnctl receipts allocation` | partial | concrete gateway client `reqwest GET {gateway}/v1/receipts/allocations/{hash}` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` ReceiptCommands::Allocation); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/main.rs`:299 |
 | `icnctl receipts chain` | partial | concrete gateway client `reqwest GET {gateway}/v1/receipts/chain/{decision_hash}` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` ReceiptCommands::Chain); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/main.rs`:281 |
 | `icnctl receipts intent` | partial | concrete gateway client `reqwest GET {gateway}/v1/receipts/intents/{hash}` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` ReceiptCommands::Intent); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/main.rs`:313 |
+| `icnctl recovery attest` | partial | authenticated daemon RPC `client.attest_recovery()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Attest); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:656 |
+| `icnctl recovery cancel` | partial | authenticated daemon RPC `client.cancel_recovery()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Cancel); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:681 |
+| `icnctl recovery finalize` | partial | authenticated daemon RPC `client.finalize_recovery()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Finalize); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:675 |
+| `icnctl recovery initiate` | partial | authenticated daemon RPC `client.initiate_recovery()` via `create_authenticated_rpc_client` in `handle_recovery_command` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Initiate); "Is icnd running?"; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:650 |
+| `icnctl recovery list` | partial | authenticated daemon RPC `client.list_recoveries()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::List); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:666 |
+| `icnctl recovery status` | partial | authenticated daemon RPC `client.get_recovery_status()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Status); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:669 |
 | `icnctl registry list` | partial | concrete gateway client `reqwest GET {gateway}/v1/registry/decisions` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` RegistryCommands::List); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/main.rs`:366 |
 | `icnctl registry trace` | partial | concrete gateway client `reqwest GET {gateway}/v1/registry/decisions/{receipt_id}/trace` (route in `docs/reference/project-index/generated/route-inventory.md`) (`icn/bins/icnctl/src/main.rs` RegistryCommands::Trace); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/main.rs`:389 |
 | `icnctl status` | partial | RPC client to the daemon (`create_rpc_client` + `client.get_status()`) in `handle_status_command` (`icn/bins/icnctl/src/main.rs` Commands::Status); prints local config and fails gracefully when no daemon; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:51 |

--- a/docs/scripts/icnctl_command_inventory.py
+++ b/docs/scripts/icnctl_command_inventory.py
@@ -267,7 +267,10 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     # partial (pass 9, issue #2113) — `recovery` storage-based ops + the whole `ledger` group are
     # daemon RPC clients: each arm calls a real `client.*().await` (via create_authenticated_rpc_client
     # / create_rpc_client) that fails with "Is icnd running?" — real work, but requires a running
-    # daemon and has no binary-spawning e2e test (icnctl tests cover only i18n keys / backup-restore).
+    # daemon. No icnctl test spawns a daemon, so none of these recovery/ledger RPC arms has a
+    # binary-spawning e2e test: the binary-spawning tests drive other commands (backup/restore,
+    # coop entity-report/backfill, qr/device-pairing), audit_verify_test builds typed payloads, and
+    # i18n_test only asserts `cli.ledger.*` translation keys — none invokes a recovery/ledger RPC.
     "recovery initiate": (STATUS_PARTIAL, "authenticated daemon RPC `client.initiate_recovery()` via `create_authenticated_rpc_client` in `handle_recovery_command` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Initiate); \"Is icnd running?\"; requires a running daemon, not integration-tested"),
     "recovery attest": (STATUS_PARTIAL, "authenticated daemon RPC `client.attest_recovery()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Attest); requires a running daemon, not integration-tested"),
     "recovery list": (STATUS_PARTIAL, "authenticated daemon RPC `client.list_recoveries()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::List); requires a running daemon, not integration-tested"),

--- a/docs/scripts/icnctl_command_inventory.py
+++ b/docs/scripts/icnctl_command_inventory.py
@@ -177,6 +177,11 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     "charter inspect": (STATUS_LIVE, "local CCL parse+print `icn_ccl::schema::CclDocument::from_yaml`; no client/network (`icn/bins/icnctl/src/main.rs` CharterCommands::Inspect)"),
     "steward config": (STATUS_LIVE, "local read+print of the `[steward]` section of `data_dir/config.toml`; no client/network (`icn/bins/icnctl/src/main.rs` StewardCommands::Config)"),
     "steward topics": (STATUS_LIVE, "prints static steward gossip-topic constants (`icn_steward::topics::*`); local-only, no network (`icn/bins/icnctl/src/main.rs` StewardCommands::Topics)"),
+    # live (pass 9, issue #2113) — local-only `recovery` keystore ops. `setup`/`config` open+unlock
+    # the local `AgeKeyStore` and read/update the DID document's recovery config; no client/network
+    # (the handler itself comments "Setup and Config are local-only operations").
+    "recovery setup": (STATUS_LIVE, "local keystore op: opens+unlocks `AgeKeyStore` and writes the social-recovery config into the DID document via `update_did_document`; no client/network (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Setup)"),
+    "recovery config": (STATUS_LIVE, "local keystore read: opens+unlocks `AgeKeyStore` and prints the DID document's recovery config; no client/network (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Config)"),
     # partial — real work, but depends on incomplete/unproven runtime; not integration-tested end-to-end.
     "audit verify": (STATUS_PARTIAL, "concrete gateway client `GET /v1/receipts/chain/{hash}` (`icn/bins/icnctl/src/main.rs` AuditCommands::Verify); chain-verification algorithm covered by `icn/bins/icnctl/tests/audit_verify_test.rs` (inlined copy); end-to-end against a live gateway not integration-tested"),
     "preflight": (STATUS_PARTIAL, "runs real local health checks (data-dir, keystore open via `AgeKeyStore`) in `handle_preflight_command`; the gateway-connectivity check requires a running gateway; not integration-tested"),
@@ -259,6 +264,24 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     "steward attesters": (STATUS_PARTIAL, "gateway client `reqwest GET {gateway}/v1/steward/attesters` (route in route-inventory) (`icn/bins/icnctl/src/main.rs` StewardCommands::Attesters); requires a running gateway, not integration-tested"),
     "steward register": (STATUS_PARTIAL, "gateway client `reqwest POST {gateway}/v1/steward` (route in route-inventory) (`icn/bins/icnctl/src/main.rs` StewardCommands::Register); requires a running gateway, not integration-tested"),
     "steward retire": (STATUS_PARTIAL, "gateway client `reqwest POST {gateway}/v1/steward/{id}/retire` (route in route-inventory) (`icn/bins/icnctl/src/main.rs` StewardCommands::Retire); requires a running gateway, not integration-tested"),
+    # partial (pass 9, issue #2113) — `recovery` storage-based ops + the whole `ledger` group are
+    # daemon RPC clients: each arm calls a real `client.*().await` (via create_authenticated_rpc_client
+    # / create_rpc_client) that fails with "Is icnd running?" — real work, but requires a running
+    # daemon and has no binary-spawning e2e test (icnctl tests cover only i18n keys / backup-restore).
+    "recovery initiate": (STATUS_PARTIAL, "authenticated daemon RPC `client.initiate_recovery()` via `create_authenticated_rpc_client` in `handle_recovery_command` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Initiate); \"Is icnd running?\"; requires a running daemon, not integration-tested"),
+    "recovery attest": (STATUS_PARTIAL, "authenticated daemon RPC `client.attest_recovery()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Attest); requires a running daemon, not integration-tested"),
+    "recovery list": (STATUS_PARTIAL, "authenticated daemon RPC `client.list_recoveries()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::List); requires a running daemon, not integration-tested"),
+    "recovery status": (STATUS_PARTIAL, "authenticated daemon RPC `client.get_recovery_status()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Status); requires a running daemon, not integration-tested"),
+    "recovery finalize": (STATUS_PARTIAL, "authenticated daemon RPC `client.finalize_recovery()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Finalize); requires a running daemon, not integration-tested"),
+    "recovery cancel": (STATUS_PARTIAL, "authenticated daemon RPC `client.cancel_recovery()` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` RecoveryCommands::Cancel); requires a running daemon, not integration-tested"),
+    "ledger head": (STATUS_PARTIAL, "daemon RPC client `client.get_ledger_head()` via `create_rpc_client` in `handle_ledger_command` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Head); \"Is icnd running?\"; requires a running daemon, not integration-tested"),
+    "ledger balance": (STATUS_PARTIAL, "daemon RPC client `client.get_ledger_balance()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Balance); requires a running daemon, not integration-tested"),
+    "ledger history": (STATUS_PARTIAL, "daemon RPC client `client.get_ledger_history()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::History); requires a running daemon, not integration-tested"),
+    "ledger quarantine list": (STATUS_PARTIAL, "daemon RPC client `client.quarantine_list()` via `create_rpc_client` in `handle_quarantine_command` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::List); requires a running daemon, not integration-tested"),
+    "ledger quarantine get": (STATUS_PARTIAL, "daemon RPC client `client.quarantine_get()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::Get); requires a running daemon, not integration-tested"),
+    "ledger quarantine release": (STATUS_PARTIAL, "daemon RPC client `client.quarantine_release()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::Release); requires a running daemon, not integration-tested"),
+    "ledger quarantine drop": (STATUS_PARTIAL, "daemon RPC client `client.quarantine_drop()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::Drop); requires a running daemon, not integration-tested"),
+    "ledger quarantine purge": (STATUS_PARTIAL, "daemon RPC client `client.quarantine_purge()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Quarantine -> QuarantineCommands::Purge); requires a running daemon, not integration-tested"),
     # planned — handler is an explicit placeholder / prints "not yet implemented".
     "charter deploy": (STATUS_PLANNED, "handler validates the CCL doc locally, then prints \"Not yet implemented — charter deployment requires gateway integration\" (`icn/bins/icnctl/src/main.rs` CharterCommands::Deploy)"),
     "steward check-vui": (STATUS_PLANNED, "placeholder; validates input then prints \"VUI registry check requires running steward daemon\" (`icn/bins/icnctl/src/main.rs` StewardCommands::CheckVui)"),


### PR DESCRIPTION
## Summary

Ninth #2113 classification pass: classifies the **remaining `recovery` (8) + `ledger` (8)** commands — 16 commands — in the curated `STATUS_BY_COMMAND` map. 2 `live` (local keystore ops), 14 `partial` (daemon-RPC clients). Generator + regenerated artifact only; no `icnctl` behavior change, no Rust.

## #2220 status

**Merged** (squash `73cceb1c`, on `origin/main`). #2220 (pass 8) classified the remaining charter/steward commands and corrected the `steward info` two-route basis (counts live 32 / partial 59 / planned 10 / unknown 61). This PR builds directly on it.

## #2113 status after #2220

Still **OPEN** and stays open — through #2220, 101 of 162 default-build commands were classified; this PR classifies 16 more (117 total), leaving 45 `unknown`. The full acceptance criterion (all default-build commands distinguished) is not met, so no closing keyword.

## Groups inspected

`recovery` (`setup`, `config`, `initiate`, `attest`, `list`, `status`, `finalize`, `cancel`) and `ledger` (`head`, `balance`, `history`, plus the nested `ledger quarantine` `list`/`get`/`release`/`drop`/`purge`). Read both handlers directly: `handle_recovery_command` (`recovery setup`/`config` are local-only keystore ops — the handler itself comments *"Setup and Config are local-only operations"* and *"Storage-based commands use RPC"*; the other six build `create_authenticated_rpc_client` and `await client.*`), and `handle_ledger_command` + `handle_quarantine_command` (every arm opens `create_rpc_client` and `await`s a `client.*()` that fails with *"Is icnd running?"*). No gateway HTTP in either group — these are daemon (icnd) RPC clients.

## Commands newly classified

**live (2)** — local-only keystore ops, no network:

- `recovery setup` — opens+unlocks `AgeKeyStore`, writes the social-recovery config into the DID document via `update_did_document` (`RecoveryCommands::Setup`).
- `recovery config` — opens+unlocks `AgeKeyStore`, prints the DID document's recovery config (`RecoveryCommands::Config`).

**partial (14)** — daemon (icnd) RPC clients (real `client.*().await`, depends on a running daemon, no binary-spawning e2e test):

- `recovery initiate` — `client.initiate_recovery()`; `recovery attest` — `client.attest_recovery()`; `recovery list` — `client.list_recoveries()`; `recovery status` — `client.get_recovery_status()`; `recovery finalize` — `client.finalize_recovery()`; `recovery cancel` — `client.cancel_recovery()` (all via `create_authenticated_rpc_client`).
- `ledger head` — `client.get_ledger_head()`; `ledger balance` — `client.get_ledger_balance()`; `ledger history` — `client.get_ledger_history()` (via `create_rpc_client`).
- `ledger quarantine list` — `client.quarantine_list()`; `ledger quarantine get` — `client.quarantine_get()`; `ledger quarantine release` — `client.quarantine_release()`; `ledger quarantine drop` — `client.quarantine_drop()`; `ledger quarantine purge` — `client.quarantine_purge()` (in `handle_quarantine_command`).

## Commands inspected but left unknown

None in these two groups — all 16 were cleanly classifiable. I checked the `icnctl` tests dir: only `i18n_test.rs` (asserts `cli.ledger.*` translation-string keys, not execution) and `backup_restore_test.rs` (runs `backup`/`restore`/`id`, not `recovery`/`ledger`) touch these names, so none has a binary-spawning e2e test that would justify `live` for the RPC arms. The other 45 `unknown` commands (gov, federation, and small leftovers) are out of this narrow pass.

## Before / after counts (default build, total 162)

| Status | Before (#2220) | After |
|---|---|---|
| live | 32 | **34** |
| partial | 59 | **73** |
| planned | 10 | 10 |
| fixture-demo | 0 | 0 |
| unknown / needs local verification | 61 | **45** |

Classified: 101 → **117**. Only the 16 newly-classified commands changed; role assignments, command set, counts, feature-gated count (1, `id upgrade-pq`), and unparsed (0) are unchanged.

## Validation

- `python3 docs/scripts/icnctl_command_inventory.py --check` — **OK** (162 default-build + 1 feature-gated, 0 unparsed).
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — **passed** (897 docs, 65 enforcement warnings, unchanged baseline).
- `bash ops/scripts/drift-check.sh` — **PASS** (0/0).
- `python3 scripts/check-state-lag.py` — **OK**.
- `git diff --check` — clean.
- No cargo: no Rust/Cargo files touched (generator + generated markdown only).

## Follow-ups

- Keep classifying remaining `unknown` groups — next candidates: the large `gov` (~15) and `federation` (~25) groups, plus any small leftovers.
- Consider a CI drift gate for `icnctl_command_inventory.py --check` (route_inventory has one in `docs-freshness.yml`; the icnctl inventory still has none — pre-existing gap, out of scope here).
- Avoid Summit Ops / pilot-UI fixture commits until #2099 is handled.

## Nonclaims

- Does not change `icnctl` behavior; does not add commands.
- Does not change route behavior; does not change authn/authz; does not change OpenAPI; does not regenerate SDK types; no gateway/Rust change.
- A `partial` or `live` status is **not** production-readiness. Static inventory is **not** runtime execution proof unless the basis cites an actual test — the 2 `live` here are local-only by handler structure; the 14 `partial` cite the RPC method + handler enum variant, not a passing e2e.
- Does not claim organizer readiness, a formal NYCN pilot, live federation, or Phase 2 completion.
- Does not sync Google; does not mutate the NYCN repo; does not commit private attendee/sponsor/accessibility/volunteer/incident/registration/payment data.
- Does not affect #2082; does not start A2e.
- #2113 remains **open** (45 unknown). `Refs #2113` only (no closing keyword).

Refs #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
