### PR TITLE
docs(security): scrub public operational addresses from non-runtime surfaces

### DIFF
--- a/.agents/skills/icn-dev/SKILL.md
+++ b/.agents/skills/icn-dev/SKILL.md
@@ -63,8 +63,8 @@ gh run list --repo InterCooperative-Network/icn --branch main --limit 3 --json s
 ```
 
 **Cluster endpoints** (post Feb-2026 VLAN 30 migration):
-- Control: `10.8.30.40`, Workers: `10.8.30.41`, `10.8.30.42`, Dev VM: `10.8.30.45`
-- Gateway: `10.8.30.40:30080`, Pilot UI: `10.8.30.40:30030`, Metrics: `10.8.30.40:30090`
+- Control: `${ICN_K3S_CONTROL}`, Workers: `${ICN_K3S_WORKER1}`, `${ICN_K3S_WORKER2}`, Dev VM: `${ICN_DEV_HOST}`
+- Gateway: `${ICN_K3S_CONTROL}:30080`, Pilot UI: `${ICN_K3S_CONTROL}:30030`, Metrics: `${ICN_K3S_CONTROL}:30090`
 
 ## Convention Enforcement
 
@@ -98,7 +98,7 @@ icn-ledger, icn-ccl, icn-compute, icn-gateway, icn-governance, icn-federation, i
 **Launchpad docs** (on Zentith / Launchpad HQ — not on this dev VM):
 - `~/.claude_launchpad/projects/icn/icn-crate-reference.md`
 - `~/.claude_launchpad/projects/icn/icn-forward-plan.md`
-- Only accessible if SSH'd to Zentith (10.8.10.100) or running locally there.
+- Only accessible if SSH'd to Zentith (operator-supplied host) or running locally there.
 
 ## Commands
 

--- a/.agents/skills/integrate-pr-stack/SKILL.md
+++ b/.agents/skills/integrate-pr-stack/SKILL.md
@@ -162,7 +162,7 @@ Lessons:  none new
 
 - Required gates: `Build Release`, `Test`, `Clippy`, `Format Check` (from branch protection API).
 - Non-blocking: `Test Coverage`, `Compare Against Base`, `Benchmarks`, `Codex-review`.
-- Single self-hosted runner (`ci-runner` at 10.8.30.46) means parallel PRs queue up. A PR
+- Single self-hosted runner (`ci-runner` at operator-supplied host) means parallel PRs queue up. A PR
   showing `pending / 0s` for >30 min is likely queue-stalled, not failing.
 - `mergeStateStatus=UNSTABLE` with `mergeable=MERGEABLE` means only non-blocking checks failed.
   Safe to merge with `--admin`.

--- a/.claude/agents/icn-ops.md
+++ b/.claude/agents/icn-ops.md
@@ -18,11 +18,11 @@ You are a specialist in ICN's deployment infrastructure, K3s cluster state, demo
 
 ## Cluster Topology
 
-**K3s Cluster (VLAN 30, 10.8.30.0/24):**
-- `k3s-control` — 10.8.30.40 (control plane + worker)
-- `k3s-worker-1` — 10.8.30.41
-- `k3s-worker-2` — 10.8.30.42
-- `icn-dev` — 10.8.30.45 (build VM, runs ops/mcp)
+**K3s Cluster (VLAN 30, operator-supplied subnet):**
+- `k3s-control` — ${ICN_K3S_CONTROL} (control plane + worker)
+- `k3s-worker-1` — ${ICN_K3S_WORKER1}
+- `k3s-worker-2` — ${ICN_K3S_WORKER2}
+- `icn-dev` — ${ICN_DEV_HOST} (build VM, runs ops/mcp)
 
 **Namespaces:**
 - `icn-alpha`, `icn-beta`, `icn-gamma`, `icn-delta` — four pilot coop nodes
@@ -83,7 +83,7 @@ Before any demo or rehearsal:
 ```
 [ ] All 3 K3s nodes Ready: kubectl get nodes
 [ ] All 4 coop namespace pods Running: kubectl get pods -A
-[ ] icnd health endpoint responding: curl http://10.8.30.40:8080/health
+[ ] icnd health endpoint responding: curl http://${ICN_K3S_CONTROL}:8080/health
 [ ] Flow 1A: governance proposal + vote succeeds
 [ ] Flow 2: patronage distribution succeeds
 [ ] P2P addresses: check advertised addresses are NOT 0.0.0.0

--- a/.claude/commands/icn-demo-check.md
+++ b/.claude/commands/icn-demo-check.md
@@ -23,7 +23,7 @@ Flag any:
 **Step 2: Daemon Health**
 
 ```
-curl -s http://10.8.30.40:8080/health | python3 -m json.tool
+curl -s http://${ICN_GATEWAY_HOST}:8080/health | python3 -m json.tool
 ```
 
 Expected: `{"status": "healthy"}` or similar. Flag any unhealthy components.

--- a/.claude/skills/icn-dev/SKILL.md
+++ b/.claude/skills/icn-dev/SKILL.md
@@ -63,8 +63,8 @@ gh run list --repo InterCooperative-Network/icn --branch main --limit 3 --json s
 ```
 
 **Cluster endpoints** (post Feb-2026 VLAN 30 migration):
-- Control: `10.8.30.40`, Workers: `10.8.30.41`, `10.8.30.42`, Dev VM: `10.8.30.45`
-- Gateway: `10.8.30.40:30080`, Pilot UI: `10.8.30.40:30030`, Metrics: `10.8.30.40:30090`
+- Control: `${ICN_K3S_CONTROL}`, Workers: `${ICN_K3S_WORKER1}`, `${ICN_K3S_WORKER2}`, Dev VM: `${ICN_DEV_HOST}`
+- Gateway: `${ICN_K3S_CONTROL}:30080`, Pilot UI: `${ICN_K3S_CONTROL}:30030`, Metrics: `${ICN_K3S_CONTROL}:30090`
 
 ## Convention Enforcement
 
@@ -98,7 +98,7 @@ icn-ledger, icn-ccl, icn-compute, icn-gateway, icn-governance, icn-federation, i
 **Launchpad docs** (on Zentith / Launchpad HQ — not on this dev VM):
 - `~/.claude_launchpad/projects/icn/icn-crate-reference.md`
 - `~/.claude_launchpad/projects/icn/icn-forward-plan.md`
-- Only accessible if SSH'd to Zentith (10.8.10.100) or running locally there.
+- Only accessible if SSH'd to Zentith (operator-supplied host) or running locally there.
 
 ## Commands
 

--- a/.claude/skills/integrate-pr-stack/SKILL.md
+++ b/.claude/skills/integrate-pr-stack/SKILL.md
@@ -162,7 +162,7 @@ Lessons:  none new
 
 - Required gates: `Build Release`, `Test`, `Clippy`, `Format Check` (from branch protection API).
 - Non-blocking: `Test Coverage`, `Compare Against Base`, `Benchmarks`, `claude-review`.
-- Single self-hosted runner (`ci-runner` at 10.8.30.46) means parallel PRs queue up. A PR
+- Single self-hosted runner (`ci-runner` at operator-supplied host) means parallel PRs queue up. A PR
   showing `pending / 0s` for >30 min is likely queue-stalled, not failing.
 - `mergeStateStatus=UNSTABLE` with `mergeable=MERGEABLE` means only non-blocking checks failed.
   Safe to merge with `--admin`.

--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -10,10 +10,15 @@ on:
       - 'ops/scripts/drift-check.sh'
       - 'scripts/check-preflight-consistency.sh'
       - 'scripts/check-truth-spine.py'
+      - 'scripts/tests/test_public_docs_boundary.py'
       - 'ops/state/config/**'
       - 'CLAUDE.md'
       - 'ops/CLAUDE.md'
       - 'AGENTS.md'
+      # icn#2393 public docs/agent/test address-boundary surfaces
+      - 'docs/**'
+      - 'CHANGELOG.md'
+      - 'web/pilot-ui/tests/**'
   pull_request:
     # No paths filter: run on ALL PRs so any new skill/agent is checked for truth_contract
     # and registry entries. The check is fast (~5s) and catches silent drift early.
@@ -39,6 +44,9 @@ jobs:
 
       - name: Truth-spine validation (warning-mode, Refs icn#2141)
         run: python3 scripts/check-truth-spine.py
+
+      - name: Public docs address-boundary guard tests (Refs icn#2393)
+        run: python3 scripts/tests/test_public_docs_boundary.py
 
       - name: Validate JSON truth files are parseable
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -622,7 +622,7 @@ Appeal Endpoints:
 **Deployment Verification**:
 - All CI checks passing (formatting, clippy, tests)
 - K3s deployment successful with image `icn:b84f0d4`
-- Gateway health endpoint operational at `http://10.8.10.40:30080/v1/health`
+- Gateway health endpoint operational at `http://${ICN_GATEWAY_HOST}:30080/v1/health`
 
 **Authentication Flow**:
 - Created new identity with `icnctl id init`

--- a/docs/adr/ADR-0016-admin-merge-exception-policy.md
+++ b/docs/adr/ADR-0016-admin-merge-exception-policy.md
@@ -11,7 +11,7 @@ ICN uses GitHub branch protection with four required status checks:
 `Build Release`, `Test`, `Clippy`, `Format Check`.
 
 All four run on `ubuntu-latest` (GitHub-hosted runners). The self-hosted `ci-runner`
-(VM 446, 10.8.30.46, labels `homelab,k3s`) handles Docker build/deploy
+(VM 446, operator-supplied host, labels `homelab,k3s`) handles Docker build/deploy
 (`docker-build-deploy.yml`) only — it is not in the required-check path.
 
 Required jobs queue at `pending / 0s` when the GitHub-hosted runner pool for the

--- a/docs/archive/2026/FORWARD_PLAN_20260312.md
+++ b/docs/archive/2026/FORWARD_PLAN_20260312.md
@@ -119,7 +119,7 @@ icnctl coop create
 
 | Component | Status |
 |---|---|
-| K3s cluster | 3 nodes Ready, v1.34.4+k3s1, up 12 days at 10.8.30.40–42 |
+| K3s cluster | 3 nodes Ready, v1.34.4+k3s1, up 12 days on the private cluster (operator-supplied node range) |
 | ICN pods | alpha/beta/delta/gamma all 1/1 Running (5d16h), daemon + pilot-ui (12d) |
 | Monitoring | Prometheus + Grafana + Alertmanager running |
 | etcd snapshots | Completing on schedule |

--- a/docs/archive/2026/plans-scratch/human-interface.md
+++ b/docs/archive/2026/plans-scratch/human-interface.md
@@ -104,7 +104,7 @@ Total: ~10K LOC (app + SDK), 21 screens
 
 **i18n**: EN + ES via `i18next` + `react-i18next`.
 
-**Gateway target**: `http://10.8.10.40:30080` (homelab staging), configurable in `src/config.ts`.
+**Gateway target**: `http://${ICN_GATEWAY_HOST}:30080` (homelab staging), configurable in `src/config.ts`.
 
 ### 1.4 icnctl Command Coverage
 

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -132,7 +132,7 @@ To access the demo from another machine on your network:
 ### 2. Set CORS origins for your LAN IP
 
 ```bash
-export ICN_CORS_ORIGINS="http://10.8.10.45:3000,http://10.8.10.45:8080"
+export ICN_CORS_ORIGINS="http://${ICN_GATEWAY_HOST}:3000,http://${ICN_GATEWAY_HOST}:8080"
 ```
 
 ### 3. Start UI server on all interfaces

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -131,8 +131,12 @@ To access the demo from another machine on your network:
 
 ### 2. Set CORS origins for your LAN IP
 
+Set `ICN_LAN_HOST` to the workstation/LAN address that browsers use to reach the
+UI and gateway (this is the request Origin that must be allow-listed — not
+necessarily the in-cluster gateway host).
+
 ```bash
-export ICN_CORS_ORIGINS="http://${ICN_GATEWAY_HOST}:3000,http://${ICN_GATEWAY_HOST}:8080"
+export ICN_CORS_ORIGINS="http://${ICN_LAN_HOST}:3000,http://${ICN_LAN_HOST}:8080"
 ```
 
 ### 3. Start UI server on all interfaces

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -546,9 +546,9 @@ Use nginx or HAProxy to distribute gateway API traffic:
 
 ```nginx
 upstream icn_gateways {
-    server 10.0.0.1:8080;
-    server 10.0.0.2:8080;
-    server 10.0.0.3:8080;
+    server 192.0.2.11:8080;
+    server 192.0.2.12:8080;
+    server 192.0.2.13:8080;
 }
 
 server {

--- a/docs/deployment/DEPLOY_TEST_NETWORK.md
+++ b/docs/deployment/DEPLOY_TEST_NETWORK.md
@@ -24,10 +24,10 @@
 
 | Host | IP | Role |
 |------|-----|------|
-| k3s-control | 10.8.30.40 | K3s control plane |
-| k3s-worker-1 | 10.8.30.41 | K3s worker node |
-| k3s-worker-2 | 10.8.30.42 | K3s worker node |
-| Atlas | 10.8.10.25 | NFS storage (`atlas-nfs` StorageClass) |
+| k3s-control | ${ICN_K3S_CONTROL} | K3s control plane |
+| k3s-worker-1 | ${ICN_K3S_WORKER1} | K3s worker node |
+| k3s-worker-2 | ${ICN_K3S_WORKER2} | K3s worker node |
+| Atlas | ${ICN_NFS_HOST} | NFS storage (`atlas-nfs` StorageClass) |
 
 **Current ICN Identity**: `did:icn:z3TE1ei6B4L5j6Jp29RmJKt1FYonGaQAXQoYHJL3GULR3`
 
@@ -35,7 +35,7 @@
 
 ```bash
 # SSH to K3s control plane
-ssh ubuntu@10.8.30.40
+ssh ubuntu@${ICN_K3S_CONTROL}
 
 # Check cluster status
 sudo kubectl get nodes
@@ -56,7 +56,7 @@ curl http://localhost:9100/metrics
 
 | Service | Access |
 |---------|--------|
-| **Grafana** | http://10.8.30.40:30300 |
+| **Grafana** | http://${ICN_K3S_CONTROL}:30300 |
 | **ICN Metrics** | Port-forward to 9100 |
 | **Dashboard** | ICN Node Dashboard |
 
@@ -544,7 +544,7 @@ Once the network is running successfully:
 ### Docker Compose
 - **File**: `docker-compose.test.yml`
 - **Services**: node1, node2, node3, node4 (optional), prometheus, grafana
-- **Networks**: icn_test (172.20.0.0/16)
+- **Networks**: icn_test (192.0.2.0/16)
 - **Volumes**: 6 persistent volumes
 
 ### Security Configuration

--- a/docs/deployment/DEPLOY_TEST_NETWORK.md
+++ b/docs/deployment/DEPLOY_TEST_NETWORK.md
@@ -544,7 +544,7 @@ Once the network is running successfully:
 ### Docker Compose
 - **File**: `docker-compose.test.yml`
 - **Services**: node1, node2, node3, node4 (optional), prometheus, grafana
-- **Networks**: icn_test (192.0.2.0/16)
+- **Networks**: icn_test (operator-supplied bridge subnet)
 - **Volumes**: 6 persistent volumes
 
 ### Security Configuration

--- a/docs/deployment/DEPLOY_TO_K3S.md
+++ b/docs/deployment/DEPLOY_TO_K3S.md
@@ -1,8 +1,15 @@
 # ICN Invite System - K3s Deployment Guide
 
-**Infrastructure:** K3s on Hyperion (10.8.30.40-42)
+**Infrastructure:** K3s on Hyperion — private cluster node range (operator-supplied; addresses via private `network-ops`)
 **Date:** 2025-12-12  
 **Status:** Ready to Deploy
+
+> **Operator inputs (ATLAS §5 boundary):** the commands below use operator-supplied
+> host variables — export `ICN_GATEWAY_HOST` (NodePort HTTP/WS entry), `ICN_K3S_CONTROL`
+> (control node for SSH/admin), `ICN_K3S_WORKER1`, and `ICN_K3S_WORKER2` with your
+> private cluster node addresses, resolved from the private `network-ops` source. In a
+> single-entry setup `ICN_GATEWAY_HOST` and `ICN_K3S_CONTROL` are the same node address.
+> Concrete provider addresses must never be committed to this public repo.
 
 ---
 
@@ -12,7 +19,7 @@
 
 ```bash
 # 1. SSH access works
-ssh ubuntu@10.8.30.40 "echo 'SSH OK'"
+ssh ubuntu@${ICN_K3S_CONTROL} "echo 'SSH OK'"
 
 # 2. In ICN repo with latest code
 cd /home/matt/projects/icn
@@ -34,7 +41,7 @@ make full-deploy-with-ui
 This single command will:
 1. ✅ Build `icn:latest` Docker image from source
 2. ✅ Build `icn-pilot-ui:latest` Docker image
-3. ✅ Sync both images to all K3s nodes (10.8.30.40-42)
+3. ✅ Sync both images to all K3s nodes (private cluster node range — operator-supplied)
 4. ✅ Deploy ICN daemon to Kubernetes
 5. ✅ Deploy Pilot UI to Kubernetes
 6. ✅ Apply all configs, secrets, services
@@ -52,8 +59,8 @@ make logs
 make ui-logs
 
 # Test access
-curl http://10.8.30.40:30080/v1/health  # Gateway API
-curl http://10.8.30.40:30030/           # Pilot UI
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health  # Gateway API
+curl http://${ICN_GATEWAY_HOST}:30030/           # Pilot UI
 ```
 
 ---
@@ -97,9 +104,9 @@ make sync-all-images
 ```
 
 This copies images to:
-- k3s-control (10.8.30.40)
-- k3s-worker-1 (10.8.30.41)
-- k3s-worker-2 (10.8.30.42)
+- k3s-control (${ICN_K3S_CONTROL})
+- k3s-worker-1 (${ICN_K3S_WORKER1})
+- k3s-worker-2 (${ICN_K3S_WORKER2})
 
 ### Step 3: Configure Secrets (First Time Only)
 
@@ -114,7 +121,7 @@ if [ ! -f secret.yaml ]; then
 fi
 
 # Deploy secrets
-ssh ubuntu@10.8.30.40 "sudo kubectl apply -f -" < secret.yaml
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl apply -f -" < secret.yaml
 ```
 
 ### Step 4: Deploy to Kubernetes (1 min)
@@ -132,7 +139,7 @@ make deploy-ui        # Pilot UI
 
 ```bash
 # Check all pods are running
-ssh ubuntu@10.8.30.40 "sudo kubectl get pods -n icn"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl get pods -n icn"
 
 # Expected output:
 # NAME                              READY   STATUS    RESTARTS   AGE
@@ -140,7 +147,7 @@ ssh ubuntu@10.8.30.40 "sudo kubectl get pods -n icn"
 # pilot-ui-xxxxxxxxxx-xxxxx         1/1     Running   0          2m
 
 # Check services
-ssh ubuntu@10.8.30.40 "sudo kubectl get svc -n icn"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl get svc -n icn"
 
 # Expected output:
 # NAME              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)
@@ -157,14 +164,14 @@ ssh ubuntu@10.8.30.40 "sudo kubectl get svc -n icn"
 After deployment, the services are available at:
 
 ### ICN Gateway API
-- **URL:** `http://10.8.30.40:30080`
+- **URL:** `http://${ICN_GATEWAY_HOST}:30080`
 - **Endpoints:**
-  - Health: `http://10.8.30.40:30080/v1/health`
-  - Invites: `http://10.8.30.40:30080/v1/invites`
-  - WebSocket: `ws://10.8.30.40:30080/v1/ws`
+  - Health: `http://${ICN_GATEWAY_HOST}:30080/v1/health`
+  - Invites: `http://${ICN_GATEWAY_HOST}:30080/v1/invites`
+  - WebSocket: `ws://${ICN_GATEWAY_HOST}:30080/v1/ws`
 
 ### Pilot UI
-- **URL:** `http://10.8.30.40:30030`
+- **URL:** `http://${ICN_GATEWAY_HOST}:30030`
 - **Features:**
   - Login screen
   - Join via invite code
@@ -173,7 +180,7 @@ After deployment, the services are available at:
   - Invite creation (admin)
 
 ### Metrics (Prometheus)
-- **URL:** `http://10.8.30.40:30090/metrics`
+- **URL:** `http://${ICN_GATEWAY_HOST}:30090/metrics`
 
 ---
 
@@ -183,7 +190,7 @@ After deployment, the services are available at:
 
 ```bash
 # SSH into K3s control node
-ssh ubuntu@10.8.30.40
+ssh ubuntu@${ICN_K3S_CONTROL}
 
 # Get pod name
 POD=$(sudo kubectl get pods -n icn -l component=daemon -o jsonpath='{.items[0].metadata.name}')
@@ -201,9 +208,9 @@ Save the token that's printed!
 
 ### 2. Create Invite via UI
 
-1. Open browser: `http://10.8.30.40:30030`
+1. Open browser: `http://${ICN_GATEWAY_HOST}:30030`
 2. Login with:
-   - Gateway URL: `http://10.8.30.40:30080`
+   - Gateway URL: `http://${ICN_GATEWAY_HOST}:30080`
    - Coop ID: `test-coop`
    - Your DID: (from step 1)
    - Token: (from step 1)
@@ -216,10 +223,10 @@ Save the token that's printed!
 
 ### 3. Test Join Flow
 
-1. Open incognito window: `http://10.8.30.40:30030`
+1. Open incognito window: `http://${ICN_GATEWAY_HOST}:30030`
 2. Click **Join with Invite Code**
 3. Enter:
-   - Gateway URL: `http://10.8.30.40:30080`
+   - Gateway URL: `http://${ICN_GATEWAY_HOST}:30080`
    - Invite Code: (paste from step 2)
 4. Click **Join Cooperative**
 5. Verify:
@@ -232,7 +239,7 @@ Save the token that's printed!
 
 ```bash
 # Check invite metrics
-curl http://10.8.30.40:30090/metrics | grep invite
+curl http://${ICN_GATEWAY_HOST}:30090/metrics | grep invite
 
 # Expected:
 # icn_gateway_invites_created_total{coop_id="test-coop"} 1
@@ -297,22 +304,22 @@ make ui-port-forward     # Forward UI to localhost:3000
 
 ```bash
 # Check pod status
-ssh ubuntu@10.8.30.40 "sudo kubectl get pods -n icn"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl get pods -n icn"
 
 # Check pod logs
-ssh ubuntu@10.8.30.40 "sudo kubectl logs -n icn -l component=daemon"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl logs -n icn -l component=daemon"
 
 # Check events
-ssh ubuntu@10.8.30.40 "sudo kubectl get events -n icn --sort-by='.lastTimestamp'"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl get events -n icn --sort-by='.lastTimestamp'"
 ```
 
 ### Issue: Image not found
 
 ```bash
 # Verify image exists on nodes
-ssh ubuntu@10.8.30.40 "sudo ctr -n k8s.io images ls | grep icn"
-ssh ubuntu@10.8.30.41 "sudo ctr -n k8s.io images ls | grep icn"
-ssh ubuntu@10.8.30.42 "sudo ctr -n k8s.io images ls | grep icn"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo ctr -n k8s.io images ls | grep icn"
+ssh ubuntu@${ICN_K3S_WORKER1} "sudo ctr -n k8s.io images ls | grep icn"
+ssh ubuntu@${ICN_K3S_WORKER2} "sudo ctr -n k8s.io images ls | grep icn"
 
 # Re-sync if missing
 cd /home/matt/projects/icn/deploy/k8s
@@ -323,27 +330,27 @@ make sync-all-images
 
 ```bash
 # Check services are exposed
-ssh ubuntu@10.8.30.40 "sudo kubectl get svc -n icn"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl get svc -n icn"
 
 # Check NodePorts
 # Gateway should be on port 30080
 # Pilot UI should be on port 30030
 
 # Test from local machine
-curl -v http://10.8.30.40:30080/v1/health
-curl -v http://10.8.30.40:30030/
+curl -v http://${ICN_GATEWAY_HOST}:30080/v1/health
+curl -v http://${ICN_GATEWAY_HOST}:30030/
 ```
 
 ### Issue: Invite creation fails
 
 ```bash
 # Check gateway logs
-ssh ubuntu@10.8.30.40 "sudo kubectl logs -n icn -l component=daemon | grep invite"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl logs -n icn -l component=daemon | grep invite"
 
 # Verify token is valid
 # Verify user has admin role
 # Check gateway metrics endpoint
-curl http://10.8.30.40:30090/metrics | grep auth
+curl http://${ICN_GATEWAY_HOST}:30090/metrics | grep auth
 ```
 
 ---
@@ -377,33 +384,33 @@ The entire cycle takes about 3-5 minutes.
 
 ```bash
 # Gateway health
-curl http://10.8.30.40:30080/v1/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health
 
 # Prometheus metrics
-curl http://10.8.30.40:30090/metrics | grep icn_gateway
+curl http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_gateway
 ```
 
 ### View Logs
 
 ```bash
 # Live daemon logs
-ssh ubuntu@10.8.30.40 "sudo kubectl logs -f -n icn -l component=daemon"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl logs -f -n icn -l component=daemon"
 
 # Live UI logs
-ssh ubuntu@10.8.30.40 "sudo kubectl logs -f -n icn -l component=pilot-ui"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl logs -f -n icn -l component=pilot-ui"
 
 # Last 100 lines
-ssh ubuntu@10.8.30.40 "sudo kubectl logs --tail=100 -n icn -l component=daemon"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl logs --tail=100 -n icn -l component=daemon"
 ```
 
 ### Resource Usage
 
 ```bash
 # Pod resource usage
-ssh ubuntu@10.8.30.40 "sudo kubectl top pods -n icn"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl top pods -n icn"
 
 # Node resource usage
-ssh ubuntu@10.8.30.40 "sudo kubectl top nodes"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl top nodes"
 ```
 
 ---
@@ -464,9 +471,9 @@ make logs
 make restart
 
 # Access points
-Gateway: http://10.8.30.40:30080
-UI:      http://10.8.30.40:30030
-Metrics: http://10.8.30.40:30090/metrics
+Gateway: http://${ICN_GATEWAY_HOST}:30080
+UI:      http://${ICN_GATEWAY_HOST}:30030
+Metrics: http://${ICN_GATEWAY_HOST}:30090/metrics
 ```
 
 ---

--- a/docs/deployment/FULL_STACK_DEPLOY.md
+++ b/docs/deployment/FULL_STACK_DEPLOY.md
@@ -350,7 +350,7 @@ curl http://localhost:8080/v1/health
 ifconfig | grep "inet "
 
 # Update app.json with your local IP:
-# "apiUrl": "http://192.168.1.100:8080"
+# "apiUrl": "http://${ICN_GATEWAY_HOST}:8080"
 
 # Ensure phone and computer are on same network
 ```

--- a/docs/deployment/FULL_STACK_DEPLOY.md
+++ b/docs/deployment/FULL_STACK_DEPLOY.md
@@ -350,7 +350,7 @@ curl http://localhost:8080/v1/health
 ifconfig | grep "inet "
 
 # Update app.json with your local IP:
-# "apiUrl": "http://${ICN_GATEWAY_HOST}:8080"
+# "apiUrl": "http://<ICN_GATEWAY_HOST>:8080"
 
 # Ensure phone and computer are on same network
 ```

--- a/docs/development/sessions/2025-11/2025-11-11-user-onboarding-scaffolds.md
+++ b/docs/development/sessions/2025-11/2025-11-11-user-onboarding-scaffolds.md
@@ -123,7 +123,7 @@ Volumes:
 - Config mounted read-only
 
 Networks:
-- Bridge network (172.20.0.0/16)
+- Bridge network (private bridge subnet)
 - Isolated from host
 - Inter-container communication
 

--- a/docs/development/sessions/2025-11/2025-11-12-phase-status-assessment.md
+++ b/docs/development/sessions/2025-11/2025-11-12-phase-status-assessment.md
@@ -358,7 +358,7 @@ Supervisor:
 **Status:** mDNS working, bootstrap peers working, trust integration pending
 
 **Current State:**
-- mDNS local discovery (broadcast/receive on 224.0.0.251:5353)
+- mDNS local discovery (broadcast/receive on the mDNS multicast group, port 5353)
 - Bootstrap peer configuration in TOML
 - Automatic dialing on startup
 - Connection pooling and reuse

--- a/docs/development/sessions/2025-11/2025-11-17-nat-traversal-phases-1-3.md
+++ b/docs/development/sessions/2025-11/2025-11-17-nat-traversal-phases-1-3.md
@@ -89,7 +89,7 @@ Implemented comprehensive NAT traversal infrastructure enabling ICN nodes behind
 ```rust
 ConnectionCandidate {
     did: Did,
-    local_addr: SocketAddr,      // 192.168.1.100:7777
+    local_addr: SocketAddr,      // 192.0.2.10:7777
     public_addr: SocketAddr,     // 203.0.113.5:12345 (STUN)
     relay_addr: Option<...>,     // Future: TURN relay
     timestamp: u64,              // Unix timestamp
@@ -152,7 +152,7 @@ ConnectionCandidate {
 
 **Connection Logging**:
 ```
-✅ Connected to did:icn:abc via local address 192.168.1.100:7777
+✅ Connected to did:icn:abc via local address 192.0.2.10:7777
 ✅ Connected to did:icn:xyz via public address 203.0.113.5:12345 (NAT traversal)
 Could not establish direct connection to did:icn:def
 ```

--- a/docs/development/sessions/2025-12/2025-12-14-session-handoff.md
+++ b/docs/development/sessions/2025-12/2025-12-14-session-handoff.md
@@ -3,11 +3,11 @@
 ## Current State
 
 ### Deployment Status
-- **K3s Cluster**: Running on `10.8.10.40`
+- **K3s Cluster**: Running on `${ICN_GATEWAY_HOST}`
 - **ICN Pod**: `icn-alpha` in `icn-coop-alpha` namespace
 - **Image**: `icn:b84f0d4` (latest from main branch)
-- **Gateway**: `http://10.8.10.40:30080`
-- **Pilot UI**: `http://10.8.10.40:30030`
+- **Gateway**: `http://${ICN_GATEWAY_HOST}:30080`
+- **Pilot UI**: `http://${ICN_GATEWAY_HOST}:30030`
 
 ### Test Identity
 - **DID**: `did:icn:z8p6hkHaFFM2aMjWfhsksvUx3AWt7ZVFhjTsxLn93MaRR`
@@ -28,26 +28,26 @@ The original token was removed during sanitization and had a ~1 hour lifetime an
 ### Get New Token (when current expires)
 ```bash
 cd /home/matt/projects/icn/icn
-./target/release/icnctl auth token --gateway http://10.8.10.40:30080 --coop-id test-coop --scopes "coop:read,coop:write,coop:admin,ledger:read,ledger:write,gov:read,gov:write"
+./target/release/icnctl auth token --gateway http://${ICN_GATEWAY_HOST}:30080 --coop-id test-coop --scopes "coop:read,coop:write,coop:admin,ledger:read,ledger:write,gov:read,gov:write"
 # Passphrase is empty (just press Enter)
 ```
 
 ### Check Deployment Status
 ```bash
-ssh matt@10.8.10.40 "kubectl -n icn-coop-alpha get pods"
-ssh matt@10.8.10.40 "kubectl -n icn-coop-alpha logs deployment/icn-alpha --tail=50"
+ssh matt@${ICN_GATEWAY_HOST} "kubectl -n icn-coop-alpha get pods"
+ssh matt@${ICN_GATEWAY_HOST} "kubectl -n icn-coop-alpha logs deployment/icn-alpha --tail=50"
 ```
 
 ### Test API Endpoints
 ```bash
 # Health check
-curl http://10.8.10.40:30080/v1/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health
 
 # Get coop (requires auth)
-curl -H "Authorization: Bearer TOKEN" http://10.8.10.40:30080/v1/coops/test-coop
+curl -H "Authorization: Bearer TOKEN" http://${ICN_GATEWAY_HOST}:30080/v1/coops/test-coop
 
 # Get balance
-curl -H "Authorization: Bearer TOKEN" "http://10.8.10.40:30080/v1/ledger/test-coop/balance/did:icn:z8p6hkHaFFM2aMjWfhsksvUx3AWt7ZVFhjTsxLn93MaRR"
+curl -H "Authorization: Bearer TOKEN" "http://${ICN_GATEWAY_HOST}:30080/v1/ledger/test-coop/balance/did:icn:z8p6hkHaFFM2aMjWfhsksvUx3AWt7ZVFhjTsxLn93MaRR"
 ```
 
 ### Redeploy
@@ -82,7 +82,7 @@ make full-deploy-dev
 
 1. **Token expiry display bug**: `icnctl auth token` shows "Expires: 1970-01-01" but tokens work correctly
 2. **Pilot UI services loading**: May show loading state if no services have been created yet
-3. **SSH to cluster**: May need password or key setup for `matt@10.8.10.40`
+3. **SSH to cluster**: May need password or key setup for `matt@${ICN_GATEWAY_HOST}`
 
 ## Files Modified This Session
 

--- a/docs/development/sessions/2025-12/2025-12-14-session-handoff.md
+++ b/docs/development/sessions/2025-12/2025-12-14-session-handoff.md
@@ -34,8 +34,8 @@ cd /home/matt/projects/icn/icn
 
 ### Check Deployment Status
 ```bash
-ssh matt@${ICN_GATEWAY_HOST} "kubectl -n icn-coop-alpha get pods"
-ssh matt@${ICN_GATEWAY_HOST} "kubectl -n icn-coop-alpha logs deployment/icn-alpha --tail=50"
+ssh matt@${ICN_K3S_CONTROL} "kubectl -n icn-coop-alpha get pods"
+ssh matt@${ICN_K3S_CONTROL} "kubectl -n icn-coop-alpha logs deployment/icn-alpha --tail=50"
 ```
 
 ### Test API Endpoints

--- a/docs/development/sessions/2025-12/SESSION_SDIS_20251212.md
+++ b/docs/development/sessions/2025-12/SESSION_SDIS_20251212.md
@@ -175,7 +175,7 @@ curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/enrollment/complete \
 
 1. **SSH to K3s node:**
    ```bash
-   ssh ubuntu@${ICN_GATEWAY_HOST}
+   ssh ubuntu@${ICN_K3S_CONTROL}
    ```
 
 2. **Check current deployment:**

--- a/docs/development/sessions/2025-12/SESSION_SDIS_20251212.md
+++ b/docs/development/sessions/2025-12/SESSION_SDIS_20251212.md
@@ -111,7 +111,7 @@ docker push username/icn:0bf1f61
 cd icn && cargo build --release --bin icnd
 
 # Copy to K3s node
-scp target/release/icnd ubuntu@10.8.10.40:/tmp/
+scp target/release/icnd ubuntu@${ICN_GATEWAY_HOST}:/tmp/
 
 # On K3s node, replace binary in running pod
 POD=$(sudo kubectl get pods -n icn -l component=daemon -o jsonpath='{.items[0].metadata.name}')
@@ -125,10 +125,10 @@ Once deployment is fixed, these endpoints are ready:
 
 ```bash
 # 1. Health check (already working)
-curl http://10.8.10.40:30080/v1/sdis/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 
 # 2. Start enrollment (NEW)
-curl -X POST http://10.8.10.40:30080/v1/sdis/enrollment/start \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/enrollment/start \
   -H "Content-Type: application/json" \
   -d '{"identity_name":"Alice","coop_id":"test-coop"}'
 
@@ -141,18 +141,18 @@ curl -X POST http://10.8.10.40:30080/v1/sdis/enrollment/start \
 }
 
 # 3. Level 1 verification (NEW)
-curl -X POST http://10.8.10.40:30080/v1/sdis/verify/level1 \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/verify/level1 \
   -H "Content-Type: application/json" \
   -d '{"enrollment_id":"uuid...","device_proof":"base64..."}'
 
 # 4. Level 2 verification (NEW)
-curl -X POST http://10.8.10.40:30080/v1/sdis/verify/level2 \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/verify/level2 \
   -H "Authorization: Bearer <steward-token>" \
   -H "Content-Type: application/json" \
   -d '{"enrollment_id":"uuid...","vouch_statement":"I vouch for Alice"}'
 
 # 5. Complete enrollment (NEW)
-curl -X POST http://10.8.10.40:30080/v1/sdis/enrollment/complete \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/enrollment/complete \
   -H "Content-Type: application/json" \
   -d '{
     "enrollment_id":"uuid...",
@@ -175,7 +175,7 @@ curl -X POST http://10.8.10.40:30080/v1/sdis/enrollment/complete \
 
 1. **SSH to K3s node:**
    ```bash
-   ssh ubuntu@10.8.10.40
+   ssh ubuntu@${ICN_GATEWAY_HOST}
    ```
 
 2. **Check current deployment:**
@@ -189,7 +189,7 @@ curl -X POST http://10.8.10.40:30080/v1/sdis/enrollment/complete \
    # On local machine
    cd /home/matt/projects/icn/icn
    cargo build --release --bin icnd
-   scp target/release/icnd ubuntu@10.8.10.40:/tmp/
+   scp target/release/icnd ubuntu@${ICN_GATEWAY_HOST}:/tmp/
    
    # On K3s node
    POD=$(sudo kubectl get pods -n icn -l component=daemon -o jsonpath='{.items[0].metadata.name}')

--- a/docs/development/sessions/2025-12/SESSION_SDIS_PHASE2_COMPLETE.md
+++ b/docs/development/sessions/2025-12/SESSION_SDIS_PHASE2_COMPLETE.md
@@ -312,7 +312,7 @@ Prover → Generate → Sign → Share → Verifier → Verify → Accept/Reject
 - Tests: `icn/crates/icn-gateway/src/api/sdis/tests/`
 
 **Deployment:**
-- K3s cluster: `10.8.10.40`
+- K3s cluster: `${ICN_NODE_HOST}`
 - Node ports: 30080 (UI), 30081 (Gateway)
 - Docker images: `icn:latest`, `icn-pilot-ui:latest`
 

--- a/docs/development/sessions/undated/E2E_TESTING_2025-12-19.md
+++ b/docs/development/sessions/undated/E2E_TESTING_2025-12-19.md
@@ -2,16 +2,16 @@
 
 ## Summary
 
-E2E testing of the ICN stack on K3s cluster (10.8.10.40).
+E2E testing of the ICN stack on K3s cluster (${ICN_GATEWAY_HOST}).
 
 ## Infrastructure Status
 
 | Component | Status | Access |
 |-----------|--------|--------|
 | icn-daemon | Running (1/1) | - |
-| Gateway API | Working | http://10.8.10.40:30080 |
-| Pilot UI | Running (1/1) | http://10.8.10.40:30030 |
-| Metrics | Available | http://10.8.10.40:30091 |
+| Gateway API | Working | http://${ICN_GATEWAY_HOST}:30080 |
+| Pilot UI | Running (1/1) | http://${ICN_GATEWAY_HOST}:30030 |
+| Metrics | Available | http://${ICN_GATEWAY_HOST}:30091 |
 
 ## Fixes Applied This Session
 
@@ -52,7 +52,7 @@ E2E testing of the ICN stack on K3s cluster (10.8.10.40).
 ### 1. Get an Auth Token
 
 ```bash
-ssh ubuntu@10.8.10.40 "sudo kubectl -n icn exec deployment/icn-daemon -- /usr/local/bin/icnctl auth token --coop-id test-coop --scopes ledger:read,ledger:write,coop:read,coop:write,gov:read,gov:write"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn exec deployment/icn-daemon -- /usr/local/bin/icnctl auth token --coop-id test-coop --scopes ledger:read,ledger:write,coop:read,coop:write,gov:read,gov:write"
 ```
 
 ### 2. Test API with Token
@@ -61,19 +61,19 @@ ssh ubuntu@10.8.10.40 "sudo kubectl -n icn exec deployment/icn-daemon -- /usr/lo
 TOKEN="<paste-token-here>"
 
 # Health check
-curl http://10.8.10.40:30080/v1/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health
 
 # Get coop details
-curl -H "Authorization: Bearer $TOKEN" http://10.8.10.40:30080/v1/coops/test-coop
+curl -H "Authorization: Bearer $TOKEN" http://${ICN_GATEWAY_HOST}:30080/v1/coops/test-coop
 
 # Get balance
-curl -H "Authorization: Bearer $TOKEN" "http://10.8.10.40:30080/v1/ledger/test-coop/balance/did:icn:z9AWguvsTEkAVXkpQrHWthPuK86Tw3c8DunToVWLJeP4s"
+curl -H "Authorization: Bearer $TOKEN" "http://${ICN_GATEWAY_HOST}:30080/v1/ledger/test-coop/balance/did:icn:z9AWguvsTEkAVXkpQrHWthPuK86Tw3c8DunToVWLJeP4s"
 ```
 
 ### 3. Access Pilot UI
 
-1. Open browser: http://10.8.10.40:30030
-2. Enter Gateway URL: `http://10.8.10.40:30080`
+1. Open browser: http://${ICN_GATEWAY_HOST}:30030
+2. Enter Gateway URL: `http://${ICN_GATEWAY_HOST}:30080`
 3. Enter Cooperative ID: `test-coop`
 4. Use icnctl to generate a token and paste it
 
@@ -84,7 +84,7 @@ curl -H "Authorization: Bearer $TOKEN" "http://10.8.10.40:30080/v1/ledger/test-c
 | Coop ID | test-coop |
 | Name | Test Cooperative |
 | DID | did:icn:z9AWguvsTEkAVXkpQrHWthPuK86Tw3c8DunToVWLJeP4s |
-| Node | k3s-control (10.8.10.40) |
+| Node | k3s-control (${ICN_GATEWAY_HOST}) |
 
 ## Recommendations
 

--- a/docs/development/sessions/undated/E2E_TESTING_2025-12-19.md
+++ b/docs/development/sessions/undated/E2E_TESTING_2025-12-19.md
@@ -52,7 +52,7 @@ E2E testing of the ICN stack on K3s cluster (${ICN_GATEWAY_HOST}).
 ### 1. Get an Auth Token
 
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn exec deployment/icn-daemon -- /usr/local/bin/icnctl auth token --coop-id test-coop --scopes ledger:read,ledger:write,coop:read,coop:write,gov:read,gov:write"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn exec deployment/icn-daemon -- /usr/local/bin/icnctl auth token --coop-id test-coop --scopes ledger:read,ledger:write,coop:read,coop:write,gov:read,gov:write"
 ```
 
 ### 2. Test API with Token

--- a/docs/development/sessions/undated/MOBILE_APP_DEPLOYMENT_STATUS.md
+++ b/docs/development/sessions/undated/MOBILE_APP_DEPLOYMENT_STATUS.md
@@ -1,6 +1,6 @@
 # Mobile App Deployment Test Results
 **Date**: 2025-12-16
-**Gateway**: http://10.8.10.40:30080
+**Gateway**: http://${ICN_GATEWAY_HOST}:30080
 **Environment**: K3s Homelab Cluster
 
 ---
@@ -14,7 +14,7 @@
 - **Health Check**: ✅ Responding at `/v1/health`
 
 ### Services Exposed
-- **Gateway API**: http://10.8.10.40:30080 (NodePort 30080)
+- **Gateway API**: http://${ICN_GATEWAY_HOST}:30080 (NodePort 30080)
 - **Prometheus Metrics**: Port 9100
 - **QUIC P2P**: Port 7777/UDP (NodePort 30777)
 - **RPC**: Port 5601/TCP (NodePort 30601)
@@ -59,7 +59,7 @@ All protected endpoints are properly secured and require JWT authentication.
 
 **Configuration** (`src/config.ts`):
 ```typescript
-export const GATEWAY_URL = 'http://10.8.10.40:30080';  // ✅ Correctly configured
+export const GATEWAY_URL = 'http://${ICN_GATEWAY_HOST}:30080';  // ✅ Correctly configured
 ```
 
 **Features**:
@@ -205,7 +205,7 @@ The mobile app backend is **fully operational** and ready for:
 2. **Test SDIS Enrollment Flow**:
    - Use the app to create a new identity
    - Complete device verification
-   - Get steward to vouch (can use steward dashboard at http://10.8.10.40:30030/steward-dashboard.html)
+   - Get steward to vouch (can use steward dashboard at http://${ICN_GATEWAY_HOST}:30030/steward-dashboard.html)
 
 3. **Test Authenticated Features**:
    - View balance

--- a/docs/development/sessions/undated/MOBILE_APP_DEPLOYMENT_STATUS.md
+++ b/docs/development/sessions/undated/MOBILE_APP_DEPLOYMENT_STATUS.md
@@ -59,7 +59,7 @@ All protected endpoints are properly secured and require JWT authentication.
 
 **Configuration** (`src/config.ts`):
 ```typescript
-export const GATEWAY_URL = 'http://${ICN_GATEWAY_HOST}:30080';  // ✅ Correctly configured
+export const GATEWAY_URL = 'http://<ICN_GATEWAY_HOST>:30080';  // ✅ Correctly configured
 ```
 
 **Features**:

--- a/docs/development/testing/BETA_TESTING_GUIDE.md
+++ b/docs/development/testing/BETA_TESTING_GUIDE.md
@@ -142,13 +142,13 @@ ICN_PASSPHRASE="your-passphrase" ./target/release/icnctl auth token \
 curl -s http://${ICN_GATEWAY_HOST}:30080/v1/health | jq .
 
 # Node status
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn get pods"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn get pods"
 
 # Node logs
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn logs -f deployment/icn-daemon --tail=50"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn logs -f deployment/icn-daemon --tail=50"
 
 # Pilot UI logs
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn logs -f deployment/pilot-ui"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn logs -f deployment/pilot-ui"
 ```
 
 ### Grafana Dashboard

--- a/docs/development/testing/BETA_TESTING_GUIDE.md
+++ b/docs/development/testing/BETA_TESTING_GUIDE.md
@@ -10,10 +10,10 @@
 
 | Service | URL | Notes |
 |---------|-----|-------|
-| **Web UI** | http://10.8.30.40:30030 | Timebank pilot interface |
-| **Gateway API** | http://10.8.30.40:30080 | REST + WebSocket API |
-| **Grafana** | http://10.8.30.40:30300 | Monitoring dashboard |
-| **Prometheus** | http://10.8.30.40:30090 | Metrics (internal) |
+| **Web UI** | http://${ICN_GATEWAY_HOST}:30030 | Timebank pilot interface |
+| **Gateway API** | http://${ICN_GATEWAY_HOST}:30080 | REST + WebSocket API |
+| **Grafana** | http://${ICN_GATEWAY_HOST}:30300 | Monitoring dashboard |
+| **Prometheus** | http://${ICN_GATEWAY_HOST}:30090 | Metrics (internal) |
 
 ---
 
@@ -139,21 +139,21 @@ ICN_PASSPHRASE="your-passphrase" ./target/release/icnctl auth token \
 
 ```bash
 # Gateway health
-curl -s http://10.8.30.40:30080/v1/health | jq .
+curl -s http://${ICN_GATEWAY_HOST}:30080/v1/health | jq .
 
 # Node status
-ssh ubuntu@10.8.30.40 "sudo kubectl -n icn get pods"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn get pods"
 
 # Node logs
-ssh ubuntu@10.8.30.40 "sudo kubectl -n icn logs -f deployment/icn-daemon --tail=50"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn logs -f deployment/icn-daemon --tail=50"
 
 # Pilot UI logs
-ssh ubuntu@10.8.30.40 "sudo kubectl -n icn logs -f deployment/pilot-ui"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn logs -f deployment/pilot-ui"
 ```
 
 ### Grafana Dashboard
 
-Open http://10.8.30.40:30300 for metrics:
+Open http://${ICN_GATEWAY_HOST}:30300 for metrics:
 - **ICN Node Dashboard**: Network, gossip, ledger metrics
 - **Byzantine Detection**: Quarantine status, anomalies
 - **Performance**: Latency, throughput, errors

--- a/docs/development/testing/testing-rpc.md
+++ b/docs/development/testing/testing-rpc.md
@@ -82,7 +82,7 @@ Tip: Ensure other ICN nodes are running on the network.
 
 #### Dial a Peer (Example)
 ```bash
-./target/debug/icnctl network dial did:icn:z6MkpTHR8VNs... --addr 192.168.1.100:7777
+./target/debug/icnctl network dial did:icn:z6MkpTHR8VNs... --addr 192.0.2.10:7777
 ```
 
 Note: This requires a valid peer DID and address.

--- a/docs/guides/QUICK_REFERENCE.md
+++ b/docs/guides/QUICK_REFERENCE.md
@@ -77,7 +77,7 @@ cat DEPLOY_TO_K3S.md
 
 ### 1. Get Admin Token
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST}
+ssh ubuntu@${ICN_K3S_CONTROL}
 POD=$(sudo kubectl get pods -n icn -l component=daemon -o jsonpath='{.items[0].metadata.name}')
 sudo kubectl exec -it -n icn $POD -- icnctl id show
 sudo kubectl exec -it -n icn $POD -- icnctl auth login \
@@ -153,26 +153,26 @@ make logs
 
 **Pods not starting?**
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl get pods -n icn"
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl describe pod -n icn -l component=daemon"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl get pods -n icn"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl describe pod -n icn -l component=daemon"
 ```
 
 **Gateway not responding?**
 ```bash
 curl http://${ICN_GATEWAY_HOST}:30080/v1/health
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl logs -n icn -l component=daemon"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl logs -n icn -l component=daemon"
 ```
 
 **UI not loading?**
 ```bash
 curl http://${ICN_GATEWAY_HOST}:30030/
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl logs -n icn -l component=pilot-ui"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl logs -n icn -l component=pilot-ui"
 ```
 
 **Disk space issues?**
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST} "df -h /"
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo docker system prune -a"
+ssh ubuntu@${ICN_K3S_CONTROL} "df -h /"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo docker system prune -a"
 ```
 
 ---

--- a/docs/guides/QUICK_REFERENCE.md
+++ b/docs/guides/QUICK_REFERENCE.md
@@ -77,7 +77,7 @@ cat DEPLOY_TO_K3S.md
 
 ### 1. Get Admin Token
 ```bash
-ssh ubuntu@10.8.30.40
+ssh ubuntu@${ICN_GATEWAY_HOST}
 POD=$(sudo kubectl get pods -n icn -l component=daemon -o jsonpath='{.items[0].metadata.name}')
 sudo kubectl exec -it -n icn $POD -- icnctl id show
 sudo kubectl exec -it -n icn $POD -- icnctl auth login \
@@ -85,7 +85,7 @@ sudo kubectl exec -it -n icn $POD -- icnctl auth login \
 ```
 
 ### 2. Login to UI
-- Open: http://10.8.30.40:30030
+- Open: http://${ICN_GATEWAY_HOST}:30030
 - Use credentials from step 1
 
 ### 3. Create Invite
@@ -103,7 +103,7 @@ sudo kubectl exec -it -n icn $POD -- icnctl auth login \
 
 ```bash
 # Check invite metrics
-curl http://10.8.30.40:30090/metrics | grep invite
+curl http://${ICN_GATEWAY_HOST}:30090/metrics | grep invite
 
 # Expected output:
 # icn_gateway_invites_created_total{coop_id="test-coop"} N
@@ -153,26 +153,26 @@ make logs
 
 **Pods not starting?**
 ```bash
-ssh ubuntu@10.8.30.40 "sudo kubectl get pods -n icn"
-ssh ubuntu@10.8.30.40 "sudo kubectl describe pod -n icn -l component=daemon"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl get pods -n icn"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl describe pod -n icn -l component=daemon"
 ```
 
 **Gateway not responding?**
 ```bash
-curl http://10.8.30.40:30080/v1/health
-ssh ubuntu@10.8.30.40 "sudo kubectl logs -n icn -l component=daemon"
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl logs -n icn -l component=daemon"
 ```
 
 **UI not loading?**
 ```bash
-curl http://10.8.30.40:30030/
-ssh ubuntu@10.8.30.40 "sudo kubectl logs -n icn -l component=pilot-ui"
+curl http://${ICN_GATEWAY_HOST}:30030/
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl logs -n icn -l component=pilot-ui"
 ```
 
 **Disk space issues?**
 ```bash
-ssh ubuntu@10.8.30.40 "df -h /"
-ssh ubuntu@10.8.30.40 "sudo docker system prune -a"
+ssh ubuntu@${ICN_GATEWAY_HOST} "df -h /"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo docker system prune -a"
 ```
 
 ---
@@ -182,7 +182,7 @@ ssh ubuntu@10.8.30.40 "sudo docker system prune -a"
 - **GitHub Repo:** https://github.com/InterCooperative-Network/icn
 - **Backend Code:** https://github.com/InterCooperative-Network/icn/blob/main/icn/crates/icn-gateway/src/invite.rs
 - **Frontend Code:** https://github.com/InterCooperative-Network/icn/blob/main/web/pilot-ui/app.js
-- **Live UI:** http://10.8.30.40:30030
+- **Live UI:** http://${ICN_GATEWAY_HOST}:30030
 - **API Docs:** See `DEPLOYMENT_INVITE_SYSTEM.md`
 
 ---

--- a/docs/guides/developer/DEV_ENVIRONMENT.md
+++ b/docs/guides/developer/DEV_ENVIRONMENT.md
@@ -2,13 +2,13 @@
 
 ## icn-dev VM
 
-Dedicated development VM for ICN work, hosted on Hyperion (10.8.10.15).
+Dedicated development VM for ICN work, hosted on Hyperion (${ICN_HYPERION_HOST}).
 
 | Setting | Value |
 |---------|-------|
 | **VMID** | 600 |
 | **Name** | icn-dev |
-| **IP** | 10.8.10.45 |
+| **IP** | ${ICN_DEV_HOST} |
 | **RAM** | 12GB |
 | **CPU** | 6 vCPUs |
 | **Disk** | 100GB |
@@ -18,10 +18,10 @@ Dedicated development VM for ICN work, hosted on Hyperion (10.8.10.15).
 
 ```bash
 # SSH
-ssh ubuntu@10.8.10.45
+ssh ubuntu@${ICN_DEV_HOST}
 
 # Web VSCode (code-server)
-http://10.8.10.45:8443
+http://${ICN_DEV_HOST}:8443
 # Access credential: retrieve from secure channel (vault/team secret manager)
 ```
 
@@ -88,7 +88,7 @@ To set up Claude Code on the dev VM:
 
 ```bash
 # SSH to dev VM
-ssh ubuntu@10.8.10.45
+ssh ubuntu@${ICN_DEV_HOST}
 
 # Install Claude Code
 curl -fsSL https://claude.ai/code/install.sh | sh
@@ -110,16 +110,16 @@ The ICN repo contains `CLAUDE.md` with all project-specific instructions.
 ```
 Workstation (matt)
     |
-    +-- SSH --> icn-dev (10.8.10.45) --> ~/projects/icn
+    +-- SSH --> icn-dev (${ICN_DEV_HOST}) --> ~/projects/icn
     |              |
     |              +-- kubectl --> K3s Cluster
     |                                  |
-    +-- SSH --> k3s-control (10.8.30.40)
+    +-- SSH --> k3s-control (${ICN_K3S_CONTROL})
                     |
-                    +-- k3s-worker-1 (10.8.30.41)
-                    +-- k3s-worker-2 (10.8.30.42)
+                    +-- k3s-worker-1 (${ICN_K3S_WORKER1})
+                    +-- k3s-worker-2 (${ICN_K3S_WORKER2})
                            |
-                           +-- ICN pods (NFS from Atlas 10.8.10.25)
+                           +-- ICN pods (NFS from Atlas ${ICN_NFS_HOST})
 ```
 
 ## Related Documentation

--- a/docs/guides/operations/PILOT_RUNBOOK.md
+++ b/docs/guides/operations/PILOT_RUNBOOK.md
@@ -25,9 +25,9 @@
 
 | Component | Where | How to verify |
 |-----------|-------|---------------|
-| K3s control plane | `k3s-control` (10.8.30.40) | `kubectl get nodes` |
+| K3s control plane | `k3s-control` (${ICN_K3S_CONTROL}) | `kubectl get nodes` |
 | ICN gateway pods | `icn` namespace | `kubectl get pods -n icn` |
-| Atlas NFS | 10.8.10.25 | `kubectl get pvc -n icn` — must be `Bound` |
+| Atlas NFS | ${ICN_NFS_HOST} | `kubectl get pvc -n icn` — must be `Bound` |
 
 ### Tools required on your workstation
 
@@ -49,11 +49,11 @@ jq --version
 
 | Port  | Instance        | URL |
 |-------|----------------|-----|
-| 30080 | Default gateway | http://10.8.30.40:30080 |
-| 30081 | Coop instance 1 | http://10.8.30.40:30081 |
-| 30082 | Coop instance 2 | http://10.8.30.40:30082 |
-| 30083 | Coop instance 3 | http://10.8.30.40:30083 |
-| 30084 | Coop instance 4 | http://10.8.30.40:30084 |
+| 30080 | Default gateway | http://${ICN_K3S_CONTROL}:30080 |
+| 30081 | Coop instance 1 | http://${ICN_K3S_CONTROL}:30081 |
+| 30082 | Coop instance 2 | http://${ICN_K3S_CONTROL}:30082 |
+| 30083 | Coop instance 3 | http://${ICN_K3S_CONTROL}:30083 |
+| 30084 | Coop instance 4 | http://${ICN_K3S_CONTROL}:30084 |
 
 ---
 
@@ -62,7 +62,7 @@ jq --version
 Set these in your shell before running any commands:
 
 ```bash
-export HOST="http://10.8.30.40:30080"   # default gateway
+export HOST="http://${ICN_K3S_CONTROL}:30080"   # default gateway
 export COOP_ID="pilot-coop-1"           # your cooperative ID
 export TOKEN=""                         # filled in after auth (§4)
 ```
@@ -91,7 +91,7 @@ HTTP 200 means the gateway is up and accepting requests.
 
 ```bash
 for port in 30080 30081 30082 30083 30084; do
-    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://10.8.30.40:${port}/v1/health")
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://${ICN_K3S_CONTROL}:${port}/v1/health")
     echo "port $port → $code"
 done
 ```
@@ -442,7 +442,7 @@ curl -s "$HOST/v1/gov/proposals/$PROPOSAL_ID" \
 Prometheus scrapes on port 30090:
 
 ```bash
-curl -s http://10.8.30.40:30090/metrics | grep gateway_governance
+curl -s http://${ICN_K3S_CONTROL}:30090/metrics | grep gateway_governance
 ```
 
 Key metrics:

--- a/docs/guides/operations/nat-traversal.md
+++ b/docs/guides/operations/nat-traversal.md
@@ -191,11 +191,11 @@ If TURN is unavailable or unreliable, a VPN provides guaranteed connectivity:
 
 ```bash
 # On each node, create a WireGuard interface
-# Peers see each other on the WireGuard subnet (e.g., 10.10.0.0/24)
+# Peers see each other on the WireGuard subnet (e.g., 192.0.2.0/24)
 # ICN nodes listen on the WireGuard IP instead of the public interface
 
-icnd --listen 10.10.0.1:4433  # Node A on WireGuard IP
-icnd --listen 10.10.0.2:4433  # Node B on WireGuard IP
+icnd --listen 192.0.2.11:4433  # Node A on WireGuard IP
+icnd --listen 192.0.2.12:4433  # Node B on WireGuard IP
 ```
 
 With a VPN, nodes appear to be on the same network. No STUN or TURN is needed — direct dial works because the VPN handles NAT traversal at the network layer.

--- a/docs/guides/operations/network-policies.md
+++ b/docs/guides/operations/network-policies.md
@@ -155,8 +155,11 @@ spec:
     - ipBlock:
         cidr: 0.0.0.0/0
         except:
-        - 192.0.2.0/8      # block intra-cluster non-mesh traffic via external path
-        - 198.51.100.0/16
+        # operator-supplied: your cluster's private CIDRs (node subnet + pod/service
+        # ranges) so intra-cluster non-mesh traffic is not permitted via the external
+        # path. Resolve from the private network-ops source; do not hardcode here.
+        - <cluster-node-cidr>
+        - <pod-service-cidr>
     ports:
     - port: 7825    # QUIC range covering all coops + main daemon
       protocol: UDP

--- a/docs/guides/operations/network-policies.md
+++ b/docs/guides/operations/network-policies.md
@@ -34,7 +34,7 @@ All other namespaces (`icn-coop-*`, `monitoring`, `registry`) have **no policies
 
 Each coop also has a NodePort service exposing QUIC and RPC externally for P2P federation.
 
-**mDNS note**: All coop configs have `mdns_enabled = true`. mDNS uses multicast UDP to `224.0.0.251:5353`. Kubernetes NetworkPolicies operate on unicast only — multicast bypasses them entirely. Do not rely on NetworkPolicy to control mDNS; it will still broadcast within the node's subnet regardless.
+**mDNS note**: All coop configs have `mdns_enabled = true`. mDNS uses multicast UDP to the mDNS multicast group (UDP 5353). Kubernetes NetworkPolicies operate on unicast only — multicast bypasses them entirely. Do not rely on NetworkPolicy to control mDNS; it will still broadcast within the node's subnet regardless.
 
 ---
 
@@ -155,8 +155,8 @@ spec:
     - ipBlock:
         cidr: 0.0.0.0/0
         except:
-        - 10.0.0.0/8      # block intra-cluster non-mesh traffic via external path
-        - 192.168.0.0/16
+        - 192.0.2.0/8      # block intra-cluster non-mesh traffic via external path
+        - 198.51.100.0/16
     ports:
     - port: 7825    # QUIC range covering all coops + main daemon
       protocol: UDP
@@ -193,8 +193,8 @@ Prometheus needs to scrape all namespaces — its egress must remain fully open.
 
 ## Design: `registry` Namespace
 
-The in-cluster registry (`10.8.30.40:30500`) is accessed two ways:
-1. **ci-runner** (external, 10.8.30.46) → NodePort 30500 (Docker push)
+The in-cluster registry (`${ICN_K3S_CONTROL}:30500`) is accessed two ways:
+1. **ci-runner** (external, ${ICN_CI_RUNNER_HOST}) → NodePort 30500 (Docker push)
 2. **K3s containerd** on each node → NodePort 30500 (image pull via `registries.yaml`)
 
 Both paths go through NodePort/iptables at the node level, not through pod-to-pod networking. The registry pod IP (`10.43.x.x`) is only directly accessed by in-cluster actors (e.g., `kubectl` commands against the registry API).
@@ -226,7 +226,7 @@ Both paths go through NodePort/iptables at the node level, not through pod-to-po
 kubectl exec -n icn-coop-alpha deploy/icn-alpha -- icnctl peer list
 
 # Confirm Prometheus is scraping all coop metrics endpoints
-curl -s http://10.8.30.40:30090/api/v1/targets | jq '.data.activeTargets | length'
+curl -s http://${ICN_K3S_CONTROL}:30090/api/v1/targets | jq '.data.activeTargets | length'
 
 # After applying any policy, immediately recheck mesh formation
 kubectl exec -n icn-coop-alpha deploy/icn-alpha -- icnctl peer list
@@ -240,6 +240,6 @@ During active development:
 - Developers need `kubectl exec` / `kubectl port-forward` into any pod freely
 - Feature branches may add new ports or communication patterns before they're documented
 - Broken NetworkPolicy is subtle — a misconfigured egress rule silently drops gossip messages with no error visible in app logs
-- The cluster is on a private VLAN (10.8.30.0/24) behind OPNsense — the perimeter is already controlled
+- The cluster is on a private VLAN (operator-supplied subnet) behind OPNsense — the perimeter is already controlled
 
 **Re-evaluate when**: First external pilot participant connects, OR when coop namespaces start holding real identity/ledger data.

--- a/docs/guides/operations/phase-0-monitoring.md
+++ b/docs/guides/operations/phase-0-monitoring.md
@@ -147,7 +147,7 @@ To configure Slack/Email alerting, edit `deploy/k8s/alertmanager-config.yaml`.
 ```bash
 # Generate 10 auth failures quickly
 for i in {1..10}; do
-  curl -X POST http://10.8.30.40:30080/v1/auth/verify \
+  curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/auth/verify \
     -H "Content-Type: application/json" \
     -d "{\"did\": \"did:icn:test$i\", \"challenge_id\": \"bad\", \"signature\": \"fake\"}" &
 done

--- a/docs/guides/operations/runbooks/05-troubleshooting.md
+++ b/docs/guides/operations/runbooks/05-troubleshooting.md
@@ -109,7 +109,7 @@ grep bootstrap ~/.icn/config.toml
 
 # Add bootstrap peer
 # [network]
-# bootstrap_peers = ["icn://did:icn:...@1.2.3.4:7777"]
+# bootstrap_peers = ["icn://did:icn:...@192.0.2.10:7777"]
 ```
 
 **3. mDNS not working (LAN only)**

--- a/docs/guides/operations/troubleshooting.md
+++ b/docs/guides/operations/troubleshooting.md
@@ -109,10 +109,10 @@ container_memory_working_set_bytes{namespace="icn", container="icnd"} / containe
 3. **Identify workload patterns**:
    ```bash
    # Check gossip message rate
-   curl -s http://10.8.30.40:30090/metrics | grep icn_gossip_messages
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_gossip_messages
 
    # Check active connections
-   curl -s http://10.8.30.40:30090/metrics | grep icn_network_connections
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_network_connections
    ```
 
 4. **Decision tree**:
@@ -154,7 +154,7 @@ sudo kubectl -n icn edit deployment icn-daemon
    sudo kubectl -n icn exec deploy/icn-daemon -- cat /proc/1/smaps > smaps.txt
 
    # Capture current metrics
-   curl -s http://10.8.30.40:30090/metrics > metrics-snapshot.txt
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics > metrics-snapshot.txt
    ```
 2. Report to ICN developers with:
    - Memory diagnostics (smaps, metrics snapshot)
@@ -195,7 +195,7 @@ sudo kubectl -n icn edit deployment icn-daemon
 
 ```bash
 # Check gossip metrics
-curl -s http://10.8.30.40:30090/metrics | grep icn_gossip
+curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_gossip
 
 # Key metrics to watch:
 # - icn_gossip_entries_received_total (incoming entries)
@@ -210,7 +210,7 @@ curl -s http://10.8.30.40:30090/metrics | grep icn_gossip
 1. **Check network connectivity**:
    ```bash
    # Verify peer count
-   curl http://10.8.30.40:30080/v1/health | jq '.active_connections'
+   curl http://${ICN_GATEWAY_HOST}:30080/v1/health | jq '.active_connections'
 
    # Check if peers are reachable
    sudo kubectl -n icn exec deploy/icn-daemon -- curl -s localhost:9100/metrics | grep icn_network
@@ -219,7 +219,7 @@ curl -s http://10.8.30.40:30090/metrics | grep icn_gossip
 2. **Check topic subscriptions**:
    ```bash
    # List subscribed topics
-   curl -s http://10.8.30.40:30090/metrics | grep icn_gossip_subscriptions
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_gossip_subscriptions
 
    # Compare subscription counts across nodes (if multi-node)
    ```
@@ -229,13 +229,13 @@ curl -s http://10.8.30.40:30090/metrics | grep icn_gossip
    - Large imbalance indicates sync issues
    ```bash
    # Check message flow balance
-   curl -s http://10.8.30.40:30090/metrics | grep -E "icn_gossip_(entries_received|entries_published)_total"
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep -E "icn_gossip_(entries_received|entries_published)_total"
    ```
 
 4. **Check for rejected messages**:
    ```bash
    # High rejection rate indicates trust or rate limiting issues
-   curl -s http://10.8.30.40:30090/metrics | grep rejected
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep rejected
    ```
 
 5. **Decision tree**:
@@ -318,7 +318,7 @@ sudo kubectl -n icn rollout restart deployment/icn-daemon
 
 ```bash
 # Check ledger metrics
-curl -s http://10.8.30.40:30090/metrics | grep icn_ledger
+curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_ledger
 
 # Key metrics:
 # - icn_ledger_sync_lag_seconds
@@ -331,12 +331,12 @@ curl -s http://10.8.30.40:30090/metrics | grep icn_ledger
 
 1. **Check peer connectivity**:
    ```bash
-   curl http://10.8.30.40:30080/v1/health | jq '.active_connections'
+   curl http://${ICN_GATEWAY_HOST}:30080/v1/health | jq '.active_connections'
    ```
 
 2. **Check quarantine size** (indicates problematic entries):
    ```bash
-   curl -s http://10.8.30.40:30090/metrics | grep quarantine
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep quarantine
    ```
 
 3. **Verify entry propagation**:
@@ -368,7 +368,7 @@ curl -s http://10.8.30.40:30090/metrics | grep icn_ledger
 **If slow propagation** (high volume):
 ```bash
 # Monitor progress - should improve over time
-watch -n 5 "curl -s http://10.8.30.40:30090/metrics | grep icn_ledger_entries_total"
+watch -n 5 "curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_ledger_entries_total"
 ```
 
 **If quarantine issues**:
@@ -424,7 +424,7 @@ sudo kubectl -n icn rollout restart deployment/icn-daemon
 
 ```bash
 # Check trust metrics
-curl -s http://10.8.30.40:30090/metrics | grep icn_trust
+curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_trust
 
 # Key metrics:
 # - icn_trust_computation_errors_total
@@ -443,7 +443,7 @@ curl -s http://10.8.30.40:30090/metrics | grep icn_trust
 2. **Verify graph consistency**:
    ```bash
    # Check edge count
-   curl -s http://10.8.30.40:30090/metrics | grep icn_trust_edges
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_trust_edges
 
    # Check for cycles or invalid edges in logs
    sudo kubectl -n icn logs deployment/icn-daemon | grep -i "trust.*cycle\|invalid.*edge"
@@ -452,7 +452,7 @@ curl -s http://10.8.30.40:30090/metrics | grep icn_trust
 3. **Check computation performance**:
    ```bash
    # High computation time indicates graph issues
-   curl -s http://10.8.30.40:30090/metrics | grep icn_trust_computation_duration
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_trust_computation_duration
    ```
 
 4. **Decision tree**:
@@ -478,7 +478,7 @@ sudo kubectl -n icn rollout restart deployment/icn-daemon
 **Verify edge data** via metrics:
 ```bash
 # Check edge count from Prometheus metrics
-curl -s http://10.8.30.40:30090/metrics | grep icn_trust_edges
+curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_trust_edges
 ```
 
 **If graph corruption suspected**:
@@ -525,10 +525,10 @@ Currently, trust edges are managed through the RPC API or gossip protocol.
 
 ```bash
 # Check rate limiting metrics
-curl -s http://10.8.30.40:30090/metrics | grep rate_limit
+curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep rate_limit
 
 # Check gateway response codes
-curl -s http://10.8.30.40:30090/metrics | grep icn_gateway_requests | grep 429
+curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_gateway_requests | grep 429
 ```
 
 ### Diagnosis Steps
@@ -548,7 +548,7 @@ curl -s http://10.8.30.40:30090/metrics | grep icn_gateway_requests | grep 429
 3. **Analyze request patterns**:
    ```bash
    # Check request rate by endpoint
-   curl -s http://10.8.30.40:30090/metrics | grep icn_gateway_requests_total
+   curl -s http://${ICN_GATEWAY_HOST}:30090/metrics | grep icn_gateway_requests_total
    ```
 
 4. **Decision tree**:

--- a/docs/manual/ICN_USER_MANUAL.md
+++ b/docs/manual/ICN_USER_MANUAL.md
@@ -420,7 +420,7 @@ Cooperatives share bootstrap information through:
 1. **Connect to bootstrap node**:
    ```bash
    # Add to config or run directly
-   icnctl network add-peer 192.168.1.100:7777 did:icn:BOOTSTRAP_DID
+   icnctl network add-peer 192.0.2.10:7777 did:icn:BOOTSTRAP_DID
    ```
 
 2. **Request trust attestation**:
@@ -916,8 +916,8 @@ data_dir = "~/.icn"
 [network]
 listen_addr = "0.0.0.0:7777"
 bootstrap_peers = [
-  "icn://did:icn:PEER1_DID@192.168.1.100:7777",
-  "icn://did:icn:PEER2_DID@192.168.1.101:7777"
+  "icn://did:icn:PEER1_DID@192.0.2.10:7777",
+  "icn://did:icn:PEER2_DID@192.0.2.11:7777"
 ]
 
 [gateway]
@@ -1109,7 +1109,7 @@ sudo ufw allow 7777/udp
 grep bootstrap ~/.icn/config.toml
 
 # Manually add peer
-icnctl network add-peer 192.168.1.100:7777 did:icn:PEER_DID
+icnctl network add-peer 192.0.2.10:7777 did:icn:PEER_DID
 ```
 
 #### "Transaction rejected: insufficient credit"
@@ -1493,8 +1493,8 @@ listen_addr = "0.0.0.0:7777"
 
 # Bootstrap peers for initial network discovery
 bootstrap_peers = [
-  "icn://did:icn:PEER1@192.168.1.100:7777",
-  "icn://did:icn:PEER2@192.168.1.101:7777"
+  "icn://did:icn:PEER1@192.0.2.10:7777",
+  "icn://did:icn:PEER2@192.0.2.11:7777"
 ]
 
 # Enable mDNS for local network discovery

--- a/docs/onboarding/reference/module-09-ops-deploy.md
+++ b/docs/onboarding/reference/module-09-ops-deploy.md
@@ -72,7 +72,7 @@ data_dir = "/var/lib/icn"
 listen_addr = "0.0.0.0:7777"
 mdns_enabled = true
 bootstrap_peers = [
-    "icn://did:icn:abc@192.168.1.10:7777",
+    "icn://did:icn:abc@192.0.2.10:7777",
 ]
 
 [gateway]

--- a/docs/operations/deployment/HOMELAB_DEPLOYMENT.md
+++ b/docs/operations/deployment/HOMELAB_DEPLOYMENT.md
@@ -7,17 +7,17 @@
 | Component | Details |
 |-----------|---------|
 | **K3s Version** | v1.34.4+k3s1 |
-| **K3s Control** | `k3s-control` (10.8.30.40) — 4 vCPU, 8GB RAM on Hyperion, tainted `NoSchedule` |
-| **Worker 1** | `k3s-worker-1` (10.8.30.41) — 4 vCPU, 16GB RAM on node-2 |
-| **Worker 2** | `k3s-worker-2` (10.8.30.42) — 4 vCPU, 16GB RAM on node-3 |
-| **CI Runner** | `ci-runner` (10.8.30.46) — 8 vCPU, 6GB RAM on Hyperion (standalone, not in K3s) |
-| **Storage** | NFS from Atlas (10.8.10.25) via `atlas-nfs` StorageClass (csi-driver-nfs v4.9.0) |
-| **Registry** | In-cluster at `10.8.30.40:30500` (NFS-backed PVC) |
+| **K3s Control** | `k3s-control` (${ICN_K3S_CONTROL}) — 4 vCPU, 8GB RAM on Hyperion, tainted `NoSchedule` |
+| **Worker 1** | `k3s-worker-1` (${ICN_K3S_WORKER1}) — 4 vCPU, 16GB RAM on node-2 |
+| **Worker 2** | `k3s-worker-2` (${ICN_K3S_WORKER2}) — 4 vCPU, 16GB RAM on node-3 |
+| **CI Runner** | `ci-runner` (${ICN_CI_RUNNER_HOST}) — 8 vCPU, 6GB RAM on Hyperion (standalone, not in K3s) |
+| **Storage** | NFS from Atlas (${ICN_NFS_HOST}) via `atlas-nfs` StorageClass (csi-driver-nfs v4.9.0) |
+| **Registry** | In-cluster at `${ICN_K3S_CONTROL}:30500` (NFS-backed PVC) |
 | **Ports** | 7777/UDP (QUIC), 5601/TCP (RPC), 9100/TCP (Prometheus), 8080/TCP (Gateway) |
 
 ### Image Strategy
 
-All images use `imagePullPolicy: Always` and pull from the in-cluster registry at `10.8.30.40:30500`. SCP-based image sync is deprecated.
+All images use `imagePullPolicy: Always` and pull from the in-cluster registry at `${ICN_K3S_CONTROL}:30500`. SCP-based image sync is deprecated.
 
 ```bash
 # Default deploy path (build + push to registry + rolling restart)
@@ -35,11 +35,11 @@ cd deploy/k8s && make fast-deploy-all
 
 # Check status
 make status
-# OR: ssh ubuntu@10.8.30.40 "sudo kubectl -n icn get pods"
+# OR: ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn get pods"
 
 # View logs
 make logs
-# OR: ssh ubuntu@10.8.30.40 "sudo kubectl -n icn logs -f deployment/icn-daemon"
+# OR: ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn logs -f deployment/icn-daemon"
 ```
 
 ## Deployment Paths
@@ -59,8 +59,8 @@ lives in [`deploy/k8s/monitoring/`](../../../deploy/k8s/monitoring/README.md).
 
 | Component | Access | Notes |
 |-----------|--------|-------|
-| **Grafana** | http://10.8.30.40:30300 | Default admin/prom-operator |
-| **Prometheus** | http://10.8.30.40:30090 | Scrapes ICN metrics |
+| **Grafana** | http://${ICN_K3S_CONTROL}:30300 | Default admin/prom-operator |
+| **Prometheus** | http://${ICN_K3S_CONTROL}:30090 | Scrapes ICN metrics |
 | **AlertManager** | K3s internal only | Via kube-prometheus-stack |
 
 Storage: Prometheus and Alertmanager use PVCs on the `atlas-nfs` StorageClass
@@ -74,18 +74,18 @@ via `deploy/k8s/monitoring/values-kube-prometheus-stack.yaml`. Apply with
 | Component | Details |
 |-----------|---------|
 | **Runner Name** | `ci-runner` |
-| **Runner Host** | `ci-runner` VM (10.8.30.46) on Hyperion |
+| **Runner Host** | `ci-runner` VM (${ICN_CI_RUNNER_HOST}) on Hyperion |
 | **Specs** | 8 vCPU, 6GB RAM, 80GB disk |
 | **Labels** | `self-hosted, linux, x64, homelab, k3s` |
 | **Rust** | 1.88.0 with sccache |
 | **sccache** | Shared Atlas NFS at `/mnt/icn-sccache` (see [`deploy/ci-runner/`](../../../deploy/ci-runner/README.md), issue #1597) |
-| **Docker** | Configured with insecure registry (10.8.30.40:30500) |
+| **Docker** | Configured with insecure registry (${ICN_K3S_CONTROL}:30500) |
 | **kubectl** | Has kubeconfig for cluster access |
 
 **Runner Management**:
 ```bash
-ssh ubuntu@10.8.30.46 "sudo systemctl status actions.runner.InterCooperative-Network-icn.ci-runner"
-ssh ubuntu@10.8.30.46 "journalctl -u actions.runner.InterCooperative-Network-icn.ci-runner -f"
+ssh ubuntu@${ICN_CI_RUNNER_HOST} "sudo systemctl status actions.runner.InterCooperative-Network-icn.ci-runner"
+ssh ubuntu@${ICN_CI_RUNNER_HOST} "journalctl -u actions.runner.InterCooperative-Network-icn.ci-runner -f"
 ```
 
 ## Pilot Testing Status (2025-12-05)
@@ -103,8 +103,8 @@ ssh ubuntu@10.8.30.46 "journalctl -u actions.runner.InterCooperative-Network-icn
 
 **Test Commands** (via Gateway API):
 ```bash
-TOKEN=$(icnctl auth token --gateway http://10.8.30.40:30080 --coop pilot-coop)
-curl -H "Authorization: Bearer $TOKEN" http://10.8.30.40:30080/v1/gov/domains
+TOKEN=$(icnctl auth token --gateway http://${ICN_K3S_CONTROL}:30080 --coop pilot-coop)
+curl -H "Authorization: Bearer $TOKEN" http://${ICN_K3S_CONTROL}:30080/v1/gov/domains
 ```
 
 ## SDIS & Steward Dashboard (deployed 2025-12-13)
@@ -113,10 +113,10 @@ curl -H "Authorization: Bearer $TOKEN" http://10.8.30.40:30080/v1/gov/domains
 
 | Component | Access |
 |-----------|--------|
-| **Pilot UI** | http://10.8.30.40:30030 |
-| **Steward Dashboard** | http://10.8.30.40:30030/steward-dashboard.html |
-| **SDIS Enrollment** | http://10.8.30.40:30030/sdis-enrollment.html |
-| **Gateway API** | http://10.8.30.40:30080/v1/sdis/* |
+| **Pilot UI** | http://${ICN_K3S_CONTROL}:30030 |
+| **Steward Dashboard** | http://${ICN_K3S_CONTROL}:30030/steward-dashboard.html |
+| **SDIS Enrollment** | http://${ICN_K3S_CONTROL}:30030/sdis-enrollment.html |
+| **Gateway API** | http://${ICN_K3S_CONTROL}:30080/v1/sdis/* |
 
 ### SDIS API Endpoints
 
@@ -138,16 +138,16 @@ curl -H "Authorization: Bearer $TOKEN" http://10.8.30.40:30080/v1/gov/domains
 
 ```bash
 # Check SDIS health
-curl http://10.8.30.40:30080/v1/sdis/health
+curl http://${ICN_K3S_CONTROL}:30080/v1/sdis/health
 
 # List pending enrollments
-curl http://10.8.30.40:30080/v1/sdis/pending
+curl http://${ICN_K3S_CONTROL}:30080/v1/sdis/pending
 
 # Get steward stats
-curl http://10.8.30.40:30080/v1/sdis/steward/stats
+curl http://${ICN_K3S_CONTROL}:30080/v1/sdis/steward/stats
 
 # Start an enrollment
-curl -X POST http://10.8.30.40:30080/v1/sdis/enrollment/start \
+curl -X POST http://${ICN_K3S_CONTROL}:30080/v1/sdis/enrollment/start \
   -H "Content-Type: application/json" \
   -d '{"identity_name":"Test User","coop_id":"pilot-coop"}'
 ```

--- a/docs/operations/deployment/deployment-guide.md
+++ b/docs/operations/deployment/deployment-guide.md
@@ -492,7 +492,7 @@ Error: Permission denied
 
 **Manual peer dialing:**
 ```bash
-icnctl network dial did:icn:abc123... 192.168.1.100:7777
+icnctl network dial did:icn:abc123... 192.0.2.10:7777
 ```
 
 ### High memory usage

--- a/docs/operations/deployment/incident-response.md
+++ b/docs/operations/deployment/incident-response.md
@@ -68,7 +68,7 @@ This section provides K3s-specific commands for the live homelab deployment.
 
 ```bash
 # SSH to control plane
-ssh ubuntu@10.8.30.40
+ssh ubuntu@${ICN_K3S_CONTROL}
 
 # All kubectl commands require sudo on control plane
 sudo kubectl -n icn <command>
@@ -103,13 +103,13 @@ sudo kubectl -n icn get pvc
 
 ```bash
 # ICN health endpoint
-curl http://10.8.30.40:30080/v1/health
+curl http://${ICN_K3S_CONTROL}:30080/v1/health
 
 # Prometheus metrics
-curl http://10.8.30.40:30090/metrics | head -50
+curl http://${ICN_K3S_CONTROL}:30090/metrics | head -50
 
 # Grafana dashboard
-# Open: http://10.8.30.40:30300
+# Open: http://${ICN_K3S_CONTROL}:30300
 
 # Check node identity
 sudo kubectl -n icn exec deploy/icn-daemon -- /usr/local/bin/icnctl id show
@@ -165,10 +165,10 @@ sudo kubectl -n icn get svc
 
 ```bash
 # View active alerts
-curl -s http://10.8.30.40:30093/api/v1/alerts | jq '.data[] | {labels: .labels, state: .status.state}'
+curl -s http://${ICN_K3S_CONTROL}:30093/api/v1/alerts | jq '.data[] | {labels: .labels, state: .status.state}'
 
 # Silence an alert (for maintenance)
-# Use Alertmanager UI: http://10.8.30.40:30093
+# Use Alertmanager UI: http://${ICN_K3S_CONTROL}:30093
 ```
 
 ---
@@ -595,7 +595,7 @@ journalctl -u icnd --since "1 week ago" | grep upgrade
 1. **Check network connectivity**:
    ```bash
    # Test internet connection
-   ping 8.8.8.8
+   ping "$PING_TARGET"          # set PING_TARGET to a reliable public host (e.g. your upstream resolver)
 
    # Test DNS
    nslookup google.com
@@ -670,7 +670,7 @@ journalctl -u icnd --since "1 week ago" | grep upgrade
 
 1. **Check pod status**:
    ```bash
-   ssh ubuntu@10.8.30.40
+   ssh ubuntu@${ICN_K3S_CONTROL}
    sudo kubectl -n icn get pods -o wide
    ```
 
@@ -766,7 +766,7 @@ journalctl -u icnd --since "1 week ago" | grep upgrade
 3. **Check NFS server** (Atlas):
    ```bash
    ssh atlas "systemctl status nfs-kernel-server"
-   showmount -e 10.8.10.25
+   showmount -e ${ICN_NFS_HOST}
    ```
 
 ### Prevention
@@ -894,7 +894,7 @@ journalctl -u icnd --since "1 week ago" | grep upgrade
 
 1. **Check PVC status**:
    ```bash
-   ssh ubuntu@10.8.30.40
+   ssh ubuntu@${ICN_K3S_CONTROL}
    sudo kubectl -n icn get pvc
    sudo kubectl -n icn describe pvc icn-data
    ```
@@ -927,7 +927,7 @@ journalctl -u icnd --since "1 week ago" | grep upgrade
 
 1. **Check network connectivity**:
    ```bash
-   ping 10.8.10.25
+   ping ${ICN_NFS_HOST}
    ```
 
 2. **Restart NFS service**:
@@ -937,7 +937,7 @@ journalctl -u icnd --since "1 week ago" | grep upgrade
 
 3. **Verify exports**:
    ```bash
-   showmount -e 10.8.10.25
+   showmount -e ${ICN_NFS_HOST}
    ```
 
 4. **Restart ICN pod** (to remount):
@@ -1009,7 +1009,7 @@ journalctl -u icnd --since "1 week ago" | grep upgrade
 
 1. **Check backup job status**:
    ```bash
-   ssh ubuntu@10.8.30.40
+   ssh ubuntu@${ICN_K3S_CONTROL}
    sudo kubectl -n icn get jobs -l component=backup
    sudo kubectl -n icn get jobs -l component=backup-verify
    ```
@@ -1147,7 +1147,7 @@ journalctl -u icnd --since "1 week ago" | grep upgrade
 6. **Verify restoration**:
    ```bash
    # Check health
-   curl http://10.8.30.40:30080/v1/health
+   curl http://${ICN_K3S_CONTROL}:30080/v1/health
 
    # Check identity
    sudo kubectl -n icn exec deploy/icn-daemon -- /usr/local/bin/icnctl id show

--- a/docs/planning/icn-crate-reference.md
+++ b/docs/planning/icn-crate-reference.md
@@ -1,7 +1,7 @@
 # ICN Crate Reference — Accurate Technical Inventory
 # Generated from live repo exploration, 2026-03-12
 
-**Source:** `~/projects/icn` on icn-dev (10.8.30.45)
+**Source:** `~/projects/icn` on icn-dev (${ICN_DEV_HOST})
 **Workspace root:** `icn/` (38 members in Cargo.toml)
 **Binaries:** `icnd`, `icnctl`, `icn-console`
 **Last explored commit:** `72a8b7a3` (docs: FORWARD_PLAN_2026-03)
@@ -671,10 +671,10 @@ These are Phase 2 Track A deliverables. They're the "governance constitution tem
 
 ## Current Deployment State
 
-**K3s cluster on icn-dev (10.8.30.45):**
+**K3s cluster on icn-dev (${ICN_DEV_HOST}):**
 - 4 pods: icn-alpha, icn-beta, icn-gamma (+ delta)
-- Gateway API accessible at `10.8.30.40:30080` (K3s NodePort)
-- SDIS API: `http://10.8.30.40:30080/v1/sdis/health`
+- Gateway API accessible at `${ICN_GATEWAY_HOST}:30080` (K3s NodePort)
+- SDIS API: `http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health`
 
 **Known gaps in K3s deployment:**
 - `treasury:read/write` scopes not in `ALLOWED_SCOPES` → treasury API unreachable

--- a/docs/planning/icn-vertical-slice-assessment.md
+++ b/docs/planning/icn-vertical-slice-assessment.md
@@ -1,7 +1,7 @@
 # ICN Vertical Slice: Phase 1 Assessment
 
 **Date:** 2026-03-13
-**Source:** Direct code audit of /home/ubuntu/projects/icn/icn on icn-dev (10.8.30.45)
+**Source:** Direct code audit of /home/ubuntu/projects/icn/icn on icn-dev (operator-supplied host)
 **Branch:** main (post feat/demo-federation-system merge)
 
 ---

--- a/docs/plans/2026-02-16-c3-nat-traversal.md
+++ b/docs/plans/2026-02-16-c3-nat-traversal.md
@@ -108,7 +108,7 @@ mod tests {
         let quinn_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let fake_turn_server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let turn_addr = fake_turn_server.local_addr().unwrap();
-        let peer_relay_addr: SocketAddr = "10.0.0.99:5000".parse().unwrap();
+        let peer_relay_addr: SocketAddr = "192.0.2.10:5000".parse().unwrap();
 
         let proxy = TurnRelayProxy::start_test(
             turn_addr,
@@ -149,7 +149,7 @@ mod tests {
         let quinn_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let fake_turn_server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let turn_addr = fake_turn_server.local_addr().unwrap();
-        let peer_relay_addr: SocketAddr = "10.0.0.99:5000".parse().unwrap();
+        let peer_relay_addr: SocketAddr = "192.0.2.10:5000".parse().unwrap();
 
         let proxy = TurnRelayProxy::start_test(
             turn_addr,

--- a/docs/plans/2026-02-21-sprint-11-federated-governance-design.md
+++ b/docs/plans/2026-02-21-sprint-11-federated-governance-design.md
@@ -306,8 +306,8 @@ cd /home/ubuntu/projects/icn && docker build -f deploy/Dockerfile.icnd -t icn:la
 **Step 3: Push to registry**
 
 ```bash
-docker tag icn:latest 10.8.30.40:30500/icn:latest
-docker push 10.8.30.40:30500/icn:latest
+docker tag icn:latest ${ICN_NODE_HOST}:30500/icn:latest
+docker push ${ICN_NODE_HOST}:30500/icn:latest
 ```
 
 **Step 4: Create PR**
@@ -366,7 +366,7 @@ In the deployment YAML (line 259-268), add after the HOME env var:
 
 ```yaml
         - name: ICN_CORS_ORIGINS
-          value: "http://10.8.30.40:30030"
+          value: "http://${ICN_NODE_HOST}:30030"
 ```
 
 **Step 3: Print gateway port in summary**
@@ -441,14 +441,14 @@ For each coop, patch the deployment to add `ICN_CORS_ORIGINS`:
 ```bash
 for COOP in alpha beta gamma delta; do
     NS="icn-coop-${COOP}"
-    kubectl -n $NS set env deployment/icn-${COOP} ICN_CORS_ORIGINS="http://10.8.30.40:30030"
+    kubectl -n $NS set env deployment/icn-${COOP} ICN_CORS_ORIGINS="http://${ICN_NODE_HOST}:30030"
 done
 ```
 
 **Step 3: Verify all 4 coop gateways respond**
 
 ```bash
-NODE_IP=10.8.30.40
+NODE_IP=${ICN_NODE_HOST}
 for PORT in 30081 30082 30083 30084; do
     echo -n "Port $PORT: "
     curl -s "http://${NODE_IP}:${PORT}/v1/health" | jq -r '.status'
@@ -481,7 +481,7 @@ gh pr create --title "feat(deploy): add gateway NodePorts for coop instances" --
 # Idempotent: re-running is safe.
 set -euo pipefail
 
-NODE_IP="${NODE_IP:-10.8.30.40}"
+NODE_IP="${NODE_IP:-${ICN_NODE_HOST}}"
 COOPS=("alpha:30081" "beta:30082" "gamma:30083" "delta:30084")
 FED_ID="${FED_ID:-pilot-fed}"
 

--- a/docs/plans/2026-03-07-demo-system-implementation.md
+++ b/docs/plans/2026-03-07-demo-system-implementation.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Four live K3s coop nodes (alpha/beta/gamma/delta) are reseeded with canonical personas and story data. Bash flow scripts use `kubectl port-forward` to access each coop's gateway (ClusterIP-only, no NodePort on port 8080). A shared port library handles setup/teardown so each flow script stays focused on narration.
 
-**Tech Stack:** Bash, kubectl, curl, icnctl CLI, K3s cluster at 10.8.30.40, coop gateways behind ClusterIP services
+**Tech Stack:** Bash, kubectl, curl, icnctl CLI, K3s cluster at ${ICN_CLUSTER_ENDPOINT}, coop gateways behind ClusterIP services
 
 **Design doc:** `docs/plans/2026-03-07-demo-system-design.md`
 
@@ -16,10 +16,10 @@
 
 | Persona | Node | K8s Namespace | ClusterIP | Local port (port-forward) |
 |---|---|---|---|---|
-| BrightWorks Cooperative (worker) | icn-alpha | icn-coop-alpha | 10.43.97.80:8080 | 18081 |
-| River City Tool Library (resource) | icn-beta | icn-coop-beta | 10.43.194.7:8080 | 18082 |
-| Harbor Homes Cooperative (housing) | icn-gamma | icn-coop-gamma | 10.43.12.70:8080 | 18083 |
-| Finger Lakes CDN (intermediate org) | icn-delta | icn-coop-delta | 10.43.110.197:8080 | 18084 |
+| BrightWorks Cooperative (worker) | icn-alpha | icn-coop-alpha | 192.0.2.11:8080 | 18081 |
+| River City Tool Library (resource) | icn-beta | icn-coop-beta | 192.0.2.12:8080 | 18082 |
+| Harbor Homes Cooperative (housing) | icn-gamma | icn-coop-gamma | 192.0.2.13:8080 | 18083 |
+| Finger Lakes CDN (intermediate org) | icn-delta | icn-coop-delta | 192.0.2.14:8080 | 18084 |
 
 Use ports 18081–18084 to avoid collision with the main icn-daemon NodePort (30080).
 
@@ -32,7 +32,7 @@ Use ports 18081–18084 to avoid collision with the main icn-daemon NodePort (30
 kubectl get pods -A | grep -E "icn-(alpha|beta|gamma|delta)" | grep -v Succeeded
 
 # Confirm you can reach the main gateway
-curl -s http://10.8.30.40:30080/v1/health | python3 -m json.tool
+curl -s http://${ICN_CLUSTER_ENDPOINT}:30080/v1/health | python3 -m json.tool
 
 # Confirm kubectl works
 kubectl get nodes

--- a/docs/sdis/SDIS_API_GUIDE.md
+++ b/docs/sdis/SDIS_API_GUIDE.md
@@ -332,7 +332,7 @@ QR codes contain enrollment data:
   "type": "icn-enrollment",
   "enrollment_id": "enroll_abc123...",
   "challenge": "base64-challenge",
-  "gateway_url": "http://${ICN_GATEWAY_HOST}:30080"
+  "gateway_url": "http://<ICN_GATEWAY_HOST>:30080"
 }
 ```
 

--- a/docs/sdis/SDIS_API_GUIDE.md
+++ b/docs/sdis/SDIS_API_GUIDE.md
@@ -5,7 +5,7 @@ Complete guide to using the Secure Distributed Identity System (SDIS) API.
 ## Base URL
 
 ```
-http://10.8.30.40:30080/v1/sdis
+http://${ICN_GATEWAY_HOST}:30080/v1/sdis
 ```
 
 ## Authentication
@@ -29,7 +29,7 @@ kubectl exec -it -n icn $POD -- icnctl auth token --coop-id <COOP_ID> --gateway 
 Check if SDIS is operational.
 
 ```bash
-curl http://10.8.30.40:30080/v1/sdis/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 ```
 
 **Response:**
@@ -51,7 +51,7 @@ Begin the SDIS enrollment process to create a new identity.
 **POST** `/v1/sdis/enrollment/start`
 
 ```bash
-curl -X POST http://10.8.30.40:30080/v1/sdis/enrollment/start \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/enrollment/start \
   -H "Content-Type: application/json" \
   -d '{
     "identity_name": "Alice",
@@ -76,7 +76,7 @@ Finalize enrollment after verification.
 **POST** `/v1/sdis/enrollment/complete`
 
 ```bash
-curl -X POST http://10.8.30.40:30080/v1/sdis/enrollment/complete \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/enrollment/complete \
   -H "Content-Type: application/json" \
   -d '{
     "enrollment_id": "enroll_abc123...",
@@ -110,7 +110,7 @@ Verify device possession via QR scan.
 **POST** `/v1/sdis/verify/level1`
 
 ```bash
-curl -X POST http://10.8.30.40:30080/v1/sdis/verify/level1 \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/verify/level1 \
   -H "Content-Type: application/json" \
   -d '{
     "enrollment_id": "enroll_abc123...",
@@ -125,7 +125,7 @@ Get vouched by a trusted steward.
 **POST** `/v1/sdis/verify/level2`
 
 ```bash
-curl -X POST http://10.8.30.40:30080/v1/sdis/verify/level2 \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/verify/level2 \
   -H "Authorization: Bearer <steward-token>" \
   -H "Content-Type: application/json" \
   -d '{
@@ -145,7 +145,7 @@ Get all trusted devices for a specific anchor.
 **GET** `/v1/sdis/anchor/{anchor_id}/devices`
 
 ```bash
-curl http://10.8.30.40:30080/v1/sdis/anchor/anchor_123/devices \
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/anchor/anchor_123/devices \
   -H "Authorization: Bearer <your-token>"
 ```
 
@@ -170,7 +170,7 @@ Add a new anchor device.
 **POST** `/v1/sdis/anchor/devices/add`
 
 ```bash
-curl -X POST http://10.8.30.40:30080/v1/sdis/anchor/devices/add \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/anchor/devices/add \
   -H "Authorization: Bearer <your-token>" \
   -H "Content-Type: application/json" \
   -d '{
@@ -187,7 +187,7 @@ Get anchor metadata and rotation/device information.
 **GET** `/v1/sdis/anchor/{anchor_id}`
 
 ```bash
-curl http://10.8.30.40:30080/v1/sdis/anchor/anchor_123 \
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/anchor/anchor_123 \
   -H "Authorization: Bearer <your-token>"
 ```
 
@@ -198,7 +198,7 @@ Rotate keys for an existing anchor.
 **POST** `/v1/sdis/anchor/rotate-keys`
 
 ```bash
-curl -X POST http://10.8.30.40:30080/v1/sdis/anchor/rotate-keys \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/anchor/rotate-keys \
   -H "Authorization: Bearer <your-token>" \
   -H "Content-Type: application/json" \
   -d '{
@@ -224,7 +224,7 @@ Start identity recovery ceremony using anchor/vui context and verification data.
 **POST** `/v1/sdis/recovery/start`
 
 ```bash
-curl -X POST http://10.8.30.40:30080/v1/sdis/recovery/start \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/recovery/start \
   -H "Content-Type: application/json" \
   -d '{
     "anchor_id": "anchor_123",
@@ -251,7 +251,7 @@ curl -X POST http://10.8.30.40:30080/v1/sdis/recovery/start \
 **GET** `/v1/sdis/recovery/{recovery_id}`
 
 ```bash
-curl http://10.8.30.40:30080/v1/sdis/recovery/recovery_xyz... \
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/recovery/recovery_xyz... \
   -H "Authorization: Bearer <your-token>"
 ```
 
@@ -262,7 +262,7 @@ Finalize recovery with challenge response.
 **POST** `/v1/sdis/recovery/{recovery_id}/complete`
 
 ```bash
-curl -X POST http://10.8.30.40:30080/v1/sdis/recovery/recovery_xyz.../complete \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/recovery/recovery_xyz.../complete \
   -H "Content-Type: application/json" \
   -d '{
     "recovery_share": "optional-share-fragment"
@@ -280,7 +280,7 @@ Get a temporary DID for device pairing.
 **POST** `/v1/sdis/ephemeral/generate`
 
 ```bash
-curl -X POST http://10.8.30.40:30080/v1/sdis/ephemeral/generate \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/ephemeral/generate \
   -H "Content-Type: application/json" \
   -d '{
     "purpose": "enrollment",
@@ -332,7 +332,7 @@ QR codes contain enrollment data:
   "type": "icn-enrollment",
   "enrollment_id": "enroll_abc123...",
   "challenge": "base64-challenge",
-  "gateway_url": "http://10.8.30.40:30080"
+  "gateway_url": "http://${ICN_GATEWAY_HOST}:30080"
 }
 ```
 
@@ -408,17 +408,17 @@ Test the full flow:
 
 ```bash
 # 1. Health check
-curl http://10.8.30.40:30080/v1/sdis/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 
 # 2. Start enrollment
-ENROLLMENT=$(curl -X POST http://10.8.30.40:30080/v1/sdis/enrollment/start \
+ENROLLMENT=$(curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/enrollment/start \
   -H "Content-Type: application/json" \
   -d '{"identity_name":"TestUser","coop_id":"test-coop"}' | jq -r '.enrollment_id')
 
 echo "Enrollment ID: $ENROLLMENT"
 
 # 3. Generate ephemeral DID for device
-EPHEMERAL=$(curl -X POST http://10.8.30.40:30080/v1/sdis/ephemeral/generate \
+EPHEMERAL=$(curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/ephemeral/generate \
   -H "Content-Type: application/json" \
   -d '{"purpose":"enrollment","ttl_seconds":3600}' | jq -r '.ephemeral_did')
 

--- a/docs/sdis/SDIS_DEPLOYMENT_STATUS.md
+++ b/docs/sdis/SDIS_DEPLOYMENT_STATUS.md
@@ -8,9 +8,9 @@
 ## 🎯 What's Working Now
 
 ### 1. ICN Gateway Deployed ✅
-- **URL:** `http://10.8.30.40:30080`
-- **Health Check:** `http://10.8.30.40:30080/v1/health` → Working
-- **SDIS Health:** `http://10.8.30.40:30080/v1/sdis/health` → Working
+- **URL:** `http://${ICN_GATEWAY_HOST}:30080`
+- **Health Check:** `http://${ICN_GATEWAY_HOST}:30080/v1/health` → Working
+- **SDIS Health:** `http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health` → Working
 
 ### 2. SDIS API Endpoints ✅
 All SDIS endpoints are deployed and accessible:
@@ -52,7 +52,7 @@ icn/crates/icn-gateway/src/api/sdis/
 ```
 
 ### 4. Pilot UI Deployed ✅
-- **URL:** `http://10.8.30.40:30030`
+- **URL:** `http://${ICN_GATEWAY_HOST}:30030`
 - Static files served via nginx
 - Ready for SDIS UI integration
 
@@ -168,22 +168,22 @@ Level 3: Anchor Created    → Permanent DID issued
 
 ### Test SDIS Health
 ```bash
-curl http://10.8.30.40:30080/v1/sdis/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 ```
 
 ### Test Gateway Health
 ```bash
-curl http://10.8.30.40:30080/v1/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health
 ```
 
 ### Check Pod Status
 ```bash
-ssh ubuntu@10.8.30.40 'sudo kubectl get pods -n icn'
+ssh ubuntu@${ICN_GATEWAY_HOST} 'sudo kubectl get pods -n icn'
 ```
 
 ### View Gateway Logs
 ```bash
-ssh ubuntu@10.8.30.40 'sudo kubectl logs -n icn -l component=daemon --tail=50'
+ssh ubuntu@${ICN_GATEWAY_HOST} 'sudo kubectl logs -n icn -l component=daemon --tail=50'
 ```
 
 ---

--- a/docs/sdis/SDIS_DEPLOYMENT_STATUS.md
+++ b/docs/sdis/SDIS_DEPLOYMENT_STATUS.md
@@ -178,12 +178,12 @@ curl http://${ICN_GATEWAY_HOST}:30080/v1/health
 
 ### Check Pod Status
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST} 'sudo kubectl get pods -n icn'
+ssh ubuntu@${ICN_K3S_CONTROL} 'sudo kubectl get pods -n icn'
 ```
 
 ### View Gateway Logs
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST} 'sudo kubectl logs -n icn -l component=daemon --tail=50'
+ssh ubuntu@${ICN_K3S_CONTROL} 'sudo kubectl logs -n icn -l component=daemon --tail=50'
 ```
 
 ---

--- a/docs/sdis/SDIS_SESSION_COMPLETE.md
+++ b/docs/sdis/SDIS_SESSION_COMPLETE.md
@@ -292,7 +292,7 @@ cd /home/matt/projects/icn/deploy/k8s
 make full-deploy-with-ui
 
 # Test enrollment endpoint
-curl -X POST http://10.8.30.40:30080/v1/sdis/enrollment/start \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/enrollment/start \
   -H "Content-Type: application/json" \
   -d '{
     "pathway": {"type": "genesis", "reason": "Testing"},

--- a/docs/sdis/SDIS_STATUS.md
+++ b/docs/sdis/SDIS_STATUS.md
@@ -53,7 +53,7 @@ Base route: **`/v1/sdis`**
 
 **Verified Working:**
 ```bash
-$ curl http://10.8.30.40:30080/v1/sdis/health
+$ curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 {"status":"healthy","timestamp":"2025-12-12T22:00:00Z"}
 ```
 
@@ -158,13 +158,13 @@ $ curl http://10.8.30.40:30080/v1/sdis/health
 1. **Test SDIS API end-to-end:**
    ```bash
    # Test enrollment
-   curl -X POST http://10.8.30.40:30080/v1/sdis/enrollment/start \
+   curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/enrollment/start \
      -H "Content-Type: application/json" \
      -d '{"identity_name":"TestUser","coop_id":"test-coop"}'
    ```
 
 2. **Verify Pilot UI enrollment wizard:**
-   - Access Pilot UI at `http://10.8.30.40:30030`
+   - Access Pilot UI at `http://${ICN_GATEWAY_HOST}:30030`
    - Test enrollment flow
    - Verify QR code generation
    - Test verification levels
@@ -237,10 +237,10 @@ $ curl http://10.8.30.40:30080/v1/sdis/health
 
 ```bash
 # 1. Health check
-curl http://10.8.30.40:30080/v1/sdis/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 
 # 2. Start enrollment
-ENROLLMENT=$(curl -X POST http://10.8.30.40:30080/v1/sdis/enrollment/start \
+ENROLLMENT=$(curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/enrollment/start \
   -H "Content-Type: application/json" \
   -d '{"identity_name":"Alice","coop_id":"test-coop"}' \
   | jq -r '.enrollment_id')
@@ -248,7 +248,7 @@ ENROLLMENT=$(curl -X POST http://10.8.30.40:30080/v1/sdis/enrollment/start \
 echo "Enrollment ID: $ENROLLMENT"
 
 # 3. Generate ephemeral DID
-EPHEMERAL=$(curl -X POST http://10.8.30.40:30080/v1/sdis/ephemeral/generate \
+EPHEMERAL=$(curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/ephemeral/generate \
   -H "Content-Type: application/json" \
   -d '{"purpose":"enrollment","ttl_seconds":3600}' \
   | jq -r '.ephemeral_did')
@@ -262,7 +262,7 @@ TOKEN=$(kubectl exec -it -n icn $POD -- icnctl auth token \
   --gateway http://localhost:8080)
 
 # 5. Steward vouches for enrollment
-curl -X POST http://10.8.30.40:30080/v1/sdis/verify/level2 \
+curl -X POST http://${ICN_GATEWAY_HOST}:30080/v1/sdis/verify/level2 \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d "{\"enrollment_id\":\"$ENROLLMENT\",\"vouch_statement\":\"I vouch for Alice\"}"
@@ -272,7 +272,7 @@ curl -X POST http://10.8.30.40:30080/v1/sdis/verify/level2 \
 
 1. **Access Pilot UI:**
    ```
-   http://10.8.30.40:30030
+   http://${ICN_GATEWAY_HOST}:30030
    ```
 
 2. **Test enrollment flow:**

--- a/docs/state/ICN-Platform-Baseline-2026-03.md
+++ b/docs/state/ICN-Platform-Baseline-2026-03.md
@@ -150,7 +150,7 @@ not attested receipts.
 `cargo-tarpaulin` v0.35.2 consistently times out on GitHub-hosted runners due to
 instrumented build time. The gate is classified `observational` (does not block merges).
 Resolution options include scoping tarpaulin to a subset of crates or switching to the
-self-hosted `ci-runner` at `10.8.30.46`. No resolution is required before Sprint 24 begins.
+self-hosted `ci-runner` at `${ICN_CI_RUNNER_HOST}`. No resolution is required before Sprint 24 begins.
 See `ops/state/ci-exceptions.md` for full technical detail.
 
 ### Commons Compute Layer — Not Yet Started
@@ -201,6 +201,6 @@ Full Sprint 24 planning is out of scope for this document.
 | Kernel API | `icn/crates/icn-kernel-api/src/` |
 | Storage spec | `docs/state/storage-governance-spec.md` |
 | Gateway port | 8080 (local), 30080 (K3s NodePort) |
-| K3s cluster | control `10.8.30.40`, workers `.41` `.42` (VLAN 30) |
+| K3s cluster | control `${ICN_K3S_CONTROL}`, workers `${ICN_K3S_WORKER1}` `${ICN_K3S_WORKER2}` (VLAN 30) |
 | Demo flows | `demo/scripts/flow-1-governance.sh`, `flow-2-patronage.sh`, `flow-3-federation.sh` |
 | Demo entry point | `demo/scripts/present-governance.sh --port 9080` |

--- a/docs/state/demo-path-2026-03.md
+++ b/docs/state/demo-path-2026-03.md
@@ -43,7 +43,7 @@ The following Sprint 23 items do NOT affect demo execution:
 ## Prerequisites
 
 **For K3s cluster flows (flow-1, flow-2, flow-3)**:
-- `kubectl` with access to the K3s cluster at 10.8.30.40
+- `kubectl` with access to the K3s cluster at ${ICN_CLUSTER_ENDPOINT}
 - `icnctl` binary present inside each cooperative pod (confirmed present)
 - `python3` (for JSON parsing in scripts)
 - All four gateways reachable via `kubectl port-forward`

--- a/docs/status/demo-audit-2026-03-19.md
+++ b/docs/status/demo-audit-2026-03-19.md
@@ -1,6 +1,6 @@
 # Demo Audit — 2026-03-19
 
-**Cluster target:** K3s at 10.8.30.40:30080
+**Cluster target:** K3s at ${ICN_GATEWAY_HOST}:30080
 **Auditor:** Claude Code (s15-t1)
 **Reseed:** `reseed-federation-demo.sh` — seeded 4, skipped 9, failed 0
 **Timestamp:** 2026-03-19, sprint 15 phase B

--- a/docs/strategy/ICN-Evolution-Arc.md
+++ b/docs/strategy/ICN-Evolution-Arc.md
@@ -197,11 +197,11 @@ The language shift is telling. August 2025: "here is the exact bytecode and wire
 
 ### K3s Deployment: December 3, 2025
 
-ICN deploys to a real K3s cluster: three nodes at 10.8.30.40-42. No longer specification. Running code.
+ICN deploys to a real K3s cluster: three nodes on the private cluster (operator-supplied node range). No longer specification. Running code.
 
 ### The VLAN Migration: February 28, 2026
 
-K3s migrates from VLAN 10 to VLAN 30 (10.8.30.40-42) — same VLAN as icn-dev. Flannel reconfigured, NFS ACLs fixed, DNS updated, SOPS/Age secrets management deployed. This is production infrastructure work.
+K3s migrates from VLAN 10 to VLAN 30 (private cluster node range — operator-supplied) — same VLAN as icn-dev. Flannel reconfigured, NFS ACLs fixed, DNS updated, SOPS/Age secrets management deployed. This is production infrastructure work.
 
 ### The Governance Demo Sprint: March 13-14, 2026
 

--- a/docs/strategy/ICN-Sprint-March17.md
+++ b/docs/strategy/ICN-Sprint-March17.md
@@ -143,7 +143,7 @@ Sprint is complete when:
 
 Right now, in order:
 
-1. **SSH into icn-dev** (10.8.30.45). Check `icnd` is running on K3s. If not, start it with `--gateway-enable`.
+1. **SSH into icn-dev** (operator-supplied host). Check `icnd` is running on K3s. If not, start it with `--gateway-enable`.
 2. **Run `demo-governance.py`** against the live gateway. Record output.
 3. **Hit the proof endpoint** manually: `curl https://<gateway>/v1/gov/proposals/{id}/proof`. See what comes back.
 4. **Run the other 3 demo scripts** (patronage, federation, reporting). Record what passes and what breaks.

--- a/docs/superpowers/plans/2026-03-22-sprint-23-baseline-lock.md
+++ b/docs/superpowers/plans/2026-03-22-sprint-23-baseline-lock.md
@@ -963,7 +963,7 @@ All hardcoded policy constants extracted to typed configuration structs:
 
 **Infrastructure:**
 - K3s cluster (3 workers + control) — deployed Dec 2025, migrated VLAN 30 Feb 2026
-- Registry at 10.8.30.40:30500, gateway at :30080, Pilot UI at :30030
+- Registry at ${ICN_NODE_HOST}:30500, gateway at :30080, Pilot UI at :30030
 - Prometheus + Grafana at :30090 / :30300
 - Backup CronJobs running (etcd-snapshot + ICN state backup)
 
@@ -1126,7 +1126,7 @@ Record actual output. This demonstrates: three autonomous nodes, cross-coop coor
 
 **Date:** 2026-03-22
 **Branch:** main
-**Cluster:** Local devnet (localhost) OR K3s (10.8.30.40)
+**Cluster:** Local devnet (localhost) OR K3s (${ICN_NODE_HOST})
 
 > This document is tested against reality. Commands are exact.
 > If something fails, update the doc — do not leave aspirational commands.

--- a/docs/superpowers/specs/2026-03-22-coverage-ci-decision.md
+++ b/docs/superpowers/specs/2026-03-22-coverage-ci-decision.md
@@ -88,7 +88,7 @@ Full inventory of accessible nodes from icn-dev:
 | **k3s-worker-1** | ${ICN_K3S_WORKER1} | i5-6500 4c/4t @ 3.2GHz | 15GB | **14GB** | 28GB | ICN pods; no Rust installed; disk may be tight |
 | **k3s-worker-2** | ${ICN_K3S_WORKER2} | i5-6500 4c/4t @ 3.2GHz | 15GB | **14GB** | 29GB | ICN pods; no Rust installed; disk may be tight |
 | **Hyperion** | ${ICN_HYPERION_HOST} | Ryzen 9 3900X 12c/24t | 15GB (bad) | — | — | Proxmox; RAM RMA in progress; offline for CI |
-| **Zentith** | ${ICN_ZENITH_HOST} | Ryzen 7 7800X3D 8c/16t | **54GB** | high | — | Matt's workstation; WSL2 Ubuntu 24.04; strongest available |
+| **Zentith** | ${ICN_WORKSTATION_HOST} | Ryzen 7 7800X3D 8c/16t | **54GB** | high | — | Matt's workstation; WSL2 Ubuntu 24.04; strongest available |
 
 Proxmox nodes node-1 through node-4 (operator-supplied range): SSH not authorized from icn-dev; capacity unknown.
 

--- a/docs/superpowers/specs/2026-03-22-coverage-ci-decision.md
+++ b/docs/superpowers/specs/2026-03-22-coverage-ci-decision.md
@@ -10,10 +10,10 @@
 
 - `.github/workflows/ci.yml` (lines 414–466, the `coverage` job)
 - `ops/state/ci-exceptions.md` (exception classification from s23-t1)
-- ci-runner (10.8.30.46) — SSH live testing
-- k3s-worker-1 (10.8.30.41) — SSH census
-- k3s-worker-2 (10.8.30.42) — SSH census
-- k3s-control (10.8.30.40) — SSH census
+- ci-runner (${ICN_CI_RUNNER_HOST}) — SSH live testing
+- k3s-worker-1 (${ICN_K3S_WORKER1}) — SSH census
+- k3s-worker-2 (${ICN_K3S_WORKER2}) — SSH census
+- k3s-control (${ICN_K3S_CONTROL}) — SSH census
 
 ---
 
@@ -51,7 +51,7 @@ This is not OOM. It is spot preemption — the runner is killed mid-build becaus
 
 ### What was tested
 
-Attempted two runs of `cargo-llvm-cov` on ci-runner (10.8.30.46):
+Attempted two runs of `cargo-llvm-cov` on ci-runner (${ICN_CI_RUNNER_HOST}):
 
 **Run 1 — full workspace:**
 ```bash
@@ -83,14 +83,14 @@ Full inventory of accessible nodes from icn-dev:
 
 | Node | IP | CPU | RAM | RAM Free | Disk Free | Notes |
 |------|-----|-----|-----|----------|-----------|-------|
-| **ci-runner** | 10.8.30.46 | i7-7700K 4c/4t @ 4.2GHz | 3.8GB | ~0.3GB | 39GB | Hyperion VM 446; current GH runner; **proven insufficient** |
-| **k3s-control** | 10.8.30.40 | 4c | 7.8GB | 6.5GB | unknown | Control plane, tainted NoSchedule; not a CI candidate |
-| **k3s-worker-1** | 10.8.30.41 | i5-6500 4c/4t @ 3.2GHz | 15GB | **14GB** | 28GB | ICN pods; no Rust installed; disk may be tight |
-| **k3s-worker-2** | 10.8.30.42 | i5-6500 4c/4t @ 3.2GHz | 15GB | **14GB** | 29GB | ICN pods; no Rust installed; disk may be tight |
-| **Hyperion** | 10.8.10.15 | Ryzen 9 3900X 12c/24t | 15GB (bad) | — | — | Proxmox; RAM RMA in progress; offline for CI |
-| **Zentith** | 10.8.10.100 | Ryzen 7 7800X3D 8c/16t | **54GB** | high | — | Matt's workstation; WSL2 Ubuntu 24.04; strongest available |
+| **ci-runner** | ${ICN_CI_RUNNER_HOST} | i7-7700K 4c/4t @ 4.2GHz | 3.8GB | ~0.3GB | 39GB | Hyperion VM 446; current GH runner; **proven insufficient** |
+| **k3s-control** | ${ICN_K3S_CONTROL} | 4c | 7.8GB | 6.5GB | unknown | Control plane, tainted NoSchedule; not a CI candidate |
+| **k3s-worker-1** | ${ICN_K3S_WORKER1} | i5-6500 4c/4t @ 3.2GHz | 15GB | **14GB** | 28GB | ICN pods; no Rust installed; disk may be tight |
+| **k3s-worker-2** | ${ICN_K3S_WORKER2} | i5-6500 4c/4t @ 3.2GHz | 15GB | **14GB** | 29GB | ICN pods; no Rust installed; disk may be tight |
+| **Hyperion** | ${ICN_HYPERION_HOST} | Ryzen 9 3900X 12c/24t | 15GB (bad) | — | — | Proxmox; RAM RMA in progress; offline for CI |
+| **Zentith** | ${ICN_ZENITH_HOST} | Ryzen 7 7800X3D 8c/16t | **54GB** | high | — | Matt's workstation; WSL2 Ubuntu 24.04; strongest available |
 
-Proxmox nodes node-1 through node-4 (10.8.10.11–14): SSH not authorized from icn-dev; capacity unknown.
+Proxmox nodes node-1 through node-4 (operator-supplied range): SSH not authorized from icn-dev; capacity unknown.
 
 ---
 

--- a/docs/superpowers/specs/2026-03-22-flow2-repair-checklist.md
+++ b/docs/superpowers/specs/2026-03-22-flow2-repair-checklist.md
@@ -29,7 +29,7 @@ have been run against the current cluster. Pod rebuilds change the DID.
 
 ## Pre-Conditions
 
-- K3s cluster is running (k3s-control at 10.8.30.40, workers at .41/.42)
+- K3s cluster is running (k3s-control at ${ICN_K3S_CONTROL}, workers at ${ICN_K3S_WORKER1}/${ICN_K3S_WORKER2})
 - `kubectl` access from icn-dev
 - `demo/scripts/reseed-federation-demo.sh` exists and is runnable
 - NodePort access: `localhost:18081` routes to BrightWorks node gateway (K3s mode)
@@ -50,7 +50,7 @@ If pods are down, start the cluster before continuing. This checklist assumes ru
 ### Step 2 — Verify NodePort routing
 
 ```bash
-# From icn-dev (10.8.30.45), test the BrightWorks gateway health endpoint
+# From icn-dev (${ICN_DEV_HOST}), test the BrightWorks gateway health endpoint
 curl -s http://localhost:18081/v1/health
 # Expected: 200 with JSON body
 # If: connection refused → NodePort 18081 not mapped, check K3s service config
@@ -189,7 +189,7 @@ Sprint 24 kickoff on #925/#947/#964 can proceed without this as a distraction.
 **Method:** kubectl port-forward + icnctl auth token + direct curl
 
 ### Environment
-- icn-dev (10.8.30.45), kubectl access to K3s cluster
+- icn-dev (${ICN_DEV_HOST}), kubectl access to K3s cluster
 - `kubectl port-forward -n icn-coop-alpha svc/icn-alpha 18081:8080`
 - Token acquired via `kubectl exec ... icnctl auth token --coop-id brightworks-cooperative`
 

--- a/docs/superpowers/specs/2026-03-22-zenith-coverage-runner-setup.md
+++ b/docs/superpowers/specs/2026-03-22-zenith-coverage-runner-setup.md
@@ -231,7 +231,7 @@ If Zenith goes offline after the PR merges and the `coverage` label has no activ
 
 If k3s-worker becomes the temporary fallback:
 ```bash
-# On k3s-worker-1 (${ICN_NODE_HOST}, 15GB RAM, 28GB disk):
+# On k3s-worker-1 (${ICN_K3S_WORKER1}, 15GB RAM, 28GB disk):
 curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0
 source ~/.cargo/env
 rustup component add llvm-tools-preview

--- a/docs/superpowers/specs/2026-03-22-zenith-coverage-runner-setup.md
+++ b/docs/superpowers/specs/2026-03-22-zenith-coverage-runner-setup.md
@@ -231,7 +231,7 @@ If Zenith goes offline after the PR merges and the `coverage` label has no activ
 
 If k3s-worker becomes the temporary fallback:
 ```bash
-# On k3s-worker-1 (10.8.30.41, 15GB RAM, 28GB disk):
+# On k3s-worker-1 (${ICN_NODE_HOST}, 15GB RAM, 28GB disk):
 curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0
 source ~/.cargo/env
 rustup component add llvm-tools-preview

--- a/docs/testing/MOBILE_APP_TESTING_GUIDE.md
+++ b/docs/testing/MOBILE_APP_TESTING_GUIDE.md
@@ -5,7 +5,7 @@
 - ✅ Node.js v20.19.4 (installed)
 - ✅ npm v11.7.0 (installed)
 - ✅ Expo v54.0.19 (installed)
-- ✅ ICN Gateway running at http://10.8.30.40:30080
+- ✅ ICN Gateway running at http://${ICN_GATEWAY_HOST}:30080
 
 ## Option 1: Test in Web Browser (Easiest) 🌐
 
@@ -99,8 +99,8 @@ npm run ios
 
 1. **App launches** - You'll see the Login screen
 
-2. **Enter Gateway URL**: `http://10.8.30.40:30080`
-   - If testing from phone and can't reach 10.8.30.40, use tunnel mode or your computer's IP
+2. **Enter Gateway URL**: `http://${ICN_GATEWAY_HOST}:30080`
+   - If testing from phone and can't reach ${ICN_GATEWAY_HOST}, use tunnel mode or your computer's IP
 
 3. **Choose Login Method**:
 
@@ -154,7 +154,7 @@ The app is pre-configured for your homelab deployment:
 
 **File**: `src/config.ts`
 ```typescript
-export const GATEWAY_URL = 'http://10.8.30.40:30080';
+export const GATEWAY_URL = 'http://${ICN_GATEWAY_HOST}:30080';
 ```
 
 To change gateway URL:
@@ -168,17 +168,17 @@ To change gateway URL:
 
 ### Test Gateway from Your Computer
 ```bash
-curl http://10.8.30.40:30080/v1/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health
 # Should return: {"status":"ok","version":"0.1.0"}
 ```
 
 ### Test Gateway from Your Phone's Network
 If you can access your homelab from your phone:
 ```bash
-curl http://10.8.30.40:30080/v1/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health
 ```
 
-If you can't reach 10.8.30.40 from your phone:
+If you can't reach ${ICN_GATEWAY_HOST} from your phone:
 - Use tunnel mode: `npx expo start --tunnel`
 - Or update gateway URL to your computer's IP
 
@@ -193,8 +193,8 @@ If you can't reach 10.8.30.40 from your phone:
 
 ### "Network request failed" in app
 - Gateway URL might be incorrect
-- Phone can't reach 10.8.30.40 (use tunnel or your computer's IP)
-- Test connectivity: `curl http://10.8.30.40:30080/v1/health`
+- Phone can't reach ${ICN_GATEWAY_HOST} (use tunnel or your computer's IP)
+- Test connectivity: `curl http://${ICN_GATEWAY_HOST}:30080/v1/health`
 
 ### "Authentication failed"
 - Make sure you completed the enrollment or have valid credentials
@@ -237,18 +237,18 @@ npx expo start --clear
 
 ### Check if gateway is healthy
 ```bash
-curl http://10.8.30.40:30080/v1/health
-curl http://10.8.30.40:30080/v1/sdis/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 ```
 
 ### View gateway logs
 ```bash
-ssh ubuntu@10.8.30.40 "sudo kubectl -n icn logs -f deployment/icn-daemon"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn logs -f deployment/icn-daemon"
 ```
 
 ### Check pod status
 ```bash
-ssh ubuntu@10.8.30.40 "sudo kubectl -n icn get pods"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn get pods"
 ```
 
 ---

--- a/docs/testing/MOBILE_APP_TESTING_GUIDE.md
+++ b/docs/testing/MOBILE_APP_TESTING_GUIDE.md
@@ -154,7 +154,7 @@ The app is pre-configured for your homelab deployment:
 
 **File**: `src/config.ts`
 ```typescript
-export const GATEWAY_URL = 'http://${ICN_GATEWAY_HOST}:30080';
+export const GATEWAY_URL = 'http://<ICN_GATEWAY_HOST>:30080';
 ```
 
 To change gateway URL:
@@ -243,12 +243,12 @@ curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 
 ### View gateway logs
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn logs -f deployment/icn-daemon"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn logs -f deployment/icn-daemon"
 ```
 
 ### Check pod status
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn get pods"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn get pods"
 ```
 
 ---

--- a/docs/testing/QUICK_MOBILE_TEST.md
+++ b/docs/testing/QUICK_MOBILE_TEST.md
@@ -56,7 +56,7 @@ curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 ## Common Issues
 
 ### "Cannot connect to gateway"
-- Check gateway is running: `ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn get pods"`
+- Check gateway is running: `ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn get pods"`
 - Test endpoint: `curl http://${ICN_GATEWAY_HOST}:30080/v1/health`
 
 ### "Authentication failed"
@@ -99,12 +99,12 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 ### Check Pod Status
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn get pods"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn get pods"
 ```
 
 ### View Logs
 ```bash
-ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn logs -f deployment/icn-daemon"
+ssh ubuntu@${ICN_K3S_CONTROL} "sudo kubectl -n icn logs -f deployment/icn-daemon"
 ```
 
 ### Grafana Dashboard

--- a/docs/testing/QUICK_MOBILE_TEST.md
+++ b/docs/testing/QUICK_MOBILE_TEST.md
@@ -2,7 +2,7 @@
 
 ## ✅ Status: Ready for Testing
 
-**Gateway**: http://10.8.30.40:30080
+**Gateway**: http://${ICN_GATEWAY_HOST}:30080
 **Last Updated**: 2025-12-16
 
 ---
@@ -19,7 +19,7 @@ Press `i` for iOS, `a` for Android, or `w` for web.
 
 ### 2. First Time Setup
 In the app:
-1. Enter Gateway URL: `http://10.8.30.40:30080`
+1. Enter Gateway URL: `http://${ICN_GATEWAY_HOST}:30080`
 2. Enter Cooperative ID: `test-coop`
 3. Choose "New Identity" or "Import Existing"
 
@@ -36,13 +36,13 @@ In the app:
 
 ### Check Gateway Health
 ```bash
-curl http://10.8.30.40:30080/v1/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/health
 # Should return: {"status":"ok","version":"0.1.0"}
 ```
 
 ### Check SDIS Health
 ```bash
-curl http://10.8.30.40:30080/v1/sdis/health
+curl http://${ICN_GATEWAY_HOST}:30080/v1/sdis/health
 # Should return: {"service":"sdis","status":"ok","version":"1.0"}
 ```
 
@@ -56,12 +56,12 @@ curl http://10.8.30.40:30080/v1/sdis/health
 ## Common Issues
 
 ### "Cannot connect to gateway"
-- Check gateway is running: `ssh ubuntu@10.8.30.40 "sudo kubectl -n icn get pods"`
-- Test endpoint: `curl http://10.8.30.40:30080/v1/health`
+- Check gateway is running: `ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn get pods"`
+- Test endpoint: `curl http://${ICN_GATEWAY_HOST}:30080/v1/health`
 
 ### "Authentication failed"
 - Make sure you created an identity first
-- Check gateway URL is exactly `http://10.8.30.40:30080` (no trailing slash)
+- Check gateway URL is exactly `http://${ICN_GATEWAY_HOST}:30080` (no trailing slash)
 
 ### "Balance shows as 0"
 - This is normal for new identities
@@ -82,7 +82,7 @@ ICN_PASSPHRASE="test" ./target/release/icnctl id init
 ### Get Auth Token
 ```bash
 ICN_PASSPHRASE="test" ./target/release/icnctl auth token \
-  --gateway http://10.8.30.40:30080 \
+  --gateway http://${ICN_GATEWAY_HOST}:30080 \
   --coop-id test-coop
 ```
 
@@ -90,7 +90,7 @@ ICN_PASSPHRASE="test" ./target/release/icnctl auth token \
 ```bash
 TOKEN="<your-token-here>"
 curl -H "Authorization: Bearer $TOKEN" \
-  http://10.8.30.40:30080/v1/ledger/test-coop/balance/<your-did>
+  http://${ICN_GATEWAY_HOST}:30080/v1/ledger/test-coop/balance/<your-did>
 ```
 
 ---
@@ -99,16 +99,16 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 ### Check Pod Status
 ```bash
-ssh ubuntu@10.8.30.40 "sudo kubectl -n icn get pods"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn get pods"
 ```
 
 ### View Logs
 ```bash
-ssh ubuntu@10.8.30.40 "sudo kubectl -n icn logs -f deployment/icn-daemon"
+ssh ubuntu@${ICN_GATEWAY_HOST} "sudo kubectl -n icn logs -f deployment/icn-daemon"
 ```
 
 ### Grafana Dashboard
-Open: http://10.8.30.40:30300
+Open: http://${ICN_GATEWAY_HOST}:30300
 
 ---
 

--- a/docs/vision/COOPOS.md
+++ b/docs/vision/COOPOS.md
@@ -332,7 +332,7 @@ workstation_policy:
     allow_usb_storage: false
 
   network:
-    dns_servers: [10.0.0.1, 10.0.0.2]  # Org DNS
+    dns_servers: [192.0.2.10, 192.0.2.11]  # Org DNS
     proxy: http://proxy.foodcoop.internal:8080
 
   sync:

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -126,6 +126,101 @@ def scan_public_map_boundary(root: Path) -> None:
             )
 
 
+# ---------------------------------------------------------------------------
+# Public docs/agent/test address boundary guard (icn#2393). The non-runtime
+# public surfaces cleaned in the #2393 docs slice must never carry a concrete
+# provider IPv4/IPv6 host address. Reuses the #2392 IPv4 regex/allowlist; the
+# IPv6 rule is tightened (bracketed [..] OR >=3 hextets) so hex-looking Rust
+# paths / capability-action strings (e.g. `aead::`, `read::write`) are NOT
+# false-flagged. HARD failure, value always withheld. Hostname detection is
+# intentionally omitted here — on prose it false-positives on filenames like
+# `.env.local` and illustrative `*.internal`/`*.example` config; the §5
+# provider concern on these surfaces is IP literals.
+_PUBLIC_DOCS_DIRS = ("docs", ".claude", ".agents")   # scanned recursively for *.md
+_PUBLIC_DOCS_EXTRA = (                                # specific non-.md cleaned surfaces
+    "CHANGELOG.md",
+    "web/pilot-ui/tests/steward-gateway-url.test.js",
+)
+# Deferred to a separate targeted review (NOT ATLAS §5 provider topology, so
+# excluded to keep this guard free of false positives): IPv6 address-TYPE
+# illustrations (ULA / global / link-local / CGN format examples in
+# protocol-design docs) and Rust-syntax / capability-action-string matches.
+_PUBLIC_DOCS_EXCLUDE = frozenset({
+    "docs/adr/ADR-0003-ipv6-dual-stack-transport-with-endpoint-sets.md",
+    "docs/architecture/ARCHITECTURE_MAP.md",
+    "docs/design/ipv6-endpoint-sets-design.md",
+    "docs/features/ACTION_ITEMS_EXCHANGE.md",
+    "docs/plans/2026-02-23-authz-capability-graph-design.md",
+    "docs/plans/2026-02-23-authz-capability-graph-impl-plan.md",
+})
+
+
+def docs_address_violations(text: str) -> list[tuple[int, str]]:
+    """Return [(line_no, category)] for disallowed concrete host literals in a
+    cleaned public-docs surface. Never includes the value. Category is
+    'ipv4-host' or 'ipv6-host'. Allowed: loopback / bind-all / QEMU slirp alias
+    / RFC5737 (v4); ::1 / :: / RFC3849 2001:db8::/32 (v6). IPv6 is flagged only
+    when bracketed ([..]) or written with >=3 hextets, so hex-looking
+    identifiers such as `aead::` or `read::write` are not false-flagged."""
+    out: list[tuple[int, str]] = []
+    for i, line in enumerate(text.splitlines(), 1):
+        for m in _IPV4_RE.finditer(line):
+            if not _IPV4_ALLOWED_RE.match(m.group(0)):
+                out.append((i, "ipv4-host"))
+                break
+        for m in _IPV6_RE.finditer(line):
+            tok = m.group(0)
+            if _IPV6_ALLOWED_RE.match(tok):
+                continue
+            s, e = m.start(), m.end()
+            bracketed = s > 0 and line[s - 1] == "[" and e < len(line) and line[e] == "]"
+            hextets = [g for g in tok.split(":") if g]
+            if bracketed or len(hextets) >= 3:
+                out.append((i, "ipv6-host"))
+                break
+    return out
+
+
+def scan_public_docs_boundary(root: Path) -> None:
+    """HARD-fail if a cleaned public docs/agent/test surface (icn#2393 slice)
+    carries a concrete provider IPv4/IPv6 host address — public icn must not
+    (docs/ATLAS.md §5; icn-infra ADR-0005). Never echoes the offending value;
+    fails closed on unreadable/undecodable surfaces."""
+    seen: set[str] = set()
+    surfaces: list[tuple[str, Path]] = []
+    for d in _PUBLIC_DOCS_DIRS:
+        base = root / d
+        if not base.is_dir():
+            continue
+        for p in sorted(base.rglob("*.md")):
+            rel = p.relative_to(root).as_posix()
+            if rel in _PUBLIC_DOCS_EXCLUDE or rel in seen:
+                continue
+            seen.add(rel)
+            surfaces.append((rel, p))
+    for extra in _PUBLIC_DOCS_EXTRA:
+        p = root / extra
+        if p.is_file() and extra not in _PUBLIC_DOCS_EXCLUDE and extra not in seen:
+            seen.add(extra)
+            surfaces.append((extra, p))
+    for rel, p in surfaces:
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as e:
+            err(
+                f"{rel}: present but unreadable/undecodable ({type(e).__name__}) — "
+                f"cannot boundary-scan a public docs surface; failing closed."
+            )
+            continue
+        for ln, cat in docs_address_violations(text):
+            err(
+                f"{rel}:{ln}: contains a concrete {cat} address — public icn docs "
+                f"must not (docs/ATLAS.md §5; icn#2393). Use ${{ICN_*}} env vars / "
+                f"symbolic roles / RFC5737 / RFC3849 examples; concrete values live "
+                f"in the private network-ops repo. (value withheld)"
+            )
+
+
 def parse_date(value: str) -> datetime.date | None:
     try:
         return datetime.date.fromisoformat(str(value)[:10])
@@ -266,6 +361,9 @@ def main() -> int:
 
     # 4. Public-map boundary guard — HARD fail regardless of --strict.
     scan_public_map_boundary(root)
+
+    # 5. Public docs/agent/test address boundary guard (icn#2393) — HARD fail.
+    scan_public_docs_boundary(root)
 
     # Result
     if errors:

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -131,8 +131,8 @@ def scan_public_map_boundary(root: Path) -> None:
 # public surfaces cleaned in the #2393 docs slice must never carry a concrete
 # provider IPv4/IPv6 host address. Reuses the #2392 IPv4 regex/allowlist; the
 # IPv6 rule is tightened (bracketed [..] OR >=3 hextets) so hex-looking Rust
-# paths / capability-action strings (e.g. `aead::`, `read::write`) are NOT
-# false-flagged. HARD failure, value always withheld. Hostname detection is
+# path segments and short capability-action strings are NOT false-flagged.
+# HARD failure, value always withheld. Hostname detection is
 # intentionally omitted here — on prose it false-positives on filenames like
 # `.env.local` and illustrative `*.internal`/`*.example` config; the §5
 # provider concern on these surfaces is IP literals.
@@ -161,7 +161,8 @@ def docs_address_violations(text: str) -> list[tuple[int, str]]:
     'ipv4-host' or 'ipv6-host'. Allowed: loopback / bind-all / QEMU slirp alias
     / RFC5737 (v4); ::1 / :: / RFC3849 2001:db8::/32 (v6). IPv6 is flagged only
     when bracketed ([..]) or written with >=3 hextets, so hex-looking
-    identifiers such as `aead::` or `read::write` are not false-flagged."""
+    identifiers (Rust path segments, short capability strings) are not
+    false-flagged."""
     out: list[tuple[int, str]] = []
     for i, line in enumerate(text.splitlines(), 1):
         for m in _IPV4_RE.finditer(line):

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -48,6 +48,9 @@ _IPV4_RE = re.compile(
 _IPV4_ALLOWED_RE = re.compile(
     r"^(?:127\.|0\.0\.0\.0$|10\.0\.2\.2$|192\.0\.2\.|198\.51\.100\.|203\.0\.113\.)"
 )
+# RFC5737 documentation ranges (each a /24) — used to reject a doc-range base
+# carrying a CIDR mask that escapes its reserved /24 (e.g. 192.0.2.0/8).
+_RFC5737_RE = re.compile(r"^(?:192\.0\.2\.|198\.51\.100\.|203\.0\.113\.)")
 # IPv6 literals — comprehensive: full 8-group, or any "::" compression anywhere in
 # the token (including mid-address). Requires 8 groups (7 colons) or a "::", so a
 # HH:MM:SS time (2 colons, no "::") is NOT matched. A boundary guard fails closed.
@@ -170,12 +173,27 @@ def docs_address_violations(text: str) -> list[tuple[int, str]]:
     out: list[tuple[int, str]] = []
     for i, line in enumerate(text.splitlines(), 1):
         for m in _IPV4_RE.finditer(line):
-            if not _IPV4_ALLOWED_RE.match(m.group(0)):
+            tok = m.group(0)
+            if not _IPV4_ALLOWED_RE.match(tok):
                 out.append((i, "ipv4-host"))
                 break
+            # A permitted RFC5737 base with a CIDR mask that escapes its reserved
+            # /24 (e.g. 192.0.2.0/8) is NOT a valid documentation range — reject
+            # it so an over-broad or policy-changing subnet cannot slip through.
+            if _RFC5737_RE.match(tok):
+                mm = re.match(r"/(\d{1,3})", line[m.end():])
+                if mm and int(mm.group(1)) < 24:
+                    out.append((i, "ipv4-doc-mask"))
+                    break
         for m in _IPV6_RE.finditer(line):
             tok = m.group(0)
             if _IPV6_ALLOWED_RE.match(tok):
+                # RFC3849 2001:db8::/32 with a mask escaping /32 is likewise invalid.
+                if tok.lower().startswith("2001:"):
+                    mm = re.match(r"/(\d{1,3})", line[m.end():])
+                    if mm and int(mm.group(1)) < 32:
+                        out.append((i, "ipv6-doc-mask"))
+                        break
                 continue
             s, e = m.start(), m.end()
             bracketed = s > 0 and line[s - 1] == "[" and e < len(line) and line[e] == "]"

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -21,6 +21,7 @@ private-repo access — VM-session concern, not CI).
 
 import argparse
 import datetime
+import ipaddress
 import json
 import re
 import sys
@@ -130,9 +131,10 @@ def scan_public_map_boundary(root: Path) -> None:
 # Public docs/agent/test address boundary guard (icn#2393). The non-runtime
 # public surfaces cleaned in the #2393 docs slice must never carry a concrete
 # provider IPv4/IPv6 host address. Reuses the #2392 IPv4 regex/allowlist; the
-# IPv6 rule is tightened (bracketed [..] OR >=3 hextets) so hex-looking Rust
-# path segments and short capability-action strings are NOT false-flagged.
-# HARD failure, value always withheld. Hostname detection is
+# IPv6 rule: bracketed [..], >=3 hextets, or short 2-hextet forms that parse
+# into a ULA / link-local range (fc00::/7, fe80::/10) are flagged; hex-looking
+# global-range identifiers (Rust path segments, short capability strings) are
+# NOT false-flagged. HARD failure, value always withheld. Hostname detection is
 # intentionally omitted here — on prose it false-positives on filenames like
 # `.env.local` and illustrative `*.internal`/`*.example` config; the §5
 # provider concern on these surfaces is IP literals.
@@ -159,10 +161,12 @@ def docs_address_violations(text: str) -> list[tuple[int, str]]:
     """Return [(line_no, category)] for disallowed concrete host literals in a
     cleaned public-docs surface. Never includes the value. Category is
     'ipv4-host' or 'ipv6-host'. Allowed: loopback / bind-all / QEMU slirp alias
-    / RFC5737 (v4); ::1 / :: / RFC3849 2001:db8::/32 (v6). IPv6 is flagged only
-    when bracketed ([..]) or written with >=3 hextets, so hex-looking
-    identifiers (Rust path segments, short capability strings) are not
-    false-flagged."""
+    / RFC5737 (v4); ::1 / :: / RFC3849 2001:db8::/32 (v6). IPv6 is flagged when
+    bracketed ([..]), written with >=3 hextets, OR (for short 2-hextet forms)
+    when it parses into a ULA / link-local range (fc00::/7, fe80::/10) — so real
+    provider IPv6 hosts like `fd00::1` are caught while hex-looking global-range
+    identifiers (Rust path segments, short capability strings such as `dead:beef::`)
+    are not false-flagged."""
     out: list[tuple[int, str]] = []
     for i, line in enumerate(text.splitlines(), 1):
         for m in _IPV4_RE.finditer(line):
@@ -176,7 +180,17 @@ def docs_address_violations(text: str) -> list[tuple[int, str]]:
             s, e = m.start(), m.end()
             bracketed = s > 0 and line[s - 1] == "[" and e < len(line) and line[e] == "]"
             hextets = [g for g in tok.split(":") if g]
-            if bracketed or len(hextets) >= 3:
+            flag = bracketed or len(hextets) >= 3
+            if not flag:
+                # short (<=2 hextet) compressed forms: flag only if the token
+                # actually parses into a ULA / link-local address range so that
+                # hex-looking global-range identifiers are not false-flagged.
+                try:
+                    a = ipaddress.IPv6Address(tok.strip("[]"))
+                    flag = a.is_private or a.is_link_local
+                except ValueError:
+                    flag = False
+            if flag:
                 out.append((i, "ipv6-host"))
                 break
     return out

--- a/scripts/tests/test_public_docs_boundary.py
+++ b/scripts/tests/test_public_docs_boundary.py
@@ -49,6 +49,8 @@ FLAG = [
     ("full 8-group IPv6", "fd00:1:2:3:4:5:6:7 up"),
     ("bracketed IPv6 URL (2-group, bracket forces flag)", "http://[fdff::1]:8080/x"),
     ("bracketed IPv6 URL (>=3 group)", "ws://[fd12:3456::1]:30080/ws"),
+    ("bare 2-hextet ULA (fd00::1)", "note fd00::1 somewhere"),
+    ("bare 2-hextet link-local (fe80::1)", "iface fe80::1 up"),
 ]
 
 # ---- MUST NOT FLAG (allowed documentation / bind / protocol-safe forms) ------
@@ -73,7 +75,8 @@ ALLOW = [
     ("capability action a::b (2 groups)", 'Action::new("read::write")'),
     ("four-plus-part version string", "version 1.2.3.4.5 released"),
     ("semver three-part", "release 1.2.3 shipped"),
-    ("bare 2-group IPv6 (intentional FP-avoidance gap)", "note fd00::1 somewhere"),
+    ("global-range hex identifier (cafe::)", "type cafe:: marker"),
+    ("global-range hex identifier (face:: 2-hextet)", "face::b00c token"),
 ]
 
 print("== MUST FLAG ==")

--- a/scripts/tests/test_public_docs_boundary.py
+++ b/scripts/tests/test_public_docs_boundary.py
@@ -40,9 +40,9 @@ def flagged(text):
 # ---- MUST FLAG (disallowed concrete host literals) ---------------------------
 FLAG = [
     ("planted disallowed IPv4 (private)", "peer at 10.20.30.40 here"),
-    ("planted disallowed IPv4 (public)", "resolver 8.8.8.8"),
+    ("planted disallowed IPv4 (public)", "resolver 9.9.9.9"),
     ("planted disallowed IPv4 (rfc1918 172.16)", "node 172.16.9.9"),
-    ("URL authority with disallowed IPv4", "curl http://10.0.0.5:8080/v1/health"),
+    ("URL authority with disallowed IPv4", "curl http://172.31.254.7:8080/v1/health"),
     ("compressed IPv6 at start (>=3 groups)", "addr ::a:b:c:d listening"),
     ("compressed IPv6 in middle (>=3 groups)", "route 1:2::3:4:5 via mesh"),
     ("compressed IPv6 at end (>=3 groups)", "fd12:3456:789a::1 reachable"),

--- a/scripts/tests/test_public_docs_boundary.py
+++ b/scripts/tests/test_public_docs_boundary.py
@@ -51,6 +51,9 @@ FLAG = [
     ("bracketed IPv6 URL (>=3 group)", "ws://[fd12:3456::1]:30080/ws"),
     ("bare 2-hextet ULA (fd00::1)", "note fd00::1 somewhere"),
     ("bare 2-hextet link-local (fe80::1)", "iface fe80::1 up"),
+    ("RFC5737 base with oversized /8 mask", "range 192.0.2.0/8 here"),
+    ("RFC5737 base with oversized /16 mask", "range 198.51.100.0/16 here"),
+    ("RFC3849 base with oversized /16 mask", "prefix 2001:db8::/16 here"),
 ]
 
 # ---- MUST NOT FLAG (allowed documentation / bind / protocol-safe forms) ------
@@ -62,6 +65,11 @@ ALLOW = [
     ("RFC5737 198.51.100.x", "peer 198.51.100.9"),
     ("RFC5737 203.0.113.x", "peer 203.0.113.7"),
     ("RFC5737 network form", "subnet 192.0.2.0/24"),
+    ("RFC5737 valid /25 mask", "subnet 192.0.2.0/25"),
+    ("RFC5737 host /32 mask", "host 192.0.2.10/32"),
+    ("RFC3849 valid /32 mask", "prefix 2001:db8::/32"),
+    ("RFC3849 valid /48 mask", "prefix 2001:db8:1::/48"),
+    ("loopback /8 mask allowed (not RFC5737)", "net 127.0.0.0/8"),
     ("IPv6 loopback", "bind ::1 only"),
     ("IPv6 unspecified", "bind [::]:8080"),
     ("RFC3849 2001:db8::1", "example v6 2001:db8::1"),

--- a/scripts/tests/test_public_docs_boundary.py
+++ b/scripts/tests/test_public_docs_boundary.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Synthetic tests for the public-docs address boundary guard added for icn#2393.
+
+Runs the scan_public_docs_boundary / docs_address_violations logic in
+scripts/check-truth-spine.py against SYNTHETIC values only. No concrete provider
+address ever appears here (that is the whole point of the guard). Exit 0 = pass.
+
+Run: python3 scripts/tests/test_public_docs_boundary.py
+"""
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SPINE = ROOT / "scripts" / "check-truth-spine.py"
+
+spec = importlib.util.spec_from_file_location("cts_under_test", SPINE)
+cts = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cts)
+
+failures = []
+
+
+def check(desc, cond):
+    if cond:
+        print(f"  ok   {desc}")
+    else:
+        print(f"  FAIL {desc}")
+        failures.append(desc)
+
+
+def flagged(text):
+    """True if docs_address_violations reports at least one violation."""
+    return bool(cts.docs_address_violations(text))
+
+
+# ---- MUST FLAG (disallowed concrete host literals) ---------------------------
+FLAG = [
+    ("planted disallowed IPv4 (private)", "peer at 10.20.30.40 here"),
+    ("planted disallowed IPv4 (public)", "resolver 8.8.8.8"),
+    ("planted disallowed IPv4 (rfc1918 172.16)", "node 172.16.9.9"),
+    ("URL authority with disallowed IPv4", "curl http://10.0.0.5:8080/v1/health"),
+    ("compressed IPv6 at start (>=3 groups)", "addr ::a:b:c:d listening"),
+    ("compressed IPv6 in middle (>=3 groups)", "route 1:2::3:4:5 via mesh"),
+    ("compressed IPv6 at end (>=3 groups)", "fd12:3456:789a::1 reachable"),
+    ("full 8-group IPv6", "fd00:1:2:3:4:5:6:7 up"),
+    ("bracketed IPv6 URL (2-group, bracket forces flag)", "http://[fdff::1]:8080/x"),
+    ("bracketed IPv6 URL (>=3 group)", "ws://[fd12:3456::1]:30080/ws"),
+]
+
+# ---- MUST NOT FLAG (allowed documentation / bind / protocol-safe forms) ------
+ALLOW = [
+    ("IPv4 loopback", "bind 127.0.0.1:8080"),
+    ("IPv4 wildcard", "listen 0.0.0.0:8080"),
+    ("QEMU slirp host alias", "host is 10.0.2.2 inside qemu"),
+    ("RFC5737 192.0.2.x", "example gateway 192.0.2.10:30080"),
+    ("RFC5737 198.51.100.x", "peer 198.51.100.9"),
+    ("RFC5737 203.0.113.x", "peer 203.0.113.7"),
+    ("RFC5737 network form", "subnet 192.0.2.0/24"),
+    ("IPv6 loopback", "bind ::1 only"),
+    ("IPv6 unspecified", "bind [::]:8080"),
+    ("RFC3849 2001:db8::1", "example v6 2001:db8::1"),
+    ("RFC3849 multi-group", "example 2001:db8:1:2::3"),
+    ("RFC3849 bracketed URL", "http://[2001:db8::5]:8080/x"),
+    (".example hostname (no host detection)", "gateway.example.coop:30080"),
+    ("env-var placeholder", "curl http://${ICN_GATEWAY_HOST}:30080/v1/health"),
+    # False-positive guards: hex-looking Rust / capability syntax, versions
+    ("rust crypto import aead::", "use chacha20poly1305::aead::{Aead, KeyInit, OsRng};"),
+    ("short 2-group hex :: (dead:beef::)", "marker dead:beef:: token"),
+    ("capability action a::b (2 groups)", 'Action::new("read::write")'),
+    ("four-plus-part version string", "version 1.2.3.4.5 released"),
+    ("semver three-part", "release 1.2.3 shipped"),
+    ("bare 2-group IPv6 (intentional FP-avoidance gap)", "note fd00::1 somewhere"),
+]
+
+print("== MUST FLAG ==")
+for desc, text in FLAG:
+    check(desc, flagged(text))
+
+print("== MUST NOT FLAG ==")
+for desc, text in ALLOW:
+    check(desc, not flagged(text))
+
+# ---- Diagnostics must never contain the matched value ------------------------
+print("== diagnostics withhold value ==")
+cts.errors.clear()
+cts.warnings.clear()
+with tempfile.TemporaryDirectory() as td:
+    root = pathlib.Path(td)
+    (root / "docs").mkdir()
+    (root / "docs" / "planted.md").write_text("gateway at 10.99.88.77 here\n", encoding="utf-8")
+    with contextlib.redirect_stdout(io.StringIO()):
+        cts.scan_public_docs_boundary(root)
+    msgs = "\n".join(cts.errors)
+    check("scan flagged the planted file", "docs/planted.md" in msgs)
+    check("diagnostic does NOT contain the planted value", "10.99.88.77" not in msgs)
+    check("diagnostic reports a line number", "docs/planted.md:1" in msgs)
+
+# ---- Fail closed on undecodable input ---------------------------------------
+print("== fail closed on unreadable/undecodable ==")
+cts.errors.clear()
+cts.warnings.clear()
+with tempfile.TemporaryDirectory() as td:
+    root = pathlib.Path(td)
+    (root / "docs").mkdir()
+    # invalid UTF-8 bytes in a .md surface -> must fail closed, not skip silently
+    (root / "docs" / "bad.md").write_bytes(b"\xff\xfe gateway \x80\x81\n")
+    with contextlib.redirect_stdout(io.StringIO()):
+        cts.scan_public_docs_boundary(root)
+    check("undecodable surface fails closed (error raised)", len(cts.errors) >= 1)
+
+# ---- Excluded files are not scanned -----------------------------------------
+print("== deferred-file exclusion honored ==")
+cts.errors.clear()
+cts.warnings.clear()
+with tempfile.TemporaryDirectory() as td:
+    root = pathlib.Path(td)
+    (root / "docs" / "adr").mkdir(parents=True)
+    excluded = "docs/adr/ADR-0003-ipv6-dual-stack-transport-with-endpoint-sets.md"
+    (root / excluded).write_text("ULA fd12:3456:789a::1 illustration\n", encoding="utf-8")
+    with contextlib.redirect_stdout(io.StringIO()):
+        cts.scan_public_docs_boundary(root)
+    check("excluded illustration file is not flagged", len(cts.errors) == 0)
+
+print()
+if failures:
+    print(f"FAILED: {len(failures)} case(s)")
+    sys.exit(1)
+print("ALL PASS")
+sys.exit(0)

--- a/web/pilot-ui/tests/steward-gateway-url.test.js
+++ b/web/pilot-ui/tests/steward-gateway-url.test.js
@@ -23,7 +23,7 @@ const deriveGatewayUrl = loadDeriveGatewayUrl();
 
 describe('deriveGatewayUrl', () => {
     test('explicit localStorage override wins over everything', () => {
-        expect(deriveGatewayUrl('10.8.30.40', 'http:', 'http://custom-gateway:9000'))
+        expect(deriveGatewayUrl('192.0.2.10', 'http:', 'http://custom-gateway:9000'))
             .toBe('http://custom-gateway:9000');
     });
 
@@ -33,8 +33,8 @@ describe('deriveGatewayUrl', () => {
     });
 
     test('non-localhost host derives port 30080 from same hostname', () => {
-        expect(deriveGatewayUrl('10.8.30.40', 'http:', null))
-            .toBe('http://10.8.30.40:30080');
+        expect(deriveGatewayUrl('192.0.2.10', 'http:', null))
+            .toBe('http://192.0.2.10:30080');
     });
 
     test('preserves https protocol for TLS deployments', () => {
@@ -53,8 +53,8 @@ describe('deriveGatewayUrl', () => {
     });
 
     test('undefined savedGateway treated as no override', () => {
-        expect(deriveGatewayUrl('10.8.30.40', 'http:', undefined))
-            .toBe('http://10.8.30.40:30080');
+        expect(deriveGatewayUrl('192.0.2.10', 'http:', undefined))
+            .toBe('http://192.0.2.10:30080');
     });
 
     test('empty string savedGateway treated as no override', () => {


### PR DESCRIPTION
## What

Refs #2393. First safe, focused remediation slice: scrub concrete provider
infrastructure addresses (a private cluster IPv4 range + service endpoints) out
of the **non-runtime** public surfaces, and add a fail-closed regression guard
scoped to exactly those cleaned surfaces.

This is a public-boundary remediation (`docs/ATLAS.md` §5), **not** a Rehearsal
Node / feature change. It deliberately touches only non-executable text and one
test fixture — no deployment workflows, operator tooling, demo runtime, or
infrastructure config.

## Categories cleaned (this PR)

| Category | Surface | Files | Result |
|---|---|---|---|
| Documentation narrative / historical | `docs/**/*.md` | 52 | 0 disallowed |
| Agent instructions | `.claude/**`, `.agents/**` | 6 | 0 disallowed |
| Changelog | `CHANGELOG.md` | 1 | 0 disallowed |
| Test fixture | `web/pilot-ui/tests/steward-gateway-url.test.js` | 1 | 0 disallowed |
| **Regression guard + tests** | `scripts/check-truth-spine.py`, `scripts/tests/`, drift-check CI | 3 | new |

**Redacted before → after (cleaned surfaces): 355 → 0** occurrences across 60
files (265 in the private cluster /24, 90 historical/secondary gateway or
illustrative example addresses; 0 IPv6). Verified by a repeated, value-free
repo scan. Counts only — no address values anywhere in this PR.

## Categories explicitly deferred (unchanged here — later #2393 slices)

- **GitHub Actions / deployment workflows** and **`deploy/**`** (manifests,
  Makefiles, k8s scripts) — need env/secret/vars + fail-closed missing-config
  and private-runner verification.
- **Operator tooling** (`scripts/*.sh`) and **demo runtime** (`demo/**`).
- **Executable config / examples consumed by tooling** (`config/*.example`,
  `docker*.yml`, `monitoring/`, `ops/mcp/*.ts`).
- **Six docs whose flagged tokens are NOT §5 provider topology** — IPv6
  address-*type* illustrations (ULA / global / link-local / CGN format examples
  in protocol-design docs) and Rust-syntax / capability-action-string false
  positives (e.g. `aead::`, `read::write`). Listed in the guard's documented
  exclude set; deferred to a separate targeted review. Scrubbing them would
  misrepresent protocol semantics or corrupt code snippets.

Deferred surfaces are **not** described as fixed. A separate note flags that
gateway source (`icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`)
hardcodes provider topology and needs its own PR with `cargo test`.

## Replacement policy (per-use, not per-string)

- **Reusable command hosts** (`curl`/`ssh`/`kubectl` targets) → clearly-named
  operator-supplied env vars: `${ICN_GATEWAY_HOST}`, `${ICN_K3S_CONTROL}`,
  `${ICN_K3S_WORKER1/2}`, `${ICN_NODE_HOST}`, `${ICN_DEV_HOST}`,
  `${ICN_CI_RUNNER_HOST}`, `${ICN_NFS_HOST}`, `${ICN_CLUSTER_ENDPOINT}`,
  `${ICN_HYPERION_HOST}`, `${ICN_ZENITH_HOST}`. Heavy deployment docs gained an
  “Operator inputs (ATLAS §5)” note documenting required inputs + the
  never-commit expectation.
- **Topology prose / node ranges** → symbolic roles: “control-plane node”,
  “operator-supplied host”, “private cluster node range (operator-supplied; via
  private `network-ops`)”.
- **Illustrative examples** (peer/socket literals, bootstrap examples, LB
  backends, ClusterIP tables, org-DNS) → RFC5737 `192.0.2.0/24` /
  `198.51.100.0/24`; IPv6 would use RFC3849 `2001:db8::/32`.
- **Well-known protocol constants** → symbolic descriptions (the mDNS multicast
  group; the Docker/private bridge subnet) rather than a misleading RFC value.

## Guard scope + allowed forms

`scripts/check-truth-spine.py` gains `scan_public_docs_boundary` — a sibling of
the #2392 `scan_public_map_boundary`, reusing its IPv4 regex + allowlist (the
"small shared helper"). It runs inside the **required Agent Tooling Drift
Check**, which executes on every PR, so no new workflow is required; the
drift-check push paths and a guard-test step were added.

- **Scope:** `docs/**/*.md`, `.claude/**/*.md`, `.agents/**/*.md`,
  `CHANGELOG.md`, and the test fixture — **minus** the documented 6-file
  exclude set. HARD fail, value always withheld, fails closed on
  unreadable/undecodable input. Reports `path:line:category` only.
- **Allowed:** loopback (`127.0.0.0/8`, `::1`), bind-all (`0.0.0.0`, `::`),
  QEMU slirp alias, RFC5737 v4 doc ranges, RFC3849 `2001:db8::/32`.
- **IPv6 detection is docs-tuned** (bracketed `[..]` OR ≥3 hextets) so
  hex-looking Rust paths / capability strings are not false-flagged. Hostname
  detection is intentionally omitted here (would false-positive on filenames
  like `.env.local` and illustrative `*.internal`/`*.example` config).
- The #2392 machine-map guard is **unchanged** and remains green.

## Validation performed

- New guard synthetic-value test matrix (`scripts/tests/test_public_docs_boundary.py`):
  planted disallowed IPv4 / URL-authority / compressed & bracketed IPv6 all
  fail; loopback / wildcard / RFC5737 / RFC3849 / `.example` / env-var
  placeholders / `aead::` / `read::write` / version strings all pass;
  diagnostics withhold the value; fails closed on undecodable input; deferred
  files excluded. **All pass.**
- `scripts/check-truth-spine.py --repo-root .` → **exit 0** (both boundary
  guards clean; one pre-existing sprint-age warning, unrelated).
- `doc_control_check.py`, `freshness-check.py`, `compliance_linter.py`,
  `readiness_overclaim_linter.py`, `check-state-lag.py` → all pass.
- `check-agent-context-spine.py --check` → up to date. `generate-live-state-overlay.py --check` → OK.
  (`generate_repo_record.py --check` drifts — pre-existing observational snapshot
  staleness, ~114 files behind main before this PR; non-blocking, not regenerated.)
- `node --check` on the test fixture; substitutions are value-preserving
  (RFC5737 host used identically on both call and expected assertion).
- Final scoped scan proves **0 disallowed addresses** remain in every cleaned
  surface; whitespace-clean diff; py_compile clean; workflow YAML valid.

## Safety / disclosure

- **No concrete provider address** appears in this diff, description, or any
  diagnostic (guard messages withhold the value).
- **No private repository or infrastructure was accessed**; no repo/env secrets
  or variables were created or changed; deployment targets unchanged.
- **No deployment or runtime behavior changes.**
- **Historical Git caveat:** this is a forward fix; prior Git objects may still
  retain removed values. History rewriting is a separate security/governance
  operation and is out of scope here.

Refs #2393. Companion to icn-infra ADR-0005 and PR #2392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
