### PR TITLE
docs(ops): add cross-repo PR stack protocol manifest

### DIFF
--- a/ops/coordination/PR_STACK_PROTOCOL.md
+++ b/ops/coordination/PR_STACK_PROTOCOL.md
@@ -1,7 +1,8 @@
 # Cross-Repo PR Stack Protocol
 
-Coordinates pull requests across ICN, NYCN, and ICN Academy when a
-single idea, concept, or feature touches more than one repo.
+Coordinates pull requests across the InterCooperative-Network org
+repos when a single idea, concept, or feature touches more than one
+repo.
 
 > **Order matters.** Stacks merged out of order produce stale PR
 > bodies, broken cross-references, and review-thread confusion. This
@@ -9,28 +10,94 @@ single idea, concept, or feature touches more than one repo.
 
 ## Cross-repo merge order
 
-For any change that spans more than one repo:
+For any change that spans more than one repo, the full ecosystem
+order is:
 
-1. **ICN canonical first.** Generic primitives, design direction
-   docs, ADRs, RFCs, runtime, and shared types land in
+1. **`icn` — canonical first.** Generic primitives, design direction
+   docs, ADRs, RFCs, runtime, shared types, and canonical wording
+   land in
    [`InterCooperative-Network/icn`](https://github.com/InterCooperative-Network/icn).
-2. **NYCN application second.** Institution-specific application,
-   package shapes, and operating material land in
-   [`InterCooperative-Network/nycn`](https://github.com/InterCooperative-Network/nycn).
-3. **ICN Academy teaching third.** Cross-role orientation packets,
-   role packets, tracks, and teaching surfaces land in
-   [`InterCooperative-Network/icn-learn`](https://github.com/InterCooperative-Network/icn-learn).
+2. **`icn-infra` — org contracts second.** Cross-repo boundary
+   definitions, public-claims gates, and source classification bind
+   what the rest of the org may say and ship.
+3. **`nycn` — institution application third.** Institution-specific
+   application, package shapes, and operating material, pinned to
+   icn via a human-signed upstream lock.
+4. **`icn-learn` — teaching fourth.** Orientation packets, role
+   packets, tracks, and teaching surfaces cite canonical truth and
+   go stale if they land before it.
+5. **`icn-community-bridge` — outreach fifth.** Onboarding/outreach
+   scaffold, gated by icn-infra operating contracts; never canonical.
+6. **`.github` — mirror last.** The org profile mirrors public truth
+   that already landed in icn; it originates nothing.
 
 Reasons:
 
 - ICN canonical wording is what the other repos cite. Citing a
   not-yet-merged ICN PR produces broken or stale links.
-- Teaching surfaces are downstream of canonical truth. A packet that
-  cites a canonical doc that has not landed will go stale on the
-  first edit.
-- Public website changes are downstream of all three (per
+- Teaching and outreach surfaces are downstream of canonical truth.
+  A packet that cites a canonical doc that has not landed will go
+  stale on the first edit.
+- Public website changes are downstream of all of the above (per
   ADR-0032/-0033) and are gated separately on evidence, not on the
   stack.
+
+Stage numbers are the **default** dependency direction: lower stages
+are upstream of higher ones. A specific stack may skip stages (no
+work in that repo) or declare a narrower dependency set in its
+manifest — `depends_on_stages` makes explicit what the numbering
+leaves implicit. Example: a dashboard that consumes downstream
+status envelopes legitimately depends on stages 3–5 even though it
+lives at stage 2.
+
+## Stack status vocabulary
+
+Every stack PR and manifest stage distinguishes, and never
+conflates:
+
+| Status | Means | Does NOT mean |
+|---|---|---|
+| `planned` | scoped, not started | done, or even started |
+| `implemented` | change exists on a branch/PR | reviewed or merged |
+| `reviewed` | review completed | merged |
+| `merged` | landed on that repo's default branch | adopted downstream |
+| `adopted` | a downstream consumer actually uses it (caller workflow on its default branch, lock citing the new ref) | anything about runtime |
+
+No readiness claim may be inferred from any of these. A stack stage
+existing — or reaching `merged` or `adopted` — says nothing about
+runtime state, deployment, pilots, or live federation. Claim
+discipline belongs to the claim firewall (readiness-overclaim
+linter, PUBLIC-CLAIMS gates), not to this protocol.
+
+## Stack manifests (`stacks/`)
+
+Live cross-repo stacks are recorded as machine-readable manifests:
+`ops/coordination/stacks/<slug>.stack.yaml`, format `icn-pr-stack/v1`.
+A manifest encodes one stack's stage order, per-stage status and
+dependencies, known PRs, and dependency policy.
+
+Manifests are **coordination metadata, not architectural or runtime
+truth**. `ops/state/truth/sources.json` remains the arbiter of truth
+ownership: it names this directory as owner of the
+`cross_repo_pr_stacks` domain — merge order and stack state, nothing
+else. On any conflict, sources.json wins.
+
+Validate manifests with:
+
+```bash
+bash scripts/check-pr-stack.sh --repo-root . --offline   # shape + ordering, no network
+bash scripts/check-pr-stack.sh --repo-root .             # + gh-backed PR/issue checks
+bash scripts/check-pr-stack.sh --repo-root . --strict    # findings become failures
+```
+
+The checker is run manually and from VM sessions, not wired into CI
+(as of the PR that introduced it): the checks that matter most —
+close-keyword and Refs discipline in PR bodies across private
+downstream repos — need an authenticated cross-repo `gh` context
+that public CI does not have, and wiring only the offline subset
+would read as more enforcement than it is. This protocol is a
+planner plus checker, not an enforcement gate. Wiring the offline
+subset into the drift workflow is a possible later ratchet.
 
 ## When to deviate
 
@@ -48,8 +115,8 @@ the deviation does not apply — wait for the ICN PR.
 Every PR body must include:
 
 1. **Summary.** What this PR does in one or two sentences.
-2. **Layer classification.** ICN core / ICN app / NYCN package /
-   icn-learn / website / private overlay.
+2. **Layer classification.** ICN core / ICN app / ops coordination /
+   NYCN package / icn-learn / website / private overlay.
 3. **Boundary check.** What stays out of this PR (the explicit
    non-goals — institution-specific meaning out of ICN core; private
    data out of any repo; etc.).
@@ -64,8 +131,11 @@ Every PR body must include:
 8. **Review-thread status.** Whether prior review threads are
    resolved or marked outdated, with reason.
 9. **Cross-repo dependency status.** Names the upstream/downstream
-   PRs in the stack and whether this PR depends on them merging
-   first.
+   PRs in the stack, states each one's status using the stack status
+   vocabulary above, and says whether this PR depends on them
+   merging first.
+
+Template: [`templates/stack-pr-body-template.md`](templates/stack-pr-body-template.md).
 
 ## The "Refs vs close-keyword" warning
 
@@ -80,9 +150,10 @@ If you do not intend to close the issue, **always** use `Refs #NNNN`
 or write the relationship in plain prose ("relates to issue #NNNN",
 "part of #NNNN").
 
-This is enforced by convention, not by tooling. Reviewers should
-flag any PR body that uses an auto-close keyword unless the closure
-is intentional and noted in the summary.
+This is enforced by convention, with `scripts/check-pr-stack.sh` as
+a backstop for manifests and manifest-listed PR bodies. Reviewers
+should still flag any PR body that uses an auto-close keyword unless
+the closure is intentional and noted in the summary.
 
 ## Stale PR body detection
 
@@ -112,6 +183,11 @@ slice plus an icn-learn packet), the stack follows this protocol.
 
 ## Reference
 
+- [`ops/coordination/stacks/`](stacks/) — live stack manifests
+  (`icn-pr-stack/v1`), owner of the `cross_repo_pr_stacks` truth
+  domain.
+- [`ops/coordination/templates/`](templates/) — stack PR body and
+  handoff templates.
 - [`ops/coordination/README.md`](README.md) — the post-promotion
   pipeline (RFC → ADR → issue → tests → website).
 - [`ops/ideas/README.md`](../ideas/README.md) — the pre-RFC

--- a/ops/coordination/PR_STACK_PROTOCOL.md
+++ b/ops/coordination/PR_STACK_PROTOCOL.md
@@ -62,6 +62,12 @@ conflates:
 | `reviewed` | review completed | merged |
 | `merged` | landed on that repo's default branch | adopted downstream |
 | `adopted` | a downstream consumer actually uses it (caller workflow on its default branch, lock citing the new ref) | anything about runtime |
+| `none` | a stage in the order with no work planned in this stack | that the stage/repo is irrelevant in general |
+
+These are the only values a manifest stage's `status` may take;
+`scripts/check-pr-stack.sh` rejects any other. A partly-done stage (some
+rungs merged, more in flight) is `implemented`, not `merged` — `merged`
+means the whole stage is done.
 
 No readiness claim may be inferred from any of these. A stack stage
 existing — or reaching `merged` or `adopted` — says nothing about

--- a/ops/coordination/stacks/control-plane-v1.stack.yaml
+++ b/ops/coordination/stacks/control-plane-v1.stack.yaml
@@ -34,10 +34,10 @@ dependency_policy:
 stages:
   - stage: 1
     repo: InterCooperative-Network/icn
-    status: in_progress
+    status: implemented
     depends_on_stages: []
     merged_prs: [2354, 2356, 2358]
-    note: "Preflight/root hardening (also Refs icn#2140), org-repo registry + truth-spine validator, config-driven claim linter + reusable workflow. The PR introducing this manifest is further stage-1 work; more stage-1 rungs may follow."
+    note: "Preflight/root hardening (also Refs icn#2140), org-repo registry + truth-spine validator, config-driven claim linter + reusable workflow — all merged. The PR introducing this manifest is further stage-1 work in flight; status is 'implemented' (work exists, more stage-1 rungs may follow), not 'merged' (the whole stage is not done)."
 
   - stage: 2
     repo: InterCooperative-Network/icn-infra

--- a/ops/coordination/stacks/control-plane-v1.stack.yaml
+++ b/ops/coordination/stacks/control-plane-v1.stack.yaml
@@ -1,0 +1,75 @@
+# control-plane-v1.stack.yaml — stack manifest for the ecosystem control-plane PR stack.
+#
+# Coordination metadata ONLY. This file records cross-repo merge order and
+# stack state (format: icn-pr-stack/v1 — see ops/coordination/PR_STACK_PROTOCOL.md;
+# validate with scripts/check-pr-stack.sh). It is not architectural truth
+# (ops/state/truth/sources.json is the arbiter), not runtime truth, and no
+# readiness claim of any kind may be inferred from anything recorded here.
+#
+# Parsing contract: scalar keys are `key: value` on one line; list values use
+# flow style on one line (e.g. `merged_prs: [2354, 2356]`). Keep it that way —
+# the checker is deliberately line-oriented.
+
+schema: icn-pr-stack/v1
+stack_id: control-plane-v1
+anchor_issue: InterCooperative-Network/icn#2141
+description: >-
+  Ecosystem control plane: preflight/root hardening, org-repo coordination
+  registry + truth-spine validator, reusable claim firewall, stack protocol
+  + manifests, then downstream locks, status envelopes, caller workflows,
+  and a dashboard home. Coordination metadata for the stack itself.
+
+non_claims:
+  - not-runtime
+  - not-production
+  - not-pilot
+  - not-live-federation
+  - no-downstream-adoption-yet
+
+dependency_policy:
+  - "A stage may be marked merged or adopted only after every stage it depends on is merged or adopted."
+  - "Downstream repos must not claim claim-lint adoption until a caller workflow lands on their default branch (none exists yet)."
+  - "Upstream lock refreshes must cite the exact icn merge commit they were reviewed against."
+
+stages:
+  - stage: 1
+    repo: InterCooperative-Network/icn
+    status: in_progress
+    depends_on_stages: []
+    merged_prs: [2354, 2356, 2358]
+    note: "Preflight/root hardening (also Refs icn#2140), org-repo registry + truth-spine validator, config-driven claim linter + reusable workflow. The PR introducing this manifest is further stage-1 work; more stage-1 rungs may follow."
+
+  - stage: 2
+    repo: InterCooperative-Network/icn-infra
+    status: planned
+    depends_on_stages: [1, 3, 4, 5]
+    merged_prs: []
+    note: "Ecosystem dashboard home. Consumes downstream status envelopes, so in THIS stack it intentionally depends on stages 3-5 despite its lower stage number."
+
+  - stage: 3
+    repo: InterCooperative-Network/nycn
+    status: planned
+    depends_on_stages: [1]
+    merged_prs: []
+    note: "Intended next stage after stage-1 protocol work: upstream lock refresh + drift memo first (no workflow changes), then status envelope + claim-lint caller as a separate PR. Planned, not started."
+
+  - stage: 4
+    repo: InterCooperative-Network/icn-learn
+    status: planned
+    depends_on_stages: [1]
+    merged_prs: []
+    note: "Upstream lock + status envelope + claim-lint caller + checked-against policy. Planned, not started."
+
+  - stage: 5
+    repo: InterCooperative-Network/icn-community-bridge
+    status: planned
+    depends_on_stages: [1]
+    merged_prs: []
+    note: "Upstream lock + status envelope + claim-lint caller. Planned, not started."
+
+  - stage: 6
+    repo: InterCooperative-Network/.github
+    status: none
+    depends_on_stages: []
+    merged_prs: []
+    note: "No work planned in this stack: org profile verified clean 2026-07-07. Mirror updates land last, only after public truth lands in icn."

--- a/ops/coordination/templates/downstream-caller-workflow-handoff.md
+++ b/ops/coordination/templates/downstream-caller-workflow-handoff.md
@@ -1,0 +1,33 @@
+# Handoff template — downstream claim-lint caller workflow
+
+For the PR that gives a downstream repo (`nycn`, `icn-learn`,
+`icn-community-bridge`) its claim-firewall caller. Fill the angle brackets;
+keep the non-goals verbatim.
+
+---
+
+**Repo:** `InterCooperative-Network/<repo>` · **Branch:** `chore/claim-lint-caller`
+**Stack:** `<stack_id>` (anchor: Refs `<org/repo#NNNN>`)
+
+**Scope (exactly this, nothing else):**
+
+1. `.github/workflows/claim-lint.yml` — a ~12-line caller invoking icn's
+   `.github/workflows/reusable-claim-lint.yml@<icn-ref>` (warning-mode by
+   construction; the reusable side never fails the caller).
+2. Optional `.claim-lint.json` naming this repo's claim-sensitive dirs.
+
+**Non-goals / non-claims:**
+
+- No blocking mode. The linter warns; it does not gate.
+- No content rewrites, no lock changes, no envelope changes in this PR.
+- Adding the caller adopts the *linter*, not any claim it scans: it is not
+  evidence that any readiness statement in this repo is true.
+- The stack manifest stage flips to `adopted` only after this workflow exists
+  on the repo's default branch — not when this PR opens.
+
+**Acceptance:**
+
+- Workflow syntax valid (`gh workflow view` after push, or actionlint).
+- The caller run completes on a PR in this repo and surfaces linter output
+  as warnings.
+- PR body follows `stack-pr-body-template.md`; `Refs` only, no close keywords.

--- a/ops/coordination/templates/stack-pr-body-template.md
+++ b/ops/coordination/templates/stack-pr-body-template.md
@@ -1,0 +1,39 @@
+# Stack PR body template
+
+Copy into the PR description and fill every section — all nine are required by
+[`ops/coordination/PR_STACK_PROTOCOL.md`](../PR_STACK_PROTOCOL.md). Use `Refs #NNNN`
+only; never `close`/`fix`/`resolve` near an issue number unless closure is
+intended and stated in the summary.
+
+```markdown
+## Summary
+<what this PR does, one or two sentences>
+
+## Layer classification
+<ICN core / ICN app / ops coordination / NYCN package / icn-learn / website / private overlay>
+
+## Boundary check / non-goals
+- <what deliberately stays out of this PR>
+
+## What changed
+- <files touched and why>
+
+## What did not change
+- <adjacent surfaces a reader might expect to change but should not>
+
+## Validation evidence
+- <commands run and their results — cite, don't summarize from memory>
+
+## Issue status
+Refs #NNNN — left open; closure is the issue owner's call.
+
+## Review-thread status
+<none yet / resolved with reason / outdated with reason>
+
+## Cross-repo dependency status
+- Upstream: <repo PR/commit + status: planned | implemented | reviewed | merged | adopted>
+- Downstream: <repo + status — say "planned, not started" when that is the truth>
+
+## Review notes / known warnings
+- <known warnings and why they are acceptable>
+```

--- a/ops/coordination/templates/upstream-lock-refresh-handoff.md
+++ b/ops/coordination/templates/upstream-lock-refresh-handoff.md
@@ -1,0 +1,35 @@
+# Handoff template — upstream lock refresh
+
+For the PR that refreshes a downstream repo's `ops/upstream/icn.lock.yaml`
+(format `icn-upstream-lock/v1` — see `docs/reference/upstream-lock-format.md`
+in icn). A lock is a **human-signed review attestation**, not an automated
+dependency constraint: agents draft the drift review, a human signs `reviewer:`.
+
+---
+
+**Repo:** `InterCooperative-Network/<repo>` · **Branch:** `chore/upstream-lock-refresh`
+**Stack:** `<stack_id>` (anchor: Refs `<org/repo#NNNN>`)
+
+**Scope (exactly this, nothing else):**
+
+1. `ops/upstream/icn.lock.yaml` — pin moves to `<icn merge commit SHA>`.
+   Cite the exact upstream merge commit reviewed against, never a branch name.
+2. The dependency drift memo (e.g. `docs/sync/ICN_DEPENDENCY_STATUS.md`) —
+   per-surface verdicts, one of: **reviewed** / **not adopted** /
+   **action-needed**. Never a bare "none blocking" without the surface list.
+
+**Rules:**
+
+- `reviewed_at` is the date the review actually happened; `reviewer:` is a
+  human, left blank until they sign.
+- Existing proof references that are no longer current get re-marked as
+  historical proof artifacts (ref + date + evidence pointer) — preserved,
+  never scrubbed, never re-claimed as current.
+- A refreshed lock means "someone looked at the delta", not "the delta is
+  adopted". Adoption is separate downstream work with its own status.
+
+**Non-goals:** no workflow changes, no status envelope, no content rewrites,
+no new claims of any kind.
+
+**Acceptance:** lock parses; drift memo lists every reviewed surface; PR body
+follows `stack-pr-body-template.md`; `Refs` only, no close keywords.

--- a/ops/state/truth/sources.json
+++ b/ops/state/truth/sources.json
@@ -41,9 +41,9 @@
       "description": "Human-signed review attestations pinning the ICN ref each downstream repo (nycn today; icn-learn and icn-community-bridge planned) was last reviewed against. Format: icn-upstream-lock/v1 (docs/reference/upstream-lock-format.md). The lock files live in the downstream repos, never in this repo — a lock is a review attestation, not an automated dependency constraint."
     },
     "cross_repo_pr_stacks": {
-      "owner": "ops/coordination/PR_STACK_PROTOCOL.md",
+      "owner": "ops/coordination/stacks/",
       "stability": "slow-changing",
-      "description": "Cross-repo PR merge-order discipline (icn first, downstream after). When the stack-manifest extension lands under ops/coordination/stacks/, that directory becomes the owner and this entry's pointer moves with it."
+      "description": "Cross-repo PR merge order and per-stack state: machine-readable stack manifests (<slug>.stack.yaml, format icn-pr-stack/v1, validated by scripts/check-pr-stack.sh). ops/coordination/PR_STACK_PROTOCOL.md documents the discipline; the manifests own stack state. Coordination metadata only — plan/order facts, never runtime or readiness truth."
     },
     "adr_decisions": {
       "owner": "docs/adr/",

--- a/scripts/check-pr-stack.sh
+++ b/scripts/check-pr-stack.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# check-pr-stack.sh — validate cross-repo PR stack manifests (Refs icn#2141).
+#
+# Companion to ops/coordination/PR_STACK_PROTOCOL.md. Checks every
+# ops/coordination/stacks/*.stack.yaml (format icn-pr-stack/v1):
+#
+#   offline (always):
+#     - required keys present, stack_id matches filename, statuses in vocabulary
+#     - stage numbers unique; depends_on_stages reference existing earlier stages
+#     - no stage marked merged/adopted before the stages it depends on are
+#     - no GitHub close-keyword (close/fix/resolve...) next to an issue number
+#       anywhere in the manifest text
+#   online (needs authenticated gh; skipped with --offline or when gh is absent):
+#     - anchor issue exists (its open/closed state is reported, not judged)
+#     - every merged_prs entry exists and is actually MERGED
+#     - each such PR body Refs the anchor issue and has no close-keyword near it
+#     - inaccessible (private/access-gated) repos are reported as UNVERIFIED,
+#       never guessed at
+#
+# Manifests are coordination metadata, not architectural or runtime truth —
+# ops/state/truth/sources.json stays the arbiter. This is a planner's checker,
+# not an enforcement gate; it is run manually / from VM sessions, not CI.
+#
+# Exit codes: 0 ok (warnings allowed) · 1 findings under --strict · 2 malformed
+# manifest or usage error.
+set -euo pipefail
+
+usage() {
+  echo "usage: check-pr-stack.sh [--repo-root DIR] [--stack ID] [--offline] [--strict]"
+}
+
+REPO_ROOT="."
+STRICT=0
+OFFLINE=0
+ONLY_STACK=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root) REPO_ROOT="${2:?--repo-root needs a value}"; shift 2 ;;
+    --stack)     ONLY_STACK="${2:?--stack needs a value}"; shift 2 ;;
+    --offline)   OFFLINE=1; shift ;;
+    --strict)    STRICT=1; shift ;;
+    -h|--help)   usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+cd "$REPO_ROOT" || { echo "FAIL cannot cd to repo root: $REPO_ROOT" >&2; exit 2; }
+STACKS_DIR="ops/coordination/stacks"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+FINDINGS=0
+MALFORMED=0
+pass()     { echo -e "${GREEN}  ok${NC}  $1"; }
+note()     { echo -e "  --  $1"; }
+finding()  { echo -e "${YELLOW}  !!${NC}  $1"; FINDINGS=$((FINDINGS + 1)); }
+malformed(){ echo -e "${RED}  FAIL${NC}  $1"; MALFORMED=$((MALFORMED + 1)); }
+
+# Close-keyword next to an issue number (GitHub auto-close syntax). Optional
+# repo prefix (org/repo#N). Word-bounded so e.g. "prefix #12" does not match.
+CLOSE_KW_RE='\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[[:space:]:]+([A-Za-z0-9._/-]+)?#[0-9]+'
+STATUS_ENUM='none|planned|in_progress|merged|adopted'
+
+echo "check-pr-stack"
+
+if [ ! -d "$STACKS_DIR" ]; then
+  malformed "stacks directory missing: $STACKS_DIR"
+  exit 2
+fi
+
+GH_OK=0
+if [ "$OFFLINE" -eq 1 ]; then
+  note "offline mode: gh-backed issue/PR checks skipped"
+elif ! command -v gh >/dev/null 2>&1; then
+  note "gh not installed — gh-backed checks skipped (shape validation only)"
+elif ! gh auth status >/dev/null 2>&1; then
+  note "gh not authenticated — gh-backed checks skipped (shape validation only)"
+else
+  GH_OK=1
+fi
+
+scalar() { # scalar <key> <file> — first top-level "key: value", quotes stripped
+  awk -F': ' -v k="$1" '$1 == k { sub(/^[^:]+: */, ""); gsub(/^["'\'']|["'\'']$/, ""); print; exit }' "$2"
+}
+
+CHECKED=0
+for manifest in "$STACKS_DIR"/*.stack.yaml; do
+  [ -e "$manifest" ] || { malformed "no *.stack.yaml manifests in $STACKS_DIR"; break; }
+  fname="$(basename "$manifest")"
+
+  stack_id="$(scalar stack_id "$manifest")"
+  if [ -n "$ONLY_STACK" ] && [ "$stack_id" != "$ONLY_STACK" ] && [ "$fname" != "$ONLY_STACK.stack.yaml" ]; then
+    continue
+  fi
+  CHECKED=$((CHECKED + 1))
+  echo "── $fname"
+
+  schema="$(scalar schema "$manifest")"
+  anchor="$(scalar anchor_issue "$manifest")"
+
+  if [ "$schema" = "icn-pr-stack/v1" ]; then
+    pass "schema: icn-pr-stack/v1"
+  else
+    malformed "schema must be icn-pr-stack/v1 (got: '${schema:-<missing>}')"
+  fi
+
+  if [ -z "$stack_id" ] || ! echo "$stack_id" | grep -qE '^[a-z0-9][a-z0-9-]*$'; then
+    malformed "stack_id missing or not kebab-case (got: '${stack_id:-<missing>}')"
+  elif [ "$fname" != "$stack_id.stack.yaml" ]; then
+    malformed "filename $fname does not match stack_id '$stack_id'"
+  else
+    pass "stack_id matches filename"
+  fi
+
+  anchor_repo=""; anchor_num=""
+  if echo "$anchor" | grep -qE '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+$'; then
+    anchor_repo="${anchor%%#*}"
+    anchor_num="${anchor##*#}"
+    pass "anchor_issue: $anchor"
+  else
+    malformed "anchor_issue must be org/repo#N (got: '${anchor:-<missing>}')"
+  fi
+
+  # Close-keyword scan of the manifest text itself: a manifest must never
+  # carry auto-close phrasing that could be pasted into a PR body.
+  kw_hits="$(grep -inE "$CLOSE_KW_RE" "$manifest" || true)"
+  if [ -n "$kw_hits" ]; then
+    finding "close-keyword next to an issue number in manifest text:"
+    echo "$kw_hits" | sed 's/^/        /'
+  else
+    pass "no close-keyword near issue numbers in manifest text"
+  fi
+
+  # Stage records: NUM|REPO|STATUS|DEPS|PRS ("-" = key absent).
+  stage_rows="$(awk '
+    function flush() { if (stage != "") printf "%s|%s|%s|%s|%s\n", stage, repo, status, deps, prs }
+    function val(s) { sub(/^[^:]*:[[:space:]]*/, "", s); gsub(/^["'\''[:space:]]+|["'\''[:space:]]+$/, "", s); return s }
+    /^stages:/ { in_s = 1; next }
+    in_s && /^[^[:space:]#]/ { flush(); stage = ""; in_s = 0 }
+    in_s && /^[[:space:]]*-[[:space:]]*stage:/ {
+      flush(); stage = val($0); repo = "-"; status = "-"; deps = "-"; prs = "-"; next
+    }
+    in_s && stage != "" {
+      if ($0 ~ /^[[:space:]]*repo:/)              repo = val($0)
+      else if ($0 ~ /^[[:space:]]*status:/)       status = val($0)
+      else if ($0 ~ /^[[:space:]]*depends_on_stages:/) deps = val($0)
+      else if ($0 ~ /^[[:space:]]*merged_prs:/)   prs = val($0)
+    }
+    END { flush() }
+  ' "$manifest")"
+
+  if [ -z "$stage_rows" ]; then
+    malformed "no stages found (need a 'stages:' block with '- stage: N' entries)"
+    continue
+  fi
+
+  declare -A st_repo=() st_status=() st_deps=() st_prs=()
+  stage_order=""
+  stages_ok=1
+  while IFS='|' read -r num repo status deps prs; do
+    if ! echo "$num" | grep -qE '^[0-9]+$'; then
+      malformed "stage number not numeric: '$num'"; stages_ok=0; continue
+    fi
+    if [ -n "${st_repo[$num]+x}" ]; then
+      malformed "duplicate stage number: $num"; stages_ok=0; continue
+    fi
+    if ! echo "$repo" | grep -qE '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$'; then
+      malformed "stage $num: repo must be org/name (got: '$repo')"; stages_ok=0
+    fi
+    if ! echo "$status" | grep -qE "^(${STATUS_ENUM})$"; then
+      malformed "stage $num: status '$status' not in vocabulary (${STATUS_ENUM})"; stages_ok=0
+    fi
+    st_repo[$num]="$repo"; st_status[$num]="$status"; st_deps[$num]="$deps"; st_prs[$num]="$prs"
+    stage_order="$stage_order $num"
+  done <<< "$stage_rows"
+
+  if [ "$stages_ok" -eq 1 ]; then
+    pass "$(echo "$stage_order" | wc -w) stages parsed, statuses in vocabulary"
+  fi
+
+  # Dependency + ordering rules. Declared deps must exist and point at earlier
+  # stages; a merged/adopted stage requires all its deps merged/adopted. When
+  # depends_on_stages is absent, the default is every earlier non-'none' stage.
+  for num in $stage_order; do
+    deps="${st_deps[$num]}"
+    dep_list=""
+    if [ "$deps" = "-" ]; then
+      for other in $stage_order; do
+        if [ "$other" -lt "$num" ] && [ "${st_status[$other]}" != "none" ]; then
+          dep_list="$dep_list $other"
+        fi
+      done
+    else
+      dep_list="$(echo "$deps" | tr -d '[]' | tr ',' ' ')"
+      for dep in $dep_list; do
+        if [ -z "${st_repo[$dep]+x}" ]; then
+          malformed "stage $num: depends_on_stages references missing stage $dep"
+        elif [ "$dep" = "$num" ]; then
+          malformed "stage $num: depends on itself"
+        fi
+      done
+    fi
+    case "${st_status[$num]}" in
+      merged|adopted)
+        for dep in $dep_list; do
+          [ -n "${st_status[$dep]+x}" ] || continue
+          case "${st_status[$dep]}" in
+            merged|adopted) ;;
+            *) finding "stage $num (${st_repo[$num]}) is '${st_status[$num]}' but upstream stage $dep (${st_repo[$dep]:-?}) is only '${st_status[$dep]}' — downstream must not land before upstream" ;;
+          esac
+        done
+        ;;
+    esac
+  done
+
+  # gh-backed checks.
+  if [ "$GH_OK" -eq 1 ] && [ -n "$anchor_num" ]; then
+    if anchor_state="$(gh issue view "$anchor_num" --repo "$anchor_repo" --json state --jq .state 2>/dev/null)"; then
+      pass "anchor issue $anchor exists (state: $anchor_state)"
+    else
+      finding "anchor issue $anchor not found or not accessible"
+    fi
+
+    for num in $stage_order; do
+      prs="${st_prs[$num]}"
+      if [ "$prs" = "-" ] || [ -z "$(echo "$prs" | tr -d '[] ,')" ]; then
+        continue
+      fi
+      repo="${st_repo[$num]}"
+      for pr in $(echo "$prs" | tr -d '[]' | tr ',' ' '); do
+        if ! pr_json="$(gh pr view "$pr" --repo "$repo" --json state,body 2>/dev/null)"; then
+          note "stage $num: $repo#$pr UNVERIFIED (repo/PR not accessible from here — not inventing state)"
+          continue
+        fi
+        pr_state="$(echo "$pr_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])')"
+        if [ "$pr_state" = "MERGED" ]; then
+          pass "stage $num: $repo#$pr is MERGED as listed"
+        else
+          finding "stage $num: $repo#$pr listed in merged_prs but state is $pr_state"
+        fi
+        pr_body="$(echo "$pr_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["body"] or "")')"
+        if echo "$pr_body" | grep -qE "Refs[[:space:]]+([A-Za-z0-9._/-]+)?#${anchor_num}\b"; then
+          pass "stage $num: $repo#$pr body Refs the anchor (#${anchor_num})"
+        else
+          finding "stage $num: $repo#$pr body has no 'Refs #${anchor_num}' for the stack anchor"
+        fi
+        kw="$(echo "$pr_body" | grep -inE "\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[[:space:]:]+([A-Za-z0-9._/-]+)?#${anchor_num}\b" || true)"
+        if [ -n "$kw" ]; then
+          finding "stage $num: $repo#$pr body uses a close-keyword next to the anchor issue:"
+          echo "$kw" | sed 's/^/        /'
+        fi
+      done
+    done
+  fi
+done
+
+if [ "$CHECKED" -eq 0 ] && [ -n "$ONLY_STACK" ]; then
+  malformed "no manifest matched --stack $ONLY_STACK"
+fi
+
+echo
+if [ "$MALFORMED" -gt 0 ]; then
+  echo "check-pr-stack: $MALFORMED malformed, $FINDINGS finding(s)"
+  exit 2
+fi
+if [ "$FINDINGS" -gt 0 ]; then
+  if [ "$STRICT" -eq 1 ]; then
+    echo "check-pr-stack: $FINDINGS finding(s) (strict: failing)"
+    exit 1
+  fi
+  echo "check-pr-stack: $FINDINGS finding(s) (warning-mode)"
+  exit 0
+fi
+echo "check-pr-stack: clean ($CHECKED manifest(s))"

--- a/scripts/check-pr-stack.sh
+++ b/scripts/check-pr-stack.sh
@@ -60,9 +60,13 @@ finding()  { echo -e "${YELLOW}  !!${NC}  $1"; FINDINGS=$((FINDINGS + 1)); }
 malformed(){ echo -e "${RED}  FAIL${NC}  $1"; MALFORMED=$((MALFORMED + 1)); }
 
 # Close-keyword next to an issue number (GitHub auto-close syntax). Optional
-# repo prefix (org/repo#N). Word-bounded so e.g. "prefix #12" does not match.
-CLOSE_KW_RE='\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[[:space:]:]+([A-Za-z0-9._/-]+)?#[0-9]+'
-STATUS_ENUM='none|planned|in_progress|merged|adopted'
+# repo prefix (org/repo#N). ERE-safe boundaries only: `\b` is not portable in
+# POSIX ERE (grep -E), so the leading boundary is `(^|[^A-Za-z])` and the
+# trailing one is the required `[[:space:]:]+` separator before the ref.
+CLOSE_KW_RE='(^|[^A-Za-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]:]+([A-Za-z0-9._/-]+)?#[0-9]+'
+# Status vocabulary — kept identical to ops/coordination/PR_STACK_PROTOCOL.md.
+# `none` = a stage in the order with no work planned in this stack.
+STATUS_ENUM='none|planned|implemented|reviewed|merged|adopted'
 
 echo "check-pr-stack"
 
@@ -115,10 +119,13 @@ for manifest in "$STACKS_DIR"/*.stack.yaml; do
     pass "stack_id matches filename"
   fi
 
-  anchor_repo=""; anchor_num=""
+  anchor_repo=""; anchor_num=""; anchor_repo_re=""
   if echo "$anchor" | grep -qE '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+$'; then
     anchor_repo="${anchor%%#*}"
     anchor_num="${anchor##*#}"
+    # Escape regex-special chars (only '.' is possible in a repo slug) so the
+    # anchor repo can be matched literally inside ERE patterns below.
+    anchor_repo_re="$(printf '%s' "$anchor_repo" | sed 's/[.]/\\./g')"
     pass "anchor_issue: $anchor"
   else
     malformed "anchor_issue must be org/repo#N (got: '${anchor:-<missing>}')"
@@ -181,9 +188,12 @@ for manifest in "$STACKS_DIR"/*.stack.yaml; do
     pass "$(echo "$stage_order" | wc -w) stages parsed, statuses in vocabulary"
   fi
 
-  # Dependency + ordering rules. Declared deps must exist and point at earlier
-  # stages; a merged/adopted stage requires all its deps merged/adopted. When
-  # depends_on_stages is absent, the default is every earlier non-'none' stage.
+  # Dependency + ordering rules. A merged/adopted stage requires all its deps
+  # merged/adopted. Declared depends_on_stages may reference ANY other stage
+  # (the protocol allows a lower-numbered stage to depend on higher-numbered
+  # ones — e.g. a dashboard consuming downstream envelopes); they need only
+  # exist and not be self-referential. When depends_on_stages is absent, the
+  # default is every earlier non-'none' stage.
   for num in $stage_order; do
     deps="${st_deps[$num]}"
     dep_list=""
@@ -242,12 +252,21 @@ for manifest in "$STACKS_DIR"/*.stack.yaml; do
           finding "stage $num: $repo#$pr listed in merged_prs but state is $pr_state"
         fi
         pr_body="$(echo "$pr_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["body"] or "")')"
-        if echo "$pr_body" | grep -qE "Refs[[:space:]]+([A-Za-z0-9._/-]+)?#${anchor_num}\b"; then
-          pass "stage $num: $repo#$pr body Refs the anchor (#${anchor_num})"
+        # A bare "#N" resolves to an issue in the PR's OWN repo. It only points
+        # at the stack anchor when the PR lives in the anchor repo; a downstream
+        # PR must spell out the full "anchor_repo#N" cross-repo reference, or it
+        # links its own repo's issue #N and the anchor is never actually cited.
+        if [ "$repo" = "$anchor_repo" ]; then
+          ref_re="Refs[[:space:]]+(${anchor_repo_re}#|#)${anchor_num}([^0-9]|$)"
         else
-          finding "stage $num: $repo#$pr body has no 'Refs #${anchor_num}' for the stack anchor"
+          ref_re="Refs[[:space:]]+${anchor_repo_re}#${anchor_num}([^0-9]|$)"
         fi
-        kw="$(echo "$pr_body" | grep -inE "\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\b[[:space:]:]+([A-Za-z0-9._/-]+)?#${anchor_num}\b" || true)"
+        if echo "$pr_body" | grep -qE "$ref_re"; then
+          pass "stage $num: $repo#$pr body Refs the anchor ($anchor)"
+        else
+          finding "stage $num: $repo#$pr body has no 'Refs $anchor' for the stack anchor"
+        fi
+        kw="$(echo "$pr_body" | grep -inE "(^|[^A-Za-z])(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]:]+([A-Za-z0-9._/-]+)?#${anchor_num}([^0-9]|$)" || true)"
         if [ -n "$kw" ]; then
           finding "stage $num: $repo#$pr body uses a close-keyword next to the anchor issue:"
           echo "$kw" | sed 's/^/        /'

--- a/scripts/test-check-pr-stack.sh
+++ b/scripts/test-check-pr-stack.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# test-check-pr-stack.sh — fixture-based tests for scripts/check-pr-stack.sh.
+#
+# Everything runs --offline against throwaway fixture repo-roots, so the tests
+# need no network, no gh, and never touch real manifests except the final
+# read-only pass over this repo's own stacks/ directory.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="${SCRIPT_DIR}/check-pr-stack.sh"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TMP="$(mktemp -d /tmp/icn-pr-stack-test-XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+# expect <name> <expected-exit> <fixture-root> [extra checker args...]
+expect() {
+  local name="$1" want="$2" root="$3"
+  shift 3
+  local got=0
+  bash "$CHECKER" --repo-root "$root" --offline "$@" >"$TMP/out.log" 2>&1 || got=$?
+  if [ "$got" -eq "$want" ]; then
+    echo "  ok  $name (exit $got)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $name: expected exit $want, got $got"
+    sed 's/^/        /' "$TMP/out.log"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+mkfixture() { # mkfixture <name> -> prints root; manifest body on stdin
+  local root="$TMP/$1"
+  mkdir -p "$root/ops/coordination/stacks"
+  cat > "$root/ops/coordination/stacks/$2"
+  echo "$root"
+}
+
+echo "test-check-pr-stack"
+
+# 1. Good manifest: upstream merged, downstream planned.
+root="$(mkfixture good good-stack.stack.yaml <<'EOF'
+schema: icn-pr-stack/v1
+stack_id: good-stack
+anchor_issue: example-org/example#1
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: merged
+    merged_prs: [10]
+  - stage: 2
+    repo: example-org/downstream
+    status: planned
+    merged_prs: []
+EOF
+)"
+expect "good manifest passes" 0 "$root"
+expect "good manifest passes strict" 0 "$root" --strict
+
+# 2. Malformed: missing anchor_issue.
+root="$(mkfixture no-anchor no-anchor.stack.yaml <<'EOF'
+schema: icn-pr-stack/v1
+stack_id: no-anchor
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: planned
+EOF
+)"
+expect "missing anchor_issue is malformed" 2 "$root"
+
+# 3. Malformed: bad schema line.
+root="$(mkfixture bad-schema bad-schema.stack.yaml <<'EOF'
+schema: something-else/v9
+stack_id: bad-schema
+anchor_issue: example-org/example#1
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: planned
+EOF
+)"
+expect "wrong schema is malformed" 2 "$root"
+
+# 4. Malformed: status outside the vocabulary.
+root="$(mkfixture bad-status bad-status.stack.yaml <<'EOF'
+schema: icn-pr-stack/v1
+stack_id: bad-status
+anchor_issue: example-org/example#1
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: shipped
+EOF
+)"
+expect "unknown status is malformed" 2 "$root"
+
+# 5. Malformed: filename does not match stack_id.
+root="$(mkfixture wrong-name mismatch.stack.yaml <<'EOF'
+schema: icn-pr-stack/v1
+stack_id: something-else
+anchor_issue: example-org/example#1
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: planned
+EOF
+)"
+expect "filename/stack_id mismatch is malformed" 2 "$root"
+
+# 6. Downstream merged before upstream: warning-mode passes, strict fails.
+root="$(mkfixture out-of-order out-of-order.stack.yaml <<'EOF'
+schema: icn-pr-stack/v1
+stack_id: out-of-order
+anchor_issue: example-org/example#1
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: planned
+  - stage: 2
+    repo: example-org/downstream
+    status: merged
+EOF
+)"
+expect "downstream-before-upstream warns (non-strict exit 0)" 0 "$root"
+expect "downstream-before-upstream fails under --strict" 1 "$root" --strict
+
+# 7. Explicit depends_on_stages overrides the default ordering.
+root="$(mkfixture explicit-deps explicit-deps.stack.yaml <<'EOF'
+schema: icn-pr-stack/v1
+stack_id: explicit-deps
+anchor_issue: example-org/example#1
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: merged
+  - stage: 2
+    repo: example-org/dashboard
+    status: planned
+    depends_on_stages: [1, 3]
+  - stage: 3
+    repo: example-org/downstream
+    status: merged
+    depends_on_stages: [1]
+EOF
+)"
+expect "stage 3 merged before stage 2 is fine with explicit deps" 0 "$root" --strict
+
+# 8. depends_on_stages referencing a missing stage is malformed.
+root="$(mkfixture bad-dep bad-dep.stack.yaml <<'EOF'
+schema: icn-pr-stack/v1
+stack_id: bad-dep
+anchor_issue: example-org/example#1
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: planned
+    depends_on_stages: [7]
+EOF
+)"
+expect "dep on missing stage is malformed" 2 "$root"
+
+# 9. Close-keyword next to an issue number in manifest text.
+root="$(mkfixture close-kw close-kw.stack.yaml <<'EOF'
+schema: icn-pr-stack/v1
+stack_id: close-kw
+anchor_issue: example-org/example#1
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: planned
+    note: "Closes #1 when done"
+EOF
+)"
+expect "close-keyword in manifest warns (non-strict exit 0)" 0 "$root"
+expect "close-keyword in manifest fails under --strict" 1 "$root" --strict
+
+# 10. --stack filter: unknown id is an error, matching id checks one manifest.
+root="$(mkfixture filter filter.stack.yaml <<'EOF'
+schema: icn-pr-stack/v1
+stack_id: filter
+anchor_issue: example-org/example#1
+stages:
+  - stage: 1
+    repo: example-org/example
+    status: planned
+EOF
+)"
+expect "--stack with unknown id errors" 2 "$root" --stack nope
+expect "--stack with matching id passes" 0 "$root" --stack filter
+
+# 11. The real repo manifests validate offline.
+expect "real repo manifests pass offline" 0 "$REPO_ROOT"
+
+echo
+echo "test-check-pr-stack: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test-check-pr-stack.sh
+++ b/scripts/test-check-pr-stack.sh
@@ -32,7 +32,7 @@ expect() {
   fi
 }
 
-mkfixture() { # mkfixture <name> -> prints root; manifest body on stdin
+mkfixture() { # mkfixture <dir-name> <manifest-filename> -> prints root; manifest body on stdin
   local root="$TMP/$1"
   mkdir -p "$root/ops/coordination/stacks"
   cat > "$root/ops/coordination/stacks/$2"
@@ -41,7 +41,8 @@ mkfixture() { # mkfixture <name> -> prints root; manifest body on stdin
 
 echo "test-check-pr-stack"
 
-# 1. Good manifest: upstream merged, downstream planned.
+# 1. Good manifest: upstream merged, mid/downstream stages exercise the
+# 'implemented' and 'none' statuses so the full vocabulary passes end-to-end.
 root="$(mkfixture good good-stack.stack.yaml <<'EOF'
 schema: icn-pr-stack/v1
 stack_id: good-stack
@@ -53,7 +54,11 @@ stages:
     merged_prs: [10]
   - stage: 2
     repo: example-org/downstream
-    status: planned
+    status: implemented
+    merged_prs: []
+  - stage: 3
+    repo: example-org/mirror
+    status: none
     merged_prs: []
 EOF
 )"
@@ -112,6 +117,9 @@ EOF
 expect "filename/stack_id mismatch is malformed" 2 "$root"
 
 # 6. Downstream merged before upstream: warning-mode passes, strict fails.
+# Upstream is 'reviewed' (in the vocabulary but intentionally NOT equivalent to
+# 'merged'), so the ordering check must still fire — this doubles as coverage
+# for the 'reviewed' status.
 root="$(mkfixture out-of-order out-of-order.stack.yaml <<'EOF'
 schema: icn-pr-stack/v1
 stack_id: out-of-order
@@ -119,14 +127,14 @@ anchor_issue: example-org/example#1
 stages:
   - stage: 1
     repo: example-org/example
-    status: planned
+    status: reviewed
   - stage: 2
     repo: example-org/downstream
     status: merged
 EOF
 )"
-expect "downstream-before-upstream warns (non-strict exit 0)" 0 "$root"
-expect "downstream-before-upstream fails under --strict" 1 "$root" --strict
+expect "downstream-merged-before-upstream-reviewed warns (non-strict exit 0)" 0 "$root"
+expect "downstream-merged-before-upstream-reviewed fails under --strict" 1 "$root" --strict
 
 # 7. Explicit depends_on_stages overrides the default ordering.
 root="$(mkfixture explicit-deps explicit-deps.stack.yaml <<'EOF'


### PR DESCRIPTION
## Summary

Makes the cross-repo PR stack protocol machine-readable: extends `ops/coordination/PR_STACK_PROTOCOL.md` to the full 6-stage ecosystem order, records the current control-plane stack as the first manifest under `ops/coordination/stacks/`, adds a `gh`-based checker with offline shape validation, adds stack PR/handoff templates, and flips the `cross_repo_pr_stacks` truth-domain owner to the now-existing manifests directory.

## Layer classification

Ops coordination (control-plane metadata + one shell checker). No runtime/protocol code, no Rust, no workflows.

## Boundary check / non-goals

- **Control-plane coordination only.** No runtime/protocol code.
- **No downstream repo edits** (nycn, icn-infra, icn-learn, icn-community-bridge, .github untouched).
- **No claim-lint caller workflows yet** — downstream adoption remains future work, and the manifest says so (`no-downstream-adoption-yet`).
- **No NYCN lock refresh yet** (that is the intended next stage, recorded as `planned`).
- **No readiness, pilot, live-federation, or production claims.** The manifest carries an explicit `non_claims` block, and the protocol states that no readiness claim may be inferred from any stack status.
- Manifests are **coordination metadata, not architectural or runtime truth** — `ops/state/truth/sources.json` remains the arbiter.

## What changed

- `ops/coordination/PR_STACK_PROTOCOL.md` — merge order extended from 3 to 6 stages (icn → icn-infra → nycn → icn-learn → icn-community-bridge → .github); new stack status vocabulary (`planned / implemented / reviewed / merged / adopted`, with explicit "does NOT mean" columns); new stack-manifests section; PR-body item 9 now requires dependency statuses in that vocabulary.
- `ops/coordination/stacks/control-plane-v1.stack.yaml` — first manifest (`icn-pr-stack/v1`): anchor `InterCooperative-Network/icn#2141`, six stages with per-stage `status`/`depends_on_stages`/`merged_prs`, `non_claims`, and dependency policy. Stage 1 (icn) records merged PRs #2354/#2356/#2358; stages 3–5 are `planned`; stage 2 (icn-infra dashboard) explicitly depends on stages 1,3,4,5 because it consumes downstream status envelopes; stage 6 (.github) is `none` (no work planned).
- `scripts/check-pr-stack.sh` — validates manifests. Offline (always): required keys, status vocabulary, unique stages, dependency references, downstream-merged-before-upstream detection, close-keyword-near-issue scan of manifest text. Online (authenticated `gh`, skipped with `--offline` or when `gh` is absent/unauthenticated): anchor issue exists, listed PRs are actually MERGED, PR bodies `Refs` the anchor and carry no close-keyword near it; inaccessible private repos are reported UNVERIFIED, never guessed. Flags: `--repo-root`, `--stack`, `--offline`, `--strict`. Exit codes: 0 ok / 1 strict findings / 2 malformed.
- `scripts/test-check-pr-stack.sh` — 15 fixture-based tests (offline-only, temp dirs): good manifest passes, malformed variants exit 2, downstream-before-upstream warns (0) / fails strict (1), explicit `depends_on_stages` overrides default ordering, close-keyword caught, `--stack` filter, real repo manifests pass.
- `ops/coordination/templates/` — `stack-pr-body-template.md`, `downstream-caller-workflow-handoff.md`, `upstream-lock-refresh-handoff.md` (short, repeatability-focused).
- `ops/state/truth/sources.json` — `cross_repo_pr_stacks` owner flipped `ops/coordination/PR_STACK_PROTOCOL.md` → `ops/coordination/stacks/`, exactly as the previous entry's description said it would once the directory existed. `check-truth-spine.py` needed no change: directory owners already validate (`docs/adr/` precedent).

## What did not change

- No CI wiring for the checker. The approved plan wired `check-truth-spine.py` into the drift workflow explicitly but deliberately did not specify CI wiring for this checker ("planner + checker, not enforcement"); its highest-value checks need an authenticated cross-repo `gh` view of private downstream PR bodies that public CI does not have. It is manually runnable; the protocol documents this and names wiring the offline subset as a possible later ratchet.
- `check-truth-spine.py`, `check-preflight-consistency.sh`, drift workflow, claim linter, `repo-map.json` — untouched.
- `docs/registry.toml` / generated indexes — untouched; new files live under `ops/coordination/`, outside doc-control registry scope (doc-control gate passes unchanged).
- The known stale `sprint_state` truth-spine warning (106d) — deliberately untouched, pending its own decision.

## Validation evidence

- `bash scripts/check-pr-stack.sh --repo-root . --offline` → clean, exit 0.
- `bash scripts/check-pr-stack.sh --repo-root .` (online) → anchor #2141 exists (OPEN); #2354/#2356/#2358 each verified MERGED, each body `Refs #2141`, no close-keywords → clean, exit 0. `--strict` also exit 0.
- `gh`-absent degradation proven via stripped-PATH run → "gh not installed — gh-backed checks skipped", exit 0.
- `bash scripts/test-check-pr-stack.sh` → **15 passed, 0 failed**.
- `python3 scripts/check-truth-spine.py` → new owner `ops/coordination/stacks/` validates; only the pre-existing `sprint_state` staleness warning remains; exit 0.
- `python3 -m json.tool` on sources.json + repo-map.json → valid.
- `check-preflight-consistency.sh`, `ops/scripts/drift-check.sh`, `ops/scripts/what-matters-now.sh --drift`, `doc_control_check.py`, `freshness-check.py`, `compliance_linter.py`, `readiness_overclaim_linter.py` → all pass.
- `shellcheck` on both scripts → no warnings above style level (two SC2001 style notes retained: `sed` is used for multi-line indentation).
- `git diff --check` → clean.

## Issue status

Refs #2141 (stack anchor — left open). Refs #2357 (PR3 lineage: the claim-lint reusable workflow this stack's later stages will call — left open).

## Review-thread status

None yet (fresh PR).

## Cross-repo dependency status

- **Upstream:** builds on merged icn PRs #2354 (`fc6e3c3d`), #2356 (`5b99d981`), #2358 (`c78a9f7a`) — all `merged`.
- **Downstream:** nycn / icn-learn / icn-community-bridge stages are `planned`, not started; icn-infra dashboard `planned` (depends on downstream envelopes); .github `none`. No downstream repo is touched or claimed as adopted by this PR.

## Review notes / known warnings

- `scripts/test-check-pr-stack.sh:175` contains the literal string `Closes #1` **inside a negative-test fixture** (heredoc content proving the checker catches close-keywords). It is committed file content, not a PR/commit message, so GitHub auto-close never parses it.
- The manifest parsing contract is deliberately line-oriented (scalars one per line, flow-style lists) so the checker needs no YAML library; the manifest header documents this.
- Checker `Refs`-check severity was chosen after verifying all three merged stack PR bodies already carry `Refs #2141` — so `--strict` is clean on live data today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
