### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 to clear RUSTSEC-2026-0204

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -1469,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Lockfile-only bump of the transitive dependency `crossbeam-epoch` from **0.9.18 → 0.9.20** to clear **RUSTSEC-2026-0204**, which the CI Security Audit job (`.github/workflows/ci.yml`, bare `cargo audit`) started flagging repository-wide after the advisory was published 2026-07-06. There is no `deny.toml`/`audit.toml`, so bare `cargo audit` fails on any advisory — this fixes the dependency rather than suppressing the signal.

## Advisory

- **ID:** RUSTSEC-2026-0204 (published 2026-07-06)
- **Crate:** `crossbeam-epoch` (transitive)
- **Issue:** the pre-0.9.20 `fmt::Display` / `fmt::Pointer` impl for `Atomic` and `Shared` dereferences the underlying pointer — an invalid pointer dereference when the pointer is null (e.g. created with `Atomic::null` / `Shared::null`). `fmt::Debug` impls and pre-0.9 `fmt::Display` impls are unaffected.
- **Resolved (vulnerable) version:** 0.9.18
- **Patched:** `>= 0.9.20` (upstream fix: crossbeam-rs/crossbeam#1276)

## Dependency path

`crossbeam-epoch` is **transitive only** — ICN declares no direct dependency on it. It enters the tree via:

- `crossbeam-deque 0.8.6` → `rayon-core`/`rayon` (→ `wasmtime` → `icn-baseline-lock`) and `ignore` → `globwalk` → `rust-i18n` (→ `icn-gateway`)
- `metrics-util 0.20.1` → `metrics-exporter-prometheus` → `icn-obs`

## Reachability

ICN code never formats a `crossbeam-epoch` `Atomic`/`Shared` value via `Display`/`Pointer`; those types are internal to `crossbeam-deque`'s work-stealing implementation. The vulnerable code path is therefore **not reachable in ICN usage**. The bump is applied regardless because it is trivial, semver-compatible, and clears the repository-wide red Security Audit.

## Change

```
cargo update -p crossbeam-epoch --precise 0.9.20
```

The diff is **only** the `crossbeam-epoch` version + checksum in `icn/Cargo.lock`. `crossbeam-utils` and every other package are unchanged (284 dependencies untouched). No `Cargo.toml`/manifest change, no direct-dependency bump, no MSRV / feature-flag / public-API / serialization impact.

## Validation

- **`cargo audit` → 0 vulnerabilities** (was: 1). Confirmed against a fresh advisory-db: it flags `crossbeam-epoch 0.9.18` (exit 1) and clears at `0.9.20` (exit 0).
- `cargo fmt --all --check` → clean
- `cargo check --workspace` → clean
- Required CI (Build Release / Test / Clippy / Format) runs on this PR.

## Remaining audit warnings (out of scope)

The 8 non-fatal `unmaintained`/`unsound` warnings remain (`atomic-polyfill` RUSTSEC-2023-0089, `bincode`, `pqcrypto-internals` RUSTSEC-2026-0163, RUSTSEC-2025-0141, …). These are **warnings, not vulnerabilities** — bare `cargo audit` does not fail on them, and clearing them requires upstream crate migrations. Left as a separate follow-up rather than folded into this focused vulnerability fix; the Security Audit job passes with them present.

## Relationship to #2389

Independent. #2389 (pending-publish read-model) changes no `Cargo.toml`/`Cargo.lock` and did not introduce this advisory — its non-required Security Audit red is this same repository-wide advisory. Once this PR merges, #2389 updated onto main will see a green Security Audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
