### PR TITLE
feat(governance): completion-only action-item scope (#2400)

### DIFF
--- a/deploy/appliance/scripts/icn-demo-seed.sh
+++ b/deploy/appliance/scripts/icn-demo-seed.sh
@@ -21,12 +21,12 @@
 #      per-VM at first boot and is never printed.
 #      TWO least-privilege credentials are minted (issue #2396 hardening):
 #        - a SETUP JWT (never printed) that provisions the demo loop, and
-#        - a narrow BROWSER JWT (governance:read + governance:meeting:write) — the
-#          ONLY JWT handed to the member shell. meeting:write is the narrowest
-#          gateway scope that authorizes the shell's action-item completion; as a
-#          member of the seeded fictional domain it ALSO permits creating action
-#          items / meetings there (a completion-only scope decomposition is a
-#          tracked follow-up), but it canNOT reach cooperative-admin, entity,
+#        - a narrow BROWSER JWT (governance:read + governance:action-item:complete)
+#          — the ONLY JWT handed to the member shell. governance:action-item:complete
+#          is the completion-only capability (#2400): as a member of the seeded
+#          fictional domain it lets the operator complete their assigned action
+#          item and NOTHING more — it canNOT create action items or meetings,
+#          administer a cooperative, read entities, or reach cooperative-admin,
 #          treasury, or the broad/other governance write classes.
 #   3. Applies the in-tree NYCN institution package (fictional fixture
 #      institution — same package the nycn-dogfood rehearsal kit uses).
@@ -64,12 +64,15 @@ DOMAIN="${ICN_DEMO_DOMAIN:-nycn-federation-gov}"
 #     standing-bootstrap. NEVER emitted to the browser.
 #   - BROWSER: the member-shell's live routes — standing / action-cards /
 #     pending-publish / completion-receipt (governance:read) and the action-item
-#     completion PUT (governance:meeting:write). This is the ONLY JWT printed.
-# Neither needs any coop:* scope, and the browser JWT carries NO broad
-# governance:write, entity:write, or coop:admin — so it cannot reach
-# cooperative-admin, entity, or broad governance-mutation routes.
+#     completion PUT (governance:action-item:complete, the completion-only
+#     capability from #2400 — accepted only for the `completed` transition). This
+#     is the ONLY JWT printed.
+# Neither needs any coop:* scope, and the browser JWT carries NO governance:write,
+# NO governance:meeting:write, NO entity:write, and NO coop:admin — so it cannot
+# create action items or meetings, administer a cooperative, read entities, or
+# reach broad governance-mutation routes.
 SETUP_SCOPES="governance:meeting:write"
-BROWSER_SCOPES="governance:read,governance:meeting:write"
+BROWSER_SCOPES="governance:read,governance:action-item:complete"
 JSON_OUT=0
 [ "${1:-}" = "--json" ] && JSON_OUT=1
 

--- a/deploy/appliance/smoke/demo-seed-auth-check.sh
+++ b/deploy/appliance/smoke/demo-seed-auth-check.sh
@@ -16,8 +16,9 @@
 #      CLI flag / never a literal), so it cannot leak to a process list or journal.
 #   5. The seed bakes NO credential: no hardcoded JWT/bearer literal.
 #   6. The seed never calls the self-asserted /v1/auth/verify endpoint directly.
-#   7. The BROWSER JWT is least-privilege: governance:read + governance:meeting:write
-#      (the narrowest scope for completion) — no coop:* and no broad governance:write.
+#   7. The BROWSER JWT is least-privilege: governance:read + governance:action-item:complete
+#      (the completion-only capability, #2400) — no governance:meeting:write (which
+#      would also authorize creating items/meetings), no coop:*, no broad governance:write.
 #   8. The SETUP JWT is internal: only the browser JWT is ever emitted/printed.
 #   9. The icn child process gets a MINIMAL environment (no --preserve-environment;
 #      an explicit allowlist), so unrelated root env never reaches icnctl.
@@ -84,13 +85,14 @@ else
     ok "seed does not call /v1/auth/verify directly"
 fi
 
-# 7. Browser JWT is least-privilege: governance:read + the single completion
-#    class, and NOTHING broader.
+# 7. Browser JWT is least-privilege: governance:read + the completion-only
+#    action-item capability (#2400), and NOTHING broader — in particular NOT
+#    governance:meeting:write, which would also authorize creating items/meetings.
 browser_scopes="$(awk -F'"' '/^BROWSER_SCOPES=/{print $2; exit}' "$SEED")"
-if [ "$browser_scopes" = "governance:read,governance:meeting:write" ]; then
-    ok "browser JWT is least-privilege: governance:read,governance:meeting:write"
+if [ "$browser_scopes" = "governance:read,governance:action-item:complete" ]; then
+    ok "browser JWT is completion-only least-privilege: governance:read,governance:action-item:complete"
 else
-    bad "BROWSER_SCOPES is not the expected least-privilege set (got: '${browser_scopes:-<unset>}'); it must not carry coop:* or broad governance:write"
+    bad "BROWSER_SCOPES is not the expected completion-only set (got: '${browser_scopes:-<unset>}'); it must be governance:read,governance:action-item:complete — no governance:meeting:write, no coop:*, no broad governance:write"
 fi
 
 # 8. SETUP JWT is internal — only the BROWSER JWT is emitted/printed.

--- a/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
+++ b/docs/demo/ICN_REHEARSAL_NODE_V0.1_RUNBOOK.md
@@ -93,12 +93,14 @@ one VM's secret does not verify on any other node.
 
 The seed mints two least-privilege credentials: an internal **setup** token that
 provisions the demo (never printed), and the **browser** token it hands to the
-member shell — scoped to `governance:read` plus `governance:meeting:write`, the
-narrowest gateway scope that authorizes the action-item completion the shell
-performs. As a member of the seeded fictional domain that scope also permits
-creating action items / meetings there (a completion-only scope decomposition is
-a tracked follow-up), but the browser token cannot reach cooperative-admin,
-entity, treasury, or the broad / other governance write classes.
+member shell — scoped to `governance:read` plus `governance:action-item:complete`,
+the completion-only capability (#2400). That capability authorizes only the
+`completed` transition of an action item the caller is assigned, so the browser
+token cannot create action items or meetings, drive other status transitions,
+administer a cooperative, read entities, touch treasury, or reach the broad /
+other governance write classes. The internal setup token retains
+`governance:meeting:write` because it creates the fixture action item; it is
+never emitted.
 
 ## Fast path A — smoke an already-built demo image
 

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2990,6 +2990,16 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
         return Err(ApiError::Forbidden(msg.into()));
     }
 
+    // Idempotent PUT: re-requesting the status the item already holds is a no-op.
+    // Returning the item unchanged (rather than re-saving) keeps a repeated
+    // "completion" from bumping proof-visible metadata (e.g. `updated_at`) after
+    // the item is already completed, without emitting a new receipt — so the
+    // completion-only capability cannot become a repeatable metadata-mutation
+    // lever (#2400 Codex review).
+    if existing.status == new_status {
+        return Ok(HttpResponse::Ok().json(action_item_to_response(&existing)));
+    }
+
     // Record the scope that actually authorized THIS request as evidence
     // (`capability_scope_presented`). An assignee-completion is authorized by —
     // and records — the narrowest matched scope (the completion-only capability

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2935,9 +2935,8 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
     // `completed`; every transition continues to accept the broad
     // `governance:meeting:write` class scope and the legacy `governance:write`
     // fallback (accepted-also, #1868). Listed narrowest-first so
-    // `require_any_scope_matched` prefers and records the finest scope actually
-    // held as completion evidence (`capability_scope_presented`) — an existing
-    // meeting:write/write client is recorded exactly as before.
+    // `require_any_scope_matched` prefers the finest scope actually held. This is
+    // the gate that rejects an unauthorized scope with a stable 403.
     let candidates: &[&str] = if matches!(new_status, ActionItemStatus::Completed) {
         &[
             "governance:action-item:complete",
@@ -2947,8 +2946,7 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
     } else {
         &["governance:meeting:write", "governance:write"]
     };
-    let (claims, presented_scope) =
-        require_any_scope_matched::<BasicClaims>(&http_req, candidates)?;
+    let (claims, matched_scope) = require_any_scope_matched::<BasicClaims>(&http_req, candidates)?;
     let user_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, item_id) = path.into_inner();
@@ -2965,25 +2963,44 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
 
     let is_creator = existing.created_by == user_did;
     let is_assignee = existing.assignee.as_ref().is_some_and(|a| a == &user_did);
-    // The completion-only capability (#2400) authorizes completing an item the
-    // caller is ASSIGNED — not one they merely created. Creator-based status
-    // updates remain available to the broader `governance:meeting:write` /
-    // `governance:write` scopes. Keying on the scope that actually authorized the
-    // request keeps a completion-only browser/session credential from marking
-    // another member's assigned card done.
-    let owner_ok = if presented_scope == "governance:action-item:complete" {
-        is_assignee
-    } else {
-        is_creator || is_assignee
-    };
+    // Ownership + evidence keyed on the caller's ACTUAL authority, not merely the
+    // narrowest scope matched (#2400). The completion-only capability
+    // `governance:action-item:complete` authorizes completing an item the caller
+    // is ASSIGNED. Creator-based status updates require a broad
+    // `governance:meeting:write` / `governance:write` scope — which stays
+    // available to an operator/steward even if their token also carries the
+    // completion-only scope. So the ownership decision turns on whether a broad
+    // scope authorized, not on the (narrowest) scope recorded for evidence.
+    let broad_scope = require_any_scope_matched::<BasicClaims>(
+        &http_req,
+        &["governance:meeting:write", "governance:write"],
+    )
+    .ok()
+    .map(|(_, scope)| scope);
+    let owner_ok = is_assignee || (is_creator && broad_scope.is_some());
     if !owner_ok {
-        let msg = if presented_scope == "governance:action-item:complete" {
+        // A creator who is not the assignee reached here only via the
+        // completion-only scope (no broad scope); everyone else is neither
+        // creator nor assignee.
+        let msg = if is_creator {
             "The completion-only capability can only complete an action item assigned to you"
         } else {
             "Only the creator or assignee can update action item status"
         };
         return Err(ApiError::Forbidden(msg.into()));
     }
+
+    // Record the scope that actually authorized THIS request as evidence
+    // (`capability_scope_presented`). An assignee-completion is authorized by —
+    // and records — the narrowest matched scope (the completion-only capability
+    // when held). A creator-completion is authorized by the broad scope, so
+    // record that truthfully rather than the completion-only capability the
+    // caller may also carry.
+    let presented_scope = if is_assignee {
+        matched_scope
+    } else {
+        broad_scope.unwrap_or(matched_scope)
+    };
 
     let item = ctx
         .manager

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2923,13 +2923,32 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
     path: web::Path<(String, String)>,
     req: web::Json<StatusUpdateRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    // Record the scope that actually authorized the request (evidence): the
-    // narrowed class scope when present, else the legacy broad scope during
-    // the compatibility period. Listed narrowest-first so it is preferred.
-    let (claims, presented_scope) = require_any_scope_matched::<BasicClaims>(
-        &http_req,
-        &["governance:meeting:write", "governance:write"],
-    )?;
+    // Parse the requested transition first. The body was already deserialized by
+    // the extractor, so this value is server-validated and trustworthy — the
+    // point at which value-sensitive authorization is safe. An unknown
+    // transition fails closed here (400) before any authorization or state
+    // change, so the scope gate below can never act on an untrusted value.
+    let new_status = parse_status(&req.status)?;
+
+    // Value-sensitive authorization (#2400). The completion-only capability
+    // `governance:action-item:complete` authorizes ONLY the transition into
+    // `completed`; every transition continues to accept the broad
+    // `governance:meeting:write` class scope and the legacy `governance:write`
+    // fallback (accepted-also, #1868). Listed narrowest-first so
+    // `require_any_scope_matched` prefers and records the finest scope actually
+    // held as completion evidence (`capability_scope_presented`) — an existing
+    // meeting:write/write client is recorded exactly as before.
+    let candidates: &[&str] = if matches!(new_status, ActionItemStatus::Completed) {
+        &[
+            "governance:action-item:complete",
+            "governance:meeting:write",
+            "governance:write",
+        ]
+    } else {
+        &["governance:meeting:write", "governance:write"]
+    };
+    let (claims, presented_scope) =
+        require_any_scope_matched::<BasicClaims>(&http_req, candidates)?;
     let user_did = parse_did(&claims.sub, "Invalid DID in token")?;
 
     let (domain_id, item_id) = path.into_inner();
@@ -2952,7 +2971,6 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
         ));
     }
 
-    let new_status = parse_status(&req.status)?;
     let item = ctx
         .manager
         .update_action_item_status(&domain, &id, new_status, &user_did, &presented_scope)

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -2965,10 +2965,24 @@ pub async fn update_action_item_status<E: GovernanceEventEmitter + Clone + 'stat
 
     let is_creator = existing.created_by == user_did;
     let is_assignee = existing.assignee.as_ref().is_some_and(|a| a == &user_did);
-    if !is_creator && !is_assignee {
-        return Err(ApiError::Forbidden(
-            "Only the creator or assignee can update action item status".into(),
-        ));
+    // The completion-only capability (#2400) authorizes completing an item the
+    // caller is ASSIGNED — not one they merely created. Creator-based status
+    // updates remain available to the broader `governance:meeting:write` /
+    // `governance:write` scopes. Keying on the scope that actually authorized the
+    // request keeps a completion-only browser/session credential from marking
+    // another member's assigned card done.
+    let owner_ok = if presented_scope == "governance:action-item:complete" {
+        is_assignee
+    } else {
+        is_creator || is_assignee
+    };
+    if !owner_ok {
+        let msg = if presented_scope == "governance:action-item:complete" {
+            "The completion-only capability can only complete an action item assigned to you"
+        } else {
+            "Only the creator or assignee can update action item status"
+        };
+        return Err(ApiError::Forbidden(msg.into()));
     }
 
     let item = ctx

--- a/icn/apps/governance/tests/action_item_completion_scope.rs
+++ b/icn/apps/governance/tests/action_item_completion_scope.rs
@@ -470,3 +470,90 @@ async fn completion_scope_cannot_complete_another_members_item() {
         "a completion-scoped member must NOT complete another member's item"
     );
 }
+
+// ── The completion-only capability completes an item ASSIGNED to the caller —
+// not one they merely created. Creator-based completion is reserved for the
+// broader meeting:write / write scopes (Codex #2400 review). ──
+
+#[actix_web::test]
+async fn completion_scope_cannot_complete_item_it_created_for_another_assignee() {
+    let alice = fresh_did();
+    let bob = fresh_did();
+    let ctx = ctx_from_manager(GovernanceManager::new());
+    let domain = seed_domain(&ctx.manager, vec![alice.clone(), bob.clone()], "test-coop").await;
+    // Item created BY alice, assigned TO bob.
+    let item = ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "alice's item for bob".to_string(),
+            None,
+            alice.clone(),
+            Some(bob.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    let item_id = item.id.to_string();
+
+    // Alice holds the completion-only scope and is the creator, but NOT the assignee.
+    let app = gov_app!(ctx, &alice, format!("{READ} {COMPLETE}"));
+    let req = test::TestRequest::put()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/status",
+            domain.0, item_id
+        ))
+        .set_json(json!({ "status": "completed" }))
+        .to_request();
+    let status = test::call_service(&app, req).await.status();
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "the completion-only scope must NOT complete an item the caller created but is not assigned"
+    );
+}
+
+#[actix_web::test]
+async fn meeting_scope_creator_can_still_complete_item_assigned_to_another() {
+    let alice = fresh_did();
+    let bob = fresh_did();
+    let ctx = ctx_from_manager(GovernanceManager::new());
+    let domain = seed_domain(&ctx.manager, vec![alice.clone(), bob.clone()], "test-coop").await;
+    // Item created BY alice, assigned TO bob.
+    let item = ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "alice's item for bob".to_string(),
+            None,
+            alice.clone(),
+            Some(bob.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    let item_id = item.id.to_string();
+
+    // The broader meeting:write scope retains creator-or-assignee status updates:
+    // alice (creator) may complete an item assigned to bob.
+    let app = gov_app!(ctx, &alice, format!("{READ} {MEETING_CLASS}"));
+    let req = test::TestRequest::put()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/status",
+            domain.0, item_id
+        ))
+        .set_json(json!({ "status": "completed" }))
+        .to_request();
+    let status = test::call_service(&app, req).await.status();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the broad meeting:write scope must retain creator-based completion"
+    );
+}

--- a/icn/apps/governance/tests/action_item_completion_scope.rs
+++ b/icn/apps/governance/tests/action_item_completion_scope.rs
@@ -557,3 +557,65 @@ async fn meeting_scope_creator_can_still_complete_item_assigned_to_another() {
         "the broad meeting:write scope must retain creator-based completion"
     );
 }
+
+// ── A caller holding BOTH the completion-only scope AND a broad scope keeps
+// broad-scope creator-completion; the recorded evidence is the broad scope that
+// actually authorized it, not the completion-only capability (Codex #2400
+// review — the ownership mode turns on whether a broad scope authorized, not on
+// the narrowest scope matched). ──
+
+#[actix_web::test]
+async fn dual_scope_creator_completes_item_for_another_and_records_broad_scope() {
+    let store = Arc::new(V2CapturingStore::default());
+    let manager = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let alice = fresh_did();
+    let bob = fresh_did();
+    let ctx = ctx_from_manager(manager);
+    let domain = seed_domain(&ctx.manager, vec![alice.clone(), bob.clone()], "test-coop").await;
+    // Item created BY alice, assigned TO bob.
+    let item = ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "alice's item for bob".to_string(),
+            None,
+            alice.clone(),
+            Some(bob.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    let item_id = item.id.to_string();
+
+    // Alice holds the completion-only scope AND the broad meeting:write scope.
+    let app = gov_app!(ctx, &alice, format!("{READ} {COMPLETE} {MEETING_CLASS}"));
+    let req = test::TestRequest::put()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/status",
+            domain.0, item_id
+        ))
+        .set_json(json!({ "status": "completed" }))
+        .to_request();
+    let status = test::call_service(&app, req).await.status();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a broad-scope creator must retain creator-based completion even if the \
+         token also carries the completion-only scope"
+    );
+
+    let v2 = store.v2.lock().unwrap();
+    let receipt = v2
+        .iter()
+        .find(|r| r.item_id == item_id)
+        .expect("a v2 completion receipt must be persisted");
+    assert_eq!(
+        receipt.capability_scope_presented, MEETING_CLASS,
+        "a creator-completion must record the broad scope that authorized it, \
+         not the completion-only capability the caller also carries"
+    );
+}

--- a/icn/apps/governance/tests/action_item_completion_scope.rs
+++ b/icn/apps/governance/tests/action_item_completion_scope.rs
@@ -1,0 +1,472 @@
+//! #2400 — completion-only action-item capability
+//! (`governance:action-item:complete`).
+//!
+//! Value-sensitive authorization on
+//! `PUT /gov/domains/{domain}/action-items/{item}/status`: the completion-only
+//! scope authorizes **only** the `completed` transition and nothing else, while
+//! the broad `governance:meeting:write` / `governance:write` scopes keep
+//! full-range access (backward compatible). The completion evidence
+//! (`capability_scope_presented`) must record the narrow scope truthfully.
+//!
+//! Gate-semantics (authorization) assertions follow the `*_scope_migration`
+//! family: acceptance = "not 401 and not 403" (the request passes the gate; its
+//! downstream status depends on domain/item state, not under test here);
+//! rejection = exactly 403 at the gate. Malformed transitions fail closed (400).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex};
+
+use actix_web::{dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance::{
+    ActionItemCompletionReceipt, ActionItemCompletionReceiptV2, ActionItemPriority,
+    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    MembershipSource,
+};
+use icn_governance_actor::{
+    http::{self, GovernanceContext},
+    manager::GovernanceManager,
+    receipt_backend::GovernanceReceiptBackend,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+use serde_json::{json, Value};
+
+const COMPLETE: &str = "governance:action-item:complete";
+const MEETING_CLASS: &str = "governance:meeting:write";
+const LEGACY_BROAD: &str = "governance:write";
+const READ: &str = "governance:read";
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+/// Minimal receipt backend that captures the v2 completion receipts so a test
+/// can assert the `capability_scope_presented` evidence. All other trait methods
+/// use no-op/None defaults (v1 persistence and opaque routing are not under test
+/// here).
+#[derive(Default)]
+struct V2CapturingStore {
+    v2: Mutex<Vec<ActionItemCompletionReceiptV2>>,
+}
+
+impl GovernanceReceiptBackend for V2CapturingStore {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+    fn put_action_item_completion(&self, _r: &ActionItemCompletionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn put_action_item_completion_v2(
+        &self,
+        receipt: &ActionItemCompletionReceiptV2,
+    ) -> Result<(), String> {
+        self.v2.lock().unwrap().push(receipt.clone());
+        Ok(())
+    }
+}
+
+fn make_ctx() -> GovernanceContext<NoopEventEmitter> {
+    ctx_from_manager(GovernanceManager::new())
+}
+
+fn ctx_from_manager(manager: GovernanceManager) -> GovernanceContext<NoopEventEmitter> {
+    GovernanceContext {
+        manager: Arc::new(manager),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        mandate_gate: None,
+        build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
+    }
+}
+
+async fn seed_domain(
+    mgr: &GovernanceManager,
+    members: Vec<Did>,
+    domain_id: &str,
+) -> GovernanceDomainId {
+    let domain = GovernanceDomainId::new(domain_id);
+    mgr.create_domain(
+        domain.clone(),
+        "Test Coop".to_string(),
+        "default".to_string(),
+        GovernanceParams {
+            quorum_percentage: 1,
+            approval_threshold_percentage: 51,
+            voting_period_seconds: 86_400,
+            require_deliberation: false,
+            ..GovernanceParams::default()
+        },
+        MembershipConfig {
+            source: MembershipSource::StaticList(members),
+        },
+    )
+    .await
+    .expect("create_domain");
+    domain
+}
+
+macro_rules! gov_app {
+    ($ctx:expr, $caller:expr, $scope:expr) => {{
+        let scope: String = $scope.to_string();
+        let caller = $caller.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some(scope.clone()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+/// Drive a single request against a fresh (unseeded) context with the given
+/// scope, returning the HTTP status. Used for gate-semantics assertions.
+async fn status_for(method: &str, path: &str, body: &Value, scope: &'static str) -> StatusCode {
+    let ctx = make_ctx();
+    let caller = fresh_did();
+    let app = gov_app!(ctx, &caller, scope);
+    let builder = match method {
+        "POST" => test::TestRequest::post(),
+        "PUT" => test::TestRequest::put(),
+        other => panic!("unsupported method {other}"),
+    };
+    let req = builder.uri(path).set_json(body).to_request();
+    test::call_service(&app, req).await.status()
+}
+
+const STATUS_ROUTE: &str = "/domains/test-domain/action-items/test-item/status";
+
+fn assert_gate_accepted(status: StatusCode, scope: &str, ctx: &str) {
+    assert!(
+        status != StatusCode::UNAUTHORIZED && status != StatusCode::FORBIDDEN,
+        "{scope} must be accepted at the gate ({ctx}); {status} is a downstream \
+         outcome, not an auth rejection"
+    );
+}
+
+// ── The completion-only scope authorizes exactly the `completed` transition ──
+
+#[actix_web::test]
+async fn complete_scope_accepts_completed_transition() {
+    let status = status_for(
+        "PUT",
+        STATUS_ROUTE,
+        &json!({ "status": "completed" }),
+        COMPLETE,
+    )
+    .await;
+    assert_gate_accepted(status, COMPLETE, "completed transition");
+}
+
+#[actix_web::test]
+async fn complete_scope_rejects_in_progress_transition() {
+    let status = status_for(
+        "PUT",
+        STATUS_ROUTE,
+        &json!({ "status": "in_progress" }),
+        COMPLETE,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "completion-only scope must NOT authorize the in_progress transition"
+    );
+}
+
+#[actix_web::test]
+async fn complete_scope_rejects_cancelled_transition() {
+    let status = status_for(
+        "PUT",
+        STATUS_ROUTE,
+        &json!({ "status": "cancelled" }),
+        COMPLETE,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "completion-only scope must NOT authorize the cancelled transition"
+    );
+}
+
+#[actix_web::test]
+async fn complete_scope_rejects_deferred_transition() {
+    let status = status_for(
+        "PUT",
+        STATUS_ROUTE,
+        &json!({ "status": "deferred" }),
+        COMPLETE,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "completion-only scope must NOT authorize the deferred transition"
+    );
+}
+
+// ── The completion-only scope cannot create items/meetings or add notes ──
+
+#[actix_web::test]
+async fn complete_scope_rejects_create_action_item() {
+    let status = status_for(
+        "POST",
+        "/domains/test-domain/action-items",
+        &json!({ "title": "nope" }),
+        COMPLETE,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "completion-only scope must NOT authorize creating an action item"
+    );
+}
+
+#[actix_web::test]
+async fn complete_scope_rejects_create_meeting() {
+    let status = status_for(
+        "POST",
+        "/domains/test-domain/meetings",
+        &json!({ "title": "nope" }),
+        COMPLETE,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "completion-only scope must NOT authorize creating a meeting"
+    );
+}
+
+#[actix_web::test]
+async fn complete_scope_rejects_add_action_item_note() {
+    let status = status_for(
+        "POST",
+        "/domains/test-domain/action-items/test-item/notes",
+        &json!({ "content": "nope" }),
+        COMPLETE,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "completion-only scope must NOT authorize adding an action-item note"
+    );
+}
+
+// ── Backward compatibility: broad scopes keep full-range access ──
+
+#[actix_web::test]
+async fn meeting_class_still_accepts_completed_transition() {
+    let status = status_for(
+        "PUT",
+        STATUS_ROUTE,
+        &json!({ "status": "completed" }),
+        MEETING_CLASS,
+    )
+    .await;
+    assert_gate_accepted(status, MEETING_CLASS, "completed transition");
+}
+
+#[actix_web::test]
+async fn meeting_class_still_accepts_in_progress_transition() {
+    let status = status_for(
+        "PUT",
+        STATUS_ROUTE,
+        &json!({ "status": "in_progress" }),
+        MEETING_CLASS,
+    )
+    .await;
+    assert_gate_accepted(status, MEETING_CLASS, "in_progress transition");
+}
+
+#[actix_web::test]
+async fn legacy_broad_still_accepts_completed_transition() {
+    let status = status_for(
+        "PUT",
+        STATUS_ROUTE,
+        &json!({ "status": "completed" }),
+        LEGACY_BROAD,
+    )
+    .await;
+    assert_gate_accepted(status, LEGACY_BROAD, "completed transition");
+}
+
+#[actix_web::test]
+async fn read_scope_rejects_completed_transition() {
+    let status = status_for("PUT", STATUS_ROUTE, &json!({ "status": "completed" }), READ).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "governance:read must NOT authorize completing an action item"
+    );
+}
+
+// ── Unknown transitions fail closed (400) before any state mutation, and
+// before scope selection, so the value-sensitive gate can never see an
+// untrusted transition value. ──
+
+#[actix_web::test]
+async fn unknown_transition_fails_closed_for_complete_scope() {
+    let status = status_for("PUT", STATUS_ROUTE, &json!({ "status": "bogus" }), COMPLETE).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an unknown transition must fail closed (400), not be authorized"
+    );
+}
+
+#[actix_web::test]
+async fn unknown_transition_fails_closed_for_meeting_scope() {
+    let status = status_for(
+        "PUT",
+        STATUS_ROUTE,
+        &json!({ "status": "bogus" }),
+        MEETING_CLASS,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an unknown transition must fail closed (400) regardless of scope"
+    );
+}
+
+// ── Positive end-to-end: the completion-only scope completes an assigned item,
+// and the evidence records the narrow scope that authorized it. ──
+
+#[actix_web::test]
+async fn completion_scope_completes_assigned_item_and_records_evidence() {
+    let store = Arc::new(V2CapturingStore::default());
+    let manager = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let ctx = ctx_from_manager(manager);
+
+    let caller = fresh_did();
+    let domain = seed_domain(&ctx.manager, vec![caller.clone()], "test-coop").await;
+    let item = ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "complete me".to_string(),
+            None,
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    let item_id = item.id.to_string();
+
+    let app = gov_app!(ctx, &caller, format!("{READ} {COMPLETE}"));
+    let req = test::TestRequest::put()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/status",
+            domain.0, item_id
+        ))
+        .set_json(json!({ "status": "completed" }))
+        .to_request();
+    let status = test::call_service(&app, req).await.status();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the completion-only scope must complete an item assigned to its subject"
+    );
+
+    let v2 = store.v2.lock().unwrap();
+    let receipt = v2
+        .iter()
+        .find(|r| r.item_id == item_id)
+        .expect("a v2 completion receipt must be persisted");
+    assert_eq!(
+        receipt.capability_scope_presented, COMPLETE,
+        "evidence must record the completion-only scope that authorized the request"
+    );
+}
+
+// ── Ownership stays decisive: the completion scope cannot complete another
+// member's item, even when the caller is a domain member. ──
+
+#[actix_web::test]
+async fn completion_scope_cannot_complete_another_members_item() {
+    let alice = fresh_did();
+    let bob = fresh_did();
+    let manager = GovernanceManager::new();
+    let ctx = ctx_from_manager(manager);
+    let domain = seed_domain(&ctx.manager, vec![alice.clone(), bob.clone()], "test-coop").await;
+    // Item created by and assigned to bob.
+    let item = ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "bob's item".to_string(),
+            None,
+            bob.clone(),
+            Some(bob.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    let item_id = item.id.to_string();
+
+    // Alice holds the completion scope and is a domain member, but is neither
+    // the creator nor the assignee.
+    let app = gov_app!(ctx, &alice, format!("{READ} {COMPLETE}"));
+    let req = test::TestRequest::put()
+        .uri(&format!(
+            "/domains/{}/action-items/{}/status",
+            domain.0, item_id
+        ))
+        .set_json(json!({ "status": "completed" }))
+        .to_request();
+    let status = test::call_service(&app, req).await.status();
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "a completion-scoped member must NOT complete another member's item"
+    );
+}

--- a/icn/apps/governance/tests/action_item_completion_scope.rs
+++ b/icn/apps/governance/tests/action_item_completion_scope.rs
@@ -619,3 +619,87 @@ async fn dual_scope_creator_completes_item_for_another_and_records_broad_scope()
          not the completion-only capability the caller also carries"
     );
 }
+
+// ── Re-completing an already-completed item is an idempotent no-op: the
+// completion-only capability must not become a repeatable lever to mutate
+// proof-visible metadata (updated_at) after completion (Codex #2400 review). ──
+
+#[actix_web::test]
+async fn completion_scope_recomplete_does_not_bump_metadata() {
+    let store = Arc::new(V2CapturingStore::default());
+    let manager = GovernanceManager::new()
+        .with_receipt_store(store.clone() as Arc<dyn GovernanceReceiptBackend>);
+    let caller = fresh_did();
+    let ctx = ctx_from_manager(manager);
+    let domain = seed_domain(&ctx.manager, vec![caller.clone()], "test-coop").await;
+    let item = ctx
+        .manager
+        .create_action_item(
+            domain.clone(),
+            "complete me".to_string(),
+            None,
+            caller.clone(),
+            Some(caller.clone()),
+            None,
+            ActionItemPriority::Medium,
+            None,
+            None,
+            vec![],
+        )
+        .expect("create_action_item");
+    let item_id = item.id.to_string();
+    let mgr = ctx.manager.clone();
+    let app = gov_app!(ctx, &caller, format!("{READ} {COMPLETE}"));
+    let uri = format!("/domains/{}/action-items/{}/status", domain.0, item_id);
+
+    // First completion succeeds and emits a receipt.
+    let r1 = test::call_service(
+        &app,
+        test::TestRequest::put()
+            .uri(&uri)
+            .set_json(json!({ "status": "completed" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(r1.status(), StatusCode::OK);
+    let after_first = mgr
+        .get_action_item(&domain, &item.id)
+        .unwrap()
+        .unwrap()
+        .updated_at;
+
+    // Advance the wall clock so a redundant save would be observable via updated_at.
+    std::thread::sleep(std::time::Duration::from_millis(1_100));
+
+    // Re-completing the already-completed item must be an idempotent no-op.
+    let r2 = test::call_service(
+        &app,
+        test::TestRequest::put()
+            .uri(&uri)
+            .set_json(json!({ "status": "completed" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(r2.status(), StatusCode::OK);
+    let after_second = mgr
+        .get_action_item(&domain, &item.id)
+        .unwrap()
+        .unwrap()
+        .updated_at;
+
+    assert_eq!(
+        after_second, after_first,
+        "re-completing an already-completed item must not bump updated_at (idempotent no-op)"
+    );
+    assert_eq!(
+        store
+            .v2
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.item_id == item_id)
+            .count(),
+        1,
+        "re-completion must not emit a second completion receipt"
+    );
+}

--- a/icn/crates/icn-gateway/src/validation.rs
+++ b/icn/crates/icn-gateway/src/validation.rs
@@ -7,9 +7,9 @@
 
 use crate::error::{GatewayError, Result};
 use icn_rpc::auth::scopes::{
-    GOVERNANCE_ACTIVITY_WRITE, GOVERNANCE_CHARTER_WRITE, GOVERNANCE_COMMENT_WRITE,
-    GOVERNANCE_FEDERATION_WRITE, GOVERNANCE_MEETING_WRITE, GOVERNANCE_PROCESS_WRITE,
-    GOVERNANCE_PROPOSAL_WRITE, GOVERNANCE_STEWARD_WRITE,
+    GOVERNANCE_ACTION_ITEM_COMPLETE, GOVERNANCE_ACTIVITY_WRITE, GOVERNANCE_CHARTER_WRITE,
+    GOVERNANCE_COMMENT_WRITE, GOVERNANCE_FEDERATION_WRITE, GOVERNANCE_MEETING_WRITE,
+    GOVERNANCE_PROCESS_WRITE, GOVERNANCE_PROPOSAL_WRITE, GOVERNANCE_STEWARD_WRITE,
 };
 
 /// Maximum length for cooperative ID
@@ -72,6 +72,14 @@ pub const ALLOWED_SCOPES: &[&str] = &[
     GOVERNANCE_ACTIVITY_WRITE,
     GOVERNANCE_COMMENT_WRITE,
     GOVERNANCE_PROCESS_WRITE,
+    // Governance sub-capability scopes (finer than the class-level write scopes).
+    // A completion-only action-item capability (#2400), decomposed from
+    // `governance:meeting:write`: it authorizes only the `completed` transition on
+    // the action-item status route, so a browser/member credential can complete an
+    // assigned item without also being able to create items or meetings. Sourced
+    // from `icn_rpc::auth::scopes`; locked by
+    // `test_allowed_scopes_contains_action_item_complete`.
+    GOVERNANCE_ACTION_ITEM_COMPLETE,
     // Settlement operations
     "settlements:read",
     "settlements:write",
@@ -901,6 +909,38 @@ mod tests {
         assert!(
             validate_scopes(&bundled).is_ok(),
             "all of GOVERNANCE_CLASS_WRITE must be acceptable in a single request"
+        );
+    }
+
+    /// Cross-crate invariant: the completion-only action-item capability
+    /// (`icn_rpc::auth::scopes::GOVERNANCE_ACTION_ITEM_COMPLETE`, #2400) must be
+    /// issuable by the gateway auth endpoint. Without this lock a browser
+    /// credential scoped to completion-only could never be minted, and the
+    /// appliance `BROWSER_SCOPES` migration off `governance:meeting:write` would
+    /// silently fail at token issuance. It is a *finer* capability than the
+    /// class-level `GOVERNANCE_*_WRITE` scopes, so it is deliberately NOT a
+    /// member of `GOVERNANCE_CLASS_WRITE`.
+    #[test]
+    fn test_allowed_scopes_contains_action_item_complete() {
+        use icn_rpc::auth::scopes::{GOVERNANCE_ACTION_ITEM_COMPLETE, GOVERNANCE_CLASS_WRITE};
+
+        assert_eq!(
+            GOVERNANCE_ACTION_ITEM_COMPLETE, "governance:action-item:complete",
+            "canonical wire string must not drift"
+        );
+        assert!(
+            ALLOWED_SCOPES.contains(&GOVERNANCE_ACTION_ITEM_COMPLETE),
+            "icn-rpc canonical scope {GOVERNANCE_ACTION_ITEM_COMPLETE:?} must be in the gateway ALLOWED_SCOPES"
+        );
+        assert!(
+            validate_scopes(&[GOVERNANCE_ACTION_ITEM_COMPLETE.to_string()]).is_ok(),
+            "icn-rpc canonical scope {GOVERNANCE_ACTION_ITEM_COMPLETE:?} must pass validate_scopes"
+        );
+        // A finer capability, not a class-write: it must NOT be conflated with
+        // the class-level decomposition set.
+        assert!(
+            !GOVERNANCE_CLASS_WRITE.contains(&GOVERNANCE_ACTION_ITEM_COMPLETE),
+            "the completion-only scope must not be a member of GOVERNANCE_CLASS_WRITE"
         );
     }
 

--- a/icn/crates/icn-http-kit/src/auth.rs
+++ b/icn/crates/icn-http-kit/src/auth.rs
@@ -406,6 +406,60 @@ mod tests {
         ));
     }
 
+    /// Least-privilege boundary for the completion-only browser credential shape
+    /// (`governance:read governance:action-item:complete`, #2400). It must satisfy
+    /// the action-item completion candidate list and the read surface, and be
+    /// denied everything broader — including the `governance:meeting:write` class
+    /// that authorizes *creating* items/meetings, the broad/sibling governance
+    /// writes, entity mutation, and cooperative admin. Guards the credential split
+    /// against a browser session silently regaining create/admin authority.
+    #[test]
+    fn narrow_read_plus_action_item_complete_cannot_create_or_reach_broad_routes() {
+        const COMPLETE: &str = "governance:action-item:complete";
+        let req = req_with_scope(Some("governance:read governance:action-item:complete"));
+
+        // MUST satisfy the member-shell read surface and the completion PUT
+        // (the completion candidate list is narrowest-first).
+        assert!(require_scope::<BasicClaims>(&req, "governance:read").is_ok());
+        assert!(
+            require_any_scope::<BasicClaims>(&req, &[COMPLETE, MEETING, BROAD]).is_ok(),
+            "completion candidate list must accept the completion-only scope"
+        );
+        // Evidence must record the narrow completion scope, not a broad fallback.
+        let (_c, matched) =
+            require_any_scope_matched::<BasicClaims>(&req, &[COMPLETE, MEETING, BROAD]).unwrap();
+        assert_eq!(
+            matched, COMPLETE,
+            "evidence must record the completion-only scope"
+        );
+
+        // MUST NOT reach creation / broader authority. The completion scope is a
+        // sibling of meeting:write and governance:write — it neither implies nor
+        // is implied by them (no accidental sub-scope escalation).
+        for denied in [
+            MEETING,
+            BROAD,
+            CHARTER,
+            "entity:write",
+            "coop:admin",
+            "coop:write",
+        ] {
+            assert!(
+                matches!(
+                    require_scope::<BasicClaims>(&req, denied).unwrap_err(),
+                    ApiError::Forbidden(_)
+                ),
+                "completion-only session must NOT grant {denied}"
+            );
+        }
+        // The create / non-completion-transition gate (meeting:write | write)
+        // must reject the completion-only session outright.
+        assert!(matches!(
+            require_any_scope::<BasicClaims>(&req, &[MEETING, BROAD]).unwrap_err(),
+            ApiError::Forbidden(_)
+        ));
+    }
+
     #[test]
     fn require_any_scope_honors_sub_scope_match() {
         // `governance:write:admin` satisfies the broad `governance:write` candidate.

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -1005,6 +1005,12 @@ pub mod scopes {
     /// browser/member credential can complete an assigned item without also
     /// being able to create items or meetings.
     ///
+    /// When this scope authorizes the status request, the route additionally
+    /// requires the caller to be the item's **assignee** (not merely its
+    /// creator): the capability is "complete *my* assigned action item".
+    /// Creator-based status updates remain available to the broader
+    /// `GOVERNANCE_MEETING_WRITE` / `GOVERNANCE_WRITE` scopes.
+    ///
     /// By the sub-scope matching rule (`icn-http-kit`) this scope is a sibling
     /// of `GOVERNANCE_MEETING_WRITE` and `GOVERNANCE_WRITE`: it neither implies
     /// nor is implied by them. The completion route lists it narrowest-first and

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -987,6 +987,31 @@ pub mod scopes {
         GOVERNANCE_PROCESS_WRITE,
     ];
 
+    // Governance sub-capability scopes (finer than the class-level write scopes).
+    //
+    // These carve a single, specific act out of a class scope so a consumer can
+    // be granted exactly that act and nothing more. They are NOT members of
+    // `GOVERNANCE_CLASS_WRITE` — a class-write scope authorizes a whole family of
+    // acts; a sub-capability authorizes one.
+
+    /// Completion-only action-item capability (#2400).
+    ///
+    /// Authorizes *only* the transition of an action item into `completed` on
+    /// `PUT /gov/domains/{domain_id}/action-items/{item_id}/status`. It does
+    /// **not** authorize creating action items or meetings, non-completion
+    /// status transitions (in-progress / cancelled / deferred / pending), or any
+    /// broad governance write. Decomposed from `GOVERNANCE_MEETING_WRITE` — the
+    /// narrowest scope that previously reached action-item completion — so a
+    /// browser/member credential can complete an assigned item without also
+    /// being able to create items or meetings.
+    ///
+    /// By the sub-scope matching rule (`icn-http-kit`) this scope is a sibling
+    /// of `GOVERNANCE_MEETING_WRITE` and `GOVERNANCE_WRITE`: it neither implies
+    /// nor is implied by them. The completion route lists it narrowest-first and
+    /// keeps the broad meeting/write scopes as accepted-also fallbacks for the
+    /// full transition range during the migration.
+    pub const GOVERNANCE_ACTION_ITEM_COMPLETE: &str = "governance:action-item:complete";
+
     // Admin scopes
     pub const ADMIN: &str = "admin";
 

--- a/web/member-shell/README.md
+++ b/web/member-shell/README.md
@@ -70,7 +70,7 @@ see `docs/dev/openapi-member-surface-gaps.md`):
 |---|---|---|
 | Standing | `GET /v1/gov/me/standing` | `governance:read` |
 | Action cards | `GET /v1/gov/me/action-cards` | `governance:read` |
-| Mark task complete | `PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status` body `{"status":"completed"}` | `governance:action-item:complete` (completion-only, least-privilege — accepted only for the `completed` transition) — or the broader `governance:meeting:write` / `governance:write` (plus: caller must be the item's creator or assignee, and a member of the domain — enforced server-side) |
+| Mark task complete | `PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status` body `{"status":"completed"}` | `governance:action-item:complete` (completion-only, least-privilege — accepted only for the `completed` transition, and only for an item **assigned to the caller**) — or the broader `governance:meeting:write` / `governance:write` (creator **or** assignee). Caller must also be a member of the domain — all enforced server-side. |
 | Completion receipt | `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `governance:read` |
 
 **The one mutation shipped (dogfood loop):** marking an `action_item` /

--- a/web/member-shell/README.md
+++ b/web/member-shell/README.md
@@ -70,7 +70,7 @@ see `docs/dev/openapi-member-surface-gaps.md`):
 |---|---|---|
 | Standing | `GET /v1/gov/me/standing` | `governance:read` |
 | Action cards | `GET /v1/gov/me/action-cards` | `governance:read` |
-| Mark task complete | `PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status` body `{"status":"completed"}` | `governance:meeting:write` or `governance:write` (plus: caller must be the item's creator or assignee, and a member of the domain — enforced server-side) |
+| Mark task complete | `PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status` body `{"status":"completed"}` | `governance:action-item:complete` (completion-only, least-privilege — accepted only for the `completed` transition) — or the broader `governance:meeting:write` / `governance:write` (plus: caller must be the item's creator or assignee, and a member of the domain — enforced server-side) |
 | Completion receipt | `GET /v1/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `governance:read` |
 
 **The one mutation shipped (dogfood loop):** marking an `action_item` /

--- a/web/member-shell/index.html
+++ b/web/member-shell/index.html
@@ -85,7 +85,7 @@
                aria-describedby="credential-help">
         <p id="credential-help" class="help">
           <span data-i18n="connect.credentialHelp.before">Needs the </span><code>governance:read</code><span data-i18n="connect.credentialHelp.middle"> scope to read your standing
-          and action cards. Marking a task complete additionally needs </span><code>governance:meeting:write</code><span data-i18n="connect.credentialHelp.or"> or </span><code>governance:write</code><span data-i18n="connect.credentialHelp.after">.
+          and action cards. Marking a task complete additionally needs </span><code>governance:action-item:complete</code><span data-i18n="connect.credentialHelp.or"> or </span><code>governance:write</code><span data-i18n="connect.credentialHelp.after">.
           If connecting fails immediately with "Failed to fetch", the node
           was not started with this page's address in </span><code>ICN_CORS_ORIGINS</code><span data-i18n="connect.credentialHelp.end"> — see this directory's README.</span>
         </p>

--- a/web/member-shell/index.html
+++ b/web/member-shell/index.html
@@ -85,7 +85,7 @@
                aria-describedby="credential-help">
         <p id="credential-help" class="help">
           <span data-i18n="connect.credentialHelp.before">Needs the </span><code>governance:read</code><span data-i18n="connect.credentialHelp.middle"> scope to read your standing
-          and action cards. Marking a task complete additionally needs </span><code>governance:action-item:complete</code><span data-i18n="connect.credentialHelp.or"> or </span><code>governance:write</code><span data-i18n="connect.credentialHelp.after">.
+          and action cards. Marking a task complete additionally needs </span><code>governance:action-item:complete</code><span data-i18n="connect.credentialHelp.or"> or </span><code>governance:meeting:write</code> / <code>governance:write</code><span data-i18n="connect.credentialHelp.after">.
           If connecting fails immediately with "Failed to fetch", the node
           was not started with this page's address in </span><code>ICN_CORS_ORIGINS</code><span data-i18n="connect.credentialHelp.end"> — see this directory's README.</span>
         </p>

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -668,7 +668,7 @@
   // The single mutation: complete an action item (live mode).
   // PUT /v1/gov/domains/{domain_id}/action-items/{item_id}/status
   //   body {"status": "completed"}
-  //   scopes: governance:meeting:write OR governance:write
+  //   scopes: governance:action-item:complete (completion-only) OR governance:meeting:write OR governance:write
   //   (caller must also be the item's creator or assignee and a domain
   //   member — the gateway enforces this; we render its answer honestly.)
   // Then GET .../completion-receipt (scope governance:read).


### PR DESCRIPTION
## What

Introduce `governance:action-item:complete` — a **completion-only** action-item capability decomposed from `governance:meeting:write` (issue #2400) — and move the appliance browser JWT onto it.

Old browser scope: `governance:read,governance:meeting:write`
New browser scope: `governance:read,governance:action-item:complete`

## Why

#2397 gave the Rehearsal Node browser a least-privilege JWT scoped to `governance:read` + `governance:meeting:write` — the narrowest **existing** scope that reached action-item completion. But `governance:meeting:write` also authorizes `create_action_item` and `create_meeting` (Codex review of #2397), so a completion-scoped browser could still create items/meetings. #2400 carves out a scope that can complete an assigned action item and nothing more.

## How (chosen capability + rationale)

Selected the issue's **Option B**: a completion-specific capability, value-gated to the `completed` transition. It is the smallest capability with clean semantics.

- New canonical constant `icn_rpc::auth::scopes::GOVERNANCE_ACTION_ITEM_COMPLETE = "governance:action-item:complete"` (a finer sub-capability — deliberately **not** a member of `GOVERNANCE_CLASS_WRITE`).
- Registered in the gateway allowlist `icn-gateway::validation::ALLOWED_SCOPES`, locked by a new drift test `test_allowed_scopes_contains_action_item_complete`.
- `update_action_item_status` (`apps/governance/src/http/handlers.rs`) now parses the requested transition **first** (the body is already server-deserialized, so the value is trustworthy), then selects scope candidates by value:
  - `completed` → `["governance:action-item:complete", "governance:meeting:write", "governance:write"]` (narrowest-first)
  - any other transition → `["governance:meeting:write", "governance:write"]` (unchanged)
  - unknown transition → fail closed (400) before authorization or state change.
- `require_any_scope_matched` records the true authorizing scope as evidence (`capability_scope_presented`), so an existing `meeting:write`/`write` client is recorded exactly as before; a completion-scoped client records `governance:action-item:complete`.
- **Ownership keyed on the authorizing authority** (Codex review): the completion-only capability requires the caller be the item's **assignee** — "complete *my* assigned item". Creator-based status updates require a broad `meeting:write` / `write` scope, which stays available to an operator/steward even if their token *also* carries the completion-only scope (`owner_ok = is_assignee || (is_creator && holds_broad_scope)`). Evidence records the scope that actually authorized the request: an assignee-completion records the completion-only capability when held; a creator-completion records the broad scope. No existing client holds the new scope, so broad-scope behaviour is unchanged.

**Rejected alternatives:** (A) route-wide `governance:action-item:status` still authorizes in-progress/cancelled → not completion-only. (C) an assignee-scoped capability is redundant — the creator/assignee gate is already enforced unconditionally and would not restrict the transition set.

## Transition / scope matrix

| Operation | Accepts new scope? | Completion-only browser JWT result |
|---|---|---|
| `status=completed` (assigned item) | yes | 200 + completion receipt |
| `status=in_progress`/`cancelled`/`deferred` | no | 403 |
| create action item / create meeting / add note | no | 403 |
| read entities / coop-admin / broad gov write | no | 403 |
| complete another member's item (incl. one the completion-only caller *created*) | assignee-gated for the completion scope | 403 |
| unknown transition | — | 400 (fail closed) |
| re-complete an already-completed item | idempotent no-op | 200, unchanged (no metadata bump, no receipt) |

For the completion-only scope the caller must be the **assignee**; the broader `meeting:write`/`write` scopes keep creator-or-assignee. Domain-membership gate is unchanged and remains decisive.

## Compatibility

`governance:meeting:write` and `governance:write` keep full-range access on every transition (accepted-also fallback, #1868). No scope is retired. For non-`completed` transitions the candidate list is byte-identical to before, so existing clients are unaffected. Only observable change for existing clients: a **malformed** status string now fails closed as 400 before the auth/existence checks (was 403/404 depending on scope/id) — no legitimate client sends a malformed transition.

## Test plan

- New `icn-governance-actor` integration suite `action_item_completion_scope.rs` (19 tests): completion-only scope accepts `completed`, rejects in-progress/cancelled/deferred/create-item/create-meeting/add-note; `meeting:write`/`write` still accept full range; read rejects completion; unknown transition → 400; **positive** end-to-end (200 + evidence records `governance:action-item:complete`); ownership negatives — cannot complete another member's item, and (completion-only) cannot complete an item it *created* but is not assigned; the broad `meeting:write` creator path still succeeds. Re-completing an already-completed item is an idempotent no-op (no `updated_at` bump, no second receipt).
- `icn-http-kit` boundary unit test: the `read + action-item:complete` browser shape satisfies the completion candidate list and is denied `meeting:write`/broad/sibling/entity/coop scopes (no sub-scope escalation).
- `icn-gateway` drift test locks the allowlist ↔ `icn-rpc` constant.
- Appliance static guard `demo-seed-auth-check.sh` asserts the exact completion-only `BROWSER_SCOPES` (and the absence of `meeting:write`).
- Post-merge: a fresh-image Rehearsal Node witness (restricted boot → seed → standing → cards → completion → receipt → card clears; browser-JWT create-item/create-meeting/entity → 403; non-completion transitions → 403; another member's item → 403; unauth/invalid → reject; outbound canary; teardown).

## Boundaries

- #2075 self-asserted `/auth/verify` gate untouched; no unauthenticated issuance path; trusted-local `--local-mint` remains appliance-local bootstrap, not production enrollment.
- **#2080 remains open** (broad-fallback retirement depends on it). #2398/#2399/#2393 are explicitly out of scope.
- No approval/publication/custody/pending-publish mutation controls introduced; pending-publish stays read-only; evidence semantics preserved.

Fixes #2400
Refs #2397 #2386
