### PR TITLE
feat(authz): wire charter governance fallback observation

### DIFF
--- a/icn/apps/governance/src/fallback_observation_emitter.rs
+++ b/icn/apps/governance/src/fallback_observation_emitter.rs
@@ -24,7 +24,8 @@
 //! a later, separately-reviewed slice can back with a real (bounded)
 //! metrics/audit sink and wire to a single handler family.
 
-use crate::fallback_observation::GovernanceScopeAdmission;
+use crate::fallback_observation::{GovernanceScopeAdmission, RequiredClass, RouteFamily};
+use icn_http_kit::auth::{classify_scope_admission_for_claims, ClaimsLike};
 use icn_http_kit::{ObservationOutcome, ObservationSurface, ScopeAdmission};
 
 /// The bounded, closed-label aggregate key for one governance fallback
@@ -122,12 +123,60 @@ impl FallbackObservationEmitter for NoopFallbackObservationEmitter {
     }
 }
 
+/// The class scope the `CharterDomain` family prefers.
+const CHARTER_CLASS_SCOPE: &str = "governance:charter:write";
+/// The broad compatibility fallback retained across governance write surfaces
+/// until it is (separately, and only after its prerequisites) retired.
+const GOVERNANCE_BROAD_SCOPE: &str = "governance:write";
+
+/// Side-band, observe-only recording of how a **CharterDomain** scope gate was
+/// satisfied — via the required class scope or via the broad fallback.
+///
+/// Call this **after** the handler's unchanged
+/// `["governance:charter:write", "governance:write"]` gate has already accepted
+/// the request, passing the same `claims` the gate validated. It re-derives the
+/// [`ScopeAdmission`] from the claims' scope string with
+/// [`classify_scope_admission_for_claims`], which shares the gate's matching rule
+/// ([`icn_http_kit`]'s `scope_str_grants`), so the observation can never disagree
+/// with the authorization decision. It then emits one bounded
+/// [`GovernanceScopeAdmission`] on `emitter`.
+///
+/// **Cannot affect the request.** [`FallbackObservationEmitter::emit`] returns
+/// unit, so neither the classification nor an emission failure can change the
+/// request, response, or authorization outcome; the default production emitter is
+/// [`NoopFallbackObservationEmitter`], so the default path does no I/O. Only
+/// closed-enum labels are produced — no scope string, subject, DID, domain id,
+/// policy id, or payload is read out or retained.
+///
+/// Because it is reached only on the allow path, the admission is one of
+/// [`ScopeAdmission::Class`], [`ClassPreferred`](ScopeAdmission::ClassPreferred),
+/// or [`Fallback`](ScopeAdmission::Fallback); the sibling set is therefore empty
+/// (the `Rejected*` variants are unreachable here).
+pub fn observe_charter_domain_admission<C, E>(emitter: &E, claims: &C)
+where
+    C: ClaimsLike,
+    E: FallbackObservationEmitter,
+{
+    let match_outcome = classify_scope_admission_for_claims(
+        claims,
+        CHARTER_CLASS_SCOPE,
+        GOVERNANCE_BROAD_SCOPE,
+        &[],
+    );
+    emitter.emit(GovernanceScopeAdmission::new(
+        RouteFamily::CharterDomain,
+        RequiredClass::Charter,
+        match_outcome,
+        ObservationOutcome::Observed,
+    ));
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
 
     use super::*;
-    use crate::fallback_observation::{RequiredClass, RouteFamily};
+    use icn_http_kit::auth::BasicClaims;
     use std::collections::BTreeSet;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
@@ -319,5 +368,59 @@ mod tests {
     fn emitter_usable_behind_a_trait_object() {
         let emitter: &dyn FallbackObservationEmitter = &NoopFallbackObservationEmitter;
         emitter.emit(sample(RouteFamily::StewardDirect, RequiredClass::Steward));
+    }
+
+    fn claims_with_scope(scope: &str) -> BasicClaims {
+        BasicClaims {
+            sub: "did:icn:test-subject".to_string(),
+            scope: Some(scope.to_string()),
+        }
+    }
+
+    #[test]
+    fn observe_charter_domain_admission_records_bounded_class_labels() {
+        let emitter = RecordingEmitter::default();
+        observe_charter_domain_admission(&emitter, &claims_with_scope(CHARTER_CLASS_SCOPE));
+        let seen = emitter.seen.lock().expect("poisoned").clone();
+        assert_eq!(seen.len(), 1);
+        // Every field is a bounded control-map §4 static label — the charter
+        // route family, its class, an accept outcome, on the governance HTTP
+        // surface. No scope string, subject, DID, or payload is present.
+        assert_eq!(seen[0].surface, "governance_http");
+        assert_eq!(seen[0].route_family, "charter_domain");
+        assert_eq!(seen[0].required_class, "charter");
+        assert_eq!(seen[0].match_outcome, "class");
+        assert_eq!(seen[0].observation_outcome, "observed");
+    }
+
+    #[test]
+    fn observe_charter_domain_admission_records_broad_fallback() {
+        let emitter = RecordingEmitter::default();
+        observe_charter_domain_admission(&emitter, &claims_with_scope(GOVERNANCE_BROAD_SCOPE));
+        let seen = emitter.seen.lock().expect("poisoned").clone();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].route_family, "charter_domain");
+        assert_eq!(seen[0].required_class, "charter");
+        assert_eq!(seen[0].match_outcome, "fallback");
+    }
+
+    #[test]
+    fn observe_charter_domain_admission_prefers_class_when_both_present() {
+        let emitter = RecordingEmitter::default();
+        let both = format!("{CHARTER_CLASS_SCOPE} {GOVERNANCE_BROAD_SCOPE}");
+        observe_charter_domain_admission(&emitter, &claims_with_scope(&both));
+        let seen = emitter.seen.lock().expect("poisoned").clone();
+        assert_eq!(seen[0].match_outcome, "class_preferred");
+    }
+
+    #[test]
+    fn observe_charter_domain_admission_with_noop_default_records_nothing_and_returns_unit() {
+        // The production default: observing changes nothing and returns unit, so
+        // it can never influence the request it observes.
+        let unit: () = observe_charter_domain_admission(
+            &NoopFallbackObservationEmitter,
+            &claims_with_scope(CHARTER_CLASS_SCOPE),
+        );
+        assert_eq!(unit, ());
     }
 }

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -30,6 +30,9 @@ use crate::domain_policy_adoption::{
     InstitutionalDomainStoreError,
 };
 use crate::events::GovernanceEventEmitter;
+use crate::fallback_observation_emitter::{
+    observe_charter_domain_admission, NoopFallbackObservationEmitter,
+};
 
 // ============================================================================
 // Internal helpers
@@ -3488,6 +3491,10 @@ pub async fn adopt_domain_policy<E: GovernanceEventEmitter + Clone + 'static>(
         &http_req,
         &["governance:charter:write", "governance:write"],
     )?;
+    // Observe-only (#2352): record how the *unchanged* charter gate was
+    // satisfied (class vs. broad fallback) via the no-op emission seam. Returns
+    // unit and defaults to the no-op emitter, so it cannot affect this request.
+    observe_charter_domain_admission(&NoopFallbackObservationEmitter, &claims);
     let actor = parse_did(&claims.sub, "Invalid DID in token")?;
 
     // Reject empty/whitespace and oversize bodies before content-addressing
@@ -3629,6 +3636,10 @@ pub async fn declare_institutional_domain<E: GovernanceEventEmitter + Clone + 's
         &http_req,
         &["governance:charter:write", "governance:write"],
     )?;
+    // Observe-only (#2352): record how the *unchanged* charter gate was
+    // satisfied (class vs. broad fallback) via the no-op emission seam. Returns
+    // unit and defaults to the no-op emitter, so it cannot affect this request.
+    observe_charter_domain_admission(&NoopFallbackObservationEmitter, &claims);
     let actor = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let domain = GovernanceDomainId(path.into_inner());

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -55,7 +55,8 @@ pub use events::{GovernanceEventEmitter, NoopEventEmitter};
 pub use executor::{ExecutionCallback, GovernanceProposalExecutor};
 pub use fallback_observation::{GovernanceScopeAdmission, RequiredClass, RouteFamily};
 pub use fallback_observation_emitter::{
-    FallbackObservationEmitter, FallbackObservationLabels, NoopFallbackObservationEmitter,
+    observe_charter_domain_admission, FallbackObservationEmitter, FallbackObservationLabels,
+    NoopFallbackObservationEmitter,
 };
 pub use handlers::translate_payload_to_effects;
 pub use institutional_effect::InstitutionalEffectRecord;


### PR DESCRIPTION
## Summary

First **single-family observe-only wiring** for the governance broad-fallback observability lane (design §9 slice 4, runtime). Wires the two **constitutional charter routes** — `adopt_domain_policy` and `declare_institutional_domain` — to the no-op fallback-observation emission seam landed in #2351, as a pure side-observation **after** the existing scope gate has already decided allow/deny. Three files, +118/−3.

## Why

#2351 landed the emission seam (`FallbackObservationLabels`, `FallbackObservationEmitter`, `NoopFallbackObservationEmitter`) but wired nothing. This is the first handler wiring: it records *how* a charter scope gate was satisfied — via the required class scope (`governance:charter:write`) or via the broad fallback (`governance:write`) — so migration off the broad fallback can eventually be measured. Supports #1868 / #2061. Nothing consumes the observation yet (the only emitter is the no-op), so this is groundwork a later, separately-reviewed slice backs with a real bounded metric/audit sink.

## What changed

- **`icn/apps/governance/src/fallback_observation_emitter.rs`** — new governance-local helper `observe_charter_domain_admission(emitter, claims)`. It re-derives the `ScopeAdmission` from the already-validated claims via `icn_http_kit::auth::classify_scope_admission_for_claims` (which shares the gate's `scope_str_grants` matching rule, so the observation cannot disagree with the gate) and emits one bounded `GovernanceScopeAdmission { RouteFamily::CharterDomain, RequiredClass::Charter, <match>, ObservationOutcome::Observed }`. Plus 4 unit tests.
- **`icn/apps/governance/src/http/handlers.rs`** — one call to the helper after each unchanged `["governance:charter:write", "governance:write"]` gate, with the default `NoopFallbackObservationEmitter`.
- **`icn/apps/governance/src/lib.rs`** — re-export the helper.

**No app-state DI / no `GovernanceContext` refactor.** The default emitter is a zero-sized no-op constructed at the call site, and the helper is unit-tested directly by injecting a recording emitter — so no emitter had to be threaded through handler context. Reached only on the allow path, so the admission is `Class` / `ClassPreferred` / `Fallback`; the sibling set is empty (reject variants unreachable), so **no `icn-rpc` dependency** is added.

## Scope note (route family vs. this slice)

`RouteFamily::CharterDomain` (the design label) covers six charter/domain routes; this slice wires only the **two constitutional routes** (`adopt_domain_policy`, `declare_institutional_domain`) — the cleanly test-backed subset in `direct_scope_migration.rs`. The other four (`create_domain`, `add_domain_member`, `remove_domain_member`, `activate_charter`) are a deliberate follow-up, keeping this diff minimal and avoiding mass handler wiring. Since nothing consumes the observation yet, partial coverage cannot mislead any live surface.

## Validation

- `cargo fmt --all --check` — clean
- `cargo check -p icn-governance-actor` — builds
- `cargo test -p icn-governance-actor fallback_observation` — emitter + wrapper unit tests pass (incl. 4 new helper tests: class / broad-fallback / class-preferred / no-op default)
- `cargo test -p icn-governance-actor --test direct_scope_migration` — **the existing allow/deny matrix (charter class accepted, broad fallback accepted, sibling/unrelated/missing rejected) still passes unchanged**, proving no authorization behavior change
- `cargo test -p icn-http-kit` — no regression
- `cargo clippy -p icn-http-kit -p icn-governance-actor --all-targets -- -D warnings` — clean
- `git diff --check` — clean

## Security Audit note

The non-required `Security Audit` check may be red due to a **pre-existing, repo-wide `cargo audit` advisory** (`RUSTSEC-2026-0204`, transitive `crossbeam-epoch`). This PR changed **no `Cargo.toml`/`Cargo.lock`/dependency files**, so it audits identically on `main`. Out of scope for this lane (a separate dependency-remediation task).

## Non-goals / non-claims

Observe-only wiring of one family's two constitutional routes. No authorization behavior change; `governance:charter:write` still passes, `governance:write` fallback still passes, sibling/unrelated/missing still reject exactly as before. No `governance:write` fallback removal. No real telemetry (no logs/metrics/events); no receipts; no AccessReceipt / ScopedVault; no private-data capture (no scope string, subject, DID, domain id, policy id, payload, IP, UA, free-form label/error). No mass handler wiring; no app-state refactor. `icn-http-kit` untouched; no dependency remediation; no OpenAPI/SDK/route-surface change; no provider-import / NYCN / icn-learn / icn-infra. No production/pilot/organizer/member/live-federation/NYCN/Phase-2/#2041 completion claim.

## Refs

Refs #2352
Refs #2342
Refs #2344
Refs #2345
Refs #2347
Refs #2349
Refs #2351
Refs #1868
Refs #2061
