### PR TITLE
docs(index): clarify security claim boundaries

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -327,14 +327,16 @@ Continuous integration and delivery:
 
 Security documentation, threat models, and audit reports.
 
+These links include historical reports, current scanning notes, and point-in-time triage records. They do not by themselves establish current production readiness, vulnerability remediation status, deployment approval, or security hardening completion.
+
 ### Security Documentation (`security/`)
 
-**Production Security:**
-- [FINAL_SECURITY_STATUS.md](security/FINAL_SECURITY_STATUS.md) - Production readiness assessment ✅
-- [COMPREHENSIVE_SECURITY_IMPROVEMENTS.md](security/COMPREHENSIVE_SECURITY_IMPROVEMENTS.md) - Security overview
-- [SECURITY_FIXES_2025-12-18.md](security/SECURITY_FIXES_2025-12-18.md) - Detailed vulnerability fixes
+**Historical security assessments and references:**
+- [FINAL_SECURITY_STATUS.md](security/FINAL_SECURITY_STATUS.md) - Historical assessment snapshot; not current readiness evidence
+- [COMPREHENSIVE_SECURITY_IMPROVEMENTS.md](security/COMPREHENSIVE_SECURITY_IMPROVEMENTS.md) - Historical improvements report
+- [SECURITY_FIXES_2025-12-18.md](security/SECURITY_FIXES_2025-12-18.md) - Historical fix record; current status requires verification
 - [SECURITY_TESTING_GUIDE.md](security/SECURITY_TESTING_GUIDE.md) - Testing procedures
-- [production-hardening.md](security/production-hardening.md) - Production hardening measures
+- [production-hardening.md](security/production-hardening.md) - Historical hardening reference
 
 **Threat Models & Audits:**
 - [threat-model.md](security/threat-model.md) - Comprehensive threat analysis


### PR DESCRIPTION
## Summary

Clarify the Security & Compliance claim boundary in the hand-maintained documentation index.

## Why

The section still described historical 2025 security reports with current-sounding production and hardening language, while the security documentation index already treats them as historical reference material.

## What changed

- add a short boundary statement explaining that the linked material does not establish current readiness, remediation, deployment approval, or hardening completion
- rename the current-sounding security group as historical assessments and references
- relabel the historical status, improvements, fix, and hardening documents
- preserve both point-in-time CodeQL triage links

Only `docs/INDEX.md` changed.

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — passed with existing non-blocking repository warnings
- `bash ops/scripts/drift-check.sh`
- `python3 scripts/check-state-lag.py`
- `python3 .github/scripts/test_readiness_overclaim_linter.py`
- `python3 .github/scripts/readiness_overclaim_linter.py`
- `git diff --check`
- targeted readiness and completion-claim searches in `docs/INDEX.md`

Human AT was not run.

## Issue effects

No issue status changes.

## Follow-ups

- Alerts #29 and #37 remain separate security follow-ups.
- Maintainer review of CodeQL alert disposition remains separate.
- Human AT remains open under #2041.
- Broader acceptance work under #1727 and #1746 remains open.

## Nonclaims

- This is documentation claim-boundary cleanup only.
- This does not remediate any vulnerability.
- This does not dismiss or modify any CodeQL/code-scanning alert.
- This does not change CodeQL setup, branch protection, security settings, workflows, or runtime behavior.
- This does not complete security hardening.
- This does not make ICN production-ready, pilot-ready, organizer-ready, member-ready, or live-federated.
- This does not complete Phase 2.
- This does not complete #2041.
- This does not claim #2082 or #2113 completion.
- Alerts #29 and #37 remain separate follow-ups.
- Human AT remains open under #2041.