### PR TITLE
tools(bridge): model record-state custody predicates

### DIFF
--- a/docs/spec/governed-bridge-nycn-handoff-map.md
+++ b/docs/spec/governed-bridge-nycn-handoff-map.md
@@ -182,9 +182,12 @@ follow-up (§13).
 - NYCN-side verifiable reviewer authority reference (beyond the role-only field).
 - A stronger NYCN fake-fixture privacy scan (real-name and external-id shape
   detection, which the NYCN validator does not yet perform).
-- Record-state-dependent custody (one field path currently has one custody
-  target; a declined record's public name cannot route differently from an
-  active record's — see §14).
+- ~~Record-state-dependent custody~~ — **partially addressed (v0)**: a field's
+  custody entry may now carry an optional `condition` predicate declaring the
+  source-state precondition under which its route is eligible (§15). Per-state
+  *multi-kind* routing — the same field path routing to a different custody kind by
+  record state — remains a future change (one field path still has one custody
+  kind).
 
 These are recorded as direction only; this document opens no issues.
 
@@ -206,7 +209,7 @@ kinds, and receipts are entirely generic.
 | Invoice reference / certificate-of-insurance status | `relationship.external_invoice_reference`, `relationship.external_insurance_reference` | `scoped_vault` (`finance-restricted`) | approve | review + import + `VaultObjectWriteReceipt` | **Held references** — reference/status only; documents stay with the external custodian; nothing is processed. |
 | Payment status observed | `relationship.external_status_observed` | `external_reference` | approve | review + import + `ExternalReferenceObservationReceipt` | The only true observe-only external reference; observed, never processed. |
 | Consent-gated follow-up | `relationship.follow_up_consent` | `governed_object`, `object_class: follow-up-record` | approve where consent present (001, 003); **automatic block** where absent (002) | review + import + `FollowUpObjectCreationReceipt`; block: `ConsentPolicyBlockReceipt` | Same pattern as the intake handoff (§5); the follow-up class instance is its honest receipt. |
-| Declined prospect (declined ≠ obligation) | `relationship.closure_reason` | `scoped_vault` (`relationship-internal`) | approve | review + import + `VaultObjectWriteReceipt` — never a commitment receipt | **Record-state custody limit**: the declined record's public name is NOT proposed — `public_listing_name` is binding-bound to the publication registry and one field path has one custody kind. No renamed field is invented; the limit is a candidate future contract feature (§13). |
+| Declined prospect (declined ≠ obligation) | `relationship.closure_reason` | `scoped_vault` (`relationship-internal`) | approve | review + import + `VaultObjectWriteReceipt` — never a commitment receipt | **Record-state custody**: the declined record's public name is NOT proposed — `public_listing_name` now carries a v0 `condition` (eligible only where `record_state == active`, §15), making that source-state precondition explicit instead of silent omission. One field path still has one custody kind; no renamed field is invented. |
 | Recognition-fulfillment / follow-up "cards" | — (no conformance action) | — | — | — | Cards are derived read views over the commitment and follow-up objects, which are already receipted; the deprecated card-write receipt name never appears in the fixture. |
 | Free text | `relationship.free_text_note` | `discard` | discard | `DiscardDecisionReceipt` | Discard-by-default. |
 | Credential guard | — (no per-field counterpart) | — | — | — | Cross-cutting refusal doctrine, not a field decision; `reject` stays naturally unexercised. |
@@ -216,3 +219,52 @@ organizer-derived → `institution_derived`, external-accounting-system →
 `external_accounting_system`. Privacy classes translate as: sponsor_restricted →
 `relationship_restricted`, organizer_only → `internal_only`; the rest pass
 through. All are opaque strings to ICN core.
+
+## 15. Record-state-dependent custody (v0: eligibility conditions)
+
+§14's declined-prospect row exposed a real v0 limit: the custody *meaning* of a
+source field can depend on the source record's **state**. A declined record is an
+internal closure record, not a commitment; a public-recognition field must stay
+unproposed unless the record's state permits publication. The original fixture
+handled this by **omission** — the declined record simply does not propose
+`public_listing_name` — which is safe but invisible to the conformance validator,
+and the tempting-but-forbidden shortcut is to invent a renamed field to bypass
+source state.
+
+**v0 mechanism — an optional `condition` predicate on a `field_custody_map`
+entry.** A field's custody entry may declare the source-state precondition under
+which its route is eligible:
+
+```yaml
+relationship.public_listing_name:
+  custody_target: { kind: artifact_registry, namespace: public-recognition }
+  required_receipts: [BridgeImportReceipt, ArtifactRegistrationReceipt]
+  condition:
+    source_field_path: relationship.record_state   # opaque source field
+    op: equals                                      # closed ICN operator set
+    value: active                                   # opaque literal
+```
+
+- **Generic and opaque.** `source_field_path` and `value` are opaque strings/scalars
+  ICN core never interprets — exactly like `field_path`, `privacy_class`, and
+  `object_class`. Only `op` is ICN vocabulary, drawn from a closed set: `equals`,
+  `not_equals`, `in`, `not_in`, `present`, `absent`. The predicate's keys are
+  **strict** (`source_field_path` / `op` / `value` only) so a package noun (e.g. a
+  `sponsor_status` key) cannot ride in — the Meaning Firewall holds.
+- **Explicit, not silent.** The condition records *why* a field is unproposed for a
+  given record (its state does not satisfy the predicate) rather than leaving it to
+  omission. It is producer-declared intent the validator can shape-check.
+- **v0 scope — shape only.** The validator validates the predicate's shape; it does
+  **not** evaluate it or route custody by state. A conditioned field must still be
+  exercised by at least one dry-run action where its condition holds (the existing
+  binding-coverage rule is unchanged), and a field path still has exactly **one**
+  custody kind.
+- **Deferred (future change).** Per-state *multi-kind* routing — the same field
+  routing to a different custody kind under different record states — would require
+  the binding to hold per-condition custody variants and the dry-run kind-match
+  check to become condition-aware. That is a larger change, recorded here as
+  direction only; this v0 slice does not open it.
+
+**Non-claims.** Fake-fixture / conformance design only: no runtime bridge, no
+connector, no live source scan, no real data, no package-specific ICN custody kind
+or receipt class, and no claim that NYCN operations are ICN-native today.

--- a/tools/bridge-conformance/nycn-relationship-handoff-v0/README.md
+++ b/tools/bridge-conformance/nycn-relationship-handoff-v0/README.md
@@ -55,13 +55,15 @@ never a legal instrument or a claim about external enforceability.
 - **`policy_gate` is not exercised** — the flow's one gate (recognition
   permission) is a publication *block* where denied and a consumed approval
   basis where granted; no field was invented to reach the remaining kind.
-- **Record-state custody limit**: a field path has one custody target in the
-  binding. Record 003 (declined/closed relationship) therefore does **not**
-  propose its public name — the binding routes `public_listing_name` to the
-  publication registry, and a declined record's name must stay internal. The
-  declined record is carried by `closure_reason` into an internal vault scope,
-  never a commitment object, and no renamed field was invented to bypass the
-  limit (documented in the handoff map as a candidate future contract feature).
+- **Record-state custody**: a field path has one custody target in the binding.
+  Record 003 (declined/closed relationship) therefore does **not** propose its
+  public name — the binding routes `public_listing_name` to the publication
+  registry, and a declined record's name must stay internal. The declined record is
+  carried by `closure_reason` into an internal vault scope, never a commitment
+  object, and no renamed field was invented to bypass the limit. `public_listing_name`
+  now carries a v0 `condition` predicate (eligible only where `record_state ==
+  active`) so that source-state precondition is explicit rather than a silent
+  omission; per-state *multi-kind* routing remains a future change (handoff map §15).
 - **Held references vs observed status**: the external invoice/insurance
   references are **vault-held references** (reference/status only; the documents
   stay with their external custodian); only `external_status_observed` is a true

--- a/tools/bridge-conformance/nycn-relationship-handoff-v0/binding.example.yaml
+++ b/tools/bridge-conformance/nycn-relationship-handoff-v0/binding.example.yaml
@@ -49,6 +49,16 @@ field_custody_map:
     custody_target:
       kind: artifact_registry
       namespace: public-recognition
+    # v0 record-state custody: this publication route is eligible only where the
+    # source record's state permits a public listing. A declined/closed record does
+    # not propose this field (see the dry-run for rel_rec_fake_003 and §15 of the
+    # handoff map) — the condition makes that source-state precondition explicit,
+    # instead of relying on silent omission or a renamed field. source_field_path
+    # and value are opaque to ICN core; only `op` is ICN vocabulary.
+    condition:
+      source_field_path: relationship.record_state
+      op: equals
+      value: active
     required_receipts:
       - BridgeImportReceipt
       - ArtifactRegistrationReceipt

--- a/tools/validate-governed-bridge-conformance.py
+++ b/tools/validate-governed-bridge-conformance.py
@@ -120,6 +120,17 @@ WRITE_KINDS = frozenset(TARGET_RECEIPT.keys()) | {"governed_object"}
 POLICY_BLOCK_KINDS = frozenset({"policy_gate", "policy_block"})
 DISCARD_KIND = "discard"
 
+# Optional field-custody CONDITION (v0 record-state-dependent custody): a source-
+# state predicate declaring WHEN a field's single custody route is eligible. The
+# operator is a closed ICN vocabulary; the condition keys are strict and generic so
+# a package noun cannot ride in as a predicate key. source_field_path and value
+# stay opaque to core. present/absent take no value; in/not_in take a list;
+# equals/not_equals take a scalar.
+CONDITION_KEYS = frozenset({"source_field_path", "op", "value"})
+CONDITION_OPS = frozenset(
+    {"equals", "not_equals", "in", "not_in", "present", "absent"}
+)
+
 DECISION_VERBS = frozenset(
     {
         "approve",
@@ -247,6 +258,46 @@ def _is_opaque_ref(s: str) -> bool:
 # --------------------------------------------------------------------------- #
 # per-file checks
 # --------------------------------------------------------------------------- #
+def check_condition(cond, lbl, errors):
+    """Validate an OPTIONAL field-custody condition — a package-neutral source-state
+    predicate that declares WHEN a field's (single) custody route is eligible. Keys
+    are strict and generic so a package noun cannot ride in as a predicate key;
+    source_field_path and value are opaque to ICN core, and only the operator is a
+    closed ICN vocabulary. This validates the predicate SHAPE only — it neither
+    evaluates the predicate nor routes custody by state (per-state multi-kind
+    routing stays a documented future change; see the handoff-map spec)."""
+    c = require_mapping(cond, lbl, errors)
+    if not c:
+        return
+    extra = sorted(set(c) - CONDITION_KEYS)
+    if extra:
+        errors.append(
+            f"{lbl}: non-generic condition key(s) {extra}; only {sorted(CONDITION_KEYS)} "
+            f"are allowed (predicate keys must be generic, never package nouns)"
+        )
+    require_str(c.get("source_field_path"), f"{lbl}.source_field_path", errors)
+    op = require_str(c.get("op"), f"{lbl}.op", errors)
+    if op is None:
+        return
+    if op not in CONDITION_OPS:
+        errors.append(
+            f"{lbl}.op {op!r} is not an allowed condition operator {sorted(CONDITION_OPS)}"
+        )
+        return
+    if op in ("present", "absent"):
+        if "value" in c:
+            errors.append(f"{lbl}: op {op!r} takes no value")
+    elif op in ("in", "not_in"):
+        v = c.get("value")
+        if not isinstance(v, list) or not v:
+            errors.append(f"{lbl}.value must be a non-empty list for op {op!r}")
+        elif not all(isinstance(x, (str, int, float, bool)) for x in v):
+            errors.append(f"{lbl}.value list entries must be scalars")
+    else:  # equals / not_equals
+        if not isinstance(c.get("value"), (str, int, float, bool)):
+            errors.append(f"{lbl}.value must be a scalar for op {op!r}")
+
+
 def check_binding(data, errors, rel):
     b = require_mapping(data, rel, errors)
     if not b:
@@ -302,6 +353,8 @@ def check_binding(data, errors, rel):
         for r in rr:
             if r == FORBIDDEN_RECEIPT:
                 errors.append(f"{lbl}.required_receipts: {FORBIDDEN_RECEIPT} must not be used")
+        if "condition" in s:
+            check_condition(s.get("condition"), f"{lbl}.condition", errors)
         field_map[field_path] = (kind, rr)
 
     # real_row_read must be false unless every promotion gate is marked satisfied.

--- a/tools/validate-governed-bridge-conformance.py
+++ b/tools/validate-governed-bridge-conformance.py
@@ -266,9 +266,10 @@ def check_condition(cond, lbl, errors):
     closed ICN vocabulary. This validates the predicate SHAPE only — it neither
     evaluates the predicate nor routes custody by state (per-state multi-kind
     routing stays a documented future change; see the handoff-map spec)."""
-    c = require_mapping(cond, lbl, errors)
-    if not c:
+    if not isinstance(cond, dict):
+        require_mapping(cond, lbl, errors)  # emit the "expected a mapping" error
         return
+    c = cond  # a present-but-empty {} must still fail the required-key checks below
     extra = sorted(set(c) - CONDITION_KEYS)
     if extra:
         errors.append(


### PR DESCRIPTION
## What

Adds a generic, package-neutral record-state-dependent custody mechanism to the governed bridge conformance contract.

A field's custody entry may now declare the source-record **state** under which its custody route is eligible — without inventing package-specific ICN concepts or a renamed field to bypass source state.

## Why

The NYCN relationship/recognition/obligation handoff fixture in #2382 exposed a real v0 limitation: the custody meaning of a source field can depend on the source record's state.

Examples:

- a declined record is an internal closure record, not a commitment;
- a public recognition field must stay unproposed unless source state permits it.

The v0 workaround was to handle this by **omission** (the declined record simply does not propose `public_listing_name`) and document the limit. That is safe but invisible to the conformance validator, and the tempting-but-forbidden shortcut is to invent a renamed field. This PR designs the package-neutral mechanism.

## Changes

- **`docs/spec/governed-bridge-nycn-handoff-map.md`** — new **§15 "Record-state-dependent custody (v0: eligibility conditions)"** defining the mechanism, the closed operator set, the Meaning-Firewall stance, the v0 scope (shape-only), and the deferred future change (per-state multi-kind routing); §13 marks the item partially addressed; §14's declined-prospect row references the condition.
- **`tools/validate-governed-bridge-conformance.py`** — add `CONDITION_KEYS` / `CONDITION_OPS` constants and a small `check_condition()` that shape-validates an **optional** `condition` on a `field_custody_map` entry: mapping shape, strict generic keys (`source_field_path`/`op`/`value` only — a package-noun key is rejected), operator ∈ the closed set (`equals`/`not_equals`/`in`/`not_in`/`present`/`absent`), and value shape per operator (scalar / non-empty list / none). Wired into `check_binding`.
- **`tools/bridge-conformance/nycn-relationship-handoff-v0/binding.example.yaml`** — annotate `relationship.public_listing_name` with a `condition` (eligible where `record_state == active`), making #2382's declined-record precondition explicit.
- **`tools/bridge-conformance/nycn-relationship-handoff-v0/README.md`** — update the record-state limit bullet to reference the v0 condition.

Package-local NYCN meaning stays in source-vocabulary / map context only. The mechanism is **backward-compatible**: `condition` is optional; existing fixtures pass byte-unchanged (the two intake/review fixtures carry no condition; the coverage rule is unchanged). This validates predicate **shape only** — it does not evaluate the predicate or route custody by state (one field path still has one custody kind).

## Validation

- `python3 tools/validate-governed-bridge-conformance.py` → **ok** (all 3 fixtures)
- `python3 tools/validate-governed-bridge-conformance.py tools/bridge-conformance/nycn-relationship-handoff-v0` → **ok**
- `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` → **passed** (66 pre-existing warnings on unrelated project-index docs; no new)
- `.github/scripts/compliance_linter.py` / `readiness_overclaim_linter.py` → clean
- `git diff --check` → ok
- negative coverage (in-repo temp copies of the relationship fixture, never committed):
  - non-mapping `condition` rejects (`condition: expected a mapping`);
  - unsupported operator rejects (`op … is not an allowed condition operator`);
  - package-noun predicate key rejects (`non-generic condition key(s) ['sponsor_status']`);
  - non-scalar value for `equals` rejects (`value must be a scalar`);
  - control (unmodified fixture) passes.

## Meaning Firewall

Package nouns remain source-vocabulary / fixture / map context only. No package-specific custody kind, receipt class, validator branch, runtime service, or ICN-core concept is added. The condition's keys are strict and generic; `source_field_path` and `value` are opaque to ICN core, and only the operator is ICN vocabulary. (The single `sponsor_status` mention in the spec is a *forbidden-example* illustrating what the strict-keys check rejects.)

## Non-claims

- fake fixtures / bridge conformance only
- no runtime bridge implementation
- no connector implementation
- no live Drive / Sheets / Gmail / SimpleTix scan
- no real source-system export read
- no real data
- no private operational data
- no production, pilot-readiness, or live-federation claim
- no payment-processing, wallet, token, cryptocurrency, or settlement framing
- no claim that NYCN operations are ICN-native today

## Refs

Refs #2377
Refs #2382
Refs InterCooperative-Network/nycn#90
Refs InterCooperative-Network/nycn#91
Refs InterCooperative-Network/nycn#92
Refs InterCooperative-Network/nycn#93
Refs InterCooperative-Network/nycn#94
