### PR TITLE
feat(authz): add governance process scope gate

### DIFF
--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -3094,10 +3094,9 @@ pub async fn get_action_item_completion_receipt<E: GovernanceEventEmitter + Clon
 /// carries the persisted receipt and its `record_hash` is the verification
 /// evidence. This adds no new receipt type and no process runtime.
 ///
-/// Authorization mirrors the action-item write surface: the existing
-/// `governance:write` scope plus domain membership for the caller. This
-/// handler composes those existing gates and changes no authorization
-/// decision. The manager performs no authority check itself — charter
+/// Authorization accepts `governance:process:write` first and retains
+/// `governance:write` as a compatibility fallback, then requires domain
+/// membership for the caller. The manager performs no authority check itself — charter
 /// enforcement of "who may record a gate result for this domain/session"
 /// is upstream of this slice.
 ///
@@ -3106,8 +3105,8 @@ pub async fn get_action_item_completion_receipt<E: GovernanceEventEmitter + Clon
 /// - 400 when `result`/`gate_kind` is outside its closed taxonomy
 ///   (deserialization) or `session_id` is empty/whitespace.
 /// - 401 when the bearer token is missing/invalid.
-/// - 403 when the token lacks `governance:write` or the caller is not a
-///   member of the domain.
+/// - 403 when the token lacks both accepted write scopes or the caller is not
+///   a member of the domain.
 /// - 404 when the domain does not exist.
 pub async fn record_process_gate_result<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
@@ -3115,7 +3114,10 @@ pub async fn record_process_gate_result<E: GovernanceEventEmitter + Clone + 'sta
     path: web::Path<(String, String)>,
     req: web::Json<RecordProcessGateResultRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:process:write", "governance:write"],
+    )?;
     let recorded_by = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, session_id) = path.into_inner();
@@ -3158,19 +3160,18 @@ pub async fn record_process_gate_result<E: GovernanceEventEmitter + Clone + 'sta
 /// evidence, not proof of permission.
 ///
 /// Authorization mirrors the gate-result write surface exactly (per the
-/// #2275 contract): the existing `governance:write` scope plus domain
-/// membership for the caller — sticky duplicate-open semantics would
+/// #2275 contract): process-class-first scope admission with broad fallback,
+/// plus domain membership for the caller — sticky duplicate-open semantics would
 /// otherwise let an authenticated outsider preempt a session id in
-/// someone else's domain. This handler composes those existing gates and
-/// changes no authorization decision.
+/// someone else's domain.
 ///
 /// Returns:
 /// - 200 with the persisted `ProcessSessionOpenedReceipt` JSON (first
 ///   open AND same-opener retry).
 /// - 400 when `session_id` is empty/whitespace.
 /// - 401 when the bearer token is missing/invalid.
-/// - 403 when the token lacks `governance:write` or the caller is not a
-///   member of the domain.
+/// - 403 when the token lacks both accepted write scopes or the caller is not
+///   a member of the domain.
 /// - 404 when the domain does not exist.
 /// - 409 when the session was already opened by a different actor.
 pub async fn open_process_session<E: GovernanceEventEmitter + Clone + 'static>(
@@ -3178,7 +3179,10 @@ pub async fn open_process_session<E: GovernanceEventEmitter + Clone + 'static>(
     http_req: HttpRequest,
     path: web::Path<(String, String)>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:process:write", "governance:write"],
+    )?;
     let opened_by = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, session_id) = path.into_inner();
@@ -3229,9 +3233,9 @@ pub async fn open_process_session<E: GovernanceEventEmitter + Clone + 'static>(
 /// zero authority; `author` is the authenticated caller as actor
 /// evidence, not proof of entitlement.
 ///
-/// Authorization mirrors the session-open surface exactly: the existing
-/// `governance:write` scope plus domain membership for the caller. No new
-/// capability is introduced.
+/// Authorization mirrors the session-open surface exactly:
+/// process-class-first scope admission with broad fallback, plus domain
+/// membership for the caller.
 ///
 /// Returns:
 /// - 200 with the persisted `DeliberationEntryRecordedReceipt` JSON
@@ -3240,8 +3244,8 @@ pub async fn open_process_session<E: GovernanceEventEmitter + Clone + 'static>(
 ///   `entry_kind` is outside the closed taxonomy (serde rejects it), or
 ///   `body_hash` is not 64 hex characters.
 /// - 401 when the bearer token is missing/invalid.
-/// - 403 when the token lacks `governance:write` or the caller is not a
-///   member of the domain.
+/// - 403 when the token lacks both accepted write scopes or the caller is not
+///   a member of the domain.
 /// - 404 when the domain does not exist, or when the session has no
 ///   recorded opening (`deliberation_entry_session_not_opened`) — the
 ///   referenced anchor is absent, mirroring the existing missing-domain
@@ -3254,7 +3258,10 @@ pub async fn record_deliberation_entry<E: GovernanceEventEmitter + Clone + 'stat
     path: web::Path<(String, String, String)>,
     req: web::Json<RecordDeliberationEntryRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:process:write", "governance:write"],
+    )?;
     let author = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, session_id, entry_id) = path.into_inner();
@@ -3331,8 +3338,8 @@ pub async fn record_deliberation_entry<E: GovernanceEventEmitter + Clone + 'stat
 /// evidence — not decider identity, not proof of entitlement.
 ///
 /// Authorization mirrors the sibling process-receipt surfaces exactly:
-/// the existing `governance:write` scope plus domain membership for the
-/// caller. No new capability is introduced.
+/// process-class-first scope admission with broad fallback, plus domain
+/// membership for the caller.
 ///
 /// Returns:
 /// - 200 with the persisted `DecisionRecordedReceipt` JSON (first record
@@ -3340,8 +3347,8 @@ pub async fn record_deliberation_entry<E: GovernanceEventEmitter + Clone + 'stat
 /// - 400 when `domain_id`/`session_id`/`decision_id` is empty/whitespace
 ///   or `body_hash` is not 64 hex characters.
 /// - 401 when the bearer token is missing/invalid.
-/// - 403 when the token lacks `governance:write` or the caller is not a
-///   member of the domain.
+/// - 403 when the token lacks both accepted write scopes or the caller is not
+///   a member of the domain.
 /// - 404 when the domain does not exist, or when the session has no
 ///   recorded opening (`decision_recorded_session_not_opened`) — the
 ///   referenced anchor is absent, mirroring the existing missing-domain
@@ -3354,7 +3361,10 @@ pub async fn record_decision<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<(String, String, String)>,
     req: web::Json<RecordDecisionRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:process:write", "governance:write"],
+    )?;
     let recorded_by = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, session_id, decision_id) = path.into_inner();
@@ -3436,7 +3446,8 @@ fn institutional_domain_store_err_to_api(e: InstitutionalDomainStoreError) -> Ap
 /// Drives the existing persisted adoption seam end-to-end over HTTP:
 ///
 /// ```text
-/// POST → governance:write scope + domain-membership gate
+/// POST → governance:charter:write class scope (or broad compatibility fallback)
+///      → domain-membership gate
 ///      → GovernanceManager::adopt_domain_policy_persisted
 ///        → load InstitutionalDomain
 ///        → DefaultMandateGate authority resolution (actor → active grants →
@@ -3462,8 +3473,8 @@ fn institutional_domain_store_err_to_api(e: InstitutionalDomainStoreError) -> Ap
 /// - 400 when `policy_content` is empty/whitespace or exceeds
 ///   `MAX_DOMAIN_POLICY_CONTENT_BYTES`, or the body/DID is malformed.
 /// - 401 when the bearer token is missing/invalid.
-/// - 403 when the token lacks `governance:write`, the caller is not a domain
-///   member, or the `DefaultMandateGate` refuses adoption authority.
+/// - 403 when the token lacks both accepted write scopes, the caller is not a
+///   domain member, or the `DefaultMandateGate` refuses adoption authority.
 /// - 404 when no `InstitutionalDomain` is declared for `domain_id` (or the
 ///   `GovernanceDomain` membership target does not exist).
 /// - 500 when no domain/receipt store is wired, or a backend read/write fails.
@@ -3473,7 +3484,10 @@ pub async fn adopt_domain_policy<E: GovernanceEventEmitter + Clone + 'static>(
     path: web::Path<String>,
     req: web::Json<AdoptDomainPolicyRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:charter:write", "governance:write"],
+    )?;
     let actor = parse_did(&claims.sub, "Invalid DID in token")?;
 
     // Reject empty/whitespace and oversize bodies before content-addressing
@@ -3570,7 +3584,7 @@ fn declare_institutional_domain_err_to_api(e: DeclareInstitutionalDomainError) -
 /// Drives the mandate-gated declaration seam end-to-end over HTTP:
 ///
 /// ```text
-/// POST → governance:write scope
+/// POST → governance:charter:write class scope (or broad compatibility fallback)
 ///      → GovernanceManager::declare_institutional_domain_gated
 ///        → DefaultMandateGate authority resolution (actor → active grants →
 ///          domain-scoped Execution `institutional_domain:declare` grant +
@@ -3601,8 +3615,8 @@ fn declare_institutional_domain_err_to_api(e: DeclareInstitutionalDomainError) -
 /// - 400 when `entity_type` is out of taxonomy, `charter_id` is malformed, or
 ///   the body/DID is malformed.
 /// - 401 when the bearer token is missing/invalid.
-/// - 403 when the token lacks `governance:write` or the `DefaultMandateGate`
-///   refuses declaration authority.
+/// - 403 when the token lacks both accepted write scopes or the
+///   `DefaultMandateGate` refuses declaration authority.
 /// - 409 when an `InstitutionalDomain` is already declared for `domain_id`.
 /// - 500 when no receipt/domain store is wired, or a backend read/write fails.
 pub async fn declare_institutional_domain<E: GovernanceEventEmitter + Clone + 'static>(
@@ -3611,7 +3625,10 @@ pub async fn declare_institutional_domain<E: GovernanceEventEmitter + Clone + 's
     path: web::Path<String>,
     req: web::Json<DeclareInstitutionalDomainRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let claims = require_scope::<BasicClaims>(&http_req, "governance:write")?;
+    let claims = require_any_scope::<BasicClaims>(
+        &http_req,
+        &["governance:charter:write", "governance:write"],
+    )?;
     let actor = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let domain = GovernanceDomainId(path.into_inner());

--- a/icn/apps/governance/tests/direct_scope_migration.rs
+++ b/icn/apps/governance/tests/direct_scope_migration.rs
@@ -1,0 +1,187 @@
+//! Focused authorization wiring for the six governance handlers that remained
+//! broad-scope-only after the first class-scope migrations.
+//!
+//! The four process-recording routes now accept `governance:process:write`
+//! first, while the two constitutional/domain routes accept
+//! `governance:charter:write` first. All six retain `governance:write` as a
+//! compatibility fallback. These tests use a missing domain (or an unwired
+//! mandate backend for declaration): a 404/500 proves the request passed scope
+//! admission and reached handler logic without mutating state.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{dev::Service as _, http::StatusCode, test, App, HttpMessage as _};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+
+const PROCESS_CLASS: &str = "governance:process:write";
+const CHARTER_CLASS: &str = "governance:charter:write";
+const LEGACY_BROAD: &str = "governance:write";
+const UNRELATED: &str = "governance:read";
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(GovernanceManager::new()),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        mandate_gate: None,
+        build_mode: http::GovernanceContextBuildMode::Test,
+    }
+}
+
+macro_rules! scope_app {
+    ($ctx:expr, $caller:expr, $scope:expr) => {{
+        let caller = $caller.to_string();
+        let scope: Option<String> = $scope.map(str::to_owned);
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: scope.clone(),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+macro_rules! assert_direct_handler_statuses {
+    ($scope:expr, $expected:expr) => {{
+        let ctx = make_ctx();
+        let caller = fresh_did();
+        let app = scope_app!(ctx, &caller, $scope);
+        let hash = "09".repeat(32);
+        let expected: [StatusCode; 6] = $expected;
+        let cases = vec![
+            (
+                test::TestRequest::post()
+                    .uri("/domains/missing/process-sessions/session/gate-results")
+                    .set_json(serde_json::json!({
+                        "gate_kind": "privacy_review",
+                        "result": "pass"
+                    })),
+                "record_process_gate_result",
+            ),
+            (
+                test::TestRequest::post()
+                    .uri("/domains/missing/process-sessions/session/open"),
+                "open_process_session",
+            ),
+            (
+                test::TestRequest::post()
+                    .uri("/domains/missing/process-sessions/session/deliberation-entries/entry/record")
+                    .set_json(serde_json::json!({
+                        "entry_kind": "question",
+                        "body_hash": hash
+                    })),
+                "record_deliberation_entry",
+            ),
+            (
+                test::TestRequest::post()
+                    .uri("/domains/missing/process-sessions/session/decisions/decision/record")
+                    .set_json(serde_json::json!({ "body_hash": hash })),
+                "record_decision",
+            ),
+            (
+                test::TestRequest::post()
+                    .uri("/domains/missing/domain-policy/adopt")
+                    .set_json(serde_json::json!({ "policy_content": "policy v1" })),
+                "adopt_domain_policy",
+            ),
+            (
+                test::TestRequest::post()
+                    .uri("/domains/missing/institutional-domain/declare")
+                    .set_json(serde_json::json!({ "entity_type": "cooperative" })),
+                "declare_institutional_domain",
+            ),
+        ];
+
+        for ((request, handler), expected_status) in cases.into_iter().zip(expected) {
+            let response = test::call_service(&app, request.to_request()).await;
+            assert_eq!(
+                response.status(),
+                expected_status,
+                "unexpected scope-admission outcome for {handler}"
+            );
+        }
+    }};
+}
+
+#[actix_web::test]
+async fn process_class_is_accepted_only_by_the_four_process_handlers() {
+    assert_direct_handler_statuses!(
+        Some(PROCESS_CLASS),
+        [
+            StatusCode::NOT_FOUND,
+            StatusCode::NOT_FOUND,
+            StatusCode::NOT_FOUND,
+            StatusCode::NOT_FOUND,
+            StatusCode::FORBIDDEN,
+            StatusCode::FORBIDDEN,
+        ]
+    );
+}
+
+#[actix_web::test]
+async fn charter_class_is_accepted_only_by_the_two_constitutional_handlers() {
+    assert_direct_handler_statuses!(
+        Some(CHARTER_CLASS),
+        [
+            StatusCode::FORBIDDEN,
+            StatusCode::FORBIDDEN,
+            StatusCode::FORBIDDEN,
+            StatusCode::FORBIDDEN,
+            StatusCode::NOT_FOUND,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ]
+    );
+}
+
+#[actix_web::test]
+async fn broad_fallback_remains_accepted_by_all_six_handlers() {
+    assert_direct_handler_statuses!(
+        Some(LEGACY_BROAD),
+        [
+            StatusCode::NOT_FOUND,
+            StatusCode::NOT_FOUND,
+            StatusCode::NOT_FOUND,
+            StatusCode::NOT_FOUND,
+            StatusCode::NOT_FOUND,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ]
+    );
+}
+
+#[actix_web::test]
+async fn unrelated_scope_is_rejected_by_all_six_handlers() {
+    assert_direct_handler_statuses!(Some(UNRELATED), [StatusCode::FORBIDDEN; 6]);
+}
+
+#[actix_web::test]
+async fn missing_scope_is_rejected_by_all_six_handlers() {
+    assert_direct_handler_statuses!(None, [StatusCode::FORBIDDEN; 6]);
+}

--- a/icn/crates/icn-gateway/src/validation.rs
+++ b/icn/crates/icn-gateway/src/validation.rs
@@ -8,8 +8,8 @@
 use crate::error::{GatewayError, Result};
 use icn_rpc::auth::scopes::{
     GOVERNANCE_ACTIVITY_WRITE, GOVERNANCE_CHARTER_WRITE, GOVERNANCE_COMMENT_WRITE,
-    GOVERNANCE_FEDERATION_WRITE, GOVERNANCE_MEETING_WRITE, GOVERNANCE_PROPOSAL_WRITE,
-    GOVERNANCE_STEWARD_WRITE,
+    GOVERNANCE_FEDERATION_WRITE, GOVERNANCE_MEETING_WRITE, GOVERNANCE_PROCESS_WRITE,
+    GOVERNANCE_PROPOSAL_WRITE, GOVERNANCE_STEWARD_WRITE,
 };
 
 /// Maximum length for cooperative ID
@@ -58,14 +58,12 @@ pub const ALLOWED_SCOPES: &[&str] = &[
     "governance:read",
     "governance:write",
     // Governance class-level write scopes (subdivisions of `governance:write`).
-    // Minted by §10 step 1 of `docs/design/governance/governance-write-decomposition.md`.
+    // Minted by the `governance:write` decomposition designs.
     // Wire strings are sourced from `icn_rpc::auth::scopes` so the gateway
     // allowlist and the RPC scope constants cannot drift; the test
     // `test_allowed_scopes_contains_governance_class_write` locks that
-    // invariant. No handler in `apps/governance/src/http/handlers.rs`
-    // references these yet; handler migration happens in later steps. The
-    // broad `governance:write` remains in the allowlist during the
-    // migration.
+    // invariant. Handler migration is incremental. The broad
+    // `governance:write` remains in the allowlist during the migration.
     GOVERNANCE_CHARTER_WRITE,
     GOVERNANCE_PROPOSAL_WRITE,
     GOVERNANCE_STEWARD_WRITE,
@@ -73,6 +71,7 @@ pub const ALLOWED_SCOPES: &[&str] = &[
     GOVERNANCE_MEETING_WRITE,
     GOVERNANCE_ACTIVITY_WRITE,
     GOVERNANCE_COMMENT_WRITE,
+    GOVERNANCE_PROCESS_WRITE,
     // Settlement operations
     "settlements:read",
     "settlements:write",
@@ -824,17 +823,16 @@ mod tests {
         assert!(validate_scopes(&too_many_scopes).is_err());
     }
 
-    /// Each governance class-level scope minted by §10 step 1 of the
-    /// `governance:write` decomposition design must be requestable via the
+    /// Each governance class-level scope minted by the `governance:write`
+    /// decomposition designs must be requestable via the
     /// gateway auth endpoint. The broad `governance:write` and `governance:read`
     /// remain accepted; an obviously bogus governance subscope is rejected.
     ///
     /// This is a structural test: passing it asserts the allowlist contains
-    /// the seven class strings, not that any handler enforces them. Handler
-    /// migration is a separate PR (see §10 steps 3+ of the design doc).
+    /// the class strings, not that every handler migration is complete.
     #[test]
     fn test_validate_scopes_governance_class_level() {
-        // All seven class-level scopes are accepted, both individually and
+        // All class-level scopes are accepted, both individually and
         // together in a single token request.
         let class_scopes = [
             "governance:charter:write",
@@ -844,6 +842,7 @@ mod tests {
             "governance:meeting:write",
             "governance:activity:write",
             "governance:comment:write",
+            "governance:process:write",
         ];
         for scope in class_scopes.iter() {
             assert!(
@@ -854,7 +853,7 @@ mod tests {
         let bundled: Vec<String> = class_scopes.iter().map(|s| s.to_string()).collect();
         assert!(
             validate_scopes(&bundled).is_ok(),
-            "all seven class-level scopes must be acceptable in a single request"
+            "all class-level scopes must be acceptable in a single request"
         );
 
         // Broad scopes remain accepted during migration.

--- a/icn/crates/icn-gateway/tests/scope_validation_integration.rs
+++ b/icn/crates/icn-gateway/tests/scope_validation_integration.rs
@@ -73,16 +73,15 @@ fn test_scope_count_limit() {
 
 #[test]
 fn test_all_allowed_scopes_are_valid() {
-    // Verify all scopes in ALLOWED_SCOPES actually pass validation
-    let all_allowed_scopes = validation::ALLOWED_SCOPES
-        .iter()
-        .map(|s| s.to_string())
-        .collect::<Vec<String>>();
-
-    assert!(
-        validation::validate_scopes(&all_allowed_scopes).is_ok(),
-        "All ALLOWED_SCOPES should be valid"
-    );
+    // Verify each allowlisted scope passes validation independently. The
+    // allowlist may contain more entries than a single request is permitted
+    // to carry under MAX_SCOPES.
+    for scope in validation::ALLOWED_SCOPES {
+        assert!(
+            validation::validate_scopes(&[scope.to_string()]).is_ok(),
+            "Allowlisted scope '{scope}' should be valid"
+        );
+    }
 }
 
 #[test]

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -953,12 +953,11 @@ pub mod scopes {
 
     // Governance class-level write scopes (subdivisions of `governance:write`).
     //
-    // These are minted by §10 step 1 of
-    // `docs/design/governance/governance-write-decomposition.md`. Handler
-    // migration happens in later steps; this PR only mints the strings and
-    // adds them to the gateway allowlist
-    // (`icn-gateway/src/validation.rs::ALLOWED_SCOPES`). No handler in
-    // `apps/governance/src/http/handlers.rs` references these constants yet.
+    // The first seven scopes were minted by §10 step 1 of
+    // `docs/design/governance/governance-write-decomposition.md`; the process
+    // class was added by the current-state completion map in
+    // `docs/design/governance-write-authority-decomposition.md`. Handler
+    // migrations are incremental and retain the broad fallback.
     //
     // `GOVERNANCE_WRITE` remains in place during the migration and is only
     // retired by step 13 once no production code references it (see §10
@@ -970,9 +969,10 @@ pub mod scopes {
     pub const GOVERNANCE_MEETING_WRITE: &str = "governance:meeting:write";
     pub const GOVERNANCE_ACTIVITY_WRITE: &str = "governance:activity:write";
     pub const GOVERNANCE_COMMENT_WRITE: &str = "governance:comment:write";
+    pub const GOVERNANCE_PROCESS_WRITE: &str = "governance:process:write";
 
-    /// Class-level governance write scopes minted by §10 step 1 of the
-    /// `governance:write` decomposition design. Listed in declaration order so
+    /// Class-level governance write scopes minted by the `governance:write`
+    /// decomposition designs. Listed in declaration order so
     /// downstream consumers (gateway allowlist, RPC method mappings, future
     /// handler migrations) can iterate over them without depending on the
     /// individual constant names.
@@ -984,6 +984,7 @@ pub mod scopes {
         GOVERNANCE_MEETING_WRITE,
         GOVERNANCE_ACTIVITY_WRITE,
         GOVERNANCE_COMMENT_WRITE,
+        GOVERNANCE_PROCESS_WRITE,
     ];
 
     // Admin scopes
@@ -1687,8 +1688,8 @@ mod tests {
         );
     }
 
-    /// The seven governance class-level scope constants minted by §10 step 1
-    /// of the `governance:write` decomposition design must have their declared
+    /// The governance class-level scope constants minted by the
+    /// `governance:write` decomposition designs must have their declared
     /// wire-string values, and the `GOVERNANCE_CLASS_WRITE` slice must
     /// enumerate them in declaration order.
     ///
@@ -1707,8 +1708,9 @@ mod tests {
         assert_eq!(GOVERNANCE_MEETING_WRITE, "governance:meeting:write");
         assert_eq!(GOVERNANCE_ACTIVITY_WRITE, "governance:activity:write");
         assert_eq!(GOVERNANCE_COMMENT_WRITE, "governance:comment:write");
+        assert_eq!(GOVERNANCE_PROCESS_WRITE, "governance:process:write");
 
-        assert_eq!(GOVERNANCE_CLASS_WRITE.len(), 7);
+        assert_eq!(GOVERNANCE_CLASS_WRITE.len(), 8);
         assert_eq!(
             GOVERNANCE_CLASS_WRITE,
             &[
@@ -1719,6 +1721,7 @@ mod tests {
                 GOVERNANCE_MEETING_WRITE,
                 GOVERNANCE_ACTIVITY_WRITE,
                 GOVERNANCE_COMMENT_WRITE,
+                GOVERNANCE_PROCESS_WRITE,
             ]
         );
 


### PR DESCRIPTION
## Summary
- adds `governance:process:write` as a governance class scope and gateway-allowlisted capability
- migrates the four process-recording governance handlers from broad-only to process-scope-first gates while retaining `governance:write` fallback
- migrates the two constitutional/domain handlers from broad-only to charter-scope-first gates while retaining `governance:write` fallback
- preserves existing `MandateGate`, domain-membership, route, payload, and receipt behavior
- adds focused auth tests for accepted class scopes, broad fallback, sibling/unrelated-scope rejection, and missing-scope rejection across all six handlers

## Validation
- `cargo fmt --all --check` — passed
- `cargo test -p icn-rpc` — passed: 83 unit, 43 integration, and 4 doc tests; 1 doc test ignored
- `cargo test -p icn-governance` — passed: 684 unit, 46 integration/safety, and 7 doc tests; 6 doc tests ignored
- `cargo test -p icn-governance-actor` — passed, including 316 unit tests, all integration suites, and the new five-case direct-scope migration matrix; 2 doc tests ignored
- `cargo test -p icn-gateway test_validate_scopes_governance_class_level` — passed
- `cargo test -p icn-gateway test_allowed_scopes_contains_governance_class_write` — passed
- `cargo clippy -p icn-rpc -p icn-governance-actor -p icn-governance -p icn-gateway --all-targets -- -D warnings` — passed
- `git diff --check` — passed
- semantic scans — confirmed the six class-first gates and found no auto-close or readiness-overclaim language

## Non-claims
- no removal of broad fallback
- no trusted token issuance
- no entity-auth enforcement cutover
- no AccessReceipt runtime
- no new receipt class
- no route/OpenAPI/SDK expansion
- no mandate-bundle redesign
- no vault implementation
- no encryption implementation
- no NYCN package update
- no icn-learn update
- no icn-infra update
- no production, pilot, organizer-ready, member-ready, live-federation, NYCN, Phase-2, or #2041 completion claim
- leaves #1748, #2141, #2041, #1868, #2061, #2080, #2081, and #1907 open

Refs #2339.
Refs #2338.
Refs #1868.
Refs #2061.
Refs #2080.
Refs #2081.
Refs #1748.
Refs #2141.
Refs #2041.
