### PR TITLE
ci(bridge): run governed bridge conformance validator in standard checks

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -30,6 +30,11 @@ on:
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'
+      # governed bridge conformance fixtures + validator: the fixtures live under
+      # tools/ (outside docs/**), so trigger the workflow when they or the
+      # validator change, otherwise a fixtures-only PR would not fire this check.
+      - 'tools/bridge-conformance/**'
+      - 'tools/validate-governed-bridge-conformance.py'
   pull_request:
     paths:
       - 'docs/**'
@@ -62,6 +67,11 @@ on:
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'
+      # governed bridge conformance fixtures + validator: the fixtures live under
+      # tools/ (outside docs/**), so trigger the workflow when they or the
+      # validator change, otherwise a fixtures-only PR would not fire this check.
+      - 'tools/bridge-conformance/**'
+      - 'tools/validate-governed-bridge-conformance.py'
   schedule:
     # Sunday at midnight UTC
     - cron: '0 0 * * 0'
@@ -235,6 +245,36 @@ jobs:
           python3 docs/scripts/validate-rehearsal-shell-fixtures.py
         continue-on-error: false
 
+  bridge_conformance:
+    name: Governed Bridge Conformance Fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install pyyaml
+
+      # Guards the governed bridge conformance fixtures (#2375/#2376): the FAKE
+      # fixture sets under tools/bridge-conformance/*/ must keep the minimum
+      # governed-bridge chain honest — binding -> dry-run -> steward review ->
+      # expected receipts — with per-(record,field) review coverage, a required
+      # reviewer authority ref, a dry-run that writes nothing, observe-only
+      # external references, and a conservative privacy scan. The check is
+      # deterministic and offline (reads no source, writes no node, reaches no
+      # network); it validates fake fixtures only — it implements no runtime
+      # bridge, connector, or import.
+      # Manual equivalent: python3 tools/validate-governed-bridge-conformance.py
+      - name: Validate governed bridge conformance fixtures (offline, deterministic)
+        run: |
+          python3 tools/validate-governed-bridge-conformance.py
+        continue-on-error: false
+
   route_inventory:
     name: Check Generated Route Inventory
     runs-on: ubuntu-latest
@@ -298,7 +338,7 @@ jobs:
 
   summary:
     name: Documentation CI Summary
-    needs: [doc_control, lint, freshness, index, fixture_bundle, route_inventory, icnctl_inventory]
+    needs: [doc_control, lint, freshness, index, fixture_bundle, bridge_conformance, route_inventory, icnctl_inventory]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -316,6 +356,12 @@ jobs:
           # drift guard — anything but explicit success fails the summary.
           if [ "${{ needs.fixture_bundle.result }}" != "success" ]; then
             echo "::error::Rehearsal-shell fixture bundle validation did not succeed (result: ${{ needs.fixture_bundle.result }})"
+            exit 1
+          fi
+          # Fail closed, same posture as fixture_bundle: a cancelled or skipped
+          # governed bridge conformance job must not pass the guard.
+          if [ "${{ needs.bridge_conformance.result }}" != "success" ]; then
+            echo "::error::Governed bridge conformance fixture validation did not succeed (result: ${{ needs.bridge_conformance.result }})"
             exit 1
           fi
           if [ "${{ needs.freshness.result }}" = "failure" ]; then


### PR DESCRIPTION
## What

Wires the governed bridge conformance validator into the standard docs/fixture validation path so fake bridge conformance fixtures are checked automatically instead of only by manual invocation.

Single-file change to `.github/workflows/docs-freshness.yml`:
- new `bridge_conformance` job mirroring the existing offline/deterministic rehearsal-shell fixture bundle job (setup-python 3.11 → `pip install pyyaml` → `python3 tools/validate-governed-bridge-conformance.py`, `continue-on-error: false`);
- wired into the `summary` job's fail-closed aggregation gate (same posture as `fixture_bundle`);
- `tools/bridge-conformance/**` and the validator path added to the `push`/`pull_request` path filters, since the fixtures live outside `docs/**` and a fixtures-only change would otherwise not fire the workflow.

## Why

ICN #2375 landed the first fake governed bridge conformance fixture and validator. #2376 tracks the follow-up to place that validator in ordinary repo checks while keeping the fixtures fake, self-contained, and offline. #2376 stays open pending review.

## Validation

- `python3 tools/validate-governed-bridge-conformance.py` → passed (exit 0)
- workflow YAML parses; new job present, wired into `summary.needs` and the fail-closed guard; both path-filter blocks updated
- CI: pending — let CI be the proof

## Non-claims

- no validator logic changes
- no new fixtures
- no runtime bridge implementation
- no connector implementation
- no real data import
- no raw Drive import or live sync
- no private data
- no branch-protection change
- no production, pilot-readiness, or live-federation claim
- no payment-processing, wallet, token, cryptocurrency, or settlement framing

## Refs

Refs #2376
Refs #2375