### PR TITLE
chore(ops): add org repo registry and truth-spine validator

### DIFF
--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -9,6 +9,8 @@ on:
       - 'ops/state/truth/**'
       - 'ops/scripts/drift-check.sh'
       - 'scripts/check-preflight-consistency.sh'
+      - 'scripts/check-truth-spine.py'
+      - 'ops/state/config/**'
       - 'CLAUDE.md'
       - 'ops/CLAUDE.md'
       - 'AGENTS.md'
@@ -34,6 +36,9 @@ jobs:
 
       - name: Preflight/root guidance consistency (Refs icn#2140)
         run: bash scripts/check-preflight-consistency.sh
+
+      - name: Truth-spine validation (warning-mode, Refs icn#2141)
+        run: python3 scripts/check-truth-spine.py
 
       - name: Validate JSON truth files are parseable
         run: |

--- a/docs/DOCUMENT_REGISTRY.md
+++ b/docs/DOCUMENT_REGISTRY.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-07-05
+Last Reviewed: 2026-07-07
 ---
 
 # ICN Document Registry (human summary)
@@ -41,9 +41,9 @@ python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml
 
 ## Corpus coverage
 
-- **Markdown files under docs/**: 928
+- **Markdown files under docs/**: 932
 - **By truth_class (merged):**
-  - `descriptive`: 547
+  - `descriptive`: 551
   - `draft`: 44
   - `historical`: 79
   - `normative`: 81
@@ -76,5 +76,5 @@ What fails in CI, what warns, what `--strict` adds, and when to promote strict t
 
 ## Registry coverage (this snapshot)
 
-- **Files scanned:** 928 Markdown files under `docs/`
-- **Explicit `[docs."…"]` rows under `docs/`:** 342 (remaining files rely on `[[doc_path_defaults]]` only)
+- **Files scanned:** 932 Markdown files under `docs/`
+- **Explicit `[docs."…"]` rows under `docs/`:** 346 (remaining files rely on `[[doc_path_defaults]]` only)

--- a/docs/INDEX.generated.md
+++ b/docs/INDEX.generated.md
@@ -1878,6 +1878,12 @@ Top-level repo surfaces and what each is for; monorepo root vs Rust workspace at
 
 **For:** `contributors`, `developers` | **Updated:** 2026-04-29
 
+### 📝 **Living** [ICN Upstream Lock Format (icn-upstream-lock/v1)](/docs/reference/upstream-lock-format.md)
+
+Lock-file format downstream repos use to record the ICN ref they were last reviewed against; a human-signed review attestation, not an automated constraint
+
+**For:** `developers`, `operators` | **Updated:** 2026-07-07
+
 ### 📝 **Living** [SDIS API Guide](/docs/sdis/SDIS_API_GUIDE.md)
 
 Complete API guide for Sovereign Digital Identity System
@@ -2156,10 +2162,10 @@ Assessment of pilot readiness and gaps
 
 ## Summary
 
-**Total documents:** 352
+**Total documents:** 353
 
 **By status:**
 - Active: 1
 - Canonical: 40
 - Draft: 99
-- Living: 212
+- Living: 213

--- a/docs/reference/upstream-lock-format.md
+++ b/docs/reference/upstream-lock-format.md
@@ -1,0 +1,69 @@
+---
+Status: descriptive
+Canonical: yes
+Last Reviewed: 2026-07-07
+---
+
+# ICN Upstream Lock Format (`icn-upstream-lock/v1`)
+
+Defines the lock-file format downstream repos use to record which ICN ref they were last
+**reviewed against**. Generalized from the format already in production in the `nycn` repo
+(`ops/upstream/icn.lock.yaml`); `icn-learn` and `icn-community-bridge` adopt the same file at the
+same path when their locks are introduced.
+
+**A lock is a review attestation, not an automated dependency constraint.** It records that a
+named human reviewed the downstream repo's ICN-facing assumptions against a specific ICN commit on
+a specific date. Nothing enforces the pin at build time; drift against it is *measured* (see
+"Auditing drift" below) and burned down by a deliberate review, never by a silent bump.
+
+## File location and registration
+
+- Path in each downstream repo: `ops/upstream/icn.lock.yaml`
+- Registered in icn's coordination registry: `ops/state/config/repo-map.json#org_repos`
+  (`lock.path` / `lock.format`)
+- Truth-spine domain: `downstream_dependency_locks` in `ops/state/truth/sources.json`
+  (the lock files themselves live in the downstream repos, never in icn)
+
+## Format (v1)
+
+```yaml
+icn:
+  repo: InterCooperative-Network/icn
+  pinned_ref: <full 40-char commit SHA on icn main>
+  pinned_ref_short: "<8-char short SHA>"
+  pinned_ref_subject: "<subject line of the pinned commit>"
+  reviewed_at: <YYYY-MM-DD>
+  reviewer: <human identity — a person, not an agent>
+```
+
+Field rules:
+
+- `pinned_ref` — full SHA of a commit on `icn` `main`. Never a branch name, never a tag.
+- `reviewed_at` — the date the *review* happened. Refreshing this date without re-reviewing is
+  readiness laundering; do not do it.
+- `reviewer` — a human signs the attestation. Agents may prepare the diff analysis; a person
+  owns the judgment.
+- Free-form YAML comments are encouraged for review context (what changed since the previous
+  pin, what was deliberately not adopted) — the nycn lock demonstrates this style.
+
+## Bump procedure (mirrors the nycn header)
+
+1. Update `pinned_ref` (+ short/subject) to the new ICN main SHA.
+2. Update `reviewed_at` to today; `reviewer` signs.
+3. Review the downstream repo's dependency-status doc (e.g. nycn
+   `docs/sync/ICN_DEPENDENCY_STATUS.md`) and update drift rows: each upstream change relevant to
+   the repo is classified **reviewed / not adopted / action-needed**.
+4. Land the lock bump and the dependency-status update together in one PR, `Refs`-linked —
+   never a bare pin bump.
+
+## Auditing drift
+
+From any checkout with the local bare stores available:
+
+```bash
+git --git-dir=$HOME/icn-dev/repos/icn.git rev-list --count <pinned_ref>..origin/main
+```
+
+A large count is not itself a failure — it is unreviewed exposure. The failure mode this format
+exists to prevent is a stale `reviewed_at` silently coexisting with claims that downstream
+assumptions still hold.

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -2001,6 +2001,18 @@ last_updated = "2026-03-10"
 owner = "matt"
 audiences = ["developers", "integrators"]
 
+[docs."docs/reference/upstream-lock-format.md"]
+category = "reference"
+status = "living"
+truth_class = "descriptive"
+canonical = "yes"
+title = "ICN Upstream Lock Format (icn-upstream-lock/v1)"
+description = "Lock-file format downstream repos use to record the ICN ref they were last reviewed against; a human-signed review attestation, not an automated constraint"
+last_updated = "2026-07-07"
+last_reviewed = "2026-07-07"
+owner = "matt"
+audiences = ["developers", "operators"]
+
 [docs."docs/reference/api/API_REFERENCE.md"]
 category = "reference"
 status = "living"

--- a/ops/state/config/repo-map.json
+++ b/ops/state/config/repo-map.json
@@ -27,6 +27,88 @@
       "notes": "Manages the infrastructure ICN runs on. icn-ops observes but never mutates homelab state."
     }
   },
+  "org_repos": {
+    "description": "InterCooperative-Network org repos and adjacent private layers, seen from icn: repo discovery / coordination metadata for the ecosystem control plane. NOT architectural truth — ops/state/truth/sources.json wins on any truth-ownership conflict, and docs/ATLAS.md + ops/state/ecosystem.json remain the role/boundary index. Fields record CURRENT state only (a null lock/envelope means none exists yet; planned is not done). stack_stage = cross-repo merge order per ops/coordination/PR_STACK_PROTOCOL.md (1=icn canonical first; 6=org profile mirror last; null=not part of PR stacks).",
+    "repos": {
+      "nycn": {
+        "remote": "InterCooperative-Network/nycn",
+        "visibility": "private",
+        "default_branch": "main",
+        "local_store": "~/icn-dev/repos/nycn.git",
+        "lock": { "path": "ops/upstream/icn.lock.yaml", "format": "icn-upstream-lock/v1" },
+        "status_envelope": null,
+        "claim_enforcement": "none",
+        "stack_stage": 3,
+        "role_note": "First institution ecosystem package (NYCN / Summit 2026); depends on icn via a human-signed review-attestation lock"
+      },
+      "icn-infra": {
+        "remote": "InterCooperative-Network/icn-infra",
+        "visibility": "private",
+        "default_branch": "main",
+        "local_store": "~/icn-dev/repos/icn-infra.git",
+        "lock": null,
+        "status_envelope": null,
+        "claim_enforcement": "none",
+        "stack_stage": 2,
+        "role_note": "Org operating contracts: cross-repo boundary, public-claims gates, source classification"
+      },
+      "icn-learn": {
+        "remote": "InterCooperative-Network/icn-learn",
+        "visibility": "private",
+        "default_branch": "main",
+        "local_store": "~/icn-dev/repos/icn-learn.git",
+        "lock": null,
+        "status_envelope": null,
+        "claim_enforcement": "none",
+        "stack_stage": 4,
+        "role_note": "ICN Academy: teaches from canonical sources, is never canonical; no upstream lock exists yet"
+      },
+      "icn-community-bridge": {
+        "remote": "InterCooperative-Network/icn-community-bridge",
+        "visibility": "private",
+        "default_branch": "main",
+        "local_store": "~/icn-dev/repos/icn-community-bridge.git",
+        "lock": null,
+        "status_envelope": null,
+        "claim_enforcement": "none",
+        "stack_stage": 5,
+        "role_note": "Discord-to-Matrix onboarding bridge: policy/scaffold only, not deployed, no governance authority, no canonical truth"
+      },
+      "org-github": {
+        "remote": "InterCooperative-Network/.github",
+        "visibility": "public",
+        "default_branch": "main",
+        "local_store": "~/icn-dev/repos/org-github.git",
+        "lock": null,
+        "status_envelope": null,
+        "claim_enforcement": "none",
+        "stack_stage": 6,
+        "role_note": "Org profile mirror: mirrors public icn truth, originates no claims, updated last in any stack"
+      },
+      "network-ops": {
+        "remote": null,
+        "visibility": "private",
+        "default_branch": null,
+        "local_store": null,
+        "lock": null,
+        "status_envelope": null,
+        "claim_enforcement": "none",
+        "stack_stage": null,
+        "role_note": "Provider/personal layer (most private), access-gated outside the GitHub org; feeds icn-infra only via the ADR-0005 scrub gate; never referenced by concrete pointer from public icn"
+      },
+      "demo-repository": {
+        "remote": "InterCooperative-Network/demo-repository",
+        "visibility": "private",
+        "default_branch": "main",
+        "local_store": null,
+        "lock": null,
+        "status_envelope": null,
+        "claim_enforcement": "none",
+        "stack_stage": null,
+        "role_note": "role: none — GitHub-generated demo noise per docs/reference/project-index/repository-map.md; archive-or-ignore decision pending"
+      }
+    }
+  },
   "worktrees": {
     "root": "..",
     "notes": "Resolved relative to the monorepo root. Canonical dev-VM layout: bare stores in ~/icn-dev/repos/*.git with worktrees at ~/icn-dev/worktrees/icn/<name>, so sibling worktrees live one level up ('..'). The older repo-adjacent ../icn-wt layout is retired (legacy); ops/mcp/src/paths.ts resolveWorktreeRoot() keeps it only as a last-resort fallback (ICN_WT_ROOT env overrides everything).",

--- a/ops/state/truth/sources.json
+++ b/ops/state/truth/sources.json
@@ -12,7 +12,7 @@
       "owner": "ops/state/config/repo-map.json",
       "sections": ["repos", "org_repos", "worktrees", "relationships", "infrastructure"],
       "stability": "slow-changing",
-      "description": "Monorepo layout, subdirectory purposes, org-repo coordination metadata (org_repos), worktree root, K3s cluster IPs. org_repos is repo discovery / coordination metadata, not architectural truth — role/boundary meaning stays with docs/ATLAS.md + ops/state/ecosystem.json, and this file wins on truth-ownership conflicts."
+      "description": "Monorepo layout, subdirectory purposes, org-repo coordination metadata (org_repos), worktree root, K3s cluster IPs. org_repos is repo discovery / coordination metadata, not architectural truth — role/boundary meaning stays with docs/ATLAS.md + ops/state/ecosystem.json, and ops/state/truth/sources.json (this arbiter file, not repo-map.json) wins on truth-ownership conflicts."
     },
     "sprint_state": {
       "owner": "ops/state/sprint/current.json",

--- a/ops/state/truth/sources.json
+++ b/ops/state/truth/sources.json
@@ -10,9 +10,9 @@
     },
     "repo_topology": {
       "owner": "ops/state/config/repo-map.json",
-      "sections": ["repos", "worktrees", "relationships", "infrastructure"],
+      "sections": ["repos", "org_repos", "worktrees", "relationships", "infrastructure"],
       "stability": "slow-changing",
-      "description": "Monorepo layout, subdirectory purposes, worktree root, K3s cluster IPs"
+      "description": "Monorepo layout, subdirectory purposes, org-repo coordination metadata (org_repos), worktree root, K3s cluster IPs. org_repos is repo discovery / coordination metadata, not architectural truth — role/boundary meaning stays with docs/ATLAS.md + ops/state/ecosystem.json, and this file wins on truth-ownership conflicts."
     },
     "sprint_state": {
       "owner": "ops/state/sprint/current.json",
@@ -33,6 +33,17 @@
       "owner": "ops/state/truth/skills.json",
       "stability": "slow-changing",
       "description": "All available skills, their canonical paths, and ownership"
+    },
+    "downstream_dependency_locks": {
+      "owner": "downstream-repos",
+      "query": "each downstream repo's ops/upstream/icn.lock.yaml, registered in ops/state/config/repo-map.json#org_repos",
+      "stability": "slow-changing",
+      "description": "Human-signed review attestations pinning the ICN ref each downstream repo (nycn today; icn-learn and icn-community-bridge planned) was last reviewed against. Format: icn-upstream-lock/v1 (docs/reference/upstream-lock-format.md). The lock files live in the downstream repos, never in this repo — a lock is a review attestation, not an automated dependency constraint."
+    },
+    "cross_repo_pr_stacks": {
+      "owner": "ops/coordination/PR_STACK_PROTOCOL.md",
+      "stability": "slow-changing",
+      "description": "Cross-repo PR merge-order discipline (icn first, downstream after). When the stack-manifest extension lands under ops/coordination/stacks/, that directory becomes the owner and this entry's pointer moves with it."
     },
     "adr_decisions": {
       "owner": "docs/adr/",

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -73,18 +73,28 @@ def main() -> int:
     seen_owners: dict[str, str] = {}
     for name, dom in domains.items():
         owner = dom.get("owner", "")
-        if owner in NONFILE_OWNERS or " " in owner:
+        # Classify the owner once; only genuine path owners get existence,
+        # duplicate, and staleness treatment. Blank/malformed owners must not
+        # resolve to the repo root and silently "exist".
+        is_path_owner = False
+        if not owner.strip():
+            warn(f"{name}: blank owner — every domain must name its source")
+        elif owner in NONFILE_OWNERS:
             ok(f"{name}: non-file owner ({owner!r}) — skipped existence check")
+        elif " " in owner:
+            ok(f"{name}: descriptive (non-path) owner — skipped existence check")
         else:
+            is_path_owner = True
             owner_path = root / owner.split("#", 1)[0]
             if not owner_path.exists():
                 warn(f"{name}: owner path missing on disk: {owner}")
             else:
                 ok(f"{name}: owner exists ({owner})")
 
-        # Duplicate-owner rule applies to file owners only: live-query owners
-        # (git / github-api) legitimately serve multiple volatile domains.
-        if owner not in NONFILE_OWNERS:
+        # Duplicate-owner rule applies to path owners only: live-query and
+        # descriptive owners legitimately serve multiple domains, and blank
+        # owners were already warned above.
+        if is_path_owner:
             if owner in seen_owners:
                 warn(
                     f"duplicate owner: {name} and {seen_owners[owner]} both claim {owner!r} "
@@ -105,8 +115,10 @@ def main() -> int:
                     warn(f"{name}: machine_view unparseable: {mv} ({e})")
 
         # 2. Staleness by stability class, where the owner file carries a date.
+        # An unparseable date must not suppress the check — fall through to the
+        # next candidate key, and say so.
         threshold = STALENESS_DAYS.get(dom.get("stability", ""))
-        if threshold and owner not in NONFILE_OWNERS and " " not in owner:
+        if threshold and is_path_owner:
             owner_file = root / owner.split("#", 1)[0]
             if owner_file.is_file() and owner_file.suffix == ".json":
                 try:
@@ -115,15 +127,22 @@ def main() -> int:
                     data = None
                 if isinstance(data, dict):
                     for key in DATE_KEYS:
-                        if key in data:
-                            d = parse_date(data[key])
-                            if d and (today - d).days > threshold:
-                                warn(
-                                    f"{name}: {owner} {key}={data[key]} is "
-                                    f"{(today - d).days}d old (> {threshold}d for "
-                                    f"{dom.get('stability')})"
-                                )
-                            break
+                        if key not in data:
+                            continue
+                        d = parse_date(data[key])
+                        if d is None:
+                            warn(
+                                f"{name}: {owner} {key}={data[key]!r} is not an "
+                                "ISO date — trying the next date key"
+                            )
+                            continue
+                        if (today - d).days > threshold:
+                            warn(
+                                f"{name}: {owner} {key}={data[key]} is "
+                                f"{(today - d).days}d old (> {threshold}d for "
+                                f"{dom.get('stability')})"
+                            )
+                        break
 
     # 3. Ecosystem index vs org-repo registry consistency.
     eco_path = root / "ops/state/ecosystem.json"
@@ -136,21 +155,31 @@ def main() -> int:
         eco, repo_map = {}, {}
 
     eco_repos = eco.get("repos", {})
-    org_repos = repo_map.get("org_repos", {}).get("repos", {})
-    if eco_repos and org_repos:
+    org_section = repo_map.get("org_repos") or {}
+    org_repos = (org_section.get("repos") or {}) if isinstance(org_section, dict) else {}
+    if eco_repos:
         # icn is "this repo" in ecosystem.json; homelab-inventory lives in #repos.
         expected = set(eco_repos) - {"icn", "homelab-inventory"}
-        missing = expected - set(org_repos)
-        for r in sorted(missing):
-            warn(f"ecosystem.json names repo {r!r} but repo-map.json#org_repos does not register it")
-        if not missing:
-            ok(f"registry covers all {len(expected)} ecosystem repos (extras allowed)")
+        if not org_repos:
+            # The registry this validator exists to protect has disappeared —
+            # that must be a warning, never a silent skip.
+            if expected:
+                warn(
+                    f"repo-map.json#org_repos is missing/empty while ecosystem.json "
+                    f"names {len(expected)} downstream repos — coverage check cannot run"
+                )
+        else:
+            missing = expected - set(org_repos)
+            for r in sorted(missing):
+                warn(f"ecosystem.json names repo {r!r} but repo-map.json#org_repos does not register it")
+            if not missing:
+                ok(f"registry covers all {len(expected)} ecosystem repos (extras allowed)")
 
-        for r in sorted(expected & set(org_repos)):
-            ev = eco_repos[r].get("visibility")
-            rv = org_repos[r].get("visibility")
-            if ev and rv and ev != rv:
-                warn(f"visibility disagrees for {r}: ecosystem.json={ev} registry={rv}")
+            for r in sorted(expected & set(org_repos)):
+                ev = eco_repos[r].get("visibility")
+                rv = org_repos[r].get("visibility")
+                if ev and rv and ev != rv:
+                    warn(f"visibility disagrees for {r}: ecosystem.json={ev} registry={rv}")
 
     # Result
     if warnings:

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""check-truth-spine.py — validate the truth spine's own integrity (warning-mode).
+
+Companion to ops/scripts/drift-check.sh and scripts/check-preflight-consistency.sh.
+Checks that ops/state/truth/sources.json — the arbiter of truth ownership — points at
+things that exist, does not double-assign owners, and that the org-repo coordination
+registry (ops/state/config/repo-map.json#org_repos) stays consistent with the
+ecosystem index (ops/state/ecosystem.json).
+
+Warning-mode by default: exits 0 with warnings printed unless --strict is passed
+(future ratchet, mirroring the readiness-overclaim linter's warning->blocking path).
+The only unconditional failure is an unreadable/unparseable sources.json.
+
+Deliberately NOT checked (v1): section-level owner overlap (cluster_topology is a
+documented pointer view into repo-map.json#infrastructure); content freshness of
+downstream lock files (needs private-repo access — VM-session concern, not CI).
+"""
+
+import argparse
+import datetime
+import json
+import sys
+from pathlib import Path
+
+# Owners that are not files in this repo: live git/API state or downstream repos.
+NONFILE_OWNERS = {"git", "github-api", "downstream-repos"}
+
+# Staleness warning thresholds by declared stability class (days).
+STALENESS_DAYS = {"volatile": 14, "slow-changing": 120}
+
+# Date-ish keys we look for in JSON owner files, in preference order.
+DATE_KEYS = ("last_reviewed", "reviewed_at", "start_date")
+
+warnings: list[str] = []
+
+
+def warn(msg: str) -> None:
+    warnings.append(msg)
+    print(f"  !!  {msg}")
+
+
+def ok(msg: str) -> None:
+    print(f"  ok  {msg}")
+
+
+def parse_date(value: str) -> datetime.date | None:
+    try:
+        return datetime.date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-root", default=".", help="repo root to validate (default: .)")
+    ap.add_argument("--strict", action="store_true", help="exit 1 if any warnings (ratchet mode)")
+    args = ap.parse_args()
+    root = Path(args.repo_root)
+
+    print("check-truth-spine")
+
+    sources_path = root / "ops/state/truth/sources.json"
+    try:
+        sources = json.loads(sources_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"  FAIL  cannot read/parse {sources_path}: {e}")
+        return 1
+
+    domains = sources.get("domains", {})
+    today = datetime.date.today()
+
+    # 1. Every file-owner must exist; machine_view files must exist and parse.
+    seen_owners: dict[str, str] = {}
+    for name, dom in domains.items():
+        owner = dom.get("owner", "")
+        if owner in NONFILE_OWNERS or " " in owner:
+            ok(f"{name}: non-file owner ({owner!r}) — skipped existence check")
+        else:
+            owner_path = root / owner.split("#", 1)[0]
+            if not owner_path.exists():
+                warn(f"{name}: owner path missing on disk: {owner}")
+            else:
+                ok(f"{name}: owner exists ({owner})")
+
+        # Duplicate-owner rule applies to file owners only: live-query owners
+        # (git / github-api) legitimately serve multiple volatile domains.
+        if owner not in NONFILE_OWNERS:
+            if owner in seen_owners:
+                warn(
+                    f"duplicate owner: {name} and {seen_owners[owner]} both claim {owner!r} "
+                    "(one source per domain — sources.json's own rule)"
+                )
+            else:
+                seen_owners[owner] = name
+
+        mv = dom.get("machine_view")
+        if mv:
+            mv_path = root / mv
+            if not mv_path.exists():
+                warn(f"{name}: machine_view missing: {mv}")
+            elif mv_path.suffix == ".json":
+                try:
+                    json.loads(mv_path.read_text())
+                except json.JSONDecodeError as e:
+                    warn(f"{name}: machine_view unparseable: {mv} ({e})")
+
+        # 2. Staleness by stability class, where the owner file carries a date.
+        threshold = STALENESS_DAYS.get(dom.get("stability", ""))
+        if threshold and owner not in NONFILE_OWNERS and " " not in owner:
+            owner_file = root / owner.split("#", 1)[0]
+            if owner_file.is_file() and owner_file.suffix == ".json":
+                try:
+                    data = json.loads(owner_file.read_text())
+                except json.JSONDecodeError:
+                    data = None
+                if isinstance(data, dict):
+                    for key in DATE_KEYS:
+                        if key in data:
+                            d = parse_date(data[key])
+                            if d and (today - d).days > threshold:
+                                warn(
+                                    f"{name}: {owner} {key}={data[key]} is "
+                                    f"{(today - d).days}d old (> {threshold}d for "
+                                    f"{dom.get('stability')})"
+                                )
+                            break
+
+    # 3. Ecosystem index vs org-repo registry consistency.
+    eco_path = root / "ops/state/ecosystem.json"
+    map_path = root / "ops/state/config/repo-map.json"
+    try:
+        eco = json.loads(eco_path.read_text())
+        repo_map = json.loads(map_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        warn(f"cannot cross-check ecosystem vs registry: {e}")
+        eco, repo_map = {}, {}
+
+    eco_repos = eco.get("repos", {})
+    org_repos = repo_map.get("org_repos", {}).get("repos", {})
+    if eco_repos and org_repos:
+        # icn is "this repo" in ecosystem.json; homelab-inventory lives in #repos.
+        expected = set(eco_repos) - {"icn", "homelab-inventory"}
+        missing = expected - set(org_repos)
+        for r in sorted(missing):
+            warn(f"ecosystem.json names repo {r!r} but repo-map.json#org_repos does not register it")
+        if not missing:
+            ok(f"registry covers all {len(expected)} ecosystem repos (extras allowed)")
+
+        for r in sorted(expected & set(org_repos)):
+            ev = eco_repos[r].get("visibility")
+            rv = org_repos[r].get("visibility")
+            if ev and rv and ev != rv:
+                warn(f"visibility disagrees for {r}: ecosystem.json={ev} registry={rv}")
+
+    # Result
+    if warnings:
+        print(f"check-truth-spine: {len(warnings)} warning(s)")
+        return 1 if args.strict else 0
+    print("check-truth-spine: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the ecosystem control-plane's coordination registry (`repo-map.json#org_repos`) and a truth-spine validator (`scripts/check-truth-spine.py`), plus the documented `icn-upstream-lock/v1` format generalized from nycn's production lock. Second PR of the control-plane stack; builds on merged PR #2354.

## Layer classification

ICN ops/orchestration plane (state config + validator script + CI wiring + one reference doc). No runtime/protocol code, no Rust.

## Boundary check / non-goals

- **The registry is repo discovery / coordination metadata, not architectural truth — `ops/state/truth/sources.json` wins on conflict.** That sentence is embedded verbatim in the registry's own `description` and in the widened `repo_topology` domain, and `docs/ATLAS.md` + `ops/state/ecosystem.json` remain the role/boundary index. No parallel source of truth is created.
- No claim-linter/reusable-workflow work (PR3 of the stack).
- No NYCN lock refresh, no cross-repo edits, no changes to nycn/icn-learn/bridge/infra/.github.
- No dashboard, no lock auditor script (later stack stages).
- No readiness/liveness/pilot claims. Registry fields record **current** state only: `lock: null` / `status_envelope: null` / `claim_enforcement: "none"` are statements of absence — planned ≠ done.
- No secrets/private topology: entries carry only repo names, visibility, branch names, and bare-store paths — all already public-safe in `docs/ATLAS.md` / `repository-map.md`. network-ops deliberately has `remote: null` (access-gated outside the org; no concrete pointer from public icn).

## What changed

- **ops/state/config/repo-map.json** — new `org_repos` section: 7 entries (nycn, icn-infra, icn-learn, icn-community-bridge, org-github, network-ops, demo-repository) with `remote`, `visibility`, `default_branch`, `local_store`, `lock`, `status_envelope`, `claim_enforcement`, `stack_stage` (merge order per PR_STACK_PROTOCOL; null = not in PR stacks), `role_note`. demo-repository is registered as `role: none` per repository-map.md.
- **ops/state/truth/sources.json** — `repo_topology.sections` widened with `org_repos`; two new domains: `downstream_dependency_locks` (non-file owner — the locks live in downstream repos; format pointer) and `cross_repo_pr_stacks` (owner = `ops/coordination/PR_STACK_PROTOCOL.md`; the pointer moves to `ops/coordination/stacks/` when that extension lands — no owner entry for a directory that doesn't exist yet).
- **docs/reference/upstream-lock-format.md** (new, +registry.toml entry, +regenerated `INDEX.generated.md`/`DOCUMENT_REGISTRY.md`) — documents `icn-upstream-lock/v1` verbatim from nycn's shape: a **human-signed review attestation, not an automated dependency constraint**; bump procedure requires lock + dependency-status update landing together.
- **scripts/check-truth-spine.py** (new, warning-mode, `--strict` ratchet flag, `--repo-root` for testability) — validates: every file-owner in sources.json exists (fragments stripped; `git`/`github-api`/`downstream-repos` owners skipped); no duplicate *file* owners (live-query owners exempt — they legitimately serve multiple volatile domains); `machine_view` files parse; staleness by stability class (volatile >14d, slow-changing >120d) where owner files carry dates; ecosystem.json repo set covered by the registry (extras allowed); visibility agreement. Only an unreadable sources.json is an unconditional failure.
- **.github/workflows/agent-drift-check.yml** — runs the validator (warning-mode step); push-trigger paths extended with the validator and `ops/state/config/**`.

## What did not change

- `ops/state/ecosystem.json` untouched (stays index-only, `canonical: false`).
- No existing sources.json domain re-owned; `cluster_topology`'s pointer-view into `repo-map.json#infrastructure` intentionally left as-is (documented v1 non-check in the validator header).
- nycn's actual lock file (a downstream-repo concern — refresh is a later stack stage in nycn itself).
- No linter/CI behavior changes beyond the one additive warning-mode step.

## Evidence / validation

At head of `chore/org-repo-registry-truth-spine` (base = merged #2354, `fc6e3c3d`):

- `python3 scripts/check-truth-spine.py` → exit 0, **1 warning**, which is a true positive: `sprint_state ... start_date=2026-03-23 is 106d old (> 14d for volatile)` — live evidence for the known stale-sprint-plane question; all 16 domains otherwise verified, "registry covers all 6 ecosystem repos".
- Negative tests on a scratch fixture: missing owner, duplicate file owner, registry coverage gap, and visibility mismatch all warn; non-strict exit 0; `--strict` exit 1; corrupted sources.json → exit 1 unconditionally.
- `python3 -m json.tool` on repo-map.json and sources.json → both parse. Workflow YAML parses.
- `bash scripts/check-preflight-consistency.sh` → clean. `bash ops/scripts/drift-check.sh` → pass. `bash ops/scripts/what-matters-now.sh --drift` → pass (CI parity).
- Doc-control: `doc_control_check.py` OK (932 files; 66 pre-existing warnings, unchanged — the new doc contributes 0); freshness ✓; compliance ✅; readiness-overclaim ✅. `git diff --check` clean.
- Doc regenerated per convention: `generate-index.py > docs/INDEX.generated.md` (redirect, deterministic) and `doc_control_check.py --write-document-registry docs/DOCUMENT_REGISTRY.md`.

## Issue status

Refs #2141 (control-plane stack anchor). Refs #2140 only as lineage via PR #2354 — no close keywords anywhere; #2140 stays open for owner judgment.

## Review-thread status

None yet (fresh PR).

## Cross-repo dependency status

Stack `control-plane-v1`, stage 1 (icn), second PR. **Upstream: PR #2354 (merged `fc6e3c3d`) — this PR builds on its repo-map `worktrees` fix and its CI slot in agent-drift-check.yml.** Downstream: the stack-protocol/manifest PR and the claim-linter PR consume the two new truth-spine domains; the nycn lock refresh (nycn repo, stage 3) consumes `docs/reference/upstream-lock-format.md` and the registry's `lock` entry. Day-0 evidence baseline: `~/icn-dev/handoffs/ecosystem/CURRENT-EVIDENCE-2026-07-07.md` (VM-local).
