### PR TITLE
feat(membership): carry effective_at through durable Member timestamps

### DIFF
--- a/docs/design/membership-durable-timestamp-semantics.md
+++ b/docs/design/membership-durable-timestamp-semantics.md
@@ -331,23 +331,24 @@ The implementation PR made the two open sub-decisions this contract left to
 it. Recorded here so the doc stays the audit trail.
 
 **Source of `effective_at` (§5): `ProposalAccepted.decided_at`.** The
-governance decision's own recorded time (`icn-kernel-api/src/events.rs`,
+governance decision's own recorded time
+(`icn/crates/icn-kernel-api/src/events.rs`,
 `SystemEvent::ProposalAccepted.decided_at`) is threaded through
-`translate_payload_to_effects` (`apps/governance/src/lib.rs` →
-`handlers/execution.rs`) into the four durable membership effects. It is
-sampled exactly once when the proposal is closed
-(`apps/governance/src/actor.rs`, `decided_at: now`), persisted in the close
-journal (`apps/governance/src/close_journal.rs` — "recovery reproduces the
-same `decided_at` rather than using restart time"), and gossiped in the
-event, so every node replaying the decision reads an identical value and
-never a local clock. It is the membership analogue of the protocol lane's
-decision-carried `effective_at`, and is unrelated to the deprecated
-proposal-level delayed-execution field (#282).
+`translate_payload_to_effects` (`icn/apps/governance/src/lib.rs` →
+`icn/apps/governance/src/handlers/execution.rs`) into the four durable
+membership effects. It is sampled exactly once when the proposal is closed
+(`icn/apps/governance/src/actor.rs`, `decided_at: now`), persisted in the
+close journal (`icn/apps/governance/src/close_journal.rs` — "recovery
+reproduces the same `decided_at` rather than using restart time"), and
+gossiped in the event, so every node replaying the decision reads an
+identical value and never a local clock. It is the membership analogue of
+the protocol lane's decision-carried `effective_at`, and is unrelated to the
+deprecated proposal-level delayed-execution field (#282).
 
 **Compatibility posture (§6): versioned `Option<u64>`, not fail-closed.**
 The audit found that membership effects are persisted in
 `ExecutionRecord.effects` and re-decoded on the crash-recovery convergence
-path (`icn-core/src/supervisor/decision_executor.rs`), so a bare
+path (`icn/crates/icn-core/src/supervisor/decision_executor.rs`), so a bare
 non-`default` field would break recovery of in-flight pre-upgrade decisions.
 The field is therefore `effective_at: Option<u64>` with `#[serde(default)]`:
 new decisions always carry `Some(decided_at)` (fully convergent); effects
@@ -364,3 +365,19 @@ callers), and the `membership:v2` `state_change_hash` layout (a regression
 test asserts the fingerprint is independent of `effective_at`). No schema
 exposed to OpenAPI/SDK (the kernel-api request/effect types carry no
 `ToSchema` derive and appear in neither the generated spec nor the SDK).
+
+**Scope of the convergence claim (metadata / raw bytes).** This PR makes the
+durable *logical* state converge — the timestamp fields plus the
+decision-derived metadata are identical across nodes replaying one decision.
+It does **not** claim the raw `save_member` byte stream is identical.
+`Member.metadata` is a `HashMap<String, String>` and `CoopStore::save_member`
+serializes the whole struct with postcard, so map iteration order (and thus
+the byte encoding) is not deterministic across processes even when the
+logical contents match. Accordingly the two-node test asserts a **normalized
+durable-state projection** (the §7-sanctioned option): typed fields compared
+directly, and `metadata` compared order-normalized (sorted), not as raw
+bytes. A true byte-level durable/audit/sync comparison would first require a
+canonical `Member` serialization (e.g. a `BTreeMap` metadata or a canonical
+encoder) — a separate concern from the timestamp determinism fixed here, and
+explicitly out of scope for #2286. The convergence claim in this lane is
+therefore scoped to the normalized projection, not raw record bytes.

--- a/docs/design/membership-durable-timestamp-semantics.md
+++ b/docs/design/membership-durable-timestamp-semantics.md
@@ -324,3 +324,43 @@ implementation PR referencing this contract. The one sub-decision that
 could justify a split — the *source* of `effective_at` on the deciding path
 (§5) — is small enough to be pinned in the implementation PR's design
 section; split it out only if it turns out to be contested.
+
+## 10. Implementation PR decision (`feat/membership-effective-at-durable-timestamps`)
+
+The implementation PR made the two open sub-decisions this contract left to
+it. Recorded here so the doc stays the audit trail.
+
+**Source of `effective_at` (§5): `ProposalAccepted.decided_at`.** The
+governance decision's own recorded time (`icn-kernel-api/src/events.rs`,
+`SystemEvent::ProposalAccepted.decided_at`) is threaded through
+`translate_payload_to_effects` (`apps/governance/src/lib.rs` →
+`handlers/execution.rs`) into the four durable membership effects. It is
+sampled exactly once when the proposal is closed
+(`apps/governance/src/actor.rs`, `decided_at: now`), persisted in the close
+journal (`apps/governance/src/close_journal.rs` — "recovery reproduces the
+same `decided_at` rather than using restart time"), and gossiped in the
+event, so every node replaying the decision reads an identical value and
+never a local clock. It is the membership analogue of the protocol lane's
+decision-carried `effective_at`, and is unrelated to the deprecated
+proposal-level delayed-execution field (#282).
+
+**Compatibility posture (§6): versioned `Option<u64>`, not fail-closed.**
+The audit found that membership effects are persisted in
+`ExecutionRecord.effects` and re-decoded on the crash-recovery convergence
+path (`icn-core/src/supervisor/decision_executor.rs`), so a bare
+non-`default` field would break recovery of in-flight pre-upgrade decisions.
+The field is therefore `effective_at: Option<u64>` with `#[serde(default)]`:
+new decisions always carry `Some(decided_at)` (fully convergent); effects
+serialized before this field decode as `None` — **not** epoch zero — and the
+service falls back to the pre-#2286 node-local `current_timestamp_secs()`
+for the durable write, a path that is explicitly non-convergent and
+reachable only by legacy effects. No fabricated protocol time is ever
+written; `None` never means "0".
+
+**Not changed:** `UpdateMember`/`UpdateMemberRequest` (persist no durable
+timestamp), `Member::new` (a `with_joined_at_secs` seam sets `joined_at`
+after construction, leaving the constructor intact for non-governance
+callers), and the `membership:v2` `state_change_hash` layout (a regression
+test asserts the fingerprint is independent of `effective_at`). No schema
+exposed to OpenAPI/SDK (the kernel-api request/effect types carry no
+`ToSchema` derive and appear in neither the generated spec nor the SDK).

--- a/icn/apps/governance/src/handlers/execution.rs
+++ b/icn/apps/governance/src/handlers/execution.rs
@@ -43,6 +43,13 @@ impl fmt::Display for TranslationError {
 /// # Arguments
 /// * `payload` - The domain-specific proposal payload
 /// * `decision_receipt_id` - The receipt ID for audit linkage
+/// * `decision_hash` - Canonical governance decision hash for provenance
+/// * `domain_id` - Domain (entity) the decision applies to
+/// * `effective_at` - Decision-carried effective time (Unix seconds), sourced from
+///   `ProposalAccepted.decided_at`. Threaded into durable membership effects so nodes
+///   replaying the same decision persist identical timestamps instead of local
+///   wall-clock (#2286). Same value for every replaying node; sampled once at the
+///   decision boundary, never read per-node here.
 ///
 /// # Returns
 /// A vector of kernel effects (usually 1, but some proposals produce multiple)
@@ -51,6 +58,7 @@ pub fn translate_payload_to_effects(
     decision_receipt_id: &str,
     decision_hash: &str,
     domain_id: &str,
+    effective_at: u64,
 ) -> Result<Vec<KernelEffect>, TranslationError> {
     match payload {
         // Treasury proposals
@@ -97,7 +105,7 @@ pub fn translate_payload_to_effects(
 
         // Membership proposals
         ProposalPayload::Membership { action, member } => {
-            translate_membership_action(action, member, domain_id, decision_hash)
+            translate_membership_action(action, member, domain_id, decision_hash, effective_at)
         }
 
         ProposalPayload::FreezeMember {
@@ -111,6 +119,7 @@ pub fn translate_payload_to_effects(
                 reason: reason.clone(),
                 duration_secs: *duration_seconds,
                 decision_hash: decision_hash.to_string(),
+                effective_at: Some(effective_at),
             },
         )]),
 
@@ -120,6 +129,7 @@ pub fn translate_payload_to_effects(
                     entity_id: domain_id.to_string(),
                     member_did: member.to_string(),
                     decision_hash: decision_hash.to_string(),
+                    effective_at: Some(effective_at),
                 },
             )])
         }
@@ -586,6 +596,7 @@ fn translate_membership_action(
     member: &icn_identity::Did,
     domain_id: &str,
     decision_hash: &str,
+    effective_at: u64,
 ) -> Result<Vec<KernelEffect>, TranslationError> {
     use icn_governance::MembershipAction;
 
@@ -597,6 +608,7 @@ fn translate_membership_action(
                 role: String::new(),
                 tier: String::new(),
                 decision_hash: decision_hash.to_string(),
+                effective_at: Some(effective_at),
             },
         )]),
         MembershipAction::Remove => Ok(vec![KernelEffect::Membership(
@@ -605,6 +617,7 @@ fn translate_membership_action(
                 member_did: member.to_string(),
                 reason: String::new(),
                 decision_hash: decision_hash.to_string(),
+                effective_at: Some(effective_at),
             },
         )]),
     }
@@ -745,6 +758,7 @@ mod tests {
             "receipt-123",
             "decision-hash-123",
             "domain-translation-test",
+            1_700_000_000,
         )
         .expect("translation should succeed");
         assert_eq!(effects.len(), 1);
@@ -786,6 +800,7 @@ mod tests {
             "receipt-bond-001",
             "decision-hash-bond-001",
             "did:icn:zTreasury",
+            1_700_000_000,
         )
         .expect("BondIssuance must translate successfully");
 
@@ -832,6 +847,7 @@ mod tests {
             "receipt-abc",
             "decision-hash-abc",
             "domain-translation-test",
+            1_700_000_000,
         );
         let err = effects.expect_err("unsupported payload must be explicit");
         assert_eq!(err.kind, "payload");
@@ -861,6 +877,7 @@ mod tests {
             "receipt-redeem-001",
             "decision-hash-redeem-001",
             "did:icn:zTreasury",
+            1_700_000_000,
         )
         .expect("ShareRedemption must translate successfully");
 
@@ -942,6 +959,7 @@ mod tests {
                 "receipt-pilot",
                 "hash-pilot",
                 "domain-pilot",
+                1_700_000_000,
             )
             .expect("pilot treasury payloads should translate");
             assert!(
@@ -989,6 +1007,7 @@ mod tests {
             "receipt-alloc-1",
             "decision-hash-alloc-1",
             "domain-alloc",
+            1_700_000_000,
         )
         .expect("allocation should translate");
 
@@ -1098,6 +1117,7 @@ mod tests {
             "receipt-surplus-1",
             "hash-surplus-1",
             "domain-coop-x",
+            1_700_000_000,
         )
         .expect("surplus allocation should translate");
         assert_eq!(effects.len(), 1);
@@ -1136,9 +1156,14 @@ mod tests {
                 reason: "persistent imbalance violations".to_string(),
             },
         );
-        let effects =
-            translate_payload_to_effects(&payload, "receipt-tc-1", "hash-tc-1", "coop-alpha")
-                .expect("TerminateClearing should translate");
+        let effects = translate_payload_to_effects(
+            &payload,
+            "receipt-tc-1",
+            "hash-tc-1",
+            "coop-alpha",
+            1_700_000_000,
+        )
+        .expect("TerminateClearing should translate");
         assert_eq!(effects.len(), 1);
         match &effects[0] {
             KernelEffect::Federation(
@@ -1172,9 +1197,14 @@ mod tests {
                 reason: "governance misconduct".to_string(),
             },
         );
-        let effects =
-            translate_payload_to_effects(&payload, "receipt-rv-1", "hash-rv-1", "coop-alpha")
-                .expect("RevokeVouch should translate");
+        let effects = translate_payload_to_effects(
+            &payload,
+            "receipt-rv-1",
+            "hash-rv-1",
+            "coop-alpha",
+            1_700_000_000,
+        )
+        .expect("RevokeVouch should translate");
         assert_eq!(effects.len(), 1);
         match &effects[0] {
             KernelEffect::Federation(icn_kernel_api::effects::FederationEffect::RevokeVouch {
@@ -1219,9 +1249,14 @@ mod tests {
                 source_agreement_id: Some("agreement-direct-1".to_string()),
             },
         );
-        let effects =
-            translate_payload_to_effects(&payload, "receipt-ec-1", "hash-ec-1", "coop-alpha")
-                .expect("EstablishClearing should translate");
+        let effects = translate_payload_to_effects(
+            &payload,
+            "receipt-ec-1",
+            "hash-ec-1",
+            "coop-alpha",
+            1_700_000_000,
+        )
+        .expect("EstablishClearing should translate");
         assert_eq!(effects.len(), 1);
         match &effects[0] {
             KernelEffect::Federation(

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -150,6 +150,7 @@ where
             proposal_id,
             payload,
             domain_id,
+            decided_at,
             canonical_payload_hash,
             governance_decision_hash,
             ..
@@ -169,12 +170,15 @@ where
             // Deserialize payload
             match serde_json::from_value::<ProposalPayload>(payload.clone()) {
                 Ok(proposal_payload) => {
-                    // Translate to effects
+                    // Translate to effects. `decided_at` is the decision-carried
+                    // effective time (same for every node replaying this decision);
+                    // durable membership effects use it so records converge (#2286).
                     let effects = translate_payload_to_effects(
                         &proposal_payload,
                         &decision_receipt_id,
                         &decision_hash,
                         domain_id,
+                        *decided_at,
                     );
                     match effects {
                         Ok(effects) => {

--- a/icn/crates/icn-coop/src/types.rs
+++ b/icn/crates/icn-coop/src/types.rs
@@ -732,6 +732,23 @@ impl Member {
         self
     }
 
+    /// Overwrite `joined_at` with a decision-carried effective time (Unix seconds).
+    ///
+    /// Governance-driven membership adds set `joined_at` from the decision's
+    /// `effective_at` rather than the node-local `Utc::now()` stamped by
+    /// [`Member::new`], so nodes replaying the same decision persist identical
+    /// durable records (issue #2286). `Member::new` is left intact for
+    /// non-governance callers.
+    ///
+    /// Deterministic and total: the same `secs` yields the same `DateTime` on every
+    /// node; an out-of-range value (unreachable for a real governance `decided_at`)
+    /// saturates to the representable bound rather than reading a local clock.
+    pub fn with_joined_at_secs(mut self, secs: u64) -> Self {
+        let clamped = i64::try_from(secs).unwrap_or(i64::MAX);
+        self.joined_at = DateTime::from_timestamp(clamped, 0).unwrap_or(DateTime::<Utc>::MAX_UTC);
+        self
+    }
+
     /// Set capital contribution
     pub fn with_capital(mut self, amount: u64) -> Self {
         self.capital_contribution = amount;

--- a/icn/crates/icn-core/src/services/membership_service.rs
+++ b/icn/crates/icn-core/src/services/membership_service.rs
@@ -182,6 +182,16 @@ impl MembershipService for MembershipServiceImpl {
             member = member.with_tier(tier);
         }
 
+        // Durable `joined_at` is the decision-carried `effective_at`, so nodes
+        // replaying the same governance decision persist an identical record
+        // (#2286). Legacy effects without `effective_at` (`None`) keep
+        // `Member::new`'s node-local `Utc::now()` — the pre-#2286 behavior, which
+        // is non-convergent but only reachable by effects serialized before this
+        // field existed.
+        if let Some(effective_at) = request.effective_at {
+            member = member.with_joined_at_secs(effective_at);
+        }
+
         // Start as Active (governance already approved via proposal)
         member.status = MemberStatus::Active;
 
@@ -259,7 +269,12 @@ impl MembershipService for MembershipServiceImpl {
             "Processing remove member request"
         );
 
+        // Node-local wall-clock, retained only for the in-memory audit provenance.
         let timestamp = icn_time::current_timestamp_secs();
+        // Durable `removed_at` uses the decision-carried `effective_at` so records
+        // converge across nodes (#2286); legacy effects (`None`) fall back to the
+        // node-local `timestamp` — non-convergent, pre-#2286 behavior.
+        let durable_ts = request.effective_at.unwrap_or(timestamp);
 
         // Parse the member DID
         let did = match Self::parse_did(&request.member_did) {
@@ -283,7 +298,7 @@ impl MembershipService for MembershipServiceImpl {
                     .insert("removal_reason".to_string(), request.reason.clone());
                 member
                     .metadata
-                    .insert("removed_at".to_string(), timestamp.to_string());
+                    .insert("removed_at".to_string(), durable_ts.to_string());
                 // Governance provenance — enables cold-cache recovery after restart
                 member.metadata.insert(
                     "gov_decision_receipt_id".to_string(),
@@ -466,7 +481,12 @@ impl MembershipService for MembershipServiceImpl {
             "Processing freeze member request"
         );
 
+        // Node-local wall-clock, retained only for the in-memory audit provenance.
         let timestamp = icn_time::current_timestamp_secs();
+        // Durable `frozen_at`/`freeze_expires_at` use the decision-carried
+        // `effective_at` so records converge across nodes (#2286); legacy effects
+        // (`None`) fall back to the node-local `timestamp` — non-convergent.
+        let durable_ts = request.effective_at.unwrap_or(timestamp);
 
         // Parse the member DID
         let did = match Self::parse_did(&request.member_did) {
@@ -504,7 +524,7 @@ impl MembershipService for MembershipServiceImpl {
                     .insert("freeze_reason".to_string(), request.reason.clone());
                 member
                     .metadata
-                    .insert("frozen_at".to_string(), timestamp.to_string());
+                    .insert("frozen_at".to_string(), durable_ts.to_string());
                 // Governance provenance — enables cold-cache recovery after restart
                 member.metadata.insert(
                     "gov_decision_receipt_id".to_string(),
@@ -518,8 +538,9 @@ impl MembershipService for MembershipServiceImpl {
                     .metadata
                     .insert("gov_operation".to_string(), "freeze".to_string());
 
-                // Calculate expiration if duration specified
-                let expires_at = request.duration_secs.map(|d| timestamp + d);
+                // Calculate expiration if duration specified. Deterministic:
+                // freeze_expires_at = effective_at + duration_secs (saturating).
+                let expires_at = request.duration_secs.map(|d| durable_ts.saturating_add(d));
                 if let Some(exp) = expires_at {
                     member
                         .metadata
@@ -599,7 +620,12 @@ impl MembershipService for MembershipServiceImpl {
             "Processing unfreeze member request"
         );
 
+        // Node-local wall-clock, retained only for the in-memory audit provenance.
         let timestamp = icn_time::current_timestamp_secs();
+        // Durable `unfrozen_at` uses the decision-carried `effective_at` so records
+        // converge across nodes (#2286); legacy effects (`None`) fall back to the
+        // node-local `timestamp` — non-convergent, pre-#2286 behavior.
+        let durable_ts = request.effective_at.unwrap_or(timestamp);
 
         // Parse the member DID
         let did = match Self::parse_did(&request.member_did) {
@@ -632,7 +658,7 @@ impl MembershipService for MembershipServiceImpl {
                 member.status = MemberStatus::Active;
                 member
                     .metadata
-                    .insert("unfrozen_at".to_string(), timestamp.to_string());
+                    .insert("unfrozen_at".to_string(), durable_ts.to_string());
                 member.metadata.remove("freeze_expires_at");
                 // Governance provenance — enables cold-cache recovery after restart
                 member.metadata.insert(
@@ -798,6 +824,7 @@ mod tests {
             tier: "Standard".to_string(),
             decision_receipt_id: "gov:proposal:add-member:receipt:test-123".to_string(),
             decision_hash: "sha256:addtest12345".to_string(),
+            effective_at: Some(1_700_000_000),
         };
 
         let result = service
@@ -850,6 +877,7 @@ mod tests {
                 tier: "Founder".to_string(),
                 decision_receipt_id: "gov:proposal:add:receipt:reload-123".to_string(),
                 decision_hash: "sha256:reload-test-hash".to_string(),
+                effective_at: Some(1_700_000_000),
             };
 
             let result = service.add_member(request).expect("add_member failed");
@@ -918,6 +946,7 @@ mod tests {
                 tier: "Standard".to_string(),
                 decision_receipt_id: "gov:add:receipt:1".to_string(),
                 decision_hash: "sha256:add1".to_string(),
+                effective_at: Some(1_700_000_000),
             };
             let add_result = service.add_member(add_req).expect("add failed");
             assert!(add_result.success, "Add should succeed");
@@ -930,6 +959,7 @@ mod tests {
                 duration_secs: Some(86400),
                 decision_receipt_id: "gov:freeze:receipt:1".to_string(),
                 decision_hash: "sha256:freeze1".to_string(),
+                effective_at: Some(1_700_000_000),
             };
             let freeze_result = service.freeze_member(freeze_req).expect("freeze failed");
             assert!(freeze_result.success, "Freeze should succeed");
@@ -997,6 +1027,7 @@ mod tests {
                 tier: "Standard".to_string(),
                 decision_receipt_id: "gov:add:receipt:2".to_string(),
                 decision_hash: "sha256:add2".to_string(),
+                effective_at: Some(1_700_000_000),
             };
             service.add_member(add_req).expect("add failed");
 
@@ -1007,6 +1038,7 @@ mod tests {
                 reason: "Voluntary resignation".to_string(),
                 decision_receipt_id: "gov:remove:receipt:2".to_string(),
                 decision_hash: "sha256:remove2".to_string(),
+                effective_at: Some(1_700_000_000),
             };
             let remove_result = service.remove_member(remove_req).expect("remove failed");
             assert!(remove_result.success, "Remove should succeed");
@@ -1069,6 +1101,7 @@ mod tests {
                 tier: "Standard".to_string(),
                 decision_receipt_id: "gov:add:receipt:3".to_string(),
                 decision_hash: "sha256:add3".to_string(),
+                effective_at: Some(1_700_000_000),
             };
             service.add_member(add_req).expect("add failed");
 
@@ -1144,6 +1177,7 @@ mod tests {
             tier: "Standard".to_string(),
             decision_receipt_id: "gov:add:status".to_string(),
             decision_hash: "sha256:status".to_string(),
+            effective_at: Some(1_700_000_000),
         };
         service.add_member(add_req).expect("add failed");
 
@@ -1159,6 +1193,7 @@ mod tests {
             duration_secs: None,
             decision_receipt_id: "gov:freeze:status".to_string(),
             decision_hash: "sha256:freezestatus".to_string(),
+            effective_at: Some(1_700_000_000),
         };
         service.freeze_member(freeze_req).expect("freeze failed");
 
@@ -1243,6 +1278,178 @@ mod tests {
             a, b,
             "hash input must be injective — shifting a `:` boundary between \
              adjacent fields must change the hash"
+        );
+    }
+
+    // ==================================================================
+    // #2286 — durable timestamps come from decision-carried effective_at
+    // ==================================================================
+
+    const TEST_EFFECTIVE_AT: u64 = 1_700_000_000;
+
+    fn add_request(entity: &str, did: &str, effective_at: Option<u64>) -> AddMemberRequest {
+        AddMemberRequest {
+            entity_id: entity.to_string(),
+            member_did: did.to_string(),
+            role: "Worker".to_string(),
+            tier: "Standard".to_string(),
+            decision_receipt_id: "gov:add:eff".to_string(),
+            decision_hash: "sha256:add-eff".to_string(),
+            effective_at,
+        }
+    }
+
+    /// `Some(effective_at)` → durable `joined_at` is exactly that decision time,
+    /// not a node-local `Utc::now()`.
+    #[test]
+    fn add_member_joined_at_is_decision_effective_at() {
+        let (store, _t) = make_test_store();
+        let service = MembershipServiceImpl::new(store.clone());
+        let did = make_test_did();
+        let entity = "coop:eff-add";
+
+        service
+            .add_member(add_request(
+                entity,
+                &did.to_string(),
+                Some(TEST_EFFECTIVE_AT),
+            ))
+            .expect("add failed");
+
+        let m = store.get_member(entity, &did).expect("get_member");
+        assert_eq!(
+            m.joined_at.timestamp(),
+            TEST_EFFECTIVE_AT as i64,
+            "joined_at must be the decision-carried effective_at"
+        );
+    }
+
+    /// remove/freeze/unfreeze persist the decision-carried `effective_at` into their
+    /// durable metadata, and `freeze_expires_at = effective_at + duration_secs`.
+    #[test]
+    fn mutation_ops_persist_decision_effective_at() {
+        let (store, _t) = make_test_store();
+        let service = MembershipServiceImpl::new(store.clone());
+        let did = make_test_did();
+        let did_str = did.to_string();
+        let entity = "coop:eff-mut";
+        const DURATION: u64 = 3600;
+
+        service
+            .add_member(add_request(entity, &did_str, Some(TEST_EFFECTIVE_AT)))
+            .expect("add failed");
+
+        // Freeze → frozen_at == effective_at; freeze_expires_at == effective_at + duration.
+        let freeze = service
+            .freeze_member(FreezeMemberRequest {
+                entity_id: entity.to_string(),
+                member_did: did_str.clone(),
+                reason: "review".to_string(),
+                duration_secs: Some(DURATION),
+                decision_receipt_id: "gov:freeze:eff".to_string(),
+                decision_hash: "sha256:freeze-eff".to_string(),
+                effective_at: Some(TEST_EFFECTIVE_AT),
+            })
+            .expect("freeze failed");
+        assert_eq!(freeze.expires_at, Some(TEST_EFFECTIVE_AT + DURATION));
+        let frozen = store.get_member(entity, &did).expect("get_member");
+        assert_eq!(
+            frozen.metadata.get("frozen_at").map(String::as_str),
+            Some(TEST_EFFECTIVE_AT.to_string().as_str())
+        );
+        assert_eq!(
+            frozen.metadata.get("freeze_expires_at").map(String::as_str),
+            Some((TEST_EFFECTIVE_AT + DURATION).to_string().as_str()),
+            "freeze_expires_at must be effective_at + duration_secs"
+        );
+
+        // Unfreeze → unfrozen_at == effective_at.
+        service
+            .unfreeze_member(UnfreezeMemberRequest {
+                entity_id: entity.to_string(),
+                member_did: did_str.clone(),
+                decision_receipt_id: "gov:unfreeze:eff".to_string(),
+                decision_hash: "sha256:unfreeze-eff".to_string(),
+                effective_at: Some(TEST_EFFECTIVE_AT),
+            })
+            .expect("unfreeze failed");
+        let unfrozen = store.get_member(entity, &did).expect("get_member");
+        assert_eq!(
+            unfrozen.metadata.get("unfrozen_at").map(String::as_str),
+            Some(TEST_EFFECTIVE_AT.to_string().as_str())
+        );
+
+        // Remove → removed_at == effective_at.
+        service
+            .remove_member(RemoveMemberRequest {
+                entity_id: entity.to_string(),
+                member_did: did_str.clone(),
+                reason: "exit".to_string(),
+                decision_receipt_id: "gov:remove:eff".to_string(),
+                decision_hash: "sha256:remove-eff".to_string(),
+                effective_at: Some(TEST_EFFECTIVE_AT),
+            })
+            .expect("remove failed");
+        let removed = store.get_member(entity, &did).expect("get_member");
+        assert_eq!(
+            removed.metadata.get("removed_at").map(String::as_str),
+            Some(TEST_EFFECTIVE_AT.to_string().as_str())
+        );
+    }
+
+    /// Legacy effects (`effective_at: None`) fall back to node-local time — the
+    /// pre-#2286 behavior. This path is explicitly non-convergent, but must NOT
+    /// fabricate an epoch-zero protocol timestamp.
+    #[test]
+    fn legacy_none_effective_at_uses_local_time_not_epoch_zero() {
+        let (store, _t) = make_test_store();
+        let service = MembershipServiceImpl::new(store.clone());
+        let did = make_test_did();
+        let entity = "coop:eff-legacy";
+
+        service
+            .add_member(add_request(entity, &did.to_string(), None))
+            .expect("add failed");
+
+        let m = store.get_member(entity, &did).expect("get_member");
+        assert!(
+            m.joined_at.timestamp() > 1_600_000_000,
+            "legacy None must fall back to a real local timestamp, never epoch zero"
+        );
+    }
+
+    /// The `membership:v2` `state_change_hash` is a decision-identity fingerprint
+    /// and must be independent of `effective_at`: two adds differing only in
+    /// `effective_at` produce the same hash.
+    #[test]
+    fn state_change_hash_ignores_effective_at() {
+        let (store_a, _a) = make_test_store();
+        let (store_b, _b) = make_test_store();
+        let service_a = MembershipServiceImpl::new(store_a);
+        let service_b = MembershipServiceImpl::new(store_b);
+        let did = make_test_did();
+        let entity = "coop:eff-hash";
+
+        let hash_a = service_a
+            .add_member(add_request(
+                entity,
+                &did.to_string(),
+                Some(TEST_EFFECTIVE_AT),
+            ))
+            .expect("add a")
+            .state_change_hash;
+        let hash_b = service_b
+            .add_member(add_request(
+                entity,
+                &did.to_string(),
+                Some(TEST_EFFECTIVE_AT + 12345),
+            ))
+            .expect("add b")
+            .state_change_hash;
+
+        assert_eq!(
+            hash_a, hash_b,
+            "state_change_hash must not depend on effective_at (membership:v2 unchanged)"
         );
     }
 }

--- a/icn/crates/icn-core/src/supervisor/governance_executor.rs
+++ b/icn/crates/icn-core/src/supervisor/governance_executor.rs
@@ -1923,6 +1923,7 @@ impl KernelMembershipExecutor {
                     role,
                     tier,
                     decision_hash: effect_decision_hash,
+                    effective_at,
                 } => {
                     // Use the content hash carried in the effect when available;
                     // fall back to blake3(receipt_id) for effects without one.
@@ -1938,6 +1939,7 @@ impl KernelMembershipExecutor {
                         tier,
                         decision_receipt_id: receipt_id.to_string(),
                         decision_hash: resolved_hash,
+                        effective_at,
                     };
 
                     let result = service.add_member(request)?;
@@ -1966,6 +1968,7 @@ impl KernelMembershipExecutor {
                     member_did,
                     reason,
                     decision_hash: effect_decision_hash,
+                    effective_at,
                 } => {
                     let resolved_hash = if effect_decision_hash.is_empty() {
                         compute_decision_hash(receipt_id)
@@ -1978,6 +1981,7 @@ impl KernelMembershipExecutor {
                         reason,
                         decision_receipt_id: receipt_id.to_string(),
                         decision_hash: resolved_hash,
+                        effective_at,
                     };
 
                     let result = service.remove_member(request)?;
@@ -2043,6 +2047,7 @@ impl KernelMembershipExecutor {
                     reason,
                     duration_secs,
                     decision_hash: effect_decision_hash,
+                    effective_at,
                 } => {
                     let resolved_hash = if effect_decision_hash.is_empty() {
                         compute_decision_hash(receipt_id)
@@ -2056,6 +2061,7 @@ impl KernelMembershipExecutor {
                         duration_secs,
                         decision_receipt_id: receipt_id.to_string(),
                         decision_hash: resolved_hash,
+                        effective_at,
                     };
 
                     let result = service.freeze_member(request)?;
@@ -2084,6 +2090,7 @@ impl KernelMembershipExecutor {
                     entity_id,
                     member_did,
                     decision_hash: effect_decision_hash,
+                    effective_at,
                 } => {
                     let resolved_hash = if effect_decision_hash.is_empty() {
                         compute_decision_hash(receipt_id)
@@ -2095,6 +2102,7 @@ impl KernelMembershipExecutor {
                         member_did: member_did.clone(),
                         decision_receipt_id: receipt_id.to_string(),
                         decision_hash: resolved_hash,
+                        effective_at,
                     };
 
                     let result = service.unfreeze_member(request)?;

--- a/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
+++ b/icn/crates/icn-core/tests/decision_executor_runtime_test.rs
@@ -1238,9 +1238,14 @@ async fn test_withdraw_payload_restart_resume_single_mutation() {
         },
     };
 
-    let effects =
-        translate_payload_to_effects(&payload, decision_receipt_id, decision_hash, domain_id)
-            .expect("withdraw payload should translate");
+    let effects = translate_payload_to_effects(
+        &payload,
+        decision_receipt_id,
+        decision_hash,
+        domain_id,
+        1_700_000_000,
+    )
+    .expect("withdraw payload should translate");
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         KernelEffect::Treasury(TreasuryEffect::Spend {
@@ -1303,9 +1308,14 @@ async fn test_withdraw_payload_restart_resume_single_mutation() {
         entry_hash
     };
 
-    let replay_effects =
-        translate_payload_to_effects(&payload, decision_receipt_id, decision_hash, domain_id)
-            .expect("withdraw replay payload should translate");
+    let replay_effects = translate_payload_to_effects(
+        &payload,
+        decision_receipt_id,
+        decision_hash,
+        domain_id,
+        1_700_000_000,
+    )
+    .expect("withdraw replay payload should translate");
     let reopened_ledger_store = Arc::new(SledStore::open(&ledger_store_path).unwrap());
     let reopened_ledger = Ledger::new(reopened_ledger_store).unwrap();
     let reopened_ledger = Arc::new(tokio::sync::RwLock::new(reopened_ledger));
@@ -1395,9 +1405,14 @@ fn test_treasury_spend_payload_translation_produces_treasury_spend_effect() {
         },
     };
 
-    let effects =
-        translate_payload_to_effects(&payload, decision_receipt_id, decision_hash, domain_id)
-            .expect("treasury spend payload should translate");
+    let effects = translate_payload_to_effects(
+        &payload,
+        decision_receipt_id,
+        decision_hash,
+        domain_id,
+        1_700_000_000,
+    )
+    .expect("treasury spend payload should translate");
     assert_eq!(effects.len(), 1);
     match &effects[0] {
         KernelEffect::Treasury(TreasuryEffect::Spend {

--- a/icn/crates/icn-core/tests/effect_group_integration.rs
+++ b/icn/crates/icn-core/tests/effect_group_integration.rs
@@ -181,6 +181,7 @@ async fn test_membership_add_member_provenance_chain() -> Result<()> {
         role: "Worker".to_string(),
         tier: "Standard".to_string(),
         decision_hash: String::new(),
+        effective_at: Some(1_700_000_000),
     };
 
     // Execute the membership operation
@@ -273,6 +274,7 @@ async fn test_membership_freeze_member_provenance_chain() -> Result<()> {
         tier: "Standard".to_string(),
         decision_receipt_id: "gov:membership:add:pre-freeze".to_string(),
         decision_hash: "hash-add".to_string(),
+        effective_at: Some(1_700_000_000),
     };
     membership_service.add_member(add_request)?;
 
@@ -287,6 +289,7 @@ async fn test_membership_freeze_member_provenance_chain() -> Result<()> {
         reason: "Policy violation under review".to_string(),
         duration_secs: Some(86400), // 24 hours
         decision_hash: String::new(),
+        effective_at: Some(1_700_000_000),
     };
 
     let outcome = executor
@@ -365,6 +368,7 @@ async fn test_membership_unfreeze_member_provenance_chain() -> Result<()> {
         tier: "Standard".to_string(),
         decision_receipt_id: "gov:add:pre-unfreeze".to_string(),
         decision_hash: "hash-add".to_string(),
+        effective_at: Some(1_700_000_000),
     })?;
     membership_service.freeze_member(FreezeMemberRequest {
         entity_id: "coop-unfreeze-test".to_string(),
@@ -373,6 +377,7 @@ async fn test_membership_unfreeze_member_provenance_chain() -> Result<()> {
         duration_secs: Some(3600),
         decision_receipt_id: "gov:freeze:pre-unfreeze".to_string(),
         decision_hash: "hash-freeze".to_string(),
+        effective_at: Some(1_700_000_000),
     })?;
 
     // Verify member is frozen
@@ -384,6 +389,7 @@ async fn test_membership_unfreeze_member_provenance_chain() -> Result<()> {
         entity_id: "coop-unfreeze-test".to_string(),
         member_did: member_did_str.clone(),
         decision_hash: String::new(),
+        effective_at: Some(1_700_000_000),
     };
 
     let outcome = executor

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -389,13 +389,31 @@ async fn test_two_node_membership_add_determinism() -> Result<()> {
 
     // === ASSERT DURABLE RECORD CONVERGENCE (#2286) ===
     // The decision-identity fingerprint (state_change_hash) converging is not
-    // enough: the durable `Member` record must also be byte-identical across
+    // enough: the durable `Member` *logical* state must also converge across
     // nodes. Before #2286, `joined_at` was each node's local `Utc::now()` and
-    // diverged across a seconds boundary. Compare a normalized durable-state
-    // projection that includes the timestamp.
+    // diverged across a seconds boundary.
+    //
+    // We assert a NORMALIZED durable-state projection, not raw `save_member`
+    // bytes: `Member.metadata` is a `HashMap` and `save_member` postcard-encodes
+    // the whole struct, so map iteration order (and thus the byte stream) is not
+    // deterministic across processes even when the logical contents match. A
+    // byte-level guarantee would need a canonical `Member` encoding, which is a
+    // separate concern from the timestamp determinism under test here (see
+    // docs/design/membership-durable-timestamp-semantics.md §10).
     let member_a = coop_store_a.get_member("coop-sunrise-pilot", &member_did)?;
     let member_b = coop_store_b.get_member("coop-sunrise-pilot", &member_did)?;
 
+    // Order-normalized metadata so HashMap iteration order can't mask/forge a
+    // difference — this proves the *logical* metadata converges.
+    let sorted_metadata = |m: &icn_coop::Member| {
+        let mut kv: Vec<(String, String)> = m
+            .metadata
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        kv.sort();
+        kv
+    };
     let project = |m: &icn_coop::Member| {
         (
             m.joined_at,
@@ -404,12 +422,14 @@ async fn test_two_node_membership_add_determinism() -> Result<()> {
             m.tier.as_ref().map(|t| t.name.clone()),
             m.shares,
             m.capital_contribution,
+            sorted_metadata(m),
         )
     };
     assert_eq!(
         project(&member_a),
         project(&member_b),
-        "Durable Member records must converge across nodes replaying the same decision"
+        "Durable Member logical state (incl. order-normalized metadata) must \
+         converge across nodes replaying the same decision"
     );
 
     // And the durable timestamp must be the decision-carried `effective_at`, not a

--- a/icn/crates/icn-core/tests/federated_two_node_pilot.rs
+++ b/icn/crates/icn-core/tests/federated_two_node_pilot.rs
@@ -296,6 +296,11 @@ async fn test_two_node_membership_add_determinism() -> Result<()> {
     let member_did = generate_test_did();
     let decision_receipt_id = DecisionReceiptId::new("gov:membership:add:pilot:001");
 
+    // Decision-carried effective time (same value replayed on both nodes). The
+    // durable `joined_at` must equal this on both nodes, not each node's local
+    // wall-clock (#2286).
+    let effective_at: u64 = 1_700_000_000;
+
     // Create the effect
     let effect = MembershipEffect::AddMember {
         entity_id: "coop-sunrise-pilot".to_string(),
@@ -303,6 +308,7 @@ async fn test_two_node_membership_add_determinism() -> Result<()> {
         role: "Worker".to_string(),
         tier: "Standard".to_string(),
         decision_hash: String::new(),
+        effective_at: Some(effective_at),
     };
 
     // === Node A Setup ===
@@ -381,7 +387,40 @@ async fn test_two_node_membership_add_determinism() -> Result<()> {
         hash_a, hash_b
     );
 
-    info!("✅ Membership add determinism verified");
+    // === ASSERT DURABLE RECORD CONVERGENCE (#2286) ===
+    // The decision-identity fingerprint (state_change_hash) converging is not
+    // enough: the durable `Member` record must also be byte-identical across
+    // nodes. Before #2286, `joined_at` was each node's local `Utc::now()` and
+    // diverged across a seconds boundary. Compare a normalized durable-state
+    // projection that includes the timestamp.
+    let member_a = coop_store_a.get_member("coop-sunrise-pilot", &member_did)?;
+    let member_b = coop_store_b.get_member("coop-sunrise-pilot", &member_did)?;
+
+    let project = |m: &icn_coop::Member| {
+        (
+            m.joined_at,
+            format!("{:?}", m.role),
+            format!("{:?}", m.status),
+            m.tier.as_ref().map(|t| t.name.clone()),
+            m.shares,
+            m.capital_contribution,
+        )
+    };
+    assert_eq!(
+        project(&member_a),
+        project(&member_b),
+        "Durable Member records must converge across nodes replaying the same decision"
+    );
+
+    // And the durable timestamp must be the decision-carried `effective_at`, not a
+    // node-local clock read.
+    assert_eq!(
+        member_a.joined_at.timestamp(),
+        effective_at as i64,
+        "joined_at must equal the decision-carried effective_at"
+    );
+
+    info!("✅ Membership add determinism + durable record convergence verified");
     Ok(())
 }
 
@@ -693,6 +732,7 @@ async fn test_two_node_effect_batch_determinism() -> Result<()> {
             role: "Coordinator".to_string(),
             tier: "Founding".to_string(),
             decision_hash: String::new(),
+            effective_at: Some(1_700_000_000),
         }),
         KernelEffect::NoOp {
             reason: "Resolution text recorded".to_string(),
@@ -885,6 +925,7 @@ async fn test_two_node_federation_reload_durability() -> Result<()> {
         role: "Worker".to_string(),
         tier: "Standard".to_string(),
         decision_hash: String::new(),
+        effective_at: Some(1_700_000_000),
     };
 
     // === Create persistent tempdirs for both nodes ===

--- a/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
+++ b/icn/crates/icn-core/tests/receipt_chain_vertical_slice.rs
@@ -286,6 +286,7 @@ async fn test_allocation_receipt_chain_end_to_end() -> Result<()> {
         "receipt-vertical-slice",
         "decision-hash-vertical-slice",
         event_domain_id.as_str(),
+        1_700_000_000,
     )
     .expect("allocation payload should translate into executable kernel effects");
 

--- a/icn/crates/icn-kernel-api/src/effects.rs
+++ b/icn/crates/icn-kernel-api/src/effects.rs
@@ -200,6 +200,17 @@ pub enum MembershipEffect {
         /// without recomputing from the receipt_id string.
         #[serde(default)]
         decision_hash: String,
+        /// Decision-carried effective time (Unix seconds) used for the durable
+        /// `joined_at` timestamp, so nodes replaying the same governance decision
+        /// persist identical records instead of each stamping local wall-clock
+        /// (issue #2286). Sourced from `ProposalAccepted.decided_at`.
+        ///
+        /// `Option` + `#[serde(default)]` for compatibility: effects serialized
+        /// before this field decode as `None` (a legacy, non-convergent path that
+        /// falls back to local time) rather than fabricating epoch-zero protocol
+        /// time. New governance decisions always carry `Some(decided_at)`.
+        #[serde(default)]
+        effective_at: Option<u64>,
     },
     /// Remove a member
     RemoveMember {
@@ -209,6 +220,10 @@ pub enum MembershipEffect {
         /// Canonical content hash of the governance decision payload.
         #[serde(default)]
         decision_hash: String,
+        /// Decision-carried effective time (Unix seconds) for the durable
+        /// `removed_at` timestamp. See `AddMember::effective_at` (#2286).
+        #[serde(default)]
+        effective_at: Option<u64>,
     },
     /// Change member role/tier
     UpdateMember {
@@ -226,6 +241,11 @@ pub enum MembershipEffect {
         /// Canonical content hash of the governance decision payload.
         #[serde(default)]
         decision_hash: String,
+        /// Decision-carried effective time (Unix seconds) for the durable
+        /// `frozen_at` timestamp; `freeze_expires_at = effective_at + duration_secs`.
+        /// See `AddMember::effective_at` (#2286).
+        #[serde(default)]
+        effective_at: Option<u64>,
     },
     /// Unfreeze member (restore rights)
     UnfreezeMember {
@@ -234,6 +254,10 @@ pub enum MembershipEffect {
         /// Canonical content hash of the governance decision payload.
         #[serde(default)]
         decision_hash: String,
+        /// Decision-carried effective time (Unix seconds) for the durable
+        /// `unfrozen_at` timestamp. See `AddMember::effective_at` (#2286).
+        #[serde(default)]
+        effective_at: Option<u64>,
     },
 }
 
@@ -927,11 +951,39 @@ mod tests {
             reason: "Policy violation".into(),
             duration_secs: Some(86400),
             decision_hash: String::new(),
+            effective_at: Some(1_700_000_000),
         };
 
         let json = serde_json::to_string(&effect).unwrap();
         assert!(json.contains("freeze_member"));
         assert!(json.contains("duration_secs"));
+        assert!(json.contains("effective_at"));
+    }
+
+    /// A membership effect serialized before `effective_at` existed must still
+    /// decode (as `None`), so persisted/in-flight effects survive the #2286 upgrade
+    /// on the crash-recovery path. `None` is an explicit legacy marker, never a
+    /// fabricated epoch-zero protocol timestamp.
+    #[test]
+    fn membership_effect_decodes_legacy_without_effective_at() {
+        let legacy = r#"{"action":"add_member","entity_id":"coop-1","member_did":"did:icn:bob","role":"worker","tier":"standard","decision_hash":"h"}"#;
+        match serde_json::from_str::<MembershipEffect>(legacy).unwrap() {
+            MembershipEffect::AddMember { effective_at, .. } => {
+                assert_eq!(effective_at, None, "legacy add_member must decode as None");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+
+        let legacy_freeze = r#"{"action":"freeze_member","entity_id":"coop-1","member_did":"did:icn:bob","reason":"x","duration_secs":3600,"decision_hash":"h"}"#;
+        match serde_json::from_str::<MembershipEffect>(legacy_freeze).unwrap() {
+            MembershipEffect::FreezeMember { effective_at, .. } => {
+                assert_eq!(
+                    effective_at, None,
+                    "legacy freeze_member must decode as None"
+                );
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
     }
 
     #[test]
@@ -1026,6 +1078,7 @@ mod tests {
                 role: "worker".into(),
                 tier: "standard".into(),
                 decision_hash: String::new(),
+                effective_at: None,
             }),
             KernelEffect::Membership(MembershipEffect::UpdateMember {
                 entity_id: "coop-1".into(),
@@ -1039,6 +1092,7 @@ mod tests {
                 reason: "Policy violation".into(),
                 duration_secs: Some(86400),
                 decision_hash: String::new(),
+                effective_at: None,
             }),
             KernelEffect::Protocol(ProtocolEffect::SetParameter {
                 parameter_name: "voting_period".into(),
@@ -1202,12 +1256,14 @@ mod tests {
                 role: "worker".into(),
                 tier: "standard".into(),
                 decision_hash: String::new(),
+                effective_at: Some(1_700_000_000),
             },
             MembershipEffect::RemoveMember {
                 entity_id: "e1".into(),
                 member_did: "did:icn:m1".into(),
                 reason: "Voluntary exit".into(),
                 decision_hash: String::new(),
+                effective_at: Some(1_700_000_001),
             },
             MembershipEffect::UpdateMember {
                 entity_id: "e1".into(),
@@ -1221,11 +1277,13 @@ mod tests {
                 reason: "Investigation".into(),
                 duration_secs: Some(3600),
                 decision_hash: String::new(),
+                effective_at: Some(1_700_000_002),
             },
             MembershipEffect::UnfreezeMember {
                 entity_id: "e1".into(),
                 member_did: "did:icn:m1".into(),
                 decision_hash: String::new(),
+                effective_at: Some(1_700_000_003),
             },
         ];
 

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -1538,6 +1538,11 @@ pub struct AddMemberRequest {
     pub decision_receipt_id: String,
     /// Hash of the decision that authorized this addition
     pub decision_hash: String,
+    /// Decision-carried effective time (Unix seconds) for the durable `joined_at`
+    /// timestamp, so replaying the same decision converges across nodes (#2286).
+    /// `None` = legacy effect with no decision time → non-convergent local fallback.
+    #[serde(default)]
+    pub effective_at: Option<u64>,
 }
 
 /// Result of adding a member
@@ -1564,6 +1569,10 @@ pub struct RemoveMemberRequest {
     pub decision_receipt_id: String,
     /// Hash of the decision that authorized this removal
     pub decision_hash: String,
+    /// Decision-carried effective time (Unix seconds) for the durable `removed_at`
+    /// timestamp. See [`AddMemberRequest::effective_at`] (#2286).
+    #[serde(default)]
+    pub effective_at: Option<u64>,
 }
 
 /// Result of removing a member
@@ -1620,6 +1629,11 @@ pub struct FreezeMemberRequest {
     pub decision_receipt_id: String,
     /// Hash of the decision that authorized this freeze
     pub decision_hash: String,
+    /// Decision-carried effective time (Unix seconds) for the durable `frozen_at`
+    /// timestamp; `freeze_expires_at = effective_at + duration_secs`.
+    /// See [`AddMemberRequest::effective_at`] (#2286).
+    #[serde(default)]
+    pub effective_at: Option<u64>,
 }
 
 /// Result of freezing a member
@@ -1646,6 +1660,10 @@ pub struct UnfreezeMemberRequest {
     pub decision_receipt_id: String,
     /// Hash of the decision that authorized this unfreeze
     pub decision_hash: String,
+    /// Decision-carried effective time (Unix seconds) for the durable `unfrozen_at`
+    /// timestamp. See [`AddMemberRequest::effective_at`] (#2286).
+    #[serde(default)]
+    pub effective_at: Option<u64>,
 }
 
 /// Result of unfreezing a member


### PR DESCRIPTION
## What

Implements the #2286 durable membership timestamp contract from #2287 ([`docs/design/membership-durable-timestamp-semantics.md`](docs/design/membership-durable-timestamp-semantics.md)).

Durable membership timestamps for add/remove/freeze/unfreeze now come from a decision-carried `effective_at` rather than node-local wall-clock reads, so two nodes replaying the same governance decision converge on the durable `Member` **logical** state (a normalized durable-state projection) — closing the durability gap #2284 left after making `state_change_hash` a deterministic decision-identity fingerprint.

> **Scope of the convergence claim:** this claims *logical* convergence (typed fields + order-normalized metadata), not raw `save_member` byte-identity. `Member.metadata` is a `HashMap` postcard-encoded as part of the whole struct, so iteration order (hence bytes) is nondeterministic across processes even when contents match. A byte-level guarantee would need a canonical `Member` encoding — a separate concern, out of scope for #2286. The two-node test asserts the §7-sanctioned normalized projection (metadata sorted). Raised by Codex review; addressed in doc §10 + test.

## Design decisions

- `effective_at` is carried on `MembershipEffect::{AddMember, RemoveMember, FreezeMember, UnfreezeMember}` and mirrored on the corresponding kernel-api request structs.
- `UpdateMember` / `UpdateMemberRequest` are **unchanged** — they persist no durable timestamp today (the audit confirmed their wall-clock read feeds only in-memory provenance), so adding one would be new surface, not #2286 repair.
- `freeze_expires_at = effective_at + duration_secs` (saturating).
- The `membership:v2` `state_change_hash` layout is **byte-for-byte unchanged**; a regression test asserts the fingerprint is independent of `effective_at`.
- `Member::new` is left intact for non-governance callers; a new `with_joined_at_secs` seam sets `joined_at` from `effective_at` after construction.
- The in-memory `MembershipProvenance.timestamp` stays node-local audit metadata, separate from durable convergence state.

**Effective-at source: `SystemEvent::ProposalAccepted.decided_at`.** The governance decision's own recorded time — sampled once when the proposal is closed (`actor.rs`, `decided_at: now`), persisted in the close journal (`close_journal.rs`: *"recovery reproduces the same `decided_at` rather than using restart time"*), and gossiped in the event. Every node replaying the decision reads the same value; it is never a per-node clock read, and is unrelated to the deprecated proposal-level delayed-execution field (#282). Threaded via `translate_payload_to_effects` (`apps/governance/src/lib.rs` → `handlers/execution.rs`).

**Compatibility posture: versioned `Option<u64>` + `#[serde(default)]`, not fail-closed.** Live evidence: membership effects are persisted in `ExecutionRecord.effects` and re-decoded on the crash-recovery convergence path (`decision_executor.rs`), so a bare non-`default` field would break recovery of in-flight pre-upgrade decisions. Therefore:
- new decisions always carry `Some(decided_at)` — fully convergent;
- effects serialized before this field decode as `None` (**never** epoch zero — no fabricated protocol time) and the service falls back to the pre-#2286 node-local `current_timestamp_secs()` for the durable write, a path that is explicitly non-convergent and reachable only by legacy effects.

## Files

- `icn-kernel-api/src/effects.rs`, `services.rs` — `effective_at: Option<u64>` on the four effects/requests.
- `icn-core/src/supervisor/governance_executor.rs` — thread effect → request.
- `apps/governance/src/handlers/execution.rs`, `lib.rs` — producer + `decided_at` source.
- `icn-coop/src/types.rs` — `Member::with_joined_at_secs` seam.
- `icn-core/src/services/membership_service.rs` — durable fields use `effective_at`; new tests.
- Test call-site/fixtures updates + `federated_two_node_pilot.rs` durable-record convergence assertion.
- `docs/design/membership-durable-timestamp-semantics.md` — §10 records the two sub-decisions made here.

## Validation

- `cargo test -p icn-kernel-api --lib` → 616 passed.
- `cargo test -p icn-coop --lib` → 164 passed.
- `cargo test -p icn-core --lib services::membership_service` → 14 passed (4 new: joined_at == effective_at; mutation ops persist effective_at + freeze expiry; legacy `None` → local, non-epoch-zero; hash ignores `effective_at`).
- `cargo test -p icn-core --test federated_two_node_pilot` → 6 passed (extended: two-node durable `Member` projection convergence + `joined_at == effective_at`).
- `cargo test -p icn-core --test {effect_group_integration, membership_action_governance_integration, freeze_unfreeze_governance_integration, remove_member_governance_integration}` → 10 / 2 / 3 / 2 passed.
- `cargo fmt --all --check` clean; `cargo clippy -p icn-kernel-api -p icn-coop -p icn-governance-actor -p icn-core --all-targets -- -D warnings` clean; `cargo check --workspace --all-targets` clean; `git diff --check` clean.
- No OpenAPI/SDK impact: the changed kernel-api types carry no `utoipa::ToSchema` derive and appear in neither `docs/api/openapi.generated.yaml` nor the TS SDK.

## Non-claims

No production, pilot, organizer-ready, member-ready, live-federation, or Phase 2 completion claim.
No #1748/#2141 closure.
No #2081/#2080/#2274 progress.
No process-spine change.
No `membership:v2` hash-layout change.
Durable convergence is claimed only for the membership add/remove/freeze/unfreeze path implemented and tested here; legacy (`None`) effects remain intentionally non-convergent.

Refs #2286
Refs #2287
Refs #2284
Refs #2283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
