### PR TITLE
feat(process): emit mutation applied receipt

### DIFF
--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -2802,6 +2802,26 @@ pub enum MutationPlanRecordedOutcome {
     AlreadyRecorded(icn_governance::MutationPlanRecordedReceipt),
 }
 
+/// Outcome of [`GovernanceManager::record_mutation_applied`] (#2307 contract +
+/// #2308 A1/A2/A3/A4 decision rung). Both variants are successes; the
+/// fail-closed mismatch conflict surfaces as an `Err` with stable prefix
+/// `mutation_applied_conflict`. Precondition failures surface as `Err`s with
+/// their own stable prefixes and persist nothing:
+/// `mutation_applied_session_not_opened` (unopened session),
+/// `mutation_applied_plan_not_found` / `mutation_applied_plan_mismatch` (A1
+/// plan reference absent or hash-mismatched).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MutationAppliedOutcome {
+    /// This call recorded the application: the receipt is the newly persisted
+    /// mutation-applied fact.
+    Applied(icn_governance::MutationAppliedReceipt),
+    /// The application was already recorded with the **same** stable identity
+    /// (`plan_id`, `plan_record_hash`, `applied_by`, `result_hash`); carries
+    /// the **original** persisted receipt (original `applied_at` /
+    /// `record_hash` — a retry is never restamped).
+    AlreadyApplied(icn_governance::MutationAppliedReceipt),
+}
+
 /// Action items are always managed locally (not gossiped) and can use either
 /// in-memory or Sled-backed persistent storage.
 pub struct GovernanceManager {
@@ -6922,6 +6942,204 @@ impl GovernanceManager {
         store
             .list_mutation_plans_recorded_for_session_in_domain(&domain_id.0, session_id)
             .map_err(|e| anyhow::anyhow!("Failed to list mutation-plan-recorded receipts: {e}"))
+    }
+
+    /// Record that a previously recorded mutation plan was applied — the
+    /// seventh `ProcessTransitionReceipt` class (#2307 contract + #2308
+    /// A1/A2/A3/A4 decision rung). Emits a [`MutationAppliedReceipt`].
+    ///
+    /// This records a **process fact and grants zero authority.** It is NOT a
+    /// mutation-application engine: this method performs no domain-state
+    /// mutation beyond persisting the receipt, and does not execute, authorize,
+    /// validate, enforce, roll back, or prove the semantic correctness of the
+    /// mutation (A4). `applied_by` is recorder / apply-witness evidence, not an
+    /// authority to apply.
+    ///
+    /// Preconditions (all fail-closed; on any failure nothing is persisted),
+    /// each with a stable error prefix:
+    /// - ids non-empty / non-whitespace; a receipt store is required;
+    /// - the `(domain_id, session_id)` session was opened first
+    ///   (`mutation_applied_session_not_opened`);
+    /// - **A1:** the referenced [`MutationAppliedReceipt::plan_id`] plan exists
+    ///   in the same `(domain_id, session_id)`
+    ///   (`mutation_applied_plan_not_found`) and its `record_hash` equals the
+    ///   supplied `plan_record_hash` (`mutation_applied_plan_mismatch`).
+    ///
+    /// On success returns [`MutationAppliedOutcome::Applied`]; a same-identity
+    /// retry returns [`MutationAppliedOutcome::AlreadyApplied`] carrying the
+    /// original receipt (never restamped); a same `(domain, session,
+    /// application_id)` with a different plan reference, recorder, or result
+    /// hash fails closed with the stable `mutation_applied_conflict` prefix.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_mutation_applied(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        application_id: &str,
+        plan_id: &str,
+        plan_record_hash: [u8; 32],
+        result_hash: [u8; 32],
+        applied_by: &Did,
+    ) -> Result<MutationAppliedOutcome> {
+        // Whitespace-only ids are rejected alongside empty ones: a caller
+        // bypassing the HTTP layer must not mint receipts with visually-empty
+        // identifiers or whitespace storage keys.
+        if domain_id.0.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_applied: domain_id must be non-empty and non-whitespace"
+            ));
+        }
+        if session_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_applied: session_id must be non-empty and non-whitespace"
+            ));
+        }
+        if application_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_applied: application_id must be non-empty and non-whitespace"
+            ));
+        }
+        if plan_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_applied: plan_id must be non-empty and non-whitespace"
+            ));
+        }
+        let applied_by_str = applied_by.to_string();
+        if applied_by_str.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_mutation_applied: applied_by must be non-empty"
+            ));
+        }
+        let store = self.receipt_store.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "record_mutation_applied: a receipt store is required — application \
+                 uniqueness and the plan precondition are enforced at the storage \
+                 layer and cannot be faked in memory"
+            )
+        })?;
+
+        // Precondition: the session was opened first. No silent creation.
+        let opened = store
+            .get_process_session_opened(&domain_id.0, session_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_mutation_applied: failed to read session-open state for \
+                     session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        if opened.is_none() {
+            return Err(anyhow::anyhow!(
+                "mutation_applied_session_not_opened: session {session_id} in domain {} \
+                 has no recorded opening; refusing to record an application against an \
+                 unanchored session",
+                domain_id.0
+            ));
+        }
+
+        // A1 precondition: the plan being applied must exist in this same
+        // (domain, session) under `plan_id`, and its `record_hash` must equal
+        // the supplied `plan_record_hash`. The composite storage key makes a
+        // plan recorded under a different session/domain invisible here, so a
+        // wrong-session/wrong-domain reference fails closed as "not found".
+        let plan = store
+            .get_mutation_plan_recorded(&domain_id.0, session_id, plan_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_mutation_applied: failed to read plan state for plan \
+                     {plan_id} in session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        let plan = plan.ok_or_else(|| {
+            anyhow::anyhow!(
+                "mutation_applied_plan_not_found: no plan {plan_id} recorded in session \
+                 {session_id} in domain {}; refusing to record an application for an \
+                 unrecorded plan",
+                domain_id.0
+            )
+        })?;
+        if plan.record_hash != plan_record_hash {
+            return Err(anyhow::anyhow!(
+                "mutation_applied_plan_mismatch: plan {plan_id} in session {session_id} \
+                 in domain {} was recorded with a different record_hash than the one \
+                 supplied; refusing to record an application on a mismatched plan reference",
+                domain_id.0
+            ));
+        }
+
+        let now = icn_time::current_timestamp_secs();
+        let receipt = icn_governance::MutationAppliedReceipt::new(
+            domain_id.0.clone(),
+            session_id.to_string(),
+            application_id.to_string(),
+            plan_id.to_string(),
+            plan_record_hash,
+            applied_by_str.clone(),
+            result_hash,
+            now,
+        );
+
+        match store.put_mutation_applied(&receipt).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to persist mutation-applied receipt for application \
+                 {application_id} in session {session_id} in domain {}: {e}",
+                domain_id.0
+            )
+        })? {
+            crate::receipt_backend::MutationAppliedPersist::Inserted => {
+                Ok(MutationAppliedOutcome::Applied(receipt))
+            }
+            crate::receipt_backend::MutationAppliedPersist::Existing(original) => {
+                if original.plan_id == plan_id
+                    && original.plan_record_hash == plan_record_hash
+                    && original.applied_by == applied_by_str
+                    && original.result_hash == result_hash
+                {
+                    Ok(MutationAppliedOutcome::AlreadyApplied(*original))
+                } else {
+                    Err(anyhow::anyhow!(
+                        "mutation_applied_conflict: application {application_id} in session \
+                         {session_id} in domain {} was already recorded with a different \
+                         plan reference, recorder, or result hash; refusing to overwrite",
+                        domain_id.0
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Retrieve the persisted mutation-applied receipt for a `(domain_id,
+    /// session_id, application_id)`, or `None` when no application has been
+    /// recorded. Read-only.
+    pub fn get_mutation_applied(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        application_id: &str,
+    ) -> Result<Option<icn_governance::MutationAppliedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(None);
+        };
+        store
+            .get_mutation_applied(&domain_id.0, session_id, application_id)
+            .map_err(|e| anyhow::anyhow!("Failed to read mutation-applied receipt: {e}"))
+    }
+
+    /// List all mutation-applied receipts recorded against one `(domain_id,
+    /// session_id)` anchor, in the store's deterministic chronological
+    /// `(recorded_at, record_hash)` order. Read-only.
+    pub fn list_mutation_applied_in_domain(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+    ) -> Result<Vec<icn_governance::MutationAppliedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(vec![]);
+        };
+        store
+            .list_mutation_applied_for_session_in_domain(&domain_id.0, session_id)
+            .map_err(|e| anyhow::anyhow!("Failed to list mutation-applied receipts: {e}"))
     }
 
     // ========================================================================

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -5,8 +5,9 @@ use icn_governance::{
     ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActivationCrossedReceipt,
     AuthorityGrant, AuthorityGrantId, DecisionRecordedReceipt, DeliberationEntryRecordedReceipt,
     GovernanceDecisionReceipt, GovernanceDecisionReceiptV3, Grantee, Mandate,
-    MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, MutationPlanRecordedReceipt,
-    ProcessGateKind, ProcessGateResultReceipt, ProcessSessionOpenedReceipt, Timestamp,
+    MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, MutationAppliedReceipt,
+    MutationPlanRecordedReceipt, ProcessGateKind, ProcessGateResultReceipt,
+    ProcessSessionOpenedReceipt, Timestamp,
 };
 use icn_kernel_api::{AllocationReceipt, Hash};
 
@@ -212,6 +213,50 @@ pub enum MutationPlanRecordedPersist {
     /// unboxed variant would make this enum needlessly large next to the unit
     /// `Inserted`.
     Existing(Box<MutationPlanRecordedReceipt>),
+}
+
+/// Class string for `MutationAppliedReceipt` opaque storage (#2307 contract +
+/// #2308 A1/A2/A3/A4 decision rung). Chosen in the apps layer so the gateway
+/// never sees the typed name. Distinct from every other process class store.
+const MUTATION_APPLIED_CLASS: &str = "mutation_applied";
+
+/// Build the injective composite `key1` binding a recorded mutation
+/// application to its `(domain_id, session_id)` anchor in opaque storage.
+///
+/// Sibling of [`mutation_plan_recorded_composite_key1`] with the identical
+/// netstring-style encoding (decimal length of `domain_id`, a colon, then the
+/// two ids concatenated), kept as a separate function so this class's key
+/// derivation is independently anchored by its own anti-aliasing test. The
+/// length prefix delimits `domain_id` exactly, so `("ab","c")` and `("a","bc")`
+/// can never produce the same key, and two domains sharing a `session_id` scan
+/// different `key1` prefixes.
+pub fn mutation_applied_composite_key1(domain_id: &str, session_id: &str) -> String {
+    format!("{}:{domain_id}{session_id}", domain_id.len())
+}
+
+/// Outcome of persisting a [`MutationAppliedReceipt`] through
+/// [`GovernanceReceiptBackend::put_mutation_applied`].
+///
+/// The backend enforces at most one application per `(domain_id, session_id,
+/// application_id)` **atomically at the storage layer** (same
+/// `put_opaque_if_absent` primitive as the sibling process classes). The caller
+/// (the manager) turns `Existing` into either a same-identity idempotent
+/// success or a fail-closed conflict — stable identity is `plan_id` +
+/// `plan_record_hash` + `applied_by` + `result_hash` (per the #2308 rung §8;
+/// `applied_at`/`record_hash` are NOT identity inputs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MutationAppliedPersist {
+    /// This call won the insert: the receipt is now the one persisted
+    /// application for its `(domain_id, session_id, application_id)`.
+    Inserted,
+    /// An application already existed for this triple; nothing was written.
+    /// Carries the original persisted receipt (original `applied_at` /
+    /// `record_hash` — never restamped). Boxed because [`MutationAppliedReceipt`]
+    /// is a large payload (five string fields plus three 32-byte hashes —
+    /// `plan_record_hash`, `result_hash`, and `record_hash`), so an unboxed
+    /// variant would make this enum needlessly large next to the unit
+    /// `Inserted`.
+    Existing(Box<MutationAppliedReceipt>),
 }
 
 /// Class string for `MeetingAttendanceReceiptV2` opaque storage (#1868).
@@ -1398,6 +1443,98 @@ pub trait GovernanceReceiptBackend: Send + Sync {
             out.push(
                 serde_json::from_slice(&bytes)
                     .map_err(|e| format!("deserialize MutationPlanRecordedReceipt in list: {e}"))?,
+            );
+        }
+        Ok(out)
+    }
+
+    /// Persist a [`MutationAppliedReceipt`] emitted when the runtime records
+    /// that a recorded mutation plan was applied (#2307 contract + #2308 rung).
+    ///
+    /// **Default routes through opaque storage.** Serialises the typed receipt
+    /// to JSON and delegates to [`Self::put_opaque_if_absent`] under class
+    /// `"mutation_applied"` with `key1 =` [`mutation_applied_composite_key1`]
+    /// (the injective domain+session composite) and `key2 = application_id`. On
+    /// a lost insert the original persisted receipt is hydrated and returned
+    /// (never restamped). A backend that has not opted in to opaque storage
+    /// inherits the fail-closed `opaque_storage_not_implemented` default.
+    fn put_mutation_applied(
+        &self,
+        receipt: &MutationAppliedReceipt,
+    ) -> Result<MutationAppliedPersist, String> {
+        let payload = serde_json::to_vec(receipt)
+            .map_err(|e| format!("serialize MutationAppliedReceipt: {e}"))?;
+        let key1 = mutation_applied_composite_key1(&receipt.domain_id, &receipt.session_id);
+        let existing = self.put_opaque_if_absent(
+            MUTATION_APPLIED_CLASS,
+            &key1,
+            Some(&receipt.application_id),
+            receipt.applied_at,
+            receipt.record_hash,
+            &payload,
+        )?;
+        match existing {
+            None => Ok(MutationAppliedPersist::Inserted),
+            Some(_winning_hash) => {
+                let original = self
+                    .get_mutation_applied(
+                        &receipt.domain_id,
+                        &receipt.session_id,
+                        &receipt.application_id,
+                    )?
+                    .ok_or_else(|| {
+                        // The unique marker says an application exists but the
+                        // payload cannot be hydrated — surface loudly rather
+                        // than minting a second application.
+                        "mutation_applied_inconsistent: unique marker present \
+                         but no persisted application payload could be read"
+                            .to_string()
+                    })?;
+                Ok(MutationAppliedPersist::Existing(Box::new(original)))
+            }
+        }
+    }
+
+    /// Retrieve the persisted [`MutationAppliedReceipt`] for a `(domain_id,
+    /// session_id, application_id)`, or `None` when no application has been
+    /// recorded. Same key convention as [`Self::put_mutation_applied`]; at most
+    /// one application exists per triple (uniqueness is enforced on write).
+    fn get_mutation_applied(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+        application_id: &str,
+    ) -> Result<Option<MutationAppliedReceipt>, String> {
+        let key1 = mutation_applied_composite_key1(domain_id, session_id);
+        let payload =
+            self.get_latest_opaque(MUTATION_APPLIED_CLASS, &key1, Some(application_id))?;
+        match payload {
+            Some(bytes) => {
+                Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                    format!("deserialize MutationAppliedReceipt: {e}")
+                })?))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// List all mutation-applied receipts recorded against one `(domain_id,
+    /// session_id)` anchor, in the store's deterministic chronological
+    /// `(recorded_at, record_hash)` order. Because `key1` is the injective
+    /// domain+session composite, two domains sharing a `session_id` can never
+    /// mix here — no payload-side filtering is needed.
+    fn list_mutation_applied_for_session_in_domain(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+    ) -> Result<Vec<MutationAppliedReceipt>, String> {
+        let key1 = mutation_applied_composite_key1(domain_id, session_id);
+        let payloads = self.list_opaque_for(MUTATION_APPLIED_CLASS, &key1)?;
+        let mut out = Vec::with_capacity(payloads.len());
+        for bytes in payloads {
+            out.push(
+                serde_json::from_slice(&bytes)
+                    .map_err(|e| format!("deserialize MutationAppliedReceipt in list: {e}"))?,
             );
         }
         Ok(out)

--- a/icn/apps/governance/tests/mutation_applied_receipt_runtime_slice.rs
+++ b/icn/apps/governance/tests/mutation_applied_receipt_runtime_slice.rs
@@ -1,0 +1,1011 @@
+//! Runtime proof for the seventh `ProcessTransitionReceipt` class —
+//! [`MutationAppliedReceipt`] — per the merged #2307 contract
+//! (`docs/design/mutation-applied-receipt.md`) and the #2308 A1/A2/A3/A4
+//! decision rung (`docs/design/mutation-applied-receipt-decision-rung.md`).
+//!
+//! Pins the merged decisions:
+//!
+//! 1. `GovernanceManager::record_mutation_applied` requires an already-opened
+//!    session and a **recorded plan** to reference (A1), constructs a receipt
+//!    with a real blake3 `record_hash`, persists it through the backend's
+//!    atomic insert-if-absent BEFORE returning, and returns `Applied(receipt)`.
+//! 2. A1: the application names the plan by both `plan_id` and
+//!    `plan_record_hash`; the reference is **verified** — a missing,
+//!    wrong-session, wrong-domain, or hash-mismatched plan fails closed and
+//!    persists nothing. Activation + decision + gate basis are inherited
+//!    transitively (not re-referenced).
+//! 3. A2: `result_hash`-only; the persisted payload carries no applied-result
+//!    body / plan body / operation list / target / effect payload.
+//! 4. A3: a single caller-supplied `applied_at`, hashed but excluded from
+//!    identity — a retry with identical stable identity returns the ORIGINAL
+//!    receipt unchanged, never restamped.
+//! 5. A4: recording an application persists only the receipt (no domain-state
+//!    mutation); `applied_by` is recorder/apply-witness evidence, zero
+//!    authority. A same `application_id` with a different plan reference,
+//!    recorder, or result hash fails closed with the stable
+//!    `mutation_applied_conflict` prefix; the original is untouched.
+//! 6. Empty/whitespace ids rejected; missing receipt store is an error;
+//!    backend failure fails closed; concurrent duplicates serialize to one
+//!    winner; composite key injective; two domains sharing a `session_id`
+//!    never mix.
+//!
+//! This records a **process fact and grants zero authority.** It is not a
+//! mutation-application engine.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use icn_governance::{
+    GovernanceDecisionReceipt, GovernanceDomainId, ProcessGateKind, ProcessGateResult,
+};
+use icn_governance_actor::manager::{
+    ActivationCrossedOutcome, DecisionRecordOutcome, GovernanceManager, MutationAppliedOutcome,
+    MutationPlanRecordedOutcome, ProcessSessionOpenOutcome,
+};
+use icn_governance_actor::receipt_backend::{
+    mutation_applied_composite_key1, GovernanceReceiptBackend,
+};
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+
+// ============================================================================
+// Opaque-backed test store — the test analog of the production gateway-backed
+// ReceiptStore: it implements the opaque primitives (atomic
+// `put_opaque_if_absent` + append `put_opaque`) and NO typed overrides, so
+// the trait's typed defaults are exercised end-to-end.
+// ============================================================================
+
+type ChainKey = (String, String, Option<String>);
+type ChainEntry = (u64, [u8; 32], Vec<u8>);
+
+#[derive(Default)]
+struct OpaqueUniqueBackend {
+    chains: Mutex<HashMap<ChainKey, Vec<ChainEntry>>>,
+    unique: Mutex<HashMap<ChainKey, [u8; 32]>>,
+}
+
+impl OpaqueUniqueBackend {
+    fn chain_len(&self, class: &str, key1: &str, key2: Option<&str>) -> usize {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .map_or(0, Vec::len)
+    }
+
+    fn raw_payload(&self, class: &str, key1: &str, key2: Option<&str>) -> Option<Vec<u8>> {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .and_then(|chain| chain.first().map(|(_, _, p)| p.clone()))
+    }
+}
+
+impl GovernanceReceiptBackend for OpaqueUniqueBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(())
+    }
+
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        let mut unique = self.unique.lock().unwrap();
+        if let Some(winner) = unique.get(&key) {
+            return Ok(Some(*winner));
+        }
+        unique.insert(key.clone(), record_hash);
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(None)
+    }
+
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        Ok(self.chains.lock().unwrap().get(&key).and_then(|chain| {
+            chain
+                .iter()
+                .max_by_key(|(t, h, _)| (*t, *h))
+                .map(|(_, _, p)| p.clone())
+        }))
+    }
+
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        let chains = self.chains.lock().unwrap();
+        let mut hits: Vec<ChainEntry> = chains
+            .iter()
+            .filter(|((c, k1, _), _)| c == class && k1 == key1)
+            .flat_map(|(_, chain)| chain.iter().cloned())
+            .collect();
+        hits.sort_by_key(|(t, h, _)| (*t, *h));
+        Ok(hits.into_iter().map(|(_, _, p)| p).collect())
+    }
+}
+
+/// Backend that persists everything except the mutation-applied insert —
+/// proves fail-closed application persistence with all preconditions satisfied
+/// (the full plan chain is recorded through the same store first).
+#[derive(Default)]
+struct FailingMutationAppliedBackend {
+    inner: OpaqueUniqueBackend,
+}
+
+impl GovernanceReceiptBackend for FailingMutationAppliedBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        self.inner
+            .put_opaque(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        if class == "mutation_applied" {
+            return Err("simulated mutation-applied backend failure".to_string());
+        }
+        self.inner
+            .put_opaque_if_absent(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        self.inner.get_latest_opaque(class, key1, key2)
+    }
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        self.inner.list_opaque_for(class, key1)
+    }
+}
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_manager() -> (GovernanceManager, Arc<OpaqueUniqueBackend>) {
+    let store = Arc::new(OpaqueUniqueBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    (mgr, store)
+}
+
+fn coop_test() -> GovernanceDomainId {
+    GovernanceDomainId::new("coop:test")
+}
+
+fn app_key1(domain: &str, session: &str) -> String {
+    mutation_applied_composite_key1(domain, session)
+}
+
+fn open_session(mgr: &GovernanceManager, domain: &GovernanceDomainId, session: &str, by: &Did) {
+    match mgr
+        .record_process_session_opened(domain, session, by)
+        .unwrap()
+    {
+        ProcessSessionOpenOutcome::Opened(_) | ProcessSessionOpenOutcome::AlreadyOpened(_) => {}
+    }
+}
+
+/// Record the full activation chain (session opened, decision, Pass gate,
+/// activation crossing) and return the `ActivationCrossedReceipt.record_hash`.
+/// Each call uses an `activation_id`-derived decision id so distinct
+/// activations are distinct.
+fn setup_activation(
+    mgr: &GovernanceManager,
+    domain: &GovernanceDomainId,
+    session: &str,
+    activation_id: &str,
+    by: &Did,
+) -> [u8; 32] {
+    open_session(mgr, domain, session, by);
+    let decision_id = format!("decision-for-{activation_id}");
+    let decision_hash = match mgr
+        .record_decision(domain, session, &decision_id, by, [9u8; 32])
+        .unwrap()
+    {
+        DecisionRecordOutcome::Recorded(r) | DecisionRecordOutcome::AlreadyRecorded(r) => {
+            r.record_hash
+        }
+    };
+    let gate_hash = mgr
+        .record_process_gate_result(
+            domain,
+            session,
+            ProcessGateKind::PrivacyReview,
+            ProcessGateResult::Pass,
+            by,
+        )
+        .unwrap()
+        .record_hash;
+    match mgr
+        .record_activation_crossed(
+            domain,
+            session,
+            activation_id,
+            &decision_id,
+            decision_hash,
+            &[gate_hash],
+            by,
+        )
+        .unwrap()
+    {
+        ActivationCrossedOutcome::Crossed(r) | ActivationCrossedOutcome::AlreadyCrossed(r) => {
+            r.record_hash
+        }
+    }
+}
+
+/// Record the full chain up to a recorded mutation plan (activation chain +
+/// plan) and return the `MutationPlanRecordedReceipt.record_hash` — the A1
+/// proof link a mutation application references. The activation id is derived
+/// from `plan_id` so distinct plans reference distinct activations.
+fn setup_plan(
+    mgr: &GovernanceManager,
+    domain: &GovernanceDomainId,
+    session: &str,
+    plan_id: &str,
+    by: &Did,
+) -> [u8; 32] {
+    let activation_id = format!("activation-for-{plan_id}");
+    let ah = setup_activation(mgr, domain, session, &activation_id, by);
+    match mgr
+        .record_mutation_plan_recorded(domain, session, plan_id, &activation_id, ah, [5u8; 32], by)
+        .unwrap()
+    {
+        MutationPlanRecordedOutcome::Recorded(r)
+        | MutationPlanRecordedOutcome::AlreadyRecorded(r) => r.record_hash,
+    }
+}
+
+// ============================================================================
+// Happy path — construct, persist, retrieve, verify A1 link
+// ============================================================================
+
+#[test]
+fn application_persists_and_returns_receipt_with_verified_plan_link() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+
+    let outcome = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-001",
+            "application-001",
+            "plan-001",
+            ph,
+            [4u8; 32],
+            &actor,
+        )
+        .expect("first application must succeed");
+    let MutationAppliedOutcome::Applied(receipt) = outcome else {
+        panic!("first application must be Applied, got {outcome:?}");
+    };
+    assert_eq!(receipt.domain_id, "coop:test");
+    assert_eq!(receipt.session_id, "session-001");
+    assert_eq!(receipt.application_id, "application-001");
+    assert_eq!(receipt.plan_id, "plan-001");
+    assert_eq!(receipt.applied_by, actor.to_string());
+    assert_eq!(receipt.result_hash, [4u8; 32]);
+    assert_ne!(receipt.record_hash, [0u8; 32], "real blake3 hash");
+    // A1: plan_record_hash equals the persisted plan receipt hash.
+    assert_eq!(
+        receipt.plan_record_hash, ph,
+        "A1 proof link binds the recorded plan's real record_hash"
+    );
+    assert_eq!(
+        store.chain_len(
+            "mutation_applied",
+            &app_key1("coop:test", "session-001"),
+            Some("application-001"),
+        ),
+        1,
+        "exactly one persisted application"
+    );
+    let read = mgr
+        .get_mutation_applied(&domain, "session-001", "application-001")
+        .unwrap()
+        .expect("point read must hydrate");
+    assert_eq!(read, receipt);
+}
+
+#[test]
+fn same_identity_retry_returns_original_never_restamped() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+
+    let MutationAppliedOutcome::Applied(original) = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-001",
+            "application-001",
+            "plan-001",
+            ph,
+            [4u8; 32],
+            &actor,
+        )
+        .unwrap()
+    else {
+        panic!("first application must be Applied");
+    };
+
+    let outcome = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-001",
+            "application-001",
+            "plan-001",
+            ph,
+            [4u8; 32],
+            &actor,
+        )
+        .expect("same-identity retry must succeed");
+    let MutationAppliedOutcome::AlreadyApplied(returned) = outcome else {
+        panic!("retry must be AlreadyApplied, got {outcome:?}");
+    };
+    assert_eq!(returned.applied_at, original.applied_at, "never restamped");
+    assert_eq!(returned.record_hash, original.record_hash);
+    assert_eq!(returned, original);
+    assert_eq!(
+        store.chain_len(
+            "mutation_applied",
+            &app_key1("coop:test", "session-001"),
+            Some("application-001"),
+        ),
+        1,
+        "retry must not append a second record"
+    );
+}
+
+// ============================================================================
+// A1 — plan reference preconditions (verified, not asserted)
+// ============================================================================
+
+#[test]
+fn unopened_session_fails_closed_and_creates_nothing() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    // No session opened, no plan.
+    let err = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-ghost",
+            "application-001",
+            "plan-001",
+            [1u8; 32],
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("unopened session must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_applied_session_not_opened"),
+        "stable precondition prefix, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "mutation_applied",
+            &app_key1("coop:test", "session-ghost"),
+            Some("application-001"),
+        ),
+        0
+    );
+}
+
+#[test]
+fn missing_plan_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    // Session opened but no plan recorded.
+    let err = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-001",
+            "application-001",
+            "plan-404",
+            [1u8; 32],
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("missing plan must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_applied_plan_not_found"),
+        "stable prefix, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "mutation_applied",
+            &app_key1("coop:test", "session-001"),
+            Some("application-001"),
+        ),
+        0
+    );
+}
+
+#[test]
+fn wrong_session_plan_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    // Plan recorded in session-a; application attempted in session-b.
+    let ph = setup_plan(&mgr, &domain, "session-a", "plan-001", &actor);
+    open_session(&mgr, &domain, "session-b", &actor);
+    let err = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-b",
+            "application-001",
+            "plan-001",
+            ph,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("wrong-session plan must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_applied_plan_not_found"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn wrong_domain_plan_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    let ph = setup_plan(&mgr, &d1, "session-shared", "plan-001", &actor);
+    open_session(&mgr, &d2, "session-shared", &actor);
+    let err = mgr
+        .record_mutation_applied(
+            &d2,
+            "session-shared",
+            "application-001",
+            "plan-001",
+            ph,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("wrong-domain plan must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_applied_plan_not_found"),
+        "stable prefix, got: {err}"
+    );
+}
+
+#[test]
+fn plan_hash_mismatch_fails_closed() {
+    // The supplied plan_id references a real plan, but the supplied
+    // plan_record_hash does not match it.
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+    let err = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-001",
+            "application-001",
+            "plan-001",
+            [123u8; 32], // wrong hash for plan-001
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("plan hash mismatch must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("mutation_applied_plan_mismatch"),
+        "stable prefix, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "mutation_applied",
+            &app_key1("coop:test", "session-001"),
+            Some("application-001"),
+        ),
+        0
+    );
+}
+
+// ============================================================================
+// Conflicts — same application_id, different identity fields
+// ============================================================================
+
+#[test]
+fn conflict_on_different_plan_reference_fails_closed() {
+    // plan_id and plan_record_hash are both stable-identity inputs; through the
+    // validated path they co-vary (a same-id/wrong-hash reference is caught
+    // earlier as plan_mismatch). Referencing a DIFFERENT recorded plan for the
+    // same application_id conflicts.
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let p1 = setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+    let p2 = setup_plan(&mgr, &domain, "session-001", "plan-002", &actor);
+
+    mgr.record_mutation_applied(
+        &domain,
+        "session-001",
+        "application-001",
+        "plan-001",
+        p1,
+        [4u8; 32],
+        &actor,
+    )
+    .expect("first application");
+
+    let err = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-001",
+            "application-001",
+            "plan-002",
+            p2,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("different plan reference must conflict");
+    assert!(
+        err.to_string().starts_with("mutation_applied_conflict"),
+        "stable conflict prefix, got: {err}"
+    );
+    let read = mgr
+        .get_mutation_applied(&domain, "session-001", "application-001")
+        .unwrap()
+        .unwrap();
+    assert_eq!(read.plan_id, "plan-001", "original untouched");
+    assert_eq!(
+        store.chain_len(
+            "mutation_applied",
+            &app_key1("coop:test", "session-001"),
+            Some("application-001"),
+        ),
+        1
+    );
+}
+
+#[test]
+fn conflict_on_different_result_hash_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+
+    mgr.record_mutation_applied(
+        &domain,
+        "session-001",
+        "application-001",
+        "plan-001",
+        ph,
+        [4u8; 32],
+        &actor,
+    )
+    .expect("first application");
+
+    let err = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-001",
+            "application-001",
+            "plan-001",
+            ph,
+            [10u8; 32],
+            &actor,
+        )
+        .expect_err("different result hash must conflict");
+    assert!(
+        err.to_string().starts_with("mutation_applied_conflict"),
+        "stable conflict prefix, got: {err}"
+    );
+}
+
+#[test]
+fn conflict_on_different_applier_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let other = fresh_did();
+    let domain = coop_test();
+    let ph = setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+
+    mgr.record_mutation_applied(
+        &domain,
+        "session-001",
+        "application-001",
+        "plan-001",
+        ph,
+        [4u8; 32],
+        &actor,
+    )
+    .expect("first application");
+
+    let err = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-001",
+            "application-001",
+            "plan-001",
+            ph,
+            [4u8; 32],
+            &other,
+        )
+        .expect_err("different applier must conflict");
+    assert!(
+        err.to_string().starts_with("mutation_applied_conflict"),
+        "stable conflict prefix, got: {err}"
+    );
+}
+
+// ============================================================================
+// Input validation, missing store, backend failure
+// ============================================================================
+
+#[test]
+fn empty_and_whitespace_ids_rejected_before_persistence() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+
+    for (d, s, a, p) in [
+        ("", "session-001", "application-001", "plan-001"),
+        ("   ", "session-001", "application-001", "plan-001"),
+        ("coop:test", "", "application-001", "plan-001"),
+        ("coop:test", "  \t", "application-001", "plan-001"),
+        ("coop:test", "session-001", "", "plan-001"),
+        ("coop:test", "session-001", " \n ", "plan-001"),
+        ("coop:test", "session-001", "application-001", ""),
+        ("coop:test", "session-001", "application-001", "  "),
+    ] {
+        let err = mgr
+            .record_mutation_applied(&GovernanceDomainId::new(d), s, a, p, ph, [4u8; 32], &actor)
+            .expect_err("empty/whitespace ids must be rejected");
+        assert!(
+            err.to_string().contains("non-empty"),
+            "id-validation error, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn missing_receipt_store_is_an_error() {
+    let mgr = GovernanceManager::new(); // no receipt store wired
+    let actor = fresh_did();
+    let err = mgr
+        .record_mutation_applied(
+            &coop_test(),
+            "session-001",
+            "application-001",
+            "plan-001",
+            [1u8; 32],
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("missing store must be an error");
+    assert!(
+        err.to_string().contains("receipt store is required"),
+        "store-required error, got: {err}"
+    );
+}
+
+#[test]
+fn backend_failure_fails_closed() {
+    let store = Arc::new(FailingMutationAppliedBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let actor = fresh_did();
+    let domain = coop_test();
+    // The full plan chain records fine (the backend only rejects the
+    // mutation_applied class); the application insert then fails closed.
+    let ph = setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+
+    let err = mgr
+        .record_mutation_applied(
+            &domain,
+            "session-001",
+            "application-001",
+            "plan-001",
+            ph,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("backend failure must surface");
+    assert!(
+        err.to_string()
+            .contains("simulated mutation-applied backend failure"),
+        "backend error surfaced, got: {err}"
+    );
+    assert!(
+        mgr.get_mutation_applied(&domain, "session-001", "application-001")
+            .unwrap()
+            .is_none(),
+        "nothing half-written"
+    );
+}
+
+// ============================================================================
+// Concurrency — atomic uniqueness under racing duplicates
+// ============================================================================
+
+#[test]
+fn concurrent_duplicate_records_serialize_to_one_application() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+
+    let mgr = Arc::new(mgr);
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let mgr = mgr.clone();
+        let actor = actor.clone();
+        let domain = domain.clone();
+        handles.push(std::thread::spawn(move || {
+            mgr.record_mutation_applied(
+                &domain,
+                "session-001",
+                "application-race",
+                "plan-001",
+                ph,
+                [4u8; 32],
+                &actor,
+            )
+        }));
+    }
+    let mut receipts = Vec::new();
+    for h in handles {
+        let outcome = h.join().unwrap().expect("same-identity race must succeed");
+        match outcome {
+            MutationAppliedOutcome::Applied(r) | MutationAppliedOutcome::AlreadyApplied(r) => {
+                receipts.push(r)
+            }
+        }
+    }
+    assert_eq!(
+        store.chain_len(
+            "mutation_applied",
+            &app_key1("coop:test", "session-001"),
+            Some("application-race"),
+        ),
+        1,
+        "atomic uniqueness: one winner"
+    );
+    let first = &receipts[0];
+    for r in &receipts {
+        assert_eq!(r, first, "all threads observe the single winner");
+    }
+}
+
+// ============================================================================
+// Key injectivity, cross-domain isolation, payload audit
+// ============================================================================
+
+#[test]
+fn composite_key_is_injective_no_aliasing() {
+    assert_ne!(
+        mutation_applied_composite_key1("ab", "c"),
+        mutation_applied_composite_key1("a", "bc"),
+        "netstring length prefix must prevent domain/session aliasing"
+    );
+
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d_ab = GovernanceDomainId::new("ab");
+    let d_a = GovernanceDomainId::new("a");
+    let ph = setup_plan(&mgr, &d_ab, "c", "plan-001", &actor);
+    // Only ("ab","c") is opened; ("a","bc") must NOT see it through key
+    // aliasing — the precondition fails closed for the unopened pair.
+    let err = mgr
+        .record_mutation_applied(
+            &d_a,
+            "bc",
+            "application-001",
+            "plan-001",
+            ph,
+            [4u8; 32],
+            &actor,
+        )
+        .expect_err("aliased pair must not inherit the opened session");
+    assert!(err
+        .to_string()
+        .starts_with("mutation_applied_session_not_opened"));
+    // The genuinely opened pair records fine.
+    mgr.record_mutation_applied(
+        &d_ab,
+        "c",
+        "application-001",
+        "plan-001",
+        ph,
+        [4u8; 32],
+        &actor,
+    )
+    .expect("opened pair records");
+}
+
+#[test]
+fn two_domains_sharing_session_id_never_mix() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    let p1 = setup_plan(&mgr, &d1, "shared-session", "plan-1", &actor);
+    let p2 = setup_plan(&mgr, &d2, "shared-session", "plan-2", &actor);
+
+    mgr.record_mutation_applied(
+        &d1,
+        "shared-session",
+        "application-1",
+        "plan-1",
+        p1,
+        [1u8; 32],
+        &actor,
+    )
+    .unwrap();
+    mgr.record_mutation_applied(
+        &d2,
+        "shared-session",
+        "application-2",
+        "plan-2",
+        p2,
+        [2u8; 32],
+        &actor,
+    )
+    .unwrap();
+
+    let list1 = mgr
+        .list_mutation_applied_in_domain(&d1, "shared-session")
+        .unwrap();
+    let list2 = mgr
+        .list_mutation_applied_in_domain(&d2, "shared-session")
+        .unwrap();
+    assert_eq!(list1.len(), 1);
+    assert_eq!(list2.len(), 1);
+    assert_eq!(list1[0].application_id, "application-1");
+    assert_eq!(list2[0].application_id, "application-2");
+    assert_eq!(list1[0].domain_id, "coop:one");
+    assert_eq!(list2[0].domain_id, "coop:two");
+}
+
+#[test]
+fn persisted_payload_carries_only_v1_fields_no_result_body() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_plan(&mgr, &domain, "session-001", "plan-001", &actor);
+    mgr.record_mutation_applied(
+        &domain,
+        "session-001",
+        "application-001",
+        "plan-001",
+        ph,
+        [4u8; 32],
+        &actor,
+    )
+    .unwrap();
+
+    let payload = store
+        .raw_payload(
+            "mutation_applied",
+            &app_key1("coop:test", "session-001"),
+            Some("application-001"),
+        )
+        .expect("payload persisted");
+    let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+    let obj = value.as_object().unwrap();
+    let expected: std::collections::BTreeSet<&str> = [
+        "domain_id",
+        "session_id",
+        "application_id",
+        "plan_id",
+        "plan_record_hash",
+        "applied_by",
+        "result_hash",
+        "applied_at",
+        "record_hash",
+    ]
+    .into_iter()
+    .collect();
+    let actual: std::collections::BTreeSet<&str> = obj.keys().map(|k| k.as_str()).collect();
+    assert_eq!(
+        actual, expected,
+        "persisted payload must carry exactly the v1 field set — no applied-result body, \
+         plan body, operation list, target list, or effect payload"
+    );
+}

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -147,8 +147,9 @@ pub use proof::{
     GovernanceDecisionReceiptV3Error, GovernanceProof, GovernanceProofV2, MandateGrantRef,
     MandateGrantRefError, MandateGrantRefTarget, MeetingAttendanceReceipt,
     MeetingAttendanceReceiptV2, MeetingAttendanceReceiptV2Error, MeetingAttendanceTransition,
-    MutationPlanRecordedReceipt, NoMandateReason, ProcessGateKind, ProcessGateResult,
-    ProcessGateResultReceipt, ProcessSessionOpenedReceipt, ProofOutcome, ReceiptMandateAttestation,
+    MutationAppliedReceipt, MutationPlanRecordedReceipt, NoMandateReason, ProcessGateKind,
+    ProcessGateResult, ProcessGateResultReceipt, ProcessSessionOpenedReceipt, ProofOutcome,
+    ReceiptMandateAttestation,
 };
 pub use proposal::{
     AllocationOption, DataSharingLevel, DisputeResolutionMethod, DisputeResolutionOutcome,

--- a/icn/crates/icn-governance/src/proof.rs
+++ b/icn/crates/icn-governance/src/proof.rs
@@ -3099,6 +3099,171 @@ impl MutationPlanRecordedReceipt {
     }
 }
 
+/// Seventh ADR-0026 Layer-2 `ProcessTransitionReceipt` class (per the #2307
+/// contract `docs/design/mutation-applied-receipt.md` + the #2308 A1/A2/A3/A4
+/// decision rung `docs/design/mutation-applied-receipt-decision-rung.md`).
+///
+/// Witnesses that a previously recorded **mutation plan was applied**, recorded
+/// after a [`MutationPlanRecordedReceipt`] for the same session. It records a
+/// **process fact and grants zero authority.** It is NOT a mutation-application
+/// engine: recording an application performs no domain-state mutation beyond
+/// persisting this receipt, and the receipt does not execute, authorize,
+/// validate, enforce, roll back, or prove the semantic correctness of the
+/// mutation (A4).
+///
+/// **A1 — plan reference.** The application names the plan it applies by BOTH
+/// its caller-opaque `plan_id` and the content-addressed `plan_record_hash`
+/// (the `record_hash` of the referenced `MutationPlanRecordedReceipt`). The
+/// reference is verified fail-closed before the application is recorded (the
+/// plan must exist in the same `(domain_id, session_id)` with a matching
+/// `plan_id`). The activation, decision, and gate basis are inherited
+/// transitively through the plan → activation chain and are NOT re-referenced.
+///
+/// **A2 — `result_hash`-only.** A caller-supplied 32-byte fingerprint of the
+/// application-result record; the applied-result body — its operation list,
+/// target list, effect payload, or any typed operation/result/effect model — is
+/// never stored (meaning firewall). Named distinctly from the plan's
+/// `body_hash` to mark the applied-result artifact. No application-kind
+/// taxonomy.
+///
+/// **A3 — a single `applied_at`**, hashed into `record_hash` but **excluded**
+/// from duplicate identity — identical treatment to the six landed classes'
+/// `recorded_at`. A retry never restamps.
+///
+/// **At most one application exists per `(domain_id, session_id,
+/// application_id)`** — the receipt backend enforces uniqueness atomically at
+/// the storage layer. A retry with identical stable identity (`plan_id`,
+/// `plan_record_hash`, `applied_by`, `result_hash`) returns this original
+/// receipt unchanged (never restamped); any mismatch fails closed.
+///
+/// `applied_by` is actor evidence — the recorder / apply-witness of the
+/// application, not an authority to apply or act ("recorder, not applier").
+/// Equality is anchored to `record_hash`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MutationAppliedReceipt {
+    /// Governance domain the session (and this application) is scoped to.
+    pub domain_id: String,
+    /// Identifier of the already-opened process session this application
+    /// attaches to. Caller-provided, treated as opaque, meaningful only
+    /// together with `domain_id` (session ids are not globally unique).
+    pub session_id: String,
+    /// Caller-supplied opaque identifier for this application, unique within
+    /// `(domain_id, session_id)` — uniqueness is enforced at the storage
+    /// layer, not assumed of the id.
+    pub application_id: String,
+    /// Caller-opaque `plan_id` of the [`MutationPlanRecordedReceipt`] this
+    /// application applies — the human/index handle (A1).
+    pub plan_id: String,
+    /// Content-addressed `record_hash` of that [`MutationPlanRecordedReceipt`]
+    /// — the cryptographic proof link (A1). Verified to exist in-session
+    /// before the application is recorded.
+    pub plan_record_hash: Hash,
+    /// DID of the authenticated actor who recorded the application — recorder /
+    /// apply-witness evidence, not an authority to apply or act. Grants zero
+    /// authority.
+    pub applied_by: String,
+    /// Caller-supplied 32-byte content fingerprint of the application-result
+    /// record (A2). The applied-result body itself is never stored in the
+    /// receipt.
+    pub result_hash: Hash,
+    /// Unix-seconds the application was applied. Not part of duplicate identity
+    /// — a retry never restamps (A3).
+    pub applied_at: u64,
+    /// blake3 canonical record hash binding the fields above.
+    pub record_hash: Hash,
+}
+
+impl PartialEq for MutationAppliedReceipt {
+    fn eq(&self, other: &Self) -> bool {
+        self.record_hash == other.record_hash
+    }
+}
+
+impl Eq for MutationAppliedReceipt {}
+
+impl MutationAppliedReceipt {
+    /// Domain separation tag for canonical mutation-applied record hashes.
+    /// Distinct from every other receipt-family tag — and in particular it must
+    /// NEVER converge with `icn:gov:mutation_plan_recorded:v1`,
+    /// `icn:gov:activation_crossed:v1`, `icn:gov:decision_recorded:v1`,
+    /// `icn:gov:process_gate_result:v1`, or the proposal/vote
+    /// `icn:gov:decision:v1/v2/v3` lineage.
+    pub const DOMAIN_TAG: &[u8] = b"icn:gov:mutation_applied:v1";
+
+    /// Build a new receipt and compute its canonical `record_hash`.
+    ///
+    /// `result_hash` is a caller-supplied fingerprint of the never-stored
+    /// application-result record (A2), mirroring how the plan/decision/
+    /// deliberation classes take a pre-computed body fingerprint.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        domain_id: String,
+        session_id: String,
+        application_id: String,
+        plan_id: String,
+        plan_record_hash: Hash,
+        applied_by: String,
+        result_hash: Hash,
+        applied_at: u64,
+    ) -> Self {
+        let record_hash = Self::compute_record_hash(
+            &domain_id,
+            &session_id,
+            &application_id,
+            &plan_id,
+            &plan_record_hash,
+            &applied_by,
+            &result_hash,
+            applied_at,
+        );
+        Self {
+            domain_id,
+            session_id,
+            application_id,
+            plan_id,
+            plan_record_hash,
+            applied_by,
+            result_hash,
+            applied_at,
+            record_hash,
+        }
+    }
+
+    /// Compute the canonical record hash from the input fields.
+    ///
+    /// Layout (per the #2307 contract as resolved by the #2308 A1/A2/A3/A4
+    /// decision rung §8): [`Self::DOMAIN_TAG`] first; each string field
+    /// length-prefixed (u64 LE) in order `domain_id`, `session_id`,
+    /// `application_id`, `plan_id`, `applied_by`; then `plan_record_hash` and
+    /// `result_hash` appended **raw as fixed 32-byte fields with no length
+    /// prefix** (fixed-size fields cannot alias); then `applied_at` as LE
+    /// bytes. No discriminant byte (this class has no kind taxonomy).
+    #[allow(clippy::too_many_arguments)]
+    pub fn compute_record_hash(
+        domain_id: &str,
+        session_id: &str,
+        application_id: &str,
+        plan_id: &str,
+        plan_record_hash: &Hash,
+        applied_by: &str,
+        result_hash: &Hash,
+        applied_at: u64,
+    ) -> Hash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(Self::DOMAIN_TAG);
+        for field in [domain_id, session_id, application_id, plan_id, applied_by] {
+            hasher.update(&(field.len() as u64).to_le_bytes());
+            hasher.update(field.as_bytes());
+        }
+        hasher.update(plan_record_hash);
+        hasher.update(result_hash);
+        hasher.update(&applied_at.to_le_bytes());
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hasher.finalize().as_bytes());
+        out
+    }
+}
+
 // ============================================================================
 // Mandate grant reference (#1868 step 2 primitive — wire form only)
 // ============================================================================
@@ -5286,6 +5451,313 @@ mod tests {
             assert!(
                 !lower.contains(forbidden),
                 "MutationPlanRecordedReceipt JSON must not contain `{forbidden}`; got: {json}"
+            );
+        }
+    }
+
+    // ============================================================================
+    // MutationAppliedReceipt — seventh ProcessTransitionReceipt class (per the
+    // #2307 contract + #2308 A1/A2/A3/A4 decision rung)
+    // ============================================================================
+
+    fn sample_mutation_applied_receipt() -> MutationAppliedReceipt {
+        MutationAppliedReceipt::new(
+            "domain-food-coop".to_string(),
+            "session-alpha".to_string(),
+            "application-001".to_string(),
+            "plan-001".to_string(),
+            [7u8; 32],                        // plan_record_hash (A1 proof link)
+            "did:icn:recorder-1".to_string(), // recorder, not applier
+            [5u8; 32],                        // result_hash (A2 fingerprint)
+            1_750_000_000,
+        )
+    }
+
+    #[test]
+    fn mutation_applied_golden_vector() {
+        // Golden canonical hash vector: pins the FULL v1 layout (domain tag,
+        // length-prefixed strings domain_id/session_id/application_id/plan_id/
+        // applied_by, raw fixed 32-byte plan_record_hash then result_hash,
+        // applied_at LE — no discriminant byte). Any layout change breaks this
+        // test and requires a new tag version, not an edit here.
+        let r = sample_mutation_applied_receipt();
+        assert_eq!(
+            hex32(&r.record_hash),
+            "0a1c4ad25af114acc04242cafd85d08a52e9c0859541c6123c3a0aa6873a2227",
+            "canonical v1 hash layout drifted"
+        );
+    }
+
+    #[test]
+    fn mutation_applied_record_hash_determinism() {
+        let r1 = sample_mutation_applied_receipt();
+        let r2 = sample_mutation_applied_receipt();
+        assert_eq!(r1.record_hash, r2.record_hash);
+        assert_ne!(r1.record_hash, [0u8; 32]);
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn mutation_applied_record_hash_changes_per_field() {
+        // Each field independently changes the hash — including
+        // plan_record_hash and result_hash (the A1/A2 links) and applied_at.
+        let base = sample_mutation_applied_receipt();
+        let variants = [
+            MutationAppliedReceipt::new(
+                "domain-other".to_string(),
+                base.session_id.clone(),
+                base.application_id.clone(),
+                base.plan_id.clone(),
+                base.plan_record_hash,
+                base.applied_by.clone(),
+                base.result_hash,
+                base.applied_at,
+            ),
+            MutationAppliedReceipt::new(
+                base.domain_id.clone(),
+                "session-other".to_string(),
+                base.application_id.clone(),
+                base.plan_id.clone(),
+                base.plan_record_hash,
+                base.applied_by.clone(),
+                base.result_hash,
+                base.applied_at,
+            ),
+            MutationAppliedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                "application-other".to_string(),
+                base.plan_id.clone(),
+                base.plan_record_hash,
+                base.applied_by.clone(),
+                base.result_hash,
+                base.applied_at,
+            ),
+            MutationAppliedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.application_id.clone(),
+                "plan-other".to_string(),
+                base.plan_record_hash,
+                base.applied_by.clone(),
+                base.result_hash,
+                base.applied_at,
+            ),
+            MutationAppliedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.application_id.clone(),
+                base.plan_id.clone(),
+                [8u8; 32],
+                base.applied_by.clone(),
+                base.result_hash,
+                base.applied_at,
+            ),
+            MutationAppliedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.application_id.clone(),
+                base.plan_id.clone(),
+                base.plan_record_hash,
+                "did:icn:applier-other".to_string(),
+                base.result_hash,
+                base.applied_at,
+            ),
+            MutationAppliedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.application_id.clone(),
+                base.plan_id.clone(),
+                base.plan_record_hash,
+                base.applied_by.clone(),
+                [6u8; 32],
+                base.applied_at,
+            ),
+            MutationAppliedReceipt::new(
+                base.domain_id.clone(),
+                base.session_id.clone(),
+                base.application_id.clone(),
+                base.plan_id.clone(),
+                base.plan_record_hash,
+                base.applied_by.clone(),
+                base.result_hash,
+                base.applied_at + 1,
+            ),
+        ];
+        for (i, v) in variants.iter().enumerate() {
+            assert_ne!(
+                base.record_hash, v.record_hash,
+                "variant {i} must change the record hash"
+            );
+        }
+    }
+
+    #[test]
+    fn mutation_applied_tag_separates_from_other_families() {
+        // Family separation from the six landed process-transition classes.
+        assert_ne!(
+            MutationAppliedReceipt::DOMAIN_TAG,
+            ProcessSessionOpenedReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationAppliedReceipt::DOMAIN_TAG,
+            ProcessGateResultReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationAppliedReceipt::DOMAIN_TAG,
+            DeliberationEntryRecordedReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationAppliedReceipt::DOMAIN_TAG,
+            DecisionRecordedReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationAppliedReceipt::DOMAIN_TAG,
+            ActivationCrossedReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationAppliedReceipt::DOMAIN_TAG,
+            MutationPlanRecordedReceipt::DOMAIN_TAG
+        );
+        // Must NEVER converge with the proposal/vote decision lineage.
+        assert_ne!(
+            MutationAppliedReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceipt::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationAppliedReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceiptV2::DOMAIN_TAG
+        );
+        assert_ne!(
+            MutationAppliedReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceiptV3::DOMAIN_TAG
+        );
+        let applied = sample_mutation_applied_receipt();
+        let plan = sample_mutation_plan_recorded_receipt();
+        assert_ne!(applied.record_hash, plan.record_hash);
+    }
+
+    #[test]
+    fn mutation_applied_length_prefix_prevents_field_shifting() {
+        // Shifting bytes between adjacent string fields must change the hash —
+        // the length prefix delimits each field exactly.
+        let a = MutationAppliedReceipt::compute_record_hash(
+            "ab",
+            "c",
+            "application-001",
+            "plan-001",
+            &[0u8; 32],
+            "did:icn:x",
+            &[0u8; 32],
+            1,
+        );
+        let b = MutationAppliedReceipt::compute_record_hash(
+            "a",
+            "bc",
+            "application-001",
+            "plan-001",
+            &[0u8; 32],
+            "did:icn:x",
+            &[0u8; 32],
+            1,
+        );
+        assert_ne!(a, b, "domain/session byte shift must change the hash");
+        let c = MutationAppliedReceipt::compute_record_hash(
+            "d",
+            "s",
+            "xy",
+            "z",
+            &[0u8; 32],
+            "did:icn:x",
+            &[0u8; 32],
+            1,
+        );
+        let d = MutationAppliedReceipt::compute_record_hash(
+            "d",
+            "s",
+            "x",
+            "yz",
+            &[0u8; 32],
+            "did:icn:x",
+            &[0u8; 32],
+            1,
+        );
+        assert_ne!(
+            c, d,
+            "application_id/plan_id byte shift must change the hash"
+        );
+    }
+
+    #[test]
+    fn mutation_applied_serde_roundtrip_and_payload_audit() {
+        // Round-trip preserves everything (equality anchored to record_hash),
+        // and the persisted payload carries ONLY the v1 field set — no applied
+        // result body, plan body, operation list, target, or effect payload.
+        let r = sample_mutation_applied_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let back: MutationAppliedReceipt = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(r, back);
+        assert_eq!(back.applied_at, r.applied_at);
+        assert_eq!(back.plan_record_hash, r.plan_record_hash);
+        assert_eq!(back.result_hash, r.result_hash);
+        let value: serde_json::Value = serde_json::from_str(&json).expect("value");
+        let obj = value.as_object().expect("object");
+        let expected: std::collections::BTreeSet<&str> = [
+            "domain_id",
+            "session_id",
+            "application_id",
+            "plan_id",
+            "plan_record_hash",
+            "applied_by",
+            "result_hash",
+            "applied_at",
+            "record_hash",
+        ]
+        .into_iter()
+        .collect();
+        let actual: std::collections::BTreeSet<&str> = obj.keys().map(|k| k.as_str()).collect();
+        assert_eq!(
+            actual, expected,
+            "payload must carry exactly the v1 field set — no applied-result body, \
+             plan body, operation list, target list, or effect payload"
+        );
+    }
+
+    #[test]
+    fn mutation_applied_no_prohibited_vocabulary() {
+        // "applied" is core vocabulary for this class (applied_by / applied_at),
+        // so it is NOT forbidden here. Instead this enforces the A4 boundary:
+        // no authority/execution overclaim leaks into the payload, and no
+        // regulated-finance or proposal/vote lineage vocabulary appears.
+        let r = sample_mutation_applied_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let lower = json.to_lowercase();
+        for forbidden in [
+            // regulated-finance vocabulary (same list as the sibling
+            // process-receipt tests)
+            "wallet",
+            "balance",
+            "currency",
+            "payment",
+            "withdraw",
+            "deposit",
+            // A4 no-overclaim: the receipt records a fact, it does not execute,
+            // authorize, verify, or roll back the mutation
+            "authorized",
+            "executed",
+            "verified",
+            "rolled back",
+            "roll back",
+            // proposal/vote lineage vocabulary
+            "proposal",
+            "vote",
+            "tally",
+            "quorum",
+            "mandate",
+        ] {
+            assert!(
+                !lower.contains(forbidden),
+                "MutationAppliedReceipt JSON must not contain `{forbidden}`; got: {json}"
             );
         }
     }


### PR DESCRIPTION
## What

Adds `MutationAppliedReceipt`, the seventh ADR-0026 Layer-2 `ProcessTransitionReceipt` class, after `MutationPlanRecordedReceipt`.

It witnesses that a previously recorded mutation plan was applied, recorded after the plan. The receipt records a process fact and grants zero authority.

## Why

Implements the runtime slice after the merged `MutationAppliedReceipt` design/audit contract (#2306/#2307) and A1/A2/A3/A4 decision rung (#2308/#2309).

## How

- **`icn-governance`** (`proof.rs`, `lib.rs`): new `MutationAppliedReceipt` with tag `icn:gov:mutation_applied:v1`, canonical `record_hash`, `PartialEq`/`Eq` on `record_hash` only, public export, and proof unit tests.
- **`apps/governance`** (`receipt_backend.rs`, `manager.rs`): class `mutation_applied`, injective composite key for `(domain_id, session_id)`, `key2 = application_id`, persistence through `put_opaque_if_absent`, manager method `record_mutation_applied`, `MutationAppliedOutcome` enum, get/list helpers, and a runtime-slice test.
- **A1:** the application references the plan by **both** `plan_id` and content-addressed `plan_record_hash`, verified fail-closed in the same `(domain_id, session_id)` (via `get_mutation_plan_recorded` then `record_hash` compare). Activation, decision, and gate basis are inherited transitively through the plan → activation chain.
- **A2:** `result_hash`-only (distinct name from the plan's `body_hash`). No applied-result body, operation list, target list, effect payload, typed model, or application-kind taxonomy is stored.
- **A3:** single `applied_at`, hashed into `record_hash` but excluded from stable duplicate identity. Same-identity retry returns the original receipt and never restamps.
- **A4:** "applied" is an application **fact recorded** — recording it performs no domain-state mutation beyond persisting the receipt, and the receipt does not execute, authorize, validate, enforce, roll back, or prove correctness. `applied_by` is recorder / apply-witness evidence granting zero authority.

Stable duplicate identity: `(domain_id, session_id, application_id, plan_id, plan_record_hash, applied_by, result_hash)`. Conflict on a changed identity for the same `(domain, session, application_id)` fails closed with the stable `mutation_applied_conflict` prefix. No HTTP route, OpenAPI/SDK, member-shell, or `STATE.md`/`PHASE_PROGRESS.md` change (governance crate + app only).

## Validation

- `cargo fmt --all --check` — clean.
- `cargo test -p icn-governance mutation_applied` — **7 passed** (golden vector `0a1c4ad2…`, determinism, per-field, tag-disjointness, length-prefix, serde/payload audit, A4 no-overclaim vocabulary).
- `cargo test -p icn-governance-actor --test mutation_applied_receipt_runtime_slice` — **17 passed** (happy path w/ verified A1 link, idempotent retry, unopened session, missing/wrong-session/wrong-domain/hash-mismatched plan, conflict on plan-ref/result-hash/applier, empty/whitespace ids, missing store, backend failure, concurrency, composite-key injectivity, two-domain isolation, payload audit).
- `cargo test -p icn-governance -p icn-governance-actor` — full governance suites green, no regression in the six sibling process-receipt classes.
- `cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings` — clean.
- `python3 docs/scripts/route_inventory.py --check` — **OK** (287 routes, unchanged; no route added).
- `ops/scripts/drift-check.sh` — PASS. `git diff --check` — clean. Scope — `icn/crates/icn-governance/` + `icn/apps/governance/` only. Close-keyword scan — clean. Overclaim scan — clean.

## Non-claims

- No mutation application engine — recording an application performs no domain-state mutation beyond persisting the receipt.
- No execution, authorization, validation, enforcement, rollback, or proof of semantic correctness.
- No `EvidencePacketProducedReceipt`.
- No evidence-packet producer.
- No action-card trigger.
- No workflow engine.
- No new authorization semantics.
- No applied-result body storage.
- No plan body storage.
- No operation list / target list / effect payload storage.
- No typed/kernel-readable mutation operation/result/effect model.
- No application-kind taxonomy.
- No verifiable-effect binding (deferred to a future `:v2`).
- No HTTP route / OpenAPI / SDK / served-schema change.
- No member-shell implementation.
- No human/AT execution.
- Not #2041 completion.
- Not production-ready.
- Not pilot-ready.
- Not organizer-ready.
- Not member-ready.
- Not live federation.
- Not NYCN activation.
- Not Phase 2 completion.
- #1748 and #2141 remain open.
- #2041 remains open/parked.

## Refs

Refs #2308.
Refs #2309.
Refs #2307.
Refs #2306.
Refs #2303.
Refs #1748.
Refs #2141.
Refs #2041.
