### PR TITLE
fix(runtime): drop local wall-clock from membership state_change_hash

### DIFF
--- a/icn/crates/icn-core/src/services/membership_service.rs
+++ b/icn/crates/icn-core/src/services/membership_service.rs
@@ -72,12 +72,27 @@ impl MembershipServiceImpl {
     }
 
     /// Compute a state change hash for an operation.
+    ///
+    /// This hash is contractually **cross-node deterministic**: two
+    /// independent nodes replaying the same governance decision (same
+    /// operation, entity, member, and `decision_receipt_id`) must produce
+    /// the same value — see
+    /// `crates/icn-core/tests/federated_two_node_pilot.rs`. It therefore
+    /// hashes only decision-derived inputs and **must never** include a
+    /// local execution wall-clock: `decision_receipt_id` is unique per
+    /// governance decision, so it (not a timestamp) supplies cross-decision
+    /// uniqueness. Mixing in `icn_time::current_timestamp_secs()` here made
+    /// the hash diverge across nodes whenever the seconds boundary ticked
+    /// between their executions (issue #2283). This mirrors
+    /// `KernelProtocolExecutor::compute_state_change_hash`, which hashes the
+    /// decision-carried `effective_at`, never a `now()` read. The
+    /// per-execution timestamp is still retained in `MembershipProvenance`
+    /// for audit; it just does not enter this fingerprint.
     fn compute_state_change_hash(
         operation: &str,
         entity_id: &str,
         member_did: &str,
         decision_receipt_id: &str,
-        timestamp: u64,
     ) -> String {
         let mut hasher = Sha256::new();
         hasher.update(b"membership:");
@@ -88,8 +103,6 @@ impl MembershipServiceImpl {
         hasher.update(member_did.as_bytes());
         hasher.update(b":");
         hasher.update(decision_receipt_id.as_bytes());
-        hasher.update(b":");
-        hasher.update(timestamp.to_le_bytes());
         let hash = hasher.finalize();
         hex::encode(&hash[..20]) // First 20 bytes for reasonable length
     }
@@ -180,7 +193,6 @@ impl MembershipService for MembershipServiceImpl {
                     &request.entity_id,
                     &request.member_did,
                     &request.decision_receipt_id,
-                    timestamp,
                 );
 
                 // Also maintain in-memory provenance index for fast lookups
@@ -279,7 +291,6 @@ impl MembershipService for MembershipServiceImpl {
                             &request.entity_id,
                             &request.member_did,
                             &request.decision_receipt_id,
-                            timestamp,
                         );
 
                         // Store provenance
@@ -378,7 +389,6 @@ impl MembershipService for MembershipServiceImpl {
                             &request.entity_id,
                             &request.member_did,
                             &request.decision_receipt_id,
-                            timestamp,
                         );
 
                         // Store provenance
@@ -510,7 +520,6 @@ impl MembershipService for MembershipServiceImpl {
                             &request.entity_id,
                             &request.member_did,
                             &request.decision_receipt_id,
-                            timestamp,
                         );
 
                         // Store provenance
@@ -632,7 +641,6 @@ impl MembershipService for MembershipServiceImpl {
                             &request.entity_id,
                             &request.member_did,
                             &request.decision_receipt_id,
-                            timestamp,
                         );
 
                         // Store provenance
@@ -1152,14 +1160,12 @@ mod tests {
             "entity-1",
             "did:icn:member1",
             "receipt-123",
-            1700000000,
         );
         let hash2 = MembershipServiceImpl::compute_state_change_hash(
             "add",
             "entity-1",
             "did:icn:member1",
             "receipt-123",
-            1700000000,
         );
         assert_eq!(hash1, hash2, "Same inputs should produce same hash");
     }
@@ -1171,18 +1177,42 @@ mod tests {
             "entity-1",
             "did:icn:member1",
             "receipt-123",
-            1700000000,
         );
         let hash2 = MembershipServiceImpl::compute_state_change_hash(
             "remove",
             "entity-1",
             "did:icn:member1",
             "receipt-123",
-            1700000000,
         );
         assert_ne!(
             hash1, hash2,
             "Different operations should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_compute_state_change_hash_ignores_wall_clock() {
+        // Regression guard for issue #2283: the state-change hash is
+        // cross-node deterministic and must depend only on decision-derived
+        // inputs. The function no longer accepts a timestamp, so two calls
+        // with identical decision inputs — as two independent nodes would
+        // make while replaying the same decision at different wall-clock
+        // instants — always agree.
+        let a = MembershipServiceImpl::compute_state_change_hash(
+            "add",
+            "coop-sunrise-pilot",
+            "did:icn:member1",
+            "gov:membership:add:pilot:001",
+        );
+        let b = MembershipServiceImpl::compute_state_change_hash(
+            "add",
+            "coop-sunrise-pilot",
+            "did:icn:member1",
+            "gov:membership:add:pilot:001",
+        );
+        assert_eq!(
+            a, b,
+            "state-change hash must be independent of execution wall-clock (#2283)"
         );
     }
 }

--- a/icn/crates/icn-core/src/services/membership_service.rs
+++ b/icn/crates/icn-core/src/services/membership_service.rs
@@ -71,13 +71,14 @@ impl MembershipServiceImpl {
         format!("{}:{}", entity_id, member_did)
     }
 
-    /// Compute a state change hash for an operation.
+    /// Compute a decision-identity hash for a membership operation.
     ///
-    /// This hash is contractually **cross-node deterministic**: two
-    /// independent nodes replaying the same governance decision (same
-    /// operation, entity, member, and `decision_receipt_id`) must produce
-    /// the same value — see
-    /// `crates/icn-core/tests/federated_two_node_pilot.rs`. It therefore
+    /// **What this fingerprints:** the decision-derived identity of the
+    /// operation — `operation`, `entity_id`, `member_did`, and
+    /// `decision_receipt_id`. It is contractually **cross-node
+    /// deterministic**: two independent nodes replaying the same governance
+    /// decision must produce the same value (see
+    /// `crates/icn-core/tests/federated_two_node_pilot.rs`). It therefore
     /// hashes only decision-derived inputs and **must never** include a
     /// local execution wall-clock: `decision_receipt_id` is unique per
     /// governance decision, so it (not a timestamp) supplies cross-decision
@@ -88,6 +89,22 @@ impl MembershipServiceImpl {
     /// decision-carried `effective_at`, never a `now()` read. The
     /// per-execution timestamp is still retained in `MembershipProvenance`
     /// for audit; it just does not enter this fingerprint.
+    ///
+    /// **What this does NOT fingerprint:** the persisted `Member` record
+    /// still carries node-local wall-clock audit fields (`joined_at` on add;
+    /// `removed_at`/`frozen_at`/`freeze_expires_at`/`unfrozen_at` metadata on
+    /// the other ops), so the durable record is not itself byte-identical
+    /// across nodes. This fingerprint is the decision-identity of the state
+    /// change, not a checksum of the full durable record. Making the durable
+    /// record fully deterministic requires a decision-carried `effective_at`
+    /// threaded through `MembershipEffect` (a schema change) — tracked in
+    /// issue #2286.
+    ///
+    /// Fields are **length-prefixed** (u64 LE length before each field), not
+    /// `:`-joined, so the input is injective: `member_did`, `entity_id`, and
+    /// `decision_receipt_id` may themselves contain `:` (DIDs are
+    /// `did:icn:…`), and a bare `:` separator would let distinct tuples
+    /// collide onto the same byte stream.
     fn compute_state_change_hash(
         operation: &str,
         entity_id: &str,
@@ -95,14 +112,11 @@ impl MembershipServiceImpl {
         decision_receipt_id: &str,
     ) -> String {
         let mut hasher = Sha256::new();
-        hasher.update(b"membership:");
-        hasher.update(operation.as_bytes());
-        hasher.update(b":");
-        hasher.update(entity_id.as_bytes());
-        hasher.update(b":");
-        hasher.update(member_did.as_bytes());
-        hasher.update(b":");
-        hasher.update(decision_receipt_id.as_bytes());
+        hasher.update(b"membership:v2:");
+        for field in [operation, entity_id, member_did, decision_receipt_id] {
+            hasher.update((field.len() as u64).to_le_bytes());
+            hasher.update(field.as_bytes());
+        }
         let hash = hasher.finalize();
         hex::encode(&hash[..20]) // First 20 bytes for reasonable length
     }
@@ -1213,6 +1227,22 @@ mod tests {
         assert_eq!(
             a, b,
             "state-change hash must be independent of execution wall-clock (#2283)"
+        );
+    }
+
+    #[test]
+    fn test_compute_state_change_hash_injective_across_colon_fields() {
+        // Regression guard for the injectivity gap: `member_did` /
+        // `entity_id` / `decision_receipt_id` can contain `:` (DIDs are
+        // `did:icn:…`). Under the old `:`-joined encoding these two tuples
+        // both serialized to `membership:add:e:did:icn:x:r` and collided;
+        // length-prefixing makes the input injective, so they must differ.
+        let a = MembershipServiceImpl::compute_state_change_hash("add", "e", "did:icn:x", "r");
+        let b = MembershipServiceImpl::compute_state_change_hash("add", "e:did", "icn:x", "r");
+        assert_ne!(
+            a, b,
+            "hash input must be injective — shifting a `:` boundary between \
+             adjacent fields must change the hash"
         );
     }
 }


### PR DESCRIPTION
## What

Removes the local execution wall-clock (`icn_time::current_timestamp_secs()`) from `MembershipServiceImpl::compute_state_change_hash` in `icn/crates/icn-core/src/services/membership_service.rs`. The hash now covers only decision-derived inputs: `operation`, `entity_id`, `member_did`, `decision_receipt_id`. Updates the five call sites (`add`/`remove`/`update`/`freeze`/`unfreeze`) and two unit tests, and adds a regression guard.

## Why

The membership `state_change_hash` is contractually **cross-node deterministic** — its entire purpose is that two independent nodes replaying the same governance decision produce the same fingerprint, which is exactly what `icn/crates/icn-core/tests/federated_two_node_pilot.rs::test_two_node_membership_add_determinism` asserts. Hashing each node's local wall-clock broke that invariant: whenever the seconds boundary ticked between the two node executions, the hashes diverged and the test failed.

Observed on **PR #2282** CI (an unrelated docs + governance-receipt PR): run `28625425017`, job `84890714964`, `Node A hash: cf3b6f47…` vs `Node B hash: 4759bda7…`, identical `MembershipEffect::AddMember` + `DecisionReceiptId` — only the wall-clock second differed. Full diagnosis in #2283.

This is a latent cross-node determinism defect, not just a test flake: two real nodes replaying the same decision across a second boundary would genuinely compute divergent membership state hashes.

## How

- `decision_receipt_id` is unique per governance decision, so it (not a timestamp) supplies cross-decision uniqueness — dropping the timestamp does not collapse distinct operations.
- The per-execution timestamp is **retained in `MembershipProvenance`** for audit; it just no longer enters the fingerprint.
- Mirrors the correct sibling pattern: `KernelProtocolExecutor::compute_state_change_hash` hashes the decision-carried `effective_at`, never a `now()` read.

## Risk / blast radius

Low. The membership `state_change_hash` is **never persisted durably and never compared against a stored value** anywhere in the tree — consumers only assert it is non-empty (`federation_service.rs`, `sdis_service.rs` tests) or use fixture strings. So there is no migration/compat surface for the value-form change.

**This does change production hash semantics**, so it wants a maintainer design sign-off — that is the purpose of #2283 and this PR is the proposed fix for review. **Do not merge without explicit authorization.**

## Test plan

- `cargo test -p icn-core --lib services::membership_service` — 9/9 (incl. new `test_compute_state_change_hash_ignores_wall_clock`).
- `cargo test -p icn-core --test federated_two_node_pilot` — 6/6; the previously-flaky `test_two_node_membership_add_determinism` run 5× consecutively, all green (and now structurally cannot depend on wall-clock — the function no longer accepts a timestamp).
- `cargo clippy -p icn-core --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

Refs #2283


---

## Review round 1 (update)

- **Injectivity (Copilot):** the hash joined fields with `:` separators, but `member_did`/`entity_id`/`decision_receipt_id` can contain `:` (DIDs are `did:icn:…`), so distinct tuples could collide. Fields are now **length-prefixed** (`membership:v2:` tag) with an injectivity regression test.
- **Durable timestamps (Codex P1) — acknowledged, deliberately out of scope here:** the durable `Member` record still persists node-local wall-clock (`joined_at` on add; `removed_at`/`frozen_at`/`freeze_expires_at`/`unfrozen_at` on the other ops), so durable state is not byte-identical across nodes regardless of this hash. This fingerprint is scoped (in code + docs) as a **decision-identity** fingerprint, not a full-record checksum. Making the durable record deterministic needs a decision-carried `effective_at` threaded through `MembershipEffect` (schema change) + a design decision — filed as **#2286**. That thread is left **unresolved** so a maintainer can decide whether to require the fuller fix before merging this flake fix.

Refs #2286
