### PR TITLE
docs(cli): classify remaining icnctl command statuses

### DIFF
--- a/docs/reference/project-index/generated/icnctl-command-inventory.md
+++ b/docs/reference/project-index/generated/icnctl-command-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-26T20:17:59+00:00
+Generated: 2026-06-26T20:30:42+00:00
 ---
 
 # `icnctl` Command Inventory (generated)
@@ -19,7 +19,7 @@ Generated: 2026-06-26T20:17:59+00:00
 
 ## Snapshot
 
-- Source commit: `a3cdd5ac46917504962209af17f117909542df2e`
+- Source commit: `791af47ea51abb0e29dbfa0643d67b5507689a11`
 - Source scanned: `icn/bins/icnctl/src/**` (clap `#[derive(Subcommand)]` / `#[derive(Parser)]` tree)
 
 ## Summary
@@ -27,7 +27,7 @@ Generated: 2026-06-26T20:17:59+00:00
 - **Total leaf commands (default build): 162**
 - Top-level command groups: 33
 - By role (curated, needs review): organizer 53 · operator 64 · developer 43 · maintainer 2
-- By status (curated, see section below): live 38 · partial 103 · planned 13 · unknown / needs local verification 8
+- By status (curated, see section below): live 38 · partial 107 · planned 13 · unknown / needs local verification 4
 - Proof level: every command is `L1` (declaration exists in source).
 - **Feature-gated commands (NOT in the default build, excluded from the counts above): 1** (see section below).
 - Unparsed / unresolved candidates: 0 (see section below).
@@ -129,10 +129,10 @@ Role is the **curated** top-level-group heuristic (needs review). `status` is a 
 | `icnctl network peers` | partial | L1 | `icn/bins/icnctl/src/main.rs`:834 |
 | `icnctl network stats` | partial | L1 | `icn/bins/icnctl/src/main.rs`:847 |
 | `icnctl network status` | partial | L1 | `icn/bins/icnctl/src/main.rs`:850 |
-| `icnctl policy list` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:531 |
-| `icnctl policy remove` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:534 |
-| `icnctl policy set` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:513 |
-| `icnctl policy show` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:524 |
+| `icnctl policy list` | partial | L1 | `icn/bins/icnctl/src/main.rs`:531 |
+| `icnctl policy remove` | partial | L1 | `icn/bins/icnctl/src/main.rs`:534 |
+| `icnctl policy set` | partial | L1 | `icn/bins/icnctl/src/main.rs`:513 |
+| `icnctl policy show` | partial | L1 | `icn/bins/icnctl/src/main.rs`:524 |
 | `icnctl preflight` | partial | L1 | `icn/bins/icnctl/src/main.rs`:203 |
 | `icnctl quota list` | partial | L1 | `icn/bins/icnctl/src/main.rs`:555 |
 | `icnctl quota show` | partial | L1 | `icn/bins/icnctl/src/main.rs`:544 |
@@ -243,12 +243,12 @@ Status is a **curated** classification (issue #2113), defaulting to `unknown / n
 | Status | Count |
 |---|---|
 | live | 38 |
-| partial | 103 |
+| partial | 107 |
 | fixture-demo | 0 |
 | planned | 13 |
-| unknown / needs local verification | 8 |
+| unknown / needs local verification | 4 |
 
-### Classified commands (154)
+### Classified commands (158)
 
 Every non-`unknown` command, with its evidence basis. (All other default-build commands carry `unknown / needs local verification`.)
 
@@ -370,6 +370,10 @@ Every non-`unknown` command, with its evidence basis. (All other default-build c
 | `icnctl network peers` | partial | daemon RPC client `client.get_peers()` via `create_rpc_client` in `handle_network_command` (`icn/bins/icnctl/src/main.rs` NetworkCommands::Peers); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:834 |
 | `icnctl network stats` | partial | daemon RPC client `client.get_stats()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` NetworkCommands::Stats); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:847 |
 | `icnctl network status` | partial | daemon RPC client `client.get_status()` then optionally `client.get_nat_status()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` NetworkCommands::Status); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:850 |
+| `icnctl policy list` | partial | daemon RPC `client.call("policy.list")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` PolicyCommands::List); method registered server.rs:774; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:531 |
+| `icnctl policy remove` | partial | daemon RPC `client.call("policy.remove")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` PolicyCommands::Remove); method registered server.rs:777; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:534 |
+| `icnctl policy set` | partial | daemon RPC `client.call("policy.set")` via `create_authenticated_rpc_client` (reads the policy JSON file locally first) (`icn/bins/icnctl/src/main.rs` PolicyCommands::Set); method registered `icn/crates/icn-rpc/src/server.rs`:768; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:513 |
+| `icnctl policy show` | partial | daemon RPC `client.call("policy.get")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` PolicyCommands::Show); method registered server.rs:771; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:524 |
 | `icnctl preflight` | partial | runs real local health checks (data-dir, keystore open via `AgeKeyStore`) in `handle_preflight_command`; the gateway-connectivity check requires a running gateway; not integration-tested | `icn/bins/icnctl/src/main.rs`:203 |
 | `icnctl quota list` | partial | authenticated daemon RPC `client.call("quota.list", ...)` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` QuotaCommands::List); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:555 |
 | `icnctl quota show` | partial | authenticated daemon RPC `client.call("quota.usage", ...)` via `create_authenticated_rpc_client` in `handle_quota_command` (`icn/bins/icnctl/src/main.rs` QuotaCommands::Show); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:544 |

--- a/docs/scripts/icnctl_command_inventory.py
+++ b/docs/scripts/icnctl_command_inventory.py
@@ -348,6 +348,26 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     # planned (pass 11, issue #2113) — `federation clearing rate` makes NO client call: it prints the rate
     # back plus a note, with the in-source comment "Rate updates are not yet implemented via RPC".
     "federation clearing rate": (STATUS_PLANNED, "no client call — prints \"Exchange rate noted...\" + a note; in-source comment \"Rate updates are not yet implemented via RPC\" (`icn/bins/icnctl/src/main.rs` ClearingCommands::Rate)"),
+    # partial (pass 12, issue #2113) — `policy` arms are daemon RPC: `handle_policy_command` builds
+    # `create_authenticated_rpc_client` then each arm `await`s `client.call("policy.*")`; every cited
+    # method is registered in the daemon dispatch `icn/crates/icn-rpc/src/server.rs` (set:768, get:771,
+    # list:774, remove:777). Daemon-dependent, no binary-spawning e2e test (no icnctl test references policy).
+    "policy set": (STATUS_PARTIAL, "daemon RPC `client.call(\"policy.set\")` via `create_authenticated_rpc_client` (reads the policy JSON file locally first) (`icn/bins/icnctl/src/main.rs` PolicyCommands::Set); method registered `icn/crates/icn-rpc/src/server.rs`:768; requires a running daemon, not integration-tested"),
+    "policy show": (STATUS_PARTIAL, "daemon RPC `client.call(\"policy.get\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` PolicyCommands::Show); method registered server.rs:771; requires a running daemon, not integration-tested"),
+    "policy list": (STATUS_PARTIAL, "daemon RPC `client.call(\"policy.list\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` PolicyCommands::List); method registered server.rs:774; requires a running daemon, not integration-tested"),
+    "policy remove": (STATUS_PARTIAL, "daemon RPC `client.call(\"policy.remove\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` PolicyCommands::Remove); method registered server.rs:777; requires a running daemon, not integration-tested"),
+    # unknown (pass 12, issue #2113) — `init-coop` is intentionally NOT classified (left unknown by
+    # omission). `handle_init_coop_command` is a hybrid local-first setup wizard: it ALWAYS does local
+    # work (create/unlock AgeKeyStore, write icn.toml, write governance_setup.json bootstrap, create
+    # SledStore trust edges), then makes a BEST-EFFORT gateway call (GET /v1/health, and POST
+    # /v1/gov/domains only if the daemon is up AND ICN_TOKEN is set), falling back to the local bootstrap
+    # file otherwise (no daemon is spawned; `--no-start` only changes printed guidance). Its end state is
+    # environment-dependent (pure-local vs live gateway domain creation), so no single static L1 status is
+    # honest — `unknown / needs local verification` pending a runtime check.
+    # unknown (pass 10, issue #2113) — `gov vote delegate/delegations/revoke` remain unknown: re-confirmed
+    # this pass that `governance.delegation.{create,list,revoke}` is still NOT registered in the daemon
+    # dispatch `icn/crates/icn-rpc/src/server.rs` (governance arms there are domain.*/proposal.*/vote.cast
+    # only) and a repo-wide search finds `governance.delegation` only in those three icnctl client calls.
     # planned — handler is an explicit placeholder / prints "not yet implemented".
     "charter deploy": (STATUS_PLANNED, "handler validates the CCL doc locally, then prints \"Not yet implemented — charter deployment requires gateway integration\" (`icn/bins/icnctl/src/main.rs` CharterCommands::Deploy)"),
     "steward check-vui": (STATUS_PLANNED, "placeholder; validates input then prints \"VUI registry check requires running steward daemon\" (`icn/bins/icnctl/src/main.rs` StewardCommands::CheckVui)"),


### PR DESCRIPTION
## Summary

Twelfth and final #2113 cleanup pass over the last unknown default-build commands: classifies the **`policy` group (4) as `partial`**, and leaves **`init-coop` + the 3 `gov vote` delegation arms `unknown`** with documented reasons. Generator + regenerated artifact only; no `icnctl` behavior change, no Rust. Drives `unknown` from 8 → **4**.

## Previous PR status

#2223 (pass 11, `federation`) **merged** (squash `791af47e`, on `origin/main`) — classified all 25 `federation` commands (4 live / 20 partial / 1 planned), 0 federation unknown. Counts after #2223: live 38 / partial 103 / planned 13 / unknown 8, classified 154/162. This PR builds directly on it.

## #2113 status before/after

Still **OPEN** and stays open. Through #2223, 154 of 162 default-build commands were classified; this PR classifies 4 more (**158 total**), leaving **4 `unknown`** (`init-coop` + `gov vote delegate/delegations/revoke`). The acceptance criterion (all default-build commands distinguished) is not fully met — 4 remain honestly `unknown` — so **no closing keyword** — `Refs #2113` only.

## Commands inspected

The 8 remaining `unknown` default-build commands: `policy set/show/list/remove`, `init-coop`, and `gov vote delegate/delegations/revoke`. Read `handle_policy_command` (main.rs:7671), `handle_init_coop_command` (main.rs:7090), the gov delegation arms (main.rs:6603–6702), `icn/crates/icn-rpc/src/server.rs` (dispatch), and `icn/bins/icnctl/tests/**`.

## Commands newly classified

**partial (4)** — `policy` group. `handle_policy_command` builds `create_authenticated_rpc_client` then each arm `await`s `client.call("policy.*")`; **every method is registered in the daemon dispatch** `icn/crates/icn-rpc/src/server.rs`. Daemon-dependent; no binary-spawning e2e test (no icnctl test references `policy`):

| Command | Client call | RPC method | Wired? |
|---|---|---|---|
| `policy set` | `client.call("policy.set")` | `policy.set` | server.rs:768 ✓ (reads policy JSON file locally first) |
| `policy show` | `client.call("policy.get")` | `policy.get` | server.rs:771 ✓ |
| `policy list` | `client.call("policy.list")` | `policy.list` | server.rs:774 ✓ |
| `policy remove` | `client.call("policy.remove")` | `policy.remove` | server.rs:777 ✓ |

## Commands inspected but left unknown (4)

**`init-coop` (1)** — `handle_init_coop_command` is a **hybrid local-first setup wizard**: it *always* does local work (create/unlock `AgeKeyStore`, write `icn.toml`, write `governance_setup.json` bootstrap, create `SledStore` trust edges), then makes a **best-effort** gateway call — `GET /v1/health`, and `POST /v1/gov/domains` *only if the daemon is up AND `ICN_TOKEN` is set* — falling back to the local bootstrap file otherwise. No daemon is spawned (`--no-start` only changes printed guidance). Its end state is **environment-dependent** (pure-local bootstrap vs live gateway-created governance domain), so no single static L1 status is honest. Left **`unknown / needs local verification`** by omission, with a `NOTE` in the generator recording the reasoning.

**`gov vote delegate`, `gov vote delegations`, `gov vote revoke` (3)** — **re-confirmed this pass** that `governance.delegation.{create,list,revoke}` is **still not registered** in the daemon dispatch: `icn/crates/icn-rpc/src/server.rs` governance arms remain `domain.*` / `proposal.*` / `vote.cast` only (lines 686–746), and a repo-wide search for `governance.delegation` finds it **only in the three icnctl client calls** (`main.rs`:6627/6642/6698; the rest are unrelated `icn_governance_delegation_*` metric names). Against a running daemon these return method-not-found, so they are not `partial`. The generator's validator only accepts the four positive statuses, so `unknown` is expressed by omission; a `NOTE` records the re-confirmation. (No Rust/server change made — this is a docs-only lane.)

## Before / after counts (default build, total 162)

| Status | Before (#2223) | After |
|---|---|---|
| live | 38 | 38 |
| partial | 103 | **107** |
| planned | 13 | 13 |
| fixture-demo | 0 | 0 |
| unknown / needs local verification | 8 | **4** |

Classified: 154 → **158**. Only the 4 newly-classified `policy` commands changed; role assignments, command set, feature-gated count (1, `id upgrade-pq`), and unparsed (0) are unchanged.

## Remaining unknown count

**4** — `init-coop` (environment-dependent hybrid) and `gov vote delegate/delegations/revoke` (`governance.delegation.*` unwired). Both are honest `unknown`s that need a runtime check or a server-side wiring change to resolve, not further static classification.

## Evidence basis (incl. server-side wiring checks)

- `handle_policy_command` (main.rs:7671) — all 4 arms `client.call("policy.{set,get,list,remove}")`; **verified registered** in `icn/crates/icn-rpc/src/server.rs`:768/771/774/777.
- `handle_init_coop_command` (main.rs:7090–7470) — local keystore/config/store/bootstrap + best-effort `reqwest GET /v1/health` and `POST /v1/gov/domains` (gated on daemon-up + `ICN_TOKEN`); no daemon spawn.
- gov delegation: `server.rs` governance dispatch (686–746) has no `governance.delegation.*` arm; `grep -rn governance.delegation` (minus metric names) → only `main.rs`:6627/6642/6698.
- e2e: `grep -ri 'policy\|init.?coop' icn/bins/icnctl/tests/` → no matches; no binary-spawning e2e for any of these.

## Validation

- `python3 docs/scripts/icnctl_command_inventory.py --check` — **OK** (162 default-build + 1 feature-gated, 0 unparsed).
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — **passed** (897 docs, 65 enforcement warnings, unchanged baseline).
- `bash ops/scripts/drift-check.sh` — **PASS** (0/0).
- `python3 scripts/check-state-lag.py` — **OK**.
- `git diff --check` — clean.
- No cargo: no Rust/Cargo files touched (generator + generated markdown only).

## Follow-ups

- The 4 remaining `unknown`s need non-static resolution: a runtime check to characterize `init-coop`'s two modes, and (for the 3 `gov vote` delegation arms) either a daemon-side `governance.delegation.*` registration or an explicit CLI placeholder — both out of scope for this docs-only lane.
- Consider a CI drift gate for `icnctl_command_inventory.py --check` (route_inventory has one in `docs-freshness.yml`; the icnctl inventory still has none — pre-existing gap, out of scope here).
- Avoid Summit Ops / pilot-UI fixture commits until #2099 is handled.

## Nonclaims

- No `icnctl` behavior change; no command added or renamed.
- No route/auth/OpenAPI/SDK/gateway/Rust behavior change; no SDK regen. (The gov delegation re-confirmation is read-only; no server wiring was added.)
- Static inventory proof remains **L1** — a static clap scan proves a command is *declared*, not how far its handler runs. The 4 `partial` cite the RPC method with its `server.rs` registration line, not a passing e2e.
- A `live` or `partial` status is **not** production readiness.
- Does not claim organizer readiness.
- Does not claim a formal NYCN pilot readiness.
- Does not claim live federation.
- Does not claim Phase 2 completion.
- Does not affect #2082.
- Does not address #2099; pilot-UI / Summit Ops fixture expansion remains gated by #2099.

Refs #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
