### PR TITLE
feat(icnctl): add treasury entity-id backfill report

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -147,6 +147,10 @@ enum Commands {
     #[command(subcommand)]
     Coop(CoopMaintenanceCommands),
 
+    /// Treasury read-only maintenance queries
+    #[command(subcommand)]
+    Treasury(TreasuryMaintenanceCommands),
+
     /// Gateway authentication (get JWT tokens)
     #[command(subcommand)]
     Auth(AuthCommands),
@@ -260,6 +264,27 @@ enum CoopMaintenanceCommands {
         #[arg(long, conflicts_with = "apply")]
         dry_run: bool,
         /// Emit machine-readable JSON instead of a human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum TreasuryMaintenanceCommands {
+    /// Read-only plan of which legacy treasuries (`entity_id: None`) could have
+    /// their `entity_id` populated from a trusted, non-ambiguous `coop_id` ↔
+    /// `EntityId` binding (#2082 lane). Writes nothing.
+    ///
+    /// Hydrates treasuries from the local ledger store and classifies each as
+    /// would-populate, already-bound, no-mapping, untrusted-provenance,
+    /// non-cooperative-entity, ambiguous-binding, or storage-error against the
+    /// canonical [`icn_entity::CoopEntityMap`]. Surfaces the already-merged
+    /// planner — it never populates `entity_id`, binds nothing, normalizes
+    /// nothing, and changes no authorization state (a mapping grants no
+    /// authority). Reads the ledger and cooperative stores directly, so run it
+    /// with the daemon stopped (the daemon holds an exclusive lock).
+    EntityBackfillReport {
+        /// Emit machine-readable JSON instead of a human-readable summary.
         #[arg(long)]
         json: bool,
     },
@@ -2152,6 +2177,154 @@ fn handle_coop_maintenance_command(cmd: CoopMaintenanceCommands, data_dir: &Path
     }
 }
 
+fn handle_treasury_maintenance_command(
+    cmd: TreasuryMaintenanceCommands,
+    data_dir: &Path,
+) -> Result<()> {
+    match cmd {
+        TreasuryMaintenanceCommands::EntityBackfillReport { json } => {
+            treasury_entity_backfill_report(data_dir, json)
+        }
+    }
+}
+
+/// Render a read-only treasury `entity_id` backfill plan (#2082 lane).
+///
+/// This hydrates persisted treasuries from the local ledger store and runs the
+/// already-merged [`icn_ledger::TreasuryManager::plan_entity_id_backfill`] against
+/// the canonical [`icn_entity::CoopEntityMap`], using only read operations. It
+/// performs **no writes**, never populates `treasury.entity_id`, binds nothing,
+/// normalizes nothing, and changes no authorization state — a mapping is a name
+/// binding only and grants no authority. Mutation belongs to a later, separately
+/// reviewed rung (populating `entity_id` is not authorization-neutral under the
+/// treasury entity-auth gate).
+fn treasury_entity_backfill_report(data_dir: &Path, json: bool) -> Result<()> {
+    use icn_entity::{InMemoryCoopEntityMap, SledCoopEntityMap};
+    use icn_ledger::TreasuryManager;
+    use icn_store::Store;
+    use std::sync::Arc;
+
+    let ledger_store_path = get_store_path(data_dir).join("ledger");
+
+    // Read-only contract: never create a database. A missing ledger store means
+    // there are no persisted treasuries to inspect — report an empty plan rather
+    // than materializing a store on disk.
+    if !ledger_store_path.exists() {
+        if !json {
+            eprintln!(
+                "No ledger store found at {} — reporting an empty plan (nothing was created).",
+                ledger_store_path.display()
+            );
+        }
+        let empty = TreasuryManager::new().plan_entity_id_backfill(&InMemoryCoopEntityMap::new());
+        return render_treasury_entity_backfill_plan(&empty, json);
+    }
+
+    let ledger_store: Arc<dyn Store> = Arc::new(SledStore::open(&ledger_store_path).with_context(
+        || {
+            format!(
+                "Failed to open ledger store at {} (stop the daemon first; it holds an exclusive lock)",
+                ledger_store_path.display()
+            )
+        },
+    )?);
+    let treasury_mgr = TreasuryManager::with_store(ledger_store)
+        .context("Failed to hydrate treasuries from the ledger store")?;
+
+    let coop_store_path = get_store_path(data_dir).join("cooperative");
+
+    // The canonical map lives in the cooperative store. When it is absent we must
+    // NOT collapse to `total: 0` (that would hide persisted treasuries): classify
+    // every hydrated treasury against an explicit empty map, so each safely
+    // surfaces as `skipped_no_mapping`. Never create the cooperative store.
+    let plan = if coop_store_path.exists() {
+        let coop_store = SledStore::open(&coop_store_path).with_context(|| {
+            format!(
+                "Failed to open cooperative store at {} (stop the daemon first; it holds an exclusive lock)",
+                coop_store_path.display()
+            )
+        })?;
+        // Share one Db with the canonical map, exactly as the daemon does in
+        // init_coop — no separate database is opened.
+        let db = Arc::new(coop_store.db().clone());
+        let map = SledCoopEntityMap::new(db);
+        treasury_mgr.plan_entity_id_backfill(&map)
+    } else {
+        if !json {
+            eprintln!(
+                "No cooperative store found at {} — every persisted treasury is reported as \
+                 skipped_no_mapping (nothing was created).",
+                coop_store_path.display()
+            );
+        }
+        treasury_mgr.plan_entity_id_backfill(&InMemoryCoopEntityMap::new())
+    };
+
+    render_treasury_entity_backfill_plan(&plan, json)
+}
+
+/// Print a [`icn_ledger::TreasuryEntityIdBackfillPlan`] as JSON or a human
+/// summary. The per-row `action` is one of the planner's fail-closed outcomes;
+/// the report only surfaces them and never relaxes a skip.
+fn render_treasury_entity_backfill_plan(
+    plan: &icn_ledger::TreasuryEntityIdBackfillPlan,
+    json: bool,
+) -> Result<()> {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(plan)
+                .context("Failed to serialize the treasury backfill plan as JSON")?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "treasury entity_id backfill plan (read-only; a mapping grants no authority, nothing was written)"
+    );
+    println!();
+    println!("  total:                          {}", plan.total);
+    println!("  would_populate:                 {}", plan.would_populate);
+    println!(
+        "  skipped_already_has_entity_id:  {}",
+        plan.skipped_already_has_entity_id
+    );
+    println!(
+        "  skipped_no_mapping:             {}",
+        plan.skipped_no_mapping
+    );
+    println!(
+        "  skipped_untrusted_provenance:   {}",
+        plan.skipped_untrusted_provenance
+    );
+    println!(
+        "  skipped_non_cooperative_entity: {}",
+        plan.skipped_non_cooperative_entity
+    );
+    println!(
+        "  skipped_ambiguous_binding:      {}",
+        plan.skipped_ambiguous_binding
+    );
+    println!(
+        "  skipped_storage_error:          {}",
+        plan.skipped_storage_error
+    );
+
+    if !plan.entries.is_empty() {
+        println!();
+        println!("  entries:");
+        for entry in &plan.entries {
+            let did = entry.treasury_did.as_deref().unwrap_or("-");
+            println!(
+                "    [{:?}] coop_id={} treasury_did={} — {}",
+                entry.action, entry.coop_id, did, entry.reason
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Render a read-only `coop_id` ↔ `EntityId` mapping inventory (#2082 lane).
 ///
 /// This opens the existing cooperative sled store, lists the stored
@@ -2644,6 +2817,9 @@ async fn main() -> Result<()> {
         } => handle_init_coop_command(&data_dir, name, members, yes, no_start).await?,
 
         Commands::Coop(coop_cmd) => handle_coop_maintenance_command(coop_cmd, &data_dir)?,
+        Commands::Treasury(treasury_cmd) => {
+            handle_treasury_maintenance_command(treasury_cmd, &data_dir)?
+        }
 
         Commands::Auth(auth_cmd) => handle_auth_command(auth_cmd, &data_dir).await?,
 

--- a/icn/bins/icnctl/tests/treasury_entity_backfill_report_test.rs
+++ b/icn/bins/icnctl/tests/treasury_entity_backfill_report_test.rs
@@ -1,0 +1,287 @@
+//! Integration tests for `icnctl treasury entity-backfill-report` (#2082 lane).
+//!
+//! End-to-end: seed the ledger store with one legacy treasury whose `coop_id`
+//! has a trusted cooperative binding (would-populate) and one with no binding
+//! (skipped-no-mapping), run the real binary, and assert the read-only plan — and
+//! that the report writes nothing, populates no `entity_id`, and creates no store.
+//!
+//! `entries` order is not deterministic (`list_treasuries` iterates a `HashMap`),
+//! so assertions search entries by `action` and compare counters, never fixed
+//! indices or raw stdout.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use icn_entity::{CoopEntityBindingProvenance, CoopEntityMap, EntityId, SledCoopEntityMap};
+use icn_identity::KeyPair;
+use icn_ledger::TreasuryManager;
+use icn_store::{SledStore, Store};
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// Path to the icnctl binary (respects custom target directories).
+fn icnctl_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
+}
+
+/// Ledger store path used by the daemon and by `icnctl`: `<data_dir>/store/ledger`.
+fn ledger_store_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("store").join("ledger")
+}
+
+/// Cooperative store path: `<data_dir>/store/cooperative`.
+fn coop_store_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("store").join("cooperative")
+}
+
+/// Seed the ledger store with two legacy treasuries (`entity_id: None`): one for
+/// `food-coop` (will be eligible once a trusted binding exists) and one for
+/// `no-map-coop` (no binding → skipped). Releases the sled lock on return.
+fn seed_two_legacy_treasuries(data_dir: &Path) {
+    let sled = Arc::new(SledStore::open(ledger_store_path(data_dir)).unwrap());
+    let store: Arc<dyn Store> = sled.clone();
+    let mut mgr = TreasuryManager::with_store(store).unwrap();
+
+    let creator = KeyPair::generate().unwrap().did().clone();
+    let food_did = KeyPair::generate().unwrap().did().clone();
+    let no_map_did = KeyPair::generate().unwrap().did().clone();
+
+    mgr.register_treasury(
+        food_did,
+        "food-coop".to_string(),
+        "USD".to_string(),
+        creator.clone(),
+        None,
+    )
+    .unwrap();
+    mgr.register_treasury(
+        no_map_did,
+        "no-map-coop".to_string(),
+        "USD".to_string(),
+        creator,
+        None,
+    )
+    .unwrap();
+
+    sled.db().flush().unwrap();
+    // mgr, store, sled drop here -> sled lock released for the binary.
+}
+
+/// Seed the cooperative store with a trusted activation binding
+/// `food-coop -> cooperative:food-coop`. Releases the sled lock on return.
+fn seed_trusted_binding(data_dir: &Path) {
+    let store = SledStore::open(coop_store_path(data_dir)).unwrap();
+    let db = Arc::new(store.db().clone());
+    let map = SledCoopEntityMap::new(db.clone());
+    map.bind_resolved_with_provenance(
+        "food-coop",
+        &EntityId::cooperative("food-coop").unwrap(),
+        CoopEntityBindingProvenance::Activation,
+    )
+    .unwrap();
+    db.flush().unwrap();
+    // store, db, map drop here -> sled lock released for the binary.
+}
+
+/// Run `icnctl --data-dir <dir> treasury entity-backfill-report [--json]`.
+fn run_report(data_dir: &Path, json: bool) -> std::process::Output {
+    let mut cmd = Command::new(icnctl_bin());
+    cmd.env("RUST_LOG", "off")
+        .arg("--data-dir")
+        .arg(data_dir)
+        .arg("treasury")
+        .arg("entity-backfill-report");
+    if json {
+        cmd.arg("--json");
+    }
+    cmd.output().unwrap()
+}
+
+/// Find the single entry whose `action` matches, or fail.
+fn entry_with_action<'a>(v: &'a Value, action: &str) -> &'a Value {
+    v["entries"]
+        .as_array()
+        .expect("entries array")
+        .iter()
+        .find(|e| e["action"].as_str() == Some(action))
+        .unwrap_or_else(|| panic!("no entry with action {action}"))
+}
+
+#[test]
+fn report_json_classifies_would_populate_and_skip() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+
+    seed_two_legacy_treasuries(&data_dir);
+    seed_trusted_binding(&data_dir);
+
+    let output = run_report(&data_dir, true);
+    assert!(
+        output.status.success(),
+        "command failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: Value = serde_json::from_str(stdout.trim()).expect("stdout should be valid JSON");
+
+    // Counters partition the total.
+    assert_eq!(v["total"].as_u64(), Some(2));
+    assert_eq!(v["would_populate"].as_u64(), Some(1));
+    assert_eq!(v["skipped_no_mapping"].as_u64(), Some(1));
+    assert_eq!(v["skipped_already_has_entity_id"].as_u64(), Some(0));
+    assert_eq!(v["skipped_untrusted_provenance"].as_u64(), Some(0));
+    assert_eq!(v["skipped_non_cooperative_entity"].as_u64(), Some(0));
+    assert_eq!(v["skipped_ambiguous_binding"].as_u64(), Some(0));
+    assert_eq!(v["skipped_storage_error"].as_u64(), Some(0));
+    assert_eq!(v["entries"].as_array().map(|e| e.len()), Some(2));
+
+    // The eligible row is food-coop with a resolved cooperative candidate.
+    let would = entry_with_action(&v, "would_populate");
+    assert_eq!(would["coop_id"].as_str(), Some("food-coop"));
+    assert!(
+        !would["resolved_entity_id"].is_null(),
+        "would_populate entry must surface its resolved candidate entity_id"
+    );
+
+    // The skipped row is the unbound coop.
+    let skipped = entry_with_action(&v, "skipped_no_mapping");
+    assert_eq!(skipped["coop_id"].as_str(), Some("no-map-coop"));
+}
+
+#[test]
+fn report_human_output_includes_counts() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+
+    seed_two_legacy_treasuries(&data_dir);
+    seed_trusted_binding(&data_dir);
+
+    let output = run_report(&data_dir, false);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("total:"));
+    assert!(stdout.contains("would_populate:"));
+    assert!(stdout.contains("skipped_no_mapping:"));
+    assert!(stdout.contains("a mapping grants no authority"));
+}
+
+#[test]
+fn report_writes_nothing() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+
+    seed_two_legacy_treasuries(&data_dir);
+    seed_trusted_binding(&data_dir);
+
+    let output = run_report(&data_dir, true);
+    assert!(output.status.success());
+
+    // Re-open the ledger store: no treasury may have gained an entity_id.
+    let sled = Arc::new(SledStore::open(ledger_store_path(&data_dir)).unwrap());
+    let store: Arc<dyn Store> = sled.clone();
+    let mgr = TreasuryManager::with_store(store).unwrap();
+    let food = mgr
+        .list_treasuries()
+        .into_iter()
+        .find(|t| t.coop_id == "food-coop")
+        .expect("food-coop treasury persists");
+    assert_eq!(
+        food.entity_id, None,
+        "read-only report must not populate treasury.entity_id"
+    );
+    drop(mgr);
+    drop(sled);
+
+    // Re-open the map: the binding is unchanged and no new binding was created.
+    let coop_store = SledStore::open(coop_store_path(&data_dir)).unwrap();
+    let db = Arc::new(coop_store.db().clone());
+    let map = SledCoopEntityMap::new(db);
+    assert_eq!(
+        map.entity_for_coop("food-coop").unwrap(),
+        Some(EntityId::cooperative("food-coop").unwrap()),
+        "the pre-existing trusted binding must be untouched"
+    );
+    assert_eq!(
+        map.entity_for_coop("no-map-coop").unwrap(),
+        None,
+        "read-only report must not bind the unmapped coop"
+    );
+}
+
+#[test]
+fn report_on_missing_ledger_store_reports_empty() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data"); // never created
+
+    let output = run_report(&data_dir, true);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: Value = serde_json::from_str(stdout.trim()).expect("stdout should be valid JSON");
+    assert_eq!(v["total"].as_u64(), Some(0));
+
+    // The read-only command must not have materialized the ledger store.
+    assert!(
+        !ledger_store_path(&data_dir).exists(),
+        "missing-store report must not create the ledger store"
+    );
+}
+
+#[test]
+fn report_missing_coop_store_classifies_all_as_no_mapping() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+
+    // Ledger has treasuries, but no cooperative map store exists.
+    seed_two_legacy_treasuries(&data_dir);
+    assert!(!coop_store_path(&data_dir).exists());
+
+    let output = run_report(&data_dir, true);
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: Value = serde_json::from_str(stdout.trim()).expect("stdout should be valid JSON");
+
+    // Persisted treasuries must NOT be hidden behind total: 0.
+    assert_eq!(v["total"].as_u64(), Some(2));
+    assert_eq!(v["skipped_no_mapping"].as_u64(), Some(2));
+    assert_eq!(v["would_populate"].as_u64(), Some(0));
+
+    // The command must not have materialized the cooperative store.
+    assert!(
+        !coop_store_path(&data_dir).exists(),
+        "missing cooperative store must not be created by the report"
+    );
+}
+
+#[test]
+fn report_repeat_run_is_stable() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+
+    seed_two_legacy_treasuries(&data_dir);
+    seed_trusted_binding(&data_dir);
+
+    let first = run_report(&data_dir, true);
+    let second = run_report(&data_dir, true);
+    assert!(first.status.success() && second.status.success());
+
+    let v1: Value = serde_json::from_slice(&first.stdout).unwrap();
+    let v2: Value = serde_json::from_slice(&second.stdout).unwrap();
+
+    // Counters are stable across runs (entry order is not guaranteed).
+    for field in [
+        "total",
+        "would_populate",
+        "skipped_no_mapping",
+        "skipped_already_has_entity_id",
+        "skipped_untrusted_provenance",
+        "skipped_non_cooperative_entity",
+        "skipped_ambiguous_binding",
+        "skipped_storage_error",
+    ] {
+        assert_eq!(v1[field], v2[field], "counter {field} drifted across runs");
+    }
+}


### PR DESCRIPTION
## What
Adds a read-only `icnctl treasury entity-backfill-report [--json]` command. It hydrates persisted treasuries from the local ledger store and runs the already-merged `TreasuryManager::plan_entity_id_backfill` (#2258) against the canonical `coop_id ↔ EntityId` map, rendering the eligibility plan as a human summary or JSON.

## Why
#2258 landed the read-only treasury `entity_id` backfill **planner** but left it unreachable by operators. This surfaces that planner against **real persisted state**, making backfill eligibility visible *before* any apply/cutover work. It is the read-only operator-report rung of the #2082 lane (authority → evidence/reportability).

## How
Mirrors the existing `coop entity-report` (#2105) read-only contract:
- Opens `<data_dir>/store/ledger` (→ `TreasuryManager::with_store`, which eagerly hydrates all persisted treasuries via a prefix scan) and `<data_dir>/store/cooperative` (→ `SledCoopEntityMap`), each behind a **no-create guard** so a missing store is never materialized.
- Calls the planner and renders counters + per-treasury detail (`action`, `reason`).
- Pure CLI slice — no `icn-ledger`/`icn-entity` changes; all symbols were already public and already in `icnctl`'s deps.

**Missing-store behavior** (invariant: never hide persisted treasuries behind `total: 0`):
- Ledger store absent → empty plan, warn (human mode), create nothing.
- Ledger present, cooperative map store absent → classify every hydrated treasury against an explicit empty map so each surfaces as `skipped_no_mapping` (never `total: 0`), warn, create nothing.

## What it does NOT do
- No mutation: never populates `treasury.entity_id`, binds nothing, normalizes nothing, creates no store.
- No enforcement-default change; does not touch `ICN_TREASURY_ENTITY_AUTH_MODE`; #2081 is untouched.
- No new schema, receipts, dependencies, appliance behavior, or process-substrate behavior.
- A `coop_id ↔ EntityId` mapping grants **zero authority** — this is descriptive operator evidence only. (Populating `entity_id` is not authorization-neutral under the treasury entity-auth gate, which is why #2258 was a planner, not an apply; mutation belongs to a later, separately reviewed rung.)

## Risk
Low — additive, read-only. Inherits the established `coop entity-report` operational constraint: reads the sled stores directly, so run with the daemon stopped (it holds an exclusive lock).

## Test plan
- New `bins/icnctl/tests/treasury_entity_backfill_report_test.rs` (6 tests): would-populate + skip classification (JSON), human counters, **read-only contract** (reopen both stores, assert no `entity_id` populated and no binding changed), missing-ledger-store empty report, missing-cooperative-store all-`skipped_no_mapping` (no `total: 0`), and repeat-run counter stability. **6/6 pass.**
- `cargo test -p icn-ledger --lib treasury_entity_backfill` (planner suite) — **15/15 pass.**
- `cargo fmt --all`, `cargo clippy --all-targets -p icnctl` — clean (0 warnings).

Refs #2082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)