### PR TITLE
feat(appliance): add icn-appliance crate + icnctl emit-manifest

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2828,6 +2828,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "icn-appliance"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "icn-authz"
 version = "0.1.0"
 dependencies = [
@@ -3913,6 +3923,7 @@ dependencies = [
  "clap_complete",
  "dirs",
  "hex",
+ "icn-appliance",
  "icn-ccl",
  "icn-coop",
  "icn-core",

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2834,6 +2834,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/icn/Cargo.toml
+++ b/icn/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/icn-authz",
     "crates/icn-baseline-lock",
     "crates/icn-boundary",
+    "crates/icn-appliance",
     "apps/charter",
     "apps/governance",
     "apps/membership",
@@ -163,6 +164,7 @@ icn-api = { path = "crates/icn-api" }
 icn-naming = { path = "crates/icn-naming" }
 icn-authz = { path = "crates/icn-authz" }
 icn-baseline-lock = { path = "crates/icn-baseline-lock" }
+icn-appliance = { path = "crates/icn-appliance" }
 icn-boundary = { path = "crates/icn-boundary" }
 icn-commons = { path = "crates/icn-commons" }
 

--- a/icn/bins/icnctl/Cargo.toml
+++ b/icn/bins/icnctl/Cargo.toml
@@ -44,6 +44,7 @@ qrcode = "0.14"
 image = { version = "0.25", default-features = false, features = ["png"] }
 
 # ICN crates
+icn-appliance.workspace = true
 icn-core.workspace = true
 icn-identity.workspace = true
 icn-crypto-pq = { workspace = true, optional = true }

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -319,9 +319,11 @@ enum ApplianceCommands {
         #[arg(long, default_value = "qcow2")]
         image_format: String,
 
-        /// Mark the image as a non-production dev artifact.
+        /// Opt out of the default non-production posture. The appliance build
+        /// path only produces unsigned, non-immutable dev images, so a manifest
+        /// records `non_production: true` unless this is explicitly set.
         #[arg(long)]
-        non_production: bool,
+        production: bool,
 
         /// Mark the image as a signed release artifact.
         #[arg(long)]
@@ -10520,7 +10522,7 @@ fn handle_appliance_command(cmd: ApplianceCommands) -> Result<()> {
             appliance_id,
             arch,
             image_format,
-            non_production,
+            production,
             signed,
             immutable,
             demo_profile,
@@ -10562,7 +10564,8 @@ fn handle_appliance_command(cmd: ApplianceCommands) -> Result<()> {
                 git_commit,
                 build_timestamp_utc: build_timestamp,
                 built_binaries,
-                non_production,
+                // Default to the honest dev posture; --production opts out.
+                non_production: !production,
                 signed,
                 immutable,
                 demo_profile,

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -10507,7 +10507,7 @@ fn handle_api_command(cmd: ApiCommands) -> Result<()> {
 /// records them in an [`icn_appliance::ApplianceManifest`]. This is the typed
 /// replacement for the JSON heredoc in `deploy/appliance/build-image.sh`.
 fn handle_appliance_command(cmd: ApplianceCommands) -> Result<()> {
-    use icn_appliance::{sha256_hex, ApplianceManifest, BinaryRecord, MANIFEST_VERSION};
+    use icn_appliance::{sha256_file_hex, ApplianceManifest, BinaryRecord, MANIFEST_VERSION};
 
     match cmd {
         ApplianceCommands::EmitManifest {
@@ -10527,9 +10527,9 @@ fn handle_appliance_command(cmd: ApplianceCommands) -> Result<()> {
             output,
         } => {
             let hash_file = |p: &std::path::Path| -> Result<String> {
-                let bytes =
-                    std::fs::read(p).with_context(|| format!("Failed to read {}", p.display()))?;
-                Ok(sha256_hex(&bytes))
+                // Stream the artifact through SHA-256 rather than reading it into
+                // memory: real appliance images (QCOW2/raw) are multi-GB.
+                sha256_file_hex(p).with_context(|| format!("Failed to hash {}", p.display()))
             };
 
             let image_sha256 = hash_file(&image)?;

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -303,8 +303,9 @@ enum ApplianceCommands {
         #[arg(long)]
         build_timestamp: String,
 
-        /// A built binary as `IN_PATH=SOURCE=FILE` (repeatable).
-        #[arg(long = "binary", value_name = "IN_PATH=SOURCE=FILE")]
+        /// A built binary as `IN_PATH=SOURCE=FILE` (repeatable; at least one is
+        /// required — a manifest with no binary attestations is not valid).
+        #[arg(long = "binary", value_name = "IN_PATH=SOURCE=FILE", required = true)]
         binaries: Vec<String>,
 
         /// Appliance identifier.
@@ -319,9 +320,9 @@ enum ApplianceCommands {
         #[arg(long, default_value = "qcow2")]
         image_format: String,
 
-        /// Opt out of the default non-production posture. The appliance build
-        /// path only produces unsigned, non-immutable dev images, so a manifest
-        /// records `non_production: true` unless this is explicitly set.
+        /// Declare production posture (`non_production: false`). Requires
+        /// `--signed` and `--immutable` and a non-demo image; otherwise the
+        /// build path produces unsigned dev images recorded `non_production: true`.
         #[arg(long)]
         production: bool,
 
@@ -10528,6 +10529,14 @@ fn handle_appliance_command(cmd: ApplianceCommands) -> Result<()> {
             demo_profile,
             output,
         } => {
+            // A production manifest must declare real release posture. The build
+            // path only produces unsigned, non-immutable dev images, so fail
+            // closed unless --production is paired with --signed and --immutable
+            // on a non-demo image.
+            if production && (!signed || !immutable || demo_profile) {
+                bail!("--production requires --signed and --immutable and not --demo-profile");
+            }
+
             let hash_file = |p: &std::path::Path| -> Result<String> {
                 // Stream the artifact through SHA-256 rather than reading it into
                 // memory: real appliance images (QCOW2/raw) are multi-GB.
@@ -10564,7 +10573,8 @@ fn handle_appliance_command(cmd: ApplianceCommands) -> Result<()> {
                 git_commit,
                 build_timestamp_utc: build_timestamp,
                 built_binaries,
-                // Default to the honest dev posture; --production opts out.
+                // Defaults to the honest dev posture; --production (gated above)
+                // is the only way to record false.
                 non_production: !production,
                 signed,
                 immutable,

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -187,6 +187,10 @@ enum Commands {
     #[command(subcommand)]
     Api(ApiCommands),
 
+    /// Appliance image build manifest (emit a wire-stable build manifest)
+    #[command(subcommand)]
+    Appliance(ApplianceCommands),
+
     /// Economic receipt chain queries
     #[command(subcommand)]
     Receipts(ReceiptCommands),
@@ -272,6 +276,68 @@ enum ApiCommands {
         /// Output format: yaml or json
         #[arg(short, long, default_value = "yaml")]
         format: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ApplianceCommands {
+    /// Emit a wire-stable appliance build manifest (JSON) to stdout or a file.
+    EmitManifest {
+        /// Version label for this image build.
+        #[arg(long = "image-version")]
+        version: String,
+
+        /// Built image file to hash and record.
+        #[arg(long)]
+        image: PathBuf,
+
+        /// Base OS image file to hash and record.
+        #[arg(long)]
+        base_image: PathBuf,
+
+        /// Git commit the build was produced from.
+        #[arg(long)]
+        git_commit: String,
+
+        /// Build timestamp (RFC 3339 UTC).
+        #[arg(long)]
+        build_timestamp: String,
+
+        /// A built binary as `IN_PATH=SOURCE=FILE` (repeatable).
+        #[arg(long = "binary", value_name = "IN_PATH=SOURCE=FILE")]
+        binaries: Vec<String>,
+
+        /// Appliance identifier.
+        #[arg(long, default_value = "icn-appliance-dev")]
+        appliance_id: String,
+
+        /// Target architecture.
+        #[arg(long, default_value = "amd64")]
+        arch: String,
+
+        /// Emitted image format.
+        #[arg(long, default_value = "qcow2")]
+        image_format: String,
+
+        /// Mark the image as a non-production dev artifact.
+        #[arg(long)]
+        non_production: bool,
+
+        /// Mark the image as a signed release artifact.
+        #[arg(long)]
+        signed: bool,
+
+        /// Mark the image as immutable (A-B updates, rollback).
+        #[arg(long)]
+        immutable: bool,
+
+        /// Mark the image as carrying the DEV/DEMO profile payload.
+        #[arg(long)]
+        demo_profile: bool,
+
+        /// Output file path (defaults to stdout).
+        #[arg(short, long)]
+        output: Option<PathBuf>,
     },
 }
 
@@ -2604,6 +2670,7 @@ async fn main() -> Result<()> {
         }
 
         Commands::Api(api_cmd) => handle_api_command(api_cmd)?,
+        Commands::Appliance(app_cmd) => handle_appliance_command(app_cmd)?,
 
         Commands::Receipts(receipt_cmd) => {
             handle_receipt_command(receipt_cmd).await?;
@@ -10427,6 +10494,90 @@ fn handle_api_command(cmd: ApiCommands) -> Result<()> {
                 println!("OpenAPI specification written to {}", path.display());
             } else {
                 print!("{content}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Emit a wire-stable appliance build manifest (JSON) to stdout or a file.
+///
+/// Hashes the built image, base image, and each built binary with SHA-256 and
+/// records them in an [`icn_appliance::ApplianceManifest`]. This is the typed
+/// replacement for the JSON heredoc in `deploy/appliance/build-image.sh`.
+fn handle_appliance_command(cmd: ApplianceCommands) -> Result<()> {
+    use icn_appliance::{sha256_hex, ApplianceManifest, BinaryRecord, MANIFEST_VERSION};
+
+    match cmd {
+        ApplianceCommands::EmitManifest {
+            version,
+            image,
+            base_image,
+            git_commit,
+            build_timestamp,
+            binaries,
+            appliance_id,
+            arch,
+            image_format,
+            non_production,
+            signed,
+            immutable,
+            demo_profile,
+            output,
+        } => {
+            let hash_file = |p: &std::path::Path| -> Result<String> {
+                let bytes =
+                    std::fs::read(p).with_context(|| format!("Failed to read {}", p.display()))?;
+                Ok(sha256_hex(&bytes))
+            };
+
+            let image_sha256 = hash_file(&image)?;
+            let base_image_sha256 = hash_file(&base_image)?;
+
+            let mut built_binaries = Vec::with_capacity(binaries.len());
+            for spec in &binaries {
+                let parts: Vec<&str> = spec.split('=').collect();
+                if parts.len() != 3 {
+                    bail!("--binary expects IN_PATH=SOURCE=FILE, got: {spec}");
+                }
+                let sha256 = hash_file(std::path::Path::new(parts[2]))?;
+                built_binaries.push(BinaryRecord {
+                    path: parts[0].to_string(),
+                    source: parts[1].to_string(),
+                    sha256,
+                });
+            }
+
+            let manifest = ApplianceManifest {
+                manifest_version: MANIFEST_VERSION,
+                appliance_id,
+                version,
+                arch,
+                image_format,
+                image_path: image.display().to_string(),
+                image_sha256,
+                base_image_path: base_image.display().to_string(),
+                base_image_sha256,
+                git_commit,
+                build_timestamp_utc: build_timestamp,
+                built_binaries,
+                non_production,
+                signed,
+                immutable,
+                demo_profile,
+            };
+
+            let content = manifest
+                .to_json_pretty()
+                .context("Failed to serialize appliance manifest")?;
+
+            if let Some(path) = output {
+                std::fs::write(&path, format!("{content}\n"))
+                    .with_context(|| format!("Failed to write to {}", path.display()))?;
+                println!("Appliance manifest written to {}", path.display());
+            } else {
+                println!("{content}");
             }
         }
     }

--- a/icn/crates/icn-appliance/Cargo.toml
+++ b/icn/crates/icn-appliance/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "icn-appliance"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Wire-stable appliance image build manifest types (emit + verify)"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/icn/crates/icn-appliance/Cargo.toml
+++ b/icn/crates/icn-appliance/Cargo.toml
@@ -12,5 +12,8 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3.24"
+
 [lints]
 workspace = true

--- a/icn/crates/icn-appliance/src/error.rs
+++ b/icn/crates/icn-appliance/src/error.rs
@@ -10,4 +10,8 @@ pub enum ApplianceError {
     /// Reading a build artifact for hashing failed.
     #[error("appliance artifact I/O error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// The manifest's `manifest_version` is not the supported schema version.
+    #[error("unsupported appliance manifest_version {found} (this build supports {expected})")]
+    UnsupportedVersion { found: u32, expected: u32 },
 }

--- a/icn/crates/icn-appliance/src/error.rs
+++ b/icn/crates/icn-appliance/src/error.rs
@@ -1,9 +1,13 @@
 //! Error type for appliance manifest operations.
 
-/// Errors from serializing or parsing an [`crate::ApplianceManifest`].
+/// Errors from serializing, parsing, or hashing for an [`crate::ApplianceManifest`].
 #[derive(Debug, thiserror::Error)]
 pub enum ApplianceError {
     /// JSON serialization or deserialization failed.
     #[error("appliance manifest JSON error: {0}")]
     Json(#[from] serde_json::Error),
+
+    /// Reading a build artifact for hashing failed.
+    #[error("appliance artifact I/O error: {0}")]
+    Io(#[from] std::io::Error),
 }

--- a/icn/crates/icn-appliance/src/error.rs
+++ b/icn/crates/icn-appliance/src/error.rs
@@ -1,0 +1,9 @@
+//! Error type for appliance manifest operations.
+
+/// Errors from serializing or parsing an [`crate::ApplianceManifest`].
+#[derive(Debug, thiserror::Error)]
+pub enum ApplianceError {
+    /// JSON serialization or deserialization failed.
+    #[error("appliance manifest JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/icn/crates/icn-appliance/src/hash.rs
+++ b/icn/crates/icn-appliance/src/hash.rs
@@ -1,6 +1,15 @@
 //! Content hashing for appliance build artifacts.
 
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
 use sha2::{Digest, Sha256};
+
+use crate::error::ApplianceError;
+
+/// Read-buffer size for streaming file hashing (64 KiB).
+const HASH_BUF_LEN: usize = 64 * 1024;
 
 /// Lowercase hex SHA-256 of `bytes`.
 ///
@@ -8,8 +17,31 @@ use sha2::{Digest, Sha256};
 /// so an emitted manifest's hashes are comparable byte-for-byte with the shell
 /// build path (and re-checkable by a later `verify` rung).
 pub fn sha256_hex(bytes: &[u8]) -> String {
-    Sha256::digest(bytes)
-        .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect()
+    to_hex(&Sha256::digest(bytes))
+}
+
+/// Lowercase hex SHA-256 of the file at `path`, computed by streaming.
+///
+/// Reads the file incrementally through a [`BufReader`] into the hasher instead
+/// of loading it into memory, so multi-gigabyte appliance artifacts (QCOW2/raw
+/// images, staged base images) hash with bounded memory. The result is identical
+/// to [`sha256_hex`] of the same bytes and to `sha256sum`.
+pub fn sha256_file_hex(path: impl AsRef<Path>) -> Result<String, ApplianceError> {
+    let file = File::open(path.as_ref())?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; HASH_BUF_LEN];
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(to_hex(&hasher.finalize()))
+}
+
+/// Lowercase hex encoding of a digest's bytes.
+fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }

--- a/icn/crates/icn-appliance/src/hash.rs
+++ b/icn/crates/icn-appliance/src/hash.rs
@@ -1,0 +1,15 @@
+//! Content hashing for appliance build artifacts.
+
+use sha2::{Digest, Sha256};
+
+/// Lowercase hex SHA-256 of `bytes`.
+///
+/// Matches the `sha256sum` output recorded by `deploy/appliance/build-image.sh`,
+/// so an emitted manifest's hashes are comparable byte-for-byte with the shell
+/// build path (and re-checkable by a later `verify` rung).
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}

--- a/icn/crates/icn-appliance/src/lib.rs
+++ b/icn/crates/icn-appliance/src/lib.rs
@@ -15,5 +15,5 @@ pub mod hash;
 pub mod manifest;
 
 pub use error::ApplianceError;
-pub use hash::sha256_hex;
+pub use hash::{sha256_file_hex, sha256_hex};
 pub use manifest::{ApplianceManifest, BinaryRecord, MANIFEST_VERSION};

--- a/icn/crates/icn-appliance/src/lib.rs
+++ b/icn/crates/icn-appliance/src/lib.rs
@@ -1,0 +1,19 @@
+//! Wire-stable appliance image build manifest.
+//!
+//! `icn-appliance` owns the typed, serializable record describing what an ICN
+//! appliance image build produced: the built binaries and their hashes, the
+//! image hash, and the honest production-posture flags. It replaces the ad-hoc
+//! JSON heredoc emitted by `deploy/appliance/build-image.sh` with a single
+//! wire-stable contract that the build path emits and (in a later rung) a
+//! `verify` path can re-hash against.
+//!
+//! This crate is deployment-layer and **kernel-agnostic**: it imports no domain
+//! crates and carries no protocol semantics — it only describes a build.
+
+pub mod error;
+pub mod hash;
+pub mod manifest;
+
+pub use error::ApplianceError;
+pub use hash::sha256_hex;
+pub use manifest::{ApplianceManifest, BinaryRecord, MANIFEST_VERSION};

--- a/icn/crates/icn-appliance/src/manifest.rs
+++ b/icn/crates/icn-appliance/src/manifest.rs
@@ -76,8 +76,19 @@ impl ApplianceManifest {
         Ok(serde_json::to_string_pretty(self)?)
     }
 
-    /// Parse from a JSON string, rejecting unknown fields.
+    /// Parse from a JSON string, rejecting unknown fields and unsupported
+    /// schema versions.
+    ///
+    /// Fails closed when `manifest_version` is not [`MANIFEST_VERSION`]: a reader
+    /// must never silently accept a manifest whose schema it does not understand.
     pub fn from_json_str(s: &str) -> Result<Self, ApplianceError> {
-        Ok(serde_json::from_str(s)?)
+        let manifest: Self = serde_json::from_str(s)?;
+        if manifest.manifest_version != MANIFEST_VERSION {
+            return Err(ApplianceError::UnsupportedVersion {
+                found: manifest.manifest_version,
+                expected: MANIFEST_VERSION,
+            });
+        }
+        Ok(manifest)
     }
 }

--- a/icn/crates/icn-appliance/src/manifest.rs
+++ b/icn/crates/icn-appliance/src/manifest.rs
@@ -1,0 +1,83 @@
+//! The wire-stable appliance build manifest.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ApplianceError;
+
+/// Current schema version of [`ApplianceManifest`]. Bump only on a
+/// schema-breaking change to the field set.
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// A single binary installed into the appliance image, with the content hash
+/// of the artifact that was built and copied in.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BinaryRecord {
+    /// Absolute path of the binary inside the image (e.g. `/usr/local/bin/icnd`).
+    pub path: String,
+    /// Repo-relative source the binary was built from (e.g.
+    /// `icn/target/release/icnd`).
+    pub source: String,
+    /// Lowercase hex SHA-256 of the built binary.
+    pub sha256: String,
+}
+
+/// Self-describing record of what an ICN appliance image build produced.
+///
+/// This is the wire-stable contract emitted by the appliance build path. It is
+/// intentionally flat and free of host-protocol semantics: it describes a build
+/// artifact and its provenance, nothing more. `#[serde(deny_unknown_fields)]`
+/// makes emitter/consumer drift a hard error rather than a silent mismatch.
+///
+/// Field names serialize as `snake_case` (serde default) to stay byte-compatible
+/// with the manifest `deploy/appliance/build-image.sh` already emits and the
+/// `appliance.manifest.example.yaml` template. This is a build-record artifact,
+/// not a gateway API boundary, so the camelCase JSON convention does not apply.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApplianceManifest {
+    /// Schema version; see [`MANIFEST_VERSION`].
+    pub manifest_version: u32,
+    /// Stable, operator-meaningful identifier for the appliance.
+    pub appliance_id: String,
+    /// Version label for this image build.
+    pub version: String,
+    /// Target architecture (e.g. `amd64`).
+    pub arch: String,
+    /// Emitted image format (e.g. `qcow2`, `raw`).
+    pub image_format: String,
+    /// Host-local path of the built image (build-host context, not portable).
+    pub image_path: String,
+    /// Lowercase hex SHA-256 of the built image.
+    pub image_sha256: String,
+    /// Host-local path of the base OS image the build layered on.
+    pub base_image_path: String,
+    /// Lowercase hex SHA-256 of the base OS image, or `unset` if not verified.
+    pub base_image_sha256: String,
+    /// Git commit the build was produced from.
+    pub git_commit: String,
+    /// Build time, RFC 3339 UTC.
+    pub build_timestamp_utc: String,
+    /// Binaries installed into the image, with content hashes.
+    pub built_binaries: Vec<BinaryRecord>,
+    /// True when the image is a non-production dev artifact.
+    pub non_production: bool,
+    /// True when the image is a signed release artifact.
+    pub signed: bool,
+    /// True when the image is immutable (A-B updates, rollback).
+    pub immutable: bool,
+    /// True when the DEV/DEMO profile payload was installed.
+    pub demo_profile: bool,
+}
+
+impl ApplianceManifest {
+    /// Serialize to pretty JSON.
+    pub fn to_json_pretty(&self) -> Result<String, ApplianceError> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+
+    /// Parse from a JSON string, rejecting unknown fields.
+    pub fn from_json_str(s: &str) -> Result<Self, ApplianceError> {
+        Ok(serde_json::from_str(s)?)
+    }
+}

--- a/icn/crates/icn-appliance/tests/manifest.rs
+++ b/icn/crates/icn-appliance/tests/manifest.rs
@@ -77,3 +77,36 @@ fn manifest_rejects_unknown_fields() {
         "unknown fields must be rejected, not silently ignored"
     );
 }
+
+#[test]
+fn sha256_file_hex_matches_known_vector() {
+    use std::io::Write;
+    let mut f = tempfile::NamedTempFile::new().expect("temp file");
+    f.write_all(b"abc").expect("write");
+    assert_eq!(
+        icn_appliance::sha256_file_hex(f.path()).expect("hash file"),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+#[test]
+fn sha256_file_hex_matches_byte_helper_across_buffer_boundaries() {
+    use std::io::Write;
+    // ~250 KB spans multiple streaming read buffers, proving the chunk loop
+    // produces the same digest as the one-shot byte helper.
+    let data = b"icn appliance image bytes \x00\x01\x02 across a buffer".repeat(5000);
+    let mut f = tempfile::NamedTempFile::new().expect("temp file");
+    f.write_all(&data).expect("write");
+    assert_eq!(
+        icn_appliance::sha256_file_hex(f.path()).expect("hash file"),
+        sha256_hex(&data)
+    );
+}
+
+#[test]
+fn sha256_file_hex_errors_on_missing_file() {
+    assert!(
+        icn_appliance::sha256_file_hex("/nonexistent/icn-appliance/missing.qcow2").is_err(),
+        "missing file must return a clean error"
+    );
+}

--- a/icn/crates/icn-appliance/tests/manifest.rs
+++ b/icn/crates/icn-appliance/tests/manifest.rs
@@ -1,0 +1,79 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use icn_appliance::hash::sha256_hex;
+use icn_appliance::{ApplianceManifest, BinaryRecord, MANIFEST_VERSION};
+
+#[test]
+fn sha256_hex_matches_known_vector() {
+    // NIST/standard SHA-256 of the ASCII string "abc".
+    assert_eq!(
+        sha256_hex(b"abc"),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+fn sample() -> ApplianceManifest {
+    ApplianceManifest {
+        manifest_version: MANIFEST_VERSION,
+        appliance_id: "icn-appliance-dev".to_string(),
+        version: "0.1.0-test".to_string(),
+        arch: "amd64".to_string(),
+        image_format: "qcow2".to_string(),
+        image_path: "/out/icn-appliance.qcow2".to_string(),
+        image_sha256: "aa".repeat(32),
+        base_image_path: "/base/debian-12-genericcloud-amd64.qcow2".to_string(),
+        base_image_sha256: "bb".repeat(32),
+        git_commit: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+        build_timestamp_utc: "2026-06-30T00:00:00Z".to_string(),
+        built_binaries: vec![
+            BinaryRecord {
+                path: "/usr/local/bin/icnd".to_string(),
+                source: "icn/target/release/icnd".to_string(),
+                sha256: "cc".repeat(32),
+            },
+            BinaryRecord {
+                path: "/usr/local/bin/icnctl".to_string(),
+                source: "icn/target/release/icnctl".to_string(),
+                sha256: "dd".repeat(32),
+            },
+        ],
+        non_production: true,
+        signed: false,
+        immutable: false,
+        demo_profile: false,
+    }
+}
+
+#[test]
+fn manifest_json_round_trips() {
+    let m = sample();
+    let json = m.to_json_pretty().expect("serialize");
+    let back = ApplianceManifest::from_json_str(&json).expect("deserialize");
+    assert_eq!(m, back);
+}
+
+#[test]
+fn manifest_records_schema_version_one() {
+    assert_eq!(MANIFEST_VERSION, 1);
+    let json = sample().to_json_pretty().expect("serialize");
+    assert!(
+        json.contains("\"manifest_version\": 1"),
+        "json was:\n{json}"
+    );
+}
+
+#[test]
+fn manifest_rejects_unknown_fields() {
+    // A field the wire-stable contract does not define must be rejected, not
+    // silently ignored — emitter/consumer drift is an error, not a no-op.
+    let json = sample().to_json_pretty().expect("serialize");
+    let tampered = json.replacen(
+        "\"manifest_version\": 1",
+        "\"manifest_version\": 1,\n  \"surprise_field\": true",
+        1,
+    );
+    assert!(
+        ApplianceManifest::from_json_str(&tampered).is_err(),
+        "unknown fields must be rejected, not silently ignored"
+    );
+}

--- a/icn/crates/icn-appliance/tests/manifest.rs
+++ b/icn/crates/icn-appliance/tests/manifest.rs
@@ -110,3 +110,15 @@ fn sha256_file_hex_errors_on_missing_file() {
         "missing file must return a clean error"
     );
 }
+
+#[test]
+fn manifest_rejects_unsupported_version() {
+    // A v1-shaped manifest carrying a different schema version must fail closed:
+    // an older reader must never silently accept a schema it does not understand.
+    let json = sample().to_json_pretty().expect("serialize");
+    let bumped = json.replacen("\"manifest_version\": 1", "\"manifest_version\": 2", 1);
+    assert!(
+        ApplianceManifest::from_json_str(&bumped).is_err(),
+        "manifest_version != MANIFEST_VERSION must be rejected"
+    );
+}


### PR DESCRIPTION
## Summary

First rung of making the ICN appliance build a self-describing "forge": introduce a wire-stable, Rust-owned appliance build manifest (`icn-appliance`) as the typed replacement for the ad-hoc JSON heredoc in `deploy/appliance/build-image.sh`, plus an `icnctl appliance emit-manifest` subcommand that produces it.

## Changes

- New **kernel-agnostic** crate `icn-appliance`: `ApplianceManifest` + `BinaryRecord` (serde, `#[serde(deny_unknown_fields)]`, `manifest_version: 1`), `sha256_hex`, and JSON `to_json_pretty` / `from_json_str`.
- New `icnctl appliance emit-manifest` subcommand: SHA-256-hashes the built image, base image, and each built binary, then emits the typed manifest to stdout or `--output`.
- Workspace wiring: `icn-appliance` added to members + workspace deps; `icnctl` depends on it.

## Motivation

The appliance manifest had two divergent, un-owned shapes — the declarative `appliance.manifest.example.yaml` template and an ad-hoc JSON heredoc in `build-image.sh` (whose own header notes "No Rust code reads this file today"). This PR gives the build a single wire-stable contract it can emit. snake_case JSON is kept deliberately for byte-continuity with the manifest already emitted.

## Testing

- [x] Unit tests added (`icn-appliance`): SHA-256 known-vector, JSON round-trip, schema-version, unknown-field rejection — **4/4 pass**.
- [x] Manual testing: `icnctl appliance emit-manifest` on temp files — emitted `image_sha256` matches an independent `sha256sum`; malformed `--binary` → exit 1 with a clear message.

## Invariants

- [x] No panics in protocol paths (no `unwrap`/`expect` in non-test code).
- [x] Determinism preserved (pure serialization + SHA-256).
- [x] Canonical encodings unchanged (additive type; snake_case = existing manifest shape; `manifest_version` field for future versioning).
- [x] Trust gates not weakened (no auth/trust/write surface touched).
- [x] Kernel/app boundaries respected (`icn-appliance` is deployment-layer; imports no domain crates).

## Verification

```
cargo fmt --all --check                                              -> clean
cargo clippy -p icn-appliance -p icnctl --all-targets -- -D warnings -> clean
cargo test -p icn-appliance                                          -> 4 passed
ops/scripts/drift-check.sh                                           -> PASS (0 error, 0 warning)
emit-manifest smoke                                                  -> image_sha256 == sha256sum; bad --binary -> exit 1
```

## Documentation

- [x] Crate + struct doc comments explain wire-stability and the snake_case rationale.
- [ ] API changes reflected in OpenAPI — N/A (not a gateway API surface).

## Scope (deferred to follow-ups)

- The fail-closed `verify` rung (re-hash recorded inputs, modeled on the domain-policy body store) and wiring `build-image.sh` to call `emit-manifest` instead of the heredoc are separate PRs. `deploy/appliance/**` is currently owned by another active lane, so this PR deliberately does **not** touch the build script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
