### PR TITLE
feat(process): emit mutation plan recorded receipt

### DIFF
--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -2781,6 +2781,27 @@ pub enum ActivationCrossedOutcome {
     AlreadyCrossed(icn_governance::ActivationCrossedReceipt),
 }
 
+/// Outcome of [`GovernanceManager::record_mutation_plan_recorded`] (#2300
+/// contract + #2302 M1/M2/M3 decision rung). Both variants are successes;
+/// the fail-closed mismatch conflict surfaces as an `Err` with stable prefix
+/// `mutation_plan_recorded_conflict`. Precondition failures surface as `Err`s
+/// with their own stable prefixes and persist nothing:
+/// `mutation_plan_recorded_session_not_opened` (unopened session),
+/// `mutation_plan_recorded_activation_not_found` /
+/// `mutation_plan_recorded_activation_mismatch` (M1 activation reference
+/// absent or hash-mismatched).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MutationPlanRecordedOutcome {
+    /// This call recorded the plan: the receipt is the newly persisted
+    /// mutation-plan-recorded fact.
+    Recorded(icn_governance::MutationPlanRecordedReceipt),
+    /// The plan was already recorded with the **same** stable identity
+    /// (`activation_id`, `activation_record_hash`, `recorded_by`,
+    /// `body_hash`); carries the **original** persisted receipt (original
+    /// `recorded_at` / `record_hash` — a retry is never restamped).
+    AlreadyRecorded(icn_governance::MutationPlanRecordedReceipt),
+}
+
 /// Action items are always managed locally (not gossiped) and can use either
 /// in-memory or Sled-backed persistent storage.
 pub struct GovernanceManager {
@@ -6687,6 +6708,220 @@ impl GovernanceManager {
         store
             .list_activations_crossed_for_session_in_domain(&domain_id.0, session_id)
             .map_err(|e| anyhow::anyhow!("Failed to list activation-crossed receipts: {e}"))
+    }
+
+    /// Record that a mutation plan was recorded against a process session,
+    /// after an activation crossing and before any mutation is applied — the
+    /// sixth `ProcessTransitionReceipt` class (#2300 contract + #2302 M1/M2/M3
+    /// decision rung). Emits a [`MutationPlanRecordedReceipt`].
+    ///
+    /// This records a **process fact and grants zero authority.** It is not
+    /// mutation application. `recorded_by` is recorder evidence, not an
+    /// authority to plan or act.
+    ///
+    /// **All preconditions fail closed and persist nothing on failure**
+    /// (each with a stable error prefix; see [`MutationPlanRecordedOutcome`]):
+    ///
+    /// 1. `domain_id` / `session_id` / `plan_id` / `activation_id` and
+    ///    `recorded_by` must be non-empty and non-whitespace; a receipt store
+    ///    must be wired.
+    /// 2. The `(domain_id, session_id)` session must have a recorded opening
+    ///    (`mutation_plan_recorded_session_not_opened`) — no silent creation.
+    /// 3. **M1:** an [`ActivationCrossedReceipt`] with `activation_id` must
+    ///    exist in the same `(domain_id, session_id)`
+    ///    (`mutation_plan_recorded_activation_not_found`) and its `record_hash`
+    ///    must equal the supplied `activation_record_hash`
+    ///    (`mutation_plan_recorded_activation_mismatch`). Verified, not
+    ///    asserted. The decision and gate basis are inherited transitively
+    ///    through the activation and are not re-referenced here.
+    ///
+    /// **M2:** the plan body is never seen by this method — callers supply
+    /// only its 32-byte `body_hash` fingerprint.
+    ///
+    /// **At most one plan exists per `(domain_id, session_id, plan_id)`**,
+    /// enforced atomically by the backend:
+    ///
+    /// - first record → [`MutationPlanRecordedOutcome::Recorded`];
+    /// - retry with identical stable identity (`activation_id`,
+    ///   `activation_record_hash`, `recorded_by`, `body_hash`) →
+    ///   [`MutationPlanRecordedOutcome::AlreadyRecorded`] carrying the
+    ///   **original** receipt unchanged (never restamped;
+    ///   `recorded_at`/`record_hash` are not identity inputs);
+    /// - same `plan_id` with a different activation reference, recorder, or
+    ///   body hash → fail-closed error (stable prefix
+    ///   `mutation_plan_recorded_conflict`); the original is untouched.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_mutation_plan_recorded(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        plan_id: &str,
+        activation_id: &str,
+        activation_record_hash: [u8; 32],
+        body_hash: [u8; 32],
+        recorded_by: &Did,
+    ) -> Result<MutationPlanRecordedOutcome> {
+        // Whitespace-only ids are rejected alongside empty ones: a caller
+        // bypassing the HTTP layer must not mint receipts with visually-empty
+        // identifiers or whitespace storage keys.
+        if domain_id.0.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_plan_recorded: domain_id must be non-empty and non-whitespace"
+            ));
+        }
+        if session_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_plan_recorded: session_id must be non-empty and non-whitespace"
+            ));
+        }
+        if plan_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_plan_recorded: plan_id must be non-empty and non-whitespace"
+            ));
+        }
+        if activation_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_plan_recorded: activation_id must be non-empty and non-whitespace"
+            ));
+        }
+        let recorded_by_str = recorded_by.to_string();
+        if recorded_by_str.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_plan_recorded: recorded_by must be non-empty"
+            ));
+        }
+        let store = self.receipt_store.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "record_mutation_plan_recorded: a receipt store is required — plan \
+                 uniqueness and the activation precondition are enforced at the storage \
+                 layer and cannot be faked in memory"
+            )
+        })?;
+
+        // Precondition: the session was opened first. No silent creation.
+        let opened = store
+            .get_process_session_opened(&domain_id.0, session_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_mutation_plan_recorded: failed to read session-open state for \
+                     session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        if opened.is_none() {
+            return Err(anyhow::anyhow!(
+                "mutation_plan_recorded_session_not_opened: session {session_id} in domain {} \
+                 has no recorded opening; refusing to record a plan against an unanchored \
+                 session",
+                domain_id.0
+            ));
+        }
+
+        // M1 precondition: the activation being followed must exist in this
+        // same (domain, session) under `activation_id`, and its `record_hash`
+        // must equal the supplied `activation_record_hash`. The composite
+        // storage key makes an activation recorded under a different
+        // session/domain invisible here, so a wrong-session/wrong-domain
+        // reference fails closed as "not found".
+        let activation = store
+            .get_activation_crossed(&domain_id.0, session_id, activation_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_mutation_plan_recorded: failed to read activation state for \
+                     activation {activation_id} in session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        let activation = activation.ok_or_else(|| {
+            anyhow::anyhow!(
+                "mutation_plan_recorded_activation_not_found: no activation {activation_id} \
+                 recorded in session {session_id} in domain {}; refusing to record a plan for \
+                 an unrecorded activation",
+                domain_id.0
+            )
+        })?;
+        if activation.record_hash != activation_record_hash {
+            return Err(anyhow::anyhow!(
+                "mutation_plan_recorded_activation_mismatch: activation {activation_id} in \
+                 session {session_id} in domain {} was recorded with a different record_hash \
+                 than the one supplied; refusing to record a plan on a mismatched activation \
+                 reference",
+                domain_id.0
+            ));
+        }
+
+        let now = icn_time::current_timestamp_secs();
+        let receipt = icn_governance::MutationPlanRecordedReceipt::new(
+            domain_id.0.clone(),
+            session_id.to_string(),
+            plan_id.to_string(),
+            activation_id.to_string(),
+            activation_record_hash,
+            recorded_by_str.clone(),
+            body_hash,
+            now,
+        );
+
+        match store.put_mutation_plan_recorded(&receipt).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to persist mutation-plan-recorded receipt for plan {plan_id} in \
+                 session {session_id} in domain {}: {e}",
+                domain_id.0
+            )
+        })? {
+            crate::receipt_backend::MutationPlanRecordedPersist::Inserted => {
+                Ok(MutationPlanRecordedOutcome::Recorded(receipt))
+            }
+            crate::receipt_backend::MutationPlanRecordedPersist::Existing(original) => {
+                if original.activation_id == activation_id
+                    && original.activation_record_hash == activation_record_hash
+                    && original.recorded_by == recorded_by_str
+                    && original.body_hash == body_hash
+                {
+                    Ok(MutationPlanRecordedOutcome::AlreadyRecorded(*original))
+                } else {
+                    Err(anyhow::anyhow!(
+                        "mutation_plan_recorded_conflict: plan {plan_id} in session \
+                         {session_id} in domain {} was already recorded with a different \
+                         activation reference, recorder, or body hash; refusing to overwrite",
+                        domain_id.0
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Retrieve the persisted mutation-plan-recorded receipt for a
+    /// `(domain_id, session_id, plan_id)`, or `None` when no plan has been
+    /// recorded. Read-only.
+    pub fn get_mutation_plan_recorded(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        plan_id: &str,
+    ) -> Result<Option<icn_governance::MutationPlanRecordedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(None);
+        };
+        store
+            .get_mutation_plan_recorded(&domain_id.0, session_id, plan_id)
+            .map_err(|e| anyhow::anyhow!("Failed to read mutation-plan-recorded receipt: {e}"))
+    }
+
+    /// List all mutation-plan-recorded receipts recorded against one
+    /// `(domain_id, session_id)` anchor, in the store's deterministic
+    /// chronological `(recorded_at, record_hash)` order. Read-only.
+    pub fn list_mutation_plans_recorded_in_domain(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+    ) -> Result<Vec<icn_governance::MutationPlanRecordedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(vec![]);
+        };
+        store
+            .list_mutation_plans_recorded_for_session_in_domain(&domain_id.0, session_id)
+            .map_err(|e| anyhow::anyhow!("Failed to list mutation-plan-recorded receipts: {e}"))
     }
 
     // ========================================================================

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -207,8 +207,10 @@ pub enum MutationPlanRecordedPersist {
     /// A plan already existed for this triple; nothing was written. Carries
     /// the original persisted receipt (original `recorded_at` / `record_hash`
     /// — never restamped). Boxed because [`MutationPlanRecordedReceipt`] is a
-    /// large payload (five ids plus two 32-byte hashes), so an unboxed variant
-    /// would make this enum needlessly large next to the unit `Inserted`.
+    /// large payload (five string fields plus three 32-byte hashes —
+    /// `activation_record_hash`, `body_hash`, and `record_hash`), so an
+    /// unboxed variant would make this enum needlessly large next to the unit
+    /// `Inserted`.
     Existing(Box<MutationPlanRecordedReceipt>),
 }
 

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -5,8 +5,8 @@ use icn_governance::{
     ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActivationCrossedReceipt,
     AuthorityGrant, AuthorityGrantId, DecisionRecordedReceipt, DeliberationEntryRecordedReceipt,
     GovernanceDecisionReceipt, GovernanceDecisionReceiptV3, Grantee, Mandate,
-    MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, ProcessGateKind,
-    ProcessGateResultReceipt, ProcessSessionOpenedReceipt, Timestamp,
+    MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, MutationPlanRecordedReceipt,
+    ProcessGateKind, ProcessGateResultReceipt, ProcessSessionOpenedReceipt, Timestamp,
 };
 use icn_kernel_api::{AllocationReceipt, Hash};
 
@@ -167,6 +167,49 @@ pub enum ActivationCrossedPersist {
     /// (five ids plus two 32-byte hashes), so an unboxed variant would make
     /// this enum needlessly large next to the unit `Inserted`.
     Existing(Box<ActivationCrossedReceipt>),
+}
+
+/// Class string for `MutationPlanRecordedReceipt` opaque storage (#2300
+/// contract + #2302 M1/M2/M3 decision rung). Chosen in the apps layer so the
+/// gateway never sees the typed name. Distinct from every other process
+/// class store.
+const MUTATION_PLAN_RECORDED_CLASS: &str = "mutation_plan_recorded";
+
+/// Build the injective composite `key1` binding a recorded mutation plan to
+/// its `(domain_id, session_id)` anchor in opaque storage.
+///
+/// Sibling of [`activation_crossed_composite_key1`] with the identical
+/// netstring-style encoding (decimal length of `domain_id`, a colon, then
+/// the two ids concatenated), kept as a separate function so this class's
+/// key derivation is independently anchored by its own anti-aliasing test.
+/// The length prefix delimits `domain_id` exactly, so `("ab","c")` and
+/// `("a","bc")` can never produce the same key, and two domains sharing a
+/// `session_id` scan different `key1` prefixes.
+pub fn mutation_plan_recorded_composite_key1(domain_id: &str, session_id: &str) -> String {
+    format!("{}:{domain_id}{session_id}", domain_id.len())
+}
+
+/// Outcome of persisting a [`MutationPlanRecordedReceipt`] through
+/// [`GovernanceReceiptBackend::put_mutation_plan_recorded`].
+///
+/// The backend enforces at most one plan per `(domain_id, session_id,
+/// plan_id)` **atomically at the storage layer** (same `put_opaque_if_absent`
+/// primitive as the sibling process classes). The caller (the manager) turns
+/// `Existing` into either a same-identity idempotent success or a fail-closed
+/// conflict — stable identity is `activation_id` + `activation_record_hash` +
+/// `recorded_by` + `body_hash` (per the #2302 rung §7; `recorded_at`/
+/// `record_hash` are NOT identity inputs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MutationPlanRecordedPersist {
+    /// This call won the insert: the receipt is now the one persisted plan
+    /// for its `(domain_id, session_id, plan_id)`.
+    Inserted,
+    /// A plan already existed for this triple; nothing was written. Carries
+    /// the original persisted receipt (original `recorded_at` / `record_hash`
+    /// — never restamped). Boxed because [`MutationPlanRecordedReceipt`] is a
+    /// large payload (five ids plus two 32-byte hashes), so an unboxed variant
+    /// would make this enum needlessly large next to the unit `Inserted`.
+    Existing(Box<MutationPlanRecordedReceipt>),
 }
 
 /// Class string for `MeetingAttendanceReceiptV2` opaque storage (#1868).
@@ -1259,6 +1302,100 @@ pub trait GovernanceReceiptBackend: Send + Sync {
             out.push(
                 serde_json::from_slice(&bytes)
                     .map_err(|e| format!("deserialize ActivationCrossedReceipt in list: {e}"))?,
+            );
+        }
+        Ok(out)
+    }
+
+    /// Persist a [`MutationPlanRecordedReceipt`] emitted when the runtime
+    /// records that a mutation plan was recorded after an activation (#2300
+    /// contract + #2302 rung).
+    ///
+    /// **Default routes through opaque storage.** Serialises the typed
+    /// receipt to JSON and delegates to [`Self::put_opaque_if_absent`] under
+    /// class `"mutation_plan_recorded"` with
+    /// `key1 =` [`mutation_plan_recorded_composite_key1`] (the injective
+    /// domain+session composite) and `key2 = plan_id`. On a lost insert the
+    /// original persisted receipt is hydrated and returned (never restamped).
+    /// A backend that has not opted in to opaque storage inherits the
+    /// fail-closed `opaque_storage_not_implemented` default.
+    fn put_mutation_plan_recorded(
+        &self,
+        receipt: &MutationPlanRecordedReceipt,
+    ) -> Result<MutationPlanRecordedPersist, String> {
+        let payload = serde_json::to_vec(receipt)
+            .map_err(|e| format!("serialize MutationPlanRecordedReceipt: {e}"))?;
+        let key1 = mutation_plan_recorded_composite_key1(&receipt.domain_id, &receipt.session_id);
+        let existing = self.put_opaque_if_absent(
+            MUTATION_PLAN_RECORDED_CLASS,
+            &key1,
+            Some(&receipt.plan_id),
+            receipt.recorded_at,
+            receipt.record_hash,
+            &payload,
+        )?;
+        match existing {
+            None => Ok(MutationPlanRecordedPersist::Inserted),
+            Some(_winning_hash) => {
+                let original = self
+                    .get_mutation_plan_recorded(
+                        &receipt.domain_id,
+                        &receipt.session_id,
+                        &receipt.plan_id,
+                    )?
+                    .ok_or_else(|| {
+                        // The unique marker says a plan exists but the payload
+                        // cannot be hydrated — surface loudly rather than
+                        // minting a second plan.
+                        "mutation_plan_recorded_inconsistent: unique marker present \
+                         but no persisted plan payload could be read"
+                            .to_string()
+                    })?;
+                Ok(MutationPlanRecordedPersist::Existing(Box::new(original)))
+            }
+        }
+    }
+
+    /// Retrieve the persisted [`MutationPlanRecordedReceipt`] for a
+    /// `(domain_id, session_id, plan_id)`, or `None` when no plan has been
+    /// recorded. Same key convention as
+    /// [`Self::put_mutation_plan_recorded`]; at most one plan exists per
+    /// triple (uniqueness is enforced on write).
+    fn get_mutation_plan_recorded(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+        plan_id: &str,
+    ) -> Result<Option<MutationPlanRecordedReceipt>, String> {
+        let key1 = mutation_plan_recorded_composite_key1(domain_id, session_id);
+        let payload = self.get_latest_opaque(MUTATION_PLAN_RECORDED_CLASS, &key1, Some(plan_id))?;
+        match payload {
+            Some(bytes) => {
+                Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                    format!("deserialize MutationPlanRecordedReceipt: {e}")
+                })?))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// List all mutation-plan-recorded receipts recorded against one
+    /// `(domain_id, session_id)` anchor, in the store's deterministic
+    /// chronological `(recorded_at, record_hash)` order. Because `key1` is
+    /// the injective domain+session composite, two domains sharing a
+    /// `session_id` can never mix here — no payload-side filtering is needed.
+    fn list_mutation_plans_recorded_for_session_in_domain(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+    ) -> Result<Vec<MutationPlanRecordedReceipt>, String> {
+        let key1 = mutation_plan_recorded_composite_key1(domain_id, session_id);
+        let payloads = self.list_opaque_for(MUTATION_PLAN_RECORDED_CLASS, &key1)?;
+        let mut out = Vec::with_capacity(payloads.len());
+        for bytes in payloads {
+            out.push(
+                serde_json::from_slice(&bytes)
+                    .map_err(|e| format!("deserialize MutationPlanRecordedReceipt in list: {e}"))?,
             );
         }
         Ok(out)

--- a/icn/apps/governance/tests/mutation_plan_recorded_receipt_runtime_slice.rs
+++ b/icn/apps/governance/tests/mutation_plan_recorded_receipt_runtime_slice.rs
@@ -1,0 +1,998 @@
+//! Runtime proof for the sixth `ProcessTransitionReceipt` class —
+//! [`MutationPlanRecordedReceipt`] — per the merged #2300 contract
+//! (`docs/design/mutation-plan-recorded-receipt.md`) and the #2302 M1/M2/M3
+//! decision rung (`docs/design/mutation-plan-recorded-receipt-decision-rung.md`).
+//!
+//! Pins the merged decisions:
+//!
+//! 1. `GovernanceManager::record_mutation_plan_recorded` requires an
+//!    already-opened session and a **recorded activation** to reference (M1),
+//!    constructs a receipt with a real blake3 `record_hash`, persists it
+//!    through the backend's atomic insert-if-absent BEFORE returning, and
+//!    returns `Recorded(receipt)`.
+//! 2. M1: the plan names the activation by both `activation_id` and
+//!    `activation_record_hash`; the reference is **verified** — a missing,
+//!    wrong-session, wrong-domain, or hash-mismatched activation fails closed
+//!    and persists nothing. Decision + gate basis are inherited transitively
+//!    (not re-referenced).
+//! 3. M2: `body_hash`-only; the persisted payload carries no plan body /
+//!    operation list / target / effect payload.
+//! 4. M3: a single caller-supplied `recorded_at`, hashed but excluded from
+//!    identity — a retry with identical stable identity returns the ORIGINAL
+//!    receipt unchanged, never restamped.
+//! 5. Same `plan_id` with a different activation reference, recorder, or body
+//!    hash fails closed with the stable `mutation_plan_recorded_conflict`
+//!    prefix; the original is untouched.
+//! 6. Empty/whitespace ids rejected; missing receipt store is an error;
+//!    backend failure fails closed; concurrent duplicates serialize to one
+//!    winner; composite key injective; two domains sharing a `session_id`
+//!    never mix.
+//!
+//! This records a **process fact and grants zero authority.** It is not
+//! mutation application.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use icn_governance::{
+    GovernanceDecisionReceipt, GovernanceDomainId, ProcessGateKind, ProcessGateResult,
+};
+use icn_governance_actor::manager::{
+    ActivationCrossedOutcome, DecisionRecordOutcome, GovernanceManager,
+    MutationPlanRecordedOutcome, ProcessSessionOpenOutcome,
+};
+use icn_governance_actor::receipt_backend::{
+    mutation_plan_recorded_composite_key1, GovernanceReceiptBackend,
+};
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+
+// ============================================================================
+// Opaque-backed test store — the test analog of the production gateway-backed
+// ReceiptStore: it implements the opaque primitives (atomic
+// `put_opaque_if_absent` + append `put_opaque`) and NO typed overrides, so
+// the trait's typed defaults are exercised end-to-end.
+// ============================================================================
+
+type ChainKey = (String, String, Option<String>);
+type ChainEntry = (u64, [u8; 32], Vec<u8>);
+
+#[derive(Default)]
+struct OpaqueUniqueBackend {
+    chains: Mutex<HashMap<ChainKey, Vec<ChainEntry>>>,
+    unique: Mutex<HashMap<ChainKey, [u8; 32]>>,
+}
+
+impl OpaqueUniqueBackend {
+    fn chain_len(&self, class: &str, key1: &str, key2: Option<&str>) -> usize {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .map_or(0, Vec::len)
+    }
+
+    fn raw_payload(&self, class: &str, key1: &str, key2: Option<&str>) -> Option<Vec<u8>> {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .and_then(|chain| chain.first().map(|(_, _, p)| p.clone()))
+    }
+}
+
+impl GovernanceReceiptBackend for OpaqueUniqueBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(())
+    }
+
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        let mut unique = self.unique.lock().unwrap();
+        if let Some(winner) = unique.get(&key) {
+            return Ok(Some(*winner));
+        }
+        unique.insert(key.clone(), record_hash);
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(None)
+    }
+
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        Ok(self.chains.lock().unwrap().get(&key).and_then(|chain| {
+            chain
+                .iter()
+                .max_by_key(|(t, h, _)| (*t, *h))
+                .map(|(_, _, p)| p.clone())
+        }))
+    }
+
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        let chains = self.chains.lock().unwrap();
+        let mut hits: Vec<ChainEntry> = chains
+            .iter()
+            .filter(|((c, k1, _), _)| c == class && k1 == key1)
+            .flat_map(|(_, chain)| chain.iter().cloned())
+            .collect();
+        hits.sort_by_key(|(t, h, _)| (*t, *h));
+        Ok(hits.into_iter().map(|(_, _, p)| p).collect())
+    }
+}
+
+/// Backend that persists everything except the mutation-plan insert — proves
+/// fail-closed plan persistence with all preconditions satisfied.
+#[derive(Default)]
+struct FailingMutationPlanBackend {
+    inner: OpaqueUniqueBackend,
+}
+
+impl GovernanceReceiptBackend for FailingMutationPlanBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        self.inner
+            .put_opaque(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        if class == "mutation_plan_recorded" {
+            return Err("simulated mutation-plan-recorded backend failure".to_string());
+        }
+        self.inner
+            .put_opaque_if_absent(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        self.inner.get_latest_opaque(class, key1, key2)
+    }
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        self.inner.list_opaque_for(class, key1)
+    }
+}
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_manager() -> (GovernanceManager, Arc<OpaqueUniqueBackend>) {
+    let store = Arc::new(OpaqueUniqueBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    (mgr, store)
+}
+
+fn coop_test() -> GovernanceDomainId {
+    GovernanceDomainId::new("coop:test")
+}
+
+fn plan_key1(domain: &str, session: &str) -> String {
+    mutation_plan_recorded_composite_key1(domain, session)
+}
+
+fn open_session(mgr: &GovernanceManager, domain: &GovernanceDomainId, session: &str, by: &Did) {
+    match mgr
+        .record_process_session_opened(domain, session, by)
+        .unwrap()
+    {
+        ProcessSessionOpenOutcome::Opened(_) | ProcessSessionOpenOutcome::AlreadyOpened(_) => {}
+    }
+}
+
+/// Record the full activation chain (session opened, decision, Pass gate,
+/// activation crossing) and return the `ActivationCrossedReceipt.record_hash`
+/// — the M1 proof link a mutation plan references. Each call uses an
+/// `activation_id`-derived decision id so distinct activations are distinct.
+fn setup_activation(
+    mgr: &GovernanceManager,
+    domain: &GovernanceDomainId,
+    session: &str,
+    activation_id: &str,
+    by: &Did,
+) -> [u8; 32] {
+    open_session(mgr, domain, session, by);
+    let decision_id = format!("decision-for-{activation_id}");
+    let decision_hash = match mgr
+        .record_decision(domain, session, &decision_id, by, [9u8; 32])
+        .unwrap()
+    {
+        DecisionRecordOutcome::Recorded(r) | DecisionRecordOutcome::AlreadyRecorded(r) => {
+            r.record_hash
+        }
+    };
+    let gate_hash = mgr
+        .record_process_gate_result(
+            domain,
+            session,
+            ProcessGateKind::PrivacyReview,
+            ProcessGateResult::Pass,
+            by,
+        )
+        .unwrap()
+        .record_hash;
+    match mgr
+        .record_activation_crossed(
+            domain,
+            session,
+            activation_id,
+            &decision_id,
+            decision_hash,
+            &[gate_hash],
+            by,
+        )
+        .unwrap()
+    {
+        ActivationCrossedOutcome::Crossed(r) | ActivationCrossedOutcome::AlreadyCrossed(r) => {
+            r.record_hash
+        }
+    }
+}
+
+// ============================================================================
+// Happy path — construct, persist, retrieve, verify M1 link
+// ============================================================================
+
+#[test]
+fn plan_persists_and_returns_receipt_with_verified_activation_link() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+
+    let outcome = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-001",
+            "plan-001",
+            "activation-001",
+            ah,
+            [4u8; 32],
+            &actor,
+        )
+        .expect("first plan must succeed");
+    let MutationPlanRecordedOutcome::Recorded(receipt) = outcome else {
+        panic!("first plan must be Recorded, got {outcome:?}");
+    };
+    assert_eq!(receipt.domain_id, "coop:test");
+    assert_eq!(receipt.session_id, "session-001");
+    assert_eq!(receipt.plan_id, "plan-001");
+    assert_eq!(receipt.activation_id, "activation-001");
+    assert_eq!(receipt.recorded_by, actor.to_string());
+    assert_eq!(receipt.body_hash, [4u8; 32]);
+    assert_ne!(receipt.record_hash, [0u8; 32], "real blake3 hash");
+    // M1: activation_record_hash equals the persisted activation receipt hash.
+    assert_eq!(
+        receipt.activation_record_hash, ah,
+        "M1 proof link binds the recorded activation's real record_hash"
+    );
+    assert_eq!(
+        store.chain_len(
+            "mutation_plan_recorded",
+            &plan_key1("coop:test", "session-001"),
+            Some("plan-001"),
+        ),
+        1,
+        "exactly one persisted plan"
+    );
+    let read = mgr
+        .get_mutation_plan_recorded(&domain, "session-001", "plan-001")
+        .unwrap()
+        .expect("point read must hydrate");
+    assert_eq!(read, receipt);
+}
+
+#[test]
+fn same_identity_retry_returns_original_never_restamped() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+
+    let MutationPlanRecordedOutcome::Recorded(original) = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-001",
+            "plan-001",
+            "activation-001",
+            ah,
+            [4u8; 32],
+            &actor,
+        )
+        .unwrap()
+    else {
+        panic!("first plan must be Recorded");
+    };
+
+    let outcome = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-001",
+            "plan-001",
+            "activation-001",
+            ah,
+            [4u8; 32],
+            &actor,
+        )
+        .expect("same-identity retry must succeed");
+    let MutationPlanRecordedOutcome::AlreadyRecorded(returned) = outcome else {
+        panic!("retry must be AlreadyRecorded, got {outcome:?}");
+    };
+    assert_eq!(
+        returned.recorded_at, original.recorded_at,
+        "never restamped"
+    );
+    assert_eq!(returned.record_hash, original.record_hash);
+    assert_eq!(returned, original);
+    assert_eq!(
+        store.chain_len(
+            "mutation_plan_recorded",
+            &plan_key1("coop:test", "session-001"),
+            Some("plan-001"),
+        ),
+        1,
+        "retry must not append a second record"
+    );
+}
+
+// ============================================================================
+// M1 — activation reference preconditions (verified, not asserted)
+// ============================================================================
+
+#[test]
+fn unopened_session_fails_closed_and_creates_nothing() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    // No session opened, no activation.
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-ghost",
+            "plan-001",
+            "activation-001",
+            [1u8; 32],
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("unopened session must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_plan_recorded_session_not_opened"),
+        "stable precondition prefix, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "mutation_plan_recorded",
+            &plan_key1("coop:test", "session-ghost"),
+            Some("plan-001"),
+        ),
+        0
+    );
+}
+
+#[test]
+fn missing_activation_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    // Session opened but no activation recorded.
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-001",
+            "plan-001",
+            "activation-404",
+            [1u8; 32],
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("missing activation must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_plan_recorded_activation_not_found"),
+        "stable prefix, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "mutation_plan_recorded",
+            &plan_key1("coop:test", "session-001"),
+            Some("plan-001"),
+        ),
+        0
+    );
+}
+
+#[test]
+fn wrong_session_activation_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    // Activation recorded in session-a; plan attempted in session-b.
+    let ah = setup_activation(&mgr, &domain, "session-a", "activation-001", &actor);
+    open_session(&mgr, &domain, "session-b", &actor);
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-b",
+            "plan-001",
+            "activation-001",
+            ah,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("wrong-session activation must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_plan_recorded_activation_not_found"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn wrong_domain_activation_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    let ah = setup_activation(&mgr, &d1, "session-shared", "activation-001", &actor);
+    open_session(&mgr, &d2, "session-shared", &actor);
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &d2,
+            "session-shared",
+            "plan-001",
+            "activation-001",
+            ah,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("wrong-domain activation must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_plan_recorded_activation_not_found"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn activation_id_hash_mismatch_fails_closed() {
+    // The supplied activation_id references a real activation, but the
+    // supplied activation_record_hash does not match it.
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-001",
+            "plan-001",
+            "activation-001",
+            [123u8; 32], // wrong hash for activation-001
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("activation hash mismatch must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_plan_recorded_activation_mismatch"),
+        "stable prefix, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "mutation_plan_recorded",
+            &plan_key1("coop:test", "session-001"),
+            Some("plan-001"),
+        ),
+        0
+    );
+}
+
+// ============================================================================
+// Conflicts — same plan_id, different identity fields
+// ============================================================================
+
+#[test]
+fn conflict_on_different_activation_reference_fails_closed() {
+    // activation_id and activation_record_hash are both stable-identity
+    // inputs; through the validated path they co-vary (a same-id/wrong-hash
+    // reference is caught earlier as activation_mismatch). Referencing a
+    // DIFFERENT recorded activation for the same plan_id conflicts.
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let a1 = setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+    let a2 = setup_activation(&mgr, &domain, "session-001", "activation-002", &actor);
+
+    mgr.record_mutation_plan_recorded(
+        &domain,
+        "session-001",
+        "plan-001",
+        "activation-001",
+        a1,
+        [4u8; 32],
+        &actor,
+    )
+    .expect("first plan");
+
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-001",
+            "plan-001",
+            "activation-002",
+            a2,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("different activation reference must conflict");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_plan_recorded_conflict"),
+        "stable conflict prefix, got: {err}"
+    );
+    let read = mgr
+        .get_mutation_plan_recorded(&domain, "session-001", "plan-001")
+        .unwrap()
+        .unwrap();
+    assert_eq!(read.activation_id, "activation-001", "original untouched");
+    assert_eq!(
+        store.chain_len(
+            "mutation_plan_recorded",
+            &plan_key1("coop:test", "session-001"),
+            Some("plan-001"),
+        ),
+        1
+    );
+}
+
+#[test]
+fn conflict_on_different_body_hash_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+
+    mgr.record_mutation_plan_recorded(
+        &domain,
+        "session-001",
+        "plan-001",
+        "activation-001",
+        ah,
+        [4u8; 32],
+        &actor,
+    )
+    .expect("first plan");
+
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-001",
+            "plan-001",
+            "activation-001",
+            ah,
+            [10u8; 32],
+            &actor,
+        )
+        .expect_err("different body hash must conflict");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_plan_recorded_conflict"),
+        "stable conflict prefix, got: {err}"
+    );
+}
+
+#[test]
+fn conflict_on_different_recorder_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let other = fresh_did();
+    let domain = coop_test();
+    let ah = setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+
+    mgr.record_mutation_plan_recorded(
+        &domain,
+        "session-001",
+        "plan-001",
+        "activation-001",
+        ah,
+        [4u8; 32],
+        &actor,
+    )
+    .expect("first plan");
+
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-001",
+            "plan-001",
+            "activation-001",
+            ah,
+            [4u8; 32],
+            &other,
+        )
+        .expect_err("different recorder must conflict");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_plan_recorded_conflict"),
+        "stable conflict prefix, got: {err}"
+    );
+}
+
+// ============================================================================
+// Input validation, missing store, backend failure
+// ============================================================================
+
+#[test]
+fn empty_and_whitespace_ids_rejected_before_persistence() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+
+    for (d, s, p, a) in [
+        ("", "session-001", "plan-001", "activation-001"),
+        ("   ", "session-001", "plan-001", "activation-001"),
+        ("coop:test", "", "plan-001", "activation-001"),
+        ("coop:test", "  \t", "plan-001", "activation-001"),
+        ("coop:test", "session-001", "", "activation-001"),
+        ("coop:test", "session-001", " \n ", "activation-001"),
+        ("coop:test", "session-001", "plan-001", ""),
+        ("coop:test", "session-001", "plan-001", "  "),
+    ] {
+        let err = mgr
+            .record_mutation_plan_recorded(
+                &GovernanceDomainId::new(d),
+                s,
+                p,
+                a,
+                ah,
+                [4u8; 32],
+                &actor,
+            )
+            .expect_err("empty/whitespace ids must be rejected");
+        assert!(
+            err.to_string().contains("non-empty"),
+            "id-validation error, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn missing_receipt_store_is_an_error() {
+    let mgr = GovernanceManager::new(); // no receipt store wired
+    let actor = fresh_did();
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &coop_test(),
+            "session-001",
+            "plan-001",
+            "activation-001",
+            [1u8; 32],
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("missing store must be an error");
+    assert!(
+        err.to_string().contains("receipt store is required"),
+        "store-required error, got: {err}"
+    );
+}
+
+#[test]
+fn backend_failure_fails_closed() {
+    let store = Arc::new(FailingMutationPlanBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &domain,
+            "session-001",
+            "plan-001",
+            "activation-001",
+            ah,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("backend failure must surface");
+    assert!(
+        err.to_string()
+            .contains("simulated mutation-plan-recorded backend failure"),
+        "backend error surfaced, got: {err}"
+    );
+    assert!(
+        mgr.get_mutation_plan_recorded(&domain, "session-001", "plan-001")
+            .unwrap()
+            .is_none(),
+        "nothing half-written"
+    );
+}
+
+// ============================================================================
+// Concurrency — atomic uniqueness under racing duplicates
+// ============================================================================
+
+#[test]
+fn concurrent_duplicate_records_serialize_to_one_plan() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+
+    let mgr = Arc::new(mgr);
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let mgr = mgr.clone();
+        let actor = actor.clone();
+        let domain = domain.clone();
+        handles.push(std::thread::spawn(move || {
+            mgr.record_mutation_plan_recorded(
+                &domain,
+                "session-001",
+                "plan-race",
+                "activation-001",
+                ah,
+                [4u8; 32],
+                &actor,
+            )
+        }));
+    }
+    let mut receipts = Vec::new();
+    for h in handles {
+        let outcome = h.join().unwrap().expect("same-identity race must succeed");
+        match outcome {
+            MutationPlanRecordedOutcome::Recorded(r)
+            | MutationPlanRecordedOutcome::AlreadyRecorded(r) => receipts.push(r),
+        }
+    }
+    assert_eq!(
+        store.chain_len(
+            "mutation_plan_recorded",
+            &plan_key1("coop:test", "session-001"),
+            Some("plan-race"),
+        ),
+        1,
+        "atomic uniqueness: one winner"
+    );
+    let first = &receipts[0];
+    for r in &receipts {
+        assert_eq!(r, first, "all threads observe the single winner");
+    }
+}
+
+// ============================================================================
+// Key injectivity, cross-domain isolation, payload audit
+// ============================================================================
+
+#[test]
+fn composite_key_is_injective_no_aliasing() {
+    assert_ne!(
+        mutation_plan_recorded_composite_key1("ab", "c"),
+        mutation_plan_recorded_composite_key1("a", "bc"),
+        "netstring length prefix must prevent domain/session aliasing"
+    );
+
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d_ab = GovernanceDomainId::new("ab");
+    let d_a = GovernanceDomainId::new("a");
+    let ah = setup_activation(&mgr, &d_ab, "c", "activation-001", &actor);
+    // Only ("ab","c") is opened; ("a","bc") must NOT see it through key
+    // aliasing — the precondition fails closed for the unopened pair.
+    let err = mgr
+        .record_mutation_plan_recorded(
+            &d_a,
+            "bc",
+            "plan-001",
+            "activation-001",
+            ah,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("aliased pair must not inherit the opened session");
+    assert!(err
+        .to_string()
+        .starts_with("mutation_plan_recorded_session_not_opened"));
+    // The genuinely opened pair records fine.
+    mgr.record_mutation_plan_recorded(
+        &d_ab,
+        "c",
+        "plan-001",
+        "activation-001",
+        ah,
+        [4u8; 32],
+        &actor,
+    )
+    .expect("opened pair records");
+}
+
+#[test]
+fn two_domains_sharing_session_id_never_mix() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    let a1 = setup_activation(&mgr, &d1, "shared-session", "activation-1", &actor);
+    let a2 = setup_activation(&mgr, &d2, "shared-session", "activation-2", &actor);
+
+    mgr.record_mutation_plan_recorded(
+        &d1,
+        "shared-session",
+        "plan-1",
+        "activation-1",
+        a1,
+        [1u8; 32],
+        &actor,
+    )
+    .unwrap();
+    mgr.record_mutation_plan_recorded(
+        &d2,
+        "shared-session",
+        "plan-2",
+        "activation-2",
+        a2,
+        [2u8; 32],
+        &actor,
+    )
+    .unwrap();
+
+    let list1 = mgr
+        .list_mutation_plans_recorded_in_domain(&d1, "shared-session")
+        .unwrap();
+    let list2 = mgr
+        .list_mutation_plans_recorded_in_domain(&d2, "shared-session")
+        .unwrap();
+    assert_eq!(list1.len(), 1);
+    assert_eq!(list2.len(), 1);
+    assert_eq!(list1[0].plan_id, "plan-1");
+    assert_eq!(list2[0].plan_id, "plan-2");
+    assert_eq!(list1[0].domain_id, "coop:one");
+    assert_eq!(list2[0].domain_id, "coop:two");
+}
+
+#[test]
+fn persisted_payload_carries_only_v1_fields_no_plan_body() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_activation(&mgr, &domain, "session-001", "activation-001", &actor);
+    mgr.record_mutation_plan_recorded(
+        &domain,
+        "session-001",
+        "plan-001",
+        "activation-001",
+        ah,
+        [4u8; 32],
+        &actor,
+    )
+    .unwrap();
+
+    let payload = store
+        .raw_payload(
+            "mutation_plan_recorded",
+            &plan_key1("coop:test", "session-001"),
+            Some("plan-001"),
+        )
+        .expect("payload persisted");
+    let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+    let obj = value.as_object().unwrap();
+    let expected: std::collections::BTreeSet<&str> = [
+        "domain_id",
+        "session_id",
+        "plan_id",
+        "activation_id",
+        "activation_record_hash",
+        "recorded_by",
+        "body_hash",
+        "recorded_at",
+        "record_hash",
+    ]
+    .into_iter()
+    .collect();
+    let actual: std::collections::BTreeSet<&str> = obj.keys().map(|k| k.as_str()).collect();
+    assert_eq!(
+        actual, expected,
+        "persisted payload must carry exactly the v1 field set — no plan body, \
+         operation list, target list, or effect payload"
+    );
+}

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -147,8 +147,8 @@ pub use proof::{
     GovernanceDecisionReceiptV3Error, GovernanceProof, GovernanceProofV2, MandateGrantRef,
     MandateGrantRefError, MandateGrantRefTarget, MeetingAttendanceReceipt,
     MeetingAttendanceReceiptV2, MeetingAttendanceReceiptV2Error, MeetingAttendanceTransition,
-    NoMandateReason, ProcessGateKind, ProcessGateResult, ProcessGateResultReceipt,
-    ProcessSessionOpenedReceipt, ProofOutcome, ReceiptMandateAttestation,
+    MutationPlanRecordedReceipt, NoMandateReason, ProcessGateKind, ProcessGateResult,
+    ProcessGateResultReceipt, ProcessSessionOpenedReceipt, ProofOutcome, ReceiptMandateAttestation,
 };
 pub use proposal::{
     AllocationOption, DataSharingLevel, DisputeResolutionMethod, DisputeResolutionOutcome,

--- a/icn/crates/icn-governance/src/proof.rs
+++ b/icn/crates/icn-governance/src/proof.rs
@@ -5003,9 +5003,9 @@ mod tests {
             "session-alpha".to_string(),
             "plan-001".to_string(),
             "activation-001".to_string(),
-            [7u8; 32], // activation_record_hash (M1 proof link)
-            "did:icn:planner-1".to_string(),
-            [5u8; 32], // body_hash (M2 fingerprint)
+            [7u8; 32],                        // activation_record_hash (M1 proof link)
+            "did:icn:recorder-1".to_string(), // recorder, not planner
+            [5u8; 32],                        // body_hash (M2 fingerprint)
             1_750_000_000,
         )
     }
@@ -5020,7 +5020,7 @@ mod tests {
         let r = sample_mutation_plan_recorded_receipt();
         assert_eq!(
             hex32(&r.record_hash),
-            "57448b28c5109764b51af97f90a431c7701d016792ac0e59998c13f6eb86050d",
+            "4147346ea5be5e6dc5b1a1402fa08f6b51b1a0d1af7719c22103b04cc4557414",
             "canonical v1 hash layout drifted"
         );
     }

--- a/icn/crates/icn-governance/src/proof.rs
+++ b/icn/crates/icn-governance/src/proof.rs
@@ -2928,6 +2928,177 @@ impl ActivationCrossedReceipt {
     }
 }
 
+/// Cross-node deterministic receipt recording that a **mutation plan was
+/// recorded** against a process session, after an activation crossing and
+/// before any mutation is applied.
+///
+/// The sixth `ProcessTransitionReceipt` class (ADR-0026 Layer 2), after
+/// [`ProcessGateResultReceipt`] (#2144), [`ProcessSessionOpenedReceipt`]
+/// (#2276), [`DeliberationEntryRecordedReceipt`] (#2279),
+/// [`DecisionRecordedReceipt`] (#2282), and [`ActivationCrossedReceipt`]
+/// (#2296), per the merged `docs/design/mutation-plan-recorded-receipt.md`
+/// contract (#2300) and the `docs/design/mutation-plan-recorded-receipt-decision-rung.md`
+/// M1/M2/M3 decision (#2302).
+///
+/// **This receipt records a process fact; it grants zero authority and is
+/// not mutation application.** It witnesses that a plan-of-record was
+/// recorded following an activation — **not** that any mutation was planned
+/// safely, authorized, or applied. Applying a plan (and any receipt of
+/// application) is a strictly later rung.
+///
+/// **M1 — the plan names the activation it follows by BOTH the caller-opaque
+/// `activation_id` and the content-addressed `activation_record_hash`** of
+/// the [`ActivationCrossedReceipt`]. Both fields participate in the canonical
+/// `record_hash` and in stable duplicate identity. The reference is verified,
+/// not merely asserted: the emitting manager requires an activation receipt
+/// with exactly `activation_record_hash` (and a matching `activation_id`) to
+/// exist in the same `(domain_id, session_id)` before the plan is recorded.
+/// This is the lane's second inter-receipt link. The decision and gate basis
+/// are **not** re-referenced here; they are inherited transitively through
+/// the activation (which already binds `decision_id`, `decision_record_hash`,
+/// and `gate_basis`).
+///
+/// **M2 — `body_hash`-only.** A caller-supplied 32-byte `body_hash`
+/// fingerprints the `MutationPlan` body; the plan body — its operation list,
+/// target list, effect payload, or any typed operation model — is **never
+/// stored**. There is no plan-kind taxonomy. The kernel never reads the plan
+/// semantically (meaning firewall).
+///
+/// **M3 — a single caller-supplied `recorded_at`**, hashed into `record_hash`
+/// but **excluded** from duplicate identity — identical to the five landed
+/// classes. No distinct `planned_at`. A retry never restamps.
+///
+/// **At most one plan exists per `(domain_id, session_id, plan_id)`** — the
+/// receipt backend enforces uniqueness atomically at the storage layer. A
+/// retry with identical stable identity (`activation_id`,
+/// `activation_record_hash`, `recorded_by`, `body_hash`) returns this
+/// original receipt unchanged (never restamped); any mismatch fails closed.
+///
+/// `recorded_by` is actor evidence — the recorder of the plan, not an
+/// authority to plan or act ("recorder, not planner"). Equality is anchored
+/// to `record_hash`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MutationPlanRecordedReceipt {
+    /// Governance domain the session (and this plan) is scoped to.
+    pub domain_id: String,
+    /// Identifier of the already-opened process session this plan attaches
+    /// to. Caller-provided, treated as opaque, meaningful only together with
+    /// `domain_id` (session ids are not globally unique).
+    pub session_id: String,
+    /// Caller-supplied opaque identifier for this plan, unique within
+    /// `(domain_id, session_id)` — uniqueness is enforced at the storage
+    /// layer, not assumed of the id.
+    pub plan_id: String,
+    /// Caller-opaque `activation_id` of the [`ActivationCrossedReceipt`] this
+    /// plan follows — the human/index handle (M1).
+    pub activation_id: String,
+    /// Content-addressed `record_hash` of that [`ActivationCrossedReceipt`] —
+    /// the cryptographic proof link (M1). Verified to exist in-session before
+    /// the plan is recorded.
+    pub activation_record_hash: Hash,
+    /// DID of the authenticated actor who recorded the plan — recorder
+    /// evidence, not an authority to plan or act. Grants zero authority.
+    pub recorded_by: String,
+    /// Caller-supplied 32-byte content fingerprint of the `MutationPlan`
+    /// body (M2). The plan body itself is never stored in the receipt.
+    pub body_hash: Hash,
+    /// Unix-seconds the plan was recorded. Not part of duplicate identity —
+    /// a retry never restamps (M3).
+    pub recorded_at: u64,
+    /// blake3 canonical record hash binding the fields above.
+    pub record_hash: Hash,
+}
+
+impl PartialEq for MutationPlanRecordedReceipt {
+    fn eq(&self, other: &Self) -> bool {
+        self.record_hash == other.record_hash
+    }
+}
+
+impl Eq for MutationPlanRecordedReceipt {}
+
+impl MutationPlanRecordedReceipt {
+    /// Domain separation tag for canonical mutation-plan-recorded record
+    /// hashes. Distinct from every other receipt-family tag — and in
+    /// particular it must NEVER converge with `icn:gov:activation_crossed:v1`,
+    /// `icn:gov:decision_recorded:v1`, `icn:gov:process_gate_result:v1`, or
+    /// the proposal/vote `icn:gov:decision:v1/v2/v3` lineage.
+    pub const DOMAIN_TAG: &[u8] = b"icn:gov:mutation_plan_recorded:v1";
+
+    /// Build a new receipt and compute its canonical `record_hash`.
+    ///
+    /// `body_hash` is a caller-supplied fingerprint of the never-stored
+    /// `MutationPlan` body (M2), mirroring how the decision/deliberation
+    /// classes take a pre-computed `body_hash`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        domain_id: String,
+        session_id: String,
+        plan_id: String,
+        activation_id: String,
+        activation_record_hash: Hash,
+        recorded_by: String,
+        body_hash: Hash,
+        recorded_at: u64,
+    ) -> Self {
+        let record_hash = Self::compute_record_hash(
+            &domain_id,
+            &session_id,
+            &plan_id,
+            &activation_id,
+            &activation_record_hash,
+            &recorded_by,
+            &body_hash,
+            recorded_at,
+        );
+        Self {
+            domain_id,
+            session_id,
+            plan_id,
+            activation_id,
+            activation_record_hash,
+            recorded_by,
+            body_hash,
+            recorded_at,
+            record_hash,
+        }
+    }
+
+    /// Compute the canonical record hash from the input fields.
+    ///
+    /// Layout (per the #2300 contract as resolved by the #2302 M1/M2/M3
+    /// decision rung §7): [`Self::DOMAIN_TAG`] first; each string field
+    /// length-prefixed (u64 LE) in order `domain_id`, `session_id`,
+    /// `plan_id`, `activation_id`, `recorded_by`; then `activation_record_hash`
+    /// and `body_hash` appended **raw as fixed 32-byte fields with no length
+    /// prefix** (fixed-size fields cannot alias); then `recorded_at` as LE
+    /// bytes. No discriminant byte (this class has no kind taxonomy).
+    #[allow(clippy::too_many_arguments)]
+    pub fn compute_record_hash(
+        domain_id: &str,
+        session_id: &str,
+        plan_id: &str,
+        activation_id: &str,
+        activation_record_hash: &Hash,
+        recorded_by: &str,
+        body_hash: &Hash,
+        recorded_at: u64,
+    ) -> Hash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(Self::DOMAIN_TAG);
+        for field in [domain_id, session_id, plan_id, activation_id, recorded_by] {
+            hasher.update(&(field.len() as u64).to_le_bytes());
+            hasher.update(field.as_bytes());
+        }
+        hasher.update(activation_record_hash);
+        hasher.update(body_hash);
+        hasher.update(&recorded_at.to_le_bytes());
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hasher.finalize().as_bytes());
+        out
+    }
+}
+
 // ============================================================================
 // Mandate grant reference (#1868 step 2 primitive — wire form only)
 // ============================================================================
@@ -4817,6 +4988,304 @@ mod tests {
             assert!(
                 !lower.contains(forbidden),
                 "ActivationCrossedReceipt JSON must not contain `{forbidden}`; got: {json}"
+            );
+        }
+    }
+
+    // ============================================================================
+    // MutationPlanRecordedReceipt — sixth ProcessTransitionReceipt class (per
+    // the #2300 contract + #2302 M1/M2/M3 decision rung)
+    // ============================================================================
+
+    fn sample_mutation_plan_recorded_receipt() -> MutationPlanRecordedReceipt {
+        MutationPlanRecordedReceipt::new(
+            "domain-food-coop".to_string(),
+            "session-alpha".to_string(),
+            "plan-001".to_string(),
+            "activation-001".to_string(),
+            [7u8; 32], // activation_record_hash (M1 proof link)
+            "did:icn:planner-1".to_string(),
+            [5u8; 32], // body_hash (M2 fingerprint)
+            1_750_000_000,
+        )
+    }
+
+    #[test]
+    fn mutation_plan_recorded_golden_vector() {
+        // Golden canonical hash vector: pins the FULL v1 layout (domain tag,
+        // length-prefixed strings domain_id/session_id/plan_id/activation_id/
+        // recorded_by, raw fixed 32-byte activation_record_hash then body_hash,
+        // recorded_at LE — no discriminant byte). Any layout change breaks
+        // this test and requires a new tag version, not an edit here.
+        let r = sample_mutation_plan_recorded_receipt();
+        assert_eq!(
+            hex32(&r.record_hash),
+            "57448b28c5109764b51af97f90a431c7701d016792ac0e59998c13f6eb86050d",
+            "canonical v1 hash layout drifted"
+        );
+    }
+
+    #[test]
+    fn mutation_plan_recorded_record_hash_determinism() {
+        let r1 = sample_mutation_plan_recorded_receipt();
+        let r2 = sample_mutation_plan_recorded_receipt();
+        assert_eq!(r1.record_hash, r2.record_hash);
+        assert_ne!(r1.record_hash, [0u8; 32]);
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn mutation_plan_recorded_record_hash_changes_per_field() {
+        // Each field independently changes the hash — including
+        // activation_record_hash and body_hash (the M1/M2 links) and
+        // recorded_at.
+        let base = sample_mutation_plan_recorded_receipt();
+        let variants = [
+            MutationPlanRecordedReceipt::new(
+                "domain-other".to_string(),
+                base.session_id.clone(),
+                base.plan_id.clone(),
+                base.activation_id.clone(),
+                base.activation_record_hash,
+                base.recorded_by.clone(),
+                base.body_hash,
+                base.recorded_at,
+            ),
+            MutationPlanRecordedReceipt::new(
+                base.domain_id.clone(),
+                "session-other".to_string(),
+                base.plan_id.clone(),
+                base.activation_id.clone(),
+                base.activation_record_hash,
+                base.recorded_by.clone(),
+                base.body_hash,
+                base.recorded_at,
+            ),
+            MutationPlanRecordedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                "plan-other".to_string(),
+                base.activation_id.clone(),
+                base.activation_record_hash,
+                base.recorded_by.clone(),
+                base.body_hash,
+                base.recorded_at,
+            ),
+            MutationPlanRecordedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.plan_id.clone(),
+                "activation-other".to_string(),
+                base.activation_record_hash,
+                base.recorded_by.clone(),
+                base.body_hash,
+                base.recorded_at,
+            ),
+            MutationPlanRecordedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.plan_id.clone(),
+                base.activation_id.clone(),
+                [8u8; 32],
+                base.recorded_by.clone(),
+                base.body_hash,
+                base.recorded_at,
+            ),
+            MutationPlanRecordedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.plan_id.clone(),
+                base.activation_id.clone(),
+                base.activation_record_hash,
+                "did:icn:planner-other".to_string(),
+                base.body_hash,
+                base.recorded_at,
+            ),
+            MutationPlanRecordedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.plan_id.clone(),
+                base.activation_id.clone(),
+                base.activation_record_hash,
+                base.recorded_by.clone(),
+                [6u8; 32],
+                base.recorded_at,
+            ),
+            MutationPlanRecordedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.plan_id.clone(),
+                base.activation_id.clone(),
+                base.activation_record_hash,
+                base.recorded_by.clone(),
+                base.body_hash,
+                base.recorded_at + 1,
+            ),
+        ];
+        for (i, v) in variants.iter().enumerate() {
+            assert_ne!(
+                base.record_hash, v.record_hash,
+                "variant {i} must change the record hash"
+            );
+        }
+    }
+
+    #[test]
+    fn mutation_plan_recorded_tag_separates_from_other_families() {
+        // Family separation from the five landed process-transition classes.
+        assert_ne!(
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            ProcessSessionOpenedReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            ProcessGateResultReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            DeliberationEntryRecordedReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            DecisionRecordedReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            ActivationCrossedReceipt::DOMAIN_TAG
+        );
+        // Must NEVER converge with the proposal/vote decision lineage.
+        assert_ne!(
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceiptV2::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceiptV3::DOMAIN_TAG
+        );
+        let plan = sample_mutation_plan_recorded_receipt();
+        let activation = sample_activation_crossed_receipt();
+        assert_ne!(plan.record_hash, activation.record_hash);
+    }
+
+    #[test]
+    fn mutation_plan_recorded_length_prefix_prevents_field_shifting() {
+        // Shifting bytes between adjacent string fields must change the
+        // hash — the length prefix delimits each field exactly.
+        let a = MutationPlanRecordedReceipt::compute_record_hash(
+            "ab",
+            "c",
+            "plan-001",
+            "activation-001",
+            &[0u8; 32],
+            "did:icn:x",
+            &[0u8; 32],
+            1,
+        );
+        let b = MutationPlanRecordedReceipt::compute_record_hash(
+            "a",
+            "bc",
+            "plan-001",
+            "activation-001",
+            &[0u8; 32],
+            "did:icn:x",
+            &[0u8; 32],
+            1,
+        );
+        assert_ne!(a, b, "domain/session byte shift must change the hash");
+        let c = MutationPlanRecordedReceipt::compute_record_hash(
+            "d",
+            "s",
+            "xy",
+            "z",
+            &[0u8; 32],
+            "did:icn:x",
+            &[0u8; 32],
+            1,
+        );
+        let d = MutationPlanRecordedReceipt::compute_record_hash(
+            "d",
+            "s",
+            "x",
+            "yz",
+            &[0u8; 32],
+            "did:icn:x",
+            &[0u8; 32],
+            1,
+        );
+        assert_ne!(
+            c, d,
+            "plan_id/activation_id byte shift must change the hash"
+        );
+    }
+
+    #[test]
+    fn mutation_plan_recorded_serde_roundtrip_and_payload_audit() {
+        // Round-trip preserves everything (equality anchored to record_hash),
+        // and the persisted payload carries ONLY the v1 field set — no plan
+        // body, operation list, target, or effect payload.
+        let r = sample_mutation_plan_recorded_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let back: MutationPlanRecordedReceipt = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(r, back);
+        assert_eq!(back.recorded_at, r.recorded_at);
+        assert_eq!(back.activation_record_hash, r.activation_record_hash);
+        assert_eq!(back.body_hash, r.body_hash);
+        let value: serde_json::Value = serde_json::from_str(&json).expect("value");
+        let obj = value.as_object().expect("object");
+        let expected: std::collections::BTreeSet<&str> = [
+            "domain_id",
+            "session_id",
+            "plan_id",
+            "activation_id",
+            "activation_record_hash",
+            "recorded_by",
+            "body_hash",
+            "recorded_at",
+            "record_hash",
+        ]
+        .into_iter()
+        .collect();
+        let actual: std::collections::BTreeSet<&str> = obj.keys().map(|k| k.as_str()).collect();
+        assert_eq!(
+            actual, expected,
+            "payload must carry exactly the v1 field set — no plan body, \
+             operation list, target list, or effect payload"
+        );
+    }
+
+    #[test]
+    fn mutation_plan_recorded_no_prohibited_vocabulary() {
+        let r = sample_mutation_plan_recorded_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let lower = json.to_lowercase();
+        for forbidden in [
+            // regulated-finance vocabulary (same list as the sibling
+            // process-receipt tests)
+            "wallet",
+            "balance",
+            "currency",
+            "payment",
+            "withdraw",
+            "deposit",
+            // mutation-application vocabulary — that is a later rung, must not
+            // leak into this plan-recorded payload
+            "mutation applied",
+            "plan applied",
+            "applied",
+            // proposal/vote lineage vocabulary
+            "proposal",
+            "vote",
+            "tally",
+            "quorum",
+            "mandate",
+        ] {
+            assert!(
+                !lower.contains(forbidden),
+                "MutationPlanRecordedReceipt JSON must not contain `{forbidden}`; got: {json}"
             );
         }
     }


### PR DESCRIPTION
## What

Adds `MutationPlanRecordedReceipt`, the sixth ADR-0026 Layer-2 `ProcessTransitionReceipt` class, after `ActivationCrossedReceipt`.

It witnesses that a mutation plan was recorded after activation and before any mutation is applied. The receipt records a process fact and grants zero authority.

## Why

Implements the runtime slice after the merged `MutationPlanRecordedReceipt` design/audit contract (#2299/#2300) and M1/M2/M3 decision rung (#2301/#2302).

## How

- **`icn-governance`** (`proof.rs`, `lib.rs`): new `MutationPlanRecordedReceipt` (tag `icn:gov:mutation_plan_recorded:v1`), `compute_record_hash`, `PartialEq`/`Eq` on `record_hash` only, public export, and unit tests (golden vector, determinism, per-field, tag-disjointness, length-prefix, serde/payload audit, vocabulary). Canonical hash: domain tag → length-prefixed `domain_id`/`session_id`/`plan_id`/`activation_id`/`recorded_by` → raw-32 `activation_record_hash` → raw-32 `body_hash` → `recorded_at` LE.
- **`apps/governance`** (`receipt_backend.rs`, `manager.rs`): class `mutation_plan_recorded`, injective netstring composite `key1 = (domain_id, session_id)`, `key2 = plan_id`, persisted via `put_opaque_if_absent`; `MutationPlanRecordedPersist`; `put`/`get`/`list` methods; and `record_mutation_plan_recorded` / `get` / `list` + `MutationPlanRecordedOutcome`.
- **M1** — the plan references the activation by **both** `activation_id` and content-addressed `activation_record_hash`, **verified fail-closed** (`get_activation_crossed` then `record_hash` compare; the activation must exist in the same `(domain_id, session_id)` with a matching `activation_id`). Decision + gate basis are inherited transitively through the activation, not re-referenced.
- **M2** — `body_hash`-only; the plan body / operation list / target / effect payload is never stored; no typed operation model, no plan-kind taxonomy.
- **M3** — a single caller-supplied `recorded_at`, hashed but excluded from stable duplicate identity; no `planned_at`.
- **Runtime tests** verify the session + activation preconditions, idempotent retry (never restamps), conflict on activation-reference / recorder / body-hash, cross-domain/session isolation, composite-key injectivity, concurrency, and fail-closed behavior (unopened session, missing/wrong-domain/wrong-session/mismatched activation, missing store, backend failure).

No HTTP route / OpenAPI / SDK is added (mirroring the activation slice #2296). No `STATE.md`/`PHASE_PROGRESS.md` edit (kept to the code slice, as #2296 did).

## Validation

- `cargo fmt --all --check` — clean.
- `cargo test -p icn-governance mutation_plan` — **7 passed** (golden vector, determinism, per-field, tag-disjointness, length-prefix, serde/payload audit, vocabulary).
- `cargo test -p icn-governance-actor --test mutation_plan_recorded_receipt_runtime_slice` — **17 passed**.
- `cargo test -p icn-governance -p icn-governance-actor` — full governance suites green, no regression in the five sibling process-receipt classes.
- `cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings` — clean.
- `python3 docs/scripts/route_inventory.py --check` — **OK** (287 routes, up to date; no route added).
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — exit 0.
- `git diff --check` — clean. Scope — `icn/crates/icn-governance/` + `icn/apps/governance/` only. Close-keyword scan — clean. Overclaim scan — the only hits are the vocabulary-test forbidden-list entries (`"mutation applied"`/`"plan applied"`), which assert the payload does *not* contain them.

## Non-claims

- No mutation application.
- No `MutationAppliedReceipt`.
- No `EvidencePacketProducedReceipt`.
- No action-card trigger.
- No workflow engine.
- No new authorization semantics.
- No plan body storage.
- No typed/kernel-readable mutation-plan operation model.
- No plan-kind taxonomy.
- No OpenAPI / SDK / served-schema publication.
- No member-shell implementation.
- No human/AT execution.
- Not #2041 completion.
- Not production-ready.
- Not pilot-ready.
- Not organizer-ready.
- Not member-ready.
- Not live federation.
- Not NYCN activation.
- Not Phase 2 completion.
- #1748 and #2141 remain open.
- #2041 remains open/parked.
- #2081 / #2080 / #2274 untouched.

## Refs

Refs #2301.
Refs #2302.
Refs #2299.
Refs #2300.
Refs #1748.
Refs #2141.
Refs #2041.
Refs #2296.
Refs #2298.
