### PR TITLE
fix(ops): scrub concrete infra host addresses from the public repo-map + boundary guard

### DIFF
--- a/docs/reference/project-index/generated/agent-context-spine.json
+++ b/docs/reference/project-index/generated/agent-context-spine.json
@@ -2,8 +2,8 @@
   "schema": "icn-agent-context-spine/v0",
   "status": "generated",
   "canonical": false,
-  "generated": "2026-06-21T14:08:16+00:00",
-  "source_commit": "cb3ac76d36ea64f25d65e59d614f2f1c048496e2",
+  "generated": "2026-07-10T23:48:18+00:00",
+  "source_commit": "0708cd5c6764df3fa3d743030b00badb567542fe",
   "generator": "scripts/generate-agent-context-spine.py",
   "regenerate": "python3 scripts/generate-agent-context-spine.py --write",
   "check": "python3 scripts/generate-agent-context-spine.py --check",
@@ -35,7 +35,7 @@
     "verifies"
   ],
   "counts": {
-    "nodes": 131,
+    "nodes": 134,
     "edges": 92
   },
   "nodes": [
@@ -300,6 +300,26 @@
         },
         {
           "source": "icn/crates/icn-api",
+          "kind": "crate-dir"
+        }
+      ]
+    },
+    {
+      "id": "crate:icn-appliance",
+      "type": "crate",
+      "name": "icn-appliance",
+      "group": "crates",
+      "path": "icn/crates/icn-appliance",
+      "description": "Workspace member crate (crates). v0 spine records membership and path only; it does not parse module internals.",
+      "source_of_truth": "icn/Cargo.toml",
+      "status": "present",
+      "evidence": [
+        {
+          "source": "icn/Cargo.toml",
+          "kind": "workspace-member"
+        },
+        {
+          "source": "icn/crates/icn-appliance",
           "kind": "crate-dir"
         }
       ]
@@ -2496,7 +2516,7 @@
       "type": "truth_source",
       "name": "cluster_topology",
       "owner": "ops/state/config/repo-map.json#infrastructure",
-      "description": "K3s node IPs, service ports. Source: repo-map.json .infrastructure.k3s",
+      "description": "K3s node/service ROLES only (role:<name> tokens). Concrete node IPs / service ports are private operational values (docs/ATLAS.md §5) held in the private network-ops repo, never in this public map; repo-map.json .infrastructure.k3s lists roles, resolve to addresses only from the private source.",
       "stability": "slow-changing",
       "source_of_truth": "ops/state/truth/sources.json",
       "status": "present",
@@ -2508,6 +2528,42 @@
         {
           "source": "ops/state/config/repo-map.json",
           "kind": "truth-owner"
+        }
+      ]
+    },
+    {
+      "id": "truth_source:cross_repo_pr_stacks",
+      "type": "truth_source",
+      "name": "cross_repo_pr_stacks",
+      "owner": "ops/coordination/stacks/",
+      "description": "Cross-repo PR merge order and per-stack state: machine-readable stack manifests (<slug>.stack.yaml, format icn-pr-stack/v1, validated by scripts/check-pr-stack.sh). ops/coordination/PR_STACK_PROTOCOL.md documents the discipline; the manifests own stack state. Coordination metadata only — plan/order facts, never runtime or readiness truth.",
+      "stability": "slow-changing",
+      "source_of_truth": "ops/state/truth/sources.json",
+      "status": "present",
+      "evidence": [
+        {
+          "source": "ops/state/truth/sources.json",
+          "kind": "truth-domain"
+        },
+        {
+          "source": "ops/coordination/stacks/",
+          "kind": "truth-owner"
+        }
+      ]
+    },
+    {
+      "id": "truth_source:downstream_dependency_locks",
+      "type": "truth_source",
+      "name": "downstream_dependency_locks",
+      "owner": "downstream-repos",
+      "description": "Review attestations pinning the ICN ref each downstream repo (nycn, icn-learn, icn-community-bridge) was last reviewed against. Format: icn-upstream-lock/v1 (docs/reference/upstream-lock-format.md). A lock is human-signed once a person fills `reviewer`; a first machine-prepared lock carries `reviewer: pending` with no `reviewed_at` and is registered in org_repos with `lock.review_status: pending-human-signoff` so tooling does NOT treat it as a completed human attestation — icn-learn and icn-community-bridge are in that state today, while nycn carries a human-signed prior review (previous_review). The lock files live in the downstream repos, never in this repo — a lock is a review attestation, not an automated dependency constraint.",
+      "stability": "slow-changing",
+      "source_of_truth": "ops/state/truth/sources.json",
+      "status": "present",
+      "evidence": [
+        {
+          "source": "ops/state/truth/sources.json",
+          "kind": "truth-domain"
         }
       ]
     },
@@ -2624,7 +2680,7 @@
       "type": "truth_source",
       "name": "repo_topology",
       "owner": "ops/state/config/repo-map.json",
-      "description": "Monorepo layout, subdirectory purposes, worktree root, K3s cluster IPs",
+      "description": "Monorepo layout, subdirectory purposes, org-repo coordination metadata (org_repos), worktree root, K3s cluster ROLES (concrete addresses are private — network-ops). org_repos is repo discovery / coordination metadata, not architectural truth — role/boundary meaning stays with docs/ATLAS.md + ops/state/ecosystem.json, and ops/state/truth/sources.json (this arbiter file, not repo-map.json) wins on truth-ownership conflicts.",
       "stability": "slow-changing",
       "source_of_truth": "ops/state/truth/sources.json",
       "status": "present",

--- a/ops/CLAUDE.md
+++ b/ops/CLAUDE.md
@@ -79,7 +79,7 @@ The `state/truth/` directory is the canonical truth spine. It owns the authorita
 
 **Critical rules:**
 - Never hardcode sprint numbers, PR numbers, branch names, or blockers in skills or agents.
-- Never hardcode cluster IPs in agent files — read from `repo-map.json#infrastructure`.
+- Never hardcode cluster IPs in agent files — `repo-map.json#infrastructure` lists ROLES only; concrete addresses are private (network-ops), never in this public repo.
 - `ops/automation/skills/` is the canonical source for shared operational skills.
 - `.claude/skills/{status,sync-and-build,worktree}` must be symlinks to `ops/automation/skills/` — run `bash ops/scripts/setup-skill-symlinks.sh` to create/verify.
 - Run `bash ops/scripts/what-matters-now.sh` at session start for live truth synthesis.
@@ -94,4 +94,4 @@ See `state/config/repo-map.json` for the authoritative map. Key relationships:
 - `icn/` is the Cargo workspace root (not repo root)
 - Worktrees live under `~/icn-dev/worktrees/<repo>/` on the dev VM (root of record:
   `state/config/repo-map.json#worktrees.root`; the older repo-adjacent `../icn-wt/` layout is retired/legacy)
-- K3s cluster: control at `10.8.30.40`, workers at `.41`/`.42` (VLAN 30, post Feb 2026 migration)
+- K3s cluster: roles `role:k3s-control-plane` + `role:k3s-worker` ×2 (concrete addresses are private — network-ops; VLAN 30 post Feb 2026 migration)

--- a/ops/automation/skills/status/SKILL.md
+++ b/ops/automation/skills/status/SKILL.md
@@ -4,7 +4,7 @@ description: Show full ICN development status dashboard — active sessions, spr
 truth_contract:
   canonical_sources:
     - ops/state/sprint/current.json     # sprint state (always live-read — never hardcode sprint number)
-    - ops/state/config/repo-map.json    # cluster IPs, service ports
+    - ops/state/config/repo-map.json    # cluster ROLES (concrete addresses are private/network-ops)
     - ops/state/truth/policy.json       # required checks list
   live_load_required:
     - "cat \"$(git rev-parse --show-toplevel)/ops/state/sprint/current.json\""
@@ -13,7 +13,7 @@ truth_contract:
   examples_only: []
   never_hardcode:
     - sprint number or name
-    - cluster IPs (read from repo-map.json)
+    - cluster IPs (repo-map.json lists ROLES only; concrete addresses are private/network-ops)
     - open PR list
 ---
 
@@ -70,7 +70,7 @@ Use this structure with ✅ ⏳ ❌ ⚠️ symbols:
   ✅ ci · 3 min ago
   ✅ ci · 2 hrs ago
 
-**Cluster** 10.8.30.40
+**Cluster** role:k3s-control-plane
   ✅ 3/3 pods healthy · gateway ✅ · pilot-ui ✅ · metrics ✅
 
 **Build Cache** sccache hit rate: 74%

--- a/ops/state/config/repo-map.json
+++ b/ops/state/config/repo-map.json
@@ -35,10 +35,7 @@
         "visibility": "private",
         "default_branch": "main",
         "local_store": "~/icn-dev/repos/nycn.git",
-        "lock": {
-          "path": "ops/upstream/icn.lock.yaml",
-          "format": "icn-upstream-lock/v1"
-        },
+        "lock": { "path": "ops/upstream/icn.lock.yaml", "format": "icn-upstream-lock/v1" },
         "status_envelope": "ops/status-envelope.json",
         "claim_enforcement": "reusable-claim-lint-caller (warning-mode, advisory; not blocking)",
         "stack_stage": 3,
@@ -67,11 +64,7 @@
         "visibility": "private",
         "default_branch": "main",
         "local_store": "~/icn-dev/repos/icn-learn.git",
-        "lock": {
-          "path": "ops/upstream/icn.lock.yaml",
-          "format": "icn-upstream-lock/v1",
-          "review_status": "pending-human-signoff"
-        },
+        "lock": { "path": "ops/upstream/icn.lock.yaml", "format": "icn-upstream-lock/v1", "review_status": "pending-human-signoff" },
         "status_envelope": "ops/status-envelope.json",
         "claim_enforcement": "reusable-claim-lint-caller (warning-mode, advisory; not blocking)",
         "stack_stage": 4,
@@ -82,11 +75,7 @@
         "visibility": "private",
         "default_branch": "main",
         "local_store": "~/icn-dev/repos/icn-community-bridge.git",
-        "lock": {
-          "path": "ops/upstream/icn.lock.yaml",
-          "format": "icn-upstream-lock/v1",
-          "review_status": "pending-human-signoff"
-        },
+        "lock": { "path": "ops/upstream/icn.lock.yaml", "format": "icn-upstream-lock/v1", "review_status": "pending-human-signoff" },
         "status_envelope": "ops/status-envelope.json",
         "claim_enforcement": "reusable-claim-lint-caller (warning-mode, advisory; not blocking)",
         "stack_stage": 5,
@@ -148,10 +137,7 @@
       "type": "deployment",
       "direction": "push",
       "cluster_control": "role:k3s-control-plane (private:network-ops)",
-      "workers": [
-        "role:k3s-worker (private:network-ops)",
-        "role:k3s-worker (private:network-ops)"
-      ]
+      "workers": ["role:k3s-worker (private:network-ops)", "role:k3s-worker (private:network-ops)"]
     },
     {
       "from": "homelab-inventory",
@@ -165,10 +151,7 @@
     "note": "Public map: ROLES ONLY. Concrete node/service addresses are private operational values (docs/ATLAS.md §5) held in the private network-ops repo; extraction requires the icn-infra scrub gate (ADR-0005). Never add host addresses, IPs, or provider values to this public map.",
     "k3s": {
       "control": "role:k3s-control-plane (private:network-ops)",
-      "workers": [
-        "role:k3s-worker (private:network-ops)",
-        "role:k3s-worker (private:network-ops)"
-      ],
+      "workers": ["role:k3s-worker (private:network-ops)", "role:k3s-worker (private:network-ops)"],
       "icn_dev": "role:icn-dev-vm (private:network-ops)",
       "ci_runner": "role:ci-runner (private:network-ops)",
       "services": {

--- a/ops/state/config/repo-map.json
+++ b/ops/state/config/repo-map.json
@@ -35,7 +35,10 @@
         "visibility": "private",
         "default_branch": "main",
         "local_store": "~/icn-dev/repos/nycn.git",
-        "lock": { "path": "ops/upstream/icn.lock.yaml", "format": "icn-upstream-lock/v1" },
+        "lock": {
+          "path": "ops/upstream/icn.lock.yaml",
+          "format": "icn-upstream-lock/v1"
+        },
         "status_envelope": "ops/status-envelope.json",
         "claim_enforcement": "reusable-claim-lint-caller (warning-mode, advisory; not blocking)",
         "stack_stage": 3,
@@ -64,7 +67,11 @@
         "visibility": "private",
         "default_branch": "main",
         "local_store": "~/icn-dev/repos/icn-learn.git",
-        "lock": { "path": "ops/upstream/icn.lock.yaml", "format": "icn-upstream-lock/v1", "review_status": "pending-human-signoff" },
+        "lock": {
+          "path": "ops/upstream/icn.lock.yaml",
+          "format": "icn-upstream-lock/v1",
+          "review_status": "pending-human-signoff"
+        },
         "status_envelope": "ops/status-envelope.json",
         "claim_enforcement": "reusable-claim-lint-caller (warning-mode, advisory; not blocking)",
         "stack_stage": 4,
@@ -75,7 +82,11 @@
         "visibility": "private",
         "default_branch": "main",
         "local_store": "~/icn-dev/repos/icn-community-bridge.git",
-        "lock": { "path": "ops/upstream/icn.lock.yaml", "format": "icn-upstream-lock/v1", "review_status": "pending-human-signoff" },
+        "lock": {
+          "path": "ops/upstream/icn.lock.yaml",
+          "format": "icn-upstream-lock/v1",
+          "review_status": "pending-human-signoff"
+        },
         "status_envelope": "ops/status-envelope.json",
         "claim_enforcement": "reusable-claim-lint-caller (warning-mode, advisory; not blocking)",
         "stack_stage": 5,
@@ -136,8 +147,11 @@
       "to": "k3s-cluster",
       "type": "deployment",
       "direction": "push",
-      "cluster_control": "10.8.30.40",
-      "workers": ["10.8.30.41", "10.8.30.42"]
+      "cluster_control": "role:k3s-control-plane (private:network-ops)",
+      "workers": [
+        "role:k3s-worker (private:network-ops)",
+        "role:k3s-worker (private:network-ops)"
+      ]
     },
     {
       "from": "homelab-inventory",
@@ -148,15 +162,19 @@
     }
   ],
   "infrastructure": {
+    "note": "Public map: ROLES ONLY. Concrete node/service addresses are private operational values (docs/ATLAS.md §5) held in the private network-ops repo; extraction requires the icn-infra scrub gate (ADR-0005). Never add host addresses, IPs, or provider values to this public map.",
     "k3s": {
-      "control": "10.8.30.40",
-      "workers": ["10.8.30.41", "10.8.30.42"],
-      "icn_dev": "10.8.30.45",
-      "ci_runner": "10.8.30.46",
+      "control": "role:k3s-control-plane (private:network-ops)",
+      "workers": [
+        "role:k3s-worker (private:network-ops)",
+        "role:k3s-worker (private:network-ops)"
+      ],
+      "icn_dev": "role:icn-dev-vm (private:network-ops)",
+      "ci_runner": "role:ci-runner (private:network-ops)",
       "services": {
-        "gateway": "10.8.30.40:30080",
-        "pilot_ui": "10.8.30.40:30030",
-        "metrics": "10.8.30.40:30090"
+        "gateway": "role:icn-gateway (private:network-ops)",
+        "pilot_ui": "role:pilot-ui (private:network-ops)",
+        "metrics": "role:metrics (private:network-ops)"
       }
     }
   }

--- a/ops/state/truth/sources.json
+++ b/ops/state/truth/sources.json
@@ -12,7 +12,7 @@
       "owner": "ops/state/config/repo-map.json",
       "sections": ["repos", "org_repos", "worktrees", "relationships", "infrastructure"],
       "stability": "slow-changing",
-      "description": "Monorepo layout, subdirectory purposes, org-repo coordination metadata (org_repos), worktree root, K3s cluster IPs. org_repos is repo discovery / coordination metadata, not architectural truth — role/boundary meaning stays with docs/ATLAS.md + ops/state/ecosystem.json, and ops/state/truth/sources.json (this arbiter file, not repo-map.json) wins on truth-ownership conflicts."
+      "description": "Monorepo layout, subdirectory purposes, org-repo coordination metadata (org_repos), worktree root, K3s cluster ROLES (concrete addresses are private — network-ops). org_repos is repo discovery / coordination metadata, not architectural truth — role/boundary meaning stays with docs/ATLAS.md + ops/state/ecosystem.json, and ops/state/truth/sources.json (this arbiter file, not repo-map.json) wins on truth-ownership conflicts."
     },
     "sprint_state": {
       "owner": "ops/state/sprint/current.json",
@@ -53,7 +53,7 @@
     "cluster_topology": {
       "owner": "ops/state/config/repo-map.json#infrastructure",
       "stability": "slow-changing",
-      "description": "K3s node IPs, service ports. Source: repo-map.json .infrastructure.k3s"
+      "description": "K3s node/service ROLES only (role:<name> tokens). Concrete node IPs / service ports are private operational values (docs/ATLAS.md §5) held in the private network-ops repo, never in this public map; repo-map.json .infrastructure.k3s lists roles, resolve to addresses only from the private source."
     },
     "invariants": {
       "owner": "AGENTS.md",
@@ -88,7 +88,7 @@
   "forbidden": [
     "Do NOT hardcode sprint numbers in skills or agents — read ops/state/sprint/current.json",
     "Do NOT hardcode PR numbers or branch lists — query via gh",
-    "Do NOT hardcode cluster IPs — read from repo-map.json#infrastructure",
+    "Do NOT hardcode cluster IPs — repo-map.json#infrastructure lists ROLES only; resolve concrete addresses from the private network-ops source",
     "Do NOT use icn-ops/state paths — canonical is ops/state/ (inside monorepo)",
     "Do NOT use icn-website/ paths — canonical is website/ (inside monorepo)",
     "Do NOT reference sync-from-icn.sh — the website reads docs directly"

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -47,11 +47,21 @@ _IPV4_RE = re.compile(
 _IPV4_ALLOWED_RE = re.compile(
     r"^(?:127\.|0\.0\.0\.0$|10\.0\.2\.2$|192\.0\.2\.|198\.51\.100\.|203\.0\.113\.)"
 )
-# IPv6 literals: full/partial (>=5 hex:hex groups — safely above a HH:MM:SS time)
-# or any "::" compression. Broad on purpose (a boundary guard should fail closed).
+# IPv6 literals — comprehensive: full 8-group, or any "::" compression anywhere in
+# the token (including mid-address). Requires 8 groups (7 colons) or a "::", so a
+# HH:MM:SS time (2 colons, no "::") is NOT matched. A boundary guard fails closed.
 _IPV6_RE = re.compile(
-    r"(?<![\w:.])(?:[A-Fa-f0-9]{1,4}:){4,7}[A-Fa-f0-9]{1,4}(?![\w:.])"
-    r"|(?<![\w:.])[A-Fa-f0-9]{0,4}::[A-Fa-f0-9:]*[A-Fa-f0-9](?![\w:.])"
+    r"(?<![:.\w])(?:"
+    r"(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}"
+    r"|(?:[A-Fa-f0-9]{1,4}:){1,7}:"
+    r"|(?:[A-Fa-f0-9]{1,4}:){1,6}:[A-Fa-f0-9]{1,4}"
+    r"|(?:[A-Fa-f0-9]{1,4}:){1,5}(?::[A-Fa-f0-9]{1,4}){1,2}"
+    r"|(?:[A-Fa-f0-9]{1,4}:){1,4}(?::[A-Fa-f0-9]{1,4}){1,3}"
+    r"|(?:[A-Fa-f0-9]{1,4}:){1,3}(?::[A-Fa-f0-9]{1,4}){1,4}"
+    r"|(?:[A-Fa-f0-9]{1,4}:){1,2}(?::[A-Fa-f0-9]{1,4}){1,5}"
+    r"|[A-Fa-f0-9]{1,4}:(?::[A-Fa-f0-9]{1,4}){1,6}"
+    r"|:(?::[A-Fa-f0-9]{1,4}){1,7}"
+    r")(?![:.\w])"
 )
 # ::1 loopback / :: unspecified / RFC3849 documentation range 2001:db8::/32
 _IPV6_ALLOWED_RE = re.compile(r"^(?:::1$|2001:0?db8:)", re.IGNORECASE)

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -9,16 +9,20 @@ ecosystem index (ops/state/ecosystem.json).
 
 Warning-mode by default: exits 0 with warnings printed unless --strict is passed
 (future ratchet, mirroring the readiness-overclaim linter's warning->blocking path).
-The only unconditional failure is an unreadable/unparseable sources.json.
+Unconditional (HARD, independent of --strict) failures: an unreadable/unparseable
+sources.json; and the public-map boundary guard — the public icn machine-readable
+maps (repo-map.json, ecosystem.json) must carry NO concrete host addresses or
+operational values (docs/ATLAS.md §5; icn-infra ADR-0005). Those live only in the
+private network-ops repo; this map lists infrastructure ROLES only.
 
-Deliberately NOT checked (v1): section-level owner overlap (cluster_topology is a
-documented pointer view into repo-map.json#infrastructure); content freshness of
-downstream lock files (needs private-repo access — VM-session concern, not CI).
+Deliberately NOT checked (v1): content freshness of downstream lock files (needs
+private-repo access — VM-session concern, not CI).
 """
 
 import argparse
 import datetime
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -31,7 +35,24 @@ STALENESS_DAYS = {"volatile": 14, "slow-changing": 120}
 # Date-ish keys we look for in JSON owner files, in preference order.
 DATE_KEYS = ("last_reviewed", "reviewed_at", "start_date")
 
+# Public-map boundary guard (docs/ATLAS.md §5; icn-infra ADR-0005): the PUBLIC
+# icn repo's machine-readable maps must never carry concrete host addresses or
+# operational values — those live only in the private network-ops repo. This is
+# a HARD failure (independent of --strict) if any reappear.
+PUBLIC_MAP_FILES = ("ops/state/config/repo-map.json", "ops/state/ecosystem.json")
+_IPV4_RE = re.compile(
+    r"(?<![\d.])(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?![\d.])"
+)
+# loopback / RFC5737 documentation ranges / QEMU slirp host alias are not sensitive
+_IPV4_ALLOWED_RE = re.compile(
+    r"^(?:127\.|0\.0\.0\.0$|255\.255|10\.0\.2\.2$|192\.0\.2\.|198\.51\.100\.|203\.0\.113\.)"
+)
+_PRIVATE_HOST_RE = re.compile(
+    r"[A-Za-z0-9_-]+\.(?:lan|local|internal|home|homelab|lab)\b", re.IGNORECASE
+)
+
 warnings: list[str] = []
+errors: list[str] = []
 
 
 def warn(msg: str) -> None:
@@ -39,8 +60,38 @@ def warn(msg: str) -> None:
     print(f"  !!  {msg}")
 
 
+def err(msg: str) -> None:
+    errors.append(msg)
+    print(f"  FAIL  {msg}")
+
+
 def ok(msg: str) -> None:
     print(f"  ok  {msg}")
+
+
+def scan_public_map_boundary(root: Path) -> None:
+    """HARD-fail if any public machine-readable map carries a concrete host
+    address or private hostname. The public icn repo must not (docs/ATLAS.md §5;
+    icn-infra ADR-0005). Never echoes the offending value."""
+    for rel in PUBLIC_MAP_FILES:
+        try:
+            text = (root / rel).read_text()
+        except OSError:
+            continue
+        for m in _IPV4_RE.finditer(text):
+            if not _IPV4_ALLOWED_RE.match(m.group(0)):
+                err(
+                    f"{rel}: contains a concrete IPv4 host address — the public icn "
+                    f"repo must not (docs/ATLAS.md §5; icn-infra ADR-0005). Use "
+                    f"role-level/symbolic refs; concrete values live in the private "
+                    f"network-ops repo. (value withheld)"
+                )
+                break
+        if _PRIVATE_HOST_RE.search(text):
+            err(
+                f"{rel}: contains a private host name — the public icn repo must not "
+                f"(docs/ATLAS.md §5). Use role-level/symbolic refs. (value withheld)"
+            )
 
 
 def parse_date(value: str) -> datetime.date | None:
@@ -181,7 +232,16 @@ def main() -> int:
                 if ev and rv and ev != rv:
                     warn(f"visibility disagrees for {r}: ecosystem.json={ev} registry={rv}")
 
+    # 4. Public-map boundary guard — HARD fail regardless of --strict.
+    scan_public_map_boundary(root)
+
     # Result
+    if errors:
+        print(
+            f"check-truth-spine: {len(errors)} boundary error(s) — FAIL "
+            f"(public-map must not carry concrete host addresses / operational values)"
+        )
+        return 1
     if warnings:
         print(f"check-truth-spine: {len(warnings)} warning(s)")
         return 1 if args.strict else 0

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -43,10 +43,18 @@ PUBLIC_MAP_FILES = ("ops/state/config/repo-map.json", "ops/state/ecosystem.json"
 _IPV4_RE = re.compile(
     r"(?<![\d.])(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?![\d.])"
 )
-# loopback / RFC5737 documentation ranges / QEMU slirp host alias are not sensitive
+# loopback / bind-all / RFC5737 documentation ranges / QEMU slirp host alias are not sensitive
 _IPV4_ALLOWED_RE = re.compile(
-    r"^(?:127\.|0\.0\.0\.0$|255\.255|10\.0\.2\.2$|192\.0\.2\.|198\.51\.100\.|203\.0\.113\.)"
+    r"^(?:127\.|0\.0\.0\.0$|10\.0\.2\.2$|192\.0\.2\.|198\.51\.100\.|203\.0\.113\.)"
 )
+# IPv6 literals: full/partial (>=5 hex:hex groups — safely above a HH:MM:SS time)
+# or any "::" compression. Broad on purpose (a boundary guard should fail closed).
+_IPV6_RE = re.compile(
+    r"(?<![\w:.])(?:[A-Fa-f0-9]{1,4}:){4,7}[A-Fa-f0-9]{1,4}(?![\w:.])"
+    r"|(?<![\w:.])[A-Fa-f0-9]{0,4}::[A-Fa-f0-9:]*[A-Fa-f0-9](?![\w:.])"
+)
+# ::1 loopback / :: unspecified / RFC3849 documentation range 2001:db8::/32
+_IPV6_ALLOWED_RE = re.compile(r"^(?:::1$|2001:0?db8:)", re.IGNORECASE)
 _PRIVATE_HOST_RE = re.compile(
     r"[A-Za-z0-9_-]+\.(?:lan|local|internal|home|homelab|lab)\b", re.IGNORECASE
 )
@@ -75,8 +83,14 @@ def scan_public_map_boundary(root: Path) -> None:
     icn-infra ADR-0005). Never echoes the offending value."""
     for rel in PUBLIC_MAP_FILES:
         try:
-            text = (root / rel).read_text()
-        except OSError:
+            text = (root / rel).read_text(encoding="utf-8")
+        except FileNotFoundError:
+            continue  # not every checkout carries every map
+        except (OSError, UnicodeError) as e:
+            err(
+                f"{rel}: present but unreadable/undecodable ({type(e).__name__}) — "
+                f"cannot boundary-scan a public map; failing closed."
+            )
             continue
         for m in _IPV4_RE.finditer(text):
             if not _IPV4_ALLOWED_RE.match(m.group(0)):
@@ -85,6 +99,14 @@ def scan_public_map_boundary(root: Path) -> None:
                     f"repo must not (docs/ATLAS.md §5; icn-infra ADR-0005). Use "
                     f"role-level/symbolic refs; concrete values live in the private "
                     f"network-ops repo. (value withheld)"
+                )
+                break
+        for m in _IPV6_RE.finditer(text):
+            if not _IPV6_ALLOWED_RE.match(m.group(0)):
+                err(
+                    f"{rel}: contains a concrete IPv6 host address — the public icn "
+                    f"repo must not (docs/ATLAS.md §5; icn-infra ADR-0005). Use "
+                    f"role-level/symbolic refs. (value withheld)"
                 )
                 break
         if _PRIVATE_HOST_RE.search(text):


### PR DESCRIPTION
## What

Scrub concrete provider infrastructure values out of the **public** machine-readable map `ops/state/config/repo-map.json`, and add a hard CI regression guard so they cannot come back.

## Why

`docs/ATLAS.md` §5 states plainly: `network-ops` / `icn-infra` **operational values, host addresses, secrets → never into public `icn`** (extraction requires the private icn-infra ADR-0005 scrub gate). The public repo-map violated this — `infrastructure.k3s.*` (control / workers / ci_runner / icn_dev + service endpoints) and `relationships[1]` (the `deploy/k8s/` → cluster deployment relationship) carried concrete host addresses. Nothing should expose provider topology from a public repo.

## How

- **Symbolize, don't delete the structure.** Concrete values → role-level references `role:<name> (private:network-ops)` + an explicit boundary `note`. The public map still communicates the infrastructure **roles**; the addresses now resolve only through the private `network-ops` layer.
- **No tooling breaks.** Confirmed the concrete values were read by **no** code: `ops/mcp/src/paths.ts` reads `worktrees.root`; `buildRepoMap` and `scripts/check-truth-spine.py` read `org_repos`/`worktrees`; nothing reads `infrastructure.*` values. `org_repos` / `repos` / `worktrees` are **byte-unchanged** (verified by per-section hash).
- **Hard regression guard.** `scripts/check-truth-spine.py` (already run by the required **Agent Tooling Drift Check**) gains `scan_public_map_boundary`: it **hard-fails** (independent of `--strict`, with the offending value withheld from the message) if `repo-map.json` or `ecosystem.json` ever reintroduces a concrete IPv4 host address or a private hostname. Loopback / RFC5737 documentation ranges / the QEMU slirp host alias are allowlisted.

## Risk

Low. Data-only + a check addition. The removed values were unconsumed by code. This is a **forward** fix — it does not rewrite git history (a separate, heavier operation if ever desired). Concrete values were **not** copied into `icn-infra` or anywhere else; extracting them there would require that repo's ADR-0005 scrub/classification gate.

## Test plan

- [x] `scripts/check-truth-spine.py --repo-root .` → **clean, exit 0** on the scrubbed tree.
- [x] Planted a routable IP into `ops/state/ecosystem.json` → checker **hard-fails, exit 1**, value withheld; restored.
- [x] `python3 -m py_compile scripts/check-truth-spine.py` clean.
- [x] `org_repos` / `repos` / `worktrees` sections byte-identical to `origin/main`; `relationships` count + `[0]` unchanged.
- [x] 0 non-allowlisted IPv4 tokens remain in `repo-map.json` / `ecosystem.json`.

Scope: boundary safety only — **not** mixed with any evidence-export or feature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review round 1 (addressed)

5 files now (all review threads resolved):
- **Surgical repo-map diff** — redone as a text edit, not a jq whole-file rewrite; `org_repos`/`repos`/`worktrees` are **byte-identical** to main (Copilot flagged jq had reformatted the `lock` sub-objects).
- **Guard hardening** — removed the over-broad `255.255` allowlist entry; `read_text` catches `UnicodeError` (present-but-undecodable map fails closed, missing map skips); **added IPv6-literal detection** (≥5 hex groups or `::` compression; `::1` + RFC3849 `2001:db8::/32` allowlisted; HH:MM:SS times not flagged).
- **Dangling topology-consumers fixed** — `ops/state/truth/sources.json` (cluster_topology + never_hardcode rule), `ops/automation/skills/status/SKILL.md`, and `ops/CLAUDE.md` still told agents to read cluster IPs from `repo-map.json#infrastructure`; all now describe it as ROLES only and point at the private network-ops source. Two more concrete IPs found in those files were scrubbed.

## Scope note (separate follow-up)

The same provider IP prefix is hardcoded in **~20 other public files** (`deploy/k8s/` guides + Makefile, `.github/workflows/docker-build-deploy.yml`, `demo/` docs/scripts, `.claude/agents/`) — several of which **use** the addresses operationally. That is a larger, operationally-sensitive scrub requiring a private-config/secrets path (not find-replace), tracked as a **separate focused PR**; deliberately not folded in here to keep this change safe and reviewable.
