### PR TITLE
docs(security): record CodeQL setup audit

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,7 +2,7 @@
 
 Comprehensive security documentation, threat models, audit reports, and hardening guides.
 
-**Last Updated**: 2026-02-10  
+**Last Updated**: 2026-06-29
 **Security Status**: Historical assessment snapshot (as of 2025-12-18)
 
 ## 🚨 Quick Links
@@ -21,6 +21,14 @@ This directory contains all security-related documentation for ICN, including:
 - Hardening guides and best practices
 - SDIS-specific security documentation
 - Testing and validation procedures
+
+## Code scanning configuration audit (2026-06-29)
+
+A live repository audit found that GitHub CodeQL **default setup** is configured. GitHub dynamically analyzes Actions, JavaScript/TypeScript, Python, and Rust for pull requests and the default branch, with a weekly schedule and the default query suite. The repository does not contain a repo-owned `.github/workflows/codeql.yml` advanced setup workflow.
+
+No advanced workflow was added by this audit. The current default setup already provides the repository's observed language and event coverage. GitHub's [setup guidance](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types) reserves advanced setup for cases that need more granular control, and [switching from default to advanced setup](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/configure-code-scanning/configuring-advanced-setup-for-code-scanning) requires a coordinated repository-settings change. Adding an advanced workflow while leaving default setup active would not create a clean, independently reviewable transition.
+
+If maintainers later choose repo-owned configuration or the `security-extended` query suite, treat that as a coordinated settings-and-workflow change. Alert triage remains separate. This point-in-time audit did not change repository settings, branch protection, runtime behavior, or any CodeQL alert, and it makes no claim about vulnerability remediation, hardening completion, or readiness.
 
 ## 📊 Production Security
 


### PR DESCRIPTION
## Summary

Records the 2026-06-29 CodeQL configuration audit in the existing security documentation. No advanced workflow is added.

## Why

The repository currently uses GitHub CodeQL default setup and has no repo-owned advanced workflow. Default setup already provides the observed language and event coverage. GitHub requires a coordinated repository-settings transition to move from default to advanced setup, which is outside this PR's authorized scope.

## Current state observed

- CodeQL default setup is configured.
- Actions, JavaScript/TypeScript, Python, and Rust are analyzed dynamically.
- Pull requests, the default branch, and a weekly schedule are covered.
- The default query suite is selected.
- No `.github/workflows/codeql.yml` advanced setup workflow exists.
- Existing CodeQL alert state was inspected but left unchanged.

## What changed

- Updated `docs/security/README.md` with a dated, point-in-time configuration audit.
- Documented why an advanced workflow was not added while default setup remains active.
- Recorded the bounded follow-up for any future coordinated settings-and-workflow transition.

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — passed with pre-existing non-blocking repository warnings.
- `bash ops/scripts/drift-check.sh` — passed.
- `python3 scripts/check-state-lag.py` — passed.
- `python3 .github/scripts/test_readiness_overclaim_linter.py` — 51 tests passed.
- `python3 .github/scripts/readiness_overclaim_linter.py` — passed.
- `git diff --check` — passed.

## Issue effects

No issue status changes.

## Follow-ups

If maintainers later choose repo-owned advanced setup or the `security-extended` query suite, coordinate the repository-settings transition with the workflow change. CodeQL alert triage remains a separate workstream.

## Nonclaims

- This does not remediate any CodeQL alert.
- This does not dismiss any CodeQL alert.
- This does not complete security hardening.
- This does not make ICN production-ready, pilot-ready, organizer-ready, member-ready, or live-federated.
- This does not complete Phase 2.
- This does not complete #2041.
- This does not claim #2082 or #2113 completion.
- This does not change runtime behavior.
- This does not change branch protection or repository security settings.
