### PR TITLE
fix(authz): tighten scope admission matcher semantics

### DIFF
--- a/icn/crates/icn-http-kit/src/auth.rs
+++ b/icn/crates/icn-http-kit/src/auth.rs
@@ -150,17 +150,31 @@ pub fn require_any_scope_matched<C: ClaimsLike>(
 /// (which only observes) use it, so an observation can never disagree with the
 /// gate it describes.
 fn scope_str_grants(raw: &str, required: &str) -> bool {
-    raw.split_whitespace()
-        .any(|s| s == required || s.starts_with(&format!("{required}:")))
+    raw.split_whitespace().any(|s| {
+        // Exact match, or a colon-delimited sub-scope (e.g. `governance:write:admin`
+        // grants `governance:write`) — never a bare prefix like `governance:writer`.
+        // `strip_prefix` avoids allocating a `format!("{required}:")` per token.
+        s.strip_prefix(required)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with(':'))
+    })
 }
 
 /// Centralized scope checking. Split and normalize once, not in every handler.
+///
+/// A missing scope claim and a whitespace-only (tokenless) scope string are both
+/// treated as "no scope present": a whitespace-only string carries no usable
+/// scope, so it takes the same rejection path as an absent claim. This keeps the
+/// gate aligned with [`classify_scope_admission`], which classifies both `None`
+/// and whitespace-only as [`ScopeAdmission::RejectedMissing`]. Only the error
+/// *message* changes for the whitespace-only edge; the `ApiError` variant, HTTP
+/// status, and allow/deny outcome are unchanged (both were already `Forbidden`).
 fn check_scope<C: ClaimsLike>(claims: &C, required: &str) -> Result<(), ApiError> {
-    let Some(raw) = claims.raw_scope() else {
+    let raw = claims.raw_scope().unwrap_or_default();
+    if raw.split_whitespace().next().is_none() {
         return Err(ApiError::Forbidden(format!(
             "scope '{required}' required but no scope present"
         )));
-    };
+    }
 
     if scope_str_grants(raw, required) {
         Ok(())
@@ -471,6 +485,45 @@ mod tests {
         assert_eq!(
             classify_scope_admission(Some("governance:write:admin"), CHARTER, BROAD, SIBLINGS),
             ScopeAdmission::Fallback
+        );
+    }
+
+    #[test]
+    fn scope_prefix_without_colon_does_not_grant() {
+        // A bare prefix like `governance:writer` must NOT satisfy `governance:write`
+        // — only an exact match or a colon-delimited sub-scope grants. Guards the
+        // `strip_prefix`-based matcher against false prefix positives, for both the
+        // gate (`require_scope`) and the classifier.
+        let req = req_with_scope(Some("governance:writer"));
+        assert!(
+            require_scope::<BasicClaims>(&req, BROAD).is_err(),
+            "bare prefix `governance:writer` must not grant `governance:write`"
+        );
+        assert_eq!(
+            classify_scope_admission(Some("governance:writer"), CHARTER, BROAD, SIBLINGS),
+            ScopeAdmission::RejectedUnrelated
+        );
+    }
+
+    #[test]
+    fn whitespace_only_scope_takes_the_no_scope_present_path() {
+        // Post-#2344 alignment: the gate treats a whitespace-only (tokenless) scope
+        // as "no scope present" — the same rejection class as a missing claim —
+        // matching the classifier's `RejectedMissing`. The `ApiError` variant and
+        // HTTP status are unchanged (`Forbidden` either way); only the message text
+        // changes, so this is not an authorization-behavior change.
+        let req = req_with_scope(Some("   "));
+        match require_any_scope::<BasicClaims>(&req, &[CHARTER, BROAD]).unwrap_err() {
+            ApiError::Forbidden(msg) => assert!(
+                msg.contains("no scope present"),
+                "whitespace-only scope should use the no-scope-present message, got: {msg}"
+            ),
+            other => panic!("expected Forbidden, got {other:?}"),
+        }
+        // Gate and classifier now agree this is the "missing" case.
+        assert_eq!(
+            classify_scope_admission(Some("   "), CHARTER, BROAD, SIBLINGS),
+            ScopeAdmission::RejectedMissing
         );
     }
 


### PR DESCRIPTION
## Summary

Narrow post-#2344 cleanup in the domain-agnostic `icn-http-kit` auth layer, addressing the two Copilot review comments on #2344. One file changed (`icn/crates/icn-http-kit/src/auth.rs`), +57/−4.

1. **No per-token allocation in `scope_str_grants`.** The per-token `format!("{required}:")` inside the `any` closure is replaced by `strip_prefix` with an empty-or-`:`-rest check. Matching semantics are byte-for-byte identical: exact match grants, `required:anything` grants, and a bare prefix like `governance:writer` still does **not** grant `governance:write`.
2. **Aligned whitespace-only scope semantics.** `check_scope` now treats a whitespace-only (tokenless) scope string as "no scope present" — the same rejection path as a missing scope claim — so the gate agrees with `classify_scope_admission`, which already classifies both `None` and whitespace-only as `RejectedMissing`.

## Why

Copilot flagged (a) an avoidable allocation now that `scope_str_grants` is reused by both enforcement and classification, and (b) that the classifier claimed stronger agreement with the gate than existed: for `Some("   ")` the classifier returned `RejectedMissing` while `check_scope` routed it through the "present-but-not-granting" message. Aligning the gate makes the observation honest.

**Semantic decision (whitespace-only):** treat `None` and whitespace-only consistently as "no usable scope". The gate change is message-only — the `ApiError` variant (`Forbidden`), HTTP status, and allow/deny outcome are unchanged (whitespace-only was already `Forbidden`). So there is **no observable authorization behavior change**; the classifier now genuinely agrees with the gate instead of over-claiming.

## Validation

- `cargo fmt -p icn-http-kit --check` — clean
- `cargo test -p icn-http-kit` — **29 passed / 0 failed** (2 new tests: bare-prefix rejection for gate + classifier; whitespace-only "no scope present" alignment; `classification_accept_set_agrees_with_require_any_scope` still green)
- `cargo clippy -p icn-http-kit --all-targets --all-features -- -D warnings` — clean
- `git diff --check` — clean
- Semantic scans — no auto-close keywords near issue refs, no readiness/completion claims, no telemetry/logging/metrics/receipts/private-id capture added, `governance:write` fallback intact.

## Non-goals / non-claims

No telemetry, logging, metrics, observation sink, or gate wiring; no authorization expansion; no `governance:write` fallback removal; no trusted issuance; no entity-auth cutover; no AccessReceipt; no new receipt class; no route/OpenAPI/SDK/mandate/vault/encryption/provider-import/NYCN/icn-learn/icn-infra work; no docs/memory change. No production/pilot/organizer/member/live-federation/NYCN/Phase-2/#2041 completion claim.

## Refs

Refs #2344
Refs #2343
Refs #2342
Refs #1868
Refs #2061
