### PR TITLE
feat(ledger): add read-only treasury entity_id backfill plan

### DIFF
--- a/icn/crates/icn-entity/src/coop_entity_map.rs
+++ b/icn/crates/icn-entity/src/coop_entity_map.rs
@@ -134,6 +134,38 @@ pub enum CoopEntityBindingProvenance {
     UnknownLegacy,
 }
 
+impl CoopEntityBindingProvenance {
+    /// Whether this provenance is **trusted** for *resolving* a `coop_id` to its
+    /// bound [`EntityId`] (i.e. for treating the binding as usable evidence for
+    /// enforce/issue-class purposes).
+    ///
+    /// Trusted: [`Activation`](Self::Activation),
+    /// [`OperatorBackfill`](Self::OperatorBackfill),
+    /// [`Surrogate`](Self::Surrogate), and
+    /// [`GovernanceReceipt`](Self::GovernanceReceipt) — each records a concrete,
+    /// accountable origin for the binding. **Fail-closed:**
+    /// [`UnknownLegacy`](Self::UnknownLegacy) — a pre-provenance binding, none
+    /// recorded, or an unrecognized future variant — is **never** trusted.
+    ///
+    /// This is the canonical predicate for "is this binding trustworthy enough to
+    /// act on as evidence". The gateway resolver keeps an enforcement-local copy
+    /// (`icn-gateway::coop_entity_resolver::provenance_is_trusted_for_resolution`)
+    /// that MUST classify the same set; the two are pinned by tests on each side.
+    /// Trust here gates only whether a binding may be *used as evidence* — a
+    /// mapping still confers **zero** authority on its own (see the module docs):
+    /// it never says what a caller is allowed to do, only which entity an
+    /// identifier denotes.
+    pub fn is_trusted_for_resolution(&self) -> bool {
+        match self {
+            CoopEntityBindingProvenance::Activation
+            | CoopEntityBindingProvenance::OperatorBackfill
+            | CoopEntityBindingProvenance::Surrogate
+            | CoopEntityBindingProvenance::GovernanceReceipt { .. } => true,
+            CoopEntityBindingProvenance::UnknownLegacy => false,
+        }
+    }
+}
+
 /// A `coop_id ↔ EntityId` binding together with its [`CoopEntityBindingProvenance`].
 ///
 /// Returned by the provenance-aware reads. The `coop_id` is preserved byte-for-byte
@@ -773,6 +805,25 @@ mod tests {
 
     fn coop_eid(slug: &str) -> EntityId {
         EntityId::cooperative(slug).unwrap()
+    }
+
+    // ------------------------------------------------------------------
+    // Provenance trust set (canonical predicate; pinned)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn provenance_trust_set_is_pinned() {
+        use CoopEntityBindingProvenance as P;
+        // Trusted: every recorded, accountable origin.
+        assert!(P::Activation.is_trusted_for_resolution());
+        assert!(P::OperatorBackfill.is_trusted_for_resolution());
+        assert!(P::Surrogate.is_trusted_for_resolution());
+        assert!(P::GovernanceReceipt {
+            receipt_id: "receipt-1".into()
+        }
+        .is_trusted_for_resolution());
+        // Fail-closed: the legacy/unknown sentinel is never trusted.
+        assert!(!P::UnknownLegacy.is_trusted_for_resolution());
     }
 
     // ------------------------------------------------------------------

--- a/icn/crates/icn-ledger/src/lib.rs
+++ b/icn/crates/icn-ledger/src/lib.rs
@@ -80,6 +80,7 @@ pub mod settlement;
 #[allow(missing_docs)]
 pub mod sync;
 pub mod treasury;
+pub mod treasury_entity_backfill;
 pub mod types;
 pub mod use_access;
 
@@ -113,6 +114,10 @@ pub use sync::{deserialize_sync_message, ledger_topic, serialize_sync_message, L
 pub use treasury::{
     ApprovalType, BudgetStatus, PaginatedAuditTrail, SpendingRule, Treasury, TreasuryAuditRecord,
     TreasuryBudget, TreasuryManager, TreasuryOperation, VelocityLimit, VelocityWindow,
+};
+pub use treasury_entity_backfill::{
+    plan_treasury_entity_id_backfill, TreasuryEntityIdBackfillAction,
+    TreasuryEntityIdBackfillEntry, TreasuryEntityIdBackfillPlan, TreasuryEntityIdBackfillTarget,
 };
 pub use types::{
     AccountBalances, AccountDelta, ContentHash, CreditLimit, Currency, Dispute, DisputeOutcome,

--- a/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
+++ b/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
@@ -1,0 +1,693 @@
+//! Read-only **plan** for populating a legacy treasury's `entity_id` from the
+//! canonical, trusted [`CoopEntityMap`] (#2082 lane).
+//!
+//! # What this is
+//!
+//! A treasury created via the legacy [`Treasury::new`](crate::Treasury::new)
+//! path carries `entity_id: None` (its only organizational identity is the flat
+//! `coop_id`). This module computes — **read-only, no mutation** — which such
+//! treasuries *could* have their `entity_id` populated from a **trusted,
+//! non-ambiguous** `coop_id → EntityId` binding in the canonical
+//! [`CoopEntityMap`], and *why* each ineligible treasury is skipped. It writes
+//! nothing and changes no authorization state.
+//!
+//! # Why a plan, not an apply
+//!
+//! Populating `treasury.entity_id` is **not** authorization-neutral under the
+//! operator-opt-in `EnforceTrustedResolver` treasury gate: that gate uses
+//! `treasury.entity_id()` as the entity-membership *target* (see
+//! `icn-gateway`'s `compute_treasury_observation` / `decide_treasury_gate`). In
+//! the default `ObserveOnly` mode it changes nothing (the observation is
+//! discarded), but in enforce mode flipping `None → Some` can change which
+//! entity membership is checked against — e.g. a non-mappable `coop:<uuid>`
+//! would move from an indeterminate "missing target" to an evaluable one. So
+//! the *mutation* belongs in a separate, explicitly-reviewed follow-up; this
+//! slice ships only the safe, read-only classification core. A mapping is a
+//! name binding and grants **zero** authority — this plan moves no power and,
+//! being read-only, changes no decision in any mode.
+//!
+//! # Trust is fail-closed
+//!
+//! A treasury is eligible only when its `coop_id` has a binding whose provenance
+//! is trusted-for-resolution
+//! ([`CoopEntityBindingProvenance::is_trusted_for_resolution`]) **and** whose
+//! target is a well-formed cooperative [`EntityId`] **and** whose reverse index
+//! points back to the same `coop_id` (unambiguous). Every other case —
+//! `UnknownLegacy`/unprovenanced/gossip-originated provenance, a missing
+//! binding, a non-cooperative or malformed target, an ambiguous reverse binding,
+//! or a storage read error — is **skipped** (fail closed).
+
+use crate::treasury::{Treasury, TreasuryManager};
+use icn_entity::{CoopEntityMap, EntityId};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// The outcome the plan assigns to a single treasury row. Exactly one action is
+/// assigned per row, and every action maps to exactly one aggregate counter, so
+/// the per-row actions partition [`TreasuryEntityIdBackfillPlan::total`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TreasuryEntityIdBackfillAction {
+    /// Eligible: a legacy treasury (`entity_id: None`) whose `coop_id` has a
+    /// trusted, non-ambiguous cooperative binding. Under a (future, separate)
+    /// apply it *would* be populated; this plan writes nothing.
+    WouldPopulate,
+    /// Skipped: the treasury already carries an `entity_id` (nothing to do).
+    SkippedAlreadyHasEntityId,
+    /// Skipped: the `coop_id` has no binding in the canonical map.
+    SkippedNoMapping,
+    /// Skipped: a binding exists but its provenance is not trusted for resolution
+    /// (`UnknownLegacy` / unprovenanced / gossip-originated). Fail closed.
+    SkippedUntrustedProvenance,
+    /// Skipped: the bound `EntityId` is not a well-formed cooperative entity
+    /// (a flat `coop_id` denotes a cooperative target — RFC-0018). Fail closed.
+    SkippedNonCooperativeEntity,
+    /// Skipped: the binding is internally inconsistent — the resolved entity's
+    /// reverse binding points to a *different* `coop_id`. Fail closed.
+    SkippedAmbiguousBinding,
+    /// Skipped: a storage read error prevented establishing safety. Fail closed.
+    SkippedStorageError,
+}
+
+/// One treasury row to plan over. The original `coop_id` is used as-is (the
+/// lookup key into the map) and is never normalized.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreasuryEntityIdBackfillTarget {
+    /// The treasury's flat `coop_id` (the map lookup key).
+    pub coop_id: String,
+    /// The treasury DID, for operator-facing identification. `None` when planning
+    /// over raw `(coop_id, entity_id)` rows rather than concrete treasuries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub treasury_did: Option<String>,
+    /// The treasury's current `entity_id` (`None` for a legacy treasury — the
+    /// only kind that is a backfill candidate).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_entity_id: Option<EntityId>,
+}
+
+/// Per-treasury audit detail. The `coop_id` is preserved byte-for-byte.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreasuryEntityIdBackfillEntry {
+    /// The treasury's flat `coop_id`, exactly as supplied.
+    pub coop_id: String,
+    /// The treasury DID, when planning over concrete treasuries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub treasury_did: Option<String>,
+    /// The trusted cooperative `EntityId` that *would* populate this treasury
+    /// (present for [`WouldPopulate`](TreasuryEntityIdBackfillAction::WouldPopulate)),
+    /// and surfaced for several skip reasons so an operator can see the rejected
+    /// candidate. `None` for no-mapping / storage-error-on-lookup rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_entity_id: Option<EntityId>,
+    /// The action assigned to this row.
+    pub action: TreasuryEntityIdBackfillAction,
+    /// A short, human-readable explanation of the action.
+    pub reason: String,
+    /// The underlying map read error string when one exists. `None` for clean
+    /// outcomes and for policy findings (ambiguity is surfaced in `reason`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Aggregate, auditable result of a read-only treasury `entity_id` backfill plan.
+///
+/// The counters partition [`total`](Self::total): `total == would_populate +
+/// skipped_already_has_entity_id + skipped_no_mapping +
+/// skipped_untrusted_provenance + skipped_non_cooperative_entity +
+/// skipped_ambiguous_binding + skipped_storage_error`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreasuryEntityIdBackfillPlan {
+    /// Total number of treasuries considered (`== entries.len()`).
+    pub total: usize,
+    /// Eligible: trusted, non-ambiguous cooperative bindings for legacy rows.
+    pub would_populate: usize,
+    /// Skipped because the treasury already has an `entity_id`.
+    pub skipped_already_has_entity_id: usize,
+    /// Skipped because the `coop_id` has no binding in the map.
+    pub skipped_no_mapping: usize,
+    /// Skipped because the binding's provenance is not trusted (fail closed).
+    pub skipped_untrusted_provenance: usize,
+    /// Skipped because the bound `EntityId` is not a well-formed cooperative.
+    pub skipped_non_cooperative_entity: usize,
+    /// Skipped because the binding's reverse index is ambiguous (fail closed).
+    pub skipped_ambiguous_binding: usize,
+    /// Skipped because a storage read error prevented establishing safety.
+    pub skipped_storage_error: usize,
+    /// Per-treasury detail, in input order.
+    pub entries: Vec<TreasuryEntityIdBackfillEntry>,
+}
+
+impl TreasuryEntityIdBackfillPlan {
+    /// An empty plan (used for an empty / missing treasury set).
+    fn new() -> Self {
+        Self {
+            total: 0,
+            would_populate: 0,
+            skipped_already_has_entity_id: 0,
+            skipped_no_mapping: 0,
+            skipped_untrusted_provenance: 0,
+            skipped_non_cooperative_entity: 0,
+            skipped_ambiguous_binding: 0,
+            skipped_storage_error: 0,
+            entries: Vec::new(),
+        }
+    }
+
+    /// Record one classified entry, bumping the matching counter and `total`.
+    fn record(&mut self, entry: TreasuryEntityIdBackfillEntry) {
+        match entry.action {
+            TreasuryEntityIdBackfillAction::WouldPopulate => self.would_populate += 1,
+            TreasuryEntityIdBackfillAction::SkippedAlreadyHasEntityId => {
+                self.skipped_already_has_entity_id += 1
+            }
+            TreasuryEntityIdBackfillAction::SkippedNoMapping => self.skipped_no_mapping += 1,
+            TreasuryEntityIdBackfillAction::SkippedUntrustedProvenance => {
+                self.skipped_untrusted_provenance += 1
+            }
+            TreasuryEntityIdBackfillAction::SkippedNonCooperativeEntity => {
+                self.skipped_non_cooperative_entity += 1
+            }
+            TreasuryEntityIdBackfillAction::SkippedAmbiguousBinding => {
+                self.skipped_ambiguous_binding += 1
+            }
+            TreasuryEntityIdBackfillAction::SkippedStorageError => self.skipped_storage_error += 1,
+        }
+        self.total += 1;
+        self.entries.push(entry);
+    }
+}
+
+/// Plan (read-only) which treasury rows could have their `entity_id` populated
+/// from a **trusted, non-ambiguous** cooperative binding in `map`.
+///
+/// Read-only by construction: it performs only `binding_for_coop` /
+/// `coop_for_entity` reads and **never** binds or mutates the map or any
+/// treasury. A binding confers no authority; this plan changes no authorization
+/// decision in any mode.
+pub fn plan_treasury_entity_id_backfill(
+    targets: impl IntoIterator<Item = TreasuryEntityIdBackfillTarget>,
+    map: &dyn CoopEntityMap,
+) -> TreasuryEntityIdBackfillPlan {
+    let mut plan = TreasuryEntityIdBackfillPlan::new();
+    for target in targets {
+        plan.record(plan_target(&target, map));
+    }
+    plan
+}
+
+/// Decide the (read-only) action for a single treasury row.
+fn plan_target(
+    target: &TreasuryEntityIdBackfillTarget,
+    map: &dyn CoopEntityMap,
+) -> TreasuryEntityIdBackfillEntry {
+    let make = |action: TreasuryEntityIdBackfillAction,
+                resolved: Option<EntityId>,
+                reason: String,
+                error: Option<String>| TreasuryEntityIdBackfillEntry {
+        coop_id: target.coop_id.clone(),
+        treasury_did: target.treasury_did.clone(),
+        resolved_entity_id: resolved,
+        action,
+        reason,
+        error,
+    };
+
+    // Already populated: nothing to plan (idempotent — a re-run after a future
+    // apply re-classifies these rows here, never re-populating them).
+    if target.current_entity_id.is_some() {
+        return make(
+            TreasuryEntityIdBackfillAction::SkippedAlreadyHasEntityId,
+            None,
+            "treasury already has an entity_id".into(),
+            None,
+        );
+    }
+
+    // Look up the binding (entity + provenance) for this coop_id. A read error
+    // fails closed: safety cannot be established, so nothing is proposed.
+    let binding = match map.binding_for_coop(&target.coop_id) {
+        Ok(Some(binding)) => binding,
+        Ok(None) => {
+            return make(
+                TreasuryEntityIdBackfillAction::SkippedNoMapping,
+                None,
+                "no coop_id -> EntityId binding in the canonical map".into(),
+                None,
+            )
+        }
+        Err(e) => {
+            return make(
+                TreasuryEntityIdBackfillAction::SkippedStorageError,
+                None,
+                "map read failed; cannot establish a safe binding".into(),
+                Some(e.to_string()),
+            )
+        }
+    };
+
+    // Fail-closed on untrusted provenance (UnknownLegacy / unprovenanced /
+    // gossip-originated). This is the canonical trust predicate shared with the
+    // gateway resolver.
+    if !binding.provenance.is_trusted_for_resolution() {
+        return make(
+            TreasuryEntityIdBackfillAction::SkippedUntrustedProvenance,
+            Some(binding.entity_id.clone()),
+            "binding provenance is not trusted for resolution (fail closed)".into(),
+            None,
+        );
+    }
+
+    // A flat coop_id denotes a cooperative target (RFC-0018): the resolved
+    // EntityId must be a *well-formed* cooperative. Re-parse via FromStr so a
+    // cooperative-typed but invalid-slug id (constructible via serde, never via
+    // the validating constructors) is rejected rather than populated.
+    let is_well_formed_cooperative = EntityId::from_str(binding.entity_id.as_str())
+        .map(|parsed| parsed.is_cooperative())
+        .unwrap_or(false);
+    if !is_well_formed_cooperative {
+        return make(
+            TreasuryEntityIdBackfillAction::SkippedNonCooperativeEntity,
+            Some(binding.entity_id.clone()),
+            "bound EntityId is not a well-formed cooperative entity".into(),
+            None,
+        );
+    }
+
+    // Non-ambiguity cross-check: the resolved entity's reverse binding must point
+    // back to THIS coop_id. A mismatch (the entity is reverse-bound to a different
+    // coop_id) or a reverse read error fails closed.
+    match map.coop_for_entity(&binding.entity_id) {
+        Ok(Some(reverse)) if reverse != target.coop_id => {
+            return make(
+                TreasuryEntityIdBackfillAction::SkippedAmbiguousBinding,
+                Some(binding.entity_id.clone()),
+                format!("resolved entity is reverse-bound to a different coop_id ({reverse:?})"),
+                None,
+            );
+        }
+        Ok(_) => {}
+        Err(e) => {
+            return make(
+                TreasuryEntityIdBackfillAction::SkippedStorageError,
+                Some(binding.entity_id.clone()),
+                "reverse-index read failed; cannot verify the binding is unambiguous".into(),
+                Some(e.to_string()),
+            );
+        }
+    }
+
+    // Eligible: a trusted, non-ambiguous, cooperative binding for a legacy
+    // treasury that currently has no entity_id. READ-ONLY — report the intent;
+    // populate nothing.
+    let resolved = binding.entity_id.as_str().to_string();
+    make(
+        TreasuryEntityIdBackfillAction::WouldPopulate,
+        Some(binding.entity_id),
+        format!("would populate entity_id from trusted binding to {resolved}"),
+        None,
+    )
+}
+
+impl TreasuryManager {
+    /// Read-only: plan which legacy treasuries (those with `entity_id: None`)
+    /// could have their `entity_id` populated from a **trusted, non-ambiguous**
+    /// cooperative binding in `map`.
+    ///
+    /// Performs **no** writes — neither to the treasury store nor to the map —
+    /// and changes no authorization state. The mutating apply is a separate,
+    /// explicitly-reviewed follow-up (populating `treasury.entity_id` affects the
+    /// operator-opt-in `EnforceTrustedResolver` treasury gate's membership
+    /// target; see the module docs). A mapping confers no authority.
+    pub fn plan_entity_id_backfill(&self, map: &dyn CoopEntityMap) -> TreasuryEntityIdBackfillPlan {
+        let targets = self.list_treasuries().into_iter().map(treasury_to_target);
+        plan_treasury_entity_id_backfill(targets, map)
+    }
+}
+
+/// Project a concrete [`Treasury`] to its backfill target row (read-only).
+fn treasury_to_target(treasury: &Treasury) -> TreasuryEntityIdBackfillTarget {
+    TreasuryEntityIdBackfillTarget {
+        coop_id: treasury.coop_id().to_string(),
+        treasury_did: Some(treasury.treasury_did.to_string()),
+        current_entity_id: treasury.entity_id().cloned(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use icn_entity::{
+        CoopEntityBinding, CoopEntityBindingProvenance, CoopEntityMapError, InMemoryCoopEntityMap,
+    };
+
+    fn coop_eid(slug: &str) -> EntityId {
+        EntityId::cooperative(slug).unwrap()
+    }
+
+    fn target(coop_id: &str, current: Option<EntityId>) -> TreasuryEntityIdBackfillTarget {
+        TreasuryEntityIdBackfillTarget {
+            coop_id: coop_id.to_string(),
+            treasury_did: None,
+            current_entity_id: current,
+        }
+    }
+
+    fn one(plan: &TreasuryEntityIdBackfillPlan) -> &TreasuryEntityIdBackfillEntry {
+        assert_eq!(plan.entries.len(), 1, "expected exactly one entry");
+        &plan.entries[0]
+    }
+
+    // ------------------------------------------------------------------
+    // Eligible: trusted, non-ambiguous cooperative binding for a legacy row.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn would_populate_on_trusted_activation_binding() {
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+
+        assert_eq!(plan.total, 1);
+        assert_eq!(plan.would_populate, 1);
+        let entry = one(&plan);
+        assert_eq!(entry.action, TreasuryEntityIdBackfillAction::WouldPopulate);
+        assert_eq!(entry.resolved_entity_id, Some(coop_eid("food-coop")));
+        assert!(entry.error.is_none());
+    }
+
+    #[test]
+    fn would_populate_on_trusted_operator_backfill_surrogate() {
+        // A non-mappable legacy id (coop:<uuid>) bound to a surrogate via the
+        // operator backfill is a trusted, non-ambiguous binding.
+        let map = InMemoryCoopEntityMap::new();
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        map.bind_resolved_with_provenance(
+            "coop:550e8400-e29b-41d4-a716-446655440000",
+            &surrogate,
+            CoopEntityBindingProvenance::OperatorBackfill,
+        )
+        .unwrap();
+
+        let plan = plan_treasury_entity_id_backfill(
+            vec![target("coop:550e8400-e29b-41d4-a716-446655440000", None)],
+            &map,
+        );
+        assert_eq!(plan.would_populate, 1);
+        assert_eq!(one(&plan).resolved_entity_id, Some(surrogate));
+    }
+
+    // ------------------------------------------------------------------
+    // Skips.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn skipped_when_treasury_already_has_entity_id() {
+        // A trusted binding exists, but the treasury already carries entity_id —
+        // there is nothing to populate, regardless of the map.
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+
+        let plan = plan_treasury_entity_id_backfill(
+            vec![target("food-coop", Some(coop_eid("food-coop")))],
+            &map,
+        );
+        assert_eq!(plan.skipped_already_has_entity_id, 1);
+        assert_eq!(plan.would_populate, 0);
+        assert_eq!(
+            one(&plan).action,
+            TreasuryEntityIdBackfillAction::SkippedAlreadyHasEntityId
+        );
+    }
+
+    #[test]
+    fn skipped_when_no_mapping() {
+        let map = InMemoryCoopEntityMap::new();
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+        assert_eq!(plan.skipped_no_mapping, 1);
+        assert_eq!(
+            one(&plan).action,
+            TreasuryEntityIdBackfillAction::SkippedNoMapping
+        );
+        assert!(one(&plan).resolved_entity_id.is_none());
+    }
+
+    #[test]
+    fn skipped_when_provenance_untrusted_unknown_legacy() {
+        // A plain bind_resolved records no provenance; it reads back as the
+        // fail-closed UnknownLegacy sentinel and must NOT be populated.
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved("food-coop", &coop_eid("food-coop"))
+            .unwrap();
+
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+        assert_eq!(plan.skipped_untrusted_provenance, 1);
+        assert_eq!(plan.would_populate, 0);
+        let entry = one(&plan);
+        assert_eq!(
+            entry.action,
+            TreasuryEntityIdBackfillAction::SkippedUntrustedProvenance
+        );
+        // The rejected candidate is still surfaced for operator visibility.
+        assert_eq!(entry.resolved_entity_id, Some(coop_eid("food-coop")));
+    }
+
+    // ------------------------------------------------------------------
+    // Fail-closed paths exercised via test doubles (the InMemory/Sled maps
+    // refuse non-cooperative binds and keep both indexes consistent, so these
+    // states only arise from an inconsistent/erroring backend).
+    // ------------------------------------------------------------------
+
+    /// A configurable read-only double. `bind_resolved` is `unreachable!` so a
+    /// test fails loudly if the plan ever tries to WRITE — proving read-only.
+    struct StubMap {
+        binding: fn(&str) -> Result<Option<CoopEntityBinding>, CoopEntityMapError>,
+        reverse: fn(&EntityId) -> Result<Option<String>, CoopEntityMapError>,
+    }
+    impl CoopEntityMap for StubMap {
+        fn bind_resolved(&self, _: &str, _: &EntityId) -> Result<(), CoopEntityMapError> {
+            unreachable!("read-only backfill plan must never bind/mutate the map");
+        }
+        fn entity_for_coop(&self, _: &str) -> Result<Option<EntityId>, CoopEntityMapError> {
+            Ok(None)
+        }
+        fn coop_for_entity(&self, entity: &EntityId) -> Result<Option<String>, CoopEntityMapError> {
+            (self.reverse)(entity)
+        }
+        fn binding_for_coop(
+            &self,
+            coop_id: &str,
+        ) -> Result<Option<CoopEntityBinding>, CoopEntityMapError> {
+            (self.binding)(coop_id)
+        }
+    }
+
+    #[test]
+    fn skipped_when_bound_entity_is_not_cooperative() {
+        let map = StubMap {
+            binding: |coop_id| {
+                Ok(Some(CoopEntityBinding {
+                    coop_id: coop_id.to_string(),
+                    // Trusted provenance, but a community (non-cooperative) target.
+                    entity_id: EntityId::community("some-community").unwrap(),
+                    provenance: CoopEntityBindingProvenance::Activation,
+                }))
+            },
+            reverse: |_| Ok(None),
+        };
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+        assert_eq!(plan.skipped_non_cooperative_entity, 1);
+        assert_eq!(plan.would_populate, 0);
+        assert_eq!(
+            one(&plan).action,
+            TreasuryEntityIdBackfillAction::SkippedNonCooperativeEntity
+        );
+    }
+
+    #[test]
+    fn skipped_when_binding_is_ambiguous_reverse_mismatch() {
+        let map = StubMap {
+            binding: |coop_id| {
+                Ok(Some(CoopEntityBinding {
+                    coop_id: coop_id.to_string(),
+                    entity_id: EntityId::cooperative("food-coop").unwrap(),
+                    provenance: CoopEntityBindingProvenance::Activation,
+                }))
+            },
+            // The resolved entity is reverse-bound to a DIFFERENT coop_id.
+            reverse: |_| Ok(Some("other-coop".to_string())),
+        };
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+        assert_eq!(plan.skipped_ambiguous_binding, 1);
+        assert_eq!(plan.would_populate, 0);
+        let entry = one(&plan);
+        assert_eq!(
+            entry.action,
+            TreasuryEntityIdBackfillAction::SkippedAmbiguousBinding
+        );
+        assert!(entry.reason.contains("other-coop"));
+    }
+
+    #[test]
+    fn skipped_on_forward_storage_error() {
+        let map = StubMap {
+            binding: |_| {
+                Err(CoopEntityMapError::Storage(
+                    "forward index unreadable".into(),
+                ))
+            },
+            reverse: |_| Ok(None),
+        };
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+        assert_eq!(plan.skipped_storage_error, 1);
+        let entry = one(&plan);
+        assert_eq!(
+            entry.action,
+            TreasuryEntityIdBackfillAction::SkippedStorageError
+        );
+        assert!(entry.error.as_ref().unwrap().contains("forward index"));
+    }
+
+    #[test]
+    fn skipped_on_reverse_storage_error() {
+        let map = StubMap {
+            binding: |coop_id| {
+                Ok(Some(CoopEntityBinding {
+                    coop_id: coop_id.to_string(),
+                    entity_id: EntityId::cooperative("food-coop").unwrap(),
+                    provenance: CoopEntityBindingProvenance::Activation,
+                }))
+            },
+            reverse: |_| {
+                Err(CoopEntityMapError::Storage(
+                    "reverse index unreadable".into(),
+                ))
+            },
+        };
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+        assert_eq!(plan.skipped_storage_error, 1);
+        assert!(one(&plan).error.as_ref().unwrap().contains("reverse index"));
+    }
+
+    // ------------------------------------------------------------------
+    // Aggregate: counters partition the input on a mixed batch.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn counts_partition_total_on_mixed_batch() {
+        let map = InMemoryCoopEntityMap::new();
+        // food-coop: trusted Activation binding -> eligible.
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+        // legacy-coop: plain bind -> UnknownLegacy -> untrusted.
+        map.bind_resolved("legacy-coop", &coop_eid("legacy-coop"))
+            .unwrap();
+
+        let plan = plan_treasury_entity_id_backfill(
+            vec![
+                target("food-coop", None),                         // would_populate
+                target("legacy-coop", None),                       // untrusted
+                target("no-map-coop", None),                       // no_mapping
+                target("already", Some(coop_eid("already-coop"))), // already_has
+            ],
+            &map,
+        );
+
+        assert_eq!(plan.total, 4);
+        assert_eq!(
+            plan.would_populate
+                + plan.skipped_already_has_entity_id
+                + plan.skipped_no_mapping
+                + plan.skipped_untrusted_provenance
+                + plan.skipped_non_cooperative_entity
+                + plan.skipped_ambiguous_binding
+                + plan.skipped_storage_error,
+            plan.total
+        );
+        assert_eq!(plan.would_populate, 1);
+        assert_eq!(plan.skipped_untrusted_provenance, 1);
+        assert_eq!(plan.skipped_no_mapping, 1);
+        assert_eq!(plan.skipped_already_has_entity_id, 1);
+    }
+
+    // ------------------------------------------------------------------
+    // JSON shape: counts and entry fields serialize with expected keys.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn json_includes_expected_counts_and_entry_fields() {
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+        let v: serde_json::Value = serde_json::to_value(&plan).unwrap();
+        assert_eq!(v["total"].as_u64(), Some(1));
+        assert_eq!(v["would_populate"].as_u64(), Some(1));
+        assert!(v.get("skipped_untrusted_provenance").is_some());
+        let entry = &v["entries"][0];
+        assert_eq!(entry["coop_id"].as_str(), Some("food-coop"));
+        assert_eq!(entry["action"].as_str(), Some("would_populate"));
+        assert!(entry["resolved_entity_id"].as_str().is_some());
+        assert!(entry["reason"].as_str().is_some());
+    }
+
+    // ------------------------------------------------------------------
+    // End-to-end via the real TreasuryManager + a concrete legacy treasury.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn treasury_manager_plans_over_real_legacy_treasuries() {
+        use icn_identity::KeyPair;
+
+        let creator = KeyPair::generate().unwrap().did().clone();
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+
+        // Register a legacy treasury (entity_id: None) for `food-coop` via the
+        // real registration API (Treasury::new under the hood).
+        let mut mgr = TreasuryManager::new();
+        mgr.register_treasury(
+            treasury_did,
+            "food-coop".to_string(),
+            "USD".to_string(),
+            creator,
+            None,
+        )
+        .unwrap();
+
+        // A trusted Activation binding for that coop.
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+
+        let plan = mgr.plan_entity_id_backfill(&map);
+        assert_eq!(plan.total, 1);
+        assert_eq!(plan.would_populate, 1);
+        let entry = one(&plan);
+        assert_eq!(entry.action, TreasuryEntityIdBackfillAction::WouldPopulate);
+        assert_eq!(entry.resolved_entity_id, Some(coop_eid("food-coop")));
+        assert!(entry.treasury_did.is_some(), "treasury_did is surfaced");
+    }
+}

--- a/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
+++ b/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
@@ -62,9 +62,12 @@ pub enum TreasuryEntityIdBackfillAction {
     /// Skipped: the bound `EntityId` is not a well-formed cooperative entity
     /// (a flat `coop_id` denotes a cooperative target — RFC-0018). Fail closed.
     SkippedNonCooperativeEntity,
-    /// Skipped: the binding's reverse index does not unambiguously confirm this
-    /// `coop_id` — it points to a *different* `coop_id`, or is *missing* (a
-    /// one-sided / inconsistent store). Fail closed.
+    /// Skipped: the binding is ambiguous or conflicting and cannot safely confirm
+    /// this `coop_id`'s target. Covers: a reverse index pointing to a *different*
+    /// `coop_id`; a *missing* reverse (a one-sided / inconsistent store); or a
+    /// *projectable* `coop_id` whose strict legacy projection differs from the
+    /// trusted binding's target (the resolver would treat that as a conflict).
+    /// Fail closed.
     SkippedAmbiguousBinding,
     /// Skipped: a storage read error prevented establishing safety. Fail closed.
     SkippedStorageError,
@@ -307,9 +310,36 @@ fn plan_target(
         }
     }
 
+    // Resolver/legacy-projection conflict guard. If `target.coop_id` is itself
+    // strictly projectable to a cooperative EntityId — same reject-not-normalize
+    // semantics as the gateway's legacy fallback, which delegates to
+    // `EntityId::cooperative` (used directly here to avoid an icn-gateway
+    // dependency / layering violation) — and that projection DIFFERS from the
+    // trusted binding's target, the gateway resolver classifies the same
+    // condition as `Disagree`/`ResolverConflict`, NOT a trusted target. Do not
+    // bless a treasury `entity_id` the auth gate would treat as a conflict: fail
+    // closed. A NON-projectable `coop_id` (e.g. a default `coop:<uuid>`, or an
+    // uppercase/underscore id) has no legacy projection to disagree with, so the
+    // resolver-only / surrogate case below stays eligible.
+    if let Ok(projected) = EntityId::cooperative(&target.coop_id) {
+        if projected != binding.entity_id {
+            return make(
+                TreasuryEntityIdBackfillAction::SkippedAmbiguousBinding,
+                Some(binding.entity_id.clone()),
+                format!(
+                    "coop_id projects to {} but the trusted binding resolves to {} — the resolver would treat this as a conflict; fail closed",
+                    projected.as_str(),
+                    binding.entity_id.as_str()
+                ),
+                None,
+            );
+        }
+    }
+
     // Eligible: a trusted, non-ambiguous, cooperative binding for a legacy
-    // treasury that currently has no entity_id. READ-ONLY — report the intent;
-    // populate nothing.
+    // treasury that currently has no entity_id. The binding either matches the
+    // legacy projection of `coop_id` or `coop_id` is non-projectable (resolver-
+    // only / surrogate). READ-ONLY — report the intent; populate nothing.
     let resolved = binding.entity_id.as_str().to_string();
     make(
         TreasuryEntityIdBackfillAction::WouldPopulate,
@@ -578,6 +608,66 @@ mod tests {
             TreasuryEntityIdBackfillAction::SkippedAmbiguousBinding
         );
         assert!(entry.reason.contains("no reverse binding"));
+    }
+
+    #[test]
+    fn skipped_when_projectable_coop_id_conflicts_with_binding() {
+        // `food-coop` is itself strictly projectable to `cooperative:food-coop`,
+        // but the trusted map binds it to a DIFFERENT cooperative (`other-coop`)
+        // with a matching reverse index. The gateway resolver would call this a
+        // Disagree/ResolverConflict, so the planner must NOT bless it — fail
+        // closed as SkippedAmbiguousBinding.
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("other-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+        // Sanity: the binding is trusted with a matching reverse, so only the
+        // projection-conflict guard can skip it.
+        assert_eq!(
+            map.coop_for_entity(&coop_eid("other-coop")).unwrap(),
+            Some("food-coop".to_string())
+        );
+
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+        assert_eq!(
+            plan.would_populate, 0,
+            "must not populate when the projectable coop_id disagrees with the binding"
+        );
+        assert_eq!(plan.skipped_ambiguous_binding, 1);
+        let entry = one(&plan);
+        assert_eq!(
+            entry.action,
+            TreasuryEntityIdBackfillAction::SkippedAmbiguousBinding
+        );
+        assert_eq!(entry.resolved_entity_id, Some(coop_eid("other-coop")));
+        assert!(entry.reason.contains("conflict"));
+    }
+
+    #[test]
+    fn would_populate_when_non_projectable_coop_id_has_trusted_surrogate() {
+        // `coop_A` is NON-projectable (uppercase + underscore), so there is no
+        // legacy projection to disagree with. A trusted surrogate binding with a
+        // matching reverse is the resolver-only case and stays eligible.
+        let map = InMemoryCoopEntityMap::new();
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        map.bind_resolved_with_provenance(
+            "coop_A",
+            &surrogate,
+            CoopEntityBindingProvenance::OperatorBackfill,
+        )
+        .unwrap();
+        // `coop_A` must not be strictly projectable (else this would be a conflict).
+        assert!(EntityId::cooperative("coop_A").is_err());
+
+        let plan = plan_treasury_entity_id_backfill(vec![target("coop_A", None)], &map);
+        assert_eq!(plan.would_populate, 1);
+        assert_eq!(plan.skipped_ambiguous_binding, 0);
+        let entry = one(&plan);
+        assert_eq!(entry.action, TreasuryEntityIdBackfillAction::WouldPopulate);
+        assert_eq!(entry.resolved_entity_id, Some(surrogate));
     }
 
     #[test]

--- a/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
+++ b/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
@@ -62,8 +62,9 @@ pub enum TreasuryEntityIdBackfillAction {
     /// Skipped: the bound `EntityId` is not a well-formed cooperative entity
     /// (a flat `coop_id` denotes a cooperative target — RFC-0018). Fail closed.
     SkippedNonCooperativeEntity,
-    /// Skipped: the binding is internally inconsistent — the resolved entity's
-    /// reverse binding points to a *different* `coop_id`. Fail closed.
+    /// Skipped: the binding's reverse index does not unambiguously confirm this
+    /// `coop_id` — it points to a *different* `coop_id`, or is *missing* (a
+    /// one-sided / inconsistent store). Fail closed.
     SkippedAmbiguousBinding,
     /// Skipped: a storage read error prevented establishing safety. Fail closed.
     SkippedStorageError,
@@ -274,18 +275,28 @@ fn plan_target(
     }
 
     // Non-ambiguity cross-check: the resolved entity's reverse binding must point
-    // back to THIS coop_id. A mismatch (the entity is reverse-bound to a different
-    // coop_id) or a reverse read error fails closed.
+    // back to THIS coop_id. The CoopEntityMap writes the forward and reverse
+    // indexes atomically, so for a consistent store a trusted forward binding
+    // always has a matching reverse. Anything else fails closed: a reverse bound
+    // to a DIFFERENT coop_id (ambiguous), or a MISSING reverse (a one-sided /
+    // inconsistent store — a partial write, corruption, or a backend that does
+    // not maintain the reverse index) — neither unambiguously confirms this
+    // coop_id, so neither is eligible to populate entity_id. A reverse read error
+    // also fails closed.
     match map.coop_for_entity(&binding.entity_id) {
-        Ok(Some(reverse)) if reverse != target.coop_id => {
+        Ok(Some(reverse)) if reverse == target.coop_id => {}
+        Ok(reverse_opt) => {
+            let detail = match reverse_opt {
+                Some(reverse) => format!("is reverse-bound to a different coop_id ({reverse:?})"),
+                None => "has no reverse binding (one-sided / inconsistent store)".to_string(),
+            };
             return make(
                 TreasuryEntityIdBackfillAction::SkippedAmbiguousBinding,
                 Some(binding.entity_id.clone()),
-                format!("resolved entity is reverse-bound to a different coop_id ({reverse:?})"),
+                format!("resolved entity {detail}; fail closed"),
                 None,
             );
         }
-        Ok(_) => {}
         Err(e) => {
             return make(
                 TreasuryEntityIdBackfillAction::SkippedStorageError,
@@ -537,6 +548,36 @@ mod tests {
             TreasuryEntityIdBackfillAction::SkippedAmbiguousBinding
         );
         assert!(entry.reason.contains("other-coop"));
+    }
+
+    #[test]
+    fn skipped_when_reverse_binding_missing_one_sided() {
+        // A trusted forward binding but NO reverse binding (a one-sided /
+        // inconsistent store). The atomic forward+reverse invariant is broken, so
+        // the reverse does not confirm this coop_id — fail closed, never populate.
+        let map = StubMap {
+            binding: |coop_id| {
+                Ok(Some(CoopEntityBinding {
+                    coop_id: coop_id.to_string(),
+                    entity_id: EntityId::cooperative("food-coop").unwrap(),
+                    provenance: CoopEntityBindingProvenance::Activation,
+                }))
+            },
+            // Reverse index is missing entirely.
+            reverse: |_| Ok(None),
+        };
+        let plan = plan_treasury_entity_id_backfill(vec![target("food-coop", None)], &map);
+        assert_eq!(
+            plan.would_populate, 0,
+            "must not populate from a one-sided binding"
+        );
+        assert_eq!(plan.skipped_ambiguous_binding, 1);
+        let entry = one(&plan);
+        assert_eq!(
+            entry.action,
+            TreasuryEntityIdBackfillAction::SkippedAmbiguousBinding
+        );
+        assert!(entry.reason.contains("no reverse binding"));
     }
 
     #[test]


### PR DESCRIPTION
## Audit summary (what exists vs what this adds)

`Refs #2082` (the canonical persisted reversible `coop_id ↔ EntityId` mapping/backfill umbrella). Auditing current code (not the stale PR1 issue comment):

**Already built** — the *mapping* side of #2082: the persisted reversible `CoopEntityMap` (forward/reverse, conflict-detecting, atomic), inventory/classifier (`coop entity-report`), deterministic surrogate proposal, the surrogate **map** backfill (`icnctl coop entity-backfill-surrogates --apply`), the persisted provenance substrate (`CoopEntityBindingProvenance` + `bind_resolved_with_provenance` + `binding_for_coop/entity`), and trusted producers (`Activation`, `OperatorBackfill`).

**The declared gap** (named in `coop_entity_map.rs` module docs and ADR-0035): the **consumer** side — populating a treasury's `entity_id` from the map. Legacy treasuries created via `Treasury::new` carry `entity_id: None`, and `Treasury` exposed only an `entity_id()` getter — no path resolved `coop_id → EntityId` for them.

**This PR adds** the safe, read-only core of that path:
- `icn-entity`: a canonical `CoopEntityBindingProvenance::is_trusted_for_resolution()` predicate (trusted = `Activation`/`OperatorBackfill`/`Surrogate`/`GovernanceReceipt`; `UnknownLegacy` fails closed) + a pinning test. The gateway resolver keeps its enforcement-local copy; both are pinned to the same set.
- `icn-ledger`: a new `treasury_entity_backfill` module — `plan_treasury_entity_id_backfill()` and `TreasuryManager::plan_entity_id_backfill(&map)` that classify, **read-only**, which legacy treasuries *would* be populated vs. why each is skipped.

## Why this is the next #2082 slice (and why read-only, not apply/CLI)

Two findings shaped the scope:

1. **A mutating apply is not authorization-neutral.** The operator-opt-in `EnforceTrustedResolver` treasury gate uses `treasury.entity_id()` as the entity-membership *target* (`icn-gateway` `compute_treasury_observation` / `decide_treasury_gate`). In the default `ObserveOnly` mode flipping `None → Some` changes nothing (the observation is discarded), but in enforce mode it changes which entity membership is checked against (e.g. a non-mappable `coop:<uuid>` moves from an indeterminate "missing target" to an evaluable one). So the **mutation** belongs in a separate, explicitly-reviewed follow-up; a **read-only plan** carries the "no authorization behavior change" guarantee cleanly.
2. **No clean persistent treasury store is reachable from `icnctl` today** (`GatewayTreasuryManager` runs in-memory standalone; the daemon wires no persistent `TreasuryManager::with_store(path)`), so an operator CLI report would read a hollow/guessed path. The CLI is deferred with the apply.

The result is the reviewable decision core both the future apply and CLI will consume — mirroring the lane's "observe → measure → enforce" discipline as **report → apply**.

## Behavior before / after

- **Before:** no way to identify which legacy treasuries are safely backfillable from a trusted, non-ambiguous map binding.
- **After:** a read-only library plan classifies each treasury as `WouldPopulate` or one of six fail-closed skip reasons (`SkippedAlreadyHasEntityId`, `SkippedNoMapping`, `SkippedUntrustedProvenance`, `SkippedNonCooperativeEntity`, `SkippedAmbiguousBinding`, `SkippedStorageError`). It **writes nothing** (a test double asserts `bind_resolved` is never called) and changes **no** authorization decision in any mode.

## Validation

- `cargo fmt --all --check` — clean
- `cargo test -p icn-entity --lib --all-features` — **248 passed, 0 failed** (incl. `provenance_trust_set_is_pinned`)
- `cargo test -p icn-ledger --lib --all-features` — **433 passed, 0 failed** (incl. 13 new `treasury_entity_backfill` tests: eligibility, every skip reason via test doubles, count-partitioning, JSON shape, and an end-to-end `TreasuryManager` plan over a real legacy treasury)
- `cargo clippy -p icn-entity -p icn-ledger --all-targets --all-features -- -D warnings` — clean
- `git diff --check` — clean

Rebased onto `main` after the `anyhow` advisory fix (#2257) merged; CI re-verifies the full required set.

## Issue effects

- `Refs #2082` — **#2082 stays OPEN**; `closingIssuesReferences` is empty. This advances the consumer side but does not complete it (no apply, no CLI, no activation-time wiring, no upgrade of pre-existing `UnknownLegacy` rows).

## Nonclaims

- A mapping grants **zero** authority. Entity membership remains the authority signal; `CoopEntityMap` / resolver data remain **target evidence / trust qualifiers, never authority**.
- Does **not** mutate any treasury or the map; no `--apply`; no CLI.
- Does **not** enable treasury enforcement by default; does not change deploy/config defaults.
- Does **not** issue positive `entity_id` / `entity_type` token claims.
- Does **not** trust `UnknownLegacy`, gossip-originated, or unprovenanced mappings (all fail closed).
- Does **not** complete #2082, #2081, #2041, or #2113; does not make ICN production-/pilot-/organizer-/member-ready or live-federated; does not complete Phase 2.

### Follow-ups (out of scope here)
- Operator CLI report once a persistent, enumerable treasury store exists.
- The mutating `--apply` (with explicit enforce-mode-impact review), consuming this plan.
- Activation-time treasury `entity_id` population alongside the map binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)