### PR TITLE
feat(pilot-ui): add fixture-only organizer facilitator walkthrough

### DIFF
--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -29,7 +29,7 @@ const DEMO_MODE = (() => {
     }
 })();
 const DEMO_MODE_MESSAGES = {
-    demo:    'Local organizer/member demo. Review Preview, Standing, and Action Cards are fixture-backed today.',
+    demo:    'UI is in DEMO mode — a labeling convention. Local organizer/member demo. Review Preview, Standing, and Action Cards are fixture-backed today.',
     fixture: 'UI is in FIXTURE mode — committed test data only; not real participant state.',
     devnet:  'UI is in DEVNET mode — local 3-node Docker cluster; not production.',
     local:   'UI is in LOCAL mode — single-node local gateway.',
@@ -91,6 +91,8 @@ function applyDemoMode() {
         });
         const reviewPreviewNav = document.getElementById('review-preview-nav-btn');
         if (reviewPreviewNav) reviewPreviewNav.classList.remove('hidden');
+        const facilitatorWalkthrough = document.getElementById('facilitator-walkthrough');
+        if (facilitatorWalkthrough) facilitatorWalkthrough.classList.remove('hidden');
     }
 }
 
@@ -3243,6 +3245,66 @@ if (myStandingNavBtn) {
         loadMemberActionCards();
     });
 }
+
+const FACILITATOR_STEP_STATUS = {
+    standing: 'Step 1 of 4: inspect fictional Standing. No participant standing is queried or changed.',
+    'action-cards': 'Step 2 of 4: inspect fictional Action Cards. No work is assigned or completed.',
+    'review-preview': 'Step 3 of 4: inspect proposed rows and disabled review choices. No decision is recorded.',
+    evidence: 'Step 4 of 4: expected receipt categories are explanatory only. No receipt or evidence packet is created.',
+};
+
+function setFacilitatorStep(step) {
+    document.querySelectorAll('[data-facilitator-step]').forEach((button) => {
+        const current = button.dataset.facilitatorStep === step;
+        button.classList.toggle('current', current);
+        if (current) button.setAttribute('aria-current', 'step');
+        else button.removeAttribute('aria-current');
+    });
+    const status = document.getElementById('facilitator-walkthrough-status');
+    if (status) status.textContent = FACILITATOR_STEP_STATUS[step] || '';
+}
+
+function focusFacilitatorSurface(id) {
+    const target = document.getElementById(id);
+    if (target) target.focus();
+}
+
+async function openFacilitatorStep(step) {
+    if (DEMO_MODE !== 'demo') return;
+    setFacilitatorStep(step);
+
+    if (step === 'standing') {
+        switchTab('my-standing');
+        await loadMemberStanding();
+        focusFacilitatorSurface('member-standing-heading');
+        return;
+    }
+    if (step === 'action-cards') {
+        switchTab('my-standing');
+        await loadMemberActionCards();
+        focusFacilitatorSurface('member-action-cards-heading');
+        return;
+    }
+    if (step === 'review-preview') {
+        switchTab('review-preview');
+        await loadOrganizerReviewPreview();
+        focusFacilitatorSurface('organizer-review-heading');
+        return;
+    }
+    if (step === 'evidence') {
+        if (!state.organizerReviewWrapper || !Array.isArray(state.organizerReviewRows) || state.organizerReviewRows.length === 0) {
+            await loadOrganizerReviewPreview();
+        }
+        renderFacilitatorEvidenceExplanation();
+        const explanation = document.getElementById('facilitator-evidence-explanation');
+        if (explanation) explanation.open = true;
+        focusFacilitatorSurface('facilitator-evidence-summary');
+    }
+}
+
+document.querySelectorAll('[data-facilitator-step]').forEach((button) => {
+    button.addEventListener('click', () => openFacilitatorStep(button.dataset.facilitatorStep));
+});
 
 // PR 2 — paint the demo-mode banner and Demo Guide nav button as soon
 // as the DOM has the elements wired. Idempotent; refresh of DID/gateway
@@ -7604,6 +7666,40 @@ function renderOrganizerReviewPreview() {
 
     layout.append(listSection, detail);
     container.append(layout);
+}
+
+function renderFacilitatorEvidenceExplanation() {
+    const container = document.getElementById('facilitator-evidence-categories');
+    if (!container) return;
+    container.replaceChildren();
+
+    const intro = document.createElement('p');
+    intro.textContent = 'The committed Review Preview fixture says these receipt categories would be expected after separate future actions:';
+    container.append(intro);
+
+    const rows = Array.isArray(state.organizerReviewRows) ? state.organizerReviewRows : [];
+    const categories = [...new Set(rows
+        .filter((row) => row.receipt_expected && row.receipt_expected.expected && row.receipt_expected.category)
+        .map((row) => row.receipt_expected.category))];
+
+    if (categories.length > 0) {
+        const list = document.createElement('ul');
+        categories.forEach((category) => {
+            const item = document.createElement('li');
+            item.textContent = organizerReviewLabel({}, category);
+            list.append(item);
+        });
+        container.append(list);
+    } else {
+        const empty = document.createElement('p');
+        empty.textContent = 'No expected receipt categories are present in the loaded fixture.';
+        container.append(empty);
+    }
+
+    const boundary = document.createElement('p');
+    boundary.className = 'facilitator-evidence-warning';
+    boundary.textContent = 'Expected does not mean issued. This walkthrough displays category labels only; it creates and exports nothing.';
+    container.append(boundary);
 }
 
 function buildOrganizerReviewDetail(row, index, total) {

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -684,6 +684,48 @@
                 </button>
             </nav>
 
+            <!-- Demo-only facilitator path over existing committed fixtures. -->
+            <section id="facilitator-walkthrough" class="facilitator-walkthrough hidden" aria-labelledby="facilitator-walkthrough-heading">
+                <div class="facilitator-walkthrough-copy">
+                    <p class="facilitator-walkthrough-eyebrow">Fixture-backed facilitator path</p>
+                    <h2 id="facilitator-walkthrough-heading">Rehearse the read-only organizer story</h2>
+                    <p class="facilitator-walkthrough-boundary">DEMO MODE · COMMITTED FICTIONAL FIXTURES · READ-ONLY · NON-MUTATING</p>
+                    <p>Use these steps in order. They open the existing Standing, Action Cards, and Review Preview surfaces without a terminal, gateway, review decision, assignment, or write.</p>
+                </div>
+                <ol class="facilitator-walkthrough-steps" aria-label="Facilitator walkthrough steps">
+                    <li><button type="button" data-facilitator-step="standing"><span>1</span> Start rehearsal: Standing</button></li>
+                    <li><button type="button" data-facilitator-step="action-cards"><span>2</span> View Action Cards</button></li>
+                    <li><button type="button" data-facilitator-step="review-preview"><span>3</span> Open Review Preview</button></li>
+                    <li><button type="button" data-facilitator-step="evidence"><span>4</span> Explain receipt / evidence</button></li>
+                </ol>
+                <p id="facilitator-walkthrough-status" class="facilitator-walkthrough-status" aria-live="polite">Choose “Start rehearsal” to begin with the fictional Standing fixture.</p>
+                <details id="facilitator-evidence-explanation" class="facilitator-evidence-explanation">
+                    <summary id="facilitator-evidence-summary">Receipt and evidence boundaries</summary>
+                    <div id="facilitator-evidence-categories" class="facilitator-evidence-categories">
+                        <p>Open this step to read expected categories from the committed review fixture.</p>
+                    </div>
+                    <div class="facilitator-boundary-grid">
+                        <section aria-labelledby="facilitator-fixture-heading">
+                            <h3 id="facilitator-fixture-heading">Organizer / facilitator</h3>
+                            <p>Guides the read-only story, inspects fictional proposed rows, and explains disabled review choices and expected categories at L2 fixture-backed evidence.</p>
+                        </section>
+                        <section aria-labelledby="facilitator-member-heading">
+                            <h3 id="facilitator-member-heading">Member-facing fixtures</h3>
+                            <p>Standing and Action Cards show what a fictional member could see. No member action is completed, assigned, or recorded here.</p>
+                        </section>
+                        <section aria-labelledby="facilitator-steward-heading">
+                            <h3 id="facilitator-steward-heading">Steward / operator boundary</h3>
+                            <p>Any later assignment binding, approved next step, runtime producer, or evidence handling belongs to a separately authorized steward or operator workflow outside this surface.</p>
+                        </section>
+                        <section aria-labelledby="facilitator-future-heading">
+                            <h3 id="facilitator-future-heading">Future, not implemented</h3>
+                            <p>This walkthrough does not persist review decisions, mutate gateway state, create Action Cards, issue receipts, or export evidence packets.</p>
+                        </section>
+                    </div>
+                    <p class="facilitator-walkthrough-nonclaims"><strong>Nonclaims:</strong> no production readiness, organizer readiness, formal NYCN pilot readiness, live federation, Phase 2 completion, entity-aware auth enforcement, #2082 completion, #2113 completion, live cloud sync, persisted review decision, mutation, receipt creation, or evidence export is claimed.</p>
+                </details>
+            </section>
+
             <!-- Dashboard Tab -->
             <main id="main-content" class="tab-container">
                 <!-- Demo Guide Tab (PR 2 — guided demo landing; reads existing app state only, no new endpoint consumers) -->
@@ -1798,7 +1840,7 @@ did:icn:charlie,did:icn:alice,3.5,Childcare</code></pre>
             <main id="review-preview" class="tab-content" role="tabpanel" aria-labelledby="review-preview-nav-btn">
                 <section class="organizer-review-section" aria-labelledby="organizer-review-heading">
                     <p class="organizer-review-eyebrow">Fixture-only rehearsal</p>
-                    <h2 id="organizer-review-heading">Review preview</h2>
+                    <h2 id="organizer-review-heading" tabindex="-1">Review preview</h2>
                     <p class="organizer-review-intro">
                         Review four fictional proposed items in plain language before any later step. This surface is read-only: opening it, selecting a row, or inspecting a review choice records nothing and changes nothing.
                     </p>
@@ -1811,7 +1853,7 @@ did:icn:charlie,did:icn:alice,3.5,Childcare</code></pre>
             <!-- My Standing & Action Cards (PR 3 — answers "Who am I, what is my standing, what can I do?") -->
             <main id="my-standing" class="tab-content" role="tabpanel" aria-labelledby="tab-my-standing">
                 <section class="member-standing-section" aria-labelledby="member-standing-heading">
-                    <h2 id="member-standing-heading">My Standing</h2>
+                    <h2 id="member-standing-heading" tabindex="-1">My Standing</h2>
                     <p class="member-standing-intro">
                         Who you are in this institution: domain memberships, role assignments, and the union of authority scopes that follow from those roles. This view reads the per-member <code>/v1/gov/me/standing</code> read-model (#1627). The trust graph is the source of truth for trust-threshold memberships; rows marked <strong>unverified</strong> indicate the read-model deferred to the trust graph rather than evaluating membership here.
                     </p>
@@ -1820,7 +1862,7 @@ did:icn:charlie,did:icn:alice,3.5,Childcare</code></pre>
                     </div>
                 </section>
                 <section class="member-action-cards-section" aria-labelledby="member-action-cards-heading">
-                    <h2 id="member-action-cards-heading">Action Cards</h2>
+                    <h2 id="member-action-cards-heading" tabindex="-1">Action Cards</h2>
                     <p class="member-action-cards-intro">
                         Your queue of actions across all governance domains. Each card surfaces who has authority, what is required, and whether completing the action produces a receipt. This view reads the per-member <code>/v1/gov/me/action-cards</code> read-model (#1659) and is <strong>distinct</strong> from the per-domain <a href="#governance" data-demo-target="governance">Action Items tab</a>, which uses a different endpoint and concept.
                     </p>

--- a/web/pilot-ui/style.css
+++ b/web/pilot-ui/style.css
@@ -6395,6 +6395,172 @@ body[data-demo-mode="true"] .member-action-cards-list {
     align-items: stretch;
 }
 
+/* === Demo-only facilitator walkthrough === */
+.facilitator-walkthrough {
+    max-width: 76rem;
+    margin: 1rem auto 0;
+    padding: 1.15rem 1.25rem;
+    border: 2px solid #7c3aed;
+    border-radius: 12px;
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-sm);
+}
+
+.facilitator-walkthrough-copy {
+    max-width: 75ch;
+}
+
+.facilitator-walkthrough-eyebrow,
+.facilitator-walkthrough-boundary {
+    margin: 0 0 0.4rem;
+    color: #6d28d9;
+    font-size: 0.875rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.facilitator-walkthrough h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+}
+
+.facilitator-walkthrough-copy > p:last-child {
+    margin-bottom: 1rem;
+    line-height: 1.55;
+}
+
+.facilitator-walkthrough-steps {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.65rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.facilitator-walkthrough-steps button {
+    width: 100%;
+    min-height: 48px;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.7rem 0.8rem;
+    border: 2px solid var(--border-color);
+    border-radius: 9px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    font: inherit;
+    font-weight: 650;
+    text-align: left;
+    cursor: pointer;
+}
+
+.facilitator-walkthrough-steps button:hover,
+.facilitator-walkthrough-steps button.current {
+    border-color: #7c3aed;
+}
+
+.facilitator-walkthrough-steps button.current {
+    background: rgba(124, 58, 237, 0.1);
+    box-shadow: 0 0 0 2px rgba(124, 58, 237, 0.14);
+}
+
+.facilitator-walkthrough-steps button span {
+    flex: 0 0 auto;
+    width: 1.65rem;
+    height: 1.65rem;
+    display: inline-grid;
+    place-items: center;
+    border-radius: 50%;
+    background: #6d28d9;
+    color: #fff;
+    font-size: 0.8rem;
+}
+
+.facilitator-walkthrough-status {
+    margin: 0.8rem 0 0;
+    color: var(--text-secondary);
+    font-size: 0.925rem;
+}
+
+.facilitator-evidence-explanation {
+    margin-top: 0.85rem;
+    padding-top: 0.85rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.facilitator-evidence-explanation summary {
+    min-height: 44px;
+    padding: 0.65rem 0;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.facilitator-evidence-categories,
+.facilitator-boundary-grid,
+.facilitator-walkthrough-nonclaims {
+    line-height: 1.55;
+}
+
+.facilitator-evidence-categories ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0;
+    list-style: none;
+}
+
+.facilitator-evidence-categories li {
+    padding: 0.35rem 0.6rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--bg-secondary);
+    font-weight: 650;
+}
+
+.facilitator-evidence-warning,
+.facilitator-walkthrough-nonclaims {
+    padding: 0.75rem 0.9rem;
+    border-left: 4px solid #7c3aed;
+    border-radius: 8px;
+    background: var(--bg-secondary);
+}
+
+.facilitator-boundary-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin: 1rem 0;
+}
+
+.facilitator-boundary-grid section {
+    padding: 0.85rem;
+    border: 1px solid var(--border-color);
+    border-radius: 9px;
+}
+
+.facilitator-boundary-grid h3 {
+    margin: 0 0 0.4rem;
+    font-size: 1rem;
+}
+
+.facilitator-boundary-grid p {
+    margin: 0;
+}
+
+[data-theme="dark"] .facilitator-walkthrough-eyebrow,
+[data-theme="dark"] .facilitator-walkthrough-boundary {
+    color: #c4b5fd;
+}
+
+@media (max-width: 800px) {
+    .facilitator-walkthrough-steps,
+    .facilitator-boundary-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* === Fixture-only organizer review preview === */
 body[data-demo-mode="true"] .organizer-review-section {
     max-width: 76rem;

--- a/web/pilot-ui/sw.js
+++ b/web/pilot-ui/sw.js
@@ -7,7 +7,7 @@
 // changes meaningfully so existing installs reliably pick up the new bundle.
 // The activate event purges any cache whose name doesn't match the current
 // CACHE_VERSION, which forces clients off the old asset set.
-const CACHE_VERSION = 'icn-timebank-v1.5';
+const CACHE_VERSION = 'icn-timebank-v1.6';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const API_CACHE = `${CACHE_VERSION}-api`;

--- a/web/pilot-ui/tests/e2e/facilitator-walkthrough.spec.js
+++ b/web/pilot-ui/tests/e2e/facilitator-walkthrough.spec.js
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.use({ serviceWorkers: 'block' });
+
+test.describe('Fixture-only facilitator walkthrough', () => {
+    test('is demo-only and states the read-only boundary', async ({ page }) => {
+        await page.goto('/');
+        await expect(page.locator('#facilitator-walkthrough')).toHaveClass(/hidden/);
+
+        await page.goto('/?mode=demo');
+        const walkthrough = page.locator('#facilitator-walkthrough');
+        await expect(walkthrough).not.toHaveClass(/hidden/);
+        await expect(walkthrough).toContainText('COMMITTED FICTIONAL FIXTURES');
+        await expect(walkthrough).toContainText('READ-ONLY');
+        await expect(walkthrough).toContainText('NON-MUTATING');
+    });
+
+    test('walks Standing, Action Cards, and Review Preview using local fixtures', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        const fixtureRequests = [];
+        page.on('request', (request) => {
+            if (request.url().includes('/fixtures/icn-organizer-demo/')) fixtureRequests.push(request.url());
+        });
+
+        await page.getByRole('button', { name: 'Start rehearsal: Standing' }).click();
+        await expect(page.locator('#my-standing')).toHaveClass(/active/);
+        await expect(page.locator('#member-standing-heading')).toBeFocused();
+        await expect(page.locator('#member-standing-content')).toContainText('Demo organizer (fictional)');
+
+        await page.getByRole('button', { name: 'View Action Cards' }).click();
+        await expect(page.locator('#member-action-cards-heading')).toBeFocused();
+        await expect(page.locator('.member-action-card')).toHaveCount(4);
+
+        await page.getByRole('button', { name: 'Open Review Preview' }).click();
+        await expect(page.locator('#review-preview')).toHaveClass(/active/);
+        await expect(page.locator('#organizer-review-heading')).toBeFocused();
+        await expect(page.locator('.organizer-review-row-select')).toHaveCount(4);
+
+        expect(fixtureRequests.every((url) => new URL(url).origin === 'http://localhost:8000')).toBeTruthy();
+        expect(fixtureRequests.some((url) => url.endsWith('/standing.json'))).toBeTruthy();
+        expect(fixtureRequests.some((url) => url.endsWith('/action-cards.json'))).toBeTruthy();
+        expect(fixtureRequests.some((url) => url.endsWith('/preview-review.pending-publish-summary.json'))).toBeTruthy();
+        expect(fixtureRequests.some((url) => url.endsWith('/pending-publish-summary.json'))).toBeTruthy();
+    });
+
+    test('explains fixture categories without claiming a receipt or export', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.getByRole('button', { name: 'Explain receipt / evidence' }).click();
+
+        const explanation = page.locator('#facilitator-evidence-explanation');
+        await expect(explanation).toHaveAttribute('open', '');
+        await expect(page.locator('#facilitator-evidence-summary')).toBeFocused();
+        await expect(explanation).toContainText('Action item completion receipt');
+        await expect(explanation).toContainText('Governance receipt');
+        await expect(explanation).toContainText('Attendance receipt');
+        await expect(explanation).toContainText('Settlement receipt');
+        await expect(explanation).toContainText('Expected does not mean issued');
+        await expect(explanation).toContainText('creates and exports nothing');
+        await expect(explanation).toContainText('Steward / operator boundary');
+        await expect(explanation).toContainText('Future, not implemented');
+    });
+
+    test('keeps every walkthrough action keyboard reachable and non-mutating', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        const buttons = page.locator('[data-facilitator-step]');
+        await expect(buttons).toHaveCount(4);
+        for (const button of await buttons.all()) {
+            await expect(button).toBeEnabled();
+            await expect(button).not.toHaveAttribute('formaction');
+        }
+
+        await buttons.first().focus();
+        await page.keyboard.press('Enter');
+        await expect(buttons.first()).toHaveAttribute('aria-current', 'step');
+        await expect(page.locator('#facilitator-walkthrough-status')).toContainText('No participant standing is queried or changed');
+    });
+
+    test('has no automated WCAG A/AA violations in the walkthrough panel', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.getByRole('button', { name: 'Explain receipt / evidence' }).click();
+        const results = await new AxeBuilder({ page })
+            .include('#facilitator-walkthrough')
+            .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+            .analyze();
+        expect(results.violations).toEqual([]);
+    });
+
+    test('does not overflow a narrow mobile viewport', async ({ page }) => {
+        await page.setViewportSize({ width: 375, height: 812 });
+        await page.goto('/?mode=demo');
+        await page.getByRole('button', { name: 'Explain receipt / evidence' }).click();
+        const dimensions = await page.evaluate(() => ({
+            viewport: document.documentElement.clientWidth,
+            content: document.documentElement.scrollWidth,
+        }));
+        expect(dimensions.content).toBeLessThanOrEqual(dimensions.viewport);
+    });
+});


### PR DESCRIPTION
## Summary

Adds the smallest no-terminal facilitator path over the existing demo-mode surfaces:

`Standing → Action Cards → Review Preview → receipt/evidence explanation`

The walkthrough is fixture-backed, read-only, demo-mode, non-mutating, and L2 evidence only.

## Why

Standing, Action Cards, and Review Preview already rendered committed fictional fixtures, but a facilitator still had to know which tabs to open and how to explain the proof boundary. This panel connects those existing surfaces without adding an app, producer endpoint, live sync, or mutation path.

## What changed

- adds a demo-only facilitator panel that remains visible across the existing tabs
- gives keyboard-reachable steps for Standing, Action Cards, Review Preview, and expected receipt/evidence categories
- derives expected category labels from the committed Review Preview fixture and renders them with DOM APIs / `textContent`
- separates organizer/facilitator, member-facing fixture, steward/operator, and future boundaries in plain language
- keeps all review choices disabled and adds no persistence, assignment, receipt, export, or gateway write
- bumps the service-worker cache version for the changed static bundle
- adds Playwright coverage for demo-only visibility, fixture requests, focus, nonclaims, axe, and mobile overflow

## Validation

- `node --check web/pilot-ui/app.js` — pass
- `node --check web/pilot-ui/sw.js` — pass
- `npm test -- --runInBand` — 40/40 pass
- related Chromium suites (`facilitator-walkthrough`, `organizer-review-preview`, `standing-action-cards`, `demo-mode`) — 37/37 pass
- `python3 docs/scripts/validate-rehearsal-shell-fixtures.py` — pass
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — pass with existing non-blocking registry/YAML warnings
- `bash ops/scripts/drift-check.sh` — pass
- `python3 scripts/check-state-lag.py` — pass
- `python3 .github/scripts/test_readiness_overclaim_linter.py` — 51/51 pass
- `python3 .github/scripts/readiness_overclaim_linter.py` — pass
- `git diff --check` — pass

The unscoped legacy Chromium suite was also attempted locally: 90 passed, 16 failed, 2 were interrupted, and 14 did not run before the run was stopped. Failures were confined to existing dashboard/login/member-profile/service-board tests (including hidden service-board targets and local clipboard/download behavior); none were in the four organizer/demo suites above. CI is pending.

## Issue effects

Refs #1726 and #1746. Does not close either issue.

This touches frontend-only demo-mode mechanics relevant to #1727, but does not implement or close the full backend `--demo-mode` requirement.

## Follow-ups

- run a separate human accessibility / assistive-technology pass over the four-step path
- consider a later fixture-only evidence packet display only as a separate, bounded slice
- keep runtime receipt production, review persistence, identity binding, and backend demo mode in their existing follow-up lanes

## Nonclaims

- No production readiness claim.
- No organizer readiness claim.
- No formal NYCN pilot readiness claim.
- No live federation claim.
- No Phase 2 completion claim.
- No entity-aware auth enforcement claim.
- No #2082 completion claim.
- No #2113 completion claim while init-coop remains unresolved.
- No Forge/Forgejo canonical claim.
- No Matrix-as-governance claim.
- No private/provider topology is included.
- No live Google Drive, Groups, or Sheets sync claim.
- No persisted review-decision claim.
- No mutation claim.
- No receipt creation or evidence-export claim.
- No human accessibility-pass completion claim; coverage here is automated only.
