### PR TITLE
feat(process): render evidence packet export prepared receipt in member shell

### DIFF
--- a/docs/demo/JULY_DEMO_CANDIDATE_0.1_PROCESS_EVIDENCE_WALKTHROUGH.md
+++ b/docs/demo/JULY_DEMO_CANDIDATE_0.1_PROCESS_EVIDENCE_WALKTHROUGH.md
@@ -9,15 +9,21 @@ not organizer-ready, not member-ready, not live federation, not NYCN activation,
 Phase 2 completion, not real member/partner data, and makes no signed/partner claim.
 
 This surface reads the **eight already-landed ADR-0026 Layer 2 process-transition
-receipt classes** (`icn/crates/icn-governance/src/proof.rs`) — no new receipt class is
-introduced, no Rust runtime is changed, and no OpenAPI/SDK is touched. It implements the
+receipt classes plus the ninth `EvidencePacketExportPreparedReceipt`** — the
+export-boundary follow-on that extends the receipt family — all landed in
+`icn/crates/icn-governance/src/proof.rs`. **No new receipt class is introduced by this
+render pass**, no Rust runtime is changed, and no OpenAPI/SDK is touched. It implements the
 design contract landed in **#2290**
 ([`docs/design/organizer-steward-evidence-surface-runtime-dogfood.md`](../design/organizer-steward-evidence-surface-runtime-dogfood.md));
 the fifth class (`ActivationCrossedReceipt`, landed in **#2296**) was added to this
 fixture/demo surface by **#2297**, the sixth (`MutationPlanRecordedReceipt`, landed
 in **#2303**) by **#2304**, the seventh (`MutationAppliedReceipt`, landed in
-**#2310**) by **#2311**, and the eighth (`EvidencePacketProducedReceipt`, landed in
-**#2318**) by **#2319**.
+**#2310**) by **#2311**, the eighth (`EvidencePacketProducedReceipt`, landed in
+**#2318**) by **#2319**, and the ninth (`EvidencePacketExportPreparedReceipt`,
+`icn:gov:evidence_packet_export_prepared:v1`, landed at runtime in **#2326** under the
+**#2322** boundary contract / **#2324** EX1–EX8 decision rung) by **#2327** (this pass).
+The ninth is the first class beyond the eight process-transition classes; rendering it
+completes no **#1748** acceptance gate and asserts no delivery.
 
 ## 1. What was run, and what was not
 
@@ -78,7 +84,7 @@ in **#2303**) by **#2304**, the seventh (`MutationAppliedReceipt`, landed in
 ## 3. Rendered walkthrough — observed
 
 The process-evidence view renders the `receipt → surface → evidence/export` tail of the
-vertical spine **as read views**: the eight process-transition receipts in sequence, a
+vertical spine **as read views**: the nine process/evidence receipts in sequence, a
 fixture-safe privacy/redaction boundary, and a repo-safe evidence-summary export. No
 mutation is performed; no gateway is contacted.
 
@@ -87,11 +93,12 @@ mutation is performed; no gateway is contacted.
 | Honesty banner text (permanently visible) | `Fixture-backed demo — no live node, nothing signed.` |
 | Standing pane visible; memberships / roles rendered | yes (reused demo standing) |
 | Action cards pane visible | yes (reused demo cards) |
-| Receipts pane: eight process-transition receipts rendered in order | yes — **8 receipts** (`ProcessSessionOpenedReceipt` → `DeliberationEntryRecordedReceipt` → `DecisionRecordedReceipt` → `ProcessGateResultReceipt` → `ActivationCrossedReceipt` → `MutationPlanRecordedReceipt` → `MutationAppliedReceipt` → `EvidencePacketProducedReceipt`) |
+| Receipts pane: nine process/evidence receipts rendered in order | yes — **9 receipts** (`ProcessSessionOpenedReceipt` → `DeliberationEntryRecordedReceipt` → `DecisionRecordedReceipt` → `ProcessGateResultReceipt` → `ActivationCrossedReceipt` → `MutationPlanRecordedReceipt` → `MutationAppliedReceipt` → `EvidencePacketProducedReceipt` → `EvidencePacketExportPreparedReceipt`) |
 | Activation boundary legible (icn#2297) | yes — the activation receipt names the boundary plainly ("crossed from decision toward later action planning") and distinguishes the three states: the recorded decision, the activation crossing itself, and the later mutation-planning work that remains deferred. It shows the decision reference (`decision_id` + `decision_record_hash` proof pointer) and the gate basis (`gate_basis` fingerprint + the declared passed gate-result `record_hash`), never body text; copy states it "records a process fact and grants zero authority" |
 | Mutation-plan-recorded boundary legible (icn#2304) | yes — the mutation-plan receipt names the boundary plainly ("a mutation plan was recorded after activation, before any mutation was applied") and distinguishes the states: the recorded decision, the activation crossing, the plan being recorded here, and the two later steps that remain deferred (mutation application and evidence-packet production). It shows the activation reference (`activation_id` + `activation_record_hash` proof pointer to the crossing above) and the plan proof pointer (`plan_id` + `body_hash`), never the plan body / operation list / target list / effect payload; `recorded_by` is labeled "who recorded the plan, not the planner, approver, applier, or authority holder"; copy states it "records a process fact and grants zero authority" |
 | Mutation-applied boundary legible (icn#2311) | yes — the mutation-applied receipt names the boundary plainly ("the plan's application was recorded after the plan — an application fact") and distinguishes the states: the recorded decision, the activation crossing, the mutation plan recorded, the plan's application recorded here, and the later evidence-packet production that remains deferred. It shows the plan reference (`plan_id` + `plan_record_hash` proof pointer to the mutation-plan receipt above) and the result proof pointer (`result_hash`), never the applied-result body / operation list / target list / effect payload; `applied_by` is labeled "who recorded the application — recorder / apply-witness, not the applier, approver, or authority holder"; copy states it "does not execute, authorize, validate, enforce, roll back, or prove the mutation correct" and "grants zero authority" |
 | Evidence-packet-produced boundary legible (icn#2319) | yes — the evidence-packet-produced receipt names the terminal boundary plainly ("an evidence packet was produced and recorded here") and distinguishes the states: the recorded decision, the activation crossing, the mutation plan recorded, the plan's application recorded, the packet's production recorded here, and the explicit non-claim that producing is not delivering ("does not assert delivery, acceptance, audit certification, human or assistive-technology verification, correctness, completeness, or legal sufficiency"). It shows the applied reference (`mutation_application_id` + `mutation_applied_record_hash` proof pointer to the mutation-applied receipt above), the source-set commitment (`receipt_set_hash` — references, never bodies), the packet fingerprint (`packet_hash` — public/redacted artifact only, body never stored), and the redaction-profile fingerprint (`redaction_profile_hash` — profile body never stored, no completeness/sufficiency claim); `produced_by` is labeled "who recorded this production fact — recorder / producer-witness, not an authority to produce, deliver, certify, or audit"; copy states the receipt "records a process fact and grants zero authority" |
+| Export-prepared boundary legible (icn#2327) | yes — the evidence-packet-export-prepared receipt names the export boundary plainly ("an export of the produced evidence packet was prepared for a named recipient scope and recorded here") and distinguishes the states: the produced packet, the export preparation recorded here, and the stacked negations (prepared is **not** made available, delivered, received, accepted, audited, or certified). It shows the produced-packet reference (`packet_id` + `packet_produced_record_hash` proof pointer to the evidence-packet-produced receipt above), the echoed packet fingerprint (`packet_hash`, the produced receipt's public/redacted artifact hash echoed as a proof link — not a delivery/made-available claim), the export-policy fingerprint (`export_policy_hash` — policy body never stored, no authorized/complete/legally-sufficient claim), and the recipient scope (`recipient_scope_id`, a caller-opaque handle — never a name, email, address, or contact data); `prepared_by` is labeled "recorder / export-witness, not an authority to export, release, deliver, certify, or audit"; copy states "no export artifact was assembled by this surface", it "carries no access, vault, custody, location, or retrieval meaning", and "records a process fact and grants zero authority" |
 | Plain-language summary first; record fields under "Show evidence detail" | yes (per receipt) |
 | Privacy/redaction boundary legible | yes — the deliberation entry shows "What the steward body sees" (fictional summary) **and** "What members and the export see" (redaction reason + `record_hash`/`body_hash` proof pointers, no input text) |
 | Proof pointers labeled honestly | yes — `record_hash` = proof pointer; `body_hash` = "proof of content; the input itself is never stored"; recorder DIDs labeled "who recorded this fact, not who decided" |
@@ -115,7 +122,7 @@ Process-evidence view (`?mode=demo&set=process-evidence`), and the two regressio
 | **axe-core** (`wcag2a, wcag2aa, wcag21a, wcag21aa, wcag22aa`) | **0 violations**, 27 passes | 0 violations, 27 passes | 0 violations, 27 passes |
 | Keyboard: focusables reached by Tab | 16 | 16 | 15 |
 | Keyboard: **every** focused element had a visible outline | **true** | true | true |
-| Receipts rendered | **8** | 1 | 1 |
+| Receipts rendered | **9** | 1 | 1 |
 | 200% CSS zoom render | no layout break | no layout break | no layout break |
 | Mobile (360px) horizontal scroll | none | none | none |
 | `prefers-reduced-motion: reduce` render | standing pane renders | renders | renders |
@@ -281,14 +288,15 @@ them.
 - Human 200% browser-zoom + small-device pass (3.3 / 3.5 / 3.8). [#2041]
 - External contrast-audit-tool confirmation of the documented ratios (3.3). [#2041]
 - Extend the process-evidence human/AT packet (§4G of the human-a11y-validation doc) to
-  cover the fifth, sixth, seventh, and eighth receipts (`ActivationCrossedReceipt`,
-  `MutationPlanRecordedReceipt`, `MutationAppliedReceipt`, `EvidencePacketProducedReceipt`)
-  in the real human pass — the automated floor above now covers all eight, but §4G currently
-  enumerates the four-receipt story; adding the activation, mutation-plan, mutation-applied,
-  and evidence-packet-produced rows is owed, not done here. [#2041]
+  cover the fifth through ninth receipts (`ActivationCrossedReceipt`,
+  `MutationPlanRecordedReceipt`, `MutationAppliedReceipt`, `EvidencePacketProducedReceipt`,
+  `EvidencePacketExportPreparedReceipt`) in the real human pass — the automated floor above
+  now covers all nine, but §4G currently enumerates the four-receipt story; adding the
+  activation, mutation-plan, mutation-applied, evidence-packet-produced, and
+  evidence-packet-export-prepared rows is owed, not done here. [#2041]
 - (Separate lanes, not this pass) real translations + human language QA (#1740); the
   broader human-operability spine (#1748 / #2141) remains open.
 
 ---
 
-_Refs #2289. Refs #2290. Refs #2291. Refs #2296. Refs #2297. Refs #2303. Refs #2304. Refs #2310. Refs #2311. Refs #2318. Refs #2319. Refs #1748. Refs #2141. Refs #2041._
+_Refs #2289. Refs #2290. Refs #2291. Refs #2296. Refs #2297. Refs #2303. Refs #2304. Refs #2310. Refs #2311. Refs #2318. Refs #2319. Refs #2322. Refs #2324. Refs #2326. Refs #2327. Refs #1748. Refs #2141. Refs #1792. Refs #2041._

--- a/web/member-shell/fixtures/process-evidence-export.json
+++ b/web/member-shell/fixtures/process-evidence-export.json
@@ -8,7 +8,7 @@
     {
       "kind": "committed-fixture",
       "basename": "process-evidence-receipts.json",
-      "summary": "Fictional fixture pack of eight process-transition receipts (session opened, deliberation entry recorded, decision recorded, accessibility-gate result, activation crossed, mutation plan recorded, mutation applied, evidence packet produced). No real people and no real domain; all hashes are illustrative."
+      "summary": "Fictional fixture pack of nine process/evidence receipts (session opened, deliberation entry recorded, decision recorded, accessibility-gate result, activation crossed, mutation plan recorded, mutation applied, evidence packet produced, evidence packet export prepared). No real people and no real domain; all hashes are illustrative."
     }
   ],
   "workflow_steps_completed": [
@@ -41,6 +41,10 @@
     {
       "category": "deferred",
       "plain_summary": "An evidence packet's production was recorded after the applied step — the terminal evidence fact in this fixture story. The receipt references the mutation application it draws from, commits to the source receipt set as a fingerprint, and fingerprints the public/redacted packet artifact and its redaction profile. It records only that a packet was produced and recorded — nothing was delivered, accepted, audited, certified, or human/AT-verified; no packet body is stored; and it grants zero authority. Evidence export and delivery remain deferred."
+    },
+    {
+      "category": "deferred",
+      "plain_summary": "An export of the produced evidence packet was prepared for a named recipient scope and recorded. The receipt references the produced packet (by id and record hash), echoes its public/redacted fingerprint, and fingerprints the export policy that shaped the preparation. It records only that an export was prepared: nothing was made available, delivered, received, accepted, audited, or certified; no export artifact is assembled here; no packet body, policy body, recipient list, or contact data is stored; and it grants zero authority. Delivery and everything after it remain deferred."
     }
   ],
   "preview_review_boundary": {
@@ -50,10 +54,10 @@
   "mutation_boundary": {
     "executed": false,
     "target": "none",
-    "notes": "Fixture-only rehearsal; no gateway contacted, no write attempted, no network egress. The activation crossing, the mutation-plan recording, the mutation-applied recording, and the evidence-packet-produced recording are all process facts, not mutations. The evidence-packet-produced receipt records that a redacted packet artifact was produced and content-addressed; it does not assert delivery, acceptance, audit certification, correctness, completeness, legal sufficiency, human/AT verification, or readiness. Evidence export and delivery remain deferred and are not part of this surface."
+    "notes": "Fixture-only rehearsal; no gateway contacted, no write attempted, no network egress. The activation, mutation-plan, mutation-applied, evidence-packet-produced, and evidence-packet-export-prepared recordings are all process facts, not mutations. Producing a packet is not delivering it, and preparing an export is not sending it: the export-prepared receipt records that an export was prepared for a named recipient scope — it asserts no made-available, delivery, receipt, acceptance, audit, or certification, and no export artifact is assembled here. Export delivery remains deferred."
   },
   "warnings": [
-    "The eight process-transition receipt hashes are illustrative fixture values, not real blake3 bindings; nothing is signed.",
+    "The nine process/evidence receipt hashes are illustrative fixture values, not real blake3 bindings; nothing is signed.",
     "This surface renders read views only; no live gateway, federation, or production posture is implied."
   ],
   "follow_ups": [
@@ -79,11 +83,13 @@
     "Not a live federation, live Google Drive / Groups / Sheets sync, or any K3s / DNS / Forgejo mutation.",
     "Not private-data handling; all material is fictional and repo-safe by construction.",
     "Not organizer-ready or member-ready; this is a dev/fixture evidence view only.",
-    "Not a new receipt class; it reads the eight existing ADR-0026 Layer 2 process-transition receipts only (evidence packet produced landed in icn#2318).",
+    "Not a new receipt class; it reads existing landed classes only — the eight ADR-0026 Layer 2 process-transition receipts plus the ninth evidence-packet-export-prepared receipt, which landed at runtime in icn#2326.",
     "Not a mutation, a planned or applied mutation, a mutation-application engine, an action card, or an evidence-packet producer; activation records only that a decision crossed toward later action planning, and the mutation-plan receipt records only that a plan was recorded — recording a plan is not applying it.",
     "The mutation-applied receipt records only that a plan's application happened; it does not execute, authorize, validate, enforce, roll back, or prove the mutation correct.",
     "The evidence-packet-produced receipt records only that a redacted evidence packet artifact was produced and recorded; it asserts no delivery, acceptance, audit certification, human/AT verification, correctness, completeness, or legal sufficiency, and evidence export/delivery remain deferred.",
     "Not a plan body, applied-result body, packet body, source-receipt body, redaction-profile body, operation list, target list, or effect payload; the plan, applied, and packet receipts carry content fingerprints only (body hash, result hash, packet / receipt-set / redaction-profile hashes).",
+    "The evidence-packet-export-prepared receipt records only that an export of the produced packet was prepared for a named recipient scope; it asserts no made-available, delivery, receipt, acceptance, audit, certification, or legal sufficiency, assembles no export artifact, and carries no access/vault/custody/location/retrieval meaning — delivery and everything after it remain deferred.",
+    "Not an export policy body, recipient scope body, recipient DID list, email, phone, address, URL, endpoint, or any contact data; the export-prepared receipt carries an export-policy fingerprint and a caller-opaque recipient scope handle only.",
     "Not NYCN activation and not Phase 2 completion."
   ]
 }

--- a/web/member-shell/fixtures/process-evidence-receipts.json
+++ b/web/member-shell/fixtures/process-evidence-receipts.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Fixture-only, dev-safe process-evidence pack for the organizer-steward evidence surface (icn#2289, extended for ActivationCrossedReceipt by icn#2297, MutationPlanRecordedReceipt by icn#2304, MutationAppliedReceipt by icn#2311, and EvidencePacketProducedReceipt by icn#2319). Renders on web/member-shell/ at ?mode=demo&set=process-evidence. All eight receipt objects are wire-shaped per icn/crates/icn-governance/src/proof.rs (bare JSON, snake_case enums, 32-byte hashes as integer arrays); the entry-level fields (kind, plainContext, redaction metadata, and the activation entry's declaredGateBasis) are display-only, not wire fields. Every record_hash / body_hash / decision_record_hash / gate_basis / activation_record_hash / plan_record_hash / result_hash / mutation_applied_record_hash / receipt_set_hash / packet_hash / redaction_profile_hash below is an ILLUSTRATIVE fixture value — NOT a real blake3 binding; nothing is signed. All DIDs are fictional (example-…-not-live). No new receipt class: this reads the eight existing ADR-0026 Layer 2 process-transition classes only (the eighth, EvidencePacketProducedReceipt, landed in icn#2318). The deliberation body is never stored — the receipt carries a body_hash content fingerprint only, which is what makes the redaction demo honest. The activation receipt carries no body at all: it references the recorded decision by decision_id + decision_record_hash and fingerprints the passed gate results as gate_basis; declaredGateBasis (a display-only sibling of the receipt, not a wire field) lists the passed gate-result record_hash(es) the fixture's gate_basis stands for. The mutation-plan-recorded receipt references the activation it follows by activation_id + activation_record_hash (a proof pointer to the activation crossing above, whose record_hash it echoes) and fingerprints the plan body as body_hash only — the plan body, operation list, target list, and effect payload are never stored, and mutation application remains deferred. The mutation-applied receipt references the plan it applies by plan_id + plan_record_hash (a proof pointer to the mutation-plan-recorded receipt above, whose record_hash it echoes) and fingerprints the applied result as result_hash only — the applied-result body is never stored; the receipt records an application fact, not the execution/authorization/validation/enforcement/rollback/proof-of-correctness of the mutation. The evidence-packet-produced receipt references the applied step it draws from by mutation_application_id + mutation_applied_record_hash (a proof pointer to the mutation-applied receipt above, whose record_hash it echoes), commits to the set of source receipts as receipt_set_hash (a fingerprint over source-receipt record_hashes — references only, never bodies), and fingerprints the public/redacted packet artifact as packet_hash and the redaction profile that shaped it as redaction_profile_hash — the packet body, source receipt bodies, and redaction profile body are never stored; the receipt records that a packet was produced and recorded, not that it was delivered, accepted, audited, certified, or human/AT-verified, and evidence export/delivery remain deferred.",
+  "_note": "Fixture-only, dev-safe process-evidence pack for the organizer-steward evidence surface (icn#2289, extended for ActivationCrossedReceipt by icn#2297, MutationPlanRecordedReceipt by icn#2304, MutationAppliedReceipt by icn#2311, EvidencePacketProducedReceipt by icn#2319, and EvidencePacketExportPreparedReceipt by icn#2327). Renders on web/member-shell/ at ?mode=demo&set=process-evidence. All nine receipt objects are wire-shaped per icn/crates/icn-governance/src/proof.rs (bare JSON, snake_case enums, 32-byte hashes as integer arrays); the entry-level fields (kind, plainContext, redaction metadata, and the activation entry's declaredGateBasis) are display-only, not wire fields. Every record_hash / body_hash / decision_record_hash / gate_basis / activation_record_hash / plan_record_hash / result_hash / mutation_applied_record_hash / receipt_set_hash / packet_hash / redaction_profile_hash / packet_produced_record_hash / export_policy_hash below is an ILLUSTRATIVE fixture value — NOT a real blake3 binding; nothing is signed. All DIDs are fictional (example-…-not-live). No new receipt class here: this reads existing landed classes only — the eight ADR-0026 Layer 2 process-transition classes (the eighth, EvidencePacketProducedReceipt, landed in icn#2318) plus the ninth EvidencePacketExportPreparedReceipt (icn:gov:evidence_packet_export_prepared:v1), the export-boundary follow-on that landed at runtime in icn#2326. The ninth extends the receipt family — it is the first class beyond the eight and must not be read as completing any #1748 acceptance gate. The deliberation body is never stored — the receipt carries a body_hash content fingerprint only, which is what makes the redaction demo honest. The activation receipt carries no body at all: it references the recorded decision by decision_id + decision_record_hash and fingerprints the passed gate results as gate_basis; declaredGateBasis (a display-only sibling of the receipt, not a wire field) lists the passed gate-result record_hash(es) the fixture's gate_basis stands for. The mutation-plan-recorded receipt references the activation it follows by activation_id + activation_record_hash (a proof pointer to the activation crossing above, whose record_hash it echoes) and fingerprints the plan body as body_hash only — the plan body, operation list, target list, and effect payload are never stored, and mutation application remains deferred. The mutation-applied receipt references the plan it applies by plan_id + plan_record_hash (a proof pointer to the mutation-plan-recorded receipt above, whose record_hash it echoes) and fingerprints the applied result as result_hash only — the applied-result body is never stored; the receipt records an application fact, not the execution/authorization/validation/enforcement/rollback/proof-of-correctness of the mutation. The evidence-packet-produced receipt references the applied step it draws from by mutation_application_id + mutation_applied_record_hash (a proof pointer to the mutation-applied receipt above, whose record_hash it echoes), commits to the set of source receipts as receipt_set_hash (a fingerprint over source-receipt record_hashes — references only, never bodies), and fingerprints the public/redacted packet artifact as packet_hash and the redaction profile that shaped it as redaction_profile_hash — the packet body, source receipt bodies, and redaction profile body are never stored; the receipt records that a packet was produced and recorded, not that it was delivered, accepted, audited, certified, or human/AT-verified, and evidence export/delivery remain deferred. The evidence-packet-export-prepared receipt references the produced packet it exports by packet_id + packet_produced_record_hash (a proof pointer to the evidence-packet-produced receipt above, whose record_hash it echoes), echoes that receipt's public/redacted packet_hash as a proof link, and fingerprints the export policy that shaped the preparation as export_policy_hash — the export policy body, packet body, and recipient scope body are never stored, and recipient_scope_id is a caller-opaque handle carrying no name, email, address, or contact data; the receipt records that an export was prepared for a named recipient scope, not that anything was made available, delivered, received, accepted, audited, or certified, no export artifact is assembled here, and delivery and everything after it remain deferred.",
   "domain_id": "demo.coop.stewardship",
   "session_id": "demo-process-session-0001",
   "sequence": [
@@ -228,6 +228,43 @@
           33, 5, 40, 201, 119, 240, 11, 64,
           29, 8, 73, 156, 101, 47, 90, 134,
           52, 175, 3, 68, 199, 26, 7, 145
+        ]
+      }
+    },
+    {
+      "kind": "evidence_packet_export_prepared",
+      "plainContext": "An export of the produced evidence packet was prepared for a named recipient scope and recorded here — the export-boundary follow-on to the produced packet above, and the first receipt beyond the eight process-transition classes. This receipt references the produced packet it exports (by id and record hash), echoes that packet's public/redacted fingerprint as a proof link, and fingerprints the export policy that shaped the preparation. An export was prepared and recorded — nothing was made available, delivered, received, accepted, audited, or certified; no export artifact was assembled here; no packet body, policy body, recipient list, or contact data is stored; the recipient scope is a caller-opaque handle; and it grants zero authority. Delivery and everything after it remain deferred.",
+      "receipt": {
+        "domain_id": "demo.coop.stewardship",
+        "session_id": "demo-process-session-0001",
+        "export_id": "demo-evidence-packet-export-0001",
+        "packet_id": "demo-evidence-packet-0001",
+        "packet_produced_record_hash": [
+          88, 210, 44, 17, 71, 92, 3, 155,
+          33, 5, 40, 201, 119, 240, 11, 64,
+          29, 8, 73, 156, 101, 47, 90, 134,
+          52, 175, 3, 68, 199, 26, 7, 145
+        ],
+        "packet_hash": [
+          71, 92, 155, 3, 88, 44, 17, 210,
+          11, 64, 119, 240, 33, 5, 201, 40,
+          90, 101, 47, 134, 29, 8, 156, 73,
+          7, 145, 199, 26, 52, 175, 68, 3
+        ],
+        "export_policy_hash": [
+          101, 47, 134, 90, 3, 155, 71, 92,
+          40, 201, 5, 33, 240, 119, 11, 64,
+          88, 44, 17, 210, 29, 8, 73, 156,
+          7, 145, 199, 26, 52, 175, 68, 3
+        ],
+        "recipient_scope_id": "demo-partner-review-scope-0001",
+        "prepared_by": "did:icn:example-recorder-demo-not-live",
+        "prepared_at": 1729904800,
+        "record_hash": [
+          17, 210, 88, 44, 92, 71, 155, 3,
+          201, 40, 33, 5, 119, 240, 64, 11,
+          8, 29, 156, 73, 47, 101, 134, 90,
+          175, 52, 68, 3, 26, 199, 145, 7
         ]
       }
     }

--- a/web/member-shell/i18n.js
+++ b/web/member-shell/i18n.js
@@ -270,10 +270,12 @@
       "launcher.startFailed": "Could not start the local demo ({error}). Use Connect manually instead, or check the launcher tunnel.",
 
       // --- #2289 organizer-steward evidence surface (fixture-only) -------
-      // Renders the eight already-landed ADR-0026 Layer 2 process-transition
-      // receipts as a plain-language evidence story, plus a repo-safe evidence
-      // summary. Fixture/dev only; nothing signed; read-only. No readiness is
-      // claimed and no new receipt class is introduced.
+      // Renders the nine already-landed process/evidence receipts (the eight
+      // ADR-0026 Layer 2 process-transition classes plus the export-boundary
+      // EvidencePacketExportPreparedReceipt) as a plain-language evidence story,
+      // plus a repo-safe evidence summary. Fixture/dev only; nothing signed;
+      // read-only. No readiness is claimed and no new receipt class is
+      // introduced (the ninth landed at runtime in icn#2326).
       "evidence.process_session_opened.heading": "Process session opened",
       "evidence.deliberation_entry_recorded.heading": "Deliberation input recorded",
       "evidence.decision_recorded.heading": "Decision recorded",

--- a/web/member-shell/i18n.js
+++ b/web/member-shell/i18n.js
@@ -282,6 +282,7 @@
       "evidence.mutation_plan_recorded.heading": "Mutation plan recorded",
       "evidence.mutation_applied.heading": "Mutation applied",
       "evidence.evidence_packet_produced.heading": "Evidence packet produced",
+      "evidence.evidence_packet_export_prepared.heading": "Evidence packet export prepared",
 
       // Deliberation redaction demo (steward-visible vs member/export-redacted).
       "evidence.redaction.stewardHeading": "What the steward body sees",
@@ -326,7 +327,18 @@
       "evidence.evidencePacket.boundary.producedHere": "An evidence packet was produced and recorded here. This receipt references the applied step it draws from, commits to the set of source receipts as a single fingerprint, and fingerprints the public/redacted packet artifact and the redaction profile that shaped it. No packet body, source receipt body, or private data is stored — fingerprints only.",
       "evidence.evidencePacket.boundary.notDelivered": "Producing the packet is not delivering it. This receipt does not assert delivery, acceptance, audit certification, human or assistive-technology verification, correctness, completeness, or legal sufficiency — those remain separate, later concerns. The receipt records a process fact and grants zero authority.",
 
-      // Evidence-detail key/value labels for the eight receipt classes.
+      // Evidence-packet-export-prepared explainer (icn#2327): names the states
+      // plainly so a preparation-recorded fact is never read as delivery, being
+      // made available, receipt, acceptance, audit, or certification. This is
+      // the ninth receipt class — the first beyond the eight process-transition
+      // classes — and completes no #1748 acceptance gate.
+      "evidence.exportPrepared.boundaryHeading": "What preparing an evidence packet export means here",
+      "evidence.exportPrepared.boundary.produced": "An evidence packet was produced and recorded (the evidence-packet-produced receipt above) — a public/redacted artifact fingerprinted there, with no packet body stored.",
+      "evidence.exportPrepared.boundary.preparedHere": "An export of that produced packet was then prepared here for a named recipient scope, under a declared export policy. This receipt references the produced packet (by id and record hash), echoes its public/redacted fingerprint as a proof link, and fingerprints the export policy — the policy body, packet body, recipient list, and any contact data are never stored; the recipient scope is a caller-opaque handle.",
+      "evidence.exportPrepared.boundary.notDelivered": "Preparing an export is not sending it. This receipt does not assert that anything was made available, delivered, received, accepted, audited, or certified — those remain separate, later concerns. No export artifact was assembled by this surface.",
+      "evidence.exportPrepared.boundary.noAuthority": "It carries no access, vault, custody, location, or retrieval meaning, records a process fact, and grants zero authority. Delivery and everything after it remain deferred.",
+
+      // Evidence-detail key/value labels for the nine receipt classes.
       "evidence.kv.domainId": "Domain id",
       "evidence.kv.sessionId": "Session id",
       "evidence.kv.openedBy": "Opened by (who recorded this fact)",
@@ -364,6 +376,14 @@
       "evidence.kv.redactionProfileHash": "Redaction profile fingerprint (which redaction profile shaped the public packet; the profile body is never stored — not a claim the redaction is complete or legally sufficient)",
       "evidence.kv.producedBy": "Produced by (who recorded this production fact — recorder / producer-witness, not an authority to produce, deliver, certify, or audit)",
       "evidence.kv.producedAt": "Produced at (unix seconds)",
+      "evidence.kv.exportId": "Export id",
+      "evidence.kv.exportPacketRef": "Referenced produced packet id (the produced packet this export prepares)",
+      "evidence.kv.packetProducedRecordHash": "Referenced produced record hash (proof pointer to the evidence-packet-produced receipt above — not its body)",
+      "evidence.kv.exportPacketHashEcho": "Echoed packet fingerprint (the produced receipt's public/redacted packet hash, echoed here as a proof link — the packet body is never stored; not a claim it was delivered or made available)",
+      "evidence.kv.exportPolicyHash": "Export policy fingerprint (which export policy shaped this preparation; the policy body is never stored — not a claim the export is authorized, complete, satisfied, or legally sufficient)",
+      "evidence.kv.recipientScopeId": "Recipient scope (a caller-opaque governance handle naming which scope this export was prepared for — never a name, email, address, or any contact data)",
+      "evidence.kv.preparedBy": "Prepared by (who recorded this preparation fact — recorder / export-witness, not an authority to export, release, deliver, certify, or audit)",
+      "evidence.kv.preparedAt": "Prepared at (unix seconds)",
 
       // Evidence summary / export (read-only render of the committed fixture).
       "evidence.export.heading": "Evidence summary",

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -105,10 +105,12 @@
 
   // #2289 organizer-steward evidence surface. `?mode=demo&set=process-evidence`
   // swaps the demo pack for a fixture-only, read-only evidence story over the
-  // eight already-landed ADR-0026 Layer 2 process-transition receipts (session
+  // eight already-landed ADR-0026 Layer 2 process-transition receipts plus the
+  // ninth, export-boundary EvidencePacketExportPreparedReceipt (session
   // opened -> deliberation entry recorded -> decision recorded -> gate result
   // -> activation crossed -> mutation plan recorded -> mutation applied ->
-  // evidence packet produced) plus a repo-safe evidence-summary export.
+  // evidence packet produced -> evidence packet export prepared) plus a
+  // repo-safe evidence-summary export.
   // Fixture/dev only: nothing is live, every hash is illustrative (see the
   // demo hash label), and the surface renders read views only — no download,
   // no mutation. `set` is demo-only.
@@ -169,7 +171,7 @@
   }
 
   // #2289 organizer-steward evidence surface (fixture-only). Keeps the demo
-  // standing + cards pack; adds the eight-receipt process-evidence sequence and
+  // standing + cards pack; adds the nine-receipt process-evidence sequence and
   // its repo-safe evidence-summary export (both member-shell-local fixtures).
   if (SET === "process-evidence") {
     FIXTURES.processEvidence = "fixtures/process-evidence-receipts.json";
@@ -630,7 +632,7 @@
   // opts is optional. Existing callers (live completion + demo completion) pass
   // no opts, so the entry keeps its original {receipt, plainContext} shape and
   // renders through renderCompletionReceipt exactly as before. The #2289
-  // process-evidence pack passes opts.kind (one of the eight process-transition
+  // process-evidence pack passes opts.kind (one of the nine process/evidence
   // classes) plus optional redaction metadata, routing to renderProcessReceipt.
   // No existing behavior changes.
   function addReceipt(receipt, plainContext, opts) {
@@ -703,8 +705,10 @@
 
   // ---------------------------------------------------------------------
   // #2289 organizer-steward evidence surface (fixture-only, read-only).
-  // Renders one of the eight ADR-0026 Layer 2 process-transition receipts
-  // (proof.rs) as a plain-language summary first, with the record-level fields
+  // Renders one of the nine process/evidence receipts — the eight ADR-0026
+  // Layer 2 process-transition classes plus the export-boundary
+  // EvidencePacketExportPreparedReceipt — from proof.rs as a plain-language
+  // summary first, with the record-level fields
   // under a progressive-disclosure "Show evidence detail" control. record_hash
   // is the proof pointer; body_hash is labeled proof-of-content (the body is
   // never stored). In demo mode the hashes are illustrative, mirroring the
@@ -1089,7 +1093,7 @@
   }
 
   // #2289 organizer-steward evidence surface (fixture-only). Reuses the demo
-  // standing + cards render path, then renders the eight-receipt process
+  // standing + cards render path, then renders the nine-receipt process
   // sequence and the repo-safe evidence-summary export. No network beyond the
   // committed fixtures; nothing signed; read-only.
   function loadProcessEvidenceDemo() {

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -718,7 +718,8 @@
     activation_crossed: "ActivationCrossedReceipt",
     mutation_plan_recorded: "MutationPlanRecordedReceipt",
     mutation_applied: "MutationAppliedReceipt",
-    evidence_packet_produced: "EvidencePacketProducedReceipt"
+    evidence_packet_produced: "EvidencePacketProducedReceipt",
+    evidence_packet_export_prepared: "EvidencePacketExportPreparedReceipt"
   };
 
   // record_hash label mirrors renderCompletionReceipt's maturity-tier honesty:
@@ -836,6 +837,27 @@
       li.appendChild(packetBoundary);
     }
 
+    // Evidence-packet-export-prepared explainer (icn#2327): make the export
+    // boundary legible by naming the states plainly — the produced packet, the
+    // export preparation recorded here for a named recipient scope, and the
+    // stacked negations (prepared is not made-available / delivered / received /
+    // accepted / audited / certified). Preparing an export is not sending it;
+    // this surface assembles no export artifact, carries no access / vault /
+    // custody / retrieval meaning, and grants zero authority. This is the ninth
+    // receipt class — the first beyond the eight process-transition classes —
+    // and does not complete any #1748 acceptance gate.
+    if (kind === "evidence_packet_export_prepared") {
+      var exportBoundary = el("div", { class: "boundary" });
+      exportBoundary.appendChild(el("h4", { text: t("evidence.exportPrepared.boundaryHeading") }));
+      var xbul = el("ul", { class: "card-list" });
+      xbul.appendChild(el("li", { text: t("evidence.exportPrepared.boundary.produced") }));
+      xbul.appendChild(el("li", { text: t("evidence.exportPrepared.boundary.preparedHere") }));
+      xbul.appendChild(el("li", { text: t("evidence.exportPrepared.boundary.notDelivered") }));
+      xbul.appendChild(el("li", { text: t("evidence.exportPrepared.boundary.noAuthority") }));
+      exportBoundary.appendChild(xbul);
+      li.appendChild(exportBoundary);
+    }
+
     var details = el("details");
     details.appendChild(el("summary", { text: t("receipt.showEvidence") }));
     var dl = el("dl", { class: "kv" });
@@ -940,6 +962,33 @@
         el("code", { text: hashToHex(r.redaction_profile_hash) }));
       kvRow(dl, t("evidence.kv.producedBy"), el("code", { text: String(r.produced_by || "") }));
       kvRow(dl, t("evidence.kv.producedAt"), String(r.produced_at || ""));
+    } else if (kind === "evidence_packet_export_prepared") {
+      kvRow(dl, t("evidence.kv.exportId"), String(r.export_id || ""));
+      // Produced-packet reference (icn#2327 / EX5): the export names the
+      // produced packet it prepares by both its caller-opaque id and its
+      // content-addressed record hash. Both are proof pointers to the
+      // evidence-packet-produced receipt above — never body text. Applied,
+      // plan, activation, decision, and gate provenance are inherited
+      // transitively through that produced packet, not restated here.
+      kvRow(dl, t("evidence.kv.exportPacketRef"), String(r.packet_id || ""));
+      kvRow(dl, t("evidence.kv.packetProducedRecordHash"),
+        el("code", { text: hashToHex(r.packet_produced_record_hash) }));
+      // Echoed packet fingerprint (EX5): the produced receipt's public/redacted
+      // packet_hash, echoed here as a proof link — the packet body is never
+      // stored and no delivery / made-available fact is asserted by echoing it.
+      kvRow(dl, t("evidence.kv.exportPacketHashEcho"),
+        el("code", { text: hashToHex(r.packet_hash) }));
+      // Export policy fingerprint (EX5): which export policy shaped this
+      // preparation — the policy body is never stored; not a claim the export
+      // is authorized, complete, satisfied, or legally sufficient.
+      kvRow(dl, t("evidence.kv.exportPolicyHash"),
+        el("code", { text: hashToHex(r.export_policy_hash) }));
+      // Recipient scope (EX3): a caller-opaque governance handle naming *which*
+      // scope this export was prepared for — never a name, email, address, or
+      // any personal contact data.
+      kvRow(dl, t("evidence.kv.recipientScopeId"), String(r.recipient_scope_id || ""));
+      kvRow(dl, t("evidence.kv.preparedBy"), el("code", { text: String(r.prepared_by || "") }));
+      kvRow(dl, t("evidence.kv.preparedAt"), String(r.prepared_at || ""));
     }
     recordHashRow(dl, r.record_hash);
     details.appendChild(dl);


### PR DESCRIPTION
## Summary
- Renders the runtime-landed `EvidencePacketExportPreparedReceipt` (`icn:gov:evidence_packet_export_prepared:v1`, landed in #2326) in the fixture-only process-evidence member-shell demo (`?mode=demo&set=process-evidence`), as the EX8 render follow-on to the #2322 boundary contract / #2324 EX1–EX8 decision rung.
- Appends one wire-shaped `evidence_packet_export_prepared` fixture entry (the ninth).
- Echoes the produced fixture `packet_id`, `packet_produced_record_hash`, and `packet_hash`.
- Uses a fictional, contact-data-free `recipient_scope_id` (`demo-partner-review-scope-0001`).
- Preserves the EX1 boundary: prepared, not delivered, received, accepted, audited, certified, or made available.
- No runtime/routes/OpenAPI/SDK/exporter/delivery/vault/access/custody changes.

Changed files (5, +140/−20):
- `web/member-shell/fixtures/process-evidence-receipts.json` — eight→nine receipts; new wire-shaped entry echoing the produced receipt.
- `web/member-shell/shell.js` — class map + render branch + boundary explainer (technical fields under the evidence-detail disclosure only).
- `web/member-shell/i18n.js` — member-facing strings (closed vocabulary; no hardcoded prose).
- `web/member-shell/fixtures/process-evidence-export.json` — evidence-summary export updated to nine receipts (still validates against the contract).
- `docs/demo/JULY_DEMO_CANDIDATE_0.1_PROCESS_EVIDENCE_WALKTHROUGH.md` — walkthrough updated to nine; a11y numbers re-run this pass.

## Validation
- JSON parse of both fixtures → OK.
- `python3 docs/scripts/validate-rehearsal-evidence.py web/member-shell/fixtures/process-evidence-export.json` → `OK: … validates against urn:icn:contract:rehearsal-evidence-export:v1` (exit 0).
- `node --check shell.js` and `node --check i18n.js` → OK.
- i18n coverage: all new/dynamic `t()` keys present in the `en` catalog; `?lang=qps-ploc` renders the new copy bracketed (`⟦Évídéncé páckét éxpórt prépáréd⟧`) → no hardcoded English leaked.
- Accessibility / rendered-browser walkthrough (`MSHELL_SET=process-evidence … web/member-shell/a11y-walkthrough.cjs`, Playwright 1.60.0 / chromium-1223): **9 receipts, 0 axe violations / 27 passes, 16 focusables all with a visible outline, clean 360px reflow, reduced-motion render OK, `REPORT_WRITTEN` (exit 0)**.
- Regression: default `?mode=demo` (1 receipt, 0 violations) and `&set=community` (1 receipt, 0 violations) both still pass.
- `git diff --check` clean; changed files limited to member-shell fixture/render/i18n + the walkthrough doc (no `icn/crates`, `icn/apps`, gateway, OpenAPI, SDK, deploy, VM config, or dotfiles).

## Non-claims
- not production
- not pilot
- not organizer-ready
- not member-ready
- not live federation
- not NYCN activation
- not Phase 2 completion
- not #2041 completion (human/AT screen-reader / low-vision / switch pass remains owed)
- no new receipt class (this renders the class already landed at runtime in #2326; the ninth extends the family and completes no #1748 acceptance gate)
- no export artifact assembled
- no export performed
- no made-available fact
- no external delivery
- no recipient receipt or acceptance
- no audit certification
- no legal sufficiency
- no vault / access / custody / location / retrieval semantics
- no route/OpenAPI/SDK/runtime change
- leaves #1748, #2141, #1792, and #2041 open — this render pass does not address them

Refs #2327. Refs #2326. Refs #2324. Refs #2322. Refs #2320. Refs #1748. Refs #2141. Refs #1792. Refs #2041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
