### PR TITLE
feat(process): emit evidence packet export prepared receipt

### DIFF
--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -2847,6 +2847,30 @@ pub enum EvidencePacketProducedOutcome {
     AlreadyProduced(icn_governance::EvidencePacketProducedReceipt),
 }
 
+/// Outcome of [`GovernanceManager::record_evidence_packet_export_prepared`]
+/// (#2322 boundary contract + #2324 EX1–EX8 decision rung). Both variants are
+/// successes; the fail-closed mismatch conflict surfaces as an `Err` with
+/// stable prefix `evidence_packet_export_prepared_conflict`. Precondition
+/// failures surface as `Err`s with their own stable prefixes and persist
+/// nothing: `evidence_packet_export_prepared_session_not_opened` (unopened
+/// session), `evidence_packet_export_prepared_predecessor_not_found` /
+/// `evidence_packet_export_prepared_predecessor_mismatch` (EX5 produced
+/// predecessor absent or record-hash-mismatched), and
+/// `evidence_packet_export_prepared_packet_hash_mismatch` (the echoed
+/// `packet_hash` differs from the stored produced receipt's `packet_hash`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvidencePacketExportPreparedOutcome {
+    /// This call recorded the export preparation: the receipt is the newly
+    /// persisted export-prepared fact.
+    Prepared(icn_governance::EvidencePacketExportPreparedReceipt),
+    /// The export preparation was already recorded with the **same** stable
+    /// identity (`packet_id`, `packet_produced_record_hash`, `packet_hash`,
+    /// `export_policy_hash`, `recipient_scope_id`, `prepared_by`); carries the
+    /// **original** persisted receipt (original `prepared_at` / `record_hash`
+    /// — a retry is never restamped).
+    AlreadyPrepared(icn_governance::EvidencePacketExportPreparedReceipt),
+}
+
 /// Action items are always managed locally (not gossiped) and can use either
 /// in-memory or Sled-backed persistent storage.
 pub struct GovernanceManager {
@@ -7426,6 +7450,250 @@ impl GovernanceManager {
         store
             .list_evidence_packet_produced_for_session_in_domain(&domain_id.0, session_id)
             .map_err(|e| anyhow::anyhow!("Failed to list evidence-packet-produced receipts: {e}"))
+    }
+
+    /// Record that an **export of a produced evidence packet was prepared**
+    /// for a named recipient scope under a declared export policy — the ninth
+    /// process/evidence receipt class (#2322 boundary contract + #2324 EX1–EX8
+    /// decision rung), and the first beyond the eight named by the idea-0019
+    /// framing. Records a process fact and grants zero authority; it does not
+    /// export, assemble, release, deliver, transmit, make available, certify,
+    /// audit, or accept anything — prepared is **not** delivered, received, or
+    /// accepted (EX1/EX4).
+    ///
+    /// Fail-closed preconditions (on any failure nothing is persisted):
+    /// - all ids are non-empty / non-whitespace (`recipient_scope_id` is a
+    ///   caller-opaque governance handle — never contact data);
+    /// - a receipt store is wired (uniqueness and the predecessor precondition
+    ///   are enforced at the storage layer and cannot be faked in memory);
+    /// - the `(domain_id, session_id)` session was opened first
+    ///   (`evidence_packet_export_prepared_session_not_opened`);
+    /// - EX5: an [`icn_governance::EvidencePacketProducedReceipt`] exists in
+    ///   the **same** `(domain_id, session_id)` under `packet_id`
+    ///   (`evidence_packet_export_prepared_predecessor_not_found`), its
+    ///   `record_hash` equals the supplied `packet_produced_record_hash`
+    ///   (`evidence_packet_export_prepared_predecessor_mismatch`), and its
+    ///   stored `packet_hash` equals the supplied `packet_hash`
+    ///   (`evidence_packet_export_prepared_packet_hash_mismatch`) — the
+    ///   record-hash link is checked before the packet-hash echo so a stale
+    ///   predecessor reference surfaces as the more specific mismatch.
+    ///
+    /// On success returns [`EvidencePacketExportPreparedOutcome::Prepared`]; a
+    /// same-identity retry returns
+    /// [`EvidencePacketExportPreparedOutcome::AlreadyPrepared`] carrying the
+    /// **original** receipt (never restamped). A same-`export_id` record with
+    /// a different stable identity fails closed with the stable
+    /// `evidence_packet_export_prepared_conflict` prefix. Multiple exports per
+    /// packet (distinct `export_id`s) are permitted at the substrate layer;
+    /// how many is charter policy.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_evidence_packet_export_prepared(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        export_id: &str,
+        packet_id: &str,
+        packet_produced_record_hash: [u8; 32],
+        packet_hash: [u8; 32],
+        export_policy_hash: [u8; 32],
+        recipient_scope_id: &str,
+        prepared_by: &Did,
+    ) -> Result<EvidencePacketExportPreparedOutcome> {
+        // Whitespace-only ids are rejected alongside empty ones: a caller
+        // bypassing the HTTP layer must not mint receipts with visually-empty
+        // identifiers or whitespace storage keys.
+        if domain_id.0.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_export_prepared: domain_id must be non-empty and \
+                 non-whitespace"
+            ));
+        }
+        if session_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_export_prepared: session_id must be non-empty and \
+                 non-whitespace"
+            ));
+        }
+        if export_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_export_prepared: export_id must be non-empty and \
+                 non-whitespace"
+            ));
+        }
+        if packet_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_export_prepared: packet_id must be non-empty and \
+                 non-whitespace"
+            ));
+        }
+        if recipient_scope_id.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_export_prepared: recipient_scope_id must be non-empty \
+                 and non-whitespace"
+            ));
+        }
+        let prepared_by_str = prepared_by.to_string();
+        if prepared_by_str.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "record_evidence_packet_export_prepared: prepared_by must be non-empty"
+            ));
+        }
+        let store = self.receipt_store.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "record_evidence_packet_export_prepared: a receipt store is required — export \
+                 uniqueness and the predecessor precondition are enforced at the storage layer \
+                 and cannot be faked in memory"
+            )
+        })?;
+
+        // Precondition: the session was opened first. No silent creation.
+        let opened = store
+            .get_process_session_opened(&domain_id.0, session_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_evidence_packet_export_prepared: failed to read session-open state \
+                     for session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        if opened.is_none() {
+            return Err(anyhow::anyhow!(
+                "evidence_packet_export_prepared_session_not_opened: session {session_id} in \
+                 domain {} has no recorded opening; refusing to record an export preparation \
+                 against an unanchored session",
+                domain_id.0
+            ));
+        }
+
+        // EX5 precondition: the produced packet this export prepares must exist
+        // in this same (domain, session) under `packet_id`. The composite
+        // storage key makes a packet recorded under a different session/domain
+        // invisible here, so a wrong-session/wrong-domain reference fails
+        // closed as "not found".
+        let produced = store
+            .get_evidence_packet_produced(&domain_id.0, session_id, packet_id)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "record_evidence_packet_export_prepared: failed to read produced state for \
+                     packet {packet_id} in session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })?;
+        let produced = produced.ok_or_else(|| {
+            anyhow::anyhow!(
+                "evidence_packet_export_prepared_predecessor_not_found: no packet {packet_id} \
+                 recorded in session {session_id} in domain {}; refusing to record an export \
+                 preparation for an unrecorded predecessor",
+                domain_id.0
+            )
+        })?;
+        if produced.record_hash != packet_produced_record_hash {
+            return Err(anyhow::anyhow!(
+                "evidence_packet_export_prepared_predecessor_mismatch: packet {packet_id} in \
+                 session {session_id} in domain {} was recorded with a different record_hash \
+                 than the one supplied; refusing to record an export preparation on a \
+                 mismatched predecessor reference",
+                domain_id.0
+            ));
+        }
+        // EX5 echoed-field verification: the supplied packet_hash must equal
+        // the stored produced receipt's packet_hash — the echo is a proof, not
+        // an assertion (verified in the same fetch as the predecessor link).
+        if produced.packet_hash != packet_hash {
+            return Err(anyhow::anyhow!(
+                "evidence_packet_export_prepared_packet_hash_mismatch: the supplied packet_hash \
+                 for packet {packet_id} in session {session_id} in domain {} does not equal the \
+                 stored produced receipt's packet_hash; refusing to record an export \
+                 preparation for a different artifact fingerprint",
+                domain_id.0
+            ));
+        }
+
+        let now = icn_time::current_timestamp_secs();
+        let receipt = icn_governance::EvidencePacketExportPreparedReceipt::new(
+            domain_id.0.clone(),
+            session_id.to_string(),
+            export_id.to_string(),
+            packet_id.to_string(),
+            packet_produced_record_hash,
+            packet_hash,
+            export_policy_hash,
+            recipient_scope_id.to_string(),
+            prepared_by_str.clone(),
+            now,
+        );
+
+        match store
+            .put_evidence_packet_export_prepared(&receipt)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to persist evidence-packet-export-prepared receipt for export \
+                     {export_id} in session {session_id} in domain {}: {e}",
+                    domain_id.0
+                )
+            })? {
+            crate::receipt_backend::EvidencePacketExportPreparedPersist::Inserted => {
+                Ok(EvidencePacketExportPreparedOutcome::Prepared(receipt))
+            }
+            crate::receipt_backend::EvidencePacketExportPreparedPersist::Existing(original) => {
+                if original.packet_id == packet_id
+                    && original.packet_produced_record_hash == packet_produced_record_hash
+                    && original.packet_hash == packet_hash
+                    && original.export_policy_hash == export_policy_hash
+                    && original.recipient_scope_id == recipient_scope_id
+                    && original.prepared_by == prepared_by_str
+                {
+                    Ok(EvidencePacketExportPreparedOutcome::AlreadyPrepared(
+                        *original,
+                    ))
+                } else {
+                    Err(anyhow::anyhow!(
+                        "evidence_packet_export_prepared_conflict: export {export_id} in session \
+                         {session_id} in domain {} was already recorded with a different packet \
+                         reference, packet hash, export policy, recipient scope, or recorder; \
+                         refusing to overwrite",
+                        domain_id.0
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Retrieve the persisted evidence-packet-export-prepared receipt for a
+    /// `(domain_id, session_id, export_id)`, or `None` when no export
+    /// preparation has been recorded. Read-only.
+    pub fn get_evidence_packet_export_prepared(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+        export_id: &str,
+    ) -> Result<Option<icn_governance::EvidencePacketExportPreparedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(None);
+        };
+        store
+            .get_evidence_packet_export_prepared(&domain_id.0, session_id, export_id)
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to read evidence-packet-export-prepared receipt: {e}")
+            })
+    }
+
+    /// List all evidence-packet-export-prepared receipts recorded against one
+    /// `(domain_id, session_id)` anchor, in the store's deterministic
+    /// chronological `(prepared_at, record_hash)` order. Read-only.
+    pub fn list_evidence_packet_export_prepared_in_domain(
+        &self,
+        domain_id: &GovernanceDomainId,
+        session_id: &str,
+    ) -> Result<Vec<icn_governance::EvidencePacketExportPreparedReceipt>> {
+        let Some(ref store) = self.receipt_store else {
+            return Ok(vec![]);
+        };
+        store
+            .list_evidence_packet_export_prepared_for_session_in_domain(&domain_id.0, session_id)
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to list evidence-packet-export-prepared receipts: {e}")
+            })
     }
 
     // ========================================================================

--- a/icn/apps/governance/src/receipt_backend.rs
+++ b/icn/apps/governance/src/receipt_backend.rs
@@ -4,10 +4,10 @@
 use icn_governance::{
     ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActivationCrossedReceipt,
     AuthorityGrant, AuthorityGrantId, DecisionRecordedReceipt, DeliberationEntryRecordedReceipt,
-    EvidencePacketProducedReceipt, GovernanceDecisionReceipt, GovernanceDecisionReceiptV3, Grantee,
-    Mandate, MeetingAttendanceReceipt, MeetingAttendanceReceiptV2, MutationAppliedReceipt,
-    MutationPlanRecordedReceipt, ProcessGateKind, ProcessGateResultReceipt,
-    ProcessSessionOpenedReceipt, Timestamp,
+    EvidencePacketExportPreparedReceipt, EvidencePacketProducedReceipt, GovernanceDecisionReceipt,
+    GovernanceDecisionReceiptV3, Grantee, Mandate, MeetingAttendanceReceipt,
+    MeetingAttendanceReceiptV2, MutationAppliedReceipt, MutationPlanRecordedReceipt,
+    ProcessGateKind, ProcessGateResultReceipt, ProcessSessionOpenedReceipt, Timestamp,
 };
 use icn_kernel_api::{AllocationReceipt, Hash};
 
@@ -302,6 +302,51 @@ pub enum EvidencePacketProducedPersist {
     /// unboxed variant would make this enum needlessly large next to the unit
     /// `Inserted`.
     Existing(Box<EvidencePacketProducedReceipt>),
+}
+
+/// Class string for `EvidencePacketExportPreparedReceipt` opaque storage
+/// (#2322 boundary contract + #2324 EX1–EX8 decision rung). Chosen in the apps
+/// layer so the gateway never sees the typed name. Distinct from every other
+/// process class store.
+const EVIDENCE_PACKET_EXPORT_PREPARED_CLASS: &str = "evidence_packet_export_prepared";
+
+/// Build the injective composite `key1` binding a prepared evidence-packet
+/// export to its `(domain_id, session_id)` anchor in opaque storage.
+///
+/// Sibling of [`evidence_packet_produced_composite_key1`] with the identical
+/// netstring-style encoding (decimal length of `domain_id`, a colon, then the
+/// two ids concatenated), kept as a separate function so this class's key
+/// derivation is independently anchored by its own anti-aliasing test. The
+/// length prefix delimits `domain_id` exactly, so `("ab","c")` and `("a","bc")`
+/// can never produce the same key, and two domains sharing a `session_id` scan
+/// different `key1` prefixes.
+pub fn evidence_packet_export_prepared_composite_key1(domain_id: &str, session_id: &str) -> String {
+    format!("{}:{domain_id}{session_id}", domain_id.len())
+}
+
+/// Outcome of persisting an [`EvidencePacketExportPreparedReceipt`] through
+/// [`GovernanceReceiptBackend::put_evidence_packet_export_prepared`].
+///
+/// The backend enforces at most one export preparation per `(domain_id,
+/// session_id, export_id)` **atomically at the storage layer** (same
+/// `put_opaque_if_absent` primitive as the sibling process classes). The
+/// caller (the manager) turns `Existing` into either a same-identity
+/// idempotent success or a fail-closed conflict — stable identity is
+/// `packet_id` + `packet_produced_record_hash` + `packet_hash` +
+/// `export_policy_hash` + `recipient_scope_id` + `prepared_by` (per the #2324
+/// rung §12; `prepared_at`/`record_hash` are NOT identity inputs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvidencePacketExportPreparedPersist {
+    /// This call won the insert: the receipt is now the one persisted export
+    /// preparation for its `(domain_id, session_id, export_id)`.
+    Inserted,
+    /// An export preparation already existed for this triple; nothing was
+    /// written. Carries the original persisted receipt (original `prepared_at`
+    /// / `record_hash` — never restamped). Boxed because
+    /// [`EvidencePacketExportPreparedReceipt`] is a large payload (six string
+    /// fields plus three 32-byte hashes), so an unboxed variant would make
+    /// this enum needlessly large next to the unit `Inserted`.
+    Existing(Box<EvidencePacketExportPreparedReceipt>),
 }
 
 /// Class string for `MeetingAttendanceReceiptV2` opaque storage (#1868).
@@ -1676,6 +1721,104 @@ pub trait GovernanceReceiptBackend: Send + Sync {
                     format!("deserialize EvidencePacketProducedReceipt in list: {e}")
                 })?,
             );
+        }
+        Ok(out)
+    }
+
+    /// Persist an [`EvidencePacketExportPreparedReceipt`] emitted when the
+    /// runtime records that an export of a produced evidence packet was
+    /// prepared (#2322 contract + #2324 rung).
+    ///
+    /// **Default routes through opaque storage.** Serialises the typed receipt
+    /// to JSON and delegates to [`Self::put_opaque_if_absent`] under class
+    /// `"evidence_packet_export_prepared"` with `key1 =`
+    /// [`evidence_packet_export_prepared_composite_key1`] (the injective
+    /// domain+session composite) and `key2 = export_id`. On a lost insert the
+    /// original persisted receipt is hydrated and returned (never restamped).
+    /// A backend that has not opted in to opaque storage inherits the
+    /// fail-closed `opaque_storage_not_implemented` default.
+    fn put_evidence_packet_export_prepared(
+        &self,
+        receipt: &EvidencePacketExportPreparedReceipt,
+    ) -> Result<EvidencePacketExportPreparedPersist, String> {
+        let payload = serde_json::to_vec(receipt)
+            .map_err(|e| format!("serialize EvidencePacketExportPreparedReceipt: {e}"))?;
+        let key1 =
+            evidence_packet_export_prepared_composite_key1(&receipt.domain_id, &receipt.session_id);
+        let existing = self.put_opaque_if_absent(
+            EVIDENCE_PACKET_EXPORT_PREPARED_CLASS,
+            &key1,
+            Some(&receipt.export_id),
+            receipt.prepared_at,
+            receipt.record_hash,
+            &payload,
+        )?;
+        match existing {
+            None => Ok(EvidencePacketExportPreparedPersist::Inserted),
+            Some(_winning_hash) => {
+                let original = self
+                    .get_evidence_packet_export_prepared(
+                        &receipt.domain_id,
+                        &receipt.session_id,
+                        &receipt.export_id,
+                    )?
+                    .ok_or_else(|| {
+                        // The unique marker says a preparation exists but the
+                        // payload cannot be hydrated — surface loudly rather
+                        // than minting a second preparation.
+                        "evidence_packet_export_prepared_inconsistent: unique marker present \
+                         but no persisted export-prepared payload could be read"
+                            .to_string()
+                    })?;
+                Ok(EvidencePacketExportPreparedPersist::Existing(Box::new(
+                    original,
+                )))
+            }
+        }
+    }
+
+    /// Retrieve the persisted [`EvidencePacketExportPreparedReceipt`] for a
+    /// `(domain_id, session_id, export_id)`, or `None` when no export
+    /// preparation has been recorded. Same key convention as
+    /// [`Self::put_evidence_packet_export_prepared`]; at most one preparation
+    /// exists per triple (uniqueness is enforced on write).
+    fn get_evidence_packet_export_prepared(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+        export_id: &str,
+    ) -> Result<Option<EvidencePacketExportPreparedReceipt>, String> {
+        let key1 = evidence_packet_export_prepared_composite_key1(domain_id, session_id);
+        let payload = self.get_latest_opaque(
+            EVIDENCE_PACKET_EXPORT_PREPARED_CLASS,
+            &key1,
+            Some(export_id),
+        )?;
+        match payload {
+            Some(bytes) => Ok(Some(serde_json::from_slice(&bytes).map_err(|e| {
+                format!("deserialize EvidencePacketExportPreparedReceipt: {e}")
+            })?)),
+            None => Ok(None),
+        }
+    }
+
+    /// List all evidence-packet-export-prepared receipts recorded against one
+    /// `(domain_id, session_id)` anchor, in the store's deterministic
+    /// chronological `(prepared_at, record_hash)` order. Because `key1` is the
+    /// injective domain+session composite, two domains sharing a `session_id`
+    /// can never mix here — no payload-side filtering is needed.
+    fn list_evidence_packet_export_prepared_for_session_in_domain(
+        &self,
+        domain_id: &str,
+        session_id: &str,
+    ) -> Result<Vec<EvidencePacketExportPreparedReceipt>, String> {
+        let key1 = evidence_packet_export_prepared_composite_key1(domain_id, session_id);
+        let payloads = self.list_opaque_for(EVIDENCE_PACKET_EXPORT_PREPARED_CLASS, &key1)?;
+        let mut out = Vec::with_capacity(payloads.len());
+        for bytes in payloads {
+            out.push(serde_json::from_slice(&bytes).map_err(|e| {
+                format!("deserialize EvidencePacketExportPreparedReceipt in list: {e}")
+            })?);
         }
         Ok(out)
     }

--- a/icn/apps/governance/tests/evidence_packet_export_prepared_receipt_runtime_slice.rs
+++ b/icn/apps/governance/tests/evidence_packet_export_prepared_receipt_runtime_slice.rs
@@ -1,0 +1,1029 @@
+//! Runtime-slice integration tests for the ninth process/evidence receipt
+//! class, `EvidencePacketExportPreparedReceipt` (#2322 boundary contract +
+//! #2324 EX1–EX8 decision rung, issue #2325).
+//!
+//! These exercise `GovernanceManager::record_evidence_packet_export_prepared`
+//! end to end through an opaque-backed test store (the analog of the
+//! production gateway-backed `ReceiptStore`), proving:
+//!
+//! 1. it requires an already-opened session and a verified produced
+//!    predecessor (`EvidencePacketProducedReceipt`) in the same
+//!    `(domain, session)` under `packet_id`;
+//! 2. the echoed `packet_hash` is verified against the stored produced
+//!    receipt (the lane's first verified echoed content field) — a mismatch
+//!    fails closed;
+//! 3. persistence is idempotent on stable identity and fail-closed on a
+//!    conflicting re-record; multiple exports per packet (distinct
+//!    `export_id`s) succeed;
+//! 4. no packet/policy body, contact data, or transmission/acceptance claim
+//!    is ever stored — prepared is not delivered, received, or accepted.
+//!
+//! Mirrors `evidence_packet_produced_receipt_runtime_slice.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use icn_governance::{
+    EvidencePacketSourceRef, GovernanceDecisionReceipt, GovernanceDomainId, ProcessGateKind,
+    ProcessGateResult,
+};
+use icn_governance_actor::manager::{
+    ActivationCrossedOutcome, DecisionRecordOutcome, EvidencePacketExportPreparedOutcome,
+    EvidencePacketProducedOutcome, GovernanceManager, MutationAppliedOutcome,
+    MutationPlanRecordedOutcome, ProcessSessionOpenOutcome,
+};
+use icn_governance_actor::receipt_backend::{
+    evidence_packet_export_prepared_composite_key1, GovernanceReceiptBackend,
+};
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+
+// ============================================================================
+// Opaque-backed test store — exercises the trait's typed defaults end-to-end.
+// ============================================================================
+
+type ChainKey = (String, String, Option<String>);
+type ChainEntry = (u64, [u8; 32], Vec<u8>);
+
+#[derive(Default)]
+struct OpaqueUniqueBackend {
+    chains: Mutex<HashMap<ChainKey, Vec<ChainEntry>>>,
+    unique: Mutex<HashMap<ChainKey, [u8; 32]>>,
+}
+
+impl OpaqueUniqueBackend {
+    fn chain_len(&self, class: &str, key1: &str, key2: Option<&str>) -> usize {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .map_or(0, Vec::len)
+    }
+
+    fn raw_payload(&self, class: &str, key1: &str, key2: Option<&str>) -> Option<Vec<u8>> {
+        self.chains
+            .lock()
+            .unwrap()
+            .get(&(class.to_string(), key1.to_string(), key2.map(String::from)))
+            .and_then(|chain| chain.first().map(|(_, _, p)| p.clone()))
+    }
+}
+
+impl GovernanceReceiptBackend for OpaqueUniqueBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(())
+    }
+
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        let mut unique = self.unique.lock().unwrap();
+        if let Some(winner) = unique.get(&key) {
+            return Ok(Some(*winner));
+        }
+        unique.insert(key.clone(), record_hash);
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(None)
+    }
+
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        Ok(self.chains.lock().unwrap().get(&key).and_then(|chain| {
+            chain
+                .iter()
+                .max_by_key(|(t, h, _)| (*t, *h))
+                .map(|(_, _, p)| p.clone())
+        }))
+    }
+
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        let chains = self.chains.lock().unwrap();
+        let mut hits: Vec<ChainEntry> = chains
+            .iter()
+            .filter(|((c, k1, _), _)| c == class && k1 == key1)
+            .flat_map(|(_, chain)| chain.iter().cloned())
+            .collect();
+        hits.sort_by_key(|(t, h, _)| (*t, *h));
+        Ok(hits.into_iter().map(|(_, _, p)| p).collect())
+    }
+}
+
+/// Backend that persists everything except the export-prepared insert — proves
+/// fail-closed export persistence with all preconditions satisfied (the full
+/// produced chain is recorded through the same store first).
+#[derive(Default)]
+struct FailingEvidencePacketExportPreparedBackend {
+    inner: OpaqueUniqueBackend,
+}
+
+impl GovernanceReceiptBackend for FailingEvidencePacketExportPreparedBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        self.inner
+            .put_opaque(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        if class == "evidence_packet_export_prepared" {
+            return Err("simulated evidence-packet-export-prepared backend failure".to_string());
+        }
+        self.inner
+            .put_opaque_if_absent(class, key1, key2, recorded_at, record_hash, payload)
+    }
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        self.inner.get_latest_opaque(class, key1, key2)
+    }
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        self.inner.list_opaque_for(class, key1)
+    }
+}
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_manager() -> (GovernanceManager, Arc<OpaqueUniqueBackend>) {
+    let store = Arc::new(OpaqueUniqueBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    (mgr, store)
+}
+
+fn coop_test() -> GovernanceDomainId {
+    GovernanceDomainId::new("coop:test")
+}
+
+fn exp_key1(domain: &str, session: &str) -> String {
+    evidence_packet_export_prepared_composite_key1(domain, session)
+}
+
+fn open_session(mgr: &GovernanceManager, domain: &GovernanceDomainId, session: &str, by: &Did) {
+    match mgr
+        .record_process_session_opened(domain, session, by)
+        .unwrap()
+    {
+        ProcessSessionOpenOutcome::Opened(_) | ProcessSessionOpenOutcome::AlreadyOpened(_) => {}
+    }
+}
+
+/// Record the full chain up to a recorded `MutationAppliedReceipt` and return
+/// its `record_hash`. The activation/plan ids are derived from
+/// `application_id`. Mirrors the produced slice's helper.
+fn setup_applied(
+    mgr: &GovernanceManager,
+    domain: &GovernanceDomainId,
+    session: &str,
+    application_id: &str,
+    by: &Did,
+) -> [u8; 32] {
+    let plan_id = format!("plan-for-{application_id}");
+    let activation_id = format!("activation-for-{plan_id}");
+    open_session(mgr, domain, session, by);
+    let decision_id = format!("decision-for-{activation_id}");
+    let decision_hash = match mgr
+        .record_decision(domain, session, &decision_id, by, [9u8; 32])
+        .unwrap()
+    {
+        DecisionRecordOutcome::Recorded(r) | DecisionRecordOutcome::AlreadyRecorded(r) => {
+            r.record_hash
+        }
+    };
+    let gate_hash = mgr
+        .record_process_gate_result(
+            domain,
+            session,
+            ProcessGateKind::PrivacyReview,
+            ProcessGateResult::Pass,
+            by,
+        )
+        .unwrap()
+        .record_hash;
+    let activation_hash = match mgr
+        .record_activation_crossed(
+            domain,
+            session,
+            &activation_id,
+            &decision_id,
+            decision_hash,
+            &[gate_hash],
+            by,
+        )
+        .unwrap()
+    {
+        ActivationCrossedOutcome::Crossed(r) | ActivationCrossedOutcome::AlreadyCrossed(r) => {
+            r.record_hash
+        }
+    };
+    let plan_hash = match mgr
+        .record_mutation_plan_recorded(
+            domain,
+            session,
+            &plan_id,
+            &activation_id,
+            activation_hash,
+            [5u8; 32],
+            by,
+        )
+        .unwrap()
+    {
+        MutationPlanRecordedOutcome::Recorded(r)
+        | MutationPlanRecordedOutcome::AlreadyRecorded(r) => r.record_hash,
+    };
+    match mgr
+        .record_mutation_applied(
+            domain,
+            session,
+            application_id,
+            &plan_id,
+            plan_hash,
+            [4u8; 32],
+            by,
+        )
+        .unwrap()
+    {
+        MutationAppliedOutcome::Applied(r) | MutationAppliedOutcome::AlreadyApplied(r) => {
+            r.record_hash
+        }
+    }
+}
+
+/// The packet-artifact fingerprint every produced fixture in this file uses.
+const PACKET_HASH: [u8; 32] = [5u8; 32];
+
+/// Record the full chain through a recorded `EvidencePacketProducedReceipt`
+/// for `packet_id` and return the produced receipt's `record_hash` — the EX5
+/// predecessor link an export preparation references. The produced receipt's
+/// stored `packet_hash` is [`PACKET_HASH`].
+fn setup_produced(
+    mgr: &GovernanceManager,
+    domain: &GovernanceDomainId,
+    session: &str,
+    packet_id: &str,
+    by: &Did,
+) -> [u8; 32] {
+    let application_id = format!("application-for-{packet_id}");
+    let ah = setup_applied(mgr, domain, session, &application_id, by);
+    let source = vec![EvidencePacketSourceRef {
+        ladder_position: 6,
+        record_hash: ah,
+    }];
+    match mgr
+        .record_evidence_packet_produced(
+            domain,
+            session,
+            packet_id,
+            &application_id,
+            ah,
+            &source,
+            PACKET_HASH,
+            [9u8; 32],
+            by,
+        )
+        .unwrap()
+    {
+        EvidencePacketProducedOutcome::Produced(r)
+        | EvidencePacketProducedOutcome::AlreadyProduced(r) => r.record_hash,
+    }
+}
+
+// ============================================================================
+// Happy path — construct, persist, retrieve, verify EX5 links
+// ============================================================================
+
+#[test]
+fn export_prepared_persists_and_returns_receipt_with_verified_links() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_produced(&mgr, &domain, "session-001", "packet-001", &actor);
+
+    let outcome = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-001",
+            ph,
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect("first export preparation must succeed");
+    let EvidencePacketExportPreparedOutcome::Prepared(receipt) = outcome else {
+        panic!("first export preparation must be Prepared, got {outcome:?}");
+    };
+    assert_eq!(receipt.domain_id, "coop:test");
+    assert_eq!(receipt.session_id, "session-001");
+    assert_eq!(receipt.export_id, "export-001");
+    assert_eq!(receipt.packet_id, "packet-001");
+    assert_eq!(receipt.recipient_scope_id, "scope-partner-review");
+    assert_eq!(receipt.prepared_by, actor.to_string());
+    assert_eq!(receipt.export_policy_hash, [3u8; 32]);
+    assert_ne!(receipt.record_hash, [0u8; 32], "real blake3 hash");
+    // EX5: packet_produced_record_hash equals the persisted produced receipt
+    // hash, and packet_hash is the verified echo of its artifact fingerprint.
+    assert_eq!(
+        receipt.packet_produced_record_hash, ph,
+        "EX5 proof link binds the recorded packet's real record_hash"
+    );
+    assert_eq!(
+        receipt.packet_hash, PACKET_HASH,
+        "EX5 echo binds the produced receipt's stored packet_hash"
+    );
+    assert_eq!(
+        store.chain_len(
+            "evidence_packet_export_prepared",
+            &exp_key1("coop:test", "session-001"),
+            Some("export-001"),
+        ),
+        1,
+        "exactly one persisted export preparation"
+    );
+    let read = mgr
+        .get_evidence_packet_export_prepared(&domain, "session-001", "export-001")
+        .unwrap()
+        .expect("point read must hydrate");
+    assert_eq!(read, receipt);
+}
+
+// ============================================================================
+// Idempotency, conflict, multiplicity
+// ============================================================================
+
+#[test]
+fn same_identity_retry_returns_original_never_restamped() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_produced(&mgr, &domain, "session-001", "packet-001", &actor);
+
+    let first = match mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-001",
+            ph,
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .unwrap()
+    {
+        EvidencePacketExportPreparedOutcome::Prepared(r) => r,
+        other => panic!("expected Prepared, got {other:?}"),
+    };
+    // Retry with byte-identical inputs — same stable identity, no restamp.
+    let retry = match mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-001",
+            ph,
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .unwrap()
+    {
+        EvidencePacketExportPreparedOutcome::AlreadyPrepared(r) => r,
+        other => panic!("expected AlreadyPrepared, got {other:?}"),
+    };
+    assert_eq!(retry, first, "retry returns the original, never restamped");
+    assert_eq!(retry.prepared_at, first.prepared_at);
+    assert_eq!(retry.record_hash, first.record_hash);
+}
+
+#[test]
+fn conflicting_identity_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_produced(&mgr, &domain, "session-001", "packet-001", &actor);
+
+    mgr.record_evidence_packet_export_prepared(
+        &domain,
+        "session-001",
+        "export-001",
+        "packet-001",
+        ph,
+        PACKET_HASH,
+        [3u8; 32],
+        "scope-partner-review",
+        &actor,
+    )
+    .expect("first export preparation");
+    // Same export_id, different recipient scope → conflict, fail closed.
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-001",
+            ph,
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-other",
+            &actor,
+        )
+        .expect_err("conflicting re-record must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_export_prepared_conflict"),
+        "expected conflict sentinel, got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "evidence_packet_export_prepared",
+            &exp_key1("coop:test", "session-001"),
+            Some("export-001"),
+        ),
+        1,
+        "the original preparation remains the only persisted record"
+    );
+}
+
+#[test]
+fn multiple_exports_per_packet_with_distinct_export_ids_succeed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_produced(&mgr, &domain, "session-001", "packet-001", &actor);
+
+    // Same packet, two scopes, two export ids — both recordable (how many is
+    // charter policy, not substrate policy).
+    for (export_id, scope) in [
+        ("export-001", "scope-partner-review"),
+        ("export-002", "scope-member-summary"),
+    ] {
+        let outcome = mgr
+            .record_evidence_packet_export_prepared(
+                &domain,
+                "session-001",
+                export_id,
+                "packet-001",
+                ph,
+                PACKET_HASH,
+                [3u8; 32],
+                scope,
+                &actor,
+            )
+            .expect("each distinct export_id must succeed");
+        assert!(matches!(
+            outcome,
+            EvidencePacketExportPreparedOutcome::Prepared(_)
+        ));
+    }
+    let listed = mgr
+        .list_evidence_packet_export_prepared_in_domain(&domain, "session-001")
+        .unwrap();
+    assert_eq!(listed.len(), 2, "both preparations listed");
+}
+
+// ============================================================================
+// Predecessor + echo verification (EX5) fail-closed
+// ============================================================================
+
+#[test]
+fn missing_predecessor_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    open_session(&mgr, &domain, "session-001", &actor);
+    // No EvidencePacketProducedReceipt recorded.
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-404",
+            [6u8; 32],
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect_err("must fail closed when the predecessor is absent");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_export_prepared_predecessor_not_found"),
+        "got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "evidence_packet_export_prepared",
+            &exp_key1("coop:test", "session-001"),
+            Some("export-001"),
+        ),
+        0,
+        "nothing persisted"
+    );
+}
+
+#[test]
+fn predecessor_hash_mismatch_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let _ph = setup_produced(&mgr, &domain, "session-001", "packet-001", &actor);
+    // Supply a wrong packet_produced_record_hash for a real packet id.
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-001",
+            [0xEEu8; 32],
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect_err("mismatched predecessor hash must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_export_prepared_predecessor_mismatch"),
+        "got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "evidence_packet_export_prepared",
+            &exp_key1("coop:test", "session-001"),
+            Some("export-001"),
+        ),
+        0,
+        "nothing persisted"
+    );
+}
+
+#[test]
+fn cross_packet_reference_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    // Two real packets in the same session; supply packet B's record_hash
+    // under packet A's id — the fetched receipt is A, so the link mismatches.
+    let _ph_a = setup_produced(&mgr, &domain, "session-001", "packet-A", &actor);
+    let ph_b = setup_produced(&mgr, &domain, "session-001", "packet-B", &actor);
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-A",
+            ph_b,
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect_err("cross-packet id/hash swap must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_export_prepared_predecessor_mismatch"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn packet_hash_mismatch_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_produced(&mgr, &domain, "session-001", "packet-001", &actor);
+    // Correct predecessor record_hash, wrong echoed packet_hash — the verified
+    // echo must fail closed (EX5).
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-001",
+            ph,
+            [0xAAu8; 32],
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect_err("mismatched packet_hash echo must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_export_prepared_packet_hash_mismatch"),
+        "got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "evidence_packet_export_prepared",
+            &exp_key1("coop:test", "session-001"),
+            Some("export-001"),
+        ),
+        0,
+        "nothing persisted"
+    );
+}
+
+#[test]
+fn wrong_session_predecessor_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    // Packet produced in session-A; try to prepare an export in session-B.
+    let ph = setup_produced(&mgr, &domain, "session-A", "packet-001", &actor);
+    open_session(&mgr, &domain, "session-B", &actor);
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-B",
+            "export-001",
+            "packet-001",
+            ph,
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect_err("cross-session predecessor must fail closed as not found");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_export_prepared_predecessor_not_found"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn wrong_domain_predecessor_fails_closed() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    // Packet produced in d1; d2 opens the same session name but has no packet.
+    let ph = setup_produced(&mgr, &d1, "shared-session", "packet-001", &actor);
+    open_session(&mgr, &d2, "shared-session", &actor);
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &d2,
+            "shared-session",
+            "export-001",
+            "packet-001",
+            ph,
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect_err("cross-domain predecessor must fail closed as not found");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_export_prepared_predecessor_not_found"),
+        "got: {err}"
+    );
+}
+
+// ============================================================================
+// Session anchoring, input validation, store wiring
+// ============================================================================
+
+#[test]
+fn unopened_session_fails_closed() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-unopened",
+            "export-001",
+            "packet-001",
+            [6u8; 32],
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect_err("unopened session must fail closed");
+    assert!(
+        err.to_string()
+            .starts_with("evidence_packet_export_prepared_session_not_opened"),
+        "got: {err}"
+    );
+    assert_eq!(
+        store.chain_len(
+            "evidence_packet_export_prepared",
+            &exp_key1("coop:test", "session-unopened"),
+            Some("export-001"),
+        ),
+        0
+    );
+}
+
+#[test]
+fn whitespace_ids_rejected() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_produced(&mgr, &domain, "session-001", "packet-001", &actor);
+    for (session, export, packet, scope) in [
+        ("   ", "export-001", "packet-001", "scope-partner-review"),
+        ("session-001", "  ", "packet-001", "scope-partner-review"),
+        ("session-001", "export-001", "   ", "scope-partner-review"),
+        ("session-001", "export-001", "packet-001", "  "),
+    ] {
+        let err = mgr
+            .record_evidence_packet_export_prepared(
+                &domain,
+                session,
+                export,
+                packet,
+                ph,
+                PACKET_HASH,
+                [3u8; 32],
+                scope,
+                &actor,
+            )
+            .expect_err("whitespace id must be rejected");
+        assert!(err.to_string().contains("non-whitespace"), "got: {err}");
+    }
+}
+
+#[test]
+fn no_receipt_store_fails_closed() {
+    let mgr = GovernanceManager::new(); // no receipt store wired
+    let actor = fresh_did();
+    let domain = coop_test();
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-001",
+            [6u8; 32],
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect_err("a receipt store is required");
+    assert!(
+        err.to_string().contains("a receipt store is required"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn backend_failure_propagates() {
+    let store = Arc::new(FailingEvidencePacketExportPreparedBackend::default());
+    let mgr = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_produced(&mgr, &domain, "session-001", "packet-001", &actor);
+    let err = mgr
+        .record_evidence_packet_export_prepared(
+            &domain,
+            "session-001",
+            "export-001",
+            "packet-001",
+            ph,
+            PACKET_HASH,
+            [3u8; 32],
+            "scope-partner-review",
+            &actor,
+        )
+        .expect_err("backend failure must propagate");
+    assert!(
+        err.to_string()
+            .contains("simulated evidence-packet-export-prepared backend failure"),
+        "got: {err}"
+    );
+}
+
+// ============================================================================
+// Isolation, key injectivity, privacy audit
+// ============================================================================
+
+#[test]
+fn two_domain_isolation() {
+    let (mgr, _store) = make_manager();
+    let actor = fresh_did();
+    let d1 = GovernanceDomainId::new("coop:one");
+    let d2 = GovernanceDomainId::new("coop:two");
+    let ph1 = setup_produced(&mgr, &d1, "shared-session", "packet-001", &actor);
+    let ph2 = setup_produced(&mgr, &d2, "shared-session", "packet-001", &actor);
+
+    mgr.record_evidence_packet_export_prepared(
+        &d1,
+        "shared-session",
+        "export-001",
+        "packet-001",
+        ph1,
+        PACKET_HASH,
+        [3u8; 32],
+        "scope-partner-review",
+        &actor,
+    )
+    .expect("d1 export preparation");
+    mgr.record_evidence_packet_export_prepared(
+        &d2,
+        "shared-session",
+        "export-001",
+        "packet-001",
+        ph2,
+        PACKET_HASH,
+        [3u8; 32],
+        "scope-partner-review",
+        &actor,
+    )
+    .expect("d2 export preparation");
+
+    let r1 = mgr
+        .get_evidence_packet_export_prepared(&d1, "shared-session", "export-001")
+        .unwrap()
+        .unwrap();
+    let r2 = mgr
+        .get_evidence_packet_export_prepared(&d2, "shared-session", "export-001")
+        .unwrap()
+        .unwrap();
+    assert_eq!(r1.domain_id, "coop:one");
+    assert_eq!(r2.domain_id, "coop:two");
+    assert_ne!(r1.record_hash, r2.record_hash, "two domains never mix");
+}
+
+#[test]
+fn composite_key1_is_injective() {
+    // ("ab","c") and ("a","bc") must not alias.
+    assert_ne!(
+        evidence_packet_export_prepared_composite_key1("ab", "c"),
+        evidence_packet_export_prepared_composite_key1("a", "bc"),
+    );
+}
+
+#[test]
+fn stored_payload_carries_no_bodies_or_contact_data() {
+    let (mgr, store) = make_manager();
+    let actor = fresh_did();
+    let domain = coop_test();
+    let ph = setup_produced(&mgr, &domain, "session-001", "packet-001", &actor);
+    mgr.record_evidence_packet_export_prepared(
+        &domain,
+        "session-001",
+        "export-001",
+        "packet-001",
+        ph,
+        PACKET_HASH,
+        [3u8; 32],
+        "scope-partner-review",
+        &actor,
+    )
+    .expect("export preparation");
+    let raw = store
+        .raw_payload(
+            "evidence_packet_export_prepared",
+            &exp_key1("coop:test", "session-001"),
+            Some("export-001"),
+        )
+        .expect("payload present");
+    let json = String::from_utf8(raw).expect("utf8");
+    for forbidden in [
+        // deliberately-absent semantics (EX2/EX6/EX7)
+        "delivered",
+        "transmitted",
+        "received",
+        "accepted",
+        "audited",
+        "certified",
+        "availability",
+        "custody",
+        "vault",
+        "location",
+        "endpoint",
+        "retrieval",
+        "credential",
+        "status",
+        "superseded",
+        "withdrawn",
+        "challenged",
+        // bodies (never stored — fingerprints only)
+        "packet_body",
+        "export_policy_body",
+        "redaction_profile_body",
+        "source_receipt_bod",
+        // recipient contact data (EX3 — scope handle only)
+        "recipient_did",
+        "recipient_name",
+        "recipient_email",
+        "recipient_phone",
+        "recipient_address",
+        "recipient_list",
+        "recipient_scope_hash",
+        "scope_definition",
+        "@",
+        // human/AT status (excluded; #2041 stays open)
+        "human_at_status",
+    ] {
+        assert!(
+            !json.contains(forbidden),
+            "stored payload must not carry `{forbidden}`; got: {json}"
+        );
+    }
+}

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -142,9 +142,10 @@ pub use profile::{DecisionOutcome, GovernanceProfile, GovernanceProfileId, Gover
 pub use proof::{
     ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActionItemCompletionReceiptV2Error,
     ActionItemTransition, ActivationCrossedReceipt, DecisionRecordedReceipt, DeliberationEntryKind,
-    DeliberationEntryRecordedReceipt, EvidencePacketProducedReceipt, EvidencePacketReceiptSetError,
-    EvidencePacketSourceRef, GovernanceDecisionAttestation, GovernanceDecisionReceipt,
-    GovernanceDecisionReceiptV2, GovernanceDecisionReceiptV2Error, GovernanceDecisionReceiptV3,
+    DeliberationEntryRecordedReceipt, EvidencePacketExportPreparedReceipt,
+    EvidencePacketProducedReceipt, EvidencePacketReceiptSetError, EvidencePacketSourceRef,
+    GovernanceDecisionAttestation, GovernanceDecisionReceipt, GovernanceDecisionReceiptV2,
+    GovernanceDecisionReceiptV2Error, GovernanceDecisionReceiptV3,
     GovernanceDecisionReceiptV3Error, GovernanceProof, GovernanceProofV2, MandateGrantRef,
     MandateGrantRefError, MandateGrantRefTarget, MeetingAttendanceReceipt,
     MeetingAttendanceReceiptV2, MeetingAttendanceReceiptV2Error, MeetingAttendanceTransition,

--- a/icn/crates/icn-governance/src/proof.rs
+++ b/icn/crates/icn-governance/src/proof.rs
@@ -3568,6 +3568,209 @@ impl EvidencePacketProducedReceipt {
 }
 
 // ============================================================================
+// EvidencePacketExportPreparedReceipt — ninth process/evidence receipt class
+// (#2322 boundary contract + #2324 EX1–EX8 decision rung). The FIRST class
+// beyond the eight named by the idea-0019 framing — it extends the family and
+// must not be presented as completing a #1748 acceptance gate.
+// ============================================================================
+
+/// Receipt of record that an **export of a produced evidence packet was
+/// prepared** for a named recipient scope under a declared export policy —
+/// the sender-side preparation/staging fact chosen by the #2324 EX1 decision.
+///
+/// Per the #2322 boundary contract as resolved by the #2324 EX1–EX8 rung:
+///
+/// **EX1 — prepared, not transmitted.** The fact is the *preparation* of an
+/// export: a specific produced packet artifact bound to a recipient scope
+/// under an export policy, recorded. Nothing in this receipt asserts that
+/// anything moved. Prepared is **not** delivered, made available, received,
+/// accepted, audited, or certified.
+///
+/// **EX3 — recipient scope.** `recipient_scope_id` is a caller-opaque
+/// governance handle naming *which* scope, never *what* the scope is — no
+/// scope-definition body or hash, no recipient DID enumeration, and **never**
+/// personal contact data.
+///
+/// **EX5 — verified proof links.** `packet_id` + `packet_produced_record_hash`
+/// name the [`EvidencePacketProducedReceipt`] this export prepares (verified
+/// fail-closed — the lane's fifth inter-receipt link), and `packet_hash`
+/// echoes that receipt's public/redacted artifact fingerprint (verified equal
+/// to the stored produced receipt's `packet_hash` in the same fetch — the
+/// lane's first verified echoed content field). `export_policy_hash`
+/// fingerprints the export policy that shaped this preparation; the policy
+/// body is never stored. Plan/activation/decision/gate provenance is inherited
+/// transitively through the produced receipt, not restated.
+///
+/// **EX2/EX6/EX7 — deliberately absent.** No availability, custody, vault,
+/// location, retrieval, transport, delivery, receipt, acceptance, audit,
+/// certification, status, supersession, or challenge semantics exist in `:v1`.
+///
+/// `prepared_at` is node-stamped Unix seconds, hashed into `record_hash` but
+/// **excluded** from duplicate identity — a retry never restamps.
+/// `prepared_by` is actor evidence (the recorder / export-witness), not an
+/// authority to export, release, deliver, certify, or audit ("recorder, not
+/// releaser"). Equality is anchored to `record_hash`. Human/AT status is
+/// excluded; #2041 stays open.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EvidencePacketExportPreparedReceipt {
+    /// Governance domain the session (and this export preparation) is scoped to.
+    pub domain_id: String,
+    /// Identifier of the already-opened process session this export attaches
+    /// to. Caller-provided, opaque, meaningful only together with `domain_id`.
+    pub session_id: String,
+    /// Caller-supplied opaque identifier for this export preparation, unique
+    /// within `(domain_id, session_id)` — uniqueness is enforced at the
+    /// storage layer. Multiple exports per packet (distinct `export_id`s) are
+    /// permitted at the substrate layer; how many is charter policy.
+    pub export_id: String,
+    /// Caller-opaque `packet_id` of the [`EvidencePacketProducedReceipt`] this
+    /// export prepares — the predecessor's human/index handle (EX5).
+    pub packet_id: String,
+    /// Content-addressed `record_hash` of that
+    /// [`EvidencePacketProducedReceipt`] — the cryptographic proof link to the
+    /// produced packet (EX5). Verified to exist in-session before the export
+    /// preparation is recorded.
+    pub packet_produced_record_hash: Hash,
+    /// Echo of the produced receipt's fingerprint of the **public/redacted**
+    /// packet artifact being exported (EX5). Verified equal to the stored
+    /// produced receipt's `packet_hash` — an assertion-free proof echo. The
+    /// packet body itself is never stored.
+    pub packet_hash: Hash,
+    /// Caller-supplied fingerprint of the export policy that shaped/authorized
+    /// this preparation for this scope (EX5). The policy body itself is never
+    /// stored; the hash records *which* policy, not that the policy is
+    /// complete, correct, satisfied, or legally sufficient.
+    pub export_policy_hash: Hash,
+    /// Caller-opaque handle of the recipient scope this export was prepared
+    /// for (EX3). An opaque governance handle — never a name, email, phone
+    /// number, address, or any personal contact data.
+    pub recipient_scope_id: String,
+    /// DID of the authenticated actor who recorded the preparation — recorder
+    /// / export-witness evidence, not an authority to export, release,
+    /// deliver, certify, or audit. Grants zero authority.
+    pub prepared_by: String,
+    /// Unix-seconds the preparation was recorded (node-stamped). Not part of
+    /// duplicate identity — a retry never restamps.
+    pub prepared_at: u64,
+    /// blake3 canonical record hash binding the fields above.
+    pub record_hash: Hash,
+}
+
+impl PartialEq for EvidencePacketExportPreparedReceipt {
+    fn eq(&self, other: &Self) -> bool {
+        self.record_hash == other.record_hash
+    }
+}
+
+impl Eq for EvidencePacketExportPreparedReceipt {}
+
+impl EvidencePacketExportPreparedReceipt {
+    /// Domain separation tag for canonical evidence-packet-export-prepared
+    /// record hashes. Distinct from every other receipt-family tag — and in
+    /// particular it must NEVER converge with
+    /// `icn:gov:evidence_packet_produced:v1` (or its `:receipt_set:v1`
+    /// sub-tag), `icn:gov:mutation_applied:v1`,
+    /// `icn:gov:mutation_plan_recorded:v1`, `icn:gov:activation_crossed:v1`,
+    /// `icn:gov:decision_recorded:v1`, `icn:gov:process_gate_result:v1`,
+    /// `icn:gov:deliberation_entry_recorded:v1`,
+    /// `icn:gov:process_session_opened:v1`, or the proposal/vote
+    /// `icn:gov:decision:v1/v2/v3` lineage.
+    pub const DOMAIN_TAG: &[u8] = b"icn:gov:evidence_packet_export_prepared:v1";
+
+    /// Build a new receipt and compute its canonical `record_hash`.
+    ///
+    /// `packet_produced_record_hash` and `packet_hash` must reference/echo the
+    /// stored [`EvidencePacketProducedReceipt`] (the manager verifies both
+    /// fail-closed before recording); `export_policy_hash` is a caller-supplied
+    /// fingerprint of the never-stored export policy (EX5), mirroring how the
+    /// sibling classes take pre-computed fingerprints.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        domain_id: String,
+        session_id: String,
+        export_id: String,
+        packet_id: String,
+        packet_produced_record_hash: Hash,
+        packet_hash: Hash,
+        export_policy_hash: Hash,
+        recipient_scope_id: String,
+        prepared_by: String,
+        prepared_at: u64,
+    ) -> Self {
+        let record_hash = Self::compute_record_hash(
+            &domain_id,
+            &session_id,
+            &export_id,
+            &packet_id,
+            &packet_produced_record_hash,
+            &packet_hash,
+            &export_policy_hash,
+            &recipient_scope_id,
+            &prepared_by,
+            prepared_at,
+        );
+        Self {
+            domain_id,
+            session_id,
+            export_id,
+            packet_id,
+            packet_produced_record_hash,
+            packet_hash,
+            export_policy_hash,
+            recipient_scope_id,
+            prepared_by,
+            prepared_at,
+            record_hash,
+        }
+    }
+
+    /// Compute the canonical record hash from the input fields.
+    ///
+    /// Layout (per the #2322 contract as resolved by the #2324 EX1–EX8
+    /// decision rung §12): [`Self::DOMAIN_TAG`] first; each string field
+    /// length-prefixed (u64 LE) in order `domain_id`, `session_id`,
+    /// `export_id`, `packet_id`, `recipient_scope_id`, `prepared_by`; then
+    /// `packet_produced_record_hash`, `packet_hash`, `export_policy_hash`
+    /// appended **raw as fixed 32-byte fields with no length prefix**
+    /// (fixed-size fields cannot alias); then `prepared_at` as LE bytes (Unix
+    /// seconds). No discriminant byte (this class has no kind taxonomy).
+    #[allow(clippy::too_many_arguments)]
+    pub fn compute_record_hash(
+        domain_id: &str,
+        session_id: &str,
+        export_id: &str,
+        packet_id: &str,
+        packet_produced_record_hash: &Hash,
+        packet_hash: &Hash,
+        export_policy_hash: &Hash,
+        recipient_scope_id: &str,
+        prepared_by: &str,
+        prepared_at: u64,
+    ) -> Hash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(Self::DOMAIN_TAG);
+        for field in [
+            domain_id,
+            session_id,
+            export_id,
+            packet_id,
+            recipient_scope_id,
+            prepared_by,
+        ] {
+            hasher.update(&(field.len() as u64).to_le_bytes());
+            hasher.update(field.as_bytes());
+        }
+        hasher.update(packet_produced_record_hash);
+        hasher.update(packet_hash);
+        hasher.update(export_policy_hash);
+        hasher.update(&prepared_at.to_le_bytes());
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hasher.finalize().as_bytes());
+        out
+    }
+}
+
+// ============================================================================
 // Mandate grant reference (#1868 step 2 primitive — wire form only)
 // ============================================================================
 
@@ -6525,6 +6728,376 @@ mod tests {
             assert!(
                 !lower.contains(forbidden),
                 "EvidencePacketProducedReceipt JSON must not contain `{forbidden}`; got: {json}"
+            );
+        }
+    }
+
+    // ============================================================================
+    // EvidencePacketExportPreparedReceipt — ninth process/evidence class
+    // (#2322 boundary contract + #2324 EX1–EX8 decision rung)
+    // ============================================================================
+
+    fn sample_evidence_packet_export_prepared_receipt() -> EvidencePacketExportPreparedReceipt {
+        EvidencePacketExportPreparedReceipt::new(
+            "domain-food-coop".to_string(),
+            "session-alpha".to_string(),
+            "export-001".to_string(),
+            "packet-001".to_string(),
+            [6u8; 32], // packet_produced_record_hash (EX5 proof link)
+            [5u8; 32], // packet_hash (verified echo of the produced receipt)
+            [3u8; 32], // export_policy_hash (EX5, body never stored)
+            "scope-partner-review".to_string(), // caller-opaque scope handle, never contact data
+            "did:icn:preparer-1".to_string(), // recorder, not releaser
+            1_750_000_000,
+        )
+    }
+
+    #[test]
+    fn evidence_packet_export_prepared_golden_vector() {
+        // Golden canonical hash vector: pins the FULL v1 layout (domain tag,
+        // length-prefixed strings domain_id/session_id/export_id/packet_id/
+        // recipient_scope_id/prepared_by, raw fixed 32-byte
+        // packet_produced_record_hash then packet_hash then export_policy_hash,
+        // prepared_at LE — no discriminant byte). Any layout change breaks this
+        // test and requires a new tag version.
+        let r = sample_evidence_packet_export_prepared_receipt();
+        assert_eq!(
+            hex32(&r.record_hash),
+            "59401de677d38971de079d8bee2a77206a508908f9e61ce9224397e1be8dafa6",
+            "canonical v1 hash layout drifted"
+        );
+    }
+
+    #[test]
+    fn evidence_packet_export_prepared_record_hash_determinism() {
+        let r1 = sample_evidence_packet_export_prepared_receipt();
+        let r2 = sample_evidence_packet_export_prepared_receipt();
+        assert_eq!(r1.record_hash, r2.record_hash);
+        assert_ne!(r1.record_hash, [0u8; 32]);
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn evidence_packet_export_prepared_record_hash_changes_per_field() {
+        // Every hashed field independently changes the record hash — including
+        // prepared_at (hashed but excluded from duplicate identity; the
+        // identity exclusion is proven at the runtime-slice layer).
+        let base = sample_evidence_packet_export_prepared_receipt();
+        let mk = |domain: &str,
+                  session: &str,
+                  export: &str,
+                  packet: &str,
+                  produced_hash: [u8; 32],
+                  packet_hash: [u8; 32],
+                  policy_hash: [u8; 32],
+                  scope: &str,
+                  by: &str,
+                  at: u64| {
+            EvidencePacketExportPreparedReceipt::new(
+                domain.to_string(),
+                session.to_string(),
+                export.to_string(),
+                packet.to_string(),
+                produced_hash,
+                packet_hash,
+                policy_hash,
+                scope.to_string(),
+                by.to_string(),
+                at,
+            )
+        };
+        let variants = [
+            mk(
+                "domain-other",
+                &base.session_id,
+                &base.export_id,
+                &base.packet_id,
+                base.packet_produced_record_hash,
+                base.packet_hash,
+                base.export_policy_hash,
+                &base.recipient_scope_id,
+                &base.prepared_by,
+                base.prepared_at,
+            ),
+            mk(
+                &base.domain_id,
+                "session-other",
+                &base.export_id,
+                &base.packet_id,
+                base.packet_produced_record_hash,
+                base.packet_hash,
+                base.export_policy_hash,
+                &base.recipient_scope_id,
+                &base.prepared_by,
+                base.prepared_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                "export-other",
+                &base.packet_id,
+                base.packet_produced_record_hash,
+                base.packet_hash,
+                base.export_policy_hash,
+                &base.recipient_scope_id,
+                &base.prepared_by,
+                base.prepared_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.export_id,
+                "packet-other",
+                base.packet_produced_record_hash,
+                base.packet_hash,
+                base.export_policy_hash,
+                &base.recipient_scope_id,
+                &base.prepared_by,
+                base.prepared_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.export_id,
+                &base.packet_id,
+                [1u8; 32],
+                base.packet_hash,
+                base.export_policy_hash,
+                &base.recipient_scope_id,
+                &base.prepared_by,
+                base.prepared_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.export_id,
+                &base.packet_id,
+                base.packet_produced_record_hash,
+                [2u8; 32],
+                base.export_policy_hash,
+                &base.recipient_scope_id,
+                &base.prepared_by,
+                base.prepared_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.export_id,
+                &base.packet_id,
+                base.packet_produced_record_hash,
+                base.packet_hash,
+                [4u8; 32],
+                &base.recipient_scope_id,
+                &base.prepared_by,
+                base.prepared_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.export_id,
+                &base.packet_id,
+                base.packet_produced_record_hash,
+                base.packet_hash,
+                base.export_policy_hash,
+                "scope-other",
+                &base.prepared_by,
+                base.prepared_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.export_id,
+                &base.packet_id,
+                base.packet_produced_record_hash,
+                base.packet_hash,
+                base.export_policy_hash,
+                &base.recipient_scope_id,
+                "did:icn:preparer-other",
+                base.prepared_at,
+            ),
+            mk(
+                &base.domain_id,
+                &base.session_id,
+                &base.export_id,
+                &base.packet_id,
+                base.packet_produced_record_hash,
+                base.packet_hash,
+                base.export_policy_hash,
+                &base.recipient_scope_id,
+                &base.prepared_by,
+                base.prepared_at + 1,
+            ),
+        ];
+        for (i, v) in variants.iter().enumerate() {
+            assert_ne!(
+                base.record_hash, v.record_hash,
+                "variant {i} must change the record hash"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_packet_export_prepared_tag_separates_from_other_families() {
+        // Family separation from every landed proof.rs domain tag — the eight
+        // process-transition classes, the produced receipt's set sub-tag, the
+        // proposal/vote decision lineage, and the remaining receipt families.
+        for other in [
+            GovernanceProof::DOMAIN_TAG,
+            ProcessSessionOpenedReceipt::DOMAIN_TAG,
+            DeliberationEntryRecordedReceipt::DOMAIN_TAG,
+            DecisionRecordedReceipt::DOMAIN_TAG,
+            ProcessGateResultReceipt::DOMAIN_TAG,
+            ActivationCrossedReceipt::DOMAIN_TAG,
+            MutationPlanRecordedReceipt::DOMAIN_TAG,
+            MutationAppliedReceipt::DOMAIN_TAG,
+            // Must NEVER converge with the produced predecessor or its sub-tag.
+            EvidencePacketProducedReceipt::DOMAIN_TAG,
+            EvidencePacketProducedReceipt::RECEIPT_SET_DOMAIN_TAG,
+            // Must NEVER converge with the proposal/vote decision lineage.
+            GovernanceDecisionReceipt::DOMAIN_TAG,
+            GovernanceDecisionReceiptV2::DOMAIN_TAG,
+            GovernanceDecisionReceiptV3::DOMAIN_TAG,
+            GovernanceDecisionAttestation::DOMAIN_TAG,
+            ActionItemCompletionReceipt::DOMAIN_TAG,
+            ActionItemCompletionReceiptV2::DOMAIN_TAG,
+            MeetingAttendanceReceipt::DOMAIN_TAG,
+            MeetingAttendanceReceiptV2::DOMAIN_TAG,
+            MandateGrantRef::DOMAIN_TAG,
+        ] {
+            assert_ne!(EvidencePacketExportPreparedReceipt::DOMAIN_TAG, other);
+        }
+    }
+
+    #[test]
+    fn evidence_packet_export_prepared_length_prefix_prevents_field_shifting() {
+        // Shifting bytes between adjacent string fields must change the hash —
+        // the length prefix delimits each field exactly.
+        let a = EvidencePacketExportPreparedReceipt::compute_record_hash(
+            "ab",
+            "c",
+            "export-001",
+            "packet-001",
+            &[0u8; 32],
+            &[0u8; 32],
+            &[0u8; 32],
+            "scope-x",
+            "did:icn:x",
+            1,
+        );
+        let b = EvidencePacketExportPreparedReceipt::compute_record_hash(
+            "a",
+            "bc",
+            "export-001",
+            "packet-001",
+            &[0u8; 32],
+            &[0u8; 32],
+            &[0u8; 32],
+            "scope-x",
+            "did:icn:x",
+            1,
+        );
+        assert_ne!(a, b, "length prefix must delimit adjacent string fields");
+    }
+
+    #[test]
+    fn evidence_packet_export_prepared_serde_roundtrip_and_payload_audit() {
+        let r = sample_evidence_packet_export_prepared_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let back: EvidencePacketExportPreparedReceipt =
+            serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(r, back);
+        // v1 layout audit: exactly the pinned fields are present, and NONE of
+        // the deliberately-absent fields (EX2/EX3/EX6/EX7) leak into the
+        // payload.
+        for present in [
+            "domain_id",
+            "session_id",
+            "export_id",
+            "packet_id",
+            "packet_produced_record_hash",
+            "packet_hash",
+            "export_policy_hash",
+            "recipient_scope_id",
+            "prepared_by",
+            "prepared_at",
+            "record_hash",
+        ] {
+            assert!(json.contains(present), "field `{present}` must be present");
+        }
+        for forbidden in [
+            "availability",
+            "custody",
+            "vault",
+            "location",
+            "url",
+            "endpoint",
+            "retrieval",
+            "credential",
+            "recipient_did",
+            "recipient_name",
+            "recipient_email",
+            "recipient_phone",
+            "recipient_address",
+            "recipient_list",
+            "recipient_scope_hash",
+            "scope_definition",
+            "status",
+            "superseded",
+            "withdrawn",
+            "challenged",
+            "packet_body",
+            "export_policy_body",
+            "redaction_profile_body",
+            "source_receipt_bod",
+            "human_at_status",
+            "ready",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "field `{forbidden}` must NOT be present; got: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_packet_export_prepared_no_prohibited_vocabulary() {
+        // "prepared" is core vocabulary for this class (prepared_by /
+        // prepared_at), so it is NOT forbidden. This enforces the EX1/EX4
+        // boundary: no transmission/receipt/acceptance/audit overclaim leaks
+        // into the payload, and no regulated-finance or proposal/vote lineage
+        // vocabulary appears.
+        let r = sample_evidence_packet_export_prepared_receipt();
+        let json = serde_json::to_string(&r).expect("serialize");
+        let lower = json.to_lowercase();
+        for forbidden in [
+            // regulated-finance vocabulary
+            "wallet",
+            "token",
+            "payment",
+            "currency",
+            "balance",
+            "deposit",
+            // EX1/EX4 no-overclaim: prepared, not moved/evaluated
+            "delivered",
+            "transmitted",
+            "\"sent\"",
+            "received",
+            "accepted",
+            "audited",
+            "certified",
+            "authorized",
+            "executed",
+            "verified",
+            // proposal/vote lineage vocabulary
+            "proposal",
+            "vote",
+            "tally",
+            "quorum",
+            "mandate",
+        ] {
+            assert!(
+                !lower.contains(forbidden),
+                "EvidencePacketExportPreparedReceipt JSON must not contain `{forbidden}`; got: {json}"
             );
         }
     }


### PR DESCRIPTION
## Summary
- adds the **`EvidencePacketExportPreparedReceipt`** runtime slice — the ninth process/evidence receipt class, chosen by the merged #2324 EX1–EX8 decision rung, mirroring the #2318 slice shape (5 files: `proof.rs` + `lib.rs` + `receipt_backend.rs` + `manager.rs` + a new runtime-slice test)
- pins **`icn:gov:evidence_packet_export_prepared:v1`** with a fail-first golden vector (`59401de677d38971de079d8bee2a77206a508908f9e61ce9224397e1be8dafa6`); hash layout exactly per the rung §12 (tag → length-prefixed `domain_id`/`session_id`/`export_id`/`packet_id`/`recipient_scope_id`/`prepared_by` → raw-32 `packet_produced_record_hash`/`packet_hash`/`export_policy_hash` → `prepared_at` LE)
- verifies the produced predecessor **fail-closed** through the existing `get_evidence_packet_produced(domain_id, session_id, packet_id)` seam (`_predecessor_not_found` / `_predecessor_mismatch`) — the lane's fifth inter-receipt link
- verifies `packet_produced_record_hash` **and** the echoed `packet_hash` against the stored produced receipt in the same fetch (`_packet_hash_mismatch`) — the lane's first **verified echoed content field**
- persistence via `put_opaque_if_absent` (class `evidence_packet_export_prepared`, injective netstring `key1`, `key2 = export_id`); same-identity retry returns the **original un-restamped** receipt; conflicting identity fails closed (`evidence_packet_export_prepared_conflict`); multiple exports per packet with distinct `export_id`s succeed (how many is charter policy)
- preserves the boundary: **export-prepared ≠ delivered / made available / received / accepted / audited / certified / ready**; `prepared_by` is recorder/export-witness evidence granting zero authority; `prepared_at` is node-stamped, hashed, excluded from duplicate identity; `recipient_scope_id` is a caller-opaque governance handle, never contact data; policy/packet bodies are never stored (fingerprints only)
- framing honesty: this is the **first class beyond the eight named by idea-0019** — it extends the family and completes no #1748 acceptance gate

## Scope
- runtime receipt class only
- no exporter
- no transport/delivery
- no route
- no OpenAPI/SDK
- no member-shell
- no fixtures

## Validation
- `cargo fmt --all --check`: clean
- `cargo clippy -p icn-governance -p icn-governance-actor --all-targets -- -D warnings`: clean
- `cargo test -p icn-governance evidence_packet_export_prepared`: **7/7** unit tests (golden vector pinned fail-first, determinism, per-field hash sensitivity incl. all three raw-32 fields and `prepared_at`, tag disjointness vs **every** landed proof.rs domain tag incl. the produced `:receipt_set:v1` sub-tag, length-prefix anti-aliasing, serde payload audit of the full deliberately-absent list, no-prohibited-vocabulary)
- `cargo test -p icn-governance-actor --test evidence_packet_export_prepared_receipt_runtime_slice`: **17/17** (happy path w/ point read, same-identity retry un-restamped, conflict fail-closed w/ chain-len 1, multiplicity, missing/mismatched/cross-packet/wrong-session/wrong-domain predecessor, packet-hash echo mismatch, unopened session, whitespace ids, no store, backend failure, two-domain isolation, composite-key injectivity, stored-payload privacy/contact-data audit)
- `cargo test -p icn-governance -p icn-governance-actor` (full suites): all green, exit 0 — no regression in the eight sibling classes
- `python3 docs/scripts/route_inventory.py --check`: OK (287 routes unchanged — **no route added**)
- `ops/scripts/drift-check.sh`: PASS (0 errors, 0 warnings)
- `git diff --check`: clean
- no-overclaim / vocabulary / close-keyword greps: matches are only test blocklists, doc-comment negations, and incidental substrings ("pre**sent**"); zero positive claims
- `~/bin/icn-prereview`: could not run — local model tunnel down at 127.0.0.1:11435 (all mechanical checks above green)

## Non-claims
- not production
- not pilot
- not organizer-ready
- not member-ready
- not live federation
- not NYCN activation
- not Phase 2 completion
- not #2041 completion
- no export artifact assembled
- no export performed
- no external delivery performed
- no made-available fact recorded
- no recipient receipt/acceptance recorded
- no audit certification recorded
- no legal sufficiency claim
- no route/OpenAPI/SDK/member-shell/fixture change

Refs #2325.
Refs #2324.
Refs #2323.
Refs #2322.
Refs #2318.
Refs #2320.
Refs #1748.
Refs #2141.
Refs #1792.
Refs #2041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)