### PR TITLE
demo(node): add rehearsal node v0 entrypoint

### DIFF
--- a/demo/SELF_SERVE.md
+++ b/demo/SELF_SERVE.md
@@ -127,6 +127,17 @@ independent organizations — it demonstrates that nodes are
 self-contained, not that production federation exists (that remains
 design-only).
 
+## Appliance rehearsal node (VM route)
+
+If you want the Path 1/2 single-node loop as a disposable local VM with a
+browser launcher instead of a workstation process, the appliance DEV/DEMO
+profile has a named wrapper: `deploy/appliance/scripts/icn-rehearsal-node.sh`
+— see
+[docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md](../docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md).
+It requires a locally built demo-profile image first (not a two-minute path).
+Same honesty tier as Paths 1–2: live-local — not production, not a pilot, not
+federation.
+
 ## Presenter path — scripted flows on owned infrastructure
 
 `demo/scripts/flow-1-governance.sh` through `flow-5-compute.sh` (plus

--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -98,6 +98,15 @@ ssh -p 2222 debian@127.0.0.1 sudo icn-demo-seed
 The seed prints the member-shell URLs, the open action item, and a dev
 session JWT (local VM only).
 
+## Rehearsal Node v0.1 wrapper
+
+The appliance DEV/DEMO paths on this page have one named operator entrypoint:
+`deploy/appliance/scripts/icn-rehearsal-node.sh` (`smoke-image`,
+`open-running-node`, `verify-running-node`, `--dry-run`, `--help`). It only
+delegates to the commands documented here — same env vars, same safety
+boundaries, same non-claims. Runbook:
+[docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md](../../docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md).
+
 ## One-command launcher (recommended for a live human demo)
 
 If a node instance is already running (e.g. a Proxmox VM at `192.0.2.50` — use your node's real IP),

--- a/deploy/appliance/scripts/icn-rehearsal-node.sh
+++ b/deploy/appliance/scripts/icn-rehearsal-node.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ============================================================================
+# icn-rehearsal-node.sh — ICN Rehearsal Node v0.1: one named operator
+# entrypoint for the existing appliance DEV/DEMO paths.
+# ----------------------------------------------------------------------------
+# DEV/DEMO ONLY. Not production, not a pilot, not federation.
+#
+# This wrapper does not implement a new node path. It delegates to the
+# appliance DEV/DEMO substrate that already exists:
+#   - smoke/smoke-local.sh --real --demo   (headless proof on a disposable VM)
+#   - scripts/open-proxmox-demo.sh         (browser shell for a running node)
+#   - in-VM helpers: icn-demo-seed / icn-demo-verify / icn-demo-reset
+#
+# Usage:
+#   icn-rehearsal-node.sh --help
+#   icn-rehearsal-node.sh --dry-run
+#   icn-rehearsal-node.sh smoke-image          # needs an already-built
+#                                              # DEMO-profile image
+#   icn-rehearsal-node.sh open-running-node    # needs an already-running
+#                                              # DEMO-profile node instance
+#   icn-rehearsal-node.sh verify-running-node  # prints verification steps
+#
+# Env (smoke-image — same contract as smoke-local.sh):
+#   ICN_APPLIANCE_IMAGE            required  path to DEMO-profile QCOW2
+#   ICN_APPLIANCE_SSH_KEY          required  smoke-only SSH private key
+#   ICN_APPLIANCE_CLOUD_INIT_SEED  optional  seed ISO (built via cloud-localds
+#                                            from the key when unset)
+#
+# Env (open-running-node / verify-running-node — same contract as
+# open-proxmox-demo.sh):
+#   ICN_DEMO_VM_IP        required            running node instance IP
+#   ICN_DEMO_SSH_KEY      direct route        SSH key on this workstation
+#   ICN_DEMO_JUMP         jump route          user@jump-host
+#   ICN_DEMO_REMOTE_KEY   jump route          key path on the jump host
+#
+# What this wrapper does NOT do:
+#   - does not build or download images (see build-image.sh)
+#   - does not create the cloud-init seed by itself
+#   - does not add a runtime mode or alter icnd flags
+#   - does not store or print credentials
+#   - does not bypass the demo-session loopback/dev-gate boundary
+#
+# Honest non-claims: single-node, fictional fixture institution, dev gates,
+# test posture — NOT production, NOT a pilot, NOT federation.
+#
+# Docs: deploy/appliance/DEMO_QUICKSTART.md
+#       docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APPLIANCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+log()   { printf '[rehearsal-node] %s\n' "$*"; }
+err()   { printf '[rehearsal-node] ERROR: %s\n' "$*" >&2; }
+fatal() { err "$*"; exit 2; }
+
+usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; }
+
+DOCS_HINT="See deploy/appliance/DEMO_QUICKSTART.md and docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md."
+
+banner() {
+  log "ICN Rehearsal Node v0.1 — wrapper over the appliance DEV/DEMO profile."
+  log "Not production, not a pilot, not federation. Fictional fixture data only."
+}
+
+require_smoke_env() {
+  local missing=0
+  if [ -z "${ICN_APPLIANCE_IMAGE:-}" ]; then
+    err "ICN_APPLIANCE_IMAGE is not set (path to an already-built DEMO-profile QCOW2)."
+    missing=1
+  fi
+  if [ -z "${ICN_APPLIANCE_SSH_KEY:-}" ]; then
+    err "ICN_APPLIANCE_SSH_KEY is not set (smoke-only SSH private key)."
+    missing=1
+  fi
+  if [ "$missing" -ne 0 ]; then
+    err "smoke-image needs an image built with ICN_APPLIANCE_DEMO_PROFILE=1."
+    err "ICN_APPLIANCE_CLOUD_INIT_SEED is optional (smoke-local builds one via cloud-localds when unset)."
+    fatal "$DOCS_HINT"
+  fi
+}
+
+require_open_env() {
+  if [ -z "${ICN_DEMO_VM_IP:-}" ]; then
+    err "ICN_DEMO_VM_IP is not set (IP of an already-running DEMO-profile node instance)."
+    fatal "$DOCS_HINT"
+  fi
+  if [ -z "${ICN_DEMO_SSH_KEY:-}" ] && { [ -z "${ICN_DEMO_JUMP:-}" ] || [ -z "${ICN_DEMO_REMOTE_KEY:-}" ]; }; then
+    err "no usable SSH route: set ICN_DEMO_SSH_KEY (direct route),"
+    err "or BOTH ICN_DEMO_JUMP and ICN_DEMO_REMOTE_KEY (jump route)."
+    fatal "$DOCS_HINT"
+  fi
+}
+
+print_verify_steps() {
+  banner
+  log "Verification runs INSIDE the running node instance (VM):"
+  log "  sudo icn-demo-verify <item-id>   # re-fetch + consistency check of one completion receipt"
+  log "  sudo icn-demo-verify --chain     # deeper 13-of-13 governed receipt-chain rehearsal"
+  log "Neither command re-derives hashes client-side; the hash binding is created"
+  log "server-side when the receipt is emitted. Chain evidence lands under"
+  log "/var/lib/icn-demo/receipt-chain-13of13/ in the VM."
+  if [ -n "${ICN_DEMO_VM_IP:-}" ]; then
+    local ssh_user="${ICN_DEMO_SSH_USER:-debian}"
+    if [ -n "${ICN_DEMO_SSH_KEY:-}" ]; then
+      log "Ready-to-copy (direct route):"
+      log "  ssh -i \"${ICN_DEMO_SSH_KEY}\" ${ssh_user}@${ICN_DEMO_VM_IP} 'sudo icn-demo-verify --chain'"
+    fi
+    if [ -n "${ICN_DEMO_JUMP:-}" ] && [ -n "${ICN_DEMO_REMOTE_KEY:-}" ]; then
+      log "Ready-to-copy (jump route):"
+      log "  ssh -J \"${ICN_DEMO_JUMP}\" -i \"${ICN_DEMO_REMOTE_KEY}\" ${ssh_user}@${ICN_DEMO_VM_IP} 'sudo icn-demo-verify --chain'"
+    fi
+  else
+    log "Set ICN_DEMO_VM_IP (plus a route, as for open-running-node) to get a"
+    log "ready-to-copy ssh command printed here."
+  fi
+  log "This command prints instructions only; it does not run anything remotely."
+}
+
+dry_run() {
+  banner
+  log "--dry-run: nothing is executed, no VM is booted, no network is used."
+  log ""
+  log "smoke-image would run:"
+  log "  bash ${APPLIANCE_DIR}/smoke/smoke-local.sh --real --demo"
+  log "  (boots a disposable local QEMU overlay from ICN_APPLIANCE_IMAGE and"
+  log "   drives the loop headlessly: health -> member shell -> seed ->"
+  log "   standing -> action card -> complete -> receipt)"
+  log "  requires: ICN_APPLIANCE_IMAGE, ICN_APPLIANCE_SSH_KEY"
+  log "  optional: ICN_APPLIANCE_CLOUD_INIT_SEED"
+  log ""
+  log "open-running-node would run:"
+  log "  bash ${SCRIPT_DIR}/open-proxmox-demo.sh"
+  log "  (SSH-tunnels gateway/shell/session ports 18080/18090/18091 to an"
+  log "   already-running DEMO-profile node instance and opens the member"
+  log "   shell with the no-paste 'Start local demo' launcher)"
+  log "  requires: ICN_DEMO_VM_IP + ICN_DEMO_SSH_KEY (direct)"
+  log "        or: ICN_DEMO_VM_IP + ICN_DEMO_JUMP + ICN_DEMO_REMOTE_KEY (jump)"
+  log ""
+  log "verify-running-node would print the in-VM verification commands"
+  log "(sudo icn-demo-verify <item-id> | --chain); it never executes remotely."
+}
+
+cmd="${1:---help}"
+case "$cmd" in
+  -h|--help|help)
+    usage
+    ;;
+  --dry-run)
+    dry_run
+    ;;
+  smoke-image)
+    banner
+    require_smoke_env
+    log "delegating to smoke-local.sh --real --demo ..."
+    exec bash "${APPLIANCE_DIR}/smoke/smoke-local.sh" --real --demo
+    ;;
+  open-running-node)
+    banner
+    require_open_env
+    log "delegating to open-proxmox-demo.sh ..."
+    exec bash "${SCRIPT_DIR}/open-proxmox-demo.sh"
+    ;;
+  verify-running-node)
+    print_verify_steps
+    ;;
+  *)
+    err "unknown command: ${cmd}"
+    err "commands: smoke-image | open-running-node | verify-running-node | --dry-run | --help"
+    fatal "$DOCS_HINT"
+    ;;
+esac

--- a/deploy/appliance/scripts/icn-rehearsal-node.sh
+++ b/deploy/appliance/scripts/icn-rehearsal-node.sh
@@ -36,6 +36,9 @@
 #   ICN_DEMO_SSH_KEY      direct route        SSH key on this workstation
 #   ICN_DEMO_JUMP         jump route          user@jump-host
 #   ICN_DEMO_REMOTE_KEY   jump route          key path on the jump host
+#   ICN_DEMO_SSH_USER     optional            VM ssh user (default: debian)
+#   Other launcher knobs (ICN_DEMO_GW_PORT, ICN_DEMO_SESSION_PORT,
+#   ICN_DEMO_NO_BROWSER, ...) pass through to open-proxmox-demo.sh unchanged.
 #
 # What this wrapper does NOT do:
 #   - does not build or download images (see build-image.sh)

--- a/deploy/appliance/scripts/icn-rehearsal-node.sh
+++ b/deploy/appliance/scripts/icn-rehearsal-node.sh
@@ -23,8 +23,12 @@
 # Env (smoke-image — same contract as smoke-local.sh):
 #   ICN_APPLIANCE_IMAGE            required  path to DEMO-profile QCOW2
 #   ICN_APPLIANCE_SSH_KEY          required  smoke-only SSH private key
-#   ICN_APPLIANCE_CLOUD_INIT_SEED  optional  seed ISO (built via cloud-localds
-#                                            from the key when unset)
+#   ICN_APPLIANCE_CLOUD_INIT_SEED  seed ISO. May be left unset ONLY after
+#                                  editing smoke/cloud-init/user-data.example.yaml
+#                                  with your smoke-only PUBLIC key (smoke-local
+#                                  then builds a seed via cloud-localds; it
+#                                  refuses the shipped placeholder key and does
+#                                  NOT derive the key from ICN_APPLIANCE_SSH_KEY)
 #
 # Env (open-running-node / verify-running-node — same contract as
 # open-proxmox-demo.sh):
@@ -76,7 +80,19 @@ require_smoke_env() {
   fi
   if [ "$missing" -ne 0 ]; then
     err "smoke-image needs an image built with ICN_APPLIANCE_DEMO_PROFILE=1."
-    err "ICN_APPLIANCE_CLOUD_INIT_SEED is optional (smoke-local builds one via cloud-localds when unset)."
+    fatal "$DOCS_HINT"
+  fi
+  # Fail fast on the seed precondition instead of mid-run: without a pre-built
+  # seed ISO, smoke-local builds one from smoke/cloud-init/*.example.yaml and
+  # refuses the shipped placeholder key (it never derives the public key from
+  # ICN_APPLIANCE_SSH_KEY).
+  local ex_user="${APPLIANCE_DIR}/smoke/cloud-init/user-data.example.yaml"
+  if [ -z "${ICN_APPLIANCE_CLOUD_INIT_SEED:-}" ] && [ -f "$ex_user" ] \
+     && grep -q "INVALIDREPLACEME" "$ex_user"; then
+    err "no ICN_APPLIANCE_CLOUD_INIT_SEED set, and ${ex_user}"
+    err "still contains the placeholder SSH key — smoke-local will refuse it."
+    err "Either point ICN_APPLIANCE_CLOUD_INIT_SEED at a pre-built seed ISO, or"
+    err "edit that file to carry the smoke-only PUBLIC key matching ICN_APPLIANCE_SSH_KEY."
     fatal "$DOCS_HINT"
   fi
 }
@@ -108,8 +124,10 @@ print_verify_steps() {
       log "  ssh -i \"${ICN_DEMO_SSH_KEY}\" ${ssh_user}@${ICN_DEMO_VM_IP} 'sudo icn-demo-verify --chain'"
     fi
     if [ -n "${ICN_DEMO_JUMP:-}" ] && [ -n "${ICN_DEMO_REMOTE_KEY:-}" ]; then
-      log "Ready-to-copy (jump route):"
-      log "  ssh -J \"${ICN_DEMO_JUMP}\" -i \"${ICN_DEMO_REMOTE_KEY}\" ${ssh_user}@${ICN_DEMO_VM_IP} 'sudo icn-demo-verify --chain'"
+      log "Ready-to-copy (jump route — the demo key lives on the jump host, so"
+      log "the inner ssh runs THERE, mirroring open-proxmox-demo.sh):"
+      log "  ssh -o StrictHostKeyChecking=accept-new \"${ICN_DEMO_JUMP}\" \\"
+      log "    \"ssh -o StrictHostKeyChecking=accept-new -i '${ICN_DEMO_REMOTE_KEY}' ${ssh_user}@${ICN_DEMO_VM_IP} 'sudo icn-demo-verify --chain'\""
     fi
   else
     log "Set ICN_DEMO_VM_IP (plus a route, as for open-running-node) to get a"
@@ -128,7 +146,9 @@ dry_run() {
   log "   drives the loop headlessly: health -> member shell -> seed ->"
   log "   standing -> action card -> complete -> receipt)"
   log "  requires: ICN_APPLIANCE_IMAGE, ICN_APPLIANCE_SSH_KEY"
-  log "  optional: ICN_APPLIANCE_CLOUD_INIT_SEED"
+  log "  seed:     ICN_APPLIANCE_CLOUD_INIT_SEED, or an edited"
+  log "            smoke/cloud-init/user-data.example.yaml carrying your real"
+  log "            smoke public key (the shipped placeholder is refused)"
   log ""
   log "open-running-node would run:"
   log "  bash ${SCRIPT_DIR}/open-proxmox-demo.sh"

--- a/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
+++ b/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
@@ -82,11 +82,20 @@ bash deploy/appliance/scripts/icn-rehearsal-node.sh smoke-image
 
 This boots a disposable local QEMU overlay (the image is never modified) and
 drives the demo loop headlessly: health → member shell → seed → standing →
-action card → complete → receipt. `ICN_APPLIANCE_CLOUD_INIT_SEED` is optional
-— when unset, smoke-local builds a seed ISO from the SSH key via
-`cloud-localds` (and refuses the placeholder key shipped in-tree). The image
-must have been built with `ICN_APPLIANCE_DEMO_PROFILE=1`; building it is a
-separate step documented in `deploy/appliance/DEMO_QUICKSTART.md`.
+action card → complete → receipt.
+
+Cloud-init seed: one of two preconditions must hold, or the run fails before
+the VM boots (the wrapper preflights this):
+
+- `ICN_APPLIANCE_CLOUD_INIT_SEED` points at a pre-built seed ISO, **or**
+- `deploy/appliance/smoke/cloud-init/user-data.example.yaml` has been edited
+  to carry the smoke-only **public** key matching `ICN_APPLIANCE_SSH_KEY`
+  (smoke-local then builds a seed via `cloud-localds`). smoke-local refuses
+  the shipped `INVALIDREPLACEME` placeholder and does **not** derive the
+  public key from `ICN_APPLIANCE_SSH_KEY`.
+
+The image must have been built with `ICN_APPLIANCE_DEMO_PROFILE=1`; building
+it is a separate step documented in `deploy/appliance/DEMO_QUICKSTART.md`.
 
 ## Fast path B — open an already-running node instance
 

--- a/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
+++ b/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
@@ -1,0 +1,163 @@
+# ICN Rehearsal Node v0.1 Runbook
+
+Status: dev/demo operator runbook
+Related: #2386
+
+## What this is
+
+A single-node, fixture-backed rehearsal node path built on the existing ICN
+appliance DEV/DEMO profile, with one named operator entrypoint:
+
+```bash
+bash deploy/appliance/scripts/icn-rehearsal-node.sh --help
+```
+
+"Rehearsal Node v0.1" is a name and a runbook for machinery that already
+shipped (the July Demo Candidate 0.1 appliance profile), not a new node path.
+The node instance is a disposable local VM; the demo data is a fictional
+fixture institution; operation needs no outbound network beyond the operator's
+own SSH tunnels.
+
+## What this proves
+
+- A local ICN node can boot from the DEV/DEMO appliance image (per-VM secrets
+  generated at first boot; no secrets baked into the image).
+- `icnd` serves health and gateway endpoints (`GET /v1/health`, `/v1/gov/*`).
+- The member shell can render the organizer/member loop in a browser.
+- Fictional fixture work can become an action card
+  (`GET /v1/gov/me/action-cards`).
+- Completing that action produces a completion receipt (the canonical mutation
+  is `PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status` with
+  `{"status":"completed"}`; the receipt is fetched from
+  `GET .../completion-receipt`).
+- The receipt can be re-fetched and consistency-checked
+  (`sudo icn-demo-verify <item-id>`).
+- The deeper 13-of-13 governed receipt-chain rehearsal remains available
+  through `sudo icn-demo-verify --chain`.
+
+A note on verification honesty: `icn-demo-verify <item-id>` and
+`icn-demo-verify --chain` are **re-fetch + consistency / provenance-linkage
+audits**. Neither re-derives the BLAKE3 `record_hash` or checks a signature on
+the client. The hash binding is created server-side when the receipt is
+emitted (`ActionItemCompletionReceipt`, domain tag
+`icn:gov:action_item_completion:v1`). Do not describe the client verify steps
+as cryptographic verification.
+
+## What this does not prove
+
+- No production readiness.
+- No pilot adoption.
+- No live federation.
+- No multi-organization network.
+- No real NYCN data.
+- No private overlay.
+- No live DID activation.
+- No runtime bridge.
+- No connectors.
+- No payment / wallet / balance / currency / token framing — the loop is
+  governed coordination with provenance receipts.
+
+## Existing pieces reused
+
+| Piece | Role |
+|---|---|
+| `deploy/appliance/build-image.sh` | Builds the QCOW2 appliance image; `ICN_APPLIANCE_DEMO_PROFILE=1` adds the DEMO profile. Run separately — the wrapper never builds. |
+| `deploy/appliance/smoke/smoke-local.sh --real --demo` | Boots a disposable QEMU overlay and drives the full loop headlessly over the same forwarded ports a browser would use. |
+| `deploy/appliance/scripts/icn-demo-seed.sh` | In-VM: mints a short-lived DEV/DEMO JWT, bootstraps the fixture institution, creates one action item. Not idempotent — use reset for a clean slate. |
+| `deploy/appliance/scripts/icn-demo-verify.sh` | In-VM: per-item receipt consistency check; `--chain` runs the bundled 13-of-13 receipt-chain rehearsal. |
+| `deploy/appliance/scripts/icn-demo-reset.sh` | In-VM: marker-gated demo-state reset (does not reseed). |
+| `deploy/appliance/scripts/icn-demo-session.py` | In-VM loopback (`127.0.0.1:8091`) session endpoint behind a double dev-gate and an Origin allow-list; powers the shell's no-paste "Start local demo" button. |
+| `deploy/appliance/scripts/open-proxmox-demo.sh` | Workstation launcher: SSH-tunnels gateway/shell/session ports and opens the member shell — no JWT paste, no gateway typing. |
+| `web/member-shell/` | The browser surface the appliance serves (`:8090` in-VM): standing, action cards, the single completion mutation, receipt rendering, permanent honesty banner, i18n seam, automated accessibility harness. |
+| `demo/nycn-dogfood/run.sh` | The workstation-native sibling of the same loop (deliberately on gateway `:8085`); useful for development without a VM. |
+| `scripts/local_receipt_chain_13of13_rehearsal.sh` | The strongest single proof artifact (governed proposal → vote → close → allocation, 13/13 audit, repo-safe evidence packet); bundled in-VM as `icn-demo-verify --chain`. |
+
+## Fast path A — smoke an already-built demo image
+
+```bash
+ICN_APPLIANCE_IMAGE=/path/to/icn-appliance-demo.qcow2 \
+ICN_APPLIANCE_SSH_KEY=/path/to/smoke_ed25519 \
+bash deploy/appliance/scripts/icn-rehearsal-node.sh smoke-image
+```
+
+This boots a disposable local QEMU overlay (the image is never modified) and
+drives the demo loop headlessly: health → member shell → seed → standing →
+action card → complete → receipt. `ICN_APPLIANCE_CLOUD_INIT_SEED` is optional
+— when unset, smoke-local builds a seed ISO from the SSH key via
+`cloud-localds` (and refuses the placeholder key shipped in-tree). The image
+must have been built with `ICN_APPLIANCE_DEMO_PROFILE=1`; building it is a
+separate step documented in `deploy/appliance/DEMO_QUICKSTART.md`.
+
+## Fast path B — open an already-running node instance
+
+Direct route:
+
+```bash
+ICN_DEMO_VM_IP=192.0.2.50 \
+ICN_DEMO_SSH_KEY=~/.ssh/icn_demo_ed25519 \
+bash deploy/appliance/scripts/icn-rehearsal-node.sh open-running-node
+```
+
+Jump-host route (key lives on the jump host):
+
+```bash
+ICN_DEMO_VM_IP=192.0.2.50 \
+ICN_DEMO_JUMP=user@jump.example.internal \
+ICN_DEMO_REMOTE_KEY=/home/user/.ssh/icn_demo_ed25519 \
+bash deploy/appliance/scripts/icn-rehearsal-node.sh open-running-node
+```
+
+This tunnels the gateway (`18080`), member shell (`18090` — fixed: it is the
+browser Origin the gateway CORS and the session endpoint pin), and the
+loopback demo-session port (`18091`), then opens the shell with
+`?demo=launcher`. The "Start local demo" button mints a short-lived DEV/DEMO
+session via the in-VM loopback endpoint — the credential lives in page memory
+only, never in a URL, never pasted.
+
+## Evidence path
+
+- `sudo icn-demo-verify <item-id>` — re-fetches the completion receipt and
+  checks its field binding (item, domain, transition, 32-byte `record_hash`
+  present). A consistency check, not a client-side hash re-derivation.
+- `sudo icn-demo-verify --chain` — runs the deeper 13-of-13 governed
+  receipt-chain rehearsal (`icnctl audit verify`) against an ephemeral in-VM
+  gateway and emits a repo-safe evidence packet conforming to
+  `urn:icn:contract:rehearsal-evidence-export:v1`.
+- Evidence lives under `/var/lib/icn-demo/` in the demo VM
+  (`receipt-chain-13of13/` for the chain packet).
+- `bash deploy/appliance/scripts/icn-rehearsal-node.sh verify-running-node`
+  prints these steps (and ready-to-copy ssh one-liners when the route env vars
+  are set); it never executes anything remotely.
+
+## Relationship to other ICN run paths
+
+| Path | What it is | Where it fits |
+|---|---|---|
+| `demo/SELF_SERVE.md` Path 0 | Fixture-only static browser demo (pilot-ui `?mode=demo`), zero build | First look, two minutes, nothing live |
+| `demo/SELF_SERVE.md` Path 1 | `scripts/local_receipt_chain_13of13_rehearsal.sh` — the strongest single proof (live-local 13/13 + evidence packet) | Proof, not presentation |
+| `demo/SELF_SERVE.md` Path 2 | `demo/nycn-dogfood/run.sh` — same loop, workstation-native, gateway `:8085` | Developer story runner, no VM |
+| `deploy/devnet/` | Three-node Docker devnet | Multi-node gossip/convergence; explicitly not federation |
+| **Appliance DEV/DEMO profile (this runbook)** | Disposable VM + member shell + launcher + in-VM verify | **The Rehearsal Node v0.1 route** |
+
+Rehearsal Node v0.1 is specifically the appliance/member-shell route because
+it is the only path where a facilitator can walk the loop in a browser with no
+terminal after startup, on a node instance that is disposable-by-construction,
+with per-VM secrets, honesty labels on the surface, and the deeper chain proof
+one command away inside the same VM.
+
+## Known gaps
+
+- The demo-profile image must be built or staged separately
+  (`build-image.sh --real` with `ICN_APPLIANCE_DEMO_PROFILE=1`); the wrapper
+  does not build or download images.
+- The wrapper does not create the Debian base image or the cloud-init seed by
+  itself.
+- The shell is the member-shell v0 reference client, not a production app and
+  not the #1726 organizer rehearsal shell; the human assistive-technology pass
+  (#2041) is still owed, and only automated accessibility evidence exists.
+- Demo mode's "no outbound network" property is by construction of the VM and
+  tunnels, not yet proven by a dedicated guard/test — that is #1727's
+  deliverable, not this runbook's claim.
+- Action cards derive from three of five source paths; `signal_rule` and
+  `obligation_lifecycle` are reserved and not emitted.
+- v0.2 (a two-node local proof) is a separate follow-up issue, not this path.

--- a/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
+++ b/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
@@ -159,8 +159,10 @@ one command away inside the same VM.
 - The demo-profile image must be built or staged separately
   (`build-image.sh --real` with `ICN_APPLIANCE_DEMO_PROFILE=1`); the wrapper
   does not build or download images.
-- The wrapper does not create the Debian base image or the cloud-init seed by
-  itself.
+- The wrapper does not create the Debian base image or a cloud-init seed
+  itself; it only preflights the seed precondition described in Fast path A
+  (pre-built ISO, or an edited `user-data.example.yaml` from which smoke-local
+  builds one).
 - The shell is the member-shell v0 reference client, not a production app and
   not the #1726 organizer rehearsal shell; the human assistive-technology pass
   (#2041) is still owed, and only automated accessibility evidence exists.

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -19,6 +19,7 @@
 | [JULY_DEMO_OPERATOR_CHECKLIST.md](JULY_DEMO_OPERATOR_CHECKLIST.md) | **Keep-open live-demo card** — preflight, launch command, expected states, and panic fixes. |
 | [JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md](JULY_DEMO_CANDIDATE_0.1_OPERATOR_SCRIPT.md) | **Reviewer / evidence-hygiene handoff** — claim boundary by proof level, secret/evidence capture, known-gaps map, reviewer checklist. |
 | [deploy/appliance/DEMO_QUICKSTART.md](../../deploy/appliance/DEMO_QUICKSTART.md) | **Appliance build/run** — image build, the one-command launcher, and the manual fallback. |
+| [ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md](ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md) | **Rehearsal Node v0.1 operator runbook** — the named wrapper entrypoint over the appliance DEV/DEMO profile (smoke an image, open a running node, print verification steps), what it proves / does not prove, and how it relates to the other run paths. |
 | [JULY_DEMO_CANDIDATE_0.1_ACCESSIBILITY_WALKTHROUGH.md](JULY_DEMO_CANDIDATE_0.1_ACCESSIBILITY_WALKTHROUGH.md) | **Accessibility + rendered-browser evidence** — the 12-category organizer/member gate outcome, automated axe + keyboard results, what a reviewer can verify, and the human screen-reader/zoom pass still owed. |
 
 > The sections below describe the older one-click tool-library / devnet demo,


### PR DESCRIPTION
## Summary

Adds the first ICN Rehearsal Node v0.1 operator entrypoint and runbook.

This does not invent a new node path. It wraps the existing appliance DEV/DEMO profile:

- `smoke-local.sh --real --demo`
- `open-proxmox-demo.sh`
- `icn-demo-seed`
- `icn-demo-verify`
- `icn-demo-reset`
- `web/member-shell`

## Repo orientation

Before implementation, this PR performed a repo-wide orientation pass across:

- appliance/node runtime paths;
- demo/proof/evidence scripts;
- member/pilot/dashboard web surfaces;
- governance/action-card/receipt APIs;
- truth roots and open gates;
- existing command/task-runner conventions.

The decision from that pass: #2386 should start by naming and consolidating the existing appliance DEV/DEMO route, not by creating a parallel demo node. Orientation-driven adjustments to the original sketch: `ICN_APPLIANCE_CLOUD_INIT_SEED` is documented as optional (smoke-local has a `cloud-localds` fallback); `verify-running-node` is print-only (no remote-execution framework); no task-runner alias (neither `justfile` nor `Makefile` has a demo-command convention — every sibling entrypoint is invoked bash-direct); and the runbook corrects the verify semantics (client-side `icn-demo-verify` steps are consistency/provenance audits, not cryptographic re-derivation — the BLAKE3 binding is created server-side at emission).

## Why

#2386 needs to start from what already boots. The appliance demo profile already proves the single-node loop; this PR gives it one named v0.1 entrypoint and a runbook so operators can use it consistently.

## What changed

- Added `deploy/appliance/scripts/icn-rehearsal-node.sh` (delegation-only wrapper: `smoke-image`, `open-running-node`, `verify-running-node`, `--dry-run`, `--help`; house style; vocab-scan-safe; passes `deploy/appliance/check.sh`).
- Added `docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md` (what it proves / does not prove, reused pieces, fast paths A/B, evidence path, honest comparison with SELF_SERVE Paths 0–3 / nycn-dogfood / devnet, known gaps).
- Cross-linked from `deploy/appliance/DEMO_QUICKSTART.md` (short wrapper section before the one-command launcher).
- Cross-linked from `docs/demo/README.md` (one row in the July Candidate doc table).
- Cross-linked from `demo/SELF_SERVE.md` (small appliance-route pointer; it is the public self-serve entrypoint).
- No task-runner aliases (no existing convention to fit).

This PR advances #2386 acceptance criteria 1/2/4/6/7/8/9/10 by naming and documenting existing machinery. #2386 stays OPEN after this PR merges — the no-outbound-network guard/test remains #1727's deliverable, and the organizer shell remains #1726 (on the #1728 contract). The surface this opens is the member-shell v0 reference client, not the #1726 organizer shell.

## Validation

- [x] `bash -n deploy/appliance/scripts/icn-rehearsal-node.sh`
- [x] `bash deploy/appliance/scripts/icn-rehearsal-node.sh --dry-run`
- [x] `bash deploy/appliance/scripts/icn-rehearsal-node.sh --help`
- [x] negative paths: `smoke-image` with missing env → clear error, exit 2; unknown command → exit 2
- [x] `bash deploy/appliance/check.sh` — 23 passed / 0 failed (typed-manifest round-trip SKIP: no prebuilt icnctl, as designed); includes the forbidden-vocabulary scan
- [x] `python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml` — OK (940 files; no new warnings)
- [x] `python3 .github/scripts/compliance_linter.py` + `readiness_overclaim_linter.py` — clean
- [x] `git diff --check`

Not run: `build-image.sh --real` / QEMU smoke (no staged base image on this VM; the wrapper never builds images).

## Non-claims

- No production-readiness claim.
- No pilot-readiness claim.
- No live-federation claim.
- No multi-node proof.
- No runtime bridge.
- No connector.
- No real Drive / Sheets / Gmail / SimpleTix data.
- No private operational data.
- No claim that NYCN operations are ICN-native today.
- No Phase 2 completion claim.
- No branch-protection / ruleset mutation.
- No required-check mutation.

Refs #2386.
Refs #1727.
Refs #1726.
Refs #1728.
Refs #1746.
Refs #1703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
