### PR TITLE
feat(demo): rehearsal-node pending-publish evidence export + steward verification

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -243,6 +243,10 @@ jobs:
       - name: Validate rehearsal-shell fixture bundle (offline, deterministic)
         run: |
           python3 docs/scripts/validate-rehearsal-shell-fixtures.py
+          # The committed pending-publish evidence packet must equal the generator's
+          # output (deterministic apart from recorded_at), so a fixture edit cannot
+          # silently drift the committed packet. Offline, fail-closed.
+          python3 scripts/rehearsal_pending_publish_evidence.py --check
         continue-on-error: false
 
   bridge_conformance:

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -30,6 +30,11 @@ on:
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'
+      # pending-publish evidence-export inputs the generator --check reads (the
+      # committed packet + its source rows) and the generator itself, so a
+      # fixture/generator edit fires the drift guard, not just a manifest edit.
+      - 'web/member-shell/fixtures/**'
+      - 'scripts/rehearsal_pending_publish_evidence.py'
       # governed bridge conformance fixtures + validator: the fixtures live under
       # tools/ (outside docs/**), so trigger the workflow when they or the
       # validator change, otherwise a fixtures-only PR would not fire this check.
@@ -67,6 +72,11 @@ on:
       # rehearsal-shell fixture bundle (manifest + packets) — validators/schemas
       # under docs/scripts + docs/contracts are already covered by docs/**
       - 'web/pilot-ui/fixtures/**'
+      # pending-publish evidence-export inputs the generator --check reads (the
+      # committed packet + its source rows) and the generator itself, so a
+      # fixture/generator edit fires the drift guard, not just a manifest edit.
+      - 'web/member-shell/fixtures/**'
+      - 'scripts/rehearsal_pending_publish_evidence.py'
       # governed bridge conformance fixtures + validator: the fixtures live under
       # tools/ (outside docs/**), so trigger the workflow when they or the
       # validator change, otherwise a fixtures-only PR would not fire this check.

--- a/deploy/appliance/build-image.sh
+++ b/deploy/appliance/build-image.sh
@@ -356,6 +356,9 @@ if [ "$DEMO_PROFILE" = "1" ]; then
     done
     for f in "$REPO_ROOT/scripts/local_receipt_chain_13of13_rehearsal.sh" \
              "$REPO_ROOT/scripts/local_economic_receipt_chain_demo.sh" \
+             "$REPO_ROOT/scripts/rehearsal_pending_publish_evidence.py" \
+             "$REPO_ROOT/web/member-shell/fixtures/pending-publish-summary.json" \
+             "$REPO_ROOT/web/member-shell/fixtures/pending-publish-evidence-export.json" \
              "$REPO_ROOT/docs/scripts/validate-rehearsal-evidence.py"; do
         if [ ! -f "$f" ]; then
             err "Demo profile payload file missing: $f"
@@ -378,6 +381,7 @@ if [ "$DEMO_PROFILE" = "1" ]; then
         "$DEMO_STAGE/demo/institutions" \
         "$DEMO_STAGE/demo/repo/scripts" \
         "$DEMO_STAGE/demo/repo/docs/scripts" \
+        "$DEMO_STAGE/demo/repo/web/member-shell/fixtures" \
         "$DEMO_STAGE/demo/repo/demo"
     cp -r "$REPO_ROOT/web/member-shell"            "$DEMO_STAGE/static/web/"
     cp -r "$REPO_ROOT/web/pilot-ui/fixtures"       "$DEMO_STAGE/static/web/pilot-ui/"
@@ -385,9 +389,15 @@ if [ "$DEMO_PROFILE" = "1" ]; then
     cp -r "$REPO_ROOT/demo/nycn-dogfood"           "$DEMO_STAGE/demo/repo/demo/"
     cp "$REPO_ROOT/scripts/local_receipt_chain_13of13_rehearsal.sh" \
        "$REPO_ROOT/scripts/local_economic_receipt_chain_demo.sh" \
+       "$REPO_ROOT/scripts/rehearsal_pending_publish_evidence.py" \
        "$DEMO_STAGE/demo/repo/scripts/"
     cp "$REPO_ROOT/docs/scripts/validate-rehearsal-evidence.py" \
        "$DEMO_STAGE/demo/repo/docs/scripts/"
+    # Fixtures the pending-publish evidence generator reads (icn-demo-verify
+    # --pending-publish resolves ROOT as demo/repo, so co-locate them there).
+    cp "$REPO_ROOT/web/member-shell/fixtures/pending-publish-summary.json" \
+       "$REPO_ROOT/web/member-shell/fixtures/pending-publish-evidence-export.json" \
+       "$DEMO_STAGE/demo/repo/web/member-shell/fixtures/"
     if [ -d "$REPO_ROOT/docs/contracts" ]; then
         cp -r "$REPO_ROOT/docs/contracts" "$DEMO_STAGE/demo/repo/docs/"
     fi

--- a/deploy/appliance/scripts/icn-demo-verify.sh
+++ b/deploy/appliance/scripts/icn-demo-verify.sh
@@ -24,6 +24,13 @@
 #       `icnctl audit verify` reports a complete 13/13 receipt chain and
 #       emits a schema-validated, repo-safe evidence packet.
 #       Output: /var/lib/icn-demo/receipt-chain-13of13/
+#
+#   sudo icn-demo-verify --pending-publish
+#       Steward-verifies the pending-publish review-preview evidence packet:
+#       maps the committed pending-publish rows into a
+#       urn:icn:contract:rehearsal-evidence-export:v1 packet and validates it
+#       (fixture-only, offline, no gateway, no writes; fails closed on drift).
+#       Output: /var/lib/icn-demo/pending-publish-evidence/
 # ============================================================================
 set -uo pipefail
 
@@ -61,9 +68,32 @@ if [ "${1:-}" = "--chain" ]; then
   exit "$rc"
 fi
 
+if [ "${1:-}" = "--pending-publish" ]; then
+  # Steward verification of the pending-publish review-preview evidence packet.
+  # Fixture-only + offline: maps the committed pending-publish rows into a
+  # urn:icn:contract:rehearsal-evidence-export:v1 packet and validates it.
+  # No gateway, no network, no writes. Fails closed on any validation drift.
+  GEN="$REPO/scripts/rehearsal_pending_publish_evidence.py"
+  [ -f "$GEN" ] || fatal "bundled pending-publish evidence generator missing at $GEN"
+  command -v python3 >/dev/null || fatal "python3 missing"
+  OUT=/var/lib/icn-demo
+  mkdir -p "$OUT"
+  log "verifying the committed pending-publish evidence packet (determinism + :v1 schema, fixture-only, no network)..."
+  python3 "$GEN" --check || fatal "committed pending-publish evidence packet failed the determinism/drift + :v1 schema guard"
+  log "generating a fresh timestamped packet + re-validating..."
+  python3 "$GEN" --write || fatal "pending-publish evidence packet failed generation/validation"
+  if [ -d "$REPO/demo/output/pending-publish-evidence" ]; then
+    rm -rf "$OUT/pending-publish-evidence"
+    cp -r "$REPO/demo/output/pending-publish-evidence" "$OUT/" 2>/dev/null || true
+    log "evidence copied to $OUT/pending-publish-evidence/"
+  fi
+  log "OK: pending-publish evidence packet validates against urn:icn:contract:rehearsal-evidence-export:v1"
+  exit 0
+fi
+
 ITEM_ID="${1:-}"
 DOMAIN="${2:-nycn-federation-gov}"
-[ -n "$ITEM_ID" ] || fatal "usage: icn-demo-verify <item-id> [domain]   (or --chain)"
+[ -n "$ITEM_ID" ] || fatal "usage: icn-demo-verify <item-id> [domain]   (or --chain, or --pending-publish)"
 [ -f "$ENV_FILE" ] || fatal "$ENV_FILE missing — has firstboot run?"
 command -v python3 >/dev/null || fatal "python3 missing"
 

--- a/deploy/appliance/scripts/icn-demo-verify.sh
+++ b/deploy/appliance/scripts/icn-demo-verify.sh
@@ -72,7 +72,8 @@ if [ "${1:-}" = "--pending-publish" ]; then
   # Steward verification of the pending-publish review-preview evidence packet.
   # Fixture-only + offline: maps the committed pending-publish rows into a
   # urn:icn:contract:rehearsal-evidence-export:v1 packet and validates it.
-  # No gateway, no network, no writes. Fails closed on any validation drift.
+  # No gateway, no network egress, no custody/gateway writes; the only writes are
+  # local repo-safe evidence artifacts under /var/lib/icn-demo/. Fails closed on drift.
   GEN="$REPO/scripts/rehearsal_pending_publish_evidence.py"
   [ -f "$GEN" ] || fatal "bundled pending-publish evidence generator missing at $GEN"
   command -v python3 >/dev/null || fatal "python3 missing"

--- a/scripts/rehearsal_pending_publish_evidence.py
+++ b/scripts/rehearsal_pending_publish_evidence.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Rehearsal Node — pending-publish evidence-export generator.
+
+Maps the committed pending-publish review-preview rows (the shape served by
+GET /v1/gov/me/pending-publish-summary in a non-production build mode,
+origin=committed_fixture) into a repo-safe evidence packet conforming to
+urn:icn:contract:rehearsal-evidence-export:v1, then validates it.
+
+Honest operator/steward layer — NOT the browser. The packet:
+  * carries rehearsal_mode="fixture-only" (or "local-dry-run" only if a real
+    loopback GET was performed by the caller; this script never touches the
+    network);
+  * NEVER copies the caller `did`, any credential, or any private path;
+  * maps every review row to a `deferred` decision_outcome — a preview row is
+    evidence for review, never an authorization; `approved_for_publish` is a
+    review disposition, not an authority;
+  * marks every expected receipt as proof_loop_references[].status="not-attempted"
+    (an expectation, never issued);
+  * declares mutation_boundary.executed=false / target="none".
+
+Deterministic apart from `recorded_at`.
+
+Usage:
+    # write a packet to the gitignored output dir (recorded_at = now, UTC):
+    python3 scripts/rehearsal_pending_publish_evidence.py --write
+    # verify the committed canonical packet matches a fresh generation
+    # (byte-identical after masking recorded_at) and both validate:
+    python3 scripts/rehearsal_pending_publish_evidence.py --check
+Exit 0 on success; non-zero (fail closed) on any validation/consistency failure.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ROWS_FIXTURE = ROOT / "web/member-shell/fixtures/pending-publish-summary.json"
+COMMITTED_PACKET = ROOT / "web/member-shell/fixtures/pending-publish-evidence-export.json"
+VALIDATOR = ROOT / "docs/scripts/validate-rehearsal-evidence.py"
+OUTDIR = ROOT / "demo/output/pending-publish-evidence"
+
+# Review status -> repo-safe decision_outcome category. A preview row is NEVER
+# an authorization: approved_for_publish is a review disposition -> deferred.
+STATUS_TO_OUTCOME = {
+    "pending_review": "deferred",
+    "needs_more_info": "deferred",
+    "approved_for_publish": "deferred",
+    "needs_edit": "edit-and-resubmit",
+    "rejected": "rejected",
+}
+# receipt category -> proof_loop_references kind. settlement_receipt / none have
+# no receipt kind in the contract -> represented via provenance only (skipped here).
+RECEIPT_TO_PLR_KIND = {
+    "action_item_completion_receipt": "action-item-completion-receipt",
+    "governance_receipt": "governance-decision-receipt",
+    "attendance_receipt": "meeting-attendance-receipt",
+}
+FIXED_RECORDED_AT = "2026-07-10T00:00:00Z"  # committed-packet anchor (documented)
+
+
+def build_packet(recorded_at: str) -> dict:
+    rows = json.loads(ROWS_FIXTURE.read_text()).get("rows", [])
+    decision_outcomes = []
+    receipt_kinds: list[str] = []
+    for row in rows:
+        cat = STATUS_TO_OUTCOME.get(row.get("status"), "deferred")
+        decision_outcomes.append(
+            {
+                "category": cat,
+                "plain_summary": row.get("plain_summary", "")
+                + " Preview only — no decision was recorded.",
+            }
+        )
+        rc = (row.get("receipt_expected") or {})
+        if rc.get("expected"):
+            k = RECEIPT_TO_PLR_KIND.get(rc.get("category"))
+            if k and k not in receipt_kinds:
+                receipt_kinds.append(k)
+    proof_loop_references = [
+        {
+            "kind": "provenance-summary",
+            "public_id_or_category": "pending-publish-committed-fixture",
+            "status": "closed",
+        }
+    ] + [{"kind": k, "status": "not-attempted"} for k in receipt_kinds]
+    return {
+        "schema_version": "0.1.0",
+        "recorded_at": recorded_at,
+        "rehearsal_label": "Pending-publish review preview — committed-fixture rehearsal evidence",
+        "rehearsal_mode": "fixture-only",
+        "audience_categories": ["organizer", "steward", "reviewer"],
+        "source_material": [
+            {
+                "kind": "committed-fixture",
+                "basename": "pending-publish-summary.json",
+                "summary": "Committed pending-publish review-preview rows, as served by GET /v1/gov/me/pending-publish-summary in a non-production build mode (origin = committed_fixture). Fictional rehearsal data; no real people or organization.",
+            }
+        ],
+        "workflow_steps_completed": [
+            "start",
+            "select-material",
+            "preview",
+            "surface-result",
+            "export-evidence",
+        ],
+        "decision_outcomes": decision_outcomes,
+        "preview_review_boundary": {
+            "enforced": True,
+            "notes": "Preview rows are evidence presented for review — not authorization, publication, custody writes, or completed actions.",
+        },
+        "mutation_boundary": {
+            "executed": False,
+            "target": "none",
+            "notes": "Read-only projection (GET only). No write, no publish, no action-card creation, no custody write; no network egress in fixture mode.",
+        },
+        "proof_loop_references": proof_loop_references,
+        "privacy_review": {
+            "reviewer_role": "reviewer",
+            "status": "reviewed-clean",
+            "notes": "Rows carry only generic plain-language labels — no DIDs, no private paths, no partner data. The runtime response's caller DID is deliberately not carried into this packet.",
+        },
+        "export_safety_classification": "repo-safe",
+        "non_claims": [
+            "Not production readiness and not a formal pilot.",
+            "No live federation, no cloud sync.",
+            "No private participant data is handled; the rows are fictional committed-fixture rehearsal data, never live participant state.",
+            "An expected receipt is an evidence expectation for the reviewer, not authority. No preview row was authorized, published, or turned into a custody write; no receipt was issued.",
+        ],
+    }
+
+
+def validate(packet_path: Path) -> None:
+    r = subprocess.run(
+        [sys.executable, str(VALIDATOR), str(packet_path)],
+        capture_output=True,
+        text=True,
+    )
+    if r.returncode != 0:
+        sys.stderr.write(r.stdout + r.stderr)
+        raise SystemExit(f"FAIL: evidence packet failed :v1 schema validation: {packet_path}")
+
+
+def dump(packet: dict) -> str:
+    return json.dumps(packet, indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--write", action="store_true", help="generate + validate a packet in the gitignored output dir")
+    g.add_argument("--check", action="store_true", help="verify the committed canonical packet matches a fresh generation (mask recorded_at) and both validate")
+    args = ap.parse_args()
+
+    if args.write:
+        now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        OUTDIR.mkdir(parents=True, exist_ok=True)
+        out = OUTDIR / "rehearsal-evidence-export.json"
+        out.write_text(dump(build_packet(now)))
+        validate(out)
+        print(f"OK: wrote + validated {out} (recorded_at={now})")
+        return 0
+
+    # --check: the committed packet must equal a fresh generation apart from recorded_at,
+    # and both must validate. This is the determinism + drift guard.
+    committed = json.loads(COMMITTED_PACKET.read_text())
+    generated = build_packet(committed["recorded_at"])
+    validate(COMMITTED_PACKET)
+    if generated != committed:
+        # show the differing top-level keys only (never dump private data — there is none)
+        diff = sorted(k for k in set(generated) | set(committed) if generated.get(k) != committed.get(k))
+        raise SystemExit(f"FAIL: committed packet drifted from generator output; differing keys: {diff}")
+    fresh = build_packet("1970-01-01T00:00:00Z")
+    committed_masked = {**committed, "recorded_at": "1970-01-01T00:00:00Z"}
+    if fresh != committed_masked:
+        raise SystemExit("FAIL: generator is not deterministic apart from recorded_at")
+    print("OK: committed packet matches generator (deterministic apart from recorded_at) and validates against :v1")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rehearsal_pending_publish_evidence.py
+++ b/scripts/rehearsal_pending_publish_evidence.py
@@ -6,10 +6,9 @@ GET /v1/gov/me/pending-publish-summary in a non-production build mode,
 origin=committed_fixture) into a repo-safe evidence packet conforming to
 urn:icn:contract:rehearsal-evidence-export:v1, then validates it.
 
-Honest operator/steward layer — NOT the browser. The packet:
-  * carries rehearsal_mode="fixture-only" (or "local-dry-run" only if a real
-    loopback GET was performed by the caller; this script never touches the
-    network);
+Honest operator/steward layer — NOT the browser. This generator is OFFLINE and
+never touches the network. The packet:
+  * carries rehearsal_mode="fixture-only";
   * NEVER copies the caller `did`, any credential, or any private path;
   * maps every review row to a `deferred` decision_outcome — a preview row is
     evidence for review, never an authorization; `approved_for_publish` is a
@@ -63,30 +62,62 @@ FIXED_RECORDED_AT = "2026-07-10T00:00:00Z"  # committed-packet anchor (documente
 
 
 def build_packet(recorded_at: str) -> dict:
-    rows = json.loads(ROWS_FIXTURE.read_text()).get("rows", [])
+    data = json.loads(ROWS_FIXTURE.read_text())
+    rows = data.get("rows")
+    if not isinstance(rows, list) or not rows:
+        raise SystemExit(f"FAIL: {ROWS_FIXTURE} has no non-empty 'rows' list (fail closed).")
     decision_outcomes = []
-    receipt_kinds: list[str] = []
-    for row in rows:
-        cat = STATUS_TO_OUTCOME.get(row.get("status"), "deferred")
-        decision_outcomes.append(
-            {
-                "category": cat,
-                "plain_summary": row.get("plain_summary", "")
-                + " Preview only — no decision was recorded.",
-            }
-        )
-        rc = (row.get("receipt_expected") or {})
-        if rc.get("expected"):
-            k = RECEIPT_TO_PLR_KIND.get(rc.get("category"))
-            if k and k not in receipt_kinds:
-                receipt_kinds.append(k)
+    # provenance ref is always first; each EXPECTED receipt then follows, deduped.
     proof_loop_references = [
         {
             "kind": "provenance-summary",
             "public_id_or_category": "pending-publish-committed-fixture",
             "status": "closed",
         }
-    ] + [{"kind": k, "status": "not-attempted"} for k in receipt_kinds]
+    ]
+    seen: set[str] = set()
+    for row in rows:
+        status = row.get("status")
+        if status not in STATUS_TO_OUTCOME:
+            raise SystemExit(
+                f"FAIL: unknown pending-publish row status {status!r} — refusing to map "
+                f"(fail closed). Add it to STATUS_TO_OUTCOME with a repo-safe outcome."
+            )
+        decision_outcomes.append(
+            {
+                "category": STATUS_TO_OUTCOME[status],
+                "plain_summary": row.get("plain_summary", "")
+                + " Preview only — no decision was recorded.",
+            }
+        )
+        rc = row.get("receipt_expected") or {}
+        if not rc.get("expected"):
+            continue
+        # Every EXPECTED receipt is represented — never silently dropped. A category
+        # with a dedicated proof-loop kind uses it; any other expected category (e.g.
+        # settlement_receipt) becomes a validator-output-category so the expectation
+        # stays explicit. Status is always "not-attempted" (an expectation, never issued).
+        cat = rc.get("category")
+        if cat in RECEIPT_TO_PLR_KIND:
+            entry = {"kind": RECEIPT_TO_PLR_KIND[cat], "status": "not-attempted"}
+            key = "k:" + RECEIPT_TO_PLR_KIND[cat]
+        elif cat and cat != "none":
+            entry = {
+                "kind": "validator-output-category",
+                "public_id_or_category": cat.replace("_", "-") + "-expected",
+                "status": "not-attempted",
+            }
+            key = "v:" + cat
+        else:
+            entry = {
+                "kind": "validator-output-category",
+                "public_id_or_category": "receipt-expected-unspecified",
+                "status": "not-attempted",
+            }
+            key = "v:unspecified"
+        if key not in seen:
+            seen.add(key)
+            proof_loop_references.append(entry)
     return {
         "schema_version": "0.1.0",
         "recorded_at": recorded_at,
@@ -167,6 +198,11 @@ def main() -> int:
     # --check: the committed packet must equal a fresh generation apart from recorded_at,
     # and both must validate. This is the determinism + drift guard.
     committed = json.loads(COMMITTED_PACKET.read_text())
+    if committed.get("recorded_at") != FIXED_RECORDED_AT:
+        raise SystemExit(
+            f"FAIL: committed packet recorded_at {committed.get('recorded_at')!r} != documented "
+            f"anchor {FIXED_RECORDED_AT!r}; regenerate the committed packet from this generator."
+        )
     generated = build_packet(committed["recorded_at"])
     validate(COMMITTED_PACKET)
     if generated != committed:

--- a/web/member-shell/fixtures/pending-publish-evidence-export.json
+++ b/web/member-shell/fixtures/pending-publish-evidence-export.json
@@ -70,6 +70,11 @@
     {
       "kind": "meeting-attendance-receipt",
       "status": "not-attempted"
+    },
+    {
+      "kind": "validator-output-category",
+      "public_id_or_category": "settlement-receipt-expected",
+      "status": "not-attempted"
     }
   ],
   "privacy_review": {

--- a/web/member-shell/fixtures/pending-publish-evidence-export.json
+++ b/web/member-shell/fixtures/pending-publish-evidence-export.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": "0.1.0",
+  "recorded_at": "2026-07-10T00:00:00Z",
+  "rehearsal_label": "Pending-publish review preview — committed-fixture rehearsal evidence",
+  "rehearsal_mode": "fixture-only",
+  "audience_categories": [
+    "organizer",
+    "steward",
+    "reviewer"
+  ],
+  "source_material": [
+    {
+      "kind": "committed-fixture",
+      "basename": "pending-publish-summary.json",
+      "summary": "Committed pending-publish review-preview rows, as served by GET /v1/gov/me/pending-publish-summary in a non-production build mode (origin = committed_fixture). Fictional rehearsal data; no real people or organization."
+    }
+  ],
+  "workflow_steps_completed": [
+    "start",
+    "select-material",
+    "preview",
+    "surface-result",
+    "export-evidence"
+  ],
+  "decision_outcomes": [
+    {
+      "category": "deferred",
+      "plain_summary": "Draft task parsed from example meeting notes, awaiting review before it becomes an assignable action item. Preview only — no decision was recorded."
+    },
+    {
+      "category": "deferred",
+      "plain_summary": "Proposed governance decision summarized for review before any publish step. Preview only — no decision was recorded."
+    },
+    {
+      "category": "deferred",
+      "plain_summary": "Proposed attendance/participation record parsed from example notes, awaiting review. Preview only — no decision was recorded."
+    },
+    {
+      "category": "rejected",
+      "plain_summary": "Proposed shared commitment summarized for review; the reviewer set it aside as not ready to record. Preview only — no decision was recorded."
+    },
+    {
+      "category": "edit-and-resubmit",
+      "plain_summary": "Proposed allocation of shared meeting-room time slots, awaiting an edit before it goes back for review. Preview only — no decision was recorded."
+    }
+  ],
+  "preview_review_boundary": {
+    "enforced": true,
+    "notes": "Preview rows are evidence presented for review — not authorization, publication, custody writes, or completed actions."
+  },
+  "mutation_boundary": {
+    "executed": false,
+    "target": "none",
+    "notes": "Read-only projection (GET only). No write, no publish, no action-card creation, no custody write; no network egress in fixture mode."
+  },
+  "proof_loop_references": [
+    {
+      "kind": "provenance-summary",
+      "public_id_or_category": "pending-publish-committed-fixture",
+      "status": "closed"
+    },
+    {
+      "kind": "action-item-completion-receipt",
+      "status": "not-attempted"
+    },
+    {
+      "kind": "governance-decision-receipt",
+      "status": "not-attempted"
+    },
+    {
+      "kind": "meeting-attendance-receipt",
+      "status": "not-attempted"
+    }
+  ],
+  "privacy_review": {
+    "reviewer_role": "reviewer",
+    "status": "reviewed-clean",
+    "notes": "Rows carry only generic plain-language labels — no DIDs, no private paths, no partner data. The runtime response's caller DID is deliberately not carried into this packet."
+  },
+  "export_safety_classification": "repo-safe",
+  "non_claims": [
+    "Not production readiness and not a formal pilot.",
+    "No live federation, no cloud sync.",
+    "No private participant data is handled; the rows are fictional committed-fixture rehearsal data, never live participant state.",
+    "An expected receipt is an evidence expectation for the reviewer, not authority. No preview row was authorized, published, or turned into a custody write; no receipt was issued."
+  ]
+}

--- a/web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json
+++ b/web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json
@@ -63,6 +63,15 @@
       "validate": "schema",
       "validator": "docs/scripts/validate-rehearsal-evidence.py",
       "schema": "docs/contracts/rehearsal-evidence-export.schema.json"
+    },
+    {
+      "name": "pending_publish_evidence_export",
+      "surface": "Repo-safe evidence packet for the pending-publish review-preview rehearsal; the member-shell renders a committed copy read-only",
+      "urn": "urn:icn:contract:rehearsal-evidence-export:v1",
+      "path": "web/member-shell/fixtures/pending-publish-evidence-export.json",
+      "validate": "schema",
+      "validator": "docs/scripts/validate-rehearsal-evidence.py",
+      "schema": "docs/contracts/rehearsal-evidence-export.schema.json"
     }
   ],
   "url_allowlist_hosts": ["github.com", "raw.githubusercontent.com"],


### PR DESCRIPTION
## Summary

The smallest honest **evidence-export + steward-verification** vertical for the Rehearsal Node (#2386 tail): a rehearsal produces a **repo-safe, schema-valid** evidence packet for the pending-publish review-preview observation, an operator/steward tool validates it, and CI guards it. **No schema change** — it uses the existing `urn:icn:contract:rehearsal-evidence-export:v1` (so #1729 stays closed and the NYCN/canonical example packets stay valid).

```
committed pending-publish rows  →  operator generator maps rows→decision_outcomes,
  receipts→proof_loop_references(not-attempted), origin→rehearsal_mode:fixture-only
  →  :v1 schema validation (fail-closed)  →  steward re-validation (icn-demo-verify --pending-publish)
  →  committed copy the member-shell can render read-only
```

## Honest mapping (the load-bearing part)

| Pending-publish source | Packet field | Why |
|---|---|---|
| `origin = committed_fixture` | `rehearsal_mode: fixture-only` + `source_material.kind: committed-fixture` | fictional, offline |
| each row (`plain_summary`, `status`) | one `decision_outcomes[]` | **`approved_for_publish → deferred`, never `approved`** — a preview row is evidence for review, not an authorization |
| `receipt_expected{expected:true}` | `proof_loop_references[].status: not-attempted` | an expected receipt is an expectation, **never issued** |
| read-only posture | `mutation_boundary{executed:false, target:none}`, `preview_review_boundary{enforced:true}` | no write, publish, or custody |
| caller `did` | **dropped** | no DID / credential / private path in the packet |

## Files

| File | Change |
|---|---|
| `web/member-shell/fixtures/pending-publish-evidence-export.json` | **new** committed v1 packet (the generator's canonical output) |
| `scripts/rehearsal_pending_publish_evidence.py` | **new** operator/steward generator: `--write` (validated packet → gitignored `demo/output/`), `--check` (committed == generator, deterministic apart from `recorded_at`, validates `:v1`) |
| `deploy/appliance/scripts/icn-demo-verify.sh` | **new `--pending-publish`** steward-verify mode (fixture-only, offline, fail-closed, non-root refused) |
| `deploy/appliance/build-image.sh` | bundle the generator + its fixtures into the demo-profile payload |
| `web/pilot-ui/fixtures/icn-organizer-demo/rehearsal-shell.manifest.json` | new `read_model` so `validate-rehearsal-shell-fixtures.py` (docs-freshness CI) schema-validates the packet + runs the forbidden-reference guard |
| `.github/workflows/docs-freshness.yml` | run the generator `--check` in CI (drift/determinism guard, offline) |

## Honest generation layer

The **operator/steward tool** attests the packet (it controls `rehearsal_mode`/`mutation_boundary`, so it cannot misrepresent a fixture as live or a preview as authorized). The **browser only views** a committed, CI-validated copy read-only — it generates no authority. (Reject: browser-generated "evidence".)

## Risk

Additive, no schema change, no runtime/gateway/API change, no Rust. The generator + verifier are offline + fail-closed. `demo/output/` is gitignored (generated packets never committed).

## Test plan

- [x] `scripts/rehearsal_pending_publish_evidence.py --check` — committed packet == generator output, deterministic apart from `recorded_at`, validates `:v1`.
- [x] `python3 docs/scripts/validate-rehearsal-evidence.py <packet>` — schema-valid.
- [x] `python3 docs/scripts/validate-rehearsal-shell-fixtures.py` — schema-valid + **forbidden-reference guard clean** (no live hosts / JWTs / private paths / money framing); 7 read models PASS.
- [x] Honesty invariants: no `approved` outcome; all expected receipts `not-attempted`; `mutation_boundary.executed=false`; no `did:`/credential/private path.
- [x] `compliance_linter.py` + `readiness_overclaim_linter.py` clean; `bash -n` (shell) + `py_compile` (python) clean; whitespace clean.

## Non-claims

Not organizer-ready (human AT rehearsal remains #2041); not a pilot; not production; not live federation; not Phase 2 complete. No mutation, publish, action-card creation, or authority. Member-shell rendering of this packet in the default demo set is a bounded follow-up (`renderEvidenceExport` already renders the sibling process-evidence packet read-only).

Refs #2386.
Refs #1726.
Refs #1728.
Refs #2141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
