### PR TITLE
fix(pilot-ui): rebuild SDIS identity innerHTML sinks with DOM APIs

### DIFF
--- a/web/pilot-ui/sdis-identity.js
+++ b/web/pilot-ui/sdis-identity.js
@@ -136,27 +136,53 @@ function displayAnchors(anchors) {
         return;
     }
 
-    container.innerHTML = anchors.map(anchor => `
-        <div class="anchor-item">
-            <div class="anchor-info">
-                <div class="anchor-type">${anchor.anchor_type}</div>
-                <div class="anchor-value">${anchor.anchor_value}</div>
-            </div>
-            <div class="anchor-status ${anchor.verified ? 'verified' : 'pending'}">
-                ${anchor.verified ? 'Verified' : 'Pending'}
-            </div>
-            <div class="anchor-actions">
-                ${!anchor.verified ? `
-                    <button class="icon-btn" onclick="verifyAnchor('${anchor.id}')">
-                        ✓
-                    </button>
-                ` : ''}
-                <button class="icon-btn danger" onclick="removeAnchor('${anchor.id}')">
-                    ✕
-                </button>
-            </div>
-        </div>
-    `).join('');
+    // Build with DOM APIs rather than innerHTML: anchor_type / anchor_value / id
+    // are attacker-influenced (server-returned anchor records), so they must
+    // render as text and never enter markup or a JS string via an inline
+    // onclick (CodeQL js/xss-through-dom, issue #2099).
+    container.replaceChildren();
+
+    anchors.forEach(anchor => {
+        const item = document.createElement('div');
+        item.className = 'anchor-item';
+
+        const info = document.createElement('div');
+        info.className = 'anchor-info';
+
+        const type = document.createElement('div');
+        type.className = 'anchor-type';
+        type.textContent = anchor.anchor_type;
+
+        const value = document.createElement('div');
+        value.className = 'anchor-value';
+        value.textContent = anchor.anchor_value;
+
+        info.append(type, value);
+
+        const statusEl = document.createElement('div');
+        statusEl.className = `anchor-status ${anchor.verified ? 'verified' : 'pending'}`;
+        statusEl.textContent = anchor.verified ? 'Verified' : 'Pending';
+
+        const actions = document.createElement('div');
+        actions.className = 'anchor-actions';
+
+        if (!anchor.verified) {
+            const verifyBtn = document.createElement('button');
+            verifyBtn.className = 'icon-btn';
+            verifyBtn.textContent = '✓';
+            verifyBtn.addEventListener('click', () => verifyAnchor(anchor.id));
+            actions.append(verifyBtn);
+        }
+
+        const removeBtn = document.createElement('button');
+        removeBtn.className = 'icon-btn danger';
+        removeBtn.textContent = '✕';
+        removeBtn.addEventListener('click', () => removeAnchor(anchor.id));
+        actions.append(removeBtn);
+
+        item.append(info, statusEl, actions);
+        container.append(item);
+    });
 }
 
 async function loadCredentials() {
@@ -182,22 +208,49 @@ function displayCredentials(credentials) {
         return;
     }
 
-    container.innerHTML = credentials.map(cred => `
-        <div class="credential-item">
-            <div class="credential-header">
-                <div>
-                    <div class="credential-type">${cred.type}</div>
-                    <div class="credential-issuer">Issued by: ${cred.issuer}</div>
-                </div>
-                <button class="icon-btn" onclick="viewCredential('${cred.id}')">
-                    👁️
-                </button>
-            </div>
-            <ul class="credential-claims">
-                ${cred.claims.map(claim => `<li>${claim}</li>`).join('')}
-            </ul>
-        </div>
-    `).join('');
+    // Build with DOM APIs rather than innerHTML: type / issuer / id / claims are
+    // attacker-influenced (server-returned credential records), so they must
+    // render as text and never enter markup or a JS string via an inline
+    // onclick (CodeQL js/xss-through-dom, issue #2099).
+    container.replaceChildren();
+
+    credentials.forEach(cred => {
+        const item = document.createElement('div');
+        item.className = 'credential-item';
+
+        const header = document.createElement('div');
+        header.className = 'credential-header';
+
+        const headerText = document.createElement('div');
+
+        const type = document.createElement('div');
+        type.className = 'credential-type';
+        type.textContent = cred.type;
+
+        const issuer = document.createElement('div');
+        issuer.className = 'credential-issuer';
+        issuer.textContent = `Issued by: ${cred.issuer}`;
+
+        headerText.append(type, issuer);
+
+        const viewBtn = document.createElement('button');
+        viewBtn.className = 'icon-btn';
+        viewBtn.textContent = '👁️';
+        viewBtn.addEventListener('click', () => viewCredential(cred.id));
+
+        header.append(headerText, viewBtn);
+
+        const claims = document.createElement('ul');
+        claims.className = 'credential-claims';
+        cred.claims.forEach(claim => {
+            const li = document.createElement('li');
+            li.textContent = claim;
+            claims.append(li);
+        });
+
+        item.append(header, claims);
+        container.append(item);
+    });
 }
 
 async function loadActivity() {


### PR DESCRIPTION
## Summary

Rebuilds the two remaining SDIS identity renderers that interpolated server-returned fields into `innerHTML`, using DOM construction and text-only assignment instead.

## Why

`displayAnchors()` and `displayCredentials()` rendered attacker-influenceable anchor, credential, claim, and identifier fields as markup. Several identifiers also entered inline JavaScript event-handler strings. These are structural siblings of the DOM-XSS sinks fixed by #2231.

## What changed

- `displayAnchors()` now builds its nodes with `createElement`, assigns record values through `textContent`, and binds verify/remove actions with `addEventListener`.
- `displayCredentials()` now builds credential and claim nodes with DOM APIs, assigns values through `textContent`, and binds its view action with `addEventListener`.
- The duplicate `sdis-proofs.js` changes from the original branch were dropped after #2231 landed.
- Empty-state literals and static QR placeholder markup remain unchanged.

## Validation

- `node --check web/pilot-ui/sdis-identity.js` ✓
- `git diff --check origin/main...HEAD` ✓
- Diff is exactly one file: `web/pilot-ui/sdis-identity.js` ✓
- Local `node_modules` is absent; Jest and Playwright remain CI-verified rather than claimed locally.
- Fresh PR CI and CodeQL are required before merge.

## Issue effects

Refs #2099. `closingIssuesReferences` remains empty. #2099 must remain open until the default-branch CodeQL findings from #2231 are verified closed or explicitly triaged.

## Follow-ups

- Recheck the #2099 default-branch alerts after CodeQL analyzes the merged #2231 commit.
- Treat any broader Pilot UI sink audit as separate work; this PR stays limited to the two identity renderers.

## Nonclaims

- Does not claim production readiness, organizer readiness, formal NYCN pilot readiness, live federation, or Phase 2 completion.
- Does not claim #2099 complete.
- Does not change API, authorization, gateway routing, or institutional semantics.
- Does not touch #1746, #2082, or #2113.
- Does not touch private institution/provider data or topology.
