### PR TITLE
fix(pilot-ui): improve facilitator keyboard continuation

### DIFF
--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -93,6 +93,11 @@ function applyDemoMode() {
         if (reviewPreviewNav) reviewPreviewNav.classList.remove('hidden');
         const facilitatorWalkthrough = document.getElementById('facilitator-walkthrough');
         if (facilitatorWalkthrough) facilitatorWalkthrough.classList.remove('hidden');
+        document.querySelectorAll('[data-facilitator-continue]').forEach((control) => {
+            control.classList.remove('hidden');
+        });
+        const actionCardDemoLimits = document.getElementById('member-action-cards-demo-limits');
+        if (actionCardDemoLimits) actionCardDemoLimits.classList.remove('hidden');
     }
 }
 
@@ -3304,6 +3309,10 @@ async function openFacilitatorStep(step) {
 
 document.querySelectorAll('[data-facilitator-step]').forEach((button) => {
     button.addEventListener('click', () => openFacilitatorStep(button.dataset.facilitatorStep));
+});
+
+document.querySelectorAll('[data-facilitator-continue]').forEach((button) => {
+    button.addEventListener('click', () => openFacilitatorStep(button.dataset.facilitatorContinue));
 });
 
 // PR 2 — paint the demo-mode banner and Demo Guide nav button as soon
@@ -7839,6 +7848,83 @@ async function loadMemberActionCards() {
     renderMemberActionCards();
 }
 
+const DEMO_MEMBERSHIP_SOURCE_LABELS = {
+    static_list: 'Committed demo member list',
+    trust_threshold: 'Trust threshold; verification deferred',
+};
+
+const DEMO_STANDING_STATUS_LABELS = {
+    member: 'Member',
+    unverified: 'Verification pending',
+};
+
+const DEMO_ROLE_LABELS = {
+    chair: 'Committee chair',
+    member: 'Committee member',
+};
+
+const DEMO_AUTHORITY_SCOPE_LABELS = {
+    session_scheduling: 'Schedule sessions',
+    program_review: 'Review the program',
+    veto_for_cause: 'Raise a for-cause objection',
+    registration_desk: 'Coordinate the registration desk',
+};
+
+const DEMO_ACTION_SOURCE_LABELS = {
+    proposal: 'Proposal',
+    meeting: 'Meeting',
+    action_item: 'Action item',
+};
+
+const DEMO_ACTION_KIND_LABELS = {
+    vote: 'Vote',
+    attend: 'Attend meeting',
+    complete: 'Mark complete',
+};
+
+const DEMO_RISK_LEVEL_LABELS = {
+    low: 'Low risk',
+    normal: 'Standard risk',
+    elevated: 'Elevated risk',
+};
+
+function demoFixtureLabel(labels, value) {
+    if (DEMO_MODE !== 'demo') return String(value || 'unknown');
+    if (labels[value]) return labels[value];
+    const words = String(value || 'unknown').replace(/_/g, ' ');
+    return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+function buildDemoFixtureTechnicalDetails(summaryText, entries) {
+    if (DEMO_MODE !== 'demo') return null;
+    const populatedEntries = entries.filter((entry) => {
+        if (Array.isArray(entry.value)) return entry.value.length > 0;
+        return entry.value !== undefined && entry.value !== null && entry.value !== '';
+    });
+    if (populatedEntries.length === 0) return null;
+
+    const details = document.createElement('details');
+    details.className = 'member-technical-detail member-fixture-technical-detail';
+    const summary = document.createElement('summary');
+    summary.textContent = summaryText;
+    const list = document.createElement('dl');
+    populatedEntries.forEach((entry) => {
+        const term = document.createElement('dt');
+        term.textContent = entry.label;
+        const description = document.createElement('dd');
+        const values = Array.isArray(entry.value) ? entry.value : [entry.value];
+        values.forEach((value, index) => {
+            if (index > 0) description.appendChild(document.createTextNode(', '));
+            const code = document.createElement('code');
+            code.textContent = String(value);
+            description.appendChild(code);
+        });
+        list.append(term, description);
+    });
+    details.append(summary, list);
+    return details;
+}
+
 function renderMemberStanding() {
     const container = document.getElementById('member-standing-content');
     if (!container) return;
@@ -7856,20 +7942,30 @@ function renderMemberStanding() {
     // DID + display label header
     const didBlock = document.createElement('dl');
     didBlock.className = 'standing-id-block';
-    const didDt = document.createElement('dt');
-    didDt.textContent = 'DID';
-    const didDd = document.createElement('dd');
-    didDd.className = 'did-display';
-    didDd.textContent = standing.did || state.did || '—';
-    didBlock.appendChild(didDt);
-    didBlock.appendChild(didDd);
-    if (standing.display_label) {
+    const appendDisplayLabel = () => {
+        if (!standing.display_label) return;
         const labelDt = document.createElement('dt');
         labelDt.textContent = 'Display label';
         const labelDd = document.createElement('dd');
         labelDd.textContent = standing.display_label;
         didBlock.appendChild(labelDt);
         didBlock.appendChild(labelDd);
+    };
+    const appendDid = () => {
+        const didDt = document.createElement('dt');
+        didDt.textContent = DEMO_MODE === 'demo' ? 'Technical DID' : 'DID';
+        const didDd = document.createElement('dd');
+        didDd.className = 'did-display';
+        didDd.textContent = standing.did || state.did || '—';
+        didBlock.appendChild(didDt);
+        didBlock.appendChild(didDd);
+    };
+    if (DEMO_MODE === 'demo') {
+        appendDisplayLabel();
+        appendDid();
+    } else {
+        appendDid();
+        appendDisplayLabel();
     }
     container.appendChild(didBlock);
 
@@ -7892,17 +7988,21 @@ function renderMemberStanding() {
             const name = document.createElement('strong');
             name.textContent = d.domain_name || d.domain_id || '(unnamed domain)';
             li.appendChild(name);
-            const id = document.createElement('span');
-            id.className = 'standing-domain-id';
-            id.textContent = ` (${d.domain_id || ''})`;
-            li.appendChild(id);
+            if (DEMO_MODE !== 'demo') {
+                const id = document.createElement('span');
+                id.className = 'standing-domain-id';
+                id.textContent = ` (${d.domain_id || ''})`;
+                li.appendChild(id);
+            }
             const status = document.createElement('span');
             status.className = `standing-status standing-status-${d.status || 'unknown'}`;
-            status.textContent = d.status || 'unknown';
+            status.textContent = demoFixtureLabel(DEMO_STANDING_STATUS_LABELS, d.status);
             li.appendChild(status);
             const source = document.createElement('span');
             source.className = 'standing-source';
-            source.textContent = `via ${d.membership_source || 'unknown'}`;
+            source.textContent = DEMO_MODE === 'demo'
+                ? `Membership source: ${demoFixtureLabel(DEMO_MEMBERSHIP_SOURCE_LABELS, d.membership_source)}`
+                : `via ${d.membership_source || 'unknown'}`;
             li.appendChild(source);
             domainList.appendChild(li);
         });
@@ -7926,7 +8026,7 @@ function renderMemberStanding() {
             const li = document.createElement('li');
             li.className = 'standing-role';
             const role = document.createElement('strong');
-            role.textContent = r.role || '(unnamed role)';
+            role.textContent = demoFixtureLabel(DEMO_ROLE_LABELS, r.role || '(unnamed role)');
             li.appendChild(role);
             if (r.structure_name || r.structure_id) {
                 const structure = document.createElement('span');
@@ -7944,7 +8044,7 @@ function renderMemberStanding() {
                 r.authority_scope.forEach((s) => {
                     const badge = document.createElement('span');
                     badge.className = 'standing-scope-badge';
-                    badge.textContent = s;
+                    badge.textContent = demoFixtureLabel(DEMO_AUTHORITY_SCOPE_LABELS, s);
                     scopeWrap.appendChild(badge);
                 });
                 li.appendChild(scopeWrap);
@@ -7958,18 +8058,26 @@ function renderMemberStanding() {
     const scopes = Array.isArray(standing.authority_scopes) ? standing.authority_scopes : [];
     if (scopes.length > 0) {
         const scopesHeading = document.createElement('h3');
-        scopesHeading.textContent = 'Authority scopes (union)';
+        scopesHeading.textContent = DEMO_MODE === 'demo' ? 'Combined responsibilities' : 'Authority scopes (union)';
         container.appendChild(scopesHeading);
         const scopeWrap = document.createElement('div');
         scopeWrap.className = 'standing-scope-union';
         scopes.forEach((s) => {
             const badge = document.createElement('span');
             badge.className = 'standing-scope-badge';
-            badge.textContent = s;
+            badge.textContent = demoFixtureLabel(DEMO_AUTHORITY_SCOPE_LABELS, s);
             scopeWrap.appendChild(badge);
         });
         container.appendChild(scopeWrap);
     }
+
+    const standingTechnicalDetails = buildDemoFixtureTechnicalDetails('Technical standing fixture values', [
+        { label: 'Domain identifiers', value: domains.map((domain) => domain.domain_id).filter(Boolean) },
+        { label: 'Membership-source values', value: [...new Set(domains.map((domain) => domain.membership_source).filter(Boolean))] },
+        { label: 'Role values', value: [...new Set(roles.map((role) => role.role).filter(Boolean))] },
+        { label: 'Authority-scope values', value: scopes },
+    ]);
+    if (standingTechnicalDetails) container.appendChild(standingTechnicalDetails);
 }
 
 function renderMemberActionCards() {
@@ -8014,19 +8122,21 @@ function buildMemberActionCardElement(card) {
     if (card.source_kind) {
         const b = document.createElement('span');
         b.className = 'badge badge-source';
-        b.textContent = card.source_kind;
+        b.textContent = demoFixtureLabel(DEMO_ACTION_SOURCE_LABELS, card.source_kind);
         badges.appendChild(b);
     }
     if (card.action_kind) {
         const b = document.createElement('span');
         b.className = 'badge badge-action';
-        b.textContent = card.action_kind;
+        b.textContent = demoFixtureLabel(DEMO_ACTION_KIND_LABELS, card.action_kind);
         badges.appendChild(b);
     }
     if (card.risk_level) {
         const b = document.createElement('span');
         b.className = `badge badge-risk badge-risk-${String(card.risk_level).toLowerCase()}`;
-        b.textContent = `risk: ${card.risk_level}`;
+        b.textContent = DEMO_MODE === 'demo'
+            ? demoFixtureLabel(DEMO_RISK_LEVEL_LABELS, card.risk_level)
+            : `risk: ${card.risk_level}`;
         badges.appendChild(b);
     }
     header.appendChild(badges);
@@ -8049,12 +8159,15 @@ function buildMemberActionCardElement(card) {
         authority.appendChild(dt); authority.appendChild(dd);
     }
     if (Array.isArray(card.required_authority_scope) && card.required_authority_scope.length > 0) {
-        const dt = document.createElement('dt'); dt.textContent = 'Required scope';
-        const dd = document.createElement('dd'); dd.textContent = card.required_authority_scope.join(', ');
+        const dt = document.createElement('dt'); dt.textContent = DEMO_MODE === 'demo' ? 'Required responsibility' : 'Required scope';
+        const dd = document.createElement('dd');
+        dd.textContent = card.required_authority_scope
+            .map((scope) => demoFixtureLabel(DEMO_AUTHORITY_SCOPE_LABELS, scope))
+            .join(', ');
         authority.appendChild(dt); authority.appendChild(dd);
     }
     if (card.deadline !== undefined && card.deadline !== null) {
-        const dt = document.createElement('dt'); dt.textContent = 'Deadline';
+        const dt = document.createElement('dt'); dt.textContent = DEMO_MODE === 'demo' ? 'Demo fixture date' : 'Deadline';
         const dd = document.createElement('dd');
         // formatDateTime exists elsewhere in app.js; fall back to a Date conversion
         // when it is not in scope yet (defensive — shouldn't happen in practice).
@@ -8064,11 +8177,23 @@ function buildMemberActionCardElement(card) {
         } else {
             dd.textContent = String(card.deadline);
         }
+        if (DEMO_MODE === 'demo') {
+            dd.appendChild(document.createTextNode(' — frozen fictional value; not a current deadline.'));
+        }
         authority.appendChild(dt); authority.appendChild(dd);
     }
     if (authority.children.length > 0) {
         article.appendChild(authority);
     }
+
+    const technicalDetails = buildDemoFixtureTechnicalDetails('Technical action-card fixture values', [
+        { label: 'Source kind', value: card.source_kind },
+        { label: 'Action kind', value: card.action_kind },
+        { label: 'Required authority scopes', value: card.required_authority_scope || [] },
+        { label: 'Source identifier', value: card.source_id },
+        { label: 'Domain identifier', value: card.domain_id },
+    ]);
+    if (technicalDetails) article.appendChild(technicalDetails);
 
     // Accessibility hint (schema field — surface explicitly)
     if (card.accessibility_hint) {
@@ -8085,7 +8210,9 @@ function buildMemberActionCardElement(card) {
     if (card.receipt_expected) {
         const r = document.createElement('p');
         r.className = 'member-action-card-receipt-expected';
-        r.textContent = 'Completing this action will produce a receipt.';
+        r.textContent = DEMO_MODE === 'demo'
+            ? 'The fixture marks a receipt as expected after a later completed action. This card does not complete the action or create a receipt.'
+            : 'Completing this action will produce a receipt.';
         article.appendChild(r);
     }
 

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -1841,6 +1841,9 @@ did:icn:charlie,did:icn:alice,3.5,Childcare</code></pre>
                 <section class="organizer-review-section" aria-labelledby="organizer-review-heading">
                     <p class="organizer-review-eyebrow">Fixture-only rehearsal</p>
                     <h2 id="organizer-review-heading" tabindex="-1">Review preview</h2>
+                    <button type="button" class="btn btn-secondary facilitator-continuation hidden" data-facilitator-continue="evidence">
+                        Continue to receipt and evidence explanation
+                    </button>
                     <p class="organizer-review-intro">
                         Review four fictional proposed items in plain language before any later step. This surface is read-only: opening it, selecting a row, or inspecting a review choice records nothing and changes nothing.
                     </p>
@@ -1854,17 +1857,34 @@ did:icn:charlie,did:icn:alice,3.5,Childcare</code></pre>
             <main id="my-standing" class="tab-content" role="tabpanel" aria-labelledby="tab-my-standing">
                 <section class="member-standing-section" aria-labelledby="member-standing-heading">
                     <h2 id="member-standing-heading" tabindex="-1">My Standing</h2>
+                    <button type="button" class="btn btn-secondary facilitator-continuation hidden" data-facilitator-continue="action-cards">
+                        Continue to Action Cards
+                    </button>
                     <p class="member-standing-intro">
-                        Who you are in this institution: domain memberships, role assignments, and the union of authority scopes that follow from those roles. This view reads the per-member <code>/v1/gov/me/standing</code> read-model (#1627). The trust graph is the source of truth for trust-threshold memberships; rows marked <strong>unverified</strong> indicate the read-model deferred to the trust graph rather than evaluating membership here.
+                        Who you are in this institution: domain memberships, role assignments, and the combined responsibilities that follow from those roles. A “verification pending” label means this read-only view did not evaluate that membership itself.
                     </p>
+                    <details class="member-technical-detail">
+                        <summary>Technical read-model detail</summary>
+                        <p>This surface reads <code>/v1/gov/me/standing</code> (#1627). The trust graph remains the source of truth for trust-threshold memberships; the fixture value <code>unverified</code> means evaluation was deferred.</p>
+                    </details>
                     <div id="member-standing-content" class="member-standing-content" aria-live="polite">
                         <p class="empty-state">Loading standing&hellip;</p>
                     </div>
                 </section>
                 <section class="member-action-cards-section" aria-labelledby="member-action-cards-heading">
                     <h2 id="member-action-cards-heading" tabindex="-1">Action Cards</h2>
+                    <button type="button" class="btn btn-secondary facilitator-continuation hidden" data-facilitator-continue="review-preview">
+                        Continue to Review Preview
+                    </button>
                     <p class="member-action-cards-intro">
-                        Your queue of actions across all governance domains. Each card surfaces who has authority, what is required, and whether completing the action produces a receipt. This view reads the per-member <code>/v1/gov/me/action-cards</code> read-model (#1659) and is <strong>distinct</strong> from the per-domain <a href="#governance" data-demo-target="governance">Action Items tab</a>, which uses a different endpoint and concept.
+                        Your queue of actions across governance domains. Each card explains who has authority, what is required, and whether a later completed action would be expected to produce a receipt.
+                    </p>
+                    <details class="member-technical-detail">
+                        <summary>Technical read-model detail</summary>
+                        <p>This surface reads <code>/v1/gov/me/action-cards</code> (#1659). It is <strong>distinct</strong> from the per-domain <a href="#governance" data-demo-target="governance">Action Items tab</a>, which uses a different endpoint and concept.</p>
+                    </details>
+                    <p id="member-action-cards-demo-limits" class="member-action-cards-demo-limits hidden">
+                        <strong>Demo limits:</strong> these cards are read-only examples. Current action status, reversal or challenge windows, “review later,” and help-request paths are not implemented in this demo fixture.
                     </p>
                     <div id="member-action-cards-list" class="member-action-cards-list" role="list" aria-live="polite">
                         <p class="empty-state" role="listitem">Loading action cards&hellip;</p>

--- a/web/pilot-ui/style.css
+++ b/web/pilot-ui/style.css
@@ -6484,6 +6484,12 @@ body[data-demo-mode="true"] .member-action-cards-list {
     font-size: 0.925rem;
 }
 
+.facilitator-continuation {
+    min-height: 44px;
+    margin: 0.25rem 0 0.85rem;
+    text-align: left;
+}
+
 .facilitator-evidence-explanation {
     margin-top: 0.85rem;
     padding-top: 0.85rem;
@@ -6558,6 +6564,22 @@ body[data-demo-mode="true"] .member-action-cards-list {
     .facilitator-walkthrough-steps,
     .facilitator-boundary-grid {
         grid-template-columns: 1fr;
+    }
+
+    body[data-demo-mode="true"] .member-action-cards-list {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    body[data-demo-mode="true"] .member-action-card {
+        min-width: 0;
+    }
+
+    .member-fixture-technical-detail dl {
+        grid-template-columns: 1fr;
+    }
+
+    .member-fixture-technical-detail dd {
+        margin-bottom: 0.45rem;
     }
 }
 
@@ -6858,7 +6880,7 @@ body[data-demo-mode="true"] .member-action-card .badge-action {
 
 body[data-demo-mode="true"] .member-action-card .badge-risk-low {
     background: rgba(22, 163, 74, 0.12);
-    color: #15803d;
+    color: #166534;
     border-color: rgba(22, 163, 74, 0.30);
     margin-left: auto;
 }
@@ -6928,6 +6950,53 @@ body[data-demo-mode="true"] .member-action-card-accessibility strong {
     font-weight: 700;
     letter-spacing: 0.06em;
     text-transform: uppercase;
+}
+
+.member-technical-detail {
+    margin: 0.35rem 0 1rem;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+}
+
+.member-technical-detail > summary {
+    min-height: 44px;
+    display: list-item;
+    box-sizing: border-box;
+    padding: 0.65rem 0;
+    font-weight: 650;
+    cursor: pointer;
+}
+
+.member-technical-detail > p {
+    margin: 0.35rem 0 0;
+    max-width: 78ch;
+    line-height: 1.5;
+}
+
+.member-fixture-technical-detail dl {
+    display: grid;
+    grid-template-columns: minmax(10rem, auto) minmax(0, 1fr);
+    gap: 0.35rem 0.75rem;
+    margin: 0.35rem 0 0;
+}
+
+.member-fixture-technical-detail dt {
+    font-weight: 650;
+}
+
+.member-fixture-technical-detail dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+body[data-demo-mode="true"] .member-action-cards-demo-limits {
+    margin: 0 0 1rem;
+    padding: 0.75rem 0.9rem;
+    border-left: 4px solid #7c3aed;
+    border-radius: 8px;
+    background: var(--bg-secondary);
+    line-height: 1.5;
 }
 
 /* Receipt-expected footer: full-width subtle pill */

--- a/web/pilot-ui/tests/e2e/facilitator-walkthrough.spec.js
+++ b/web/pilot-ui/tests/e2e/facilitator-walkthrough.spec.js
@@ -7,13 +7,54 @@ test.describe('Fixture-only facilitator walkthrough', () => {
     test('is demo-only and states the read-only boundary', async ({ page }) => {
         await page.goto('/');
         await expect(page.locator('#facilitator-walkthrough')).toHaveClass(/hidden/);
+        await expect(page.locator('[data-facilitator-continue]')).toHaveCount(3);
+        for (const control of await page.locator('[data-facilitator-continue]').all()) {
+            await expect(control).toBeHidden();
+        }
 
         await page.goto('/?mode=demo');
         const walkthrough = page.locator('#facilitator-walkthrough');
         await expect(walkthrough).not.toHaveClass(/hidden/);
+        for (const control of await page.locator('[data-facilitator-continue]').all()) {
+            await expect(control).not.toHaveClass(/hidden/);
+        }
         await expect(walkthrough).toContainText('COMMITTED FICTIONAL FIXTURES');
         await expect(walkthrough).toContainText('READ-ONLY');
         await expect(walkthrough).toContainText('NON-MUTATING');
+    });
+
+    test('continues the four-step story with forward Tab from each destination heading', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        const writeRequests = [];
+        page.on('request', (request) => {
+            if (!['GET', 'HEAD'].includes(request.method())) writeRequests.push(request.url());
+        });
+
+        const firstStep = page.getByRole('button', { name: 'Start rehearsal: Standing' });
+        await firstStep.focus();
+        await page.keyboard.press('Enter');
+        await expect(page.locator('#member-standing-heading')).toBeFocused();
+
+        await page.keyboard.press('Tab');
+        const continueToCards = page.getByRole('button', { name: 'Continue to Action Cards' });
+        await expect(continueToCards).toBeFocused();
+        await page.keyboard.press('Enter');
+        await expect(page.locator('#member-action-cards-heading')).toBeFocused();
+
+        await page.keyboard.press('Tab');
+        const continueToReview = page.getByRole('button', { name: 'Continue to Review Preview' });
+        await expect(continueToReview).toBeFocused();
+        await page.keyboard.press('Enter');
+        await expect(page.locator('#organizer-review-heading')).toBeFocused();
+
+        await page.keyboard.press('Tab');
+        const continueToEvidence = page.getByRole('button', { name: 'Continue to receipt and evidence explanation' });
+        await expect(continueToEvidence).toBeFocused();
+        await page.keyboard.press('Enter');
+        await expect(page.locator('#facilitator-evidence-summary')).toBeFocused();
+        await expect(page.locator('#facilitator-evidence-explanation')).toHaveAttribute('open', '');
+
+        expect(writeRequests).toEqual([]);
     });
 
     test('walks Standing, Action Cards, and Review Preview using local fixtures', async ({ page }) => {
@@ -69,6 +110,10 @@ test.describe('Fixture-only facilitator walkthrough', () => {
             await expect(button).toBeEnabled();
             await expect(button).not.toHaveAttribute('formaction');
         }
+        for (const button of await page.locator('[data-facilitator-continue]').all()) {
+            await expect(button).toBeEnabled();
+            await expect(button).not.toHaveAttribute('formaction');
+        }
 
         await buttons.first().focus();
         await page.keyboard.press('Enter');
@@ -76,20 +121,66 @@ test.describe('Fixture-only facilitator walkthrough', () => {
         await expect(page.locator('#facilitator-walkthrough-status')).toContainText('No participant standing is queried or changed');
     });
 
-    test('has no automated WCAG A/AA violations in the walkthrough panel', async ({ page }) => {
+    test('leads with plain fixture labels and identifies frozen dates and missing demo workflows', async ({ page }) => {
         await page.goto('/?mode=demo');
-        await page.getByRole('button', { name: 'Explain receipt / evidence' }).click();
-        const results = await new AxeBuilder({ page })
+        await page.getByRole('button', { name: 'Start rehearsal: Standing' }).click();
+
+        await expect(page.locator('.standing-status').first()).toHaveText('Member');
+        await expect(page.locator('.standing-source').first()).toContainText('Committed demo member list');
+        await expect(page.locator('.standing-role-scope .standing-scope-badge').first()).toHaveText('Schedule sessions');
+        await expect(page.getByRole('heading', { name: 'Combined responsibilities' })).toBeVisible();
+
+        const standingTechnical = page.getByText('Technical standing fixture values');
+        await expect(standingTechnical).toBeVisible();
+        await standingTechnical.click();
+        await expect(page.locator('.member-fixture-technical-detail').first()).toContainText('program_review');
+
+        await page.getByRole('button', { name: 'Continue to Action Cards' }).click();
+        const firstCard = page.locator('.member-action-card').first();
+        await expect(firstCard.locator('.badge-source')).toHaveText('Proposal');
+        await expect(firstCard.locator('.badge-action')).toHaveText('Vote');
+        await expect(firstCard.locator('.badge-risk')).toHaveText('Standard risk');
+        await expect(firstCard).toContainText('Demo fixture date');
+        await expect(firstCard).toContainText('frozen fictional value; not a current deadline');
+        await expect(firstCard).toContainText('does not complete the action or create a receipt');
+
+        const technicalCardValues = firstCard.getByText('Technical action-card fixture values');
+        await expect(technicalCardValues).toBeVisible();
+        await technicalCardValues.click();
+        await expect(firstCard).toContainText('program_review');
+
+        const demoLimits = page.locator('#member-action-cards-demo-limits');
+        await expect(demoLimits).toBeVisible();
+        await expect(demoLimits).toContainText('not implemented in this demo fixture');
+        await expect(demoLimits).toContainText('challenge windows');
+        await expect(demoLimits).toContainText('help-request paths');
+    });
+
+    test('has no automated WCAG A/AA violations in the touched demo surfaces', async ({ page }) => {
+        await page.goto('/?mode=demo');
+        await page.getByRole('button', { name: 'View Action Cards' }).click();
+        const standingResults = await new AxeBuilder({ page })
             .include('#facilitator-walkthrough')
+            .include('#my-standing')
             .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
             .analyze();
-        expect(results.violations).toEqual([]);
+        expect(standingResults.violations).toEqual([]);
+
+        await page.getByRole('button', { name: 'Open Review Preview' }).click();
+        await page.getByRole('button', { name: 'Explain receipt / evidence' }).click();
+        const reviewResults = await new AxeBuilder({ page })
+            .include('#facilitator-walkthrough')
+            .include('#review-preview')
+            .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+            .analyze();
+        expect(reviewResults.violations).toEqual([]);
     });
 
     test('does not overflow a narrow mobile viewport', async ({ page }) => {
         await page.setViewportSize({ width: 375, height: 812 });
         await page.goto('/?mode=demo');
-        await page.getByRole('button', { name: 'Explain receipt / evidence' }).click();
+        await page.getByRole('button', { name: 'View Action Cards' }).click();
+        await expect(page.getByRole('button', { name: 'Continue to Review Preview' })).toBeVisible();
         const dimensions = await page.evaluate(() => ({
             viewport: document.documentElement.clientWidth,
             content: document.documentElement.scrollWidth,

--- a/web/pilot-ui/tests/e2e/standing-action-cards.spec.js
+++ b/web/pilot-ui/tests/e2e/standing-action-cards.spec.js
@@ -51,26 +51,33 @@ test.describe('My Standing & Action Cards (PR 3)', () => {
         await expect(cardsList).toHaveCount(1);
     });
 
-    test('intro text labels Action Cards as distinct from Action Items', async ({ page }) => {
+    test('keeps Action Card technical distinctions behind secondary detail', async ({ page }) => {
         await page.goto('/');
         await page.waitForLoadState('networkidle');
 
         const intro = page.locator('.member-action-cards-intro');
-        await expect(intro).toContainText('distinct');
-        await expect(intro).toContainText('Action Items tab');
-        await expect(intro).toContainText('different endpoint and concept');
-        // Cite the actual endpoint that this surface consumes
-        await expect(intro).toContainText('/v1/gov/me/action-cards');
+        await expect(intro).toContainText('who has authority');
+        await expect(intro).toContainText('later completed action');
+
+        const technicalDetail = page.locator('.member-action-cards-section > .member-technical-detail');
+        await expect(technicalDetail).toContainText('distinct');
+        await expect(technicalDetail).toContainText('Action Items tab');
+        await expect(technicalDetail).toContainText('different endpoint and concept');
+        await expect(technicalDetail).toContainText('/v1/gov/me/action-cards');
     });
 
-    test('standing intro labels the standing read-model endpoint', async ({ page }) => {
+    test('leads with plain Standing language and keeps the endpoint secondary', async ({ page }) => {
         await page.goto('/');
         await page.waitForLoadState('networkidle');
 
         const intro = page.locator('.member-standing-intro');
-        await expect(intro).toContainText('/v1/gov/me/standing');
-        await expect(intro).toContainText('trust graph');
-        await expect(intro).toContainText('unverified');
+        await expect(intro).toContainText('combined responsibilities');
+        await expect(intro).toContainText('verification pending');
+
+        const technicalDetail = page.locator('.member-standing-section > .member-technical-detail');
+        await expect(technicalDetail).toContainText('/v1/gov/me/standing');
+        await expect(technicalDetail).toContainText('trust graph');
+        await expect(technicalDetail).toContainText('unverified');
     });
 
     test('empty-state messaging is plain language pre-fetch', async ({ page }) => {


### PR DESCRIPTION
## Summary

Improves the fixture-backed organizer facilitator walkthrough's keyboard continuation and plain-language comprehension.

After each destination heading, the next forward Tab now reaches a native, clearly named continuation button for the following step. Demo Standing and Action Card content leads with human labels, while raw fixture tokens remain available in closed technical-detail disclosures.

## Why

The partial accessibility evidence in #2240 identified two bounded follow-ups: F2, where forward Tab did not naturally continue the four-step story, and F4, where raw tokens and historical fictional dates added cognitive burden. This PR addresses those items under #1726 and adds a truthful adjacent note for the still-unimplemented Action Card affordances from F7.

## What changed

- adds demo-only `Continue to Action Cards`, `Continue to Review Preview`, and `Continue to receipt and evidence explanation` buttons immediately after their destination headings
- gives Standing roles, membership state, authority scopes, Action Card kinds, action kinds, and risk levels plain-language labels in demo mode
- moves raw fixture values into closed technical-detail disclosures
- labels historical dates as frozen fictional demo values rather than current deadlines
- states that status changes, reversal/challenge windows, review-later behavior, and help requests are not implemented in this demo fixture
- keeps expected-receipt copy read-only and explicit that the card creates nothing
- fixes the low-risk badge's automated contrast result and the Action Card grid's 375px overflow
- adds focused coverage for the sequential keyboard path, demo-only visibility, no-write behavior, boundaries, labels, axe checks, and narrow layout

## Validation

- `node --check web/pilot-ui/app.js` — PASS
- `node --check web/pilot-ui/sw.js` — PASS
- `npm test -- --runInBand` — PASS (40 tests)
- `npx playwright test tests/e2e/facilitator-walkthrough.spec.js tests/e2e/organizer-review-preview.spec.js tests/e2e/standing-action-cards.spec.js tests/e2e/demo-mode.spec.js --project=chromium` — PASS (39 tests)
- `python3 docs/scripts/validate-rehearsal-shell-fixtures.py` — PASS (six read models)
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — PASS (existing non-blocking registry warnings only)
- `bash ops/scripts/drift-check.sh` — PASS
- `python3 scripts/check-state-lag.py` — PASS
- `python3 .github/scripts/test_readiness_overclaim_linter.py` — PASS (51 tests)
- `python3 .github/scripts/readiness_overclaim_linter.py` — PASS
- `git diff --check` — PASS

## Issue effects

- Refs #1726 for the bounded keyboard continuation and plain-language follow-up.
- Refs #2041 because a real human accessibility / assistive-technology pass is still required.
- Refs #1746 because broader organizer rehearsal operability remains unfinished.
- Refs #1727 for the separate external-network-independent demo-mode work.
- #1726, #1727, #1746, #2041, #2082, and #2113 all remain open.

## Follow-ups

- perform the named human screen-reader, switch/voice input, graphical-browser zoom, low-vision, and physical-device checks under #2041
- retain the external QR/CDN and full no-network requirement under #1727
- design real status, reversal/challenge, review-later, and help affordances in a separately authorized member-facing slice; this demo only labels their absence

## Nonclaims

This is not a human accessibility pass. It leaves #2041 open. It does not make the surface organizer-ready, member-ready, pilot-ready, production-ready, or live-federated.

The surface remains fixture-backed, read-only, demo-mode, non-mutating, and L2 evidence only. No persisted review decision, mutation, assignment persistence, DID binding, receipt creation, evidence export, gateway write, live sync, or actual challenge/help workflow is added.
