### PR TITLE
feat(process): emit activation crossed receipt

### DIFF
--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -2758,6 +2758,29 @@ pub enum DecisionRecordOutcome {
     AlreadyRecorded(icn_governance::DecisionRecordedReceipt),
 }
 
+/// Outcome of [`GovernanceManager::record_activation_crossed`] (#2294
+/// contract + #2295 B1/B2/B3 decision rung). Both variants are successes;
+/// the fail-closed mismatch conflict surfaces as an `Err` with stable prefix
+/// `activation_crossed_conflict`. Precondition failures surface as `Err`s
+/// with their own stable prefixes and persist nothing:
+/// `activation_crossed_session_not_opened` (unopened session),
+/// `activation_crossed_decision_not_found` / `activation_crossed_decision_mismatch`
+/// (B1 decision reference absent or mismatched),
+/// `activation_crossed_empty_gate_basis` (empty basis),
+/// `activation_crossed_gate_not_found` / `activation_crossed_gate_not_passed`
+/// (a declared gate result is absent/wrong-scope or did not pass).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActivationCrossedOutcome {
+    /// This call recorded the crossing: the receipt is the newly persisted
+    /// activation-crossed fact.
+    Crossed(icn_governance::ActivationCrossedReceipt),
+    /// The crossing was already recorded with the **same** stable identity
+    /// (`decision_id`, `decision_record_hash`, `gate_basis`, `crossed_by`);
+    /// carries the **original** persisted receipt (original `recorded_at` /
+    /// `record_hash` — a retry is never restamped).
+    AlreadyCrossed(icn_governance::ActivationCrossedReceipt),
+}
+
 /// Action items are always managed locally (not gossiped) and can use either
 /// in-memory or Sled-backed persistent storage.
 pub struct GovernanceManager {
@@ -6389,6 +6412,271 @@ impl GovernanceManager {
         store
             .list_decisions_recorded_for_session_in_domain(&domain_id.0, session_id)
             .map_err(|e| anyhow::anyhow!("Failed to list decision receipts: {e}"))
+    }
+
+    /// Record that an already-recorded decision **crossed the activation
+    /// boundary** for a process session — the fifth `ProcessTransitionReceipt`
+    /// class (#2294 contract + #2295 B1/B2/B3 decision rung). Emits an
+    /// [`ActivationCrossedReceipt`].
+    ///
+    /// This records a **process fact and grants zero authority.** It is not
+    /// a workflow engine, not mutation planning, and not mutation
+    /// application. `crossed_by` is recorder evidence, not an authority to
+    /// act.
+    ///
+    /// **All preconditions fail closed and persist nothing on failure**
+    /// (each with a stable error prefix; see [`ActivationCrossedOutcome`]):
+    ///
+    /// 1. `domain_id` / `session_id` / `activation_id` / `decision_id` and
+    ///    `crossed_by` must be non-empty and non-whitespace; a receipt store
+    ///    must be wired.
+    /// 2. The `(domain_id, session_id)` session must have a recorded opening
+    ///    (`activation_crossed_session_not_opened`) — no silent creation.
+    /// 3. **B1:** a [`DecisionRecordedReceipt`] with `decision_id` must exist
+    ///    in the same `(domain_id, session_id)`
+    ///    (`activation_crossed_decision_not_found`) and its `record_hash`
+    ///    must equal the supplied `decision_record_hash`
+    ///    (`activation_crossed_decision_mismatch`). Verified, not asserted.
+    /// 4. **B2:** the declared `gate_result_hashes` basis must be non-empty
+    ///    (`activation_crossed_empty_gate_basis`); every declared
+    ///    `record_hash` must name a [`ProcessGateResultReceipt`] in the same
+    ///    `(domain_id, session_id)` (`activation_crossed_gate_not_found`)
+    ///    carrying `result == Pass` (`activation_crossed_gate_not_passed`). A
+    ///    `Fail`, absent, wrong-domain, or wrong-session gate refuses the
+    ///    crossing. `gate_basis` is recomputed from the sorted, de-duplicated
+    ///    declared hashes, so basis input ordering does not matter.
+    ///
+    /// **At most one crossing exists per `(domain_id, session_id,
+    /// activation_id)`**, enforced atomically by the backend:
+    ///
+    /// - first record → [`ActivationCrossedOutcome::Crossed`];
+    /// - retry with identical stable identity (`decision_id`,
+    ///   `decision_record_hash`, `gate_basis`, `crossed_by`) →
+    ///   [`ActivationCrossedOutcome::AlreadyCrossed`] carrying the
+    ///   **original** receipt unchanged (never restamped;
+    ///   `recorded_at`/`record_hash` are not identity inputs);
+    /// - same `activation_id` with a different decision reference, gate
+    ///   basis, or crosser → fail-closed error (stable prefix
+    ///   `activation_crossed_conflict`); the original is untouched.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_activation_crossed(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        activation_id: &str,
+        decision_id: &str,
+        decision_record_hash: [u8; 32],
+        gate_result_hashes: &[[u8; 32]],
+        crossed_by: &Did,
+    ) -> Result<ActivationCrossedOutcome> {
+        // Whitespace-only ids are rejected alongside empty ones: a caller
+        // bypassing the HTTP layer must not mint receipts with
+        // visually-empty identifiers or whitespace storage keys.
+        if domain_id.0.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_activation_crossed: domain_id must be non-empty and non-whitespace"
+            ));
+        }
+        if session_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_activation_crossed: session_id must be non-empty and non-whitespace"
+            ));
+        }
+        if activation_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_activation_crossed: activation_id must be non-empty and non-whitespace"
+            ));
+        }
+        if decision_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_activation_crossed: decision_id must be non-empty and non-whitespace"
+            ));
+        }
+        let crossed_by_str = crossed_by.to_string();
+        if crossed_by_str.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_activation_crossed: crossed_by must be non-empty"
+            ));
+        }
+        let store = self.receipt_store.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "record_activation_crossed: a receipt store is required — activation \
+                 uniqueness and the decision/gate preconditions are enforced at the \
+                 storage layer and cannot be faked in memory"
+            )
+        })?;
+
+        // Precondition: the session was opened first. No silent creation.
+        let opened = store
+            .get_process_session_opened(&domain_id.0, session_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_activation_crossed: failed to read session-open state for \
+                     session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        if opened.is_none() {
+            return Err(anyhow::anyhow!(
+                "activation_crossed_session_not_opened: session {session_id} in domain {} \
+                 has no recorded opening; refusing to cross activation against an \
+                 unanchored session",
+                domain_id.0
+            ));
+        }
+
+        // B1 precondition: the decision being activated must exist in this
+        // same (domain, session) under `decision_id`, and its `record_hash`
+        // must equal the supplied `decision_record_hash`. The composite
+        // storage key makes a decision recorded under a different
+        // session/domain invisible here, so a wrong-session/wrong-domain
+        // reference fails closed as "not found".
+        let decision = store
+            .get_decision_recorded(&domain_id.0, session_id, decision_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_activation_crossed: failed to read decision state for decision \
+                     {decision_id} in session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        let decision = decision.ok_or_else(|| {
+            anyhow::anyhow!(
+                "activation_crossed_decision_not_found: no decision {decision_id} recorded in \
+                 session {session_id} in domain {}; refusing to cross activation for an \
+                 unrecorded decision",
+                domain_id.0
+            )
+        })?;
+        if decision.record_hash != decision_record_hash {
+            return Err(anyhow::anyhow!(
+                "activation_crossed_decision_mismatch: decision {decision_id} in session \
+                 {session_id} in domain {} was recorded with a different record_hash than the \
+                 one supplied; refusing to cross activation on a mismatched decision reference",
+                domain_id.0
+            ));
+        }
+
+        // B2 precondition: the declared gate-result basis must be non-empty,
+        // and every declared record_hash must name a gate result in this same
+        // (domain, session) carrying `Pass`. A Fail, absent, wrong-domain, or
+        // wrong-session gate result refuses the crossing.
+        if gate_result_hashes.is_empty() {
+            return Err(anyhow::anyhow!(
+                "activation_crossed_empty_gate_basis: at least one passed gate-result \
+                 record_hash must be declared as the activation basis; refusing to cross \
+                 activation with an empty basis"
+            ));
+        }
+        let gate_results = store
+            .list_process_gate_results_for_session_in_domain(&domain_id.0, session_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_activation_crossed: failed to read gate-result state for session \
+                     {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        for declared in gate_result_hashes {
+            match gate_results.iter().find(|g| g.record_hash == *declared) {
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "activation_crossed_gate_not_found: a declared gate-result record_hash \
+                         is not recorded in session {session_id} in domain {}; refusing to \
+                         cross activation on an unverifiable gate basis",
+                        domain_id.0
+                    ));
+                }
+                Some(g) => {
+                    if g.result != icn_governance::ProcessGateResult::Pass {
+                        return Err(anyhow::anyhow!(
+                            "activation_crossed_gate_not_passed: a declared gate-result in \
+                             session {session_id} in domain {} did not pass; refusing to cross \
+                             activation on a failed gate",
+                            domain_id.0
+                        ));
+                    }
+                }
+            }
+        }
+
+        // B2: recompute gate_basis from the sorted, de-duplicated declared
+        // record_hashes — order-independent and dedup-stable by construction.
+        let gate_basis =
+            icn_governance::ActivationCrossedReceipt::compute_gate_basis(gate_result_hashes);
+
+        let now = icn_time::current_timestamp_secs();
+        let receipt = icn_governance::ActivationCrossedReceipt::new(
+            domain_id.0.clone(),
+            session_id.to_string(),
+            activation_id.to_string(),
+            decision_id.to_string(),
+            decision_record_hash,
+            gate_basis,
+            crossed_by_str.clone(),
+            now,
+        );
+
+        match store.put_activation_crossed(&receipt).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to persist activation-crossed receipt for activation {activation_id} in \
+                 session {session_id} in domain {}: {e}",
+                domain_id.0
+            )
+        })? {
+            crate::receipt_backend::ActivationCrossedPersist::Inserted => {
+                Ok(ActivationCrossedOutcome::Crossed(receipt))
+            }
+            crate::receipt_backend::ActivationCrossedPersist::Existing(original) => {
+                if original.decision_id == decision_id
+                    && original.decision_record_hash == decision_record_hash
+                    && original.gate_basis == gate_basis
+                    && original.crossed_by == crossed_by_str
+                {
+                    Ok(ActivationCrossedOutcome::AlreadyCrossed(*original))
+                } else {
+                    Err(anyhow::anyhow!(
+                        "activation_crossed_conflict: activation {activation_id} in session \
+                         {session_id} in domain {} was already recorded with a different \
+                         decision reference, gate basis, or crosser; refusing to overwrite",
+                        domain_id.0
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Retrieve the persisted activation-crossed receipt for a
+    /// `(domain_id, session_id, activation_id)`, or `None` when no crossing
+    /// has been recorded. Read-only.
+    pub fn get_activation_crossed(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        activation_id: &str,
+    ) -> Result<Option<icn_governance::ActivationCrossedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(None);
+        };
+        store
+            .get_activation_crossed(&domain_id.0, session_id, activation_id)
+            .map_err(|e| anyhow::anyhow!("Failed to read activation-crossed receipt: {e}"))
+    }
+
+    /// List all activation-crossed receipts recorded against one
+    /// `(domain_id, session_id)` anchor, in the store's deterministic
+    /// chronological `(recorded_at, record_hash)` order. Read-only.
+    pub fn list_activations_crossed_in_domain(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+    ) -> Result<Vec<icn_governance::ActivationCrossedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(vec![]);
+        };
+        store
+            .list_activations_crossed_for_session_in_domain(&domain_id.0, session_id)
+            .map_err(|e| anyhow::anyhow!("Failed to list activation-crossed receipts: {e}"))
     }
 
     // ========================================================================

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -6577,8 +6577,18 @@ impl GovernanceManager {
                     domain_id.0
                 )
             })?;
+        // Index the in-scope gate results by `record_hash` once so each
+        // declared basis hash is an O(1) lookup rather than a linear scan
+        // (a session can accumulate many gate results over time). Distinct
+        // `record_hash`es are unique by construction, so the map is
+        // collision-free; iterating the declared list in order preserves the
+        // original first-failure error semantics.
+        let gate_index: HashMap<[u8; 32], icn_governance::ProcessGateResult> = gate_results
+            .iter()
+            .map(|g| (g.record_hash, g.result))
+            .collect();
         for declared in gate_result_hashes {
-            match gate_results.iter().find(|g| g.record_hash == *declared) {
+            match gate_index.get(declared) {
                 None => {
                     return Err(anyhow::anyhow!(
                         "activation_crossed_gate_not_found: a declared gate-result record_hash \
@@ -6587,8 +6597,8 @@ impl GovernanceManager {
                         domain_id.0
                     ));
                 }
-                Some(g) => {
-                    if g.result != icn_governance::ProcessGateResult::Pass {
+                Some(result) => {
+                    if *result != icn_governance::ProcessGateResult::Pass {
                         return Err(anyhow::anyhow!(
                             "activation_crossed_gate_not_passed: a declared gate-result in \
                              session {session_id} in domain {} did not pass; refusing to cross \

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -2,11 +2,11 @@
 //! in this crate without a circular dependency on icn-gateway.
 
 use icn_governance::{
-    ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, AuthorityGrant, AuthorityGrantId,
-    DecisionRecordedReceipt, DeliberationEntryRecordedReceipt, GovernanceDecisionReceipt,
-    GovernanceDecisionReceiptV3, Grantee, Mandate, MeetingAttendanceReceipt,
-    MeetingAttendanceReceiptV2, ProcessGateKind, ProcessGateResultReceipt,
-    ProcessSessionOpenedReceipt, Timestamp,
+    ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActivationCrossedReceipt,
+    AuthorityGrant, AuthorityGrantId, DecisionRecordedReceipt, DeliberationEntryRecordedReceipt,
+    GovernanceDecisionReceipt, GovernanceDecisionReceiptV3, Grantee, Mandate,
+    MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, ProcessGateKind,
+    ProcessGateResultReceipt, ProcessSessionOpenedReceipt, Timestamp,
 };
 use icn_kernel_api::{AllocationReceipt, Hash};
 
@@ -122,6 +122,51 @@ pub enum DecisionRecordedPersist {
     /// Carries the original persisted receipt (original `recorded_at` /
     /// `record_hash` — never restamped).
     Existing(DecisionRecordedReceipt),
+}
+
+/// Class string for `ActivationCrossedReceipt` opaque storage (#2294
+/// contract + #2295 B1/B2/B3 decision rung). Chosen in the apps layer so the
+/// gateway never sees the typed name. Distinct from every other process
+/// class store.
+const ACTIVATION_CROSSED_CLASS: &str = "activation_crossed";
+
+/// Build the injective composite `key1` binding an activation crossing to
+/// its `(domain_id, session_id)` anchor in opaque storage.
+///
+/// Sibling of [`decision_recorded_composite_key1`] with the identical
+/// netstring-style encoding (decimal length of `domain_id`, a colon, then
+/// the two ids concatenated), kept as a separate function so this class's
+/// key derivation is independently anchored by its own anti-aliasing test.
+/// The length prefix delimits `domain_id` exactly, so `("ab","c")` and
+/// `("a","bc")` can never produce the same key, and two domains sharing a
+/// `session_id` scan different `key1` prefixes.
+pub fn activation_crossed_composite_key1(domain_id: &str, session_id: &str) -> String {
+    format!("{}:{domain_id}{session_id}", domain_id.len())
+}
+
+/// Outcome of persisting an [`ActivationCrossedReceipt`] through
+/// [`GovernanceReceiptBackend::put_activation_crossed`].
+///
+/// The backend enforces at most one crossing per
+/// `(domain_id, session_id, activation_id)` **atomically at the storage
+/// layer** (same `put_opaque_if_absent` primitive as the sibling process
+/// classes). The caller (the manager) turns `Existing` into either a
+/// same-identity idempotent success or a fail-closed conflict — stable
+/// identity is `decision_id` + `decision_record_hash` + `gate_basis` +
+/// `crossed_by` (per the #2295 rung §7; `recorded_at`/`record_hash` are NOT
+/// identity inputs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActivationCrossedPersist {
+    /// This call won the insert: the receipt is now the one persisted
+    /// crossing for its `(domain_id, session_id, activation_id)`.
+    Inserted,
+    /// A crossing already existed for this triple; nothing was written.
+    /// Carries the original persisted receipt (original `recorded_at` /
+    /// `record_hash` — never restamped). Boxed because
+    /// [`ActivationCrossedReceipt`] is the largest process-receipt payload
+    /// (five ids plus two 32-byte hashes), so an unboxed variant would make
+    /// this enum needlessly large next to the unit `Inserted`.
+    Existing(Box<ActivationCrossedReceipt>),
 }
 
 /// Class string for `MeetingAttendanceReceiptV2` opaque storage (#1868).
@@ -1119,6 +1164,101 @@ pub trait GovernanceReceiptBackend: Send + Sync {
             out.push(
                 serde_json::from_slice(&bytes)
                     .map_err(|e| format!("deserialize DecisionRecordedReceipt in list: {e}"))?,
+            );
+        }
+        Ok(out)
+    }
+
+    /// Persist an [`ActivationCrossedReceipt`] emitted when the runtime
+    /// records that a decision crossed the activation boundary (#2294
+    /// contract + #2295 rung).
+    ///
+    /// **Default routes through opaque storage.** Serialises the typed
+    /// receipt to JSON and delegates to [`Self::put_opaque_if_absent`] under
+    /// class `"activation_crossed"` with
+    /// `key1 =` [`activation_crossed_composite_key1`] (the injective
+    /// domain+session composite) and `key2 = activation_id`. On a lost
+    /// insert the original persisted receipt is hydrated and returned
+    /// (never restamped). A backend that has not opted in to opaque storage
+    /// inherits the fail-closed `opaque_storage_not_implemented` default.
+    fn put_activation_crossed(
+        &self,
+        receipt: &ActivationCrossedReceipt,
+    ) -> Result<ActivationCrossedPersist, String> {
+        let payload = serde_json::to_vec(receipt)
+            .map_err(|e| format!("serialize ActivationCrossedReceipt: {e}"))?;
+        let key1 = activation_crossed_composite_key1(&receipt.domain_id, &receipt.session_id);
+        let existing = self.put_opaque_if_absent(
+            ACTIVATION_CROSSED_CLASS,
+            &key1,
+            Some(&receipt.activation_id),
+            receipt.recorded_at,
+            receipt.record_hash,
+            &payload,
+        )?;
+        match existing {
+            None => Ok(ActivationCrossedPersist::Inserted),
+            Some(_winning_hash) => {
+                let original = self
+                    .get_activation_crossed(
+                        &receipt.domain_id,
+                        &receipt.session_id,
+                        &receipt.activation_id,
+                    )?
+                    .ok_or_else(|| {
+                        // The unique marker says a crossing exists but the
+                        // payload cannot be hydrated — surface loudly rather
+                        // than minting a second crossing.
+                        "activation_crossed_inconsistent: unique marker present \
+                         but no persisted crossing payload could be read"
+                            .to_string()
+                    })?;
+                Ok(ActivationCrossedPersist::Existing(Box::new(original)))
+            }
+        }
+    }
+
+    /// Retrieve the persisted [`ActivationCrossedReceipt`] for a
+    /// `(domain_id, session_id, activation_id)`, or `None` when no crossing
+    /// has been recorded. Same key convention as
+    /// [`Self::put_activation_crossed`]; at most one crossing exists per
+    /// triple (uniqueness is enforced on write).
+    fn get_activation_crossed(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+        activation_id: &str,
+    ) -> Result<Option<ActivationCrossedReceipt>, String> {
+        let key1 = activation_crossed_composite_key1(domain_id, session_id);
+        let payload =
+            self.get_latest_opaque(ACTIVATION_CROSSED_CLASS, &key1, Some(activation_id))?;
+        match payload {
+            Some(bytes) => {
+                Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                    format!("deserialize ActivationCrossedReceipt: {e}")
+                })?))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// List all activation-crossed receipts recorded against one
+    /// `(domain_id, session_id)` anchor, in the store's deterministic
+    /// chronological `(recorded_at, record_hash)` order. Because `key1` is
+    /// the injective domain+session composite, two domains sharing a
+    /// `session_id` can never mix here — no payload-side filtering is needed.
+    fn list_activations_crossed_for_session_in_domain(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+    ) -> Result<Vec<ActivationCrossedReceipt>, String> {
+        let key1 = activation_crossed_composite_key1(domain_id, session_id);
+        let payloads = self.list_opaque_for(ACTIVATION_CROSSED_CLASS, &key1)?;
+        let mut out = Vec::with_capacity(payloads.len());
+        for bytes in payloads {
+            out.push(
+                serde_json::from_slice(&bytes)
+                    .map_err(|e| format!("deserialize ActivationCrossedReceipt in list: {e}"))?,
             );
         }
         Ok(out)

--- a/icn/apps/governance/tests/activation_crossed_receipt_runtime_slice.rs
+++ b/icn/apps/governance/tests/activation_crossed_receipt_runtime_slice.rs
@@ -1,0 +1,1593 @@
+//! Runtime proof for the fifth `ProcessTransitionReceipt` class —
+//! [`ActivationCrossedReceipt`] — per the merged #2294 contract
+//! (`docs/design/activation-crossed-receipt-runtime-dogfood.md`) and the
+//! #2295 B1/B2/B3 decision rung
+//! (`docs/design/activation-crossed-receipt-decision-rung.md`).
+//!
+//! Pins the merged contract:
+//!
+//! 1. `GovernanceManager::record_activation_crossed` requires an
+//!    already-opened session, a **recorded decision** to reference (B1), and
+//!    a **non-empty basis of passed gate results** (B2). It constructs a
+//!    receipt with a real blake3 `record_hash`, persists it through the
+//!    backend's atomic insert-if-absent BEFORE returning, and returns
+//!    `Crossed(receipt)`.
+//! 2. B1: the crossing names the decision by both `decision_id` and
+//!    `decision_record_hash`; the reference is **verified** — a missing,
+//!    wrong-session, wrong-domain, or hash-mismatched decision fails closed
+//!    and persists nothing.
+//! 3. B2: `gate_basis` is a fingerprint over the sorted, de-duplicated
+//!    passed gate-result `record_hash`es; a `Fail`, absent, wrong-domain, or
+//!    wrong-session gate refuses the crossing; an empty basis refuses; basis
+//!    input ordering does not matter and duplicates de-dupe.
+//! 4. B3: a single caller-supplied `recorded_at`, hashed but excluded from
+//!    identity — a retry with identical stable identity returns the ORIGINAL
+//!    receipt unchanged, never restamped.
+//! 5. Same `activation_id` with a different decision reference, gate basis,
+//!    or crosser fails closed with the stable `activation_crossed_conflict`
+//!    prefix; the original is untouched.
+//! 6. Empty/whitespace ids rejected; a missing receipt store is an error;
+//!    backend failure fails closed; concurrent duplicate records serialize
+//!    to exactly one persisted crossing.
+//! 7. The composite storage key is injective: `("ab","c")` vs `("a","bc")`
+//!    domain/session pairs never alias, and two domains sharing a
+//!    `session_id` never mix crossings.
+//!
+//! This records a **process fact and grants zero authority.** "Activation"
+//! here is a local/dev/fixture institutional fact — a recorded decision
+//! accepted as ready to drive a later action-planning step, conditioned on
+//! its required gates observing `pass`. It is the gate, not the mutation; it
+//! is not production activation, mutation planning, or mutation application.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use icn_governance::{
+    ActivationCrossedReceipt, GovernanceDecisionReceipt, GovernanceDomainId, ProcessGateKind,
+    ProcessGateResult,
+};
+use icn_governance_actor::manager::{
+    ActivationCrossedOutcome, DecisionRecordOutcome, GovernanceManager, ProcessSessionOpenOutcome,
+};
+use icn_governance_actor::receipt_backend::{
+    activation_crossed_composite_key1, GovernanceReceiptBackend,
+};
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+
+// ============================================================================
+// Opaque-backed test store — the test analog of the production
+// gateway-backed ReceiptStore: it implements the opaque primitives
+// (including the atomic `put_opaque_if_absent` and the append `put_opaque`)
+// and NO typed overrides, so the trait's typed activation-crossed defaults
+// are exercised end-to-end.
+// ============================================================================
+
+type ChainKey = (String, String, Option<String>);
+
+/// One persisted opaque entry: `(recorded_at, record_hash, payload)`.
+type ChainEntry = (u64, [u8; 32], Vec<u8>);
+
+#[derive(Default)]
+struct OpaqueUniqueBackend {
+    /// `(class, key1, key2)` → chain of `(recorded_at, record_hash, payload)`.
+    chains: Mutex<HashMap<ChainKey, Vec<ChainEntry>>>,
+    /// `(class, key1, key2)` → winning `record_hash` (unique marker).
+    unique: Mutex<HashMap<ChainKey, [u8; 32]>>,
+}
+
+impl OpaqueUniqueBackend {
+    fn chain_len(&self, class: &str, key1: &str, key2: Option<&str>) -> usize {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .map_or(0, Vec::len)
+    }
+
+    fn raw_payload(&self, class: &str, key1: &str, key2: Option<&str>) -> Option<Vec<u8>> {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .and_then(|chain| chain.first().map(|(_, _, p)| p.clone()))
+    }
+}
+
+impl GovernanceReceiptBackend for OpaqueUniqueBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(())
+    }
+
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        // One lock guards marker + chain, mirroring the production sled
+        // transaction's atomicity: check-and-set happens under the same
+        // critical section, so concurrent records serialize.
+        let mut unique = self.unique.lock().unwrap();
+        if let Some(winner) = unique.get(&key) {
+            return Ok(Some(*winner));
+        }
+        unique.insert(key.clone(), record_hash);
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(None)
+    }
+
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        Ok(self.chains.lock().unwrap().get(&key).and_then(|chain| {
+            chain
+                .iter()
+                .max_by_key(|(t, h, _)| (*t, *h))
+                .map(|(_, _, p)| p.clone())
+        }))
+    }
+
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        // Mirrors the production store's documented deterministic order:
+        // chronological by recorded_at with a record_hash tiebreak.
+        let chains = self.chains.lock().unwrap();
+        let mut hits: Vec<ChainEntry> = chains
+            .iter()
+            .filter(|((c, k1, _), _)| c == class && k1 == key1)
+            .flat_map(|(_, chain)| chain.iter().cloned())
+            .collect();
+        hits.sort_by_key(|(t, h, _)| (*t, *h));
+        Ok(hits.into_iter().map(|(_, _, p)| p).collect())
+    }
+}
+
+/// Backend that persists everything except the activation-crossed insert —
+/// proves fail-closed activation persistence with all preconditions
+/// satisfied.
+#[derive(Default)]
+struct FailingActivationBackend {
+    inner: OpaqueUniqueBackend,
+}
+
+impl GovernanceReceiptBackend for FailingActivationBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        self.inner
+            .put_opaque(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        if class == "activation_crossed" {
+            return Err("simulated activation-crossed backend failure".to_string());
+        }
+        self.inner
+            .put_opaque_if_absent(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        self.inner.get_latest_opaque(class, key1, key2)
+    }
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        self.inner.list_opaque_for(class, key1)
+    }
+}
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_manager() -> (GovernanceManager, Arc<OpaqueUniqueBackend>) {
+    let store = Arc::new(OpaqueUniqueBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    (mgr, store)
+}
+
+fn coop_test() -> GovernanceDomainId {
+    GovernanceDomainId::new("coop:test")
+}
+
+/// The composite key the activation chain lives under (for chain_len asserts).
+fn activation_key1(domain: &str, session: &str) -> String {
+    activation_crossed_composite_key1(domain, session)
+}
+
+/// Open a session so the activation precondition is satisfied.
+fn open_session(mgr: &GovernanceManager, domain: &GovernanceDomainId, session: &str, by: &Did) {
+    match mgr
+        .record_process_session_opened(domain, session, by)
+        .unwrap()
+    {
+        ProcessSessionOpenOutcome::Opened(_) | ProcessSessionOpenOutcome::AlreadyOpened(_) => {}
+    }
+}
+
+/// Record a decision and return its `record_hash` (the B1 proof link).
+fn record_decision(
+    mgr: &GovernanceManager,
+    domain: &GovernanceDomainId,
+    session: &str,
+    decision_id: &str,
+    by: &Did,
+    body: [u8; 32],
+) -> [u8; 32] {
+    match mgr
+        .record_decision(domain, session, decision_id, by, body)
+        .unwrap()
+    {
+        DecisionRecordOutcome::Recorded(r) | DecisionRecordOutcome::AlreadyRecorded(r) => {
+            r.record_hash
+        }
+    }
+}
+
+/// Record a passed gate result and return its `record_hash` (a basis input).
+fn record_pass_gate(
+    mgr: &GovernanceManager,
+    domain: &GovernanceDomainId,
+    session: &str,
+    kind: ProcessGateKind,
+    by: &Did,
+) -> [u8; 32] {
+    mgr.record_process_gate_result(domain, session, kind, ProcessGateResult::Pass, by)
+        .unwrap()
+        .record_hash
+}
+
+/// Record a failed gate result and return its `record_hash`.
+fn record_fail_gate(
+    mgr: &GovernanceManager,
+    domain: &GovernanceDomainId,
+    session: &str,
+    kind: ProcessGateKind,
+    by: &Did,
+) -> [u8; 32] {
+    mgr.record_process_gate_result(domain, session, kind, ProcessGateResult::Fail, by)
+        .unwrap()
+        .record_hash
+}
+
+// ============================================================================
+// Happy path — construct, persist, retrieve, verify B1 + B2 links
+// ============================================================================
+
+#[test]
+fn cross_persists_and_returns_receipt_with_verified_links() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+    let g2 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::AccessibilityReview,
+        &actor,
+    );
+
+    let outcome = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g1, g2],
+            &actor,
+        )
+        .expect("first crossing must succeed");
+    let ActivationCrossedOutcome::Crossed(receipt) = outcome else {
+        panic!("first crossing must be Crossed, got {outcome:?}");
+    };
+    assert_eq!(receipt.domain_id, "coop:test");
+    assert_eq!(receipt.session_id, "session-001");
+    assert_eq!(receipt.activation_id, "activation-001");
+    assert_eq!(receipt.decision_id, "decision-001");
+    assert_eq!(receipt.crossed_by, actor.to_string());
+    assert_ne!(receipt.record_hash, [0u8; 32], "real blake3 hash");
+
+    // B1: decision_record_hash equals the persisted decision receipt hash.
+    assert_eq!(
+        receipt.decision_record_hash, decision_hash,
+        "B1 proof link binds the recorded decision's real record_hash"
+    );
+    // B2: gate_basis equals an independent sorted/de-duped fingerprint of the
+    // passed gate-result hashes.
+    assert_eq!(
+        receipt.gate_basis,
+        ActivationCrossedReceipt::compute_gate_basis(&[g1, g2]),
+        "B2 gate_basis is the fingerprint of the declared passed gate results"
+    );
+
+    // Persist-before-return: durable under the injective composite key.
+    assert_eq!(
+        store.chain_len(
+            "activation_crossed",
+            &activation_key1("coop:test", "session-001"),
+            Some("activation-001"),
+        ),
+        1,
+        "exactly one persisted crossing"
+    );
+    // Point read hydrates the same receipt.
+    let read = mgr
+        .get_activation_crossed(&domain, "session-001", "activation-001")
+        .unwrap()
+        .expect("point read must hydrate");
+    assert_eq!(read, receipt);
+}
+
+// ============================================================================
+// Session precondition
+// ============================================================================
+
+#[test]
+fn unopened_session_fails_closed_and_creates_nothing() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    // No open_session call.
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-ghost",
+            "activation-001",
+            "decision-001",
+            [1u8; 32],
+            &[[2u8; 32]],
+            &actor,
+        )
+        .expect_err("unopened session must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_session_not_opened"),
+        "stable precondition prefix, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "activation_crossed",
+            &activation_key1("coop:test", "session-ghost"),
+            Some("activation-001"),
+        ),
+        0,
+        "nothing persisted"
+    );
+}
+
+// ============================================================================
+// B1 — decision reference preconditions (verified, not asserted)
+// ============================================================================
+
+#[test]
+fn missing_decision_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+    // No decision recorded.
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-404",
+            [7u8; 32],
+            &[g1],
+            &actor,
+        )
+        .expect_err("missing decision must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_decision_not_found"),
+        "stable prefix, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "activation_crossed",
+            &activation_key1("coop:test", "session-001"),
+            Some("activation-001"),
+        ),
+        0
+    );
+}
+
+#[test]
+fn wrong_session_decision_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-a", &actor);
+    open_session(&mgr, &domain, "session-b", &actor);
+    // Decision recorded in session-a only.
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-a",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-b",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    // Activation in session-b cites the session-a decision — invisible under
+    // session-b's composite key.
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-b",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g1],
+            &actor,
+        )
+        .expect_err("wrong-session decision must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_decision_not_found"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn wrong_domain_decision_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    open_session(&mgr, &d1, "session-shared", &actor);
+    open_session(&mgr, &d2, "session-shared", &actor);
+    // Decision recorded in domain d1 only.
+    let decision_hash = record_decision(
+        &mgr,
+        &d1,
+        "session-shared",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &d2,
+        "session-shared",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    // Activation in d2 cites the d1 decision — invisible under d2's composite
+    // key.
+    let err = mgr
+        .record_activation_crossed(
+            &d2,
+            "session-shared",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g1],
+            &actor,
+        )
+        .expect_err("wrong-domain decision must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_decision_not_found"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn decision_id_hash_mismatch_fails_closed() {
+    // The supplied decision_id references a real decision, but the supplied
+    // decision_record_hash belongs to a DIFFERENT decision — the reference is
+    // verified against the recorded decision and refused on mismatch.
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let other_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-002",
+        &actor,
+        [8u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            other_hash, // hash of decision-002, not decision-001
+            &[g1],
+            &actor,
+        )
+        .expect_err("decision_id/record_hash mismatch must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_decision_mismatch"),
+        "stable prefix, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "activation_crossed",
+            &activation_key1("coop:test", "session-001"),
+            Some("activation-001"),
+        ),
+        0
+    );
+}
+
+// ============================================================================
+// B2 — gate-basis preconditions
+// ============================================================================
+
+#[test]
+fn empty_gate_basis_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[],
+            &actor,
+        )
+        .expect_err("empty basis must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_empty_gate_basis"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn absent_gate_hash_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    // No gate results recorded; cite a phantom hash.
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[[123u8; 32]],
+            &actor,
+        )
+        .expect_err("absent gate hash must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_gate_not_found"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn failed_gate_hash_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let failed = record_fail_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[failed],
+            &actor,
+        )
+        .expect_err("failed gate in basis must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_gate_not_passed"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn wrong_domain_gate_hash_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    open_session(&mgr, &d1, "session-shared", &actor);
+    open_session(&mgr, &d2, "session-shared", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &d2,
+        "session-shared",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    // Pass gate recorded in domain d1 only (same session id).
+    let g_d1 = record_pass_gate(
+        &mgr,
+        &d1,
+        "session-shared",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    // Activation in d2 cites the d1 gate — the domain-scoped read excludes it.
+    let err = mgr
+        .record_activation_crossed(
+            &d2,
+            "session-shared",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g_d1],
+            &actor,
+        )
+        .expect_err("wrong-domain gate must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_gate_not_found"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn wrong_session_gate_hash_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-a", &actor);
+    open_session(&mgr, &domain, "session-b", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-b",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    // Pass gate recorded in session-a only.
+    let g_a = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-a",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-b",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g_a],
+            &actor,
+        )
+        .expect_err("wrong-session gate must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("activation_crossed_gate_not_found"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn basis_ordering_does_not_matter() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+    let g2 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::AccessibilityReview,
+        &actor,
+    );
+
+    let ActivationCrossedOutcome::Crossed(a) = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "act-a",
+            "decision-001",
+            decision_hash,
+            &[g1, g2],
+            &actor,
+        )
+        .unwrap()
+    else {
+        panic!("act-a must cross");
+    };
+    let ActivationCrossedOutcome::Crossed(b) = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "act-b",
+            "decision-001",
+            decision_hash,
+            &[g2, g1],
+            &actor,
+        )
+        .unwrap()
+    else {
+        panic!("act-b must cross");
+    };
+    assert_eq!(
+        a.gate_basis, b.gate_basis,
+        "gate_basis is order-independent for the same declared set"
+    );
+}
+
+#[test]
+fn duplicated_basis_hashes_dedupe_deterministically() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+    let g2 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::AccessibilityReview,
+        &actor,
+    );
+
+    let ActivationCrossedOutcome::Crossed(dup) = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "act-dup",
+            "decision-001",
+            decision_hash,
+            &[g1, g1, g2, g1],
+            &actor,
+        )
+        .unwrap()
+    else {
+        panic!("act-dup must cross");
+    };
+    assert_eq!(
+        dup.gate_basis,
+        ActivationCrossedReceipt::compute_gate_basis(&[g1, g2]),
+        "duplicated basis hashes de-dupe to the same fingerprint as the unique set"
+    );
+}
+
+// ============================================================================
+// B3 / idempotency — retry returns original, never restamped
+// ============================================================================
+
+#[test]
+fn same_identity_retry_returns_original_never_restamped() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    let ActivationCrossedOutcome::Crossed(original) = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g1],
+            &actor,
+        )
+        .unwrap()
+    else {
+        panic!("first crossing must be Crossed");
+    };
+
+    // Retry with identical stable identity. The manager stamps a fresh
+    // recorded_at internally on every attempt — proving recorded_at /
+    // record_hash are NOT identity inputs: the retry still resolves to the
+    // ORIGINAL receipt, byte-identical.
+    let outcome = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g1],
+            &actor,
+        )
+        .expect("same-identity retry must succeed");
+    let ActivationCrossedOutcome::AlreadyCrossed(returned) = outcome else {
+        panic!("retry must be AlreadyCrossed, got {outcome:?}");
+    };
+    assert_eq!(
+        returned.recorded_at, original.recorded_at,
+        "never restamped"
+    );
+    assert_eq!(returned.record_hash, original.record_hash);
+    assert_eq!(returned, original);
+    assert_eq!(
+        store.chain_len(
+            "activation_crossed",
+            &activation_key1("coop:test", "session-001"),
+            Some("activation-001"),
+        ),
+        1,
+        "retry must not append a second record"
+    );
+}
+
+// ============================================================================
+// Conflicts — same activation_id, different identity fields
+// ============================================================================
+
+#[test]
+fn conflict_on_different_decision_reference_fails_closed() {
+    // decision_id and decision_record_hash are both stable-identity inputs.
+    // Through the validated path they co-vary (each decision_id maps to one
+    // record_hash; a same-id/wrong-hash reference is caught earlier as
+    // `activation_crossed_decision_mismatch`, tested above). Referencing a
+    // DIFFERENT recorded decision for the same activation_id conflicts.
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let d1 = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let d2 = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-002",
+        &actor,
+        [8u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    mgr.record_activation_crossed(
+        &domain,
+        "session-001",
+        "activation-001",
+        "decision-001",
+        d1,
+        &[g1],
+        &actor,
+    )
+    .expect("first crossing");
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-002",
+            d2,
+            &[g1],
+            &actor,
+        )
+        .expect_err("different decision reference must conflict");
+    assert!(
+        err.to_string().starts_with("activation_crossed_conflict"),
+        "stable conflict prefix, got: {err}"
+    );
+    let read = mgr
+        .get_activation_crossed(&domain, "session-001", "activation-001")
+        .unwrap()
+        .unwrap();
+    assert_eq!(read.decision_id, "decision-001", "original untouched");
+    assert_eq!(
+        store.chain_len(
+            "activation_crossed",
+            &activation_key1("coop:test", "session-001"),
+            Some("activation-001"),
+        ),
+        1
+    );
+}
+
+#[test]
+fn conflict_on_different_gate_basis_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+    let g2 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::AccessibilityReview,
+        &actor,
+    );
+
+    mgr.record_activation_crossed(
+        &domain,
+        "session-001",
+        "activation-001",
+        "decision-001",
+        decision_hash,
+        &[g1],
+        &actor,
+    )
+    .expect("first crossing with basis [g1]");
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g1, g2],
+            &actor,
+        )
+        .expect_err("different gate basis must conflict");
+    assert!(
+        err.to_string().starts_with("activation_crossed_conflict"),
+        "stable conflict prefix, got: {err}"
+    );
+}
+
+#[test]
+fn conflict_on_different_crosser_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let other = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    mgr.record_activation_crossed(
+        &domain,
+        "session-001",
+        "activation-001",
+        "decision-001",
+        decision_hash,
+        &[g1],
+        &actor,
+    )
+    .expect("first crossing");
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g1],
+            &other,
+        )
+        .expect_err("different crosser must conflict");
+    assert!(
+        err.to_string().starts_with("activation_crossed_conflict"),
+        "stable conflict prefix, got: {err}"
+    );
+}
+
+// ============================================================================
+// Input validation, missing store, backend failure
+// ============================================================================
+
+#[test]
+fn empty_and_whitespace_ids_rejected_before_persistence() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    for (d, s, a, dec) in [
+        ("", "session-001", "activation-001", "decision-001"),
+        ("   ", "session-001", "activation-001", "decision-001"),
+        ("coop:test", "", "activation-001", "decision-001"),
+        ("coop:test", "  \t", "activation-001", "decision-001"),
+        ("coop:test", "session-001", "", "decision-001"),
+        ("coop:test", "session-001", " \n ", "decision-001"),
+        ("coop:test", "session-001", "activation-001", ""),
+        ("coop:test", "session-001", "activation-001", "  "),
+    ] {
+        let err = mgr
+            .record_activation_crossed(
+                &GovernanceDomainId::new(d),
+                s,
+                a,
+                dec,
+                decision_hash,
+                &[g1],
+                &actor,
+            )
+            .expect_err("empty/whitespace ids must be rejected");
+        assert!(
+            err.to_string().contains("non-empty"),
+            "id-validation error, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn missing_receipt_store_is_an_error() {
+    let mgr = GovernanceManager::new(); // no receipt store wired
+    let actor = fresh_did();
+    let err = mgr
+        .record_activation_crossed(
+            &coop_test(),
+            "session-001",
+            "activation-001",
+            "decision-001",
+            [1u8; 32],
+            &[[2u8; 32]],
+            &actor,
+        )
+        .expect_err("missing store must be an error");
+    assert!(
+        err.to_string().contains("receipt store is required"),
+        "store-required error, got: {err}"
+    );
+}
+
+#[test]
+fn backend_failure_fails_closed() {
+    let store = Arc::new(FailingActivationBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    let err = mgr
+        .record_activation_crossed(
+            &domain,
+            "session-001",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g1],
+            &actor,
+        )
+        .expect_err("backend failure must surface");
+    assert!(
+        err.to_string()
+            .contains("simulated activation-crossed backend failure"),
+        "backend error surfaced, got: {err}"
+    );
+    assert!(
+        mgr.get_activation_crossed(&domain, "session-001", "activation-001")
+            .unwrap()
+            .is_none(),
+        "nothing half-written"
+    );
+}
+
+// ============================================================================
+// Concurrency — atomic uniqueness under racing duplicates
+// ============================================================================
+
+#[test]
+fn concurrent_duplicate_crossings_serialize_to_one_winner() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    let mgr = Arc::new(mgr);
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let mgr = mgr.clone();
+        let actor = actor.clone();
+        let domain = domain.clone();
+        handles.push(std::thread::spawn(move || {
+            mgr.record_activation_crossed(
+                &domain,
+                "session-001",
+                "activation-race",
+                "decision-001",
+                decision_hash,
+                &[g1],
+                &actor,
+            )
+        }));
+    }
+    let mut receipts = Vec::new();
+    for h in handles {
+        let outcome = h.join().unwrap().expect("same-identity race must succeed");
+        match outcome {
+            ActivationCrossedOutcome::Crossed(r) | ActivationCrossedOutcome::AlreadyCrossed(r) => {
+                receipts.push(r)
+            }
+        }
+    }
+    assert_eq!(
+        store.chain_len(
+            "activation_crossed",
+            &activation_key1("coop:test", "session-001"),
+            Some("activation-race"),
+        ),
+        1,
+        "atomic uniqueness: one winner"
+    );
+    let first = &receipts[0];
+    for r in &receipts {
+        assert_eq!(r, first, "all threads observe the single winner");
+    }
+}
+
+// ============================================================================
+// Key injectivity, cross-domain isolation, payload audit
+// ============================================================================
+
+#[test]
+fn composite_key_is_injective_no_aliasing() {
+    assert_ne!(
+        activation_crossed_composite_key1("ab", "c"),
+        activation_crossed_composite_key1("a", "bc"),
+        "netstring length prefix must prevent domain/session aliasing"
+    );
+
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d_ab = GovernanceDomainId::new("ab");
+    let d_a = GovernanceDomainId::new("a");
+    open_session(&mgr, &d_ab, "c", &actor);
+    let decision_hash = record_decision(&mgr, &d_ab, "c", "decision-001", &actor, [9u8; 32]);
+    let g1 = record_pass_gate(&mgr, &d_ab, "c", ProcessGateKind::PrivacyReview, &actor);
+
+    // Only ("ab","c") is opened; ("a","bc") must NOT see it through key
+    // aliasing — the precondition fails closed for the unopened pair.
+    let err = mgr
+        .record_activation_crossed(
+            &d_a,
+            "bc",
+            "activation-001",
+            "decision-001",
+            decision_hash,
+            &[g1],
+            &actor,
+        )
+        .expect_err("aliased pair must not inherit the opened session");
+    assert!(err
+        .to_string()
+        .starts_with("activation_crossed_session_not_opened"));
+    // The genuinely opened pair records fine.
+    mgr.record_activation_crossed(
+        &d_ab,
+        "c",
+        "activation-001",
+        "decision-001",
+        decision_hash,
+        &[g1],
+        &actor,
+    )
+    .expect("opened pair records");
+}
+
+#[test]
+fn two_domains_sharing_session_id_never_mix() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    open_session(&mgr, &d1, "shared-session", &actor);
+    open_session(&mgr, &d2, "shared-session", &actor);
+    let h1 = record_decision(&mgr, &d1, "shared-session", "decision-1", &actor, [1u8; 32]);
+    let h2 = record_decision(&mgr, &d2, "shared-session", "decision-2", &actor, [2u8; 32]);
+    let g1 = record_pass_gate(
+        &mgr,
+        &d1,
+        "shared-session",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+    let g2 = record_pass_gate(
+        &mgr,
+        &d2,
+        "shared-session",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+
+    mgr.record_activation_crossed(
+        &d1,
+        "shared-session",
+        "act-1",
+        "decision-1",
+        h1,
+        &[g1],
+        &actor,
+    )
+    .unwrap();
+    mgr.record_activation_crossed(
+        &d2,
+        "shared-session",
+        "act-2",
+        "decision-2",
+        h2,
+        &[g2],
+        &actor,
+    )
+    .unwrap();
+
+    let list1 = mgr
+        .list_activations_crossed_in_domain(&d1, "shared-session")
+        .unwrap();
+    let list2 = mgr
+        .list_activations_crossed_in_domain(&d2, "shared-session")
+        .unwrap();
+    assert_eq!(list1.len(), 1);
+    assert_eq!(list2.len(), 1);
+    assert_eq!(list1[0].activation_id, "act-1");
+    assert_eq!(list2[0].activation_id, "act-2");
+    assert_eq!(list1[0].domain_id, "coop:one");
+    assert_eq!(list2[0].domain_id, "coop:two");
+}
+
+#[test]
+fn persisted_payload_carries_only_v1_fields() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    let decision_hash = record_decision(
+        &mgr,
+        &domain,
+        "session-001",
+        "decision-001",
+        &actor,
+        [9u8; 32],
+    );
+    let g1 = record_pass_gate(
+        &mgr,
+        &domain,
+        "session-001",
+        ProcessGateKind::PrivacyReview,
+        &actor,
+    );
+    mgr.record_activation_crossed(
+        &domain,
+        "session-001",
+        "activation-001",
+        "decision-001",
+        decision_hash,
+        &[g1],
+        &actor,
+    )
+    .unwrap();
+
+    let payload = store
+        .raw_payload(
+            "activation_crossed",
+            &activation_key1("coop:test", "session-001"),
+            Some("activation-001"),
+        )
+        .expect("payload persisted");
+    let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+    let obj = value.as_object().unwrap();
+    let expected: std::collections::BTreeSet<&str> = [
+        "domain_id",
+        "session_id",
+        "activation_id",
+        "decision_id",
+        "decision_record_hash",
+        "gate_basis",
+        "crossed_by",
+        "recorded_at",
+        "record_hash",
+    ]
+    .into_iter()
+    .collect();
+    let actual: std::collections::BTreeSet<&str> = obj.keys().map(|k| k.as_str()).collect();
+    assert_eq!(
+        actual, expected,
+        "persisted payload must carry exactly the v1 field set — no body, no \
+         gate kind/result, no outcome/tally/vote/proposal/mandate field"
+    );
+}

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -141,7 +141,7 @@ pub use message::{GovernanceMessage, ProposalOutcome, TallySnapshot};
 pub use profile::{DecisionOutcome, GovernanceProfile, GovernanceProfileId, GovernanceRule};
 pub use proof::{
     ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActionItemCompletionReceiptV2Error,
-    ActionItemTransition, DecisionRecordedReceipt, DeliberationEntryKind,
+    ActionItemTransition, ActivationCrossedReceipt, DecisionRecordedReceipt, DeliberationEntryKind,
     DeliberationEntryRecordedReceipt, GovernanceDecisionAttestation, GovernanceDecisionReceipt,
     GovernanceDecisionReceiptV2, GovernanceDecisionReceiptV2Error, GovernanceDecisionReceiptV3,
     GovernanceDecisionReceiptV3Error, GovernanceProof, GovernanceProofV2, MandateGrantRef,

--- a/icn/crates/icn-governance/src/proof.rs
+++ b/icn/crates/icn-governance/src/proof.rs
@@ -2711,6 +2711,223 @@ impl DecisionRecordedReceipt {
     }
 }
 
+/// Domain separation tag for the `gate_basis` fingerprint of an
+/// [`ActivationCrossedReceipt`]. Distinct from every receipt `DOMAIN_TAG`
+/// so a basis fingerprint can never be confused with a receipt
+/// `record_hash`.
+const ACTIVATION_GATE_BASIS_TAG: &[u8] = b"icn:gov:activation_gate_basis:v1";
+
+/// Cross-node deterministic receipt recording that an already-recorded
+/// decision **crossed the activation boundary** for a process session —
+/// the spine's "boundary between deciding and doing" — with the required
+/// gates observed as passed.
+///
+/// The fifth `ProcessTransitionReceipt` class (ADR-0026 Layer 2), after
+/// [`ProcessGateResultReceipt`] (#2144), [`ProcessSessionOpenedReceipt`]
+/// (#2276), [`DeliberationEntryRecordedReceipt`] (#2279), and
+/// [`DecisionRecordedReceipt`] (#2282), per the merged
+/// `docs/design/activation-crossed-receipt-runtime-dogfood.md` contract
+/// (#2294) and the `docs/design/activation-crossed-receipt-decision-rung.md`
+/// B1/B2/B3 decision (#2295).
+///
+/// **This receipt records a process fact; it grants zero authority and is
+/// not a workflow engine.** "Activation" here is a local/dev/fixture
+/// institutional fact — a recorded decision was accepted as ready to drive
+/// a later action-planning step, conditioned on its required gates observing
+/// `pass`. It is the gate, not the mutation: it is **not** production
+/// activation, service deployment, NYCN launch, mutation planning, or
+/// mutation application. Crossing the boundary produces a receipt of the
+/// crossing and nothing else.
+///
+/// **B1 — the crossing names the decision it activates by BOTH the
+/// caller-opaque `decision_id` and the content-addressed
+/// `decision_record_hash`** of the [`DecisionRecordedReceipt`]. Both fields
+/// participate in the canonical `record_hash` and in stable duplicate
+/// identity. The reference is verified, not merely asserted: the emitting
+/// manager requires a decision receipt with exactly `decision_record_hash`
+/// to exist in the same `(domain_id, session_id)` before the crossing is
+/// recorded. This is the lane's first inter-receipt link; it points at the
+/// decision's own self-hashed `record_hash` and claims no signed-envelope
+/// inheritance (ADR-0026 §7).
+///
+/// **B2 — `gate_basis` is a fingerprint over the sorted, de-duplicated
+/// `record_hash`es of the `ProcessGateResultReceipt`s the caller declares
+/// as the basis for this crossing** (see [`Self::compute_gate_basis`]). The
+/// receipt carries **no `ProcessGateKind`, no `result`, and no gate
+/// evaluation** — only the content fingerprint of the passed gate receipts.
+/// It witnesses that gates passed; it does not re-derive the passing, and it
+/// owns no "required set" policy (that is charter/app-layer). The emitting
+/// manager verifies every declared gate result exists in the same
+/// `(domain_id, session_id)` and carries `result == Pass` before recording.
+///
+/// **B3 — a single caller-supplied `recorded_at`**, hashed into
+/// `record_hash` but **excluded** from duplicate identity — identical to the
+/// four landed classes. No distinct `crossed_at` field; no `effective_at` is
+/// carried or derived. A retry never restamps.
+///
+/// **At most one crossing exists per `(domain_id, session_id,
+/// activation_id)`** — the receipt backend enforces uniqueness atomically at
+/// the storage layer. A retry with identical stable identity (`decision_id`,
+/// `decision_record_hash`, `gate_basis`, `crossed_by`) returns this original
+/// receipt unchanged (never restamped); any mismatch fails closed.
+///
+/// `crossed_by` is actor evidence — the recorder of the crossing, not an
+/// authority to act ("recorder, not crosser"). Equality is anchored to
+/// `record_hash`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ActivationCrossedReceipt {
+    /// Governance domain the session (and this crossing) is scoped to.
+    pub domain_id: String,
+    /// Identifier of the already-opened process session this crossing
+    /// attaches to. Caller-provided, treated as opaque, meaningful only
+    /// together with `domain_id` (session ids are not globally unique).
+    pub session_id: String,
+    /// Caller-supplied opaque identifier for this activation, unique within
+    /// `(domain_id, session_id)` — uniqueness is enforced at the storage
+    /// layer, not assumed of the id.
+    pub activation_id: String,
+    /// Caller-opaque `decision_id` of the [`DecisionRecordedReceipt`] being
+    /// activated — the human/index handle (B1).
+    pub decision_id: String,
+    /// Content-addressed `record_hash` of that [`DecisionRecordedReceipt`] —
+    /// the cryptographic proof link (B1). Verified to exist in-session
+    /// before the crossing is recorded.
+    pub decision_record_hash: Hash,
+    /// Fingerprint over the sorted, de-duplicated `record_hash`es of the
+    /// passed [`ProcessGateResultReceipt`]s declared as the basis for this
+    /// crossing (B2). See [`Self::compute_gate_basis`].
+    pub gate_basis: Hash,
+    /// DID of the authenticated actor who recorded the crossing — recorder
+    /// evidence, not an authority to act. Grants zero authority.
+    pub crossed_by: String,
+    /// Unix-seconds the crossing was recorded. Not part of duplicate
+    /// identity — a retry never restamps.
+    pub recorded_at: u64,
+    /// blake3 canonical record hash binding the fields above.
+    pub record_hash: Hash,
+}
+
+impl PartialEq for ActivationCrossedReceipt {
+    fn eq(&self, other: &Self) -> bool {
+        self.record_hash == other.record_hash
+    }
+}
+
+impl Eq for ActivationCrossedReceipt {}
+
+impl ActivationCrossedReceipt {
+    /// Domain separation tag for canonical activation-crossed record hashes.
+    /// Distinct from every other receipt-family tag — and in particular it
+    /// must NEVER converge with `icn:gov:decision_recorded:v1`,
+    /// `icn:gov:process_gate_result:v1`, or the proposal/vote
+    /// `icn:gov:decision:v1/v2/v3` lineage.
+    pub const DOMAIN_TAG: &[u8] = b"icn:gov:activation_crossed:v1";
+
+    /// Compute the canonical `gate_basis` fingerprint (B2) from the declared
+    /// gate-result `record_hash`es.
+    ///
+    /// The inputs are **sorted and de-duplicated** before hashing, so the
+    /// basis is a set fingerprint: the same passed gate receipts in any
+    /// order, with any duplication, always yield the same `gate_basis`
+    /// (contract §5.2 / decision rung §5.2). The count is length-prefixed
+    /// under a dedicated domain tag; each 32-byte hash is appended raw
+    /// (fixed-size fields cannot alias).
+    pub fn compute_gate_basis(gate_result_hashes: &[Hash]) -> Hash {
+        let mut sorted: Vec<Hash> = gate_result_hashes.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(ACTIVATION_GATE_BASIS_TAG);
+        hasher.update(&(sorted.len() as u64).to_le_bytes());
+        for h in &sorted {
+            hasher.update(h);
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hasher.finalize().as_bytes());
+        out
+    }
+
+    /// Build a new receipt and compute its canonical `record_hash`.
+    ///
+    /// `gate_basis` is supplied pre-computed (via [`Self::compute_gate_basis`]
+    /// over the verified passed gate-result hashes), mirroring how the
+    /// decision/deliberation classes take a pre-computed `body_hash`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        domain_id: String,
+        session_id: String,
+        activation_id: String,
+        decision_id: String,
+        decision_record_hash: Hash,
+        gate_basis: Hash,
+        crossed_by: String,
+        recorded_at: u64,
+    ) -> Self {
+        let record_hash = Self::compute_record_hash(
+            &domain_id,
+            &session_id,
+            &activation_id,
+            &decision_id,
+            &decision_record_hash,
+            &gate_basis,
+            &crossed_by,
+            recorded_at,
+        );
+        Self {
+            domain_id,
+            session_id,
+            activation_id,
+            decision_id,
+            decision_record_hash,
+            gate_basis,
+            crossed_by,
+            recorded_at,
+            record_hash,
+        }
+    }
+
+    /// Compute the canonical record hash from the input fields.
+    ///
+    /// Layout (per the #2294 contract as resolved by the #2295 B1/B2/B3
+    /// decision rung §7): [`Self::DOMAIN_TAG`] first; each string field
+    /// length-prefixed (u64 LE) in order `domain_id`, `session_id`,
+    /// `activation_id`, `decision_id`, `crossed_by`; then
+    /// `decision_record_hash` and `gate_basis` appended **raw as fixed
+    /// 32-byte fields with no length prefix** (fixed-size fields cannot
+    /// alias); then `recorded_at` as LE bytes. No `body_hash` in this first
+    /// slice; no discriminant byte (this class has no kind taxonomy).
+    #[allow(clippy::too_many_arguments)]
+    pub fn compute_record_hash(
+        domain_id: &str,
+        session_id: &str,
+        activation_id: &str,
+        decision_id: &str,
+        decision_record_hash: &Hash,
+        gate_basis: &Hash,
+        crossed_by: &str,
+        recorded_at: u64,
+    ) -> Hash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(Self::DOMAIN_TAG);
+        for field in [
+            domain_id,
+            session_id,
+            activation_id,
+            decision_id,
+            crossed_by,
+        ] {
+            hasher.update(&(field.len() as u64).to_le_bytes());
+            hasher.update(field.as_bytes());
+        }
+        hasher.update(decision_record_hash);
+        hasher.update(gate_basis);
+        hasher.update(&recorded_at.to_le_bytes());
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hasher.finalize().as_bytes());
+        out
+    }
+}
+
 // ============================================================================
 // Mandate grant reference (#1868 step 2 primitive — wire form only)
 // ============================================================================
@@ -4274,6 +4491,332 @@ mod tests {
             assert!(
                 !lower.contains(forbidden),
                 "DecisionRecordedReceipt JSON must not contain `{forbidden}`; got: {json}"
+            );
+        }
+    }
+
+    // ============================================================================
+    // ActivationCrossedReceipt — fifth ProcessTransitionReceipt class (per
+    // the #2294 contract + #2295 B1/B2/B3 decision rung)
+    // ============================================================================
+
+    fn sample_activation_crossed_receipt() -> ActivationCrossedReceipt {
+        ActivationCrossedReceipt::new(
+            "domain-food-coop".to_string(),
+            "session-alpha".to_string(),
+            "activation-001".to_string(),
+            "decision-001".to_string(),
+            [7u8; 32], // decision_record_hash (B1 proof link)
+            [5u8; 32], // gate_basis (B2 fingerprint — literal here so the
+            // receipt golden is independent of the basis derivation)
+            "did:icn:crosser-1".to_string(),
+            1_750_000_000,
+        )
+    }
+
+    #[test]
+    fn activation_crossed_golden_vector() {
+        // Golden canonical hash vector: pins the FULL v1 layout (domain tag,
+        // length-prefixed strings domain_id/session_id/activation_id/
+        // decision_id/crossed_by, raw fixed 32-byte decision_record_hash then
+        // gate_basis, recorded_at LE — no body_hash, no discriminant byte).
+        // Any layout change breaks this test and requires a new tag version,
+        // not an edit here.
+        let r = sample_activation_crossed_receipt();
+        assert_eq!(
+            hex32(&r.record_hash),
+            "2233c0322ec0509bb57070a9c3081c28715cadfa2995d0be2abc6efe9f7d1798",
+            "canonical v1 hash layout drifted"
+        );
+    }
+
+    #[test]
+    fn activation_crossed_gate_basis_golden_vector() {
+        // Pins the gate_basis fingerprint layout (its own domain tag, u64 LE
+        // count, sorted+deduped raw 32-byte hashes).
+        let basis = ActivationCrossedReceipt::compute_gate_basis(&[[4u8; 32], [3u8; 32]]);
+        assert_eq!(
+            hex32(&basis),
+            "3dd8d07807ed717cf08371ebb7f68870997a3d8c7bbec6dc0a941d402ef148ba",
+            "gate_basis fingerprint layout drifted"
+        );
+    }
+
+    #[test]
+    fn activation_crossed_gate_basis_order_and_dedup_independent() {
+        // B2 §5.2: basis is a set fingerprint — order-independent and
+        // de-duplicating.
+        let a = ActivationCrossedReceipt::compute_gate_basis(&[[1u8; 32], [2u8; 32], [3u8; 32]]);
+        let reordered =
+            ActivationCrossedReceipt::compute_gate_basis(&[[3u8; 32], [1u8; 32], [2u8; 32]]);
+        assert_eq!(
+            a, reordered,
+            "gate_basis must be order-independent (sorted)"
+        );
+        let duplicated = ActivationCrossedReceipt::compute_gate_basis(&[
+            [1u8; 32], [2u8; 32], [2u8; 32], [3u8; 32], [1u8; 32],
+        ]);
+        assert_eq!(a, duplicated, "gate_basis must de-duplicate");
+        let different = ActivationCrossedReceipt::compute_gate_basis(&[[1u8; 32], [2u8; 32]]);
+        assert_ne!(
+            a, different,
+            "a different basis set changes the fingerprint"
+        );
+        assert_ne!(a, [0u8; 32], "real blake3 fingerprint");
+    }
+
+    #[test]
+    fn activation_crossed_record_hash_determinism() {
+        let r1 = sample_activation_crossed_receipt();
+        let r2 = sample_activation_crossed_receipt();
+        assert_eq!(r1.record_hash, r2.record_hash);
+        assert_ne!(r1.record_hash, [0u8; 32]);
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn activation_crossed_record_hash_changes_per_field() {
+        // Each field independently changes the hash — including
+        // decision_record_hash and gate_basis (the B1/B2 links).
+        let base = sample_activation_crossed_receipt();
+        let variants = [
+            ActivationCrossedReceipt::new(
+                "domain-other".to_string(),
+                base.session_id.clone(),
+                base.activation_id.clone(),
+                base.decision_id.clone(),
+                base.decision_record_hash,
+                base.gate_basis,
+                base.crossed_by.clone(),
+                base.recorded_at,
+            ),
+            ActivationCrossedReceipt::new(
+                base.domain_id.clone(),
+                "session-other".to_string(),
+                base.activation_id.clone(),
+                base.decision_id.clone(),
+                base.decision_record_hash,
+                base.gate_basis,
+                base.crossed_by.clone(),
+                base.recorded_at,
+            ),
+            ActivationCrossedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                "activation-other".to_string(),
+                base.decision_id.clone(),
+                base.decision_record_hash,
+                base.gate_basis,
+                base.crossed_by.clone(),
+                base.recorded_at,
+            ),
+            ActivationCrossedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.activation_id.clone(),
+                "decision-other".to_string(),
+                base.decision_record_hash,
+                base.gate_basis,
+                base.crossed_by.clone(),
+                base.recorded_at,
+            ),
+            ActivationCrossedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.activation_id.clone(),
+                base.decision_id.clone(),
+                [8u8; 32],
+                base.gate_basis,
+                base.crossed_by.clone(),
+                base.recorded_at,
+            ),
+            ActivationCrossedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.activation_id.clone(),
+                base.decision_id.clone(),
+                base.decision_record_hash,
+                [6u8; 32],
+                base.crossed_by.clone(),
+                base.recorded_at,
+            ),
+            ActivationCrossedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.activation_id.clone(),
+                base.decision_id.clone(),
+                base.decision_record_hash,
+                base.gate_basis,
+                "did:icn:crosser-other".to_string(),
+                base.recorded_at,
+            ),
+            ActivationCrossedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.activation_id.clone(),
+                base.decision_id.clone(),
+                base.decision_record_hash,
+                base.gate_basis,
+                base.crossed_by.clone(),
+                base.recorded_at + 1,
+            ),
+        ];
+        for (i, v) in variants.iter().enumerate() {
+            assert_ne!(
+                base.record_hash, v.record_hash,
+                "variant {i} must change the record hash"
+            );
+        }
+    }
+
+    #[test]
+    fn activation_crossed_tag_separates_from_other_families() {
+        // Family separation from the four landed process-transition classes.
+        assert_ne!(
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            ProcessSessionOpenedReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            ProcessGateResultReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            DeliberationEntryRecordedReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            DecisionRecordedReceipt::DOMAIN_TAG
+        );
+        // Must NEVER converge with the proposal/vote decision lineage —
+        // that lineage records a vote outcome; this class records the fact
+        // that a recorded decision crossed the activation boundary.
+        assert_ne!(
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceiptV2::DOMAIN_TAG
+        );
+        assert_ne!(
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceiptV3::DOMAIN_TAG
+        );
+        // The gate_basis fingerprint tag is also disjoint from the receipt
+        // tag so a basis can never be confused with a record_hash.
+        assert_ne!(
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            ACTIVATION_GATE_BASIS_TAG
+        );
+        let activation = sample_activation_crossed_receipt();
+        let decision = sample_decision_recorded_receipt();
+        assert_ne!(activation.record_hash, decision.record_hash);
+    }
+
+    #[test]
+    fn activation_crossed_length_prefix_prevents_field_shifting() {
+        // Shifting bytes between adjacent string fields must change the
+        // hash — the length prefix delimits each field exactly.
+        let a = ActivationCrossedReceipt::compute_record_hash(
+            "ab",
+            "c",
+            "activation-001",
+            "decision-001",
+            &[0u8; 32],
+            &[0u8; 32],
+            "did:icn:x",
+            1,
+        );
+        let b = ActivationCrossedReceipt::compute_record_hash(
+            "a",
+            "bc",
+            "activation-001",
+            "decision-001",
+            &[0u8; 32],
+            &[0u8; 32],
+            "did:icn:x",
+            1,
+        );
+        assert_ne!(a, b, "domain/session byte shift must change the hash");
+        let c = ActivationCrossedReceipt::compute_record_hash(
+            "d",
+            "s",
+            "xy",
+            "z",
+            &[0u8; 32],
+            &[0u8; 32],
+            "did:icn:x",
+            1,
+        );
+        let d = ActivationCrossedReceipt::compute_record_hash(
+            "d",
+            "s",
+            "x",
+            "yz",
+            &[0u8; 32],
+            &[0u8; 32],
+            "did:icn:x",
+            1,
+        );
+        assert_ne!(
+            c, d,
+            "activation_id/decision_id byte shift must change the hash"
+        );
+    }
+
+    #[test]
+    fn activation_crossed_serde_roundtrip_and_payload_audit() {
+        // Round-trip preserves everything (equality anchored to
+        // record_hash), and the persisted payload carries ONLY the v1 field
+        // set — no body, no gate kind/result, no outcome/tally/vote fields.
+        let r = sample_activation_crossed_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let back: ActivationCrossedReceipt = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(r, back);
+        assert_eq!(back.recorded_at, r.recorded_at);
+        assert_eq!(back.decision_record_hash, r.decision_record_hash);
+        assert_eq!(back.gate_basis, r.gate_basis);
+        let value: serde_json::Value = serde_json::from_str(&json).expect("value");
+        let obj = value.as_object().expect("object");
+        let expected: std::collections::BTreeSet<&str> = [
+            "domain_id",
+            "session_id",
+            "activation_id",
+            "decision_id",
+            "decision_record_hash",
+            "gate_basis",
+            "crossed_by",
+            "recorded_at",
+            "record_hash",
+        ]
+        .into_iter()
+        .collect();
+        let actual: std::collections::BTreeSet<&str> = obj.keys().map(|k| k.as_str()).collect();
+        assert_eq!(
+            actual, expected,
+            "payload must carry exactly the v1 field set — no body, no gate \
+             kind/result, no outcome/tally/vote/proposal/mandate field"
+        );
+    }
+
+    #[test]
+    fn activation_crossed_no_prohibited_vocabulary() {
+        let r = sample_activation_crossed_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let lower = json.to_lowercase();
+        for forbidden in [
+            // regulated-finance vocabulary (same list as the sibling
+            // process-receipt tests)
+            "wallet", "balance", "currency", "payment", "withdraw", "deposit",
+            // proposal/vote lineage vocabulary — must not leak in
+            "proposal", "vote", "tally", "quorum", "mandate",
+            // authority-flavored actor names
+            "decider", "approver",
+        ] {
+            assert!(
+                !lower.contains(forbidden),
+                "ActivationCrossedReceipt JSON must not contain `{forbidden}`; got: {json}"
             );
         }
     }


### PR DESCRIPTION
## What

Adds `ActivationCrossedReceipt` — the fifth ADR-0026 Layer-2
`ProcessTransitionReceipt` class, after `ProcessGateResultReceipt`,
`ProcessSessionOpenedReceipt`, `DeliberationEntryRecordedReceipt`, and
`DecisionRecordedReceipt`. It witnesses that an already-recorded decision
**crossed the activation boundary** for a process session — the spine's
"boundary between deciding and doing" — with the required gates observed as
passed.

The receipt records a **process fact and grants zero authority.** It is not a
workflow engine; "activation" here is a local/dev/fixture institutional fact,
not production activation, service deployment, or mutation.

## Why

Implements #2293, following the merged design contract #2294
(`docs/design/activation-crossed-receipt-runtime-dogfood.md`) and the merged
B1/B2/B3 decision rung #2295
(`docs/design/activation-crossed-receipt-decision-rung.md`), which pin the
`:v1` layout, hashing, persistence, and preconditions this PR conforms to.

## How

- **`crates/icn-governance/src/proof.rs`** — new `ActivationCrossedReceipt`
  (domain tag `icn:gov:activation_crossed:v1`), `compute_record_hash`, and
  `compute_gate_basis` (gate-basis fingerprint tag
  `icn:gov:activation_gate_basis:v1`). Canonical hash: domain tag →
  length-prefixed `domain_id`/`session_id`/`activation_id`/`decision_id`/`crossed_by`
  → raw 32-byte `decision_record_hash` → raw 32-byte `gate_basis` →
  `recorded_at` LE. No `body_hash` in this slice. `PartialEq`/`Eq` anchored
  only to `record_hash`.
  - **B1** — the crossing names the activated decision by **both**
    `decision_id` and content-addressed `decision_record_hash`; both are in
    the canonical hash and in stable duplicate identity. Verified, not
    asserted: the manager requires a `DecisionRecordedReceipt` with that
    `record_hash` in the same `(domain_id, session_id)`.
  - **B2** — `gate_basis` is a blake3 fingerprint over the **sorted,
    de-duplicated** `record_hash`es of the declared passed
    `ProcessGateResultReceipt`s. Gate results are append-only
    (`put_opaque`, latest-by-`recorded_at`), so the basis pins the specific
    declared gate-result `record_hash` values — `(session_id, gate_kind)` is
    not the proof.
  - **B3** — a single caller-supplied `recorded_at`, hashed into the receipt
    but **excluded** from duplicate identity. No `crossed_at`, no
    `effective_at`.
- **`apps/governance/src/receipt_backend.rs`** — class `activation_crossed`,
  injective netstring composite `key1 = (domain_id, session_id)`,
  `key2 = activation_id`, persisted via the atomic `put_opaque_if_absent`;
  `ActivationCrossedPersist`; `put`/`get`/`list` methods.
- **`apps/governance/src/manager.rs`** — `record_activation_crossed`,
  `get_activation_crossed`, `list_activations_crossed_in_domain`, and
  `ActivationCrossedOutcome`. All preconditions fail closed and persist
  nothing on failure: session opened; decision referenced & hash-matched
  (B1); non-empty basis; every declared gate present in-scope and `Pass`
  (B2). A `Fail`, absent, wrong-domain, or wrong-session gate refuses the
  crossing. Same-identity retry returns the original un-restamped; a
  different decision reference / gate basis / crosser for the same
  `activation_id` fails closed (`activation_crossed_conflict`).
- **`apps/governance/tests/activation_crossed_receipt_runtime_slice.rs`** —
  runtime-slice integration tests.

## Validation

- `cargo fmt --all --check` — clean.
- `cargo test -p icn-governance activation_crossed` — 9 passed (golden
  vector, gate-basis golden, determinism, per-field, tag-disjointness,
  length-prefix, serde payload audit, vocabulary, basis order/dedup).
- `cargo test -p icn-governance-actor --test activation_crossed_receipt_runtime_slice`
  — 24 passed.
- `cargo test -p icn-governance -p icn-governance-actor` — full governance
  suites green, no regression in the four sibling process-receipt classes.
- `cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings`
  — clean.

## Non-claims

- No new `ProcessGateKind` variant; no `ActivationRequest` gate object.
- No mutation planning; no mutation application; no
  `MutationPlanRecordedReceipt` / `MutationAppliedReceipt`.
- No evidence-packet production; no action-card trigger.
- No authority grant — the receipt records a fact and grants zero authority.
- No proposal / vote / quorum / mandate / outcome semantics; the
  `DecisionRecordedReceipt` reference creates no tie to the proposal/vote
  `GovernanceDecisionReceipt` lineage.
- No `web/member-shell/` or evidence-surface rendering; no OpenAPI / SDK /
  served-schema change.
- No human/AT execution; no screen-reader / switch / low-vision validation.
- Not production-ready, pilot-ready, organizer-ready, or member-ready; not
  live federation; not NYCN activation; not Phase-2 completion.
- #1748 and #2141 remain open; #2041 remains open/parked; #2289 stays closed;
  #2081 / #2080 / #2274 untouched. #2293 remains open for maintainer
  disposition (no closing keyword).

## Refs

Refs #2293
Refs #2294
Refs #2295
Refs #1748
Refs #2141
Refs #2041
