### PR TITLE
fix(governance): reject unknown fields on gate-result and deliberation-entry requests

### DIFF
--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -62,7 +62,14 @@ fn default_weight() -> f64 {
 /// rejected by JSON deserialization (400) rather than silently coerced. The
 /// `session_id` and `domain_id` come from the path, and the recording actor
 /// comes from the authenticated token — not the body.
+///
+/// **Fails closed on unknown fields** (`deny_unknown_fields`): a client that
+/// posts extra fields alongside `gate_kind`/`result` is rejected with 400
+/// rather than having them silently discarded, so this surface's contract is
+/// enforced by rejection, not omission (mirrors the `RecordDecisionRequest`
+/// hardening in PR #2282).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RecordProcessGateResultRequest {
     /// Closed-taxonomy gate kind being recorded (e.g. `"privacy_review"`).
     pub gate_kind: ProcessGateKind,
@@ -84,7 +91,14 @@ pub struct RecordProcessGateResultRequest {
 /// — **the body itself is never sent to or stored by this surface**. The
 /// `domain_id`, `session_id`, and `entry_id` come from the path, and the
 /// author comes from the authenticated token — not the body.
+///
+/// **Fails closed on unknown fields** (`deny_unknown_fields`): a client that
+/// posts extra fields (e.g. a raw body, or decision semantics) alongside
+/// `entry_kind`/`body_hash` is rejected with 400 rather than having them
+/// silently discarded, so this surface's contract is enforced by rejection,
+/// not omission (mirrors the `RecordDecisionRequest` hardening in PR #2282).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RecordDeliberationEntryRequest {
     /// Closed-taxonomy entry kind being recorded (e.g. `"question"`).
     pub entry_kind: DeliberationEntryKind,

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -66,8 +66,8 @@ fn default_weight() -> f64 {
 /// **Fails closed on unknown fields** (`deny_unknown_fields`): a client that
 /// posts extra fields alongside `gate_kind`/`result` is rejected with 400
 /// rather than having them silently discarded, so this surface's contract is
-/// enforced by rejection, not omission (mirrors the `RecordDecisionRequest`
-/// hardening in PR #2282).
+/// enforced by rejection, not omission — clients cannot smuggle extra process
+/// semantics into a gate-result recording.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RecordProcessGateResultRequest {
@@ -96,7 +96,8 @@ pub struct RecordProcessGateResultRequest {
 /// posts extra fields (e.g. a raw body, or decision semantics) alongside
 /// `entry_kind`/`body_hash` is rejected with 400 rather than having them
 /// silently discarded, so this surface's contract is enforced by rejection,
-/// not omission (mirrors the `RecordDecisionRequest` hardening in PR #2282).
+/// not omission — clients cannot smuggle extra deliberation or decision
+/// semantics into a deliberation-entry recording.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RecordDeliberationEntryRequest {

--- a/icn/apps/governance/tests/deliberation_entry_record_http_route.rs
+++ b/icn/apps/governance/tests/deliberation_entry_record_http_route.rs
@@ -587,3 +587,45 @@ async fn record_route_bad_inputs_rejected_400() {
         0
     );
 }
+
+#[actix_web::test]
+async fn record_route_rejects_unknown_fields_400() {
+    // The request contract carries only `entry_kind`/`body_hash`; the path and
+    // token supply everything else, and the body itself never crosses this
+    // surface. `#[serde(deny_unknown_fields)]` makes an extra field (a raw
+    // body, or smuggled decision semantics) fail closed with 400 rather than
+    // be silently discarded, so the contract is enforced by rejection.
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain =
+        seed_domain_with_members(&h.ctx.manager, std::slice::from_ref(&caller), "test-coop").await;
+    open_session(&h.ctx.manager, &domain, "session-deny", &caller);
+    let app = gate_app!(h.ctx.clone(), &caller);
+
+    for extra in [
+        serde_json::json!({ "entry_kind": "question", "body_hash": hex_body_hash(1), "body": "raw text" }),
+        serde_json::json!({ "entry_kind": "question", "body_hash": hex_body_hash(1), "outcome": "accepted" }),
+        serde_json::json!({ "entry_kind": "question", "body_hash": hex_body_hash(1), "foo": 1 }),
+    ] {
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&record_uri(&domain.0, "session-deny", "entry-deny"))
+                .set_json(&extra)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "unknown request field must 400, got {} for {extra}",
+            resp.status()
+        );
+    }
+    assert_eq!(
+        h.receipts
+            .entry_count(&domain.0, "session-deny", "entry-deny"),
+        0,
+        "nothing persisted for rejected unknown-field requests"
+    );
+}

--- a/icn/apps/governance/tests/process_gate_result_http_route.rs
+++ b/icn/apps/governance/tests/process_gate_result_http_route.rs
@@ -330,6 +330,40 @@ async fn record_process_gate_result_route_rejects_unknown_result() {
 }
 
 #[actix_web::test]
+async fn record_process_gate_result_route_rejects_unknown_fields() {
+    // The request contract carries only `gate_kind`/`result`; the path and
+    // token supply everything else. `#[serde(deny_unknown_fields)]` makes an
+    // extra field fail closed with 400 rather than be silently discarded, so
+    // the surface's contract is enforced by rejection, not omission.
+    let h = make_harness();
+    let caller = fresh_did();
+    let domain = seed_domain_with_member(&h.ctx.manager, &caller, "test-coop").await;
+    let app = gate_app!(h.ctx.clone(), &caller);
+
+    for extra in [
+        serde_json::json!({ "gate_kind": "privacy_review", "result": "pass", "outcome": "accepted" }),
+        serde_json::json!({ "gate_kind": "privacy_review", "result": "pass", "foo": 1 }),
+    ] {
+        let req = test::TestRequest::post()
+            .uri(&gate_results_uri(&domain.0, "session-http-deny"))
+            .set_json(&extra)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "unknown request field must 400, got {} for {extra}",
+            resp.status()
+        );
+    }
+    assert_eq!(
+        h.receipts.total_count(),
+        0,
+        "nothing persisted for rejected unknown-field requests"
+    );
+}
+
+#[actix_web::test]
 async fn record_process_gate_result_route_rejects_whitespace_session_id() {
     // The handler's `session_id.trim().is_empty()` guard must reject a
     // whitespace-only session id (`%20`, which actix percent-decodes to a


### PR DESCRIPTION
## What

Adds `#[serde(deny_unknown_fields)]` to the two remaining process-receipt request structs in `icn/apps/governance/src/http/models.rs`:
- `RecordProcessGateResultRequest` (#2144 gate-result surface)
- `RecordDeliberationEntryRequest` (#2279 deliberation-entry surface)

Plus one route test per surface asserting an unknown field yields 400 and nothing is persisted.

## Why

Follows the `RecordDecisionRequest` hardening in PR #2282 (Codex P2 review). These two sibling structs derived `Deserialize` without `deny_unknown_fields`, so a client posting extra fields alongside the declared ones got a 200 with the extras silently discarded. Each body is supposed to carry only its declared fields — the path and authenticated token supply everything else — so the contract should be enforced by rejection, not omission.

## How

- `RecordProcessGateResultRequest`: carries only `gate_kind`/`result`.
- `RecordDeliberationEntryRequest`: carries only `entry_kind`/`body_hash` (the body never crosses this surface).
- Both gain `#[serde(deny_unknown_fields)]`, matching the established convention already used elsewhere in this file.

## Risk

Low, pure hardening. No semantic change to accepted requests; only previously-ignored-and-discarded extra fields now 400. `models.rs` touches only these two structs (the `RecordDecisionRequest` change lives in the still-open #2282, in a non-overlapping region — a trivial rebase if #2282 lands first).

## Test plan

- `cargo test -p icn-governance-actor --test process_gate_result_http_route` — 8/8 (incl. new `record_process_gate_result_route_rejects_unknown_fields`).
- `cargo test -p icn-governance-actor --test deliberation_entry_record_http_route` — 16/16 (incl. new `record_route_rejects_unknown_fields_400`).
- Runtime slices unchanged: gate-result 6/6, deliberation-entry 15/15.
- `cargo fmt --all --check` clean; `cargo clippy -p icn-governance-actor --all-targets -- -D warnings` clean.

## Non-claims

No new capability, route, proof type, or stored object. No change to accepted request semantics beyond rejecting previously-discarded unknown fields. Relates to the #1748/#2141 process spine; hardens the already-merged #2144 and #2279 surfaces. No #1748/#2141 closure.

Refs #1748
Refs #2141
