### PR TITLE
demo(appliance): block guest outbound networking in demo smoke by default

### DIFF
--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -83,14 +83,18 @@ smoke only; an already-running Proxmox/cloud node's network isolation is
 operator-provided (see the runbook's "Network posture" section).
 
 **Manual (for the browser demo):** boot QEMU yourself with the demo ports
-forwarded:
+forwarded. `restrict=on` matches the scripted smoke's default posture —
+guest-initiated outbound is blocked while the loopback port forwards keep
+working. Drop `,restrict=on` only if you deliberately want guest outbound;
+note the manual path never runs the smoke's isolation canary either way, so
+the scripted smoke remains the proven route:
 
 ```bash
 qemu-img create -f qcow2 -b "$IMAGE" -F qcow2 overlay.qcow2
 qemu-system-x86_64 -machine accel=kvm:tcg -m 2048 -smp 2 -display none \
   -drive if=virtio,format=qcow2,file=overlay.qcow2 \
   -drive if=virtio,format=raw,file=seed.iso,readonly=on \
-  -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2222-:22,hostfwd=tcp:127.0.0.1:18080-:8080,hostfwd=tcp:127.0.0.1:18090-:8090 \
+  -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2222-:22,hostfwd=tcp:127.0.0.1:18080-:8080,hostfwd=tcp:127.0.0.1:18090-:8090,restrict=on \
   -device virtio-net-pci,netdev=net0 -nographic
 ```
 

--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -75,7 +75,12 @@ bash deploy/appliance/smoke/smoke-local.sh --real --demo
 
 That boots the VM on a disposable overlay, seeds the demo, drives the whole
 loop headlessly, and prints PASS/FAIL. It is the same path your browser
-will take.
+will take. The demo smoke also blocks guest-initiated outbound networking by
+default (QEMU user-net `restrict=on`; the loopback port forwards are
+unaffected) and proves it with an in-guest canary probe — set
+`ICN_APPLIANCE_ALLOW_OUTBOUND=1` to permit outbound. This applies to the QEMU
+smoke only; an already-running Proxmox/cloud node's network isolation is
+operator-provided (see the runbook's "Network posture" section).
 
 **Manual (for the browser demo):** boot QEMU yourself with the demo ports
 forwarded:

--- a/deploy/appliance/check.sh
+++ b/deploy/appliance/check.sh
@@ -109,7 +109,21 @@ else
     printf '%s\n' "$SECRET_HITS" >&2
 fi
 
-# 6. typed manifest emit/verify round-trip (skip-aware / opt-in)
+# 6. demo netdev isolation construction (#1727 / #2386)
+#
+# Asserts smoke-local.sh constructs the QEMU user-net string with guest
+# isolation on by default in --demo (restrict=on + all hostfwds), with the
+# explicit ICN_APPLIANCE_ALLOW_OUTBOUND=1 override honored and the base
+# (non-demo) smoke unchanged. Static construction check only — the runtime
+# canary proof runs inside `smoke-local.sh --real --demo`.
+section "demo netdev isolation construction"
+if bash "$APPLIANCE_DIR/smoke/net-restrict-check.sh" >/dev/null; then
+    ok "netdev isolation construction (4/4 cases)"
+else
+    bad "netdev isolation construction (run: bash deploy/appliance/smoke/net-restrict-check.sh)"
+fi
+
+# 7. typed manifest emit/verify round-trip (skip-aware / opt-in)
 #
 # Proves the typed appliance manifest path (`icnctl appliance emit-manifest`
 # #2259 + `verify-manifest` #2260, wired into build-image.sh #2261) still honors

--- a/deploy/appliance/scripts/icn-rehearsal-node.sh
+++ b/deploy/appliance/scripts/icn-rehearsal-node.sh
@@ -29,6 +29,12 @@
 #                                  then builds a seed via cloud-localds; it
 #                                  refuses the shipped placeholder key and does
 #                                  NOT derive the key from ICN_APPLIANCE_SSH_KEY)
+#   ICN_APPLIANCE_ALLOW_OUTBOUND   optional. The demo smoke ISOLATES the guest
+#                                  network by default (QEMU user-net
+#                                  restrict=on; loopback hostfwd unaffected)
+#                                  and proves it with an in-guest canary
+#                                  probe. Set 1 to permit guest outbound
+#                                  (skips the canary; loud in output).
 #
 # Env (open-running-node / verify-running-node — same contract as
 # open-proxmox-demo.sh):
@@ -39,6 +45,14 @@
 #   ICN_DEMO_SSH_USER     optional            VM ssh user (default: debian)
 #   Other launcher knobs (ICN_DEMO_GW_PORT, ICN_DEMO_SESSION_PORT,
 #   ICN_DEMO_NO_BROWSER, ...) pass through to open-proxmox-demo.sh unchanged.
+#
+# Network posture (be precise about which route guarantees what):
+#   smoke-image        guest outbound is BLOCKED BY DEFAULT and canary-proven
+#                      (see ICN_APPLIANCE_ALLOW_OUTBOUND above).
+#   open-running-node  network isolation is OPERATOR-PROVIDED. This launcher
+#                      only opens SSH tunnels; it does not seal the VM. A
+#                      bounded preflight WARNS if the node's gateway port is
+#                      directly reachable from this workstation.
 #
 # What this wrapper does NOT do:
 #   - does not build or download images (see build-image.sh)
@@ -59,6 +73,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APPLIANCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 log()   { printf '[rehearsal-node] %s\n' "$*"; }
+warn()  { printf '[rehearsal-node] WARN: %s\n' "$*" >&2; }
 err()   { printf '[rehearsal-node] ERROR: %s\n' "$*" >&2; }
 fatal() { err "$*"; exit 2; }
 
@@ -152,6 +167,10 @@ dry_run() {
   log "  seed:     ICN_APPLIANCE_CLOUD_INIT_SEED, or an edited"
   log "            smoke/cloud-init/user-data.example.yaml carrying your real"
   log "            smoke public key (the shipped placeholder is refused)"
+  log "  network:  guest outbound is BLOCKED by default (QEMU user-net"
+  log "            restrict=on; loopback hostfwd unaffected) and proven by an"
+  log "            in-guest canary probe; ICN_APPLIANCE_ALLOW_OUTBOUND=1"
+  log "            permits outbound and skips the canary"
   log ""
   log "open-running-node would run:"
   log "  bash ${SCRIPT_DIR}/open-proxmox-demo.sh"
@@ -160,6 +179,9 @@ dry_run() {
   log "   shell with the no-paste 'Start local demo' launcher)"
   log "  requires: ICN_DEMO_VM_IP + ICN_DEMO_SSH_KEY (direct)"
   log "        or: ICN_DEMO_VM_IP + ICN_DEMO_JUMP + ICN_DEMO_REMOTE_KEY (jump)"
+  log "  network:  isolation is OPERATOR-PROVIDED (tunnels do not seal the"
+  log "            VM); a bounded preflight WARNS if the node's gateway port"
+  log "            is directly reachable from this workstation"
   log ""
   log "verify-running-node would print the in-VM verification commands"
   log "(sudo icn-demo-verify <item-id> | --chain); it never executes remotely."
@@ -182,6 +204,19 @@ case "$cmd" in
   open-running-node)
     banner
     require_open_env
+    log "network isolation for an already-running node is OPERATOR-PROVIDED:"
+    log "this launcher only opens SSH tunnels; it does not seal the VM's network."
+    # Bounded exposure preflight (warn-only). The demo profile binds services
+    # beyond loopback inside the VM; if the gateway port answers this
+    # workstation directly, the node is reachable from this network segment.
+    # The inverse is NOT proof of isolation — it only means no direct path
+    # from here.
+    if timeout 2 bash -c "exec 3<>/dev/tcp/${ICN_DEMO_VM_IP}/8080" 2>/dev/null; then
+      warn "exposure preflight: gateway port 8080 on ${ICN_DEMO_VM_IP} is DIRECTLY reachable from this workstation."
+      warn "Run this node only on a trusted/isolated network or behind an operator-provided firewall. Continuing (warning only)."
+    else
+      log "exposure preflight: no direct gateway reachability from here (NOT proof of isolation)."
+    fi
     log "delegating to open-proxmox-demo.sh ..."
     exec bash "${SCRIPT_DIR}/open-proxmox-demo.sh"
     ;;

--- a/deploy/appliance/scripts/icn-rehearsal-node.sh
+++ b/deploy/appliance/scripts/icn-rehearsal-node.sh
@@ -211,7 +211,9 @@ case "$cmd" in
     # workstation directly, the node is reachable from this network segment.
     # The inverse is NOT proof of isolation — it only means no direct path
     # from here.
-    if timeout 2 bash -c "exec 3<>/dev/tcp/${ICN_DEMO_VM_IP}/8080" 2>/dev/null; then
+    # The VM IP is passed as a positional parameter, never interpolated into
+    # the command string — a metacharacter-bearing value cannot become code.
+    if timeout 2 bash -c 'exec 3<>"/dev/tcp/${1}/8080"' _ "${ICN_DEMO_VM_IP}" 2>/dev/null; then
       warn "exposure preflight: gateway port 8080 on ${ICN_DEMO_VM_IP} is DIRECTLY reachable from this workstation."
       warn "Run this node only on a trusted/isolated network or behind an operator-provided firewall. Continuing (warning only)."
     else

--- a/deploy/appliance/scripts/open-proxmox-demo.sh
+++ b/deploy/appliance/scripts/open-proxmox-demo.sh
@@ -74,6 +74,27 @@ err()  { printf '[demo-open] ERROR: %s\n' "$*" >&2; }
 # curl is used for the post-tunnel readiness wait — require it up front.
 command -v curl >/dev/null 2>&1 || { err "curl is required but not found on PATH."; exit 2; }
 
+# ---- preflight: overridable ports must be strict decimal 1..65535 ----
+# The jump route flattens the forward flags into a remote shell command
+# (printf -v INNER ... "${FWD[*]}"), so a non-numeric port value would be
+# word-split and executed on the jump host. The free-port /dev/tcp probe
+# below silently tolerates junk values (a failed redirect just skips the
+# branch), so validate BEFORE any use. SHELL_PORT is a fixed literal.
+for pv in "ICN_DEMO_GW_PORT=$GW_PORT" "ICN_DEMO_SESSION_PORT=$SESSION_PORT"; do
+  pv_name="${pv%%=*}"
+  pv_val="${pv#*=}"
+  case "$pv_val" in
+    ''|*[!0-9]*)
+      err "$pv_name must be a decimal TCP port (1-65535); got: '$pv_val'"
+      exit 2
+      ;;
+  esac
+  if [ "$pv_val" -lt 1 ] || [ "$pv_val" -gt 65535 ]; then
+    err "$pv_name out of range 1-65535: $pv_val"
+    exit 2
+  fi
+done
+
 # ---- preflight: required host ports free ----
 for p in "$GW_PORT" "$SHELL_PORT" "$SESSION_PORT"; do
   if (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then

--- a/deploy/appliance/smoke/net-restrict-check.sh
+++ b/deploy/appliance/smoke/net-restrict-check.sh
@@ -29,8 +29,27 @@ bad()  { printf '[net-restrict-check] FAIL: %s\n' "$*" >&2; fail=1; }
 
 [ -f "$SMOKE" ] || { bad "smoke-local.sh not found at $SMOKE"; exit 1; }
 
+# Run --print-netdev with every netdev-affecting variable SCRUBBED first, so
+# an operator's ambient demo environment (exported ICN_APPLIANCE_*_PORT /
+# ALLOW_OUTBOUND from an earlier smoke run) cannot change what "default"
+# means and fail a valid checkout. Per-case overrides are passed as leading
+# KEY=VAL arguments; remaining arguments are smoke-local flags.
+netdev() {
+    local assigns=()
+    while [ "$#" -gt 0 ] && [[ "$1" == *=* ]]; do
+        assigns+=("$1")
+        shift
+    done
+    env -u ICN_APPLIANCE_ALLOW_OUTBOUND \
+        -u ICN_APPLIANCE_SSH_PORT \
+        -u ICN_APPLIANCE_GW_FWD_PORT \
+        -u ICN_APPLIANCE_SHELL_FWD_PORT \
+        ${assigns[@]+"${assigns[@]}"} \
+        bash "$SMOKE" "$@" --print-netdev
+}
+
 # Case 1: demo default -> restricted, all forwards present.
-ND="$(env -u ICN_APPLIANCE_ALLOW_OUTBOUND bash "$SMOKE" --demo --print-netdev)"
+ND="$(netdev --demo)"
 case "$ND" in
     *restrict=on*) : ;;
     *) bad "case 1: --demo default lacks restrict=on: $ND" ;;
@@ -43,14 +62,14 @@ for want in "hostfwd=tcp:127.0.0.1:2222-:22" "hostfwd=tcp:127.0.0.1:18080-:8080"
 done
 
 # Case 2: explicit override -> unrestricted.
-ND="$(ICN_APPLIANCE_ALLOW_OUTBOUND=1 bash "$SMOKE" --demo --print-netdev)"
+ND="$(netdev ICN_APPLIANCE_ALLOW_OUTBOUND=1 --demo)"
 case "$ND" in
     *restrict=on*) bad "case 2: ALLOW_OUTBOUND=1 still restricted: $ND" ;;
     *) : ;;
 esac
 
 # Case 3: base smoke unchanged -> no restrict, SSH forward only.
-ND="$(env -u ICN_APPLIANCE_ALLOW_OUTBOUND bash "$SMOKE" --print-netdev)"
+ND="$(netdev)"
 case "$ND" in
     *restrict=on*) bad "case 3: non-demo smoke gained restrict=on (behavior change): $ND" ;;
     *) : ;;
@@ -65,7 +84,7 @@ case "$ND" in
 esac
 
 # Case 4: constructed, not hard-coded — custom ports must appear.
-ND="$(env -u ICN_APPLIANCE_ALLOW_OUTBOUND ICN_APPLIANCE_SSH_PORT=2299 ICN_APPLIANCE_GW_FWD_PORT=28080 ICN_APPLIANCE_SHELL_FWD_PORT=28090 bash "$SMOKE" --demo --print-netdev)"
+ND="$(netdev ICN_APPLIANCE_SSH_PORT=2299 ICN_APPLIANCE_GW_FWD_PORT=28080 ICN_APPLIANCE_SHELL_FWD_PORT=28090 --demo)"
 for want in "hostfwd=tcp:127.0.0.1:2299-:22" "hostfwd=tcp:127.0.0.1:28080-:8080" "hostfwd=tcp:127.0.0.1:28090-:8090" "restrict=on"; do
     case "$ND" in
         *"$want"*) : ;;

--- a/deploy/appliance/smoke/net-restrict-check.sh
+++ b/deploy/appliance/smoke/net-restrict-check.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# net-restrict-check.sh
+#
+# Deterministic, VM-free check that smoke-local.sh constructs the QEMU
+# user-mode netdev with the intended isolation posture (#1727 / #2386):
+#
+#   1. --demo (default)      -> restrict=on present + all three hostfwds
+#   2. --demo + ALLOW=1      -> restrict=on ABSENT (explicit, loud override)
+#   3. base (non-demo)       -> restrict=on ABSENT, SSH hostfwd only
+#                               (ordinary smoke behavior unchanged)
+#   4. --demo + custom ports -> hostfwds reflect the configured ports
+#                               (the string is constructed, not hard-coded)
+#
+# This asserts CONFIGURATION CONSTRUCTION only. The runtime proof — a guest
+# that cannot reach a verified host-loopback canary listener — runs inside
+# `smoke-local.sh --real --demo` and needs a built demo-profile image.
+# PASS here is NOT a live no-outbound proof.
+#
+# Usage: bash deploy/appliance/smoke/net-restrict-check.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SMOKE="$SCRIPT_DIR/smoke-local.sh"
+
+fail=0
+say()  { printf '[net-restrict-check] %s\n' "$*"; }
+bad()  { printf '[net-restrict-check] FAIL: %s\n' "$*" >&2; fail=1; }
+
+[ -f "$SMOKE" ] || { bad "smoke-local.sh not found at $SMOKE"; exit 1; }
+
+# Case 1: demo default -> restricted, all forwards present.
+ND="$(env -u ICN_APPLIANCE_ALLOW_OUTBOUND bash "$SMOKE" --demo --print-netdev)"
+case "$ND" in
+    *restrict=on*) : ;;
+    *) bad "case 1: --demo default lacks restrict=on: $ND" ;;
+esac
+for want in "hostfwd=tcp:127.0.0.1:2222-:22" "hostfwd=tcp:127.0.0.1:18080-:8080" "hostfwd=tcp:127.0.0.1:18090-:8090"; do
+    case "$ND" in
+        *"$want"*) : ;;
+        *) bad "case 1: --demo default missing forward '$want': $ND" ;;
+    esac
+done
+
+# Case 2: explicit override -> unrestricted.
+ND="$(ICN_APPLIANCE_ALLOW_OUTBOUND=1 bash "$SMOKE" --demo --print-netdev)"
+case "$ND" in
+    *restrict=on*) bad "case 2: ALLOW_OUTBOUND=1 still restricted: $ND" ;;
+    *) : ;;
+esac
+
+# Case 3: base smoke unchanged -> no restrict, SSH forward only.
+ND="$(env -u ICN_APPLIANCE_ALLOW_OUTBOUND bash "$SMOKE" --print-netdev)"
+case "$ND" in
+    *restrict=on*) bad "case 3: non-demo smoke gained restrict=on (behavior change): $ND" ;;
+    *) : ;;
+esac
+case "$ND" in
+    *"hostfwd=tcp:127.0.0.1:2222-:22"*) : ;;
+    *) bad "case 3: SSH hostfwd missing: $ND" ;;
+esac
+case "$ND" in
+    *18080*|*18090*) bad "case 3: non-demo smoke gained demo forwards: $ND" ;;
+    *) : ;;
+esac
+
+# Case 4: constructed, not hard-coded — custom ports must appear.
+ND="$(env -u ICN_APPLIANCE_ALLOW_OUTBOUND ICN_APPLIANCE_SSH_PORT=2299 ICN_APPLIANCE_GW_FWD_PORT=28080 ICN_APPLIANCE_SHELL_FWD_PORT=28090 bash "$SMOKE" --demo --print-netdev)"
+for want in "hostfwd=tcp:127.0.0.1:2299-:22" "hostfwd=tcp:127.0.0.1:28080-:8080" "hostfwd=tcp:127.0.0.1:28090-:8090" "restrict=on"; do
+    case "$ND" in
+        *"$want"*) : ;;
+        *) bad "case 4: custom-port netdev missing '$want': $ND" ;;
+    esac
+done
+
+if [ "$fail" -eq 0 ]; then
+    say "PASS: 4/4 netdev-construction cases (static check; runtime canary lives in smoke-local.sh --real --demo)."
+    exit 0
+fi
+exit 1

--- a/deploy/appliance/smoke/smoke-local.sh
+++ b/deploy/appliance/smoke/smoke-local.sh
@@ -20,9 +20,22 @@
 #                - drive the member loop from the HOST through the forwarded
 #                  gateway: standing -> action card -> complete -> receipt,
 #                  with the receipt binding check (32-byte record_hash)
+#                - block guest-initiated outbound networking by DEFAULT
+#                  (QEMU user-net restrict=on; explicitly set forwarding
+#                  rules are unaffected per the QEMU manual) and prove it
+#                  with an in-guest canary probe: a host-loopback listener
+#                  started by this script must be reachable from the HOST
+#                  and unreachable from the GUEST (via the 10.0.2.2 slirp
+#                  host alias — no public internet host involved, so an
+#                  offline runner cannot false-pass)
 #              A --demo pass means the demo loop works end-to-end against
 #              this image from a clean boot. It still does NOT mean
 #              production, pilot, or federation.
+#
+# Test hook:
+#   --print-netdev  Print the exact -netdev string this invocation would
+#                   pass to QEMU (honoring --demo and env) and exit. Used
+#                   by smoke/net-restrict-check.sh; no VM, no env needed.
 #
 # Required for --real:
 #   ICN_APPLIANCE_IMAGE      Path to the QCOW2 produced by build-image.sh.
@@ -47,6 +60,14 @@
 #                                VM gateway :8080; --demo only).
 #   ICN_APPLIANCE_SHELL_FWD_PORT Default: 18090 (host port forwarded to the
 #                                VM member-shell :8090; --demo only).
+#   ICN_APPLIANCE_ALLOW_OUTBOUND Set to 1 to SKIP the --demo default of
+#                                isolating the guest network (restrict=on).
+#                                The run then permits guest-initiated
+#                                outbound traffic and SKIPS the canary
+#                                probe; the output says so loudly.
+#   ICN_APPLIANCE_CANARY_PORT    Default: 18099. Host loopback port for the
+#                                outbound-isolation canary listener
+#                                (--demo restricted runs only).
 #
 # Required tools for --real:
 #   qemu-system-x86_64, ssh, curl, sha256sum
@@ -72,17 +93,19 @@ warn() { printf '[appliance-smoke] WARN: %s\n' "$*" >&2; }
 err()  { printf '[appliance-smoke] ERROR: %s\n' "$*" >&2; }
 
 usage() {
-    sed -n '2,42p' "$0"
+    awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
     exit 0
 }
 
 DEMO=0
+PRINT_NETDEV=0
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --dry-run) MODE="dry-run" ; shift ;;
         --real)    MODE="real"    ; shift ;;
         --demo)    DEMO=1         ; shift ;;
+        --print-netdev) PRINT_NETDEV=1 ; shift ;;
         --help|-h) usage ;;
         *)
             err "unknown argument: $1"
@@ -101,6 +124,30 @@ VM_CPUS="${ICN_APPLIANCE_VM_CPUS:-2}"
 VM_TIMEOUT="${ICN_APPLIANCE_VM_TIMEOUT:-300}"
 GW_FWD_PORT="${ICN_APPLIANCE_GW_FWD_PORT:-18080}"
 SHELL_FWD_PORT="${ICN_APPLIANCE_SHELL_FWD_PORT:-18090}"
+ALLOW_OUTBOUND="${ICN_APPLIANCE_ALLOW_OUTBOUND:-0}"
+CANARY_PORT="${ICN_APPLIANCE_CANARY_PORT:-18099}"
+
+# Single source of truth for the QEMU -netdev string. --demo defaults to an
+# ISOLATED guest: user-net restrict=on blocks guest-initiated traffic to the
+# host and to the outside, while explicitly set hostfwd rules keep working
+# (QEMU manual, `restrict=on|off`). Base (non-demo) smoke is UNCHANGED.
+build_netdev() {
+    local nd="user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22"
+    if [ "$DEMO" = 1 ]; then
+        nd="${nd},hostfwd=tcp:127.0.0.1:${GW_FWD_PORT}-:8080,hostfwd=tcp:127.0.0.1:${SHELL_FWD_PORT}-:8090"
+        if [ "$ALLOW_OUTBOUND" != "1" ]; then
+            nd="${nd},restrict=on"
+        fi
+    fi
+    printf '%s\n' "$nd"
+}
+
+# Test hook: print the constructed netdev and exit before any logging, env
+# requirement, or tool check — deterministic and VM-free.
+if [ "$PRINT_NETDEV" = 1 ]; then
+    build_netdev
+    exit 0
+fi
 
 log "Mode: $MODE"
 log "Demo add-on:      $DEMO"
@@ -139,6 +186,12 @@ cat <<'EOF_PLAN'
        - drive: working overlay
        - drive: cloud-init seed ISO (read-only)
        - no display; serial-on-stdout for diagnostics
+       - with --demo: gateway + member-shell hostfwd, and guest outbound
+         BLOCKED by default (user-net restrict=on; set
+         ICN_APPLIANCE_ALLOW_OUTBOUND=1 to permit outbound). A restricted
+         --demo run ends with an isolation canary: a host-loopback
+         listener must be reachable from the host and unreachable from
+         the guest.
 
   6) Wait for SSH on 127.0.0.1:${SSH_PORT}, bounded by VM_TIMEOUT.
 
@@ -220,6 +273,9 @@ log "Working dir: $WORK_DIR"
 
 cleanup() {
     local rc=$?
+    if [ -n "${CANARY_PID:-}" ] && kill -0 "$CANARY_PID" 2>/dev/null; then
+        kill "$CANARY_PID" 2>/dev/null || true
+    fi
     if [ -n "${QEMU_PID:-}" ] && kill -0 "$QEMU_PID" 2>/dev/null; then
         log "Terminating QEMU (pid $QEMU_PID)..."
         kill "$QEMU_PID" 2>/dev/null || true
@@ -290,12 +346,18 @@ log "Creating disposable overlay $OVERLAY (backing format: $BACKING_FORMAT) ..."
 qemu-img create -f qcow2 -b "$ICN_APPLIANCE_IMAGE" -F "$BACKING_FORMAT" "$OVERLAY" >/dev/null
 
 # Launch QEMU under user-mode networking. We do NOT touch host networking.
-NETDEV="user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22"
+# Demo add-on forwards the gateway and member-shell so the loop can be driven
+# from the host — the same path a stranger's browser takes — and isolates the
+# guest by default (see build_netdev).
+NETDEV="$(build_netdev)"
 if [ "$DEMO" = 1 ]; then
-    # Demo add-on: forward the gateway and member-shell so the loop can be
-    # driven from the host — the same path a stranger's browser takes.
-    NETDEV="${NETDEV},hostfwd=tcp:127.0.0.1:${GW_FWD_PORT}-:8080,hostfwd=tcp:127.0.0.1:${SHELL_FWD_PORT}-:8090"
     log "Launching QEMU (user-mode net, hostfwd ${SSH_PORT}->22, ${GW_FWD_PORT}->8080, ${SHELL_FWD_PORT}->8090)..."
+    if [ "$ALLOW_OUTBOUND" != "1" ]; then
+        log "Guest outbound: BLOCKED by default (user-net restrict=on; hostfwd unaffected)."
+        log "                Set ICN_APPLIANCE_ALLOW_OUTBOUND=1 to permit guest outbound."
+    else
+        warn "Guest outbound: ALLOWED (ICN_APPLIANCE_ALLOW_OUTBOUND=1) — the isolation canary probe will be SKIPPED."
+    fi
 else
     log "Launching QEMU (user-mode net, hostfwd ${SSH_PORT}->22)..."
 fi
@@ -519,6 +581,43 @@ if [ "$DEMO" = 1 ]; then
         | jq --arg id "$DEMO_ITEM" '[.cards[]? | select(.source_id==$id)] | length')"
     [ "$N_AFTER" = "0" ] || { err "[demo] card did not clear after completion"; exit 13; }
     log "[demo] loop complete: standing -> card -> discharge -> receipt -> card cleared."
+
+    # ---------- outbound-isolation canary (restricted runs only) ----------
+    if [ "$ALLOW_OUTBOUND" != "1" ]; then
+        log "[demo] outbound-isolation canary: guest must NOT reach a host listener..."
+        # 10.0.2.2 is the QEMU user-net (slirp) alias for the host. Without
+        # restrict=on a guest can open TCP connections to it; with restrict=on
+        # the QEMU-documented isolation must drop them. The listener is
+        # started by THIS script and verified reachable host-side first, so a
+        # guest-side connection failure is attributable to the isolation, not
+        # to a dead listener — and no public internet host is involved, so an
+        # offline runner cannot produce a false pass.
+        ( cd "$WORK_DIR" && exec python3 -m http.server "$CANARY_PORT" --bind 127.0.0.1 ) >/dev/null 2>&1 &
+        CANARY_PID=$!
+        CANARY_UP=0
+        for _ in 1 2 3 4 5; do
+            if curl -sf -m 2 "http://127.0.0.1:${CANARY_PORT}/" >/dev/null 2>&1; then
+                CANARY_UP=1
+                break
+            fi
+            sleep 1
+        done
+        if [ "$CANARY_UP" -ne 1 ]; then
+            err "[demo] canary listener never answered on 127.0.0.1:${CANARY_PORT}."
+            err "[demo] Set ICN_APPLIANCE_CANARY_PORT to a free host port and re-run."
+            exit 14
+        fi
+        if run_in_vm "curl -s -o /dev/null -m 4 http://10.0.2.2:${CANARY_PORT}/" 2>/dev/null; then
+            err "[demo] FAIL-OPEN: the guest REACHED the host canary listener."
+            err "[demo] Guest-initiated outbound is not blocked (restrict=on ineffective?)."
+            exit 14
+        fi
+        kill "$CANARY_PID" 2>/dev/null || true
+        CANARY_PID=""
+        log "[demo] outbound-isolation canary held: listener reachable from host, unreachable from guest."
+    else
+        warn "[demo] outbound isolation OVERRIDDEN (ICN_APPLIANCE_ALLOW_OUTBOUND=1) — canary probe SKIPPED; the guest may reach external networks."
+    fi
 fi
 
 cat <<EOF_PASS
@@ -538,6 +637,9 @@ if [ "$DEMO" = 1 ]; then
   shell:    http://127.0.0.1:${SHELL_FWD_PORT}/member-shell/ (host-forwarded)
   gateway:  http://127.0.0.1:${GW_FWD_PORT} (host-forwarded, JWT-auth)
   loop:     standing -> action card -> discharge -> receipt (verified host-side)
+  outbound: $( [ "$ALLOW_OUTBOUND" != "1" ] \
+      && echo "BLOCKED (restrict=on; in-guest canary probe held)" \
+      || echo "ALLOWED (ICN_APPLIANCE_ALLOW_OUTBOUND=1; canary skipped)" )
 
 NOTE: DEMO PASS means the member loop works end-to-end on this image from a
 clean boot, over the same forwarded ports a stranger's browser would use.

--- a/deploy/appliance/smoke/smoke-local.sh
+++ b/deploy/appliance/smoke/smoke-local.sh
@@ -618,11 +618,25 @@ if [ "$DEMO" = 1 ]; then
             err "[demo] Set ICN_APPLIANCE_CANARY_PORT to a free host port and re-run."
             exit 14
         fi
-        if run_in_vm "curl -s -o /dev/null -m 4 http://10.0.2.2:${CANARY_PORT}/canary-marker.txt" 2>/dev/null; then
-            err "[demo] FAIL-OPEN: the guest REACHED the host canary listener."
-            err "[demo] Guest-initiated outbound is not blocked (restrict=on ineffective?)."
-            exit 14
-        fi
+        # The remote command always emits a sentinel when it actually ran, so
+        # an SSH/transport failure (no sentinel) is distinguishable from
+        # blocked guest traffic (BLOCKED) and cannot masquerade as isolation.
+        CANARY_PROBE="$(run_in_vm "curl -s -o /dev/null -m 4 http://10.0.2.2:${CANARY_PORT}/canary-marker.txt && echo CANARY_REACHED || echo CANARY_BLOCKED" 2>/dev/null || true)"
+        case "$CANARY_PROBE" in
+            *CANARY_REACHED*)
+                err "[demo] FAIL-OPEN: the guest REACHED the host canary listener."
+                err "[demo] Guest-initiated outbound is not blocked (restrict=on ineffective?)."
+                exit 14
+                ;;
+            *CANARY_BLOCKED*)
+                : # probe ran in the guest and the connection was blocked — the desired outcome
+                ;;
+            *)
+                err "[demo] canary probe could not RUN in the guest (SSH failed; no sentinel returned)."
+                err "[demo] The connection failure cannot be attributed to isolation — failing closed."
+                exit 14
+                ;;
+        esac
         if ! kill -0 "$CANARY_PID" 2>/dev/null; then
             err "[demo] canary listener died during the probe window — the guest's"
             err "[demo] connection failure cannot be attributed to isolation. Re-run."

--- a/deploy/appliance/smoke/smoke-local.sh
+++ b/deploy/appliance/smoke/smoke-local.sh
@@ -592,29 +592,45 @@ if [ "$DEMO" = 1 ]; then
         # guest-side connection failure is attributable to the isolation, not
         # to a dead listener — and no public internet host is involved, so an
         # offline runner cannot produce a false pass.
-        ( cd "$WORK_DIR" && exec python3 -m http.server "$CANARY_PORT" --bind 127.0.0.1 ) >/dev/null 2>&1 &
+        # Serve a dedicated directory containing only a per-run marker file, and
+        # validate the exact marker content — so a pre-existing squatter on the
+        # port (or a python that failed to bind) can never stand in as the
+        # control. The spawned PID is also re-checked AFTER the guest probe:
+        # a server that died mid-window would make "guest could not connect"
+        # unattributable, so that case fails closed instead of passing.
+        CANARY_DIR="$WORK_DIR/canary"
+        CANARY_MARKER="icn-canary-$$-$(date +%s)"
+        mkdir -p "$CANARY_DIR"
+        printf '%s' "$CANARY_MARKER" > "$CANARY_DIR/canary-marker.txt"
+        ( cd "$CANARY_DIR" && exec python3 -m http.server "$CANARY_PORT" --bind 127.0.0.1 ) >/dev/null 2>&1 &
         CANARY_PID=$!
         CANARY_UP=0
         for _ in 1 2 3 4 5; do
-            if curl -sf -m 2 "http://127.0.0.1:${CANARY_PORT}/" >/dev/null 2>&1; then
+            if [ "$(curl -sf -m 2 "http://127.0.0.1:${CANARY_PORT}/canary-marker.txt" 2>/dev/null)" = "$CANARY_MARKER" ]; then
                 CANARY_UP=1
                 break
             fi
             sleep 1
         done
-        if [ "$CANARY_UP" -ne 1 ]; then
-            err "[demo] canary listener never answered on 127.0.0.1:${CANARY_PORT}."
+        if [ "$CANARY_UP" -ne 1 ] || ! kill -0 "$CANARY_PID" 2>/dev/null; then
+            err "[demo] canary listener did not serve this run's marker on 127.0.0.1:${CANARY_PORT}"
+            err "[demo] (port in use by another process, or the listener failed to start)."
             err "[demo] Set ICN_APPLIANCE_CANARY_PORT to a free host port and re-run."
             exit 14
         fi
-        if run_in_vm "curl -s -o /dev/null -m 4 http://10.0.2.2:${CANARY_PORT}/" 2>/dev/null; then
+        if run_in_vm "curl -s -o /dev/null -m 4 http://10.0.2.2:${CANARY_PORT}/canary-marker.txt" 2>/dev/null; then
             err "[demo] FAIL-OPEN: the guest REACHED the host canary listener."
             err "[demo] Guest-initiated outbound is not blocked (restrict=on ineffective?)."
             exit 14
         fi
+        if ! kill -0 "$CANARY_PID" 2>/dev/null; then
+            err "[demo] canary listener died during the probe window — the guest's"
+            err "[demo] connection failure cannot be attributed to isolation. Re-run."
+            exit 14
+        fi
         kill "$CANARY_PID" 2>/dev/null || true
         CANARY_PID=""
-        log "[demo] outbound-isolation canary held: listener reachable from host, unreachable from guest."
+        log "[demo] outbound-isolation canary held: per-run marker served to the host, unreachable from the guest, listener alive throughout."
     else
         warn "[demo] outbound isolation OVERRIDDEN (ICN_APPLIANCE_ALLOW_OUTBOUND=1) — canary probe SKIPPED; the guest may reach external networks."
     fi

--- a/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
+++ b/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
@@ -138,6 +138,50 @@ only, never in a URL, never pasted.
   prints these steps (and ready-to-copy ssh one-liners when the route env vars
   are set); it never executes anything remotely.
 
+## Network posture (which route guarantees what)
+
+The two fast paths make **different** isolation promises. Do not collapse
+them.
+
+**Fast path A (`smoke-image`) — enforced and proven.** The demo smoke boots
+the disposable VM with QEMU user-net `restrict=on` by default. Per the QEMU
+manual, the guest "will not be able to contact the host and no guest IP
+packets will be routed over the host to the outside," while explicitly set
+`hostfwd` rules (SSH, gateway, member shell) are unaffected. Two proofs back
+this:
+
+- *Static (runs everywhere, including offline CI):*
+  `deploy/appliance/smoke/net-restrict-check.sh` asserts the constructed
+  `-netdev` string — demo default restricted, override honored, base smoke
+  unchanged — and is wired into `deploy/appliance/check.sh`.
+- *Runtime (runs on every real `--demo` smoke):* the smoke starts a canary
+  listener on host loopback, verifies it is reachable **from the host**, then
+  proves it is **unreachable from the guest** via the `10.0.2.2` slirp host
+  alias. No public internet host is involved, so an offline runner cannot
+  false-pass; a guest that reaches the listener fails the smoke loudly
+  (FAIL-OPEN). Setting `ICN_APPLIANCE_ALLOW_OUTBOUND=1` permits outbound,
+  skips the canary, and says so in the output and the PASS footer.
+
+What was tested **statically** in this change: the netdev construction matrix
+(4 cases) and all script negative paths. What was tested **through a running
+VM**: nothing in this change — no built demo-profile image is staged on this
+development VM, so the restricted boot and in-guest canary run for the first
+time on the next real `smoke-image` execution. Until then, "blocked by
+default" is a documented-QEMU-semantics + static-construction claim, not a
+witnessed runtime result. If the restricted boot misbehaves, rerun with
+`ICN_APPLIANCE_ALLOW_OUTBOUND=1` and file the finding.
+
+**Fast path B (`open-running-node`) — operator-provided, not enforced.** The
+launcher opens SSH tunnels to an already-running VM; it cannot and does not
+seal that VM's network. The demo profile binds its services beyond loopback
+inside the VM, so an already-running node on a bridged network is reachable
+from that network regardless of anything this wrapper does. The wrapper
+states this on every run and adds a bounded, warn-only exposure preflight: if
+the node's gateway port answers this workstation directly, it warns; if it
+does not, that is explicitly **not** proof of isolation. A real sealed-node
+firewall profile does not exist yet; until it does, the no-outbound-by-default
+claim is scoped to the disposable local QEMU route only.
+
 ## Relationship to other ICN run paths
 
 | Path | What it is | Where it fits |
@@ -166,9 +210,12 @@ one command away inside the same VM.
 - The shell is the member-shell v0 reference client, not a production app and
   not the #1726 organizer rehearsal shell; the human assistive-technology pass
   (#2041) is still owed, and only automated accessibility evidence exists.
-- Demo mode's "no outbound network" property is by construction of the VM and
-  tunnels, not yet proven by a dedicated guard/test — that is #1727's
-  deliverable, not this runbook's claim.
+- The no-outbound guarantee is scoped to the `smoke-image` QEMU route (see
+  "Network posture"): enforced by default, statically tested, canary-proven on
+  each real `--demo` run — but not yet witnessed on a live VM from this change
+  itself. The `open-running-node` route stays operator-provided. #1727's
+  shell-level demo-mode criteria (fixture loader as default, live mode as a
+  labeled opt-in with a mutation warning) remain open.
 - Action cards derive from three of five source paths; `signal_rule` and
   `obligation_lifecycle` are reserved and not emitted.
 - v0.2 (a two-node local proof) is a separate follow-up issue, not this path.


### PR DESCRIPTION
## Summary

Makes the appliance demo smoke's disposable QEMU VM refuse guest-initiated outbound networking **by default**, proves that refusal two ways, and describes every other route with the isolation it actually has.

Advances #2386 acceptance criterion 3 ("Demo mode performs no outbound network calls" + "a test or guard proving it") **scoped to the `smoke-image` QEMU route**. #2386 remains open after this PR. #1727 remains open — its shell-level demo-mode criteria (fixture loader default, live-mode opt-in with warning) are untouched; this PR enforces the no-outbound property for the appliance smoke route only.

## Isolation mechanism

QEMU user-net `restrict=on`, appended to the `-netdev` string only in `--demo` mode. Verified against the **installed QEMU 8.2.2 man page** (not memory): the guest "will not be able to contact the host and no guest IP packets will be routed over the host to the outside," while "this option does not affect any explicitly set forwarding rules" — so the SSH/gateway/member-shell `hostfwd` paths the smoke depends on survive. `ICN_APPLIANCE_ALLOW_OUTBOUND=1` opts out, loudly, and the posture is printed at launch and in the DEMO PASS footer. Base (non-demo) smoke behavior is unchanged (asserted by test).

## Two proofs, honestly separated

1. **Static, deterministic, offline-safe (ran here):** `smoke-local.sh` gains a `--print-netdev` test hook; new `deploy/appliance/smoke/net-restrict-check.sh` asserts the 4-case construction matrix (demo default restricted + all three forwards; override honored; base smoke unchanged; ports constructed, not hard-coded). Wired into `deploy/appliance/check.sh` — now 25/0.
2. **Runtime negative probe (runs on every real `--demo` smoke; NOT executed in this change):** the smoke starts a canary listener on host loopback, verifies it is reachable **from the host** (so a dead listener cannot fake a pass), then requires it to be **unreachable from the guest** via the `10.0.2.2` slirp host alias. Guest reaching it = FAIL-OPEN, smoke fails. No public internet host is involved, so an offline runner cannot false-pass or go ambiguous.

**Not tested through a running VM here:** no built demo-profile image is staged on this dev VM, so the restricted boot + canary run for the first time on the next real `smoke-image` execution. The runbook says exactly this — "blocked by default" is documented-QEMU-semantics + static-construction until then, not a witnessed runtime result, with `ICN_APPLIANCE_ALLOW_OUTBOUND=1` as the documented fallback if the restricted boot misbehaves.

## QEMU route vs Proxmox route (do not collapse)

- `smoke-image`: **enforced + tested** as above.
- `open-running-node`: **operator-provided, not enforced.** The launcher opens SSH tunnels; it cannot seal an already-running bridged VM whose services bind beyond loopback. The wrapper now states this on every run and adds a **bounded, warn-only exposure preflight**: direct gateway reachability from the workstation warns; no reachability is explicitly labeled NOT proof of isolation. The runbook's new "Network posture" section carries the full separation.

## Adjacent safety fix (confirmed in source while reading the launcher)

`ICN_DEMO_GW_PORT` / `ICN_DEMO_SESSION_PORT` were interpolated unvalidated into the jump route's flattened remote shell command, and the free-port `/dev/tcp` probe silently tolerates junk values. Both are now validated as strict decimal 1–65535 before any use. Negative-tested: `'18080; echo pwned'` → clear error, exit 2, no ssh executed; valid values fall through to the pre-existing key check unchanged.

## Files changed

- `deploy/appliance/smoke/smoke-local.sh` — `build_netdev()` + `--print-netdev`, restrict-by-default in `--demo`, posture logging, canary probe, plan/header updates
- `deploy/appliance/smoke/net-restrict-check.sh` — new 4-case static test
- `deploy/appliance/check.sh` — new always-run section calling it
- `deploy/appliance/scripts/icn-rehearsal-node.sh` — posture docs in help/dry-run, operator-provided labeling + warn-only exposure preflight for `open-running-node`
- `deploy/appliance/scripts/open-proxmox-demo.sh` — strict port validation
- `docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md` — "Network posture" section; known-gaps bullet updated
- `deploy/appliance/DEMO_QUICKSTART.md` — one paragraph at the demo-smoke invocation

## Validation

- [x] `bash -n` on all five changed shell scripts
- [x] `bash deploy/appliance/smoke/net-restrict-check.sh` — PASS 4/4
- [x] `--print-netdev` matrix inspected directly (restricted / override / base)
- [x] `smoke-local.sh --dry-run --demo` + `--help` show the new posture text; rc=0
- [x] wrapper `--help` / `--dry-run` / exposure-preflight WARN branch (local listener on 8080) / no-direct branch (unroutable test IP) / missing-env negatives
- [x] launcher port validation negatives (injection-shaped and out-of-range → exit 2 before any ssh) and valid-port passthrough
- [x] `bash deploy/appliance/check.sh` — **25 passed / 0 failed** (incl. forbidden-vocab scan over the new text)
- [x] `doc_control_check.py` OK (no new warnings), compliance + readiness-overclaim linters clean
- [x] `git diff --check`, `cargo fmt --all --check`, drift-check PASS
- [ ] real `smoke-local.sh --real --demo` — **not run**: no built demo-profile image staged on this dev VM; the in-guest canary executes on the next real smoke

## Non-claims

- Not "fully offline" — the runtime proof has not yet been witnessed on a live VM from this change.
- No isolation guarantee for `open-running-node` / arbitrary bridged VMs — operator-provided.
- No production-readiness, pilot-readiness, organizer-ready, or live-federation claim.
- Client-side `icn-demo-verify` remains a consistency/provenance audit, not cryptographic re-derivation.
- No runtime bridge, connector, private data, NYCN changes, branch-protection/ruleset changes.
- Fixture-backed is not live; a local VM smoke is not production readiness.

Refs #1727.
Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)