### PR TITLE
feat(process): emit evidence packet produced receipt

### DIFF
--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -7303,6 +7303,19 @@ impl GovernanceManager {
             ));
         }
 
+        // Fail fast on an empty source set with the documented stable prefix,
+        // before the more specific predecessor-in-set check below (an empty set
+        // trivially cannot contain the predecessor, so without this the empty
+        // case would surface the less precise `_predecessor_not_in_set`).
+        if source_refs.is_empty() {
+            return Err(anyhow::anyhow!(
+                "evidence_packet_produced_empty_source_set: packet {packet_id} in session \
+                 {session_id} in domain {} declared an empty source set; a produced packet \
+                 must draw from at least its immediate predecessor",
+                domain_id.0
+            ));
+        }
+
         // The declared source set must include the immediate predecessor (EP1).
         if !source_refs
             .iter()

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -2822,6 +2822,31 @@ pub enum MutationAppliedOutcome {
     AlreadyApplied(icn_governance::MutationAppliedReceipt),
 }
 
+/// Outcome of [`GovernanceManager::record_evidence_packet_produced`] (#2314
+/// contract + #2316 EP1–EP5 decision rung). Both variants are successes; the
+/// fail-closed mismatch conflict surfaces as an `Err` with stable prefix
+/// `evidence_packet_produced_conflict`. Precondition failures surface as `Err`s
+/// with their own stable prefixes and persist nothing:
+/// `evidence_packet_produced_session_not_opened` (unopened session),
+/// `evidence_packet_produced_predecessor_not_found` /
+/// `evidence_packet_produced_predecessor_mismatch` (EP1 immediate predecessor
+/// absent or hash-mismatched), `evidence_packet_produced_empty_source_set` /
+/// `evidence_packet_produced_duplicate_source` (invalid source set), and
+/// `evidence_packet_produced_predecessor_not_in_set` (the immediate predecessor
+/// is missing from the declared source set).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvidencePacketProducedOutcome {
+    /// This call recorded the packet: the receipt is the newly persisted
+    /// evidence-packet-produced fact.
+    Produced(icn_governance::EvidencePacketProducedReceipt),
+    /// The packet was already recorded with the **same** stable identity
+    /// (`mutation_application_id`, `mutation_applied_record_hash`,
+    /// `receipt_set_hash`, `packet_hash`, `redaction_profile_hash`,
+    /// `produced_by`); carries the **original** persisted receipt (original
+    /// `produced_at` / `record_hash` — a retry is never restamped).
+    AlreadyProduced(icn_governance::EvidencePacketProducedReceipt),
+}
+
 /// Action items are always managed locally (not gossiped) and can use either
 /// in-memory or Sled-backed persistent storage.
 pub struct GovernanceManager {
@@ -7140,6 +7165,254 @@ impl GovernanceManager {
         store
             .list_mutation_applied_for_session_in_domain(&domain_id.0, session_id)
             .map_err(|e| anyhow::anyhow!("Failed to list mutation-applied receipts: {e}"))
+    }
+
+    /// Record that a redacted evidence packet artifact was produced from a set
+    /// of prior process receipts — the eighth `ProcessTransitionReceipt` class
+    /// (#2314 contract + #2316 EP1–EP5 decision rung). Records a process fact and
+    /// grants zero authority; it does not produce, deliver, certify, audit,
+    /// execute, authorize, validate, enforce, or roll back anything.
+    ///
+    /// Fail-closed preconditions (on any failure nothing is persisted):
+    /// - all ids are non-empty / non-whitespace;
+    /// - a receipt store is wired (uniqueness and the predecessor precondition
+    ///   are enforced at the storage layer and cannot be faked in memory);
+    /// - the `(domain_id, session_id)` session was opened first
+    ///   (`evidence_packet_produced_session_not_opened`);
+    /// - EP1: a [`icn_governance::MutationAppliedReceipt`] exists in the **same**
+    ///   `(domain_id, session_id)` under `mutation_application_id`
+    ///   (`evidence_packet_produced_predecessor_not_found`) and its `record_hash`
+    ///   equals the supplied `mutation_applied_record_hash`
+    ///   (`evidence_packet_produced_predecessor_mismatch`);
+    /// - the source set is non-empty and free of duplicate `record_hash` members
+    ///   (`evidence_packet_produced_empty_source_set` /
+    ///   `evidence_packet_produced_duplicate_source`);
+    /// - the source set includes `mutation_applied_record_hash`
+    ///   (`evidence_packet_produced_predecessor_not_in_set`).
+    ///
+    /// On success returns [`EvidencePacketProducedOutcome::Produced`]; a
+    /// same-identity retry returns [`EvidencePacketProducedOutcome::AlreadyProduced`]
+    /// carrying the **original** receipt (never restamped). A same-`packet_id`
+    /// record with a different stable identity fails closed with the stable
+    /// `evidence_packet_produced_conflict` prefix.
+    ///
+    /// `source_refs` are hashes/references only, used solely to compute and
+    /// validate `receipt_set_hash`; no receipt body is stored. Per the #2316
+    /// rung §4 the mandatory floor is immediate-predecessor verification (above);
+    /// full per-member in-session verification of the source set is a
+    /// recommended default deferred here.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_evidence_packet_produced(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        packet_id: &str,
+        mutation_application_id: &str,
+        mutation_applied_record_hash: [u8; 32],
+        source_refs: &[icn_governance::EvidencePacketSourceRef],
+        packet_hash: [u8; 32],
+        redaction_profile_hash: [u8; 32],
+        produced_by: &Did,
+    ) -> Result<EvidencePacketProducedOutcome> {
+        // Whitespace-only ids are rejected alongside empty ones: a caller
+        // bypassing the HTTP layer must not mint receipts with visually-empty
+        // identifiers or whitespace storage keys.
+        if domain_id.0.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_produced: domain_id must be non-empty and non-whitespace"
+            ));
+        }
+        if session_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_produced: session_id must be non-empty and non-whitespace"
+            ));
+        }
+        if packet_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_produced: packet_id must be non-empty and non-whitespace"
+            ));
+        }
+        if mutation_application_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_produced: mutation_application_id must be non-empty and \
+                 non-whitespace"
+            ));
+        }
+        let produced_by_str = produced_by.to_string();
+        if produced_by_str.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_produced: produced_by must be non-empty"
+            ));
+        }
+        let store = self.receipt_store.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "record_evidence_packet_produced: a receipt store is required — packet \
+                 uniqueness and the predecessor precondition are enforced at the storage \
+                 layer and cannot be faked in memory"
+            )
+        })?;
+
+        // Precondition: the session was opened first. No silent creation.
+        let opened = store
+            .get_process_session_opened(&domain_id.0, session_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_evidence_packet_produced: failed to read session-open state for \
+                     session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        if opened.is_none() {
+            return Err(anyhow::anyhow!(
+                "evidence_packet_produced_session_not_opened: session {session_id} in domain {} \
+                 has no recorded opening; refusing to record a packet against an unanchored session",
+                domain_id.0
+            ));
+        }
+
+        // EP1 precondition: the applied step this packet draws from must exist in
+        // this same (domain, session) under `mutation_application_id`, and its
+        // `record_hash` must equal the supplied `mutation_applied_record_hash`.
+        // The composite storage key makes an application recorded under a
+        // different session/domain invisible here, so a wrong-session/wrong-domain
+        // reference fails closed as "not found".
+        let applied = store
+            .get_mutation_applied(&domain_id.0, session_id, mutation_application_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_evidence_packet_produced: failed to read applied state for \
+                     application {mutation_application_id} in session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        let applied = applied.ok_or_else(|| {
+            anyhow::anyhow!(
+                "evidence_packet_produced_predecessor_not_found: no application \
+                 {mutation_application_id} recorded in session {session_id} in domain {}; refusing \
+                 to record a packet for an unrecorded predecessor",
+                domain_id.0
+            )
+        })?;
+        if applied.record_hash != mutation_applied_record_hash {
+            return Err(anyhow::anyhow!(
+                "evidence_packet_produced_predecessor_mismatch: application \
+                 {mutation_application_id} in session {session_id} in domain {} was recorded with \
+                 a different record_hash than the one supplied; refusing to record a packet on a \
+                 mismatched predecessor reference",
+                domain_id.0
+            ));
+        }
+
+        // The declared source set must include the immediate predecessor (EP1).
+        if !source_refs
+            .iter()
+            .any(|r| r.record_hash == mutation_applied_record_hash)
+        {
+            return Err(anyhow::anyhow!(
+                "evidence_packet_produced_predecessor_not_in_set: the declared source set for \
+                 packet {packet_id} in session {session_id} in domain {} does not include the \
+                 immediate predecessor mutation_applied_record_hash; refusing to record",
+                domain_id.0
+            ));
+        }
+
+        // Canonical, order-independent, duplicate-free source-set commitment.
+        let receipt_set_hash =
+            icn_governance::EvidencePacketProducedReceipt::compute_receipt_set_hash(source_refs)
+                .map_err(|e| match e {
+                    icn_governance::EvidencePacketReceiptSetError::Empty => anyhow::anyhow!(
+                        "evidence_packet_produced_empty_source_set: packet {packet_id} in session \
+                         {session_id} in domain {} declared an empty source set; a produced packet \
+                         must draw from at least its immediate predecessor",
+                        domain_id.0
+                    ),
+                    icn_governance::EvidencePacketReceiptSetError::DuplicateMember => {
+                        anyhow::anyhow!(
+                            "evidence_packet_produced_duplicate_source: packet {packet_id} in \
+                             session {session_id} in domain {} declared a duplicate source \
+                             record_hash; duplicate members are disallowed and fail closed",
+                            domain_id.0
+                        )
+                    }
+                })?;
+
+        let now = icn_time::current_timestamp_secs();
+        let receipt = icn_governance::EvidencePacketProducedReceipt::new(
+            domain_id.0.clone(),
+            session_id.to_string(),
+            packet_id.to_string(),
+            mutation_application_id.to_string(),
+            mutation_applied_record_hash,
+            receipt_set_hash,
+            packet_hash,
+            redaction_profile_hash,
+            produced_by_str.clone(),
+            now,
+        );
+
+        match store.put_evidence_packet_produced(&receipt).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to persist evidence-packet-produced receipt for packet {packet_id} in \
+                 session {session_id} in domain {}: {e}",
+                domain_id.0
+            )
+        })? {
+            crate::receipt_backend::EvidencePacketProducedPersist::Inserted => {
+                Ok(EvidencePacketProducedOutcome::Produced(receipt))
+            }
+            crate::receipt_backend::EvidencePacketProducedPersist::Existing(original) => {
+                if original.mutation_application_id == mutation_application_id
+                    && original.mutation_applied_record_hash == mutation_applied_record_hash
+                    && original.receipt_set_hash == receipt_set_hash
+                    && original.packet_hash == packet_hash
+                    && original.redaction_profile_hash == redaction_profile_hash
+                    && original.produced_by == produced_by_str
+                {
+                    Ok(EvidencePacketProducedOutcome::AlreadyProduced(*original))
+                } else {
+                    Err(anyhow::anyhow!(
+                        "evidence_packet_produced_conflict: packet {packet_id} in session \
+                         {session_id} in domain {} was already recorded with a different \
+                         predecessor, source set, packet hash, redaction profile, or recorder; \
+                         refusing to overwrite",
+                        domain_id.0
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Retrieve the persisted evidence-packet-produced receipt for a
+    /// `(domain_id, session_id, packet_id)`, or `None` when no packet has been
+    /// recorded. Read-only.
+    pub fn get_evidence_packet_produced(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        packet_id: &str,
+    ) -> Result<Option<icn_governance::EvidencePacketProducedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(None);
+        };
+        store
+            .get_evidence_packet_produced(&domain_id.0, session_id, packet_id)
+            .map_err(|e| anyhow::anyhow!("Failed to read evidence-packet-produced receipt: {e}"))
+    }
+
+    /// List all evidence-packet-produced receipts recorded against one
+    /// `(domain_id, session_id)` anchor, in the store's deterministic
+    /// chronological `(produced_at, record_hash)` order. Read-only.
+    pub fn list_evidence_packet_produced_in_domain(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+    ) -> Result<Vec<icn_governance::EvidencePacketProducedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(vec![]);
+        };
+        store
+            .list_evidence_packet_produced_for_session_in_domain(&domain_id.0, session_id)
+            .map_err(|e| anyhow::anyhow!("Failed to list evidence-packet-produced receipts: {e}"))
     }
 
     // ========================================================================

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -4,8 +4,8 @@
 use icn_governance::{
     ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActivationCrossedReceipt,
     AuthorityGrant, AuthorityGrantId, DecisionRecordedReceipt, DeliberationEntryRecordedReceipt,
-    GovernanceDecisionReceipt, GovernanceDecisionReceiptV3, Grantee, Mandate,
-    MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, MutationAppliedReceipt,
+    EvidencePacketProducedReceipt, GovernanceDecisionReceipt, GovernanceDecisionReceiptV3, Grantee,
+    Mandate, MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, MutationAppliedReceipt,
     MutationPlanRecordedReceipt, ProcessGateKind, ProcessGateResultReceipt,
     ProcessSessionOpenedReceipt, Timestamp,
 };
@@ -257,6 +257,51 @@ pub enum MutationAppliedPersist {
     /// variant would make this enum needlessly large next to the unit
     /// `Inserted`.
     Existing(Box<MutationAppliedReceipt>),
+}
+
+/// Class string for `EvidencePacketProducedReceipt` opaque storage (#2314
+/// contract + #2316 EP1–EP5 decision rung). Chosen in the apps layer so the
+/// gateway never sees the typed name. Distinct from every other process class
+/// store.
+const EVIDENCE_PACKET_PRODUCED_CLASS: &str = "evidence_packet_produced";
+
+/// Build the injective composite `key1` binding a produced evidence packet to
+/// its `(domain_id, session_id)` anchor in opaque storage.
+///
+/// Sibling of [`mutation_applied_composite_key1`] with the identical
+/// netstring-style encoding (decimal length of `domain_id`, a colon, then the
+/// two ids concatenated), kept as a separate function so this class's key
+/// derivation is independently anchored by its own anti-aliasing test. The
+/// length prefix delimits `domain_id` exactly, so `("ab","c")` and `("a","bc")`
+/// can never produce the same key, and two domains sharing a `session_id` scan
+/// different `key1` prefixes.
+pub fn evidence_packet_produced_composite_key1(domain_id: &str, session_id: &str) -> String {
+    format!("{}:{domain_id}{session_id}", domain_id.len())
+}
+
+/// Outcome of persisting an [`EvidencePacketProducedReceipt`] through
+/// [`GovernanceReceiptBackend::put_evidence_packet_produced`].
+///
+/// The backend enforces at most one packet per `(domain_id, session_id,
+/// packet_id)` **atomically at the storage layer** (same `put_opaque_if_absent`
+/// primitive as the sibling process classes). The caller (the manager) turns
+/// `Existing` into either a same-identity idempotent success or a fail-closed
+/// conflict — stable identity is `mutation_application_id` +
+/// `mutation_applied_record_hash` + `receipt_set_hash` + `packet_hash` +
+/// `redaction_profile_hash` + `produced_by` (per the #2316 rung §9;
+/// `produced_at`/`record_hash` are NOT identity inputs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvidencePacketProducedPersist {
+    /// This call won the insert: the receipt is now the one persisted packet for
+    /// its `(domain_id, session_id, packet_id)`.
+    Inserted,
+    /// A packet already existed for this triple; nothing was written. Carries
+    /// the original persisted receipt (original `produced_at` / `record_hash` —
+    /// never restamped). Boxed because [`EvidencePacketProducedReceipt`] is a
+    /// large payload (five string fields plus four 32-byte hashes), so an
+    /// unboxed variant would make this enum needlessly large next to the unit
+    /// `Inserted`.
+    Existing(Box<EvidencePacketProducedReceipt>),
 }
 
 /// Class string for `MeetingAttendanceReceiptV2` opaque storage (#1868).
@@ -1535,6 +1580,101 @@ pub trait GovernanceReceiptBackend: Send + Sync {
             out.push(
                 serde_json::from_slice(&bytes)
                     .map_err(|e| format!("deserialize MutationAppliedReceipt in list: {e}"))?,
+            );
+        }
+        Ok(out)
+    }
+
+    /// Persist an [`EvidencePacketProducedReceipt`] emitted when the runtime
+    /// records that a redacted evidence packet artifact was produced (#2314
+    /// contract + #2316 rung).
+    ///
+    /// **Default routes through opaque storage.** Serialises the typed receipt
+    /// to JSON and delegates to [`Self::put_opaque_if_absent`] under class
+    /// `"evidence_packet_produced"` with `key1 =`
+    /// [`evidence_packet_produced_composite_key1`] (the injective domain+session
+    /// composite) and `key2 = packet_id`. On a lost insert the original
+    /// persisted receipt is hydrated and returned (never restamped). A backend
+    /// that has not opted in to opaque storage inherits the fail-closed
+    /// `opaque_storage_not_implemented` default.
+    fn put_evidence_packet_produced(
+        &self,
+        receipt: &EvidencePacketProducedReceipt,
+    ) -> Result<EvidencePacketProducedPersist, String> {
+        let payload = serde_json::to_vec(receipt)
+            .map_err(|e| format!("serialize EvidencePacketProducedReceipt: {e}"))?;
+        let key1 = evidence_packet_produced_composite_key1(&receipt.domain_id, &receipt.session_id);
+        let existing = self.put_opaque_if_absent(
+            EVIDENCE_PACKET_PRODUCED_CLASS,
+            &key1,
+            Some(&receipt.packet_id),
+            receipt.produced_at,
+            receipt.record_hash,
+            &payload,
+        )?;
+        match existing {
+            None => Ok(EvidencePacketProducedPersist::Inserted),
+            Some(_winning_hash) => {
+                let original = self
+                    .get_evidence_packet_produced(
+                        &receipt.domain_id,
+                        &receipt.session_id,
+                        &receipt.packet_id,
+                    )?
+                    .ok_or_else(|| {
+                        // The unique marker says a packet exists but the payload
+                        // cannot be hydrated — surface loudly rather than minting
+                        // a second packet.
+                        "evidence_packet_produced_inconsistent: unique marker present \
+                         but no persisted packet payload could be read"
+                            .to_string()
+                    })?;
+                Ok(EvidencePacketProducedPersist::Existing(Box::new(original)))
+            }
+        }
+    }
+
+    /// Retrieve the persisted [`EvidencePacketProducedReceipt`] for a
+    /// `(domain_id, session_id, packet_id)`, or `None` when no packet has been
+    /// recorded. Same key convention as [`Self::put_evidence_packet_produced`];
+    /// at most one packet exists per triple (uniqueness is enforced on write).
+    fn get_evidence_packet_produced(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+        packet_id: &str,
+    ) -> Result<Option<EvidencePacketProducedReceipt>, String> {
+        let key1 = evidence_packet_produced_composite_key1(domain_id, session_id);
+        let payload =
+            self.get_latest_opaque(EVIDENCE_PACKET_PRODUCED_CLASS, &key1, Some(packet_id))?;
+        match payload {
+            Some(bytes) => {
+                Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                    format!("deserialize EvidencePacketProducedReceipt: {e}")
+                })?))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// List all evidence-packet-produced receipts recorded against one
+    /// `(domain_id, session_id)` anchor, in the store's deterministic
+    /// chronological `(produced_at, record_hash)` order. Because `key1` is the
+    /// injective domain+session composite, two domains sharing a `session_id`
+    /// can never mix here — no payload-side filtering is needed.
+    fn list_evidence_packet_produced_for_session_in_domain(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+    ) -> Result<Vec<EvidencePacketProducedReceipt>, String> {
+        let key1 = evidence_packet_produced_composite_key1(domain_id, session_id);
+        let payloads = self.list_opaque_for(EVIDENCE_PACKET_PRODUCED_CLASS, &key1)?;
+        let mut out = Vec::with_capacity(payloads.len());
+        for bytes in payloads {
+            out.push(
+                serde_json::from_slice(&bytes).map_err(|e| {
+                    format!("deserialize EvidencePacketProducedReceipt in list: {e}")
+                })?,
             );
         }
         Ok(out)

--- a/icn/apps/governance/tests/evidence_packet_produced_receipt_runtime_slice.rs
+++ b/icn/apps/governance/tests/evidence_packet_produced_receipt_runtime_slice.rs
@@ -1,0 +1,980 @@
+//! Runtime-slice integration tests for the eighth `ProcessTransitionReceipt`
+//! class, `EvidencePacketProducedReceipt` (#2314 design/audit contract + #2316
+//! EP1–EP5 decision rung, issue #2317).
+//!
+//! These exercise `GovernanceManager::record_evidence_packet_produced` end to
+//! end through an opaque-backed test store (the analog of the production
+//! gateway-backed `ReceiptStore`), proving:
+//!
+//! 1. it requires an already-opened session and a verified immediate
+//!    predecessor (`MutationAppliedReceipt`) in the same `(domain, session)`;
+//! 2. the source set is canonicalized (order-independent), rejects duplicates,
+//!    and must include the immediate predecessor;
+//! 3. persistence is idempotent on stable identity and fail-closed on a
+//!    conflicting re-record;
+//! 4. no packet/profile/source body is ever stored.
+//!
+//! Mirrors `mutation_applied_receipt_runtime_slice.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use icn_governance::{
+    EvidencePacketSourceRef, GovernanceDecisionReceipt, GovernanceDomainId, ProcessGateKind,
+    ProcessGateResult,
+};
+use icn_governance_actor::manager::{
+    ActivationCrossedOutcome, DecisionRecordOutcome, EvidencePacketProducedOutcome,
+    GovernanceManager, MutationAppliedOutcome, MutationPlanRecordedOutcome,
+    ProcessSessionOpenOutcome,
+};
+use icn_governance_actor::receipt_backend::{
+    evidence_packet_produced_composite_key1, GovernanceReceiptBackend,
+};
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+
+// ============================================================================
+// Opaque-backed test store — exercises the trait's typed defaults end-to-end.
+// ============================================================================
+
+type ChainKey = (String, String, Option<String>);
+type ChainEntry = (u64, [u8; 32], Vec<u8>);
+
+#[derive(Default)]
+struct OpaqueUniqueBackend {
+    chains: Mutex<HashMap<ChainKey, Vec<ChainEntry>>>,
+    unique: Mutex<HashMap<ChainKey, [u8; 32]>>,
+}
+
+impl OpaqueUniqueBackend {
+    fn chain_len(&self, class: &str, key1: &str, key2: Option<&str>) -> usize {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .map_or(0, Vec::len)
+    }
+
+    fn raw_payload(&self, class: &str, key1: &str, key2: Option<&str>) -> Option<Vec<u8>> {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .and_then(|chain| chain.first().map(|(_, _, p)| p.clone()))
+    }
+}
+
+impl GovernanceReceiptBackend for OpaqueUniqueBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(())
+    }
+
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        let mut unique = self.unique.lock().unwrap();
+        if let Some(winner) = unique.get(&key) {
+            return Ok(Some(*winner));
+        }
+        unique.insert(key.clone(), record_hash);
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(None)
+    }
+
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        Ok(self.chains.lock().unwrap().get(&key).and_then(|chain| {
+            chain
+                .iter()
+                .max_by_key(|(t, h, _)| (*t, *h))
+                .map(|(_, _, p)| p.clone())
+        }))
+    }
+
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        let chains = self.chains.lock().unwrap();
+        let mut hits: Vec<ChainEntry> = chains
+            .iter()
+            .filter(|((c, k1, _), _)| c == class && k1 == key1)
+            .flat_map(|(_, chain)| chain.iter().cloned())
+            .collect();
+        hits.sort_by_key(|(t, h, _)| (*t, *h));
+        Ok(hits.into_iter().map(|(_, _, p)| p).collect())
+    }
+}
+
+/// Backend that persists everything except the evidence-packet-produced insert
+/// — proves fail-closed packet persistence with all preconditions satisfied
+/// (the full applied chain is recorded through the same store first).
+#[derive(Default)]
+struct FailingEvidencePacketProducedBackend {
+    inner: OpaqueUniqueBackend,
+}
+
+impl GovernanceReceiptBackend for FailingEvidencePacketProducedBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        self.inner
+            .put_opaque(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        if class == "evidence_packet_produced" {
+            return Err("simulated evidence-packet-produced backend failure".to_string());
+        }
+        self.inner
+            .put_opaque_if_absent(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        self.inner.get_latest_opaque(class, key1, key2)
+    }
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        self.inner.list_opaque_for(class, key1)
+    }
+}
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_manager() -> (GovernanceManager, Arc<OpaqueUniqueBackend>) {
+    let store = Arc::new(OpaqueUniqueBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    (mgr, store)
+}
+
+fn coop_test() -> GovernanceDomainId {
+    GovernanceDomainId::new("coop:test")
+}
+
+fn pkt_key1(domain: &str, session: &str) -> String {
+    evidence_packet_produced_composite_key1(domain, session)
+}
+
+fn open_session(mgr: &GovernanceManager, domain: &GovernanceDomainId, session: &str, by: &Did) {
+    match mgr
+        .record_process_session_opened(domain, session, by)
+        .unwrap()
+    {
+        ProcessSessionOpenOutcome::Opened(_) | ProcessSessionOpenOutcome::AlreadyOpened(_) => {}
+    }
+}
+
+/// Record the full chain up to a recorded `MutationAppliedReceipt` and return
+/// its `record_hash` — the EP1 immediate-predecessor link a produced packet
+/// references. The activation/plan ids are derived from `application_id`.
+fn setup_applied(
+    mgr: &GovernanceManager,
+    domain: &GovernanceDomainId,
+    session: &str,
+    application_id: &str,
+    by: &Did,
+) -> [u8; 32] {
+    let plan_id = format!("plan-for-{application_id}");
+    let activation_id = format!("activation-for-{plan_id}");
+    open_session(mgr, domain, session, by);
+    let decision_id = format!("decision-for-{activation_id}");
+    let decision_hash = match mgr
+        .record_decision(domain, session, &decision_id, by, [9u8; 32])
+        .unwrap()
+    {
+        DecisionRecordOutcome::Recorded(r) | DecisionRecordOutcome::AlreadyRecorded(r) => {
+            r.record_hash
+        }
+    };
+    let gate_hash = mgr
+        .record_process_gate_result(
+            domain,
+            session,
+            ProcessGateKind::PrivacyReview,
+            ProcessGateResult::Pass,
+            by,
+        )
+        .unwrap()
+        .record_hash;
+    let activation_hash = match mgr
+        .record_activation_crossed(
+            domain,
+            session,
+            &activation_id,
+            &decision_id,
+            decision_hash,
+            &[gate_hash],
+            by,
+        )
+        .unwrap()
+    {
+        ActivationCrossedOutcome::Crossed(r) | ActivationCrossedOutcome::AlreadyCrossed(r) => {
+            r.record_hash
+        }
+    };
+    let plan_hash = match mgr
+        .record_mutation_plan_recorded(
+            domain,
+            session,
+            &plan_id,
+            &activation_id,
+            activation_hash,
+            [5u8; 32],
+            by,
+        )
+        .unwrap()
+    {
+        MutationPlanRecordedOutcome::Recorded(r)
+        | MutationPlanRecordedOutcome::AlreadyRecorded(r) => r.record_hash,
+    };
+    match mgr
+        .record_mutation_applied(
+            domain,
+            session,
+            application_id,
+            &plan_id,
+            plan_hash,
+            [4u8; 32],
+            by,
+        )
+        .unwrap()
+    {
+        MutationAppliedOutcome::Applied(r) | MutationAppliedOutcome::AlreadyApplied(r) => {
+            r.record_hash
+        }
+    }
+}
+
+/// Minimal valid source set: the immediate predecessor (MutationApplied,
+/// ladder 6). Callers may extend it.
+fn source_set(applied_hash: [u8; 32]) -> Vec<EvidencePacketSourceRef> {
+    vec![EvidencePacketSourceRef {
+        ladder_position: 6,
+        record_hash: applied_hash,
+    }]
+}
+
+// ============================================================================
+// Happy path — construct, persist, retrieve, verify EP1 link
+// ============================================================================
+
+#[test]
+fn packet_persists_and_returns_receipt_with_verified_predecessor() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+
+    let outcome = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &source_set(ah),
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect("first packet must succeed");
+    let EvidencePacketProducedOutcome::Produced(receipt) = outcome else {
+        panic!("first packet must be Produced, got {outcome:?}");
+    };
+    assert_eq!(receipt.domain_id, "coop:test");
+    assert_eq!(receipt.session_id, "session-001");
+    assert_eq!(receipt.packet_id, "packet-001");
+    assert_eq!(receipt.mutation_application_id, "application-001");
+    assert_eq!(receipt.produced_by, actor.to_string());
+    assert_eq!(receipt.packet_hash, [5u8; 32]);
+    assert_eq!(receipt.redaction_profile_hash, [9u8; 32]);
+    assert_ne!(receipt.record_hash, [0u8; 32], "real blake3 hash");
+    assert_ne!(receipt.receipt_set_hash, [0u8; 32], "real set hash");
+    // EP1: mutation_applied_record_hash equals the persisted applied receipt hash.
+    assert_eq!(
+        receipt.mutation_applied_record_hash, ah,
+        "EP1 proof link binds the recorded application's real record_hash"
+    );
+    assert_eq!(
+        store.chain_len(
+            "evidence_packet_produced",
+            &pkt_key1("coop:test", "session-001"),
+            Some("packet-001"),
+        ),
+        1,
+        "exactly one persisted packet"
+    );
+    let read = mgr
+        .get_evidence_packet_produced(&domain, "session-001", "packet-001")
+        .unwrap()
+        .expect("point read must hydrate");
+    assert_eq!(read, receipt);
+}
+
+// ============================================================================
+// Idempotency + conflict
+// ============================================================================
+
+#[test]
+fn same_identity_retry_returns_original_never_restamped() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+
+    let first = match mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &source_set(ah),
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .unwrap()
+    {
+        EvidencePacketProducedOutcome::Produced(r) => r,
+        other => panic!("expected Produced, got {other:?}"),
+    };
+    // Retry with byte-identical inputs — same stable identity, no restamp.
+    let retry = match mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &source_set(ah),
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .unwrap()
+    {
+        EvidencePacketProducedOutcome::AlreadyProduced(r) => r,
+        other => panic!("expected AlreadyProduced, got {other:?}"),
+    };
+    assert_eq!(retry, first, "retry returns the original, never restamped");
+    assert_eq!(retry.produced_at, first.produced_at);
+    assert_eq!(retry.record_hash, first.record_hash);
+}
+
+#[test]
+fn caller_source_order_cannot_fork_receipt_set_hash() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+    let applied = mgr
+        .get_mutation_applied(&domain, "session-001", "application-001")
+        .unwrap()
+        .unwrap();
+    let forward = vec![
+        EvidencePacketSourceRef {
+            ladder_position: 6,
+            record_hash: ah,
+        },
+        EvidencePacketSourceRef {
+            ladder_position: 5,
+            record_hash: applied.plan_record_hash,
+        },
+    ];
+    let mut reversed = forward.clone();
+    reversed.reverse();
+
+    let r1 = match mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &forward,
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .unwrap()
+    {
+        EvidencePacketProducedOutcome::Produced(r) => r,
+        other => panic!("expected Produced, got {other:?}"),
+    };
+    // Re-record the same packet with the source set in reversed input order —
+    // the canonical receipt_set_hash is identical, so this is a same-identity
+    // idempotent retry, NOT a conflict.
+    let r2 = match mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &reversed,
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .unwrap()
+    {
+        EvidencePacketProducedOutcome::AlreadyProduced(r) => r,
+        other => panic!("reordered source set must not fork identity; got {other:?}"),
+    };
+    assert_eq!(r1.receipt_set_hash, r2.receipt_set_hash);
+    assert_eq!(r1, r2);
+}
+
+#[test]
+fn conflicting_identity_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+
+    mgr.record_evidence_packet_produced(
+        &domain,
+        "session-001",
+        "packet-001",
+        "application-001",
+        ah,
+        &source_set(ah),
+        [5u8; 32],
+        [9u8; 32],
+        &actor,
+    )
+    .expect("first packet");
+    // Same packet_id, different packet_hash → conflict, fail closed.
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &source_set(ah),
+            [6u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("conflicting re-record must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_produced_conflict"),
+        "expected conflict sentinel, got: {err}"
+    );
+}
+
+// ============================================================================
+// Predecessor verification (EP1) fail-closed
+// ============================================================================
+
+#[test]
+fn missing_predecessor_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    // No MutationAppliedReceipt recorded.
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-404",
+            [7u8; 32],
+            &source_set([7u8; 32]),
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("must fail closed when the predecessor is absent");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_produced_predecessor_not_found"),
+        "got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "evidence_packet_produced",
+            &pkt_key1("coop:test", "session-001"),
+            Some("packet-001"),
+        ),
+        0,
+        "nothing persisted"
+    );
+}
+
+#[test]
+fn predecessor_hash_mismatch_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+    // Supply a wrong mutation_applied_record_hash for a real application id.
+    let wrong = [0xEEu8; 32];
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            wrong,
+            &source_set(wrong),
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("mismatched predecessor hash must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_produced_predecessor_mismatch"),
+        "got: {err}"
+    );
+    let _ = ah;
+}
+
+#[test]
+fn wrong_session_predecessor_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    // Applied recorded in session-A; try to produce a packet in session-B.
+    let ah = setup_applied(&mgr, &domain, "session-A", "application-001", &actor);
+    open_session(&mgr, &domain, "session-B", &actor);
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-B",
+            "packet-001",
+            "application-001",
+            ah,
+            &source_set(ah),
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("cross-session predecessor must fail closed as not found");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_produced_predecessor_not_found"),
+        "got: {err}"
+    );
+}
+
+// ============================================================================
+// Source-set validation (EP1/EP2) fail-closed
+// ============================================================================
+
+#[test]
+fn source_set_missing_predecessor_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+    // A non-empty source set that does NOT include the immediate predecessor.
+    let bad = vec![EvidencePacketSourceRef {
+        ladder_position: 5,
+        record_hash: [1u8; 32],
+    }];
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &bad,
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("source set without the predecessor must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_produced_predecessor_not_in_set"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn duplicate_source_record_hash_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+    let dup = vec![
+        EvidencePacketSourceRef {
+            ladder_position: 6,
+            record_hash: ah,
+        },
+        EvidencePacketSourceRef {
+            ladder_position: 5,
+            record_hash: ah,
+        },
+    ];
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &dup,
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("duplicate source member must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_produced_duplicate_source"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn empty_source_set_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+    // Empty set is caught by the predecessor-not-in-set guard before hashing
+    // (an empty set cannot contain the predecessor).
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &[],
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("empty source set must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_produced_predecessor_not_in_set"),
+        "got: {err}"
+    );
+}
+
+// ============================================================================
+// Session precondition / id validation / store wiring / backend failure
+// ============================================================================
+
+#[test]
+fn unopened_session_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-unopened",
+            "packet-001",
+            "application-001",
+            [7u8; 32],
+            &source_set([7u8; 32]),
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("unopened session must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_produced_session_not_opened"),
+        "got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "evidence_packet_produced",
+            &pkt_key1("coop:test", "session-unopened"),
+            Some("packet-001"),
+        ),
+        0
+    );
+}
+
+#[test]
+fn whitespace_ids_rejected() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+    for (session, packet, app) in [
+        ("   ", "packet-001", "application-001"),
+        ("session-001", "  ", "application-001"),
+        ("session-001", "packet-001", "   "),
+    ] {
+        let err = mgr
+            .record_evidence_packet_produced(
+                &domain,
+                session,
+                packet,
+                app,
+                ah,
+                &source_set(ah),
+                [5u8; 32],
+                [9u8; 32],
+                &actor,
+            )
+            .expect_err("whitespace id must be rejected");
+        assert!(err.to_string().contains("non-whitespace"), "got: {err}");
+    }
+}
+
+#[test]
+fn no_receipt_store_fails_closed() {
+    let mgr = GovernanceManager::new(); // no receipt store wired
+    let actor = fresh_did();
+    let domain = coop_test();
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            [7u8; 32],
+            &source_set([7u8; 32]),
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("a receipt store is required");
+    assert!(
+        err.to_string().contains("a receipt store is required"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn backend_failure_propagates() {
+    let store = Arc::new(FailingEvidencePacketProducedBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+    let err = mgr
+        .record_evidence_packet_produced(
+            &domain,
+            "session-001",
+            "packet-001",
+            "application-001",
+            ah,
+            &source_set(ah),
+            [5u8; 32],
+            [9u8; 32],
+            &actor,
+        )
+        .expect_err("backend failure must propagate");
+    assert!(
+        err.to_string()
+            .contains("simulated evidence-packet-produced backend failure"),
+        "got: {err}"
+    );
+}
+
+// ============================================================================
+// Isolation, key injectivity, privacy audit
+// ============================================================================
+
+#[test]
+fn two_domain_isolation() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    let ah1 = setup_applied(&mgr, &d1, "shared-session", "application-001", &actor);
+    let ah2 = setup_applied(&mgr, &d2, "shared-session", "application-001", &actor);
+
+    mgr.record_evidence_packet_produced(
+        &d1,
+        "shared-session",
+        "packet-001",
+        "application-001",
+        ah1,
+        &source_set(ah1),
+        [5u8; 32],
+        [9u8; 32],
+        &actor,
+    )
+    .expect("d1 packet");
+    mgr.record_evidence_packet_produced(
+        &d2,
+        "shared-session",
+        "packet-001",
+        "application-001",
+        ah2,
+        &source_set(ah2),
+        [5u8; 32],
+        [9u8; 32],
+        &actor,
+    )
+    .expect("d2 packet");
+
+    let r1 = mgr
+        .get_evidence_packet_produced(&d1, "shared-session", "packet-001")
+        .unwrap()
+        .unwrap();
+    let r2 = mgr
+        .get_evidence_packet_produced(&d2, "shared-session", "packet-001")
+        .unwrap()
+        .unwrap();
+    assert_eq!(r1.domain_id, "coop:one");
+    assert_eq!(r2.domain_id, "coop:two");
+    assert_ne!(r1.record_hash, r2.record_hash, "two domains never mix");
+}
+
+#[test]
+fn composite_key1_is_injective() {
+    // ("ab","c") and ("a","bc") must not alias.
+    assert_ne!(
+        evidence_packet_produced_composite_key1("ab", "c"),
+        evidence_packet_produced_composite_key1("a", "bc"),
+    );
+}
+
+#[test]
+fn stored_payload_carries_no_bodies() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
+    mgr.record_evidence_packet_produced(
+        &domain,
+        "session-001",
+        "packet-001",
+        "application-001",
+        ah,
+        &source_set(ah),
+        [5u8; 32],
+        [9u8; 32],
+        &actor,
+    )
+    .expect("packet");
+    let raw = store
+        .raw_payload(
+            "evidence_packet_produced",
+            &pkt_key1("coop:test", "session-001"),
+            Some("packet-001"),
+        )
+        .expect("payload present");
+    let json = String::from_utf8(raw).expect("utf8");
+    for forbidden in [
+        "packet_body",
+        "profile_body",
+        "redaction_profile_id",
+        "human_at_status",
+        "source_receipt_bod",
+        "plan_body",
+        "applied_result_body",
+        "operation_list",
+        "target_list",
+        "effect_payload",
+    ] {
+        assert!(
+            !json.contains(forbidden),
+            "stored payload must not carry `{forbidden}`; got: {json}"
+        );
+    }
+}

--- a/icn/apps/governance/tests/evidence_packet_produced_receipt_runtime_slice.rs
+++ b/icn/apps/governance/tests/evidence_packet_produced_receipt_runtime_slice.rs
@@ -735,8 +735,8 @@ fn empty_source_set_fails_closed() {
     let actor = fresh_did();
     let domain = coop_test();
     let ah = setup_applied(&mgr, &domain, "session-001", "application-001", &actor);
-    // Empty set is caught by the predecessor-not-in-set guard before hashing
-    // (an empty set cannot contain the predecessor).
+    // An empty source set fails fast with the dedicated stable prefix, ahead of
+    // the more specific predecessor-in-set check.
     let err = mgr
         .record_evidence_packet_produced(
             &domain,
@@ -752,7 +752,7 @@ fn empty_source_set_fails_closed() {
         .expect_err("empty source set must fail closed");
     assert!(
         err.to_string()
-            .starts_with("evidence_packet_produced_predecessor_not_in_set"),
+            .starts_with("evidence_packet_produced_empty_source_set"),
         "got: {err}"
     );
 }

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -142,7 +142,8 @@ pub use profile::{DecisionOutcome, GovernanceProfile, GovernanceProfileId, Gover
 pub use proof::{
     ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActionItemCompletionReceiptV2Error,
     ActionItemTransition, ActivationCrossedReceipt, DecisionRecordedReceipt, DeliberationEntryKind,
-    DeliberationEntryRecordedReceipt, GovernanceDecisionAttestation, GovernanceDecisionReceipt,
+    DeliberationEntryRecordedReceipt, EvidencePacketProducedReceipt, EvidencePacketReceiptSetError,
+    EvidencePacketSourceRef, GovernanceDecisionAttestation, GovernanceDecisionReceipt,
     GovernanceDecisionReceiptV2, GovernanceDecisionReceiptV2Error, GovernanceDecisionReceiptV3,
     GovernanceDecisionReceiptV3Error, GovernanceProof, GovernanceProofV2, MandateGrantRef,
     MandateGrantRefError, MandateGrantRefTarget, MeetingAttendanceReceipt,

--- a/icn/crates/icn-governance/src/proof.rs
+++ b/icn/crates/icn-governance/src/proof.rs
@@ -3272,11 +3272,13 @@ impl MutationAppliedReceipt {
 /// A single source-receipt reference contributing to an
 /// [`EvidencePacketProducedReceipt`]'s `receipt_set_hash` (EP1/EP2).
 ///
-/// Carries only the receipt-ladder position (used solely to canonically order
-/// the set before hashing) and the content-addressed `record_hash` of the
-/// source receipt. It is a **reference, never a body** — no source-receipt body,
-/// packet body, or private data is carried. The ladder position is not itself
-/// hashed; only the ordered `record_hash`es participate in `receipt_set_hash`.
+/// Carries only the receipt-ladder position (used to canonically order the set
+/// before hashing) and the content-addressed `record_hash` of the source
+/// receipt. It is a **reference, never a body** — no source-receipt body, packet
+/// body, or private data is carried. The ladder position is **not serialized
+/// into the hash input** (only the `record_hash`es are hashed), but it
+/// determines the canonical ordering of members and therefore **does influence**
+/// the resulting `receipt_set_hash`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct EvidencePacketSourceRef {
     /// Receipt-ladder position of the source receipt, used ONLY to canonically
@@ -3527,8 +3529,11 @@ impl EvidencePacketProducedReceipt {
     ///
     /// Layout: [`Self::RECEIPT_SET_DOMAIN_TAG`] first; the member count as `u64`
     /// LE; then each member's `record_hash` appended raw 32 bytes in canonical
-    /// order. Only `record_hash`es participate — ladder positions order but are
-    /// not hashed, and **bodies never participate**.
+    /// order. Ladder-position bytes are **not** part of the hash input, but they
+    /// determine the canonical member ordering above — so the hash commits to the
+    /// set of `record_hash`es *and their ladder-ordered sequence*, and a
+    /// different ladder position for a member can change the hash. **Bodies never
+    /// participate.**
     pub fn compute_receipt_set_hash(
         members: &[EvidencePacketSourceRef],
     ) -> Result<Hash, EvidencePacketReceiptSetError> {

--- a/icn/crates/icn-governance/src/proof.rs
+++ b/icn/crates/icn-governance/src/proof.rs
@@ -3265,6 +3265,304 @@ impl MutationAppliedReceipt {
 }
 
 // ============================================================================
+// EvidencePacketProducedReceipt — eighth ProcessTransitionReceipt class
+// (#2314 design/audit contract + #2316 EP1/EP2/EP3/EP4/EP5 decision rung)
+// ============================================================================
+
+/// A single source-receipt reference contributing to an
+/// [`EvidencePacketProducedReceipt`]'s `receipt_set_hash` (EP1/EP2).
+///
+/// Carries only the receipt-ladder position (used solely to canonically order
+/// the set before hashing) and the content-addressed `record_hash` of the
+/// source receipt. It is a **reference, never a body** — no source-receipt body,
+/// packet body, or private data is carried. The ladder position is not itself
+/// hashed; only the ordered `record_hash`es participate in `receipt_set_hash`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EvidencePacketSourceRef {
+    /// Receipt-ladder position of the source receipt, used ONLY to canonically
+    /// order the set before hashing (0 = `ProcessSessionOpened`, 1 =
+    /// `DeliberationEntryRecorded`, 2 = `DecisionRecorded`, 3 =
+    /// `ProcessGateResult`, 4 = `ActivationCrossed`, 5 = `MutationPlanRecorded`,
+    /// 6 = `MutationApplied` — the process ladder order pinned by #2316 §4).
+    pub ladder_position: u8,
+    /// Content-addressed `record_hash` of the source receipt.
+    pub record_hash: Hash,
+}
+
+/// Fail-closed failure computing a `receipt_set_hash` from source references
+/// (EP1/EP2, #2316 §4). On either variant the caller records nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvidencePacketReceiptSetError {
+    /// The source set was empty. A produced packet must draw from at least its
+    /// immediate predecessor, so `:v1` disallows the empty set.
+    Empty,
+    /// A `record_hash` appeared more than once. Because `receipt_set_hash` is a
+    /// *set* commitment, a repeated member would let a caller fork the hash (and
+    /// therefore the receipt identity) by padding the list; duplicates fail
+    /// closed rather than being silently de-duplicated.
+    DuplicateMember,
+}
+
+impl core::fmt::Display for EvidencePacketReceiptSetError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Empty => f.write_str(
+                "evidence_packet_produced source set is empty; a produced packet must draw \
+                 from at least its immediate predecessor",
+            ),
+            Self::DuplicateMember => f.write_str(
+                "evidence_packet_produced source set contains a duplicate record_hash; \
+                 duplicate members are disallowed and fail closed",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EvidencePacketReceiptSetError {}
+
+/// Receipt of record that a redacted **evidence packet artifact was produced**
+/// from a set of prior process receipts — the eighth `ProcessTransitionReceipt`
+/// class under #1748 / #2141, recorded after a [`MutationAppliedReceipt`].
+///
+/// Per the #2314 contract as resolved by the #2316 EP1–EP5 decision rung:
+///
+/// **EP1 — predecessor linkage.** Carries all three of `mutation_application_id`
+/// (the human/index handle of the immediate prior boundary),
+/// `mutation_applied_record_hash` (the content-addressed proof link, verified
+/// fail-closed against the stored [`MutationAppliedReceipt`]), and
+/// `receipt_set_hash` (a canonical, order-independent commitment to the ordered
+/// set of source-receipt references the packet rests on, which must include the
+/// immediate predecessor).
+///
+/// **EP2 — hash coverage.** `packet_hash` fingerprints the public/redacted
+/// packet artifact only; `receipt_set_hash` commits to the source references;
+/// neither covers private source bodies. No packet body, source-receipt body,
+/// plan/applied-result body, operation list, target list, or effect payload is
+/// ever stored (meaning firewall).
+///
+/// **EP3 — redaction boundary.** `redaction_profile_hash` fingerprints the
+/// redaction profile that shaped the public packet; no `redaction_profile_id`
+/// and no profile body in `:v1`.
+///
+/// **EP4 — meaning of "produced".** Records that an evidence packet artifact was
+/// produced/recorded and content-addressed. Distinct from export, delivery,
+/// acceptance, external audit, and action-card triggering; the receipt does not
+/// deliver, certify, audit, execute, authorize, validate, enforce, roll back, or
+/// prove the correctness of anything.
+///
+/// **EP5 — human/AT.** `:v1` carries no human/AT status; #2041 stays open.
+///
+/// `produced_at` is node-stamped Unix seconds, hashed into `record_hash` but
+/// **excluded** from duplicate identity — a retry never restamps. `produced_by`
+/// is actor evidence (the recorder / producer-witness), not an authority to
+/// produce, deliver, certify, or audit ("recorder, not producer"). Equality is
+/// anchored to `record_hash`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EvidencePacketProducedReceipt {
+    /// Governance domain the session (and this packet) is scoped to.
+    pub domain_id: String,
+    /// Identifier of the already-opened process session this packet attaches to.
+    /// Caller-provided, opaque, meaningful only together with `domain_id`.
+    pub session_id: String,
+    /// Caller-supplied opaque identifier for this packet, unique within
+    /// `(domain_id, session_id)` — uniqueness is enforced at the storage layer.
+    pub packet_id: String,
+    /// Caller-opaque `application_id` of the [`MutationAppliedReceipt`] this
+    /// packet draws from — the immediate prior boundary's human/index handle
+    /// (EP1).
+    pub mutation_application_id: String,
+    /// Content-addressed `record_hash` of that [`MutationAppliedReceipt`] — the
+    /// cryptographic proof link to the immediate prior boundary (EP1). Verified
+    /// to exist in-session before the packet is recorded.
+    pub mutation_applied_record_hash: Hash,
+    /// Canonical commitment to the ordered set of source-receipt references
+    /// (their `record_hash`es) included in the packet's evidence boundary (EP1/
+    /// EP2). Order-independent of caller input; duplicates disallowed; must
+    /// include `mutation_applied_record_hash`. Computed via
+    /// [`Self::compute_receipt_set_hash`]. Covers references, never bodies.
+    pub receipt_set_hash: Hash,
+    /// Caller-supplied fingerprint of the **public/redacted** evidence packet
+    /// artifact (EP2). The packet body itself is never stored.
+    pub packet_hash: Hash,
+    /// Caller-supplied fingerprint of the redaction profile that shaped the
+    /// public packet (EP3). The profile body itself is never stored.
+    pub redaction_profile_hash: Hash,
+    /// DID of the authenticated actor who recorded the production — recorder /
+    /// producer-witness evidence, not an authority to produce or act. Grants
+    /// zero authority.
+    pub produced_by: String,
+    /// Unix-seconds the packet was produced/recorded (node-stamped). Not part of
+    /// duplicate identity — a retry never restamps.
+    pub produced_at: u64,
+    /// blake3 canonical record hash binding the fields above.
+    pub record_hash: Hash,
+}
+
+impl PartialEq for EvidencePacketProducedReceipt {
+    fn eq(&self, other: &Self) -> bool {
+        self.record_hash == other.record_hash
+    }
+}
+
+impl Eq for EvidencePacketProducedReceipt {}
+
+impl EvidencePacketProducedReceipt {
+    /// Domain separation tag for canonical evidence-packet-produced record
+    /// hashes. Distinct from every other receipt-family tag — and in particular
+    /// it must NEVER converge with `icn:gov:mutation_applied:v1`,
+    /// `icn:gov:mutation_plan_recorded:v1`, `icn:gov:activation_crossed:v1`,
+    /// `icn:gov:decision_recorded:v1`, `icn:gov:process_gate_result:v1`,
+    /// `icn:gov:deliberation_entry_recorded:v1`,
+    /// `icn:gov:process_session_opened:v1`, or the proposal/vote
+    /// `icn:gov:decision:v1/v2/v3` lineage.
+    pub const DOMAIN_TAG: &[u8] = b"icn:gov:evidence_packet_produced:v1";
+
+    /// Domain separation tag for the canonical `receipt_set_hash` sub-hash
+    /// (EP1/EP2). Kept distinct from [`Self::DOMAIN_TAG`] so a source-set hash
+    /// can never collide with a top-level record hash.
+    pub const RECEIPT_SET_DOMAIN_TAG: &[u8] = b"icn:gov:evidence_packet_produced:receipt_set:v1";
+
+    /// Build a new receipt and compute its canonical `record_hash`.
+    ///
+    /// `receipt_set_hash` must be pre-computed via
+    /// [`Self::compute_receipt_set_hash`]; `packet_hash` and
+    /// `redaction_profile_hash` are caller-supplied fingerprints of the
+    /// never-stored public packet and redaction profile (EP2/EP3), mirroring how
+    /// the sibling classes take pre-computed fingerprints.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        domain_id: String,
+        session_id: String,
+        packet_id: String,
+        mutation_application_id: String,
+        mutation_applied_record_hash: Hash,
+        receipt_set_hash: Hash,
+        packet_hash: Hash,
+        redaction_profile_hash: Hash,
+        produced_by: String,
+        produced_at: u64,
+    ) -> Self {
+        let record_hash = Self::compute_record_hash(
+            &domain_id,
+            &session_id,
+            &packet_id,
+            &mutation_application_id,
+            &mutation_applied_record_hash,
+            &receipt_set_hash,
+            &packet_hash,
+            &redaction_profile_hash,
+            &produced_by,
+            produced_at,
+        );
+        Self {
+            domain_id,
+            session_id,
+            packet_id,
+            mutation_application_id,
+            mutation_applied_record_hash,
+            receipt_set_hash,
+            packet_hash,
+            redaction_profile_hash,
+            produced_by,
+            produced_at,
+            record_hash,
+        }
+    }
+
+    /// Compute the canonical record hash from the input fields.
+    ///
+    /// Layout (per the #2314 contract as resolved by the #2316 EP1–EP5 decision
+    /// rung §9): [`Self::DOMAIN_TAG`] first; each string field length-prefixed
+    /// (u64 LE) in order `domain_id`, `session_id`, `packet_id`,
+    /// `mutation_application_id`, `produced_by`; then `mutation_applied_record_hash`,
+    /// `receipt_set_hash`, `packet_hash`, `redaction_profile_hash` appended
+    /// **raw as fixed 32-byte fields with no length prefix** (fixed-size fields
+    /// cannot alias); then `produced_at` as LE bytes (Unix seconds). No
+    /// discriminant byte (this class has no kind taxonomy).
+    #[allow(clippy::too_many_arguments)]
+    pub fn compute_record_hash(
+        domain_id: &str,
+        session_id: &str,
+        packet_id: &str,
+        mutation_application_id: &str,
+        mutation_applied_record_hash: &Hash,
+        receipt_set_hash: &Hash,
+        packet_hash: &Hash,
+        redaction_profile_hash: &Hash,
+        produced_by: &str,
+        produced_at: u64,
+    ) -> Hash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(Self::DOMAIN_TAG);
+        for field in [
+            domain_id,
+            session_id,
+            packet_id,
+            mutation_application_id,
+            produced_by,
+        ] {
+            hasher.update(&(field.len() as u64).to_le_bytes());
+            hasher.update(field.as_bytes());
+        }
+        hasher.update(mutation_applied_record_hash);
+        hasher.update(receipt_set_hash);
+        hasher.update(packet_hash);
+        hasher.update(redaction_profile_hash);
+        hasher.update(&produced_at.to_le_bytes());
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hasher.finalize().as_bytes());
+        out
+    }
+
+    /// Compute the canonical `receipt_set_hash` over the source-receipt
+    /// references (EP1/EP2, #2316 §4).
+    ///
+    /// Canonicalization makes the hash **independent of caller input order**: the
+    /// members are sorted by `(ladder_position, record_hash bytewise ascending)`
+    /// before hashing, so two callers supplying the same set in different orders
+    /// derive the same hash. Duplicate `record_hash` members are rejected
+    /// **fail-closed** (a set commitment must not be forkable by repetition), as
+    /// is the empty set (a produced packet must draw from at least its immediate
+    /// predecessor).
+    ///
+    /// Layout: [`Self::RECEIPT_SET_DOMAIN_TAG`] first; the member count as `u64`
+    /// LE; then each member's `record_hash` appended raw 32 bytes in canonical
+    /// order. Only `record_hash`es participate — ladder positions order but are
+    /// not hashed, and **bodies never participate**.
+    pub fn compute_receipt_set_hash(
+        members: &[EvidencePacketSourceRef],
+    ) -> Result<Hash, EvidencePacketReceiptSetError> {
+        if members.is_empty() {
+            return Err(EvidencePacketReceiptSetError::Empty);
+        }
+        // Reject duplicate record_hash members regardless of ladder position —
+        // set semantics, fail-closed (never silently de-duplicated).
+        let mut seen = std::collections::HashSet::with_capacity(members.len());
+        for m in members {
+            if !seen.insert(m.record_hash) {
+                return Err(EvidencePacketReceiptSetError::DuplicateMember);
+            }
+        }
+        // Canonical order: ladder position, then record_hash bytewise ascending.
+        let mut sorted: Vec<EvidencePacketSourceRef> = members.to_vec();
+        sorted.sort_by(|a, b| {
+            a.ladder_position
+                .cmp(&b.ladder_position)
+                .then_with(|| a.record_hash.cmp(&b.record_hash))
+        });
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(Self::RECEIPT_SET_DOMAIN_TAG);
+        hasher.update(&(sorted.len() as u64).to_le_bytes());
+        for m in &sorted {
+            hasher.update(&m.record_hash);
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hasher.finalize().as_bytes());
+        Ok(out)
+    }
+}
+
+// ============================================================================
 // Mandate grant reference (#1868 step 2 primitive — wire form only)
 // ============================================================================
 
@@ -5758,6 +6056,470 @@ mod tests {
             assert!(
                 !lower.contains(forbidden),
                 "MutationAppliedReceipt JSON must not contain `{forbidden}`; got: {json}"
+            );
+        }
+    }
+
+    // ============================================================================
+    // EvidencePacketProducedReceipt — eighth ProcessTransitionReceipt class
+    // (#2314 contract + #2316 EP1–EP5 decision rung)
+    // ============================================================================
+
+    fn sample_evidence_source_refs() -> Vec<EvidencePacketSourceRef> {
+        // A minimal in-ladder-order set: the immediate predecessor
+        // (MutationApplied, ladder 6) plus the plan it applied (ladder 5).
+        vec![
+            EvidencePacketSourceRef {
+                ladder_position: 6,
+                record_hash: [7u8; 32],
+            },
+            EvidencePacketSourceRef {
+                ladder_position: 5,
+                record_hash: [4u8; 32],
+            },
+        ]
+    }
+
+    fn sample_evidence_packet_produced_receipt() -> EvidencePacketProducedReceipt {
+        let receipt_set_hash =
+            EvidencePacketProducedReceipt::compute_receipt_set_hash(&sample_evidence_source_refs())
+                .expect("sample source set is valid");
+        EvidencePacketProducedReceipt::new(
+            "domain-food-coop".to_string(),
+            "session-alpha".to_string(),
+            "packet-001".to_string(),
+            "application-001".to_string(),
+            [7u8; 32],        // mutation_applied_record_hash (EP1 proof link)
+            receipt_set_hash, // EP1/EP2 source-set commitment
+            [5u8; 32],        // packet_hash (EP2 public/redacted artifact)
+            [9u8; 32],        // redaction_profile_hash (EP3)
+            "did:icn:producer-1".to_string(), // recorder, not producer
+            1_750_000_000,
+        )
+    }
+
+    #[test]
+    fn evidence_packet_produced_golden_vector() {
+        // Golden canonical hash vector: pins the FULL v1 layout (domain tag,
+        // length-prefixed strings domain_id/session_id/packet_id/
+        // mutation_application_id/produced_by, raw fixed 32-byte
+        // mutation_applied_record_hash then receipt_set_hash then packet_hash
+        // then redaction_profile_hash, produced_at LE — no discriminant byte).
+        // Any layout change breaks this test and requires a new tag version.
+        let r = sample_evidence_packet_produced_receipt();
+        assert_eq!(
+            hex32(&r.record_hash),
+            "c6c74f06499a0a4d8c3a7ff1f3995ad2a88976e7ec1e0a9de9e95a51f53dfe57",
+            "canonical v1 hash layout drifted"
+        );
+    }
+
+    #[test]
+    fn evidence_packet_produced_receipt_set_hash_golden_vector() {
+        // Pins the canonical receipt_set_hash sub-hash layout (set tag, count
+        // u64 LE, canonically ordered member record_hashes raw 32).
+        let h =
+            EvidencePacketProducedReceipt::compute_receipt_set_hash(&sample_evidence_source_refs())
+                .expect("valid set");
+        assert_eq!(
+            hex32(&h),
+            "61f4124b565da0be8b090a20ffdccc896b343ad23c4548bb0777af62766f85e7",
+            "canonical receipt_set_hash layout drifted"
+        );
+    }
+
+    #[test]
+    fn evidence_packet_produced_record_hash_determinism() {
+        let r1 = sample_evidence_packet_produced_receipt();
+        let r2 = sample_evidence_packet_produced_receipt();
+        assert_eq!(r1.record_hash, r2.record_hash);
+        assert_ne!(r1.record_hash, [0u8; 32]);
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn evidence_packet_produced_record_hash_changes_per_field() {
+        // Every hashed field independently changes the record hash.
+        let base = sample_evidence_packet_produced_receipt();
+        let mk = |domain: &str,
+                  session: &str,
+                  packet: &str,
+                  app: &str,
+                  applied_hash: [u8; 32],
+                  set_hash: [u8; 32],
+                  packet_hash: [u8; 32],
+                  redaction: [u8; 32],
+                  by: &str,
+                  at: u64| {
+            EvidencePacketProducedReceipt::new(
+                domain.to_string(),
+                session.to_string(),
+                packet.to_string(),
+                app.to_string(),
+                applied_hash,
+                set_hash,
+                packet_hash,
+                redaction,
+                by.to_string(),
+                at,
+            )
+        };
+        let variants = [
+            mk(
+                "domain-other",
+                &base.session_id,
+                &base.packet_id,
+                &base.mutation_application_id,
+                base.mutation_applied_record_hash,
+                base.receipt_set_hash,
+                base.packet_hash,
+                base.redaction_profile_hash,
+                &base.produced_by,
+                base.produced_at,
+            ),
+            mk(
+                &base.domain_id,
+                "session-other",
+                &base.packet_id,
+                &base.mutation_application_id,
+                base.mutation_applied_record_hash,
+                base.receipt_set_hash,
+                base.packet_hash,
+                base.redaction_profile_hash,
+                &base.produced_by,
+                base.produced_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                "packet-other",
+                &base.mutation_application_id,
+                base.mutation_applied_record_hash,
+                base.receipt_set_hash,
+                base.packet_hash,
+                base.redaction_profile_hash,
+                &base.produced_by,
+                base.produced_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.packet_id,
+                "application-other",
+                base.mutation_applied_record_hash,
+                base.receipt_set_hash,
+                base.packet_hash,
+                base.redaction_profile_hash,
+                &base.produced_by,
+                base.produced_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.packet_id,
+                &base.mutation_application_id,
+                [1u8; 32],
+                base.receipt_set_hash,
+                base.packet_hash,
+                base.redaction_profile_hash,
+                &base.produced_by,
+                base.produced_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.packet_id,
+                &base.mutation_application_id,
+                base.mutation_applied_record_hash,
+                [2u8; 32],
+                base.packet_hash,
+                base.redaction_profile_hash,
+                &base.produced_by,
+                base.produced_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.packet_id,
+                &base.mutation_application_id,
+                base.mutation_applied_record_hash,
+                base.receipt_set_hash,
+                [3u8; 32],
+                base.redaction_profile_hash,
+                &base.produced_by,
+                base.produced_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.packet_id,
+                &base.mutation_application_id,
+                base.mutation_applied_record_hash,
+                base.receipt_set_hash,
+                base.packet_hash,
+                [8u8; 32],
+                &base.produced_by,
+                base.produced_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.packet_id,
+                &base.mutation_application_id,
+                base.mutation_applied_record_hash,
+                base.receipt_set_hash,
+                base.packet_hash,
+                base.redaction_profile_hash,
+                "did:icn:producer-other",
+                base.produced_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.packet_id,
+                &base.mutation_application_id,
+                base.mutation_applied_record_hash,
+                base.receipt_set_hash,
+                base.packet_hash,
+                base.redaction_profile_hash,
+                &base.produced_by,
+                base.produced_at + 1,
+            ),
+        ];
+        for (i, v) in variants.iter().enumerate() {
+            assert_ne!(
+                base.record_hash, v.record_hash,
+                "variant {i} must change the record hash"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_packet_produced_tag_separates_from_other_families() {
+        // Family separation from the seven landed process-transition classes.
+        for other in [
+            ProcessSessionOpenedReceipt::DOMAIN_TAG,
+            DeliberationEntryRecordedReceipt::DOMAIN_TAG,
+            DecisionRecordedReceipt::DOMAIN_TAG,
+            ProcessGateResultReceipt::DOMAIN_TAG,
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            MutationAppliedReceipt::DOMAIN_TAG,
+            // Must NEVER converge with the proposal/vote decision lineage.
+            GovernanceDecisionReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceiptV2::DOMAIN_TAG,
+            GovernanceDecisionReceiptV3::DOMAIN_TAG,
+        ] {
+            assert_ne!(EvidencePacketProducedReceipt::DOMAIN_TAG, other);
+        }
+        // The receipt-set sub-hash tag must never collide with the record tag.
+        assert_ne!(
+            EvidencePacketProducedReceipt::DOMAIN_TAG,
+            EvidencePacketProducedReceipt::RECEIPT_SET_DOMAIN_TAG
+        );
+    }
+
+    #[test]
+    fn evidence_packet_produced_length_prefix_prevents_field_shifting() {
+        // Shifting bytes between adjacent string fields must change the hash —
+        // the length prefix delimits each field exactly.
+        let a = EvidencePacketProducedReceipt::compute_record_hash(
+            "ab",
+            "c",
+            "packet-001",
+            "application-001",
+            &[0u8; 32],
+            &[0u8; 32],
+            &[0u8; 32],
+            &[0u8; 32],
+            "did:icn:x",
+            1,
+        );
+        let b = EvidencePacketProducedReceipt::compute_record_hash(
+            "a",
+            "bc",
+            "packet-001",
+            "application-001",
+            &[0u8; 32],
+            &[0u8; 32],
+            &[0u8; 32],
+            &[0u8; 32],
+            "did:icn:x",
+            1,
+        );
+        assert_ne!(a, b, "length prefix must delimit adjacent string fields");
+    }
+
+    #[test]
+    fn evidence_packet_produced_receipt_set_hash_order_independent() {
+        // Caller input order cannot fork the set hash: the same members in a
+        // different order canonicalize to the same hash.
+        let forward = sample_evidence_source_refs();
+        let mut reversed = forward.clone();
+        reversed.reverse();
+        let hf = EvidencePacketProducedReceipt::compute_receipt_set_hash(&forward).unwrap();
+        let hr = EvidencePacketProducedReceipt::compute_receipt_set_hash(&reversed).unwrap();
+        assert_eq!(
+            hf, hr,
+            "receipt_set_hash must be independent of input order"
+        );
+    }
+
+    #[test]
+    fn evidence_packet_produced_receipt_set_hash_rejects_duplicates() {
+        // Duplicate record_hash (even under different ladder positions) fails
+        // closed — a set commitment must not be forkable by repetition.
+        let dup = vec![
+            EvidencePacketSourceRef {
+                ladder_position: 6,
+                record_hash: [7u8; 32],
+            },
+            EvidencePacketSourceRef {
+                ladder_position: 4,
+                record_hash: [1u8; 32],
+            },
+            EvidencePacketSourceRef {
+                ladder_position: 5,
+                record_hash: [7u8; 32],
+            },
+        ];
+        assert_eq!(
+            EvidencePacketProducedReceipt::compute_receipt_set_hash(&dup),
+            Err(EvidencePacketReceiptSetError::DuplicateMember)
+        );
+    }
+
+    #[test]
+    fn evidence_packet_produced_receipt_set_hash_rejects_empty() {
+        assert_eq!(
+            EvidencePacketProducedReceipt::compute_receipt_set_hash(&[]),
+            Err(EvidencePacketReceiptSetError::Empty)
+        );
+    }
+
+    #[test]
+    fn evidence_packet_produced_receipt_set_hash_changes_with_membership() {
+        let base =
+            EvidencePacketProducedReceipt::compute_receipt_set_hash(&sample_evidence_source_refs())
+                .unwrap();
+        let mut extended = sample_evidence_source_refs();
+        extended.push(EvidencePacketSourceRef {
+            ladder_position: 4,
+            record_hash: [1u8; 32],
+        });
+        let ext = EvidencePacketProducedReceipt::compute_receipt_set_hash(&extended).unwrap();
+        assert_ne!(base, ext, "a different member set must change the hash");
+    }
+
+    #[test]
+    fn evidence_packet_produced_receipt_set_hash_ladder_position_orders() {
+        // Ladder position is the primary ordering key: two members with the same
+        // record_hashes but swapped ladder positions hash differently, proving
+        // ladder position participates in canonical ordering (not just hash).
+        let a = vec![
+            EvidencePacketSourceRef {
+                ladder_position: 6,
+                record_hash: [1u8; 32],
+            },
+            EvidencePacketSourceRef {
+                ladder_position: 5,
+                record_hash: [2u8; 32],
+            },
+        ];
+        let b = vec![
+            EvidencePacketSourceRef {
+                ladder_position: 5,
+                record_hash: [1u8; 32],
+            },
+            EvidencePacketSourceRef {
+                ladder_position: 6,
+                record_hash: [2u8; 32],
+            },
+        ];
+        let ha = EvidencePacketProducedReceipt::compute_receipt_set_hash(&a).unwrap();
+        let hb = EvidencePacketProducedReceipt::compute_receipt_set_hash(&b).unwrap();
+        assert_ne!(ha, hb);
+    }
+
+    #[test]
+    fn evidence_packet_produced_serde_roundtrip_and_payload_audit() {
+        let r = sample_evidence_packet_produced_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let back: EvidencePacketProducedReceipt = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(r, back);
+        // v1 layout audit: exactly the pinned fields are present, and NONE of the
+        // deliberately-absent fields (EP2/EP3/EP5) leak into the payload.
+        for present in [
+            "domain_id",
+            "session_id",
+            "packet_id",
+            "mutation_application_id",
+            "mutation_applied_record_hash",
+            "receipt_set_hash",
+            "packet_hash",
+            "redaction_profile_hash",
+            "produced_by",
+            "produced_at",
+            "record_hash",
+        ] {
+            assert!(json.contains(present), "field `{present}` must be present");
+        }
+        for forbidden in [
+            "redaction_profile_id",
+            "human_at_status",
+            "packet_body",
+            "source_receipt_bod",
+            "plan_body",
+            "applied_result_body",
+            "operation_list",
+            "target_list",
+            "effect_payload",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "field `{forbidden}` must NOT be present; got: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_packet_produced_no_prohibited_vocabulary() {
+        // "produced" is core vocabulary for this class (produced_by / produced_at),
+        // so it is NOT forbidden. This enforces the EP4 boundary: no
+        // delivery/acceptance/audit/authority overclaim leaks into the payload,
+        // and no regulated-finance or proposal/vote lineage vocabulary appears.
+        let r = sample_evidence_packet_produced_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let lower = json.to_lowercase();
+        for forbidden in [
+            // regulated-finance vocabulary
+            "wallet",
+            "balance",
+            "currency",
+            "payment",
+            "withdraw",
+            "deposit",
+            // EP4 no-overclaim: records a fact; does not deliver/accept/audit/
+            // certify/execute/authorize/verify/roll back
+            "delivered",
+            "accepted",
+            "audited",
+            "certified",
+            "authorized",
+            "executed",
+            "verified",
+            "rolled back",
+            "roll back",
+            // proposal/vote lineage vocabulary
+            "proposal",
+            "vote",
+            "tally",
+            "quorum",
+            "mandate",
+        ] {
+            assert!(
+                !lower.contains(forbidden),
+                "EvidencePacketProducedReceipt JSON must not contain `{forbidden}`; got: {json}"
             );
         }
     }


### PR DESCRIPTION
## What

Adds the narrow runtime receipt slice for `EvidencePacketProducedReceipt`, the eighth ADR-0026 Layer-2 process-transition receipt after `MutationAppliedReceipt`.

## Why

#2314 and #2316 landed the design contract and EP1–EP5 decision rung. This PR implements the receipt type, hashing, opaque storage, manager recording path, fail-closed predecessor verification, idempotency/conflict behavior, and tests.

## How

- Adds `EvidencePacketProducedReceipt` with tag `icn:gov:evidence_packet_produced:v1` and canonical `record_hash` (domain tag → length-prefixed `domain_id`/`session_id`/`packet_id`/`mutation_application_id`/`produced_by` → raw-32 `mutation_applied_record_hash`/`receipt_set_hash`/`packet_hash`/`redaction_profile_hash` → `produced_at` LE Unix seconds). Golden vector pinned.
- Preserves the pinned v1 field set from #2316; `produced_at` is node-stamped, hashed, and excluded from stable duplicate identity (retry never restamps).
- Verifies predecessor linkage to `MutationAppliedReceipt` **fail-closed**: `get_mutation_applied(domain, session, mutation_application_id)` then `record_hash` compare; absent/mismatched/wrong-session fails closed and persists nothing.
- Adds `receipt_set_hash` via `EvidencePacketProducedReceipt::compute_receipt_set_hash` — canonical order (ladder position, then `record_hash` bytewise) so **caller input order cannot fork identity**; **duplicate `record_hash` members and the empty set fail closed**; the declared set must include the immediate predecessor.
- Stores only hashes/references — never packet bodies, redaction-profile bodies, source-receipt bodies, private data, plan bodies, operation lists, targets, or effects.
- Adds opaque receipt backend/manager support following sibling precedent (class `evidence_packet_produced`, injective composite `key1` over `(domain_id, session_id)`, `key2 = packet_id`, `EvidencePacketProducedPersist`, `record_evidence_packet_produced` → `EvidencePacketProducedOutcome`, `evidence_packet_produced_conflict` on changed stable identity).
- Adds 13 `proof.rs` unit tests + a 17-test runtime slice.

Files: `icn/crates/icn-governance/src/{proof.rs,lib.rs}`, `icn/apps/governance/src/{receipt_backend.rs,manager.rs}`, `icn/apps/governance/tests/evidence_packet_produced_receipt_runtime_slice.rs`. No route/OpenAPI/SDK/member-shell/fixture change.

## Validation

Run from `icn/` against `origin/main` @ `39555cdb` in a fresh worktree; all green:

- `cargo fmt --all --check` — **OK**.
- `cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings` — **clean**.
- `cargo test -p icn-governance evidence_packet_produced` — **13 passed / 0 failed** (proof unit tests incl. golden vectors, determinism, per-field sensitivity, tag disjointness, receipt-set canonicalization/dedup/empty, length-prefix, serde/payload audit, no-overclaim vocabulary).
- `cargo test -p icn-governance-actor --test evidence_packet_produced_receipt_runtime_slice` — **17 passed / 0 failed** (predecessor happy path; missing/mismatched/wrong-session predecessor fail closed; source set missing predecessor / duplicate / empty fail closed; caller source order cannot fork `receipt_set_hash`; idempotent retry returns original un-restamped; conflict fail closed; unopened session; whitespace ids; no receipt store; backend failure propagation; two-domain isolation; composite-key injectivity; stored-payload body audit).
- `cargo test -p icn-governance -p icn-governance-actor` — full governance suites, **0 failed** (no sibling regression).
- `python3 docs/scripts/route_inventory.py --check` — **OK** (287 routes unchanged; no route added).
- `ops/scripts/drift-check.sh` — **STATUS: PASS**.
- `git diff --check` — **CLEAN**. Scope: 5 Rust files under `icn/crates/icn-governance` + `icn/apps/governance` only; no `Cargo.lock` change. Close-keyword / overclaim / forbidden-vocabulary scans: CLEAN (matches only inside the payload-audit test blocklists).

## Non-claims

- No evidence-packet producer.
- No packet body storage.
- No redaction profile body storage.
- No source receipt body storage.
- No private organizer/member/sponsor/attendee data handling.
- No action-card trigger.
- No workflow engine.
- No HTTP route.
- No OpenAPI / SDK / served-schema change.
- No member-shell implementation.
- No fixture/demo implementation.
- No human/AT execution.
- Not #2041 completion.
- Not production-ready.
- Not pilot-ready.
- Not organizer-ready.
- Not member-ready.
- Not live federation.
- Not NYCN activation.
- Not Phase 2 completion.
- #1748 and #2141 remain open.

## Refs

Refs #2317.
Refs #2316.
Refs #2315.
Refs #2314.
Refs #2313.
Refs #2312.
Refs #2310.
Refs #1748.
Refs #2141.
Refs #2041.
