### PR TITLE
feat(treasury): apply controlled entity-id backfill

### DIFF
--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -288,6 +288,34 @@ enum TreasuryMaintenanceCommands {
         #[arg(long)]
         json: bool,
     },
+
+    /// Controlled apply (ADR-0084): populate `entity_id` on the legacy treasuries
+    /// the read-only report classifies as would-populate (#2082 lane). Dry-run by
+    /// default — a mutation requires BOTH `--apply` and, when any row would be
+    /// populated, `--confirm-apply`.
+    ///
+    /// Mutates **only** the `entity_id` field of eligible rows from the trusted,
+    /// non-ambiguous binding; preserves each `coop_id` byte-for-byte; never writes
+    /// the `coop_id` ↔ `EntityId` map; creates no store; and changes no
+    /// enforcement mode or auth configuration. Populating `entity_id` is
+    /// authorization-relevant under `ICN_TREASURY_ENTITY_AUTH_MODE=enforce-trusted-resolver`
+    /// (the stored `entity_id` is the membership target), but a mapping grants no
+    /// authority. Reads/writes the ledger and reads the cooperative store
+    /// directly, so run it with the daemon stopped (it holds an exclusive lock).
+    EntityBackfillApply {
+        /// Perform the mutation. Without this flag the command is a dry run
+        /// (identical to `entity-backfill-report`) and writes nothing.
+        #[arg(long)]
+        apply: bool,
+        /// Second, explicit confirmation. REQUIRED in addition to `--apply` when
+        /// any treasury would be populated, so a mutation cannot be a single-flag
+        /// accident. Ignored in dry-run mode.
+        #[arg(long)]
+        confirm_apply: bool,
+        /// Emit machine-readable JSON instead of a human-readable summary.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -2185,6 +2213,11 @@ fn handle_treasury_maintenance_command(
         TreasuryMaintenanceCommands::EntityBackfillReport { json } => {
             treasury_entity_backfill_report(data_dir, json)
         }
+        TreasuryMaintenanceCommands::EntityBackfillApply {
+            apply,
+            confirm_apply,
+            json,
+        } => treasury_entity_backfill_apply(data_dir, json, apply, confirm_apply),
     }
 }
 
@@ -2283,6 +2316,14 @@ fn render_treasury_entity_backfill_plan(
         "treasury entity_id backfill plan (read-only; a mapping grants no authority, nothing was written)"
     );
     println!();
+    print_treasury_backfill_plan_body(plan);
+    Ok(())
+}
+
+/// Print the counter breakdown and per-row classification of a read-only
+/// [`icn_ledger::TreasuryEntityIdBackfillPlan`] (shared by the report renderer
+/// and the apply renderers).
+fn print_treasury_backfill_plan_body(plan: &icn_ledger::TreasuryEntityIdBackfillPlan) {
     println!("  total:                          {}", plan.total);
     println!("  would_populate:                 {}", plan.would_populate);
     println!(
@@ -2319,6 +2360,217 @@ fn render_treasury_entity_backfill_plan(
                 "    [{:?}] coop_id={} treasury_did={} — {}",
                 entry.action, entry.coop_id, did, entry.reason
             );
+        }
+    }
+}
+
+/// Controlled, mutating apply of the treasury `entity_id` backfill (ADR-0084,
+/// #2082 lane).
+///
+/// Dry-run by default (identical to `entity-backfill-report`): it renders the
+/// read-only plan and writes nothing. A mutation requires BOTH `--apply` and,
+/// when any row would be populated, a second `--confirm-apply` — so a write
+/// cannot be a single-flag accident. The apply populates **only** the
+/// `entity_id` field of the planner's `WouldPopulate` rows from the trusted,
+/// non-ambiguous binding, preserves each `coop_id` byte-for-byte, never writes
+/// the `coop_id` ↔ `EntityId` map, creates no store, and changes no enforcement
+/// mode or auth configuration. A mapping grants no authority — it binds an
+/// identity target only. Mirrors the read-only report's store handling: a
+/// missing store is reported, never materialized on disk (apply included).
+fn treasury_entity_backfill_apply(
+    data_dir: &Path,
+    json: bool,
+    apply: bool,
+    confirm_apply: bool,
+) -> Result<()> {
+    use icn_entity::{CoopEntityMap, InMemoryCoopEntityMap, SledCoopEntityMap};
+    use icn_ledger::TreasuryManager;
+    use icn_store::Store;
+    use std::sync::Arc;
+
+    let ledger_store_path = get_store_path(data_dir).join("ledger");
+
+    // Read-only contract — apply included: never create a database. A missing
+    // ledger store means there are no persisted treasuries, so there is nothing
+    // to apply; report an empty plan rather than materializing a store on disk.
+    if !ledger_store_path.exists() {
+        if !json {
+            eprintln!(
+                "No ledger store found at {} — nothing to apply (nothing was created).",
+                ledger_store_path.display()
+            );
+        }
+        let empty = TreasuryManager::new().plan_entity_id_backfill(&InMemoryCoopEntityMap::new());
+        let mode = if apply { "apply (no-op)" } else { "dry-run" };
+        return render_treasury_entity_backfill_apply_plan(&empty, json, mode);
+    }
+
+    let ledger_store: Arc<dyn Store> = Arc::new(SledStore::open(&ledger_store_path).with_context(
+        || {
+            format!(
+                "Failed to open ledger store at {} (stop the daemon first; it holds an exclusive lock)",
+                ledger_store_path.display()
+            )
+        },
+    )?);
+    let mut treasury_mgr = TreasuryManager::with_store(ledger_store)
+        .context("Failed to hydrate treasuries from the ledger store")?;
+
+    let coop_store_path = get_store_path(data_dir).join("cooperative");
+
+    // The canonical map lives in the cooperative store. When it is absent we must
+    // NOT collapse to `total: 0` (that would hide persisted treasuries): classify
+    // every hydrated treasury against an explicit empty map, so each safely
+    // surfaces as `skipped_no_mapping` and nothing is eligible. Never create the
+    // cooperative store (apply included).
+    let map: Box<dyn CoopEntityMap> = if coop_store_path.exists() {
+        let coop_store = SledStore::open(&coop_store_path).with_context(|| {
+            format!(
+                "Failed to open cooperative store at {} (stop the daemon first; it holds an exclusive lock)",
+                coop_store_path.display()
+            )
+        })?;
+        // Share one Db with the canonical map, exactly as the daemon does in
+        // init_coop — no separate database is opened. Apply never writes the map.
+        let db = Arc::new(coop_store.db().clone());
+        Box::new(SledCoopEntityMap::new(db))
+    } else {
+        if !json {
+            eprintln!(
+                "No cooperative store found at {} — every persisted treasury is reported as \
+                 skipped_no_mapping (nothing was created).",
+                coop_store_path.display()
+            );
+        }
+        Box::new(InMemoryCoopEntityMap::new())
+    };
+
+    // Plan first (read-only) — both to render a dry run and to gate confirmation.
+    let plan = treasury_mgr.plan_entity_id_backfill(map.as_ref());
+
+    if !apply {
+        // Dry-run: render the plan; mutate nothing.
+        return render_treasury_entity_backfill_apply_plan(&plan, json, "dry-run");
+    }
+
+    // Apply requested. When any row would be populated, require the second,
+    // explicit confirmation — `--apply` alone is never sufficient to mutate.
+    if plan.would_populate > 0 && !confirm_apply {
+        render_treasury_entity_backfill_apply_plan(&plan, json, "apply-requires-confirmation")?;
+        bail!(
+            "{} treasury row(s) would be populated — refusing to mutate without --confirm-apply. \
+             Re-run with `--apply --confirm-apply` to proceed. Populating entity_id is \
+             authorization-relevant under ICN_TREASURY_ENTITY_AUTH_MODE=enforce-trusted-resolver \
+             (the stored entity_id is the membership target); a mapping still grants no authority.",
+            plan.would_populate
+        );
+    }
+
+    // Confirmed (or nothing eligible): perform the controlled apply.
+    let report = treasury_mgr.apply_entity_id_backfill(map.as_ref());
+    render_treasury_entity_backfill_apply_report(&report, json)?;
+    if report.had_failures() {
+        bail!(
+            "treasury entity-id backfill --apply did not fully complete: {} applied, {} failed \
+             (left unchanged, fail closed) — see report above",
+            report.applied,
+            report.failed,
+        );
+    }
+    Ok(())
+}
+
+/// Render a dry-run or refused apply (no mutation): the read-only plan plus an
+/// explicit `mode`. JSON: `{ "mode": ..., "plan": <plan> }`.
+fn render_treasury_entity_backfill_apply_plan(
+    plan: &icn_ledger::TreasuryEntityIdBackfillPlan,
+    json: bool,
+    mode: &str,
+) -> Result<()> {
+    if json {
+        let out = serde_json::json!({ "mode": mode, "plan": plan });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out)
+                .context("Failed to serialize the treasury backfill plan as JSON")?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "treasury entity_id backfill [{mode}] (a mapping grants no authority; nothing was written)"
+    );
+    println!();
+    print_treasury_backfill_plan_body(plan);
+    Ok(())
+}
+
+/// Render the result of a mutating apply. JSON: `{ "mode": "apply", "report":
+/// <apply report> }`. Human output states plainly that a mutation occurred and
+/// gives a per-row before/after audit.
+fn render_treasury_entity_backfill_apply_report(
+    report: &icn_ledger::TreasuryEntityIdBackfillApplyReport,
+    json: bool,
+) -> Result<()> {
+    use icn_ledger::TreasuryEntityIdBackfillApplyOutcome;
+
+    if json {
+        let out = serde_json::json!({ "mode": "apply", "report": report });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out)
+                .context("Failed to serialize the treasury backfill apply report as JSON")?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "treasury entity_id backfill [apply] — MUTATING (a mapping grants no authority; coop_id preserved exactly)"
+    );
+    println!();
+    println!(
+        "  applied (entity_id populated + persisted): {}",
+        report.applied
+    );
+    println!(
+        "  failed (left unchanged, fail closed):      {}",
+        report.failed
+    );
+    println!();
+    println!("  classification (read-only plan):");
+    print_treasury_backfill_plan_body(&report.plan);
+
+    if !report.entries.is_empty() {
+        println!();
+        println!("  applied detail (entity_id before -> after):");
+        for entry in &report.entries {
+            let did = entry.treasury_did.as_deref().unwrap_or("-");
+            let before = entry
+                .entity_id_before
+                .as_ref()
+                .map(|e| e.as_str())
+                .unwrap_or("none");
+            let after = entry
+                .entity_id_after
+                .as_ref()
+                .map(|e| e.as_str())
+                .unwrap_or("-");
+            let outcome = match entry.outcome {
+                TreasuryEntityIdBackfillApplyOutcome::Populated => "populated",
+                TreasuryEntityIdBackfillApplyOutcome::Failed => "failed",
+            };
+            print!(
+                "    [{outcome}] coop_id={} treasury_did={} entity_id: {before} -> {after}",
+                entry.coop_id, did
+            );
+            if let Some(prov) = &entry.provenance {
+                print!(" (provenance: {prov:?})");
+            }
+            print!(" — {}", entry.reason);
+            if let Some(err) = &entry.error {
+                print!(" [error: {err}]");
+            }
+            println!();
         }
     }
 

--- a/icn/bins/icnctl/tests/treasury_entity_backfill_apply_test.rs
+++ b/icn/bins/icnctl/tests/treasury_entity_backfill_apply_test.rs
@@ -1,0 +1,295 @@
+//! Integration tests for `icnctl treasury entity-backfill-apply` (ADR-0084, #2082
+//! lane).
+//!
+//! End-to-end: seed the ledger store with one legacy treasury whose `coop_id`
+//! has a trusted cooperative binding (would-populate) and one with no binding
+//! (skipped-no-mapping), run the real binary, and assert the controlled apply
+//! contract:
+//! - dry-run is the default and writes nothing;
+//! - `--apply` alone refuses to mutate when rows would be populated (a second
+//!   `--confirm-apply` is required);
+//! - a confirmed apply populates **only** the eligible row, preserves `coop_id`,
+//!   never writes the map, and is idempotent on re-run;
+//! - a missing store is reported, never created (apply included).
+//!
+//! `entries` order is not deterministic (`list_treasuries` iterates a `HashMap`),
+//! so assertions compare counters and look treasuries up by `coop_id`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::Arc;
+
+use icn_entity::{CoopEntityBindingProvenance, CoopEntityMap, EntityId, SledCoopEntityMap};
+use icn_identity::KeyPair;
+use icn_ledger::TreasuryManager;
+use icn_store::{SledStore, Store};
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// Path to the icnctl binary (respects custom target directories).
+fn icnctl_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_icnctl"))
+}
+
+/// Ledger store path: `<data_dir>/store/ledger`.
+fn ledger_store_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("store").join("ledger")
+}
+
+/// Cooperative store path: `<data_dir>/store/cooperative`.
+fn coop_store_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("store").join("cooperative")
+}
+
+/// Seed two legacy treasuries (`entity_id: None`): `food-coop` (eligible once a
+/// trusted binding exists) and `no-map-coop` (no binding → skipped). Releases the
+/// sled lock on return.
+fn seed_two_legacy_treasuries(data_dir: &Path) {
+    let sled = Arc::new(SledStore::open(ledger_store_path(data_dir)).unwrap());
+    let store: Arc<dyn Store> = sled.clone();
+    let mut mgr = TreasuryManager::with_store(store).unwrap();
+
+    let creator = KeyPair::generate().unwrap().did().clone();
+    let food_did = KeyPair::generate().unwrap().did().clone();
+    let no_map_did = KeyPair::generate().unwrap().did().clone();
+
+    mgr.register_treasury(
+        food_did,
+        "food-coop".to_string(),
+        "USD".to_string(),
+        creator.clone(),
+        None,
+    )
+    .unwrap();
+    mgr.register_treasury(
+        no_map_did,
+        "no-map-coop".to_string(),
+        "USD".to_string(),
+        creator,
+        None,
+    )
+    .unwrap();
+
+    sled.db().flush().unwrap();
+    // mgr, store, sled drop here -> sled lock released for the binary.
+}
+
+/// Seed the cooperative store with a trusted activation binding
+/// `food-coop -> cooperative:food-coop`. Releases the sled lock on return.
+fn seed_trusted_binding(data_dir: &Path) {
+    let store = SledStore::open(coop_store_path(data_dir)).unwrap();
+    let db = Arc::new(store.db().clone());
+    let map = SledCoopEntityMap::new(db.clone());
+    map.bind_resolved_with_provenance(
+        "food-coop",
+        &EntityId::cooperative("food-coop").unwrap(),
+        CoopEntityBindingProvenance::Activation,
+    )
+    .unwrap();
+    db.flush().unwrap();
+    // store, db, map drop here -> sled lock released for the binary.
+}
+
+/// Run `icnctl --data-dir <dir> treasury entity-backfill-apply [--apply]
+/// [--confirm-apply] [--json]`.
+fn run_apply(data_dir: &Path, apply: bool, confirm: bool, json: bool) -> Output {
+    let mut cmd = Command::new(icnctl_bin());
+    cmd.env("RUST_LOG", "off")
+        .arg("--data-dir")
+        .arg(data_dir)
+        .arg("treasury")
+        .arg("entity-backfill-apply");
+    if apply {
+        cmd.arg("--apply");
+    }
+    if confirm {
+        cmd.arg("--confirm-apply");
+    }
+    if json {
+        cmd.arg("--json");
+    }
+    cmd.output().unwrap()
+}
+
+/// Re-open the ledger store and return the persisted `entity_id` of the treasury
+/// for `coop_id` (the treasury must exist). Proves both persistence and the
+/// byte-for-byte `coop_id` (the lookup is by exact `coop_id`).
+fn persisted_entity_id(data_dir: &Path, coop_id: &str) -> Option<EntityId> {
+    let sled = Arc::new(SledStore::open(ledger_store_path(data_dir)).unwrap());
+    let store: Arc<dyn Store> = sled.clone();
+    let mgr = TreasuryManager::with_store(store).unwrap();
+    mgr.list_treasuries()
+        .into_iter()
+        .find(|t| t.coop_id == coop_id)
+        .expect("treasury persists")
+        .entity_id()
+        .cloned()
+}
+
+#[test]
+fn apply_dry_run_is_the_default_and_writes_nothing() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    seed_two_legacy_treasuries(&data_dir);
+    seed_trusted_binding(&data_dir);
+
+    let output = run_apply(&data_dir, false, false, true);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["mode"].as_str(), Some("dry-run"));
+    assert_eq!(v["plan"]["would_populate"].as_u64(), Some(1));
+
+    // Default writes nothing: no entity_id was populated.
+    assert_eq!(persisted_entity_id(&data_dir, "food-coop"), None);
+}
+
+#[test]
+fn apply_requires_confirmation_when_rows_would_populate() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    seed_two_legacy_treasuries(&data_dir);
+    seed_trusted_binding(&data_dir);
+
+    // --apply WITHOUT --confirm-apply must refuse to mutate (non-zero exit).
+    let output = run_apply(&data_dir, true, false, true);
+    assert!(
+        !output.status.success(),
+        "apply without --confirm-apply must fail closed"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--confirm-apply"),
+        "stderr must instruct the operator to pass --confirm-apply: {stderr}"
+    );
+
+    // Fail closed: nothing was populated.
+    assert_eq!(persisted_entity_id(&data_dir, "food-coop"), None);
+}
+
+#[test]
+fn apply_with_confirmation_populates_only_eligible_rows() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    seed_two_legacy_treasuries(&data_dir);
+    seed_trusted_binding(&data_dir);
+
+    let output = run_apply(&data_dir, true, true, true);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["mode"].as_str(), Some("apply"));
+    assert_eq!(v["report"]["applied"].as_u64(), Some(1));
+    assert_eq!(v["report"]["failed"].as_u64(), Some(0));
+    // The embedded plan carries the full classification.
+    assert_eq!(v["report"]["plan"]["would_populate"].as_u64(), Some(1));
+
+    // The eligible row is populated + persisted; the unmapped row is untouched.
+    assert_eq!(
+        persisted_entity_id(&data_dir, "food-coop"),
+        Some(EntityId::cooperative("food-coop").unwrap())
+    );
+    assert_eq!(persisted_entity_id(&data_dir, "no-map-coop"), None);
+
+    // The map is untouched (apply never writes the coop_id <-> EntityId map).
+    let coop_store = SledStore::open(coop_store_path(&data_dir)).unwrap();
+    let db = Arc::new(coop_store.db().clone());
+    let map = SledCoopEntityMap::new(db);
+    assert_eq!(
+        map.entity_for_coop("food-coop").unwrap(),
+        Some(EntityId::cooperative("food-coop").unwrap()),
+        "the pre-existing trusted binding must be untouched"
+    );
+    assert_eq!(
+        map.entity_for_coop("no-map-coop").unwrap(),
+        None,
+        "apply must not bind the unmapped coop"
+    );
+}
+
+#[test]
+fn apply_is_idempotent_across_runs() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    seed_two_legacy_treasuries(&data_dir);
+    seed_trusted_binding(&data_dir);
+
+    let first = run_apply(&data_dir, true, true, true);
+    assert!(first.status.success());
+    let v1: Value = serde_json::from_slice(&first.stdout).unwrap();
+    assert_eq!(v1["report"]["applied"].as_u64(), Some(1));
+
+    // Re-run: the row now classifies skipped_already_has_entity_id; a no-op.
+    let second = run_apply(&data_dir, true, true, true);
+    assert!(second.status.success());
+    let v2: Value = serde_json::from_slice(&second.stdout).unwrap();
+    assert_eq!(v2["report"]["applied"].as_u64(), Some(0));
+    assert_eq!(v2["report"]["failed"].as_u64(), Some(0));
+    assert_eq!(
+        v2["report"]["plan"]["skipped_already_has_entity_id"].as_u64(),
+        Some(1)
+    );
+
+    assert_eq!(
+        persisted_entity_id(&data_dir, "food-coop"),
+        Some(EntityId::cooperative("food-coop").unwrap())
+    );
+}
+
+#[test]
+fn apply_with_no_eligible_rows_needs_no_confirmation() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data");
+    // Treasuries exist but there is NO cooperative map -> would_populate == 0.
+    seed_two_legacy_treasuries(&data_dir);
+    assert!(!coop_store_path(&data_dir).exists());
+
+    // --apply without --confirm-apply: nothing would be populated, so no second
+    // confirmation is required and the command succeeds as a no-op.
+    let output = run_apply(&data_dir, true, false, true);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["mode"].as_str(), Some("apply"));
+    assert_eq!(v["report"]["applied"].as_u64(), Some(0));
+    // Persisted treasuries must NOT be hidden behind total: 0.
+    assert_eq!(v["report"]["plan"]["total"].as_u64(), Some(2));
+    assert_eq!(v["report"]["plan"]["skipped_no_mapping"].as_u64(), Some(2));
+
+    // No cooperative store was materialized.
+    assert!(
+        !coop_store_path(&data_dir).exists(),
+        "apply must not create the cooperative store"
+    );
+}
+
+#[test]
+fn apply_on_missing_ledger_store_creates_nothing() {
+    let temp = TempDir::new().unwrap();
+    let data_dir = temp.path().join("data"); // never created
+
+    let output = run_apply(&data_dir, true, true, true);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let v: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["plan"]["total"].as_u64(), Some(0));
+
+    // Even with --apply --confirm-apply, a missing store must not be created.
+    assert!(
+        !ledger_store_path(&data_dir).exists(),
+        "apply on a missing store must not materialize the ledger store"
+    );
+}

--- a/icn/crates/icn-gateway/src/treasury_mgr.rs
+++ b/icn/crates/icn-gateway/src/treasury_mgr.rs
@@ -197,10 +197,22 @@ impl GatewayTreasuryManager {
 
     /// Get treasury by entity ID
     ///
-    /// Looks up a treasury using its associated entity ID.
+    /// Looks up a treasury through the manager's entity index, so it finds rows
+    /// whose `entity_id` was populated by a surrogate backfill (where the legacy
+    /// `coop_id` differs from `entity_id.identifier()`) rather than assuming
+    /// `entity_id.identifier() == coop_id`.
     pub async fn get_treasury_by_entity(&self, entity_id: &EntityId) -> Result<Option<Treasury>> {
-        // Entity ID's identifier matches the coop_id
-        self.get_treasury_by_coop(entity_id.identifier()).await
+        if let Some(ref handle) = self.treasury_handle {
+            let mgr = handle.read().await;
+            return Ok(mgr.get_treasury_by_entity(entity_id).cloned());
+        }
+
+        // Standalone mode
+        if let Some(ref standalone) = self.standalone {
+            return Ok(standalone.get_treasury_by_entity(entity_id).cloned());
+        }
+
+        Ok(None)
     }
 
     // ============================================================================

--- a/icn/crates/icn-ledger/src/lib.rs
+++ b/icn/crates/icn-ledger/src/lib.rs
@@ -117,7 +117,9 @@ pub use treasury::{
 };
 pub use treasury_entity_backfill::{
     plan_treasury_entity_id_backfill, TreasuryEntityIdBackfillAction,
-    TreasuryEntityIdBackfillEntry, TreasuryEntityIdBackfillPlan, TreasuryEntityIdBackfillTarget,
+    TreasuryEntityIdBackfillApplyEntry, TreasuryEntityIdBackfillApplyOutcome,
+    TreasuryEntityIdBackfillApplyReport, TreasuryEntityIdBackfillEntry,
+    TreasuryEntityIdBackfillPlan, TreasuryEntityIdBackfillTarget,
 };
 pub use types::{
     AccountBalances, AccountDelta, ContentHash, CreditLimit, Currency, Dispute, DisputeOutcome,

--- a/icn/crates/icn-ledger/src/treasury.rs
+++ b/icn/crates/icn-ledger/src/treasury.rs
@@ -267,7 +267,7 @@ pub struct TreasuryManager {
 }
 
 /// Outcome of the contract-bound treasury `entity_id` backfill storage seam
-/// ([`TreasuryManager::populate_treasury_entity_id`], ADR-0084).
+/// ([`TreasuryManager::populate_treasury_entity_id_for_did`], ADR-0084).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TreasuryEntityIdPopulateResult {
     /// `entity_id` was populated (`None → Some`) and persisted.
@@ -275,8 +275,13 @@ pub(crate) enum TreasuryEntityIdPopulateResult {
     /// The treasury already carried an `entity_id`; nothing was changed
     /// (idempotent guard — apply never overwrites an existing identity target).
     AlreadyPopulated,
-    /// No treasury is registered for this `coop_id`; nothing was changed.
+    /// No treasury is registered for the planned `treasury_did`; nothing was
+    /// changed.
     TreasuryNotFound,
+    /// The planned `treasury_did` resolves to a treasury whose `coop_id` no
+    /// longer matches the planned `coop_id` byte-for-byte (rows/index drifted);
+    /// nothing was changed (fail closed).
+    CoopIdMismatch,
     /// The target `EntityId` is already indexed to a *different* treasury;
     /// populating would violate entity uniqueness. Nothing was changed (fail
     /// closed).
@@ -988,6 +993,21 @@ impl TreasuryManager {
                     self.entity_treasuries
                         .insert(entity_id, treasury.treasury_did.clone());
                 }
+                // A persisted store with two treasuries sharing one coop_id is
+                // inconsistent: fail closed rather than silently collapse them into
+                // a single last-writer-wins index entry (which the apply path would
+                // then mutate ambiguously).
+                if let Some(existing_did) = self.coop_treasuries.get(&treasury.coop_id) {
+                    if existing_did != &treasury.treasury_did {
+                        bail!(
+                            "Treasury store inconsistency: coop_id {} is bound to two \
+                             treasuries ({existing_did} and {}); refusing to hydrate \
+                             (fail closed)",
+                            treasury.coop_id,
+                            treasury.treasury_did
+                        );
+                    }
+                }
                 self.coop_treasuries
                     .insert(treasury.coop_id.clone(), treasury.treasury_did.clone());
                 self.treasury_budgets
@@ -1105,38 +1125,52 @@ impl TreasuryManager {
     }
 
     /// Storage seam for the controlled treasury `entity_id` backfill **apply**
-    /// (ADR-0084, #2082 lane). Populates the `entity_id` of the single legacy
-    /// treasury registered for `coop_id` and persists it, **preserving `coop_id`
-    /// byte-for-byte**: only the `entity_id` field changes, and the `coop_id →
-    /// treasury` index is untouched (the key is unchanged).
+    /// (ADR-0084, #2082 lane). Populates the `entity_id` of the treasury
+    /// identified by the **planned `treasury_did`** and persists it, **preserving
+    /// `coop_id` byte-for-byte**: only the `entity_id` field changes.
+    ///
+    /// The write targets the exact planned DID — never whichever row currently
+    /// wins the `coop_id → DID` index — so a store whose index no longer points
+    /// at the planned treasury (e.g. an inconsistent/duplicate `coop_id`) cannot
+    /// mutate the wrong row or leave the audit disagreeing with the write.
+    /// `expected_coop_id` is re-verified against the located row byte-for-byte; a
+    /// mismatch fails closed.
     ///
     /// A `coop_id ↔ EntityId` mapping grants **zero** authority — this writes an
     /// identity *target*, never a permission. The method is `pub(crate)` on
     /// purpose: only the contract-bound
     /// [`TreasuryManager::apply_entity_id_backfill`] orchestrator — which
     /// restricts mutation to the planner's `WouldPopulate` rows — may reach it,
-    /// never an external caller with an arbitrary `(coop_id, entity_id)` pair.
+    /// never an external caller with an arbitrary target.
     ///
     /// Fail-closed and idempotent:
+    /// - a missing planned DID is a no-op
+    ///   ([`TreasuryNotFound`](TreasuryEntityIdPopulateResult::TreasuryNotFound));
+    /// - a located row whose `coop_id` differs from `expected_coop_id` fails
+    ///   closed ([`CoopIdMismatch`](TreasuryEntityIdPopulateResult::CoopIdMismatch));
     /// - a treasury that already carries an `entity_id` is left untouched
     ///   ([`AlreadyPopulated`](TreasuryEntityIdPopulateResult::AlreadyPopulated));
-    /// - a missing treasury is a no-op
-    ///   ([`TreasuryNotFound`](TreasuryEntityIdPopulateResult::TreasuryNotFound));
+    /// - a target `EntityId` already bound to a different treasury fails closed
+    ///   ([`EntityIdConflict`](TreasuryEntityIdPopulateResult::EntityIdConflict));
     /// - the durable write happens **before** the in-memory commit, so a storage
     ///   error returns `Err` with both the store and the cache left unchanged.
-    pub(crate) fn populate_treasury_entity_id(
+    pub(crate) fn populate_treasury_entity_id_for_did(
         &mut self,
-        coop_id: &str,
+        treasury_did: &Did,
+        expected_coop_id: &str,
         entity_id: EntityId,
     ) -> Result<TreasuryEntityIdPopulateResult> {
-        // Resolve the (1:1) treasury for this exact coop_id. The coop_id is the
-        // lookup key, used verbatim — never normalized.
-        let Some(treasury_did) = self.coop_treasuries.get(coop_id).cloned() else {
+        // Locate by the EXACT planned DID — never by the coop_id index winner.
+        let Some(existing) = self.treasuries.get(treasury_did) else {
             return Ok(TreasuryEntityIdPopulateResult::TreasuryNotFound);
         };
-        let Some(existing) = self.treasuries.get(&treasury_did) else {
-            return Ok(TreasuryEntityIdPopulateResult::TreasuryNotFound);
-        };
+
+        // The located row must still carry the exact coop_id the planner
+        // classified, byte-for-byte. A mismatch means the rows/index drifted since
+        // planning; fail closed rather than mutate a different identity.
+        if existing.coop_id != expected_coop_id {
+            return Ok(TreasuryEntityIdPopulateResult::CoopIdMismatch);
+        }
 
         // Idempotent: never overwrite an already-populated identity target.
         if existing.entity_id.is_some() {
@@ -1148,7 +1182,7 @@ impl TreasuryManager {
         // so the coop_id index cannot catch an entity collision — check the entity
         // index and fail closed on a conflict.
         if let Some(other_did) = self.entity_treasuries.get(&entity_id) {
-            if other_did != &treasury_did {
+            if other_did != treasury_did {
                 return Ok(TreasuryEntityIdPopulateResult::EntityIdConflict);
             }
             // Already indexed to THIS treasury (inconsistent with the entity_id:
@@ -1162,7 +1196,7 @@ impl TreasuryManager {
         let mut updated = existing.clone();
         updated.entity_id = Some(entity_id.clone());
         debug_assert_eq!(
-            updated.coop_id, existing.coop_id,
+            updated.coop_id, expected_coop_id,
             "apply must preserve coop_id byte-for-byte"
         );
 
@@ -1174,7 +1208,8 @@ impl TreasuryManager {
         // Commit in-memory only after a durable write: update the treasury cache
         // and the entity index together so they stay consistent.
         self.treasuries.insert(treasury_did.clone(), updated);
-        self.entity_treasuries.insert(entity_id, treasury_did);
+        self.entity_treasuries
+            .insert(entity_id, treasury_did.clone());
         Ok(TreasuryEntityIdPopulateResult::Populated)
     }
 }
@@ -2139,5 +2174,109 @@ mod tests {
             TreasuryManager::with_store(store).is_err(),
             "hydration must fail closed on a duplicate entity_id in the store"
         );
+    }
+
+    #[test]
+    fn hydration_fails_closed_on_duplicate_coop_id() {
+        use icn_store::{SledStore, Store};
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let store: Arc<dyn Store> = Arc::new(SledStore::open(tmp.path()).unwrap());
+        let creator = test_did("creator");
+
+        // Two legacy treasuries (entity_id: None) sharing ONE coop_id, different
+        // DIDs — an inconsistent store. Must fail closed rather than silently
+        // collapse into one last-writer-wins coop index entry.
+        let t1 = Treasury::new(
+            test_did("t1"),
+            "food-coop".to_string(),
+            "USD".to_string(),
+            creator.clone(),
+            None,
+        );
+        let t2 = Treasury::new(
+            test_did("t2"),
+            "food-coop".to_string(),
+            "USD".to_string(),
+            creator,
+            None,
+        );
+        for t in [&t1, &t2] {
+            let key = format!("{}{}", TREASURY_PREFIX, t.treasury_did);
+            store
+                .put(key.as_bytes(), &serde_json::to_vec(t).unwrap())
+                .unwrap();
+        }
+
+        assert!(
+            TreasuryManager::with_store(store).is_err(),
+            "hydration must fail closed on a duplicate coop_id in the store"
+        );
+    }
+
+    #[test]
+    fn populate_entity_id_writes_the_planned_did() {
+        let mut mgr = TreasuryManager::new();
+        let creator = test_did("creator");
+        let did = test_did("t1");
+        mgr.register_treasury(
+            did.clone(),
+            "coop:xyz".to_string(),
+            "USD".to_string(),
+            creator,
+            None,
+        )
+        .unwrap();
+        let entity = EntityId::cooperative("coop-legacy-abcd").unwrap();
+
+        let result = mgr
+            .populate_treasury_entity_id_for_did(&did, "coop:xyz", entity.clone())
+            .unwrap();
+        assert_eq!(result, TreasuryEntityIdPopulateResult::Populated);
+
+        // The exact planned DID's row was mutated; coop_id preserved byte-for-byte.
+        let t = mgr.get_treasury(&did).unwrap();
+        assert_eq!(t.entity_id(), Some(&entity));
+        assert_eq!(t.coop_id(), "coop:xyz");
+        // Entity index resolves to that same row.
+        assert_eq!(
+            mgr.get_treasury_by_entity(&entity).unwrap().coop_id(),
+            "coop:xyz"
+        );
+    }
+
+    #[test]
+    fn populate_entity_id_fails_closed_on_coop_id_mismatch_or_missing_did() {
+        let mut mgr = TreasuryManager::new();
+        let creator = test_did("creator");
+        let did = test_did("t1");
+        mgr.register_treasury(
+            did.clone(),
+            "coop:xyz".to_string(),
+            "USD".to_string(),
+            creator,
+            None,
+        )
+        .unwrap();
+        let entity = EntityId::cooperative("coop-legacy-abcd").unwrap();
+
+        // Planned coop_id no longer matches the located row's coop_id -> fail
+        // closed, nothing written, entity not indexed.
+        let mismatch = mgr
+            .populate_treasury_entity_id_for_did(&did, "coop:WRONG", entity.clone())
+            .unwrap();
+        assert_eq!(mismatch, TreasuryEntityIdPopulateResult::CoopIdMismatch);
+        assert!(mgr.get_treasury(&did).unwrap().entity_id().is_none());
+        assert!(mgr.get_treasury_by_entity(&entity).is_none());
+
+        // A DID that is not registered -> TreasuryNotFound, nothing written.
+        let ghost = test_did("ghost");
+        let notfound = mgr
+            .populate_treasury_entity_id_for_did(&ghost, "coop:xyz", entity.clone())
+            .unwrap();
+        assert_eq!(notfound, TreasuryEntityIdPopulateResult::TreasuryNotFound);
+        assert!(mgr.get_treasury_by_entity(&entity).is_none());
     }
 }

--- a/icn/crates/icn-ledger/src/treasury.rs
+++ b/icn/crates/icn-ledger/src/treasury.rs
@@ -229,6 +229,14 @@ pub struct TreasuryManager {
     /// Index: coop_id -> treasury DID
     coop_treasuries: HashMap<String, Did>,
 
+    /// Index: entity_id -> treasury DID (only for treasuries with
+    /// `entity_id: Some(...)`). Kept alongside `coop_treasuries` so entity-keyed
+    /// lookup and uniqueness work even when a treasury's legacy `coop_id` differs
+    /// from `entity_id.identifier()` — e.g. a surrogate backfill where
+    /// `coop:<uuid>` is bound to `coop-legacy-*`. The legacy `coop_id` is never
+    /// rewritten; this is an additional index, not a replacement.
+    entity_treasuries: HashMap<EntityId, Did>,
+
     /// Velocity limits by ID
     velocity_limits: HashMap<String, VelocityLimit>,
 
@@ -269,6 +277,10 @@ pub(crate) enum TreasuryEntityIdPopulateResult {
     AlreadyPopulated,
     /// No treasury is registered for this `coop_id`; nothing was changed.
     TreasuryNotFound,
+    /// The target `EntityId` is already indexed to a *different* treasury;
+    /// populating would violate entity uniqueness. Nothing was changed (fail
+    /// closed).
+    EntityIdConflict,
 }
 
 impl TreasuryManager {
@@ -282,6 +294,7 @@ impl TreasuryManager {
             spending_rules: HashMap::new(),
             treasury_rules: HashMap::new(),
             coop_treasuries: HashMap::new(),
+            entity_treasuries: HashMap::new(),
             velocity_limits: HashMap::new(),
             treasury_velocity_limits: HashMap::new(),
             velocity_windows: HashMap::new(),
@@ -305,6 +318,7 @@ impl TreasuryManager {
             spending_rules: HashMap::new(),
             treasury_rules: HashMap::new(),
             coop_treasuries: HashMap::new(),
+            entity_treasuries: HashMap::new(),
             velocity_limits: HashMap::new(),
             treasury_velocity_limits: HashMap::new(),
             velocity_windows: HashMap::new(),
@@ -389,6 +403,14 @@ impl TreasuryManager {
             bail!("Treasury already exists for DID: {treasury_did}");
         }
 
+        // Reject a duplicate by the EXACT entity, not just by its derived coop_id.
+        // A surrogate-backfilled treasury keeps its legacy `coop_id` (which differs
+        // from `entity_id.identifier()`), so the coop_id check alone would miss it
+        // and allow a second treasury for the same entity. Check the entity index.
+        if self.entity_treasuries.contains_key(&entity_id) {
+            bail!("Treasury already exists for entity: {entity_id}");
+        }
+
         if self.coop_treasuries.contains_key(&coop_id) {
             bail!("Treasury already exists for entity: {entity_id}");
         }
@@ -411,6 +433,8 @@ impl TreasuryManager {
             .insert(treasury_did.clone(), treasury.clone());
         self.coop_treasuries
             .insert(coop_id.clone(), treasury_did.clone());
+        self.entity_treasuries
+            .insert(entity_id.clone(), treasury_did.clone());
         self.treasury_budgets
             .insert(treasury_did.clone(), Vec::new());
         self.treasury_rules.insert(treasury_did.clone(), Vec::new());
@@ -433,6 +457,17 @@ impl TreasuryManager {
     pub fn get_treasury_by_coop(&self, coop_id: &str) -> Option<&Treasury> {
         self.coop_treasuries
             .get(coop_id)
+            .and_then(|did| self.treasuries.get(did))
+    }
+
+    /// Get treasury by owning `EntityId`.
+    ///
+    /// Uses the dedicated entity index, so it finds treasuries whose `entity_id`
+    /// was populated by a surrogate backfill (where the legacy `coop_id` differs
+    /// from `entity_id.identifier()`) — not just those where they happen to match.
+    pub fn get_treasury_by_entity(&self, entity_id: &EntityId) -> Option<&Treasury> {
+        self.entity_treasuries
+            .get(entity_id)
             .and_then(|did| self.treasuries.get(did))
     }
 
@@ -935,6 +970,24 @@ impl TreasuryManager {
                 continue;
             }
             if let Ok(treasury) = serde_json::from_slice::<Treasury>(&value) {
+                // Rebuild the entity index for rows that carry an entity_id
+                // (including surrogate-backfilled ones). A persisted store with two
+                // treasuries bound to the SAME entity_id is inconsistent: fail
+                // closed rather than silently keep one.
+                if let Some(entity_id) = treasury.entity_id.clone() {
+                    if let Some(existing_did) = self.entity_treasuries.get(&entity_id) {
+                        if existing_did != &treasury.treasury_did {
+                            bail!(
+                                "Treasury store inconsistency: entity_id {entity_id} is bound to \
+                                 two treasuries ({existing_did} and {}); refusing to hydrate \
+                                 (fail closed)",
+                                treasury.treasury_did
+                            );
+                        }
+                    }
+                    self.entity_treasuries
+                        .insert(entity_id, treasury.treasury_did.clone());
+                }
                 self.coop_treasuries
                     .insert(treasury.coop_id.clone(), treasury.treasury_did.clone());
                 self.treasury_budgets
@@ -1090,10 +1143,24 @@ impl TreasuryManager {
             return Ok(TreasuryEntityIdPopulateResult::AlreadyPopulated);
         }
 
+        // Entity uniqueness: the target EntityId must not already be indexed to a
+        // DIFFERENT treasury. A surrogate-backfilled row keeps its legacy coop_id,
+        // so the coop_id index cannot catch an entity collision — check the entity
+        // index and fail closed on a conflict.
+        if let Some(other_did) = self.entity_treasuries.get(&entity_id) {
+            if other_did != &treasury_did {
+                return Ok(TreasuryEntityIdPopulateResult::EntityIdConflict);
+            }
+            // Already indexed to THIS treasury (inconsistent with the entity_id:
+            // None checked above, but treat as an idempotent no-op rather than
+            // re-indexing).
+            return Ok(TreasuryEntityIdPopulateResult::AlreadyPopulated);
+        }
+
         // Populate entity_id only; coop_id (and every other field) is carried
         // through unchanged.
         let mut updated = existing.clone();
-        updated.entity_id = Some(entity_id);
+        updated.entity_id = Some(entity_id.clone());
         debug_assert_eq!(
             updated.coop_id, existing.coop_id,
             "apply must preserve coop_id byte-for-byte"
@@ -1104,7 +1171,10 @@ impl TreasuryManager {
         if let Some(ref store) = self.store {
             self.persist_treasury(&updated, store)?;
         }
-        self.treasuries.insert(treasury_did, updated);
+        // Commit in-memory only after a durable write: update the treasury cache
+        // and the entity index together so they stay consistent.
+        self.treasuries.insert(treasury_did.clone(), updated);
+        self.entity_treasuries.insert(entity_id, treasury_did);
         Ok(TreasuryEntityIdPopulateResult::Populated)
     }
 }
@@ -1995,5 +2065,79 @@ mod tests {
 
         assert_eq!(share1.accumulated_surplus, 1000);
         assert_eq!(share2.accumulated_surplus, 500);
+    }
+
+    // ------------------------------------------------------------------
+    // Entity-id index / uniqueness (Codex P2: preserve entity uniqueness).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn register_treasury_with_entity_rejects_duplicate_entity() {
+        let mut mgr = TreasuryManager::new();
+        let creator = test_did("creator");
+        let entity = EntityId::cooperative("food-coop").unwrap();
+
+        // Normal registration (coop_id == entity_id.identifier()) works and is
+        // entity-indexed.
+        mgr.register_treasury_with_entity(
+            test_did("t1"),
+            entity.clone(),
+            "USD".to_string(),
+            creator.clone(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            mgr.get_treasury_by_entity(&entity).unwrap().coop_id(),
+            "food-coop"
+        );
+
+        // A second registration for the same entity is rejected (no second row).
+        let result = mgr.register_treasury_with_entity(
+            test_did("t2"),
+            entity,
+            "USD".to_string(),
+            creator,
+            None,
+        );
+        assert!(result.is_err(), "duplicate entity registration must reject");
+    }
+
+    #[test]
+    fn hydration_fails_closed_on_duplicate_entity_id() {
+        use icn_store::{SledStore, Store};
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let store: Arc<dyn Store> = Arc::new(SledStore::open(tmp.path()).unwrap());
+        let entity = EntityId::cooperative("food-coop").unwrap();
+        let creator = test_did("creator");
+
+        // Seed TWO persisted treasuries bound to the SAME entity_id (different DIDs
+        // and coop_ids) — an inconsistent store.
+        let t1 = Treasury::new_with_entity(
+            test_did("t1"),
+            entity.clone(),
+            "USD".to_string(),
+            creator.clone(),
+            None,
+        );
+        let mut t2 =
+            Treasury::new_with_entity(test_did("t2"), entity, "USD".to_string(), creator, None);
+        t2.coop_id = "coop:other".to_string(); // same entity, distinct coop_id
+
+        for t in [&t1, &t2] {
+            let key = format!("{}{}", TREASURY_PREFIX, t.treasury_did);
+            store
+                .put(key.as_bytes(), &serde_json::to_vec(t).unwrap())
+                .unwrap();
+        }
+
+        // Hydration must fail closed rather than silently keep one mapping.
+        assert!(
+            TreasuryManager::with_store(store).is_err(),
+            "hydration must fail closed on a duplicate entity_id in the store"
+        );
     }
 }

--- a/icn/crates/icn-ledger/src/treasury.rs
+++ b/icn/crates/icn-ledger/src/treasury.rs
@@ -258,6 +258,19 @@ pub struct TreasuryManager {
     surplus_allocations: HashMap<String, SurplusAllocation>,
 }
 
+/// Outcome of the contract-bound treasury `entity_id` backfill storage seam
+/// ([`TreasuryManager::populate_treasury_entity_id`], ADR-0084).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TreasuryEntityIdPopulateResult {
+    /// `entity_id` was populated (`None → Some`) and persisted.
+    Populated,
+    /// The treasury already carried an `entity_id`; nothing was changed
+    /// (idempotent guard — apply never overwrites an existing identity target).
+    AlreadyPopulated,
+    /// No treasury is registered for this `coop_id`; nothing was changed.
+    TreasuryNotFound,
+}
+
 impl TreasuryManager {
     /// Create a new treasury manager (in-memory only)
     pub fn new() -> Self {
@@ -1036,6 +1049,63 @@ impl TreasuryManager {
         let value = treasury_did.to_string();
         store.put(key.as_bytes(), value.as_bytes())?;
         Ok(())
+    }
+
+    /// Storage seam for the controlled treasury `entity_id` backfill **apply**
+    /// (ADR-0084, #2082 lane). Populates the `entity_id` of the single legacy
+    /// treasury registered for `coop_id` and persists it, **preserving `coop_id`
+    /// byte-for-byte**: only the `entity_id` field changes, and the `coop_id →
+    /// treasury` index is untouched (the key is unchanged).
+    ///
+    /// A `coop_id ↔ EntityId` mapping grants **zero** authority — this writes an
+    /// identity *target*, never a permission. The method is `pub(crate)` on
+    /// purpose: only the contract-bound
+    /// [`TreasuryManager::apply_entity_id_backfill`] orchestrator — which
+    /// restricts mutation to the planner's `WouldPopulate` rows — may reach it,
+    /// never an external caller with an arbitrary `(coop_id, entity_id)` pair.
+    ///
+    /// Fail-closed and idempotent:
+    /// - a treasury that already carries an `entity_id` is left untouched
+    ///   ([`AlreadyPopulated`](TreasuryEntityIdPopulateResult::AlreadyPopulated));
+    /// - a missing treasury is a no-op
+    ///   ([`TreasuryNotFound`](TreasuryEntityIdPopulateResult::TreasuryNotFound));
+    /// - the durable write happens **before** the in-memory commit, so a storage
+    ///   error returns `Err` with both the store and the cache left unchanged.
+    pub(crate) fn populate_treasury_entity_id(
+        &mut self,
+        coop_id: &str,
+        entity_id: EntityId,
+    ) -> Result<TreasuryEntityIdPopulateResult> {
+        // Resolve the (1:1) treasury for this exact coop_id. The coop_id is the
+        // lookup key, used verbatim — never normalized.
+        let Some(treasury_did) = self.coop_treasuries.get(coop_id).cloned() else {
+            return Ok(TreasuryEntityIdPopulateResult::TreasuryNotFound);
+        };
+        let Some(existing) = self.treasuries.get(&treasury_did) else {
+            return Ok(TreasuryEntityIdPopulateResult::TreasuryNotFound);
+        };
+
+        // Idempotent: never overwrite an already-populated identity target.
+        if existing.entity_id.is_some() {
+            return Ok(TreasuryEntityIdPopulateResult::AlreadyPopulated);
+        }
+
+        // Populate entity_id only; coop_id (and every other field) is carried
+        // through unchanged.
+        let mut updated = existing.clone();
+        updated.entity_id = Some(entity_id);
+        debug_assert_eq!(
+            updated.coop_id, existing.coop_id,
+            "apply must preserve coop_id byte-for-byte"
+        );
+
+        // Persist first: a storage failure must leave the durable store and the
+        // in-memory cache consistent (both unchanged) — fail closed.
+        if let Some(ref store) = self.store {
+            self.persist_treasury(&updated, store)?;
+        }
+        self.treasuries.insert(treasury_did, updated);
+        Ok(TreasuryEntityIdPopulateResult::Populated)
     }
 }
 

--- a/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
+++ b/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
@@ -37,8 +37,8 @@
 //! binding, a non-cooperative or malformed target, an ambiguous reverse binding,
 //! or a storage read error — is **skipped** (fail closed).
 
-use crate::treasury::{Treasury, TreasuryManager};
-use icn_entity::{CoopEntityMap, EntityId};
+use crate::treasury::{Treasury, TreasuryEntityIdPopulateResult, TreasuryManager};
+use icn_entity::{CoopEntityBindingProvenance, CoopEntityMap, EntityId};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -371,6 +371,267 @@ fn treasury_to_target(treasury: &Treasury) -> TreasuryEntityIdBackfillTarget {
         coop_id: treasury.coop_id().to_string(),
         treasury_did: Some(treasury.treasury_did.to_string()),
         current_entity_id: treasury.entity_id().cloned(),
+    }
+}
+
+// =====================================================================
+// Controlled, mutating apply (ADR-0084).
+// =====================================================================
+
+/// What the apply did to a single eligible (`WouldPopulate`) treasury row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TreasuryEntityIdBackfillApplyOutcome {
+    /// `entity_id` was populated from the trusted binding (`None → Some`) and
+    /// persisted.
+    Populated,
+    /// The row was eligible per the plan but the apply did **not** complete (a
+    /// pre-write binding re-verification mismatch, a storage write error, or an
+    /// inconsistent state at write time). The treasury was left unchanged — fail
+    /// closed.
+    Failed,
+}
+
+/// Per-row audit for the rows the apply acted on (the planner's `WouldPopulate`
+/// set). `entity_id_before`/`entity_id_after` make the mutation explicit and
+/// reversible to inspect; the full fail-closed classification of *every* row
+/// lives in the embedded [`TreasuryEntityIdBackfillApplyReport::plan`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreasuryEntityIdBackfillApplyEntry {
+    /// The treasury's flat `coop_id`, preserved byte-for-byte (the map key).
+    pub coop_id: String,
+    /// The treasury DID, for operator-facing identification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub treasury_did: Option<String>,
+    /// What the apply did to this row.
+    pub outcome: TreasuryEntityIdBackfillApplyOutcome,
+    /// The treasury's `entity_id` before the apply. `None` for a legacy row (the
+    /// only kind eligible), surfaced explicitly for a before/after audit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity_id_before: Option<EntityId>,
+    /// The treasury's `entity_id` after a successful apply (`Some` only for
+    /// [`Populated`](TreasuryEntityIdBackfillApplyOutcome::Populated)).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity_id_after: Option<EntityId>,
+    /// Trust provenance of the binding used (present once a trusted binding was
+    /// re-verified for this row).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<CoopEntityBindingProvenance>,
+    /// A short, human-readable explanation of the outcome.
+    pub reason: String,
+    /// The underlying storage/map error string when one prevented the write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Aggregate, auditable result of a controlled treasury `entity_id` backfill
+/// **apply** (ADR-0084).
+///
+/// Embeds the read-only [`plan`](Self::plan) verbatim (the same shape the
+/// `entity-backfill-report` emits, with the full fail-closed classification and
+/// counters) and adds the apply-specific outcome: how many `WouldPopulate` rows
+/// were populated, how many failed closed, and a per-row before/after audit.
+///
+/// Invariant: `applied + failed == plan.would_populate` — every eligible row is
+/// either populated or flagged failed; no eligible row is silently dropped.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreasuryEntityIdBackfillApplyReport {
+    /// The read-only plan this apply was derived from (full classification +
+    /// counters; `total`, `would_populate`, and every `skipped_*` bucket).
+    pub plan: TreasuryEntityIdBackfillPlan,
+    /// Rows whose `entity_id` was populated from a trusted binding and persisted.
+    pub applied: usize,
+    /// Eligible rows that did not complete (re-verification mismatch or storage
+    /// error); each was left unchanged — fail closed.
+    pub failed: usize,
+    /// Per-row audit for the rows the apply acted on, in plan order.
+    pub entries: Vec<TreasuryEntityIdBackfillApplyEntry>,
+}
+
+impl TreasuryEntityIdBackfillApplyReport {
+    /// True when an apply did not fully complete (any eligible row failed to
+    /// persist). Callers (e.g. the CLI) gate a non-zero exit on this.
+    pub fn had_failures(&self) -> bool {
+        self.failed > 0
+    }
+}
+
+impl TreasuryManager {
+    /// Controlled, mutating **apply** of the treasury `entity_id` backfill
+    /// (ADR-0084, #2082 lane).
+    ///
+    /// Populates `entity_id` for **exactly** the legacy treasuries the read-only
+    /// [`plan_entity_id_backfill`](Self::plan_entity_id_backfill) classifies as
+    /// [`WouldPopulate`](TreasuryEntityIdBackfillAction::WouldPopulate), and skips
+    /// every fail-closed class unchanged (`SkippedAlreadyHasEntityId`,
+    /// `SkippedNoMapping`, `SkippedUntrustedProvenance`,
+    /// `SkippedNonCooperativeEntity`, `SkippedAmbiguousBinding`,
+    /// `SkippedStorageError`). Apply is defined entirely in terms of the planner's
+    /// `WouldPopulate` set — it never re-derives or relaxes eligibility.
+    ///
+    /// Each eligible row is re-verified against the canonical map immediately
+    /// before mutation: the binding must still resolve to the planned target with
+    /// trusted provenance, else the row fails closed and is left unchanged. The
+    /// mutation touches only `entity_id` (`None → Some`); the `coop_id` is
+    /// preserved byte-for-byte, the map is never written, and membership, roles,
+    /// capabilities, auth configuration, and enforcement mode are untouched. A
+    /// mapping grants **zero** authority — this writes an identity target only.
+    ///
+    /// Idempotent: a re-run re-classifies already-populated rows as
+    /// `SkippedAlreadyHasEntityId`, so they never re-populate. Storage errors fail
+    /// closed (per-row, since the treasury store has no all-or-nothing batch over
+    /// rows): the affected row is reported `failed` and left unchanged.
+    pub fn apply_entity_id_backfill(
+        &mut self,
+        map: &dyn CoopEntityMap,
+    ) -> TreasuryEntityIdBackfillApplyReport {
+        // Authoritative read-only classification first. Apply is defined ENTIRELY
+        // in terms of this plan's WouldPopulate set (ADR-0084 §3).
+        let plan = self.plan_entity_id_backfill(map);
+
+        let mut entries: Vec<TreasuryEntityIdBackfillApplyEntry> = Vec::new();
+        let mut applied = 0usize;
+        let mut failed = 0usize;
+
+        for row in &plan.entries {
+            // Every fail-closed class is skipped, never coerced. Their full
+            // classification is preserved in the embedded plan.
+            if row.action != TreasuryEntityIdBackfillAction::WouldPopulate {
+                continue;
+            }
+
+            let coop_id = row.coop_id.clone();
+            let treasury_did = row.treasury_did.clone();
+
+            // The planner only assigns WouldPopulate with a resolved cooperative
+            // target; defend against a malformed row rather than unwrap.
+            let Some(resolved) = row.resolved_entity_id.clone() else {
+                failed += 1;
+                entries.push(TreasuryEntityIdBackfillApplyEntry {
+                    coop_id,
+                    treasury_did,
+                    outcome: TreasuryEntityIdBackfillApplyOutcome::Failed,
+                    entity_id_before: None,
+                    entity_id_after: None,
+                    provenance: None,
+                    reason: "eligible row carried no resolved entity_id; not applied (fail closed)"
+                        .into(),
+                    error: None,
+                });
+                continue;
+            };
+
+            // Re-verify the trusted binding immediately before mutating. On the
+            // CLI path the daemon is stopped, so this matches the plan exactly; it
+            // is a defensive fail-closed re-check AND the source of the audited
+            // provenance. Anything but an exact, trusted match for the planned
+            // target fails closed — nothing is written.
+            let provenance = match map.binding_for_coop(&coop_id) {
+                Ok(Some(binding))
+                    if binding.entity_id == resolved
+                        && binding.provenance.is_trusted_for_resolution() =>
+                {
+                    binding.provenance
+                }
+                Ok(_) => {
+                    failed += 1;
+                    entries.push(TreasuryEntityIdBackfillApplyEntry {
+                        coop_id,
+                        treasury_did,
+                        outcome: TreasuryEntityIdBackfillApplyOutcome::Failed,
+                        entity_id_before: None,
+                        entity_id_after: None,
+                        provenance: None,
+                        reason: "binding no longer a trusted match for the planned target; \
+                                 not applied (fail closed)"
+                            .into(),
+                        error: None,
+                    });
+                    continue;
+                }
+                Err(e) => {
+                    failed += 1;
+                    entries.push(TreasuryEntityIdBackfillApplyEntry {
+                        coop_id,
+                        treasury_did,
+                        outcome: TreasuryEntityIdBackfillApplyOutcome::Failed,
+                        entity_id_before: None,
+                        entity_id_after: None,
+                        provenance: None,
+                        reason: "map re-read failed; cannot confirm a safe binding (fail closed)"
+                            .into(),
+                        error: Some(e.to_string()),
+                    });
+                    continue;
+                }
+            };
+
+            // Mutate exactly one row: entity_id None -> Some(resolved), coop_id
+            // preserved byte-for-byte, persisted before the in-memory commit.
+            match self.populate_treasury_entity_id(&coop_id, resolved.clone()) {
+                Ok(TreasuryEntityIdPopulateResult::Populated) => {
+                    applied += 1;
+                    let after = resolved.as_str().to_string();
+                    entries.push(TreasuryEntityIdBackfillApplyEntry {
+                        coop_id,
+                        treasury_did,
+                        outcome: TreasuryEntityIdBackfillApplyOutcome::Populated,
+                        entity_id_before: None,
+                        entity_id_after: Some(resolved),
+                        provenance: Some(provenance),
+                        reason: format!("populated entity_id from trusted binding to {after}"),
+                        error: None,
+                    });
+                }
+                // Unreachable on the single-writer CLI path (we hold &mut self
+                // between plan and apply, so state cannot change underneath), but
+                // flagged fail-closed rather than silently dropped.
+                Ok(other) => {
+                    failed += 1;
+                    let reason = match other {
+                        TreasuryEntityIdPopulateResult::AlreadyPopulated => {
+                            "treasury already carried an entity_id at write time; \
+                             not applied (fail closed)"
+                        }
+                        TreasuryEntityIdPopulateResult::TreasuryNotFound => {
+                            "treasury not found at write time; not applied (fail closed)"
+                        }
+                        TreasuryEntityIdPopulateResult::Populated => unreachable!(),
+                    };
+                    entries.push(TreasuryEntityIdBackfillApplyEntry {
+                        coop_id,
+                        treasury_did,
+                        outcome: TreasuryEntityIdBackfillApplyOutcome::Failed,
+                        entity_id_before: None,
+                        entity_id_after: None,
+                        provenance: Some(provenance),
+                        reason: reason.into(),
+                        error: None,
+                    });
+                }
+                Err(e) => {
+                    failed += 1;
+                    entries.push(TreasuryEntityIdBackfillApplyEntry {
+                        coop_id,
+                        treasury_did,
+                        outcome: TreasuryEntityIdBackfillApplyOutcome::Failed,
+                        entity_id_before: None,
+                        entity_id_after: None,
+                        provenance: Some(provenance),
+                        reason: "storage write failed; treasury left unchanged (fail closed)"
+                            .into(),
+                        error: Some(e.to_string()),
+                    });
+                }
+            }
+        }
+
+        TreasuryEntityIdBackfillApplyReport {
+            plan,
+            applied,
+            failed,
+            entries,
+        }
     }
 }
 
@@ -820,5 +1081,444 @@ mod tests {
         assert_eq!(entry.action, TreasuryEntityIdBackfillAction::WouldPopulate);
         assert_eq!(entry.resolved_entity_id, Some(coop_eid("food-coop")));
         assert!(entry.treasury_did.is_some(), "treasury_did is surfaced");
+    }
+
+    // ==================================================================
+    // Controlled apply (ADR-0084).
+    // ==================================================================
+
+    /// Build an in-memory manager holding one legacy treasury (`entity_id: None`)
+    /// per `coop_id`, registered through the real `register_treasury` path.
+    fn legacy_manager_with(coops: &[&str]) -> TreasuryManager {
+        use icn_identity::KeyPair;
+        let mut mgr = TreasuryManager::new();
+        let creator = KeyPair::generate().unwrap().did().clone();
+        for coop in coops {
+            let treasury_did = KeyPair::generate().unwrap().did().clone();
+            mgr.register_treasury(
+                treasury_did,
+                coop.to_string(),
+                "USD".to_string(),
+                creator.clone(),
+                None,
+            )
+            .unwrap();
+        }
+        mgr
+    }
+
+    /// A map double that yields a trusted, non-ambiguous binding (so the row
+    /// plans as `WouldPopulate`) yet makes `bind_resolved` `unreachable!` — proving
+    /// the apply NEVER writes the map.
+    struct ReadOnlyEligibleMap {
+        coop_id: String,
+        entity_id: EntityId,
+    }
+    impl CoopEntityMap for ReadOnlyEligibleMap {
+        fn bind_resolved(&self, _: &str, _: &EntityId) -> Result<(), CoopEntityMapError> {
+            unreachable!("apply must never write the coop_id <-> EntityId map");
+        }
+        fn entity_for_coop(&self, _: &str) -> Result<Option<EntityId>, CoopEntityMapError> {
+            Ok(None)
+        }
+        fn coop_for_entity(&self, _: &EntityId) -> Result<Option<String>, CoopEntityMapError> {
+            Ok(Some(self.coop_id.clone()))
+        }
+        fn binding_for_coop(
+            &self,
+            coop_id: &str,
+        ) -> Result<Option<CoopEntityBinding>, CoopEntityMapError> {
+            Ok(Some(CoopEntityBinding {
+                coop_id: coop_id.to_string(),
+                entity_id: self.entity_id.clone(),
+                provenance: CoopEntityBindingProvenance::Activation,
+            }))
+        }
+    }
+
+    /// A map double that returns a trusted binding on the FIRST `binding_for_coop`
+    /// read (planning ⇒ `WouldPopulate`) and a storage error on the SECOND (the
+    /// apply's pre-write re-verification) — exercising the fail-closed write guard.
+    struct ReVerifyFailMap {
+        coop_id: String,
+        entity_id: EntityId,
+        binding_calls: std::cell::Cell<u32>,
+    }
+    impl CoopEntityMap for ReVerifyFailMap {
+        fn bind_resolved(&self, _: &str, _: &EntityId) -> Result<(), CoopEntityMapError> {
+            unreachable!("apply must never write the coop_id <-> EntityId map");
+        }
+        fn entity_for_coop(&self, _: &str) -> Result<Option<EntityId>, CoopEntityMapError> {
+            Ok(None)
+        }
+        fn coop_for_entity(&self, _: &EntityId) -> Result<Option<String>, CoopEntityMapError> {
+            Ok(Some(self.coop_id.clone()))
+        }
+        fn binding_for_coop(
+            &self,
+            coop_id: &str,
+        ) -> Result<Option<CoopEntityBinding>, CoopEntityMapError> {
+            let n = self.binding_calls.get();
+            self.binding_calls.set(n + 1);
+            if n == 0 {
+                Ok(Some(CoopEntityBinding {
+                    coop_id: coop_id.to_string(),
+                    entity_id: self.entity_id.clone(),
+                    provenance: CoopEntityBindingProvenance::Activation,
+                }))
+            } else {
+                Err(CoopEntityMapError::Storage(
+                    "re-verify read failed".to_string(),
+                ))
+            }
+        }
+    }
+
+    #[test]
+    fn apply_populates_only_would_populate_rows() {
+        let mut mgr = legacy_manager_with(&["food-coop", "legacy-coop", "no-map-coop"]);
+        let map = InMemoryCoopEntityMap::new();
+        // food-coop: trusted Activation -> eligible.
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+        // legacy-coop: plain bind -> UnknownLegacy -> untrusted.
+        map.bind_resolved("legacy-coop", &coop_eid("legacy-coop"))
+            .unwrap();
+        // no-map-coop: nothing.
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.plan.would_populate, 1);
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.failed, 0);
+        // Invariant: every eligible row is either populated or flagged failed.
+        assert_eq!(report.applied + report.failed, report.plan.would_populate);
+
+        // Only the trusted row is populated; the others are untouched.
+        assert_eq!(
+            mgr.get_treasury_by_coop("food-coop").unwrap().entity_id(),
+            Some(&coop_eid("food-coop"))
+        );
+        assert!(mgr
+            .get_treasury_by_coop("legacy-coop")
+            .unwrap()
+            .entity_id()
+            .is_none());
+        assert!(mgr
+            .get_treasury_by_coop("no-map-coop")
+            .unwrap()
+            .entity_id()
+            .is_none());
+
+        // The apply audit lists only the row it acted on.
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(
+            report.entries[0].outcome,
+            TreasuryEntityIdBackfillApplyOutcome::Populated
+        );
+        assert_eq!(report.entries[0].entity_id_before, None);
+        assert_eq!(
+            report.entries[0].entity_id_after,
+            Some(coop_eid("food-coop"))
+        );
+        assert!(report.entries[0].provenance.is_some());
+        assert!(!report.had_failures());
+    }
+
+    #[test]
+    fn apply_is_idempotent_on_rerun() {
+        let mut mgr = legacy_manager_with(&["food-coop"]);
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+
+        let first = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(first.applied, 1);
+        assert_eq!(
+            mgr.get_treasury_by_coop("food-coop").unwrap().entity_id(),
+            Some(&coop_eid("food-coop"))
+        );
+
+        // Re-run: the row now classifies SkippedAlreadyHasEntityId and is a no-op.
+        let second = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(second.applied, 0);
+        assert_eq!(second.failed, 0);
+        assert_eq!(second.plan.would_populate, 0);
+        assert_eq!(second.plan.skipped_already_has_entity_id, 1);
+        assert!(second.entries.is_empty());
+        assert_eq!(
+            mgr.get_treasury_by_coop("food-coop").unwrap().entity_id(),
+            Some(&coop_eid("food-coop"))
+        );
+    }
+
+    #[test]
+    fn apply_skips_already_populated_row() {
+        use icn_identity::KeyPair;
+        let mut mgr = TreasuryManager::new();
+        let creator = KeyPair::generate().unwrap().did().clone();
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+        mgr.register_treasury_with_entity(
+            treasury_did,
+            coop_eid("food-coop"),
+            "USD".to_string(),
+            creator,
+            None,
+        )
+        .unwrap();
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.plan.skipped_already_has_entity_id, 1);
+        assert!(report.entries.is_empty());
+    }
+
+    #[test]
+    fn apply_skips_untrusted_provenance() {
+        let mut mgr = legacy_manager_with(&["food-coop"]);
+        let map = InMemoryCoopEntityMap::new();
+        // Plain bind reads back as the fail-closed UnknownLegacy sentinel.
+        map.bind_resolved("food-coop", &coop_eid("food-coop"))
+            .unwrap();
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.plan.skipped_untrusted_provenance, 1);
+        assert!(mgr
+            .get_treasury_by_coop("food-coop")
+            .unwrap()
+            .entity_id()
+            .is_none());
+    }
+
+    #[test]
+    fn apply_skips_no_mapping() {
+        let mut mgr = legacy_manager_with(&["food-coop"]);
+        let map = InMemoryCoopEntityMap::new();
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.plan.skipped_no_mapping, 1);
+        assert!(mgr
+            .get_treasury_by_coop("food-coop")
+            .unwrap()
+            .entity_id()
+            .is_none());
+    }
+
+    #[test]
+    fn apply_skips_non_cooperative_entity() {
+        let mut mgr = legacy_manager_with(&["food-coop"]);
+        let map = StubMap {
+            binding: |coop_id| {
+                Ok(Some(CoopEntityBinding {
+                    coop_id: coop_id.to_string(),
+                    entity_id: EntityId::community("some-community").unwrap(),
+                    provenance: CoopEntityBindingProvenance::Activation,
+                }))
+            },
+            reverse: |_| Ok(None),
+        };
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.plan.skipped_non_cooperative_entity, 1);
+        assert!(mgr
+            .get_treasury_by_coop("food-coop")
+            .unwrap()
+            .entity_id()
+            .is_none());
+    }
+
+    #[test]
+    fn apply_skips_ambiguous_reverse_mismatch() {
+        let mut mgr = legacy_manager_with(&["food-coop"]);
+        let map = StubMap {
+            binding: |coop_id| {
+                Ok(Some(CoopEntityBinding {
+                    coop_id: coop_id.to_string(),
+                    entity_id: EntityId::cooperative("food-coop").unwrap(),
+                    provenance: CoopEntityBindingProvenance::Activation,
+                }))
+            },
+            // Reverse points to a different coop_id -> ambiguous.
+            reverse: |_| Ok(Some("other-coop".to_string())),
+        };
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.plan.skipped_ambiguous_binding, 1);
+        assert!(mgr
+            .get_treasury_by_coop("food-coop")
+            .unwrap()
+            .entity_id()
+            .is_none());
+    }
+
+    #[test]
+    fn apply_preserves_coop_id_byte_for_byte() {
+        // A non-mappable legacy id bound to a surrogate whose identifier DIFFERS
+        // from the coop_id: proves apply sets entity_id without deriving/rewriting
+        // coop_id.
+        let coop_id = "coop:550e8400-e29b-41d4-a716-446655440000";
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let mut mgr = legacy_manager_with(&[coop_id]);
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            coop_id,
+            &surrogate,
+            CoopEntityBindingProvenance::OperatorBackfill,
+        )
+        .unwrap();
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.applied, 1);
+        let treasury = mgr.get_treasury_by_coop(coop_id).unwrap();
+        assert_eq!(
+            treasury.coop_id(),
+            coop_id,
+            "coop_id must be preserved byte-for-byte"
+        );
+        assert_eq!(treasury.entity_id(), Some(&surrogate));
+        assert_ne!(
+            surrogate.identifier(),
+            coop_id,
+            "surrogate identifier differs from coop_id (no derivation)"
+        );
+    }
+
+    #[test]
+    fn apply_persists_entity_id_and_survives_reload() {
+        use icn_identity::KeyPair;
+        use icn_store::{SledStore, Store};
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        // One shared Arc/Db reused on reopen — no second SledStore::open, no lock
+        // contention.
+        let store: Arc<dyn Store> = Arc::new(SledStore::open(tmp.path()).unwrap());
+        let creator = KeyPair::generate().unwrap().did().clone();
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+
+        {
+            let mut mgr = TreasuryManager::with_store(store.clone()).unwrap();
+            mgr.register_treasury(
+                treasury_did,
+                "food-coop".to_string(),
+                "USD".to_string(),
+                creator,
+                None,
+            )
+            .unwrap();
+            let map = InMemoryCoopEntityMap::new();
+            map.bind_resolved_with_provenance(
+                "food-coop",
+                &coop_eid("food-coop"),
+                CoopEntityBindingProvenance::Activation,
+            )
+            .unwrap();
+            let report = mgr.apply_entity_id_backfill(&map);
+            assert_eq!(report.applied, 1);
+            assert_eq!(
+                mgr.get_treasury_by_coop("food-coop").unwrap().entity_id(),
+                Some(&coop_eid("food-coop"))
+            );
+        }
+
+        // Reopen from the same store: the populated entity_id is durable.
+        let reopened = TreasuryManager::with_store(store).unwrap();
+        let treasury = reopened.get_treasury_by_coop("food-coop").unwrap();
+        assert_eq!(treasury.entity_id(), Some(&coop_eid("food-coop")));
+        assert_eq!(treasury.coop_id(), "food-coop");
+    }
+
+    #[test]
+    fn apply_report_json_includes_before_after_and_provenance() {
+        let mut mgr = legacy_manager_with(&["food-coop"]);
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+        let report = mgr.apply_entity_id_backfill(&map);
+
+        let v: serde_json::Value = serde_json::to_value(&report).unwrap();
+        assert_eq!(v["applied"].as_u64(), Some(1));
+        assert_eq!(v["failed"].as_u64(), Some(0));
+        // The embedded plan carries the full report-shape classification.
+        assert_eq!(v["plan"]["would_populate"].as_u64(), Some(1));
+        let entry = &v["entries"][0];
+        assert_eq!(entry["outcome"].as_str(), Some("populated"));
+        assert_eq!(entry["coop_id"].as_str(), Some("food-coop"));
+        assert!(entry["entity_id_after"].as_str().is_some());
+        // entity_id_before is None -> omitted from JSON.
+        assert!(entry.get("entity_id_before").is_none());
+        // Provenance of the trusted binding is surfaced for audit.
+        assert!(entry.get("provenance").is_some());
+    }
+
+    #[test]
+    fn apply_never_writes_the_map() {
+        // `coop_A` is non-projectable, so no projection-conflict skip; the stub
+        // yields a trusted binding with a matching reverse -> WouldPopulate. The
+        // stub's bind_resolved is `unreachable!`, so a successful apply proves the
+        // map is never written.
+        let coop_id = "coop_A";
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let mut mgr = legacy_manager_with(&[coop_id]);
+        let map = ReadOnlyEligibleMap {
+            coop_id: coop_id.to_string(),
+            entity_id: surrogate.clone(),
+        };
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.applied, 1);
+        assert_eq!(
+            mgr.get_treasury_by_coop(coop_id).unwrap().entity_id(),
+            Some(&surrogate)
+        );
+    }
+
+    #[test]
+    fn apply_fails_closed_on_reverify_storage_error() {
+        let coop_id = "coop_A"; // non-projectable: no projection-conflict at plan time.
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let mut mgr = legacy_manager_with(&[coop_id]);
+        let map = ReVerifyFailMap {
+            coop_id: coop_id.to_string(),
+            entity_id: surrogate,
+            binding_calls: std::cell::Cell::new(0),
+        };
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        // Planned eligible, but the apply re-verify hit a storage error.
+        assert_eq!(report.plan.would_populate, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.failed, 1);
+        assert!(report.had_failures());
+        // Fail closed: the treasury is left unchanged.
+        assert!(mgr
+            .get_treasury_by_coop(coop_id)
+            .unwrap()
+            .entity_id()
+            .is_none());
+        assert_eq!(
+            report.entries[0].outcome,
+            TreasuryEntityIdBackfillApplyOutcome::Failed
+        );
+        assert!(report.entries[0].error.is_some());
     }
 }

--- a/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
+++ b/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
@@ -39,6 +39,7 @@
 
 use crate::treasury::{Treasury, TreasuryEntityIdPopulateResult, TreasuryManager};
 use icn_entity::{CoopEntityBindingProvenance, CoopEntityMap, EntityId};
+use icn_identity::Did;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -625,9 +626,35 @@ impl TreasuryManager {
                 }
             };
 
-            // Mutate exactly one row: entity_id None -> Some(resolved), coop_id
-            // preserved byte-for-byte, persisted before the in-memory commit.
-            match self.populate_treasury_entity_id(&coop_id, resolved.clone()) {
+            // Resolve the planned treasury DID carried by this plan row. The write
+            // MUST target this exact DID — not whichever row currently wins the
+            // coop_id index — so a duplicate/inconsistent coop_id cannot mutate the
+            // wrong row or leave the audit disagreeing with the write. A missing or
+            // malformed DID fails closed.
+            let planned_did = match treasury_did.as_deref().map(Did::from_str) {
+                Some(Ok(did)) => did,
+                _ => {
+                    failed += 1;
+                    entries.push(TreasuryEntityIdBackfillApplyEntry {
+                        coop_id,
+                        treasury_did,
+                        outcome: TreasuryEntityIdBackfillApplyOutcome::Failed,
+                        entity_id_before: None,
+                        entity_id_after: None,
+                        provenance: Some(provenance),
+                        reason: "plan row carried no valid treasury DID; not applied (fail closed)"
+                            .into(),
+                        error: None,
+                    });
+                    continue;
+                }
+            };
+
+            // Mutate exactly one row by its planned DID: entity_id None ->
+            // Some(resolved), coop_id re-verified byte-for-byte, persisted before
+            // the in-memory commit.
+            match self.populate_treasury_entity_id_for_did(&planned_did, &coop_id, resolved.clone())
+            {
                 Ok(TreasuryEntityIdPopulateResult::Populated) => {
                     applied += 1;
                     let after = resolved.as_str().to_string();
@@ -653,7 +680,12 @@ impl TreasuryManager {
                              not applied (fail closed)"
                         }
                         TreasuryEntityIdPopulateResult::TreasuryNotFound => {
-                            "treasury not found at write time; not applied (fail closed)"
+                            "planned treasury DID not found at write time; \
+                             not applied (fail closed)"
+                        }
+                        TreasuryEntityIdPopulateResult::CoopIdMismatch => {
+                            "planned treasury DID no longer matches the planned coop_id; \
+                             not applied (fail closed)"
                         }
                         TreasuryEntityIdPopulateResult::EntityIdConflict => {
                             "target entity_id is already bound to a different treasury; \
@@ -1883,5 +1915,46 @@ mod tests {
         assert!(mgr
             .register_treasury_with_entity(did, surrogate, "USD".to_string(), creator, None)
             .is_ok());
+    }
+
+    #[test]
+    fn apply_writes_and_audits_the_planned_treasury_did() {
+        use icn_identity::KeyPair;
+        // End-to-end: the row the audit reports as populated is the exact treasury
+        // DID the planner carried, and that same DID's row is the one mutated.
+        let mut mgr = TreasuryManager::new();
+        let creator = KeyPair::generate().unwrap().did().clone();
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+        mgr.register_treasury(
+            treasury_did.clone(),
+            "food-coop".to_string(),
+            "USD".to_string(),
+            creator,
+            None,
+        )
+        .unwrap();
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            "food-coop",
+            &coop_eid("food-coop"),
+            CoopEntityBindingProvenance::Activation,
+        )
+        .unwrap();
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.applied, 1);
+
+        // The exact planned DID's row was mutated.
+        assert_eq!(
+            mgr.get_treasury(&treasury_did).unwrap().entity_id(),
+            Some(&coop_eid("food-coop"))
+        );
+        // The audit entry names that same DID (write target == planned == audited).
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.outcome == TreasuryEntityIdBackfillApplyOutcome::Populated)
+            .expect("a populated entry");
+        assert_eq!(entry.treasury_did.as_deref(), Some(treasury_did.as_str()));
     }
 }

--- a/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
+++ b/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
@@ -655,6 +655,10 @@ impl TreasuryManager {
                         TreasuryEntityIdPopulateResult::TreasuryNotFound => {
                             "treasury not found at write time; not applied (fail closed)"
                         }
+                        TreasuryEntityIdPopulateResult::EntityIdConflict => {
+                            "target entity_id is already bound to a different treasury; \
+                             not applied (fail closed)"
+                        }
                         TreasuryEntityIdPopulateResult::Populated => unreachable!(),
                     };
                     entries.push(TreasuryEntityIdBackfillApplyEntry {
@@ -1727,5 +1731,157 @@ mod tests {
         assert_eq!(entry.outcome, TreasuryEntityIdBackfillApplyOutcome::Failed);
         assert!(entry.error.is_some());
         assert!(entry.reason.contains("reverse-index"));
+    }
+
+    // ------------------------------------------------------------------
+    // Entity-index integrity after a (surrogate) backfill apply (Codex P2).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn apply_surrogate_backfill_indexes_entity_lookup() {
+        // A surrogate backfill: legacy coop_id "coop:<uuid>" bound to a surrogate
+        // whose identifier differs from the coop_id. After apply, entity-keyed
+        // lookup must find the treasury while the legacy coop_id is preserved.
+        let coop_id = "coop:550e8400-e29b-41d4-a716-446655440000";
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let mut mgr = legacy_manager_with(&[coop_id]);
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            coop_id,
+            &surrogate,
+            CoopEntityBindingProvenance::OperatorBackfill,
+        )
+        .unwrap();
+
+        assert_eq!(mgr.apply_entity_id_backfill(&map).applied, 1);
+
+        let by_entity = mgr
+            .get_treasury_by_entity(&surrogate)
+            .expect("entity index finds the backfilled treasury");
+        assert_eq!(by_entity.coop_id(), coop_id, "legacy coop_id preserved");
+        assert_eq!(by_entity.entity_id(), Some(&surrogate));
+        // The original coop-keyed lookup still resolves under the legacy coop_id.
+        assert_eq!(
+            mgr.get_treasury_by_coop(coop_id).unwrap().entity_id(),
+            Some(&surrogate)
+        );
+    }
+
+    #[test]
+    fn apply_surrogate_backfill_blocks_duplicate_entity_registration() {
+        use icn_identity::KeyPair;
+        let coop_id = "coop:550e8400-e29b-41d4-a716-446655440000";
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let mut mgr = legacy_manager_with(&[coop_id]);
+        let map = InMemoryCoopEntityMap::new();
+        map.bind_resolved_with_provenance(
+            coop_id,
+            &surrogate,
+            CoopEntityBindingProvenance::OperatorBackfill,
+        )
+        .unwrap();
+        assert_eq!(mgr.apply_entity_id_backfill(&map).applied, 1);
+
+        // A later entity-based registration for the SAME surrogate entity must be
+        // rejected, even though its derived coop_id differs from the backfilled
+        // treasury's legacy coop_id.
+        let creator = KeyPair::generate().unwrap().did().clone();
+        let new_did = KeyPair::generate().unwrap().did().clone();
+        let result = mgr.register_treasury_with_entity(
+            new_did,
+            surrogate.clone(),
+            "USD".to_string(),
+            creator,
+            None,
+        );
+        assert!(
+            result.is_err(),
+            "duplicate entity registration must be rejected"
+        );
+        // No second treasury was created for the entity.
+        assert_eq!(
+            mgr.get_treasury_by_entity(&surrogate).unwrap().coop_id(),
+            coop_id
+        );
+    }
+
+    #[test]
+    fn apply_surrogate_backfill_entity_index_survives_reload() {
+        use icn_identity::KeyPair;
+        use icn_store::{SledStore, Store};
+        use std::sync::Arc;
+        use tempfile::TempDir;
+
+        let coop_id = "coop:550e8400-e29b-41d4-a716-446655440000";
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let tmp = TempDir::new().unwrap();
+        let store: Arc<dyn Store> = Arc::new(SledStore::open(tmp.path()).unwrap());
+        let creator = KeyPair::generate().unwrap().did().clone();
+        let treasury_did = KeyPair::generate().unwrap().did().clone();
+
+        {
+            let mut mgr = TreasuryManager::with_store(store.clone()).unwrap();
+            mgr.register_treasury(
+                treasury_did,
+                coop_id.to_string(),
+                "USD".to_string(),
+                creator,
+                None,
+            )
+            .unwrap();
+            let map = InMemoryCoopEntityMap::new();
+            map.bind_resolved_with_provenance(
+                coop_id,
+                &surrogate,
+                CoopEntityBindingProvenance::OperatorBackfill,
+            )
+            .unwrap();
+            assert_eq!(mgr.apply_entity_id_backfill(&map).applied, 1);
+        }
+
+        // Reopen: the entity index is rebuilt from persisted rows.
+        let mut reopened = TreasuryManager::with_store(store).unwrap();
+        let by_entity = reopened
+            .get_treasury_by_entity(&surrogate)
+            .expect("entity index rebuilt on hydration");
+        assert_eq!(by_entity.coop_id(), coop_id);
+        assert_eq!(by_entity.entity_id(), Some(&surrogate));
+
+        // Duplicate entity registration is still rejected after reload.
+        let creator2 = KeyPair::generate().unwrap().did().clone();
+        let did2 = KeyPair::generate().unwrap().did().clone();
+        assert!(reopened
+            .register_treasury_with_entity(did2, surrogate, "USD".to_string(), creator2, None)
+            .is_err());
+    }
+
+    #[test]
+    fn failed_apply_does_not_index_entity() {
+        use icn_identity::KeyPair;
+        // Reverse binding drifts to missing at write -> apply fails closed. The
+        // entity must NOT be indexed, and duplicate protection must not be
+        // spuriously inserted.
+        let coop_id = "coop_A";
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let mut mgr = legacy_manager_with(&[coop_id]);
+        let map = ReverseDriftMap {
+            coop_id: coop_id.to_string(),
+            entity_id: surrogate.clone(),
+            coop_for_entity_calls: std::cell::Cell::new(0),
+            drift: ReverseDrift::Missing,
+        };
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.failed, 1);
+        // The entity was not indexed (lookup misses).
+        assert!(mgr.get_treasury_by_entity(&surrogate).is_none());
+        // And a fresh entity registration for that surrogate is NOT blocked (no
+        // spurious index entry was left behind).
+        let creator = KeyPair::generate().unwrap().did().clone();
+        let did = KeyPair::generate().unwrap().did().clone();
+        assert!(mgr
+            .register_treasury_with_entity(did, surrogate, "USD".to_string(), creator, None)
+            .is_ok());
     }
 }

--- a/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
+++ b/icn/crates/icn-ledger/src/treasury_entity_backfill.rs
@@ -456,6 +456,84 @@ impl TreasuryEntityIdBackfillApplyReport {
     }
 }
 
+/// Outcome of the apply-time re-verification of a trusted, non-ambiguous binding.
+enum ApplyReverify {
+    /// Still a trusted, non-ambiguous match for the planned target; carries the
+    /// audited binding provenance.
+    Ok(CoopEntityBindingProvenance),
+    /// No longer eligible — do not write. Carries an operator-facing `reason` and
+    /// an optional underlying map error string.
+    FailClosed {
+        reason: String,
+        error: Option<String>,
+    },
+}
+
+/// Re-validate, **immediately before a write**, that `coop_id` still has a
+/// trusted, non-ambiguous binding to exactly `resolved` — the SAME forward
+/// binding + provenance + reverse-index requirement the read-only planner uses
+/// (`plan_target`). A [`CoopEntityMap`] that changed, or that exposes
+/// inconsistent forward/reverse indexes, between planning and the write must
+/// fail closed here and never mutate (the stored `entity_id` would otherwise be
+/// ambiguous). Read-only — performs only `binding_for_coop` / `coop_for_entity`
+/// reads and binds/normalizes nothing.
+fn reverify_trusted_non_ambiguous_binding(
+    map: &dyn CoopEntityMap,
+    coop_id: &str,
+    resolved: &EntityId,
+) -> ApplyReverify {
+    // Forward binding must still resolve to the planned target with trusted
+    // provenance.
+    let provenance = match map.binding_for_coop(coop_id) {
+        Ok(Some(binding))
+            if &binding.entity_id == resolved && binding.provenance.is_trusted_for_resolution() =>
+        {
+            binding.provenance
+        }
+        Ok(_) => {
+            return ApplyReverify::FailClosed {
+                reason: "binding no longer a trusted match for the planned target; \
+                         not applied (fail closed)"
+                    .into(),
+                error: None,
+            };
+        }
+        Err(e) => {
+            return ApplyReverify::FailClosed {
+                reason: "map re-read failed; cannot confirm a safe binding (fail closed)".into(),
+                error: Some(e.to_string()),
+            };
+        }
+    };
+
+    // Reverse index must still point byte-for-byte back to THIS coop_id (the
+    // planner's non-ambiguity requirement). A reverse that was deleted, repointed
+    // to a different coop_id, or errors fails closed — the forward binding alone
+    // does not confirm the target is unambiguous.
+    match map.coop_for_entity(resolved) {
+        Ok(Some(reverse)) if reverse == coop_id => ApplyReverify::Ok(provenance),
+        Ok(reverse_opt) => {
+            let detail = match reverse_opt {
+                Some(reverse) => format!("now points to a different coop_id ({reverse:?})"),
+                None => "is missing".to_string(),
+            };
+            ApplyReverify::FailClosed {
+                reason: format!(
+                    "reverse binding {detail}; no longer points to this coop_id; \
+                     not applied (fail closed)"
+                ),
+                error: None,
+            }
+        }
+        Err(e) => ApplyReverify::FailClosed {
+            reason: "reverse-index re-read failed; cannot confirm the binding is unambiguous \
+                     (fail closed)"
+                .into(),
+            error: Some(e.to_string()),
+        },
+    }
+}
+
 impl TreasuryManager {
     /// Controlled, mutating **apply** of the treasury `entity_id` backfill
     /// (ADR-0084, #2082 lane).
@@ -521,19 +599,17 @@ impl TreasuryManager {
                 continue;
             };
 
-            // Re-verify the trusted binding immediately before mutating. On the
-            // CLI path the daemon is stopped, so this matches the plan exactly; it
-            // is a defensive fail-closed re-check AND the source of the audited
-            // provenance. Anything but an exact, trusted match for the planned
-            // target fails closed — nothing is written.
-            let provenance = match map.binding_for_coop(&coop_id) {
-                Ok(Some(binding))
-                    if binding.entity_id == resolved
-                        && binding.provenance.is_trusted_for_resolution() =>
-                {
-                    binding.provenance
-                }
-                Ok(_) => {
+            // Re-verify the FULL trusted, non-ambiguous binding immediately before
+            // mutating — the same forward binding + provenance + reverse-index
+            // check the planner uses. On the CLI path the daemon is stopped, so
+            // this matches the plan exactly; it is a defensive fail-closed re-check
+            // that also sources the audited provenance. A map that changed, or that
+            // exposes inconsistent forward/reverse indexes between planning and the
+            // write, fails closed here — nothing is written.
+            let provenance = match reverify_trusted_non_ambiguous_binding(map, &coop_id, &resolved)
+            {
+                ApplyReverify::Ok(provenance) => provenance,
+                ApplyReverify::FailClosed { reason, error } => {
                     failed += 1;
                     entries.push(TreasuryEntityIdBackfillApplyEntry {
                         coop_id,
@@ -542,25 +618,8 @@ impl TreasuryManager {
                         entity_id_before: None,
                         entity_id_after: None,
                         provenance: None,
-                        reason: "binding no longer a trusted match for the planned target; \
-                                 not applied (fail closed)"
-                            .into(),
-                        error: None,
-                    });
-                    continue;
-                }
-                Err(e) => {
-                    failed += 1;
-                    entries.push(TreasuryEntityIdBackfillApplyEntry {
-                        coop_id,
-                        treasury_did,
-                        outcome: TreasuryEntityIdBackfillApplyOutcome::Failed,
-                        entity_id_before: None,
-                        entity_id_after: None,
-                        provenance: None,
-                        reason: "map re-read failed; cannot confirm a safe binding (fail closed)"
-                            .into(),
-                        error: Some(e.to_string()),
+                        reason,
+                        error,
                     });
                     continue;
                 }
@@ -1520,5 +1579,153 @@ mod tests {
             TreasuryEntityIdBackfillApplyOutcome::Failed
         );
         assert!(report.entries[0].error.is_some());
+    }
+
+    /// How the reverse index has drifted by the time the apply re-verifies it.
+    enum ReverseDrift {
+        /// The reverse binding was deleted.
+        Missing,
+        /// The reverse binding now points to a different coop_id.
+        Different(String),
+        /// The reverse lookup errors.
+        Error,
+    }
+
+    /// A map double whose forward binding stays trusted but whose reverse index
+    /// DRIFTS between the planner pass and the apply re-verify pass: the first
+    /// `coop_for_entity` call (planning) returns the matching coop_id (so the row
+    /// plans as `WouldPopulate`), and every later call (the apply re-verify)
+    /// returns the drifted reverse. `bind_resolved` is `unreachable!` — apply must
+    /// never write the map.
+    struct ReverseDriftMap {
+        coop_id: String,
+        entity_id: EntityId,
+        coop_for_entity_calls: std::cell::Cell<u32>,
+        drift: ReverseDrift,
+    }
+    impl CoopEntityMap for ReverseDriftMap {
+        fn bind_resolved(&self, _: &str, _: &EntityId) -> Result<(), CoopEntityMapError> {
+            unreachable!("apply must never write the coop_id <-> EntityId map");
+        }
+        fn entity_for_coop(&self, _: &str) -> Result<Option<EntityId>, CoopEntityMapError> {
+            Ok(None)
+        }
+        fn coop_for_entity(&self, _: &EntityId) -> Result<Option<String>, CoopEntityMapError> {
+            let n = self.coop_for_entity_calls.get();
+            self.coop_for_entity_calls.set(n + 1);
+            if n == 0 {
+                // Planner pass: matching reverse -> WouldPopulate.
+                Ok(Some(self.coop_id.clone()))
+            } else {
+                // Apply re-verify pass: the reverse has drifted.
+                match &self.drift {
+                    ReverseDrift::Missing => Ok(None),
+                    ReverseDrift::Different(other) => Ok(Some(other.clone())),
+                    ReverseDrift::Error => Err(CoopEntityMapError::Storage(
+                        "reverse index unreadable".to_string(),
+                    )),
+                }
+            }
+        }
+        fn binding_for_coop(
+            &self,
+            coop_id: &str,
+        ) -> Result<Option<CoopEntityBinding>, CoopEntityMapError> {
+            Ok(Some(CoopEntityBinding {
+                coop_id: coop_id.to_string(),
+                entity_id: self.entity_id.clone(),
+                provenance: CoopEntityBindingProvenance::Activation,
+            }))
+        }
+    }
+
+    #[test]
+    fn apply_fails_closed_when_reverse_binding_missing_at_write() {
+        // Plan classifies WouldPopulate (matching reverse at plan time), but the
+        // reverse index is deleted before the apply write -> fail closed.
+        let coop_id = "coop_A"; // non-projectable: no projection-conflict at plan time.
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let mut mgr = legacy_manager_with(&[coop_id]);
+        let map = ReverseDriftMap {
+            coop_id: coop_id.to_string(),
+            entity_id: surrogate,
+            coop_for_entity_calls: std::cell::Cell::new(0),
+            drift: ReverseDrift::Missing,
+        };
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(
+            report.plan.would_populate, 1,
+            "planner classified the row WouldPopulate"
+        );
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.failed, 1);
+        assert!(report.had_failures());
+        // Fail closed: the treasury is left unchanged.
+        assert!(mgr
+            .get_treasury_by_coop(coop_id)
+            .unwrap()
+            .entity_id()
+            .is_none());
+        let entry = &report.entries[0];
+        assert_eq!(entry.outcome, TreasuryEntityIdBackfillApplyOutcome::Failed);
+        assert!(entry.reason.contains("reverse binding"));
+    }
+
+    #[test]
+    fn apply_fails_closed_when_reverse_binding_repointed_at_write() {
+        // Plan classifies WouldPopulate, but the reverse index now points to a
+        // DIFFERENT coop_id before the apply write -> fail closed.
+        let coop_id = "coop_A";
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let mut mgr = legacy_manager_with(&[coop_id]);
+        let map = ReverseDriftMap {
+            coop_id: coop_id.to_string(),
+            entity_id: surrogate,
+            coop_for_entity_calls: std::cell::Cell::new(0),
+            drift: ReverseDrift::Different("other-coop".to_string()),
+        };
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.plan.would_populate, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.failed, 1);
+        assert!(mgr
+            .get_treasury_by_coop(coop_id)
+            .unwrap()
+            .entity_id()
+            .is_none());
+        let entry = &report.entries[0];
+        assert_eq!(entry.outcome, TreasuryEntityIdBackfillApplyOutcome::Failed);
+        assert!(entry.reason.contains("different coop_id"));
+    }
+
+    #[test]
+    fn apply_fails_closed_when_reverse_lookup_errors_at_write() {
+        // Plan classifies WouldPopulate, but the reverse lookup errors during the
+        // apply re-verify -> fail closed with the error surfaced.
+        let coop_id = "coop_A";
+        let surrogate = coop_eid("coop-legacy-deadbeef0123");
+        let mut mgr = legacy_manager_with(&[coop_id]);
+        let map = ReverseDriftMap {
+            coop_id: coop_id.to_string(),
+            entity_id: surrogate,
+            coop_for_entity_calls: std::cell::Cell::new(0),
+            drift: ReverseDrift::Error,
+        };
+
+        let report = mgr.apply_entity_id_backfill(&map);
+        assert_eq!(report.plan.would_populate, 1);
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.failed, 1);
+        assert!(mgr
+            .get_treasury_by_coop(coop_id)
+            .unwrap()
+            .entity_id()
+            .is_none());
+        let entry = &report.entries[0];
+        assert_eq!(entry.outcome, TreasuryEntityIdBackfillApplyOutcome::Failed);
+        assert!(entry.error.is_some());
+        assert!(entry.reason.contains("reverse-index"));
     }
 }


### PR DESCRIPTION
## What

Implements the **ADR-0084 controlled apply contract** for the treasury
`entity_id` backfill (#2082 lane) — the first *mutating* rung. It populates
`treasury.entity_id` for **only** the rows the read-only planner classifies as
`WouldPopulate`, behind an explicit, audited, fail-closed operator gate.

Follows the prior rungs: **#2258** read-only planner
(`TreasuryManager::plan_entity_id_backfill`), **#2262** read-only report
(`icnctl treasury entity-backfill-report`), and **#2263 / ADR-0084** (the apply
safety contract). Off `origin/main` `5ccbd370` (#2264).

## How

**Ledger core (`icn-ledger`)**
- `TreasuryManager::populate_treasury_entity_id_for_did` — `pub(crate)` storage
  seam. Locates the treasury by the **planner's exact `treasury_did`**, re-verifies
  its `coop_id` matches byte-for-byte, then populates `entity_id` and persists it
  (only `entity_id` changes; the `coop_id → treasury` index key is untouched).
  Persist-before-commit, so a storage error leaves both the store and the in-memory
  cache unchanged. Idempotent guard never overwrites an existing target. `pub(crate)`
  on purpose — only the contract-bound orchestrator can reach it, never an external
  caller with an arbitrary target.
- `TreasuryManager::apply_entity_id_backfill` + `TreasuryEntityIdBackfillApplyReport`
  / `…ApplyEntry` / `…ApplyOutcome` — drives **only** the planner's `WouldPopulate`
  set, skips every fail-closed class unchanged, re-verifies the trusted binding
  immediately before each write, and never writes the map. Report embeds the
  read-only plan (report shape) plus `applied` / `failed` counters and a per-row
  before/after + provenance audit. **Per-row** partial-failure semantics with
  explicit results (the treasury store has no all-or-nothing batch over rows);
  storage errors fail closed.

**CLI (`icnctl`)**
- `icnctl treasury entity-backfill-apply [--apply] [--confirm-apply] [--json]`.
  Dry-run by default (identical to the report; writes nothing). `--apply` alone
  **refuses** to mutate when any row would be populated; a second `--confirm-apply`
  is then required, so a write cannot be a single-flag accident. A missing ledger
  or cooperative store is reported, **never created** (apply included). Human +
  JSON output; JSON carries an explicit `mode`.

## Contract conformance (ADR-0084)

- Mutates **only** eligible treasury `entity_id` rows from the trusted,
  non-ambiguous binding.
- A `coop_id ↔ EntityId` mapping grants **zero** authority — it binds an identity
  *target*, never a permission.
- **No** `#2081` enforcement cutover; **no** enforcement-default change; **no**
  gateway behaviour change.
- **No** store creation; **no** lossy / silent `coop_id` normalization; **no** map
  mutation; fail-closed preserved throughout.
- Populating `entity_id` is authorization-relevant under
  `ICN_TREASURY_ENTITY_AUTH_MODE=enforce-trusted-resolver` (the stored `entity_id`
  is the membership target reachable in dev/test today), which is why apply is
  explicit, gated, and audited; default enforcement is unchanged.

## Risk

Adds a mutating path. Contained by: dry-run default + two-step confirmation; the
mutation only touches `entity_id` (coop_id preserved byte-for-byte, map untouched);
persist-before-commit + fail-closed storage handling; and the mutation set is
exactly the planner's `WouldPopulate` rows (no re-derivation). Enforcement default
and `#2081` are untouched.

## Test plan

- `icn-ledger`: 27 new unit tests. Apply core (14): would-populate-only,
  idempotent re-run, every fail-closed skip (already-populated, no-mapping,
  untrusted `UnknownLegacy`, non-cooperative, ambiguous reverse-mismatch),
  `coop_id` preserved byte-for-byte via a surrogate (entity identifier ≠ coop_id),
  persist + reload, map-never-written, JSON before/after/provenance. Reverse-binding
  revalidation (3): reverse index deleted / repointed / errored between plan and
  write all fail closed. Entity-index integrity (6): surrogate backfill indexes
  entity lookup, blocks duplicate entity registration, index survives store reload,
  normal entity registration still rejects duplicates, failed apply leaves no
  spurious index, hydration fails closed on a duplicate `entity_id`. Planned-DID
  write (4): duplicate `coop_id` hydration fails closed, the write targets and
  audits the exact planned `treasury_did`, and fails closed on a coop_id mismatch
  or a missing DID. Full `icn-ledger` lib suite: 461 pass.
- `icnctl`: 6 new integration tests — dry-run default writes nothing, `--apply`
  refuses without `--confirm-apply`, confirmed apply populates + persists only the
  eligible row, idempotent across runs, missing store creates nothing, and no
  confirmation needed when nothing is eligible. #2262 report test: 6 pass (shared
  renderer refactor).
- `cargo fmt --all --check`, `cargo clippy -p icn-ledger -p icnctl -p icn-gateway
  --all-targets -- -D warnings`, `git diff --check`: clean. Readiness-overclaim /
  compliance / firewall-denylist / drift linters: clean (meaning-firewall reports
  its 3 pre-existing baseline violations, exit 0). Full-workspace `cargo test` /
  `build --release` / TS-SDK / Accessibility deferred to CI (no API/OpenAPI/SDK
  or web surface changed).

### Review fixes (Codex P2)

- **Revalidate reverse binding before apply write** (`0bd55530`): apply re-runs the
  full forward + provenance + reverse-index check immediately before each write,
  so a binding that drifts between plan and write fails closed.
- **Preserve entity uniqueness after surrogate backfills** (`4785432c`): the ledger
  `TreasuryManager` now keeps an `EntityId → Did` index (maintained on
  entity-registration, apply-populate, and hydration, fail-closed on conflicts) so
  backfilled surrogate entities are unique-checked and findable by entity — without
  rewriting the legacy `coop_id`. The unused gateway `get_treasury_by_entity` helper
  (no callers) is repointed to that index; no route/enforcement/default change.
- **Use the planned treasury DID for backfill writes** (`fb578861`): the apply write
  now targets the planner row's exact `treasury_did` (re-verifying the row's `coop_id`
  byte-for-byte) instead of whichever row wins the `coop_id` index, and
  `load_from_store` rejects a duplicate `coop_id` (two treasuries, one coop_id)
  fail-closed rather than silently collapsing them. Mismatch / missing-DID / duplicate
  states fail closed; the audit entry's DID matches the mutated row.

No production / pilot / live-federation / security-complete claim.

Refs #2082


