### PR TITLE
feat(treasury): populate entity id at activation

### DIFF
--- a/icn/crates/icn-coop/src/actor.rs
+++ b/icn/crates/icn-coop/src/actor.rs
@@ -491,16 +491,41 @@ impl CoopActor {
                         .and_then(|members| members.first().map(|m| m.did.clone()))
                         .unwrap_or_else(|| treasury_did.clone());
 
+                    let description = Some(format!("Treasury for cooperative {}", coop_id));
                     let mut treasury_guard = treasury_mgr.write().await;
-                    treasury_guard
-                        .register_treasury(
-                            treasury_did.clone(),
-                            coop_id.clone(),
-                            "HOURS".to_string(),
-                            created_by,
-                            Some(format!("Treasury for cooperative {}", coop_id)),
-                        )
-                        .map_err(|e| crate::CoopError::Ledger(e.to_string()))?;
+
+                    // #2082: a treasury is born with its canonical cooperative
+                    // EntityId when the coop_id directly projects to a cooperative
+                    // slug — the same trusted, reject-not-normalize projection the
+                    // Activation-provenance map binding (below) records, so the two
+                    // agree. A non-projectable coop_id keeps entity_id: None (no
+                    // guessing); it is surrogate-bound and backfilled later. This
+                    // sets an identity target only: it grants no authority and does
+                    // not change enforcement mode/defaults.
+                    match project_coop_id(&coop_id) {
+                        Ok(entity_id) => {
+                            treasury_guard
+                                .register_treasury_with_entity(
+                                    treasury_did.clone(),
+                                    entity_id,
+                                    "HOURS".to_string(),
+                                    created_by,
+                                    description,
+                                )
+                                .map_err(|e| crate::CoopError::Ledger(e.to_string()))?;
+                        }
+                        Err(_) => {
+                            treasury_guard
+                                .register_treasury(
+                                    treasury_did.clone(),
+                                    coop_id.clone(),
+                                    "HOURS".to_string(),
+                                    created_by,
+                                    description,
+                                )
+                                .map_err(|e| crate::CoopError::Ledger(e.to_string()))?;
+                        }
+                    }
 
                     tracing::info!(
                         coop_id = %coop_id,
@@ -2028,8 +2053,8 @@ mod tests {
         );
     }
 
-    // T6: existing treasury behavior is preserved and PR2 does NOT populate
-    // treasury entity_id.
+    // T6: existing treasury registration behavior is preserved, and activation now
+    // populates treasury entity_id for a projectable coop_id (#2082).
     #[tokio::test]
     async fn test_activation_with_map_preserves_treasury_behavior() {
         let (handle, treasury_mgr, map) = spawn_test_actor_with_treasury_and_map();
@@ -2055,14 +2080,14 @@ mod tests {
             .expect("treasury must still register during activation");
         assert_eq!(treasury.coop_id, coop.id);
         assert!(treasury.is_active);
-        // PR2 must NOT populate treasury entity_id (deferred, separate change).
-        assert!(
-            treasury.entity_id().is_none(),
-            "PR2 must not populate treasury entity_id"
-        );
 
-        // The mappable coop_id is still bound as a pure name binding.
+        // Activation now populates treasury entity_id from the trusted, projectable
+        // binding (#2082): the treasury is born with the same cooperative EntityId
+        // that the Activation-provenance map binding records.
         let entity = EntityId::cooperative("treasury-coop").unwrap();
+        assert_eq!(treasury.entity_id(), Some(&entity));
+
+        // ...and the mappable coop_id is still bound as a pure name binding.
         assert_eq!(map.entity_for_coop("treasury-coop").unwrap(), Some(entity));
     }
 
@@ -2086,6 +2111,101 @@ mod tests {
             .unwrap();
         assert_eq!(activated.id, coop.id);
         assert!(activated.treasury_did.is_some());
+    }
+
+    // === Activation-time treasury entity_id population (#2082) ===
+    //
+    // A treasury created during activation is born with the SAME cooperative
+    // EntityId the Activation-provenance map binding records — but ONLY when the
+    // coop_id directly projects to a cooperative slug (reject-not-normalize). A
+    // non-projectable coop_id keeps entity_id: None (no guessing); it is bound via
+    // a surrogate and backfilled later. Population sets an identity target only and
+    // grants no authority; enforcement mode/defaults are untouched.
+
+    // A1: a projectable coop_id => the activation treasury is born with entity_id,
+    // its legacy coop_id is preserved byte-for-byte, and it agrees with the map.
+    #[tokio::test]
+    async fn test_activation_populates_treasury_entity_id_for_projectable_coop_id() {
+        let (handle, treasury_mgr, map) = spawn_test_actor_with_treasury_and_map();
+        let founder = create_test_did();
+        let coop = handle
+            .create_cooperative(
+                Some("activation-entity-coop".to_string()),
+                "Activation Entity Coop".to_string(),
+                CoopType::Worker,
+                founder,
+            )
+            .await
+            .unwrap();
+        handle
+            .activate_cooperative(coop.id.clone(), "charter".to_string())
+            .await
+            .unwrap();
+
+        let expected = EntityId::cooperative("activation-entity-coop").unwrap();
+
+        let guard = treasury_mgr.read().await;
+        let treasury = guard
+            .get_treasury_by_coop("activation-entity-coop")
+            .expect("treasury registered at activation");
+        // Born with the canonical cooperative EntityId...
+        assert_eq!(treasury.entity_id(), Some(&expected));
+        // ...while the legacy coop_id is preserved byte-for-byte (no normalization).
+        assert_eq!(treasury.coop_id(), "activation-entity-coop");
+        // ...resolvable via the entity index.
+        assert_eq!(
+            guard
+                .get_treasury_by_entity(&expected)
+                .map(|t| t.coop_id().to_string()),
+            Some("activation-entity-coop".to_string())
+        );
+        // ...and consistent with the durable Activation-provenance map binding.
+        assert_eq!(
+            map.entity_for_coop("activation-entity-coop").unwrap(),
+            Some(expected)
+        );
+    }
+
+    // A2: a non-projectable coop_id must NOT guess an entity_id — the treasury
+    // stays legacy (entity_id: None), exactly as before, and the map stays empty.
+    #[tokio::test]
+    async fn test_activation_does_not_populate_entity_id_for_non_projectable_coop_id() {
+        let (handle, treasury_mgr, map) = spawn_test_actor_with_treasury_and_map();
+        let founder = create_test_did();
+        // Default-generated id is `coop:<uuid>` — the colon makes it a non-slug.
+        let coop = handle
+            .create_cooperative(
+                None,
+                "Non Projectable".to_string(),
+                CoopType::Worker,
+                founder,
+            )
+            .await
+            .unwrap();
+        assert!(
+            coop.id.starts_with("coop:"),
+            "expected default coop:<uuid> id, got {}",
+            coop.id
+        );
+        handle
+            .activate_cooperative(coop.id.clone(), "charter".to_string())
+            .await
+            .unwrap();
+
+        let guard = treasury_mgr.read().await;
+        let treasury = guard
+            .get_treasury_by_coop(&coop.id)
+            .expect("treasury registered at activation");
+        assert!(
+            treasury.entity_id().is_none(),
+            "a non-projectable coop_id must not receive a guessed entity_id"
+        );
+        assert_eq!(treasury.coop_id(), coop.id);
+        assert_eq!(
+            map.entity_for_coop(&coop.id).unwrap(),
+            None,
+            "a non-mappable id must not be bound"
+        );
     }
 
     // === bind_coop_entity_map outcome helper (pure, no actor) ===

--- a/icn/crates/icn-coop/src/actor.rs
+++ b/icn/crates/icn-coop/src/actor.rs
@@ -8,7 +8,7 @@ use icn_entity::{
 use icn_gossip::GossipActor;
 use icn_governance::charter::FounderSignature;
 use icn_identity::Did;
-use icn_ledger::TreasuryManager;
+use icn_ledger::{TreasuryEntityIdPopulateResult, TreasuryManager};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, RwLock};
 use tracing::{debug, info, warn};
@@ -454,13 +454,80 @@ impl CoopActor {
         let coop = self.store.get_cooperative(&coop_id)?;
         let (mut coop, treasury_id) = self.lifecycle.activate(coop, charter_hash).await?;
 
-        // Non-authoritative name binding (#2082): record the canonical
-        // `coop_id ↔ EntityId` mapping when a map is wired. Done BEFORE treasury
-        // registration so a new treasury can be born with EXACTLY the EntityId the
-        // Activation-provenance bind durably recorded — never one the bind then
-        // refuses. A binding grants NO authority; a bind failure (NotMappable /
-        // Conflict / StorageError, including the common default `coop:<uuid>` case)
-        // is reported but never fails activation.
+        // Deterministic ledger treasury DID for this cooperative — used both for
+        // registration below and for the post-commit entity_id populate.
+        let ledger_treasury_did = {
+            let anchor = crate::lifecycle::derive_treasury_anchor(&coop_id);
+            let mut anchor_32 = [0u8; 32];
+            anchor_32[..16].copy_from_slice(&anchor);
+            Did::from_anchor_id(&anchor_32)
+        };
+
+        // Assign treasury DID onto cooperative if not already set (idempotency guard).
+        // This must happen before persisting so the saved record is complete.
+        if coop.treasury_did.is_none() {
+            let treasury_did_str = crate::lifecycle::derive_treasury_did(&coop_id);
+
+            coop.assign_treasury(treasury_did_str.clone())
+                .map_err(crate::CoopError::Governance)?;
+
+            // Register the treasury in the ledger with entity_id: None. The canonical
+            // entity_id is populated AFTER activation commits (below), so neither the
+            // trusted map binding nor this treasury's identity target is written
+            // before the activation record and treasury side effects have succeeded.
+            if let Some(ref treasury_mgr) = self.treasury_manager {
+                // Idempotency guard: if treasury is already registered (e.g. a prior activation
+                // attempt crashed after register_treasury but before save_cooperative), skip
+                // registration so that retries do not fail forever.
+                let already_registered = {
+                    let guard = treasury_mgr.read().await;
+                    guard.get_treasury_by_coop(&coop_id).is_some()
+                };
+
+                if already_registered {
+                    tracing::info!(
+                        coop_id = %coop_id,
+                        treasury_did = %ledger_treasury_did,
+                        "Treasury already registered in ledger; skipping duplicate registration"
+                    );
+                } else {
+                    let created_by = self
+                        .store
+                        .list_members(&coop_id)
+                        .ok()
+                        .and_then(|members| members.first().map(|m| m.did.clone()))
+                        .unwrap_or_else(|| ledger_treasury_did.clone());
+
+                    let mut treasury_guard = treasury_mgr.write().await;
+                    treasury_guard
+                        .register_treasury(
+                            ledger_treasury_did.clone(),
+                            coop_id.clone(),
+                            "HOURS".to_string(),
+                            created_by,
+                            Some(format!("Treasury for cooperative {}", coop_id)),
+                        )
+                        .map_err(|e| crate::CoopError::Ledger(e.to_string()))?;
+
+                    tracing::info!(
+                        coop_id = %coop_id,
+                        treasury_id = %treasury_id,
+                        treasury_did = %ledger_treasury_did,
+                        "Registered treasury in ledger during activation"
+                    );
+                }
+            }
+        }
+
+        self.store.save_cooperative(&coop)?;
+
+        // Activation record + treasury row are now committed. Record the canonical
+        // `coop_id ↔ EntityId` name binding LAST (#2082): a trusted
+        // Activation-provenance row must never be durably written before activation
+        // commits, so a failed activation cannot leave trusted evidence for a
+        // cooperative that never activated. A binding grants NO authority; a bind
+        // failure (NotMappable / Conflict / StorageError, incl. the common default
+        // `coop:<uuid>` case) is reported, never failing activation.
         let bound_entity_id: Option<EntityId> = if let Some(ref map) = self.coop_entity_map {
             match bind_coop_entity_map_activation(map.as_ref(), &coop_id) {
                 EntityMapBindOutcome::Mapped(entity_id) => {
@@ -508,99 +575,51 @@ impl CoopActor {
             None
         };
 
-        // Assign treasury DID onto cooperative if not already set (idempotency guard).
-        // This must happen before persisting so the saved record is complete.
-        if coop.treasury_did.is_none() {
-            let treasury_did_str = crate::lifecycle::derive_treasury_did(&coop_id);
-
-            coop.assign_treasury(treasury_did_str.clone())
-                .map_err(crate::CoopError::Governance)?;
-
-            // Register treasury account in ledger if treasury manager is available
-            if let Some(ref treasury_mgr) = self.treasury_manager {
-                let anchor = crate::lifecycle::derive_treasury_anchor(&coop_id);
-                let mut anchor_32 = [0u8; 32];
-                anchor_32[..16].copy_from_slice(&anchor);
-                let treasury_did = Did::from_anchor_id(&anchor_32);
-
-                // Idempotency guard: if treasury is already registered (e.g. a prior activation
-                // attempt crashed after register_treasury but before save_cooperative), skip
-                // registration so that retries do not fail forever.
-                let already_registered = {
-                    let guard = treasury_mgr.read().await;
-                    guard.get_treasury_by_coop(&coop_id).is_some()
-                };
-
-                if already_registered {
-                    tracing::info!(
-                        coop_id = %coop_id,
-                        treasury_did = %treasury_did,
-                        "Treasury already registered in ledger; skipping duplicate registration"
-                    );
-                } else {
-                    let created_by = self
-                        .store
-                        .list_members(&coop_id)
-                        .ok()
-                        .and_then(|members| members.first().map(|m| m.did.clone()))
-                        .unwrap_or_else(|| treasury_did.clone());
-
-                    let description = Some(format!("Treasury for cooperative {}", coop_id));
-                    let mut treasury_guard = treasury_mgr.write().await;
-
-                    // #2082: a treasury is born with its canonical cooperative
-                    // EntityId. When a map is wired, use ONLY the EntityId the
-                    // Activation-provenance bind above actually recorded, so
-                    // treasury.entity_id() can never disagree with the map — a
-                    // Conflict / StorageError / NotMappable bind falls back to legacy
-                    // entity_id: None. When no map is wired, birth from the pure
-                    // reject-not-normalize projection directly (there is no map to
-                    // disagree with). A non-projectable coop_id keeps entity_id: None
-                    // (no guessing) and may later be surrogate-bound only through an
-                    // explicit operator workflow, never automatically here. This sets
-                    // an identity target only: it grants no authority and does not
-                    // change enforcement mode/defaults.
-                    let entity_id = if self.coop_entity_map.is_some() {
-                        bound_entity_id
-                    } else {
-                        project_coop_id(&coop_id).ok()
-                    };
-                    match entity_id {
-                        Some(entity_id) => {
-                            treasury_guard
-                                .register_treasury_with_entity(
-                                    treasury_did.clone(),
-                                    entity_id,
-                                    "HOURS".to_string(),
-                                    created_by,
-                                    description,
-                                )
-                                .map_err(|e| crate::CoopError::Ledger(e.to_string()))?;
-                        }
-                        None => {
-                            treasury_guard
-                                .register_treasury(
-                                    treasury_did.clone(),
-                                    coop_id.clone(),
-                                    "HOURS".to_string(),
-                                    created_by,
-                                    description,
-                                )
-                                .map_err(|e| crate::CoopError::Ledger(e.to_string()))?;
-                        }
-                    }
-
-                    tracing::info!(
-                        coop_id = %coop_id,
-                        treasury_id = %treasury_id,
-                        treasury_did = %treasury_did,
-                        "Registered treasury in ledger during activation"
-                    );
-                }
+        // Populate the just-committed treasury's entity_id from the trusted binding
+        // (#2082). When a map is wired, use ONLY the EntityId the bind actually
+        // recorded (Mapped) — a Conflict/StorageError/NotMappable bind leaves the
+        // treasury entity_id: None, so it can never disagree with the map. When no
+        // map is wired, use the pure reject-not-normalize projection (there is no map
+        // to disagree with). The populate is idempotent and fail-closed (byte-for-byte
+        // coop_id check + entity-uniqueness guard); a skip or failure never fails the
+        // already-committed activation — the #2265 operator backfill can complete it
+        // later. This sets an identity target only: it grants no authority.
+        let entity_id_to_populate: Option<EntityId> = if self.coop_entity_map.is_some() {
+            bound_entity_id
+        } else {
+            project_coop_id(&coop_id).ok()
+        };
+        if let (Some(entity_id), Some(treasury_mgr)) =
+            (entity_id_to_populate, self.treasury_manager.as_ref())
+        {
+            let mut treasury_guard = treasury_mgr.write().await;
+            match treasury_guard.populate_entity_id_at_activation(
+                &ledger_treasury_did,
+                &coop_id,
+                entity_id,
+            ) {
+                Ok(TreasuryEntityIdPopulateResult::Populated) => tracing::info!(
+                    target: "coop_entity_bind",
+                    coop_id = %coop_id,
+                    treasury_did = %ledger_treasury_did,
+                    "populated treasury entity_id from trusted activation binding (identity target only; grants no authority)"
+                ),
+                Ok(other) => tracing::info!(
+                    target: "coop_entity_bind",
+                    coop_id = %coop_id,
+                    treasury_did = %ledger_treasury_did,
+                    outcome = ?other,
+                    "treasury entity_id not populated at activation (idempotent/fail-closed skip); activation unaffected"
+                ),
+                Err(e) => tracing::error!(
+                    target: "coop_entity_bind",
+                    coop_id = %coop_id,
+                    treasury_did = %ledger_treasury_did,
+                    error = %e,
+                    "treasury entity_id populate failed at activation; left None (backfillable); activation NOT failed"
+                ),
             }
         }
-
-        self.store.save_cooperative(&coop)?;
 
         tracing::info!(
             coop_id = %coop.id,
@@ -2122,8 +2141,8 @@ mod tests {
         assert!(treasury.is_active);
 
         // Activation now populates treasury entity_id from the trusted, projectable
-        // binding (#2082): the treasury is born with the same cooperative EntityId
-        // that the Activation-provenance map binding records.
+        // binding (#2082): once activation commits, the treasury carries the same
+        // cooperative EntityId that the Activation-provenance map binding records.
         let entity = EntityId::cooperative("treasury-coop").unwrap();
         assert_eq!(treasury.entity_id(), Some(&entity));
 
@@ -2155,16 +2174,18 @@ mod tests {
 
     // === Activation-time treasury entity_id population (#2082) ===
     //
-    // A treasury created during activation is born with the SAME cooperative
-    // EntityId the Activation-provenance map binding records — but ONLY when the
-    // coop_id directly projects to a cooperative slug (reject-not-normalize). A
-    // non-projectable coop_id keeps entity_id: None (no guessing) here and may later
-    // be surrogate-bound only through an explicit operator workflow, never
-    // automatically on this path. Population sets an identity target only and grants
-    // no authority; enforcement mode/defaults are untouched.
+    // A treasury registered during activation is populated (after the activation
+    // record commits) with the SAME cooperative EntityId the Activation-provenance
+    // map binding records — but ONLY when the coop_id directly projects to a
+    // cooperative slug (reject-not-normalize). A non-projectable coop_id keeps
+    // entity_id: None (no guessing) here and may later be surrogate-bound only
+    // through an explicit operator workflow, never automatically on this path.
+    // Population sets an identity target only and grants no authority; enforcement
+    // mode/defaults are untouched.
 
-    // A1: a projectable coop_id => the activation treasury is born with entity_id,
-    // its legacy coop_id is preserved byte-for-byte, and it agrees with the map.
+    // A1: a projectable coop_id => the activation treasury is populated with
+    // entity_id, its legacy coop_id is preserved byte-for-byte, and it agrees with
+    // the map.
     #[tokio::test]
     async fn test_activation_populates_treasury_entity_id_for_projectable_coop_id() {
         let (handle, treasury_mgr, map) = spawn_test_actor_with_treasury_and_map();
@@ -2250,7 +2271,7 @@ mod tests {
     }
 
     // A3: when a map is wired but the Activation bind is refused (here: a pre-seeded
-    // Conflict), the treasury must NOT be born with a projected entity_id it would
+    // Conflict), the treasury must NOT be populated with a projected entity_id it would
     // then disagree with — it falls back to entity_id: None. Activation still
     // succeeds. (Guards against the gateway trusting a stored treasury entity_id that
     // the canonical map never recorded.)

--- a/icn/crates/icn-coop/src/actor.rs
+++ b/icn/crates/icn-coop/src/actor.rs
@@ -454,6 +454,60 @@ impl CoopActor {
         let coop = self.store.get_cooperative(&coop_id)?;
         let (mut coop, treasury_id) = self.lifecycle.activate(coop, charter_hash).await?;
 
+        // Non-authoritative name binding (#2082): record the canonical
+        // `coop_id ↔ EntityId` mapping when a map is wired. Done BEFORE treasury
+        // registration so a new treasury can be born with EXACTLY the EntityId the
+        // Activation-provenance bind durably recorded — never one the bind then
+        // refuses. A binding grants NO authority; a bind failure (NotMappable /
+        // Conflict / StorageError, including the common default `coop:<uuid>` case)
+        // is reported but never fails activation.
+        let bound_entity_id: Option<EntityId> = if let Some(ref map) = self.coop_entity_map {
+            match bind_coop_entity_map_activation(map.as_ref(), &coop_id) {
+                EntityMapBindOutcome::Mapped(entity_id) => {
+                    tracing::info!(
+                        target: "coop_entity_bind",
+                        coop_id = %coop_id,
+                        entity_id = %entity_id,
+                        outcome = "mapped",
+                        "bound coop_id to cooperative EntityId during activation (name binding only; grants no authority)"
+                    );
+                    Some(entity_id)
+                }
+                EntityMapBindOutcome::NotMappable(reason) => {
+                    tracing::info!(
+                        target: "coop_entity_bind",
+                        coop_id = %coop_id,
+                        outcome = "not_mappable",
+                        reason = %reason,
+                        "coop_id is not a mappable cooperative EntityId slug; left unbound; activation unaffected"
+                    );
+                    None
+                }
+                EntityMapBindOutcome::Conflict(reason) => {
+                    tracing::error!(
+                        target: "coop_entity_bind",
+                        coop_id = %coop_id,
+                        outcome = "conflict",
+                        reason = %reason,
+                        "coop_id/entity mapping conflict during activation; binding skipped; activation NOT failed"
+                    );
+                    None
+                }
+                EntityMapBindOutcome::StorageError(reason) => {
+                    tracing::error!(
+                        target: "coop_entity_bind",
+                        coop_id = %coop_id,
+                        outcome = "storage_error",
+                        reason = %reason,
+                        "coop_entity_map bind failed during activation; binding skipped; activation NOT failed"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         // Assign treasury DID onto cooperative if not already set (idempotency guard).
         // This must happen before persisting so the saved record is complete.
         if coop.treasury_did.is_none() {
@@ -495,17 +549,24 @@ impl CoopActor {
                     let mut treasury_guard = treasury_mgr.write().await;
 
                     // #2082: a treasury is born with its canonical cooperative
-                    // EntityId when the coop_id directly projects to a cooperative
-                    // slug — the same trusted, reject-not-normalize projection the
-                    // Activation-provenance map binding (below) records, so the two
-                    // agree. A non-projectable coop_id keeps entity_id: None (no
-                    // guessing) here — the map bind below reports NotMappable — and
-                    // may later be surrogate-bound only through an explicit operator
-                    // workflow, never automatically on this path. This sets an
-                    // identity target only: it grants no authority and does not
+                    // EntityId. When a map is wired, use ONLY the EntityId the
+                    // Activation-provenance bind above actually recorded, so
+                    // treasury.entity_id() can never disagree with the map — a
+                    // Conflict / StorageError / NotMappable bind falls back to legacy
+                    // entity_id: None. When no map is wired, birth from the pure
+                    // reject-not-normalize projection directly (there is no map to
+                    // disagree with). A non-projectable coop_id keeps entity_id: None
+                    // (no guessing) and may later be surrogate-bound only through an
+                    // explicit operator workflow, never automatically here. This sets
+                    // an identity target only: it grants no authority and does not
                     // change enforcement mode/defaults.
-                    match project_coop_id(&coop_id) {
-                        Ok(entity_id) => {
+                    let entity_id = if self.coop_entity_map.is_some() {
+                        bound_entity_id
+                    } else {
+                        project_coop_id(&coop_id).ok()
+                    };
+                    match entity_id {
+                        Some(entity_id) => {
                             treasury_guard
                                 .register_treasury_with_entity(
                                     treasury_did.clone(),
@@ -516,7 +577,7 @@ impl CoopActor {
                                 )
                                 .map_err(|e| crate::CoopError::Ledger(e.to_string()))?;
                         }
-                        Err(_) => {
+                        None => {
                             treasury_guard
                                 .register_treasury(
                                     treasury_did.clone(),
@@ -540,43 +601,6 @@ impl CoopActor {
         }
 
         self.store.save_cooperative(&coop)?;
-
-        // Non-authoritative name binding (#2082 PR2): record the canonical
-        // `coop_id ↔ EntityId` mapping when a map is wired. A binding grants NO
-        // authority, and a bind failure — including the common NotMappable case
-        // for default `coop:<uuid>` ids — is reported but never fails activation.
-        if let Some(ref map) = self.coop_entity_map {
-            match bind_coop_entity_map_activation(map.as_ref(), &coop_id) {
-                EntityMapBindOutcome::Mapped(entity_id) => tracing::info!(
-                    target: "coop_entity_bind",
-                    coop_id = %coop_id,
-                    entity_id = %entity_id,
-                    outcome = "mapped",
-                    "bound coop_id to cooperative EntityId during activation (name binding only; grants no authority)"
-                ),
-                EntityMapBindOutcome::NotMappable(reason) => tracing::info!(
-                    target: "coop_entity_bind",
-                    coop_id = %coop_id,
-                    outcome = "not_mappable",
-                    reason = %reason,
-                    "coop_id is not a mappable cooperative EntityId slug; left unbound; activation unaffected"
-                ),
-                EntityMapBindOutcome::Conflict(reason) => tracing::error!(
-                    target: "coop_entity_bind",
-                    coop_id = %coop_id,
-                    outcome = "conflict",
-                    reason = %reason,
-                    "coop_id/entity mapping conflict during activation; binding skipped; activation NOT failed"
-                ),
-                EntityMapBindOutcome::StorageError(reason) => tracing::error!(
-                    target: "coop_entity_bind",
-                    coop_id = %coop_id,
-                    outcome = "storage_error",
-                    reason = %reason,
-                    "coop_entity_map bind failed during activation; binding skipped; activation NOT failed"
-                ),
-            }
-        }
 
         tracing::info!(
             coop_id = %coop.id,
@@ -2223,6 +2247,51 @@ mod tests {
             None,
             "a non-mappable id must not be bound"
         );
+    }
+
+    // A3: when a map is wired but the Activation bind is refused (here: a pre-seeded
+    // Conflict), the treasury must NOT be born with a projected entity_id it would
+    // then disagree with — it falls back to entity_id: None. Activation still
+    // succeeds. (Guards against the gateway trusting a stored treasury entity_id that
+    // the canonical map never recorded.)
+    #[tokio::test]
+    async fn test_activation_does_not_populate_entity_id_when_map_bind_conflicts() {
+        let (handle, treasury_mgr, map) = spawn_test_actor_with_treasury_and_map();
+        let founder = create_test_did();
+
+        // Pre-seed a conflicting binding: conflict-coop -> a DIFFERENT cooperative
+        // entity, so the activation bind (conflict-coop -> its own projection) is
+        // refused as Conflict.
+        let decoy = EntityId::cooperative("decoy-entity").unwrap();
+        map.bind_resolved("conflict-coop", &decoy).unwrap();
+
+        let coop = handle
+            .create_cooperative(
+                Some("conflict-coop".to_string()),
+                "Conflict Coop".to_string(),
+                CoopType::Worker,
+                founder,
+            )
+            .await
+            .unwrap();
+        let activated = handle
+            .activate_cooperative(coop.id.clone(), "charter".to_string())
+            .await
+            .unwrap();
+        // A refused bind must never fail activation.
+        assert_eq!(activated.id, coop.id);
+
+        let guard = treasury_mgr.read().await;
+        let treasury = guard
+            .get_treasury_by_coop("conflict-coop")
+            .expect("treasury registered at activation");
+        assert!(
+            treasury.entity_id().is_none(),
+            "a refused (Conflict) map bind must not populate treasury entity_id"
+        );
+        assert_eq!(treasury.coop_id(), "conflict-coop");
+        // The pre-seeded (conflicting) binding is untouched; our coop was never bound.
+        assert_eq!(map.entity_for_coop("conflict-coop").unwrap(), Some(decoy));
     }
 
     // === bind_coop_entity_map outcome helper (pure, no actor) ===

--- a/icn/crates/icn-coop/src/actor.rs
+++ b/icn/crates/icn-coop/src/actor.rs
@@ -499,9 +499,11 @@ impl CoopActor {
                     // slug — the same trusted, reject-not-normalize projection the
                     // Activation-provenance map binding (below) records, so the two
                     // agree. A non-projectable coop_id keeps entity_id: None (no
-                    // guessing); it is surrogate-bound and backfilled later. This
-                    // sets an identity target only: it grants no authority and does
-                    // not change enforcement mode/defaults.
+                    // guessing) here — the map bind below reports NotMappable — and
+                    // may later be surrogate-bound only through an explicit operator
+                    // workflow, never automatically on this path. This sets an
+                    // identity target only: it grants no authority and does not
+                    // change enforcement mode/defaults.
                     match project_coop_id(&coop_id) {
                         Ok(entity_id) => {
                             treasury_guard
@@ -1924,6 +1926,20 @@ mod tests {
         assert_eq!(treasury.coop_id, coop.id);
         assert_eq!(treasury.currency, "HOURS");
         assert!(treasury.is_active);
+
+        // spawn_with_treasury wires a TreasuryManager but NO coop/entity map:
+        // activation still populates entity_id for a projectable coop_id by direct
+        // projection alone (no map store required, none written, no authority
+        // granted), and the legacy coop_id is preserved byte-for-byte.
+        let expected = EntityId::cooperative("activate-ledger-coop").unwrap();
+        assert_eq!(treasury.entity_id(), Some(&expected));
+        assert_eq!(treasury.coop_id(), "activate-ledger-coop");
+        assert_eq!(
+            guard
+                .get_treasury_by_entity(&expected)
+                .map(|t| t.coop_id().to_string()),
+            Some("activate-ledger-coop".to_string())
+        );
     }
 
     #[tokio::test]
@@ -2118,9 +2134,10 @@ mod tests {
     // A treasury created during activation is born with the SAME cooperative
     // EntityId the Activation-provenance map binding records — but ONLY when the
     // coop_id directly projects to a cooperative slug (reject-not-normalize). A
-    // non-projectable coop_id keeps entity_id: None (no guessing); it is bound via
-    // a surrogate and backfilled later. Population sets an identity target only and
-    // grants no authority; enforcement mode/defaults are untouched.
+    // non-projectable coop_id keeps entity_id: None (no guessing) here and may later
+    // be surrogate-bound only through an explicit operator workflow, never
+    // automatically on this path. Population sets an identity target only and grants
+    // no authority; enforcement mode/defaults are untouched.
 
     // A1: a projectable coop_id => the activation treasury is born with entity_id,
     // its legacy coop_id is preserved byte-for-byte, and it agrees with the map.

--- a/icn/crates/icn-ledger/src/lib.rs
+++ b/icn/crates/icn-ledger/src/lib.rs
@@ -113,7 +113,8 @@ pub use settlement::{
 pub use sync::{deserialize_sync_message, ledger_topic, serialize_sync_message, LedgerSyncMessage};
 pub use treasury::{
     ApprovalType, BudgetStatus, PaginatedAuditTrail, SpendingRule, Treasury, TreasuryAuditRecord,
-    TreasuryBudget, TreasuryManager, TreasuryOperation, VelocityLimit, VelocityWindow,
+    TreasuryBudget, TreasuryEntityIdPopulateResult, TreasuryManager, TreasuryOperation,
+    VelocityLimit, VelocityWindow,
 };
 pub use treasury_entity_backfill::{
     plan_treasury_entity_id_backfill, TreasuryEntityIdBackfillAction,

--- a/icn/crates/icn-ledger/src/treasury.rs
+++ b/icn/crates/icn-ledger/src/treasury.rs
@@ -266,10 +266,13 @@ pub struct TreasuryManager {
     surplus_allocations: HashMap<String, SurplusAllocation>,
 }
 
-/// Outcome of the contract-bound treasury `entity_id` backfill storage seam
-/// ([`TreasuryManager::populate_treasury_entity_id_for_did`], ADR-0084).
+/// Outcome of the treasury `entity_id` populate storage seam
+/// ([`TreasuryManager::populate_treasury_entity_id_for_did`]). Reached by the
+/// contract-bound operator backfill (ADR-0084) and by activation-time population
+/// ([`TreasuryManager::populate_entity_id_at_activation`], #2082); both go through
+/// the same fail-closed write.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TreasuryEntityIdPopulateResult {
+pub enum TreasuryEntityIdPopulateResult {
     /// `entity_id` was populated (`None → Some`) and persisted.
     Populated,
     /// The treasury already carried an `entity_id`; nothing was changed
@@ -1137,11 +1140,13 @@ impl TreasuryManager {
     /// mismatch fails closed.
     ///
     /// A `coop_id ↔ EntityId` mapping grants **zero** authority — this writes an
-    /// identity *target*, never a permission. The method is `pub(crate)` on
-    /// purpose: only the contract-bound
-    /// [`TreasuryManager::apply_entity_id_backfill`] orchestrator — which
-    /// restricts mutation to the planner's `WouldPopulate` rows — may reach it,
-    /// never an external caller with an arbitrary target.
+    /// identity *target*, never a permission. The method stays `pub(crate)`:
+    /// external callers reach this seam only through the contract-bound
+    /// [`TreasuryManager::apply_entity_id_backfill`] orchestrator (which restricts
+    /// mutation to the planner's `WouldPopulate` rows) or the activation-time
+    /// [`TreasuryManager::populate_entity_id_at_activation`] wrapper — both pass a
+    /// target derived from a trusted binding, never an arbitrary one. The
+    /// fail-closed checks below hold regardless of caller.
     ///
     /// Fail-closed and idempotent:
     /// - a missing planned DID is a no-op
@@ -1211,6 +1216,27 @@ impl TreasuryManager {
         self.entity_treasuries
             .insert(entity_id, treasury_did.clone());
         Ok(TreasuryEntityIdPopulateResult::Populated)
+    }
+
+    /// Activation-time entry point (#2082) to the fail-closed `entity_id` populate
+    /// seam ([`populate_treasury_entity_id_for_did`](Self::populate_treasury_entity_id_for_did)).
+    ///
+    /// A cooperative's treasury is registered with `entity_id: None`, its
+    /// activation record is committed, the canonical `coop_id ↔ EntityId` binding is
+    /// recorded, and only then is this called to populate the treasury from the
+    /// EntityId that binding produced (or the direct projection when no map store is
+    /// wired). It verifies `coop_id` byte-for-byte, never overwrites an existing
+    /// target, and enforces entity uniqueness — so a treasury never carries an
+    /// identity the map did not record. It sets an identity *target* only and grants
+    /// no authority; the caller must not fail activation on a non-`Populated`
+    /// outcome (the operator backfill can complete it later).
+    pub fn populate_entity_id_at_activation(
+        &mut self,
+        treasury_did: &Did,
+        expected_coop_id: &str,
+        entity_id: EntityId,
+    ) -> Result<TreasuryEntityIdPopulateResult> {
+        self.populate_treasury_entity_id_for_did(treasury_did, expected_coop_id, entity_id)
     }
 }
 


### PR DESCRIPTION
## What

Populate a treasury's canonical `entity_id` **at cooperative activation** so a newly
activated cooperative's treasury is *born* with the same `EntityId` that the
activation flow already records in the canonical `coop_id ↔ EntityId` map with
trusted `Activation` provenance — but only when the `coop_id` **directly projects**
to a cooperative slug. A non-projectable `coop_id` keeps today's `entity_id: None`
(reject-not-normalize, no guessing).

Single production seam changed: `CoopActor::handle_activate_cooperative`
(`icn/crates/icn-coop/src/actor.rs`). When the trusted projection succeeds the
activation treasury is registered via `register_treasury_with_entity(...)` instead
of the legacy `register_treasury(...)`; otherwise the legacy path is unchanged.

## Why

`#2082` requires the canonical `coop_id ↔ EntityId` mapping to be **"persisted per
coop at activation"** (RFC-0018 §1). The mapping side of that already lands
(`bind_coop_entity_map_activation`, #2104/#2193), and the retroactive treasury
consumer path landed as plan → report → controlled apply (#2258 / #2262 / #2265,
under ADR-0084). But every treasury was still **born** `entity_id: None` and could
only be corrected by a later backfill run — an endless treadmill for every new
cooperative. This ends that treadmill structurally: new treasuries are correct at birth,
so the retroactive apply is only ever needed for genuinely legacy rows.

This is one of the remaining follow-ups Matt enumerated on #2082 (activation-time
treasury `entity_id` population alongside the map binding).

## How

- In `handle_activate_cooperative`, at the point a **new** treasury is registered
  (guarded by `treasury_did.is_none()` + the existing `already_registered`
  idempotency check), branch on `project_coop_id(&coop_id)`:
  - `Ok(entity_id)` → `register_treasury_with_entity(treasury_did, entity_id, "HOURS", created_by, desc)`
  - `Err(_)` (non-projectable) → `register_treasury(...)` exactly as before.
- `project_coop_id` is the same pure, reject-not-normalize projection the
  Activation-provenance map bind (later in the same handler) uses, so the
  treasury's `entity_id` and the durable map binding are guaranteed identical.
- `coop_id` is preserved **byte-for-byte**: for a projectable id `c`,
  `project_coop_id(c).identifier() == c` (verified — `EntityId::cooperative`
  stores the slug verbatim), so `register_treasury_with_entity` derives the exact
  same `coop_id` string and `coop_treasuries` index as the legacy call; the
  `get_treasury_by_coop(&coop_id)` idempotency guard still matches.

## Risk / auth-safety

`treasury.entity_id()` is read by the treasury entity-auth gate (`require_entity_access`,
ADR-0035). This change is authorization-safe:

- **Default posture (`ICN_TREASURY_ENTITY_AUTH_MODE` unset / observe-only) changes
  zero route outcomes** — the gate only records an observation. No gateway route
  behavior changes.
- **Strictly safer than the #2265 backfill apply.** ADR-0084's hazard is mutating an
  *existing* treasury whose in-flight requests enforcement already relies on. Here
  the treasury is **born** with the value: there is no prior `entity_id: None` state
  a request could have been evaluated against, so no existing request outcome can
  change. Under enforce mode (opt-in, not default, #2081 not cut over) the new
  treasury is simply checked against its own correct cooperative entity.
- **Zero-authority doctrine preserved.** The mapping/`entity_id` binds an identity
  *target*; it grants no permission. Authority still derives from membership/roles/
  capabilities.
- **No map mutation** beyond the existing `bind_coop_entity_map_activation` call. No
  `coop_id` normalization. No `#2081` enforcement/default/route change.

## Test plan

New (`icn-coop` lib tests):
- `test_activation_populates_treasury_entity_id_for_projectable_coop_id` — projectable
  id ⇒ treasury born with `Some(EntityId::cooperative(coop_id))`, `coop_id` preserved
  byte-for-byte, resolvable via the entity index, consistent with the map binding.
- `test_activation_does_not_populate_entity_id_for_non_projectable_coop_id` — default
  `coop:<uuid>` ⇒ treasury stays `entity_id: None` (no guess), map stays empty.

Updated:
- `test_activation_with_map_preserves_treasury_behavior` — flipped from asserting the
  now-implemented deferred gap (`entity_id().is_none()`) to asserting activation now
  populates `entity_id` while preserving `coop_id` and the map binding.

Validation: `cargo fmt --all --check`, `cargo clippy -p icn-coop --all-targets -- -D warnings`,
`cargo test -p icn-coop`, `git diff --check`.

## Scope notes (not in this PR)

- The sibling `CreateTreasury` message path (`handle_create_treasury`) still creates
  `entity_id: None` treasuries; it does not own a trusted binding in its existing
  semantics. Same-class follow-up, deliberately out of scope here.
- The parallel `apps/membership` `coop_core` actor does not bind the map at
  activation at all; wiring it is a separate rung.
- `UnknownLegacy` evidence/repair reporting remains a separate remaining `#2082`
  follow-up.

Refs #2082. Does not touch #2081.
