### PR TITLE
feat(appliance): add fail-closed manifest verification

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -342,6 +342,17 @@ enum ApplianceCommands {
         #[arg(short, long)]
         output: Option<PathBuf>,
     },
+
+    /// Verify an emitted appliance manifest against artifacts on disk (fail-closed).
+    VerifyManifest {
+        /// Path to the manifest JSON file to verify.
+        manifest: PathBuf,
+
+        /// Root directory for resolving relative image / base / binary source
+        /// paths (defaults to the current directory).
+        #[arg(long)]
+        root: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -10592,6 +10603,21 @@ fn handle_appliance_command(cmd: ApplianceCommands) -> Result<()> {
             } else {
                 println!("{content}");
             }
+        }
+        ApplianceCommands::VerifyManifest { manifest, root } => {
+            let content = std::fs::read_to_string(&manifest)
+                .with_context(|| format!("Failed to read manifest {}", manifest.display()))?;
+            let parsed = ApplianceManifest::from_json_str(&content)
+                .with_context(|| format!("Invalid appliance manifest {}", manifest.display()))?;
+            let root = root.unwrap_or_else(|| PathBuf::from("."));
+            parsed.verify(&root).with_context(|| {
+                format!("manifest verification failed for {}", manifest.display())
+            })?;
+            println!(
+                "OK: appliance manifest verified — image + base + {} binaries re-hashed (root {})",
+                parsed.built_binaries.len(),
+                root.display()
+            );
         }
     }
 

--- a/icn/crates/icn-appliance/src/error.rs
+++ b/icn/crates/icn-appliance/src/error.rs
@@ -14,4 +14,24 @@ pub enum ApplianceError {
     /// The manifest's `manifest_version` is not the supported schema version.
     #[error("unsupported appliance manifest_version {found} (this build supports {expected})")]
     UnsupportedVersion { found: u32, expected: u32 },
+
+    /// The manifest declares no built binaries.
+    #[error("appliance manifest has no built_binaries (no binary attestations is not valid)")]
+    EmptyBinaries,
+
+    /// The posture flags are internally contradictory.
+    #[error("appliance manifest posture contradiction: {detail}")]
+    PostureContradiction { detail: String },
+
+    /// A recorded artifact hash did not match the file on disk.
+    #[error("appliance artifact hash mismatch for {path}: manifest={expected}, actual={found}")]
+    HashMismatch {
+        path: String,
+        expected: String,
+        found: String,
+    },
+
+    /// A recorded artifact could not be read for re-hashing.
+    #[error("appliance artifact missing or unreadable at {path}: {detail}")]
+    MissingArtifact { path: String, detail: String },
 }

--- a/icn/crates/icn-appliance/src/hash.rs
+++ b/icn/crates/icn-appliance/src/hash.rs
@@ -45,3 +45,23 @@ pub fn sha256_file_hex(path: impl AsRef<Path>) -> Result<String, ApplianceError>
 fn to_hex(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
+
+/// Fail-closed: stream-hash the file at `path` and compare to `expected`
+/// (lowercase hex SHA-256).
+///
+/// Returns [`ApplianceError::MissingArtifact`] when the file is missing or
+/// unreadable, and [`ApplianceError::HashMismatch`] when the digest differs.
+pub fn verify_file_hash(path: &Path, expected: &str) -> Result<(), ApplianceError> {
+    let actual = sha256_file_hex(path).map_err(|e| ApplianceError::MissingArtifact {
+        path: path.display().to_string(),
+        detail: e.to_string(),
+    })?;
+    if actual != expected {
+        return Err(ApplianceError::HashMismatch {
+            path: path.display().to_string(),
+            expected: expected.to_string(),
+            found: actual,
+        });
+    }
+    Ok(())
+}

--- a/icn/crates/icn-appliance/src/lib.rs
+++ b/icn/crates/icn-appliance/src/lib.rs
@@ -15,5 +15,5 @@ pub mod hash;
 pub mod manifest;
 
 pub use error::ApplianceError;
-pub use hash::{sha256_file_hex, sha256_hex};
+pub use hash::{sha256_file_hex, sha256_hex, verify_file_hash};
 pub use manifest::{ApplianceManifest, BinaryRecord, MANIFEST_VERSION};

--- a/icn/crates/icn-appliance/src/manifest.rs
+++ b/icn/crates/icn-appliance/src/manifest.rs
@@ -1,8 +1,11 @@
 //! The wire-stable appliance build manifest.
 
+use std::path::{Path, PathBuf};
+
 use serde::{Deserialize, Serialize};
 
 use crate::error::ApplianceError;
+use crate::hash::verify_file_hash;
 
 /// Current schema version of [`ApplianceManifest`]. Bump only on a
 /// schema-breaking change to the field set.
@@ -90,5 +93,61 @@ impl ApplianceManifest {
             });
         }
         Ok(manifest)
+    }
+
+    /// Fail-closed structural and posture checks that need no filesystem access.
+    ///
+    /// Rejects an unsupported `manifest_version`, an empty `built_binaries`, and
+    /// any production claim (`non_production == false`) not backed by a signed,
+    /// immutable, non-demo posture.
+    pub fn check_posture(&self) -> Result<(), ApplianceError> {
+        if self.manifest_version != MANIFEST_VERSION {
+            return Err(ApplianceError::UnsupportedVersion {
+                found: self.manifest_version,
+                expected: MANIFEST_VERSION,
+            });
+        }
+        if self.built_binaries.is_empty() {
+            return Err(ApplianceError::EmptyBinaries);
+        }
+        if !self.non_production && (!self.signed || !self.immutable || self.demo_profile) {
+            return Err(ApplianceError::PostureContradiction {
+                detail:
+                    "non_production=false requires signed=true, immutable=true, demo_profile=false"
+                        .to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Fail-closed verification of an emitted manifest against artifacts on disk.
+    ///
+    /// Runs [`Self::check_posture`], then re-hashes the recorded image, base
+    /// image, and each binary's `source` (resolved relative to `root` when not
+    /// absolute) with streaming SHA-256, failing closed on any missing artifact
+    /// or hash mismatch. This re-checks already-emitted inputs; it makes no
+    /// production-readiness, signed-release, or immutability claim.
+    pub fn verify(&self, root: &Path) -> Result<(), ApplianceError> {
+        self.check_posture()?;
+        verify_file_hash(&resolve(root, &self.image_path), &self.image_sha256)?;
+        verify_file_hash(
+            &resolve(root, &self.base_image_path),
+            &self.base_image_sha256,
+        )?;
+        for binary in &self.built_binaries {
+            verify_file_hash(&resolve(root, &binary.source), &binary.sha256)?;
+        }
+        Ok(())
+    }
+}
+
+/// Resolve a recorded path against `root`: absolute paths are used as-is,
+/// relative paths are joined onto `root`.
+fn resolve(root: &Path, recorded: &str) -> PathBuf {
+    let p = Path::new(recorded);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        root.join(p)
     }
 }

--- a/icn/crates/icn-appliance/tests/verify.rs
+++ b/icn/crates/icn-appliance/tests/verify.rs
@@ -1,0 +1,155 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fs;
+
+use icn_appliance::{
+    sha256_file_hex, ApplianceError, ApplianceManifest, BinaryRecord, MANIFEST_VERSION,
+};
+use tempfile::TempDir;
+
+/// Build a temp tree (image, base, one binary) and a manifest whose recorded
+/// hashes match those files. Returns the dir (keep it alive) and the manifest.
+fn fixture() -> (TempDir, ApplianceManifest) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    fs::write(root.join("image.qcow2"), b"image-bytes").unwrap();
+    fs::write(root.join("base.qcow2"), b"base-bytes").unwrap();
+    fs::create_dir(root.join("bin")).unwrap();
+    fs::write(root.join("bin/icnd"), b"icnd-bytes").unwrap();
+
+    let manifest = ApplianceManifest {
+        manifest_version: MANIFEST_VERSION,
+        appliance_id: "icn-appliance-dev".to_string(),
+        version: "0.1.0-test".to_string(),
+        arch: "amd64".to_string(),
+        image_format: "qcow2".to_string(),
+        image_path: "image.qcow2".to_string(),
+        image_sha256: sha256_file_hex(root.join("image.qcow2")).unwrap(),
+        base_image_path: "base.qcow2".to_string(),
+        base_image_sha256: sha256_file_hex(root.join("base.qcow2")).unwrap(),
+        git_commit: "deadbeef".to_string(),
+        build_timestamp_utc: "2026-06-30T00:00:00Z".to_string(),
+        built_binaries: vec![BinaryRecord {
+            path: "/usr/local/bin/icnd".to_string(),
+            source: "bin/icnd".to_string(),
+            sha256: sha256_file_hex(root.join("bin/icnd")).unwrap(),
+        }],
+        non_production: true,
+        signed: false,
+        immutable: false,
+        demo_profile: false,
+    };
+    (dir, manifest)
+}
+
+#[test]
+fn verify_ok_for_matching_artifacts() {
+    let (dir, m) = fixture();
+    let r = m.verify(dir.path());
+    assert!(r.is_ok(), "expected Ok, got {r:?}");
+}
+
+#[test]
+fn verify_rejects_image_hash_mismatch() {
+    let (dir, mut m) = fixture();
+    m.image_sha256 = "00".repeat(32);
+    assert!(matches!(
+        m.verify(dir.path()),
+        Err(ApplianceError::HashMismatch { .. })
+    ));
+}
+
+#[test]
+fn verify_rejects_base_hash_mismatch() {
+    let (dir, mut m) = fixture();
+    m.base_image_sha256 = "00".repeat(32);
+    assert!(matches!(
+        m.verify(dir.path()),
+        Err(ApplianceError::HashMismatch { .. })
+    ));
+}
+
+#[test]
+fn verify_rejects_binary_hash_mismatch() {
+    let (dir, mut m) = fixture();
+    m.built_binaries[0].sha256 = "00".repeat(32);
+    assert!(matches!(
+        m.verify(dir.path()),
+        Err(ApplianceError::HashMismatch { .. })
+    ));
+}
+
+#[test]
+fn verify_rejects_missing_image() {
+    let (dir, mut m) = fixture();
+    m.image_path = "does-not-exist.qcow2".to_string();
+    assert!(matches!(
+        m.verify(dir.path()),
+        Err(ApplianceError::MissingArtifact { .. })
+    ));
+}
+
+#[test]
+fn verify_rejects_missing_binary() {
+    let (dir, mut m) = fixture();
+    m.built_binaries[0].source = "bin/missing".to_string();
+    assert!(matches!(
+        m.verify(dir.path()),
+        Err(ApplianceError::MissingArtifact { .. })
+    ));
+}
+
+#[test]
+fn verify_rejects_unsupported_version() {
+    let (dir, mut m) = fixture();
+    m.manifest_version = MANIFEST_VERSION + 1;
+    assert!(matches!(
+        m.verify(dir.path()),
+        Err(ApplianceError::UnsupportedVersion { .. })
+    ));
+}
+
+#[test]
+fn verify_rejects_empty_binaries() {
+    let (dir, mut m) = fixture();
+    m.built_binaries.clear();
+    assert!(matches!(
+        m.verify(dir.path()),
+        Err(ApplianceError::EmptyBinaries)
+    ));
+}
+
+#[test]
+fn verify_rejects_production_without_signed_or_immutable() {
+    let (dir, mut m) = fixture();
+    // non_production: false while signed=false and immutable=false.
+    m.non_production = false;
+    assert!(matches!(
+        m.verify(dir.path()),
+        Err(ApplianceError::PostureContradiction { .. })
+    ));
+}
+
+#[test]
+fn verify_rejects_demo_production() {
+    let (dir, mut m) = fixture();
+    // A demo image cannot claim production posture.
+    m.non_production = false;
+    m.signed = true;
+    m.immutable = true;
+    m.demo_profile = true;
+    assert!(matches!(
+        m.verify(dir.path()),
+        Err(ApplianceError::PostureContradiction { .. })
+    ));
+}
+
+#[test]
+fn check_posture_ok_for_coherent_production() {
+    let (_dir, mut m) = fixture();
+    m.non_production = false;
+    m.signed = true;
+    m.immutable = true;
+    m.demo_profile = false;
+    assert!(m.check_posture().is_ok());
+}


### PR DESCRIPTION
## Summary

Second forge rung after #2259: fail-closed verification of an emitted appliance manifest. `icnctl appliance verify-manifest` re-checks already-emitted inputs; the reusable logic lives in the deployment-layer, kernel-agnostic `icn-appliance` crate.

## Changes

- **`icn-appliance`**
  - `ApplianceManifest::check_posture()` — pure structural/posture checks: unsupported `manifest_version`, empty `built_binaries`, and any `non_production == false` not backed by `signed && immutable && !demo_profile`.
  - `ApplianceManifest::verify(&root)` — runs `check_posture`, then re-hashes the recorded image, base image, and each binary `source` (resolved relative to `root` when not absolute) with streaming SHA-256, failing closed on any missing artifact or hash mismatch.
  - `hash::verify_file_hash()` helper; new `ApplianceError` variants `EmptyBinaries`, `PostureContradiction`, `HashMismatch`, `MissingArtifact`.
- **`icnctl`**: `appliance verify-manifest <MANIFEST> [--root DIR]` parses with `from_json_str` (rejecting unknown fields + unsupported versions) and calls `verify(&root)`.

## Motivation

#2259 emits a wire-stable manifest; this rung lets the same fail-closed logic re-verify those inputs (re-hash provenance), so a tampered or incomplete artifact set is rejected rather than silently trusted.

## Testing

- [x] Unit tests (`icn-appliance/tests/verify.rs`, 11 cases): OK path; image/base/binary hash mismatch; missing image; missing binary; unsupported version; empty binaries; production-without-signed/immutable; demo-production; coherent-production posture OK. Full crate suite **19/19**.
- [x] Manual smoke: `verify-manifest` of an emitted manifest → OK (exit 0); tampered image → `HashMismatch` (exit 1); missing binary → `MissingArtifact` (exit 1).

## Invariants

- [x] No panics in protocol paths (no `unwrap`/`expect` in non-test code).
- [x] Determinism preserved (pure checks + streaming SHA-256).
- [x] Canonical encodings unchanged — manifest wire shape, snake_case, `manifest_version: 1`, `deny_unknown_fields` all preserved.
- [x] Trust gates not weakened (no auth/trust surface touched).
- [x] Kernel/app boundaries respected — `icn-appliance` stays deployment-layer; imports no domain/kernel/gateway/auth/ledger/governance/federation crates.

## Verification

```
cargo fmt --all --check                                              -> clean
cargo clippy -p icn-appliance -p icnctl --all-targets -- -D warnings -> clean
cargo test -p icn-appliance                                          -> 19 passed
verify-manifest smoke                                                -> OK / HashMismatch / MissingArtifact
```

## Honesty boundary (explicit)

- Verifies **already-emitted** manifest inputs; fail-closed provenance checking only.
- Does **not** wire the builder — `deploy/appliance/build-image.sh` is untouched.
- Does **not** produce signed releases, immutable rootfs, A-B updates, or measured boot.
- Does **not** make any appliance production-readiness or partner-distribution claim.
- A separate follow-up can wire `build-image.sh` to call `emit-manifest` and optionally `verify-manifest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
