### PR TITLE
fix(pilot-ui): keep demo walkthrough external-network independent

### DIFF
--- a/web/pilot-ui/app.js
+++ b/web/pilot-ui/app.js
@@ -6530,6 +6530,45 @@ async function generateKeypair() {
 // QR Login System
 // ============================================================================
 
+const QR_CODE_LIBRARY_URL = 'https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js';
+const QR_CODE_LIBRARY_INTEGRITY = 'sha384-3zSEDfvllQohrq0PHL1fOXJuC/jSOO34H46t6UQfobFOmxE5BpjjaIJY5F2/bMnU';
+let qrCodeLibraryPromise = null;
+
+function loadQrCodeLibrary() {
+    if (typeof window.QRCode === 'function') return Promise.resolve(window.QRCode);
+    if (DEMO_MODE === 'demo') {
+        return Promise.reject(new Error('QR sign-in is not used in fixture-backed demo mode.'));
+    }
+    if (qrCodeLibraryPromise) return qrCodeLibraryPromise;
+
+    const failedScript = document.querySelector('script[data-qr-code-library="qrcodejs-1.0.0"]');
+    if (failedScript) failedScript.remove();
+
+    qrCodeLibraryPromise = new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = QR_CODE_LIBRARY_URL;
+        script.integrity = QR_CODE_LIBRARY_INTEGRITY;
+        script.crossOrigin = 'anonymous';
+        script.referrerPolicy = 'no-referrer';
+        script.dataset.qrCodeLibrary = 'qrcodejs-1.0.0';
+        script.addEventListener('load', () => {
+            if (typeof window.QRCode === 'function') {
+                resolve(window.QRCode);
+                return;
+            }
+            qrCodeLibraryPromise = null;
+            reject(new Error('QR sign-in support loaded without a QRCode implementation.'));
+        }, { once: true });
+        script.addEventListener('error', () => {
+            qrCodeLibraryPromise = null;
+            reject(new Error('Unable to load QR sign-in support.'));
+        }, { once: true });
+        document.head.appendChild(script);
+    });
+
+    return qrCodeLibraryPromise;
+}
+
 // QR Login State
 const qrLoginState = {
     sessionId: null,
@@ -6564,9 +6603,15 @@ async function showQrLogin() {
     // Show modal with loading state
     qrLoginModal?.classList.remove('hidden');
     qrCodeContainer.innerHTML = '<p class="loading">Generating QR code...</p>';
-    qrLoginStatus.textContent = 'Creating login session...';
+    qrLoginStatus.textContent = 'Loading QR sign-in support...';
 
     try {
+        // qrcodejs remains SRI-pinned but is deferred until this non-demo
+        // feature is explicitly requested. Demo mode is rejected above and
+        // therefore never performs the external library request.
+        await loadQrCodeLibrary();
+        qrLoginStatus.textContent = 'Creating login session...';
+
         // Create session on gateway
         const response = await fetch(`${gatewayUrl}/v1/sessions`, {
             method: 'POST',

--- a/web/pilot-ui/index.html
+++ b/web/pilot-ui/index.html
@@ -14,14 +14,8 @@
     <link rel="stylesheet" href="style.css?v=2026050802">
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="/icons/icon-192x192.png">
-    <!-- QR Code library for passport (DID) login.
-         Subresource Integrity pins the exact qrcodejs 1.0.0 bytes so a compromised
-         or substituted CDN response cannot execute (CodeQL js/functionality-from-
-         untrusted-source, issue #2099). sha384 computed from the cdnjs file. -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"
-            integrity="sha384-3zSEDfvllQohrq0PHL1fOXJuC/jSOO34H46t6UQfobFOmxE5BpjjaIJY5F2/bMnU"
-            crossorigin="anonymous"
-            referrerpolicy="no-referrer"></script>
+    <!-- qrcodejs is loaded on demand by app.js only when non-demo QR sign-in is
+         requested. The fixture-backed ?mode=demo path performs no CDN request. -->
 </head>
 <body>
     <!-- Skip Navigation Link -->
@@ -2369,7 +2363,7 @@ did:icn:charlie,did:icn:alice,3.5,Childcare</code></pre>
 
     <script src="crypto.js"></script>
     <script src="offline-storage.js"></script>
-    <script src="app.js?v=1780308454"></script>
+    <script src="app.js?v=2026062901"></script>
     <script src="receipts.js"></script>
 </body>
 </html>

--- a/web/pilot-ui/sw.js
+++ b/web/pilot-ui/sw.js
@@ -7,7 +7,7 @@
 // changes meaningfully so existing installs reliably pick up the new bundle.
 // The activate event purges any cache whose name doesn't match the current
 // CACHE_VERSION, which forces clients off the old asset set.
-const CACHE_VERSION = 'icn-timebank-v1.6';
+const CACHE_VERSION = 'icn-timebank-v1.7';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const API_CACHE = `${CACHE_VERSION}-api`;

--- a/web/pilot-ui/tests/e2e/demo-mode.spec.js
+++ b/web/pilot-ui/tests/e2e/demo-mode.spec.js
@@ -29,6 +29,27 @@ test.describe('Demo Mode (PR 2)', () => {
         await expect(navBtn).toHaveClass(/hidden/);
     });
 
+    test('non-demo QR support keeps its SRI pin and loads only after QR sign-in is requested', async ({ page }) => {
+        const qrLibraryUrl = 'https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js';
+        await page.route(qrLibraryUrl, (route) => route.abort());
+
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator('script[data-qr-code-library]')).toHaveCount(0);
+
+        await page.locator('#gateway-url').fill('http://localhost:8000');
+        await page.locator('#coop-id').fill('demo-coop');
+        const qrRequest = page.waitForRequest(qrLibraryUrl);
+        await page.locator('#show-qr-login-btn').click();
+        await qrRequest;
+
+        const script = page.locator('script[data-qr-code-library="qrcodejs-1.0.0"]');
+        await expect(script).toHaveAttribute('src', qrLibraryUrl);
+        await expect(script).toHaveAttribute('integrity', 'sha384-3zSEDfvllQohrq0PHL1fOXJuC/jSOO34H46t6UQfobFOmxE5BpjjaIJY5F2/bMnU');
+        await expect(script).toHaveAttribute('crossorigin', 'anonymous');
+        await expect(script).toHaveAttribute('referrerpolicy', 'no-referrer');
+    });
+
     test('?mode=demo → banner renders with DEMO badge and label-mode dataset', async ({ page }) => {
         await page.goto('/?mode=demo');
         await page.waitForLoadState('networkidle');

--- a/web/pilot-ui/tests/e2e/facilitator-walkthrough.spec.js
+++ b/web/pilot-ui/tests/e2e/facilitator-walkthrough.spec.js
@@ -23,6 +23,51 @@ test.describe('Fixture-only facilitator walkthrough', () => {
         await expect(walkthrough).toContainText('NON-MUTATING');
     });
 
+    test('keeps initial demo load and all four steps same-origin while QR sign-in stays deferred', async ({ page, context }, testInfo) => {
+        const localOrigin = new URL(testInfo.project.use.baseURL || 'http://localhost:8000').origin;
+        const observedRequests = [];
+        context.on('request', (request) => {
+            observedRequests.push({ url: request.url(), method: request.method() });
+        });
+
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator('script[data-qr-code-library]')).toHaveCount(0);
+
+        await page.getByRole('button', { name: 'Start rehearsal: Standing' }).click();
+        await expect(page.locator('#member-standing-content')).toContainText('Demo organizer (fictional)');
+        await page.getByRole('button', { name: 'Continue to Action Cards' }).click();
+        await expect(page.locator('.member-action-card')).toHaveCount(4);
+        await page.getByRole('button', { name: 'Continue to Review Preview' }).click();
+        await expect(page.locator('.organizer-review-row-select')).toHaveCount(4);
+        await page.getByRole('button', { name: 'Continue to receipt and evidence explanation' }).click();
+        await expect(page.locator('#facilitator-evidence-explanation')).toHaveAttribute('open', '');
+
+        const externalRequests = observedRequests.filter((request) => new URL(request.url).origin !== localOrigin);
+        expect(externalRequests).toEqual([]);
+        expect(observedRequests.some((request) => request.url.includes('cdnjs.cloudflare.com'))).toBeFalsy();
+        expect(observedRequests.some((request) => request.url.includes('qrcodejs'))).toBeFalsy();
+
+        const fixtureRequests = observedRequests.filter((request) => {
+            const url = new URL(request.url);
+            return url.pathname.startsWith('/fixtures/icn-organizer-demo/');
+        });
+        expect(fixtureRequests.length).toBeGreaterThan(0);
+        expect(fixtureRequests.every((request) => (
+            request.method === 'GET' && new URL(request.url).origin === localOrigin
+        ))).toBeTruthy();
+        expect(fixtureRequests.some((request) => request.url.endsWith('/standing.json'))).toBeTruthy();
+        expect(fixtureRequests.some((request) => request.url.endsWith('/action-cards.json'))).toBeTruthy();
+        expect(fixtureRequests.some((request) => request.url.endsWith('/preview-review.pending-publish-summary.json'))).toBeTruthy();
+        expect(fixtureRequests.some((request) => request.url.endsWith('/pending-publish-summary.json'))).toBeTruthy();
+
+        const walkthrough = page.locator('#facilitator-walkthrough');
+        await expect(walkthrough).toContainText('COMMITTED FICTIONAL FIXTURES');
+        await expect(walkthrough).toContainText('READ-ONLY');
+        await expect(walkthrough).toContainText('NON-MUTATING');
+        await expect(walkthrough).toContainText('No receipt or evidence packet is created');
+    });
+
     test('continues the four-step story with forward Tab from each destination heading', async ({ page }) => {
         await page.goto('/?mode=demo');
         const writeRequests = [];

--- a/web/pilot-ui/tests/e2e/facilitator-walkthrough.spec.js
+++ b/web/pilot-ui/tests/e2e/facilitator-walkthrough.spec.js
@@ -45,8 +45,9 @@ test.describe('Fixture-only facilitator walkthrough', () => {
 
         const externalRequests = observedRequests.filter((request) => new URL(request.url).origin !== localOrigin);
         expect(externalRequests).toEqual([]);
-        expect(observedRequests.some((request) => request.url.includes('cdnjs.cloudflare.com'))).toBeFalsy();
-        expect(observedRequests.some((request) => request.url.includes('qrcodejs'))).toBeFalsy();
+        expect(observedRequests.map((request) => request.url)).not.toContain(
+            'https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js'
+        );
 
         const fixtureRequests = observedRequests.filter((request) => {
             const url = new URL(request.url);


### PR DESCRIPTION
## Summary

Keeps `web/pilot-ui/?mode=demo` external-network independent during initial load and the complete four-step organizer facilitator walkthrough.

The qrcodejs asset is no longer loaded by every page. It is requested only when a person explicitly selects QR sign-in outside fixture-backed demo mode.

## Why

The partial browser-assisted evidence in #2240 recorded F6: demo-mode page load requested qrcodejs from `cdnjs.cloudflare.com` even though the walkthrough never uses QR sign-in. That request contradicted the intended no-network-by-default demo boundary.

## What changed

- removes the head-level qrcodejs request
- adds an on-demand non-demo QR loader with the existing exact version, SRI hash, anonymous CORS setting, and no-referrer policy
- rejects QR-library loading in fixture-backed demo mode
- preserves the existing non-demo QR session flow after the library loads
- bumps the app cache-buster and service-worker cache version for the changed static asset set
- adds browser-context coverage that observes initial load plus Standing, Action Cards, Review Preview, and receipt/evidence explanation and rejects every non-local origin
- verifies fixture JSON remains same-origin/static and the prior CDN request cannot recur unnoticed
- adds a non-demo regression proving QR support is deferred until requested and retains its security attributes

## Validation

- `node --check web/pilot-ui/app.js` — PASS
- `node --check web/pilot-ui/sw.js` — PASS
- `npm test -- --runInBand` — PASS (40 tests)
- `npx playwright test tests/e2e/facilitator-walkthrough.spec.js tests/e2e/organizer-review-preview.spec.js tests/e2e/standing-action-cards.spec.js tests/e2e/demo-mode.spec.js --project=chromium` — PASS (41 tests)
- `python3 docs/scripts/validate-rehearsal-shell-fixtures.py` — PASS (six read models)
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — PASS (existing non-blocking registry warnings only)
- `bash ops/scripts/drift-check.sh` — PASS
- `python3 scripts/check-state-lag.py` — PASS
- `python3 .github/scripts/test_readiness_overclaim_linter.py` — PASS (51 tests)
- `python3 .github/scripts/readiness_overclaim_linter.py` — PASS
- `git diff --check` — PASS

## Issue effects

- Refs #1727 for this bounded external-network-independent walkthrough slice. Issue status: #1727 remains open for broader demo-mode acceptance.
- Refs #1746 because broader organizer-rehearsal acceptance remains unfinished. Issue status: #1746 remains open.
- Refs #2041 because #2240 surfaced F6 during the partial accessibility evidence pass. Issue status: #2041 remains open for human AT testing.

## Follow-ups

- retain #1727 for broader backend/demo-mode and full acceptance work beyond this four-step browser path
- perform the named human screen-reader, switch/voice input, graphical-browser zoom, low-vision, and physical-device checks under #2041
- consider a separately scoped local QR asset if non-demo QR sign-in must eventually avoid its on-demand CDN dependency too

## Nonclaims

This is not a human accessibility pass. This does not make the surface organizer-ready, member-ready, pilot-ready, production-ready, or live-federated. This does not satisfy the full human AT lane under #2041. This does not complete Phase 2.

This does not claim entity-aware auth enforcement, #2082 completion, or #2113 completion. This does not add persisted review decisions, mutation, assignment persistence, DID binding, receipt creation, or evidence export.

The surface remains fixture-backed, read-only, demo-mode, non-mutating, and L2 evidence only.
