### PR TITLE
feat(process): organizer-steward evidence surface runtime dogfood slice

### DIFF
--- a/docs/demo/JULY_DEMO_CANDIDATE_0.1_PROCESS_EVIDENCE_WALKTHROUGH.md
+++ b/docs/demo/JULY_DEMO_CANDIDATE_0.1_PROCESS_EVIDENCE_WALKTHROUGH.md
@@ -1,0 +1,276 @@
+# July Demo Candidate 0.1 — organizer-steward process-evidence surface walkthrough
+
+**Truth label.** DEV/DEMO, fixture-mode, single-actor, fictional data. This document
+records an accessibility and rendered-browser review of the **organizer-steward
+evidence surface** (icn#2289) — a fixture-only, read-only view on the **member-shell v0
+reference client** (`web/member-shell/`), reached at `?mode=demo&set=process-evidence`.
+It is **proof of path, not deployment readiness**. It is not production, not a pilot,
+not organizer-ready, not member-ready, not live federation, not NYCN activation, not
+Phase 2 completion, not real member/partner data, and makes no signed/partner claim.
+
+This surface reads the **four already-landed ADR-0026 Layer 2 process-transition
+receipt classes** (`icn/crates/icn-governance/src/proof.rs`) — no new receipt class is
+introduced, no Rust runtime is changed, and no OpenAPI/SDK is touched. It implements the
+design contract landed in **#2290**
+([`docs/design/organizer-steward-evidence-surface-runtime-dogfood.md`](../design/organizer-steward-evidence-surface-runtime-dogfood.md)).
+
+## 1. What was run, and what was not
+
+| Path | Status |
+|---|---|
+| Rendered-browser walkthrough of the process-evidence view (`?mode=demo&set=process-evidence`) | **RUN** (headless Chromium, this pass) |
+| Regression check of the pre-existing demos (`?mode=demo` and `?mode=demo&set=community`) | **RUN** (this pass — both still pass; see §4) |
+| Automated WCAG scan (axe-core; tags `wcag2a, wcag2aa, wcag21a, wcag21aa, wcag22aa`) | **RUN** (this pass) |
+| Keyboard-navigation + visible-focus trace | **RUN** (this pass) |
+| 200% zoom (CSS), narrow/mobile reflow, reduced-motion render | **RUN** (this pass) |
+| i18n pseudo-locale coverage of the new evidence copy (`&lang=qps-ploc`) | **RUN** (this pass — new copy is fully keyed; see §4) |
+| Repo-safe evidence-summary export schema validation (`urn:icn:contract:rehearsal-evidence-export:v1`) | **RUN** (this pass — validates; see §4) |
+| **Live** gateway / real receipts | **NOT run** — this slice is fixture-only by design; the `ProcessGateResultReceipt` is fixture-simulated (a wire-shaped record), not a live gate run. |
+| **Screen-reader** (VoiceOver/NVDA/Orca) smoke | **NOT run** — no AT in this headless environment. Remains **owed** (tracked in **#2041**). |
+| **Human** low-vision / switch-control / low-end-device verification | **NOT run** — automated proxies only; human pass remains **owed** (**#2041**). |
+
+> Participation access is architecture, not polish. This pass clears the automated and
+> rendered-structural floor for the new evidence view **and** confirms the two existing
+> demos still pass; the human AT pass (#2041) is explicitly recorded as still owed.
+
+## 2. Method (reproducible, zero new dependencies)
+
+- Served the repo's `web/` directory statically (`python3 -m http.server 8099`), opened
+  `…/member-shell/?mode=demo&set=process-evidence`.
+- Drove headless Chromium via Playwright + `@axe-core/playwright`, the **declared
+  devDependencies of `web/pilot-ui`** (`@axe-core/playwright` per #1735) — no new
+  dependency stack is introduced.
+- **Committed audit script:** [`web/member-shell/a11y-walkthrough.cjs`](../../web/member-shell/a11y-walkthrough.cjs).
+  For #2289 it gained one additive, backward-compatible hook: an optional `MSHELL_SET`
+  env var appends `&set=<value>` to the audited URL. **Unset (the default) audits
+  `?mode=demo` byte-for-byte as before**, so the prior accessibility evidence is
+  undisturbed. Reproduce:
+  ```
+  ( cd web/pilot-ui && npm ci && npx playwright install chromium )
+  ( cd web && python3 -m http.server 8099 --bind 127.0.0.1 & )     # serve the web/ root on :8099
+  # the new process-evidence view:
+  MSHELL_SET=process-evidence NODE_PATH=web/pilot-ui/node_modules \
+    node web/member-shell/a11y-walkthrough.cjs http://127.0.0.1:8099 ./out
+  # regression: the two pre-existing demos still pass (unset = default demo; community):
+  NODE_PATH=web/pilot-ui/node_modules node web/member-shell/a11y-walkthrough.cjs http://127.0.0.1:8099 ./out-demo
+  MSHELL_SET=community NODE_PATH=web/pilot-ui/node_modules \
+    node web/member-shell/a11y-walkthrough.cjs http://127.0.0.1:8099 ./out-community
+  ```
+- **Browser-revision provenance (honest):** Playwright resolves its own pinned Chromium
+  for the *installed* Playwright version, so the exact binary is **environment-dependent,
+  not a single pinned revision**. This run used the lockfile-pinned **Playwright 1.60.0 →
+  chromium-1223**. These are static-surface WCAG checks (semantic HTML, ARIA, contrast,
+  focus); the 0-violation result is expected to be stable across recent Chromium
+  revisions, but the recorded numbers below are specifically for 1.60.0/chromium-1223.
+- **Schema validation:** `python3 docs/scripts/validate-rehearsal-evidence.py
+  web/member-shell/fixtures/process-evidence-export.json` (existing validator, no new
+  tooling; Python 3.11+ + `jsonschema`).
+- Fixtures consumed: `web/pilot-ui/fixtures/icn-organizer-demo/{standing,action-cards}.json`
+  (reused, unchanged) and the two new member-shell-local fixtures
+  `web/member-shell/fixtures/process-evidence-{receipts,export}.json` (fictional
+  `did:icn:example-*-not-live`, illustrative `record_hash`/`body_hash`, nothing signed).
+
+## 3. Rendered walkthrough — observed
+
+The process-evidence view renders the `receipt → surface → evidence/export` tail of the
+vertical spine **as read views**: the four process-transition receipts in sequence, a
+fixture-safe privacy/redaction boundary, and a repo-safe evidence-summary export. No
+mutation is performed; no gateway is contacted.
+
+| Observation | Result |
+|---|---|
+| Honesty banner text (permanently visible) | `Fixture-backed demo — no live node, nothing signed.` |
+| Standing pane visible; memberships / roles rendered | yes (reused demo standing) |
+| Action cards pane visible | yes (reused demo cards) |
+| Receipts pane: four process-transition receipts rendered in order | yes — **4 receipts** (`ProcessSessionOpenedReceipt` → `DeliberationEntryRecordedReceipt` → `DecisionRecordedReceipt` → `ProcessGateResultReceipt`) |
+| Plain-language summary first; record fields under "Show evidence detail" | yes (per receipt) |
+| Privacy/redaction boundary legible | yes — the deliberation entry shows "What the steward body sees" (fictional summary) **and** "What members and the export see" (redaction reason + `record_hash`/`body_hash` proof pointers, no input text) |
+| Proof pointers labeled honestly | yes — `record_hash` = proof pointer; `body_hash` = "proof of content; the input itself is never stored"; recorder DIDs labeled "who recorded this fact, not who decided" |
+| Evidence-summary export panel visible; read-only | yes — renders `urn:icn:contract:rehearsal-evidence-export:v1`; **no download/generate/copy control present** |
+| Landmarks present | `header, nav, main, footer` |
+| Skip link present | yes (`a.skip-link → #main`) |
+| Credential in URL (demo mode) | **none** |
+| Mobile (360px) horizontal scroll | none (clean reflow) |
+
+Screenshots (desktop, 200% zoom, mobile-360, reduced-motion) are archived in the artifact
+class (see §8). No credential, token, key, private IP/hostname, real name, or email
+appears in any screenshot or fixture (demo mode pastes nothing; all fixture data is
+fictional).
+
+## 4. Automated check results
+
+Process-evidence view (`?mode=demo&set=process-evidence`), and the two regression runs:
+
+| Check | Process-evidence | Default `?mode=demo` (regression) | `&set=community` (regression) |
+|---|---|---|---|
+| **axe-core** (`wcag2a, wcag2aa, wcag21a, wcag21aa, wcag22aa`) | **0 violations**, 27 passes | 0 violations, 27 passes | 0 violations, 27 passes |
+| Keyboard: focusables reached by Tab | 16 | 16 | 15 |
+| Keyboard: **every** focused element had a visible outline | **true** | true | true |
+| Receipts rendered | **4** | 1 | 1 |
+| 200% CSS zoom render | no layout break | no layout break | no layout break |
+| Mobile (360px) horizontal scroll | none | none | none |
+| `prefers-reduced-motion: reduce` render | standing pane renders | renders | renders |
+| Harness verdict | `REPORT_WRITTEN` (exit 0) | `REPORT_WRITTEN` (exit 0) | `REPORT_WRITTEN` (exit 0) |
+
+Additional checks this pass:
+
+| Check | Result |
+|---|---|
+| i18n pseudo-locale coverage of new evidence copy (`&lang=qps-ploc`) | **Pass** — new headings/labels render bracketed (e.g. `⟦Évídéncé súmmáry⟧`); no un-extracted English in the evidence view |
+| Evidence-summary export validates against `urn:icn:contract:rehearsal-evidence-export:v1` | **Pass** (`OK: … validates`, exit 0) |
+| Receipt objects contain no `body`/`content`/`text` field (privacy discipline) | **Pass** — `body_hash` only |
+| No download/generate/copy/mutation control in the export section | **Pass** — 0 such controls |
+
+Automated scans are a floor, not a substitute for human AT testing. 0 axe violations
+means no machine-detectable WCAG failures on the rendered fixture view; it does not
+certify screen-reader comprehension or human low-vision usability.
+
+## 5. Organizer / member accessibility gate — 12-category outcome
+
+Per `docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md` §5. Outcomes: **Pass** /
+**Pass w/ follow-ups** / **Blocked** / **N/A**. Applied to the process-evidence view.
+
+- [x] **3.1 Language access** — Pass. All new evidence copy is externalized through the
+  i18n seam (#2043) and verified under the pseudo-locale (`&lang=qps-ploc` brackets every
+  new string); canonical terms (session, deliberation entry, decision, gate result,
+  receipt, provenance, `record_hash`, `body_hash`) are paired with inline plain-language
+  explanations. **Still owed (separate lane, not blocking this English DEV/DEMO pass):**
+  real translations + human language-quality QA (the seam ships `en` + a pseudo-locale +
+  an RTL fallback demo only; broader website multilingual is #1740).
+- [x] **3.2 Screen-reader / non-visual access** — Pass with documented follow-ups (**#2041**).
+  Semantic HTML, landmarks, headings, list views, `<dl>` key/value; the redaction boundary
+  is conveyed with headings + text, not visuals. **Real screen-reader testing not
+  performed** — owed (**#2041**).
+- [x] **3.3 Low-vision access** — Pass with documented follow-ups (**#2041**). 200% CSS zoom
+  rendered without layout break (screenshot); rem units throughout; contrast ratios
+  documented per token in `shell.css` (reused, unchanged). **Human low-vision + external
+  contrast-audit-tool verification not performed** — owed (**#2041**).
+- [x] **3.4 Color-independent meaning** — Pass. Receipt status carries glyph + text; the
+  redaction boundary is carried by headings and text (not color); axe found no
+  color-contrast violations.
+- [x] **3.5 Keyboard / switch / non-pointer access** — Pass with documented follow-ups (**#2041**).
+  16 focusables reached by Tab, all with a visible focus outline; every evidence-detail
+  and export-detail disclosure is a native `<details>`/`<summary>` (keyboard-reachable);
+  no hover-only controls; targets ≥44px per `shell.css`. **Switch-control software not
+  exercised** — owed (**#2041**).
+- [ ] **3.6 Captions, transcripts, non-audio access** — N/A with reason: this view ships no
+  audio/video/narration media.
+- [x] **3.7 Cognitive load and step complexity** — Pass. Each receipt shows a plain-language
+  summary first; record-level fields sit behind progressive disclosure. This surface is
+  **read-only** — there is no confirm step and no mutation, so no irreversible action is
+  offered.
+- [x] **3.8 Low-bandwidth / low-device access** — Pass. Dependency-free static HTML/CSS/vanilla
+  JS; the two new fixtures are small JSON files fetched over the same static path; no
+  framework, build, animation, or autoplay added.
+- [ ] **3.9 Assistive-technology compatibility** — Pass with documented follow-ups (**#2041**).
+  Real HTML elements over `div[role]`; native `<details>`. **AT exercised: none** (headless
+  environment). Owed (**#2041**).
+- [x] **3.10 Privacy-preserving accommodation path** — Pass (with reason). No
+  disability/medical/accommodation data is collected, rendered, or committed. The
+  privacy/redaction boundary demonstrated here operates on **fictional deliberation
+  content only**, and is honest by construction: the receipt stores a `body_hash` (a
+  content fingerprint), never the input text, so the member/export view shows the proof
+  pointer and redaction reason and nothing else.
+- [x] **3.11 Receipts, provenance, and evidence access** — Pass. **(Load-bearing for this
+  surface.)** Each receipt shows a plain-language summary before any raw structured data;
+  the fixture maturity tier ("Fixture-backed demo — nothing signed") is visible on screen,
+  so a viewer can tell fixture-only apart **without parsing JSON**; proof surfaces are
+  explained in plain language (`record_hash` = proof pointer; `body_hash` = proof of
+  content, body never stored; recorder DIDs = who recorded, not who decided); the
+  evidence-summary export is a read-only view of a repo-safe committed artifact.
+- [x] **3.12 Governance and action access** — Pass. The receipts state authority basis
+  honestly in plain language (recorder-not-decider; the decision receipt "asserts nothing
+  about its standing"; the gate receipt states `accessibility_review` = `pass`, labeled
+  fixture-simulated). This slice is **read-only with no confirm step**, so the gate's
+  "mandate + receipt named before confirm" requirement is N/A here — there is no action to
+  confirm; the surface only reads receipts that already exist.
+
+**Surface readiness conclusion:** the process-evidence view **clears the automated +
+rendered-structural floor** and the two pre-existing demos still pass; it is **NOT
+organizer-ready / member-ready / pilot-ready** until the owed human AT pass (3.2 / 3.9,
+and human 3.3 / 3.5) is completed. No category is hard-**Blocked**; the human-AT items
+(**#2041**) remain owed-follow-ups that gate the "organizer-ready" label.
+
+## 6. Findings
+
+```
+Finding: Real screen-reader / AT testing not performed.
+Evidence: §1, gate 3.2 / 3.9; headless environment with no VoiceOver/NVDA/Orca.
+Impact: Cannot honestly call this surface "organizer-ready" or "pilot-ready" without it.
+Recommendation: One human (or AT-equipped) pass with ≥1 screen reader + ≥1 non-mouse
+  input; tracked in #2041 — attach results there.
+Blocking? no (for DEV/DEMO review) / yes (for organizer-ready / pilot-ready labeling)
+```
+```
+Finding: Automated WCAG scan is clean (0 axe violations, 27 passes) on the process-
+  evidence render, and the two pre-existing demos still pass unchanged.
+Evidence: §4.
+Impact: Positive — machine-detectable WCAG floor is met and no regression was introduced.
+Recommendation: Keep axe in the loop; re-run (all three views) if member-shell markup changes.
+Blocking? no — verified okay.
+```
+```
+Finding: The ProcessGateResultReceipt is fixture-simulated, not a live gate run.
+Evidence: §1, §3; the receipt is a wire-shaped fixture record (gate_kind=accessibility_review,
+  result=pass) so the surface can carry a receipt-backed statement that the gate ran without
+  standing up a gateway.
+Impact: A reviewer could mistake the fixture gate receipt for a live-proven one.
+Recommendation: Keep the "Fixture-backed demo — nothing signed" banner prominent (it is) and
+  the illustrative-hash label on record_hash (it is); this doc states the fixture-simulated
+  provenance explicitly.
+Blocking? no — verified okay (banner + hash label already present).
+```
+```
+Finding: The privacy/redaction boundary is demonstrated on fictional content only.
+Evidence: §3, gate 3.10/3.11; receipts hold a body_hash only, no stored text exists to leak.
+Impact: Positive — honest by construction; the "redacted" view shows exactly what the receipt
+  actually holds (a hash + metadata), and the steward summary is clearly-fictional fixture context.
+Recommendation: Keep the two-audience framing (steward-visible vs member/export-redacted).
+Blocking? no — verified okay.
+```
+
+Classification: 1 important-follow-up (screen-reader/AT #2041), 3 verified-okay. **No
+blockers** for the DEV/DEMO review; the human-AT pass (#2041) gates the organizer-/pilot-
+ready label.
+
+## 7. Interface review — does the UI keep the distinctions honest?
+
+| Distinction | Made clear? |
+|---|---|
+| DEV/DEMO posture | yes — permanent honesty banner + footer reference-client disclaimer |
+| Fixture vs live-local mode | yes — per-mode banner ("Fixture-backed demo — no live node, nothing signed.") |
+| Illustrative vs canonical hash | yes — `record_hash` labeled "illustrative fixture value — not a real blake3 binding" in demo mode |
+| Steward-visible vs member/export-redacted | yes — the deliberation entry shows both, side by side, with the redaction reason + proof pointers |
+| Recorded fact vs decision authority | yes — recorder-not-decider labeling; the decision receipt "asserts nothing about its standing" |
+| Fixture-simulated vs live gate | yes — the gate receipt is labeled fixture-simulated in copy and in this doc |
+| Read-only view vs generated/downloaded export | yes — the export panel is a read-only render of a committed fixture; no download/generate/copy control exists |
+| Proof of path vs production readiness | yes — banner + footer + this doc's non-claims |
+
+## 8. Artifacts
+
+The audit **script is committed**: [`web/member-shell/a11y-walkthrough.cjs`](../../web/member-shell/a11y-walkthrough.cjs)
+— so the checks are runnable from committed materials (see §2). The committed **fixtures**
+(`web/member-shell/fixtures/process-evidence-{receipts,export}.json`) and the committed
+**export** (which validates against the rehearsal-evidence-export contract) are the
+repo-safe evidence. The **screenshots** and the **axe/keyboard JSON reports** for the three
+runs live in the operator's local artifact store under the artifact class
+`july-demo-process-evidence-<date>` — repo-safe (no credentials/keys/IPs) but kept out of
+the repo per the evidence-log convention (they are binary / machine output). This doc is
+the committed, shareable summary; the committed script + fixtures let a reviewer regenerate
+them.
+
+## 9. Owed before "organizer-ready / pilot-ready"
+
+> The reproducible human-tester packet for the owed items below is in
+> [`JULY_DEMO_CANDIDATE_0.1_HUMAN_A11Y_VALIDATION.md`](JULY_DEMO_CANDIDATE_0.1_HUMAN_A11Y_VALIDATION.md).
+> It is a template, not a completed pass. This #2289 surface does **not** complete it.
+
+- Screen-reader smoke (≥1 of VoiceOver/NVDA/Orca) + ≥1 non-mouse input (3.2 / 3.9). [#2041]
+- Human 200% browser-zoom + small-device pass (3.3 / 3.5 / 3.8). [#2041]
+- External contrast-audit-tool confirmation of the documented ratios (3.3). [#2041]
+- (Separate lanes, not this pass) real translations + human language QA (#1740); the
+  broader human-operability spine (#1748 / #2141) remains open.
+
+---
+
+_Refs #2289. Refs #2290. Refs #1748. Refs #2141. Refs #2041._

--- a/web/member-shell/a11y-walkthrough.cjs
+++ b/web/member-shell/a11y-walkthrough.cjs
@@ -15,6 +15,13 @@
  * this static surface are not sensitive to recent Chromium revisions.
  *
  * Usage: node a11y-walkthrough.cjs <baseUrl> <outDir>   (default mode=demo / ?lang=en)
+ *
+ * Optional env var MSHELL_SET targets a demo variant by appending &set=<value>
+ * to the audited URL (icn#2289). Unset (the default) audits ?mode=demo exactly
+ * as before, so the documented reproduction command and its evidence are
+ * unchanged. Example, to audit the process-evidence evidence surface:
+ *   MSHELL_SET=process-evidence NODE_PATH=web/pilot-ui/node_modules \
+ *     node web/member-shell/a11y-walkthrough.cjs http://127.0.0.1:8099 ./out
  */
 const { chromium } = require('playwright');
 const { AxeBuilder } = require('@axe-core/playwright');
@@ -23,7 +30,11 @@ const { mkdirSync, writeFileSync } = require('node:fs');
 (async () => {
   const BASE = process.argv[2] || 'http://127.0.0.1:8099';
   const OUT = process.argv[3] || '.';
-  const URL = `${BASE}/member-shell/?mode=demo`;
+  // Optional demo variant (icn#2289). Unset → ?mode=demo, byte-for-byte the
+  // original default, so existing evidence is not disturbed.
+  const SET = process.env.MSHELL_SET
+    ? `&set=${encodeURIComponent(process.env.MSHELL_SET)}` : '';
+  const URL = `${BASE}/member-shell/?mode=demo${SET}`;
   mkdirSync(OUT, { recursive: true });
 
   const report = { url: URL, steps: {}, axe: {}, keyboard: {}, notes: [] };

--- a/web/member-shell/fixtures/process-evidence-export.json
+++ b/web/member-shell/fixtures/process-evidence-export.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "0.1.0",
+  "recorded_at": "2026-07-03T00:00:00Z",
+  "rehearsal_label": "Fictional fixture-only process-evidence surface rehearsal — sample stewardship domain",
+  "rehearsal_mode": "fixture-only",
+  "audience_categories": ["steward", "member", "reviewer"],
+  "source_material": [
+    {
+      "kind": "committed-fixture",
+      "basename": "process-evidence-receipts.json",
+      "summary": "Fictional fixture pack of four process-transition receipts (session opened, deliberation entry recorded, decision recorded, accessibility-gate result). No real people and no real domain; all hashes are illustrative."
+    }
+  ],
+  "workflow_steps_completed": [
+    "start",
+    "decide",
+    "surface-result",
+    "export-evidence"
+  ],
+  "decision_outcomes": [
+    {
+      "category": "deferred",
+      "plain_summary": "A fictional stewardship decision was recorded against the sample session and left for a later rehearsal. The receipt records only that a decision artifact was recorded — by whom, when, and a content fingerprint — and asserts nothing about its standing."
+    },
+    {
+      "category": "approved",
+      "plain_summary": "The fixture accessibility-review gate recorded a pass result over the evidence surface. This reflects the fixture-simulated gate receipt, not a live gate run."
+    }
+  ],
+  "preview_review_boundary": {
+    "enforced": true,
+    "notes": "Read-first, no mutation: the surface renders committed receipts only; no write path is exercised."
+  },
+  "mutation_boundary": {
+    "executed": false,
+    "target": "none",
+    "notes": "Fixture-only rehearsal; no gateway contacted, no write attempted, no network egress."
+  },
+  "warnings": [
+    "The four process-transition receipt hashes are illustrative fixture values, not real blake3 bindings; nothing is signed.",
+    "This surface renders read views only; no live gateway, federation, or production posture is implied."
+  ],
+  "follow_ups": [
+    {
+      "title": "Human assistive-technology accessibility pass for member-shell v0 (screen-reader, low-vision zoom, switch input)",
+      "url": "https://github.com/InterCooperative-Network/icn/issues/2041"
+    }
+  ],
+  "privacy_review": {
+    "reviewer_role": "steward",
+    "status": "redactions-applied",
+    "notes": "One fictional deliberation input is shown to the steward body in summary and redacted from the member and export views; the receipt stores a body hash only, so there is no stored text to leak."
+  },
+  "accessibility_review": {
+    "reviewer_role": "reviewer",
+    "status": "reviewed-clean",
+    "notes": "The automated, structural accessibility floor (axe-core WCAG, keyboard reachability with visible focus, landmarks, 200% zoom render) was reviewed clean on this fixture surface. The human assistive-technology categories (screen-reader, low-vision, switch input) remain pending under icn#2041 and are not claimed here."
+  },
+  "export_safety_classification": "repo-safe",
+  "non_claims": [
+    "Not a production deployment.",
+    "Not a formally committed cooperative pilot.",
+    "Not a live federation, live Google Drive / Groups / Sheets sync, or any K3s / DNS / Forgejo mutation.",
+    "Not private-data handling; all material is fictional and repo-safe by construction.",
+    "Not organizer-ready or member-ready; this is a dev/fixture evidence view only.",
+    "Not a new receipt class; it reads the four existing ADR-0026 Layer 2 process-transition receipts only.",
+    "Not NYCN activation and not Phase 2 completion."
+  ]
+}

--- a/web/member-shell/fixtures/process-evidence-receipts.json
+++ b/web/member-shell/fixtures/process-evidence-receipts.json
@@ -1,0 +1,91 @@
+{
+  "_note": "Fixture-only, dev-safe process-evidence pack for the organizer-steward evidence surface (icn#2289). Renders on web/member-shell/ at ?mode=demo&set=process-evidence. All four objects are wire-shaped per icn/crates/icn-governance/src/proof.rs (bare JSON, snake_case enums, 32-byte hashes as integer arrays). Every record_hash / body_hash below is an ILLUSTRATIVE fixture value — NOT a real blake3 binding; nothing is signed. All DIDs are fictional (example-…-not-live). No new receipt class: this reads the four existing ADR-0026 Layer 2 classes only. The deliberation body is never stored — the receipt carries a body_hash content fingerprint only, which is what makes the redaction demo honest.",
+  "domain_id": "demo.coop.stewardship",
+  "session_id": "demo-process-session-0001",
+  "sequence": [
+    {
+      "kind": "process_session_opened",
+      "plainContext": "This anchors the story: a process session was opened in a sample stewardship domain, so everything below is scoped to who opened it, where, and when.",
+      "receipt": {
+        "session_id": "demo-process-session-0001",
+        "domain_id": "demo.coop.stewardship",
+        "opened_by": "did:icn:example-steward-demo-not-live",
+        "opened_at": 1729900000,
+        "record_hash": [
+          11, 47, 162, 8, 205, 96, 7, 154,
+          33, 201, 5, 88, 119, 64, 240, 11,
+          73, 156, 29, 222, 47, 101, 134, 90,
+          3, 68, 175, 52, 199, 26, 145, 83
+        ]
+      }
+    },
+    {
+      "kind": "deliberation_entry_recorded",
+      "plainContext": "A deliberation input was recorded against the session. The input text itself is never stored — the receipt keeps only a content fingerprint (the body hash below).",
+      "memberVisibility": "redacted",
+      "stewardSummary": "Steward-body view (fictional fixture summary): a member recorded a concern that a planned meeting time would be hard to attend for some members. This one-line summary is fictional fixture context — it is not the stored input, which the receipt never holds.",
+      "redactionReason": "This deliberation input is shown to the steward body in summary form only. Members and the exported evidence see the proof pointer below, never the input text — because the receipt stores a content fingerprint (body hash), not the words.",
+      "receipt": {
+        "domain_id": "demo.coop.stewardship",
+        "session_id": "demo-process-session-0001",
+        "entry_id": "demo-deliberation-entry-0001",
+        "author": "did:icn:example-member-demo-not-live",
+        "entry_kind": "concern",
+        "recorded_at": 1729900600,
+        "body_hash": [
+          212, 9, 118, 64, 5, 33, 201, 88,
+          7, 154, 240, 11, 73, 26, 145, 83,
+          162, 8, 205, 96, 47, 101, 134, 90,
+          3, 68, 175, 52, 199, 156, 29, 222
+        ],
+        "record_hash": [
+          88, 3, 68, 175, 52, 199, 26, 145,
+          83, 11, 47, 162, 8, 205, 96, 7,
+          154, 33, 201, 5, 88, 119, 64, 240,
+          11, 73, 156, 29, 222, 47, 101, 134
+        ]
+      }
+    },
+    {
+      "kind": "decision_recorded",
+      "plainContext": "A decision artifact was recorded against the session. The receipt records that a decision was recorded — by whom it was recorded, when, and a content fingerprint — not its validity, its bindingness, or any count.",
+      "receipt": {
+        "domain_id": "demo.coop.stewardship",
+        "session_id": "demo-process-session-0001",
+        "decision_id": "demo-decision-0001",
+        "recorded_by": "did:icn:example-recorder-demo-not-live",
+        "recorded_at": 1729901200,
+        "body_hash": [
+          9, 9, 9, 9, 9, 9, 9, 9,
+          9, 9, 9, 9, 9, 9, 9, 9,
+          9, 9, 9, 9, 9, 9, 9, 9,
+          9, 9, 9, 9, 9, 9, 9, 9
+        ],
+        "record_hash": [
+          2, 158, 91, 172, 171, 240, 77, 206,
+          74, 89, 49, 100, 163, 106, 122, 82,
+          70, 159, 207, 235, 102, 115, 112, 38,
+          222, 58, 170, 156, 209, 78, 107, 68
+        ]
+      }
+    },
+    {
+      "kind": "process_gate_result",
+      "plainContext": "A process gate result was recorded: the accessibility-review gate ran over this surface and its result is pass. This is a fixture-simulated gate receipt, not a live gate run — it gives the evidence surface a receipt-backed statement that the gate ran.",
+      "receipt": {
+        "session_id": "demo-process-session-0001",
+        "domain_id": "demo.coop.stewardship",
+        "gate_kind": "accessibility_review",
+        "result": "pass",
+        "recorded_by": "did:icn:example-reviewer-demo-not-live",
+        "recorded_at": 1729901800,
+        "record_hash": [
+          160, 32, 7, 7, 7, 7, 7, 7,
+          7, 7, 7, 7, 7, 7, 7, 7,
+          7, 7, 7, 7, 7, 7, 7, 7,
+          7, 7, 7, 7, 7, 7, 32, 160
+        ]
+      }
+    }
+  ]
+}

--- a/web/member-shell/i18n.js
+++ b/web/member-shell/i18n.js
@@ -267,7 +267,54 @@
       "launcher.ready": "Ready. Select Start local demo to load your standing.",
       "launcher.notConnected": "Not connected yet. Enter your local gateway address above.",
       "launcher.starting": "Starting the local demo…",
-      "launcher.startFailed": "Could not start the local demo ({error}). Use Connect manually instead, or check the launcher tunnel."
+      "launcher.startFailed": "Could not start the local demo ({error}). Use Connect manually instead, or check the launcher tunnel.",
+
+      // --- #2289 organizer-steward evidence surface (fixture-only) -------
+      // Renders the four already-landed ADR-0026 Layer 2 process-transition
+      // receipts as a plain-language evidence story, plus a repo-safe evidence
+      // summary. Fixture/dev only; nothing signed; read-only. No readiness is
+      // claimed and no new receipt class is introduced.
+      "evidence.process_session_opened.heading": "Process session opened",
+      "evidence.deliberation_entry_recorded.heading": "Deliberation input recorded",
+      "evidence.decision_recorded.heading": "Decision recorded",
+      "evidence.process_gate_result.heading": "Gate result recorded",
+
+      // Deliberation redaction demo (steward-visible vs member/export-redacted).
+      "evidence.redaction.stewardHeading": "What the steward body sees",
+      "evidence.redaction.memberHeading": "What members and the export see",
+      "evidence.redaction.notice": "Redacted here — the input text is not shown. {reason}",
+
+      // Evidence-detail key/value labels for the four receipt classes.
+      "evidence.kv.domainId": "Domain id",
+      "evidence.kv.sessionId": "Session id",
+      "evidence.kv.openedBy": "Opened by (who recorded this fact)",
+      "evidence.kv.recordedAt": "Recorded at (unix seconds)",
+      "evidence.kv.entryId": "Entry id",
+      "evidence.kv.author": "Author (who recorded this input)",
+      "evidence.kv.entryKind": "Entry kind",
+      "evidence.kv.bodyHash": "Content fingerprint (body hash — proof of content; the input itself is never stored)",
+      "evidence.kv.decisionId": "Decision id",
+      "evidence.kv.recordedBy": "Recorded by (who recorded this fact, not who decided)",
+      "evidence.kv.gateKind": "Gate kind",
+      "evidence.kv.gateResult": "Gate result",
+
+      // Evidence summary / export (read-only render of the committed fixture).
+      "evidence.export.heading": "Evidence summary",
+      "evidence.export.explain": "This is a repo-safe evidence summary of the process story above, rendered read-only from a committed fixture. It is not generated, downloaded, copied, or sent from this page.",
+      "evidence.export.summary": "This evidence summary describes a {mode} rehearsal and is classified {safety}.",
+      "evidence.export.readonly": "Read-only view of a committed fixture — the summary is not generated, downloaded, copied, or sent from this page.",
+      "evidence.export.outcomesHeading": "What the rehearsal recorded (plain language)",
+      "evidence.export.privacy": "Privacy review: {status}. {notes}",
+      "evidence.export.showDetail": "Show export detail",
+      "evidence.export.kv.contract": "Contract",
+      "evidence.export.kv.mode": "Rehearsal mode",
+      "evidence.export.kv.steps": "Workflow steps completed",
+      "evidence.export.kv.audiences": "Audience categories",
+      "evidence.export.kv.mutation": "Mutation",
+      "evidence.export.mutationNone": "None (read-only; nothing was changed)",
+      "evidence.export.kv.accessibility": "Accessibility review status",
+      "evidence.export.kv.safety": "Export safety classification",
+      "evidence.export.nonClaimsHeading": "What this is not"
     }
     // Additional languages are added here as a single entry — no code change.
     // Example: MESSAGES.fr = { "sync.synced": "Synchronisé", ... }

--- a/web/member-shell/index.html
+++ b/web/member-shell/index.html
@@ -155,6 +155,21 @@
     <ul id="receipts-list" class="card-list"></ul>
   </section>
 
+  <!-- #2289 Evidence summary / export (fixture-only, read-only). A read-only
+       rendering of the committed export fixture that conforms to
+       urn:icn:contract:rehearsal-evidence-export:v1. Shown only in the
+       ?mode=demo&set=process-evidence view. Nothing is generated, downloaded,
+       copied, or sent from this page. -->
+  <section id="evidence-export-section" hidden aria-labelledby="evidence-export-h">
+    <h2 id="evidence-export-h" data-i18n="evidence.export.heading">Evidence summary</h2>
+    <p class="explain" data-i18n="evidence.export.explain">
+      This is a repo-safe evidence summary of the process story above,
+      rendered read-only from a committed fixture. It is not generated,
+      downloaded, copied, or sent from this page.
+    </p>
+    <div id="evidence-export-body"></div>
+  </section>
+
   <!-- Help path: the spec requires a visible way to ask for help. -->
   <section id="help-section" aria-labelledby="help-h">
     <h2 id="help-h" data-i18n="help.heading">Need help?</h2>

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -103,6 +103,15 @@
   var params = new URLSearchParams(window.location.search);
   var MODE = params.get("mode") === "demo" ? "demo" : "live";
 
+  // #2289 organizer-steward evidence surface. `?mode=demo&set=process-evidence`
+  // swaps the demo pack for a fixture-only, read-only evidence story over the
+  // four already-landed ADR-0026 Layer 2 process-transition receipts (session
+  // opened -> deliberation entry recorded -> decision recorded -> gate result)
+  // plus a repo-safe evidence-summary export. Fixture/dev only: nothing is live,
+  // every hash is illustrative (see the demo hash label), and the surface
+  // renders read views only — no download, no mutation. `set` is demo-only.
+  var SET = MODE === "demo" ? params.get("set") : null;
+
   // DEV/DEMO one-click launcher context. The local launcher
   // (deploy/appliance/scripts/open-proxmox-demo.sh) opens this page with
   // ?demo=launcher and forwards two loopback ports: the gateway to :18080 and
@@ -155,6 +164,14 @@
     FIXTURES.standing = "fixtures/community-standing.json";
     FIXTURES.cards = "fixtures/community-action-cards.json";
     FIXTURES.completionReceipt = "fixtures/community-completion-receipt.json";
+  }
+
+  // #2289 organizer-steward evidence surface (fixture-only). Keeps the demo
+  // standing + cards pack; adds the four-receipt process-evidence sequence and
+  // its repo-safe evidence-summary export (both member-shell-local fixtures).
+  if (SET === "process-evidence") {
+    FIXTURES.processEvidence = "fixtures/process-evidence-receipts.json";
+    FIXTURES.processEvidenceExport = "fixtures/process-evidence-export.json";
   }
 
   // ---------------------------------------------------------------------
@@ -608,8 +625,21 @@
   // ---------------------------------------------------------------------
   // Receipts (plain summary first; formal record under a disclosure)
   // ---------------------------------------------------------------------
-  function addReceipt(receipt, plainContext) {
-    state.receipts.push({ receipt: receipt, plainContext: plainContext });
+  // opts is optional. Existing callers (live completion + demo completion) pass
+  // no opts, so the entry keeps its original {receipt, plainContext} shape and
+  // renders through renderCompletionReceipt exactly as before. The #2289
+  // process-evidence pack passes opts.kind (one of the four process-transition
+  // classes) plus optional redaction metadata, routing to renderProcessReceipt.
+  // No existing behavior changes.
+  function addReceipt(receipt, plainContext, opts) {
+    var entry = { receipt: receipt, plainContext: plainContext };
+    if (opts) {
+      entry.kind = opts.kind;
+      entry.memberVisibility = opts.memberVisibility;
+      entry.stewardSummary = opts.stewardSummary;
+      entry.redactionReason = opts.redactionReason;
+    }
+    state.receipts.push(entry);
     renderReceipts();
   }
 
@@ -620,7 +650,9 @@
       list.appendChild(el("li", { text: t("receipts.none") }));
     } else {
       state.receipts.forEach(function (entry) {
-        list.appendChild(renderCompletionReceipt(entry.receipt, entry.plainContext));
+        list.appendChild(entry.kind
+          ? renderProcessReceipt(entry)
+          : renderCompletionReceipt(entry.receipt, entry.plainContext));
       });
     }
     show("receipts-section");
@@ -668,10 +700,164 @@
   }
 
   // ---------------------------------------------------------------------
+  // #2289 organizer-steward evidence surface (fixture-only, read-only).
+  // Renders one of the four ADR-0026 Layer 2 process-transition receipts
+  // (proof.rs) as a plain-language summary first, with the record-level fields
+  // under a progressive-disclosure "Show evidence detail" control. record_hash
+  // is the proof pointer; body_hash is labeled proof-of-content (the body is
+  // never stored). In demo mode the hashes are illustrative, mirroring the
+  // completion receipt's honesty label. No readiness is claimed.
+  // ---------------------------------------------------------------------
+  var PROCESS_RECEIPT_CLASS = {
+    process_session_opened: "ProcessSessionOpenedReceipt",
+    deliberation_entry_recorded: "DeliberationEntryRecordedReceipt",
+    decision_recorded: "DecisionRecordedReceipt",
+    process_gate_result: "ProcessGateResultReceipt"
+  };
+
+  // record_hash label mirrors renderCompletionReceipt's maturity-tier honesty:
+  // demo hashes are illustrative, only live may claim the canonical binding.
+  function recordHashRow(dl, hash) {
+    kvRow(dl, MODE === "demo"
+        ? t("receipt.kv.recordHashDemo")
+        : t("receipt.kv.recordHashLive"),
+      el("code", { text: hashToHex(hash) }));
+  }
+
+  function renderProcessReceipt(entry) {
+    var r = entry.receipt || {};
+    var kind = entry.kind;
+    var li = el("li");
+
+    li.appendChild(el("h3", { text: t("evidence." + kind + ".heading") }));
+    li.appendChild(el("p", {}, [
+      el("span", { class: "chip ok", text: "✓ " + t(SYNC.RECEIPT) })
+    ]));
+    // plainContext is a self-contained plain-language summary (the fixture
+    // supplies it per receipt); shown before any raw field per gate §3.11.
+    li.appendChild(el("p", { class: "muted", text: entry.plainContext || "" }));
+
+    // Deliberation-entry redaction demo (gate §3.11): show the steward-body
+    // view and the member/export view together so the privacy boundary is
+    // legible without leaking any private text. The steward summary is
+    // clearly-fictional fixture context; the receipt itself holds only a
+    // body_hash, so the member/export view can honestly show the proof pointer
+    // and the redaction reason and nothing else.
+    if (kind === "deliberation_entry_recorded" && entry.memberVisibility === "redacted") {
+      var red = el("div", { class: "redaction" });
+      red.appendChild(el("h4", { text: t("evidence.redaction.stewardHeading") }));
+      red.appendChild(el("p", { class: "muted", text: entry.stewardSummary || "" }));
+      red.appendChild(el("h4", { text: t("evidence.redaction.memberHeading") }));
+      red.appendChild(el("p", {
+        text: t("evidence.redaction.notice", { reason: (entry.redactionReason || "") })
+      }));
+      li.appendChild(red);
+    }
+
+    var details = el("details");
+    details.appendChild(el("summary", { text: t("receipt.showEvidence") }));
+    var dl = el("dl", { class: "kv" });
+    // Record class names are not translated (they are wire identifiers).
+    kvRow(dl, t("receipt.kv.recordClass"), PROCESS_RECEIPT_CLASS[kind] || String(kind));
+    kvRow(dl, t("evidence.kv.domainId"), String(r.domain_id || ""));
+    kvRow(dl, t("evidence.kv.sessionId"), String(r.session_id || ""));
+
+    if (kind === "process_session_opened") {
+      kvRow(dl, t("evidence.kv.openedBy"), el("code", { text: String(r.opened_by || "") }));
+      kvRow(dl, t("evidence.kv.recordedAt"), String(r.opened_at || ""));
+    } else if (kind === "deliberation_entry_recorded") {
+      kvRow(dl, t("evidence.kv.entryId"), String(r.entry_id || ""));
+      kvRow(dl, t("evidence.kv.author"), el("code", { text: String(r.author || "") }));
+      kvRow(dl, t("evidence.kv.entryKind"), String(r.entry_kind || ""));
+      kvRow(dl, t("evidence.kv.recordedAt"), String(r.recorded_at || ""));
+      kvRow(dl, t("evidence.kv.bodyHash"), el("code", { text: hashToHex(r.body_hash) }));
+    } else if (kind === "decision_recorded") {
+      kvRow(dl, t("evidence.kv.decisionId"), String(r.decision_id || ""));
+      kvRow(dl, t("evidence.kv.recordedBy"), el("code", { text: String(r.recorded_by || "") }));
+      kvRow(dl, t("evidence.kv.recordedAt"), String(r.recorded_at || ""));
+      kvRow(dl, t("evidence.kv.bodyHash"), el("code", { text: hashToHex(r.body_hash) }));
+    } else if (kind === "process_gate_result") {
+      kvRow(dl, t("evidence.kv.gateKind"), String(r.gate_kind || ""));
+      kvRow(dl, t("evidence.kv.gateResult"), String(r.result || ""));
+      kvRow(dl, t("evidence.kv.recordedBy"), el("code", { text: String(r.recorded_by || "") }));
+      kvRow(dl, t("evidence.kv.recordedAt"), String(r.recorded_at || ""));
+    }
+    recordHashRow(dl, r.record_hash);
+    details.appendChild(dl);
+    li.appendChild(details);
+    return li;
+  }
+
+  // Render the repo-safe evidence-summary export (conforms to
+  // urn:icn:contract:rehearsal-evidence-export:v1) as a READ-ONLY view of the
+  // committed fixture. The surface never generates, downloads, mutates, or
+  // copies an export — the committed JSON is the single source of truth.
+  function renderEvidenceExport(exp) {
+    exp = exp || {};
+    var body = byId("evidence-export-body");
+    clear(body);
+
+    body.appendChild(el("p", {
+      text: t("evidence.export.summary", {
+        mode: String(exp.rehearsal_mode || ""),
+        safety: String(exp.export_safety_classification || "")
+      })
+    }));
+    body.appendChild(el("p", { class: "muted", text: t("evidence.export.readonly") }));
+
+    var outcomes = exp.decision_outcomes || [];
+    if (outcomes.length) {
+      body.appendChild(el("h3", { text: t("evidence.export.outcomesHeading") }));
+      var oul = el("ul", { class: "card-list" });
+      outcomes.forEach(function (o) {
+        oul.appendChild(el("li", { text: String(o.plain_summary || "") }));
+      });
+      body.appendChild(oul);
+    }
+
+    if (exp.privacy_review) {
+      body.appendChild(el("p", {
+        text: t("evidence.export.privacy", {
+          status: String(exp.privacy_review.status || ""),
+          notes: String(exp.privacy_review.notes || "")
+        })
+      }));
+    }
+
+    var details = el("details");
+    details.appendChild(el("summary", { text: t("evidence.export.showDetail") }));
+    var dl = el("dl", { class: "kv" });
+    kvRow(dl, t("evidence.export.kv.contract"), "urn:icn:contract:rehearsal-evidence-export:v1");
+    kvRow(dl, t("evidence.export.kv.mode"), String(exp.rehearsal_mode || ""));
+    kvRow(dl, t("evidence.export.kv.steps"), (exp.workflow_steps_completed || []).join(", "));
+    kvRow(dl, t("evidence.export.kv.audiences"), (exp.audience_categories || []).join(", "));
+    kvRow(dl, t("evidence.export.kv.mutation"),
+      exp.mutation_boundary && exp.mutation_boundary.executed === false
+        ? t("evidence.export.mutationNone")
+        : String((exp.mutation_boundary && exp.mutation_boundary.target) || ""));
+    kvRow(dl, t("evidence.export.kv.accessibility"),
+      exp.accessibility_review ? String(exp.accessibility_review.status || "") : "");
+    kvRow(dl, t("evidence.export.kv.safety"), String(exp.export_safety_classification || ""));
+    details.appendChild(dl);
+    body.appendChild(details);
+
+    var nc = exp.non_claims || [];
+    if (nc.length) {
+      body.appendChild(el("h3", { text: t("evidence.export.nonClaimsHeading") }));
+      var ncul = el("ul", { class: "card-list" });
+      nc.forEach(function (c) { ncul.appendChild(el("li", { text: String(c) })); });
+      body.appendChild(ncul);
+    }
+
+    show("evidence-export-section");
+  }
+
+  // ---------------------------------------------------------------------
   // Demo mode: fixture-backed, nothing signed, no live node.
   // ---------------------------------------------------------------------
   function loadDemo() {
     setSyncChip(t(SYNC.VERIFYING), "neutral", t("demo.loadingFixture"));
+    if (SET === "process-evidence") { loadProcessEvidenceDemo(); return; }
     Promise.all([
       fetchJson(FIXTURES.standing),
       fetchJson(FIXTURES.cards),
@@ -685,6 +871,45 @@
       renderStanding(state.standing);
       renderCards(state.cards, state.standing, anchor);
       addReceipt(results[2], t("demo.receiptContext"));
+
+      setSyncChip(t(SYNC.SYNCED), "ok",
+        t("demo.syncedDetail", { when: fmtAbs(anchor) }));
+    }).catch(function (err) {
+      setSyncChip(t(SYNC.DEGRADED), "warn",
+        t("demo.loadFailed", { error: err.message }));
+    });
+  }
+
+  // #2289 organizer-steward evidence surface (fixture-only). Reuses the demo
+  // standing + cards render path, then renders the four-receipt process
+  // sequence and the repo-safe evidence-summary export. No network beyond the
+  // committed fixtures; nothing signed; read-only.
+  function loadProcessEvidenceDemo() {
+    Promise.all([
+      fetchJson(FIXTURES.standing),
+      fetchJson(FIXTURES.cards),
+      fetchJson(FIXTURES.processEvidence),
+      fetchJson(FIXTURES.processEvidenceExport)
+    ]).then(function (results) {
+      state.standing = results[0];
+      state.cards = results[1];
+      var pack = results[2] || {};
+      var exp = results[3];
+      var anchor = state.cards.generated_at || state.standing.generated_at;
+
+      renderIdentity(state.standing);
+      renderStanding(state.standing);
+      renderCards(state.cards, state.standing, anchor);
+
+      (pack.sequence || []).forEach(function (item) {
+        addReceipt(item.receipt, item.plainContext, {
+          kind: item.kind,
+          memberVisibility: item.memberVisibility,
+          stewardSummary: item.stewardSummary,
+          redactionReason: item.redactionReason
+        });
+      });
+      renderEvidenceExport(exp);
 
       setSyncChip(t(SYNC.SYNCED), "ok",
         t("demo.syncedDetail", { when: fmtAbs(anchor) }));


### PR DESCRIPTION
## What

Implements the #2289 organizer-steward evidence surface runtime dogfood slice described by the #2290 design contract.

This adds a fixture-only, read-only evidence view to the existing member-shell v0 surface at:

`?mode=demo&set=process-evidence`

The slice renders the four already-landed ADR-0026 Layer 2 process receipt classes:

- `ProcessSessionOpenedReceipt`
- `DeliberationEntryRecordedReceipt`
- `DecisionRecordedReceipt`
- `ProcessGateResultReceipt`

## Scope

- Existing `web/member-shell/` surface only.
- Fixture-only data.
- Read-only evidence view.
- No Rust changes.
- No OpenAPI/SDK changes.
- No new receipt class.
- No runtime `EvidencePacket` producer.
- No production/pilot/live-federation/NYCN/Phase 2 claim.

## What changed

- Added `web/member-shell/fixtures/process-evidence-receipts.json`.
- Added `web/member-shell/fixtures/process-evidence-export.json`.
- Added `?mode=demo&set=process-evidence` rendering in member-shell.
- Added a read-only export summary panel.
- Added fixture-safe steward/member redaction behavior.
- Added i18n strings for the evidence view.
- Extended the member-shell a11y walkthrough with an optional set selector.
- Added a docs/demo process-evidence walkthrough with the 12-category accessibility gate outcome.

## Evidence/export

The committed export fixture validates against:

`urn:icn:contract:rehearsal-evidence-export:v1`

The browser renders the export summary; it does not generate, download, mutate, or copy an export.

## Accessibility gate

Applied `docs/design/ORGANIZER_MEMBER_ACCESSIBILITY_GATE.md` §3.1–§3.12.

Load-bearing checks for this PR:

- §3.11 receipts / provenance / evidence access
- §3.12 governance / action access

Human/AT categories remain visibly pending under #2041 unless separately completed:

- §3.2 screen-reader / non-visual access
- §3.3 low-vision 200% zoom + external contrast tool
- §3.5 switch-control / non-pointer pass
- §3.9 assistive-technology compatibility

## Validation

- `python3 docs/scripts/validate-rehearsal-evidence.py web/member-shell/fixtures/process-evidence-export.json`
- served `web/` locally and smoke-tested:
  - `/member-shell/?mode=demo`
  - `/member-shell/?mode=demo&set=community`
  - `/member-shell/?mode=demo&set=process-evidence`
- member-shell a11y walkthrough (axe 0 violations each):
  - default demo
  - community demo
  - process-evidence demo
- pseudo-locale check for new evidence-view copy
- private-data leak grep
- receipt-vocab scoped grep against receipt fixture only
- raw `body` / `content` / `text` field grep against receipt fixture
- positive readiness-claim grep
- protected close-keyword grep
- `git diff --check`
- `git diff --cached --check`

## Non-claims

No production readiness.
No pilot readiness.
No organizer-ready claim.
No member-ready claim.
No live federation.
No NYCN activation.
No Phase 2 completion.
No new receipt class.
No #2081 / #2080 / #2274 progress.

Refs #2289.
Refs #2290.
Refs #1748.
Refs #2141.
Refs #2041.
