### PR TITLE
fix(authz): bind budget to path coop before entity gate

### DIFF
--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -400,6 +400,70 @@ fn path_owns_budget(path_treasury_did: Option<&Did>, budget_treasury_did: &Did) 
     path_treasury_did == Some(budget_treasury_did)
 }
 
+/// Whether the foreign-budget owner probe records observe-mode divergence telemetry for
+/// the given mode. `true` only for `ObserveOnly` — there the probe is detached and can
+/// never affect a route outcome. Under `EnforceTrustedResolver` it is `false`: an
+/// enforce-capable owner gate must NOT run before the ownership mask, or it could deny
+/// and thereby 403-leak the foreign budget's existence/ownership.
+fn budget_owner_probe_records_in_mode(mode: TreasuryEntityAuthMode) -> bool {
+    matches!(mode, TreasuryEntityAuthMode::ObserveOnly)
+}
+
+/// Observe-mode divergence telemetry for a FOUND-but-foreign (or path-coop-has-no-treasury)
+/// budget that `get_budget` is about to mask as a generic `NotFound`
+/// (`docs/architecture/ABUSE_CASE_HARDENING_STRATEGY.md` §4.11 item 5: "keep observe-mode /
+/// divergence recording firing **before** the enforced denial, so cross-context attempts
+/// stay visible as divergence rather than vanishing").
+///
+/// Records **only** under `ObserveOnly`: it resolves the budget's OWN owning treasury and
+/// fires the existing detached, fire-and-forget entity observation (so a cross-context
+/// probe stays visible — e.g. `flat_allow_entity_deny`). Under `EnforceTrustedResolver` it
+/// records NOTHING — running an enforce-capable gate against the foreign owner could deny
+/// and thereby leak its existence/ownership; the caller's response is the same generic
+/// `NotFound` either way. Returns `()`; it can never deny, change the response status, or
+/// add request-path latency.
+fn observe_foreign_budget_probe_if_observe_only(
+    req: &HttpRequest,
+    entity_mgr: &web::Data<Arc<EntityManager>>,
+    treasury_mgr: &web::Data<Arc<GatewayTreasuryManager>>,
+    owner_treasury_did: &Did,
+    action: EntityAction,
+) {
+    if !budget_owner_probe_records_in_mode(active_treasury_entity_auth_mode()) {
+        return;
+    }
+    let Some(claims) = get_claims(req) else {
+        return;
+    };
+    let Ok(caller_did) = claims.sub.parse::<Did>() else {
+        return;
+    };
+    let caller = EntityId::from_did(&caller_did);
+
+    let entity_mgr = entity_mgr.get_ref().clone();
+    let treasury_mgr = treasury_mgr.get_ref().clone();
+    let owner_treasury_did = owner_treasury_did.clone();
+    let resolver = observe_coop_entity_resolver(req);
+    actix_web::rt::spawn(async move {
+        // Resolve the budget's OWN owning treasury off the hot path; observe against its
+        // stored entity_id (and its own coop_id for the fallback projection). Discarded —
+        // observe mode never denies, so masking the response as NotFound is unaffected.
+        let (target, coop_id) = match treasury_mgr.get_treasury(&owner_treasury_did).await {
+            Ok(Some(t)) => (t.entity_id().cloned(), t.coop_id.clone()),
+            _ => (None, String::new()),
+        };
+        let _ = observe_treasury_entity_access(
+            resolver.as_ref(),
+            &entity_mgr,
+            &caller,
+            target.as_ref(),
+            &coop_id,
+            action,
+        )
+        .await;
+    });
+}
+
 #[get("/{coop_id}")]
 pub async fn get_treasury_status(
     req: HttpRequest,
@@ -724,6 +788,20 @@ pub async fn get_budget(
         &budget.treasury_did,
     );
     let Some(path_treasury) = path_treasury.filter(|_| path_owns) else {
+        // Foreign / no-path-treasury budget: mask as the SAME generic NotFound (#1642
+        // enumeration-safe). Per ABUSE_CASE_HARDENING_STRATEGY §4.11 item 5, keep
+        // observe-mode divergence recording firing BEFORE the masked denial so a
+        // cross-context probe stays visible (e.g. `flat_allow_entity_deny`) — but ONLY in
+        // ObserveOnly, where it is detached and can never deny or affect this response.
+        // Under EnforceTrustedResolver this records nothing (an enforce-capable
+        // foreign-owner gate could 403-leak existence); the response is the same NotFound.
+        observe_foreign_budget_probe_if_observe_only(
+            &req,
+            &entity_mgr,
+            &treasury_mgr,
+            &budget.treasury_did,
+            EntityAction::TreasuryRead,
+        );
         return Err(GatewayError::NotFound("Budget not found".to_string()));
     };
 
@@ -1527,7 +1605,8 @@ mod tests {
     /// Nested in its own module so the built-in `#[test]` is not shadowed by this test
     /// module's `use actix_web::test` (the actix attribute requires `async`).
     mod path_binding_precedes_entity_auth {
-        use super::super::path_owns_budget;
+        use super::super::{budget_owner_probe_records_in_mode, path_owns_budget};
+        use crate::authority::TreasuryEntityAuthMode;
         use icn_identity::KeyPair;
 
         #[test]
@@ -1542,6 +1621,20 @@ mod tests {
             assert!(!path_owns_budget(Some(&a), &b));
             // #2085: path coop has no treasury at all -> NOT owned -> generic NotFound.
             assert!(!path_owns_budget(None, &a));
+        }
+
+        /// The pre-mask divergence probe records ONLY under ObserveOnly (detached, never
+        /// denies). Under EnforceTrustedResolver it records nothing — an enforce-capable
+        /// foreign-owner gate must not run before the ownership mask, or it could 403-leak
+        /// the foreign budget's existence (ABUSE_CASE_HARDENING_STRATEGY §4.11 item 5).
+        #[test]
+        fn foreign_budget_probe_records_only_in_observe_only() {
+            assert!(budget_owner_probe_records_in_mode(
+                TreasuryEntityAuthMode::ObserveOnly
+            ));
+            assert!(!budget_owner_probe_records_in_mode(
+                TreasuryEntityAuthMode::EnforceTrustedResolver
+            ));
         }
     }
 

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -390,84 +390,14 @@ fn observe_coop_entity_resolver(req: &HttpRequest) -> Arc<dyn CoopEntityResolver
         .unwrap_or_else(|| Arc::new(UnwiredCoopEntityResolver))
 }
 
-/// Like [`observe_treasury`], but keyed by the **owning treasury's `treasury_did`**
-/// rather than a path `coop_id`. Used by `get_budget`, which fetches a budget by a
-/// globally-keyed `budget_id`: the budget may belong to a different cooperative than
-/// the path `coop_id` (the flat guard only checks the path coop). Observing against
-/// the path coop would record the entity decision for the wrong entity. Resolving
-/// from the budget's own `treasury_did` makes the observation reflect the budget's
-/// real owner — so a cross-coop budget read surfaces as a genuine `flat_allow_entity_deny`
-/// instead of a misleading `agree_allow`. The treasury is loaded **inside** the
-/// detached task (off the request hot path). (RFC-0018 observe mode, ADR-0035.)
-async fn observe_treasury_by_did(
-    req: &HttpRequest,
-    entity_mgr: &web::Data<Arc<EntityManager>>,
-    treasury_mgr: &web::Data<Arc<GatewayTreasuryManager>>,
-    treasury_did: &Did,
-    action: EntityAction,
-) -> Result<()> {
-    let Some(claims) = get_claims(req) else {
-        return Ok(());
-    };
-    let Ok(caller_did) = claims.sub.parse::<Did>() else {
-        return Ok(());
-    };
-    let caller = EntityId::from_did(&caller_did);
-
-    let entity_mgr = entity_mgr.get_ref().clone();
-    let treasury_mgr = treasury_mgr.get_ref().clone();
-    let treasury_did = treasury_did.clone();
-    let resolver = observe_coop_entity_resolver(req);
-
-    match active_treasury_entity_auth_mode() {
-        // A2e ENFORCE (operator-gated, off by default): resolve the budget's owning treasury
-        // and consume the gate decision INLINE, before returning the budget. A `WouldDeny`
-        // (including the fail-closed case where the owning treasury cannot be resolved, so no
-        // trusted target exists) denies with the existing forbidden pattern (403);
-        // `ProceedUnchanged` proceeds. This enforces against the budget's REAL owning entity,
-        // not the path coop.
-        TreasuryEntityAuthMode::EnforceTrustedResolver => {
-            let (target, coop_id) = match treasury_mgr.get_treasury(&treasury_did).await {
-                Ok(Some(t)) => (t.entity_id().cloned(), t.coop_id.clone()),
-                _ => (None, String::new()),
-            };
-            let outcome = evaluate_treasury_entity_access(
-                resolver.as_ref(),
-                &entity_mgr,
-                &caller,
-                target.as_ref(),
-                &coop_id,
-                action,
-            )
-            .await;
-            match treasury_gate_enforcement_denial(outcome.decision) {
-                Some(err) => Err(err),
-                None => Ok(()),
-            }
-        }
-        // OBSERVE (default): resolve the owning treasury and observe off the hot path; the
-        // result is discarded and never denies (byte-identical to the pre-A2e behavior).
-        TreasuryEntityAuthMode::ObserveOnly => {
-            actix_web::rt::spawn(async move {
-                // Resolve the budget's owning treasury off the hot path; observe against
-                // its stored entity_id (and its own coop_id for the fallback projection).
-                let (target, coop_id) = match treasury_mgr.get_treasury(&treasury_did).await {
-                    Ok(Some(t)) => (t.entity_id().cloned(), t.coop_id.clone()),
-                    _ => (None, String::new()),
-                };
-                let _ = observe_treasury_entity_access(
-                    resolver.as_ref(),
-                    &entity_mgr,
-                    &caller,
-                    target.as_ref(),
-                    &coop_id,
-                    action,
-                )
-                .await;
-            });
-            Ok(())
-        }
-    }
+/// Object-context binding decision for a globally-keyed budget (#2085): does the path
+/// coop's treasury (if any) own the budget? Compares the path treasury's `treasury_did`
+/// against the budget's. Returns `false` when the path coop has no treasury OR the dids
+/// differ — both MUST surface as the same generic `NotFound`, and this decision MUST run
+/// before any enforce-capable entity-auth so that an `EnforceTrustedResolver` denial can
+/// never run against (and thereby reveal the existence/ownership of) a foreign budget.
+fn path_owns_budget(path_treasury_did: Option<&Did>, budget_treasury_did: &Did) -> bool {
+    path_treasury_did == Some(budget_treasury_did)
 }
 
 #[get("/{coop_id}")]
@@ -496,7 +426,9 @@ pub async fn get_treasury_status(
         )));
     };
 
-    // RFC-0018 observe mode (ADR-0035): flat guard above remains authoritative.
+    // RFC-0018/A2e treasury entity-auth seam:
+    // default ObserveOnly preserves flat require_coop_access behavior;
+    // explicit EnforceTrustedResolver may deny here before treasury work proceeds.
     observe_treasury(
         &req,
         &entity_mgr,
@@ -580,7 +512,9 @@ pub(crate) async fn do_get_treasury_position(
         )));
     };
 
-    // RFC-0018 observe mode (ADR-0035): flat guard above remains authoritative.
+    // RFC-0018/A2e treasury entity-auth seam:
+    // default ObserveOnly preserves flat require_coop_access behavior;
+    // explicit EnforceTrustedResolver may deny here before treasury work proceeds.
     observe_treasury(
         &req,
         &entity_mgr,
@@ -639,7 +573,9 @@ pub async fn get_treasury_nonce(
         )));
     };
 
-    // RFC-0018 observe mode (ADR-0035): flat guard above remains authoritative.
+    // RFC-0018/A2e treasury entity-auth seam:
+    // default ObserveOnly preserves flat require_coop_access behavior;
+    // explicit EnforceTrustedResolver may deny here before treasury work proceeds.
     observe_treasury(
         &req,
         &entity_mgr,
@@ -698,7 +634,9 @@ pub async fn list_budgets(
         )));
     };
 
-    // RFC-0018 observe mode (ADR-0035): flat guard above remains authoritative.
+    // RFC-0018/A2e treasury entity-auth seam:
+    // default ObserveOnly preserves flat require_coop_access behavior;
+    // explicit EnforceTrustedResolver may deny here before treasury work proceeds.
     observe_treasury(
         &req,
         &entity_mgr,
@@ -768,38 +706,39 @@ pub async fn get_budget(
         return Err(GatewayError::NotFound("Budget not found".to_string()));
     };
 
-    // RFC-0018 observe mode (ADR-0035): observe against the budget's OWN treasury
-    // (resolved from budget.treasury_did inside a detached task), not the path coop
-    // — the budget is globally keyed and may belong to a different cooperative.
-    // Observation-only; the flat require_coop_access guard above stays authoritative.
-    // This fires BEFORE the ownership enforcement below so a cross-coop attempt
-    // still registers (as flat_allow_entity_deny) even though it is then denied.
-    observe_treasury_by_did(
-        &req,
-        &entity_mgr,
-        &treasury_mgr,
-        &budget.treasury_did,
-        EntityAction::TreasuryRead,
-    )
-    .await?;
-
-    // #2085: object-context binding in the flat-authz regime. The budget was
-    // fetched by a globally-keyed id; require it to belong to the treasury of the
-    // path coop before returning it. A foreign (or path-coop-has-no-treasury)
-    // budget is reported as NotFound — the same shape as a missing budget — so the
-    // caller cannot distinguish "exists elsewhere" from "does not exist." The flat
-    // require_coop_access guard above remains authoritative; this only ties the
-    // loaded object to the request path (no entity-auth enforcement; see #2081).
+    // #2085 + A2e: object-context binding MUST run BEFORE any enforce-capable
+    // entity-auth. The budget was fetched by a globally-keyed id; bind it to the path
+    // coop's treasury first. A foreign budget — or a path coop with no treasury — is
+    // reported as the SAME generic NotFound as a missing budget, so the caller cannot
+    // distinguish "exists elsewhere" from "does not exist". Crucially, ordering the
+    // bind first means the entity-auth seam below (which may DENY under explicit
+    // EnforceTrustedResolver) never runs against a foreign owner — so an enforce-mode
+    // 403 can never leak the existence/ownership of another coop's budget. Entity-auth
+    // runs only after the loaded object is proven to belong to the path coop.
     let path_treasury = treasury_mgr
         .get_treasury_by_coop(&coop_id)
         .await
         .map_err(|e| GatewayError::InternalError(e.to_string()))?;
-    let owns_budget = path_treasury
-        .as_ref()
-        .is_some_and(|t| t.treasury_did == budget.treasury_did);
-    if !owns_budget {
+    let path_owns = path_owns_budget(
+        path_treasury.as_ref().map(|t| &t.treasury_did),
+        &budget.treasury_did,
+    );
+    let Some(path_treasury) = path_treasury.filter(|_| path_owns) else {
         return Err(GatewayError::NotFound("Budget not found".to_string()));
-    }
+    };
+
+    // RFC-0018/A2e treasury entity-auth seam, now object-bound to the path coop:
+    // default ObserveOnly preserves flat require_coop_access behavior; explicit
+    // EnforceTrustedResolver may deny here before the budget is returned. The target is
+    // the path coop's treasury entity, which (post-binding) IS the budget's owner.
+    observe_treasury(
+        &req,
+        &entity_mgr,
+        path_treasury.entity_id(),
+        &coop_id,
+        EntityAction::TreasuryRead,
+    )
+    .await?;
 
     let response = BudgetDetailResponse {
         id: budget.id.clone(),
@@ -892,7 +831,9 @@ pub async fn create_budget(
         ))
     })?;
 
-    // RFC-0018 observe mode (ADR-0035): flat guard above remains authoritative.
+    // RFC-0018/A2e treasury entity-auth seam:
+    // default ObserveOnly preserves flat require_coop_access behavior;
+    // explicit EnforceTrustedResolver may deny here before treasury work proceeds.
     observe_treasury(
         &req,
         &entity_mgr,
@@ -995,7 +936,9 @@ pub async fn list_spending_rules(
         return Ok(HttpResponse::Ok().json(response));
     };
 
-    // RFC-0018 observe mode (ADR-0035): flat guard above remains authoritative.
+    // RFC-0018/A2e treasury entity-auth seam:
+    // default ObserveOnly preserves flat require_coop_access behavior;
+    // explicit EnforceTrustedResolver may deny here before treasury work proceeds.
     observe_treasury(
         &req,
         &entity_mgr,
@@ -1078,7 +1021,9 @@ pub async fn get_audit_trail(
         return Ok(HttpResponse::Ok().json(response));
     };
 
-    // RFC-0018 observe mode (ADR-0035): flat guard above remains authoritative.
+    // RFC-0018/A2e treasury entity-auth seam:
+    // default ObserveOnly preserves flat require_coop_access behavior;
+    // explicit EnforceTrustedResolver may deny here before treasury work proceeds.
     observe_treasury(
         &req,
         &entity_mgr,
@@ -1170,7 +1115,9 @@ pub async fn deposit_to_treasury(
             GatewayError::NotFound(format!("Treasury not found for cooperative: {coop_id}"))
         })?;
 
-    // RFC-0018 observe mode (ADR-0035): flat guard above remains authoritative.
+    // RFC-0018/A2e treasury entity-auth seam:
+    // default ObserveOnly preserves flat require_coop_access behavior;
+    // explicit EnforceTrustedResolver may deny here before treasury work proceeds.
     observe_treasury(
         &req,
         &entity_mgr,
@@ -1315,7 +1262,9 @@ pub(crate) async fn do_propose_spend(
         ))
     })?;
 
-    // RFC-0018 observe mode (ADR-0035): flat guard above remains authoritative.
+    // RFC-0018/A2e treasury entity-auth seam:
+    // default ObserveOnly preserves flat require_coop_access behavior;
+    // explicit EnforceTrustedResolver may deny here before treasury work proceeds.
     observe_treasury(
         &req,
         &entity_mgr,
@@ -1567,10 +1516,41 @@ mod tests {
         assert_eq!(resp.status(), actix_web::http::StatusCode::FORBIDDEN);
     }
 
+    /// Regression for the enforce-mode object-binding ordering (post-#2254): the
+    /// `get_budget` object-context binding (`path_owns_budget`) decides ownership purely
+    /// from the path treasury vs the budget's `treasury_did`, and the handler runs it
+    /// BEFORE the (enforce-capable) entity-auth seam. A foreign budget — and a path coop
+    /// with no treasury — must read as NOT owned, so the handler returns generic NotFound
+    /// before any `EnforceTrustedResolver` denial can run against (and thereby reveal) the
+    /// foreign owner. Pure + env-free, so it cannot race the global `ICN_TREASURY_ENTITY_AUTH_MODE`.
+    ///
+    /// Nested in its own module so the built-in `#[test]` is not shadowed by this test
+    /// module's `use actix_web::test` (the actix attribute requires `async`).
+    mod path_binding_precedes_entity_auth {
+        use super::super::path_owns_budget;
+        use icn_identity::KeyPair;
+
+        #[test]
+        fn path_owns_budget_masks_foreign_and_missing() {
+            let a = KeyPair::generate().unwrap().did().clone();
+            let b = KeyPair::generate().unwrap().did().clone();
+            // Own budget: path treasury present and the dids match -> owned (entity-auth
+            // may then run against the path coop's own treasury).
+            assert!(path_owns_budget(Some(&a), &a));
+            // Foreign budget: path treasury present but dids differ -> NOT owned -> generic
+            // NotFound, BEFORE any enforce-capable entity-auth (no 403 existence/ownership leak).
+            assert!(!path_owns_budget(Some(&a), &b));
+            // #2085: path coop has no treasury at all -> NOT owned -> generic NotFound.
+            assert!(!path_owns_budget(None, &a));
+        }
+    }
+
     /// #2085: a caller authorized for coop-a must not retrieve coop-b's budget
     /// through the globally-keyed budget id. The flat guard checks only the path
     /// coop; the budget is fetched by a global id and must be proven to belong to
-    /// the path coop's treasury before it is returned.
+    /// the path coop's treasury before it is returned. Post-#2254 this binding runs
+    /// BEFORE the enforce-capable entity-auth seam, so the foreign budget is masked as
+    /// NotFound even when explicit enforce mode would otherwise 403 against its owner.
     #[actix_web::test]
     async fn test_get_budget_cross_coop_read_denied() {
         let treasury_mgr = actor_backed_treasury_manager();


### PR DESCRIPTION
## Summary

Reorders `get_budget` so the object-context ownership binding (budget → path coop's treasury)
runs **before** the enforce-capable treasury entity-auth seam, closing a post-#2254 budget
existence/ownership oracle. Foreign and missing budgets remain indistinguishable
(`NotFound("Budget not found")`).

## Why

[#2254](https://github.com/InterCooperative-Network/icn/pull/2254) made the treasury route helpers
**consume the entity-auth gate decision** under explicit
`ICN_TREASURY_ENTITY_AUTH_MODE=enforce-trusted-resolver` — i.e. they can now return **403**.
`get_budget` (which fetches a **globally-keyed** `budget_id`) called the now-enforce-capable
entity-auth helper against the budget's **own** treasury **before** verifying the budget belonged
to the path coop. Before #2254 that was harmless (observation-only); after #2254, a
foreign-but-existing budget could return **403 before the intended generic 404 masking ran**,
leaking the existence/ownership of another coop's budget.

## What changed

`icn/crates/icn-gateway/src/api/treasury.rs` only:

- **Added** pure helper `path_owns_budget(path_treasury_did: Option<&Did>, budget_treasury_did: &Did) -> bool`
  — the #2085 object-binding decision: `false` when the path coop has no treasury **or** the dids
  differ (both must surface as the same generic `NotFound`).
- **Reordered `get_budget`**: bind the budget to the path coop's treasury **first**; a foreign or
  missing budget returns `NotFound("Budget not found")` **before** the entity-auth seam, so an
  enforce-mode 403 can never run against (and thereby reveal) a foreign owner. The entity-auth seam
  (`observe_treasury`) now runs **only after** binding, against the **path coop's** treasury entity
  (post-binding, that is the budget's owner).
- **Removed `observe_treasury_by_did`**: its sole rationale (observe against a possibly-foreign
  owner) is void now that binding precedes auth; `get_budget` was its only caller.
- **Replaced stale comments** (`RFC-0018 observe mode (ADR-0035): flat guard above remains
  authoritative`) with A2e seam wording, since the seam may now deny under explicit enforce mode.

## Behavior before / after

| Case | Before this PR (enforce mode) | After this PR |
|---|---|---|
| Foreign-but-existing budget | could **403** (leak) before 404 masking | generic **404** `NotFound` (binding first) |
| Missing budget | 404 | 404 (unchanged) |
| Path coop has no treasury | 404 | 404 (unchanged) |
| Own budget read | reached entity seam | reaches entity seam **after** binding |
| Default `ObserveOnly` | unchanged | **unchanged** (byte-identical to flat `require_coop_access`) |

Enforce mode denies only **after** the object is bound to the path coop. No new auth model; the
treasury route family is unchanged; no deploy-default change.

## Validation

From `icn/`:
- `cargo fmt --all --check` — clean
- `cargo test -p icn-gateway --lib --all-features -- path_owns_budget get_budget cross_coop` —
  **16 passed, 0 failed** (`path_owns_budget` + `foreign_budget_probe` + the existing
  cross-coop / same-coop / no-path-treasury masking tests)
- `cargo test -p icn-gateway --lib --all-features` — **683 passed, 0 failed**
- `cargo clippy -p icn-gateway --all-targets --all-features -- -D warnings` — clean
- `git diff --check` — clean
- `bash ops/scripts/drift-check.sh` — PASS · overclaim self-test/scan clean · `check-state-lag` OK

The regression test is a **pure, env-free** `path_owns_budget` test (nested in its own module so the
built-in `#[test]` is not shadowed by the module's `use actix_web::test`). No global
`std::env` mutation, so it cannot make sibling tests flaky; the handler ordering it guards is the
binding decision that precedes the enforce-capable seam.

## Issue effects

- `Refs #2081`
- `Refs #2082`
- `Refs #1746`

**None of these are closed by this PR.**

## Follow-ups

- **Separate** dependency PR for `RUSTSEC-2026-0190` (anyhow `1.0.100` → `1.0.103` via
  `cargo update -p anyhow`, rerun `cargo deny check`). Intentionally **not** mixed into this fix.

## Nonclaims

- This does not enable enforcement by default.
- This does not change deploy defaults.
- This does not complete #2082.
- This does not complete entity-aware authorization.
- This does not make resolver mappings authority.
- This does not make ICN production-ready, pilot-ready, organizer-ready, member-ready, or
  live-federated.
- This does not complete Phase 2.
- This does not complete #2041.
- This does not claim #2113 completion.
- This does not address the anyhow / RUSTSEC-2026-0190 advisory.


## Review follow-up

Codex (P2) correctly flagged that the first version preserved the `NotFound` mask but **dropped
observe-mode divergence telemetry** for cross-coop budget probes
(`ABUSE_CASE_HARDENING_STRATEGY.md` §4.11 item 5). Fixed in `ec3ee712` with a **mode-split**:

- **ObserveOnly:** before the foreign/no-path-treasury `NotFound` mask, `get_budget` records the
  budget-owner probe via the detached, fire-and-forget `observe_treasury_entity_access`,
  preserving migration telemetry (e.g. `flat_allow_entity_deny`).
- **EnforceTrustedResolver:** no foreign-owner gate runs before masking, so no 403
  existence/ownership leak is possible.
- The response remains generic `NotFound("Budget not found")` in both modes; enforce-capable
  entity-auth still runs only **after** object/path binding.

New pure test `foreign_budget_probe_records_only_in_observe_only` pins the mode-gating; existing
cross-coop masking tests stay green. Updated validation: targeted **16/0**, full lib **683/0**,
clippy/fmt/drift-check clean.
