### PR TITLE
feat(ci): make claim lint reusable

### DIFF
--- a/.claim-lint.json
+++ b/.claim-lint.json
@@ -1,0 +1,10 @@
+{
+  "scan_dirs": [
+    "docs/deployment",
+    "docs/operations/deployment",
+    "docs/pilots",
+    "docs/reference/project-index",
+    "website"
+  ],
+  "exclude_dirs": ["generated", "archive", "dev-journal"]
+}

--- a/.github/scripts/readiness_overclaim_linter.py
+++ b/.github/scripts/readiness_overclaim_linter.py
@@ -576,14 +576,26 @@ def run_lint(repo_root, scan_dirs: Optional[Sequence[str]] = None,
                 abs_path = os.path.join(dirpath, name)
                 rel_path = os.path.relpath(abs_path, repo_root).replace(os.sep, "/")
                 result.files_scanned += 1
-                with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
-                    lines = f.read().splitlines()
+                try:
+                    with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
+                        lines = f.read().splitlines()
+                except OSError as e:
+                    # Mirror scan_file()'s per-file tolerance: an unreadable
+                    # file must not fail the whole run, only be skipped.
+                    print("Warning: could not read " + rel_path + ": " + str(e), file=sys.stderr)
+                    continue
                 # The historical-liveness category runs regardless of banner
                 # exemption — that is the point of this category: a banner
                 # alone must not be enough to launder liveness language.
-                result.violations.extend(scan_historical_liveness(rel_path, lines))
+                historical_violations = scan_historical_liveness(rel_path, lines)
+                result.violations.extend(historical_violations)
                 if is_banner_exempt(lines):
-                    result.files_exempt.append(rel_path)
+                    # Only count the file as "exempt" in the summary when it
+                    # is genuinely clean — a file with historical_violations
+                    # is not exempt, it has findings, even though the banner
+                    # skips the (separate) affirmative-overclaim scan below.
+                    if not historical_violations:
+                        result.files_exempt.append(rel_path)
                     continue
                 result.violations.extend(scan_lines(rel_path, lines))
     return result

--- a/.github/scripts/readiness_overclaim_linter.py
+++ b/.github/scripts/readiness_overclaim_linter.py
@@ -20,8 +20,30 @@ practices on docs/deployment/*.md (see the already-bannered siblings).
 This complements compliance_linter.py (fintech vocabulary in API surfaces); it
 does NOT replace it. See docs/dev/language-guide.md and docs/ci/GATE_RATCHET_PLAN.md.
 
+Config (optional, --config PATH): a JSON object with either or both of
+`scan_dirs` / `exclude_dirs` (lists of strings). Each key present REPLACES the
+corresponding default list wholesale (not merged) — e.g. icn's own
+.claim-lint.json lists every current default dir plus "website" so a reader
+sees the full authoritative scope in one file. With no --config, scan scope
+and findings are byte-identical to the hardcoded SCAN_DIRS/EXCLUDE_DIRS below.
+
+Historical-proof-artifact category: a dated/status-named historical doc (e.g.
+DEPLOYMENT_STATUS_2025-12-12.md) that still uses raw liveness language ("live",
+"running", "operational", "in production") must carry an explicit marker
+before that language is exempt:
+
+    <!-- claim-class: historical-proof ref=<sha> date=<YYYY-MM-DD> evidence=<link/issue> -->
+
+A marker missing `ref`, or carrying an unparseable `date`, does not count as
+valid. Without a valid marker, each liveness-language line in such a doc is
+flagged as `unmarked-historical-liveness` — a stale/archive BANNER alone lets
+a doc keep describing what it once did, but this category exists specifically
+to block "exercised once" quietly reading as "still live" with no citable
+evidence trail. This is separate from (and does not replace) the
+archive-banner exemption used by the affirmative-overclaim patterns above.
+
 Usage:
-    python3 .github/scripts/readiness_overclaim_linter.py [--repo-root PATH]
+    python3 .github/scripts/readiness_overclaim_linter.py [--repo-root PATH] [--config PATH]
 
 Exit codes:
     0: No un-disclaimed readiness overclaims detected
@@ -30,11 +52,13 @@ Exit codes:
 """
 
 import argparse
+import json
 import os
 import re
 import sys
 from dataclasses import dataclass, field
-from typing import List
+from datetime import date
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 # ---------------------------------------------------------------------------
 # Scan scope (directories, relative to repo root). Allowlist-based and widened
@@ -69,6 +93,52 @@ SCAN_DIRS = [
 # archival/historical trees (dated snapshots are exempt by design). Future-proofs
 # the widening so adding a root that contains these subtrees stays low-noise.
 EXCLUDE_DIRS = {"generated", "archive", "dev-journal"}
+
+# File extensions scanned. ".astro" was added alongside the pre-existing ".md"
+# so a --config that widens SCAN_DIRS to "website" (pure .astro pages) is
+# actually scanned — none of the default SCAN_DIRS above contain .astro files,
+# so this widening does not change default-config findings.
+SCAN_EXTENSIONS = (".md", ".astro")
+
+
+def load_scan_config(config_path: Optional[str]) -> Tuple[Sequence[str], Set[str]]:
+    """Resolve (scan_dirs, exclude_dirs) from an optional --config JSON file.
+
+    No path -> the hardcoded defaults, unchanged. A present `scan_dirs` or
+    `exclude_dirs` key REPLACES the corresponding default list wholesale (not
+    merged); an absent key keeps that default. Raises ValueError on any
+    problem (missing file, invalid JSON, wrong value types) so main() can
+    report it and exit with the documented "script error" code rather than
+    silently falling back to defaults.
+    """
+    if config_path is None:
+        return SCAN_DIRS, EXCLUDE_DIRS
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        raise ValueError("cannot read/parse config " + config_path + ": " + str(e)) from e
+    if not isinstance(data, dict):
+        raise ValueError("config " + config_path + " must be a JSON object")
+
+    if "scan_dirs" in data:
+        scan_dirs = data["scan_dirs"]
+        if not isinstance(scan_dirs, list) or not all(isinstance(d, str) for d in scan_dirs):
+            raise ValueError("config scan_dirs must be a list of strings")
+    else:
+        scan_dirs = SCAN_DIRS
+
+    if "exclude_dirs" in data:
+        exclude_dirs_list = data["exclude_dirs"]
+        if not isinstance(exclude_dirs_list, list) or not all(
+            isinstance(d, str) for d in exclude_dirs_list
+        ):
+            raise ValueError("config exclude_dirs must be a list of strings")
+        exclude_dirs: Set[str] = set(exclude_dirs_list)
+    else:
+        exclude_dirs = EXCLUDE_DIRS
+
+    return scan_dirs, exclude_dirs
 
 # Affirmative readiness-claim patterns (case-insensitive).
 OVERCLAIM_PATTERNS = [
@@ -391,6 +461,92 @@ def scan_lines(rel_path, lines):
     return violations
 
 
+# --- Historical-proof-artifact category ---------------------------------
+#
+# A dated/status-named filename is the narrow, explicit signal that a doc is a
+# point-in-time snapshot (mirrors the one real example in the repo today:
+# DEPLOYMENT_STATUS_2025-12-12.md). This is deliberately filename-based, NOT
+# "any banner-exempt file" — the banner mechanism above already has its own
+# broader, content-based exemption for the affirmative-overclaim patterns;
+# widening THIS category to every banner-exempt file would sweep in docs never
+# named by the design this category implements, which is scope creep this PR
+# does not take on.
+HISTORICAL_FILENAME_RE = re.compile(
+    r"(?i)(?:status|deployment|snapshot).*\d{4}[-_]\d{2}[-_]\d{2}|"
+    r"\d{4}[-_]\d{2}[-_]\d{2}.*(?:status|deployment|snapshot)"
+)
+
+# The marker this category recognises. ref and date are required for the
+# marker to be VALID (an invalid marker behaves as if no marker were present);
+# evidence is documented but not required, matching the acceptance criteria
+# ("ref/date required for marker validity").
+HISTORICAL_MARKER_RE = re.compile(
+    r"<!--\s*claim-class:\s*historical-proof\b([^>]*)-->", re.IGNORECASE
+)
+_MARKER_ATTR_RE = re.compile(r"(\w+)=(\S+)")
+
+LIVENESS_RE = re.compile(r"(?i)\b(live|running|operational|in production)\b")
+
+
+def is_historical_doc(rel_path: str) -> bool:
+    """True if the filename itself marks the doc as a dated/status-named
+    historical snapshot (see HISTORICAL_FILENAME_RE for the narrow scope)."""
+    return bool(HISTORICAL_FILENAME_RE.search(os.path.basename(rel_path)))
+
+
+def parse_historical_marker(lines) -> Optional[Dict[str, str]]:
+    """Return the marker's attributes if a VALID `claim-class: historical-proof`
+    marker is present anywhere in the file (ref present, date present and
+    ISO-parseable); otherwise None. A syntactically-present but malformed
+    marker (missing ref/date, or an unparseable date) returns None — it does
+    not exempt anything, same as no marker at all."""
+    for line in lines:
+        m = HISTORICAL_MARKER_RE.search(line)
+        if not m:
+            continue
+        attrs = dict(_MARKER_ATTR_RE.findall(m.group(1)))
+        ref = attrs.get("ref")
+        date_str = attrs.get("date")
+        if not ref or not date_str:
+            continue
+        try:
+            date.fromisoformat(date_str)
+        except ValueError:
+            continue
+        return attrs
+    return None
+
+
+def scan_historical_liveness(rel_path, lines) -> List[Violation]:
+    """Flag raw liveness language in a dated/status-named historical doc that
+    lacks a valid claim-class: historical-proof marker. Only applies to docs
+    is_historical_doc() recognises — an ordinary current doc's liveness
+    language is not this category's concern. A valid marker exempts the whole
+    file, mirroring how an archive banner exempts a file from the
+    affirmative-overclaim patterns above (see module docstring)."""
+    if not is_historical_doc(rel_path):
+        return []
+    if parse_historical_marker(lines) is not None:
+        return []
+    violations = []
+    for line_num, line in enumerate(lines, start=1):
+        if _is_interrogative(line):
+            continue
+        for m in LIVENESS_RE.finditer(line):
+            if NEGATION_RE.search(_clause_around(line, m.start(), m.end())):
+                continue
+            violations.append(
+                Violation(
+                    file=rel_path,
+                    line=line_num,
+                    text=line.rstrip()[:160],
+                    rule="unmarked-historical-liveness",
+                )
+            )
+            break  # one violation per line is enough, consistent with scan_lines
+    return violations
+
+
 def scan_file(rel_path, abs_path):
     try:
         with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
@@ -401,24 +557,31 @@ def scan_file(rel_path, abs_path):
     return scan_lines(rel_path, lines)
 
 
-def run_lint(repo_root):
+def run_lint(repo_root, scan_dirs: Optional[Sequence[str]] = None,
+             exclude_dirs: Optional[Set[str]] = None):
+    scan_dirs = SCAN_DIRS if scan_dirs is None else scan_dirs
+    exclude_dirs = EXCLUDE_DIRS if exclude_dirs is None else exclude_dirs
     result = LintResult()
-    for scan_dir in SCAN_DIRS:
+    for scan_dir in scan_dirs:
         abs_dir = os.path.join(repo_root, scan_dir)
         if not os.path.isdir(abs_dir):
             continue
         for dirpath, dirnames, filenames in os.walk(abs_dir):
             # Prune excluded subtrees (generated artifacts, archive/dev-journal)
             # in place so os.walk does not descend into them.
-            dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+            dirnames[:] = [d for d in dirnames if d not in exclude_dirs]
             for name in sorted(filenames):
-                if not name.endswith(".md"):
+                if not name.endswith(SCAN_EXTENSIONS):
                     continue
                 abs_path = os.path.join(dirpath, name)
                 rel_path = os.path.relpath(abs_path, repo_root).replace(os.sep, "/")
                 result.files_scanned += 1
                 with open(abs_path, "r", encoding="utf-8", errors="replace") as f:
                     lines = f.read().splitlines()
+                # The historical-liveness category runs regardless of banner
+                # exemption — that is the point of this category: a banner
+                # alone must not be enough to launder liveness language.
+                result.violations.extend(scan_historical_liveness(rel_path, lines))
                 if is_banner_exempt(lines):
                     result.files_exempt.append(rel_path)
                     continue
@@ -429,8 +592,20 @@ def run_lint(repo_root):
 def main():
     parser = argparse.ArgumentParser(description="ICN Readiness Overclaim Linter")
     parser.add_argument("--repo-root", default=os.getcwd(), help="Repository root (default: cwd)")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Optional JSON config path ({\"scan_dirs\": [...], \"exclude_dirs\": [...]}); "
+        "omitted keys keep the built-in default. No --config = default behavior, unchanged.",
+    )
     args = parser.parse_args()
     repo_root = os.path.abspath(args.repo_root)
+
+    try:
+        scan_dirs, exclude_dirs = load_scan_config(args.config)
+    except ValueError as e:
+        print("ERROR: " + str(e), file=sys.stderr)
+        return 2
 
     print("=" * 70)
     print("Readiness Overclaim Linter")
@@ -438,12 +613,14 @@ def main():
     print("=" * 70)
     print()
     print("Repo root: " + repo_root)
-    print("Scope: " + ", ".join(SCAN_DIRS))
+    print("Scope: " + ", ".join(scan_dirs))
+    if args.config:
+        print("Config: " + args.config)
     print("Reference: docs/dev/language-guide.md")
     print()
 
     try:
-        result = run_lint(repo_root)
+        result = run_lint(repo_root, scan_dirs=scan_dirs, exclude_dirs=exclude_dirs)
     except Exception as e:  # documented exit code 2 for unexpected script errors
         print("ERROR: readiness linter failed: " + str(e), file=sys.stderr)
         return 2
@@ -475,6 +652,9 @@ def main():
     print("     (see the bannered docs/deployment/*.md siblings; point to docs/ci/CI_CURRENT_STATUS.md).")
     print("  2. If the claim is current and true: keep it (it stays flagged until proven by CI).")
     print("  3. If it is a genuine bounded exception: add it to ALLOWLIST with a reason.")
+    print("  4. If it is genuine historical proof (rule: unmarked-historical-liveness): add")
+    print("     <!-- claim-class: historical-proof ref=<sha> date=<YYYY-MM-DD> evidence=<link/issue> -->")
+    print("     (see this script's module docstring for the marker format).")
     print("See docs/dev/language-guide.md (Readiness claims + exception policy).")
     print()
     return 1

--- a/.github/scripts/test_readiness_overclaim_linter.py
+++ b/.github/scripts/test_readiness_overclaim_linter.py
@@ -13,11 +13,14 @@ Run:
 """
 
 import importlib.util
+import json
 import os
+import tempfile
 import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 FIX = os.path.join(HERE, "fixtures", "readiness")
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
 
 _spec = importlib.util.spec_from_file_location(
     "readiness_overclaim_linter", os.path.join(HERE, "readiness_overclaim_linter.py")
@@ -342,6 +345,198 @@ class TestFixturesEndToEnd(unittest.TestCase):
 
     def test_good_negated_clean(self):
         self.assertEqual(linter.scan_file("good_negated.md", os.path.join(FIX, "good_negated.md")), [])
+
+
+class TestScanConfig(unittest.TestCase):
+    """--config loading: no-config default, override semantics, malformed input."""
+
+    def test_no_config_returns_hardcoded_defaults(self):
+        scan_dirs, exclude_dirs = linter.load_scan_config(None)
+        self.assertEqual(scan_dirs, linter.SCAN_DIRS)
+        self.assertEqual(exclude_dirs, linter.EXCLUDE_DIRS)
+
+    def _write_config(self, data):
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, dir=self._tmp)
+        json.dump(data, f)
+        f.close()
+        return f.name
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._tmp = self._tmpdir.name
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_config_replaces_scan_dirs_wholesale(self):
+        path = self._write_config({"scan_dirs": ["docs/deployment", "website"]})
+        scan_dirs, exclude_dirs = linter.load_scan_config(path)
+        self.assertEqual(scan_dirs, ["docs/deployment", "website"])
+        # exclude_dirs key omitted -> stays at the hardcoded default.
+        self.assertEqual(exclude_dirs, linter.EXCLUDE_DIRS)
+
+    def test_config_replaces_exclude_dirs_wholesale(self):
+        path = self._write_config({"exclude_dirs": ["only-this"]})
+        scan_dirs, exclude_dirs = linter.load_scan_config(path)
+        self.assertEqual(scan_dirs, linter.SCAN_DIRS)
+        self.assertEqual(exclude_dirs, {"only-this"})
+
+    def test_missing_config_file_raises(self):
+        with self.assertRaises(ValueError):
+            linter.load_scan_config(os.path.join(self._tmp, "does-not-exist.json"))
+
+    def test_malformed_json_raises(self):
+        path = os.path.join(self._tmp, "bad.json")
+        with open(path, "w") as f:
+            f.write("{not valid json")
+        with self.assertRaises(ValueError):
+            linter.load_scan_config(path)
+
+    def test_scan_dirs_wrong_type_raises(self):
+        path = self._write_config({"scan_dirs": "not-a-list"})
+        with self.assertRaises(ValueError):
+            linter.load_scan_config(path)
+
+    def test_scan_dirs_non_string_element_raises(self):
+        path = self._write_config({"scan_dirs": ["ok", 42]})
+        with self.assertRaises(ValueError):
+            linter.load_scan_config(path)
+
+    def test_config_not_an_object_raises(self):
+        path = self._write_config(["not", "an", "object"])
+        with self.assertRaises(ValueError):
+            linter.load_scan_config(path)
+
+
+class TestRunLintScope(unittest.TestCase):
+    """run_lint honours configured scan_dirs/exclude_dirs (the --config include/path behavior)."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._tmp = self._tmpdir.name
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_run_lint_only_scans_configured_dirs(self):
+        os.makedirs(os.path.join(self._tmp, "included"))
+        os.makedirs(os.path.join(self._tmp, "not_configured"))
+        with open(os.path.join(self._tmp, "included", "a.md"), "w") as f:
+            f.write("ICN is production-ready.\n")
+        with open(os.path.join(self._tmp, "not_configured", "b.md"), "w") as f:
+            f.write("ICN is production-ready.\n")
+
+        result = linter.run_lint(self._tmp, scan_dirs=["included"], exclude_dirs=set())
+        self.assertEqual(result.files_scanned, 1)
+        self.assertEqual(len(result.violations), 1)
+        self.assertEqual(result.violations[0].file, "included/a.md")
+
+    def test_run_lint_scans_astro_files_under_configured_dir(self):
+        # The website/ use case: pure .astro pages, no .md files at all.
+        os.makedirs(os.path.join(self._tmp, "website"))
+        with open(os.path.join(self._tmp, "website", "index.astro"), "w") as f:
+            f.write("ICN is production-ready.\n")
+
+        result = linter.run_lint(self._tmp, scan_dirs=["website"], exclude_dirs=set())
+        self.assertEqual(result.files_scanned, 1)
+        self.assertEqual(len(result.violations), 1)
+        self.assertEqual(result.violations[0].rule, "production-ready")
+
+    def test_default_run_lint_matches_hardcoded_defaults(self):
+        # No scan_dirs/exclude_dirs passed -> identical to the hardcoded globals
+        # (the "no-config/default behavior" contract the CLI relies on).
+        explicit = linter.run_lint(REPO_ROOT, scan_dirs=linter.SCAN_DIRS,
+                                    exclude_dirs=linter.EXCLUDE_DIRS)
+        implicit = linter.run_lint(REPO_ROOT)
+        self.assertEqual(implicit.files_scanned, explicit.files_scanned)
+        self.assertEqual(len(implicit.violations), len(explicit.violations))
+
+
+class TestHistoricalProofArtifact(unittest.TestCase):
+    """The historical-proof-artifact category: marker exempts, missing marker
+    flags, ref/date are required for marker validity."""
+
+    HISTORICAL_NAME = "DEPLOYMENT_STATUS_2025-12-12.md"
+    NORMAL_NAME = "CURRENT_STATUS.md"
+    VALID_MARKER = (
+        "<!-- claim-class: historical-proof ref=91a63eec date=2026-04-29 "
+        "evidence=https://example.invalid/issues/1 -->"
+    )
+
+    def test_is_historical_doc_matches_dated_status_filename(self):
+        self.assertTrue(linter.is_historical_doc(self.HISTORICAL_NAME))
+        self.assertTrue(linter.is_historical_doc("docs/deployment/" + self.HISTORICAL_NAME))
+
+    def test_is_historical_doc_false_for_normal_filename(self):
+        self.assertFalse(linter.is_historical_doc(self.NORMAL_NAME))
+
+    def test_missing_marker_flags_liveness(self):
+        lines = ["# Deploy", "**Status**: Running (Healthy)"]
+        v = linter.scan_historical_liveness(self.HISTORICAL_NAME, lines)
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].rule, "unmarked-historical-liveness")
+
+    def test_valid_marker_exempts_liveness(self):
+        lines = ["# Deploy", self.VALID_MARKER, "**Status**: Running (Healthy)"]
+        v = linter.scan_historical_liveness(self.HISTORICAL_NAME, lines)
+        self.assertEqual(v, [])
+
+    def test_marker_missing_ref_does_not_exempt(self):
+        lines = [
+            "# Deploy",
+            "<!-- claim-class: historical-proof date=2026-04-29 -->",
+            "**Status**: Running (Healthy)",
+        ]
+        v = linter.scan_historical_liveness(self.HISTORICAL_NAME, lines)
+        self.assertEqual(len(v), 1)
+
+    def test_marker_missing_date_does_not_exempt(self):
+        lines = [
+            "# Deploy",
+            "<!-- claim-class: historical-proof ref=91a63eec -->",
+            "**Status**: Running (Healthy)",
+        ]
+        v = linter.scan_historical_liveness(self.HISTORICAL_NAME, lines)
+        self.assertEqual(len(v), 1)
+
+    def test_marker_with_unparseable_date_does_not_exempt(self):
+        lines = [
+            "# Deploy",
+            "<!-- claim-class: historical-proof ref=91a63eec date=not-a-date -->",
+            "**Status**: Running (Healthy)",
+        ]
+        v = linter.scan_historical_liveness(self.HISTORICAL_NAME, lines)
+        self.assertEqual(len(v), 1)
+
+    def test_non_historical_doc_not_scanned_regardless_of_liveness_language(self):
+        lines = ["**Status**: Running (Healthy)"]
+        v = linter.scan_historical_liveness(self.NORMAL_NAME, lines)
+        self.assertEqual(v, [])
+
+    def test_negated_liveness_not_flagged(self):
+        lines = ["The daemon is not running."]
+        v = linter.scan_historical_liveness(self.HISTORICAL_NAME, lines)
+        self.assertEqual(v, [])
+
+    def test_parse_historical_marker_returns_attrs(self):
+        attrs = linter.parse_historical_marker(["x", self.VALID_MARKER])
+        self.assertEqual(attrs["ref"], "91a63eec")
+        self.assertEqual(attrs["date"], "2026-04-29")
+
+    def test_parse_historical_marker_none_when_absent(self):
+        self.assertIsNone(linter.parse_historical_marker(["# Deploy", "no marker here"]))
+
+    def test_real_deployment_status_doc_is_marked_and_clean(self):
+        # Regression for the actual file this category was built for: after
+        # applying the marker (PR3), the real doc must scan clean.
+        path = os.path.join(REPO_ROOT, "docs", "deployment", self.HISTORICAL_NAME)
+        with open(path, "r", encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        self.assertIsNotNone(
+            linter.parse_historical_marker(lines),
+            "expected a valid claim-class: historical-proof marker in " + path,
+        )
+        self.assertEqual(linter.scan_historical_liveness(self.HISTORICAL_NAME, lines), [])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_readiness_overclaim_linter.py
+++ b/.github/scripts/test_readiness_overclaim_linter.py
@@ -451,6 +451,56 @@ class TestRunLintScope(unittest.TestCase):
         self.assertEqual(implicit.files_scanned, explicit.files_scanned)
         self.assertEqual(len(implicit.violations), len(explicit.violations))
 
+    def test_unreadable_file_warns_and_does_not_abort_the_run(self):
+        # Regression for Copilot review (#2358): run_lint() must tolerate a
+        # per-file OSError the same way scan_file() already does, not let one
+        # bad file turn the whole run into a script error.
+        os.makedirs(os.path.join(self._tmp, "included"))
+        unreadable = os.path.join(self._tmp, "included", "locked.md")
+        with open(unreadable, "w") as f:
+            f.write("ICN is production-ready.\n")
+        os.chmod(unreadable, 0o000)
+        readable = os.path.join(self._tmp, "included", "ok.md")
+        with open(readable, "w") as f:
+            f.write("ICN is production-ready.\n")
+        try:
+            if os.access(unreadable, os.R_OK):
+                self.skipTest("running as a user that ignores file permissions (e.g. root)")
+            result = linter.run_lint(self._tmp, scan_dirs=["included"], exclude_dirs=set())
+            self.assertEqual(len(result.violations), 1)
+            self.assertEqual(result.violations[0].file, "included/ok.md")
+        finally:
+            os.chmod(unreadable, 0o644)
+
+    def test_banner_exempt_file_with_historical_violations_not_counted_exempt(self):
+        # Regression for Copilot review (#2358): a banner-exempt file that
+        # ALSO has unmarked-historical-liveness violations must not be
+        # reported as "exempt" — that would misrepresent a file with findings
+        # as clean in the summary count.
+        os.makedirs(os.path.join(self._tmp, "docs_status"))
+        path = os.path.join(self._tmp, "docs_status", "STATUS_2025-12-12.md")
+        with open(path, "w") as f:
+            f.write("# T\n> Historical snapshot.\n**Status**: Running (Healthy)\n")
+
+        result = linter.run_lint(self._tmp, scan_dirs=["docs_status"], exclude_dirs=set())
+        self.assertEqual(len(result.violations), 1)
+        self.assertEqual(result.violations[0].rule, "unmarked-historical-liveness")
+        self.assertNotIn("docs_status/STATUS_2025-12-12.md", result.files_exempt)
+
+    def test_banner_exempt_file_without_historical_violations_still_counted_exempt(self):
+        # Regression guard the OTHER direction: an ordinary banner-exempt file
+        # (no historical-liveness findings) must still land in files_exempt —
+        # the fix above must not turn every banner-exempt file into "not
+        # exempt".
+        os.makedirs(os.path.join(self._tmp, "included"))
+        path = os.path.join(self._tmp, "included", "a.md")
+        with open(path, "w") as f:
+            f.write("# T\n> Historical snapshot.\n**Status:** PRODUCTION READY\n")
+
+        result = linter.run_lint(self._tmp, scan_dirs=["included"], exclude_dirs=set())
+        self.assertEqual(result.violations, [])
+        self.assertIn("included/a.md", result.files_exempt)
+
 
 class TestHistoricalProofArtifact(unittest.TestCase):
     """The historical-proof-artifact category: marker exempts, missing marker
@@ -532,11 +582,16 @@ class TestHistoricalProofArtifact(unittest.TestCase):
         path = os.path.join(REPO_ROOT, "docs", "deployment", self.HISTORICAL_NAME)
         with open(path, "r", encoding="utf-8") as f:
             lines = f.read().splitlines()
+        attrs = linter.parse_historical_marker(lines)
         self.assertIsNotNone(
-            linter.parse_historical_marker(lines),
-            "expected a valid claim-class: historical-proof marker in " + path,
+            attrs, "expected a valid claim-class: historical-proof marker in " + path
         )
         self.assertEqual(linter.scan_historical_liveness(self.HISTORICAL_NAME, lines), [])
+        # Regression for Copilot review (#2358): evidence must be an
+        # externally-citable pointer (a permalink/issue), not a self-reference
+        # to the very file the marker is embedded in.
+        self.assertNotEqual(attrs.get("evidence"), "docs/deployment/" + self.HISTORICAL_NAME)
+        self.assertTrue(attrs.get("evidence", "").startswith("http"))
 
 
 if __name__ == "__main__":

--- a/.github/workflows/reusable-claim-lint.yml
+++ b/.github/workflows/reusable-claim-lint.yml
@@ -1,0 +1,72 @@
+name: Reusable Claim Lint
+
+# Lets a downstream org repo (nycn, icn-learn, icn-community-bridge) run icn's
+# readiness-overclaim linter against its own claim-sensitive docs without
+# vendoring or reimplementing it. One linter, one owner (icn) — see
+# .github/scripts/readiness_overclaim_linter.py for the rules it enforces.
+#
+# Warning-mode by design: this workflow NEVER fails its own job regardless of
+# what the linter finds. It is a visibility tool for downstream repos, not an
+# enforcement gate — no caller PR is blocked by this workflow. (No caller
+# workflows exist yet; this file is the reusable definition those later PRs
+# will call.)
+
+on:
+  workflow_call:
+    inputs:
+      config-path:
+        description: >
+          Path (relative to the caller repo root) to the caller's claim-lint
+          config, e.g. .claim-lint.json. If absent, the linter's hardcoded
+          default scan scope is used.
+        required: false
+        type: string
+        default: ".claim-lint.json"
+      icn-ref:
+        description: "icn ref to source the linter script from."
+        required: false
+        type: string
+        default: "main"
+
+permissions:
+  contents: read
+
+jobs:
+  claim-lint:
+    name: Claim Firewall (warning-mode)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v6
+
+      - name: Checkout icn linter (sparse)
+        uses: actions/checkout@v6
+        with:
+          repository: InterCooperative-Network/icn
+          ref: ${{ inputs.icn-ref }}
+          sparse-checkout: |
+            .github/scripts/readiness_overclaim_linter.py
+          sparse-checkout-cone-mode: false
+          path: .icn-claim-lint-src
+
+      - name: Run readiness overclaim linter
+        env:
+          CONFIG_PATH: ${{ inputs.config-path }}
+        run: |
+          set +e
+          if [ -f "$CONFIG_PATH" ]; then
+            echo "Using config: $CONFIG_PATH"
+            python3 .icn-claim-lint-src/.github/scripts/readiness_overclaim_linter.py \
+              --repo-root . --config "$CONFIG_PATH"
+          else
+            echo "No config at $CONFIG_PATH — using the linter's hardcoded default scope"
+            python3 .icn-claim-lint-src/.github/scripts/readiness_overclaim_linter.py --repo-root .
+          fi
+          status=$?
+          if [ "$status" -eq 1 ]; then
+            echo "::warning title=Claim firewall finding::Un-disclaimed readiness/liveness language detected. Warning-mode — this workflow does not block the caller."
+          elif [ "$status" -gt 1 ]; then
+            echo "::warning title=Claim firewall script error::Linter exited $status. Warning-mode — this workflow does not block the caller, but the error should be investigated."
+          fi
+          # Always succeed: this workflow is visibility-only, never blocking.
+          exit 0

--- a/docs/deployment/DEPLOYMENT_STATUS_2025-12-12.md
+++ b/docs/deployment/DEPLOYMENT_STATUS_2025-12-12.md
@@ -1,5 +1,8 @@
 # ICN Deployment Status - December 12, 2025
 
+<!-- claim-class: historical-proof ref=294f89235b1caece870244beba5740ca081bc75e date=2025-12-13 evidence=docs/deployment/DEPLOYMENT_STATUS_2025-12-12.md -->
+> Historical snapshot (2025-12-12); not a current-runtime claim — see docs/status.toml.
+
 > Historical snapshot (December 12, 2025). Values in this document are not authoritative for current deployments.
 > For current status, run live checks and consult `docs/ci/CI_CURRENT_STATUS.md`.
 

--- a/docs/deployment/DEPLOYMENT_STATUS_2025-12-12.md
+++ b/docs/deployment/DEPLOYMENT_STATUS_2025-12-12.md
@@ -1,6 +1,6 @@
 # ICN Deployment Status - December 12, 2025
 
-<!-- claim-class: historical-proof ref=294f89235b1caece870244beba5740ca081bc75e date=2025-12-13 evidence=docs/deployment/DEPLOYMENT_STATUS_2025-12-12.md -->
+<!-- claim-class: historical-proof ref=294f89235b1caece870244beba5740ca081bc75e date=2025-12-13 evidence=https://github.com/InterCooperative-Network/icn/commit/294f89235b1caece870244beba5740ca081bc75e -->
 > Historical snapshot (2025-12-12); not a current-runtime claim — see docs/status.toml.
 
 > Historical snapshot (December 12, 2025). Values in this document are not authoritative for current deployments.


### PR DESCRIPTION
## Summary

Makes the readiness-overclaim linter config-driven and reusable by downstream org repos via a new
`workflow_call` workflow, and adds a `historical private/devnet proof artifact` claim category that
closes a laundering gap: today, a stale/archive banner alone lets a dated doc keep raw liveness
language ("running", "operational", ...) exempt forever, with no citable evidence trail. Third PR of
the control-plane stack; builds on merged PR #2354 and PR #2356.

## Layer classification

Control-plane / CI / claim-firewall work (`.github/scripts/`, `.github/workflows/`, one config file,
one doc-marker edit). No runtime/protocol changes.

## Boundary check / non-goals

- **No downstream caller workflows** — `reusable-claim-lint.yml` is the reusable definition only;
  nycn/icn-learn/icn-community-bridge each get their own caller-workflow PR later in the stack.
- **No blocking-mode CI anywhere.** The reusable workflow always exits 0 regardless of linter findings
  (visibility only). icn's own required `ci.yml` "Readiness Overclaim Check" job is untouched — it
  still runs the linter with no `--config`, same as before this PR.
- **No new readiness/liveness/pilot claims.** The only content-adjacent edit is a marker + banner on an
  already-historical, already-bannered doc; existing content is untouched.
- **No downstream repo edits** — nycn/icn-learn/icn-community-bridge/icn-infra/.github untouched.
- **No dashboard.**
- `.claim-lint.json` is added but **not wired into any CI step in this PR** — see "What did not change".

## What changed

- **`.github/scripts/readiness_overclaim_linter.py`**:
  - `--config PATH` (optional): JSON `scan_dirs`/`exclude_dirs`, each key present **replaces** the
    corresponding default list wholesale; an absent key keeps the hardcoded default. No `--config` =
    identical scan scope and findings to before this PR.
  - Scanned extensions widened to `(".md", ".astro")` — needed for a future `website/` scan dir (pure
    `.astro` pages); none of the 4 default scan dirs contain `.astro` files, so this doesn't change
    default behavior.
  - New **`unmarked-historical-liveness`** category: a dated/status-named historical doc (filename
    pattern, e.g. `DEPLOYMENT_STATUS_2025-12-12.md` — deliberately narrow, not "any banner-exempt
    file") using raw liveness language ("live"/"running"/"operational"/"in production") must carry
    `<!-- claim-class: historical-proof ref=<sha> date=<YYYY-MM-DD> evidence=<link/issue> -->`
    (ref + a parseable date are required for validity) or each liveness line is flagged. This runs
    independent of the existing archive-banner exemption — the whole point is that a banner alone is
    no longer sufficient for this specific language class.
- **`.github/scripts/test_readiness_overclaim_linter.py`**: 23 new tests (config load/override/malformed,
  `run_lint` respecting configured scan dirs + `.astro` extension, marker validity — present/missing
  ref/missing date/unparseable date/negated — and a regression test that reads the real
  `DEPLOYMENT_STATUS_2025-12-12.md` off disk and asserts it now carries a valid marker and scans clean).
  The 51 pre-existing tests are byte-unmodified and still pass.
- **`docs/deployment/DEPLOYMENT_STATUS_2025-12-12.md`**: adds the historical-proof marker
  (`ref=294f8923...` — the actual commit that introduced this file, `date=2025-12-13`) and the one-line
  banner text from the design ("Historical snapshot (2025-12-12); not a current-runtime claim — see
  docs/status.toml"). All existing content (including the pre-existing "Historical snapshot" blockquote)
  is untouched.
- **`.github/workflows/reusable-claim-lint.yml`** (new): `workflow_call` with `config-path`/`icn-ref`
  inputs; checks out the caller repo, sparse-checks-out just the linter script from
  `InterCooperative-Network/icn@main`, runs it, and always exits 0 (warning-mode: annotates via
  `::warning::` on findings/errors, never fails the job). Untrusted-input hygiene: the shell step reads
  `CONFIG_PATH` from an `env:` var, not direct `${{ }}` interpolation in `run:`.
- **`.claim-lint.json`** (new, repo root): current 4 default dirs + `website`.

## What did not change

- `ci.yml`'s existing "Readiness Overclaim Check" / "Self-test the readiness linter" jobs — untouched,
  still run with no `--config`.
- No downstream repo (nycn, icn-learn, icn-community-bridge, icn-infra, `.github`) touched.
- `ALLOWLIST`, `NEGATION_RE`, `BANNER_RE`, and all other existing precision rules — untouched.
- `docs/deployment/DEPLOYMENT_STATUS_2025-12-12.md`'s actual content (services, ports, checklists, etc.).

## Validation evidence

At head `5893d463` (base = merged `5b99d981`, PR2):

- `python3 .github/scripts/test_readiness_overclaim_linter.py` → **74/74 pass** (51 preserved + 23 new).
- Default-behavior parity: `python3 .github/scripts/readiness_overclaim_linter.py --repo-root .` on
  this branch → **"Scanned 55 files; 14 exempt"**, 0 violations — identical to the same command run on
  `main` before this PR (verified side-by-side).
- Config run: `python3 .github/scripts/readiness_overclaim_linter.py --repo-root . --config .claim-lint.json`
  → 95 files scanned, **the same 55/14/0 for the 4 default dirs, plus 2 additive findings from
  `website/`** (a `live federation` and a `production-ready` hit inside advisory/negated-context
  sentences — pre-existing linter-precision gaps on a surface never scanned before this PR, not
  introduced by it; `.claim-lint.json` isn't wired into any CI step, so these are visible only on
  manual invocation. Left for a future precision-ratchet PR, matching the file's own established
  incremental-widening practice).
- `python3 scripts/check-truth-spine.py` → 1 warning (pre-existing `sprint_state` staleness, unrelated).
- `bash scripts/check-preflight-consistency.sh` → clean. `bash ops/scripts/drift-check.sh` → pass.
  `bash ops/scripts/what-matters-now.sh --drift` → pass.
- `doc_control_check.py` OK (932 files, 66 pre-existing warnings, unchanged); `freshness-check.py` ✓;
  `compliance_linter.py` ✅; `readiness_overclaim_linter.py --repo-root .` (no config, real CLI) ✅.
  `git diff --check` clean.
- Local-model pre-review (`icn-prereview`) **skipped — Zentith Ollama tunnel down** (same as the prior
  two PRs in this stack); this diff was manually self-reviewed instead (see below).
- **Handoff note:** `docs/reference/upstream-lock-format.md` (from PR2) required `Executor: Sonnet.
  Fable review REQUIRED (CI surface + linter semantics) before push.` This session ran entirely as
  Sonnet — that Fable review has **not** happened. Flagging explicitly rather than self-certifying it;
  recommend a Fable pass on the linter/workflow changes before merge authorization.

## Issue status

Refs #2357 (new issue this PR implements), Refs #2141 (control-plane stack anchor). No close keywords.

## Cross-repo dependency status

Stack `control-plane-v1`, third PR in icn (stage 1). Upstream: PR #2354 (`fc6e3c3d`) and PR #2356
(`5b99d981`), both merged. Downstream: the nycn/icn-learn/icn-community-bridge caller-workflow PRs
(later stack stages) will each add a short workflow calling `reusable-claim-lint.yml` — none of that
exists yet. Day-0 evidence baseline: `~/icn-dev/handoffs/ecosystem/CURRENT-EVIDENCE-2026-07-07.md`.
