### PR TITLE
fix(security): scrub SDIS fixture address; guard .github/agents

### DIFF
--- a/.github/agents/icn-sdk-web.md
+++ b/.github/agents/icn-sdk-web.md
@@ -34,7 +34,7 @@ You have deep expertise in:
 ```typescript
 // Client initialization
 const client = new IcnClient({
-  gateway: 'http://10.8.10.40:30080',
+  gateway: 'http://192.0.2.10:30080',
   identity: keypair,
 });
 

--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -19,6 +19,8 @@ on:
       - 'docs/**'
       - 'CHANGELOG.md'
       - 'web/pilot-ui/tests/**'
+      - '.github/agents/**'
+      - 'icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs'
   pull_request:
     # No paths filter: run on ALL PRs so any new skill/agent is checked for truth_contract
     # and registry entries. The check is fast (~5s) and catches silent drift early.

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -1170,7 +1170,7 @@ mod tests {
 
         let req = actix_web::test::TestRequest::post()
             .uri("/v1/sdis/enrollment/start")
-            .insert_header(("host", "10.8.30.40:30080"))
+            .insert_header(("host", "192.0.2.10:30080"))
             .insert_header(("content-type", "application/json"))
             .set_payload(r#"{"identity_name":"Test User","coop_id":"test-coop"}"#)
             .to_request();
@@ -1181,7 +1181,7 @@ mod tests {
             resp["qr_code"]
                 .as_str()
                 .unwrap()
-                .contains("\"gateway_url\":\"http://10.8.30.40:30080\""),
+                .contains("\"gateway_url\":\"http://192.0.2.10:30080\""),
             "qr payload should advertise the current request gateway"
         );
     }

--- a/scripts/check-truth-spine.py
+++ b/scripts/check-truth-spine.py
@@ -141,10 +141,18 @@ def scan_public_map_boundary(root: Path) -> None:
 # intentionally omitted here — on prose it false-positives on filenames like
 # `.env.local` and illustrative `*.internal`/`*.example` config; the §5
 # provider concern on these surfaces is IP literals.
-_PUBLIC_DOCS_DIRS = ("docs", ".claude", ".agents")   # scanned recursively for *.md
+_PUBLIC_DOCS_DIRS = (                                 # scanned recursively for *.md
+    "docs",
+    ".claude",
+    ".agents",
+    ".github/agents",  # public agent definitions (icn#2393 slice 2)
+)
 _PUBLIC_DOCS_EXTRA = (                                # specific non-.md cleaned surfaces
     "CHANGELOG.md",
     "web/pilot-ui/tests/steward-gateway-url.test.js",
+    # Shipped SDIS gateway source cleaned in icn#2393 slice 2: its gateway-url
+    # test fixture must stay a documentation-range host, never provider topology.
+    "icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs",
 )
 # Deferred to a separate targeted review (NOT ATLAS §5 provider topology, so
 # excluded to keep this guard free of false positives): IPv6 address-TYPE

--- a/scripts/tests/test_public_docs_boundary.py
+++ b/scripts/tests/test_public_docs_boundary.py
@@ -136,6 +136,45 @@ with tempfile.TemporaryDirectory() as td:
         cts.scan_public_docs_boundary(root)
     check("excluded illustration file is not flagged", len(cts.errors) == 0)
 
+# ---- .github/agents public-agent surfaces are scanned (icn#2393 slice 2) -----
+print("== .github/agents coverage ==")
+cts.errors.clear()
+cts.warnings.clear()
+with tempfile.TemporaryDirectory() as td:
+    root = pathlib.Path(td)
+    (root / ".github" / "agents").mkdir(parents=True)
+    (root / ".github" / "agents" / "planted-agent.md").write_text(
+        "gateway: 'http://10.77.66.55:30080'\n", encoding="utf-8"
+    )
+    with contextlib.redirect_stdout(io.StringIO()):
+        cts.scan_public_docs_boundary(root)
+    msgs = "\n".join(cts.errors)
+    check(
+        "planted .github/agents violation is flagged",
+        ".github/agents/planted-agent.md:1" in msgs,
+    )
+    check("agents diagnostic does NOT contain the planted value", "10.77.66.55" not in msgs)
+
+# ---- corrected SDIS shipped source stays provider-free (icn#2393 slice 2) ----
+print("== sdis simple_enrollment shipped-source coverage ==")
+cts.errors.clear()
+cts.warnings.clear()
+with tempfile.TemporaryDirectory() as td:
+    root = pathlib.Path(td)
+    sdis_rel = "icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs"
+    sdis = root / sdis_rel
+    sdis.parent.mkdir(parents=True)
+    sdis.write_text('.insert_header(("host", "10.44.33.22:30080"))\n', encoding="utf-8")
+    with contextlib.redirect_stdout(io.StringIO()):
+        cts.scan_public_docs_boundary(root)
+    msgs = "\n".join(cts.errors)
+    check("planted SDIS source violation is flagged", f"{sdis_rel}:1" in msgs)
+    check("sdis diagnostic does NOT contain the planted value", "10.44.33.22" not in msgs)
+    check(
+        "RFC5737 doc-range fixture in SDIS source is allowed",
+        not cts.docs_address_violations('.insert_header(("host", "192.0.2.10:30080"))'),
+    )
+
 print()
 if failures:
     print(f"FAILED: {len(failures)} case(s)")


### PR DESCRIPTION
## Summary

Completes the focused #2393 slice-2 pair left after #2404: removes the last provider-family address from shipped Rust source (an SDIS enrollment test fixture) and the one residual in `.github/agents/`, and closes the `.github/agents/**` coverage omission in the public-boundary guard. Refs #2393 (stays open — operational categories remain deferred).

## Changes

- `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs` — replace the provider-family `host:port` fixture (2 occurrences, both inside `#[cfg(test)]` `test_start_enrollment_uses_request_gateway_url`) with the RFC5737 documentation value `192.0.2.10:30080`, the convention #2404 established in `web/pilot-ui/tests/steward-gateway-url.test.js`.
- `.github/agents/icn-sdk-web.md` — replace the one concrete address (SDK client-init illustration, line 37) with the same documentation value.
- `scripts/check-truth-spine.py` — `scan_public_docs_boundary` now scans `.github/agents/**/*.md` (new `_PUBLIC_DOCS_DIRS` entry) and the corrected SDIS source (new `_PUBLIC_DOCS_EXTRA` entry, parallel to the pilot-ui precedent).
- `scripts/tests/test_public_docs_boundary.py` — synthetic planted-violation tests for both new surfaces (flagged, line-numbered, value-withheld) plus a pin that the RFC5737 fixture form stays allowed. Planted values follow the file's existing synthetic convention; they collide with no real address family.
- `.github/workflows/agent-drift-check.yml` — add both new surfaces to the push-path filter (PRs already run the check unconditionally; this restores main-push parity).

## Motivation

ATLAS §5 / #2393: private provider topology must never appear in the public `icn` repository. After the #2404 non-runtime scrub, the residuals in this slice were the shipped SDIS gateway source and the unscanned `.github/agents/` tree.

**Semantics established before changing anything:** the two Rust occurrences are pure test fixtures — the test pins the request `Host` header and asserts it round-trips into the QR payload's `gateway_url`. Production derives `gateway_url` dynamically in `get_gateway_url()` (`GATEWAY_BASE_URL` env pin → trusted-proxy `X-Forwarded-*` → request `Host` → `http://localhost:8080` fallback) and is operator-configured via the k8s ConfigMap `gateway_base_url`. No runtime default targets private infrastructure; no client, SDK, doc, or test consumes the old value. **No external API contract change.**

**Counts (values withheld):** before — 2 provider-family occurrences in `simple_enrollment.rs`, 1 in `.github/agents/icn-sdk-web.md`, `.github/agents/**` (22 files) unscanned; after — 0 in both, both surfaces guard-covered. An empirical sweep of all `.github/**/*.md` under the detector found exactly 1 true positive (fixed here) and 0 false positives (Rust `::` path syntax in agent files is correctly not flagged), so no new exclusions were needed.

## Testing

- [x] Unit tests added/updated — 2 new planted-surface guard test blocks (5 assertions), watched failing before the guard extension (TDD); Rust fixture test updated and green
- [x] Integration tests pass — `cargo test -p icn-gateway`: 683 unit + all integration suites, 0 failures
- [x] Manual testing: extended guard run on the live tree flagged exactly the 3 real lines (value-withheld) before the content fix, and reports 0 boundary errors after

## Invariants

- [x] No panics introduced in protocol paths (test-only Rust change)
- [x] Determinism preserved
- [x] Canonical encodings unchanged
- [x] Trust gates not weakened (no auth/validation paths touched)
- [x] Kernel/app boundaries respected

## Verification

```
python3 scripts/tests/test_public_docs_boundary.py  -> ALL PASS
python3 scripts/check-truth-spine.py                -> 0 boundary errors, exit 0
cargo fmt --all --check                             -> clean
cargo clippy -p icn-gateway --all-targets -- -D warnings -> clean
cargo test -p icn-gateway                           -> 683+ passed, 0 failed
ops/scripts/drift-check.sh                          -> PASS (0 errors, 0 warnings)
scripts/check-preflight-consistency.sh              -> clean
ops/scripts/what-matters-now.sh --drift             -> no drift
compliance_linter.py / readiness_overclaim_linter.py -> clean
```

## Documentation

- [x] Docs updated: N/A (no doc-surface content change beyond the scrub itself)
- [x] API changes reflected in OpenAPI: N/A (no API change)

## Boundary statement

No private repositories, private topology sources, secrets, deployment state, or infrastructure were accessed or modified in preparing this change; all inspection was redaction-safe (concrete values never displayed anywhere, including diagnostics). Forward-fix only: historical Git objects are not rewritten — the old values remain reachable in Git history, consistent with the #2392/#2404 posture; any rotation/mitigation is a network-ops concern.

Refs #2393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
