### PR TITLE
docs(ci): teach readiness overclaim linter nonclaim context

### DIFF
--- a/.github/scripts/readiness_overclaim_linter.py
+++ b/.github/scripts/readiness_overclaim_linter.py
@@ -188,19 +188,24 @@ NONCLAIM_SECTION_RE = re.compile(
     r")\b"
 )
 
-# Explicit line-level nonclaim framing: the whole line tells the reader NOT to
-# claim something (or negates the red-line phrase itself), so an overclaim phrase
-# inside it is being forbidden, not asserted. Catches enumerations the
-# clause-local negation guard splits apart, e.g.
-# "Must not claim: ...; that any of this is production or live federation."
-# Kept to unambiguous nonclaim objects ("claim"/"formal pilot"/"organizer-ready")
-# and direct negations of the patterns, so it cannot mask a genuine assertion.
+# Explicit line-level nonclaim FRAMING: the whole line tells the reader NOT to
+# claim something, so an overclaim phrase inside it is being forbidden, not
+# asserted. Catches enumerations the clause-local negation guard splits apart,
+# e.g. "Must not claim: ...; that any of this is production or live federation."
+#
+# Because a match exempts the WHOLE line, this is kept to unambiguous nonclaim
+# *objects* ("claim" / "formal pilot" / "organizer-ready") only. It deliberately
+# does NOT include direct readiness negations like "not production-ready" /
+# "no live federation": those are handled precisely, clause-by-clause, by
+# NEGATION_RE — putting them here would let a disclaimer in one clause silently
+# mask a separate affirmative overclaim in another clause on the same line, e.g.
+# "This is not production-ready; ICN is generally available." (see the regression
+# test test_disclaimer_does_not_mask_separate_overclaim).
 NONCLAIM_LINE_RE = re.compile(
     r"(?i)("
     r"do(?:es)? not claim|must not (?:be )?claim(?:ed)?|cannot claim|never claim|"
     r"must not be (?:presented|shown)|should not be (?:claimed|presented|shown)|"
-    r"not (?:a )?formal pilot|no formal pilot|not organi[sz]er-ready|"
-    r"not production-ready|not ready for production|not live federation|no live federation"
+    r"not (?:a )?formal pilot|no formal pilot|not organi[sz]er-ready"
     r")"
 )
 

--- a/.github/scripts/readiness_overclaim_linter.py
+++ b/.github/scripts/readiness_overclaim_linter.py
@@ -44,12 +44,19 @@ from typing import List
 # docs/pilots (organizer-/partner-facing, claim-sensitive; measured low-noise —
 # 10 files, 1 bounded ALLOWLIST exception).
 #
-# NOT yet added (measured high-noise: claim-sensitive docs that *enumerate* the
-# red-line phrases as nonclaim / "does not claim" lists, FAQ questions, and
-# roadmap targets — false positives the line-local negation guard can't see).
-# Adding them needs a precision step first (nonclaim-list / question /
-# disclaimer-word handling). Tracked as a follow-up in GATE_RATCHET_PLAN.md:
-#   docs/reference/project-index, docs/demo, docs/strategy
+# NOT yet added. The nonclaim-context precision below (red-line/nonclaim section
+# headings, explicit "does not claim ..." lines, FAQ questions, "nothing/none"
+# disclaimers) was added 2026-06-26 and cut the measured noise substantially, but
+# these roots are still not clean enough to add without warnings:
+#   docs/reference/project-index : 18 -> 6 violations  (still deferred)
+#   docs/demo                    : 6  -> 4 violations
+#   docs/strategy                : 5  -> 4 violations
+# The residual hits are a different FP class (caveat-prefixed claims like
+# "Unsafe ...: <phrase>", quoted avoid-lists like `"production-ready"`, risk-column
+# table cells naming an overclaim, and checklist items describing nonclaims) that
+# narrow phrase rules can't suppress without risking real-claim masking. Adding a
+# root is a future ratchet step once its residual is bounded — see
+# docs/ci/GATE_RATCHET_PLAN.md.
 # ---------------------------------------------------------------------------
 SCAN_DIRS = [
     "docs/deployment",
@@ -84,12 +91,16 @@ OVERCLAIM_PATTERNS = [
 # in doubt we do NOT flag, because the repo deliberately uses many such non-claims.
 NEGATION_RE = re.compile(
     r"(?i)("
-    r"\bnot\b|n't|\bno\b|\bnever\b|not yet|\bwould\b|\bif\b|\bonce\b|\bwhen\b|"
+    r"\bnot\b|n't|\bno\b|\bnone\b|\bnothing\b|\bnever\b|not yet|\bwould\b|\bif\b|\bonce\b|\bwhen\b|"
     r"\btarget\b|\bgoal\b|aspir|roadmap|\bfuture\b|do not|don't|must not|\bavoid\b|"
     r"forbidden|prerequisite|before production|in a production deployment|in production:|"
     r"\U0001F7E1"  # yellow-circle status marker used for "assessed, not production-ready"
     r")"
 )
+# NOTE: the bare word "without" is deliberately NOT a negation here — it is too
+# broad (it would wrongly exempt a real claim like "production-ready without
+# caveats"). "nothing"/"none" are safe: a genuine claim's own clause never
+# carries them ("Nothing about ICN is production-ready" is a disclaimer).
 
 # A recognised stale/archive banner near the top of a file exempts the whole file
 # (the claim is then clearly labelled history, like the bannered deployment siblings).
@@ -161,13 +172,70 @@ def _clause_around(line, start, end):
     return line[lo:hi]
 
 
+# --- Nonclaim CONTEXT precision (line-local + nearest-heading; no parsing) ----
+# A markdown heading whose text matches this starts a block that is, by
+# construction, a list of things ICN does NOT claim. Every line until the next
+# heading is exempt. Narrow and explicit.
+NONCLAIM_SECTION_RE = re.compile(
+    r"(?i)\b("
+    r"non-?claims?|non-?goals?|red[\s-]?lines?|"
+    r"what (?:not to|must not be|should not be) claim(?:ed)?|"
+    r"what should not be shown(?: as finished)?|"
+    r"forbidden collapses?|"
+    r"claims? to avoid|"                            # "Claims to avoid", "Public/demo claims to avoid"
+    r"what is not\b|"                               # "What is not organizer-ready / included / working"
+    r"must not (?:imply|claim|be (?:shown|presented|claimed))"  # "What the website must not imply"
+    r")\b"
+)
+
+# Explicit line-level nonclaim framing: the whole line tells the reader NOT to
+# claim something (or negates the red-line phrase itself), so an overclaim phrase
+# inside it is being forbidden, not asserted. Catches enumerations the
+# clause-local negation guard splits apart, e.g.
+# "Must not claim: ...; that any of this is production or live federation."
+# Kept to unambiguous nonclaim objects ("claim"/"formal pilot"/"organizer-ready")
+# and direct negations of the patterns, so it cannot mask a genuine assertion.
+NONCLAIM_LINE_RE = re.compile(
+    r"(?i)("
+    r"do(?:es)? not claim|must not (?:be )?claim(?:ed)?|cannot claim|never claim|"
+    r"must not be (?:presented|shown)|should not be (?:claimed|presented|shown)|"
+    r"not (?:a )?formal pilot|no formal pilot|not organi[sz]er-ready|"
+    r"not production-ready|not ready for production|not live federation|no live federation"
+    r")"
+)
+
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.*)$")
+# Markdown decoration stripped from both ends before the interrogative test, so a
+# question is recognised even when wrapped in heading/bold/quote/list/quote marks.
+_MD_TRIM = " \t#>*_`-\"'"
+
+
+def _is_interrogative(line):
+    """True if the line, stripped of markdown decoration, is a question (an FAQ
+    prompt is not an assertion unless a later answer line asserts it)."""
+    return line.strip().strip(_MD_TRIM).strip().endswith("?")
+
+
 def scan_lines(rel_path, lines):
-    """Flag affirmative readiness claims; honour banner, negation, and allowlist."""
+    """Flag affirmative readiness claims; honour banner, nonclaim context,
+    negation, and allowlist."""
     if is_banner_exempt(lines):
         return []
 
     violations = []
+    in_nonclaim_section = False
     for line_num, line in enumerate(lines, start=1):
+        heading = _HEADING_RE.match(line)
+        if heading:
+            # Entering/leaving a nonclaim/red-line section toggles the context.
+            in_nonclaim_section = bool(NONCLAIM_SECTION_RE.search(heading.group(1)))
+
+        # Nonclaim-context exemptions (precision): lines under a nonclaim/red-line
+        # section, explicit "do/must not claim ..." lines, and interrogative/FAQ
+        # prompts are not affirmative claims.
+        if in_nonclaim_section or _is_interrogative(line) or NONCLAIM_LINE_RE.search(line):
+            continue
+
         for pattern, rule in OVERCLAIM_PATTERNS:
             m = pattern.search(line)
             if not m:

--- a/.github/scripts/test_readiness_overclaim_linter.py
+++ b/.github/scripts/test_readiness_overclaim_linter.py
@@ -127,6 +127,14 @@ class TestNonclaimContext(unittest.TestCase):
         line = "Must not claim: that any of this is production-ready or live federation."
         self.assertEqual(linter.scan_lines("x.md", [line]), [])
 
+    def test_disclaimer_does_not_mask_separate_overclaim(self):
+        # A readiness disclaimer in one clause must NOT line-skip a separate
+        # affirmative overclaim in another clause: only the disclaimer's own clause
+        # is exempt (via clause-local NEGATION_RE), the other clause still warns.
+        v = linter.scan_lines("x.md", ["This is not production-ready; ICN is generally available."])
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].rule, "general availability")
+
     def test_line_under_nonclaims_heading_suppressed(self):
         lines = ["## Nonclaims", "- ICN is production-ready and runs a live federation."]
         self.assertEqual(linter.scan_lines("x.md", lines), [])

--- a/.github/scripts/test_readiness_overclaim_linter.py
+++ b/.github/scripts/test_readiness_overclaim_linter.py
@@ -105,6 +105,64 @@ class TestScanLines(unittest.TestCase):
         self.assertEqual(linter.scan_lines("x.md", lines), [])
 
 
+class TestNonclaimContext(unittest.TestCase):
+    """Precision: explicit nonclaim / red-line / question contexts are not claims,
+    but direct affirmative assertions still warn."""
+
+    # --- true positives still warn ---
+    def test_direct_production_ready_still_warns(self):
+        v = linter.scan_lines("x.md", ["ICN is production-ready for cooperative deployments."])
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].rule, "production-ready")
+
+    def test_direct_live_federation_deployed_still_warns(self):
+        v = linter.scan_lines("x.md", ["ICN live federation is deployed across cooperatives today."])
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].rule, "live federation")
+
+    # --- false positives suppressed ---
+    def test_must_not_claim_enumeration_suppressed(self):
+        # The clause-local guard splits on ';'/':'; the line-level nonclaim rule
+        # must still recognise the whole bullet as a non-claim.
+        line = "Must not claim: that any of this is production-ready or live federation."
+        self.assertEqual(linter.scan_lines("x.md", [line]), [])
+
+    def test_line_under_nonclaims_heading_suppressed(self):
+        lines = ["## Nonclaims", "- ICN is production-ready and runs a live federation."]
+        self.assertEqual(linter.scan_lines("x.md", lines), [])
+
+    def test_question_line_suppressed(self):
+        self.assertEqual(linter.scan_lines("x.md", ["### Is this ready for production?"]), [])
+        self.assertEqual(linter.scan_lines("x.md", ['**"Is this ready for production?"**']), [])
+
+    def test_not_a_formal_pilot_suppressed(self):
+        self.assertEqual(linter.scan_lines("x.md", ["This is not a formal pilot."]), [])
+
+    def test_nothing_disclaimer_suppressed(self):
+        self.assertEqual(linter.scan_lines("x.md", ["Nothing about ICN is production-ready."]), [])
+
+    # --- nonclaim section context resets at the next heading ---
+    def test_nonclaim_section_resets_at_next_heading(self):
+        lines = [
+            "## Nonclaims",
+            "- ICN is production-ready.",   # exempt (under Nonclaims)
+            "## Status",
+            "ICN is production-ready.",      # NOT exempt (new section)
+        ]
+        v = linter.scan_lines("x.md", lines)
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].line, 4)
+
+    # --- red-line section heading variants are recognised ---
+    def test_red_lines_section_suppressed(self):
+        lines = ["## Red lines", "- No live federation is deployed; production-ready is never claimed."]
+        self.assertEqual(linter.scan_lines("x.md", lines), [])
+
+    def test_forbidden_collapses_section_suppressed(self):
+        lines = ["## Forbidden collapses", "| federation command | live federation | production-ready |"]
+        self.assertEqual(linter.scan_lines("x.md", lines), [])
+
+
 class TestFixturesEndToEnd(unittest.TestCase):
     def test_bad_fixture_flagged(self):
         v = linter.scan_file("bad_unbannered.md", os.path.join(FIX, "bad_unbannered.md"))

--- a/docs/ci/GATE_RATCHET_PLAN.md
+++ b/docs/ci/GATE_RATCHET_PLAN.md
@@ -114,12 +114,26 @@ Scope (by design, allowlist-based, to keep precision high): deployment/ops guida
 `docs/pilots` was measured low-noise (10 files, 1 bounded `ALLOWLIST` exception). Widening is a
 deliberate ratchet step taken as each surface is cleaned.
 
-NOT yet added (measured high-noise 2026-06-26): `docs/reference/project-index`, `docs/demo`,
-`docs/strategy`. These are claim-sensitive docs that *enumerate* the red-line phrases as
-nonclaim / "does not claim" lists, plus FAQ questions and roadmap targets — false positives the
-line-local negation guard cannot see. Adding them needs a precision step first (nonclaim-list /
-question / disclaimer-word handling), then a per-surface cleanup. This deliberately does NOT yet
-cover the broader SDK / website / user-manual fintech-vocabulary debt — tracked separately.
+Nonclaim-context precision (added 2026-06-26): the linter now exempts lines under nonclaim/red-line
+section headings (`Nonclaims`, `Non-goals`, `Red lines`, `Claims to avoid`, `What is not …`,
+`What … must not imply`, `Forbidden collapses`), explicit `does/must not claim …` lines, FAQ
+question lines (`Is this ready for production?`), and `nothing`/`none` disclaimers — all
+line-local + nearest-heading, no parsing. Self-tested (10 added cases). This cut the measured noise
+on the deferred roots but did not make them clean:
+
+| Candidate root | violations before precision | after precision | decision |
+|---|---|---|---|
+| `docs/reference/project-index` | 18 | **6** | **still deferred** (not added) |
+| `docs/demo` | 6 | 4 | deferred |
+| `docs/strategy` | 5 | 4 | deferred |
+
+`docs/reference/project-index` was the preferred next root but stays deferred: its 6 residual hits
+are a *different* false-positive class the narrow rules cannot suppress without risking real-claim
+masking — caveat-prefixed claims (`Unsafe …: <phrase>`), quoted avoid-lists (`"production-ready"`),
+risk-column table cells that *name* an overclaim, and checklist items describing nonclaims. Closing
+those needs either narrower per-pattern rules or a few bounded `ALLOWLIST` entries per file, taken
+as a later step. This deliberately does NOT yet cover the broader SDK / website / user-manual
+fintech-vocabulary debt — tracked separately.
 
 Remediation on failure: banner the dated doc (point to `docs/ci/CI_CURRENT_STATUS.md`), or fix the
 claim, or add an `ALLOWLIST` entry with a reason. Never weaken the patterns. Self-test:


### PR DESCRIPTION
## Summary

Teaches `.github/scripts/readiness_overclaim_linter.py` to recognize explicit **nonclaim / red-line / question contexts** so it stops flagging them — narrow, line-local + nearest-heading rules, **no semantic parsing**. The linter gets *smarter, not broader*: **no new scan root is added** in this PR (root expansion stays gated on measured noise). CI/docs-only; advisory/warn-only posture unchanged.

## Previous PR status

#2228 (widen readiness overclaim lint scope) **merged** (squash `68fc729b`, on `origin/main`) — added `docs/pilots` + `EXCLUDE_DIRS`, kept patterns/posture unchanged. This PR is the precision follow-up #2228 named.

## Why this exists

#2228's measurement showed the remaining candidate roots fire mostly *false positives*: claim-sensitive docs that enumerate the red-line phrases as nonclaim lists, FAQ questions, and roadmap targets. The disciplined next step is to make the linter recognize those contexts before widening further.

## Precision behavior added (`scan_lines`, conservative, no parsing)

1. **Nonclaim / red-line SECTION headings** exempt their block until the next heading: `Nonclaims`, `Non-goals`, `Red lines`, `Claims to avoid`, `What is not …`, `What … must not imply`, `Forbidden collapses`. (The flag resets at the next heading, so a real claim under a later normal section still warns.)
2. **Explicit line-level nonclaim framing** — `does/must not claim …`, `not a formal pilot`, `not organizer-ready`, `not production-ready`, `not/no live federation`, `not ready for production`. Catches red-line **enumerations** the clause-local negation guard splits apart (e.g. `Must not claim: … production-ready or live federation.`).
3. **Interrogative / FAQ lines** (`Is this ready for production?`) — not an assertion unless a later answer line asserts it. Recognized even when wrapped in heading/bold/quote markup.
4. **`nothing` / `none`** added to the clause-local negation set (safe disclaimers like "Nothing about ICN is production-ready."). **`without` deliberately NOT added** — too broad (would mask "production-ready without caveats").

## Tests added (`.github/scripts/test_readiness_overclaim_linter.py`, +11; 32/32 pass)

**Review fix (commit `08e4c5e9`):** Copilot caught a real masking bug — because a line-level `NONCLAIM_LINE_RE` match exempts the whole line, including direct readiness negations (`not production-ready`, `no live federation`) let a disclaimer clause silently hide a separate affirmative overclaim on the same line. Fixed by narrowing `NONCLAIM_LINE_RE` to unambiguous nonclaim *framing* only (the readiness negations are handled clause-locally by `NEGATION_RE`), plus a regression test (`test_disclaimer_does_not_mask_separate_overclaim`) asserting that `This is not production-ready; ICN is generally available.` flags **exactly one** violation (rule = general availability). Self-test is now **32/32**.

- **True positives still warn:** `ICN is production-ready …`, `ICN live federation is deployed …`.
- **The 6 required FP suppressions:** `Must not claim: … production-ready or live federation`; a line under `## Nonclaims`; `### Is this ready for production?` (and the bold-quoted form); `This is not a formal pilot.`; plus `Nothing about ICN is production-ready.`
- **Plus:** nonclaim-section context **resets** at the next heading; `## Red lines` and `## Forbidden collapses` section headings recognized.

## Scan roots before/after

| | Roots |
|---|---|
| Before | `docs/deployment`, `docs/operations/deployment`, `docs/pilots` |
| After | **unchanged** — `docs/deployment`, `docs/operations/deployment`, `docs/pilots` |

No new root added (see below).

## Candidate root measurements (before → after precision)

Measured by importing the module and overriding `SCAN_DIRS`:

| Candidate root | before precision | after precision | decision |
|---|---|---|---|
| `docs/reference/project-index` | 18 | **6** | **still deferred — not added** |
| `docs/demo` | 6 | 4 | deferred |
| `docs/strategy` | 5 | 4 | deferred |

The precision rules cut project-index noise by 67% (18→6), but 6 residual hits is still not clean enough to add without warnings, so **no root is added this PR** (the task's rule: add only if clean / clearly-bounded).

## False positives found and how handled

All remaining hits in the candidate roots are **false positives** — none is a real overclaim, so **no docs were rewritten**. The project-index residual (6) is a *different* FP class than the rules target:
- caveat-prefixed claims — `- Unsafe without more evidence: ICN is production-ready …`
- quoted avoid-lists — `- "production-ready", "fully federated", …`
- risk-column table cells naming the overclaim — `… | high: live federation overclaim | …`
- checklist items describing nonclaims — `- [ ] Includes nonclaims for … live federation`
- "without"-negated narrative — `… without requiring a live federation step.`

Suppressing these needs either narrower per-pattern rules or a few bounded `ALLOWLIST` entries per file — recorded in `GATE_RATCHET_PLAN.md` as the bounded follow-up that gates adding project-index. No patterns were weakened.

## Blocking/advisory posture

**Advisory / warn-only, unchanged.** `ci.yml` (`GATE_RATCHET_PHASE_READINESS: warning`) was **not touched**. No check promoted to blocking.

## Validation

- `python3 .github/scripts/test_readiness_overclaim_linter.py` — **OK** (32 tests).
- `python3 .github/scripts/readiness_overclaim_linter.py` — **exit 0** (clean on the 3 current roots).
- `python3 docs/scripts/icnctl_command_inventory.py --check` — **OK**.
- `python3 docs/scripts/route_inventory.py --check` — **OK**.
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — **passed** (898 docs, 65 warnings = unchanged baseline).
- `bash ops/scripts/drift-check.sh` — **PASS** (0/0).
- `python3 scripts/check-state-lag.py` — **OK**.
- `git diff --check` — clean.
- No cargo: no Rust/Cargo files touched.

## Follow-ups

- Close project-index's 6 residual FPs (narrow per-pattern rules for caveat-prefixed claims / quoted avoid-lists / risk-column cells, or bounded per-file allowlist entries), then add it as the next scan root.
- Then `docs/demo` (4) and `docs/strategy` (4) by the same method.
- Graduate the readiness check WARNING → BLOCKING via branch protection (`GATE_RATCHET_PLAN.md`) — a settings/cadence decision, out of scope.
- Implement ADR-0033's evidence-link linter (proposed, not built).

## Nonclaims

- CI/docs-only; no runtime / Rust behavior change.
- No `icnctl` behavior change; no route/auth/OpenAPI/SDK/gateway behavior change.
- **Does not fully enforce the claim-boundary firewall** — it remains a narrow phrase-level guardrail.
- **Does not implement ADR-0033's evidence-link linter.**
- No check promoted from advisory to blocking; no new scan root added.
- Does not claim production readiness, organizer readiness, formal NYCN pilot readiness, or live federation.
- Does not affect #2082; does not address #2099; pilot-UI / Summit Ops fixture expansion remains gated by #2099.

Refs #1746
Refs #2113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

