### PR TITLE
docs(project-index): refresh organization repository map

### DIFF
--- a/docs/reference/project-index/repository-map.md
+++ b/docs/reference/project-index/repository-map.md
@@ -1,7 +1,7 @@
 ---
 Status: operational
 Canonical: no
-Last Reviewed: 2026-05-19
+Last Reviewed: 2026-06-28
 ---
 
 # ICN Repository Map
@@ -18,6 +18,9 @@ This document maps the repositories under the `InterCooperative-Network` GitHub 
 | [`nycn`](https://github.com/InterCooperative-Network/nycn) | Private | NYCN institution ecosystem package. First application package built on ICN. | First "institution-in-a-box" seed. Downstream of `icn`. |
 | [`icn-learn`](https://github.com/InterCooperative-Network/icn-learn) | Private | ICN Academy. Role-based learning and onboarding. | Teaching layer. Downstream of `icn` for facts, `nycn` for application examples. |
 | [`icn-community-bridge`](https://github.com/InterCooperative-Network/icn-community-bridge) | Private | Discord-to-Matrix onboarding bridge. Scaffold/docs only, not deployed. | See `docs/BRIDGE_POLICY.md` in that repo. |
+| [`icn-infra`](https://github.com/InterCooperative-Network/icn-infra) | Private | Organization infrastructure contracts, runbooks, templates, and sanitized inventories. | Bridges public `icn` deployment artifacts and private provider truth. Not public product truth, a secrets store, or a production-readiness claim. |
+| [`.github`](https://github.com/InterCooperative-Network/.github) | Public | Organization profile and shared community-health mirror. | Follows public truth from `icn`; must not lead or redefine it. |
+| [`demo-repository`](https://github.com/InterCooperative-Network/demo-repository) | Private | GitHub-generated demonstration repository. | Non-project noise unless the organization deliberately assigns and documents an ICN role. |
 
 If you came in expecting a separate `website` repository: the public site lives **inside this repo** at [`website/`](../../../website/). Treat it as part of `icn`, not a separate property.
 
@@ -51,15 +54,30 @@ When the facts in `icn-learn` and the source repos disagree, the source repos wi
 
 A community-coordination utility, currently scaffold-and-docs only. Not deployed, not load-bearing. Treated as a small operational tool, not as a substrate component. See that repo's `docs/BRIDGE_POLICY.md`.
 
+### `icn-infra` — private organization infrastructure contracts
+
+The organization-owned home for infrastructure contracts, runbooks, templates, and sanitized inventories. It translates public deployment artifacts from `icn` into bounded operational contracts without making private provider implementation details public.
+
+`icn-infra` is not public product truth, a secrets store, or evidence of production readiness. The private external provider repository `fahertym/network-ops` remains authoritative for its own implementation and topology; material may move into `icn-infra` only as a sanitized contract or path/reference, never as copied private topology or sensitive values.
+
+### `.github` — public organization mirror
+
+Organization profile and shared community-health files. This repository mirrors public project truth after it is established in `icn`; it does not originate architecture, status, or readiness claims.
+
+### `demo-repository` — unassigned demonstration repository
+
+The GitHub demonstration repository has no current ICN project role. Treat it as non-project noise unless a deliberate retention decision assigns a documented purpose and truth relationship.
+
 ## Merge order across repos
 
 When a change crosses repo boundaries, the canonical merge order is:
 
 1. **`icn`** — primitives, public contracts, public claims.
-2. **`nycn`** — application semantics built on those primitives.
+2. **Private consuming packages** — `nycn` for institution semantics; `icn-infra` for organization infrastructure contracts; `icn-community-bridge` for its bounded scaffold/policy.
 3. **`icn-learn`** — teaching that reflects what shipped above.
+4. **`.github`** — organization-facing mirrors after public truth is established.
 
-See [`ops/coordination/PR_STACK_PROTOCOL.md`](../../../ops/coordination/PR_STACK_PROTOCOL.md) and the PR template's "Cross-repo dependency status" section. Out-of-order merges create teaching that describes something that does not yet exist, or institution behavior whose primitive moved underneath it.
+`demo-repository` is outside this merge order because it has no assigned project role. See [`ops/coordination/PR_STACK_PROTOCOL.md`](../../../ops/coordination/PR_STACK_PROTOCOL.md) and the PR template's "Cross-repo dependency status" section. Out-of-order merges create mirrors or teaching that describe something that does not yet exist, or private package behavior whose public contract moved underneath it.
 
 ## Truth and confidentiality rules per repo
 
@@ -69,8 +87,11 @@ See [`ops/coordination/PR_STACK_PROTOCOL.md`](../../../ops/coordination/PR_STACK
 | `nycn` | Private, application-canonical | Institution-specific decisions, member data models, organizing flows. Not exported to `icn`. |
 | `icn-learn` | Private, derivative | Curriculum, exercises, narrative. Re-derives from `icn`/`nycn`; not a source of truth. |
 | `icn-community-bridge` | Private, operational | Bridge config and policy. Operational only. |
+| `icn-infra` | Private, organization-infrastructure | Contracts, runbooks, templates, and sanitized inventories. Not public product truth or provider implementation truth. |
+| `.github` | Public, mirror | Organization profile and shared community-health files. Must follow `icn` public truth. |
+| `demo-repository` | Private, unassigned | GitHub demonstration content with no current project truth role. |
 
-If a fact appears in `nycn` or `icn-learn` and is meant to be public, it has to find its way back to `icn` (typically `docs/`, `website/`, or a code change) before it can be cited externally.
+If a fact appears in a private or derivative repository and is meant to be public, it has to find its way back to `icn` (typically `docs/`, `website/`, or a code change) before it can be cited externally. `.github` may mirror that fact only after the public source exists.
 
 ## Adjacent identifiers
 
@@ -79,6 +100,7 @@ A few external surfaces are referenced from ICN material but are not GitHub repo
 - **`intercooperative.network`** — the public site, built from [`website/`](../../../website/) in this repo.
 - **GitHub Sponsors** — `github.com/sponsors/InterCooperative-Network`. See [`.github/FUNDING.yml`](../../../.github/FUNDING.yml).
 - **Live K3s deployment** — see [`docs/operations/deployment/HOMELAB_DEPLOYMENT.md`](../../operations/deployment/HOMELAB_DEPLOYMENT.md). Operational, not a separate repo.
+- **`fahertym/network-ops`** — external private provider implementation truth. It is not an organization repository or public ICN truth root; do not copy private topology or sensitive values into public docs.
 
 ## Where this map fits
 


### PR DESCRIPTION
## Summary

Refreshes the human-maintained organization repository map so it matches the current `InterCooperative-Network` repository set and its truth/confidentiality boundaries.

## Why

The map was last reviewed on 2026-05-19 and omitted `icn-infra`, `.github`, and `demo-repository`. That left contributors without an explicit distinction between public canonical truth, private institution/infrastructure packages, derivative teaching, organization mirrors, private provider truth, and non-project repository noise.

## What changed

- Adds `icn-infra` as the private home for organization infrastructure contracts, runbooks, templates, and sanitized inventories.
- States that `icn-infra` bridges public `icn` deployment artifacts and private provider truth without becoming public product truth, a secrets store, or evidence of production readiness.
- Adds `.github` as a public organization/community-health mirror that follows `icn` and must not lead public truth.
- Classifies `demo-repository` as unassigned GitHub demonstration content and non-project noise unless deliberately retained with a documented role.
- Keeps `fahertym/network-ops` outside the organization table and identifies it only as external private provider implementation truth; no topology or sensitive values are copied.
- Updates cross-repository merge order, truth/confidentiality rules, and the reviewed date (2026-06-28).

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` ✓ (898 docs; 65 pre-existing enforcement warnings)
- `bash ops/scripts/drift-check.sh` ✓
- `python3 scripts/check-state-lag.py` ✓
- `python3 .github/scripts/test_readiness_overclaim_linter.py` ✓ (51 tests)
- `python3 .github/scripts/readiness_overclaim_linter.py` ✓
- `git diff --check` ✓
- Diff is exactly `docs/reference/project-index/repository-map.md` ✓

## Issue effects

No issue is closed or referenced by this PR. It does not change #1746, #2082, #2099, or #2113.

## Follow-ups

- If `demo-repository` is intentionally retained, assign its purpose and truth relationship explicitly before treating it as project material.
- Keep future `icn-infra` extraction limited to sanitized service contracts and path/references to private provider truth.

## Nonclaims

- Does not claim production readiness, organizer readiness, formal NYCN pilot readiness, live federation, or Phase 2 completion.
- Does not make `icn-infra` public product truth or provider implementation truth.
- Does not make `.github` canonical or allow it to lead `icn`.
- Does not make Forge/Forgejo canonical or Matrix a governance system.
- Does not expose private provider topology, credentials, secrets, or sensitive values.
