### PR TITLE
test(appliance): cover typed manifest emit/verify build path

### DIFF
--- a/deploy/appliance/check.sh
+++ b/deploy/appliance/check.sh
@@ -109,6 +109,41 @@ else
     printf '%s\n' "$SECRET_HITS" >&2
 fi
 
+# 6. typed manifest emit/verify round-trip (skip-aware / opt-in)
+#
+# Proves the typed appliance manifest path (`icnctl appliance emit-manifest`
+# #2259 + `verify-manifest` #2260, wired into build-image.sh #2261) still honors
+# its contract — without building a real image. To keep this script lightweight
+# it does NOT build Rust by default: it reuses a prebuilt icnctl when one exists
+# and otherwise SKIPs (not a failure). Set ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1
+# to require the check and build icnctl on demand.
+section "typed manifest emit/verify round-trip"
+ROUNDTRIP="$APPLIANCE_DIR/manifest-roundtrip-check.sh"
+REPO_ROOT="$(cd "$APPLIANCE_DIR/../.." && pwd)"
+ICNCTL_BIN=""
+for cand in "$REPO_ROOT/icn/target/release/icnctl" "$REPO_ROOT/icn/target/debug/icnctl"; do
+    [ -x "$cand" ] && ICNCTL_BIN="$cand" && break
+done
+if [ -z "$ICNCTL_BIN" ] && [ "${ICN_APPLIANCE_CHECK_TYPED_MANIFEST:-0}" = "1" ]; then
+    printf '  ..   building icnctl (ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1; no prebuilt binary)\n'
+    if ( cd "$REPO_ROOT/icn" && cargo build -p icnctl >/dev/null 2>&1 ); then
+        ICNCTL_BIN="$REPO_ROOT/icn/target/debug/icnctl"
+    fi
+fi
+if [ -n "$ICNCTL_BIN" ] && [ -x "$ICNCTL_BIN" ]; then
+    if bash "$ROUNDTRIP" "$ICNCTL_BIN"; then
+        ok "typed manifest round-trip ($ICNCTL_BIN)"
+    else
+        bad "typed manifest round-trip"
+    fi
+elif [ "${ICN_APPLIANCE_CHECK_TYPED_MANIFEST:-0}" = "1" ]; then
+    bad "typed manifest round-trip required (ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1) but icnctl is unavailable/unbuildable"
+else
+    printf '  SKIP typed manifest round-trip — no prebuilt icnctl found\n'
+    printf '       enable it: (cd icn && cargo build -p icnctl) then re-run, or\n'
+    printf '       force it:  ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1 bash %s\n' "$0"
+fi
+
 # Summary
 printf '\n[check] passed=%d failed=%d\n' "$passed" "$failed"
 [ "$failed" -eq 0 ]

--- a/deploy/appliance/check.sh
+++ b/deploy/appliance/check.sh
@@ -115,20 +115,28 @@ fi
 # #2259 + `verify-manifest` #2260, wired into build-image.sh #2261) still honors
 # its contract — without building a real image. To keep this script lightweight
 # it does NOT build Rust by default: it reuses a prebuilt icnctl when one exists
-# and otherwise SKIPs (not a failure). Set ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1
-# to require the check and build icnctl on demand.
+# and otherwise SKIPs (not a failure). When ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1
+# the check is REQUIRED and icnctl is rebuilt from current source first, so the
+# round-trip can never pass/fail against a stale prebuilt binary (old emit/verify
+# code left in target/ by an earlier checkout or cache).
 section "typed manifest emit/verify round-trip"
 ROUNDTRIP="$APPLIANCE_DIR/manifest-roundtrip-check.sh"
 REPO_ROOT="$(cd "$APPLIANCE_DIR/../.." && pwd)"
 ICNCTL_BIN=""
-for cand in "$REPO_ROOT/icn/target/release/icnctl" "$REPO_ROOT/icn/target/debug/icnctl"; do
-    [ -x "$cand" ] && ICNCTL_BIN="$cand" && break
-done
-if [ -z "$ICNCTL_BIN" ] && [ "${ICN_APPLIANCE_CHECK_TYPED_MANIFEST:-0}" = "1" ]; then
-    printf '  ..   building icnctl (ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1; no prebuilt binary)\n'
-    if ( cd "$REPO_ROOT/icn" && cargo build -p icnctl >/dev/null 2>&1 ); then
-        ICNCTL_BIN="$REPO_ROOT/icn/target/debug/icnctl"
+if [ "${ICN_APPLIANCE_CHECK_TYPED_MANIFEST:-0}" = "1" ]; then
+    # Required mode: rebuild icnctl from CURRENT source before selecting it. A
+    # preexisting target/ artifact is intentionally NOT reused, so the round-trip
+    # always exercises current emit/verify code. --release matches build-image.sh,
+    # which ships the release binary.
+    printf '  ..   building icnctl --release from current source (ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1)\n'
+    if ( cd "$REPO_ROOT/icn" && cargo build -p icnctl --release >/dev/null 2>&1 ); then
+        ICNCTL_BIN="$REPO_ROOT/icn/target/release/icnctl"
     fi
+else
+    # Default mode: reuse a prebuilt icnctl if present; never force a Rust build.
+    for cand in "$REPO_ROOT/icn/target/release/icnctl" "$REPO_ROOT/icn/target/debug/icnctl"; do
+        [ -x "$cand" ] && ICNCTL_BIN="$cand" && break
+    done
 fi
 if [ -n "$ICNCTL_BIN" ] && [ -x "$ICNCTL_BIN" ]; then
     if bash "$ROUNDTRIP" "$ICNCTL_BIN"; then
@@ -137,7 +145,7 @@ if [ -n "$ICNCTL_BIN" ] && [ -x "$ICNCTL_BIN" ]; then
         bad "typed manifest round-trip"
     fi
 elif [ "${ICN_APPLIANCE_CHECK_TYPED_MANIFEST:-0}" = "1" ]; then
-    bad "typed manifest round-trip required (ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1) but icnctl is unavailable/unbuildable"
+    bad "typed manifest round-trip required (ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1) but the icnctl --release build failed"
 else
     printf '  SKIP typed manifest round-trip — no prebuilt icnctl found\n'
     printf '       enable it: (cd icn && cargo build -p icnctl) then re-run, or\n'

--- a/deploy/appliance/manifest-roundtrip-check.sh
+++ b/deploy/appliance/manifest-roundtrip-check.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# manifest-roundtrip-check.sh — regression coverage for the typed appliance
+# manifest path (#2259 emit / #2260 verify / #2261 build-script wiring).
+#
+# Proves `icnctl appliance emit-manifest` + `icnctl appliance verify-manifest`
+# honor the typed manifest contract WITHOUT building a real QCOW2 image: it uses
+# throwaway stand-in files for the output image, base image, and the icnd/icnctl
+# binaries, emits a manifest, asserts its fields, and exercises the fail-closed
+# negatives the build path depends on (tampered binary, wrong --root for a
+# repo-relative binary source, missing binary at emit).
+#
+# This invokes no appliance runtime behavior, builds no image, and makes no
+# production-readiness, signing, immutability, reproducibility, A-B update,
+# measured-boot, or distribution claim. It is a check/test harness only.
+#
+# Usage: manifest-roundtrip-check.sh [path-to-icnctl]
+#   With no argument, a prebuilt icnctl is located under
+#   icn/target/{release,debug}/icnctl.
+#
+# Exit codes: 0 — every assertion passed; 1 — a check failed or icnctl is absent.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+ICNCTL="${1:-}"
+if [ -z "$ICNCTL" ]; then
+    for cand in "$REPO_ROOT/icn/target/release/icnctl" "$REPO_ROOT/icn/target/debug/icnctl"; do
+        [ -x "$cand" ] && ICNCTL="$cand" && break
+    done
+fi
+if [ -z "$ICNCTL" ] || [ ! -x "$ICNCTL" ]; then
+    printf 'manifest-roundtrip: no icnctl binary found (build: cd icn && cargo build -p icnctl)\n' >&2
+    exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    printf 'manifest-roundtrip: python3 required for JSON assertions\n' >&2
+    exit 1
+fi
+
+fails=0
+pass() { printf '    ok   %s\n' "$*"; }
+fail() { fails=$((fails + 1)); printf '    FAIL %s\n' "$*" >&2; }
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# ---- throwaway stand-in artifacts (NOT a real image or real binaries) -------
+mkdir -p "$WORK/bin" "$WORK/wrongroot"
+printf 'stand-in appliance output image\n' > "$WORK/image.qcow2"
+printf 'stand-in base os image\n'          > "$WORK/base.img"
+printf 'stand-in icnd\n'                   > "$WORK/bin/icnd"
+printf 'stand-in icnctl\n'                 > "$WORK/bin/icnctl"
+
+EXP_BASE_SHA="$(sha256sum "$WORK/base.img" | awk '{print $1}')"
+GIT_COMMIT="0000000000000000000000000000000000000000"
+TS="2026-01-01T00:00:00Z"
+
+# Emit a manifest mirroring build-image.sh: absolute --image / --base-image, and
+# repo-relative binary SOURCE paths resolved by verify under --root.
+emit() {
+    local out="$1"; shift
+    "$ICNCTL" appliance emit-manifest \
+        --image-version "roundtrip-test" \
+        --image-format "qcow2" \
+        --image "$WORK/image.qcow2" \
+        --base-image "$WORK/base.img" \
+        --git-commit "$GIT_COMMIT" \
+        --build-timestamp "$TS" \
+        --binary "/usr/local/bin/icnd=bin/icnd=$WORK/bin/icnd" \
+        --binary "/usr/local/bin/icnctl=bin/icnctl=$WORK/bin/icnctl" \
+        --output "$out" "$@" >/dev/null 2>&1
+}
+
+# JSON helpers (python3, no jq dependency).
+jget()  { python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$1" "$2" 2>/dev/null; }
+jbool() { python3 -c 'import json,sys; print(str(json.load(open(sys.argv[1]))[sys.argv[2]]).lower())' "$1" "$2" 2>/dev/null; }
+jlen()  { python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))[sys.argv[2]]))' "$1" "$2" 2>/dev/null; }
+jhas()  { python3 -c 'import json,sys; sys.exit(0 if sys.argv[2] in json.load(open(sys.argv[1])) else 1)' "$1" "$2"; }
+
+assert_eq() { # assert_eq <label> <actual> <expected>
+    if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (got '$2', want '$3')"; fi
+}
+expect_fail() { # expect_fail <label> <cmd...>
+    local label="$1"; shift
+    if "$@" >/dev/null 2>&1; then fail "$label (expected non-zero exit)"; else pass "$label"; fi
+}
+
+# ---- 1. default emit + field assertions -------------------------------------
+DEF="$WORK/manifest.json"
+if emit "$DEF"; then pass "emit default manifest"; else fail "emit default manifest"; fi
+
+assert_eq "manifest_version == 1"          "$(jget  "$DEF" manifest_version)" "1"
+if jhas "$DEF" notes; then fail "no notes field (present)"; else pass "no notes field"; fi
+assert_eq "non_production == true"         "$(jbool "$DEF" non_production)"   "true"
+assert_eq "signed == false"                "$(jbool "$DEF" signed)"          "false"
+assert_eq "immutable == false"             "$(jbool "$DEF" immutable)"       "false"
+assert_eq "demo_profile == false (default)" "$(jbool "$DEF" demo_profile)"   "false"
+assert_eq "base_image_sha256 == actual"    "$(jget  "$DEF" base_image_sha256)" "$EXP_BASE_SHA"
+assert_eq "built_binaries records == 2"    "$(jlen  "$DEF" built_binaries)"  "2"
+
+# ---- 2. default manifest verifies clean -------------------------------------
+if "$ICNCTL" appliance verify-manifest "$DEF" --root "$WORK" >/dev/null 2>&1; then
+    pass "verify default manifest"
+else
+    fail "verify default manifest"
+fi
+
+# ---- 3. demo-profile case ---------------------------------------------------
+DEMO="$WORK/manifest-demo.json"
+if emit "$DEMO" --demo-profile; then pass "emit demo-profile manifest"; else fail "emit demo-profile manifest"; fi
+assert_eq "demo_profile == true (--demo-profile)" "$(jbool "$DEMO" demo_profile)" "true"
+if "$ICNCTL" appliance verify-manifest "$DEMO" --root "$WORK" >/dev/null 2>&1; then
+    pass "verify demo-profile manifest"
+else
+    fail "verify demo-profile manifest"
+fi
+
+# ---- 4. fail-closed negatives -----------------------------------------------
+# Wrong --root: absolute image/base still resolve, but the repo-relative binary
+# source is not found under the wrong root, so verification must fail closed.
+expect_fail "wrong --root rejected (repo-relative binary source)" \
+    "$ICNCTL" appliance verify-manifest "$DEF" --root "$WORK/wrongroot"
+
+# Missing binary at emit: a --binary FILE that does not exist must fail closed.
+MISS="$WORK/manifest-missing.json"
+expect_fail "missing binary rejected at emit" \
+    "$ICNCTL" appliance emit-manifest \
+        --image-version "roundtrip-test" --image-format "qcow2" \
+        --image "$WORK/image.qcow2" --base-image "$WORK/base.img" \
+        --git-commit "$GIT_COMMIT" --build-timestamp "$TS" \
+        --binary "/usr/local/bin/icnctl=bin/icnctl=$WORK/bin/does-not-exist" \
+        --output "$MISS"
+
+# Tampered binary: mutate the recorded source after emit; re-hash must mismatch.
+# Done last because it mutates a shared stand-in.
+printf 'tampered\n' >> "$WORK/bin/icnctl"
+expect_fail "tampered binary rejected" \
+    "$ICNCTL" appliance verify-manifest "$DEF" --root "$WORK"
+
+# ---- summary ----------------------------------------------------------------
+if [ "$fails" -eq 0 ]; then
+    printf '  manifest round-trip: all assertions passed\n'
+    exit 0
+else
+    printf '  manifest round-trip: %d assertion(s) failed\n' "$fails" >&2
+    exit 1
+fi

--- a/deploy/appliance/manifest-roundtrip-check.sh
+++ b/deploy/appliance/manifest-roundtrip-check.sh
@@ -43,8 +43,23 @@ fails=0
 pass() { printf '    ok   %s\n' "$*"; }
 fail() { fails=$((fails + 1)); printf '    FAIL %s\n' "$*" >&2; }
 
-WORK="$(mktemp -d)"
-cleanup() { rm -rf "$WORK"; }
+# Fail closed if the temp dir cannot be created: without this, WORK stays empty
+# and later setup paths would expand to /bin, /image.qcow2, /wrongroot, etc. — a
+# root-run invocation could then write outside the intended throwaway dir.
+WORK="$(mktemp -d)" || {
+    printf 'manifest-roundtrip: mktemp -d failed (is TMPDIR writable?)\n' >&2
+    exit 1
+}
+if [ -z "${WORK:-}" ] || [ ! -d "$WORK" ]; then
+    printf 'manifest-roundtrip: temp dir was not created\n' >&2
+    exit 1
+fi
+cleanup() {
+    # Only remove the throwaway dir we actually created; never an empty path or /.
+    if [ -n "${WORK:-}" ] && [ "$WORK" != "/" ] && [ -d "$WORK" ]; then
+        rm -rf "$WORK"
+    fi
+}
 trap cleanup EXIT
 
 # ---- throwaway stand-in artifacts (NOT a real image or real binaries) -------


### PR DESCRIPTION
## What
Adds regression coverage for the **typed appliance manifest** path: a new `deploy/appliance/manifest-roundtrip-check.sh` that drives the real `icnctl appliance emit-manifest` + `verify-manifest` over throwaway stand-in files and asserts the manifest contract, wired into `deploy/appliance/check.sh` as a skip-aware / opt-in check.

## Why
This is regression coverage for the typed appliance manifest path. It protects the chain established by **#2259** (emit), **#2260** (fail-closed verify), and **#2261** (build-script wiring) so the check path guards the exact typed contract those rungs landed.

## How
- `manifest-roundtrip-check.sh` creates throwaway stand-ins (output image, base image, `icnd`, `icnctl`), runs emit + verify, and asserts: `manifest_version: 1`, **no `notes` field**, `non_production: true`, `signed: false`, `immutable: false`, `demo_profile: false` by default and `true` with `--demo-profile`, the **actual base image hash**, and **both binary records**.
- Fail-closed negatives: tampered binary rejected; **wrong `--root` rejected** for a repo-relative binary source; missing binary rejected at emit.
- Integration in `check.sh` is **skip-aware / opt-in**: it reuses a prebuilt `icnctl` when present, otherwise SKIPs (default stays lightweight — no Rust build); `ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1` requires it and builds `icnctl` on demand.

## Risk
Low — a check/test harness only. Mirrors the existing `check.sh` `ok`/`bad` pattern and forbidden-vocab discipline.

## What it does NOT do
- Does not build a real QCOW2.
- Adds no signing, immutability, reproducibility, A-B updates, measured boot, SBOM, release-channel semantics, partner distribution, or production readiness.
- Does not change appliance runtime behavior or demo-profile payload behavior.
- Does not make the appliance production-ready.

## Test plan
- `git diff --check` clean; `bash -n` clean on both scripts.
- `bash deploy/appliance/check.sh` → passed=23 failed=0 (round-trip SKIPs without a prebuilt binary; default lightweight).
- `ICN_APPLIANCE_CHECK_TYPED_MANIFEST=1 bash deploy/appliance/check.sh` → round-trip runs, **all 16 assertions pass**, passed=23 failed=0.
- `bash deploy/appliance/build-image.sh --dry-run` exit 0; `ops/scripts/drift-check.sh` STATUS PASS.
- `cargo test -p icn-appliance` 8+11 pass (no Rust changed; confirms the contract under test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)