### PR TITLE
fix(cli): mint appliance demo-seed session JWT via trusted local issuance

### DIFF
--- a/deploy/appliance/check.sh
+++ b/deploy/appliance/check.sh
@@ -123,6 +123,19 @@ else
     bad "netdev isolation construction (run: bash deploy/appliance/smoke/net-restrict-check.sh)"
 fi
 
+# 6b. demo seed trusted-local auth construction (#2386 / #2075)
+#
+# Asserts icn-demo-seed.sh authenticates via trusted local issuance
+# (icnctl --local-mint, signing with this node's own gateway secret) and NOT the
+# self-asserted /auth/verify path that #2075 fail-closes on the demo's routable
+# bind. Static structure check; the runtime proof is `smoke-image`.
+section "demo seed trusted-local auth construction"
+if bash "$APPLIANCE_DIR/smoke/demo-seed-auth-check.sh" >/dev/null; then
+    ok "demo seed trusted-local auth (6/6 checks)"
+else
+    bad "demo seed trusted-local auth (run: bash deploy/appliance/smoke/demo-seed-auth-check.sh)"
+fi
+
 # 7. typed manifest emit/verify round-trip (skip-aware / opt-in)
 #
 # Proves the typed appliance manifest path (`icnctl appliance emit-manifest`

--- a/deploy/appliance/scripts/icn-demo-seed.sh
+++ b/deploy/appliance/scripts/icn-demo-seed.sh
@@ -9,8 +9,14 @@
 #
 # What it does (all against THIS VM's own gateway on 127.0.0.1:8080):
 #   1. Waits for the gateway to be healthy.
-#   2. Resolves the node operator DID and mints a dev session JWT
-#      (signed with this VM's per-instance JWT secret).
+#   2. Resolves the node operator DID and mints a session JWT by TRUSTED LOCAL
+#      issuance: icnctl signs it in-process (the `--local-mint` path) with this
+#      VM's own per-instance gateway JWT secret (ICN_GATEWAY_JWT_SECRET from
+#      /etc/icn/icnd.env, root-only). That is the gateway issuing a JWT for
+#      itself to its local operator — it does NOT use the public self-asserted
+#      /auth/verify path, which stays fail-closed on the demo's routable
+#      0.0.0.0 bind (issue #2075). No credential is baked into the image; the
+#      secret is generated per-VM at first boot and is never printed.
 #   3. Applies the in-tree NYCN institution package (fictional fixture
 #      institution — same package the nycn-dogfood rehearsal kit uses).
 #   4. Dev-gated standing bootstrap for the operator DID (so the shell's
@@ -57,6 +63,9 @@ command -v python3 >/dev/null || fatal "python3 missing"
 # shellcheck disable=SC1090
 . "$ENV_FILE"
 [ -n "${ICN_KEYSTORE_PASSPHRASE:-}" ] || fatal "ICN_KEYSTORE_PASSPHRASE not present in $ENV_FILE"
+# Instance-local gateway signing secret — the trusted lever for local JWT
+# issuance (icnctl --local-mint). Generated per-VM by firstboot; root-only.
+[ -n "${ICN_GATEWAY_JWT_SECRET:-}" ] || fatal "ICN_GATEWAY_JWT_SECRET not present in $ENV_FILE — needed for trusted local JWT issuance (icnctl --local-mint)"
 
 as_icn(){
   # Drop from root to the icn user with `runuser`, NOT `sudo`. sudo records
@@ -66,9 +75,12 @@ as_icn(){
   # script already runs as root, so it does not need sudo to gain privilege —
   # runuser drops privilege without writing the command or env to any log.
   # The passphrase is exported only for the runuser call and passed through
-  # with --preserve-environment.
+  # with --preserve-environment. The gateway signing secret is passed the same
+  # way (env only, never a command line, never logged) so `icnctl --local-mint`
+  # can issue a trusted local JWT as the icn user.
   ICN_KEYSTORE_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" \
   ICN_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE" \
+  ICN_GATEWAY_JWT_SECRET="$ICN_GATEWAY_JWT_SECRET" \
     runuser -u icn --preserve-environment -- "$@"
 }
 
@@ -85,15 +97,15 @@ DID="$(grep -oE 'did:icn:[A-Za-z0-9]+' <<<"$id_out" | head -1)"
 [ -n "$DID" ] || fatal "could not resolve node operator DID (icnctl --data-dir $DATA_DIR id show)"
 log "operator DID: $DID"
 
-jwt_out="$(as_icn /usr/local/bin/icnctl --data-dir "$DATA_DIR" auth token --gateway "$GW" --coop-id "$COOP_ID" -s "$SCOPES" 2>/dev/null || true)" # vocab-ok: icnctl CLI subcommand name
+jwt_out="$(as_icn /usr/local/bin/icnctl --data-dir "$DATA_DIR" auth token --gateway "$GW" --coop-id "$COOP_ID" -s "$SCOPES" --local-mint 2>/dev/null || true)" # vocab-ok: icnctl CLI subcommand name
 SESSION_JWT="$(grep -oE 'eyJ[A-Za-z0-9_.-]+' <<<"$jwt_out" | head -1)"
-[ -n "$SESSION_JWT" ] || fatal "session JWT mint failed (icnctl auth subcommand)"
+[ -n "$SESSION_JWT" ] || fatal "trusted local session-JWT mint failed (icnctl --local-mint). Check ICN_GATEWAY_JWT_SECRET is present in $ENV_FILE and the keystore unlocks. This path signs with THIS VM's own gateway secret and never uses the public self-asserted /auth/verify flow (issue #2075)."
 AUTH="Authorization: Bearer $SESSION_JWT"
-log "dev session JWT minted (printed at the end — local VM only)."
+log "session JWT minted via trusted local issuance (this VM's own gateway secret; printed at the end — local VM only)."
 
 log "applying NYCN institution package (fictional fixture institution)..."
 as_icn /usr/local/bin/icnctl --data-dir "$DATA_DIR" institution bootstrap apply \
-  -g "$GW" -c "$COOP_ID" --package "$PKG" >/tmp/icn-demo-seed-bootstrap.log 2>&1 \
+  -g "$GW" -c "$COOP_ID" --package "$PKG" --local-mint >/tmp/icn-demo-seed-bootstrap.log 2>&1 \
   || fatal "institution bootstrap apply failed (see /tmp/icn-demo-seed-bootstrap.log)"
 log "institution package applied."
 
@@ -152,7 +164,8 @@ cat <<EOF
  Open action item:   $ITEM_ID
  $standing_note
 
- Dev session JWT (LOCAL VM ONLY — paste into the shell's live mode):
+ Session JWT (LOCAL VM ONLY — trusted local issuance signed with this VM's
+ own per-instance gateway secret; paste into the shell's live mode):
  $SESSION_JWT
 
  Honesty labels:

--- a/deploy/appliance/smoke/demo-seed-auth-check.sh
+++ b/deploy/appliance/smoke/demo-seed-auth-check.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# demo-seed-auth-check.sh
+#
+# Deterministic, VM-free static check that icn-demo-seed.sh authenticates via
+# TRUSTED LOCAL issuance and never via the public self-asserted path:
+#
+#   1. The session JWT is minted via icnctl's `--local-mint` path (in-process
+#      signing with this node's own gateway secret), NOT a bare mint that would
+#      hit the self-asserted /auth/verify flow — which #2075 fail-closes on the
+#      demo's routable 0.0.0.0 bind.
+#   2. `institution bootstrap apply` likewise uses `--local-mint`.
+#   3. The seed fails closed if the signing secret (ICN_GATEWAY_JWT_SECRET) is
+#      absent.
+#   4. The signing secret is passed ONLY through the environment (never a CLI
+#      flag / never a literal), so it cannot leak to a process list or journal.
+#   5. The seed bakes NO credential: no hardcoded JWT/bearer literal.
+#   6. The seed never calls the self-asserted /v1/auth/verify endpoint directly.
+#
+# This asserts SCRIPT STRUCTURE only. The runtime proof — the full seed loop
+# completing against a demo-profile image without weakening auth — runs via
+# `deploy/appliance/scripts/icn-rehearsal-node.sh smoke-image`. PASS here is not
+# a live proof.
+#
+# Usage: bash deploy/appliance/smoke/demo-seed-auth-check.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEED="$SCRIPT_DIR/../scripts/icn-demo-seed.sh"
+
+fail=0
+say() { printf '[demo-seed-auth-check] %s\n' "$*"; }
+ok()  { printf '[demo-seed-auth-check] ok: %s\n' "$*"; }
+bad() { printf '[demo-seed-auth-check] FAIL: %s\n' "$*" >&2; fail=1; }
+
+[ -f "$SEED" ] || { bad "icn-demo-seed.sh not found at $SEED"; exit 1; }
+
+# 1. Session JWT minted via trusted local issuance (the mint line carries --local-mint).
+if grep -qE 'auth[[:space:]].*--local-mint' "$SEED"; then
+    ok "session JWT uses trusted local issuance (--local-mint)"
+else
+    bad "session-JWT mint is not --local-mint (a bare mint would hit the #2075-blocked self-asserted /auth/verify on the demo 0.0.0.0 bind)"
+fi
+
+# 2. Institution bootstrap apply uses trusted local issuance (command spans lines).
+if grep -A2 'institution bootstrap apply' "$SEED" | grep -q -- '--local-mint'; then
+    ok "institution bootstrap apply uses --local-mint"
+else
+    bad "institution bootstrap apply does not use --local-mint (would hit the same self-asserted 403)"
+fi
+
+# 3. Fail-closed precondition: the seed requires the signing secret.
+if grep -qE '\[ -n "\$\{ICN_GATEWAY_JWT_SECRET' "$SEED"; then
+    ok "requires ICN_GATEWAY_JWT_SECRET (fail-closed precondition)"
+else
+    bad "no fail-closed check that ICN_GATEWAY_JWT_SECRET is present"
+fi
+
+# 4. Signing secret passed only through the environment, never a CLI flag.
+if grep -qE 'ICN_GATEWAY_JWT_SECRET="\$ICN_GATEWAY_JWT_SECRET"' "$SEED" \
+   && ! grep -qE -- '--jwt-secret|--signing-secret|--secret[ =]' "$SEED"; then
+    ok "signing secret confined to the environment (no secret on any command line)"
+else
+    bad "signing secret is not confined to the environment"
+fi
+
+# 5. No baked credential: no hardcoded JWT/bearer literal.
+if grep -qE 'eyJ[A-Za-z0-9_.-]{10,}' "$SEED"; then
+    bad "hardcoded JWT/bearer literal found in the seed"
+else
+    ok "no hardcoded JWT/bearer literal"
+fi
+
+# 6. The seed does not call the self-asserted endpoint directly (match the real
+#    /v1/ endpoint path — prose that names the flow is fine).
+if grep -qE '/v1/auth/verify' "$SEED"; then
+    bad "seed calls the self-asserted /v1/auth/verify endpoint directly"
+else
+    ok "seed does not call /v1/auth/verify directly"
+fi
+
+if [ "$fail" -eq 0 ]; then
+    say "PASS (6/6): demo seed uses trusted local issuance; #2075 self-asserted path untouched"
+    exit 0
+else
+    say "FAIL"
+    exit 1
+fi

--- a/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
+++ b/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
@@ -63,7 +63,7 @@ as cryptographic verification.
 |---|---|
 | `deploy/appliance/build-image.sh` | Builds the QCOW2 appliance image; `ICN_APPLIANCE_DEMO_PROFILE=1` adds the DEMO profile. Run separately — the wrapper never builds. |
 | `deploy/appliance/smoke/smoke-local.sh --real --demo` | Boots a disposable QEMU overlay and drives the full loop headlessly over the same forwarded ports a browser would use. |
-| `deploy/appliance/scripts/icn-demo-seed.sh` | In-VM: mints a short-lived DEV/DEMO JWT, bootstraps the fixture institution, creates one action item. Not idempotent — use reset for a clean slate. |
+| `deploy/appliance/scripts/icn-demo-seed.sh` | In-VM: mints a short-lived DEV/DEMO session JWT via **trusted local issuance** (signs with this VM's own per-instance gateway secret — see the auth-boundary note below), bootstraps the fixture institution, creates one action item. Not idempotent — use reset for a clean slate. |
 | `deploy/appliance/scripts/icn-demo-verify.sh` | In-VM: per-item receipt consistency check; `--chain` runs the bundled 13-of-13 receipt-chain rehearsal. |
 | `deploy/appliance/scripts/icn-demo-reset.sh` | In-VM: marker-gated demo-state reset (does not reseed). |
 | `deploy/appliance/scripts/icn-demo-session.py` | In-VM loopback (`127.0.0.1:8091`) session endpoint behind a double dev-gate and an Origin allow-list; powers the shell's no-paste "Start local demo" button. |
@@ -71,6 +71,23 @@ as cryptographic verification.
 | `web/member-shell/` | The browser surface the appliance serves (`:8090` in-VM): standing, action cards, the single completion mutation, receipt rendering, permanent honesty banner, i18n seam, automated accessibility harness. |
 | `demo/nycn-dogfood/run.sh` | The workstation-native sibling of the same loop (deliberately on gateway `:8085`); useful for development without a VM. |
 | `scripts/local_receipt_chain_13of13_rehearsal.sh` | The strongest single proof artifact (governed proposal → vote → close → allocation, 13/13 audit, repo-safe evidence packet); bundled in-VM as `icn-demo-verify --chain`. |
+
+## Auth boundary — trusted local issuance vs self-asserted (#2075)
+
+The demo profile binds the gateway to `0.0.0.0:8080` so a browser on the host
+reaches it through QEMU host-forwarding. On any non-loopback bind the public
+self-asserted `/auth/verify` path is **fail-closed** (issue #2075): a DID that
+proves only key ownership can never mint a JWT carrying an arbitrary `coop_id`.
+
+The seed therefore mints its session JWT by **trusted local issuance**:
+`icnctl auth token --local-mint` signs the JWT in-process with the node's own
+per-instance gateway secret (`ICN_GATEWAY_JWT_SECRET`, generated at first boot,
+root-only). That is the gateway issuing a JWT for itself to its local operator —
+categorically distinct from an untrusted remote self-asserting a coop over the
+network. It makes no network call, adds no endpoint, and leaves `/auth/verify`
+fail-closed. `institution bootstrap apply --local-mint` uses the same path. The
+secret never leaves the VM and is never baked into the image; a JWT minted with
+one VM's secret does not verify on any other node.
 
 ## Fast path A — smoke an already-built demo image
 

--- a/icn/bins/icnctl/src/institution_bootstrap.rs
+++ b/icn/bins/icnctl/src/institution_bootstrap.rs
@@ -59,6 +59,13 @@ pub enum InstitutionBootstrapCommands {
         #[arg(short, long)]
         coop_id: String,
 
+        /// Trusted LOCAL issuance for a co-located operator: mint the bootstrap
+        /// token in-process with this node's own gateway JWT secret
+        /// (ICN_GATEWAY_JWT_SECRET in the environment) instead of the network
+        /// /auth/verify flow. Does not use — or weaken — #2075.
+        #[arg(long, default_value_t = false)]
+        local_mint: bool,
+
         /// Output machine-readable JSON
         #[arg(long)]
         json: bool,
@@ -184,9 +191,11 @@ pub async fn handle_institution_command(cmd: InstitutionCommands, data_dir: &Pat
                 package,
                 gateway,
                 coop_id,
+                local_mint,
                 json,
             } => {
-                let report = apply_package(&package, &gateway, &coop_id, data_dir).await?;
+                let report =
+                    apply_package(&package, &gateway, &coop_id, data_dir, local_mint).await?;
                 if json {
                     println!("{}", serde_json::to_string_pretty(&report)?);
                 } else {
@@ -427,10 +436,11 @@ pub async fn apply_package(
     gateway: &str,
     coop_id: &str,
     data_dir: &Path,
+    local_mint: bool,
 ) -> Result<BootstrapApplyReport> {
     let loaded = load_package(package_dir)?;
     let plan = make_plan(&loaded);
-    let auth = get_bootstrap_gateway_token(gateway, coop_id, data_dir).await?;
+    let auth = get_bootstrap_gateway_token(gateway, coop_id, data_dir, local_mint).await?;
     run_apply_plan(&loaded, &plan, gateway, &auth).await
 }
 
@@ -1287,6 +1297,7 @@ async fn get_bootstrap_gateway_token(
     gateway: &str,
     coop_id: &str,
     data_dir: &Path,
+    local_mint: bool,
 ) -> Result<BootstrapAuthContext> {
     use icn_identity::{AgeKeyStore, KeyStore};
 
@@ -1300,6 +1311,26 @@ async fn get_bootstrap_gateway_token(
     keystore.unlock(&passphrase)?;
     let keypair = keystore.get_keypair()?;
     let did = keypair.did().to_string();
+
+    if local_mint {
+        // Trusted local issuance: mint the bootstrap token in-process by signing
+        // with this node's own gateway secret, instead of the network
+        // self-asserted /auth/verify flow (which fail-closes on a routable bind,
+        // issue #2075). Same trust boundary as `icnctl auth token --local-mint`.
+        let token = crate::mint_local_trusted_token(
+            keypair.did(),
+            coop_id,
+            vec![
+                "entity:write".to_string(),
+                "governance:read".to_string(),
+                "governance:write".to_string(),
+            ],
+        )?;
+        return Ok(BootstrapAuthContext {
+            token,
+            subject_did: did,
+        });
+    }
 
     let client = reqwest::Client::new();
     let challenge_url = format!("{gateway}/v1/auth/challenge");

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -7631,7 +7631,6 @@ fn handle_snapshot_command(cmd: SnapshotCommands, data_dir: &Path) -> Result<()>
     Ok(())
 }
 
-/// Handle authentication commands
 /// Trusted LOCAL capability-token issuance for a co-located operator.
 ///
 /// Mints a capability token by signing it with `secret` — THIS node's own
@@ -7652,21 +7651,29 @@ pub(crate) fn mint_trusted_token_with_secret(
     if secret.is_empty() {
         bail!("gateway JWT secret is empty");
     }
+    // Apply the SAME input validation the gateway runs at /auth/verify
+    // (icn-gateway `validation::validate_coop_id` / `validate_scopes`) so the
+    // local path rejects a malformed coop_id or a typo/unknown scope up front,
+    // instead of minting a token that only 403s later at the endpoint.
+    icn_gateway::validation::validate_coop_id(coop_id)
+        .map_err(|e| anyhow::anyhow!("invalid coop_id: {e}"))?;
+    icn_gateway::validation::validate_scopes(&scopes)
+        .map_err(|e| anyhow::anyhow!("invalid scopes: {e}"))?;
     icn_gateway::auth::AuthManager::new(secret.to_vec())
         .issue_token(did, coop_id, scopes)
         .context("trusted local token mint failed")
 }
 
 /// Read the instance-local gateway signing secret from `ICN_GATEWAY_JWT_SECRET`
-/// (hex) in the environment and mint a trusted local token. The secret is read
-/// ONLY from the environment — never a CLI argument — and is never printed.
+/// in the environment and mint a trusted local token. The secret is read ONLY
+/// from the environment — never a CLI argument — and is never printed.
 /// Fail-closed with a non-secret diagnostic when the secret is absent.
 pub(crate) fn mint_local_trusted_token(
     did: &icn_identity::Did,
     coop_id: &str,
     scopes: Vec<String>,
 ) -> Result<String> {
-    let secret_hex = std::env::var("ICN_GATEWAY_JWT_SECRET").map_err(|_| {
+    let secret = std::env::var("ICN_GATEWAY_JWT_SECRET").map_err(|_| {
         anyhow::anyhow!(
             "--local-mint needs this node's own gateway signing secret in \
              ICN_GATEWAY_JWT_SECRET (e.g. from /etc/icn/icnd.env). It is read only from the \
@@ -7675,9 +7682,12 @@ pub(crate) fn mint_local_trusted_token(
              flow, which stays fail-closed on routable binds (issue #2075)."
         )
     })?;
-    let secret =
-        hex::decode(secret_hex.trim()).context("ICN_GATEWAY_JWT_SECRET must be hex-encoded")?;
-    mint_trusted_token_with_secret(&secret, did, coop_id, scopes)
+    // Match the gateway EXACTLY: icn-core `init_gateway.rs` builds the signing key
+    // as `config.jwt_secret.clone().into_bytes()` — the secret string's bytes
+    // VERBATIM, never a hex-decode — and icnd stores ICN_GATEWAY_JWT_SECRET
+    // verbatim. Using the raw bytes here is what makes the minted JWT verify on
+    // the live gateway.
+    mint_trusted_token_with_secret(secret.as_bytes(), did, coop_id, scopes)
 }
 
 #[cfg(test)]
@@ -7738,8 +7748,62 @@ mod trusted_local_mint_tests {
         let bundle = icn_identity::IdentityBundle::generate().unwrap();
         assert!(mint_trusted_token_with_secret(&[], bundle.did(), "nycn", vec![]).is_err());
     }
+
+    /// The gateway builds its signing key as `config.jwt_secret.into_bytes()`
+    /// (raw string bytes), NOT a hex-decode. A hex-looking secret must sign with
+    /// its ASCII bytes so the token verifies on the live gateway; the same token
+    /// must NOT verify under the hex-DECODED key. This guards against
+    /// re-introducing a `hex::decode` that would silently 401 every demo token.
+    #[test]
+    fn local_mint_uses_secret_bytes_verbatim_like_the_gateway() {
+        let secret_str = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"; // hex-looking; used verbatim
+        let bundle = icn_identity::IdentityBundle::generate().unwrap();
+        let token = mint_trusted_token_with_secret(
+            secret_str.as_bytes(),
+            bundle.did(),
+            "nycn",
+            vec!["governance:read".to_string()],
+        )
+        .unwrap();
+        // The gateway (raw string-byte key, as in init_gateway.rs) accepts it.
+        icn_gateway::auth::AuthManager::new(secret_str.as_bytes().to_vec())
+            .verify_token(&token)
+            .expect("gateway must accept a token signed with the raw secret-string bytes");
+        // A hex-decoded key must NOT verify it.
+        let decoded = hex::decode(secret_str).unwrap();
+        assert!(
+            icn_gateway::auth::AuthManager::new(decoded)
+                .verify_token(&token)
+                .is_err(),
+            "token must not verify under the hex-decoded secret; the gateway uses raw string bytes"
+        );
+    }
+
+    /// The local mint runs the same input validation as /auth/verify: a malformed
+    /// coop_id or an unknown scope is rejected up front, not minted into a token
+    /// that only 403s later at the endpoint.
+    #[test]
+    fn local_mint_rejects_invalid_coop_id_and_scopes() {
+        let secret = b"instance-local-gateway-secret".to_vec();
+        let bundle = icn_identity::IdentityBundle::generate().unwrap();
+        assert!(
+            mint_trusted_token_with_secret(&secret, bundle.did(), "bad@coop#id!", vec![]).is_err(),
+            "malformed coop_id must be rejected up front"
+        );
+        assert!(
+            mint_trusted_token_with_secret(
+                &secret,
+                bundle.did(),
+                "nycn",
+                vec!["governance:read".to_string(), "totally:bogus".to_string()],
+            )
+            .is_err(),
+            "an unknown scope must be rejected up front"
+        );
+    }
 }
 
+/// Handle authentication commands
 async fn handle_auth_command(cmd: AuthCommands, data_dir: &Path) -> Result<()> {
     match cmd {
         AuthCommands::Token {

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -574,6 +574,16 @@ enum AuthCommands {
             default_value = "ledger:read,ledger:write,coop:read,governance:read,governance:write"
         )]
         scopes: String,
+
+        /// Trusted LOCAL issuance for a co-located operator: mint the token
+        /// in-process by signing with this node's own gateway JWT secret
+        /// (read from ICN_GATEWAY_JWT_SECRET in the environment) instead of the
+        /// network /auth/verify challenge/verify flow. For an operator who
+        /// already controls the gateway (holds its signing secret). Does NOT
+        /// use — or weaken — the public self-asserted /auth/verify path
+        /// (issue #2075), which stays fail-closed on routable binds.
+        #[arg(long, default_value_t = false)]
+        local_mint: bool,
     },
 }
 
@@ -7622,12 +7632,121 @@ fn handle_snapshot_command(cmd: SnapshotCommands, data_dir: &Path) -> Result<()>
 }
 
 /// Handle authentication commands
+/// Trusted LOCAL capability-token issuance for a co-located operator.
+///
+/// Mints a capability token by signing it with `secret` — THIS node's own
+/// gateway JWT secret. That secret verifies every bearer token the gateway
+/// accepts, so holding it is equivalent to controlling the gateway; minting a
+/// token with it is simply the gateway issuing a token for itself. This is
+/// categorically distinct from the PUBLIC, self-asserted `/auth/verify`
+/// challenge/verify flow, which stays fail-closed on any routable bind
+/// (issue #2075). This path never touches `/auth/verify`, makes no network
+/// call, and adds no endpoint. `entity_id` stays `None` (the legacy mint shape):
+/// the trusted-local path issues coop authority, never a fabricated typed entity.
+pub(crate) fn mint_trusted_token_with_secret(
+    secret: &[u8],
+    did: &icn_identity::Did,
+    coop_id: &str,
+    scopes: Vec<String>,
+) -> Result<String> {
+    if secret.is_empty() {
+        bail!("gateway JWT secret is empty");
+    }
+    icn_gateway::auth::AuthManager::new(secret.to_vec())
+        .issue_token(did, coop_id, scopes)
+        .context("trusted local token mint failed")
+}
+
+/// Read the instance-local gateway signing secret from `ICN_GATEWAY_JWT_SECRET`
+/// (hex) in the environment and mint a trusted local token. The secret is read
+/// ONLY from the environment — never a CLI argument — and is never printed.
+/// Fail-closed with a non-secret diagnostic when the secret is absent.
+pub(crate) fn mint_local_trusted_token(
+    did: &icn_identity::Did,
+    coop_id: &str,
+    scopes: Vec<String>,
+) -> Result<String> {
+    let secret_hex = std::env::var("ICN_GATEWAY_JWT_SECRET").map_err(|_| {
+        anyhow::anyhow!(
+            "--local-mint needs this node's own gateway signing secret in \
+             ICN_GATEWAY_JWT_SECRET (e.g. from /etc/icn/icnd.env). It is read only from the \
+             environment, never the command line, and never logged. This is a TRUSTED LOCAL \
+             operator path; it does not use — or weaken — the public /auth/verify self-asserted \
+             flow, which stays fail-closed on routable binds (issue #2075)."
+        )
+    })?;
+    let secret =
+        hex::decode(secret_hex.trim()).context("ICN_GATEWAY_JWT_SECRET must be hex-encoded")?;
+    mint_trusted_token_with_secret(&secret, did, coop_id, scopes)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod trusted_local_mint_tests {
+    use super::*;
+
+    /// A trusted local mint signs with the node's own gateway secret and yields a
+    /// token the SAME gateway accepts, carrying the requested coop_id + scopes and
+    /// NO typed entity context (the trusted-local path fabricates none). No network.
+    #[test]
+    fn local_mint_produces_a_gateway_verifiable_coop_token() {
+        let secret = b"instance-local-gateway-secret".to_vec();
+        let bundle = icn_identity::IdentityBundle::generate().unwrap();
+        let token = mint_trusted_token_with_secret(
+            &secret,
+            bundle.did(),
+            "nycn",
+            vec!["governance:read".to_string(), "coop:admin".to_string()],
+        )
+        .unwrap();
+        let claims = icn_gateway::auth::AuthManager::new(secret.clone())
+            .verify_token(&token)
+            .expect("gateway must accept a token signed with its own secret");
+        assert_eq!(claims.coop_id, "nycn");
+        assert_eq!(claims.sub, bundle.did().to_string());
+        assert!(claims.scopes.contains(&"coop:admin".to_string()));
+        assert_eq!(
+            claims.entity_id, None,
+            "trusted local mint sets no typed entity context"
+        );
+    }
+
+    /// A token minted with one node's secret is rejected under a different secret:
+    /// the credential is intrinsically per-instance and non-portable, so it is
+    /// never a reusable credential that could be baked into the shared image.
+    #[test]
+    fn local_mint_token_is_rejected_by_a_different_secret() {
+        let bundle = icn_identity::IdentityBundle::generate().unwrap();
+        let token = mint_trusted_token_with_secret(
+            b"secret-A",
+            bundle.did(),
+            "nycn",
+            vec!["governance:read".to_string()],
+        )
+        .unwrap();
+        assert!(
+            icn_gateway::auth::AuthManager::new(b"secret-B".to_vec())
+                .verify_token(&token)
+                .is_err(),
+            "a token minted with one node's secret must not verify under another's"
+        );
+    }
+
+    /// An empty secret fails closed rather than minting an unsigned/weak token.
+    #[test]
+    fn local_mint_rejects_empty_secret() {
+        let bundle = icn_identity::IdentityBundle::generate().unwrap();
+        assert!(mint_trusted_token_with_secret(&[], bundle.did(), "nycn", vec![]).is_err());
+    }
+}
+
 async fn handle_auth_command(cmd: AuthCommands, data_dir: &Path) -> Result<()> {
     match cmd {
         AuthCommands::Token {
             gateway,
             coop_id,
             scopes,
+            local_mint,
         } => {
             // Get keystore path and unlock
             let keystore_path = get_keystore_path(data_dir);
@@ -7653,6 +7772,16 @@ async fn handle_auth_command(cmd: AuthCommands, data_dir: &Path) -> Result<()> {
 
             // Parse scopes
             let scope_list: Vec<String> = scopes.split(',').map(|s| s.trim().to_string()).collect();
+
+            if local_mint {
+                // Trusted local issuance: sign with this node's own gateway
+                // secret in-process — no network call, no /auth/verify. Print
+                // ONLY the token (callers / the demo seed capture it from
+                // stdout); the signing secret is never printed.
+                let token = mint_local_trusted_token(keypair.did(), &coop_id, scope_list)?;
+                println!("{token}");
+                return Ok(());
+            }
 
             println!("Getting token for DID: {did}");
             println!("Gateway: {gateway}");


### PR DESCRIPTION
## What

The appliance demo seed could not authenticate on current `main`. This adds a **trusted local issuance** path — `icnctl auth token --local-mint` and `institution bootstrap apply --local-mint` — and points `icn-demo-seed.sh` at it. The #2075 self-asserted `/auth/verify` guard is **unchanged** (byte-for-byte) and stays fail-closed.

Fixes #2395. Refs #2386, #2075, #2080.

## Why (the regression)

The demo profile binds the gateway to `0.0.0.0:8080` so a browser on the host reaches it via QEMU host-forwarding. On any non-loopback bind, `self_serve_coop_allowed(dev_opt_in, bind) = dev_opt_in && bind.is_loopback()` (#2075) correctly fail-closes self-asserted coop issuance **regardless of `ICN_DEV_MODE`**. The seed minted its session JWT via `icnctl auth token --coop-id nycn` (that self-asserted `/auth/verify` path), and `institution bootstrap apply` self-asserts internally the same way — so both 403 on the demo bind. It worked on the pre-#2075 June image (`0ef998ba`); the demo tooling drifted from the hardened boundary. No trusted first-admin issuance is wired on a routable bind (the #2080 `TokenAuthoritySource` seam is `DenyUntilWired`; invites/enrollment presuppose a pre-existing coop admin).

## How

`icnctl` gains an opt-in `--local-mint` mode that signs a capability JWT **in-process** with the node's own instance-local gateway secret (`ICN_GATEWAY_JWT_SECRET`) via the existing `AuthManager::issue_token` — reusing the canonical claims/signing, no format drift. This is the gateway issuing a JWT **for itself** to its local operator, who already controls the gateway by holding its signing secret. Both the session JWT and the bootstrap token use it; the seed passes the secret through its existing `runuser` env passthrough.

## Security boundary — trusted local issuance vs self-asserted (why #2075 is not weakened)

| | Public self-asserted `/auth/verify` (#2075 gate) | Trusted local `--local-mint` (this PR) |
|---|---|---|
| Who can use it | any remote caller proving DID ownership | only a local root/`icn` operator holding `ICN_GATEWAY_JWT_SECRET` |
| Reachable over the network | yes | **no** — in-process CLI signing; no endpoint, no network call |
| Authority granted vs already held | binds *new* self-asserted coop authority | none — the secret already lets its holder forge any token |
| On a routable bind | **fail-closed (403)** — unchanged | works (it is not the `/auth/verify` path) |

- `self_serve_coop_allowed` and `verify_challenge` are **untouched**; the existing #2075 loopback-only + routable-rejection unit tests are unchanged and green.
- **No credential is baked into the image**: the secret is first-boot generated per VM and root-only; a JWT minted with one node's secret verifies on **no** other node (unit-tested).
- No secret appears on any command line or in logs (env-only; never printed).
- **No new endpoint**; **no unauthenticated issuance path**; production `/auth/verify` behavior and `--local-mint`-absent behavior are unchanged.

## Risk

`--local-mint` is a new icnctl capability wherever icnctl ships. It grants no authority the secret-holder does not already have (holding the gateway HMAC secret already permits forging any token), requires the secret explicitly via env, is opt-in, and does not change production defaults or `/auth/verify`.

## Test plan

- `cargo fmt --all --check` — clean
- `cargo clippy -p icnctl -p icn-gateway --all-targets -- -D warnings` — clean
- `cargo test -p icnctl` — 33 passed (incl. `institution_bootstrap::tests::apply_integration::*`)
- New unit tests `trusted_local_mint_tests` — gateway-verifiable JWT, non-portable across secrets, empty-secret fail-closed (3 passed)
- #2075 regression tests `self_serve_coop_requires_dev_optin_and_loopback`, `test_verify_challenge_self_asserted_coop_rejected_by_default` — unchanged, green
- `deploy/appliance/check.sh` — 28/0 (incl. new `demo-seed-auth-check.sh`, wired in)
- compliance + readiness-overclaim linters — clean; drift-check PASS
- Runtime end-to-end (full seed loop on a fresh current-main demo-profile image) is the follow-up appliance witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
