### PR TITLE
tools(bridge): enforce binding-required receipts in conformance fixtures

### DIFF
--- a/tools/bridge-conformance/review-coverage-v0/README.md
+++ b/tools/bridge-conformance/review-coverage-v0/README.md
@@ -38,6 +38,10 @@ proves the minimum invariants from the six governed-bridge docs:
 - a role label is **not** authority proof — a `reviewer_authority_ref` is
   required;
 - approved writes require `BridgeImportReceipt` **plus** the target receipt;
+- **the binding is the per-run receipt contract** — an approved write must also
+  expect every receipt its field's `field_custody_map` entry declares;
+- **every binding custody rule must be exercised** — a `field_custody_map`
+  field that no dry-run action proposes is an error;
 - a verified-transfer `ArtifactReceipt` does **not** satisfy
   `ArtifactRegistrationReceipt`;
 - **action cards are derived read views, not write targets** — no action-card

--- a/tools/validate-governed-bridge-conformance.py
+++ b/tools/validate-governed-bridge-conformance.py
@@ -332,6 +332,7 @@ def check_dry_run(data, binding_ctx, errors, rel):
     actions = require_list(d.get("proposed_actions"), f"{rel}: proposed_actions", errors)
     action_index = {}  # action_id -> (src_ref, field_path, kind)
     coverage = {}  # (src_ref, field_path) -> action_id
+    proposed_fields = set()  # every valid field_path proposed, regardless of action_id validity
     for i, act in enumerate(actions):
         lbl = f"{rel}: proposed_actions[{i}]"
         a = require_mapping(act, lbl, errors)
@@ -360,6 +361,8 @@ def check_dry_run(data, binding_ctx, errors, rel):
                     f"{lbl}.proposed_custody_target.kind {kind!r} != binding's "
                     f"{bound_kind!r} for field {fld!r}"
                 )
+        if fld is not None:
+            proposed_fields.add(fld)
         if aid:
             action_index[aid] = (src, fld, kind)
         if src is not None and fld is not None:
@@ -373,8 +376,9 @@ def check_dry_run(data, binding_ctx, errors, rel):
 
     # Every binding custody rule must be exercised: a field_path declared in
     # field_custody_map that no proposed action references is an unexercised
-    # (and therefore unreviewed, unreceipted) custody rule.
-    proposed_fields = {f for (_src, f, _kind) in action_index.values() if f is not None}
+    # (and therefore unreviewed, unreceipted) custody rule. proposed_fields is
+    # collected independently of action_id validity so a broken action_id does
+    # not cascade into a spurious coverage error here.
     for bound_field in field_map:
         if bound_field not in proposed_fields:
             errors.append(
@@ -545,7 +549,7 @@ def check_expected_receipts(data, binding_ctx, dry_ctx, review_ctx, errors, rel)
                         if br not in rc:
                             errors.append(
                                 f"{lbl}: approved write for field {fld!r} must include "
-                                f"binding-declared receipt {br}"
+                                f"binding-declared receipt {br!r}"
                             )
         if verb == "discard" or kind == DISCARD_KIND:
             if "DiscardDecisionReceipt" not in rc:

--- a/tools/validate-governed-bridge-conformance.py
+++ b/tools/validate-governed-bridge-conformance.py
@@ -371,6 +371,17 @@ def check_dry_run(data, binding_ctx, errors, rel):
             else:
                 coverage[key] = aid
 
+    # Every binding custody rule must be exercised: a field_path declared in
+    # field_custody_map that no proposed action references is an unexercised
+    # (and therefore unreviewed, unreceipted) custody rule.
+    proposed_fields = {f for (_src, f, _kind) in action_index.values() if f is not None}
+    for bound_field in field_map:
+        if bound_field not in proposed_fields:
+            errors.append(
+                f"{rel}: binding field_custody_map[{bound_field!r}] is never exercised "
+                f"by any dry-run proposed action"
+            )
+
     return {
         "dry_run_id": d.get("dry_run_id"),
         "plan_hash": d.get("plan_hash"),
@@ -522,6 +533,20 @@ def check_expected_receipts(data, binding_ctx, dry_ctx, review_ctx, errors, rel)
                     f"{lbl}: {ARTIFACT_TRANSFER_RECEIPT} does not satisfy {REGISTRATION_RECEIPT} "
                     f"(transfer proof is not registry registration)"
                 )
+            # The binding is the per-run receipt contract: an approved write must
+            # expect every receipt its field's custody rule declares. Scoped to
+            # approved writes only — hold/block/discard outcomes must not be
+            # forced to carry write receipts.
+            if aid in action_index:
+                fld = action_index[aid][1]
+                bound = binding_ctx.get("field_map", {}).get(fld) if fld is not None else None
+                if bound is not None:
+                    for br in bound[1]:
+                        if br not in rc:
+                            errors.append(
+                                f"{lbl}: approved write for field {fld!r} must include "
+                                f"binding-declared receipt {br}"
+                            )
         if verb == "discard" or kind == DISCARD_KIND:
             if "DiscardDecisionReceipt" not in rc:
                 errors.append(f"{lbl}: a discard must include DiscardDecisionReceipt")


### PR DESCRIPTION
## What

Hardens the governed bridge conformance validator so the binding is enforced as the per-run contract.

Adds two generic checks:

- approved actions must satisfy the field's binding-declared `required_receipts`;
- every field declared in `field_custody_map` must be exercised by at least one dry-run proposed action.

Also updates the `review-coverage-v0` README to document the new checks.

The binding-declared receipts check is scoped strictly to approved write actions — hold, block, discard, and automatic-block outcomes are not forced to carry write receipts. This scoping is load-bearing: the intake fixture's automatic consent block sits on a field whose binding declares write receipts, and it must keep passing.

## Why

The validator already parsed per-field `required_receipts` (into its binding `field_map`), but did not fully enforce them against per-action expected receipts. PR #2379 also exposed a second generic false-pass class: a binding could declare a custody rule for a field that no dry-run action ever proposed — that was caught manually in review rather than by the validator.

This closes both gaps without adding package-specific semantics, ahead of the next institution fixture.

## Validation

- `python3 tools/validate-governed-bridge-conformance.py` -> passed (both fixtures byte-unchanged)
- `python3 tools/validate-governed-bridge-conformance.py tools/bridge-conformance/review-coverage-v0` -> passed
- `python3 tools/validate-governed-bridge-conformance.py tools/bridge-conformance/nycn-intake-handoff-v0` -> passed
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` -> passed
- negative scratchpad mutations rejected: 7/7, including two differential proofs that each new check fires on its own (a binding-declared extra receipt omitted from per_action rejects with exactly one issue from check 1; a valid-YAML unexercised binding field rejects with exactly one issue from check 2), plus regressions (ArtifactReceipt substitution, automatic block carrying a review receipt, plan-hash mismatch all still reject; the unmodified intake fixture with its automatic blocks still passes)

## Non-claims

- fake fixtures only
- no runtime bridge implementation
- no connector implementation
- no real data import
- no raw Drive import or live sync
- no private data
- no production, pilot-readiness, or live-federation claim
- no payment-processing, wallet, token, cryptocurrency, or settlement framing
- no new receipt vocabulary
- no package-specific semantics
- no sponsor-specific receipt names, custody kinds, validator branches, or ICN-core concepts

## Refs

Refs #2377
Refs #2375