### PR TITLE
fix(agents): harden preflight root guidance

### DIFF
--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -8,6 +8,10 @@ on:
       - 'ops/automation/skills/**'
       - 'ops/state/truth/**'
       - 'ops/scripts/drift-check.sh'
+      - 'scripts/check-preflight-consistency.sh'
+      - 'CLAUDE.md'
+      - 'ops/CLAUDE.md'
+      - 'AGENTS.md'
   pull_request:
     # No paths filter: run on ALL PRs so any new skill/agent is checked for truth_contract
     # and registry entries. The check is fast (~5s) and catches silent drift early.
@@ -27,6 +31,9 @@ jobs:
 
       - name: Verify canonical truth files exist
         run: bash ops/scripts/drift-check.sh
+
+      - name: Preflight/root guidance consistency (Refs icn#2140)
+        run: bash scripts/check-preflight-consistency.sh
 
       - name: Validate JSON truth files are parseable
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,14 @@ conflict, the canonical owner it points to wins.
 2. **Keep diffs small and reviewable.** Prefer multiple PRs over one mega-PR.
 3. **No "fixing" by weakening safety.**
    - Do not relax validation, trust gates, signature checks, or encoding rules to make tests pass.
-4. **Run the right checks for the area you touched** (see "Change routing" below).
-5. **Docs/specs must match reality.** If you change semantics, update the relevant doc/spec in the same PR,
+4. **Verify your root, then read before edit.** Confirm `git rev-parse --show-toplevel` is the
+   checkout you intend (on the dev VM: `~/icn-dev/worktrees/icn/<worktree>`; standalone clones such
+   as `~/projects/icn` are legacy and can be weeks stale). Read a file from this checkout before
+   editing it — never edit from memory or from another checkout's copy.
+5. **Run the right checks for the area you touched** (see "Change routing" below).
+6. **Docs/specs must match reality.** If you change semantics, update the relevant doc/spec in the same PR,
    or create a blocking issue and reference it in the PR description.
-6. **No new tooling.** Do not introduce new linters, build systems, or frameworks unless explicitly requested.
+7. **No new tooling.** Do not introduce new linters, build systems, or frameworks unless explicitly requested.
 
 ---
 
@@ -188,7 +192,16 @@ npm run dev  # python3 -m http.server 8080
 | **React Native SDK** (`sdk/react-native/`) | `npm test && npm run build` |
 | **Pilot UI** (`web/pilot-ui/`) | `npm run test && npm run test:e2e && npm run test:a11y` |
 | **Deploy manifests** (`deploy/`) | Ensure no secrets committed; keep placeholders; update deploy docs if behavior changes |
-| **Documentation** (`docs/`) | Verify links, check terminology consistency |
+| **Documentation** (`docs/`) | Verify links, check terminology consistency, run the doc-control commands below |
+
+**Doc-control commands (exact forms — run from the monorepo root, not from `docs/`):**
+
+```bash
+python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml
+python3 docs/scripts/freshness-check.py --freshness docs/freshness.toml --status docs/status.toml --repo .
+python3 .github/scripts/compliance_linter.py --repo-root .
+python3 .github/scripts/readiness_overclaim_linter.py --repo-root .
+```
 
 ---
 
@@ -291,7 +304,9 @@ On the dev host, agent sessions follow the `~/icn-dev` bare-store/worktree opera
 **Rules:**
 - One agent = one branch = one worktree
 - Never commit to `main` — all work on feature branches
-- Worktrees live in `../icn-wt/` (sibling to repo root)
+- In this older/legacy layout, worktrees live in `../icn-wt/` (sibling to repo root); on the dev VM
+  the canonical location is `~/icn-dev/worktrees/icn/<name>` per
+  `ops/state/config/repo-map.json#worktrees.root`
 - Override defaults via `ICN_WT_DIR`, `ICN_WT_REMOTE`, `ICN_WT_BASE_REF`
 - **Rebase before edits**: Any agent assigned to an older branch must first run `git fetch origin && git rebase origin/main` before making any edits. This prevents CRLF phantom diffs and merge conflicts from stale bases.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,15 +55,29 @@ This monorepo has **two important roots** — mixing them up causes subtle failu
 
 | Root | Path | Contains |
 |------|------|----------|
-| **Monorepo root** | `/home/ubuntu/projects/icn` | `sdk/`, `docs/`, `web/`, `deploy/`, `scripts/`, `CLAUDE.md` |
-| **Rust workspace** | `/home/ubuntu/projects/icn/icn` | `Cargo.toml`, `crates/`, `bins/`, `Cargo.lock` |
+| **Monorepo root** | the checkout you are in — discover with `git rev-parse --show-toplevel` (on the dev VM: `~/icn-dev/worktrees/icn/<worktree>`) | `sdk/`, `docs/`, `web/`, `deploy/`, `scripts/`, `CLAUDE.md` |
+| **Rust workspace** | `$(git rev-parse --show-toplevel)/icn` | `Cargo.toml`, `crates/`, `bins/`, `Cargo.lock` |
 
-**Rule**: Rust commands (`cargo *`) run from `icn/icn/`. SDK/OpenAPI commands run from the monorepo root's subdirectories (`sdk/typescript/`, `docs/api/`).
+**Rule**: Rust commands (`cargo *`) run from the `icn/` subdirectory of the monorepo root. SDK/OpenAPI commands run from the monorepo root's subdirectories (`sdk/typescript/`, `docs/api/`).
 
 ```bash
 # Quick "where am I?" check
 git rev-parse --show-toplevel
 test -f Cargo.toml && echo "Rust root" || echo "Not Rust root"
+```
+
+**Legacy checkouts are not truth.** The standalone clone `~/projects/icn` and the repo-adjacent
+`../icn-wt/` worktree layout are retired (legacy); never treat them as current state — they can sit
+weeks behind `origin/main`. On the dev VM, work happens only in `~/icn-dev/worktrees/icn/<worktree>`
+(bare stores in `~/icn-dev/repos/*.git`). The worktree root of record is
+`ops/state/config/repo-map.json#worktrees.root`; the MCP server resolves it via `ICN_WT_ROOT` →
+repo-map → legacy fallback (`ops/mcp/src/paths.ts`).
+
+**Preflight path (one documented path — run from the monorepo root at session start):**
+
+```bash
+bash scripts/icn-preflight.sh               # repo/branch, gh auth, ports, toolchain, cargo check
+bash scripts/check-preflight-consistency.sh # root-guidance drift, stale legacy checkout, MCP-root mismatch
 ```
 
 **Crates** (38 directories in `icn/crates/`; 37 are declared in `[workspace].members`, with `icn-baseline-lock-guest` present on disk but excluded; principal crates listed below):
@@ -169,6 +183,21 @@ Navigate using `docs/INDEX.md` (complete index) or `docs/README.md` (overview).
 - `archive/` - Historical documentation (organized by year)
 
 **See `docs/DOCUMENTATION_MAINTENANCE.md` for where to put new documentation.**
+
+**Doc-control commands (exact forms — run from the monorepo root):**
+
+```bash
+python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml
+python3 docs/scripts/freshness-check.py --freshness docs/freshness.toml --status docs/status.toml --repo .
+python3 .github/scripts/compliance_linter.py --repo-root .
+python3 .github/scripts/readiness_overclaim_linter.py --repo-root .
+```
+
+**Generated orientation artifacts are navigation aids, not truth roots.** `docs/INDEX.generated.md`,
+`docs/DOCUMENT_REGISTRY.md`, `docs/reference/project-index/generated/*` (agent context spine),
+`docs/reference/project-index/full-repo-record.md`, and live-state overlays are generated to help you
+find things. Canonical ownership lives in `ops/state/truth/sources.json`; when a generated artifact
+disagrees with a canonical owner, the owner wins.
 
 ## Build & Test Commands
 
@@ -686,7 +715,11 @@ You are operating as an execution engine. Be concise. Do not narrate routine ste
 Before making ANY code change:
 1. Print current branch
 2. Identify PR number (if any) and its base branch
-3. Confirm correct repo + correct directory
+3. Confirm correct repo + correct directory (`git rev-parse --show-toplevel` — must be the intended
+   worktree, never a legacy checkout)
+4. **Read before edit**: read the file in this session, from this checkout, before modifying it.
+   Never edit from memory of another checkout's copy — stale-checkout edits are how wrong-root
+   regressions ship.
 
 If any of these are ambiguous, STOP and ask.
 

--- a/ops/CLAUDE.md
+++ b/ops/CLAUDE.md
@@ -92,5 +92,6 @@ See `state/config/repo-map.json` for the authoritative map. Key relationships:
 - `docs/` at repo root is the canonical documentation source
 - `website/` reads docs directly via path.resolve (no sync script)
 - `icn/` is the Cargo workspace root (not repo root)
-- Worktrees live in `../icn-wt/` on the dev VM
+- Worktrees live under `~/icn-dev/worktrees/<repo>/` on the dev VM (root of record:
+  `state/config/repo-map.json#worktrees.root`; the older repo-adjacent `../icn-wt/` layout is retired/legacy)
 - K3s cluster: control at `10.8.30.40`, workers at `.41`/`.42` (VLAN 30, post Feb 2026 migration)

--- a/ops/mcp/src/paths.ts
+++ b/ops/mcp/src/paths.ts
@@ -1,6 +1,7 @@
 // Centralized monorepo root resolution for the MCP server.
 // Compiled output lives at ops/mcp/dist/<file>.js — resolve up to repo root.
 
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,4 +16,41 @@ export function resolveMonorepoRoot(): string {
 
 export function resolveOpsStatePath(...parts: string[]): string {
   return path.join(resolveMonorepoRoot(), "ops", "state", ...parts);
+}
+
+let warnedLegacyWtRoot = false;
+
+// Worktree-root resolution order: ICN_WT_ROOT env → repo-map.json#worktrees.root
+// (relative values resolve against the monorepo root; a leading ~ expands to $HOME)
+// → legacy ../icn-wt sibling. The legacy layout is retired; the fallback exists only
+// so pre-worktree-OS checkouts degrade gracefully, and it logs a diagnostic when hit.
+export function resolveWorktreeRoot(): string {
+  const env = process.env["ICN_WT_ROOT"];
+  if (env) return env;
+  const root = resolveMonorepoRoot();
+  try {
+    const raw = readFileSync(
+      path.join(root, "ops", "state", "config", "repo-map.json"),
+      "utf8"
+    );
+    const configured = (JSON.parse(raw) as { worktrees?: { root?: unknown } })
+      .worktrees?.root;
+    if (typeof configured === "string" && configured.length > 0) {
+      const home = process.env["HOME"];
+      const expanded =
+        home && (configured === "~" || configured.startsWith("~/"))
+          ? path.join(home, configured.slice(1))
+          : configured;
+      return path.resolve(root, expanded);
+    }
+  } catch {
+    // unreadable/invalid repo-map — fall through to the legacy fallback
+  }
+  if (!warnedLegacyWtRoot) {
+    warnedLegacyWtRoot = true;
+    console.error(
+      "icn-ops: worktree root not configured (repo-map.json#worktrees.root missing/invalid); falling back to legacy ../icn-wt"
+    );
+  }
+  return path.resolve(root, "..", "icn-wt");
 }

--- a/ops/mcp/src/polling/git.ts
+++ b/ops/mcp/src/polling/git.ts
@@ -4,6 +4,7 @@
 import type Database from "better-sqlite3";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
+import { resolveWorktreeRoot } from "../paths.js";
 import { runCommand } from "../utils/commands.js";
 
 const INTERVAL_MS = 30_000;
@@ -55,7 +56,7 @@ async function pollOnce(db: Database.Database, icnRoot: string): Promise<void> {
     }
     writeCache(db, "git:repo_statuses", statuses);
 
-    const wtRoot = join(icnRoot, "..", "icn-wt");
+    const wtRoot = resolveWorktreeRoot();
     let dirs: string[] = [];
     try {
       dirs = readdirSync(wtRoot).filter((d) => !d.startsWith("."));

--- a/ops/mcp/src/tests/paths.test.ts
+++ b/ops/mcp/src/tests/paths.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { resolveWorktreeRoot } from "../paths.js";
+
+// resolveWorktreeRoot resolution order: ICN_WT_ROOT env → repo-map.json#worktrees.root
+// (relative to the monorepo root) → legacy ../icn-wt sibling fallback.
+describe("resolveWorktreeRoot", () => {
+  const savedWtRoot = process.env["ICN_WT_ROOT"];
+  const savedIcnRoot = process.env["ICN_ROOT"];
+  let tempRoot: string;
+
+  beforeEach(() => {
+    delete process.env["ICN_WT_ROOT"];
+    tempRoot = mkdtempSync(path.join(tmpdir(), "icn-paths-test-"));
+    process.env["ICN_ROOT"] = tempRoot;
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+    if (savedWtRoot === undefined) delete process.env["ICN_WT_ROOT"];
+    else process.env["ICN_WT_ROOT"] = savedWtRoot;
+    if (savedIcnRoot === undefined) delete process.env["ICN_ROOT"];
+    else process.env["ICN_ROOT"] = savedIcnRoot;
+  });
+
+  function writeRepoMap(root: unknown): void {
+    const dir = path.join(tempRoot, "ops", "state", "config");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "repo-map.json"),
+      JSON.stringify({ worktrees: { root } })
+    );
+  }
+
+  it("prefers the ICN_WT_ROOT env override over everything", () => {
+    writeRepoMap("../configured");
+    process.env["ICN_WT_ROOT"] = "/custom/wt-root";
+    expect(resolveWorktreeRoot()).toBe("/custom/wt-root");
+  });
+
+  it("resolves a relative repo-map root against the monorepo root", () => {
+    // The worktree-OS layout keeps sibling worktrees one level up ("..").
+    writeRepoMap("..");
+    expect(resolveWorktreeRoot()).toBe(path.resolve(tempRoot, ".."));
+  });
+
+  it("expands a leading ~ in the configured root against HOME", () => {
+    writeRepoMap("~/wt");
+    const home = process.env["HOME"];
+    expect(home).toBeTruthy();
+    expect(resolveWorktreeRoot()).toBe(path.join(home as string, "wt"));
+  });
+
+  it("falls back to the legacy ../icn-wt sibling when repo-map is missing", () => {
+    // No repo-map.json written — pre-worktree-OS checkouts degrade gracefully.
+    expect(resolveWorktreeRoot()).toBe(path.resolve(tempRoot, "..", "icn-wt"));
+  });
+
+  it("falls back to the legacy sibling when the configured root is not a string", () => {
+    writeRepoMap(42);
+    expect(resolveWorktreeRoot()).toBe(path.resolve(tempRoot, "..", "icn-wt"));
+  });
+});

--- a/ops/mcp/src/tools/repos.ts
+++ b/ops/mcp/src/tools/repos.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type Database from "better-sqlite3";
 import { join } from "path";
-import { resolveMonorepoRoot } from "../paths.js";
+import { resolveMonorepoRoot, resolveWorktreeRoot } from "../paths.js";
 import { runCommand } from "../utils/commands.js";
 
 const ICN_ROOT = resolveMonorepoRoot();
@@ -76,7 +76,7 @@ export function registerRepoTools(
     "List all git worktrees with branch, last commit, staleness vs main.",
     {},
     async () => {
-      const wtRoot = join(ICN_ROOT, "..", "icn-wt");
+      const wtRoot = resolveWorktreeRoot();
       const icnPath = join(ICN_ROOT, "icn");
       const mainHash = await gitLine(icnPath, ["rev-parse", "origin/main"]);
 

--- a/ops/mcp/src/tools/sessions.ts
+++ b/ops/mcp/src/tools/sessions.ts
@@ -23,7 +23,7 @@ export function registerSessionTools(
       worktree: z
         .string()
         .optional()
-        .describe("Worktree name if working in icn-wt/ (e.g. 1084-names-gateway-a)"),
+        .describe("Worktree name under the configured worktree root (repo-map.json#worktrees.root; e.g. task-preflight-hardening)"),
       task_description: z
         .string()
         .optional()

--- a/ops/state/config/repo-map.json
+++ b/ops/state/config/repo-map.json
@@ -28,8 +28,9 @@
     }
   },
   "worktrees": {
-    "root": "../icn-wt",
-    "managed_by": "scripts/worktrees.sh",
+    "root": "..",
+    "notes": "Resolved relative to the monorepo root. Canonical dev-VM layout: bare stores in ~/icn-dev/repos/*.git with worktrees at ~/icn-dev/worktrees/icn/<name>, so sibling worktrees live one level up ('..'). The older repo-adjacent ../icn-wt layout is retired (legacy); ops/mcp/src/paths.ts resolveWorktreeRoot() keeps it only as a last-resort fallback (ICN_WT_ROOT env overrides everything).",
+    "managed_by": "~/icn-dev/scripts (wt-new / wt-pr / wt-status / wt-clean) on the dev VM; scripts/worktrees.sh remains for the legacy layout",
     "base_branch": "origin/main",
     "active": []
   },

--- a/scripts/check-preflight-consistency.sh
+++ b/scripts/check-preflight-consistency.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# check-preflight-consistency.sh — guard against root/path guidance drift (Refs #2140).
+#
+# Companion to scripts/icn-preflight.sh (the documented preflight path is: run both).
+# CI-safe: repo-content checks always run; environment checks (stale legacy checkout,
+# MCP-root mismatch) run only where the relevant paths/vars exist and never FAIL.
+#
+# Exit 1 on FAIL (live guidance regressed), exit 0 otherwise (warnings allowed).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+FAILS=0
+pass() { echo -e "${GREEN}  ok${NC}  $1"; }
+warn() { echo -e "${YELLOW}  !!${NC}  $1"; }
+fail() { echo -e "${RED}  FAIL${NC}  $1"; FAILS=$((FAILS + 1)); }
+
+echo "check-preflight-consistency"
+
+# ── 1. Live guidance files must not present legacy roots as current truth ──────
+# `~/projects/icn` (standalone clone) and `../icn-wt` (repo-adjacent worktrees) are
+# retired. Mentions are allowed only on lines that mark them as legacy.
+GUIDANCE_FILES=(CLAUDE.md ops/CLAUDE.md AGENTS.md)
+LEGACY_MARKER='legacy|older|retired|not truth|never treat'
+
+for f in "${GUIDANCE_FILES[@]}"; do
+  if [ ! -f "$f" ]; then
+    fail "guidance file missing: $f"
+    continue
+  fi
+  bad=$(grep -nE 'projects/icn|icn-wt' "$f" | grep -viE "${LEGACY_MARKER}" || true)
+  if [ -n "$bad" ]; then
+    fail "$f presents a legacy root without a legacy marker:"
+    echo "$bad" | sed 's/^/        /'
+  else
+    pass "$f: legacy roots only appear with legacy framing"
+  fi
+done
+
+# ── 2. MCP source must not hardcode the legacy worktree root ───────────────────
+# Sanctioned places: the clearly-named fallback in ops/mcp/src/paths.ts, and the
+# tests that pin that fallback's behavior (ops/mcp/src/tests/).
+mcp_hits=$(grep -rn 'icn-wt' ops/mcp/src/ --include='*.ts' 2>/dev/null | grep -v -e 'ops/mcp/src/paths.ts' -e 'ops/mcp/src/tests/' || true)
+if [ -n "$mcp_hits" ]; then
+  fail "hardcoded legacy worktree root in MCP source (use resolveWorktreeRoot from paths.ts):"
+  echo "$mcp_hits" | sed 's/^/        /'
+else
+  pass "ops/mcp/src: no legacy worktree-root hardcoding outside paths.ts"
+fi
+
+# ── 3. Doc-control command forms: scripts exist, exact forms documented ────────
+DOC_SCRIPTS=(
+  "docs/scripts/doc_control_check.py"
+  "docs/scripts/freshness-check.py"
+  ".github/scripts/compliance_linter.py"
+  ".github/scripts/readiness_overclaim_linter.py"
+)
+for s in "${DOC_SCRIPTS[@]}"; do
+  [ -f "$s" ] && pass "doc-control script present: $s" || fail "doc-control script missing: $s"
+done
+
+DOC_COMMANDS=(
+  'python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml'
+  'python3 docs/scripts/freshness-check.py --freshness docs/freshness.toml --status docs/status.toml --repo .'
+  'python3 .github/scripts/compliance_linter.py --repo-root .'
+  'python3 .github/scripts/readiness_overclaim_linter.py --repo-root .'
+)
+for doc in CLAUDE.md AGENTS.md; do
+  missing=0
+  for c in "${DOC_COMMANDS[@]}"; do
+    grep -qF "$c" "$doc" || { missing=1; fail "$doc lost the documented command form: $c"; }
+  done
+  [ "$missing" -eq 0 ] && pass "$doc documents all four doc-control command forms"
+done
+
+# ── 4. Registries must point at files that exist (agents.json / skills.json) ───
+python3 - <<'PYEOF' || FAILS=$((FAILS + 1))
+import json, os, sys
+bad = []
+agents = json.load(open("ops/state/truth/agents.json"))
+for a in agents["agents"]:
+    if not os.path.exists(a["path"]):
+        bad.append(f'agents.json: {a["name"]} -> {a["path"]} (missing)')
+skills = json.load(open("ops/state/truth/skills.json"))
+for e in skills["skills"]["ops_automation_canonical"]:
+    if not os.path.exists(e["canonical_path"]):
+        bad.append(f'skills.json: {e["name"]} -> {e["canonical_path"]} (missing)')
+if bad:
+    print("  FAIL  registry entries point at missing files:")
+    for b in bad:
+        print(f"        {b}")
+    sys.exit(1)
+print("  ok  agents.json and skills.json registry paths all exist on disk")
+PYEOF
+
+# ── 5. Preflight skill twins: warn when .agents/ and .claude/ copies diverge ───
+# skills.json declares the .agents/skills/ copy authoritative for icn-level skills.
+for skill in preflight icn-preflight; do
+  a=".agents/skills/${skill}/SKILL.md"
+  c=".claude/skills/${skill}/SKILL.md"
+  if [ -f "$a" ] && [ -f "$c" ]; then
+    if ! diff -q "$a" "$c" >/dev/null 2>&1; then
+      warn "skill copies diverge: $a vs $c (skills.json says .agents/ is authoritative; reconcile deliberately)"
+    else
+      pass "skill copies in sync: ${skill}"
+    fi
+  fi
+done
+
+# ── 6. Environment checks (dev-VM only; skipped silently where paths absent) ───
+LEGACY_CLONE="${HOME}/projects/icn"
+if [ -d "${LEGACY_CLONE}/.git" ]; then
+  legacy_head=$(git -C "${LEGACY_CLONE}" rev-parse HEAD 2>/dev/null || echo "")
+  if [ -n "$legacy_head" ]; then
+    behind=$(git rev-list --count "${legacy_head}..origin/main" 2>/dev/null || echo "?")
+    warn "legacy checkout exists: ${LEGACY_CLONE} (${behind} commits behind origin/main) — never use it as current truth"
+  else
+    warn "legacy checkout exists: ${LEGACY_CLONE} — never use it as current truth"
+  fi
+fi
+
+TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -n "${ICN_ROOT:-}" ] && [ -n "$TOPLEVEL" ]; then
+  if [ "$(readlink -f "${ICN_ROOT}")" != "$(readlink -f "${TOPLEVEL}")" ]; then
+    warn "MCP root mismatch: ICN_ROOT=${ICN_ROOT} but this checkout is ${TOPLEVEL} — MCP repo/worktree answers describe ICN_ROOT, not this checkout"
+  else
+    pass "ICN_ROOT matches this checkout"
+  fi
+elif [ -z "${ICN_ROOT:-}" ] && [ -d "${HOME}/icn-dev/worktrees/icn/mcp-host" ] && [ -n "$TOPLEVEL" ]; then
+  if [ "$(readlink -f "${HOME}/icn-dev/worktrees/icn/mcp-host")" != "$(readlink -f "${TOPLEVEL}")" ]; then
+    warn "icn-ops MCP is rooted at ~/icn-dev/worktrees/icn/mcp-host; its repo/worktree answers describe that checkout, not this one (${TOPLEVEL})"
+  fi
+fi
+
+# ── result ──────────────────────────────────────────────────────────────────────
+if [ "$FAILS" -gt 0 ]; then
+  echo -e "${RED}check-preflight-consistency: ${FAILS} failure(s)${NC}"
+  exit 1
+fi
+echo -e "${GREEN}check-preflight-consistency: clean${NC}"


### PR DESCRIPTION
## Summary

Hardens preflight/root guidance so agents reliably land in the canonical `~/icn-dev` worktree OS: fixes stale root paths in the three live guidance files, makes the MCP worktree root config-driven instead of hardcoded, and adds a CI-wired consistency checker that catches guidance regressions, stale legacy checkouts, and MCP-root mismatch.

## Layer classification

ICN agent/dev-ops guidance (docs + ops MCP tooling + CI wiring). No runtime/protocol code.

## Boundary check / non-goals

- No MCP rewrite — one new resolver function + three call-site swaps; tool behavior otherwise unchanged.
- No skill rewrites: the five preflight skill copies are NOT reconciled here (see "What did not change").
- No changes to `scripts/icn-preflight.sh` itself.
- No K3s/DNS/Forgejo/GitHub-settings/provider mutation; no secrets, private topology, or overlays.
- No readiness claims of any kind: nothing here asserts production, pilot, live federation, running Forge, or bridge status.
- No org-repo registry / truth-spine validator / claim-lint work (that is PR2/PR3 of the control-plane stack).

## What changed

- **CLAUDE.md** — "Two Roots" table no longer hardcodes `/home/ubuntu/projects/icn`; roots are discovered via `git rev-parse --show-toplevel` (dev VM: `~/icn-dev/worktrees/icn/<worktree>`). Adds: legacy-checkouts-are-not-truth block, the documented preflight path (`icn-preflight.sh` + `check-preflight-consistency.sh`), exact doc-control command forms, generated-artifacts-are-navigation-only note, and Read-before-Edit in Branch/Target Hygiene.
- **AGENTS.md** — new Operating-mode rule "Verify your root, then read before edit"; doc-control command forms added to change routing; the `../icn-wt` quick-reference rule is explicitly marked legacy with the canonical dev-VM location.
- **ops/CLAUDE.md** — worktree line now points at `~/icn-dev/worktrees/<repo>/` with `repo-map.json#worktrees.root` as root of record.
- **ops/state/config/repo-map.json** — `worktrees.root`: `../icn-wt` → `..` (relative to monorepo root = `~/icn-dev/worktrees/icn`), with notes + updated `managed_by`.
- **ops/mcp/src/paths.ts** — new `resolveWorktreeRoot()`: `ICN_WT_ROOT` env → `repo-map.json#worktrees.root` (relative-to-root, `~` expansion) → legacy `../icn-wt` fallback with a one-time stderr diagnostic. Unit-tested (`src/tests/paths.test.ts`, 5 cases).
- **ops/mcp/src/tools/repos.ts, ops/mcp/src/polling/git.ts** — replace hardcoded `join(root, "..", "icn-wt")` with `resolveWorktreeRoot()`. **ops/mcp/src/tools/sessions.ts** — stale `icn-wt/` doc-string updated.
- **scripts/check-preflight-consistency.sh** (new) — FAILs on: legacy roots presented without legacy framing in the three guidance files, `icn-wt` hardcoding in MCP source outside `paths.ts` (+ its tests), missing doc-control scripts or lost command forms; WARNs on: registry paths missing on disk, preflight skill-twin divergence, stale `~/projects/icn` checkout (env-conditional), MCP-root mismatch (env-conditional). CI-safe: environment checks skip silently where paths/vars are absent.
- **.github/workflows/agent-drift-check.yml** — runs the new checker; push-trigger paths extended to the guidance files.

## What did not change

- `scripts/icn-preflight.sh` (the existing check content is correct; this PR adds the companion, not a rewrite).
- The five preflight skill copies (`.agents/skills/{preflight,icn-preflight}`, `.claude/skills/{preflight,icn-preflight}`, `tools/claude-code/plugins/icn-agent-pack/skills/preflight`) — all five currently differ. `skills.json` already declares `.agents/` authoritative for icn-level skills; the checker now WARNs on `.agents/` ↔ `.claude/` twin divergence, and content reconciliation is deferred to a follow-up (kept out to avoid a skill rewrite in a root-guidance PR).
- `AGENTS.md` references to `.github/agents/` — **intentionally kept**: that directory exists (Copilot specialist agents). An earlier audit note claiming it was nonexistent was wrong; verified against the tree.
- Legacy-layout docs (`docs/dev/WORKTREES.md`, `scripts/worktrees.sh`) and `docs/archive/**` history.
- No Rust code, no gateway/API surface, no website content.

## Evidence / validation

Run in the task worktree at `0f2d5526` (base `33ccc37f` = origin/main):

- `bash scripts/check-preflight-consistency.sh` → clean, exit 0; correctly WARNs on: skill-twin drift ×2, stale legacy checkout (`~/projects/icn`, 136 commits behind origin/main), MCP-root mismatch (ICN_ROOT=mcp-host vs task worktree).
- Negative test: appending a line presenting `/home/ubuntu/projects/icn` as current truth to CLAUDE.md → checker FAILs, exit 1 (then restored).
- `cd ops/mcp && npm ci && npm run build && npm test` → tsc clean, **86/86 tests pass** (9 files; 5 new `resolveWorktreeRoot` cases).
- Runtime smoke on built dist: `resolveWorktreeRoot()` → `/home/ubuntu/icn-dev/worktrees/icn` (canonical).
- `bash scripts/icn-preflight.sh` → exit 0 (branch/auth/toolchain 1.95.0/cargo check ok; port-8080 warn expected, no gateway running).
- All four documented doc-control commands run from the repo root: doc_control_check OK (931 files; warnings are pre-existing, none in files this PR touches), freshness ✓ all fresh, compliance ✅ no violations, readiness-overclaim ✅ none detected.
- Workflow YAML + repo-map.json parse clean. `git diff --check` clean. No Rust files changed (`cargo fmt --all --check` clean).
- Local-model prereview (`icn-prereview`): **skipped — Zentith Ollama tunnel down** (endpoint 127.0.0.1:11435 unreachable). TS changes were line-by-line reviewed in-session instead.

## Issue status

Refs #2140 (do not auto-close; item-by-item closure evidence below for the issue owner to judge):
- one documented preflight path → CLAUDE.md preflight block (both scripts)
- stale-checkout warning → checker env-check (observed live: 136 behind)
- MCP-root mismatch warning → checker env-check (observed live)
- correct doc-control command forms → documented in CLAUDE.md + AGENTS.md, guarded by checker, verified working
- Read-before-Edit guidance → AGENTS.md Operating mode + CLAUDE.md Branch/Target Hygiene
- generated artifacts labeled navigation-only → CLAUDE.md Documentation Structure
- preflight skill copies → source-of-truth already declared in `skills.json` (`.agents/` authoritative); divergence now surfaced by the checker; content reconciliation deferred (five copies, not three — follow-up candidate)

## Review-thread status

None yet (fresh PR).

## Cross-repo dependency status

First PR of the ecosystem control-plane stack (control-plane-v1; Refs #2141). No upstream dependencies. Downstream: the org-repo registry + truth-spine validator PR (PR2 of the stack) builds on the corrected `repo-map.json#worktrees` and this checker's CI slot. Day-0 evidence baseline: `~/icn-dev/handoffs/ecosystem/CURRENT-EVIDENCE-2026-07-07.md` (VM-local).
