### PR TITLE
fix(rpc): gate governance delegation RPCs by caller DID

### DIFF
--- a/docs/reference/project-index/generated/icnctl-command-inventory.md
+++ b/docs/reference/project-index/generated/icnctl-command-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-06-26T20:30:42+00:00
+Generated: 2026-06-27T00:54:47+00:00
 ---
 
 # `icnctl` Command Inventory (generated)
@@ -19,7 +19,7 @@ Generated: 2026-06-26T20:30:42+00:00
 
 ## Snapshot
 
-- Source commit: `791af47ea51abb0e29dbfa0643d67b5507689a11`
+- Source commit: `d9d25fd30848fbfad4e52ec08b7b686e1e5bc5cb`
 - Source scanned: `icn/bins/icnctl/src/**` (clap `#[derive(Subcommand)]` / `#[derive(Parser)]` tree)
 
 ## Summary
@@ -27,7 +27,7 @@ Generated: 2026-06-26T20:30:42+00:00
 - **Total leaf commands (default build): 162**
 - Top-level command groups: 33
 - By role (curated, needs review): organizer 53 · operator 64 · developer 43 · maintainer 2
-- By status (curated, see section below): live 38 · partial 107 · planned 13 · unknown / needs local verification 4
+- By status (curated, see section below): live 38 · partial 110 · planned 13 · unknown / needs local verification 1
 - Proof level: every command is `L1` (declaration exists in source).
 - **Feature-gated commands (NOT in the default build, excluded from the counts above): 1** (see section below).
 - Unparsed / unresolved candidates: 0 (see section below).
@@ -85,9 +85,9 @@ Role is the **curated** top-level-group heuristic (needs review). `status` is a 
 | `icnctl gov proposal open` | partial | L1 | `icn/bins/icnctl/src/main.rs`:1242 |
 | `icnctl gov proposal show` | partial | L1 | `icn/bins/icnctl/src/main.rs`:1264 |
 | `icnctl gov vote cast` | partial | L1 | `icn/bins/icnctl/src/main.rs`:1288 |
-| `icnctl gov vote delegate` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1310 |
-| `icnctl gov vote delegations` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1325 |
-| `icnctl gov vote revoke` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:1328 |
+| `icnctl gov vote delegate` | partial | L1 | `icn/bins/icnctl/src/main.rs`:1310 |
+| `icnctl gov vote delegations` | partial | L1 | `icn/bins/icnctl/src/main.rs`:1325 |
+| `icnctl gov vote revoke` | partial | L1 | `icn/bins/icnctl/src/main.rs`:1328 |
 | `icnctl gov vote show` | planned | L1 | `icn/bins/icnctl/src/main.rs`:1303 |
 | `icnctl init-coop` | unknown / needs local verification | L1 | `icn/bins/icnctl/src/main.rs`:128 |
 | `icnctl institution bootstrap apply` | partial | L1 | `icn/bins/icnctl/src/institution_bootstrap.rs`:49 |
@@ -243,12 +243,12 @@ Status is a **curated** classification (issue #2113), defaulting to `unknown / n
 | Status | Count |
 |---|---|
 | live | 38 |
-| partial | 107 |
+| partial | 110 |
 | fixture-demo | 0 |
 | planned | 13 |
-| unknown / needs local verification | 4 |
+| unknown / needs local verification | 1 |
 
-### Classified commands (158)
+### Classified commands (161)
 
 Every non-`unknown` command, with its evidence basis. (All other default-build commands carry `unknown / needs local verification`.)
 
@@ -357,6 +357,9 @@ Every non-`unknown` command, with its evidence basis. (All other default-build c
 | `icnctl gov proposal open` | partial | three daemon RPC calls via `create_authenticated_rpc_client`: `client.call("governance.proposal.get")`, then `client.call("governance.domain.get")`, then `client.call("governance.proposal.open")` (`icn/bins/icnctl/src/main.rs` ProposalCommands::Open); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:1242 |
 | `icnctl gov proposal show` | partial | daemon RPC `client.call("governance.proposal.get")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` ProposalCommands::Show); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:1264 |
 | `icnctl gov vote cast` | partial | daemon RPC `client.call("governance.vote.cast")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` VoteCommands::Cast); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:1288 |
+| `icnctl gov vote delegate` | partial | daemon RPC `client.call("governance.delegation.create")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` VoteCommands::Delegate); method registered in `icn/crates/icn-rpc/src/server.rs` -> `handle_governance_delegation_create` (`icn/crates/icn-rpc/src/handler/governance.rs`), which binds the delegator to `ctx.caller_did` (a caller can only delegate their own vote); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:1310 |
+| `icnctl gov vote delegations` | partial | daemon RPC `client.call("governance.delegation.list")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` VoteCommands::Delegations); method registered in `icn/crates/icn-rpc/src/server.rs` -> `handle_governance_delegation_list` (`icn/crates/icn-rpc/src/handler/governance.rs`), which returns only the caller's own given/received delegations; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:1325 |
+| `icnctl gov vote revoke` | partial | daemon RPC `client.call("governance.delegation.revoke")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` VoteCommands::Revoke); method registered in `icn/crates/icn-rpc/src/server.rs` -> `handle_governance_delegation_revoke` (`icn/crates/icn-rpc/src/handler/governance.rs`), which revokes only when `delegation.delegator == ctx.caller_did`; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:1328 |
 | `icnctl institution bootstrap apply` | partial | async `apply_package` posts the package to the gateway via `reqwest::Client` (`icn/bins/icnctl/src/institution_bootstrap.rs` InstitutionCommands::Bootstrap -> InstitutionBootstrapCommands::Apply); requires a running gateway, not integration-tested | `icn/bins/icnctl/src/institution_bootstrap.rs`:49 |
 | `icnctl ledger balance` | partial | daemon RPC client `client.get_ledger_balance()` via `create_rpc_client` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Balance); requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:728 |
 | `icnctl ledger head` | partial | daemon RPC client `client.get_ledger_head()` via `create_rpc_client` in `handle_ledger_command` (`icn/bins/icnctl/src/main.rs` LedgerCommands::Head); "Is icnd running?"; requires a running daemon, not integration-tested | `icn/bins/icnctl/src/main.rs`:725 |

--- a/docs/scripts/icnctl_command_inventory.py
+++ b/docs/scripts/icnctl_command_inventory.py
@@ -290,12 +290,11 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     # SocketAddr endpoint) at the top; each arm below `await`s `client.call("governance.*")` (daemon RPC),
     # except `gov domain add-member` which builds its own `reqwest` gateway HTTP client. Only the RPC
     # methods actually registered in the daemon dispatch (`icn/crates/icn-rpc/src/server.rs` governance
-    # block: domain.list/get/create, proposal.list/get/create/open/close, vote.cast) count as partial —
-    # real work, but daemon/gateway-dependent with no binary-spawning e2e test (no icnctl test drives a
-    # gov arm). The `gov vote delegate/delegations/revoke` arms call `governance.delegation.*`, which is
-    # NOT registered on the daemon (a repo-wide search finds it only in these CLI calls), so against a
-    # running daemon they return method-not-found, not real governance work — left `unknown` (not in this
-    # map), pending local verification, rather than overstated as `partial`.
+    # block: domain.list/get/create, proposal.list/get/create/open/close, vote.cast,
+    # delegation.create/list/revoke) count as partial — real work, but daemon/gateway-dependent with no
+    # binary-spawning e2e test (no icnctl test drives a gov arm). The `gov vote delegate/delegations/revoke`
+    # arms call `governance.delegation.{create,list,revoke}`, which are now registered on the daemon
+    # (issue #2113) and gated per-caller in the handler (see those three entries below).
     "gov domain create": (STATUS_PARTIAL, "daemon RPC `client.call(\"governance.domain.create\")` via `create_authenticated_rpc_client` in `handle_gov_command` (`icn/bins/icnctl/src/main.rs` DomainCommands::Create); requires a running daemon, not integration-tested"),
     "gov domain show": (STATUS_PARTIAL, "daemon RPC `client.call(\"governance.domain.get\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` DomainCommands::Show); requires a running daemon, not integration-tested"),
     "gov domain list": (STATUS_PARTIAL, "daemon RPC `client.call(\"governance.domain.list\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` DomainCommands::List); requires a running daemon, not integration-tested"),
@@ -306,9 +305,13 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     "gov proposal show": (STATUS_PARTIAL, "daemon RPC `client.call(\"governance.proposal.get\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` ProposalCommands::Show); requires a running daemon, not integration-tested"),
     "gov proposal close": (STATUS_PARTIAL, "daemon RPC `client.call(\"governance.proposal.close\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` ProposalCommands::Close); requires a running daemon, not integration-tested"),
     "gov vote cast": (STATUS_PARTIAL, "daemon RPC `client.call(\"governance.vote.cast\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` VoteCommands::Cast); requires a running daemon, not integration-tested"),
-    # NOTE: `gov vote delegate/delegations/revoke` are intentionally NOT classified here — they call
-    # `governance.delegation.{create,list,revoke}`, which is unregistered on the daemon (see comment
-    # above), so they fall back to `unknown / needs local verification` rather than `partial`.
+    # partial (issue #2113) — the three `gov vote` delegation arms now reach a registered, per-caller-gated
+    # daemon RPC path. Daemon-dependent, no binary-spawning e2e test (no icnctl test drives a gov arm) ->
+    # partial, not live. The auth gate lives in the handler, unit-tested in
+    # `icn/crates/icn-rpc/src/handler/governance.rs` (delegation_auth_tests).
+    "gov vote delegate": (STATUS_PARTIAL, "daemon RPC `client.call(\"governance.delegation.create\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` VoteCommands::Delegate); method registered in `icn/crates/icn-rpc/src/server.rs` -> `handle_governance_delegation_create` (`icn/crates/icn-rpc/src/handler/governance.rs`), which binds the delegator to `ctx.caller_did` (a caller can only delegate their own vote); requires a running daemon, not integration-tested"),
+    "gov vote delegations": (STATUS_PARTIAL, "daemon RPC `client.call(\"governance.delegation.list\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` VoteCommands::Delegations); method registered in `icn/crates/icn-rpc/src/server.rs` -> `handle_governance_delegation_list` (`icn/crates/icn-rpc/src/handler/governance.rs`), which returns only the caller's own given/received delegations; requires a running daemon, not integration-tested"),
+    "gov vote revoke": (STATUS_PARTIAL, "daemon RPC `client.call(\"governance.delegation.revoke\")` via `create_authenticated_rpc_client` (`icn/bins/icnctl/src/main.rs` VoteCommands::Revoke); method registered in `icn/crates/icn-rpc/src/server.rs` -> `handle_governance_delegation_revoke` (`icn/crates/icn-rpc/src/handler/governance.rs`), which revokes only when `delegation.delegator == ctx.caller_did`; requires a running daemon, not integration-tested"),
     # planned (pass 10, issue #2113) — `gov` arms that `bail!` with an explicit "not yet supported via
     # RPC" message before any client call (the daemon-side RPC method is unwired); the RPC client built
     # at the top of handle_gov_command is never awaited on these arms.
@@ -364,10 +367,6 @@ STATUS_BY_COMMAND: dict[str, tuple[str, str]] = {
     # file otherwise (no daemon is spawned; `--no-start` only changes printed guidance). Its end state is
     # environment-dependent (pure-local vs live gateway domain creation), so no single static L1 status is
     # honest — `unknown / needs local verification` pending a runtime check.
-    # unknown (pass 10, issue #2113) — `gov vote delegate/delegations/revoke` remain unknown: re-confirmed
-    # this pass that `governance.delegation.{create,list,revoke}` is still NOT registered in the daemon
-    # dispatch `icn/crates/icn-rpc/src/server.rs` (governance arms there are domain.*/proposal.*/vote.cast
-    # only) and a repo-wide search finds `governance.delegation` only in those three icnctl client calls.
     # planned — handler is an explicit placeholder / prints "not yet implemented".
     "charter deploy": (STATUS_PLANNED, "handler validates the CCL doc locally, then prints \"Not yet implemented — charter deployment requires gateway integration\" (`icn/bins/icnctl/src/main.rs` CharterCommands::Deploy)"),
     "steward check-vui": (STATUS_PLANNED, "placeholder; validates input then prints \"VUI registry check requires running steward daemon\" (`icn/bins/icnctl/src/main.rs` StewardCommands::CheckVui)"),

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3653,6 +3653,7 @@ name = "icn-rpc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "ed25519-dalek",
  "hex",

--- a/icn/crates/icn-core/src/supervisor/init_rpc.rs
+++ b/icn/crates/icn-core/src/supervisor/init_rpc.rs
@@ -28,7 +28,7 @@ pub struct RpcDeps {
     pub contract_runtime: Arc<RwLock<ContractRuntime>>,
     pub gossip_handle: Arc<RwLock<GossipActor>>,
     pub governance_handle: GovernanceHandle,
-    /// Cooperative membership source for auth and suspension checks.
+    /// Cooperative membership source for delegation suspension checks.
     pub coop_handle: CoopHandle,
     pub compute_handle: ComputeHandle,
     /// Trust service for trust-based operations
@@ -96,7 +96,6 @@ pub fn spawn_rpc_server(
     rpc_server.set_contract_runtime(deps.contract_runtime);
     rpc_server.set_gossip_handle(deps.gossip_handle);
     rpc_server.set_governance_handle(deps.governance_handle);
-    rpc_server.set_coop_handle(deps.coop_handle.clone());
 
     let coop_handle_for_suspension = deps.coop_handle;
     rpc_server.set_suspension_checker(Arc::new(move |did, domain_id| {

--- a/icn/crates/icn-core/src/supervisor/init_rpc.rs
+++ b/icn/crates/icn-core/src/supervisor/init_rpc.rs
@@ -11,6 +11,7 @@ use tracing::{debug, info, warn};
 
 use icn_ccl::ContractRuntime;
 use icn_compute::ComputeHandle;
+use icn_coop::{CoopHandle, MemberStatus};
 use icn_gossip::GossipActor;
 use icn_kernel_api::authz::PolicyOracle;
 use icn_kernel_api::services::TrustService;
@@ -27,6 +28,8 @@ pub struct RpcDeps {
     pub contract_runtime: Arc<RwLock<ContractRuntime>>,
     pub gossip_handle: Arc<RwLock<GossipActor>>,
     pub governance_handle: GovernanceHandle,
+    /// Cooperative membership source for auth and suspension checks.
+    pub coop_handle: CoopHandle,
     pub compute_handle: ComputeHandle,
     /// Trust service for trust-based operations
     pub trust_service: Option<Arc<dyn TrustService>>,
@@ -93,6 +96,23 @@ pub fn spawn_rpc_server(
     rpc_server.set_contract_runtime(deps.contract_runtime);
     rpc_server.set_gossip_handle(deps.gossip_handle);
     rpc_server.set_governance_handle(deps.governance_handle);
+    rpc_server.set_coop_handle(deps.coop_handle.clone());
+
+    let coop_handle_for_suspension = deps.coop_handle;
+    rpc_server.set_suspension_checker(Arc::new(move |did, domain_id| {
+        let handle = coop_handle_for_suspension.clone();
+        Box::pin(async move {
+            handle
+                .list_members(domain_id)
+                .await
+                .map(|members| {
+                    members
+                        .iter()
+                        .any(|member| member.did == did && member.status == MemberStatus::Suspended)
+                })
+                .unwrap_or(false)
+        })
+    }));
 
     // Clone compute handle for gateway before giving to RPC
     let compute_handle_for_gateway = deps.compute_handle.clone();

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -504,7 +504,7 @@ async fn spawn_actors_with_identity(
         };
 
     // Store handles for gateway integration
-    gateway_handles.coop = Some(coop_handle);
+    gateway_handles.coop = Some(coop_handle.clone());
     gateway_handles.community = Some(community_services.community_handle);
     gateway_handles.trust_service = trust_service_from_registry.clone();
     gateway_handles.entity = Some(entity_services.entity_handle);
@@ -1054,6 +1054,7 @@ async fn spawn_actors_with_identity(
             contract_runtime: contract_runtime_handle.clone(),
             gossip_handle: gossip_handle.clone(),
             governance_handle,
+            coop_handle: coop_handle.clone(),
             compute_handle,
             trust_service: trust_service_from_registry.clone(),
             dispute_manager: dispute_manager_handle,

--- a/icn/crates/icn-rpc/Cargo.toml
+++ b/icn/crates/icn-rpc/Cargo.toml
@@ -41,6 +41,9 @@ icn-api.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+# Test-only: implement the async GovernanceOps trait as an in-memory double for
+# the delegation-handler auth tests (#2113).
+async-trait = "0.1"
 
 [lints]
 workspace = true

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -1060,6 +1060,13 @@ pub fn required_scopes_for_method(method: &str) -> Option<&'static [&'static str
         | "governance.vote.cast" => {
             Some(&[scopes::GOVERNANCE_PROPOSAL_WRITE, scopes::GOVERNANCE_WRITE])
         }
+        // Vote delegation (#2113). Listing a caller's own delegations is a read;
+        // creating/revoking are governance writes gated like vote.cast. The handler
+        // additionally binds every write to ctx.caller_did (delegator == caller).
+        "governance.delegation.list" => Some(&[scopes::GOVERNANCE_READ]),
+        "governance.delegation.create" | "governance.delegation.revoke" => {
+            Some(&[scopes::GOVERNANCE_PROPOSAL_WRITE, scopes::GOVERNANCE_WRITE])
+        }
 
         // Compute methods
         "compute.status" => Some(&[scopes::COMPUTE_READ]),
@@ -1296,6 +1303,35 @@ mod tests {
             required_scopes_for_method("compute.submit"),
             Some(&[scopes::COMPUTE_WRITE][..])
         );
+    }
+
+    #[test]
+    fn delegation_methods_are_scope_gated() {
+        // #2113: the delegation write-path is gated like other governance writes,
+        // listing is a read. Defense-in-depth on top of the handler's per-caller
+        // delegator binding — a read-only token must not reach create/revoke.
+        assert_eq!(
+            required_scopes_for_method("governance.delegation.list"),
+            Some(&[scopes::GOVERNANCE_READ][..])
+        );
+        for m in [
+            "governance.delegation.create",
+            "governance.delegation.revoke",
+        ] {
+            assert_eq!(
+                required_scopes_for_method(m),
+                Some(&[scopes::GOVERNANCE_PROPOSAL_WRITE, scopes::GOVERNANCE_WRITE][..]),
+                "{m} must require a governance write scope"
+            );
+            assert!(
+                !method_authorized(m, &claims_with(&[scopes::GOVERNANCE_READ])),
+                "{m} must reject a read-only token"
+            );
+            assert!(
+                method_authorized(m, &claims_with(&[scopes::GOVERNANCE_WRITE])),
+                "{m} must accept the broad governance write token"
+            );
+        }
     }
 
     #[test]

--- a/icn/crates/icn-rpc/src/handler/governance.rs
+++ b/icn/crates/icn-rpc/src/handler/governance.rs
@@ -17,7 +17,7 @@ use icn_governance::{
 
 use crate::context::RpcContext;
 use crate::error_codes::{
-    AUTHENTICATION_REQUIRED, INVALID_PARAMS, NOT_FOUND, RESOURCE_NOT_AVAILABLE,
+    AUTHENTICATION_REQUIRED, INVALID_PARAMS, NOT_FOUND, PERMISSION_DENIED, RESOURCE_NOT_AVAILABLE,
 };
 use crate::server::RpcServer;
 use crate::types::{
@@ -775,8 +775,8 @@ fn parse_delegation_scope(scope: &str) -> Result<DelegationScope, String> {
         if proposal.is_empty() {
             return Err("proposal scope requires an id: 'proposal:<id>'".to_string());
         }
-        return Ok(DelegationScope::Proposal(icn_governance::ProposalId(
-            proposal.to_string(),
+        return Ok(DelegationScope::Proposal(icn_governance::ProposalId::new(
+            proposal,
         )));
     }
     Err(format!(
@@ -788,8 +788,55 @@ fn parse_delegation_scope(scope: &str) -> Result<DelegationScope, String> {
 fn delegation_scope_to_string(scope: &DelegationScope) -> String {
     match scope {
         DelegationScope::Blanket => "blanket".to_string(),
-        DelegationScope::Domain(d) => format!("domain:{}", d.0),
-        DelegationScope::Proposal(p) => format!("proposal:{}", p.0),
+        DelegationScope::Domain(d) => format!("domain:{d}"),
+        DelegationScope::Proposal(p) => format!("proposal:{p}"),
+    }
+}
+
+/// Return the domain in which `delegator` is suspended for this scope.
+///
+/// This mirrors the governance HTTP gate: domain scopes are checked directly,
+/// proposal scopes resolve their domain, and blanket scopes enumerate static-list
+/// domains the delegator belongs to. Missing checker or lookup errors preserve the
+/// existing fail-open behavior used by the HTTP path.
+async fn suspended_domain_for_scope(
+    state: &RpcServer,
+    governance_handle: &dyn icn_governance::GovernanceOps,
+    delegator: &icn_identity::Did,
+    scope: &DelegationScope,
+) -> Option<String> {
+    let checker = state.suspension_checker()?;
+
+    match scope {
+        DelegationScope::Blanket => {
+            let domains = governance_handle.list_domains().await.ok()?;
+            for domain in domains {
+                if domain.config.membership.source.contains_static(delegator) {
+                    let domain_id = domain.id.to_string();
+                    if checker(delegator.clone(), domain_id.clone()).await {
+                        return Some(domain_id);
+                    }
+                }
+            }
+            None
+        }
+        DelegationScope::Domain(domain) => {
+            let domain_id = domain.to_string();
+            checker(delegator.clone(), domain_id.clone())
+                .await
+                .then_some(domain_id)
+        }
+        DelegationScope::Proposal(proposal) => {
+            let domain_id = governance_handle
+                .get_proposal(proposal)
+                .await
+                .ok()??
+                .domain_id
+                .to_string();
+            checker(delegator.clone(), domain_id.clone())
+                .await
+                .then_some(domain_id)
+        }
     }
 }
 
@@ -857,9 +904,29 @@ pub async fn handle_governance_delegation_create(
         Err(e) => return RpcResponse::error(id, INVALID_PARAMS, e),
     };
 
+    if let Some(domain_id) =
+        suspended_domain_for_scope(state, governance_handle, &ctx.caller_did, &scope).await
+    {
+        return RpcResponse::error(
+            id,
+            PERMISSION_DENIED,
+            format!(
+                "Delegator {} is suspended in domain {domain_id}; suspended members may not create delegations",
+                ctx.caller_did
+            ),
+        );
+    }
+
     // SECURITY: delegator is the authenticated caller, never read from params.
     let mut delegation = Delegation::new(ctx.caller_did.clone(), delegate, scope);
     if let Some(expires_at) = request.expires_at {
+        if expires_at <= delegation.created_at {
+            return RpcResponse::error(
+                id,
+                INVALID_PARAMS,
+                "expires_at must be later than the delegation creation time".to_string(),
+            );
+        }
         delegation = delegation.with_expiry(expires_at);
     }
     let delegation_id = delegation.id.to_string();
@@ -1242,6 +1309,53 @@ mod delegation_auth_tests {
         let params = serde_json::json!({ "delegate": bob.to_string(), "scope": "blanket" });
         let resp = handle_governance_delegation_create(1, &params, &state, None).await;
         assert_eq!(resp.error.unwrap().code, AUTHENTICATION_REQUIRED);
+        assert!(gov.delegations.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_rejects_suspended_caller() {
+        let gov = RecordingGovernance::default();
+        let alice = new_did();
+        let bob = new_did();
+        let suspended_alice = alice.clone();
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let mut server = RpcServer::new(addr);
+        server.set_governance_handle(gov.clone());
+        server.set_suspension_checker(Arc::new(move |did, domain_id| {
+            let suspended_alice = suspended_alice.clone();
+            Box::pin(async move { did == suspended_alice && domain_id == "workers" })
+        }));
+        let state = Arc::new(server);
+        let ctx = RpcContext::new(alice, None, vec![]);
+        let params = serde_json::json!({
+            "delegate": bob.to_string(),
+            "scope": "domain:workers",
+        });
+
+        let resp = handle_governance_delegation_create(1, &params, &state, Some(&ctx)).await;
+
+        let err = resp.error.expect("suspended caller must be rejected");
+        assert_eq!(err.code, PERMISSION_DENIED);
+        assert!(gov.delegations.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_rejects_expired_timestamp_instead_of_persisting_unbounded() {
+        let gov = RecordingGovernance::default();
+        let state = test_state(gov.clone());
+        let alice = new_did();
+        let bob = new_did();
+        let ctx = RpcContext::new(alice, None, vec![]);
+        let params = serde_json::json!({
+            "delegate": bob.to_string(),
+            "scope": "blanket",
+            "expires_at": 0,
+        });
+
+        let resp = handle_governance_delegation_create(1, &params, &state, Some(&ctx)).await;
+
+        let err = resp.error.expect("expired timestamp must be rejected");
+        assert_eq!(err.code, INVALID_PARAMS);
         assert!(gov.delegations.lock().unwrap().is_empty());
     }
 

--- a/icn/crates/icn-rpc/src/handler/governance.rs
+++ b/icn/crates/icn-rpc/src/handler/governance.rs
@@ -10,15 +10,21 @@
 
 use std::sync::Arc;
 
-use icn_governance::{MembershipSource, ProposalPayload, ProposalState, VoteChoice};
+use icn_governance::{
+    Delegation, DelegationId, DelegationScope, MembershipSource, ProposalPayload, ProposalState,
+    VoteChoice,
+};
 
 use crate::context::RpcContext;
-use crate::error_codes::{NOT_FOUND, RESOURCE_NOT_AVAILABLE};
+use crate::error_codes::{
+    AUTHENTICATION_REQUIRED, INVALID_PARAMS, NOT_FOUND, RESOURCE_NOT_AVAILABLE,
+};
 use crate::server::RpcServer;
 use crate::types::{
-    CastVoteRequest, CloseProposalRequest, CreateDomainRequest, CreateProposalRequest,
-    CreateProposalResponse, GovernanceDomainInfo, GovernanceParamsInfo, MembershipConfigInfo,
-    OpenProposalRequest, ProposalInfo, ProposalPayloadInfo, RpcResponse,
+    CastVoteRequest, CloseProposalRequest, CreateDelegationRequest, CreateDomainRequest,
+    CreateProposalRequest, CreateProposalResponse, GovernanceDomainInfo, GovernanceParamsInfo,
+    MembershipConfigInfo, OpenProposalRequest, ProposalInfo, ProposalPayloadInfo,
+    RevokeDelegationRequest, RpcResponse,
 };
 
 /// Handle governance.domain.list RPC call - list all governance domains
@@ -731,5 +737,652 @@ pub async fn handle_governance_proposal_close(
             RpcResponse::success(id, result)
         }
         Err(e) => RpcResponse::internal_error(id, e),
+    }
+}
+
+// ============================================================================
+// Vote delegation (issue #2113)
+//
+// These three handlers wire icnctl's `gov vote delegate/delegations/revoke`
+// commands to the existing `GovernanceOps` delegation methods. The load-bearing
+// part is the authorization gate, not the storage: a governance write-path must
+// never let a caller act on another member's behalf.
+//
+//   create -> delegator is ALWAYS ctx.caller_did (never a params field)
+//   list   -> only the caller's own outgoing/incoming delegations
+//   revoke -> load first, revoke only if delegation.delegator == ctx.caller_did
+//
+// All three fail closed when the request is unauthenticated.
+// ============================================================================
+
+/// Parse a delegation scope string (`blanket` / `domain:<id>` / `proposal:<id>`).
+fn parse_delegation_scope(scope: &str) -> Result<DelegationScope, String> {
+    let scope = scope.trim();
+    if scope.eq_ignore_ascii_case("blanket") {
+        return Ok(DelegationScope::Blanket);
+    }
+    if let Some(domain) = scope.strip_prefix("domain:") {
+        let domain = domain.trim();
+        if domain.is_empty() {
+            return Err("domain scope requires an id: 'domain:<id>'".to_string());
+        }
+        return Ok(DelegationScope::Domain(
+            icn_governance::GovernanceDomainId::new(domain),
+        ));
+    }
+    if let Some(proposal) = scope.strip_prefix("proposal:") {
+        let proposal = proposal.trim();
+        if proposal.is_empty() {
+            return Err("proposal scope requires an id: 'proposal:<id>'".to_string());
+        }
+        return Ok(DelegationScope::Proposal(icn_governance::ProposalId(
+            proposal.to_string(),
+        )));
+    }
+    Err(format!(
+        "invalid delegation scope '{scope}'. Expected 'blanket', 'domain:<id>', or 'proposal:<id>'"
+    ))
+}
+
+/// Render a [`DelegationScope`] back to its wire string form.
+fn delegation_scope_to_string(scope: &DelegationScope) -> String {
+    match scope {
+        DelegationScope::Blanket => "blanket".to_string(),
+        DelegationScope::Domain(d) => format!("domain:{}", d.0),
+        DelegationScope::Proposal(p) => format!("proposal:{}", p.0),
+    }
+}
+
+/// Serialize a delegation into the JSON shape the icnctl client renders.
+fn delegation_to_json(d: &Delegation, now: u64) -> serde_json::Value {
+    serde_json::json!({
+        "id": d.id.to_string(),
+        "delegator": d.delegator.to_string(),
+        "delegate": d.delegate.to_string(),
+        "scope": delegation_scope_to_string(&d.scope),
+        "is_active": d.is_active(now),
+        "expires_at": d.expires_at,
+    })
+}
+
+/// Handle `governance.delegation.create` — create a vote delegation.
+///
+/// The delegator is the authenticated caller (`ctx.caller_did`), never a params
+/// field, so a caller can only ever delegate their own vote. Fail-closed when
+/// unauthenticated.
+pub async fn handle_governance_delegation_create(
+    id: u64,
+    params: &serde_json::Value,
+    state: &Arc<RpcServer>,
+    ctx: Option<&RpcContext>,
+) -> RpcResponse {
+    let ctx = match ctx {
+        Some(c) => c,
+        None => {
+            return RpcResponse::error(
+                id,
+                AUTHENTICATION_REQUIRED,
+                "Authentication required to create a delegation".to_string(),
+            );
+        }
+    };
+
+    tracing::debug!(caller = %ctx.caller_did, "governance.delegation.create called");
+
+    let governance_handle = match state.governance_handle() {
+        Some(handle) => handle,
+        None => {
+            return RpcResponse::error(
+                id,
+                RESOURCE_NOT_AVAILABLE,
+                "Governance not available".to_string(),
+            );
+        }
+    };
+
+    let request: CreateDelegationRequest = match serde_json::from_value(params.clone()) {
+        Ok(r) => r,
+        Err(e) => return RpcResponse::error(id, INVALID_PARAMS, format!("Invalid params: {e}")),
+    };
+
+    let delegate = match icn_identity::Did::from_str(&request.delegate) {
+        Ok(d) => d,
+        Err(e) => {
+            return RpcResponse::error(id, INVALID_PARAMS, format!("Invalid delegate DID: {e}"));
+        }
+    };
+
+    let scope = match parse_delegation_scope(&request.scope) {
+        Ok(s) => s,
+        Err(e) => return RpcResponse::error(id, INVALID_PARAMS, e),
+    };
+
+    // SECURITY: delegator is the authenticated caller, never read from params.
+    let mut delegation = Delegation::new(ctx.caller_did.clone(), delegate, scope);
+    if let Some(expires_at) = request.expires_at {
+        delegation = delegation.with_expiry(expires_at);
+    }
+    let delegation_id = delegation.id.to_string();
+
+    match governance_handle.create_delegation(delegation).await {
+        Ok(()) => RpcResponse::success(id, serde_json::json!({ "id": delegation_id })),
+        Err(e) => RpcResponse::internal_error(id, e),
+    }
+}
+
+/// Handle `governance.delegation.list` — list the caller's own delegations.
+///
+/// Returns only the authenticated caller's outgoing (`given`) and incoming
+/// (`received`) delegations. No arbitrary-DID listing is accepted.
+pub async fn handle_governance_delegation_list(
+    id: u64,
+    state: &Arc<RpcServer>,
+    ctx: Option<&RpcContext>,
+) -> RpcResponse {
+    let ctx = match ctx {
+        Some(c) => c,
+        None => {
+            return RpcResponse::error(
+                id,
+                AUTHENTICATION_REQUIRED,
+                "Authentication required to list delegations".to_string(),
+            );
+        }
+    };
+
+    tracing::debug!(caller = %ctx.caller_did, "governance.delegation.list called");
+
+    let governance_handle = match state.governance_handle() {
+        Some(handle) => handle,
+        None => {
+            return RpcResponse::error(
+                id,
+                RESOURCE_NOT_AVAILABLE,
+                "Governance not available".to_string(),
+            );
+        }
+    };
+
+    let caller = &ctx.caller_did;
+    let given = match governance_handle.get_delegations_from(caller).await {
+        Ok(v) => v,
+        Err(e) => return RpcResponse::internal_error(id, e),
+    };
+    let received = match governance_handle.get_delegations_to(caller).await {
+        Ok(v) => v,
+        Err(e) => return RpcResponse::internal_error(id, e),
+    };
+
+    let now = icn_time::current_timestamp_secs();
+    let given: Vec<_> = given.iter().map(|d| delegation_to_json(d, now)).collect();
+    let received: Vec<_> = received
+        .iter()
+        .map(|d| delegation_to_json(d, now))
+        .collect();
+
+    RpcResponse::success(
+        id,
+        serde_json::json!({ "given": given, "received": received }),
+    )
+}
+
+/// Handle `governance.delegation.revoke` — revoke one of the caller's delegations.
+///
+/// The delegation is loaded first and revoked ONLY if the caller is its delegator.
+/// A delegation that does not exist OR is not owned by the caller returns the same
+/// `NOT_FOUND` response, so the endpoint never reveals another member's delegation.
+pub async fn handle_governance_delegation_revoke(
+    id: u64,
+    params: &serde_json::Value,
+    state: &Arc<RpcServer>,
+    ctx: Option<&RpcContext>,
+) -> RpcResponse {
+    let ctx = match ctx {
+        Some(c) => c,
+        None => {
+            return RpcResponse::error(
+                id,
+                AUTHENTICATION_REQUIRED,
+                "Authentication required to revoke a delegation".to_string(),
+            );
+        }
+    };
+
+    tracing::debug!(caller = %ctx.caller_did, "governance.delegation.revoke called");
+
+    let governance_handle = match state.governance_handle() {
+        Some(handle) => handle,
+        None => {
+            return RpcResponse::error(
+                id,
+                RESOURCE_NOT_AVAILABLE,
+                "Governance not available".to_string(),
+            );
+        }
+    };
+
+    let request: RevokeDelegationRequest = match serde_json::from_value(params.clone()) {
+        Ok(r) => r,
+        Err(e) => return RpcResponse::error(id, INVALID_PARAMS, format!("Invalid params: {e}")),
+    };
+
+    let delegation_id = DelegationId::new(request.delegation_id);
+
+    // Load first, then authorize: only the delegator may revoke. "Not found" and
+    // "not owned by caller" return the SAME response so existence is never leaked.
+    let existing = match governance_handle.get_delegation(&delegation_id).await {
+        Ok(d) => d,
+        Err(e) => return RpcResponse::internal_error(id, e),
+    };
+    match existing {
+        Some(d) if d.delegator == ctx.caller_did => {}
+        _ => return RpcResponse::error(id, NOT_FOUND, "Delegation not found".to_string()),
+    }
+
+    let now = icn_time::current_timestamp_secs();
+    match governance_handle
+        .revoke_delegation(&delegation_id, now)
+        .await
+    {
+        Ok(()) => RpcResponse::success(id, serde_json::json!({ "success": true })),
+        Err(e) => RpcResponse::internal_error(id, e),
+    }
+}
+
+#[cfg(test)]
+mod delegation_auth_tests {
+    use super::*;
+    use icn_identity::KeyPair;
+    use std::net::SocketAddr;
+    use std::sync::Mutex;
+
+    /// In-memory `GovernanceOps` test double. Only the delegation methods are
+    /// functional (backed by a shared Vec the test can inspect); every other method
+    /// is unused by these tests and panics if reached.
+    #[derive(Clone, Default)]
+    struct RecordingGovernance {
+        delegations: Arc<Mutex<Vec<Delegation>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl icn_governance::GovernanceOps for RecordingGovernance {
+        // ---- functional delegation methods ----
+        async fn create_delegation(&self, delegation: Delegation) -> anyhow::Result<()> {
+            self.delegations.lock().unwrap().push(delegation);
+            Ok(())
+        }
+        async fn get_delegation(&self, id: &DelegationId) -> anyhow::Result<Option<Delegation>> {
+            Ok(self
+                .delegations
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|d| &d.id == id)
+                .cloned())
+        }
+        async fn get_delegations_from(
+            &self,
+            delegator: &icn_identity::Did,
+        ) -> anyhow::Result<Vec<Delegation>> {
+            Ok(self
+                .delegations
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|d| &d.delegator == delegator)
+                .cloned()
+                .collect())
+        }
+        async fn get_delegations_to(
+            &self,
+            delegate: &icn_identity::Did,
+        ) -> anyhow::Result<Vec<Delegation>> {
+            Ok(self
+                .delegations
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|d| &d.delegate == delegate)
+                .cloned()
+                .collect())
+        }
+        async fn revoke_delegation(
+            &self,
+            id: &DelegationId,
+            revoked_at: icn_governance::Timestamp,
+        ) -> anyhow::Result<()> {
+            let mut g = self.delegations.lock().unwrap();
+            if let Some(d) = g.iter_mut().find(|d| &d.id == id) {
+                d.revoked_at = Some(revoked_at);
+            }
+            Ok(())
+        }
+
+        // ---- unused methods (never reached by delegation handlers) ----
+        async fn list_domains(&self) -> anyhow::Result<Vec<icn_governance::GovernanceDomain>> {
+            unimplemented!()
+        }
+        async fn list_domains_paginated(
+            &self,
+            _cursor: Option<&str>,
+            _limit: usize,
+        ) -> anyhow::Result<icn_governance::PaginatedResult<icn_governance::GovernanceDomain>>
+        {
+            unimplemented!()
+        }
+        async fn get_domain(
+            &self,
+            _id: &icn_governance::GovernanceDomainId,
+        ) -> anyhow::Result<Option<icn_governance::GovernanceDomain>> {
+            unimplemented!()
+        }
+        async fn list_proposals(&self) -> anyhow::Result<Vec<icn_governance::Proposal>> {
+            unimplemented!()
+        }
+        async fn get_proposal(
+            &self,
+            _id: &icn_governance::ProposalId,
+        ) -> anyhow::Result<Option<icn_governance::Proposal>> {
+            unimplemented!()
+        }
+        async fn create_domain(
+            &self,
+            _domain_id: icn_governance::GovernanceDomainId,
+            _name: String,
+            _profile: String,
+            _params: icn_governance::GovernanceParams,
+            _membership: icn_governance::MembershipConfig,
+        ) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn create_proposal(
+            &self,
+            _domain_id: icn_governance::GovernanceDomainId,
+            _title: String,
+            _description: String,
+            _payload: icn_governance::ProposalPayload,
+            _scope: icn_governance::ProposalScope,
+        ) -> anyhow::Result<icn_governance::ProposalId> {
+            unimplemented!()
+        }
+        async fn start_deliberation(
+            &self,
+            _proposal_id: icn_governance::ProposalId,
+            _deliberation_period_seconds: u64,
+        ) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn end_deliberation_and_open(
+            &self,
+            _proposal_id: icn_governance::ProposalId,
+            _voting_period_seconds: u64,
+        ) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn open_proposal(
+            &self,
+            _proposal_id: icn_governance::ProposalId,
+            _voting_period_seconds: u64,
+        ) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn cast_vote(
+            &self,
+            _proposal_id: icn_governance::ProposalId,
+            _voter: icn_identity::Did,
+            _choice: icn_governance::VoteChoice,
+            _comment: Option<String>,
+        ) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn close_proposal(
+            &self,
+            _proposal_id: icn_governance::ProposalId,
+        ) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn update_domain_membership(
+            &self,
+            _domain_id: icn_governance::GovernanceDomainId,
+            _member: icn_identity::Did,
+            _action: icn_governance::MembershipAction,
+        ) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+        async fn get_vote_tally(
+            &self,
+            _proposal_id: &icn_governance::ProposalId,
+        ) -> anyhow::Result<icn_governance::VoteTally> {
+            unimplemented!()
+        }
+        async fn get_voter_dids(
+            &self,
+            _proposal_id: &icn_governance::ProposalId,
+        ) -> anyhow::Result<Vec<icn_identity::Did>> {
+            unimplemented!()
+        }
+        async fn get_proof(
+            &self,
+            _proposal_id: &icn_governance::ProposalId,
+        ) -> anyhow::Result<Option<icn_governance::GovernanceProofV2>> {
+            unimplemented!()
+        }
+        async fn list_protocol_parameters(
+            &self,
+        ) -> anyhow::Result<Vec<icn_governance::ProtocolParameter>> {
+            unimplemented!()
+        }
+        async fn get_protocol_parameter(
+            &self,
+            _id: &str,
+        ) -> anyhow::Result<Option<icn_governance::ProtocolParameter>> {
+            unimplemented!()
+        }
+        async fn get_effective_protocol_parameter(
+            &self,
+            _id: &str,
+            _coop_id: Option<&str>,
+            _fed_id: Option<&str>,
+        ) -> anyhow::Result<Option<icn_governance::ProtocolParameter>> {
+            unimplemented!()
+        }
+        async fn get_protocol_parameter_history(
+            &self,
+            _id: &str,
+        ) -> anyhow::Result<Vec<icn_governance::ParameterChange>> {
+            unimplemented!()
+        }
+    }
+
+    fn test_state(gov: RecordingGovernance) -> Arc<RpcServer> {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let mut server = RpcServer::new(addr);
+        server.set_governance_handle(gov);
+        Arc::new(server)
+    }
+
+    fn new_did() -> icn_identity::Did {
+        KeyPair::generate().unwrap().did().clone()
+    }
+
+    #[tokio::test]
+    async fn create_binds_delegator_to_caller_ignoring_params() {
+        let gov = RecordingGovernance::default();
+        let state = test_state(gov.clone());
+        let alice = new_did();
+        let bob = new_did();
+        let mallory = new_did();
+        let ctx = RpcContext::new(alice.clone(), None, vec![]);
+        // A spurious "delegator" field must be ignored — the delegator is the caller.
+        let params = serde_json::json!({
+            "delegate": bob.to_string(),
+            "scope": "blanket",
+            "delegator": mallory.to_string(),
+        });
+        let resp = handle_governance_delegation_create(1, &params, &state, Some(&ctx)).await;
+        assert!(
+            resp.error.is_none(),
+            "expected success, got {:?}",
+            resp.error
+        );
+        let stored = gov.delegations.lock().unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(
+            stored[0].delegator, alice,
+            "delegator must be the authenticated caller, not a params value"
+        );
+        assert_eq!(stored[0].delegate, bob);
+    }
+
+    #[tokio::test]
+    async fn create_requires_authentication() {
+        let gov = RecordingGovernance::default();
+        let state = test_state(gov.clone());
+        let bob = new_did();
+        let params = serde_json::json!({ "delegate": bob.to_string(), "scope": "blanket" });
+        let resp = handle_governance_delegation_create(1, &params, &state, None).await;
+        assert_eq!(resp.error.unwrap().code, AUTHENTICATION_REQUIRED);
+        assert!(gov.delegations.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_returns_only_callers_own_delegations() {
+        let gov = RecordingGovernance::default();
+        let state = test_state(gov.clone());
+        let alice = new_did();
+        let bob = new_did();
+        let carol = new_did();
+        let dave = new_did();
+
+        let mk = |caller: &icn_identity::Did, delegate: &icn_identity::Did| {
+            (
+                RpcContext::new(caller.clone(), None, vec![]),
+                serde_json::json!({ "delegate": delegate.to_string(), "scope": "blanket" }),
+            )
+        };
+        let (ca, pa) = mk(&alice, &carol); // alice -> carol (given by alice)
+        handle_governance_delegation_create(1, &pa, &state, Some(&ca)).await;
+        let (cb, pb) = mk(&bob, &dave); // bob -> dave (unrelated to alice)
+        handle_governance_delegation_create(2, &pb, &state, Some(&cb)).await;
+        let (cd, pd) = mk(&dave, &alice); // dave -> alice (received by alice)
+        handle_governance_delegation_create(3, &pd, &state, Some(&cd)).await;
+
+        let ctx_alice = RpcContext::new(alice.clone(), None, vec![]);
+        let resp = handle_governance_delegation_list(9, &state, Some(&ctx_alice)).await;
+        let result = resp.result.expect("list result");
+        let given = result["given"].as_array().unwrap();
+        let received = result["received"].as_array().unwrap();
+
+        assert_eq!(given.len(), 1, "alice gave exactly one delegation");
+        assert_eq!(given[0]["delegator"], alice.to_string());
+        assert_eq!(given[0]["delegate"], carol.to_string());
+        assert_eq!(received.len(), 1, "alice received exactly one delegation");
+        assert_eq!(received[0]["delegate"], alice.to_string());
+        // Bob's unrelated delegation must not leak into alice's view at all.
+        assert!(
+            !result.to_string().contains(&bob.to_string()),
+            "another member's delegation leaked into the caller's list"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_requires_authentication() {
+        let gov = RecordingGovernance::default();
+        let state = test_state(gov);
+        let resp = handle_governance_delegation_list(1, &state, None).await;
+        assert_eq!(resp.error.unwrap().code, AUTHENTICATION_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn revoke_by_owner_succeeds() {
+        let gov = RecordingGovernance::default();
+        let state = test_state(gov.clone());
+        let alice = new_did();
+        let bob = new_did();
+        let ctx_alice = RpcContext::new(alice.clone(), None, vec![]);
+        let create = serde_json::json!({ "delegate": bob.to_string(), "scope": "blanket" });
+        let cresp = handle_governance_delegation_create(1, &create, &state, Some(&ctx_alice)).await;
+        let dele_id = cresp.result.unwrap()["id"].as_str().unwrap().to_string();
+
+        let revoke = serde_json::json!({ "delegation_id": dele_id });
+        let rresp = handle_governance_delegation_revoke(2, &revoke, &state, Some(&ctx_alice)).await;
+        assert!(
+            rresp.error.is_none(),
+            "owner revoke should succeed: {:?}",
+            rresp.error
+        );
+        assert!(
+            gov.delegations.lock().unwrap()[0].revoked_at.is_some(),
+            "delegation should be revoked"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_by_non_owner_is_rejected_and_not_leaking() {
+        let gov = RecordingGovernance::default();
+        let state = test_state(gov.clone());
+        let alice = new_did();
+        let bob = new_did();
+        let ctx_alice = RpcContext::new(alice.clone(), None, vec![]);
+        let ctx_bob = RpcContext::new(bob.clone(), None, vec![]);
+        let create = serde_json::json!({ "delegate": bob.to_string(), "scope": "blanket" });
+        let cresp = handle_governance_delegation_create(1, &create, &state, Some(&ctx_alice)).await;
+        let dele_id = cresp.result.unwrap()["id"].as_str().unwrap().to_string();
+
+        // Bob is the delegate, NOT the delegator — he must not be able to revoke.
+        let revoke = serde_json::json!({ "delegation_id": dele_id });
+        let rresp = handle_governance_delegation_revoke(2, &revoke, &state, Some(&ctx_bob)).await;
+        let err = rresp.error.expect("non-owner revoke must be rejected");
+        assert_eq!(
+            err.code, NOT_FOUND,
+            "non-owner gets the same not-found as a missing id"
+        );
+        assert!(
+            gov.delegations.lock().unwrap()[0].revoked_at.is_none(),
+            "a non-owner must NOT be able to revoke another member's delegation"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_requires_authentication() {
+        let gov = RecordingGovernance::default();
+        let state = test_state(gov);
+        let params = serde_json::json!({ "delegation_id": "anything" });
+        let resp = handle_governance_delegation_revoke(1, &params, &state, None).await;
+        assert_eq!(resp.error.unwrap().code, AUTHENTICATION_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn revoke_unknown_id_returns_not_found() {
+        let gov = RecordingGovernance::default();
+        let state = test_state(gov);
+        let alice = new_did();
+        let ctx = RpcContext::new(alice, None, vec![]);
+        let params = serde_json::json!({ "delegation_id": "no-such-delegation" });
+        let resp = handle_governance_delegation_revoke(1, &params, &state, Some(&ctx)).await;
+        assert_eq!(resp.error.unwrap().code, NOT_FOUND);
+    }
+
+    #[test]
+    fn scope_parsing_accepts_known_forms_and_rejects_others() {
+        assert!(matches!(
+            parse_delegation_scope("blanket"),
+            Ok(DelegationScope::Blanket)
+        ));
+        assert!(matches!(
+            parse_delegation_scope("BLANKET"),
+            Ok(DelegationScope::Blanket)
+        ));
+        assert!(matches!(
+            parse_delegation_scope("domain:econ"),
+            Ok(DelegationScope::Domain(_))
+        ));
+        assert!(matches!(
+            parse_delegation_scope("proposal:p-1"),
+            Ok(DelegationScope::Proposal(_))
+        ));
+        assert!(parse_delegation_scope("domain:").is_err());
+        assert!(parse_delegation_scope("proposal:").is_err());
+        assert!(parse_delegation_scope("nonsense").is_err());
     }
 }

--- a/icn/crates/icn-rpc/src/server.rs
+++ b/icn/crates/icn-rpc/src/server.rs
@@ -63,6 +63,13 @@ use crate::types::{RpcRequest, RpcResponse};
 use icn_gossip::GossipActor;
 use std::sync::LazyLock;
 
+/// Async predicate used to deny governance actions by suspended members.
+pub type SuspensionChecker = Arc<
+    dyn Fn(Did, String) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>
+        + Send
+        + Sync,
+>;
+
 /// Synthetic DID for rate-limiting anonymous/unauthenticated requests.
 /// All anonymous requests share this single DID bucket, applying
 /// Isolated-level limits (10 req/sec, burst 2) to the aggregate.
@@ -107,6 +114,8 @@ pub struct RpcServer {
     rate_limiter: Option<Arc<RateLimiter>>,
     /// Cooperative handle for membership validation (coop isolation)
     coop_handle: Option<CoopHandle>,
+    /// App-provided suspension lookup used by governance mutation handlers.
+    suspension_checker: Option<SuspensionChecker>,
     listen_addr: SocketAddr,
 }
 
@@ -132,6 +141,7 @@ impl RpcServer {
             auth_manager: None,
             rate_limiter: None,
             coop_handle: None,
+            suspension_checker: None,
             listen_addr,
         }
     }
@@ -161,6 +171,7 @@ impl RpcServer {
             auth_manager: Some(Arc::new(RpcAuthManager::new(jwt_secret, true))),
             rate_limiter: None,
             coop_handle: None,
+            suspension_checker: None,
             listen_addr,
         }
     }
@@ -281,6 +292,11 @@ impl RpcServer {
         self.coop_handle = Some(handle);
     }
 
+    /// Set the suspension lookup used to gate governance mutations.
+    pub fn set_suspension_checker(&mut self, checker: SuspensionChecker) {
+        self.suspension_checker = Some(checker);
+    }
+
     // =========================================================================
     // Accessor methods for handler modules
     // =========================================================================
@@ -375,6 +391,11 @@ impl RpcServer {
     /// Get coop handle (for handler modules)
     pub fn coop_handle(&self) -> Option<&CoopHandle> {
         self.coop_handle.as_ref()
+    }
+
+    /// Get the suspension lookup used by governance mutation handlers.
+    pub fn suspension_checker(&self) -> Option<&SuspensionChecker> {
+        self.suspension_checker.as_ref()
     }
 
     /// Start the RPC server

--- a/icn/crates/icn-rpc/src/server.rs
+++ b/icn/crates/icn-rpc/src/server.rs
@@ -753,6 +753,32 @@ async fn dispatch_request(
             .await
         }
 
+        // Vote delegation (issue #2113). Each handler gates on ctx.caller_did:
+        // create binds the delegator to the caller, list returns only the caller's
+        // own delegations, revoke only succeeds for the delegation's delegator.
+        "governance.delegation.create" => {
+            handler::governance::handle_governance_delegation_create(
+                req.id,
+                &req.params,
+                state,
+                ctx.as_ref(),
+            )
+            .await
+        }
+        "governance.delegation.list" => {
+            handler::governance::handle_governance_delegation_list(req.id, state, ctx.as_ref())
+                .await
+        }
+        "governance.delegation.revoke" => {
+            handler::governance::handle_governance_delegation_revoke(
+                req.id,
+                &req.params,
+                state,
+                ctx.as_ref(),
+            )
+            .await
+        }
+
         // Compute methods (coop-scoped, ctx passed for future isolation)
         "compute.submit" => {
             handler::compute::handle_compute_submit(req.id, &req.params, state, ctx.as_ref()).await

--- a/icn/crates/icn-rpc/src/types.rs
+++ b/icn/crates/icn-rpc/src/types.rs
@@ -247,6 +247,28 @@ pub struct CloseProposalRequest {
     pub proposal_id: String,
 }
 
+/// Request to create a vote delegation.
+///
+/// The delegator is ALWAYS the authenticated caller (`ctx.caller_did`); it is
+/// never read from these params, so a caller cannot create a delegation on behalf
+/// of another DID. Any stray `delegator` field in the JSON is ignored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateDelegationRequest {
+    /// DID that will vote on the caller's behalf.
+    pub delegate: String,
+    /// Scope string: "blanket", "domain:<domain_id>", or "proposal:<proposal_id>".
+    pub scope: String,
+    /// Optional expiry as a Unix timestamp (seconds). None = never expires.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+/// Request to revoke a vote delegation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevokeDelegationRequest {
+    pub delegation_id: String,
+}
+
 // Compute task types
 
 /// Code type for compute tasks


### PR DESCRIPTION
## Summary

Wires `icnctl gov vote delegate/delegations/revoke` to the existing `GovernanceOps` delegation methods over daemon JSON-RPC. The client already called `governance.delegation.{create,list,revoke}`; the server handlers were missing.

This is a governance write path, so caller binding and standing constraints are the load-bearing behavior.

## Why

Against a running daemon, the three commands returned method-not-found. Registering handlers without preserving the existing governance constraints would also create weaker behavior than the HTTP path.

## What changed

- Registers:
  - `governance.delegation.create`
  - `governance.delegation.list`
  - `governance.delegation.revoke`
- Scope-gates dispatch:
  - list → `GOVERNANCE_READ`
  - create/revoke → `[GOVERNANCE_PROPOSAL_WRITE, GOVERNANCE_WRITE]`
- Binds create delegator to `ctx.caller_did`; a params `delegator` value is ignored.
- Mirrors the HTTP suspension gate for blanket, domain, and proposal scopes through a production-wired cooperative membership lookup.
- Rejects `expires_at` values that are not later than delegation creation instead of silently persisting an unbounded delegation.
- Returns only the caller's outgoing and incoming delegations.
- Allows revoke only when the loaded delegation's delegator equals `ctx.caller_did`.
- Returns the same `NOT_FOUND` result for missing and not-owned IDs to avoid an existence leak.
- Uses public ID constructors and `Display` implementations instead of tuple-field coupling.
- Reclassifies `gov vote delegate/delegations/revoke` from `unknown` to `partial` in the generated icnctl inventory.

Inventory totals move from partial 107 → 110 and unknown 4 → 1. `init-coop` remains the only `unknown`. Proof level remains L1; this PR makes no runtime/e2e claim.

## Validation

- `cargo fmt --all --check` ✓
- `cargo clippy -p icn-rpc --all-targets -- -D warnings` ✓
- `cargo test -p icn-rpc` ✓ — 83 unit, 43 integration, 4 doc tests passed; 1 doc test ignored
- `cargo check -p icn-core` ✓
- `python3 docs/scripts/icnctl_command_inventory.py --check` ✓
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` ✓ — 898 docs, 65 baseline warnings
- `bash ops/scripts/drift-check.sh` ✓
- `python3 scripts/check-state-lag.py` ✓
- `git diff --check` ✓

Focused tests cover authenticated create/list/revoke; spoofed delegator input; suspended caller denial; stale expiry rejection; caller-only listing; revoke ownership and non-disclosure; unauthenticated denial; scope parsing; and central dispatch scope enforcement.

## Issue effects

Refs #2113 only. The issue remains open because `init-coop` still needs a non-static, runtime-aware resolution.

Issues #1746, #2082, and #2099 are untouched. `closingIssuesReferences` must remain empty.

## Follow-ups

- Resolve `init-coop` without forcing a static classification.
- A future binary-spawning integration test could promote these commands beyond `partial`.

## Nonclaims

- Does not claim #2113 completion.
- Does not claim production readiness, organizer readiness, formal NYCN pilot readiness, live federation, or Phase 2 completion.
- Does not claim entity-aware authorization enforcement or #2082 completion.
- Does not complete #2099.
- Does not change the REST route contract or pilot UI.
- Does not touch private institution/provider data or topology.
