### PR TITLE
docs(status): extract meaning-firewall claim boundaries

### DIFF
--- a/docs/reference/project-index/README.md
+++ b/docs/reference/project-index/README.md
@@ -31,6 +31,7 @@ ICN already has several truth- and freshness-tracking systems. **This index does
 |---|---|
 | Which source wins when two disagree? (precedence, status labels, overclaim guardrails) | [`source-of-truth-map.md`](source-of-truth-map.md) |
 | How strong is the proof behind a claim? (L0–L8 ladder) | [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md) |
+| Is a claim outrunning its evidence? (two firewalls, forbidden collapses, inventory/PR claim discipline) | [`claim-boundaries.md`](claim-boundaries.md) |
 | What truth-class / canonical status does a doc carry? | [`docs/registry.toml`](../../registry.toml) + [`docs-control-map.md`](docs-control-map.md) (checked by `docs/scripts/doc_control_check.py`) |
 | How complete is a subsystem's implementation? | [`docs/status.toml`](../../status.toml) |
 | Is an `ARCHITECTURE.md` section stale? | [`docs/freshness.toml`](../../freshness.toml) (checked by `docs/scripts/freshness-check.py`; broader SME re-review tracked in [#2047](https://github.com/InterCooperative-Network/icn/issues/2047)) |
@@ -75,6 +76,7 @@ ICN already has several truth- and freshness-tracking systems. **This index does
 | [`show-readiness-map.md`](show-readiness-map.md) | What can be shown now, what should not be shown as finished, the suggested demo narrative, and red lines. |
 | [`project-coverage-matrix.md`](project-coverage-matrix.md) | Coverage-style matrix: subsystem → anchors → drift and show risks. |
 | [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md) | Proof-level taxonomy (L0–L8) as shared claim-boundary vocabulary, plus a capability matrix for the current organizer-rehearsal path. Supports #1746, narrows #1796. |
+| [`claim-boundaries.md`](claim-boundaries.md) | Operational claim-boundary manual: the two firewalls (architectural vs claim-discipline), source precedence, status-vs-proof, forbidden collapses, and the inventory/PR claim-discipline checklist. Orientation, not a truth root. |
 | [`invariants-catalog.md`](invariants-catalog.md) | Source-linked index of the four canonical invariant families (operational / firewall-contract / frozen-core / regulatory, 28 total). Index only; canonical sources remain authoritative. Machine-readable: [`invariants-catalog.toml`](invariants-catalog.toml). |
 | [`identity-crypto-map.md`](identity-crypto-map.md) | Identity, keys, DIDs, signing — where code and docs live. |
 | [`network-gossip-map.md`](network-gossip-map.md) | QUIC, gossip, discovery — runtime surfaces and overclaim guardrails. |

--- a/docs/reference/project-index/claim-boundaries.md
+++ b/docs/reference/project-index/claim-boundaries.md
@@ -21,7 +21,7 @@ ICN uses "Meaning Firewall" for an **architectural** boundary. The **claim-bound
 | Firewall | What it asserts | Where it is defined | Enforcement status |
 |---|---|---|---|
 | **Architectural Meaning Firewall** | Apps translate meaning into constraints; the kernel enforces constraints **without understanding meaning**. Kernel crates must not import/depend on domain/app crates. | [`KERNEL_APP_SEPARATION.md`](../../architecture/KERNEL_APP_SEPARATION.md), [`meaning-firewall-audit.md`](../../architecture/meaning-firewall-audit.md), onboarding [`05-the-meaning-firewall.md`](../../onboarding/path/phase-2-architecture/05-the-meaning-firewall.md) | **Tool-enforced (partial).** `scripts/check-meaning-firewall.sh` (kernel `use icn_trust::`, with known migrations #865/#866/#867) and `.github/scripts/firewall_denylist.py` (kernel→domain crate deps, #1007). Migration not complete; some couplings tracked, not yet zero. |
-| **Claim-boundary firewall** | Docs, PRs, inventories, demos, and public pages must not claim more than the evidence proves. | This map; [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md); [`show-readiness-map.md`](show-readiness-map.md); [`source-of-truth-map.md`](source-of-truth-map.md). | **Mostly convention.** Narrow tool coverage only: `compliance_linter.py` (fintech vocabulary on API surfaces), `readiness_overclaim_linter.py` (`docs/deployment` only, ~4 phrases), `doc_control_check.py` (doc truth-class front-matter), the route-inventory `--check` gate. The forbidden collapses in §5 are **not** mechanically enforced. |
+| **Claim-boundary firewall** | Docs, PRs, inventories, demos, and public pages must not claim more than the evidence proves. | This map; [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md); [`show-readiness-map.md`](show-readiness-map.md); [`source-of-truth-map.md`](source-of-truth-map.md). | **Mostly convention.** Narrow tool coverage only: `compliance_linter.py` (fintech vocabulary on API surfaces), `readiness_overclaim_linter.py` (scans `docs/deployment` + `docs/operations/deployment`; ~9 patterns across production-readiness / live-federation / blanket-operability / general-availability / governance-completion), `doc_control_check.py` (doc truth-class front-matter), the route-inventory `--check` gate. The forbidden collapses in §5 are **not** mechanically enforced. |
 
 ## 3. Source-of-truth hierarchy
 
@@ -60,11 +60,11 @@ Each row pairs a tempting overclaim with the minimum evidence that would license
 | route registered ⇒ auth/correctness/show-safe | auth gate + correctness test; accessibility/privacy review for show | handler + tests; §9 red lines | No (convention) |
 | client call exists ⇒ server/daemon method is wired | the cited RPC method is registered in daemon dispatch (or the route exists server-side) | [`icn/crates/icn-rpc/src/server.rs`](../../../icn/crates/icn-rpc/src/server.rs); `generated/route-inventory.md` | No (convention) |
 | `partial` ⇒ `live` | local-only operation, or binary-spawning e2e proof | handler; `icn/bins/icnctl/tests/**` | No (convention) |
-| `live` ⇒ production-ready | hardening: security/privacy/recovery/observability (L8) | `show-readiness-map.md`; `STATE.md` | Narrow: `readiness_overclaim_linter.py` (`docs/deployment` only) |
+| `live` ⇒ production-ready | hardening: security/privacy/recovery/observability (L8) | `show-readiness-map.md`; `STATE.md` | Narrow: `readiness_overclaim_linter.py` (deployment/ops docs only) |
 | fixture/demo data ⇒ live participant state | a live daemon/gateway run, not a committed fixture | `proof-level-taxonomy` rows 7/11/12 | No (convention) |
 | fixture-backed shell ⇒ organizer-ready rehearsal | L7 accessibility/privacy checklist **and** #1746 acceptance | `proof-level-taxonomy` §accessibility gate; #1746 | No (convention) |
 | NYCN intended partner ⇒ formal pilot | a signed agreement / committed launch | `show-readiness-map.md`; `STATE.md` | No (convention) |
-| federation commands/primitives ⇒ live federation | two cooperatives federating in production (Phase 3) | `PHASE_PROGRESS.md`; `show-readiness-map.md` | Narrow: overclaim linter catches the phrase in `docs/deployment` |
+| federation commands/primitives ⇒ live federation | two cooperatives federating in production (Phase 3) | `PHASE_PROGRESS.md`; `show-readiness-map.md` | Narrow: overclaim linter catches the "live federation" phrase, but only in the deployment/ops docs it scans |
 | local proof loop ⇒ multi-node/devnet/production | a recorded L6 devnet/K3s run | `proof-level-taxonomy` (L5 vs L6) | No (convention) |
 | website maturity band ⇒ evidence | an ADR/issue/code-path/phase link that resolves | ADR-0032 bands; ADR-0033 (**proposed**) | Editorial only; ADR-0033 linter **not built** |
 
@@ -84,6 +84,7 @@ Per [`docs/ci/GENERATED_TRUTH_DRIFT.md`](../../ci/GENERATED_TRUTH_DRIFT.md):
 - A generated artifact must state **what it proves and does not prove** (generated records prove files existed at generation time, not current truth — hierarchy rank 8).
 - **Do not hand-edit generated files.** Edit the generator and regenerate (`docs/scripts/icnctl_command_inventory.py --write`, `docs/scripts/route_inventory.py --write`).
 - Every committed generated artifact must either **have a drift check** (wired into `generated-truth.yml` / `docs-freshness.yml`) **or be explicitly declared on-demand with no committed snapshot**. A committed generated artifact with neither silently rots.
+- **Known current exception:** `generated/route-inventory.md` is drift-gated (`route_inventory.py --check` runs in `docs-freshness.yml`), but `generated/icnctl-command-inventory.md` is committed and has a `--check` script that is **not yet wired into any workflow** — so today it *can* silently rot. Wiring that gate is a tracked follow-up (see §8 of this map's PR / the lane follow-ups); until then, treat the icnctl inventory's freshness as **manually maintained**, not CI-guaranteed.
 - Generated records are orientation aids, not truth roots.
 
 ## 8. PR body / review checklist (inventory & status PRs)

--- a/docs/reference/project-index/claim-boundaries.md
+++ b/docs/reference/project-index/claim-boundaries.md
@@ -1,0 +1,126 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-06-26
+---
+
+# Claim-Boundary Map
+
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md), [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md), current source/tests, and accepted ADRs/RFCs. This map is an **operating manual**, not a truth root.
+
+## 1. Purpose
+
+This guide collects ICN's already-existing firewall, proof-level, source-precedence, and show-readiness rules into one **operational claim-boundary** reference: the rule that *a claim must not outrun its evidence*, applied to inventories, PR bodies, generated artifacts, organizer-rehearsal docs, and public language.
+
+It is **not** a canonical truth source and adds **no** new status vocabulary. It routes to the documents that already own each rule. When this map and a canonical source disagree, the canonical source wins (see §3). There is deliberately no `docs/truth/` tree — a parallel truth root is exactly what the meaning-firewall and source-precedence discipline exist to prevent (see [`README.md`](README.md) §Truth layer).
+
+## 2. Two firewalls — do not conflate
+
+ICN uses "Meaning Firewall" for an **architectural** boundary. The **claim-boundary** firewall is a separate, mostly-conventional discipline. Conflating them is itself a claim-discipline error: the architectural CI checks do **not** police claims, and the claim conventions do **not** police kernel imports.
+
+| Firewall | What it asserts | Where it is defined | Enforcement status |
+|---|---|---|---|
+| **Architectural Meaning Firewall** | Apps translate meaning into constraints; the kernel enforces constraints **without understanding meaning**. Kernel crates must not import/depend on domain/app crates. | [`KERNEL_APP_SEPARATION.md`](../../architecture/KERNEL_APP_SEPARATION.md), [`meaning-firewall-audit.md`](../../architecture/meaning-firewall-audit.md), onboarding [`05-the-meaning-firewall.md`](../../onboarding/path/phase-2-architecture/05-the-meaning-firewall.md) | **Tool-enforced (partial).** `scripts/check-meaning-firewall.sh` (kernel `use icn_trust::`, with known migrations #865/#866/#867) and `.github/scripts/firewall_denylist.py` (kernel→domain crate deps, #1007). Migration not complete; some couplings tracked, not yet zero. |
+| **Claim-boundary firewall** | Docs, PRs, inventories, demos, and public pages must not claim more than the evidence proves. | This map; [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md); [`show-readiness-map.md`](show-readiness-map.md); [`source-of-truth-map.md`](source-of-truth-map.md). | **Mostly convention.** Narrow tool coverage only: `compliance_linter.py` (fintech vocabulary on API surfaces), `readiness_overclaim_linter.py` (`docs/deployment` only, ~4 phrases), `doc_control_check.py` (doc truth-class front-matter), the route-inventory `--check` gate. The forbidden collapses in §5 are **not** mechanically enforced. |
+
+## 3. Source-of-truth hierarchy
+
+Full rules and conflict resolution: [`source-of-truth-map.md`](source-of-truth-map.md). Summary order (highest first) — **this map does not replace it**:
+
+1. Current source code and tests (test-only fixtures prove test behavior, not production readiness)
+2. `docs/STATE.md` and `docs/PHASE_PROGRESS.md`
+3. Accepted ADRs/RFCs (proposed/draft = design direction, not shipped)
+4. Recent merged PR bodies / issue-closure notes / review dispositions
+5. Runtime contracts, schemas, OpenAPI surfaces, contract docs
+6. Project-index maps (navigation; route to truth, do not override it)
+7. Architecture / strategy / design-direction docs
+8. Generated records (prove files existed at generation time, not current truth)
+9. Historical / archive material (archaeology only)
+
+## 4. Status vs proof level
+
+Two **orthogonal** axes; carry both. Detail: [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md).
+
+- **Status** answers *"is the code written, and how completely?"* (`live`/`partial`/`planned`/`fixture-demo`/`unknown`, or the `source-of-truth-map.md` implementation labels).
+- **Proof level (L0–L8)** answers *"how much verification evidence stands behind the claim?"* (`L0` named → `L1` schema/contract → `L2` unit → `L3` integration → `L4` local proof loop → `L5` live daemon/gateway → `L6` multi-node/devnet → `L7` partner/organizer rehearsal → `L8` production hardening).
+
+Load-bearing consequences:
+
+- A `live` or `partial` status is **not** a production-readiness claim.
+- A static generated inventory (clap-tree scan, route scan) is **L1** — it proves a surface is *declared*, not that its handler runs, unless stronger evidence (a test, a live run) is explicitly cited.
+
+## 5. Forbidden collapses
+
+Each row pairs a tempting overclaim with the minimum evidence that would license the stronger claim. "Enforced today?" states honestly whether tooling catches the collapse or it rests on review convention.
+
+| Unsafe collapse (do not assert) | Minimum evidence to license it | Where to verify | Enforced today? |
+|---|---|---|---|
+| declaration exists ⇒ implementation works | a test, or handler-body read showing real work | source; tests | No (convention) |
+| OpenAPI documents a path ⇒ it is mounted/complete/correct | the route is mounted in the gateway router and behaves | gateway router + handler; `generated/route-inventory.md` | No (convention) |
+| route registered ⇒ auth/correctness/show-safe | auth gate + correctness test; accessibility/privacy review for show | handler + tests; §9 red lines | No (convention) |
+| client call exists ⇒ server/daemon method is wired | the cited RPC method is registered in daemon dispatch (or the route exists server-side) | [`icn/crates/icn-rpc/src/server.rs`](../../../icn/crates/icn-rpc/src/server.rs); `generated/route-inventory.md` | No (convention) |
+| `partial` ⇒ `live` | local-only operation, or binary-spawning e2e proof | handler; `icn/bins/icnctl/tests/**` | No (convention) |
+| `live` ⇒ production-ready | hardening: security/privacy/recovery/observability (L8) | `show-readiness-map.md`; `STATE.md` | Narrow: `readiness_overclaim_linter.py` (`docs/deployment` only) |
+| fixture/demo data ⇒ live participant state | a live daemon/gateway run, not a committed fixture | `proof-level-taxonomy` rows 7/11/12 | No (convention) |
+| fixture-backed shell ⇒ organizer-ready rehearsal | L7 accessibility/privacy checklist **and** #1746 acceptance | `proof-level-taxonomy` §accessibility gate; #1746 | No (convention) |
+| NYCN intended partner ⇒ formal pilot | a signed agreement / committed launch | `show-readiness-map.md`; `STATE.md` | No (convention) |
+| federation commands/primitives ⇒ live federation | two cooperatives federating in production (Phase 3) | `PHASE_PROGRESS.md`; `show-readiness-map.md` | Narrow: overclaim linter catches the phrase in `docs/deployment` |
+| local proof loop ⇒ multi-node/devnet/production | a recorded L6 devnet/K3s run | `proof-level-taxonomy` (L5 vs L6) | No (convention) |
+| website maturity band ⇒ evidence | an ADR/issue/code-path/phase link that resolves | ADR-0032 bands; ADR-0033 (**proposed**) | Editorial only; ADR-0033 linter **not built** |
+
+## 6. Worked examples (the completed #2113 icnctl-status lane)
+
+The icnctl command-status inventory ([`generated/icnctl-command-inventory.md`](generated/icnctl-command-inventory.md), #2113) is a concrete reference implementation of §5:
+
+- **Declared ≠ implemented.** The clap-tree scan is **L1** — it proves a command is *declared*. Status is a *separate*, curated signal verified from handler source, never inferred from the declaration.
+- **#2222 (gov delegation) — client call ≠ server wiring.** `gov vote delegate/delegations/revoke` call `governance.delegation.*`, but those methods are **not registered** in [`icn-rpc/src/server.rs`](../../../icn/crates/icn-rpc/src/server.rs) and a repo-wide search finds them only in the CLI. Against a running daemon they return method-not-found, so they were **not** marked `partial` — left `unknown`.
+- **#2223 (federation) — `partial` only after a server-side check.** All 20 `partial` federation commands were classified `partial` *because* each cited `network.*`/`federation.*` RPC method was confirmed registered in `server.rs`, or the gateway route was confirmed in `route-inventory.md`. "Does not claim live federation" is on the nonclaims for exactly this reason.
+- **#2224 (final unknowns) — honest non-collapse.** `policy.*` became `partial` because the methods are registered in daemon dispatch; `init-coop` was left **`unknown`** because static review cannot honestly collapse its hybrid behavior (always-local keystore/config/bootstrap **plus** a best-effort gateway `POST /v1/gov/domains` gated on daemon-up *and* a token) into a single status.
+
+## 7. Generated artifact rules
+
+Per [`docs/ci/GENERATED_TRUTH_DRIFT.md`](../../ci/GENERATED_TRUTH_DRIFT.md):
+
+- A generated artifact must state **what it proves and does not prove** (generated records prove files existed at generation time, not current truth — hierarchy rank 8).
+- **Do not hand-edit generated files.** Edit the generator and regenerate (`docs/scripts/icnctl_command_inventory.py --write`, `docs/scripts/route_inventory.py --write`).
+- Every committed generated artifact must either **have a drift check** (wired into `generated-truth.yml` / `docs-freshness.yml`) **or be explicitly declared on-demand with no committed snapshot**. A committed generated artifact with neither silently rots.
+- Generated records are orientation aids, not truth roots.
+
+## 8. PR body / review checklist (inventory & status PRs)
+
+Reusable checklist — copy into the PR body or run it as a reviewer:
+
+- [ ] Distinguishes **mechanical discovery** (clap/route scan) from **curated status**.
+- [ ] Every `partial` cites **server-side wiring** (RPC method registered in `server.rs`) or **route registration** where relevant.
+- [ ] Every `live` cites **local-only** behavior or **binary-spawning e2e** evidence.
+- [ ] Every `planned` cites an explicit **placeholder / `bail!` / "not yet supported"** marker.
+- [ ] **Unknowns left unknown** where evidence is ambiguous (not force-fit to a positive status).
+- [ ] Uses `Refs #N` (not a closing keyword) when the issue's acceptance is not met.
+- [ ] Includes **nonclaims** for production readiness, formal pilot readiness, live federation, Phase 2 completion, and (when relevant) #2082 and #2099.
+
+## 9. Public / show-readiness language
+
+Full list and the suggested demo narrative: [`show-readiness-map.md`](show-readiness-map.md); website convention: [ADR-0032](../../adr/ADR-0032-website-truth-boundary.md) (accepted; maturity bands `strong`/`advancing`/`maturing`/`behind`/`not-yet`). Red lines to restate briefly:
+
+- No crypto / web3 / token framing (no token, no native currency, receipts are evidentiary, not tradable).
+- No financial-product framing (use settlement / unit / identity / position / obligation / allocation; the `compliance_linter.py` enforces the vocabulary on API surfaces).
+- No NYCN commitment claim (intended first partner, not a signed/launched pilot).
+- No live-federation claim (Phase 3, not Phase 2).
+- No blanket production-readiness claim across the substrate.
+
+[ADR-0033](../../adr/ADR-0033-public-maturity-claims-and-evidence-links.md) (evidence-link requirement) is **proposed, not implemented** — do not claim evidence-link enforcement exists yet.
+
+## 10. Non-goals
+
+This map is **not**: a new canonical truth source; a replacement for `STATE.md` / `PHASE_PROGRESS.md`; a new status vocabulary; a new CI gate; a runtime behavior change; and **not** a claim that the claim-boundary rules are fully enforced (most are convention — §2, §5).
+
+## Where to read deeper
+
+| You want… | Read |
+|---|---|
+| Which source wins on conflict | [`source-of-truth-map.md`](source-of-truth-map.md) |
+| How strong the proof is (L0–L8) | [`proof-level-taxonomy-capability-matrix.md`](proof-level-taxonomy-capability-matrix.md) |
+| What is safe to show / red lines | [`show-readiness-map.md`](show-readiness-map.md) |
+| Which routes / `icnctl` commands back the rehearsal | [`organizer-rehearsal-operability-map.md`](organizer-rehearsal-operability-map.md) |
+| The architectural Meaning Firewall | [`KERNEL_APP_SEPARATION.md`](../../architecture/KERNEL_APP_SEPARATION.md) |
+| Generated-artifact drift discipline | [`docs/ci/GENERATED_TRUTH_DRIFT.md`](../../ci/GENERATED_TRUTH_DRIFT.md) |

--- a/docs/reference/project-index/organizer-rehearsal-operability-map.md
+++ b/docs/reference/project-index/organizer-rehearsal-operability-map.md
@@ -6,7 +6,7 @@ Last Reviewed: 2026-06-26
 
 # Organizer Rehearsal Operability Map
 
-> For current project truth, defer to [`docs/STATE.md`](../../STATE.md) and [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md). This map is an **orientation aid**, not a source of truth: it reads the already-merged generated evidence surfaces (route inventory, `icnctl` command inventory) and the capability matrix, and translates them into "what can safely be shown to an organizer, what is fixture-backed, what needs a steward/operator, and what must not be claimed yet." It changes no behavior and grants no readiness.
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md) and [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md). This map is an **orientation aid**, not a source of truth: it reads the already-merged generated evidence surfaces (route inventory, `icnctl` command inventory) and the capability matrix, and translates them into "what can safely be shown to an organizer, what is fixture-backed, what needs a steward/operator, and what must not be claimed yet." It changes no behavior and grants no readiness. The claim-discipline rules behind these distinctions (forbidden collapses such as wired route ≠ organizer-ready) are collected in [`claim-boundaries.md`](claim-boundaries.md).
 
 ## Purpose
 

--- a/docs/reference/project-index/proof-level-taxonomy-capability-matrix.md
+++ b/docs/reference/project-index/proof-level-taxonomy-capability-matrix.md
@@ -6,7 +6,7 @@ Last Reviewed: 2026-06-26
 
 # Proof-Level Taxonomy and Capability Matrix
 
-> For current project truth, defer to [`docs/STATE.md`](../../STATE.md) and [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md). This map adds a shared **proof-level vocabulary** and a capability matrix for the current organizer-rehearsal path. It is a claim-boundary aid, not a new source of truth.
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md) and [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md). This map adds a shared **proof-level vocabulary** and a capability matrix for the current organizer-rehearsal path. It is a claim-boundary aid, not a new source of truth. For how these proof levels feed the broader claim-discipline rules (forbidden collapses, inventory/PR checklist, two firewalls), see [`claim-boundaries.md`](claim-boundaries.md).
 
 This map exists for issue [#1796](https://github.com/InterCooperative-Network/icn/issues/1796) and directly supports the organizer-rehearsal milestone [#1746](https://github.com/InterCooperative-Network/icn/issues/1746). ICN now has many overlapping readiness states — implemented, partial, fixture-backed, local proof loop, live daemon proof, K3s/devnet proof, design-only, stale, aspirational. Without shared proof language, a contributor, facilitator, reviewer, or agent can accidentally over- or under-claim. This doc gives everyone the same words so the current demo/rehearsal state is honest, legible, and reusable.
 

--- a/docs/reference/project-index/show-readiness-map.md
+++ b/docs/reference/project-index/show-readiness-map.md
@@ -6,7 +6,7 @@ Last Reviewed: 2026-04-29
 
 # Show-Readiness Map
 
-> For current project truth, defer to [`docs/STATE.md`](../../STATE.md) and [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md). This map describes what is *show-ready* — the line between what is honest to demonstrate and what should not be presented as finished.
+> For current project truth, defer to [`docs/STATE.md`](../../STATE.md) and [`docs/PHASE_PROGRESS.md`](../../PHASE_PROGRESS.md). This map describes what is *show-ready* — the line between what is honest to demonstrate and what should not be presented as finished. For the broader claim-discipline rules these red lines sit inside, see [`claim-boundaries.md`](claim-boundaries.md).
 
 This document is the load-bearing one for outside-facing conversations. Anyone presenting ICN to organizers, cooperative developers, technically curious contributors, or grant reviewers should walk this list before the meeting.
 

--- a/docs/reference/project-index/source-of-truth-map.md
+++ b/docs/reference/project-index/source-of-truth-map.md
@@ -157,6 +157,7 @@ When in doubt, update the truth-bearing source first, then update this map.
 | File | Relationship |
 |---|---|
 | `current-truth-map.md` | Short orientation to what is real now. This file explains how to rank sources when that answer is contested. |
+| `claim-boundaries.md` | Operational claim-boundary manual. Applies this precedence hierarchy (plus the proof-level taxonomy and show-readiness red lines) to inventories, PR bodies, generated artifacts, and public language. Orientation, not a truth root. |
 | `repo-atlas.md` | Directory/subsystem placement. This file tells readers which evidence outranks which. |
 | `full-repo-record.md` | Mechanical record protocol. This file explains how to interpret records against truth-bearing sources. |
 | `stale-and-archived-map.md` | Future companion map for known stale/historical docs and preserved WIP material. |

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -2565,6 +2565,21 @@ canonical = "no"
 freshness = "current"
 domain_tags = ["project-index", "navigation", "proof-level", "rehearsal", "show-readiness"]
 recommended_action = "keep"
+
+[docs."docs/reference/project-index/claim-boundaries.md"]
+category = "reference"
+status = "living"
+title = "Claim-Boundary Map"
+description = "Operational claim-boundary manual: disambiguates the architectural Meaning Firewall from the claim-discipline firewall, summarizes source precedence and status-vs-proof, tabulates forbidden collapses with their evidence and enforcement status, and gives a reusable inventory/PR claim-discipline checklist. Orientation, not a truth root. Defers to STATE.md and PHASE_PROGRESS.md for current truth."
+last_updated = "2026-06-26"
+owner = "matt"
+audiences = ["all", "team"]
+truth_class = "descriptive"
+role = "reference"
+canonical = "no"
+freshness = "current"
+domain_tags = ["project-index", "navigation", "claim-discipline", "proof-level", "show-readiness", "meaning-firewall"]
+recommended_action = "keep"
 last_reviewed = "2026-06-26"
 
 [docs."docs/reference/project-index/invariants-catalog.md"]


### PR DESCRIPTION
## Summary

Adds **`docs/reference/project-index/claim-boundaries.md`** — a concise, routing-oriented operating manual that maps ICN's already-existing firewall / proof-level / source-precedence / show-readiness rules into one **operational claim-boundary** guide for inventories, PR bodies, generated artifacts, organizer-rehearsal docs, and public language. Plus six small cross-link edits and a registry entry. Docs-only; orientation, **not** a truth root.

## Previous PR status

#2224 (final #2113 cleanup pass) **merged** (squash `1550c44c`, on `origin/main`) — classified `policy.*` as `partial`; left `init-coop` + `gov vote delegate/delegations/revoke` honestly `unknown`. The #2113 icnctl-status lane is now at **158/162 classified** (live 38 / partial 107 / planned 13 / fixture-demo 0 / unknown 4). This PR uses that completed lane as worked evidence.

## Why this exists

ICN's claim discipline — *a claim must not outrun its evidence* — is real and load-bearing, but it lives scattered across the proof-level taxonomy, the show-readiness red lines, the source-precedence hierarchy, ADRs, and (increasingly) PR-body convention from the #2113 lane. There was no single place that (a) names the forbidden collapses, (b) says honestly which are tool-enforced vs convention, and (c) gives a reusable checklist. The most consequential finding from the read-pass: **two different things share the name "Meaning Firewall"**, and conflating them is itself a claim-discipline error — the architectural CI checks do not police claims, and the claim conventions do not police kernel imports.

## Sources read

`docs/architecture/KERNEL_APP_SEPARATION.md`, `docs/architecture/meaning-firewall-audit.md`, onboarding `05-the-meaning-firewall.md`; `proof-level-taxonomy-capability-matrix.md`, `show-readiness-map.md`, `source-of-truth-map.md`, project-index `README.md`; `ADR-0032` (accepted), `ADR-0033` (proposed), `docs/ci/GENERATED_TRUTH_DRIFT.md`; `.github/scripts/firewall_denylist.py`, `scripts/check-meaning-firewall.sh`, `.github/scripts/readiness_overclaim_linter.py`; `docs/scripts/icnctl_command_inventory.py`, `docs/scripts/route_inventory.py`, `icn/crates/icn-rpc/src/server.rs`.

## What changed

- **New:** `docs/reference/project-index/claim-boundaries.md` (`Status: descriptive`, `Canonical: no`). Sections: Purpose · Two firewalls (with enforcement-status column) · Source-of-truth hierarchy · Status vs proof level · **Forbidden collapses table** (unsafe collapse → minimum evidence → where to verify → enforced-today) · Worked examples from the #2113 lane · Generated-artifact rules · **Inventory/PR claim-discipline checklist** · Public/show-readiness red lines · Non-goals.
- **Cross-links (one line each, no rewrites):** project-index `README.md` (truth-layer table + maps table), `source-of-truth-map.md` (relationship row), `proof-level-taxonomy-capability-matrix.md`, `show-readiness-map.md`, `organizer-rehearsal-operability-map.md`.
- **Registry:** `docs/registry.toml` entry (`truth_class = descriptive`, `canonical = no`).

## What did not change

- No runtime / Rust / `icnctl` / route / auth / OpenAPI / SDK / gateway behavior.
- **Generated inventories were intentionally left untouched** — no `icnctl_command_inventory.py` / `route_inventory.py` edit and no regeneration, to keep the diff small and avoid unrelated route-inventory drift. A one-sentence generator-header link to this guide is listed as a follow-up.
- No new status vocabulary; no new CI gate; no new canonical truth root.

## Enforcement status (stated honestly in the doc)

- **Architectural Meaning Firewall — tool-enforced (partial):** `scripts/check-meaning-firewall.sh` (kernel `use icn_trust::`, migrations #865/#866/#867) and `.github/scripts/firewall_denylist.py` (kernel→domain crate deps, #1007). Migration not complete.
- **Claim-boundary firewall — mostly convention:** narrow tool coverage only — `compliance_linter.py` (fintech vocabulary on API surfaces), `readiness_overclaim_linter.py` (scans `docs/deployment` + `docs/operations/deployment`; ~9 overclaim patterns across production-readiness / live-federation / blanket-operability / general-availability / governance-completion), `doc_control_check.py` (doc truth-class), the route-inventory `--check` gate. The forbidden collapses themselves are **not** mechanically enforced. ADR-0032 is accepted (editorial bands); **ADR-0033 (evidence-link linter) is proposed, not built** — the doc says so explicitly.

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — **passed** (898 docs; 65 enforcement warnings = unchanged baseline; the new doc adds no yaml-mismatch).
- `python3 docs/scripts/icnctl_command_inventory.py --check` — **OK** (untouched).
- `python3 docs/scripts/route_inventory.py --check` — **OK** (untouched).
- `bash ops/scripts/drift-check.sh` — **PASS** (0/0).
- `python3 scripts/check-state-lag.py` — **OK**.
- `git diff --check` — clean.
- No cargo: no Rust/Cargo files touched.

## Follow-ups (not in scope here)

- A one-sentence generator-header link to `claim-boundaries.md` in `icnctl_command_inventory.py` + `route_inventory.py` (requires regen; deferred to keep this PR clean).
- A CI `--check` drift gate for `icnctl_command_inventory.py` (route inventory already has one in `docs-freshness.yml`; the icnctl inventory has none — pre-existing gap).
- Widening the `readiness_overclaim_linter` scope beyond `docs/deployment` (it is designed to ratchet — `docs/ci/GATE_RATCHET_PLAN.md`).
- Implementing ADR-0033's evidence-link linter (proposed).
- A future `claim-boundary` checklist/linter (e.g. asserting inventory `partial` rows cite server-side wiring) — automation only, separate PR.

## Nonclaims

- Docs-only; no runtime / Rust / `icnctl` / route / auth / OpenAPI / SDK / gateway behavior change.
- No new CI gate (none implemented; out of scope).
- Does not create a new canonical truth root; does not replace `STATE.md` / `PHASE_PROGRESS.md`; introduces no new status vocabulary.
- Does not claim the claim-boundary rules are fully enforced — most are convention.
- Does not claim production readiness, organizer readiness, formal NYCN pilot readiness, live federation, or Phase 2 completion.
- Does not affect #2082; does not address #2099; pilot-UI / Summit Ops fixture expansion remains gated by #2099.

Refs #2113
Refs #1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

