### PR TITLE
chore(deps): update anyhow for RUSTSEC-2026-0190

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
## Summary
Bump `anyhow` `1.0.100` → `1.0.103` in `icn/Cargo.lock`. Lockfile-only: no manifest / version-requirement change, no source change.

## Why
`RUSTSEC-2026-0190` — *informational / unsound*: a borrow-rule UB in `anyhow::Error::downcast_mut()` when context was added via `Error::context()`. Affected versions are `< 1.0.103`; patched is `>= 1.0.103`.

This is **warning-level, not a CI-red break**: `cargo audit` surfaces it as `Warning: unsound` and exits `0`, and `cargo deny check advisories` already reported `advisories ok` (it does not elevate this `unsound` class to an error). The bump clears the `cargo audit` warning and lands the minimum patched version — dependency hygiene rather than an emergency fix.

## Changed files
- `icn/Cargo.lock` only (the `anyhow` version + checksum line; `cargo update -p anyhow --precise 1.0.103` left 271 other dependencies unchanged).

## Validation (run from `icn/`)
- `cargo audit` → allowed warnings `9 → 8`, `anyhow` no longer listed, exit `0`
- `cargo deny check advisories` → `advisories ok`
- `cargo fmt --all --check` → clean
- `cargo test -p icn-gateway --lib --all-features` → `683 passed; 0 failed`
- `git diff --check` → clean

## Nonclaims
- Not a toolchain change (`rust-toolchain.toml` untouched).
- The separate `icn/crates/icn-ccl/fuzz/Cargo.lock` (its own workspace, **not** scanned by the CI advisories gate, which runs from `icn/`) is intentionally **left untouched**: bumping `anyhow` there triggers an unrelated whole-graph re-resolution, out of scope for this dependency-only fix.
- No functional or authorization behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)