### PR TITLE
docs(membership): define durable Member timestamp semantics

### DIFF
--- a/docs/INDEX.generated.md
+++ b/docs/INDEX.generated.md
@@ -276,6 +276,12 @@ Defines InstitutionalDomain as the governed operating jurisdiction and DomainPol
 
 **For:** `architects`, `developers`, `contributors` | **Updated:** 2026-05-14
 
+### 📋 **Draft** [Institutional Powers and Legitimacy Invariants](/docs/spec/institutional-powers.md)
+
+Design-level doctrine defining how ICN encodes institutional power so it cannot become unaccountable state/capital power. Names the legitimacy circuit (authority basis -> adopted policy -> bounded effect -> receipt -> challenge/repair path), the InstitutionalPowerEvent envelope, and four power classes (GovernancePower, ContributionPower, ProtectivePower, RepairPower) as the ICN reconciliations of governance, contribution/taxation, protective force, and justice/repair without sovereign extraction, police power, or carceral logic. States fail-closed legitimacy invariants and maps each circuit stage to existing seams (InstitutionalDomain, DomainPolicy, CCL policy registry, AuthorityGrant, Mandate, TypedScope, EffectManifest, KernelEffect, GovernanceDecisionReceipt, InstitutionalEffectRecord, EffectDispatchEvidence, challenge/reversal/counter-receipt). Docs-only design layer over the Effect Dispatch Contract; introduces no code/schema/CCL/route/runtime change. Refs RFC-0018, ADR-0014/0019/0025/0026/0027, #2061, #2080, #1868, #2082.
+
+**For:** `architects`, `developers`, `contributors` | **Updated:** 2026-06-25
+
 ### 📋 **Draft** [Member Shell v0](/docs/spec/member-shell-v0.md)
 
 Defines the ICN member shell as the primary participation surface at v0: mobile-first, offline-tolerant, accessibility-first, plain-language-first. The shell is an app-side rendering surface that consumes ADR-0020 /me/standing, ADR-0027 ActionCard schema, ADR-0026 receipts, the closed seven-string sync vocabulary from docs/spec/network-anti-entropy-proof-loops.md (#1829), and the closed seven-string placement vocabulary from docs/spec/compute-placement-policy.md (#1826), without redefining any of them. Names five hard boundary lines (vs steward cockpit #1795, vs node operator civic-role surface #1613, vs public website, vs institution-package skin, vs backend/runtime), ten design principles, a ten-surface information architecture (Home/Today, My Standing, Current Scope, Action Cards, Decisions/Governance, Receipts, Records/Artifacts, Privacy/Access, Sync/Offline status, Help/Challenge/Review/Exit), the ActionCard rendering contract (per-field requirements + closed card states), the standing surface contract, the ten-step signing/confirmation flow with reversibility/privacy/sync warnings, the three-tier receipt rendering (plain summary → explanation → formal record under details), offline/low-bandwidth behavior including draft-intent vs sent-waiting-for-receipt vs confirmed labeling, privacy and ScopedVault member affordances (existence + scope + access path only, never body content), the twelve-category accessibility gate inherited from ADR-0028 / docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md, a closed v0 member-facing status vocabulary (sync states + execution-scope strings + action-lifecycle strings + privacy/disclosure strings + receipt-class plain-language labels), eighteen-row failure/safety table, and three fixture-first dogfood slices (read-only standing+ActionCard+receipt+sync-delayed; signing flow rehearsal; offline/degraded sync rehearsal). No new endpoints, no platform decision, no native-app implementation, no schema redefinition, no new receipt classes. Advances #1818 — does not by itself close it. Defers the live UI implementation, the platform decision (iOS/Android/PWA/web), the signal_rule and obligation_lifecycle source-path enablement, the multilingual rendering integration, and the Layer 4 ProvenanceQuery consumption to named follow-ups.
@@ -375,6 +381,42 @@ Design for ICN's execution environment and compute resource management
 
 **For:** `architects`, `developers` | **Updated:** 2025-11-18
 
+### 📋 **Draft** [Governed coop_id to EntityId Resolver — Design Seam](/docs/design/coop-id-entity-resolver.md)
+
+Seam definition for the governed coop_id to EntityId resolver named as the keystone in the entity-aware authorization control map: contract, authority/governance, migration posture, fail-closed rules, and sequenced follow-up slices (consumes the #2082 CoopEntityMap store; mirrors the TokenAuthoritySource/DenyUntilWired issuance seam). Design only — no runtime change (#2061, #2080, #1868, #2082)
+
+**For:** `architects`, `developers` | **Updated:** 2026-06-26
+
+### 📋 **Draft** [CreateTreasury — Treasury entity_id Trust Semantics](/docs/design/create-treasury-entity-id-semantics.md)
+
+Trust-semantics audit/design for the CreateTreasury message path (icn-coop actor + apps/membership coop_core duplicate): no production caller, no authority gate, no CoopEntityMap integration, entity_id None today. Pins why the path must never populate entity_id by bare projection or write map provenance, and defines the single safe future slice (read-only trusted-binding consultation mirroring #2266 activation-populate and the ADR-0084 re-verification discipline) plus the tests any implementation PR requires. Mapping stays zero-authority; UnknownLegacy stays untrusted. Design only — no runtime change (#2082; #2081/#2080 untouched)
+
+**For:** `architects`, `developers` | **Updated:** 2026-07-01
+
+### 📋 **Draft** [DecisionRecordedReceipt Q4 decision — recorded fact vs proposal/vote lineage](/docs/design/decision-recorded-q4-decision.md)
+
+Q4 decision document unblocking DecisionRecordedReceipt implementation (#1748/#2141, merged contract #2280): decides all four Q4 branches — (A) v1 stays an opaque body_hash-only recorded-decision fact (no typed DecisionRecord/HumanDecisionSet payload; the brief positions HumanDecisionSet as a read-model); (B) parallel with explicit non-convergence to the load-bearing proposal/vote GovernanceDecisionReceipt lineage icn:gov:decision:v1/v2/v3 (effect dispatch, mandate/authority-grant indexes, action cards) — the spine names but does not absorb it; any future reference is v2-or-later after its own ADR; (C) no deciding-body handle in v1, recorded_by stays recorder-not-decider; (D) resolution stays deferred out of DeliberationEntryKind v1 with discriminant 10 reserved. Hash-layout consequence: none — the merged #2280 contract is implementation-ready as written. Design decision only — no runtime change (Refs #1748, #2141; no closure claims)
+
+**For:** `architects`, `developers` | **Updated:** 2026-07-02
+
+### 📋 **Draft** [DecisionRecordedReceipt — Design/Audit Contract](/docs/design/decision-recorded-receipt.md)
+
+Implementation contract for the fourth ProcessTransitionReceipt class (#1748/#2141): a DecisionRecordedReceipt recording that one decision was recorded against an already-opened (domain_id, session_id) anchor, with caller-opaque decision_id, recorded_by as recorder-not-decider actor evidence, body_hash-only content fingerprint (the body is never stored), stable-identity retry idempotency, fail-closed conflict, and atomic per-decision uniqueness via the landed put_opaque_if_absent pattern. Audits current state (no DecisionRecordedReceipt anywhere; disambiguates the load-bearing proposal/vote GovernanceDecisionReceipt lineage icn:gov:decision:v1/v2/v3, which this class must never duplicate or converge with), keeps the receipt free of outcome/tally/vote/mandate semantics, and triages framing-brief Q4 (HumanDecisionSet/DecisionRecord vs proposal-vote boundary) as the explicit implementation blocker — recommendation Option C: a narrow Q4 decision rung before any implementation. Receipts record facts and grant no authority. Design only — no runtime change (Refs #1748, #2141; no closure claims)
+
+**For:** `architects`, `developers` | **Updated:** 2026-07-02
+
+### 📋 **Draft** [DeliberationEntry kind taxonomy — Q3 decision](/docs/design/deliberation-entry-kind-taxonomy.md)
+
+Q3 decision document unblocking DeliberationEntryRecordedReceipt implementation (#1748/#2141, merged contract #2277): chooses Option A — a closed, ADR-controlled entry_kind enum hashed by explicit u8 discriminant (the landed gate_kind_ordinal pattern) over charter-extensible strings, keeping institutional vocabulary mapped at the app layer per the framing-brief vocabulary firewall. Pins a scrutinized ten-kind v1 list with explicit discriminants (resolution deferred in writing as Q4-ambiguous), a never-reorder/never-reuse append-only evolution rule with fail-closed unknown kinds and a required golden vector, and the exact v1 hash layout instruction for the future implementation PR. Q1 target_ref stays deferred; no vote/approval/outcome kinds ever by append. Design decision only — no runtime change (Refs #1748, #2141; no closure claims)
+
+**For:** `architects`, `developers` | **Updated:** 2026-07-02
+
+### 📋 **Draft** [DeliberationEntryRecordedReceipt — Design/Audit Contract](/docs/design/deliberation-entry-recorded-receipt.md)
+
+Implementation contract for the third ProcessTransitionReceipt class (#1748/#2141): a DeliberationEntryRecordedReceipt recording one deliberation entry as an institutional fact against an already-opened (domain_id, session_id) anchor (#2276), with caller-opaque entry_id, body_hash-only content fingerprint (the body is never stored), stable-identity retry idempotency, fail-closed different-author/body conflict, and atomic per-entry uniqueness via the landed put_opaque_if_absent pattern. Audits current state (no DeliberationEntryRecordedReceipt, no stored DeliberationThread; disambiguates the test-only icn-baseline-lock namesake), keeps entries free of chat/moderation/vote semantics, and triages framing-brief Q3 (entry_kind taxonomy) as the explicit implementation blocker — recommendation Option C: a narrow Q3 taxonomy decision rung before any implementation. Receipts record facts and grant no authority. Design only — no runtime change (Refs #1748, #2141; no closure claims)
+
+**For:** `architects`, `developers` | **Updated:** 2026-07-02
+
 ### 📝 **Living** [ICN Deterministic Core Specification](/docs/design/deterministic-core.md)
 
 Specification for deterministic computation substrate ensuring reproducible state machines
@@ -422,6 +464,12 @@ Truth contract auditing all economics-related code against specification
 Maps economic operations against implementation state
 
 **For:** `architects` | **Updated:** 2026-03-10
+
+### 📋 **Draft** [Entity-Aware Authorization Control Map](/docs/design/entity-aware-auth-control-map.md)
+
+Migration control map for gateway authorization: flat coop_id guard vs entity-aware checks, observe-mode, fail-closed trusted issuance, and the coop_id to EntityId resolver keystone (#2061, #2080, #1868)
+
+**For:** `architects`, `developers` | **Updated:** 2026-06-26
 
 ### 📝 **Living** [Entity Dissolution: Before and After](/docs/design/entity-dissolution-example.md)
 
@@ -483,6 +531,18 @@ Design for managing multiple network endpoints with IPv6
 
 **For:** `architects`, `developers` | **Updated:** 2026-03-10
 
+### 📋 **Draft** [apps/membership coop_core — Map-Parity Contract (#2082 gap 12b)](/docs/design/membership-coop-core-map-parity.md)
+
+Design/audit contract for the last #2082 structural gap: the apps/membership coop_core actor is a test-harness fixture (icn-core dev-dependency; sole consumer is vertical_slice_integration.rs; no production caller) frozen pre-#2104 — no icn-entity dep, no CoopEntityMap integration, no activation binding/populate, no CreateTreasury consultation. Defines the divergence table, the parity-vs-deprecate decision (Option B deprecate/redirect recommended: migrate the vertical-slice test to icn_coop::CoopActor and freeze/remove the duplicate), the exact parity slices and test matrix if parity is chosen instead, and explicit non-claims. Mapping stays zero-authority; UnknownLegacy stays untrusted. Design only — no runtime change (#2082; #2081/#2080 untouched)
+
+**For:** `architects`, `developers` | **Updated:** 2026-07-02
+
+### 📋 **Draft** [Membership durable timestamp semantics — Design/Audit Contract](/docs/design/membership-durable-timestamp-semantics.md)
+
+Design/audit contract for #2286 after #2284 made membership state_change_hash a deterministic decision-identity fingerprint: durable Member records still persist node-local wall-clock (joined_at field; removed_at/frozen_at/freeze_expires_at/unfrozen_at metadata), so replaying the same governance decision on two nodes diverges in durable bytes. Decides the target semantics — deterministic durable timestamps via a decision-carried effective_at threaded through MembershipEffect/requests (mirroring the KernelProtocolExecutor SetParameter precedent, with the honest caveat that the protocol producer's value is currently degenerate 0 pending #282), local audit timestamps separated from durable convergence state, freeze_expires_at = effective_at + duration_secs, update-member needs no durable timestamp, membership:v2 hash layout unchanged. Names the serialized-effect compatibility choice (fail-closed vs versioned vs legacy-non-convergent) as an explicit future implementation decision — no serde(default) smuggling — plus the implementation PR's test obligations. Design only — no schema/runtime/OpenAPI/SDK change (Refs #2286, #2284, #2283; #2286 stays open)
+
+**For:** `architects`, `developers` | **Updated:** 2026-07-03
+
 ### 📋 **Draft** [Multi-Device Identity Design](/docs/design/multi-device-identity-design.md)
 
 Design for managing identity across multiple devices within a single agent
@@ -506,6 +566,12 @@ Design for platform abstractions and portability across systems
 Experimental post-quantum cryptography integration and migration strategy
 
 **For:** `architects`, `security` | **Updated:** 2026-03-10
+
+### 📋 **Draft** [ProcessSession Receipt Anchor — Design/Audit Contract](/docs/design/process-session-receipt-anchor.md)
+
+Implementation contract for the second ProcessTransitionReceipt class (#1748/#2141): a ProcessSessionOpenedReceipt anchoring caller-opaque session_ids to a recorded opening fact (domain-bound blake3 hash, ADR-0026 Layer 2, mirrors the landed #2144 ProcessGateResultReceipt pattern end to end). Audits current state (session_id opaque, no stored ProcessSession, no lifecycle), pins duplicate-open idempotency/conflict semantics, defers target_ref (Q1) and purpose taxonomy in writing, and recommends receipt-only anchoring (no stored session object) with the required test matrix. Receipts record facts and grant no authority. Design only — no runtime change (Refs #1748, #2141; no closure claims)
+
+**For:** `architects`, `developers` | **Updated:** 2026-07-02
 
 ### 📋 **Draft** [Razeto Integration Design](/docs/design/razeto-integration-design.md)
 
@@ -1122,6 +1188,12 @@ Runbooks moved to docs/guides/operations/runbooks/ (tranche 3); use that path fo
 
 **For:** `operators` | **Updated:** 2026-03-26
 
+### 📝 **Living** [Organizer facilitator walkthrough human AT test plan and evidence template](/docs/pilots/organizer-facilitator-walkthrough-human-at-test-plan.md)
+
+Reusable, deliberately blank human assistive-technology smoke-test plan and repo-safe evidence template for the fixture-backed organizer facilitator walkthrough. Records the required tester, device, OS, browser, AT, input, zoom, theme, locale, task, observation, blocker, and follow-up fields; distinguishes automated/browser-assisted evidence from real human observations; and makes no claim that human AT testing or accessibility completion has occurred.
+
+**For:** `team`, `organizers`, `contributors`, `accessibility-testers` | **Updated:** 2026-06-29
+
 ### 📋 **Draft** [Pilot Proposal Template](/docs/pilots/pilot-proposal-template.md)
 
 Template for approaching potential pilot communities
@@ -1208,6 +1280,12 @@ Runbook for rotating cryptographic secrets
 Runbook for pilot deployment verification
 
 **For:** `operators` | **Updated:** 2026-03-10
+
+### 📝 **Living** [Treasury Entity-Auth Enforce-Mode Runbook](/docs/guides/operations/runbooks/treasury-entity-auth-enforce-mode-runbook.md)
+
+Rehearse/verify the off-by-default treasury entity-auth enforce mode (ICN_TREASURY_ENTITY_AUTH_MODE=enforce-trusted-resolver) before any real enablement
+
+**For:** `operators` | **Updated:** 2026-06-29
 
 ### 🔒 **Canonical** [Operations Directory README](/docs/operations/README.md)
 
@@ -1510,7 +1588,49 @@ Approach for hosted cooperative pilot deployments
 
 Guided browser/mobile-first rehearsal story: standing, action cards, action items, receipts, provenance, repo-safe evidence; organizer vs steward vs member paths; preview-before-mutation; CLI as operator layer only; follow-ups for UI/API/evidence contracts including the landed fixture-backed demo-mode bridge slice. Partner companion doc lives in NYCN repo.
 
-**For:** `team`, `organizers` | **Updated:** 2026-06-09
+**For:** `team`, `organizers` | **Updated:** 2026-06-28
+
+### 📝 **Living** [Organizer facilitator walkthrough accessibility evidence (partial)](/docs/pilots/organizer-facilitator-walkthrough-accessibility-pass.md)
+
+Partial browser-assisted accessibility evidence for the fixture-backed, read-only organizer facilitator walkthrough merged in #2239. Records keyboard focus-order, semantic-tree, forced-colors, reduced-motion, target-size, narrow/reflow, and network observations against the twelve-category organizer/member gate. Explicitly does not claim a human, screen-reader, switch-control, low-vision, legal-conformance, organizer-readiness, member-facing-readiness, pilot-readiness, mutation, receipt, or evidence-export pass. Keeps #2041/#1726/#1727/#1746 open and records the remaining named human/AT work.
+
+**For:** `team`, `organizers`, `contributors` | **Updated:** 2026-06-28
+
+### 📝 **Living** [Summit Ops Closeout Continuity Packet (generic ICN)](/docs/pilots/summit-ops-closeout-continuity-packet.md)
+
+Docs-only map of the Summit Ops 'close the loop' lifecycle stage: how a package turns post-event work (attendance summary, speaker/sponsor follow-up, reimbursements, accessibility lessons, incident closeout, volunteer appreciation, budget reconciliation, public recap, next-year continuity, evidence export, follow-up register) into repo-safe shapes and future ICN action-card/receipt/evidence candidates. L1 declared shapes / rehearsal-ready — not fixture-backed, not runtime proof; categorical/fictional only, no private data; no pilot-UI change (#2099 gates that).
+
+**For:** `team`, `organizers` | **Updated:** 2026-06-26
+
+### 📝 **Living** [Summit Ops Closeout Recap Fixture Shape (generic ICN)](/docs/pilots/summit-ops-closeout-recap-fixture-shape.md)
+
+Fixture-shape map (spec + validation recipe) for the exact schema-valid (action_item/complete, scope structure, fictional ids) Public Recap Draft Handoff ActionCard a future contributor could append to web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json, plus the matching demo Communications role + public_recap scope that commit must add to standing.json. Leaves the lane fixture-ready, NOT fixture-backed: no runtime fixture is committed and no pilot-UI file is touched (#2099 gates pilot-UI surface). Becomes L2 only after the card + standing are committed and the validation path (per-card schema + validate-rehearsal-shell-fixtures.py + Playwright e2e + Rehearsal Fixture Bundle gate) passes; public-safe categorical/fictional only, no real event data.
+
+**For:** `team`, `organizers` | **Updated:** 2026-06-26
+
+### 📝 **Living** [Summit Ops Lifecycle Package Map (generic ICN)](/docs/pilots/summit-ops-lifecycle-package-map.md)
+
+Generic ICN-side map of how an institution package (NYCN motivating example, 2026 Summit) carries an event's full lifecycle (plan/prepare/run/close) onto the ICN vertical spine, preserving the Google-live / NYCN-package / future-ICN-node boundary. Reuses existing status + proof-level vocabulary; docs-only; no live sync, no partner-repo mutation, no formal-pilot claim.
+
+**For:** `team`, `organizers` | **Updated:** 2026-06-26
+
+### 📝 **Living** [Summit Ops Registration Action-Card Proof Loop (generic ICN)](/docs/pilots/summit-ops-registration-action-card-proof-loop.md)
+
+First proof-loop child of the run-stage facilitator path: a fictional Registration Desk lane walked end-to-end through the ICN proof loop (source packet -> reviewed candidate -> ActionCard candidate -> authorized completion -> receipt candidate -> evidence export -> follow-up). The lane is fixture-backed (L2): a committed fictional schema-valid action_item/complete ActionCard the rehearsal shell loads and the e2e validates — a rehearsal-ready shape, NOT a runtime proof, not live NYCN action cards/receipts, not a node-hosted cockpit; fictional categorical examples only; no real attendee data.
+
+**For:** `team`, `organizers` | **Updated:** 2026-06-26
+
+### 📝 **Living** [Summit Ops Registration Fixture Shape (generic ICN)](/docs/pilots/summit-ops-registration-fixture-shape.md)
+
+Fixture-shape map (spec/rationale + validation recipe) for the exact schema-valid (action_item/complete, scope structure, fictional ids) registration ActionCard in web/pilot-ui/fixtures/icn-organizer-demo/action-cards.json, with the validation path (validate-rehearsal-shell-fixtures.py + the Playwright e2e + Rehearsal Fixture Bundle gate). The card has since been committed and validated, so the Registration Desk lane is fixture-backed (L2) — a committed fictional fixture, not a runtime proof; no real attendee data.
+
+**For:** `team`, `organizers` | **Updated:** 2026-06-26
+
+### 📝 **Living** [Summit Ops Run-Stage Facilitator Path (generic ICN)](/docs/pilots/summit-ops-run-stage-facilitator-path.md)
+
+First concrete child of the Summit Ops lifecycle map: a fixture-backed, no-terminal event-day facilitator path for the run stage, mapping ten generic event-day lanes onto future ICN action cards / receipts / evidence while keeping NYCN private operating detail at boundary level. Docs-only; no live sync, no partner-repo mutation, no node-hosted cockpit claim.
+
+**For:** `team`, `organizers` | **Updated:** 2026-06-26
 
 ### 📋 **Draft** [Agent Knowledge Architecture](/docs/planning/agent-knowledge-architecture.md)
 
@@ -1596,6 +1716,12 @@ GitHub Actions workflows, deploy paths, K3s smoke runbooks, monitoring; routing 
 
 **For:** `operators`, `contributors` | **Updated:** 2026-04-29
 
+### 📝 **Living** [Claim-Boundary Map](/docs/reference/project-index/claim-boundaries.md)
+
+Operational claim-boundary manual: disambiguates the architectural Meaning Firewall from the claim-discipline firewall, summarizes source precedence and status-vs-proof, tabulates forbidden collapses with their evidence and enforcement status, and gives a reusable inventory/PR claim-discipline checklist. Orientation, not a truth root. Defers to STATE.md and PHASE_PROGRESS.md for current truth.
+
+**For:** `all`, `team` | **Updated:** 2026-06-26
+
 ### 📝 **Living** [Current Truth Map](/docs/reference/project-index/current-truth-map.md)
 
 One-screen routing for what is real now, what is not, what gates remain — pointing at STATE.md and PHASE_PROGRESS.md for the per-PR record.
@@ -1624,7 +1750,7 @@ Source-linked index of the four canonical ICN invariant families (5 operational 
 
 Proof-level taxonomy (L0-L8) as shared claim-boundary vocabulary, plus a capability matrix for the current organizer-rehearsal path. Supports #1746 and narrows #1796. Orthogonal to the project-coverage-matrix status vocabulary. Defers to STATE.md and PHASE_PROGRESS.md for current truth.
 
-**For:** `all`, `team` | **Updated:** 2026-06-09
+**For:** `all`, `team` | **Updated:** 2026-06-26
 
 ### 📋 **Draft** [ICN Repo Atlas](/docs/reference/project-index/repo-atlas.md)
 
@@ -1725,6 +1851,24 @@ Trust establishment for first-time peer contact without certificates or CAs
 
 **For:** `security`, `developers` | **Updated:** 2026-03-10
 
+### 📝 **Living** [CodeQL Alert Triage (2026-06-29)](/docs/security/codeql-alert-triage-2026-06-29.md)
+
+Point-in-time static triage of CodeQL alerts #100 and #101, with an inventory of other open alerts
+
+**For:** `security`, `developers` | **Updated:** 2026-06-29
+
+### 📝 **Living** [CodeQL Gossip Nonce Triage (2026-06-29)](/docs/security/codeql-gossip-nonce-triage-2026-06-29.md)
+
+Point-in-time static triage of gossip nonce alerts #30 through #35
+
+**For:** `security`, `developers` | **Updated:** 2026-06-29
+
+### 📝 **Living** [CodeQL Triage Closeout (2026-06-29)](/docs/security/codeql-triage-closeout-2026-06-29.md)
+
+Point-in-time open-alert inventory, detailed remaining triage, and maintainer disposition checklist
+
+**For:** `security`, `developers` | **Updated:** 2026-06-29
+
 ### 📋 **Draft** [Phase 10C Security Analysis](/docs/security/phase-10c-security-analysis.md)
 
 Security analysis and hardening for multi-party contracts
@@ -1756,7 +1900,7 @@ Comprehensive threat model covering attack vectors, adversary capabilities, and 
 
 Living snapshot of repo layout, decisions, constraints, and current engineering status
 
-**For:** `developers`, `agents` | **Updated:** 2026-06-21
+**For:** `developers`, `agents` | **Updated:** 2026-06-26
 
 
 ## Strategy
@@ -1916,10 +2060,10 @@ Assessment of pilot readiness and gaps
 
 ## Summary
 
-**Total documents:** 312
+**Total documents:** 336
 
 **By status:**
 - Active: 1
 - Canonical: 40
-- Draft: 72
-- Living: 199
+- Draft: 83
+- Living: 212

--- a/docs/design/membership-durable-timestamp-semantics.md
+++ b/docs/design/membership-durable-timestamp-semantics.md
@@ -1,0 +1,326 @@
+# Membership durable timestamp semantics — Design/Audit Contract
+
+**Status**: draft — design / audit contract (not runtime implementation)
+**Truth class**: descriptive
+**Canonical**: no — current implementation truth lives in [docs/STATE.md](../STATE.md) and [docs/PHASE_PROGRESS.md](../PHASE_PROGRESS.md)
+**Last Reviewed**: 2026-07-03
+**Source basis**: read against `main` @ `e8057cc6` (the #2284 merge commit). Code anchors were verified at that commit — re-verify before relying on exact line numbers.
+**Related**: issue #2286 (durable Member records persist node-local timestamps — the tracker this contract serves) · issue #2283 (closed — the `state_change_hash` determinism flake) · PR #2284 (merged — the narrow fingerprint fix) · `icn/crates/icn-core/tests/federated_two_node_pilot.rs` (the two-node determinism intent) · issue #282 (deprecated proposal-level delayed execution, cited below)
+
+> Narrow decision document for #2286 only. It decides the *target semantics*
+> for the durable membership timestamp fields after #2284 split the world
+> into a deterministic decision-identity fingerprint and a still-divergent
+> durable record. It changes nothing at runtime: no schema change, no
+> effect change, no request change, no test change. The implementation is a
+> future PR under #2286.
+
+## 1. Status / truth class
+
+- **Status**: draft design/audit contract.
+- **Truth class**: descriptive — this document describes verified current
+  behavior and pins a target contract; it does not claim any of the target
+  behavior exists yet.
+- Canonical current-implementation truth remains `docs/STATE.md`,
+  `docs/PHASE_PROGRESS.md`, and live code.
+- Related: #2284, #2283, #2286, `federated_two_node_pilot`.
+
+## 2. Current implementation audit (post-#2284)
+
+All anchors verified at `main` @ `e8057cc6`.
+
+### 2.1 The fingerprint is deterministic
+
+`MembershipServiceImpl::compute_state_change_hash`
+(`icn/crates/icn-core/src/services/membership_service.rs:108`) is now a
+**decision-identity fingerprint**: SHA-256 over the domain tag
+`membership:v2:` followed by four length-prefixed (u64 LE) fields —
+`operation`, `entity_id`, `member_did`, `decision_receipt_id`. It hashes
+only decision-derived inputs and contains no wall-clock read. Its own doc
+comment (same file, above the function) states the contract explicitly:
+cross-node deterministic, injective via length prefixes, and — quoting the
+part that motivates this document —
+
+> the persisted `Member` record still carries node-local wall-clock audit
+> fields (`joined_at` on add; `removed_at`/`frozen_at`/`freeze_expires_at`/
+> `unfrozen_at` metadata on the other ops), so the durable record is not
+> itself byte-identical across nodes. […] Making the durable record fully
+> deterministic requires a decision-carried `effective_at` threaded through
+> `MembershipEffect` (a schema change) — tracked in issue #2286.
+
+### 2.2 The durable record is not deterministic
+
+Every membership execution path still reads node-local wall-clock and
+persists it into the durable `Member` record
+(`icn/crates/icn-coop/src/types.rs:353` — `joined_at: DateTime<Utc>` is a
+first-class field; the other timestamps live in the string-keyed
+`metadata: HashMap<String, String>`):
+
+| Operation | Wall-clock read | Durable write |
+|---|---|---|
+| add | `Member::new` → `joined_at: Utc::now()` (`icn-coop/src/types.rs:721`) | `joined_at` field |
+| remove | `current_timestamp_secs()` (`membership_service.rs:262`) | `metadata["removed_at"]` (`:286`) |
+| freeze | `current_timestamp_secs()` (`membership_service.rs:469`) | `metadata["frozen_at"]` (`:507`); `metadata["freeze_expires_at"] = timestamp + duration_secs` (`:523–:527`) |
+| unfreeze | `current_timestamp_secs()` (`membership_service.rs:602`) | `metadata["unfrozen_at"]` (`:635`); removes `freeze_expires_at` (`:636`) |
+| update | `current_timestamp_secs()` (`membership_service.rs:371`) | **none** — the read feeds only in-memory provenance |
+
+Two nodes replaying the same governance decision across a seconds boundary
+therefore persist different durable bytes, even though their
+`state_change_hash` values now agree.
+
+### 2.3 Three distinct things, kept distinct
+
+The audit confirms three separable notions that this contract must not
+conflate:
+
+1. **Decision-identity fingerprint convergence** — `state_change_hash`
+   (`membership:v2:` layout). Cross-node deterministic as of #2284. Its
+   layout is pinned; this contract does not touch it.
+2. **Durable `Member` record byte convergence** — NOT currently guaranteed;
+   the subject of #2286 and of this contract.
+3. **Node-local audit metadata** — `MembershipProvenance`
+   (`membership_service.rs:36`), an in-memory `RwLock<HashMap>` holding a
+   per-execution `timestamp`. It is not durable, not replicated, and not
+   part of any convergence claim. It may legitimately stay node-local.
+
+### 2.4 The effect and request schemas carry no timestamp
+
+- `MembershipEffect` (`icn/crates/icn-kernel-api/src/effects.rs:191`) —
+  `AddMember`/`RemoveMember`/`UpdateMember`/`FreezeMember`/`UnfreezeMember`
+  — carries no `effective_at`. `FreezeMember` carries the decision-derived
+  `duration_secs: Option<u64>`. The `decision_hash` fields use
+  `#[serde(default)]`, the crate's existing add-a-field compatibility
+  precedent.
+- The service request structs (`icn/crates/icn-kernel-api/src/services.rs:1528`
+  onward: `AddMemberRequest`, `RemoveMemberRequest`, `UpdateMemberRequest`,
+  `FreezeMemberRequest`, `UnfreezeMemberRequest`) carry
+  `decision_receipt_id` + `decision_hash` but no timestamp.
+- `KernelMembershipExecutor::execute_membership_operation`
+  (`icn/crates/icn-core/src/supervisor/governance_executor.rs:1905`)
+  converts effect → request 1:1; membership effects are produced in
+  `icn/apps/governance/src/handlers/execution.rs` (`:594`/`:603` add/remove,
+  `:108`/`:119` freeze/unfreeze).
+
+### 2.5 The protocol precedent exists — with one honest caveat
+
+`ProtocolEffect::SetParameter` (`icn/crates/icn-kernel-api/src/effects.rs:249`)
+carries `effective_at: u64`, and `KernelProtocolExecutor::apply_protocol_change`
+(`governance_executor.rs:1038`) does exactly what this contract wants for
+membership: it persists the **decision-carried** timestamp into the durable
+record (`updated_param.updated_at = change.effective_at`) and its
+`compute_state_change_hash` (`:1017`) hashes `effective_at`, never a `now()`
+read. The two-node test (`federated_two_node_pilot.rs:539`) samples
+`effective_at` **once** and carries the same value to both nodes — the
+replication pattern in miniature.
+
+**Caveat**: the production value is currently degenerate. The producer sets
+`effective_at: proposal.effective_at.unwrap_or(0)`
+(`icn/apps/governance/src/handlers/execution.rs:160`), and
+`ProtocolChangeProposal::effective_at` is deprecated/must-be-`None` pending
+delayed execution (#282) — so real protocol changes carry `0` today. That
+is still cross-node deterministic (every node sees the same `0`), which is
+the property being mirrored; but it means the precedent proves the
+*architecture* (decision-carried, sampled at most once, replicated as
+bytes), not a production-quality *source* for the timestamp value. The
+membership implementation must pick its source deliberately (§5).
+
+### 2.6 What the existing test does and does not check
+
+`test_two_node_membership_add_determinism`
+(`icn/crates/icn-core/tests/federated_two_node_pilot.rs:287`) executes the
+same serialized `MembershipEffect::AddMember` on two independent nodes and
+compares only the extracted `state_change_hash` (plus an `is_member`
+liveness check). It never compares durable `Member` records — which is why
+#2284 could make it deterministic without touching the durable divergence.
+
+## 3. Problem
+
+Post-#2284, the convergence story is split: the *fingerprint* of a
+membership state change is cross-node deterministic, but the *durable state*
+it fingerprints is not, because five timestamp fields are read from local
+wall-clock at execution time. This matters because:
+
+- The `federated_two_node_pilot` intent is replicated-state determinism:
+  same decision in, same state out. A durable record that differs by
+  execution instant silently breaks any future durable-state convergence
+  check, state sync comparison, or byte-level audit across nodes.
+- The AGENTS.md **Determinism** invariant ("Protocol state transitions …
+  must be deterministic. Same inputs → same outputs") is currently satisfied
+  only for the hash, not for the state the hash stands in front of.
+- Freeze expiry is *behavior*, not just bookkeeping: `freeze_expires_at`
+  derives from the local read, so two nodes can disagree about **when a
+  member's suspension ends** — a real divergence in effective membership
+  state, not merely in audit trivia.
+
+It was correct not to fold this into #2284: fixing it requires a schema
+change to `MembershipEffect` and the request structs plus changes to every
+effect producer — a cross-cutting change with compatibility consequences,
+exactly what a one-function flake fix must not smuggle in. #2284's merge
+kept that boundary explicit; this contract exists so the boundary is
+decided deliberately rather than re-litigated inside an implementation
+patch.
+
+## 4. Decision
+
+**Deterministic durable timestamps via a decision-carried `effective_at`
+are the target semantics** (option 1 of #2286). The audit found no
+architectural contradiction — the protocol executor already persists a
+decision-carried timestamp into its durable record, and `MembershipEffect`'s
+`#[serde(default)] decision_hash` fields show the effect schema is designed
+to grow decision-derived fields.
+
+The contract:
+
+1. **Membership state treated as durable protocol state must be
+   replay-deterministic across nodes.** Two nodes executing the same
+   governance decision must persist byte-identical durable membership
+   convergence state — including its timestamps.
+2. **Local audit timestamps may still exist, but are separated from
+   protocol/durable convergence state.** The in-memory
+   `MembershipProvenance.timestamp` stays node-local audit metadata. If any
+   node-local execution instant is ever persisted, it must live in a
+   clearly-labeled audit location excluded from every convergence
+   comparison — never in the fields below.
+3. **The future implementation threads `effective_at` through membership
+   effects/requests and uses it for the durable fields**: `joined_at`,
+   `removed_at`, `frozen_at`, `freeze_expires_at`, and `unfrozen_at`. No
+   durable membership timestamp is sourced from `Utc::now()` /
+   `current_timestamp_secs()` on the replay path.
+4. **The `state_change_hash` `membership:v2:` layout is unchanged by this
+   contract.** It is already deterministic and pinned by #2284; whether
+   `effective_at` should ever join the fingerprint would be a separate
+   explicit `membership:v3:` decision, which this document neither makes
+   nor recommends.
+
+## 5. Future implementation sketch (no code in this PR)
+
+Likely surfaces, in dependency order:
+
+- **`MembershipEffect`** (`icn-kernel-api/src/effects.rs`): add
+  `effective_at` to the variants that persist timestamps (`AddMember`,
+  `RemoveMember`, `FreezeMember`, `UnfreezeMember`). Compatibility posture
+  for old serialized effects is §6's decision.
+- **Service request structs** (`icn-kernel-api/src/services.rs`): mirror
+  the field on `AddMemberRequest`, `RemoveMemberRequest`,
+  `FreezeMemberRequest`, `UnfreezeMemberRequest`.
+- **Effect producers** (`icn/apps/governance/src/handlers/execution.rs`):
+  stamp `effective_at` from a decision-derived source, sampled **at most
+  once per decision** before fan-out, so every node receives identical
+  bytes. The source is an open sub-decision for the implementation design:
+  candidate anchors are the decision receipt's recorded timestamp, an
+  activation-time value, or an explicit proposal-carried field. The
+  invariant is source-independence per node — never a per-node `now()`.
+  (The protocol lane's deprecated proposal-level `effective_at`, #282, is a
+  cautionary sibling: don't resurrect that field accidentally; pick a
+  source that exists on the decided path.)
+- **Governance executor** (`KernelMembershipExecutor`): pass the field
+  through effect → request conversion.
+- **Membership service** (`MembershipServiceImpl`): use `effective_at` for
+  `joined_at` (this requires the add path to stop relying on
+  `Member::new`'s internal `Utc::now()` — e.g. setting `joined_at`
+  explicitly after construction, leaving `Member::new` itself untouched for
+  non-governance callers, or a deliberate constructor-signature decision in
+  the implementation PR), `removed_at`, `frozen_at`, `freeze_expires_at`,
+  `unfrozen_at`.
+- **Tests**: `federated_two_node_pilot.rs` grows a durable-record
+  comparison (§7).
+- **OpenAPI/SDK**: expected **none**, but the implementation PR must
+  verify. The gateway's `AddMemberRequest`
+  (`icn-gateway/src/models.rs:107`) is a different, non-governance shape
+  (`did`/`role`/`display_name`) — the kernel-api request structs are not
+  the OpenAPI surface. If any effect/request shape turns out to be exposed,
+  the standard drift chain applies (OpenAPI regen + TS types).
+
+**Freeze expiration becomes deterministic for free**: `duration_secs` is
+already decision-carried on `FreezeMember`, so
+`freeze_expires_at = effective_at + duration_secs` is a pure function of
+decision inputs. (Use saturating arithmetic; both are u64 seconds.)
+
+**Update-member needs no durable timestamp.** The audit (§2.2) shows the
+update path persists no timestamp today — its wall-clock read feeds only
+the in-memory provenance map. There is nothing to make deterministic, and
+adding a new durable `updated_at` would be new surface, not determinism
+repair. `UpdateMember`/`UpdateMemberRequest` therefore do not need
+`effective_at` unless a durable update timestamp is deliberately introduced
+later — a separate decision.
+
+**Adjacent, explicitly out of scope**: `icn-entity/src/membership.rs`
+(`joined_at: now` at `:99`, `updated_at` bumps throughout) shows the same
+wall-clock pattern on the entity-level membership record. It is a different
+store behind a different lane; this contract covers only the
+`MembershipService`/`CoopStore` path named by #2286. If entity-level
+durable convergence is ever claimed, that lane needs its own audit.
+
+## 6. Compatibility and migration questions
+
+Existing serialized `MembershipEffect` values (in stores, WALs, gossip
+replay, or fixtures) lack `effective_at`. The implementation PR must decide
+— explicitly, in its design section — one of:
+
+1. **Fail closed**: replayed governance effects without `effective_at` are
+   rejected on the convergence path. Strongest determinism; requires
+   knowing whether any pre-schema effects legitimately still replay.
+2. **Versioned effect shapes**: a v2 membership effect (mirroring how the
+   hash layout was versioned `membership:v2:`), with v1 effects handled by
+   an explicit legacy path.
+3. **Legacy local-timestamp behavior confined to clearly non-convergent
+   legacy paths**: old effects keep old behavior, but no convergence claim
+   is ever made over records they produced.
+
+What the implementation must **not** do is silently default the field —
+`#[serde(default)]` on `effective_at` would stamp epoch-zero (or
+worse, a hidden `now()`) into durable records and smuggle the compatibility
+decision into a serde attribute. The `decision_hash` `#[serde(default)]`
+precedent is not automatically transferable: an empty-string hash degrades
+provenance, but a defaulted timestamp silently *fabricates* state. This
+document deliberately does not pick among the three options; it only
+requires that the choice be explicit, written down, and tested.
+
+## 7. Test obligations for the implementation PR
+
+The implementation PR is expected to carry at least:
+
+- **Two-node durable-record comparison**: extend the
+  `federated_two_node_pilot` membership tests to compare durable `Member`
+  records (or a normalized durable-state projection that includes the
+  timestamp fields) across both nodes — not just `state_change_hash`.
+- **Decision-carried persistence per operation**: add/remove/freeze/
+  unfreeze each persist exactly the decision-carried timestamp
+  (`joined_at`/`removed_at`/`frozen_at`/`unfrozen_at` equal `effective_at`,
+  not a node-local read).
+- **Deterministic freeze expiration**:
+  `freeze_expires_at == effective_at + duration_secs` on every node.
+- **Audit/convergence separation**: if a local audit timestamp is retained
+  anywhere durable, a test proves it is excluded from the durable
+  convergence comparison.
+- **Legacy behavior is explicit**: whichever §6 option is chosen, a test
+  pins it (missing `effective_at` → rejected, or versioned path taken, or
+  legacy path marked non-convergent).
+- **Fingerprint stability**: `state_change_hash` for the existing
+  `membership:v2:` layout is byte-for-byte unchanged by the implementation
+  (regression against the #2284 contract).
+
+## 8. Non-claims
+
+- **No schema change in this PR** — `MembershipEffect`, the request
+  structs, and `Member` are untouched.
+- **No runtime behavior change** — every timestamp is still read from
+  local wall-clock exactly as audited in §2.
+- **No OpenAPI/SDK change.**
+- **No production, pilot, organizer-ready, member-ready, live-federation,
+  or Phase 2 completion claim.**
+- **No #1748/#2141 closure** — both remain open; this lane is adjacent to,
+  not part of, the process-receipt spine.
+- **No #2081/#2080/#2274 progress.**
+- **No durable timestamp implementation yet** — this document is the
+  decision, not the change.
+
+## 9. Follow-up implementation issue / PR plan
+
+**#2286 remains open as the implementation tracker.** No child issue is
+proposed: the audit surfaced exactly one lane of work (thread
+`effective_at` through effect → request → executor → service, plus the §6
+compatibility choice and §7 tests), which fits a single design-first
+implementation PR referencing this contract. The one sub-decision that
+could justify a split — the *source* of `effective_at` on the deciding path
+(§5) — is small enough to be pinned in the implementation PR's design
+section; split it out only if it turns out to be contested.

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -1412,6 +1412,15 @@ last_updated = "2026-07-02"
 owner = "matt"
 audiences = ["architects", "developers"]
 
+[docs."docs/design/membership-durable-timestamp-semantics.md"]
+category = "design"
+status = "draft"
+title = "Membership durable timestamp semantics — Design/Audit Contract"
+description = "Design/audit contract for #2286 after #2284 made membership state_change_hash a deterministic decision-identity fingerprint: durable Member records still persist node-local wall-clock (joined_at field; removed_at/frozen_at/freeze_expires_at/unfrozen_at metadata), so replaying the same governance decision on two nodes diverges in durable bytes. Decides the target semantics — deterministic durable timestamps via a decision-carried effective_at threaded through MembershipEffect/requests (mirroring the KernelProtocolExecutor SetParameter precedent, with the honest caveat that the protocol producer's value is currently degenerate 0 pending #282), local audit timestamps separated from durable convergence state, freeze_expires_at = effective_at + duration_secs, update-member needs no durable timestamp, membership:v2 hash layout unchanged. Names the serialized-effect compatibility choice (fail-closed vs versioned vs legacy-non-convergent) as an explicit future implementation decision — no serde(default) smuggling — plus the implementation PR's test obligations. Design only — no schema/runtime/OpenAPI/SDK change (Refs #2286, #2284, #2283; #2286 stays open)"
+last_updated = "2026-07-03"
+owner = "matt"
+audiences = ["architects", "developers"]
+
 [docs."docs/design/README.md"]
 category = "reference"
 status = "canonical"


### PR DESCRIPTION
## What

Adds a design/audit contract for #2286: durable `Member` timestamp semantics after #2284 made `state_change_hash` a deterministic decision-identity fingerprint.

The doc audits the current split (verified at `main` @ `e8057cc6`):

- `state_change_hash` now excludes node-local execution wall-clock and fingerprints decision-derived identity inputs only (`membership:v2:` length-prefixed layout, `membership_service.rs:108`).
- durable `Member` records still persist node-local timestamp fields: the `joined_at` field (`Member::new` → `Utc::now()`, `icn-coop/src/types.rs:721`) and `removed_at`/`frozen_at`/`freeze_expires_at`/`unfrozen_at` metadata (`membership_service.rs:286/:507/:527/:635`).
- `MembershipEffect` (`icn-kernel-api/src/effects.rs:191`) does not carry `effective_at`; the kernel-api request structs don't either.
- update-member persists **no** durable timestamp today (its wall-clock read feeds only in-memory provenance), so it needs no `effective_at`.
- `KernelProtocolExecutor` is the precedent: `ProtocolEffect::SetParameter.effective_at` is decision-carried, hashed, and persisted into the durable parameter record — with the honest caveat that producers currently emit `unwrap_or(0)` because proposal-level delayed execution is deprecated (#282), so the precedent proves the architecture, not a production timestamp source.

## Decision / recommendation

The design direction is deterministic durable membership timestamps via a decision-carried `effective_at`, with local audit timestamps separated from durable convergence state if retained. Freeze expiry becomes a pure function of decision inputs (`effective_at + duration_secs`). The `membership:v2:` hash layout is explicitly unchanged. The serialized-effect compatibility posture (fail-closed vs versioned shapes vs legacy-non-convergent) is named as an explicit future implementation decision — not defaulted via serde attributes.

This is a design contract only. It does not implement the schema/runtime change. #2286 remains open as the implementation tracker; no child issue proposed.

## Why

#2284 closed the fingerprint flake/root cause in #2283 but intentionally left durable record determinism to #2286. This PR prevents that boundary from being forgotten or re-litigated inside an implementation patch.

## Files

- `docs/design/membership-durable-timestamp-semantics.md` — the contract (new).
- `docs/registry.toml` — registry entry in the established design-doc style.
- `docs/INDEX.generated.md` — mechanical regen from the registry (also catches up entries registered by earlier merged lanes; the file had drifted because the index check is warn-only).

## Validation

- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — passed; zero warnings mention the new doc (pre-existing warn-only mismatches unchanged).
- `python3 docs/scripts/generate-index.py --registry docs/registry.toml > docs/INDEX.generated.md` — regenerated, converged.
- `git diff --check` — clean.
- Code anchors in the doc verified by direct `rg` against `main` @ `e8057cc6`.

## Non-claims

No Rust schema change.
No runtime behavior change.
No OpenAPI/SDK change.
No production, pilot, organizer-ready, member-ready, live-federation, or Phase 2 completion claim.
No #1748/#2141 closure.
No #2081/#2080/#2274 progress.

Refs #2286.
Refs #2284.
Refs #2283.
Refs #1748.
Refs #2141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
