### PR TITLE
fix(web): close CodeQL DOM-XSS and missing-SRI alerts in pilot UI / gateway static

### DIFF
--- a/icn/crates/icn-gateway/static/index.html
+++ b/icn/crates/icn-gateway/static/index.html
@@ -14,8 +14,14 @@
     <link rel="stylesheet" href="style.css">
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="/icons/icon-192x192.png">
-    <!-- QR Code library for passport (DID) login -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+    <!-- QR Code library for passport (DID) login.
+         Subresource Integrity pins the exact qrcodejs 1.0.0 bytes so a compromised
+         or substituted CDN response cannot execute (CodeQL js/functionality-from-
+         untrusted-source, issue #2099). sha384 computed from the cdnjs file. -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"
+            integrity="sha384-3zSEDfvllQohrq0PHL1fOXJuC/jSOO34H46t6UQfobFOmxE5BpjjaIJY5F2/bMnU"
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"></script>
 </head>
 <body>
     <!-- Skip Navigation Link -->

--- a/icn/crates/icn-gateway/static/sw.js
+++ b/icn/crates/icn-gateway/static/sw.js
@@ -3,7 +3,7 @@
  * Provides offline support, caching, and background sync
  */
 
-const CACHE_VERSION = 'icn-timebank-v1.1';
+const CACHE_VERSION = 'icn-timebank-v1.2';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const API_CACHE = `${CACHE_VERSION}-api`;

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -14,8 +14,14 @@
     <link rel="stylesheet" href="style.css?v=2026050802">
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="/icons/icon-192x192.png">
-    <!-- QR Code library for passport (DID) login -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+    <!-- QR Code library for passport (DID) login.
+         Subresource Integrity pins the exact qrcodejs 1.0.0 bytes so a compromised
+         or substituted CDN response cannot execute (CodeQL js/functionality-from-
+         untrusted-source, issue #2099). sha384 computed from the cdnjs file. -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"
+            integrity="sha384-3zSEDfvllQohrq0PHL1fOXJuC/jSOO34H46t6UQfobFOmxE5BpjjaIJY5F2/bMnU"
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"></script>
 </head>
 <body>
     <!-- Skip Navigation Link -->

--- a/web/pilot-ui/sdis-enrollment.js
+++ b/web/pilot-ui/sdis-enrollment.js
@@ -156,11 +156,20 @@ const SDISEnrollment = {
         // Read and preview
         const reader = new FileReader();
         reader.onload = (e) => {
-            this.elements.documentPreview.innerHTML = `
-                <img src="${e.target.result}" alt="Document preview" />
-                <p class="text-sm text-gray-600 mt-2">${file.name}</p>
-            `;
-            this.elements.documentPreview.classList.remove('hidden');
+            // Build the preview with DOM APIs rather than innerHTML: a file named
+            // with HTML (e.g. "<img onerror=…>.png") must render as text, not markup
+            // (CodeQL js/xss-through-dom, issue #2099). The data: URL from
+            // readAsDataURL is safe as an img src; file.name goes via textContent.
+            const preview = this.elements.documentPreview;
+            preview.replaceChildren();
+            const img = document.createElement('img');
+            img.src = e.target.result;
+            img.alt = 'Document preview';
+            const caption = document.createElement('p');
+            caption.className = 'text-sm text-gray-600 mt-2';
+            caption.textContent = file.name;
+            preview.append(img, caption);
+            preview.classList.remove('hidden');
 
             // Store in proof data
             this.state.proofData.document = e.target.result;

--- a/web/pilot-ui/sdis-proofs.js
+++ b/web/pilot-ui/sdis-proofs.js
@@ -402,16 +402,33 @@ function displayVerificationResult(result, proof) {
     const container = document.getElementById('verificationResult');
     container.style.display = 'block';
     container.className = result.valid ? 'success' : 'failure';
-    
-    container.innerHTML = `
-        <h3>${result.valid ? '✅ Valid Proof' : '❌ Invalid Proof'}</h3>
-        <div class="verification-details">
-            <p><strong>Issuer:</strong> ${proof.issuer_did}</p>
-            <p><strong>Type:</strong> ${formatProofType(proof.type)}</p>
-            <p><strong>Created:</strong> ${new Date(proof.created_at).toLocaleString()}</p>
-            ${result.message ? `<p><strong>Message:</strong> ${result.message}</p>` : ''}
-        </div>
-    `;
+
+    // Build with DOM APIs rather than innerHTML: proof.issuer_did / proof.type /
+    // result.message are attacker-influenced (an unverified pasted proof), so they
+    // must render as text, not markup (CodeQL js/xss-through-dom, issue #2099).
+    container.replaceChildren();
+
+    const h3 = document.createElement('h3');
+    h3.textContent = result.valid ? '✅ Valid Proof' : '❌ Invalid Proof';
+
+    const details = document.createElement('div');
+    details.className = 'verification-details';
+
+    const addRow = (label, value) => {
+        const p = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = label;
+        p.append(strong, document.createTextNode(' ' + value));
+        details.append(p);
+    };
+    addRow('Issuer:', proof.issuer_did);
+    addRow('Type:', formatProofType(proof.type));
+    addRow('Created:', new Date(proof.created_at).toLocaleString());
+    if (result.message) {
+        addRow('Message:', result.message);
+    }
+
+    container.append(h3, details);
 }
 
 function scanQrCode() {

--- a/web/pilot-ui/sdis-proofs.js
+++ b/web/pilot-ui/sdis-proofs.js
@@ -240,17 +240,26 @@ function displayGeneratedProof() {
         new Date(generatedProof.expires_at).toLocaleString() : 'Never';
     document.getElementById('proofRecipient').textContent = generatedProof.recipient_did || 'Public';
     
-    // Display claims
+    // Display claims. Claim keys/values come from untrusted form input
+    // (extractClaimsFromForm), so build with DOM APIs — textContent renders them
+    // as text, not markup (CodeQL js/xss-through-dom class, issue #2099).
     const claimsContainer = document.getElementById('proofClaims');
-    claimsContainer.innerHTML = '<h3>Proven Claims</h3>';
-    
+    claimsContainer.replaceChildren();
+    const claimsHeading = document.createElement('h3');
+    claimsHeading.textContent = 'Proven Claims';
+    claimsContainer.append(claimsHeading);
+
     Object.entries(generatedProof.claims || {}).forEach(([key, value]) => {
-        claimsContainer.innerHTML += `
-            <div class="claim-item">
-                <span class="claim-label">${key.replace(/_/g, ' ')}</span>
-                <span class="claim-value">${value}</span>
-            </div>
-        `;
+        const item = document.createElement('div');
+        item.className = 'claim-item';
+        const label = document.createElement('span');
+        label.className = 'claim-label';
+        label.textContent = key.replace(/_/g, ' ');
+        const val = document.createElement('span');
+        val.className = 'claim-value';
+        val.textContent = value;
+        item.append(label, val);
+        claimsContainer.append(item);
     });
     
     // Display signature
@@ -327,30 +336,45 @@ async function loadProofHistory() {
 
 function displayProofHistory(proofs) {
     const container = document.getElementById('proofHistoryList');
-    
+    container.replaceChildren();
+
     if (proofs.length === 0) {
-        container.innerHTML = '<p class="empty-state">No proofs generated yet</p>';
+        const empty = document.createElement('p');
+        empty.className = 'empty-state';
+        empty.textContent = 'No proofs generated yet';
+        container.append(empty);
         return;
     }
 
-    container.innerHTML = proofs.map(proof => {
+    // Build with DOM APIs and bind the click via addEventListener (NOT an inline
+    // onclick="…'${proof.id}'…" attribute): a crafted proof.id containing a quote
+    // could otherwise break out of the attribute and inject script (CodeQL
+    // js/xss-through-dom class, issue #2099). proof fields go via textContent.
+    proofs.forEach(proof => {
         const isExpired = proof.expires_at && new Date(proof.expires_at) < new Date();
         const status = isExpired ? 'expired' : 'valid';
-        
-        return `
-            <div class="history-item" onclick="viewHistoryProof('${proof.id}')">
-                <div class="history-info">
-                    <div class="history-type">${formatProofType(proof.type)}</div>
-                    <div class="history-date">
-                        ${new Date(proof.created_at).toLocaleDateString()}
-                    </div>
-                </div>
-                <span class="history-status ${status}">
-                    ${status.toUpperCase()}
-                </span>
-            </div>
-        `;
-    }).join('');
+
+        const item = document.createElement('div');
+        item.className = 'history-item';
+        item.addEventListener('click', () => viewHistoryProof(proof.id));
+
+        const info = document.createElement('div');
+        info.className = 'history-info';
+        const type = document.createElement('div');
+        type.className = 'history-type';
+        type.textContent = formatProofType(proof.type);
+        const date = document.createElement('div');
+        date.className = 'history-date';
+        date.textContent = new Date(proof.created_at).toLocaleDateString();
+        info.append(type, date);
+
+        const statusEl = document.createElement('span');
+        statusEl.className = 'history-status ' + status;
+        statusEl.textContent = status.toUpperCase();
+
+        item.append(info, statusEl);
+        container.append(item);
+    });
 }
 
 function viewHistoryProof(proofId) {

--- a/web/pilot-ui/sw.js
+++ b/web/pilot-ui/sw.js
@@ -7,7 +7,7 @@
 // changes meaningfully so existing installs reliably pick up the new bundle.
 // The activate event purges any cache whose name doesn't match the current
 // CACHE_VERSION, which forces clients off the old asset set.
-const CACHE_VERSION = 'icn-timebank-v1.3';
+const CACHE_VERSION = 'icn-timebank-v1.4';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const API_CACHE = `${CACHE_VERSION}-api`;


### PR DESCRIPTION
## Summary

Fixes the four real CodeQL findings tracked by #2099 in the Pilot UI and gateway-served static UI, removes two sibling DOM-XSS sinks in the same proof-rendering file, and invalidates the affected service-worker caches so existing clients load the hardened assets.

## Why

The affected render paths accepted attacker-influenced file, proof, claim, and identifier data. Interpolating those values into `innerHTML` or inline event-handler attributes allowed markup or script-context injection. The two CDN script tags also lacked Subresource Integrity. Without cache invalidation, installed clients could continue serving the pre-fix assets.

## What changed

| Alert | Site | Fix |
|---|---|---|
| #25 `js/xss-through-dom` | `web/pilot-ui/sdis-enrollment.js` | Builds the document preview with DOM APIs; the file name is assigned through `textContent`. |
| #26 `js/xss-through-dom` | `web/pilot-ui/sdis-proofs.js` | Builds verification results with DOM APIs; unverified proof fields and messages render as text. |
| #27 `js/functionality-from-untrusted-source` | `icn/crates/icn-gateway/static/index.html` | Adds sha384 SRI, anonymous CORS mode, and no-referrer policy to pinned qrcodejs 1.0.0. |
| #28 `js/functionality-from-untrusted-source` | `web/pilot-ui/index.html` | Applies the same SRI protection. |

Review follow-ups:

- `displayGeneratedProof()` renders claim keys and values through DOM APIs / `textContent`.
- `displayProofHistory()` renders proof fields through DOM APIs and binds clicks with `addEventListener`, removing the inline JavaScript-string context.
- `web/pilot-ui/sw.js` and `icn/crates/icn-gateway/static/sw.js` bump their cache versions so existing clients discard the vulnerable/unpinned asset sets.

The remaining `innerHTML` uses in `sdis-proofs.js` are static proof-type markup and a static QR placeholder.

## Validation

- `node --check web/pilot-ui/sdis-enrollment.js` ✓
- `node --check web/pilot-ui/sdis-proofs.js` ✓
- `node --check web/pilot-ui/sw.js` ✓
- `node --check icn/crates/icn-gateway/static/sw.js` ✓
- `git diff --check` ✓
- Recomputed cdnjs qrcodejs 1.0.0 sha384 digest matches `3zSEDfvllQohrq0PHL1fOXJuC/jSOO34H46t6UQfobFOmxE5BpjjaIJY5F2/bMnU` ✓
- Local `node_modules` is absent; Jest and Playwright remain CI-verified rather than claimed locally.
- Fresh PR CI and CodeQL are required before merge.

The prior `Test` failure was runner exhaustion while linking (`No space left on device`), not a test assertion or a touched-file failure. This rebased head receives a fresh run.

## Issue effects

Refs #2099. `closingIssuesReferences` remains empty so the issue cannot close before the fixes land on `main` and the four default-branch CodeQL alerts are verified closed or explicitly triaged.

## Follow-ups

- After this PR lands, narrow #2233 to its unique `sdis-identity.js` DOM-XSS cleanup.
- Recheck default-branch CodeQL alerts #25–#28 after the merge analysis completes.

## Nonclaims

- Does not claim production readiness, organizer readiness, formal NYCN pilot readiness, live federation, or Phase 2 completion.
- Does not claim #2099 complete before default-branch CodeQL verification.
- Does not change API, authorization, gateway routing, or institutional semantics.
- Does not touch #1746, #2082, or #2113.
- Does not touch private institution/provider data or topology.
