### PR TITLE
test(pilot-ui): harden demo-mode network independence

### DIFF
--- a/web/pilot-ui/tests/e2e/demo-mode.spec.js
+++ b/web/pilot-ui/tests/e2e/demo-mode.spec.js
@@ -269,4 +269,115 @@ test.describe('Demo Mode (PR 2)', () => {
         await expect(message).not.toContainText('PR 5');
         await expect(message).not.toContainText('arrives in');
     });
+
+    test('all reachable demo navigation stays local, static, and non-mutating', async ({ page, context }, testInfo) => {
+        const localOrigin = new URL(testInfo.project.use.baseURL || 'http://localhost:8000').origin;
+        const observedRequests = [];
+        context.on('request', (request) => {
+            observedRequests.push({ url: request.url(), method: request.method() });
+        });
+
+        await page.goto('/?mode=demo');
+        await page.waitForLoadState('networkidle');
+
+        const visibleTabs = await page.locator('nav[aria-label="Main navigation"] [data-tab]:visible')
+            .evaluateAll((buttons) => buttons.map((button) => button.dataset.tab));
+        expect(visibleTabs).toEqual([
+            'demo-guide',
+            'review-preview',
+            'my-standing',
+            'governance',
+            'federation',
+            'receipts',
+        ]);
+
+        const walkthroughBoundary = page.locator('#facilitator-walkthrough');
+        await expect(walkthroughBoundary).toBeVisible();
+        await expect(walkthroughBoundary).toContainText('COMMITTED FICTIONAL FIXTURES');
+        await expect(walkthroughBoundary).toContainText('READ-ONLY');
+        await expect(walkthroughBoundary).toContainText('NON-MUTATING');
+
+        await page.getByRole('link', { name: 'Review Preview surface' }).click();
+        await expect(page.locator('#review-preview')).toHaveClass(/active/);
+        await expect(page.locator('.organizer-review-row-select')).toHaveCount(4);
+        await expect(page.locator('.organizer-review-intro')).toContainText('records nothing and changes nothing');
+
+        const demoGuideNav = page.getByRole('button', { name: 'Demo guide and orientation' });
+        await demoGuideNav.click();
+        await page.getByRole('link', { name: 'My Standing surface' }).click();
+        await expect(page.locator('#my-standing')).toHaveClass(/active/);
+
+        await demoGuideNav.click();
+        await page.getByRole('link', { name: 'Action Cards surface' }).click();
+        await expect(page.locator('#my-standing')).toHaveClass(/active/);
+
+        await demoGuideNav.click();
+        await page.getByRole('button', { name: 'Fixture-only organizer review preview' }).click();
+        await expect(page.locator('.organizer-review-row-select')).toHaveCount(4);
+
+        await page.getByRole('button', {
+            name: 'My standing in this institution and my pending action cards',
+        }).click();
+        await expect(page.locator('#member-standing-content')).toContainText('Demo organizer (fictional)');
+        await expect(page.locator('.member-action-card')).toHaveCount(4);
+        await expect(page.locator('#member-action-cards-demo-limits')).toBeVisible();
+        await expect(page.locator('#member-action-cards-demo-limits')).toContainText('read-only examples');
+
+        const actionCardTechnicalDetail = page.locator('#my-standing .member-action-cards-section details');
+        await actionCardTechnicalDetail.getByText('Technical read-model detail').click();
+        await actionCardTechnicalDetail.getByRole('link', { name: 'Action Items tab' }).click();
+        await expect(page.locator('#governance .demo-tab-placeholder')).toContainText(
+            'Governance is visible in pilot-ui but is not fixture-backed in this demo.'
+        );
+        await page.locator('#governance .demo-tab-placeholder')
+            .getByRole('link', { name: 'Demo Guide' })
+            .click();
+
+        const gatewayBackedTabs = [
+            { name: 'Governance and proposals', id: 'governance', label: 'Governance' },
+            { name: 'Federation status and peers', id: 'federation', label: 'Federation' },
+            { name: 'Economic receipt chain viewer', id: 'receipts', label: 'Receipts' },
+        ];
+        for (const tab of gatewayBackedTabs) {
+            await page.getByRole('button', { name: tab.name }).click();
+            const placeholder = page.locator(`#${tab.id} .demo-tab-placeholder`);
+            await expect(placeholder).toBeVisible();
+            await expect(placeholder).toContainText('Demo mode · Gateway-backed');
+            await expect(placeholder).toContainText(
+                `${tab.label} is visible in pilot-ui but is not fixture-backed in this demo.`
+            );
+            await placeholder.getByRole('link', { name: 'Demo Guide' }).click();
+            await expect(page.locator('#demo-guide')).toHaveClass(/active/);
+        }
+
+        await page.waitForLoadState('networkidle');
+
+        const httpRequests = observedRequests.filter((request) => {
+            const protocol = new URL(request.url).protocol;
+            return protocol === 'http:' || protocol === 'https:';
+        });
+        expect(httpRequests.length).toBeGreaterThan(0);
+        expect(httpRequests.filter((request) => new URL(request.url).origin !== localOrigin)).toEqual([]);
+        expect(httpRequests.filter((request) => !['GET', 'HEAD'].includes(request.method))).toEqual([]);
+        expect(httpRequests.filter((request) => {
+            const pathname = new URL(request.url).pathname;
+            return /^\/(?:v1|api|graphql|rpc)(?:\/|$)/.test(pathname);
+        })).toEqual([]);
+        expect(httpRequests.map((request) => request.url)).not.toContain(
+            'https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js'
+        );
+
+        const fixtureRequests = httpRequests.filter((request) => (
+            new URL(request.url).pathname.startsWith('/fixtures/icn-organizer-demo/')
+        ));
+        expect(fixtureRequests.every((request) => (
+            request.method === 'GET' && new URL(request.url).origin === localOrigin
+        ))).toBeTruthy();
+        expect([...new Set(fixtureRequests.map((request) => new URL(request.url).pathname))].sort()).toEqual([
+            '/fixtures/icn-organizer-demo/action-cards.json',
+            '/fixtures/icn-organizer-demo/pending-publish-summary.json',
+            '/fixtures/icn-organizer-demo/preview-review.pending-publish-summary.json',
+            '/fixtures/icn-organizer-demo/standing.json',
+        ]);
+    });
 });


### PR DESCRIPTION
## Summary

- Adds a focused Playwright audit for every visible, credential-free `?mode=demo` pilot-ui navigation tab and panel path.
- Keeps this follow-up test-only: no runtime behavior, endpoint, fixture, or service-worker asset changes.
- Preserves the fixture-backed, read-only, non-mutating, L2-evidence boundary.

## Why

#2242 covered initial demo load and the four-step facilitator walkthrough. This follow-up widens the regression boundary to the rest of the browser-reachable demo navigation surface without presenting gateway-backed tabs as fixture-backed functionality.

## What changed

- Drives the six visible primary tabs in stable order: Demo Guide, Review Preview, My Standing & Action Cards, Governance, Federation, and Receipts.
- Exercises all three Demo Guide surface links, the Action Items cross-link, and each gateway-backed placeholder's Demo Guide return link.
- Rejects any HTTP(S) request to a non-local origin, any non-GET/HEAD request, and any unexpected local live API/gateway path.
- Verifies the exact committed organizer-demo fixture set remains same-origin, static, and GET-only.
- Keeps the exact qrcodejs CDN regression assertion alongside the existing four-step network-independence coverage.
- Confirms Governance, Federation, and Receipts remain clearly labeled as unavailable without fixture or gateway data.

## Validation

- `node --check app.js`
- `node --check sw.js`
- `npm test -- --runInBand` — 40 passed
- `npx playwright test tests/e2e/facilitator-walkthrough.spec.js tests/e2e/organizer-review-preview.spec.js tests/e2e/standing-action-cards.spec.js tests/e2e/demo-mode.spec.js --project=chromium` — 42 passed
- `python3 docs/scripts/validate-rehearsal-shell-fixtures.py`
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml`
- `bash ops/scripts/drift-check.sh`
- `python3 scripts/check-state-lag.py`
- `python3 .github/scripts/test_readiness_overclaim_linter.py` — 51 passed
- `python3 .github/scripts/readiness_overclaim_linter.py`
- `git diff --check`

## Issue effects

Refs #1727

Refs #1746

Issue status: #1727 remains open after this bounded test/audit slice.

Issue status: #1746 remains open for broader organizer-rehearsal acceptance.

Issue status: #2041 remains open for human assistive-technology testing.

## Follow-ups

- Human screen-reader and assistive-technology evidence remains under #2041.
- Broader #1727 acceptance remains open beyond this browser-surface network regression boundary.
- Gateway-backed Governance, Federation, and Receipts still require separately authorized runtime work; this PR only verifies that demo navigation does not contact those paths.

## Nonclaims

- This is not a human accessibility pass.
- This does not make the surface organizer-ready, member-ready, pilot-ready, production-ready, or live-federated.
- This does not satisfy the full human AT lane under #2041.
- This does not complete Phase 2.
- This does not complete full #1727 acceptance.
- This does not claim entity-aware auth enforcement, #2082 completion, or #2113 completion.
- This does not add persisted review decisions, mutation, assignment persistence, DID binding, receipt creation, or evidence export.
- The surface remains fixture-backed, read-only, demo-mode, non-mutating, and L2 evidence only.
