### PR TITLE
docs(security): triage gossip nonce CodeQL alerts

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -342,6 +342,7 @@ Security documentation, threat models, and audit reports.
 - [SECURITY_AUDIT_REPORT.md](security/SECURITY_AUDIT_REPORT.md) - Audit findings
 - [SECURITY_AUDIT_RESULTS.md](security/SECURITY_AUDIT_RESULTS.md) - Audit results
 - [codeql-alert-triage-2026-06-29.md](security/codeql-alert-triage-2026-06-29.md) - Point-in-time static triage of CodeQL alerts #100 and #101
+- [codeql-gossip-nonce-triage-2026-06-29.md](security/codeql-gossip-nonce-triage-2026-06-29.md) - Point-in-time static triage of gossip nonce alerts #30–#35
 
 **SDIS Security:**
 - [SDIS_THREAT_MODEL.md](security/SDIS_THREAT_MODEL.md) - SDIS-specific threats

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -1728,6 +1728,15 @@ last_updated = "2026-06-29"
 owner = "matt"
 audiences = ["security", "developers"]
 
+[docs."docs/security/codeql-gossip-nonce-triage-2026-06-29.md"]
+category = "security"
+status = "living"
+title = "CodeQL Gossip Nonce Triage (2026-06-29)"
+description = "Point-in-time static triage of gossip nonce alerts #30 through #35"
+last_updated = "2026-06-29"
+owner = "matt"
+audiences = ["security", "developers"]
+
 # ============================================================================
 # API AND REFERENCE DOCUMENTS
 # ============================================================================

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -71,6 +71,7 @@ If maintainers later choose repo-owned configuration or the `security-extended` 
 | [SECURITY_FOLLOWUP.md](SECURITY_FOLLOWUP.md) | Various | Follow-up actions |
 | [phase-10c-security-analysis.md](phase-10c-security-analysis.md) | Phase 10c | Phase-specific analysis |
 | [codeql-alert-triage-2026-06-29.md](codeql-alert-triage-2026-06-29.md) | 2026-06-29 | Point-in-time static triage of CodeQL alerts #100 and #101 |
+| [codeql-gossip-nonce-triage-2026-06-29.md](codeql-gossip-nonce-triage-2026-06-29.md) | 2026-06-29 | Point-in-time static triage of gossip nonce alerts #30–#35 |
 
 ## 🆔 SDIS Security
 

--- a/docs/security/codeql-gossip-nonce-triage-2026-06-29.md
+++ b/docs/security/codeql-gossip-nonce-triage-2026-06-29.md
@@ -1,0 +1,62 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-06-29
+---
+
+# CodeQL gossip nonce triage — 2026-06-29
+
+This is a point-in-time, static triage record for GitHub CodeQL alerts [#30](https://github.com/InterCooperative-Network/icn/security/code-scanning/30) through [#35](https://github.com/InterCooperative-Network/icn/security/code-scanning/35). It records evidence and follow-up without changing code, alert state, CodeQL configuration, repository settings, or branch protection.
+
+## Inspection basis
+
+- Repository commit inspected: `e4af12c5556064b2e9fed058de3a6d778833d37f`.
+- CodeQL rule for all six alerts: `rust/hard-coded-cryptographic-value` (`critical` scanner severity), reporting that a hard-coded value is used as a nonce.
+- Most recent alert instances inspected: `refs/heads/main` at `76f5fcb6a3c0d04016610f0b72d0e3d162ddde19`.
+- The affected source paths did not change between the instance commit and the inspected commit.
+- Repository policy basis: [`SECURITY.md`](../../SECURITY.md) places the Rust workspace in scope.
+- Assessment method: static source, compilation-boundary, call-site, history, and nearby-test inspection only. No runtime validation or CodeQL query-engine inspection was performed.
+
+## Shared product boundary
+
+Every reported literal is below an explicit `#[cfg(test)]` module boundary: `blob_nonce_guard.rs:189` for alert #30 and `blob_transfer.rs:511` for alerts #31–#35. These fixtures are compiled only for tests and are not production nonce-generation paths.
+
+In shipped code, `GossipMessage::BlobRequest` carries `request_id` as part of the signed message, dispatch passes that field to `handle_blob_request`, and `BlobNonceGuard::check_and_record` tracks the caller-supplied identifier per sender. Blob chunks derive their replay key from `blake3(request_id || chunk_index)`. The flagged literals do not feed those paths outside test compilation.
+
+## Detailed triage
+
+| Alert | Reported location | Test purpose and static evidence | Classification | Verdict |
+|---|---|---|---|---|
+| `#30` | `icn/crates/icn-gossip/src/handlers/blob_nonce_guard.rs:212` | `duplicate_nonce_rejected` deliberately submits the same `[1u8; 32]` value twice and asserts replay rejection. | Test-only finding | `not_actionable` — high confidence |
+| `#31` | `icn/crates/icn-gossip/src/handlers/blob_transfer.rs:767` | `blob_request_handler_rejects_expired` uses the fixed request ID as an incidental fixture while `expires_at = 1` selects the expired-request path. | Test-only finding | `not_actionable` — high confidence |
+| `#32` | `icn/crates/icn-gossip/src/handlers/blob_transfer.rs:792` | `blob_request_handler_rejects_mismatched_sender` uses the fixed request ID as an incidental fixture; a separately generated requester mismatch selects the behavior under test. | Test-only finding | `not_actionable` — high confidence |
+| `#33` | `icn/crates/icn-gossip/src/handlers/blob_transfer.rs:860` | `blob_request_handler_rejects_duplicate_request` deliberately reuses `[0x11; 32]` for two calls and asserts that only one nonce is tracked. | Test-only finding | `not_actionable` — high confidence |
+| `#34` | `icn/crates/icn-gossip/src/handlers/blob_transfer.rs:889` | `blob_request_handler_allows_different_requests` uses `[0x11; 32]` as the first of two visibly distinct sentinels. | Test-only finding | `not_actionable` — high confidence |
+| `#35` | `icn/crates/icn-gossip/src/handlers/blob_transfer.rs:893` | The same test uses `[0x22; 32]` as the second distinct sentinel and asserts that two nonces are tracked. | Test-only finding | `not_actionable` — high confidence |
+
+The scanner's data flow is meaningful within test execution: each fixture reaches replay-checking code. The security disposition follows from the product boundary and intent, not from denying that test-only flow. Randomizing these fixtures would not improve shipped-code security and would make the duplicate-versus-distinct test intent less explicit.
+
+No alert was dismissed. Alert disposition remains a separate maintainer action under repository CodeQL policy. No remediation was made because the evidence does not identify a production defect or support a runtime change.
+
+Recommended next action: retain these fixtures as clear replay-test sentinels. In a separately authorized alert-management pass, maintainers may review whether CodeQL's test-file classification supports a policy-consistent disposition; this record does not prescribe or perform one.
+
+## Explicitly out of scope
+
+Alerts [#29](https://github.com/InterCooperative-Network/icn/security/code-scanning/29) and [#37](https://github.com/InterCooperative-Network/icn/security/code-scanning/37) were not assessed. Their presence under the same CodeQL rule does not imply the disposition recorded for #30–#35.
+
+## Proof gaps
+
+- No CodeQL query-engine trace was inspected beyond the live alert and instance metadata.
+- No unit, integration, or runtime tests were executed during static triage.
+- This assessment does not evaluate unrelated request-ID design questions or other hard-coded-value alerts.
+
+## Nonclaims
+
+- This does not dismiss any CodeQL/code-scanning alert.
+- This does not remediate any vulnerability.
+- This does not complete security hardening.
+- This does not establish production readiness.
+- This does not make ICN pilot-ready, organizer-ready, member-ready, or live-federated.
+- This does not complete Phase 2 or close #2041.
+- This does not claim completion of #1726, #1727, #1746, #2082, or #2113.
+- This does not change runtime behavior, CodeQL setup, workflows, branch protection, repository settings, or repository security settings.


### PR DESCRIPTION
## Summary

- record point-in-time static triage for CodeQL alerts #30–#35
- classify all six findings as test-only and `not_actionable` with high confidence
- document the shared `#[cfg(test)]` boundary, per-alert evidence, proof gaps, and nonclaims
- leave alerts #29 and #37 explicitly out of scope

## Security disposition

No runtime fix is proposed. The reported literals are intentional fixtures below `#[cfg(test)]` boundaries: duplicate values exercise replay rejection, while distinct sentinels exercise acceptance of different requests. This PR does not dismiss or otherwise change any CodeQL alert.

## Validation

- `git diff --check`
- `python3 .github/scripts/test_readiness_overclaim_linter.py`
- `python3 .github/scripts/readiness_overclaim_linter.py`
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` (passes with existing non-blocking repository warnings)
- `bash ops/scripts/drift-check.sh`
- `python3 scripts/check-state-lag.py`

No Rust tests were run because this is a documentation-only change following a static-triage-only workflow.

## Nonclaims

This PR does not remediate a vulnerability, complete security hardening, establish production or pilot readiness, change CodeQL setup, dismiss alerts, alter workflows or branch protection, or close protected project issues.