### PR TITLE
docs(ops): record infra dashboard adoption

### DIFF
--- a/ops/coordination/stacks/control-plane-v1.stack.yaml
+++ b/ops/coordination/stacks/control-plane-v1.stack.yaml
@@ -43,10 +43,10 @@ stages:
 
   - stage: 2
     repo: InterCooperative-Network/icn-infra
-    status: planned
+    status: adopted
     depends_on_stages: [1, 3, 4, 5]
-    merged_prs: []
-    note: "Ecosystem dashboard home. Consumes downstream status envelopes, so in THIS stack it intentionally depends on stages 3-5 despite its lower stage number."
+    merged_prs: [4]
+    note: "Ecosystem dashboard home. Consumes downstream status envelopes, so in THIS stack it intentionally depends on stages 3-5 despite its lower stage number. Adopted on icn-infra main: a static coordination dashboard (docs/status/ecosystem-dashboard.md + .json, schema icn-ecosystem-dashboard/v1) that reads the nycn/icn-learn/icn-community-bridge status envelopes, landed via PR #4 `docs(status): add ecosystem dashboard snapshot` (merge 7c2dd827). NOTE: icn-infra adopts by CONSUMING the downstream envelopes into a dashboard — unlike stages 3-5 it is NOT a claim-lint caller and has no upstream lock or status envelope of its own; repo-map.json#org_repos.icn-infra records a `dashboard` field (not lock/status_envelope/caller). 'adopted' here = the dashboard artifact landed on the default branch and is recorded; it is a dated static snapshot, NOT a live health check, deployment, readiness, pilot, or runtime-verification claim."
 
   - stage: 3
     repo: InterCooperative-Network/nycn

--- a/ops/state/config/repo-map.json
+++ b/ops/state/config/repo-map.json
@@ -28,7 +28,7 @@
     }
   },
   "org_repos": {
-    "description": "InterCooperative-Network org repos and adjacent private layers, seen from icn: repo discovery / coordination metadata for the ecosystem control plane. NOT architectural truth — ops/state/truth/sources.json wins on any truth-ownership conflict, and docs/ATLAS.md + ops/state/ecosystem.json remain the role/boundary index. Fields record CURRENT state only (a null lock/envelope means none exists yet; planned is not done). stack_stage = cross-repo merge order per ops/coordination/PR_STACK_PROTOCOL.md (1=icn canonical first; 6=org profile mirror last; null=not part of PR stacks).",
+    "description": "InterCooperative-Network org repos and adjacent private layers, seen from icn: repo discovery / coordination metadata for the ecosystem control plane. NOT architectural truth — ops/state/truth/sources.json wins on any truth-ownership conflict, and docs/ATLAS.md + ops/state/ecosystem.json remain the role/boundary index. Fields record CURRENT state only (a null lock/envelope means none exists yet; planned is not done). stack_stage = cross-repo merge order per ops/coordination/PR_STACK_PROTOCOL.md (1=icn canonical first; 6=org profile mirror last; null=not part of PR stacks). dashboard (present only on the ecosystem dashboard-home repo, icn-infra) points at a static coordination-snapshot artifact (schema icn-ecosystem-dashboard/v1, runtime_health:false) — it is a dated snapshot, NOT a status envelope, a claim-lint caller, or a live-health source.",
     "repos": {
       "nycn": {
         "remote": "InterCooperative-Network/nycn",
@@ -49,8 +49,15 @@
         "lock": null,
         "status_envelope": null,
         "claim_enforcement": "none",
+        "dashboard": {
+          "path": "docs/status/ecosystem-dashboard.md",
+          "machine_readable": "docs/status/ecosystem-dashboard.json",
+          "schema": "icn-ecosystem-dashboard/v1",
+          "mode": "static-coordination-snapshot",
+          "runtime_health": false
+        },
         "stack_stage": 2,
-        "role_note": "Org operating contracts: cross-repo boundary, public-claims gates, source classification"
+        "role_note": "Org operating contracts: cross-repo boundary, public-claims gates, source classification. Ecosystem dashboard home (control-plane-v1 stage 2): a static coordination snapshot of the downstream status envelopes landed via icn-infra#4 (see `dashboard`). icn-infra is the dashboard home, NOT a claim-lint caller — it has no upstream lock or status envelope of its own (lock/status_envelope stay null, claim_enforcement none). The dashboard is a dated snapshot, not a live health check or readiness claim."
       },
       "icn-learn": {
         "remote": "InterCooperative-Network/icn-learn",


### PR DESCRIPTION
## Summary

Records `control-plane-v1` stage 2 (`icn-infra`) adoption now that the ecosystem dashboard has landed in icn-infra (PR #4), **without** treating icn-infra like a downstream claim-lint caller. **Coordination metadata only.**

## Layer classification

Ops coordination metadata — `ops/coordination/stacks/control-plane-v1.stack.yaml` + `ops/state/config/repo-map.json`. No runtime, no Rust, no workflows, no downstream/icn-infra content changes.

## Boundary check / non-goals

- **Coordination metadata only.**
- **No runtime change.**
- **No downstream workflow change in this PR** (the dashboard already landed in icn-infra#4).
- **No lock refresh in this PR.**
- **No dependency drift review in this PR.**
- **No infrastructure mutation.**
- **No deployment.**
- **No live health check.**
- **No rehearsal execution claim.**
- **No readiness, pilot, live federation, production, or deployment claim.** `adopted` = the static dashboard artifact landed on icn-infra's default branch and is recorded; it is a dated snapshot.
- **Private overlays, learner data, bridge participants, organizer data, secrets, provider data, DNS data, and K3s data remain out of repo.**
- **Pending locks remain `pending-human-signoff` until a human signs.**
- **Historical proofs remain dated; they are not current runtime verification.**
- **Warning-mode claim-lint is advisory and not readiness proof.**

## What changed

- **stage 2 (icn-infra): `planned` → `adopted`**, `merged_prs: [4]`. The note preserves the `depends_on: [1,3,4,5]` + dashboard-home rationale and clarifies that icn-infra adopts by **consuming** the downstream envelopes into a dashboard (schema `icn-ecosystem-dashboard/v1`, PR #4 merge `7c2dd827`), unlike stages 3–5 which adopt via a claim-lint caller + upstream lock.
- **`repo-map.json#org_repos.icn-infra`**: added a `dashboard` field — `{path, machine_readable, schema: icn-ecosystem-dashboard/v1, mode: static-coordination-snapshot, runtime_health: false}`. **`lock` stays `null`, `status_envelope` stays `null`, `claim_enforcement` stays `"none"`** — icn-infra is the dashboard home, not a claim-lint caller or status-envelope producer. Documented the new `dashboard` field in the `org_repos` description.

## What did not change

- No other stage; stage 1 `merged`, stages 3/4/5 `adopted`, stage 6 `none` — unchanged.
- `schema`, `anchor_issue`, `description`, `dependency_policy` rules of the manifest — unchanged.
- **`icn-infra` is not recorded as a downstream claim-lint caller** (no `ops/upstream/icn.lock.yaml`, no `ops/status-envelope.json`, no caller). `claim_enforcement` stays `none` because no caller exists.
- **`sources.json` unchanged** — the `repo_topology` domain (owner `repo-map.json`, sections include `org_repos`) already covers these fields, and the dashboard is a downstream, non-authoritative artifact, not an ICN truth source.
- No file outside the two coordination-metadata files. No downstream repo, no icn-infra content.

## Evidence

- **ICN #2361** merged, commit `a314934177c4bc263aa5c7dff16717988da08c6b` (the base this PR builds on).
- **icn-infra #4** merged, commit `7c2dd827092280260e9683e06367ca5acf9ce45b`, reviewed head `ebedf1ee2cea36666c6c1396d94b0fc069e78123`; dashboard paths `docs/status/ecosystem-dashboard.md` + `docs/status/ecosystem-dashboard.json` (schema `icn-ecosystem-dashboard/v1`).

## Exact stage status chosen and why

`adopted`. The protocol vocabulary's `adopted` = "a downstream consumer actually uses it"; the manifest note designates stage 2 as the dashboard home that **consumes downstream status envelopes**, and PR #4 landed exactly that consumption (a static dashboard reading the three envelopes) on icn-infra's default branch. The dependency policy is satisfied — stage 2 depends on stages 1 (`merged`), 3/4/5 (`adopted`), all already terminal — so `--strict` ordering passes. No new status value was invented. The note explicitly distinguishes icn-infra's dashboard-consumer adoption from the caller/lock adoption of stages 3–5, so `adopted` is not misread as a caller/lock claim.

## Exact repo-map dashboard fields chosen and why

A `dashboard` object rather than overloading `status_envelope`/`claim_enforcement` (which would falsely imply icn-infra runs a caller or produces an envelope). Fields: `path`, `machine_readable`, `schema: icn-ecosystem-dashboard/v1`, `mode: static-coordination-snapshot`, and `runtime_health: false` — the last makes explicit that the dashboard is not a live-health source. `lock`/`status_envelope` stay `null` and `claim_enforcement` stays `none` because none of those exist for icn-infra.

## Confirmation: icn-infra not recorded as a downstream claim-lint caller

Confirmed. `repo-map.json#org_repos.icn-infra.claim_enforcement` remains `"none"`, `lock` and `status_envelope` remain `null`, and no `.github/workflows/claim-lint.yml` / `.claim-lint.json` exists in icn-infra. The only new field is the `dashboard` descriptor.

## Validation evidence

- `check-pr-stack.sh --offline` clean; `--strict` → exit 0 (stage 2 `adopted` with dependency stages 1/3/4/5 all merged/adopted; ordering passes). Online run verified `icn-infra#4` is MERGED and its body `Refs InterCooperative-Network/icn#2141`.
- `check-truth-spine.py` → only the pre-existing `sprint_state` staleness warning; `repo_topology` owner validates.
- `check-preflight-consistency.sh`, `drift-check.sh`, `doc_control_check.py`, `readiness_overclaim_linter.py` → all pass. `python3 -m json.tool` on `repo-map.json` valid; manifest YAML parses; `git diff --check` clean; no close-keywords; 2 files changed.

## Known warnings / gaps

- Pre-existing `sprint_state` truth-spine staleness warning (untouched, out of scope).
- `adopted` for stage 2 is a coordination fact (dashboard artifact landed); it is not a runtime/pilot/readiness claim. The dashboard is a dated snapshot that goes stale.
- `Security Audit` may remain non-required RUSTSEC noise; a `Test`/`Clippy` runner disk-space flake may recur (one rerun, as in prior stack PRs).

## Issue status

`Refs InterCooperative-Network/icn#2141`, `Refs InterCooperative-Network/icn#2357`, `Refs InterCooperative-Network/icn#2361`, `Refs InterCooperative-Network/icn-infra#4`. No issues closed; no close keywords.

## Cross-repo dependency status

- **Upstream:** stage 1 (icn) `merged`; stages 3 (nycn), 4 (icn-learn), 5 (icn-community-bridge) `adopted` — all satisfied.
- **This stage (stage 2, icn-infra):** advancing to `adopted` (dashboard home).
- **Remaining:** stage 6 (`.github`) `none` — a keep-`none`-vs-final-step decision for a later step, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
