### PR TITLE
feat(governance): rehearsal organizer review→confirm surface (runtime)

### DIFF
--- a/docs/api/openapi.generated.yaml
+++ b/docs/api/openapi.generated.yaml
@@ -259,7 +259,7 @@ paths:
       operationId: get_my_pending_publish_summary
       responses:
         '200':
-          description: 'Pending-publish preview/review rows for the caller, wrapped in `PendingPublishSummaryResponse` (`{did, origin, rows, non_claims, generated_at}`). Runtime projection of `urn:icn:contract:pending-publish-summary:v1`. Read-only: there is no mutation API on this surface, no authority is granted, and no action card is created. `origin = live_runtime` (production) returns no rows; `origin = committed_fixture` (non-production) returns deterministic, fictional rehearsal rows. Row `kind`, `status`, `risk_level`, `source_provenance`, and `receipt_expected.category` use closed enums.'
+          description: 'Pending-publish preview/review rows for the caller, wrapped in `PendingPublishSummaryResponse` (`{did, origin, rows, non_claims, generated_at}`). Runtime projection of `urn:icn:contract:pending-publish-summary:v1`. Read-only: there is no mutation API on this surface, no authority is granted, and no action card is created. `origin = live_runtime` (production) returns no rows; `origin = committed_fixture` (non-production) returns deterministic, fictional rehearsal rows; `origin = rehearsal_runtime` (rehearsal build mode, after an explicit workspace reset) returns the live rehearsal review workspace rows — still fictional, never production state. Row `kind`, `status`, `risk_level`, `source_provenance`, and `receipt_expected.category` use closed enums.'
           content:
             application/json:
               schema:
@@ -1644,6 +1644,7 @@ components:
       enum:
       - live_runtime
       - committed_fixture
+      - rehearsal_runtime
     PendingPublishProvenance:
       type: string
       description: |-

--- a/docs/contracts/rehearsal-review-workflow.md
+++ b/docs/contracts/rehearsal-review-workflow.md
@@ -1,0 +1,128 @@
+---
+Status: descriptive
+Canonical: yes
+Last Reviewed: 2026-07-11
+---
+
+# Rehearsal review workflow — runtime contract (v1)
+
+**Surface:** organizer pending-publish review/confirm on an isolated
+Rehearsal Node. **Issues:** #1726, #1728, #2386, #1746.
+
+## Where it exists
+
+These routes are mounted **only** when the governance context is built in
+`GovernanceContextBuildMode::Rehearsal` (`ICN_GOVERNANCE_BUILD_MODE=rehearsal`,
+exact value; unknown or missing values fall back to Bootstrap, which does NOT
+mount them). In Production, Bootstrap, and Test the routes do not exist
+(404). They are deliberately **not** part of the public OpenAPI document:
+they never exist on a production surface, so the production API contract
+does not advertise them. This document is their contract.
+
+Everything reviewable here is **fictional rehearsal material** seeded from the
+same deterministic in-code generator that backs the committed-fixture
+pending-publish summary. Confirmed mutations, however, are **real governance
+records** on the rehearsal node: one action item per confirmed row, plus the
+real ADR-0026 process receipts. Receipts record process facts; nothing on
+this surface grants authority.
+
+## Capabilities
+
+| Scope | Grants |
+|---|---|
+| `governance:pending-publish:review` | review decisions, bounded edits, label assignment, label→fictional-DID binding, previews, workspace reset |
+| `governance:pending-publish:confirm` | executing an approved, digest-bound mutation |
+| `governance:read` | all read surfaces (list, detail, bindings, receipts, evidence) |
+| `governance:write` (broad, technical operators) | accepted-also fallback for both, per sub-capability doctrine |
+
+Review and confirm are non-implying siblings; neither implies the other and
+`governance:read` grants neither. Reset and binding are deliberately part of
+`review` (repeating the fictional rehearsal is an organizer act; a binding
+grants no authority, and rebinding invalidates outstanding previews).
+Every route additionally requires domain membership; the path domain is the
+authority context.
+
+## Routes
+
+All under `/v1/gov` (gateway mount). `{d}` = domain id, `{r}` = row id.
+
+| Method + path | Scope | Behavior |
+|---|---|---|
+| `POST /domains/{d}/rehearsal/reset` | review | initialize/re-seed the deterministic workspace; bumps `generation` (invalidates all previews); recorded receipts and created items are NOT erased |
+| `GET /domains/{d}/rehearsal/pending-publish` | read | rows + review state (`404` until first reset) |
+| `GET /domains/{d}/rehearsal/pending-publish/{r}` | read | row detail (`assignee_bound`, `executed`, version) |
+| `POST .../{r}/review` `{decision, note?}` | review | decision ∈ {approve, reject, needs_edit, needs_more_info}; records a real `DecisionRecordedReceipt`; note ≤ 2000 bytes |
+| `PUT .../{r}` `{plain_summary}` | review | bounded edit (≤ 256 bytes; the ONLY editable field); resets status to pending_review and clears approval |
+| `POST .../{r}/assign` `{assignee_label?}` | review | assign by registered human label (≤ 120 bytes); unknown label → 422; resets status/approval; `null` clears |
+| `POST /domains/{d}/rehearsal/bindings` `{label, did}` | review | bind label → fictional DID; DID accepted on write, never echoed |
+| `GET /domains/{d}/rehearsal/bindings` | read | labels + `bound` flags only |
+| `GET .../{r}/preview` | review | pure read; requires current approval; returns the exact mutation fields + `preview_digest`; non-action-item kinds → 422 (reviewable, not executable) |
+| `POST .../{r}/confirm` `{preview_digest}` | confirm | digest-verified execution (below); duplicate identical confirm → 200 idempotent replay; different digest after execution → 409 |
+| `GET /domains/{d}/rehearsal/receipts` | read | ladder receipts recorded this workspace lifetime (ids + hashes, no DIDs) |
+| `GET /domains/{d}/rehearsal/evidence-export` | read | value-withheld evidence packet (below) |
+
+All request bodies use `#[serde(deny_unknown_fields)]` — unknown fields are
+rejected (400), not ignored.
+
+## Preview→confirm binding
+
+Preview computes a **domain-separated BLAKE3 digest** (tag
+`icn:gov:rehearsal_plan:v1`) over the canonical plan document
+`urn:icn:rehearsal-plan:v1`: domain, row id, workspace generation, row
+version, action kind, exact title/description, assignee label **and its
+currently bound DID**, due date, priority, authority basis, risk, expected
+receipt category, provenance, origin, reversibility. The browser receives the
+human-readable fields plus the digest — never the DID.
+
+Confirm **recomputes the digest from current state** and compares
+(constant-time; `blake3::Hash` equality). Any intervening edit, review
+decision, re-assignment, label re-binding, or workspace reset changes the
+digest, so the stale preview fails closed (409) and a fresh preview is
+required. The digest bytes are persisted as the plan `body_hash`, so the
+binding is auditable in the receipt chain.
+
+## Confirm execution (real machinery)
+
+On a verified confirm the node records, in order, through the existing
+`GovernanceManager` ladder (#ADR-0026): `ProcessSessionOpened` (once per
+workspace generation) → `ProcessGateResult` (`ScopeConfirmation`/`Pass`) →
+`ActivationCrossed` (referencing the approving `DecisionRecordedReceipt` and
+the gate hash) → `MutationPlanRecorded` (`body_hash` = preview digest) → **one
+real action item** via `create_action_item` (priority medium, fictional
+assignee DID if bound, else unassigned) → `MutationApplied` (referencing the
+plan and a result hash binding the created item). The response returns every
+id and record hash. Assigned items surface on the normal member action-card
+view and are completable with the existing completion-only capability
+(`governance:action-item:complete`, #2400) — unchanged by this surface.
+
+Rows whose assignee label is **unbound** cannot be confirmed (409).
+Non-action-item kinds are reviewable and previewable but **not executable**
+in this slice (422).
+
+## Summary origin
+
+`GET /v1/gov/me/pending-publish-summary` gains one origin value:
+`rehearsal_runtime` — served only in Rehearsal mode once a workspace exists
+(rows then reflect live review state). `committed_fixture` (Bootstrap/Test,
+and Rehearsal before any reset) and `live_runtime` (Production: no rows) are
+unchanged.
+
+## Evidence packet (`urn:icn:contract:rehearsal-workflow-evidence:v1`)
+
+Derived from actual workspace outcomes: per-row outcome
+(`executed | approved-not-executed | rejected | edit-and-resubmit |
+deferred`), versions, preview digests and plan/application record hashes for
+executed rows, the decision log (ids + record hashes + `note_present`
+flags), label binding states, non-claims, a privacy-review block, and a
+`packet_hash` — SHA-256 over the canonical packet content (excluding
+`packet_hash`/`generated_at`) so any tampering is detectable by
+recomputation, including in a browser via WebCrypto. The packet contains no
+DIDs, credentials, private-overlay values, paths, or topology.
+
+## Non-claims
+
+Not production governance, not a pilot, not live federation, not durable
+workflow storage (the review workspace is node-lifetime and resettable; the
+created items and receipts are the durable records). Identity binding here
+is a fictional-rehearsal convenience, not the production private-overlay
+architecture.

--- a/docs/contracts/rehearsal-review-workflow.md
+++ b/docs/contracts/rehearsal-review-workflow.md
@@ -42,9 +42,23 @@ carries review+confirm+read only: it can neither turn an arbitrary domain
 into a rehearsal workspace (designation needs setup) nor bind identities —
 and it never sees, stores, or submits a DID. A binding grants no authority,
 must reference an identity that already holds domain membership, and any
-rebinding invalidates outstanding previews. Every route additionally
-requires the caller's own domain membership; the path domain is the
-authority context.
+rebinding invalidates outstanding previews (except while an interrupted
+execution references the label — see recovery below — when rebinding is
+refused with 409). Every route additionally requires the caller's own
+domain membership; the path domain is the authority context.
+
+**The binding-target membership check never falls open.** Membership must
+be affirmatively established: a `StaticList` domain resolves it from the
+source; a `TrustThreshold` domain requires a wired membership resolver that
+confirms standing. A missing resolver, a resolver failure, or any other
+indeterminate outcome DENIES the binding — this invariant is not deferred
+to appliance wiring. Every deny is the same 422 with the same message, so
+the response never distinguishes "provable non-member" from "membership
+unknowable" and reveals nothing about hidden identities or standing in
+other domains. (The CALLER-side gate keeps the permissive Bootstrap
+dependency posture in Rehearsal mode, like every non-production surface;
+only the binding target is held to the stricter affirmative rule, because
+a binding feeds the completion loop.)
 
 ## Routes
 
@@ -52,7 +66,7 @@ All under `/v1/gov` (gateway mount). `{d}` = domain id, `{r}` = row id.
 
 | Method + path | Scope | Behavior |
 |---|---|---|
-| `POST /domains/{d}/rehearsal/reset` | setup (first) / review (re-reset) | start a new rehearsal generation with the deterministic seed and a fresh restart-safe `run_id`; invalidates all previews; the prior run's fictional action items are cancelled through the normal status machinery (completed items and all receipts remain) |
+| `POST /domains/{d}/rehearsal/reset` | setup (first) / review (re-reset) | start a new rehearsal generation with the deterministic seed and a fresh restart-safe `run_id`; invalidates all previews; the prior run's fictional action items are cancelled through the normal status machinery (completed items and all receipts remain). Retirement scans the DURABLE item store for this surface's `meeting_context` marker in addition to the in-memory workspace, so items orphaned by a daemon restart are retired too (`prior_item_scan: complete\|failed` reports the scan outcome) |
 | `GET /domains/{d}/rehearsal/pending-publish` | read | rows + review state (`404` until first reset) |
 | `GET /domains/{d}/rehearsal/pending-publish/{r}` | read | row detail (`assignee_bound`, `executed`, version) |
 | `POST .../{r}/review` `{decision, note?}` | review | decision ∈ {approve, reject, needs_edit, needs_more_info}; records a real `DecisionRecordedReceipt`; note ≤ 2000 bytes |
@@ -85,14 +99,44 @@ digest, so the stale preview fails closed (409) and a fresh preview is
 required. The digest bytes are persisted as the plan `body_hash`, so the
 binding is auditable in the receipt chain.
 
-**Interrupted-confirm recovery:** the created action item is marked in the
-workspace the moment it exists, before the mutation-applied receipt. If that
-recording fails, review mutations on the row are blocked (409) and an
-identical retried confirm RESUMES the same item — a retry can never create a
-second one. Every persistent identifier (session, decision, activation,
-plan, application) carries the workspace `run_id`, so identifiers are never
-reused across resets or daemon restarts even though the seed content is
-deterministic.
+**Interrupted-confirm recovery (same process only):** the created action
+item is marked in the workspace the moment it exists, before the
+mutation-applied receipt. If any ladder step fails, an identical retried
+confirm — same preview digest, same facilitator identity, same running
+process — resumes exactly where the interruption happened:
+
+- failure BEFORE item creation (gate/activation/plan recording): no item
+  exists; the retry re-runs the remaining steps, reusing the gate receipt
+  already recorded for this row version (gate record hashes include their
+  timestamp, so recording a fresh observation in a later second would
+  change the activation's gate basis and hard-conflict with an
+  already-recorded activation);
+- failure AFTER item creation but before the applied receipt: the row
+  carries the pending item marker; review mutations on the row AND
+  rebinding of the row's assignee label are blocked (409) so the recomputed
+  digest still matches, and the retry resumes the SAME item — a retry can
+  never create a second one;
+- a retry by a DIFFERENT confirm-capable identity fails closed (409
+  activation conflict): recovery belongs to the facilitator who started it,
+  or to a reset.
+
+**This recovery state is in-memory and does NOT survive a daemon restart.**
+Cross-restart confirm idempotency is explicitly not claimed. After a
+restart the workspace is gone (routes answer 404 until a new designation
+reset); a partially confirmed row cannot be resumed, and its receipts stop
+at the last recorded rung (e.g. a plan without an applied record — an
+honest partial trail, readable by an operator from the receipt store). The
+created-but-unreceipted action item is durable; the recovery path is the
+next reset, which retires it (below). Every persistent identifier (session,
+decision, activation, plan, application) carries the workspace `run_id`, so
+identifiers are never reused across resets or daemon restarts even though
+the seed content is deterministic.
+
+**Concurrency:** the entire review surface is serialized under one lock
+with no awaits inside critical sections; confirm's verify-then-execute is a
+single critical section. Two simultaneous confirms of one row cannot both
+execute — the loser observes the winner's execution and replays
+idempotently (same digest) or conflicts (different digest).
 
 ## Confirm execution (real machinery)
 
@@ -123,6 +167,18 @@ review state, and workspace existence are never observable from another
 domain. `committed_fixture` (Bootstrap/Test, and Rehearsal before any
 member-visible reset) and `live_runtime` (Production: no rows) are
 unchanged.
+
+The isolation filter fails closed on any provably-non-member domain and
+never exports a DID. One posture caveat, symmetric with the caller gate on
+every read route: the CALLER-side membership check keeps the permissive
+Bootstrap posture, so on a `TrustThreshold` domain with **no** wired
+membership resolver it resolves every caller as a member — there, a domain's
+fictional (label-only, DID-free) review state is visible to any
+authenticated `governance:read` caller. This is the deliberate asymmetry
+noted under Capabilities: only the binding *target* is held to the
+affirmative rule. Run rehearsals on `StaticList` fictional domains (as the
+appliance profile does) or wire a resolver for strict cross-caller read
+isolation.
 
 ## Evidence packet (`urn:icn:contract:rehearsal-workflow-evidence:v1`)
 

--- a/docs/contracts/rehearsal-review-workflow.md
+++ b/docs/contracts/rehearsal-review-workflow.md
@@ -30,16 +30,20 @@ this surface grants authority.
 
 | Scope | Grants |
 |---|---|
-| `governance:pending-publish:review` | review decisions, bounded edits, label assignment, label→fictional-DID binding, previews, workspace reset |
+| `governance:rehearsal:setup` | DESIGNATING a rehearsal domain (its first workspace initialization) and binding labels to fictional identities — internal setup credential only |
+| `governance:pending-publish:review` | review decisions, bounded edits, label assignment (labels only), previews, RE-resetting an already-designated workspace |
 | `governance:pending-publish:confirm` | executing an approved, digest-bound mutation |
 | `governance:read` | all read surfaces (list, detail, bindings, receipts, evidence) |
-| `governance:write` (broad, technical operators) | accepted-also fallback for both, per sub-capability doctrine |
+| `governance:write` (broad, technical operators) | accepted-also fallback for all three, per sub-capability doctrine (tested) |
 
-Review and confirm are non-implying siblings; neither implies the other and
-`governance:read` grants neither. Reset and binding are deliberately part of
-`review` (repeating the fictional rehearsal is an organizer act; a binding
-grants no authority, and rebinding invalidates outstanding previews).
-Every route additionally requires domain membership; the path domain is the
+All three rehearsal capabilities are non-implying siblings and
+`governance:read` grants none of them. The organizer browser credential
+carries review+confirm+read only: it can neither turn an arbitrary domain
+into a rehearsal workspace (designation needs setup) nor bind identities —
+and it never sees, stores, or submits a DID. A binding grants no authority,
+must reference an identity that already holds domain membership, and any
+rebinding invalidates outstanding previews. Every route additionally
+requires the caller's own domain membership; the path domain is the
 authority context.
 
 ## Routes
@@ -48,13 +52,13 @@ All under `/v1/gov` (gateway mount). `{d}` = domain id, `{r}` = row id.
 
 | Method + path | Scope | Behavior |
 |---|---|---|
-| `POST /domains/{d}/rehearsal/reset` | review | initialize/re-seed the deterministic workspace; bumps `generation` (invalidates all previews); recorded receipts and created items are NOT erased |
+| `POST /domains/{d}/rehearsal/reset` | setup (first) / review (re-reset) | start a new rehearsal generation with the deterministic seed and a fresh restart-safe `run_id`; invalidates all previews; the prior run's fictional action items are cancelled through the normal status machinery (completed items and all receipts remain) |
 | `GET /domains/{d}/rehearsal/pending-publish` | read | rows + review state (`404` until first reset) |
 | `GET /domains/{d}/rehearsal/pending-publish/{r}` | read | row detail (`assignee_bound`, `executed`, version) |
 | `POST .../{r}/review` `{decision, note?}` | review | decision ∈ {approve, reject, needs_edit, needs_more_info}; records a real `DecisionRecordedReceipt`; note ≤ 2000 bytes |
 | `PUT .../{r}` `{plain_summary}` | review | bounded edit (≤ 256 bytes; the ONLY editable field); resets status to pending_review and clears approval |
 | `POST .../{r}/assign` `{assignee_label?}` | review | assign by registered human label (≤ 120 bytes); unknown label → 422; resets status/approval; `null` clears |
-| `POST /domains/{d}/rehearsal/bindings` `{label, did}` | review | bind label → fictional DID; DID accepted on write, never echoed |
+| `POST /domains/{d}/rehearsal/bindings` `{label, did}` | setup | bind label → fictional DID (target must already hold domain membership, else 422); DID accepted on write, never echoed |
 | `GET /domains/{d}/rehearsal/bindings` | read | labels + `bound` flags only |
 | `GET .../{r}/preview` | review | pure read; requires current approval; returns the exact mutation fields + `preview_digest`; non-action-item kinds → 422 (reviewable, not executable) |
 | `POST .../{r}/confirm` `{preview_digest}` | confirm | digest-verified execution (below); duplicate identical confirm → 200 idempotent replay; different digest after execution → 409 |
@@ -81,6 +85,15 @@ digest, so the stale preview fails closed (409) and a fresh preview is
 required. The digest bytes are persisted as the plan `body_hash`, so the
 binding is auditable in the receipt chain.
 
+**Interrupted-confirm recovery:** the created action item is marked in the
+workspace the moment it exists, before the mutation-applied receipt. If that
+recording fails, review mutations on the row are blocked (409) and an
+identical retried confirm RESUMES the same item — a retry can never create a
+second one. Every persistent identifier (session, decision, activation,
+plan, application) carries the workspace `run_id`, so identifiers are never
+reused across resets or daemon restarts even though the seed content is
+deterministic.
+
 ## Confirm execution (real machinery)
 
 On a verified confirm the node records, in order, through the existing
@@ -102,22 +115,32 @@ in this slice (422).
 ## Summary origin
 
 `GET /v1/gov/me/pending-publish-summary` gains one origin value:
-`rehearsal_runtime` — served only in Rehearsal mode once a workspace exists
-(rows then reflect live review state). `committed_fixture` (Bootstrap/Test,
-and Rehearsal before any reset) and `live_runtime` (Production: no rows) are
+`rehearsal_runtime` — served only in Rehearsal mode, and only for workspaces
+in domains where the CALLER holds membership standing. A caller with no
+member-visible workspace receives the static `committed_fixture` response,
+exactly as if no workspace existed anywhere: one domain's rehearsal rows,
+review state, and workspace existence are never observable from another
+domain. `committed_fixture` (Bootstrap/Test, and Rehearsal before any
+member-visible reset) and `live_runtime` (Production: no rows) are
 unchanged.
 
 ## Evidence packet (`urn:icn:contract:rehearsal-workflow-evidence:v1`)
 
 Derived from actual workspace outcomes: per-row outcome
-(`executed | approved-not-executed | rejected | edit-and-resubmit |
-deferred`), versions, preview digests and plan/application record hashes for
-executed rows, the decision log (ids + record hashes + `note_present`
-flags), label binding states, non-claims, a privacy-review block, and a
-`packet_hash` — SHA-256 over the canonical packet content (excluding
-`packet_hash`/`generated_at`) so any tampering is detectable by
-recomputation, including in a browser via WebCrypto. The packet contains no
-DIDs, credentials, private-overlay values, paths, or topology.
+(`executed | interrupted-execution | approved-not-executed | rejected |
+edit-and-resubmit | deferred`), versions, preview digests and
+plan/application record hashes for executed rows, the decision log (ids +
+record hashes + `note_present` flags), label binding states, the `run_id`
+and generation, non-claims, a privacy-review result, and TWO hashes over the
+canonical packet content (the packet's JSON serialization with only the two
+hash fields removed — `generated_at` and every other exported field are
+bound): `packet_hash` (domain-separated BLAKE3, tag
+`icn:gov:rehearsal_workflow_evidence:v1`, the ICN receipt convention) and
+`packet_hash_sha256` (a mirror so a browser steward view can verify via
+WebCrypto). A reusable validator
+(`icn_governance_actor::rehearsal_workspace::validate_evidence_packet`)
+recomputes both; tampering with any field fails verification. The packet
+contains no DIDs, credentials, private-overlay values, paths, or topology.
 
 ## Non-claims
 

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -4022,6 +4022,15 @@ domain_tags = ["contracts", "pilots", "review", "evidence", "accessibility"]
 recommended_action = "keep"
 last_reviewed = "2026-05-05"
 
+[docs."docs/contracts/rehearsal-review-workflow.md"]
+category = "reference"
+status = "living"
+title = "Rehearsal review workflow — runtime contract (v1)"
+description = "Runtime contract for the Rehearsal-Node-only organizer pending-publish review/confirm surface (#1726/#1728/#2386): mounted exclusively in the rehearsal governance build mode; narrow governance:pending-publish:review / :confirm capabilities; bounded review decisions/edits/label assignment; domain-separated BLAKE3 preview digest binding confirm to the previewed mutation; confirm walks the real ADR-0026 receipt ladder and creates one real action item; rehearsal_runtime summary origin; value-withheld SHA-256-hashed evidence packet (urn:icn:contract:rehearsal-workflow-evidence:v1). Deliberately absent from the public OpenAPI document. Fictional rehearsal surface; grants no authority."
+last_updated = "2026-07-11"
+owner = "matt"
+audiences = ["contributors", "architects", "organizers"]
+
 [docs."docs/contracts/pending-publish-summary.md"]
 category = "reference"
 status = "living"

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3351,6 +3351,7 @@ dependencies = [
  "icn-time",
  "serde",
  "serde_json",
+ "sha2",
  "sled",
  "tempfile",
  "tokio",

--- a/icn/apps/governance/Cargo.toml
+++ b/icn/apps/governance/Cargo.toml
@@ -56,6 +56,7 @@ sled = "0.34"
 ed25519-dalek.workspace = true
 hex = "0.4"
 blake3 = "1.5"
+sha2.workspace = true
 
 # UUID generation (for suggestion proposal IDs)
 uuid = { version = "1", features = ["v4"] }

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -605,6 +605,13 @@ where
 
     let data = web::Data::new(ctx);
 
+    // The rehearsal review/mutation surface exists ONLY in Rehearsal mode.
+    // In every other mode the routes are not mounted at all, so the surface
+    // fails closed as 404 (no handler-level check to get wrong).
+    if data.build_mode.allows_rehearsal_mutation() {
+        super::rehearsal::configure_rehearsal_routes::<E>(cfg);
+    }
+
     cfg.app_data(data.clone())
         // ── Domain endpoints ─────────────────────────────────────────────
         .service(

--- a/icn/apps/governance/src/http/configure.rs
+++ b/icn/apps/governance/src/http/configure.rs
@@ -87,6 +87,19 @@ pub enum GovernanceContextBuildMode {
     /// dependencies do not reject startup — but distinguishable in logs
     /// so test runs are not confused with production misconfiguration.
     Test,
+
+    /// Explicit rehearsal mode for the isolated Rehearsal Node (#2386,
+    /// #1726).
+    ///
+    /// Identical permissive dependency posture to
+    /// [`Bootstrap`](Self::Bootstrap), plus it is the ONLY mode in which
+    /// the rehearsal pending-publish review/mutation surface is mounted
+    /// (see [`Self::allows_rehearsal_mutation`]). Opt-in is by the exact
+    /// value `rehearsal` in `ICN_GOVERNANCE_BUILD_MODE`; every unknown or
+    /// missing value falls back to `Bootstrap`, which keeps the surface
+    /// absent — a typo can never open a mutation path (fail-closed, the
+    /// #2075 posture applied to build modes).
+    Rehearsal,
 }
 
 impl GovernanceContextBuildMode {
@@ -97,14 +110,25 @@ impl GovernanceContextBuildMode {
     /// directly rather than this helper.
     ///
     /// Recognized values (case-insensitive): `bootstrap`, `production`,
-    /// `test`. Unrecognized values fall back to `Bootstrap` to preserve
-    /// existing behavior; the gateway logs the unrecognized value.
+    /// `test`, `rehearsal`. Unrecognized values fall back to `Bootstrap`
+    /// to preserve existing behavior; the gateway logs the unrecognized
+    /// value.
     pub fn from_env() -> Self {
-        match std::env::var("ICN_GOVERNANCE_BUILD_MODE") {
-            Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+        Self::parse(std::env::var("ICN_GOVERNANCE_BUILD_MODE").ok().as_deref())
+    }
+
+    /// Parse a raw mode value (already read from the environment or a
+    /// launcher). `None` and every unrecognized value resolve to
+    /// [`Bootstrap`](Self::Bootstrap) — the historical fallback — and
+    /// Bootstrap never enables the rehearsal mutation surface, so an
+    /// absent or misspelled mode fails closed.
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw {
+            Some(raw) => match raw.trim().to_ascii_lowercase().as_str() {
                 "bootstrap" | "" => Self::Bootstrap,
                 "production" => Self::Production,
                 "test" => Self::Test,
+                "rehearsal" => Self::Rehearsal,
                 other => {
                     warn!(
                         mode = %other,
@@ -113,7 +137,7 @@ impl GovernanceContextBuildMode {
                     Self::Bootstrap
                 }
             },
-            Err(_) => Self::Bootstrap,
+            None => Self::Bootstrap,
         }
     }
 
@@ -121,6 +145,16 @@ impl GovernanceContextBuildMode {
     /// missing optional standing checkers or the membership resolver.
     pub fn rejects_unresolved_standing(self) -> bool {
         matches!(self, Self::Production)
+    }
+
+    /// Returns `true` only for [`Rehearsal`](Self::Rehearsal): the single
+    /// mode in which the rehearsal pending-publish review/mutation routes
+    /// are mounted at all. Production, Bootstrap (the unknown/missing
+    /// fallback), and Test never mount them — in those modes the routes do
+    /// not exist, so the surface fails closed as 404 rather than trusting
+    /// a handler-level check.
+    pub fn allows_rehearsal_mutation(self) -> bool {
+        matches!(self, Self::Rehearsal)
     }
 }
 
@@ -469,10 +503,11 @@ impl<E> GovernanceContext<E> {
     /// a hard configuration error and this returns
     /// [`GovernanceContextValidationError`] naming all of them.
     ///
-    /// In [`GovernanceContextBuildMode::Bootstrap`] and
-    /// [`GovernanceContextBuildMode::Test`] this emits a `tracing::warn!`
-    /// for each missing dependency (so operators can see the fall-open
-    /// state in logs) but returns `Ok(())`.
+    /// In [`GovernanceContextBuildMode::Bootstrap`],
+    /// [`GovernanceContextBuildMode::Test`], and
+    /// [`GovernanceContextBuildMode::Rehearsal`] this emits a
+    /// `tracing::warn!` for each missing dependency (so operators can see
+    /// the fall-open state in logs) but returns `Ok(())`.
     ///
     /// Callers should invoke this at daemon/gateway startup before
     /// routes are registered, not lazily inside a handler.
@@ -487,7 +522,9 @@ impl<E> GovernanceContext<E> {
                 mode: self.build_mode,
                 missing,
             }),
-            mode @ (GovernanceContextBuildMode::Bootstrap | GovernanceContextBuildMode::Test) => {
+            mode @ (GovernanceContextBuildMode::Bootstrap
+            | GovernanceContextBuildMode::Test
+            | GovernanceContextBuildMode::Rehearsal) => {
                 self.warn_missing_dependencies(mode, &missing);
                 Ok(())
             }
@@ -954,6 +991,40 @@ mod build_mode_tests {
         assert!(GovernanceContextBuildMode::Production.rejects_unresolved_standing());
         assert!(!GovernanceContextBuildMode::Bootstrap.rejects_unresolved_standing());
         assert!(!GovernanceContextBuildMode::Test.rejects_unresolved_standing());
+        // Rehearsal keeps Bootstrap's permissive dependency posture: it is a
+        // fixture rehearsal, not a partner/production deployment.
+        assert!(!GovernanceContextBuildMode::Rehearsal.rejects_unresolved_standing());
+    }
+
+    #[test]
+    fn rehearsal_mode_parses_by_exact_value_only() {
+        // The rehearsal mutation surface is opt-in by the EXACT value
+        // "rehearsal" (case-insensitive, trimmed). Every unknown or missing
+        // value keeps the historical Bootstrap fallback — and Bootstrap never
+        // enables rehearsal mutations, so a typo can never open the surface.
+        use GovernanceContextBuildMode as M;
+        assert_eq!(M::parse(Some("rehearsal")), M::Rehearsal);
+        assert_eq!(M::parse(Some("  REHEARSAL ")), M::Rehearsal);
+        assert_eq!(M::parse(Some("production")), M::Production);
+        assert_eq!(M::parse(Some("bootstrap")), M::Bootstrap);
+        assert_eq!(M::parse(Some("test")), M::Test);
+        assert_eq!(M::parse(Some("")), M::Bootstrap);
+        assert_eq!(M::parse(Some("rehearsa")), M::Bootstrap);
+        assert_eq!(M::parse(Some("rehearsal-mode")), M::Bootstrap);
+        assert_eq!(M::parse(Some("prod")), M::Bootstrap);
+        assert_eq!(M::parse(None), M::Bootstrap);
+    }
+
+    #[test]
+    fn rehearsal_mutation_surface_is_rehearsal_only() {
+        // Fail-closed gate for every rehearsal-only mutation route: exactly
+        // one mode enables the surface. Production, Bootstrap (the unknown/
+        // missing fallback), and Test all keep it absent.
+        use GovernanceContextBuildMode as M;
+        assert!(M::Rehearsal.allows_rehearsal_mutation());
+        assert!(!M::Production.allows_rehearsal_mutation());
+        assert!(!M::Bootstrap.allows_rehearsal_mutation());
+        assert!(!M::Test.allows_rehearsal_mutation());
     }
 
     #[test]

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -6278,15 +6278,34 @@ pub async fn get_my_pending_publish_summary<E: GovernanceEventEmitter + Clone + 
     // In Rehearsal mode, an initialized review workspace replaces the static
     // fixture: same fictional material, but reflecting live review state and
     // honestly labeled as such. Production continues to serve no rows.
-    let (origin, rows) = if ctx.build_mode.allows_rehearsal_mutation()
-        && ctx.manager.rehearsal_state().any_initialized()
-    {
-        (
-            PendingPublishOrigin::RehearsalRuntime,
-            ctx.manager.rehearsal_state().summary_rows(),
-        )
-    } else {
-        pending_publish_projection(ctx.build_mode)
+    //
+    // Isolation: only workspaces in domains where the CALLER holds membership
+    // standing are visible — a workspace's rows, labels, and very existence
+    // in one domain must never be observable from another (#2052
+    // object-context doctrine applied to this self-scoped summary). A caller
+    // with no member-visible workspace falls through to the static fixture,
+    // exactly as if no workspace existed anywhere.
+    let mut rehearsal_rows: Option<Vec<PendingPublishRow>> = None;
+    if ctx.build_mode.allows_rehearsal_mutation() {
+        let mut visible = Vec::new();
+        for domain_id in ctx.manager.rehearsal_state().initialized_domains() {
+            let domain = GovernanceDomainId(domain_id.clone());
+            if check_domain_membership(&ctx, &domain, &caller)
+                .await
+                .is_ok()
+            {
+                if let Some(rows) = ctx.manager.rehearsal_state().domain_rows(&domain_id) {
+                    visible.extend(rows);
+                }
+            }
+        }
+        if !visible.is_empty() {
+            rehearsal_rows = Some(visible);
+        }
+    }
+    let (origin, rows) = match rehearsal_rows {
+        Some(rows) => (PendingPublishOrigin::RehearsalRuntime, rows),
+        None => pending_publish_projection(ctx.build_mode),
     };
 
     Ok(HttpResponse::Ok().json(PendingPublishSummaryResponse {

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -6285,22 +6285,29 @@ pub async fn get_my_pending_publish_summary<E: GovernanceEventEmitter + Clone + 
     // object-context doctrine applied to this self-scoped summary). A caller
     // with no member-visible workspace falls through to the static fixture,
     // exactly as if no workspace existed anywhere.
+    // Serve live rehearsal rows only from a SINGLE member-visible workspace.
+    // Fixture rows carry no `domain_id` and every workspace seeds the same
+    // generic row ids, so concatenating two domains would yield duplicate,
+    // indistinguishable ids a client could act on against the wrong
+    // `/domains/{id}/rehearsal/...` route. The authoritative surface is
+    // per-domain; this self-scoped summary is a convenience mirror, so a
+    // caller who is a member of more than one initialized rehearsal domain
+    // falls through to the honest static `committed_fixture` response rather
+    // than an ambiguous aggregate.
     let mut rehearsal_rows: Option<Vec<PendingPublishRow>> = None;
     if ctx.build_mode.allows_rehearsal_mutation() {
-        let mut visible = Vec::new();
+        let mut member_visible: Vec<String> = Vec::new();
         for domain_id in ctx.manager.rehearsal_state().initialized_domains() {
             let domain = GovernanceDomainId(domain_id.clone());
             if check_domain_membership(&ctx, &domain, &caller)
                 .await
                 .is_ok()
             {
-                if let Some(rows) = ctx.manager.rehearsal_state().domain_rows(&domain_id) {
-                    visible.extend(rows);
-                }
+                member_visible.push(domain_id);
             }
         }
-        if !visible.is_empty() {
-            rehearsal_rows = Some(visible);
+        if let [only] = member_visible.as_slice() {
+            rehearsal_rows = ctx.manager.rehearsal_state().domain_rows(only);
         }
     }
     let (origin, rows) = match rehearsal_rows {

--- a/icn/apps/governance/src/http/handlers.rs
+++ b/icn/apps/governance/src/http/handlers.rs
@@ -66,7 +66,7 @@ fn anyhow_to_api(e: anyhow::Error) -> ApiError {
 }
 
 /// Parse a DID string, returning ApiError::BadRequest on failure.
-fn parse_did(s: &str, context: &str) -> Result<Did, ApiError> {
+pub(crate) fn parse_did(s: &str, context: &str) -> Result<Did, ApiError> {
     s.parse::<Did>()
         .map_err(|e| err_bad(format!("{context}: {e}")))
 }
@@ -80,7 +80,7 @@ fn parse_did(s: &str, context: &str) -> Result<Did, ApiError> {
 /// endpoints this shared gate backs). Unresolved standing fails closed under
 /// `Production` posture (surfacing `unresolved_standing`); `Bootstrap`/`Test`
 /// stay permissive for dev/devnet.
-async fn check_domain_membership<E>(
+pub(crate) async fn check_domain_membership<E>(
     ctx: &GovernanceContext<E>,
     domain_id: &GovernanceDomainId,
     user_did: &Did,
@@ -6253,7 +6253,10 @@ pub async fn get_my_action_cards<E: GovernanceEventEmitter + Clone + 'static>(
                 mutation API on this surface, no authority is granted, and no action \
                 card is created. `origin = live_runtime` (production) returns no rows; \
                 `origin = committed_fixture` (non-production) returns deterministic, \
-                fictional rehearsal rows. Row `kind`, `status`, `risk_level`, \
+                fictional rehearsal rows; `origin = rehearsal_runtime` (rehearsal \
+                build mode, after an explicit workspace reset) returns the live \
+                rehearsal review workspace rows — still fictional, never \
+                production state. Row `kind`, `status`, `risk_level`, \
                 `source_provenance`, and `receipt_expected.category` use closed enums.",
             body = PendingPublishSummaryResponse),
         (status = 401, description = "Missing or invalid bearer token"),
@@ -6272,7 +6275,19 @@ pub async fn get_my_pending_publish_summary<E: GovernanceEventEmitter + Clone + 
     // Production serves no pending-publish rows: there is no runtime source
     // object, and fictional rehearsal rows must never appear on a production
     // surface. Non-production build modes serve deterministic fixture rows.
-    let (origin, rows) = pending_publish_projection(ctx.build_mode);
+    // In Rehearsal mode, an initialized review workspace replaces the static
+    // fixture: same fictional material, but reflecting live review state and
+    // honestly labeled as such. Production continues to serve no rows.
+    let (origin, rows) = if ctx.build_mode.allows_rehearsal_mutation()
+        && ctx.manager.rehearsal_state().any_initialized()
+    {
+        (
+            PendingPublishOrigin::RehearsalRuntime,
+            ctx.manager.rehearsal_state().summary_rows(),
+        )
+    } else {
+        pending_publish_projection(ctx.build_mode)
+    };
 
     Ok(HttpResponse::Ok().json(PendingPublishSummaryResponse {
         did: caller.to_string(),
@@ -6342,7 +6357,7 @@ mod pending_publish_gate_tests {
 /// `GET /me/pending-publish-summary` response. No institution-specific nouns, no
 /// DIDs, no private paths — labels are generic scope/body/assignee strings. The
 /// set is stable so two requests return identical rows.
-fn demo_pending_publish_rows() -> Vec<PendingPublishRow> {
+pub(crate) fn demo_pending_publish_rows() -> Vec<PendingPublishRow> {
     let hint = "Plain-language row. Status and receipt-expectation are read-only \
                 review context, not authority."
         .to_string();

--- a/icn/apps/governance/src/http/mod.rs
+++ b/icn/apps/governance/src/http/mod.rs
@@ -8,6 +8,7 @@
 pub mod configure;
 pub mod handlers;
 pub mod models;
+pub mod rehearsal;
 pub mod validation;
 
 pub use configure::{

--- a/icn/apps/governance/src/http/models.rs
+++ b/icn/apps/governance/src/http/models.rs
@@ -513,6 +513,11 @@ pub enum PendingPublishOrigin {
     /// live participant state. Served only in non-production (bootstrap/test)
     /// build modes so the organizer rehearsal shell can exercise the endpoint.
     CommittedFixture,
+    /// `rows` come from the live rehearsal review workspace on an isolated
+    /// Rehearsal Node (`rehearsal` build mode, after an explicit workspace
+    /// reset): still fictional, but reflecting real organizer review state
+    /// rather than the static committed fixture. Never served in production.
+    RehearsalRuntime,
 }
 
 /// Closed taxonomy of pending-publish row kinds. Mirrors the `kind` enum of

--- a/icn/apps/governance/src/http/rehearsal.rs
+++ b/icn/apps/governance/src/http/rehearsal.rs
@@ -76,6 +76,15 @@ const CONFIRM_SCOPES: &[&str] = &["governance:pending-publish:confirm", "governa
 /// bind identities — it only sees and assigns labels.
 const SETUP_SCOPES: &[&str] = &["governance:rehearsal:setup", "governance:write"];
 
+/// `meeting_context` marker prefix carried by every action item this surface
+/// creates (the full value appends the run-scoped session id). Reset scans
+/// the DURABLE item store for this marker in addition to the in-memory
+/// workspace: the workspace is node-lifetime, so after a daemon restart the
+/// prior run's created items are only findable through this persisted
+/// marker — without the scan they would stay active in the member's queue
+/// and accumulate across restarted rehearsals.
+const REHEARSAL_ITEM_CONTEXT_PREFIX: &str = "rehearsal-review session ";
+
 // ── Request models: contract enforced by rejection, not omission ───────────
 
 #[derive(Debug, Deserialize)]
@@ -196,12 +205,32 @@ fn ensure_session<E: GovernanceEventEmitter + Clone + 'static>(
     Ok(())
 }
 
-/// The ladder fails closed with descriptive conflicts (e.g. a session opened
-/// by a different actor). Map those to 409 and everything else to 500 with
-/// PLAIN client messages — backend detail goes to the log, never the client.
+/// The stable, message-leading error prefixes the `GovernanceManager` ladder
+/// uses for identity conflicts (same id re-recorded with different content).
+/// These — and only these — map to 409. Precondition failures
+/// (`*_not_opened`, `*_not_found`, `*_mismatch`, `*_gate_not_passed`, …) and
+/// storage failures stay 500: they signal state divergence or operational
+/// trouble, not a client-resolvable conflict.
+const LADDER_CONFLICT_PREFIXES: &[&str] = &[
+    "process_session_open_conflict",
+    "decision_recorded_conflict",
+    "activation_crossed_conflict",
+    "mutation_plan_recorded_conflict",
+    "mutation_applied_conflict",
+];
+
+/// The ladder fails closed with stable-prefix conflict errors (e.g. a session
+/// opened by a different actor). Map exactly those to 409 and everything else
+/// to 500 with PLAIN client messages — backend detail goes to the log, never
+/// the client. Matching is on the manager's stable prefixes at the START of
+/// the message, never on incidental substrings ("already", "conflict") that a
+/// storage-layer error could coincidentally contain.
 fn conflict_or_internal(e: anyhow::Error) -> ApiError {
     let detail = e.to_string();
-    if detail.contains("conflict") || detail.contains("already") {
+    if LADDER_CONFLICT_PREFIXES
+        .iter()
+        .any(|p| detail.starts_with(p))
+    {
         tracing::warn!(detail = %detail, "rehearsal receipt conflict");
         ApiError::Conflict(
             "A rehearsal process receipt for this step already exists with different \
@@ -289,12 +318,50 @@ pub async fn rehearsal_reset<E: GovernanceEventEmitter + Clone + 'static>(
     let (domain, caller) = gate(&ctx, &http_req, &domain_id, scopes).await?;
     let (generation, prior_items) = state.reset(&domain.0, demo_pending_publish_rows());
 
+    // The in-memory workspace only knows about items created THIS process
+    // lifetime. Action items are durable (Sled in the gateway path) and
+    // survive restarts, so also scan the durable store for this domain's
+    // rehearsal-created items (identified by the meeting_context marker
+    // this surface writes) that are still active. Without this, a daemon
+    // restart would orphan the prior run's fictional items in the member's
+    // active queue. Scan failures are reported, never silently swallowed.
+    let mut retire: Vec<String> = prior_items;
+    let mut scan_failed = false;
+    match ctx
+        .manager
+        .list_action_items(&domain, &icn_governance::ActionItemFilter::default())
+    {
+        Ok(items) => {
+            for item in items {
+                let is_rehearsal_item = item
+                    .meeting_context
+                    .as_deref()
+                    .is_some_and(|c| c.starts_with(REHEARSAL_ITEM_CONTEXT_PREFIX));
+                let is_active = !matches!(
+                    item.status,
+                    icn_governance::ActionItemStatus::Completed
+                        | icn_governance::ActionItemStatus::Cancelled
+                );
+                if is_rehearsal_item && is_active {
+                    let id = item.id.to_string();
+                    if !retire.contains(&id) {
+                        retire.push(id);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(detail = %e, "reset could not scan durable rehearsal items");
+            scan_failed = true;
+        }
+    }
+
     // Retire the prior run's fictional action items (skip anything already
     // completed — completion history is real and stays). Per-item failures
     // are reported, never silently swallowed.
     let mut cancelled = Vec::new();
     let mut not_cancelled = Vec::new();
-    for item_id in prior_items {
+    for item_id in retire {
         let Ok(uuid) = item_id.parse::<uuid::Uuid>() else {
             not_cancelled.push(item_id);
             continue;
@@ -339,6 +406,10 @@ pub async fn rehearsal_reset<E: GovernanceEventEmitter + Clone + 'static>(
         "rows": rows,
         "cancelled_action_items": cancelled,
         "not_cancelled_action_items": not_cancelled,
+        // "complete" = the durable store was scanned for prior rehearsal
+        // items (including runs before a daemon restart); "failed" = the
+        // scan errored and orphaned items may remain (re-run reset).
+        "prior_item_scan": if scan_failed { "failed" } else { "complete" },
         "non_claims": [
             "fictional rehearsal workspace — grants no authority",
             "reset starts a new rehearsal generation: recorded receipts are permanent process facts; the prior run's fictional action items are cancelled (not erased) unless already completed",
@@ -637,9 +708,65 @@ pub async fn rehearsal_assign<E: GovernanceEventEmitter + Clone + 'static>(
     }
 }
 
+/// Affirmative membership check for a BINDING TARGET — never falls open.
+///
+/// The caller gate ([`check_domain_membership`]) keeps the permissive
+/// Bootstrap dependency posture in Rehearsal mode (a `TrustThreshold`
+/// domain with no wired resolver lets the CALLER proceed, matching every
+/// other rehearsal/bootstrap surface). The binding-target invariant is
+/// stricter: the runtime contract says the bound DID must ALREADY hold
+/// membership standing in this domain, and that fact must be affirmatively
+/// established here — not deferred to future appliance wiring. So:
+///
+/// - `StaticList` — the DID is in the list, resolved from the source;
+/// - `TrustThreshold` + wired resolver — the resolver confirms membership;
+/// - `TrustThreshold` + missing resolver — DENY (standing cannot be
+///   established, so it is not established);
+/// - resolver error/indeterminate — DENY (logged; never surfaced).
+///
+/// Every deny is reported identically by the caller, so the response never
+/// distinguishes "not a member" from "membership unknowable" and leaks
+/// nothing about hidden identities or other domains' state.
+async fn binding_target_holds_membership<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: &GovernanceContext<E>,
+    domain: &GovernanceDomainId,
+    did: &Did,
+) -> bool {
+    let domain_obj = match ctx.manager.get_domain(domain).await {
+        Ok(Some(d)) => d,
+        Ok(None) => return false,
+        Err(e) => {
+            tracing::warn!(detail = %e, "rehearsal binding: domain lookup failed; denying");
+            return false;
+        }
+    };
+    match &domain_obj.config.membership.source {
+        icn_governance::MembershipSource::StaticList(members) => members.contains(did),
+        icn_governance::MembershipSource::TrustThreshold(_) => match &ctx.membership_resolver {
+            Some(resolver) => resolver.is_member(&domain_obj, did).unwrap_or_else(|e| {
+                tracing::warn!(
+                    detail = %e,
+                    "rehearsal binding: membership resolution failed; denying (fail closed)"
+                );
+                false
+            }),
+            None => {
+                tracing::warn!(
+                    domain = %domain.0,
+                    "rehearsal binding: no membership resolver for TrustThreshold domain; \
+                     denying (fail closed — binding targets must have affirmative standing)"
+                );
+                false
+            }
+        },
+    }
+}
+
 /// POST /domains/{domain_id}/rehearsal/bindings — bind a label to a fictional
 /// DID (registering the label if new). The DID is accepted on write and never
-/// echoed. Rebinding invalidates outstanding previews via the digest.
+/// echoed. Rebinding invalidates outstanding previews via the digest — except
+/// while an interrupted execution references the label, when rebinding is
+/// refused so the identical confirm retry can still resume.
 pub async fn rehearsal_bind_label<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
     http_req: HttpRequest,
@@ -658,11 +785,10 @@ pub async fn rehearsal_bind_label<E: GovernanceEventEmitter + Clone + 'static>(
     let bound_did = parse_did(&req.did, "Invalid DID in binding")?;
     // A binding target must already hold standing in this domain: binding
     // grants no authority and cannot smuggle an outside identity into the
-    // rehearsal's completion loop.
-    if check_domain_membership(&ctx, &domain, &bound_did)
-        .await
-        .is_err()
-    {
+    // rehearsal's completion loop. This check NEVER falls open: absent or
+    // indeterminate standing denies, and the deny below is identical for
+    // every cause, so nothing about hidden identities leaks.
+    if !binding_target_holds_membership(&ctx, &domain, &bound_did).await {
         return Ok(HttpResponse::UnprocessableEntity().json(json!({
             "error": "The identity for this label does not hold membership standing in this domain; bindings must reference an existing fictional domain member.",
             "label": req.label,
@@ -671,13 +797,31 @@ pub async fn rehearsal_bind_label<E: GovernanceEventEmitter + Clone + 'static>(
 
     let state = ctx.manager.rehearsal_state();
     let body = state
-        .with_workspace(&domain.0, |workspace| {
+        .with_workspace(&domain.0, |workspace| -> Result<Value, ApiError> {
+            // An interrupted execution's retry recomputes the plan digest
+            // from CURRENT state, including this label's bound DID.
+            // Rebinding now would make the identical retry stale (409) and
+            // strand the already-created action item without its applied
+            // receipt — so rebinding is refused until the retry completes
+            // or the workspace is reset.
+            let referenced_by_interrupted = workspace.rows.iter().any(|r| {
+                r.pending_item_id.is_some()
+                    && r.base.assignee_label.as_deref() == Some(req.label.as_str())
+            });
+            if referenced_by_interrupted {
+                return Err(ApiError::Conflict(
+                    "An interrupted execution references this label; retry confirm with \
+                     the same preview digest to complete it (or reset the rehearsal) \
+                     before rebinding."
+                        .to_string(),
+                ));
+            }
             workspace
                 .bindings
                 .insert(req.label.clone(), bound_did.to_string());
-            json!({ "label": req.label, "bound": true })
+            Ok(json!({ "label": req.label, "bound": true }))
         })
-        .ok_or_else(workspace_not_initialized)?;
+        .ok_or_else(workspace_not_initialized)??;
     Ok(HttpResponse::Ok().json(body))
 }
 
@@ -852,16 +996,40 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
             // Real ADR-0026 ladder: gate → activation → plan → item → applied.
             ensure_session(&ctx, &domain, workspace, &caller)?;
             let row_version = workspace.row(&row_id).ok_or_else(row_not_found)?.version;
-            let gate_receipt = ctx
-                .manager
-                .record_process_gate_result(
-                    &domain,
-                    &session_id,
-                    ProcessGateKind::ScopeConfirmation,
-                    ProcessGateResult::Pass,
-                    &caller,
-                )
-                .map_err(conflict_or_internal)?;
+            // Gate receipts are append-only observations whose record_hash
+            // includes recorded_at, and the activation's gate basis is part
+            // of the activation's stable identity. A RETRY of an interrupted
+            // confirm must therefore reuse the gate receipt already recorded
+            // for this row version: recording a fresh one in a later second
+            // would change the basis and hard-conflict with the
+            // already-recorded activation, wedging the retry. One confirm of
+            // one row version = one gate observation.
+            let gate_record_hash = {
+                let prior = workspace
+                    .row(&row_id)
+                    .ok_or_else(row_not_found)?
+                    .confirm_gate
+                    .and_then(|(v, hash)| (v == row_version).then_some(hash));
+                match prior {
+                    Some(hash) => hash,
+                    None => {
+                        let receipt = ctx
+                            .manager
+                            .record_process_gate_result(
+                                &domain,
+                                &session_id,
+                                ProcessGateKind::ScopeConfirmation,
+                                ProcessGateResult::Pass,
+                                &caller,
+                            )
+                            .map_err(conflict_or_internal)?;
+                        if let Some(row) = workspace.row_mut(&row_id) {
+                            row.confirm_gate = Some((row_version, receipt.record_hash));
+                        }
+                        receipt.record_hash
+                    }
+                }
+            };
             let activation_id = format!("rehearsal-activation-{run_id}-{row_id}-v{row_version}");
             let activation = match ctx
                 .manager
@@ -871,7 +1039,7 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
                     &activation_id,
                     &approve_ref.decision_id,
                     approve_ref.record_hash,
-                    &[gate_receipt.record_hash],
+                    &[gate_record_hash],
                     &caller,
                 )
                 .map_err(conflict_or_internal)?
@@ -926,7 +1094,7 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
                             plan.due_date,
                             ActionItemPriority::Medium,
                             None,
-                            Some(format!("rehearsal-review session {session_id}")),
+                            Some(format!("{REHEARSAL_ITEM_CONTEXT_PREFIX}{session_id}")),
                             Vec::new(),
                         )
                         .map_err(|e| {
@@ -973,7 +1141,7 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
                 session_id: session_id.clone(),
                 decision_id: approve_ref.decision_id.clone(),
                 decision_record_hash: approve_ref.record_hash,
-                gate_record_hash: gate_receipt.record_hash,
+                gate_record_hash,
                 activation_id,
                 activation_record_hash: activation.record_hash,
                 plan_id,
@@ -1278,4 +1446,70 @@ pub fn configure_rehearsal_routes<E: GovernanceEventEmitter + Clone + 'static>(
         web::resource("/domains/{domain_id}/rehearsal/evidence-export")
             .route(web::get().to(rehearsal_evidence_export::<E>)),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_conflict(msg: &str) -> bool {
+        matches!(
+            conflict_or_internal(anyhow::anyhow!("{msg}")),
+            ApiError::Conflict(_)
+        )
+    }
+
+    /// Every stable manager conflict prefix maps to 409.
+    #[test]
+    fn ladder_conflict_prefixes_map_to_conflict() {
+        for prefix in LADDER_CONFLICT_PREFIXES {
+            assert!(
+                is_conflict(&format!("{prefix}: detail elided")),
+                "{prefix} must classify as a conflict"
+            );
+        }
+    }
+
+    /// Backend/storage errors that merely CONTAIN conflict-ish words must
+    /// stay 500 — the regression the old substring matching allowed.
+    #[test]
+    fn incidental_substrings_stay_internal() {
+        for msg in [
+            "Failed to persist decision receipt for decision d1: key already exists",
+            "storage error: tree 'receipts' already open in another process",
+            "I/O error while resolving lock conflict in sled segment",
+            "record_process_gate_result: session_id must be non-empty",
+        ] {
+            assert!(
+                !is_conflict(msg),
+                "'{msg}' must classify as internal, not conflict"
+            );
+        }
+    }
+
+    /// Precondition failures (state divergence) are not client conflicts.
+    #[test]
+    fn ladder_precondition_failures_stay_internal() {
+        for msg in [
+            "activation_crossed_session_not_opened: session s in domain d has no recorded opening",
+            "activation_crossed_decision_not_found: no decision d1 recorded in session s",
+            "activation_crossed_decision_mismatch: decision d1 in session s in domain d",
+            "activation_crossed_gate_not_passed: a declared gate-result in session s did not pass",
+            "mutation_plan_recorded_activation_not_found: no activation a1 recorded",
+        ] {
+            assert!(
+                !is_conflict(msg),
+                "'{msg}' is a precondition failure and must stay internal"
+            );
+        }
+    }
+
+    /// The prefix must lead the message: a conflict token buried mid-message
+    /// (e.g. quoted inside a storage error) is not a manager conflict.
+    #[test]
+    fn conflict_prefix_must_lead_the_message() {
+        assert!(!is_conflict(
+            "sled write failed while storing 'activation_crossed_conflict' payload"
+        ));
+    }
 }

--- a/icn/apps/governance/src/http/rehearsal.rs
+++ b/icn/apps/governance/src/http/rehearsal.rs
@@ -317,14 +317,26 @@ pub async fn rehearsal_reset<E: GovernanceEventEmitter + Clone + 'static>(
     };
     let (domain, caller) = gate(&ctx, &http_req, &domain_id, scopes).await?;
     let (generation, prior_items) = state.reset(&domain.0, demo_pending_publish_rows());
+    // The run id just minted for THIS (new) generation. Items whose marker
+    // names it belong to the new run — a confirm racing this reset could
+    // create one after `state.reset()` installed the new workspace — and
+    // must NOT be retired. `run_id` is a unique nanos-derived token, so a
+    // simple containment test is unambiguous.
+    let new_run_id = state
+        .with_workspace(&domain.0, |ws| ws.run_id.clone())
+        .unwrap_or_default();
 
     // The in-memory workspace only knows about items created THIS process
     // lifetime. Action items are durable (Sled in the gateway path) and
     // survive restarts, so also scan the durable store for this domain's
-    // rehearsal-created items (identified by the meeting_context marker
-    // this surface writes) that are still active. Without this, a daemon
-    // restart would orphan the prior run's fictional items in the member's
-    // active queue. Scan failures are reported, never silently swallowed.
+    // rehearsal-created items that are still active. Without this, a daemon
+    // restart would orphan the PRIOR run's fictional items in the member's
+    // active queue. The scan is confined to the path (designated fictional
+    // rehearsal) domain and matches only the STRUCTURED marker this surface
+    // writes (`"<prefix>rehearsal-…-gen…"`), never the loose human prefix, and
+    // it excludes the current run so a concurrent new-generation confirm is
+    // never swept. Scan failures are reported, never silently swallowed.
+    let structured_marker_prefix = format!("{REHEARSAL_ITEM_CONTEXT_PREFIX}rehearsal-");
     let mut retire: Vec<String> = prior_items;
     let mut scan_failed = false;
     match ctx
@@ -333,16 +345,15 @@ pub async fn rehearsal_reset<E: GovernanceEventEmitter + Clone + 'static>(
     {
         Ok(items) => {
             for item in items {
-                let is_rehearsal_item = item
-                    .meeting_context
-                    .as_deref()
-                    .is_some_and(|c| c.starts_with(REHEARSAL_ITEM_CONTEXT_PREFIX));
+                let marker = item.meeting_context.as_deref().unwrap_or("");
+                let is_prior_rehearsal_item = marker.starts_with(&structured_marker_prefix)
+                    && !(new_run_id.is_empty() || marker.contains(&new_run_id));
                 let is_active = !matches!(
                     item.status,
                     icn_governance::ActionItemStatus::Completed
                         | icn_governance::ActionItemStatus::Cancelled
                 );
-                if is_rehearsal_item && is_active {
+                if is_prior_rehearsal_item && is_active {
                     let id = item.id.to_string();
                     if !retire.contains(&id) {
                         retire.push(id);

--- a/icn/apps/governance/src/http/rehearsal.rs
+++ b/icn/apps/governance/src/http/rehearsal.rs
@@ -1,0 +1,1113 @@
+//! HTTP surface for the rehearsal pending-publish review workspace
+//! (#1726 / #1728 / #2386 organizer workflow slice).
+//!
+//! Mounted by [`configure`](super::configure::configure) ONLY when
+//! `build_mode.allows_rehearsal_mutation()` — i.e. exclusively in
+//! [`GovernanceContextBuildMode::Rehearsal`](super::GovernanceContextBuildMode).
+//! In Production, Bootstrap (the unknown/missing-mode fallback), and Test the
+//! routes do not exist at all, so the surface fails closed as 404 without
+//! trusting any handler-level check.
+//!
+//! Capability model (sub-capability doctrine, #2400):
+//!
+//! - `governance:pending-publish:review` — review decisions, bounded edits,
+//!   label assignment, label→fictional-DID binding, and workspace reset.
+//!   Reset and binding are deliberately bundled into the review capability
+//!   rather than a separate operator scope: the workspace is fictional and
+//!   resettable BY DESIGN (repeating the rehearsal is an organizer act, not
+//!   an operator act), and a binding grants no authority — it only lets the
+//!   fictional completion loop run, and any rebinding invalidates
+//!   outstanding previews. Splitting a third scope would add allowlist
+//!   surface without a distinct trust boundary.
+//! - `governance:pending-publish:confirm` — executing the bound mutation.
+//!   Held separately so a review-only credential can never mutate governance
+//!   state, and a confirm-only credential can never manufacture the review
+//!   state it confirms.
+//! - Broad `governance:write` retains both, consistent with the existing
+//!   sub-capability decomposition; `governance:read` grants read surfaces
+//!   only.
+//!
+//! These routes are intentionally NOT part of the public OpenAPI document:
+//! they exist only on an isolated Rehearsal Node and never in production, so
+//! advertising them in the production API contract would be dishonest. The
+//! contract is documented in `docs/contracts/rehearsal-review-workflow.md`.
+//!
+//! Every mutation requires domain membership; the path domain is the
+//! authority context (a workspace, row, or binding is only reachable through
+//! its own domain — #2052 object-context doctrine). No read surface exposes
+//! a DID; previews are bound to state via a domain-separated BLAKE3 digest
+//! (see [`crate::rehearsal_workspace`]); confirm walks the real ADR-0026
+//! receipt ladder and creates a real action item through the existing
+//! manager machinery. Receipts record process facts and grant no authority.
+
+use actix_web::{web, HttpRequest, HttpResponse};
+use icn_governance::{ActionItemPriority, ProcessGateKind, ProcessGateResult};
+use icn_http_kit::auth::{require_any_scope, require_scope, BasicClaims};
+use icn_http_kit::error::ApiError;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use sha2::Digest as _;
+
+use crate::events::GovernanceEventEmitter;
+use crate::manager::{
+    ActivationCrossedOutcome, DecisionRecordOutcome, MutationAppliedOutcome,
+    MutationPlanRecordedOutcome, ProcessSessionOpenOutcome,
+};
+use crate::rehearsal_workspace::{
+    self as ws, hex32, plan_for_row, ApproveRef, DecisionLogEntry, ExecutionRecord, RehearsalRow,
+    ReviewDecision, MAX_LABEL, MAX_NOTE, MAX_PLAIN_SUMMARY,
+};
+
+use super::configure::GovernanceContext;
+use super::handlers::{check_domain_membership, demo_pending_publish_rows, parse_did};
+use super::models::PendingPublishRowStatus;
+
+use icn_governance::GovernanceDomainId;
+use icn_identity::Did;
+
+const REVIEW_SCOPES: &[&str] = &["governance:pending-publish:review", "governance:write"];
+const CONFIRM_SCOPES: &[&str] = &["governance:pending-publish:confirm", "governance:write"];
+
+// ── Request models: contract enforced by rejection, not omission ───────────
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RehearsalResetRequest {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RehearsalReviewRequest {
+    pub decision: String,
+    #[serde(default)]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RehearsalEditRequest {
+    #[serde(default)]
+    pub plain_summary: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RehearsalAssignRequest {
+    /// `None` clears the assignment.
+    #[serde(default)]
+    pub assignee_label: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RehearsalBindRequest {
+    pub label: String,
+    /// The fictional DID to bind. Accepted on write, never echoed on any
+    /// read surface.
+    pub did: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RehearsalConfirmRequest {
+    /// 64-hex BLAKE3 preview digest from `GET .../preview`.
+    pub preview_digest: String,
+}
+
+// ── Shared helpers ──────────────────────────────────────────────────────────
+
+/// Scope + DID + domain-membership gate shared by every rehearsal handler.
+async fn gate<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: &GovernanceContext<E>,
+    http_req: &HttpRequest,
+    domain_id: &str,
+    scopes: &[&str],
+) -> Result<(GovernanceDomainId, Did), ApiError> {
+    let claims = require_any_scope::<BasicClaims>(http_req, scopes)?;
+    let caller = parse_did(&claims.sub, "Invalid DID in token")?;
+    let domain = GovernanceDomainId(domain_id.to_string());
+    check_domain_membership(ctx, &domain, &caller).await?;
+    Ok((domain, caller))
+}
+
+/// Read-surface gate: `governance:read` + membership.
+async fn read_gate<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: &GovernanceContext<E>,
+    http_req: &HttpRequest,
+    domain_id: &str,
+) -> Result<(GovernanceDomainId, Did), ApiError> {
+    let claims = require_scope::<BasicClaims>(http_req, "governance:read")?;
+    let caller = parse_did(&claims.sub, "Invalid DID in token")?;
+    let domain = GovernanceDomainId(domain_id.to_string());
+    check_domain_membership(ctx, &domain, &caller).await?;
+    Ok((domain, caller))
+}
+
+fn workspace_not_initialized() -> ApiError {
+    ApiError::NotFound(
+        "No rehearsal workspace is initialized for this domain. Start one with \
+         POST /domains/{domain_id}/rehearsal/reset."
+            .to_string(),
+    )
+}
+
+fn row_not_found() -> ApiError {
+    ApiError::NotFound("No such proposed-work row in this domain's rehearsal workspace".to_string())
+}
+
+/// Ensure the workspace's process session is opened (recording the real
+/// `ProcessSessionOpenedReceipt` on first use).
+fn ensure_session<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: &GovernanceContext<E>,
+    domain: &GovernanceDomainId,
+    workspace: &mut ws::Workspace,
+    actor: &Did,
+) -> Result<(), ApiError> {
+    if workspace.session_opened {
+        return Ok(());
+    }
+    let session_id = workspace.session_id();
+    let outcome = ctx
+        .manager
+        .record_process_session_opened(domain, &session_id, actor)
+        .map_err(conflict_or_internal)?;
+    let receipt = match outcome {
+        ProcessSessionOpenOutcome::Opened(r) | ProcessSessionOpenOutcome::AlreadyOpened(r) => r,
+    };
+    workspace.session_opened = true;
+    workspace.session_record_hash = Some(receipt.record_hash);
+    Ok(())
+}
+
+/// The ladder fails closed with descriptive conflicts (e.g. a session opened
+/// by a different actor). Map those to 409, everything else to 500.
+fn conflict_or_internal(e: anyhow::Error) -> ApiError {
+    let msg = e.to_string();
+    if msg.contains("conflict") || msg.contains("already") {
+        ApiError::Conflict(msg)
+    } else {
+        ApiError::Internal(msg)
+    }
+}
+
+/// JSON shape of one rehearsal row: the generic fixture row plus review
+/// metadata. Never contains a DID.
+fn row_json(workspace: &ws::Workspace, row: &RehearsalRow) -> Value {
+    let mut v = serde_json::to_value(&row.base).expect("row serializes");
+    let obj = v.as_object_mut().expect("row is an object");
+    obj.insert("version".into(), json!(row.version));
+    obj.insert("note".into(), json!(row.note));
+    obj.insert("executed".into(), json!(row.execution.is_some()));
+    if let Some(exec) = &row.execution {
+        obj.insert(
+            "execution".into(),
+            json!({
+                "action_item_id": exec.action_item_id,
+                "plan_record_hash": hex32(&exec.plan_record_hash),
+                "application_record_hash": hex32(&exec.application_record_hash),
+            }),
+        );
+    }
+    let bound = row
+        .base
+        .assignee_label
+        .as_deref()
+        .map(|l| workspace.label_bound(l).unwrap_or(false));
+    json!({ "row": v, "assignee_bound": bound })
+}
+
+fn listing_row_json(workspace: &ws::Workspace, row: &RehearsalRow) -> Value {
+    // Flat shape for listings: the row fields at top level + review metadata.
+    let mut v = serde_json::to_value(&row.base).expect("row serializes");
+    let obj = v.as_object_mut().expect("row is an object");
+    obj.insert("version".into(), json!(row.version));
+    obj.insert("executed".into(), json!(row.execution.is_some()));
+    let bound = row
+        .base
+        .assignee_label
+        .as_deref()
+        .map(|l| workspace.label_bound(l).unwrap_or(false));
+    obj.insert("assignee_bound".into(), json!(bound));
+    v
+}
+
+// ── Handlers ────────────────────────────────────────────────────────────────
+
+/// POST /domains/{domain_id}/rehearsal/reset — initialize or re-seed the
+/// fictional workspace (deterministic; bumps the generation, which
+/// invalidates every outstanding preview digest).
+pub async fn rehearsal_reset<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    domain_id: web::Path<String>,
+    _req: web::Json<RehearsalResetRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain, _caller) = gate(&ctx, &http_req, &domain_id, REVIEW_SCOPES).await?;
+    let state = ctx.manager.rehearsal_state();
+    let generation = state.reset(&domain.0, demo_pending_publish_rows());
+    let rows = state
+        .with_workspace(&domain.0, |workspace| {
+            workspace
+                .rows
+                .iter()
+                .map(|r| listing_row_json(workspace, r))
+                .collect::<Vec<_>>()
+        })
+        .ok_or_else(workspace_not_initialized)?;
+    Ok(HttpResponse::Ok().json(json!({
+        "generation": generation,
+        "rows": rows,
+        "non_claims": [
+            "fictional rehearsal workspace — grants no authority",
+            "reset re-seeds the review workspace; already-recorded receipts and created action items are real records and are not erased",
+        ],
+    })))
+}
+
+/// GET /domains/{domain_id}/rehearsal/pending-publish — current workspace rows.
+pub async fn rehearsal_list<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    domain_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain, _caller) = read_gate(&ctx, &http_req, &domain_id).await?;
+    let state = ctx.manager.rehearsal_state();
+    let body = state
+        .with_workspace(&domain.0, |workspace| {
+            json!({
+                "generation": workspace.generation,
+                "rows": workspace
+                    .rows
+                    .iter()
+                    .map(|r| listing_row_json(workspace, r))
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .ok_or_else(workspace_not_initialized)?;
+    Ok(HttpResponse::Ok().json(body))
+}
+
+/// GET /domains/{domain_id}/rehearsal/pending-publish/{row_id} — row detail.
+pub async fn rehearsal_row_detail<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain_id, row_id) = path.into_inner();
+    let (domain, _caller) = read_gate(&ctx, &http_req, &domain_id).await?;
+    let state = ctx.manager.rehearsal_state();
+    let body = state
+        .with_workspace(&domain.0, |workspace| {
+            workspace.row(&row_id).map(|r| row_json(workspace, r))
+        })
+        .ok_or_else(workspace_not_initialized)?
+        .ok_or_else(row_not_found)?;
+    Ok(HttpResponse::Ok().json(body))
+}
+
+/// POST /domains/{domain_id}/rehearsal/pending-publish/{row_id}/review —
+/// record a bounded review decision, backed by a real DecisionRecorded
+/// receipt.
+pub async fn rehearsal_review<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+    req: web::Json<RehearsalReviewRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain_id, row_id) = path.into_inner();
+    let (domain, caller) = gate(&ctx, &http_req, &domain_id, REVIEW_SCOPES).await?;
+
+    let decision = ReviewDecision::parse(&req.decision).ok_or_else(|| {
+        ApiError::BadRequest(format!(
+            "Unknown review decision '{}'. Allowed: approve, reject, needs_edit, needs_more_info.",
+            req.decision
+        ))
+    })?;
+    if let Some(note) = &req.note {
+        if note.len() > MAX_NOTE {
+            return Err(ApiError::BadRequest(format!(
+                "note is too long ({} bytes; the limit is {MAX_NOTE})",
+                note.len()
+            )));
+        }
+    }
+
+    let state = ctx.manager.rehearsal_state();
+    let body = state
+        .with_workspace(&domain.0, |workspace| -> Result<Value, ApiError> {
+            ensure_session(&ctx, &domain, workspace, &caller)?;
+            let decision_id = workspace.next_decision_id();
+            let generation = workspace.generation;
+            let session_id = workspace.session_id();
+
+            let row = workspace.row_mut(&row_id).ok_or_else(row_not_found)?;
+            if row.execution.is_some() {
+                return Err(ApiError::Conflict(
+                    "This proposed work was already confirmed and executed; reset the rehearsal to review it again.".to_string(),
+                ));
+            }
+
+            // Provisionally advance the version; roll back if the receipt
+            // write fails so state and receipts never disagree.
+            row.version += 1;
+            let body_hash = ws::decision_body_hash_at(
+                &domain.0,
+                generation,
+                row,
+                decision,
+                req.note.as_deref(),
+            );
+            let outcome = ctx
+                .manager
+                .record_decision(&domain, &session_id, &decision_id, &caller, body_hash);
+            let receipt = match outcome {
+                Ok(DecisionRecordOutcome::Recorded(r))
+                | Ok(DecisionRecordOutcome::AlreadyRecorded(r)) => r,
+                Err(e) => {
+                    row.version -= 1;
+                    return Err(conflict_or_internal(e));
+                }
+            };
+
+            row.base.status = decision.status_after();
+            row.note = req.note.clone();
+            row.approve_ref = if decision == ReviewDecision::Approve {
+                Some(ApproveRef {
+                    decision_id: decision_id.clone(),
+                    record_hash: receipt.record_hash,
+                })
+            } else {
+                None
+            };
+            let row_version = row.version;
+            let entry_row_id = row.base.id.clone();
+            let response = json!({
+                "row": serde_json::to_value(&row.base).expect("row serializes"),
+                "version": row_version,
+                "decision_receipt": {
+                    "decision_id": decision_id,
+                    "record_hash": hex32(&receipt.record_hash),
+                },
+            });
+            workspace.decisions.push(DecisionLogEntry {
+                seq: workspace.decision_seq,
+                row_id: entry_row_id,
+                row_version,
+                decision,
+                decision_id: decision_id.clone(),
+                record_hash: receipt.record_hash,
+                note_present: req.note.is_some(),
+            });
+            Ok(response)
+        })
+        .ok_or_else(workspace_not_initialized)??;
+    Ok(HttpResponse::Ok().json(body))
+}
+
+/// PUT /domains/{domain_id}/rehearsal/pending-publish/{row_id} — bounded
+/// edit. Only the plain summary is editable; every edit invalidates prior
+/// approval and every outstanding preview.
+pub async fn rehearsal_edit<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+    req: web::Json<RehearsalEditRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain_id, row_id) = path.into_inner();
+    let (domain, _caller) = gate(&ctx, &http_req, &domain_id, REVIEW_SCOPES).await?;
+
+    let summary = match &req.plain_summary {
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                return Err(ApiError::BadRequest(
+                    "plain_summary must not be empty".to_string(),
+                ));
+            }
+            if s.len() > MAX_PLAIN_SUMMARY {
+                return Err(ApiError::BadRequest(format!(
+                    "plain_summary is too long ({} bytes; the limit is {MAX_PLAIN_SUMMARY})",
+                    s.len()
+                )));
+            }
+            s.clone()
+        }
+        None => {
+            return Err(ApiError::BadRequest(
+                "No editable field supplied (allowed: plain_summary)".to_string(),
+            ))
+        }
+    };
+
+    let state = ctx.manager.rehearsal_state();
+    let body = state
+        .with_workspace(&domain.0, |workspace| -> Result<Value, ApiError> {
+            let row = workspace.row_mut(&row_id).ok_or_else(row_not_found)?;
+            if row.execution.is_some() {
+                return Err(ApiError::Conflict(
+                    "This proposed work was already executed; reset the rehearsal to edit it again."
+                        .to_string(),
+                ));
+            }
+            if row.base.status == PendingPublishRowStatus::Rejected {
+                return Err(ApiError::Conflict(
+                    "This proposed work was rejected; record a new review decision first."
+                        .to_string(),
+                ));
+            }
+            row.base.plain_summary = summary.clone();
+            row.version += 1;
+            // An edit always demands fresh review: approval no longer covers
+            // the changed content.
+            row.base.status = PendingPublishRowStatus::PendingReview;
+            row.approve_ref = None;
+            Ok(json!({
+                "row": serde_json::to_value(&row.base).expect("row serializes"),
+                "version": row.version,
+            }))
+        })
+        .ok_or_else(workspace_not_initialized)??;
+    Ok(HttpResponse::Ok().json(body))
+}
+
+/// POST /domains/{domain_id}/rehearsal/pending-publish/{row_id}/assign —
+/// assign by human-readable label. Unknown labels fail closed; assignment
+/// invalidates prior approval and previews.
+pub async fn rehearsal_assign<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+    req: web::Json<RehearsalAssignRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain_id, row_id) = path.into_inner();
+    let (domain, _caller) = gate(&ctx, &http_req, &domain_id, REVIEW_SCOPES).await?;
+
+    if let Some(label) = &req.assignee_label {
+        if label.trim().is_empty() || label.len() > MAX_LABEL {
+            return Err(ApiError::BadRequest(format!(
+                "assignee_label must be 1..={MAX_LABEL} bytes"
+            )));
+        }
+    }
+
+    let state = ctx.manager.rehearsal_state();
+    let result = state
+        .with_workspace(&domain.0, |workspace| -> Result<Result<Value, HttpResponse>, ApiError> {
+            if let Some(label) = &req.assignee_label {
+                if workspace.label_bound(label).is_none() {
+                    // Unknown label: fail closed without inventing identities.
+                    return Ok(Err(HttpResponse::UnprocessableEntity().json(json!({
+                        "error": format!(
+                            "Unknown assignee label '{label}'. Labels must be registered in this rehearsal workspace (see GET .../rehearsal/bindings)."
+                        ),
+                    }))));
+                }
+            }
+            let (row_value, version) = {
+                let row = workspace.row_mut(&row_id).ok_or_else(row_not_found)?;
+                if row.execution.is_some() {
+                    return Err(ApiError::Conflict(
+                        "This proposed work was already executed; reset the rehearsal to change it."
+                            .to_string(),
+                    ));
+                }
+                row.base.assignee_label = req.assignee_label.clone();
+                row.version += 1;
+                row.base.status = PendingPublishRowStatus::PendingReview;
+                row.approve_ref = None;
+                (
+                    serde_json::to_value(&row.base).expect("row serializes"),
+                    row.version,
+                )
+            };
+            let bound = req
+                .assignee_label
+                .as_deref()
+                .map(|l| workspace.label_bound(l).unwrap_or(false));
+            Ok(Ok(json!({
+                "row": row_value,
+                "version": version,
+                "assignee_bound": bound,
+            })))
+        })
+        .ok_or_else(workspace_not_initialized)??;
+    match result {
+        Ok(body) => Ok(HttpResponse::Ok().json(body)),
+        Err(resp) => Ok(resp),
+    }
+}
+
+/// POST /domains/{domain_id}/rehearsal/bindings — bind a label to a fictional
+/// DID (registering the label if new). The DID is accepted on write and never
+/// echoed. Rebinding invalidates outstanding previews via the digest.
+pub async fn rehearsal_bind_label<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    domain_id: web::Path<String>,
+    req: web::Json<RehearsalBindRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain, _caller) = gate(&ctx, &http_req, &domain_id, REVIEW_SCOPES).await?;
+
+    if req.label.trim().is_empty() || req.label.len() > MAX_LABEL {
+        return Err(ApiError::BadRequest(format!(
+            "label must be 1..={MAX_LABEL} bytes"
+        )));
+    }
+    let bound_did = parse_did(&req.did, "Invalid DID in binding")?;
+
+    let state = ctx.manager.rehearsal_state();
+    let body = state
+        .with_workspace(&domain.0, |workspace| {
+            workspace
+                .bindings
+                .insert(req.label.clone(), bound_did.to_string());
+            json!({ "label": req.label, "bound": true })
+        })
+        .ok_or_else(workspace_not_initialized)?;
+    Ok(HttpResponse::Ok().json(body))
+}
+
+/// GET /domains/{domain_id}/rehearsal/bindings — labels + bound flags only.
+pub async fn rehearsal_list_bindings<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    domain_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain, _caller) = read_gate(&ctx, &http_req, &domain_id).await?;
+    let state = ctx.manager.rehearsal_state();
+    let body = state
+        .with_workspace(&domain.0, |workspace| {
+            json!({
+                "bindings": workspace
+                    .bindings
+                    .iter()
+                    .map(|(label, did)| json!({ "label": label, "bound": !did.is_empty() }))
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .ok_or_else(workspace_not_initialized)?;
+    Ok(HttpResponse::Ok().json(body))
+}
+
+/// GET /domains/{domain_id}/rehearsal/pending-publish/{row_id}/preview —
+/// pure read returning the exact bound mutation and its digest. Requires the
+/// review capability (previewing is part of reviewing) and an approved,
+/// still-current row.
+pub async fn rehearsal_preview<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain_id, row_id) = path.into_inner();
+    let (domain, _caller) = gate(&ctx, &http_req, &domain_id, REVIEW_SCOPES).await?;
+
+    let state = ctx.manager.rehearsal_state();
+    let result = state
+        .with_workspace(&domain.0, |workspace| -> Result<Result<Value, HttpResponse>, ApiError> {
+            let row = workspace.row(&row_id).ok_or_else(row_not_found)?;
+            let Some(plan) = plan_for_row(&domain.0, workspace, row) else {
+                return Ok(Err(HttpResponse::UnprocessableEntity().json(json!({
+                    "error": "This kind of proposed work is reviewable but not executable in this rehearsal slice.",
+                    "row_id": row.base.id,
+                }))));
+            };
+            if row.base.status != PendingPublishRowStatus::ApprovedForPublish
+                || row.approve_ref.is_none()
+            {
+                return Err(ApiError::Conflict(
+                    "Preview requires an approved review decision on the current version of this row.".to_string(),
+                ));
+            }
+            let assignee_bound = row
+                .base
+                .assignee_label
+                .as_deref()
+                .map(|l| workspace.label_bound(l).unwrap_or(false));
+            let confirmable = assignee_bound != Some(false);
+            Ok(Ok(json!({
+                "row_id": row.base.id,
+                "version": row.version,
+                "generation": workspace.generation,
+                "action": "create_action_item",
+                "domain_id": domain.0,
+                "title": plan.title,
+                "description": plan.description,
+                "assignee_label": row.base.assignee_label,
+                "assignee_bound": assignee_bound,
+                "authority_basis": row.base.authority_basis,
+                "risk_level": serde_json::to_value(row.base.risk_level).expect("risk serializes"),
+                "receipt_expected": serde_json::to_value(&row.base.receipt_expected).expect("receipt serializes"),
+                "reversible": false,
+                "permanence_note": "Confirming creates a real action item and permanent process receipts on this rehearsal node. The rehearsal can be reset, but recorded receipts are not erased.",
+                "privacy_note": "The preview and all receipts are value-withheld: member identities appear only as labels; identity bindings stay on the node.",
+                "confirmable": confirmable,
+                "preview_digest": plan.digest.to_hex().to_string(),
+                "plan_id": format!("rehearsal-plan-{}-v{}", row.base.id, row.version),
+                "expected_receipts": [
+                    "process_gate_result",
+                    "activation_crossed",
+                    "mutation_plan_recorded",
+                    "mutation_applied",
+                ],
+            })))
+        })
+        .ok_or_else(workspace_not_initialized)??;
+    match result {
+        Ok(body) => Ok(HttpResponse::Ok().json(body)),
+        Err(resp) => Ok(resp),
+    }
+}
+
+/// POST /domains/{domain_id}/rehearsal/pending-publish/{row_id}/confirm —
+/// execute the bound mutation. Fail-closed digest verification; real receipt
+/// ladder; idempotent replay.
+pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    path: web::Path<(String, String)>,
+    req: web::Json<RehearsalConfirmRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain_id, row_id) = path.into_inner();
+    let (domain, caller) = gate(&ctx, &http_req, &domain_id, CONFIRM_SCOPES).await?;
+
+    let submitted = blake3::Hash::from_hex(req.preview_digest.as_bytes()).map_err(|_| {
+        ApiError::BadRequest("preview_digest must be a 64-character hex digest".to_string())
+    })?;
+
+    let state = ctx.manager.rehearsal_state();
+    let result = state
+        .with_workspace(&domain.0, |workspace| -> Result<Result<(Value, bool), HttpResponse>, ApiError> {
+            let session_id = workspace.session_id();
+            let generation = workspace.generation;
+
+            // Idempotent replay / conflicting-reuse check first.
+            if let Some(row) = workspace.row(&row_id) {
+                if let Some(exec) = &row.execution {
+                    let executed_digest = blake3::Hash::from(exec.preview_digest);
+                    if executed_digest == submitted {
+                        return Ok(Ok((confirm_response(&row_id, &session_id, exec, true), false)));
+                    }
+                    return Err(ApiError::Conflict(
+                        "This proposed work was already executed from a different preview; nothing was changed.".to_string(),
+                    ));
+                }
+            } else {
+                return Err(row_not_found());
+            }
+
+            // Recompute the plan from CURRENT state and verify the digest.
+            let (plan, approve_ref, assignee_label) = {
+                let row = workspace.row(&row_id).expect("checked above");
+                if row.base.status != PendingPublishRowStatus::ApprovedForPublish
+                    || row.approve_ref.is_none()
+                {
+                    return Err(ApiError::Conflict(
+                        "Confirm requires an approved review decision on the current version of this row. Preview again after approval.".to_string(),
+                    ));
+                }
+                let Some(plan) = plan_for_row(&domain.0, workspace, row) else {
+                    return Ok(Err(HttpResponse::UnprocessableEntity().json(json!({
+                        "error": "This kind of proposed work is not executable in this rehearsal slice.",
+                    }))));
+                };
+                if let Some(label) = row.base.assignee_label.as_deref() {
+                    if workspace.bound_did(label).is_none() {
+                        return Err(ApiError::Conflict(format!(
+                            "Assignee label '{label}' is not bound to an identity; bind it or clear the assignment, then preview again."
+                        )));
+                    }
+                }
+                (plan, row.approve_ref.clone().expect("checked"), row.base.assignee_label.clone())
+            };
+            // blake3::Hash equality is constant-time.
+            if plan.digest != submitted {
+                return Err(ApiError::Conflict(
+                    "The preview is stale: the proposed work, its assignment, or the rehearsal state changed after the preview was issued. Request a new preview and re-check it.".to_string(),
+                ));
+            }
+
+            // Real ADR-0026 ladder: gate → activation → plan → item → applied.
+            ensure_session(&ctx, &domain, workspace, &caller)?;
+            let row_version = workspace.row(&row_id).expect("checked").version;
+            let gate_receipt = ctx
+                .manager
+                .record_process_gate_result(
+                    &domain,
+                    &session_id,
+                    ProcessGateKind::ScopeConfirmation,
+                    ProcessGateResult::Pass,
+                    &caller,
+                )
+                .map_err(conflict_or_internal)?;
+            let activation_id = format!("rehearsal-activation-{row_id}-v{row_version}");
+            let activation = match ctx
+                .manager
+                .record_activation_crossed(
+                    &domain,
+                    &session_id,
+                    &activation_id,
+                    &approve_ref.decision_id,
+                    approve_ref.record_hash,
+                    &[gate_receipt.record_hash],
+                    &caller,
+                )
+                .map_err(conflict_or_internal)?
+            {
+                ActivationCrossedOutcome::Crossed(r)
+                | ActivationCrossedOutcome::AlreadyCrossed(r) => r,
+            };
+            let plan_id = format!("rehearsal-plan-{row_id}-v{row_version}");
+            let plan_receipt = match ctx
+                .manager
+                .record_mutation_plan_recorded(
+                    &domain,
+                    &session_id,
+                    &plan_id,
+                    &activation_id,
+                    activation.record_hash,
+                    *plan.digest.as_bytes(),
+                    &caller,
+                )
+                .map_err(conflict_or_internal)?
+            {
+                MutationPlanRecordedOutcome::Recorded(r)
+                | MutationPlanRecordedOutcome::AlreadyRecorded(r) => r,
+            };
+
+            let assignee_did: Option<Did> = match &plan.assignee_did {
+                Some(s) => Some(parse_did(s, "Invalid bound assignee DID")?),
+                None => None,
+            };
+            let item = ctx
+                .manager
+                .create_action_item(
+                    domain.clone(),
+                    plan.title.clone(),
+                    Some(plan.description.clone()),
+                    caller.clone(),
+                    assignee_did,
+                    plan.due_date,
+                    ActionItemPriority::Medium,
+                    None,
+                    Some(format!("rehearsal-review session {session_id}")),
+                    Vec::new(),
+                )
+                .map_err(|e| ApiError::Internal(e.to_string()))?;
+            let action_item_id = item.id.to_string();
+
+            let result_hash = ws::apply_result_hash(
+                &domain.0,
+                &action_item_id,
+                &plan.title,
+                plan.assignee_did.as_deref(),
+                caller.as_str(),
+            );
+            let application_id = format!("rehearsal-apply-{row_id}-v{row_version}");
+            let applied = match ctx
+                .manager
+                .record_mutation_applied(
+                    &domain,
+                    &session_id,
+                    &application_id,
+                    &plan_id,
+                    plan_receipt.record_hash,
+                    result_hash,
+                    &caller,
+                )
+                .map_err(conflict_or_internal)?
+            {
+                MutationAppliedOutcome::Applied(r) | MutationAppliedOutcome::AlreadyApplied(r) => r,
+            };
+
+            let exec = ExecutionRecord {
+                preview_digest: *plan.digest.as_bytes(),
+                action_item_id,
+                session_id: session_id.clone(),
+                decision_id: approve_ref.decision_id.clone(),
+                decision_record_hash: approve_ref.record_hash,
+                gate_record_hash: gate_receipt.record_hash,
+                activation_id,
+                activation_record_hash: activation.record_hash,
+                plan_id,
+                plan_record_hash: plan_receipt.record_hash,
+                application_id,
+                application_record_hash: applied.record_hash,
+                result_hash,
+            };
+            let _ = generation;
+            let _ = assignee_label;
+            let response = confirm_response(&row_id, &session_id, &exec, false);
+            workspace
+                .row_mut(&row_id)
+                .expect("checked above")
+                .execution = Some(exec);
+            Ok(Ok((response, true)))
+        })
+        .ok_or_else(workspace_not_initialized)??;
+    match result {
+        Ok((body, created)) => {
+            if created {
+                Ok(HttpResponse::Created().json(body))
+            } else {
+                Ok(HttpResponse::Ok().json(body))
+            }
+        }
+        Err(resp) => Ok(resp),
+    }
+}
+
+fn confirm_response(
+    row_id: &str,
+    session_id: &str,
+    exec: &ExecutionRecord,
+    idempotent: bool,
+) -> Value {
+    json!({
+        "row_id": row_id,
+        "action_item_id": exec.action_item_id,
+        "session_id": session_id,
+        "decision_id": exec.decision_id,
+        "decision_record_hash": hex32(&exec.decision_record_hash),
+        "gate_record_hash": hex32(&exec.gate_record_hash),
+        "activation_id": exec.activation_id,
+        "activation_record_hash": hex32(&exec.activation_record_hash),
+        "plan_id": exec.plan_id,
+        "plan_record_hash": hex32(&exec.plan_record_hash),
+        "application_id": exec.application_id,
+        "application_record_hash": hex32(&exec.application_record_hash),
+        "result_hash": hex32(&exec.result_hash),
+        "preview_digest": hex32(&exec.preview_digest),
+        "idempotent": idempotent,
+        "non_claims": [
+            "the receipts record process facts; they grant no authority",
+            "this is an isolated fictional rehearsal, not production governance",
+        ],
+    })
+}
+
+/// GET /domains/{domain_id}/rehearsal/receipts — the ladder receipts recorded
+/// this workspace lifetime (ids and hashes only; no DIDs).
+pub async fn rehearsal_receipts<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    domain_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain, _caller) = read_gate(&ctx, &http_req, &domain_id).await?;
+    let state = ctx.manager.rehearsal_state();
+    let body = state
+        .with_workspace(&domain.0, |workspace| {
+            let mut receipts = Vec::new();
+            if let Some(hash) = &workspace.session_record_hash {
+                receipts.push(json!({
+                    "class": "process_session_opened",
+                    "id": workspace.session_id(),
+                    "record_hash": hex32(hash),
+                }));
+            }
+            for d in &workspace.decisions {
+                receipts.push(json!({
+                    "class": "decision_recorded",
+                    "id": d.decision_id,
+                    "record_hash": hex32(&d.record_hash),
+                    "row_id": d.row_id,
+                    "decision": d.decision.as_str(),
+                }));
+            }
+            for row in &workspace.rows {
+                if let Some(exec) = &row.execution {
+                    receipts.push(json!({
+                        "class": "process_gate_result",
+                        "id": format!("scope-confirmation:{}", exec.plan_id),
+                        "record_hash": hex32(&exec.gate_record_hash),
+                    }));
+                    receipts.push(json!({
+                        "class": "activation_crossed",
+                        "id": exec.activation_id,
+                        "record_hash": hex32(&exec.activation_record_hash),
+                        "references_decision": exec.decision_id,
+                    }));
+                    receipts.push(json!({
+                        "class": "mutation_plan_recorded",
+                        "id": exec.plan_id,
+                        "record_hash": hex32(&exec.plan_record_hash),
+                        "body_hash": hex32(&exec.preview_digest),
+                        "references_activation": exec.activation_id,
+                    }));
+                    receipts.push(json!({
+                        "class": "mutation_applied",
+                        "id": exec.application_id,
+                        "record_hash": hex32(&exec.application_record_hash),
+                        "references_plan": exec.plan_id,
+                        "result_hash": hex32(&exec.result_hash),
+                        "action_item_id": exec.action_item_id,
+                    }));
+                }
+            }
+            json!({
+                "generation": workspace.generation,
+                "receipts": receipts,
+                "non_claims": ["receipts record process facts and grant no authority"],
+            })
+        })
+        .ok_or_else(workspace_not_initialized)?;
+    Ok(HttpResponse::Ok().json(body))
+}
+
+/// GET /domains/{domain_id}/rehearsal/evidence-export — value-withheld
+/// evidence packet derived from actual workspace outcomes, with a verifiable
+/// SHA-256 packet hash.
+pub async fn rehearsal_evidence_export<E: GovernanceEventEmitter + Clone + 'static>(
+    ctx: web::Data<GovernanceContext<E>>,
+    http_req: HttpRequest,
+    domain_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    let (domain, _caller) = read_gate(&ctx, &http_req, &domain_id).await?;
+    let state = ctx.manager.rehearsal_state();
+    let body = state
+        .with_workspace(&domain.0, |workspace| {
+            let rows: Vec<Value> = workspace
+                .rows
+                .iter()
+                .map(|row| {
+                    let outcome = match (&row.execution, row.base.status) {
+                        (Some(_), _) => "executed",
+                        (None, PendingPublishRowStatus::Rejected) => "rejected",
+                        (None, PendingPublishRowStatus::NeedsEdit) => "edit-and-resubmit",
+                        (None, PendingPublishRowStatus::ApprovedForPublish) => {
+                            "approved-not-executed"
+                        }
+                        (None, _) => "deferred",
+                    };
+                    let mut v = json!({
+                        "id": row.base.id,
+                        "kind": serde_json::to_value(row.base.kind).expect("kind serializes"),
+                        "outcome": outcome,
+                        "version": row.version,
+                        "source_provenance": serde_json::to_value(row.base.source_provenance)
+                            .expect("provenance serializes"),
+                        "assignee_label": row.base.assignee_label,
+                    });
+                    if let Some(exec) = &row.execution {
+                        let obj = v.as_object_mut().expect("object");
+                        obj.insert("preview_digest".into(), json!(hex32(&exec.preview_digest)));
+                        obj.insert("plan_record_hash".into(), json!(hex32(&exec.plan_record_hash)));
+                        obj.insert(
+                            "application_record_hash".into(),
+                            json!(hex32(&exec.application_record_hash)),
+                        );
+                        obj.insert("action_item_id".into(), json!(exec.action_item_id));
+                        obj.insert("mutation_executed".into(), json!(true));
+                    } else {
+                        v.as_object_mut()
+                            .expect("object")
+                            .insert("mutation_executed".into(), json!(false));
+                    }
+                    v
+                })
+                .collect();
+            let decisions: Vec<Value> = workspace
+                .decisions
+                .iter()
+                .map(|d| {
+                    json!({
+                        "seq": d.seq,
+                        "row_id": d.row_id,
+                        "row_version": d.row_version,
+                        "decision": d.decision.as_str(),
+                        "decision_id": d.decision_id,
+                        "record_hash": hex32(&d.record_hash),
+                        "note_present": d.note_present,
+                    })
+                })
+                .collect();
+            let bindings: Vec<Value> = workspace
+                .bindings
+                .iter()
+                .map(|(label, did)| json!({ "label": label, "bound": !did.is_empty() }))
+                .collect();
+
+            let content = json!({
+                "contract": "urn:icn:contract:rehearsal-workflow-evidence:v1",
+                "origin": "rehearsal_runtime",
+                "domain_id": domain.0,
+                "generation": workspace.generation,
+                "session_id": workspace.session_id(),
+                "session_record_hash": workspace.session_record_hash.as_ref().map(hex32),
+                "rows": rows,
+                "decisions": decisions,
+                "bindings": bindings,
+                "privacy_review": {
+                    "dids_exported": false,
+                    "credentials_exported": false,
+                    "private_overlay_values_exported": false,
+                    "identity_exposure": "labels-and-bound-flags-only",
+                },
+                "non_claims": [
+                    "fictional rehearsal evidence — not production governance, not a pilot, not live federation",
+                    "receipts record process facts and grant no authority",
+                    "identity bindings stay on the rehearsal node; this packet carries labels only",
+                ],
+                "hash_algorithm": "sha256",
+            });
+            let canonical = serde_json::to_vec(&content).expect("packet serializes");
+            let packet_hash = format!("{:x}", sha2::Sha256::digest(&canonical));
+            let mut packet = content;
+            let obj = packet.as_object_mut().expect("object");
+            obj.insert("packet_hash".into(), json!(packet_hash));
+            obj.insert(
+                "generated_at".into(),
+                json!(icn_time::current_timestamp_secs()),
+            );
+            packet
+        })
+        .ok_or_else(workspace_not_initialized)?;
+    Ok(HttpResponse::Ok().json(body))
+}
+
+/// Register the rehearsal routes. Called from `configure` ONLY when the
+/// build mode allows the rehearsal mutation surface.
+pub fn configure_rehearsal_routes<E: GovernanceEventEmitter + Clone + 'static>(
+    cfg: &mut web::ServiceConfig,
+) {
+    cfg.service(
+        web::resource("/domains/{domain_id}/rehearsal/reset")
+            .route(web::post().to(rehearsal_reset::<E>)),
+    )
+    .service(
+        web::resource("/domains/{domain_id}/rehearsal/pending-publish")
+            .route(web::get().to(rehearsal_list::<E>)),
+    )
+    .service(
+        web::resource("/domains/{domain_id}/rehearsal/pending-publish/{row_id}")
+            .route(web::get().to(rehearsal_row_detail::<E>))
+            .route(web::put().to(rehearsal_edit::<E>)),
+    )
+    .service(
+        web::resource("/domains/{domain_id}/rehearsal/pending-publish/{row_id}/review")
+            .route(web::post().to(rehearsal_review::<E>)),
+    )
+    .service(
+        web::resource("/domains/{domain_id}/rehearsal/pending-publish/{row_id}/assign")
+            .route(web::post().to(rehearsal_assign::<E>)),
+    )
+    .service(
+        web::resource("/domains/{domain_id}/rehearsal/pending-publish/{row_id}/preview")
+            .route(web::get().to(rehearsal_preview::<E>)),
+    )
+    .service(
+        web::resource("/domains/{domain_id}/rehearsal/pending-publish/{row_id}/confirm")
+            .route(web::post().to(rehearsal_confirm::<E>)),
+    )
+    .service(
+        web::resource("/domains/{domain_id}/rehearsal/bindings")
+            .route(web::post().to(rehearsal_bind_label::<E>))
+            .route(web::get().to(rehearsal_list_bindings::<E>)),
+    )
+    .service(
+        web::resource("/domains/{domain_id}/rehearsal/receipts")
+            .route(web::get().to(rehearsal_receipts::<E>)),
+    )
+    .service(
+        web::resource("/domains/{domain_id}/rehearsal/evidence-export")
+            .route(web::get().to(rehearsal_evidence_export::<E>)),
+    );
+}

--- a/icn/apps/governance/src/http/rehearsal.rs
+++ b/icn/apps/governance/src/http/rehearsal.rs
@@ -10,22 +10,25 @@
 //!
 //! Capability model (sub-capability doctrine, #2400):
 //!
-//! - `governance:pending-publish:review` — review decisions, bounded edits,
-//!   label assignment, label→fictional-DID binding, and workspace reset.
-//!   Reset and binding are deliberately bundled into the review capability
-//!   rather than a separate operator scope: the workspace is fictional and
-//!   resettable BY DESIGN (repeating the rehearsal is an organizer act, not
-//!   an operator act), and a binding grants no authority — it only lets the
-//!   fictional completion loop run, and any rebinding invalidates
-//!   outstanding previews. Splitting a third scope would add allowlist
-//!   surface without a distinct trust boundary.
+//! - `governance:rehearsal:setup` — operator/fixture-setup acts: DESIGNATING
+//!   a fictional rehearsal domain (its first workspace initialization) and
+//!   binding labels to fictional identities. Held by the internal setup
+//!   credential only — an organizer browser can neither turn an arbitrary
+//!   domain into a rehearsal workspace nor bind identities, and never
+//!   handles a DID.
+//! - `governance:pending-publish:review` — the organizer surface: review
+//!   decisions, bounded edits, label assignment (labels only), previews, and
+//!   RE-resetting an already-designated workspace (repeating the fictional
+//!   rehearsal is an organizer act; each reset retires the prior run's
+//!   fictional action items through the normal status machinery).
 //! - `governance:pending-publish:confirm` — executing the bound mutation.
 //!   Held separately so a review-only credential can never mutate governance
 //!   state, and a confirm-only credential can never manufacture the review
 //!   state it confirms.
-//! - Broad `governance:write` retains both, consistent with the existing
-//!   sub-capability decomposition; `governance:read` grants read surfaces
-//!   only.
+//! - Broad `governance:write` retains all three (tested), consistent with
+//!   the existing sub-capability decomposition — operator compatibility
+//!   only; browser credentials carry only their narrow scopes.
+//!   `governance:read` grants read surfaces only.
 //!
 //! These routes are intentionally NOT part of the public OpenAPI document:
 //! they exist only on an isolated Rehearsal Node and never in production, so
@@ -46,7 +49,6 @@ use icn_http_kit::auth::{require_any_scope, require_scope, BasicClaims};
 use icn_http_kit::error::ApiError;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use sha2::Digest as _;
 
 use crate::events::GovernanceEventEmitter;
 use crate::manager::{
@@ -67,6 +69,12 @@ use icn_identity::Did;
 
 const REVIEW_SCOPES: &[&str] = &["governance:pending-publish:review", "governance:write"];
 const CONFIRM_SCOPES: &[&str] = &["governance:pending-publish:confirm", "governance:write"];
+/// Operator/fixture-setup capability: designating a fictional rehearsal
+/// domain (its FIRST workspace initialization) and binding labels to
+/// fictional identities. The organizer browser credential never holds this,
+/// so it can neither turn an arbitrary domain into a rehearsal workspace nor
+/// bind identities — it only sees and assigns labels.
+const SETUP_SCOPES: &[&str] = &["governance:rehearsal:setup", "governance:write"];
 
 // ── Request models: contract enforced by rejection, not omission ───────────
 
@@ -142,6 +150,16 @@ async fn read_gate<E: GovernanceEventEmitter + Clone + 'static>(
     Ok((domain, caller))
 }
 
+/// Serialize a value for a response. The row/enum types are plain field
+/// structs whose serialization cannot fail in practice; if it ever does,
+/// serve an explicit error value and log — never panic a worker.
+fn to_value_or_error<T: serde::Serialize>(value: &T) -> Value {
+    serde_json::to_value(value).unwrap_or_else(|e| {
+        tracing::error!(detail = %e, "rehearsal response serialization failed");
+        json!({ "error": "serialization failed" })
+    })
+}
+
 fn workspace_not_initialized() -> ApiError {
     ApiError::NotFound(
         "No rehearsal workspace is initialized for this domain. Start one with \
@@ -179,33 +197,42 @@ fn ensure_session<E: GovernanceEventEmitter + Clone + 'static>(
 }
 
 /// The ladder fails closed with descriptive conflicts (e.g. a session opened
-/// by a different actor). Map those to 409, everything else to 500.
+/// by a different actor). Map those to 409 and everything else to 500 with
+/// PLAIN client messages — backend detail goes to the log, never the client.
 fn conflict_or_internal(e: anyhow::Error) -> ApiError {
-    let msg = e.to_string();
-    if msg.contains("conflict") || msg.contains("already") {
-        ApiError::Conflict(msg)
+    let detail = e.to_string();
+    if detail.contains("conflict") || detail.contains("already") {
+        tracing::warn!(detail = %detail, "rehearsal receipt conflict");
+        ApiError::Conflict(
+            "A rehearsal process receipt for this step already exists with different \
+             content (for example, a session opened by someone else). Reset the \
+             rehearsal to start a fresh run."
+                .to_string(),
+        )
     } else {
-        ApiError::Internal(msg)
+        tracing::warn!(detail = %detail, "rehearsal receipt recording failed");
+        ApiError::Internal("Recording a rehearsal process receipt failed.".to_string())
     }
 }
 
 /// JSON shape of one rehearsal row: the generic fixture row plus review
 /// metadata. Never contains a DID.
 fn row_json(workspace: &ws::Workspace, row: &RehearsalRow) -> Value {
-    let mut v = serde_json::to_value(&row.base).expect("row serializes");
-    let obj = v.as_object_mut().expect("row is an object");
-    obj.insert("version".into(), json!(row.version));
-    obj.insert("note".into(), json!(row.note));
-    obj.insert("executed".into(), json!(row.execution.is_some()));
-    if let Some(exec) = &row.execution {
-        obj.insert(
-            "execution".into(),
-            json!({
-                "action_item_id": exec.action_item_id,
-                "plan_record_hash": hex32(&exec.plan_record_hash),
-                "application_record_hash": hex32(&exec.application_record_hash),
-            }),
-        );
+    let mut v = to_value_or_error(&row.base);
+    if let Some(obj) = v.as_object_mut() {
+        obj.insert("version".into(), json!(row.version));
+        obj.insert("note".into(), json!(row.note));
+        obj.insert("executed".into(), json!(row.execution.is_some()));
+        if let Some(exec) = &row.execution {
+            obj.insert(
+                "execution".into(),
+                json!({
+                    "action_item_id": exec.action_item_id,
+                    "plan_record_hash": hex32(&exec.plan_record_hash),
+                    "application_record_hash": hex32(&exec.application_record_hash),
+                }),
+            );
+        }
     }
     let bound = row
         .base
@@ -217,33 +244,87 @@ fn row_json(workspace: &ws::Workspace, row: &RehearsalRow) -> Value {
 
 fn listing_row_json(workspace: &ws::Workspace, row: &RehearsalRow) -> Value {
     // Flat shape for listings: the row fields at top level + review metadata.
-    let mut v = serde_json::to_value(&row.base).expect("row serializes");
-    let obj = v.as_object_mut().expect("row is an object");
-    obj.insert("version".into(), json!(row.version));
-    obj.insert("executed".into(), json!(row.execution.is_some()));
-    let bound = row
-        .base
-        .assignee_label
-        .as_deref()
-        .map(|l| workspace.label_bound(l).unwrap_or(false));
-    obj.insert("assignee_bound".into(), json!(bound));
+    let mut v = to_value_or_error(&row.base);
+    if let Some(obj) = v.as_object_mut() {
+        obj.insert("version".into(), json!(row.version));
+        obj.insert("executed".into(), json!(row.execution.is_some()));
+        let bound = row
+            .base
+            .assignee_label
+            .as_deref()
+            .map(|l| workspace.label_bound(l).unwrap_or(false));
+        obj.insert("assignee_bound".into(), json!(bound));
+    }
     v
 }
 
 // ── Handlers ────────────────────────────────────────────────────────────────
 
-/// POST /domains/{domain_id}/rehearsal/reset — initialize or re-seed the
-/// fictional workspace (deterministic; bumps the generation, which
-/// invalidates every outstanding preview digest).
+/// POST /domains/{domain_id}/rehearsal/reset — start a new rehearsal
+/// generation with the deterministic fictional seed.
+///
+/// Designation gate: the FIRST initialization of a domain's workspace is an
+/// operator/setup act (`governance:rehearsal:setup`) — a review-scoped
+/// member cannot turn an arbitrary domain into a rehearsal workspace.
+/// Re-resetting an already-designated workspace is an organizer act
+/// (`governance:pending-publish:review`).
+///
+/// Reset means "start a new rehearsal generation", not "restore a clean
+/// node": recorded receipts are permanent process facts, and the prior
+/// run's fictional action items are retired through the normal status
+/// machinery (cancelled unless already completed) so the member's active
+/// queue returns to a deterministic state while history stays inspectable.
 pub async fn rehearsal_reset<E: GovernanceEventEmitter + Clone + 'static>(
     ctx: web::Data<GovernanceContext<E>>,
     http_req: HttpRequest,
     domain_id: web::Path<String>,
     _req: web::Json<RehearsalResetRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let (domain, _caller) = gate(&ctx, &http_req, &domain_id, REVIEW_SCOPES).await?;
     let state = ctx.manager.rehearsal_state();
-    let generation = state.reset(&domain.0, demo_pending_publish_rows());
+    let scopes = if state.is_initialized(&domain_id) {
+        REVIEW_SCOPES
+    } else {
+        SETUP_SCOPES
+    };
+    let (domain, caller) = gate(&ctx, &http_req, &domain_id, scopes).await?;
+    let (generation, prior_items) = state.reset(&domain.0, demo_pending_publish_rows());
+
+    // Retire the prior run's fictional action items (skip anything already
+    // completed — completion history is real and stays). Per-item failures
+    // are reported, never silently swallowed.
+    let mut cancelled = Vec::new();
+    let mut not_cancelled = Vec::new();
+    for item_id in prior_items {
+        let Ok(uuid) = item_id.parse::<uuid::Uuid>() else {
+            not_cancelled.push(item_id);
+            continue;
+        };
+        let typed_id = icn_governance::ActionItemId::from_uuid(uuid);
+        let already_completed = ctx
+            .manager
+            .get_action_item(&domain, &typed_id)
+            .ok()
+            .flatten()
+            .map(|i| i.status == icn_governance::ActionItemStatus::Completed)
+            .unwrap_or(false);
+        if already_completed {
+            continue;
+        }
+        match ctx.manager.update_action_item_status(
+            &domain,
+            &typed_id,
+            icn_governance::ActionItemStatus::Cancelled,
+            &caller,
+            "governance:pending-publish:review",
+        ) {
+            Ok(_) => cancelled.push(item_id),
+            Err(e) => {
+                tracing::warn!(item = %item_id, detail = %e, "reset could not retire prior rehearsal item");
+                not_cancelled.push(item_id);
+            }
+        }
+    }
+
     let rows = state
         .with_workspace(&domain.0, |workspace| {
             workspace
@@ -256,9 +337,11 @@ pub async fn rehearsal_reset<E: GovernanceEventEmitter + Clone + 'static>(
     Ok(HttpResponse::Ok().json(json!({
         "generation": generation,
         "rows": rows,
+        "cancelled_action_items": cancelled,
+        "not_cancelled_action_items": not_cancelled,
         "non_claims": [
             "fictional rehearsal workspace — grants no authority",
-            "reset re-seeds the review workspace; already-recorded receipts and created action items are real records and are not erased",
+            "reset starts a new rehearsal generation: recorded receipts are permanent process facts; the prior run's fictional action items are cancelled (not erased) unless already completed",
         ],
     })))
 }
@@ -345,6 +428,13 @@ pub async fn rehearsal_review<E: GovernanceEventEmitter + Clone + 'static>(
                     "This proposed work was already confirmed and executed; reset the rehearsal to review it again.".to_string(),
                 ));
             }
+            if row.pending_item_id.is_some() {
+                return Err(ApiError::Conflict(
+                    "An interrupted execution exists for this proposed work; retry confirm \
+                     with the same preview digest to complete it, or reset the rehearsal."
+                        .to_string(),
+                ));
+            }
 
             // Provisionally advance the version; roll back if the receipt
             // write fails so state and receipts never disagree.
@@ -381,7 +471,7 @@ pub async fn rehearsal_review<E: GovernanceEventEmitter + Clone + 'static>(
             let row_version = row.version;
             let entry_row_id = row.base.id.clone();
             let response = json!({
-                "row": serde_json::to_value(&row.base).expect("row serializes"),
+                "row": to_value_or_error(&row.base),
                 "version": row_version,
                 "decision_receipt": {
                     "decision_id": decision_id,
@@ -448,6 +538,13 @@ pub async fn rehearsal_edit<E: GovernanceEventEmitter + Clone + 'static>(
                         .to_string(),
                 ));
             }
+            if row.pending_item_id.is_some() {
+                return Err(ApiError::Conflict(
+                    "An interrupted execution exists for this proposed work; retry confirm \
+                     with the same preview digest to complete it, or reset the rehearsal."
+                        .to_string(),
+                ));
+            }
             if row.base.status == PendingPublishRowStatus::Rejected {
                 return Err(ApiError::Conflict(
                     "This proposed work was rejected; record a new review decision first."
@@ -461,7 +558,7 @@ pub async fn rehearsal_edit<E: GovernanceEventEmitter + Clone + 'static>(
             row.base.status = PendingPublishRowStatus::PendingReview;
             row.approve_ref = None;
             Ok(json!({
-                "row": serde_json::to_value(&row.base).expect("row serializes"),
+                "row": to_value_or_error(&row.base),
                 "version": row.version,
             }))
         })
@@ -510,14 +607,18 @@ pub async fn rehearsal_assign<E: GovernanceEventEmitter + Clone + 'static>(
                             .to_string(),
                     ));
                 }
+                if row.pending_item_id.is_some() {
+                    return Err(ApiError::Conflict(
+                        "An interrupted execution exists for this proposed work; retry confirm \
+                         with the same preview digest to complete it, or reset the rehearsal."
+                            .to_string(),
+                    ));
+                }
                 row.base.assignee_label = req.assignee_label.clone();
                 row.version += 1;
                 row.base.status = PendingPublishRowStatus::PendingReview;
                 row.approve_ref = None;
-                (
-                    serde_json::to_value(&row.base).expect("row serializes"),
-                    row.version,
-                )
+                (to_value_or_error(&row.base), row.version)
             };
             let bound = req
                 .assignee_label
@@ -545,7 +646,9 @@ pub async fn rehearsal_bind_label<E: GovernanceEventEmitter + Clone + 'static>(
     domain_id: web::Path<String>,
     req: web::Json<RehearsalBindRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    let (domain, _caller) = gate(&ctx, &http_req, &domain_id, REVIEW_SCOPES).await?;
+    // Setup capability: the organizer browser never binds identities (and
+    // never handles a DID); only the internal fixture/setup credential does.
+    let (domain, _caller) = gate(&ctx, &http_req, &domain_id, SETUP_SCOPES).await?;
 
     if req.label.trim().is_empty() || req.label.len() > MAX_LABEL {
         return Err(ApiError::BadRequest(format!(
@@ -553,6 +656,18 @@ pub async fn rehearsal_bind_label<E: GovernanceEventEmitter + Clone + 'static>(
         )));
     }
     let bound_did = parse_did(&req.did, "Invalid DID in binding")?;
+    // A binding target must already hold standing in this domain: binding
+    // grants no authority and cannot smuggle an outside identity into the
+    // rehearsal's completion loop.
+    if check_domain_membership(&ctx, &domain, &bound_did)
+        .await
+        .is_err()
+    {
+        return Ok(HttpResponse::UnprocessableEntity().json(json!({
+            "error": "The identity for this label does not hold membership standing in this domain; bindings must reference an existing fictional domain member.",
+            "label": req.label,
+        })));
+    }
 
     let state = ctx.manager.rehearsal_state();
     let body = state
@@ -634,14 +749,17 @@ pub async fn rehearsal_preview<E: GovernanceEventEmitter + Clone + 'static>(
                 "assignee_label": row.base.assignee_label,
                 "assignee_bound": assignee_bound,
                 "authority_basis": row.base.authority_basis,
-                "risk_level": serde_json::to_value(row.base.risk_level).expect("risk serializes"),
-                "receipt_expected": serde_json::to_value(&row.base.receipt_expected).expect("receipt serializes"),
+                "risk_level": to_value_or_error(&row.base.risk_level),
+                "receipt_expected": to_value_or_error(&row.base.receipt_expected),
                 "reversible": false,
                 "permanence_note": "Confirming creates a real action item and permanent process receipts on this rehearsal node. The rehearsal can be reset, but recorded receipts are not erased.",
                 "privacy_note": "The preview and all receipts are value-withheld: member identities appear only as labels; identity bindings stay on the node.",
                 "confirmable": confirmable,
                 "preview_digest": plan.digest.to_hex().to_string(),
-                "plan_id": format!("rehearsal-plan-{}-v{}", row.base.id, row.version),
+                "plan_id": format!(
+                    "rehearsal-plan-{}-{}-v{}",
+                    workspace.run_id, row.base.id, row.version
+                ),
                 "expected_receipts": [
                     "process_gate_result",
                     "activation_crossed",
@@ -677,6 +795,7 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
     let result = state
         .with_workspace(&domain.0, |workspace| -> Result<Result<(Value, bool), HttpResponse>, ApiError> {
             let session_id = workspace.session_id();
+            let run_id = workspace.run_id.clone();
             let generation = workspace.generation;
 
             // Idempotent replay / conflicting-reuse check first.
@@ -696,7 +815,7 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
 
             // Recompute the plan from CURRENT state and verify the digest.
             let (plan, approve_ref, assignee_label) = {
-                let row = workspace.row(&row_id).expect("checked above");
+                let row = workspace.row(&row_id).ok_or_else(row_not_found)?;
                 if row.base.status != PendingPublishRowStatus::ApprovedForPublish
                     || row.approve_ref.is_none()
                 {
@@ -716,7 +835,12 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
                         )));
                     }
                 }
-                (plan, row.approve_ref.clone().expect("checked"), row.base.assignee_label.clone())
+                let approve_ref = row.approve_ref.clone().ok_or_else(|| {
+                    ApiError::Conflict(
+                        "Confirm requires an approved review decision on the current version of this row.".to_string(),
+                    )
+                })?;
+                (plan, approve_ref, row.base.assignee_label.clone())
             };
             // blake3::Hash equality is constant-time.
             if plan.digest != submitted {
@@ -727,7 +851,7 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
 
             // Real ADR-0026 ladder: gate → activation → plan → item → applied.
             ensure_session(&ctx, &domain, workspace, &caller)?;
-            let row_version = workspace.row(&row_id).expect("checked").version;
+            let row_version = workspace.row(&row_id).ok_or_else(row_not_found)?.version;
             let gate_receipt = ctx
                 .manager
                 .record_process_gate_result(
@@ -738,7 +862,7 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
                     &caller,
                 )
                 .map_err(conflict_or_internal)?;
-            let activation_id = format!("rehearsal-activation-{row_id}-v{row_version}");
+            let activation_id = format!("rehearsal-activation-{run_id}-{row_id}-v{row_version}");
             let activation = match ctx
                 .manager
                 .record_activation_crossed(
@@ -755,7 +879,7 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
                 ActivationCrossedOutcome::Crossed(r)
                 | ActivationCrossedOutcome::AlreadyCrossed(r) => r,
             };
-            let plan_id = format!("rehearsal-plan-{row_id}-v{row_version}");
+            let plan_id = format!("rehearsal-plan-{run_id}-{row_id}-v{row_version}");
             let plan_receipt = match ctx
                 .manager
                 .record_mutation_plan_recorded(
@@ -777,22 +901,47 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
                 Some(s) => Some(parse_did(s, "Invalid bound assignee DID")?),
                 None => None,
             };
-            let item = ctx
-                .manager
-                .create_action_item(
-                    domain.clone(),
-                    plan.title.clone(),
-                    Some(plan.description.clone()),
-                    caller.clone(),
-                    assignee_did,
-                    plan.due_date,
-                    ActionItemPriority::Medium,
-                    None,
-                    Some(format!("rehearsal-review session {session_id}")),
-                    Vec::new(),
-                )
-                .map_err(|e| ApiError::Internal(e.to_string()))?;
-            let action_item_id = item.id.to_string();
+            // Resume-safe creation: the pending marker is written the moment
+            // the real item exists, BEFORE the mutation-applied receipt. If
+            // that recording fails, an identical retried confirm resumes with
+            // the same item instead of creating a second one (review
+            // mutations are blocked while the marker is set, so the digest
+            // still matches).
+            let pending = workspace
+                .row(&row_id)
+                .ok_or_else(row_not_found)?
+                .pending_item_id
+                .clone();
+            let action_item_id = match pending {
+                Some(id) => id,
+                None => {
+                    let item = ctx
+                        .manager
+                        .create_action_item(
+                            domain.clone(),
+                            plan.title.clone(),
+                            Some(plan.description.clone()),
+                            caller.clone(),
+                            assignee_did.clone(),
+                            plan.due_date,
+                            ActionItemPriority::Medium,
+                            None,
+                            Some(format!("rehearsal-review session {session_id}")),
+                            Vec::new(),
+                        )
+                        .map_err(|e| {
+                            tracing::warn!(detail = %e, "rehearsal action-item creation failed");
+                            ApiError::Internal(
+                                "Creating the rehearsal action item failed.".to_string(),
+                            )
+                        })?;
+                    let id = item.id.to_string();
+                    if let Some(row) = workspace.row_mut(&row_id) {
+                        row.pending_item_id = Some(id.clone());
+                    }
+                    id
+                }
+            };
 
             let result_hash = ws::apply_result_hash(
                 &domain.0,
@@ -801,7 +950,7 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
                 plan.assignee_did.as_deref(),
                 caller.as_str(),
             );
-            let application_id = format!("rehearsal-apply-{row_id}-v{row_version}");
+            let application_id = format!("rehearsal-apply-{run_id}-{row_id}-v{row_version}");
             let applied = match ctx
                 .manager
                 .record_mutation_applied(
@@ -836,10 +985,10 @@ pub async fn rehearsal_confirm<E: GovernanceEventEmitter + Clone + 'static>(
             let _ = generation;
             let _ = assignee_label;
             let response = confirm_response(&row_id, &session_id, &exec, false);
-            workspace
-                .row_mut(&row_id)
-                .expect("checked above")
-                .execution = Some(exec);
+            if let Some(row) = workspace.row_mut(&row_id) {
+                row.pending_item_id = None;
+                row.execution = Some(exec);
+            }
             Ok(Ok((response, true)))
         })
         .ok_or_else(workspace_not_initialized)??;
@@ -879,6 +1028,7 @@ fn confirm_response(
         "idempotent": idempotent,
         "non_claims": [
             "the receipts record process facts; they grant no authority",
+            "a facilitator with a trusted narrow capability confirmed fixture work — no collective vote occurred and none is implied",
             "this is an isolated fictional rehearsal, not production governance",
         ],
     })
@@ -968,38 +1118,44 @@ pub async fn rehearsal_evidence_export<E: GovernanceEventEmitter + Clone + 'stat
                 .rows
                 .iter()
                 .map(|row| {
-                    let outcome = match (&row.execution, row.base.status) {
-                        (Some(_), _) => "executed",
-                        (None, PendingPublishRowStatus::Rejected) => "rejected",
-                        (None, PendingPublishRowStatus::NeedsEdit) => "edit-and-resubmit",
-                        (None, PendingPublishRowStatus::ApprovedForPublish) => {
-                            "approved-not-executed"
+                    let outcome = if row.execution.is_some() {
+                        "executed"
+                    } else if row.pending_item_id.is_some() {
+                        // Item created but the applied receipt was never
+                        // recorded (interrupted confirm): say so plainly.
+                        "interrupted-execution"
+                    } else {
+                        match row.base.status {
+                            PendingPublishRowStatus::Rejected => "rejected",
+                            PendingPublishRowStatus::NeedsEdit => "edit-and-resubmit",
+                            PendingPublishRowStatus::ApprovedForPublish => "approved-not-executed",
+                            _ => "deferred",
                         }
-                        (None, _) => "deferred",
                     };
                     let mut v = json!({
                         "id": row.base.id,
-                        "kind": serde_json::to_value(row.base.kind).expect("kind serializes"),
+                        "kind": to_value_or_error(&row.base.kind),
                         "outcome": outcome,
                         "version": row.version,
-                        "source_provenance": serde_json::to_value(row.base.source_provenance)
-                            .expect("provenance serializes"),
+                        "source_provenance": to_value_or_error(&row.base.source_provenance),
                         "assignee_label": row.base.assignee_label,
                     });
-                    if let Some(exec) = &row.execution {
-                        let obj = v.as_object_mut().expect("object");
-                        obj.insert("preview_digest".into(), json!(hex32(&exec.preview_digest)));
-                        obj.insert("plan_record_hash".into(), json!(hex32(&exec.plan_record_hash)));
-                        obj.insert(
-                            "application_record_hash".into(),
-                            json!(hex32(&exec.application_record_hash)),
-                        );
-                        obj.insert("action_item_id".into(), json!(exec.action_item_id));
-                        obj.insert("mutation_executed".into(), json!(true));
-                    } else {
-                        v.as_object_mut()
-                            .expect("object")
-                            .insert("mutation_executed".into(), json!(false));
+                    if let Some(obj) = v.as_object_mut() {
+                        if let Some(exec) = &row.execution {
+                            obj.insert("preview_digest".into(), json!(hex32(&exec.preview_digest)));
+                            obj.insert(
+                                "plan_record_hash".into(),
+                                json!(hex32(&exec.plan_record_hash)),
+                            );
+                            obj.insert(
+                                "application_record_hash".into(),
+                                json!(hex32(&exec.application_record_hash)),
+                            );
+                            obj.insert("action_item_id".into(), json!(exec.action_item_id));
+                            obj.insert("mutation_executed".into(), json!(true));
+                        } else {
+                            obj.insert("mutation_executed".into(), json!(false));
+                        }
                     }
                     v
                 })
@@ -1029,6 +1185,7 @@ pub async fn rehearsal_evidence_export<E: GovernanceEventEmitter + Clone + 'stat
                 "contract": "urn:icn:contract:rehearsal-workflow-evidence:v1",
                 "origin": "rehearsal_runtime",
                 "domain_id": domain.0,
+                "run_id": workspace.run_id,
                 "generation": workspace.generation,
                 "session_id": workspace.session_id(),
                 "session_record_hash": workspace.session_record_hash.as_ref().map(hex32),
@@ -1043,20 +1200,31 @@ pub async fn rehearsal_evidence_export<E: GovernanceEventEmitter + Clone + 'stat
                 },
                 "non_claims": [
                     "fictional rehearsal evidence — not production governance, not a pilot, not live federation",
-                    "receipts record process facts and grant no authority",
+                    "receipts record process facts and grant no authority; a facilitator capability confirmed fixture work — no collective vote occurred and none is implied",
                     "identity bindings stay on the rehearsal node; this packet carries labels only",
                 ],
-                "hash_algorithm": "sha256",
+                "privacy_review_result": "pass: no DIDs, credentials, private-overlay values, paths, or topology exported",
+                "hash_domain_tag": "icn:gov:rehearsal_workflow_evidence:v1",
+                "generated_at": icn_time::current_timestamp_secs(),
             });
-            let canonical = serde_json::to_vec(&content).expect("packet serializes");
-            let packet_hash = format!("{:x}", sha2::Sha256::digest(&canonical));
+            // EVERY exported field above — including generated_at — is bound
+            // by the hashes; only the two hash fields themselves are outside
+            // the canonical content. BLAKE3 (domain-separated) is primary per
+            // ICN receipt convention; the SHA-256 mirror lets a browser
+            // steward view verify via WebCrypto.
+            let canonical = match serde_json::to_vec(&content) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    tracing::error!(detail = %e, "evidence packet serialization failed");
+                    return json!({ "error": "evidence packet serialization failed" });
+                }
+            };
+            let (packet_hash, packet_hash_sha256) = ws::evidence_packet_hashes(&canonical);
             let mut packet = content;
-            let obj = packet.as_object_mut().expect("object");
-            obj.insert("packet_hash".into(), json!(packet_hash));
-            obj.insert(
-                "generated_at".into(),
-                json!(icn_time::current_timestamp_secs()),
-            );
+            if let Some(obj) = packet.as_object_mut() {
+                obj.insert("packet_hash".into(), json!(packet_hash));
+                obj.insert("packet_hash_sha256".into(), json!(packet_hash_sha256));
+            }
             packet
         })
         .ok_or_else(workspace_not_initialized)?;

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -40,9 +40,9 @@ pub mod init;
 pub mod institutional_effect;
 pub mod manager;
 pub mod mandate_gate;
-pub mod rehearsal_workspace;
 pub mod receipt_backend;
 pub mod registry;
+pub mod rehearsal_workspace;
 pub mod state_store;
 
 pub use actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle};

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -40,6 +40,7 @@ pub mod init;
 pub mod institutional_effect;
 pub mod manager;
 pub mod mandate_gate;
+pub mod rehearsal_workspace;
 pub mod receipt_backend;
 pub mod registry;
 pub mod state_store;

--- a/icn/apps/governance/src/manager.rs
+++ b/icn/apps/governance/src/manager.rs
@@ -2935,6 +2935,10 @@ pub struct GovernanceManager {
     domain_store: Option<Arc<dyn GovernanceStateStore>>,
     /// Optional receipt store for persisting GovernanceDecisionReceipts
     receipt_store: Option<Arc<dyn GovernanceReceiptBackend>>,
+    /// Isolated rehearsal review workspaces (#1726/#2386). Only the
+    /// Rehearsal-mode HTTP surface touches this; every other mode leaves it
+    /// empty. Kept on the manager so all gateway workers share one instance.
+    rehearsal_state: crate::rehearsal_workspace::RehearsalReviewState,
     /// Optional append-only log of milestone status transitions.
     ///
     /// `None` in tests and standalone mode (no log written, history falls back
@@ -2984,6 +2988,7 @@ impl GovernanceManager {
             governance_handle: None,
             domain_store: None,
             receipt_store: None,
+            rehearsal_state: Default::default(),
             milestone_event_log: None,
             program_event_log: None,
             domain_adoption_locks: Mutex::new(HashMap::new()),
@@ -3024,6 +3029,7 @@ impl GovernanceManager {
             governance_handle: Some(handle),
             domain_store: None,
             receipt_store: None,
+            rehearsal_state: Default::default(),
             milestone_event_log: None,
             program_event_log: None,
             domain_adoption_locks: Mutex::new(HashMap::new()),
@@ -3042,6 +3048,11 @@ impl GovernanceManager {
     ///
     /// When set, `close_proposal()` in standalone mode will automatically
     /// generate and store a `GovernanceDecisionReceipt` after closing.
+    /// The rehearsal review workspace container (Rehearsal build mode only).
+    pub fn rehearsal_state(&self) -> &crate::rehearsal_workspace::RehearsalReviewState {
+        &self.rehearsal_state
+    }
+
     pub fn with_receipt_store(mut self, store: Arc<dyn GovernanceReceiptBackend>) -> Self {
         self.receipt_store = Some(store);
         self
@@ -3182,6 +3193,7 @@ impl GovernanceManager {
             milestone_store: Arc::new(SledMilestoneStore::new(db.clone())),
             governance_handle: Some(handle),
             receipt_store: None,
+            rehearsal_state: Default::default(),
             // Actor-backed mode: the actor owns its own state store. Standalone-mode
             // domain persistence is intentionally not wired here.
             domain_store: None,
@@ -3245,6 +3257,7 @@ impl GovernanceManager {
             governance_handle: None,
             domain_store: Some(domain_store),
             receipt_store: None,
+            rehearsal_state: Default::default(),
             milestone_event_log: Some(Arc::new(SledMilestoneEventLog::new(db.clone()))),
             program_event_log: Some(Arc::new(SledProgramEventLog::new(db))),
             domain_adoption_locks: Mutex::new(HashMap::new()),

--- a/icn/apps/governance/src/rehearsal_workspace.rs
+++ b/icn/apps/governance/src/rehearsal_workspace.rs
@@ -17,7 +17,7 @@
 //!   a label may be bound to a fictional DID for the completion loop, but no
 //!   read surface (rows, bindings, previews, evidence) ever exposes the DID.
 //!
-//! The preview→confirm binding lives here: [`canonical_plan_digest`] computes
+//! The preview→confirm binding lives here: [`plan_for_row`] computes
 //! a domain-separated BLAKE3 digest over the canonical mutation document
 //! (`urn:icn:rehearsal-plan:v1`). Any change to the row, its review state,
 //! its assignment, the label's identity binding, or the workspace generation
@@ -30,8 +30,6 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Mutex;
-
-use serde::Serialize;
 
 use crate::http::models::{PendingPublishRow, PendingPublishRowKind, PendingPublishRowStatus};
 
@@ -138,12 +136,23 @@ pub struct RehearsalRow {
     /// Set when the current version was approved; cleared by any edit,
     /// re-assignment, or non-approve decision.
     pub approve_ref: Option<ApproveRef>,
+    /// Set the moment the real action item is created, BEFORE the
+    /// mutation-applied receipt is recorded. If that recording fails, a
+    /// retried confirm resumes with this item instead of creating a second
+    /// one; review mutations are blocked while it is set.
+    pub pending_item_id: Option<String>,
     pub execution: Option<ExecutionRecord>,
 }
 
 /// The per-domain rehearsal workspace.
 #[derive(Debug)]
 pub struct Workspace {
+    /// Restart-safe run scope for every PERSISTENT identifier this workspace
+    /// mints (session/decision/activation/plan/application ids). The receipt
+    /// store outlives this in-memory workspace, so ids must never repeat
+    /// across daemon restarts: a fresh run id per reset guarantees a new id
+    /// space while the seed CONTENT stays deterministic.
+    pub run_id: String,
     pub generation: u64,
     /// Monotonic sequence for decision ids within this workspace lifetime
     /// (NOT reset per generation, so decision ids never collide).
@@ -161,7 +170,12 @@ impl Workspace {
     /// Deterministic seed: fixture rows enter at version 0 with their labels
     /// registered (unbound). Prior bindings are cleared — a reset returns the
     /// whole fictional scenario to its clean state.
-    fn seeded(generation: u64, decision_seq: u64, rows: Vec<PendingPublishRow>) -> Self {
+    fn seeded(
+        run_id: String,
+        generation: u64,
+        decision_seq: u64,
+        rows: Vec<PendingPublishRow>,
+    ) -> Self {
         let mut bindings = BTreeMap::new();
         for row in &rows {
             if let Some(label) = &row.assignee_label {
@@ -169,6 +183,7 @@ impl Workspace {
             }
         }
         Workspace {
+            run_id,
             generation,
             decision_seq,
             session_opened: false,
@@ -180,6 +195,7 @@ impl Workspace {
                     version: 0,
                     note: None,
                     approve_ref: None,
+                    pending_item_id: None,
                     execution: None,
                 })
                 .collect(),
@@ -188,9 +204,9 @@ impl Workspace {
         }
     }
 
-    /// The process-session id for this workspace generation.
+    /// The process-session id for this workspace run (restart-safe).
     pub fn session_id(&self) -> String {
-        format!("rehearsal-review-gen{:04}", self.generation)
+        format!("rehearsal-{}-gen{:04}", self.run_id, self.generation)
     }
 
     pub fn row(&self, row_id: &str) -> Option<&RehearsalRow> {
@@ -217,7 +233,10 @@ impl Workspace {
 
     pub fn next_decision_id(&mut self) -> String {
         self.decision_seq += 1;
-        format!("rehearsal-decision-{:06}", self.decision_seq)
+        format!(
+            "rehearsal-decision-{}-{:06}",
+            self.run_id, self.decision_seq
+        )
     }
 }
 
@@ -234,18 +253,58 @@ pub struct RehearsalReviewState {
 
 impl RehearsalReviewState {
     /// Initialize or re-seed the workspace for a domain. Returns the new
-    /// generation (starts at 1).
-    pub fn reset(&self, domain_id: &str, rows: Vec<PendingPublishRow>) -> u64 {
-        let mut inner = self.inner.lock().expect("rehearsal state poisoned");
-        let (generation, decision_seq) = match inner.get(domain_id) {
-            Some(ws) => (ws.generation + 1, ws.decision_seq),
-            None => (1, 0),
+    /// generation (starts at 1) plus the action-item ids created by the
+    /// PRIOR workspace (executed or interrupted), so the caller can retire
+    /// them through the normal status machinery. Mints a fresh restart-safe
+    /// run id: persistent receipt identifiers are never reused across
+    /// resets or daemon restarts even though the seed content is
+    /// deterministic.
+    pub fn reset(&self, domain_id: &str, rows: Vec<PendingPublishRow>) -> (u64, Vec<String>) {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let mut inner = self.lock_inner();
+        let (generation, decision_seq, prior_items) = match inner.get(domain_id) {
+            Some(ws) => (
+                ws.generation + 1,
+                ws.decision_seq,
+                ws.rows
+                    .iter()
+                    .filter_map(|r| {
+                        r.execution
+                            .as_ref()
+                            .map(|e| e.action_item_id.clone())
+                            .or_else(|| r.pending_item_id.clone())
+                    })
+                    .collect(),
+            ),
+            None => (1, 0, Vec::new()),
         };
+        let run_id = format!("{nanos:x}-g{generation:04}");
         inner.insert(
             domain_id.to_string(),
-            Workspace::seeded(generation, decision_seq, rows),
+            Workspace::seeded(run_id, generation, decision_seq, rows),
         );
-        generation
+        (generation, prior_items)
+    }
+
+    /// Whether a workspace exists for this domain (drives the reset
+    /// designation gate: first initialization is a setup act).
+    pub fn is_initialized(&self, domain_id: &str) -> bool {
+        self.lock_inner().contains_key(domain_id)
+    }
+
+    /// Lock with poisoned-lock recovery: rehearsal state is fictional and
+    /// resettable, so recovering the inner value (with a warning) beats
+    /// panicking a request thread forever after one panic under the lock.
+    fn lock_inner(&self) -> std::sync::MutexGuard<'_, HashMap<String, Workspace>> {
+        self.inner.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!(
+                "rehearsal state mutex was poisoned; recovering (workspace is resettable)"
+            );
+            poisoned.into_inner()
+        })
     }
 
     /// Run `f` with the domain's workspace, if initialized.
@@ -254,58 +313,63 @@ impl RehearsalReviewState {
         domain_id: &str,
         f: impl FnOnce(&mut Workspace) -> T,
     ) -> Option<T> {
-        let mut inner = self.inner.lock().expect("rehearsal state poisoned");
+        let mut inner = self.lock_inner();
         inner.get_mut(domain_id).map(f)
     }
 
-    /// Whether any workspace has been initialized (drives the summary origin).
-    pub fn any_initialized(&self) -> bool {
-        !self
-            .inner
-            .lock()
-            .expect("rehearsal state poisoned")
-            .is_empty()
-    }
-
-    /// Snapshot every initialized workspace's rows for the self-scoped
-    /// summary read model (single workspace in practice).
-    pub fn summary_rows(&self) -> Vec<PendingPublishRow> {
-        let inner = self.inner.lock().expect("rehearsal state poisoned");
-        let mut domains: Vec<&String> = inner.keys().collect();
+    /// The initialized workspace domains, sorted. The summary handler
+    /// filters this list by the CALLER's own domain standing before serving
+    /// any rows — workspace existence in one domain must never be observable
+    /// from another.
+    pub fn initialized_domains(&self) -> Vec<String> {
+        let inner = self.lock_inner();
+        let mut domains: Vec<String> = inner.keys().cloned().collect();
         domains.sort();
         domains
-            .into_iter()
-            .flat_map(|d| inner[d].rows.iter().map(|r| r.base.clone()))
-            .collect()
+    }
+
+    /// Snapshot the rows of ONE domain's workspace for the summary read
+    /// model. Returns `None` when that domain has no workspace.
+    pub fn domain_rows(&self, domain_id: &str) -> Option<Vec<PendingPublishRow>> {
+        let inner = self.lock_inner();
+        inner
+            .get(domain_id)
+            .map(|ws| ws.rows.iter().map(|r| r.base.clone()).collect())
     }
 }
 
-/// Canonical plan document (`urn:icn:rehearsal-plan:v1`) — exactly the values
-/// that determine the mutation. Serialized with fixed field order (struct
-/// declaration order) and hashed under [`PLAN_DIGEST_TAG`]. The bound DID is
-/// part of the digest (so a rebinding invalidates previews) but the document
-/// itself is never exported — the browser receives only the digest and the
-/// human-readable fields.
-#[derive(Debug, Serialize)]
-pub struct CanonicalPlanV1<'a> {
-    pub contract: &'static str,
-    pub domain_id: &'a str,
-    pub row_id: &'a str,
-    pub generation: u64,
-    pub version: u64,
-    pub action: &'static str,
-    pub title: &'a str,
-    pub description: &'a str,
-    pub assignee_label: Option<&'a str>,
-    pub assignee_did: Option<&'a str>,
-    pub due_date: Option<u64>,
-    pub priority: &'static str,
-    pub authority_basis: &'a str,
-    pub risk_level: &'a str,
-    pub receipt_expected_category: &'a str,
-    pub source_provenance: &'a str,
-    pub origin: &'static str,
-    pub reversible: bool,
+/// Canonical field framing for the domain-separated digests: fields are
+/// appended in a fixed order, each length-prefixed (u64 LE); an `Option` adds
+/// a 0/1 presence marker before the framed value. No serde in the hash path —
+/// framing is explicit, deterministic, and cannot fail (the ICN receipt
+/// convention: hash fields directly, never a serialization).
+fn frame(hasher: &mut blake3::Hasher, bytes: &[u8]) {
+    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+fn frame_opt(hasher: &mut blake3::Hasher, value: Option<&str>) {
+    match value {
+        None => {
+            hasher.update(&[0u8]);
+        }
+        Some(s) => {
+            hasher.update(&[1u8]);
+            frame(hasher, s.as_bytes());
+        }
+    }
+}
+
+fn frame_opt_u64(hasher: &mut blake3::Hasher, value: Option<u64>) {
+    match value {
+        None => {
+            hasher.update(&[0u8]);
+        }
+        Some(v) => {
+            hasher.update(&[1u8]);
+            hasher.update(&v.to_le_bytes());
+        }
+    }
 }
 
 /// The plan document + digest for an action-item row in its current state.
@@ -317,8 +381,13 @@ pub struct PlannedMutation {
     pub due_date: Option<u64>,
 }
 
-/// Build the canonical plan for a row and compute its digest. Returns `None`
-/// for row kinds that are not executable in this slice.
+/// Build the canonical plan for a row and compute its digest
+/// (`urn:icn:rehearsal-plan:v1`, tag-separated, explicit field framing).
+/// Exactly the values that determine the mutation are bound — including the
+/// workspace run/generation, the row version, and the label's currently
+/// bound DID (part of the digest, never exported), so ANY intervening change
+/// makes an outstanding preview stale. Returns `None` for row kinds that are
+/// not executable in this slice.
 pub fn plan_for_row(
     domain_id: &str,
     ws: &Workspace,
@@ -344,32 +413,29 @@ pub fn plan_for_row(
         .map(str::to_string);
     let due_date = row_due_date(row);
 
-    let doc = CanonicalPlanV1 {
-        contract: "urn:icn:rehearsal-plan:v1",
-        domain_id,
-        row_id: &row.base.id,
-        generation: ws.generation,
-        version: row.version,
-        action: "create_action_item",
-        title: &title,
-        description: &description,
-        assignee_label: row.base.assignee_label.as_deref(),
-        assignee_did: assignee_did.as_deref(),
-        due_date,
-        priority: "medium",
-        authority_basis: &row.base.authority_basis,
-        risk_level: risk_str(&row.base),
-        receipt_expected_category: receipt_category_str(&row.base),
-        source_provenance: provenance_str(&row.base),
-        origin: "rehearsal_runtime",
-        reversible: false,
-    };
-    let bytes = serde_json::to_vec(&doc).expect("canonical plan serializes");
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(PLAN_DIGEST_TAG);
-    hasher.update(&bytes);
+    let mut h = blake3::Hasher::new();
+    h.update(PLAN_DIGEST_TAG);
+    frame(&mut h, b"urn:icn:rehearsal-plan:v1");
+    frame(&mut h, domain_id.as_bytes());
+    frame(&mut h, row.base.id.as_bytes());
+    frame(&mut h, ws.run_id.as_bytes());
+    h.update(&ws.generation.to_le_bytes());
+    h.update(&row.version.to_le_bytes());
+    frame(&mut h, b"create_action_item");
+    frame(&mut h, title.as_bytes());
+    frame(&mut h, description.as_bytes());
+    frame_opt(&mut h, row.base.assignee_label.as_deref());
+    frame_opt(&mut h, assignee_did.as_deref());
+    frame_opt_u64(&mut h, due_date);
+    frame(&mut h, b"medium");
+    frame(&mut h, row.base.authority_basis.as_bytes());
+    frame(&mut h, risk_str(&row.base).as_bytes());
+    frame(&mut h, receipt_category_str(&row.base).as_bytes());
+    frame(&mut h, provenance_str(&row.base).as_bytes());
+    frame(&mut h, b"rehearsal_runtime");
+    h.update(&[0u8]); // reversible: false
     Some(PlannedMutation {
-        digest: hasher.finalize(),
+        digest: h.finalize(),
         title,
         description,
         assignee_did,
@@ -383,7 +449,8 @@ fn row_due_date(_row: &RehearsalRow) -> Option<u64> {
     None
 }
 
-/// Canonical body hash for a review decision (`DecisionRecordedReceipt` input).
+/// Canonical body hash for a review decision (`DecisionRecordedReceipt`
+/// input; `urn:icn:rehearsal-review-decision:v1`, explicit field framing).
 /// Takes the generation explicitly so callers holding a mutable row borrow
 /// need no simultaneous workspace borrow.
 pub fn decision_body_hash_at(
@@ -393,40 +460,23 @@ pub fn decision_body_hash_at(
     decision: ReviewDecision,
     note: Option<&str>,
 ) -> [u8; 32] {
-    #[derive(Serialize)]
-    struct CanonicalDecisionV1<'a> {
-        contract: &'static str,
-        domain_id: &'a str,
-        generation: u64,
-        row_id: &'a str,
-        row_version: u64,
-        decision: &'static str,
-        status_after: &'a str,
-        plain_summary: &'a str,
-        assignee_label: Option<&'a str>,
-        note: Option<&'a str>,
-    }
-    let status_after = status_str(decision.status_after());
-    let doc = CanonicalDecisionV1 {
-        contract: "urn:icn:rehearsal-review-decision:v1",
-        domain_id,
-        generation,
-        row_id: &row.base.id,
-        row_version: row.version,
-        decision: decision.as_str(),
-        status_after,
-        plain_summary: &row.base.plain_summary,
-        assignee_label: row.base.assignee_label.as_deref(),
-        note,
-    };
-    let bytes = serde_json::to_vec(&doc).expect("canonical decision serializes");
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(DECISION_BODY_TAG);
-    hasher.update(&bytes);
-    *hasher.finalize().as_bytes()
+    let mut h = blake3::Hasher::new();
+    h.update(DECISION_BODY_TAG);
+    frame(&mut h, b"urn:icn:rehearsal-review-decision:v1");
+    frame(&mut h, domain_id.as_bytes());
+    h.update(&generation.to_le_bytes());
+    frame(&mut h, row.base.id.as_bytes());
+    h.update(&row.version.to_le_bytes());
+    frame(&mut h, decision.as_str().as_bytes());
+    frame(&mut h, status_str(decision.status_after()).as_bytes());
+    frame(&mut h, row.base.plain_summary.as_bytes());
+    frame_opt(&mut h, row.base.assignee_label.as_deref());
+    frame_opt(&mut h, note);
+    *h.finalize().as_bytes()
 }
 
-/// Result hash binding the applied mutation to the created record.
+/// Result hash binding the applied mutation to the created record
+/// (`urn:icn:rehearsal-apply-result:v1`, explicit field framing).
 pub fn apply_result_hash(
     domain_id: &str,
     action_item_id: &str,
@@ -434,28 +484,15 @@ pub fn apply_result_hash(
     assignee_did: Option<&str>,
     created_by_did: &str,
 ) -> [u8; 32] {
-    #[derive(Serialize)]
-    struct CanonicalResultV1<'a> {
-        contract: &'static str,
-        domain_id: &'a str,
-        action_item_id: &'a str,
-        title: &'a str,
-        assignee_did: Option<&'a str>,
-        created_by_did: &'a str,
-    }
-    let doc = CanonicalResultV1 {
-        contract: "urn:icn:rehearsal-apply-result:v1",
-        domain_id,
-        action_item_id,
-        title,
-        assignee_did,
-        created_by_did,
-    };
-    let bytes = serde_json::to_vec(&doc).expect("canonical result serializes");
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(RESULT_HASH_TAG);
-    hasher.update(&bytes);
-    *hasher.finalize().as_bytes()
+    let mut h = blake3::Hasher::new();
+    h.update(RESULT_HASH_TAG);
+    frame(&mut h, b"urn:icn:rehearsal-apply-result:v1");
+    frame(&mut h, domain_id.as_bytes());
+    frame(&mut h, action_item_id.as_bytes());
+    frame(&mut h, title.as_bytes());
+    frame_opt(&mut h, assignee_did);
+    frame(&mut h, created_by_did.as_bytes());
+    *h.finalize().as_bytes()
 }
 
 // ── Closed-enum wire strings (mirror the serde renames on the models; kept
@@ -510,4 +547,59 @@ pub fn hex32(bytes: &[u8; 32]) -> String {
         out.push_str(&format!("{b:02x}"));
     }
     out
+}
+
+/// Domain-separation tag for the evidence packet hash (BLAKE3, the ICN
+/// receipt convention).
+const EVIDENCE_TAG: &[u8] = b"icn:gov:rehearsal_workflow_evidence:v1";
+
+/// Hash the canonical evidence-packet bytes. Returns
+/// `(packet_hash, packet_hash_sha256)`:
+///
+/// - `packet_hash` — domain-separated BLAKE3 (primary, ICN convention);
+/// - `packet_hash_sha256` — plain SHA-256 of the same bytes, carried as a
+///   mirror so a browser steward view can verify tamper-evidence with
+///   WebCrypto (which cannot compute BLAKE3) without any dependency.
+pub fn evidence_packet_hashes(canonical: &[u8]) -> (String, String) {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(EVIDENCE_TAG);
+    hasher.update(canonical);
+    let blake = hasher.finalize().to_hex().to_string();
+    use sha2::Digest as _;
+    let sha = format!("{:x}", sha2::Sha256::digest(canonical));
+    (blake, sha)
+}
+
+/// Reusable evidence-packet tamper validator.
+///
+/// Canonicalization contract: the packet's own JSON serialization with the
+/// two hash fields (`packet_hash`, `packet_hash_sha256`) removed. EVERY other
+/// exported field — rows, decisions, receipt hashes, generation, run id,
+/// bindings, non-claims, and `generated_at` — is bound by the hashes, so any
+/// post-export change fails verification.
+pub fn validate_evidence_packet(packet: &serde_json::Value) -> Result<(), String> {
+    let obj = packet
+        .as_object()
+        .ok_or_else(|| "evidence packet must be a JSON object".to_string())?;
+    let claimed_blake = obj
+        .get("packet_hash")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "evidence packet is missing packet_hash".to_string())?;
+    let claimed_sha = obj
+        .get("packet_hash_sha256")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "evidence packet is missing packet_hash_sha256".to_string())?;
+    let mut content = obj.clone();
+    content.remove("packet_hash");
+    content.remove("packet_hash_sha256");
+    let canonical = serde_json::to_vec(&content)
+        .map_err(|e| format!("evidence packet does not serialize: {e}"))?;
+    let (blake, sha) = evidence_packet_hashes(&canonical);
+    if blake != claimed_blake {
+        return Err("evidence packet failed BLAKE3 verification: content was altered".to_string());
+    }
+    if sha != claimed_sha {
+        return Err("evidence packet failed SHA-256 verification: content was altered".to_string());
+    }
+    Ok(())
 }

--- a/icn/apps/governance/src/rehearsal_workspace.rs
+++ b/icn/apps/governance/src/rehearsal_workspace.rs
@@ -1,0 +1,513 @@
+//! Isolated rehearsal review workspace (#1726 / #1728 / #2386).
+//!
+//! Domain state for the organizer pending-publish review surface mounted only
+//! in [`GovernanceContextBuildMode::Rehearsal`](crate::http::GovernanceContextBuildMode).
+//! It holds FICTIONAL, deterministic, generic rehearsal rows (seeded from the
+//! same in-code fixture generator the read-only summary serves) plus the
+//! organizer's review state over them. It is:
+//!
+//! - **domain-scoped** — one workspace per governance domain, initialized only
+//!   by an explicit reset; no implicit fallback;
+//! - **node-lifetime, resettable** — the review WORKSPACE is deliberately not
+//!   durable storage (a reset or restart recreates the deterministic seed);
+//!   everything that must outlive it (created action items, ADR-0026 process
+//!   receipts) is persisted through the real governance manager machinery and
+//!   is explicitly NOT stored here;
+//! - **label-only on read surfaces** — assignment uses human-readable labels;
+//!   a label may be bound to a fictional DID for the completion loop, but no
+//!   read surface (rows, bindings, previews, evidence) ever exposes the DID.
+//!
+//! The preview→confirm binding lives here: [`canonical_plan_digest`] computes
+//! a domain-separated BLAKE3 digest over the canonical mutation document
+//! (`urn:icn:rehearsal-plan:v1`). Any change to the row, its review state,
+//! its assignment, the label's identity binding, or the workspace generation
+//! changes the digest, so a previously issued preview fails closed at
+//! confirm. The digest bytes are what `record_mutation_plan_recorded`
+//! persists as the plan `body_hash`, binding the approved preview to the
+//! applied mutation through the real receipt ladder.
+//!
+//! Receipts record process facts; nothing in this module grants authority.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Mutex;
+
+use serde::Serialize;
+
+use crate::http::models::{PendingPublishRow, PendingPublishRowKind, PendingPublishRowStatus};
+
+/// Domain-separation tag for the preview/plan digest (`urn:icn:rehearsal-plan:v1`).
+const PLAN_DIGEST_TAG: &[u8] = b"icn:gov:rehearsal_plan:v1";
+/// Domain-separation tag for review-decision body hashes.
+const DECISION_BODY_TAG: &[u8] = b"icn:gov:rehearsal_review_decision:v1";
+/// Domain-separation tag for the applied-mutation result hash.
+const RESULT_HASH_TAG: &[u8] = b"icn:gov:rehearsal_apply_result:v1";
+
+/// Bounded input limits (enforced at the HTTP layer; mirrored here for reuse).
+pub const MAX_PLAIN_SUMMARY: usize = 256;
+pub const MAX_NOTE: usize = 2000;
+pub const MAX_LABEL: usize = 120;
+
+/// A review decision an organizer can record. Closed set; anything else is a
+/// 400 at the HTTP layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReviewDecision {
+    Approve,
+    Reject,
+    NeedsEdit,
+    NeedsMoreInfo,
+}
+
+impl ReviewDecision {
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "approve" => Some(Self::Approve),
+            "reject" => Some(Self::Reject),
+            "needs_edit" => Some(Self::NeedsEdit),
+            "needs_more_info" => Some(Self::NeedsMoreInfo),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Approve => "approve",
+            Self::Reject => "reject",
+            Self::NeedsEdit => "needs_edit",
+            Self::NeedsMoreInfo => "needs_more_info",
+        }
+    }
+
+    pub fn status_after(self) -> PendingPublishRowStatus {
+        match self {
+            Self::Approve => PendingPublishRowStatus::ApprovedForPublish,
+            Self::Reject => PendingPublishRowStatus::Rejected,
+            Self::NeedsEdit => PendingPublishRowStatus::NeedsEdit,
+            Self::NeedsMoreInfo => PendingPublishRowStatus::NeedsMoreInfo,
+        }
+    }
+}
+
+/// Reference to the DecisionRecorded receipt that approved a row, carried
+/// into the activation step of the confirm ladder.
+#[derive(Debug, Clone)]
+pub struct ApproveRef {
+    pub decision_id: String,
+    pub record_hash: [u8; 32],
+}
+
+/// One recorded review decision (audit log for the evidence packet).
+#[derive(Debug, Clone)]
+pub struct DecisionLogEntry {
+    pub seq: u64,
+    pub row_id: String,
+    pub row_version: u64,
+    pub decision: ReviewDecision,
+    pub decision_id: String,
+    pub record_hash: [u8; 32],
+    pub note_present: bool,
+}
+
+/// Execution record for a confirmed row: every id/hash returned by the real
+/// receipt ladder plus the created action item. Hashes are copies of what the
+/// machinery persisted; the receipts themselves live in the receipt store.
+#[derive(Debug, Clone)]
+pub struct ExecutionRecord {
+    pub preview_digest: [u8; 32],
+    pub action_item_id: String,
+    pub session_id: String,
+    pub decision_id: String,
+    pub decision_record_hash: [u8; 32],
+    pub gate_record_hash: [u8; 32],
+    pub activation_id: String,
+    pub activation_record_hash: [u8; 32],
+    pub plan_id: String,
+    pub plan_record_hash: [u8; 32],
+    pub application_id: String,
+    pub application_record_hash: [u8; 32],
+    pub result_hash: [u8; 32],
+}
+
+/// One rehearsal row: the generic fixture row plus mutable review state.
+#[derive(Debug, Clone)]
+pub struct RehearsalRow {
+    pub base: PendingPublishRow,
+    /// Bumps on every successful review/edit/assign mutation; part of the
+    /// digest input, so any change invalidates outstanding previews.
+    pub version: u64,
+    pub note: Option<String>,
+    /// Set when the current version was approved; cleared by any edit,
+    /// re-assignment, or non-approve decision.
+    pub approve_ref: Option<ApproveRef>,
+    pub execution: Option<ExecutionRecord>,
+}
+
+/// The per-domain rehearsal workspace.
+#[derive(Debug)]
+pub struct Workspace {
+    pub generation: u64,
+    /// Monotonic sequence for decision ids within this workspace lifetime
+    /// (NOT reset per generation, so decision ids never collide).
+    pub decision_seq: u64,
+    pub session_opened: bool,
+    /// Record hash of the `ProcessSessionOpenedReceipt` once opened.
+    pub session_record_hash: Option<[u8; 32]>,
+    pub rows: Vec<RehearsalRow>,
+    /// Human label → fictional DID string. DIDs never leave read surfaces.
+    pub bindings: BTreeMap<String, String>,
+    pub decisions: Vec<DecisionLogEntry>,
+}
+
+impl Workspace {
+    /// Deterministic seed: fixture rows enter at version 0 with their labels
+    /// registered (unbound). Prior bindings are cleared — a reset returns the
+    /// whole fictional scenario to its clean state.
+    fn seeded(generation: u64, decision_seq: u64, rows: Vec<PendingPublishRow>) -> Self {
+        let mut bindings = BTreeMap::new();
+        for row in &rows {
+            if let Some(label) = &row.assignee_label {
+                bindings.insert(label.clone(), String::new());
+            }
+        }
+        Workspace {
+            generation,
+            decision_seq,
+            session_opened: false,
+            session_record_hash: None,
+            rows: rows
+                .into_iter()
+                .map(|base| RehearsalRow {
+                    base,
+                    version: 0,
+                    note: None,
+                    approve_ref: None,
+                    execution: None,
+                })
+                .collect(),
+            bindings,
+            decisions: Vec::new(),
+        }
+    }
+
+    /// The process-session id for this workspace generation.
+    pub fn session_id(&self) -> String {
+        format!("rehearsal-review-gen{:04}", self.generation)
+    }
+
+    pub fn row(&self, row_id: &str) -> Option<&RehearsalRow> {
+        self.rows.iter().find(|r| r.base.id == row_id)
+    }
+
+    pub fn row_mut(&mut self, row_id: &str) -> Option<&mut RehearsalRow> {
+        self.rows.iter_mut().find(|r| r.base.id == row_id)
+    }
+
+    /// Whether a label is bound to an identity. Empty string = registered but
+    /// unbound (seed state).
+    pub fn label_bound(&self, label: &str) -> Option<bool> {
+        self.bindings.get(label).map(|did| !did.is_empty())
+    }
+
+    /// The bound DID for a label, if any. Internal use only — never exported.
+    pub fn bound_did(&self, label: &str) -> Option<&str> {
+        self.bindings
+            .get(label)
+            .map(String::as_str)
+            .filter(|d| !d.is_empty())
+    }
+
+    pub fn next_decision_id(&mut self) -> String {
+        self.decision_seq += 1;
+        format!("rehearsal-decision-{:06}", self.decision_seq)
+    }
+}
+
+/// Shared container: one workspace per initialized domain. Owned by the
+/// `GovernanceManager` (one instance per node), never a process-global.
+/// All operations run under one `Mutex` with no awaits inside critical
+/// sections — the entire review surface is serialized, which is the honest
+/// concurrency model for a single-facilitator rehearsal and makes the
+/// check-then-execute in confirm atomic.
+#[derive(Debug, Default)]
+pub struct RehearsalReviewState {
+    inner: Mutex<HashMap<String, Workspace>>,
+}
+
+impl RehearsalReviewState {
+    /// Initialize or re-seed the workspace for a domain. Returns the new
+    /// generation (starts at 1).
+    pub fn reset(&self, domain_id: &str, rows: Vec<PendingPublishRow>) -> u64 {
+        let mut inner = self.inner.lock().expect("rehearsal state poisoned");
+        let (generation, decision_seq) = match inner.get(domain_id) {
+            Some(ws) => (ws.generation + 1, ws.decision_seq),
+            None => (1, 0),
+        };
+        inner.insert(
+            domain_id.to_string(),
+            Workspace::seeded(generation, decision_seq, rows),
+        );
+        generation
+    }
+
+    /// Run `f` with the domain's workspace, if initialized.
+    pub fn with_workspace<T>(
+        &self,
+        domain_id: &str,
+        f: impl FnOnce(&mut Workspace) -> T,
+    ) -> Option<T> {
+        let mut inner = self.inner.lock().expect("rehearsal state poisoned");
+        inner.get_mut(domain_id).map(f)
+    }
+
+    /// Whether any workspace has been initialized (drives the summary origin).
+    pub fn any_initialized(&self) -> bool {
+        !self
+            .inner
+            .lock()
+            .expect("rehearsal state poisoned")
+            .is_empty()
+    }
+
+    /// Snapshot every initialized workspace's rows for the self-scoped
+    /// summary read model (single workspace in practice).
+    pub fn summary_rows(&self) -> Vec<PendingPublishRow> {
+        let inner = self.inner.lock().expect("rehearsal state poisoned");
+        let mut domains: Vec<&String> = inner.keys().collect();
+        domains.sort();
+        domains
+            .into_iter()
+            .flat_map(|d| inner[d].rows.iter().map(|r| r.base.clone()))
+            .collect()
+    }
+}
+
+/// Canonical plan document (`urn:icn:rehearsal-plan:v1`) — exactly the values
+/// that determine the mutation. Serialized with fixed field order (struct
+/// declaration order) and hashed under [`PLAN_DIGEST_TAG`]. The bound DID is
+/// part of the digest (so a rebinding invalidates previews) but the document
+/// itself is never exported — the browser receives only the digest and the
+/// human-readable fields.
+#[derive(Debug, Serialize)]
+pub struct CanonicalPlanV1<'a> {
+    pub contract: &'static str,
+    pub domain_id: &'a str,
+    pub row_id: &'a str,
+    pub generation: u64,
+    pub version: u64,
+    pub action: &'static str,
+    pub title: &'a str,
+    pub description: &'a str,
+    pub assignee_label: Option<&'a str>,
+    pub assignee_did: Option<&'a str>,
+    pub due_date: Option<u64>,
+    pub priority: &'static str,
+    pub authority_basis: &'a str,
+    pub risk_level: &'a str,
+    pub receipt_expected_category: &'a str,
+    pub source_provenance: &'a str,
+    pub origin: &'static str,
+    pub reversible: bool,
+}
+
+/// The plan document + digest for an action-item row in its current state.
+pub struct PlannedMutation {
+    pub digest: blake3::Hash,
+    pub title: String,
+    pub description: String,
+    pub assignee_did: Option<String>,
+    pub due_date: Option<u64>,
+}
+
+/// Build the canonical plan for a row and compute its digest. Returns `None`
+/// for row kinds that are not executable in this slice.
+pub fn plan_for_row(
+    domain_id: &str,
+    ws: &Workspace,
+    row: &RehearsalRow,
+) -> Option<PlannedMutation> {
+    if row.base.kind != PendingPublishRowKind::ActionItem {
+        return None;
+    }
+    let title = row.base.plain_summary.clone();
+    let description = format!(
+        "Rehearsal-confirmed proposed work {} (generation {}). Authority basis: {}. \
+         Source: {}. Fictional rehearsal record — grants no authority.",
+        row.base.id,
+        ws.generation,
+        row.base.authority_basis,
+        provenance_str(&row.base),
+    );
+    let assignee_did = row
+        .base
+        .assignee_label
+        .as_deref()
+        .and_then(|l| ws.bound_did(l))
+        .map(str::to_string);
+    let due_date = row_due_date(row);
+
+    let doc = CanonicalPlanV1 {
+        contract: "urn:icn:rehearsal-plan:v1",
+        domain_id,
+        row_id: &row.base.id,
+        generation: ws.generation,
+        version: row.version,
+        action: "create_action_item",
+        title: &title,
+        description: &description,
+        assignee_label: row.base.assignee_label.as_deref(),
+        assignee_did: assignee_did.as_deref(),
+        due_date,
+        priority: "medium",
+        authority_basis: &row.base.authority_basis,
+        risk_level: risk_str(&row.base),
+        receipt_expected_category: receipt_category_str(&row.base),
+        source_provenance: provenance_str(&row.base),
+        origin: "rehearsal_runtime",
+        reversible: false,
+    };
+    let bytes = serde_json::to_vec(&doc).expect("canonical plan serializes");
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(PLAN_DIGEST_TAG);
+    hasher.update(&bytes);
+    Some(PlannedMutation {
+        digest: hasher.finalize(),
+        title,
+        description,
+        assignee_did,
+        due_date,
+    })
+}
+
+/// Rehearsal rows carry no due date today; edits may add one later. Kept as a
+/// helper so the digest input and the created item can never disagree.
+fn row_due_date(_row: &RehearsalRow) -> Option<u64> {
+    None
+}
+
+/// Canonical body hash for a review decision (`DecisionRecordedReceipt` input).
+/// Takes the generation explicitly so callers holding a mutable row borrow
+/// need no simultaneous workspace borrow.
+pub fn decision_body_hash_at(
+    domain_id: &str,
+    generation: u64,
+    row: &RehearsalRow,
+    decision: ReviewDecision,
+    note: Option<&str>,
+) -> [u8; 32] {
+    #[derive(Serialize)]
+    struct CanonicalDecisionV1<'a> {
+        contract: &'static str,
+        domain_id: &'a str,
+        generation: u64,
+        row_id: &'a str,
+        row_version: u64,
+        decision: &'static str,
+        status_after: &'a str,
+        plain_summary: &'a str,
+        assignee_label: Option<&'a str>,
+        note: Option<&'a str>,
+    }
+    let status_after = status_str(decision.status_after());
+    let doc = CanonicalDecisionV1 {
+        contract: "urn:icn:rehearsal-review-decision:v1",
+        domain_id,
+        generation,
+        row_id: &row.base.id,
+        row_version: row.version,
+        decision: decision.as_str(),
+        status_after,
+        plain_summary: &row.base.plain_summary,
+        assignee_label: row.base.assignee_label.as_deref(),
+        note,
+    };
+    let bytes = serde_json::to_vec(&doc).expect("canonical decision serializes");
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(DECISION_BODY_TAG);
+    hasher.update(&bytes);
+    *hasher.finalize().as_bytes()
+}
+
+/// Result hash binding the applied mutation to the created record.
+pub fn apply_result_hash(
+    domain_id: &str,
+    action_item_id: &str,
+    title: &str,
+    assignee_did: Option<&str>,
+    created_by_did: &str,
+) -> [u8; 32] {
+    #[derive(Serialize)]
+    struct CanonicalResultV1<'a> {
+        contract: &'static str,
+        domain_id: &'a str,
+        action_item_id: &'a str,
+        title: &'a str,
+        assignee_did: Option<&'a str>,
+        created_by_did: &'a str,
+    }
+    let doc = CanonicalResultV1 {
+        contract: "urn:icn:rehearsal-apply-result:v1",
+        domain_id,
+        action_item_id,
+        title,
+        assignee_did,
+        created_by_did,
+    };
+    let bytes = serde_json::to_vec(&doc).expect("canonical result serializes");
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(RESULT_HASH_TAG);
+    hasher.update(&bytes);
+    *hasher.finalize().as_bytes()
+}
+
+// ── Closed-enum wire strings (mirror the serde renames on the models; kept
+// here so digest inputs never depend on serde_json enum tagging) ────────────
+
+pub fn status_str(s: PendingPublishRowStatus) -> &'static str {
+    match s {
+        PendingPublishRowStatus::PendingReview => "pending_review",
+        PendingPublishRowStatus::ApprovedForPublish => "approved_for_publish",
+        PendingPublishRowStatus::Rejected => "rejected",
+        PendingPublishRowStatus::NeedsEdit => "needs_edit",
+        PendingPublishRowStatus::NeedsMoreInfo => "needs_more_info",
+    }
+}
+
+fn risk_str(row: &PendingPublishRow) -> &'static str {
+    use crate::http::models::PendingPublishRiskLevel as R;
+    match row.risk_level {
+        R::Low => "low",
+        R::Normal => "normal",
+        R::Elevated => "elevated",
+    }
+}
+
+fn receipt_category_str(row: &PendingPublishRow) -> &'static str {
+    use crate::http::models::PendingPublishReceiptCategory as C;
+    match row.receipt_expected.category {
+        C::GovernanceReceipt => "governance_receipt",
+        C::AttendanceReceipt => "attendance_receipt",
+        C::ActionItemCompletionReceipt => "action_item_completion_receipt",
+        C::SettlementReceipt => "settlement_receipt",
+        C::None => "none",
+    }
+}
+
+fn provenance_str(row: &PendingPublishRow) -> &'static str {
+    use crate::http::models::PendingPublishProvenance as P;
+    match row.source_provenance {
+        P::CommittedFixture => "committed_fixture",
+        P::MeetingRecord => "meeting_record",
+        P::GovernanceRecord => "governance_record",
+        P::ExampleSnippet => "example_snippet",
+        P::RepoSafePaste => "repo_safe_paste",
+        P::PriorEvidencePacket => "prior_evidence_packet",
+    }
+}
+
+/// Hex encoding for record hashes (lowercase, 64 chars).
+pub fn hex32(bytes: &[u8; 32]) -> String {
+    let mut out = String::with_capacity(64);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}

--- a/icn/apps/governance/src/rehearsal_workspace.rs
+++ b/icn/apps/governance/src/rehearsal_workspace.rs
@@ -136,6 +136,15 @@ pub struct RehearsalRow {
     /// Set when the current version was approved; cleared by any edit,
     /// re-assignment, or non-approve decision.
     pub approve_ref: Option<ApproveRef>,
+    /// `(row_version, gate record_hash)` of the `ProcessGateResultReceipt`
+    /// recorded for a confirm of that row version. Gate receipts are
+    /// append-only observations whose `record_hash` includes `recorded_at`,
+    /// so a retried confirm MUST reuse the original receipt: recording a
+    /// fresh one in a later second would change the activation's gate basis
+    /// and conflict with the already-recorded `ActivationCrossedReceipt`,
+    /// wedging the retry. Reused only while the version matches; a new
+    /// version (edit/assign/re-review) records a fresh gate observation.
+    pub confirm_gate: Option<(u64, [u8; 32])>,
     /// Set the moment the real action item is created, BEFORE the
     /// mutation-applied receipt is recorded. If that recording fails, a
     /// retried confirm resumes with this item instead of creating a second
@@ -195,6 +204,7 @@ impl Workspace {
                     version: 0,
                     note: None,
                     approve_ref: None,
+                    confirm_gate: None,
                     pending_item_id: None,
                     execution: None,
                 })

--- a/icn/apps/governance/tests/rehearsal_review_workflow.rs
+++ b/icn/apps/governance/tests/rehearsal_review_workflow.rs
@@ -47,6 +47,7 @@ use icn_kernel_api::{AllocationReceipt, Hash};
 use serde_json::{json, Value};
 
 const REVIEW: &str = "governance:pending-publish:review";
+const SETUP: &str = "governance:rehearsal:setup";
 const CONFIRM: &str = "governance:pending-publish:confirm";
 const READ: &str = "governance:read";
 const BROAD: &str = "governance:write";
@@ -72,6 +73,17 @@ type ChainEntry = (u64, [u8; 32], Vec<u8>);
 struct OpaqueUniqueBackend {
     chains: Mutex<HashMap<ChainKey, Vec<ChainEntry>>>,
     unique: Mutex<HashMap<ChainKey, [u8; 32]>>,
+    /// Failure injection: `put_opaque_if_absent` fails for these classes.
+    fail_classes: Mutex<std::collections::HashSet<String>>,
+}
+
+impl OpaqueUniqueBackend {
+    fn fail_class(&self, class: &str) {
+        self.fail_classes.lock().unwrap().insert(class.to_string());
+    }
+    fn clear_failures(&self) {
+        self.fail_classes.lock().unwrap().clear();
+    }
 }
 
 impl GovernanceReceiptBackend for OpaqueUniqueBackend {
@@ -124,6 +136,9 @@ impl GovernanceReceiptBackend for OpaqueUniqueBackend {
         record_hash: [u8; 32],
         payload: &[u8],
     ) -> Result<Option<[u8; 32]>, String> {
+        if self.fail_classes.lock().unwrap().contains(class) {
+            return Err(format!("injected failure for class {class}"));
+        }
         let key = (class.to_string(), key1.to_string(), key2.map(String::from));
         let mut unique = self.unique.lock().unwrap();
         if let Some(winner) = unique.get(&key) {
@@ -167,9 +182,26 @@ impl GovernanceReceiptBackend for OpaqueUniqueBackend {
 
 // ── Context / app harness ──────────────────────────────────────────────────
 
+fn make_ctx_with_backend(
+    mode: GovernanceContextBuildMode,
+) -> (
+    GovernanceContext<NoopEventEmitter>,
+    Arc<OpaqueUniqueBackend>,
+) {
+    let backend = Arc::new(OpaqueUniqueBackend::default());
+    let ctx = make_ctx_on_backend(mode, backend.clone());
+    (ctx, backend)
+}
+
 fn make_ctx(mode: GovernanceContextBuildMode) -> GovernanceContext<NoopEventEmitter> {
-    let manager =
-        GovernanceManager::new().with_receipt_store(Arc::new(OpaqueUniqueBackend::default()));
+    make_ctx_with_backend(mode).0
+}
+
+fn make_ctx_on_backend(
+    mode: GovernanceContextBuildMode,
+    backend: Arc<OpaqueUniqueBackend>,
+) -> GovernanceContext<NoopEventEmitter> {
+    let manager = GovernanceManager::new().with_receipt_store(backend);
     GovernanceContext {
         manager: Arc::new(manager),
         emitter: NoopEventEmitter,
@@ -269,18 +301,20 @@ macro_rules! rehearsal_app_reset {
         let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
         let organizer = fresh_did();
         seed_domain(&ctx.manager, vec![organizer.clone()]).await;
-        let app = gov_app!(ctx, &organizer, $scope);
+        // First initialization (designation) is a SETUP act; the app under
+        // test then carries only the scopes the test declares.
+        let setup_app = gov_app!(ctx.clone(), &organizer, format!("{READ} {SETUP}"));
         let reset = test::TestRequest::post()
             .uri(&format!("/domains/{DOMAIN}/rehearsal/reset"))
             .set_json(json!({}))
             .to_request();
-        let resp = test::call_service(&app, reset).await;
+        let resp = test::call_service(&setup_app, reset).await;
         assert_eq!(
             resp.status(),
             StatusCode::OK,
-            "reset must succeed for scope {}",
-            $scope
+            "designation reset must succeed"
         );
+        let app = gov_app!(ctx, &organizer, $scope);
         (app, organizer)
     }};
 }
@@ -481,7 +515,7 @@ async fn non_member_is_rejected_even_with_review_scope() {
     let member = fresh_did();
     let outsider = fresh_did();
     seed_domain(&ctx.manager, vec![member]).await;
-    let app = gov_app!(ctx, &outsider, format!("{READ} {REVIEW} {CONFIRM}"));
+    let app = gov_app!(ctx, &outsider, format!("{READ} {REVIEW} {CONFIRM} {SETUP}"));
     let resp = post!(
         &app,
         format!("/domains/{DOMAIN}/rehearsal/reset"),
@@ -627,7 +661,7 @@ async fn edit_bounds_fields_and_reapproval_is_required_after_edit() {
 
 #[actix_web::test]
 async fn assignment_uses_labels_and_binding_state_is_visible_without_dids() {
-    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW}"));
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {SETUP}"));
 
     // Bind a label to a DID (organizer/operator act). Response withholds the DID.
     let resp = post!(
@@ -781,7 +815,7 @@ async fn confirm_requires_matching_digest_and_fails_closed_on_stale_preview() {
 
 #[actix_web::test]
 async fn confirm_executes_ladder_creates_real_item_and_is_idempotent() {
-    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM} {SETUP}"));
 
     // Bind + assign so the created item is completable by the member.
     let resp = post!(
@@ -941,7 +975,7 @@ async fn summary_without_workspace_keeps_committed_fixture_origin_in_rehearsal_m
 
 #[actix_web::test]
 async fn evidence_export_is_value_withheld_hash_bound_and_reflects_outcomes() {
-    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM} {SETUP}"));
 
     // Full loop on the action row.
     post!(
@@ -980,8 +1014,31 @@ async fn evidence_export_is_value_withheld_hash_bound_and_reflects_outcomes() {
         "urn:icn:contract:rehearsal-workflow-evidence:v1"
     );
     assert_eq!(packet["origin"], "rehearsal_runtime");
-    assert_eq!(packet["hash_algorithm"], "sha256");
     assert_eq!(packet["packet_hash"].as_str().map(str::len), Some(64));
+    assert_eq!(
+        packet["packet_hash_sha256"].as_str().map(str::len),
+        Some(64)
+    );
+
+    // The reusable validator accepts the pristine packet and rejects EVERY
+    // semantically meaningful tamper — including generated_at, which is
+    // bound by the hashes like every other exported field.
+    use icn_governance_actor::rehearsal_workspace::validate_evidence_packet;
+    validate_evidence_packet(&packet).expect("pristine packet must validate");
+    let tamper = |mutate: &dyn Fn(&mut Value)| {
+        let mut copy = packet.clone();
+        mutate(&mut copy);
+        assert!(
+            validate_evidence_packet(&copy).is_err(),
+            "tampered packet must fail validation"
+        );
+    };
+    tamper(&|p| p["rows"][0]["outcome"] = json!("deferred"));
+    tamper(&|p| p["decisions"][0]["record_hash"] = json!("00".repeat(32)));
+    tamper(&|p| p["generation"] = json!(999));
+    tamper(&|p| p["generated_at"] = json!(0));
+    tamper(&|p| p["non_claims"] = json!([]));
+    tamper(&|p| p["run_id"] = json!("forged"));
 
     // Value-withheld: no DIDs anywhere in the packet.
     assert!(
@@ -1080,7 +1137,7 @@ async fn member_of_another_domain_cannot_touch_this_domains_workspace() {
 
     // The outsider holds full rehearsal scopes and real standing — in the
     // OTHER domain. The path domain must be the authority context.
-    let app = gov_app!(ctx, &outsider, format!("{READ} {REVIEW} {CONFIRM}"));
+    let app = gov_app!(ctx, &outsider, format!("{READ} {REVIEW} {CONFIRM} {SETUP}"));
     let resp = post!(
         &app,
         format!("/domains/{DOMAIN}/rehearsal/reset"),
@@ -1101,7 +1158,24 @@ async fn member_of_another_domain_cannot_touch_this_domains_workspace() {
 
 #[actix_web::test]
 async fn rebinding_a_label_between_preview_and_confirm_invalidates_digest() {
-    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+    // Both identities are domain members (a binding target must hold
+    // standing), so the rebinding itself is legal — what must fail closed is
+    // the STALE PREVIEW after it.
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let organizer = fresh_did();
+    let other = fresh_did();
+    seed_domain(&ctx.manager, vec![organizer.clone(), other.clone()]).await;
+    let app = gov_app!(
+        ctx,
+        &organizer,
+        format!("{READ} {REVIEW} {CONFIRM} {SETUP}")
+    );
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
 
     let resp = post!(
         &app,
@@ -1121,7 +1195,6 @@ async fn rebinding_a_label_between_preview_and_confirm_invalidates_digest() {
 
     // Re-bind the SAME label to a different identity: the mutation the
     // organizer previewed is no longer the mutation that would execute.
-    let other = fresh_did();
     let resp = post!(
         &app,
         format!("/domains/{DOMAIN}/rehearsal/bindings"),
@@ -1145,7 +1218,7 @@ async fn rebinding_a_label_between_preview_and_confirm_invalidates_digest() {
 
 #[actix_web::test]
 async fn reset_invalidates_previews_from_earlier_generations() {
-    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM} {SETUP}"));
 
     post!(
         &app,
@@ -1202,4 +1275,503 @@ async fn organizer_supplied_markup_stays_inert_text() {
         "markup is stored and returned verbatim as inert JSON text — \
          never interpreted, never mangled, escaping is the renderer's job"
     );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. Design-audit regressions: capability separation, summary isolation,
+//    restart safety, confirm atomicity, reset retirement, broad fallback
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[actix_web::test]
+async fn review_scope_cannot_designate_but_can_re_reset() {
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let organizer = fresh_did();
+    seed_domain(&ctx.manager, vec![organizer.clone()]).await;
+
+    // Designation (first reset) is a setup act: a review-scoped member
+    // cannot turn an arbitrary domain into a rehearsal workspace.
+    let review_app = gov_app!(ctx.clone(), &organizer, format!("{READ} {REVIEW}"));
+    let resp = post!(
+        &review_app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "review scope must not designate a rehearsal domain"
+    );
+
+    // Setup designates; the organizer may then repeat the rehearsal.
+    let setup_app = gov_app!(ctx.clone(), &organizer, format!("{READ} {SETUP}"));
+    let resp = post!(
+        &setup_app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "setup designates the workspace"
+    );
+    let resp = post!(
+        &review_app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "review scope re-resets an already-designated workspace"
+    );
+}
+
+#[actix_web::test]
+async fn organizer_shape_cannot_bind_and_setup_cannot_review_or_confirm() {
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+
+    // The organizer browser shape never binds identities.
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "organizer credential must not bind identities"
+    );
+
+    // A setup-only credential can bind a MEMBER identity but cannot review
+    // or confirm anything.
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let operator = fresh_did();
+    seed_domain(&ctx.manager, vec![operator.clone()]).await;
+    let setup_app = gov_app!(ctx, &operator, format!("{READ} {SETUP}"));
+    let resp = post!(
+        &setup_app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = post!(
+        &setup_app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": operator.to_string()})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "setup binds a member identity"
+    );
+    let resp = post!(
+        &setup_app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve"})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "setup must not review"
+    );
+    let resp = post!(
+        &setup_app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": "0".repeat(64)})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "setup must not confirm"
+    );
+}
+
+#[actix_web::test]
+async fn binding_a_non_member_identity_fails_closed() {
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let operator = fresh_did();
+    let stranger = fresh_did();
+    seed_domain(&ctx.manager, vec![operator.clone()]).await;
+    let setup_app = gov_app!(ctx, &operator, format!("{READ} {SETUP}"));
+    let resp = post!(
+        &setup_app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = post!(
+        &setup_app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": stranger.to_string()})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "a binding target must already hold domain membership"
+    );
+}
+
+#[actix_web::test]
+async fn summary_is_isolated_to_the_callers_own_domains() {
+    // Two domains, two members. A workspace exists ONLY in DOMAIN (member:
+    // insider). The outsider — a member of other-domain only — must not
+    // observe DOMAIN's rows, review state, or even that a workspace exists.
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let insider = fresh_did();
+    let outsider = fresh_did();
+    seed_domain(&ctx.manager, vec![insider.clone()]).await;
+    seed_named_domain(&ctx.manager, vec![outsider.clone()], "other-domain").await;
+
+    let insider_app = gov_app!(ctx.clone(), &insider, format!("{READ} {REVIEW} {SETUP}"));
+    let resp = post!(
+        &insider_app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = post!(
+        &insider_app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Insider sees their live workspace.
+    let body = body_json(get!(&insider_app, "/me/pending-publish-summary")).await;
+    assert_eq!(body["origin"], "rehearsal_runtime");
+
+    // Outsider gets the static fixture — indistinguishable from "no
+    // workspace exists anywhere", with no approved row state leaking.
+    let outsider_app = gov_app!(ctx, &outsider, format!("{READ} {REVIEW}"));
+    let body = body_json(get!(&outsider_app, "/me/pending-publish-summary")).await;
+    assert_eq!(
+        body["origin"], "committed_fixture",
+        "another domain's workspace must be unobservable"
+    );
+    let rows = body["rows"].as_array().unwrap();
+    let action = rows.iter().find(|r| r["id"] == ROW_ACTION).unwrap();
+    assert_eq!(
+        action["status"], "pending_review",
+        "review state from a foreign domain must not leak into the fixture view"
+    );
+}
+
+#[actix_web::test]
+async fn restart_with_persisted_receipts_does_not_collide_or_resolve_to_prior_run() {
+    // Run 1 on manager A; then a "daemon restart": fresh manager B (fresh
+    // in-memory rehearsal state) sharing the SAME persistent receipt
+    // backend. Every persistent identifier is run-scoped, so run 2 must
+    // complete end-to-end without colliding with — or silently resolving to
+    // — run 1's receipts.
+    let (ctx1, backend) = make_ctx_with_backend(GovernanceContextBuildMode::Rehearsal);
+    let organizer = fresh_did();
+    seed_domain(&ctx1.manager, vec![organizer.clone()]).await;
+    let app1 = gov_app!(
+        ctx1,
+        &organizer,
+        format!("{READ} {REVIEW} {CONFIRM} {SETUP}")
+    );
+    let resp = post!(
+        &app1,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    post!(
+        &app1,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    post!(
+        &app1,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    let preview1 = approve_and_preview!(&app1);
+    let d1 = preview1["preview_digest"].as_str().unwrap().to_string();
+    let resp = post!(
+        &app1,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": d1})
+    );
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let confirm1 = body_json(resp).await;
+
+    // "Restart": new manager, same receipt store.
+    let ctx2 = make_ctx_on_backend(GovernanceContextBuildMode::Rehearsal, backend);
+    seed_domain(&ctx2.manager, vec![organizer.clone()]).await;
+    let app2 = gov_app!(
+        ctx2,
+        &organizer,
+        format!("{READ} {REVIEW} {CONFIRM} {SETUP}")
+    );
+    let resp = post!(
+        &app2,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "post-restart designation succeeds"
+    );
+    post!(
+        &app2,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    post!(
+        &app2,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    let preview2 = approve_and_preview!(&app2);
+    let d2 = preview2["preview_digest"].as_str().unwrap().to_string();
+    let resp = post!(
+        &app2,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": d2})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "post-restart confirm must succeed with fresh run-scoped receipt ids"
+    );
+    let confirm2 = body_json(resp).await;
+
+    // Fresh receipts, not silent resolutions of run 1's.
+    for key in ["session_id", "decision_id", "plan_id", "application_id"] {
+        assert_ne!(
+            confirm2[key], confirm1[key],
+            "{key} must be run-scoped, never reused after restart"
+        );
+    }
+    assert_ne!(confirm2["plan_record_hash"], confirm1["plan_record_hash"]);
+    assert_ne!(confirm2["action_item_id"], confirm1["action_item_id"]);
+}
+
+#[actix_web::test]
+async fn confirm_failure_before_item_creation_leaves_no_item_and_retry_succeeds() {
+    let (ctx, backend) = make_ctx_with_backend(GovernanceContextBuildMode::Rehearsal);
+    let organizer = fresh_did();
+    seed_domain(&ctx.manager, vec![organizer.clone()]).await;
+    let app = gov_app!(
+        ctx,
+        &organizer,
+        format!("{READ} {REVIEW} {CONFIRM} {SETUP}")
+    );
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+
+    // Plan-receipt failure happens BEFORE the item exists: no item, clean
+    // retry. (An action-item creation failure is the same class: nothing to
+    // resume, nothing duplicated.)
+    backend.fail_class("mutation_plan_recorded");
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let listing = body_json(get!(&app, format!("/domains/{DOMAIN}/action-items"))).await;
+    assert_eq!(
+        listing.as_array().map(Vec::len),
+        Some(0),
+        "no action item may exist after a pre-creation failure"
+    );
+
+    backend.clear_failures();
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(resp.status(), StatusCode::CREATED, "clean retry succeeds");
+    let listing = body_json(get!(&app, format!("/domains/{DOMAIN}/action-items"))).await;
+    assert_eq!(
+        listing.as_array().map(Vec::len),
+        Some(1),
+        "exactly one item"
+    );
+}
+
+#[actix_web::test]
+async fn confirm_retry_after_applied_failure_resumes_same_item_never_duplicates() {
+    let (ctx, backend) = make_ctx_with_backend(GovernanceContextBuildMode::Rehearsal);
+    let organizer = fresh_did();
+    seed_domain(&ctx.manager, vec![organizer.clone()]).await;
+    let app = gov_app!(
+        ctx,
+        &organizer,
+        format!("{READ} {REVIEW} {CONFIRM} {SETUP}")
+    );
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+
+    // The item is created, then the mutation-applied receipt fails.
+    backend.fail_class("mutation_applied");
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let listing = body_json(get!(&app, format!("/domains/{DOMAIN}/action-items"))).await;
+    assert_eq!(
+        listing.as_array().map(Vec::len),
+        Some(1),
+        "the real item exists after the interrupted confirm"
+    );
+    let interrupted_id = listing[0]["id"].as_str().unwrap().to_string();
+
+    // Review mutations are blocked while the interrupted execution exists.
+    let resp = post!(&app, review_uri(ROW_ACTION), &json!({"decision": "reject"}));
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "review is blocked while an interrupted execution exists"
+    );
+
+    // The identical retry RESUMES the same item — never a second one.
+    backend.clear_failures();
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "retry completes the execution"
+    );
+    let confirm = body_json(resp).await;
+    assert_eq!(confirm["action_item_id"], interrupted_id.as_str());
+    let listing = body_json(get!(&app, format!("/domains/{DOMAIN}/action-items"))).await;
+    assert_eq!(
+        listing.as_array().map(Vec::len),
+        Some(1),
+        "an interrupted-then-retried confirm must never duplicate the item"
+    );
+}
+
+#[actix_web::test]
+async fn reset_retires_prior_fictional_items_from_the_active_queue() {
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM} {SETUP}"));
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let item_id = body_json(resp).await["action_item_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Reset = "start a new rehearsal generation": the prior run's fictional
+    // item leaves the active queue through the normal status machinery.
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert!(
+        body["cancelled_action_items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v == item_id.as_str()),
+        "reset must report the retired item: {body}"
+    );
+    let item = body_json(get!(
+        &app,
+        format!("/domains/{DOMAIN}/action-items/{item_id}")
+    ))
+    .await;
+    assert_eq!(
+        item["status"], "cancelled",
+        "the prior fictional item is cancelled, not erased"
+    );
+}
+
+#[actix_web::test]
+async fn broad_governance_write_retains_setup_review_and_confirm() {
+    // Operator-compatibility fallback (sub-capability doctrine): broad
+    // governance:write may drive the whole surface. Browser credentials
+    // never hold it — pinned by the icn-http-kit boundary tests.
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let operator = fresh_did();
+    seed_domain(&ctx.manager, vec![operator.clone()]).await;
+    let app = gov_app!(ctx, &operator, format!("{READ} {BROAD}"));
+
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK, "broad scope designates");
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": operator.to_string()})
+    );
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(resp.status(), StatusCode::CREATED, "broad scope confirms");
 }

--- a/icn/apps/governance/tests/rehearsal_review_workflow.rs
+++ b/icn/apps/governance/tests/rehearsal_review_workflow.rs
@@ -1,0 +1,1192 @@
+//! Integration matrix for the rehearsal pending-publish review/mutation
+//! surface (#1726 / #1728 / #2386 organizer workflow slice).
+//!
+//! Pins the contract:
+//!
+//! 1. The surface is mounted ONLY in `GovernanceContextBuildMode::Rehearsal`.
+//!    In Production, Bootstrap (the unknown/missing-mode fallback), and Test
+//!    the routes do not exist (404) — fail-closed by absence.
+//! 2. Review decisions / edits / assignment require the narrow
+//!    `governance:pending-publish:review` capability; executing a confirmed
+//!    mutation requires `governance:pending-publish:confirm`. Neither implies
+//!    the other; `governance:read` grants neither; broad `governance:write`
+//!    retains both (sub-capability model, #2400).
+//! 3. Preview is a pure GET returning a deterministic `preview_digest` over
+//!    the exact mutation payload + review-state version. Confirm requires the
+//!    digest; any state change between preview and confirm fails closed (409)
+//!    and demands a new preview. Duplicate confirm is idempotent (no second
+//!    action item, same ids returned).
+//! 4. Confirm walks the real ADR-0026 ladder (session → decision → gate →
+//!    activation → plan(body_hash = preview digest) → real action item →
+//!    applied) — receipts come from the real machinery, and the created
+//!    action item is a real governance record visible to the member surface.
+//! 5. Unknown request fields are rejected (400), oversized inputs rejected,
+//!    labels never resolve to DIDs on any read surface, and the evidence
+//!    export is value-withheld (no DIDs) with a verifiable packet hash.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use actix_web::{dev::Service as _, http::StatusCode, test, App, HttpMessage};
+use icn_governance::{
+    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
+    MembershipSource, StaticMembershipResolver,
+};
+use icn_governance_actor::{
+    http::{self, GovernanceContext, GovernanceContextBuildMode},
+    manager::GovernanceManager,
+    mandate_gate::{MandateGate, MandateGateError, MandateGrant, MandateRejection, MandateRequest},
+    receipt_backend::GovernanceReceiptBackend,
+    NoopEventEmitter,
+};
+use icn_http_kit::auth::BasicClaims;
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::{AllocationReceipt, Hash};
+use serde_json::{json, Value};
+
+const REVIEW: &str = "governance:pending-publish:review";
+const CONFIRM: &str = "governance:pending-publish:confirm";
+const READ: &str = "governance:read";
+const BROAD: &str = "governance:write";
+
+const DOMAIN: &str = "rehearsal-test-domain";
+const ROW_ACTION: &str = "pending-row-action-item-001";
+const ROW_DECISION: &str = "pending-row-decision-001";
+
+fn fresh_did() -> Did {
+    IdentityBundle::generate()
+        .expect("IdentityBundle::generate")
+        .did()
+        .clone()
+}
+
+// ── Opaque-backed receipt store (same pattern as the ladder runtime-slice
+// tests: opaque primitives only, typed defaults exercised end-to-end) ───────
+
+type ChainKey = (String, String, Option<String>);
+type ChainEntry = (u64, [u8; 32], Vec<u8>);
+
+#[derive(Default)]
+struct OpaqueUniqueBackend {
+    chains: Mutex<HashMap<ChainKey, Vec<ChainEntry>>>,
+    unique: Mutex<HashMap<ChainKey, [u8; 32]>>,
+}
+
+impl GovernanceReceiptBackend for OpaqueUniqueBackend {
+    fn put_governance(&self, _r: &GovernanceDecisionReceipt) -> Result<(), String> {
+        Ok(())
+    }
+    fn get_governance_by_proposal(
+        &self,
+        _p: &str,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn put_allocation(&self, _r: &AllocationReceipt) -> Result<Hash, String> {
+        Ok([0u8; 32])
+    }
+    fn get_governance_by_decision(
+        &self,
+        _h: &Hash,
+    ) -> Result<Option<GovernanceDecisionReceipt>, String> {
+        Ok(None)
+    }
+    fn list_allocations_by_decision(&self, _h: &Hash) -> Result<Vec<AllocationReceipt>, String> {
+        Ok(vec![])
+    }
+
+    fn put_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<(), String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(())
+    }
+
+    fn put_opaque_if_absent(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+        recorded_at: u64,
+        record_hash: [u8; 32],
+        payload: &[u8],
+    ) -> Result<Option<[u8; 32]>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        let mut unique = self.unique.lock().unwrap();
+        if let Some(winner) = unique.get(&key) {
+            return Ok(Some(*winner));
+        }
+        unique.insert(key.clone(), record_hash);
+        self.chains.lock().unwrap().entry(key).or_default().push((
+            recorded_at,
+            record_hash,
+            payload.to_vec(),
+        ));
+        Ok(None)
+    }
+
+    fn get_latest_opaque(
+        &self,
+        class: &str,
+        key1: &str,
+        key2: Option<&str>,
+    ) -> Result<Option<Vec<u8>>, String> {
+        let key = (class.to_string(), key1.to_string(), key2.map(String::from));
+        Ok(self.chains.lock().unwrap().get(&key).and_then(|chain| {
+            chain
+                .iter()
+                .max_by_key(|(t, h, _)| (*t, *h))
+                .map(|(_, _, p)| p.clone())
+        }))
+    }
+
+    fn list_opaque_for(&self, class: &str, key1: &str) -> Result<Vec<Vec<u8>>, String> {
+        let chains = self.chains.lock().unwrap();
+        let mut hits: Vec<ChainEntry> = chains
+            .iter()
+            .filter(|((c, k1, _), _)| c == class && k1 == key1)
+            .flat_map(|(_, chain)| chain.iter().cloned())
+            .collect();
+        hits.sort_by_key(|(t, h, _)| (*t, *h));
+        Ok(hits.into_iter().map(|(_, _, p)| p).collect())
+    }
+}
+
+// ── Context / app harness ──────────────────────────────────────────────────
+
+fn make_ctx(mode: GovernanceContextBuildMode) -> GovernanceContext<NoopEventEmitter> {
+    let manager =
+        GovernanceManager::new().with_receipt_store(Arc::new(OpaqueUniqueBackend::default()));
+    GovernanceContext {
+        manager: Arc::new(manager),
+        emitter: NoopEventEmitter,
+        on_charter_accepted: None,
+        on_proposal_accepted: None,
+        on_proposal_accepted_with_evidence: None,
+        member_checker: None,
+        steward_checker: None,
+        suspension_checker: None,
+        membership_resolver: None,
+        sdis_service: None,
+        mandate_gate: None,
+        build_mode: mode,
+    }
+}
+
+/// Always-rejecting mandate gate: satisfies Production's `is_some()` wiring
+/// requirement; no test here exercises `require()`.
+struct RejectingMandateGate;
+
+impl MandateGate for RejectingMandateGate {
+    fn require(&self, _req: &MandateRequest) -> Result<MandateGrant, MandateGateError> {
+        Err(MandateGateError::Rejected(MandateRejection::NoMandate))
+    }
+}
+
+/// A context that satisfies Production dependency validation (configure()
+/// panics on a bare Production context by design), so the absent-mode matrix
+/// can include Production.
+fn make_production_ctx() -> GovernanceContext<NoopEventEmitter> {
+    let mut ctx = make_ctx(GovernanceContextBuildMode::Production);
+    ctx.member_checker = Some(Arc::new(|_did, _domain| Box::pin(async { true })));
+    ctx.suspension_checker = Some(Arc::new(|_did, _domain| Box::pin(async { false })));
+    ctx.membership_resolver = Some(Arc::new(StaticMembershipResolver::new()));
+    ctx.mandate_gate = Some(Arc::new(RejectingMandateGate));
+    ctx
+}
+
+async fn seed_named_domain(
+    mgr: &GovernanceManager,
+    members: Vec<Did>,
+    name: &str,
+) -> GovernanceDomainId {
+    let domain = GovernanceDomainId::new(name);
+    mgr.create_domain(
+        domain.clone(),
+        format!("Rehearsal Test Coop ({name})"),
+        "default".to_string(),
+        GovernanceParams {
+            quorum_percentage: 1,
+            approval_threshold_percentage: 51,
+            voting_period_seconds: 86_400,
+            require_deliberation: false,
+            ..GovernanceParams::default()
+        },
+        MembershipConfig {
+            source: MembershipSource::StaticList(members),
+        },
+    )
+    .await
+    .expect("create_domain");
+    domain
+}
+
+async fn seed_domain(mgr: &GovernanceManager, members: Vec<Did>) -> GovernanceDomainId {
+    seed_named_domain(mgr, members, DOMAIN).await
+}
+
+macro_rules! gov_app {
+    ($ctx:expr, $caller:expr, $scope:expr) => {{
+        let scope: String = $scope.to_string();
+        let caller = $caller.to_string();
+        test::init_service(
+            App::new()
+                .wrap_fn(move |req, srv| {
+                    req.extensions_mut().insert(BasicClaims {
+                        sub: caller.clone(),
+                        scope: Some(scope.clone()),
+                    });
+                    srv.call(req)
+                })
+                .configure(|cfg| http::configure(cfg, $ctx)),
+        )
+        .await
+    }};
+}
+
+async fn body_json(resp: actix_web::dev::ServiceResponse) -> Value {
+    let bytes = test::read_body(resp).await;
+    serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+}
+
+/// Standard rehearsal app: Rehearsal mode, one organizer DID that is a domain
+/// member, workspace reset already performed. Returns (app, organizer_did).
+macro_rules! rehearsal_app_reset {
+    ($scope:expr) => {{
+        let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+        let organizer = fresh_did();
+        seed_domain(&ctx.manager, vec![organizer.clone()]).await;
+        let app = gov_app!(ctx, &organizer, $scope);
+        let reset = test::TestRequest::post()
+            .uri(&format!("/domains/{DOMAIN}/rehearsal/reset"))
+            .set_json(json!({}))
+            .to_request();
+        let resp = test::call_service(&app, reset).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "reset must succeed for scope {}",
+            $scope
+        );
+        (app, organizer)
+    }};
+}
+
+fn review_uri(row: &str) -> String {
+    format!("/domains/{DOMAIN}/rehearsal/pending-publish/{row}/review")
+}
+fn preview_uri(row: &str) -> String {
+    format!("/domains/{DOMAIN}/rehearsal/pending-publish/{row}/preview")
+}
+fn confirm_uri(row: &str) -> String {
+    format!("/domains/{DOMAIN}/rehearsal/pending-publish/{row}/confirm")
+}
+
+/// POST a JSON body to the app under test.
+macro_rules! post {
+    ($app:expr, $uri:expr, $body:expr) => {{
+        let uri_owned = $uri;
+        let uri: &str = uri_owned.as_ref();
+        test::call_service(
+            $app,
+            test::TestRequest::post()
+                .uri(uri)
+                .set_json($body)
+                .to_request(),
+        )
+        .await
+    }};
+}
+
+/// GET a path on the app under test.
+macro_rules! get {
+    ($app:expr, $uri:expr) => {{
+        let uri_owned = $uri;
+        let uri: &str = uri_owned.as_ref();
+        test::call_service($app, test::TestRequest::get().uri(uri).to_request()).await
+    }};
+}
+
+/// Drive approve on the action-item row, then return the preview JSON.
+macro_rules! approve_and_preview {
+    ($app:expr) => {{
+        let resp = post!($app, review_uri(ROW_ACTION), &json!({"decision": "approve"}));
+        assert_eq!(resp.status(), StatusCode::OK, "approve");
+        let resp = get!($app, preview_uri(ROW_ACTION));
+        assert_eq!(resp.status(), StatusCode::OK, "preview");
+        body_json(resp).await
+    }};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Mode gating: the surface exists ONLY in Rehearsal mode
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[actix_web::test]
+async fn rehearsal_routes_absent_outside_rehearsal_mode() {
+    for mode in [
+        GovernanceContextBuildMode::Production,
+        GovernanceContextBuildMode::Bootstrap,
+        GovernanceContextBuildMode::Test,
+    ] {
+        let ctx = if mode == GovernanceContextBuildMode::Production {
+            make_production_ctx()
+        } else {
+            make_ctx(mode)
+        };
+        let caller = fresh_did();
+        // Broad scope on purpose: absence must hold even for the most
+        // privileged caller — the routes do not exist, 404, never 403.
+        let app = gov_app!(ctx, &caller, BROAD);
+        for (method, uri) in [
+            ("POST", format!("/domains/{DOMAIN}/rehearsal/reset")),
+            (
+                "GET",
+                format!("/domains/{DOMAIN}/rehearsal/pending-publish"),
+            ),
+            ("POST", review_uri(ROW_ACTION)),
+            ("GET", preview_uri(ROW_ACTION)),
+            ("POST", confirm_uri(ROW_ACTION)),
+            (
+                "GET",
+                format!("/domains/{DOMAIN}/rehearsal/evidence-export"),
+            ),
+        ] {
+            let req = match method {
+                "POST" => test::TestRequest::post()
+                    .uri(&uri)
+                    .set_json(json!({}))
+                    .to_request(),
+                _ => test::TestRequest::get().uri(&uri).to_request(),
+            };
+            let resp = test::call_service(&app, req).await;
+            assert_eq!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "{mode:?} {method} {uri} must be absent (404)"
+            );
+        }
+    }
+}
+
+#[actix_web::test]
+async fn rehearsal_routes_present_in_rehearsal_mode() {
+    let (app, _organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+    let resp = get!(&app, format!("/domains/{DOMAIN}/rehearsal/pending-publish"));
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    let rows = body["rows"].as_array().expect("rows array");
+    assert_eq!(
+        rows.len(),
+        3,
+        "deterministic seed serves the 3 fixture rows"
+    );
+    assert!(rows.iter().any(|r| r["id"] == ROW_ACTION));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Capability gates (sub-capability model)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[actix_web::test]
+async fn read_scope_cannot_review_edit_assign_confirm_or_reset() {
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let organizer = fresh_did();
+    seed_domain(&ctx.manager, vec![organizer.clone()]).await;
+    let app = gov_app!(ctx, &organizer, READ);
+    for uri in [
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        review_uri(ROW_ACTION),
+        confirm_uri(ROW_ACTION),
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+    ] {
+        let resp = post!(&app, &uri, &json!({"decision": "approve"}));
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "read-only must be 403 at {uri}"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn review_scope_cannot_confirm_and_confirm_scope_cannot_review() {
+    // review-only: may approve, may NOT confirm.
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW}"));
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().expect("digest");
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "review scope must not confirm"
+    );
+
+    // confirm-only: may NOT review (and therefore cannot manufacture state).
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let organizer = fresh_did();
+    seed_domain(&ctx.manager, vec![organizer.clone()]).await;
+    let app2 = gov_app!(ctx, &organizer, format!("{READ} {CONFIRM}"));
+    let resp = post!(
+        &app2,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "confirm scope must not reset"
+    );
+    let resp = post!(
+        &app2,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve"})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "confirm scope must not review"
+    );
+}
+
+#[actix_web::test]
+async fn non_member_is_rejected_even_with_review_scope() {
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let member = fresh_did();
+    let outsider = fresh_did();
+    seed_domain(&ctx.manager, vec![member]).await;
+    let app = gov_app!(ctx, &outsider, format!("{READ} {REVIEW} {CONFIRM}"));
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "non-member must be rejected"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Review decisions, edits, assignment
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[actix_web::test]
+async fn approve_reject_needs_edit_move_row_status_and_record_decisions() {
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW}"));
+
+    let resp = post!(
+        &app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["row"]["status"], "approved_for_publish");
+    assert!(
+        body["decision_receipt"]["record_hash"]
+            .as_str()
+            .map(str::len)
+            == Some(64),
+        "review decision must carry a real 64-hex decision receipt hash: {body}"
+    );
+
+    let resp = post!(
+        &app,
+        review_uri(ROW_DECISION),
+        &json!({"decision": "reject", "note": "Duplicate of an earlier record."})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["row"]["status"], "rejected");
+}
+
+#[actix_web::test]
+async fn unknown_decision_value_and_unknown_fields_fail_closed() {
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW}"));
+    let resp = post!(
+        &app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "publish"})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "unknown decision value"
+    );
+
+    let resp = post!(
+        &app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve", "grant_authority": true})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "unknown field must be rejected"
+    );
+
+    let oversized = "x".repeat(4001);
+    let resp = post!(
+        &app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve", "note": oversized})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "oversized note must be rejected"
+    );
+}
+
+#[actix_web::test]
+async fn edit_bounds_fields_and_reapproval_is_required_after_edit() {
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW}"));
+
+    // Approve, then edit: the edit must push the row back to pending review.
+    let resp = post!(
+        &app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::put()
+            .uri(&format!(
+                "/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}"
+            ))
+            .set_json(json!({"plain_summary": "Confirm venue booking for the gathering"}))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(
+        body["row"]["status"], "pending_review",
+        "an edit after approval must invalidate the approval"
+    );
+
+    // Oversized summary rejected.
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::put()
+            .uri(&format!(
+                "/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}"
+            ))
+            .set_json(json!({"plain_summary": "y".repeat(300)}))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // Unknown edit field rejected.
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::put()
+            .uri(&format!(
+                "/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}"
+            ))
+            .set_json(json!({"assignee_did": "did:icn:sneaky"}))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "editing a DID directly is impossible"
+    );
+}
+
+#[actix_web::test]
+async fn assignment_uses_labels_and_binding_state_is_visible_without_dids() {
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW}"));
+
+    // Bind a label to a DID (organizer/operator act). Response withholds the DID.
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["label"], "Example member (fictional)");
+    assert_eq!(body["bound"], true);
+    assert!(
+        !body.to_string().contains(&organizer.to_string()),
+        "binding response must never echo the DID"
+    );
+
+    // Bindings listing shows labels + bound flags only.
+    let resp = get!(&app, format!("/domains/{DOMAIN}/rehearsal/bindings"));
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert!(
+        !body.to_string().contains("did:"),
+        "bindings listing must never contain DIDs: {body}"
+    );
+
+    // Assign the action row to the bound label.
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["row"]["assignee_label"], "Example member (fictional)");
+    assert_eq!(body["assignee_bound"], true);
+
+    // Assigning an unknown label fails closed.
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Nobody we know"})
+    );
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Preview → confirm binding
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[actix_web::test]
+async fn preview_requires_approval_and_is_deterministic() {
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW}"));
+
+    // Not approved yet → no preview.
+    let resp = get!(&app, preview_uri(ROW_ACTION));
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "preview before approval must 409"
+    );
+
+    let preview1 = approve_and_preview!(&app);
+    let d1 = preview1["preview_digest"]
+        .as_str()
+        .expect("digest")
+        .to_string();
+    assert_eq!(d1.len(), 64, "digest is 64-hex");
+
+    // The preview names the mission's nine facts in plain fields.
+    for key in [
+        "action",
+        "domain_id",
+        "authority_basis",
+        "assignee_label",
+        "risk_level",
+        "receipt_expected",
+        "reversible",
+        "privacy_note",
+    ] {
+        assert!(
+            preview1.get(key).is_some(),
+            "preview must carry '{key}': {preview1}"
+        );
+    }
+    assert_eq!(preview1["reversible"], false);
+
+    // Pure GET: same state → identical digest; no state was created.
+    let preview2 = body_json(get!(&app, preview_uri(ROW_ACTION))).await;
+    assert_eq!(preview2["preview_digest"].as_str().unwrap(), d1);
+}
+
+#[actix_web::test]
+async fn confirm_requires_matching_digest_and_fails_closed_on_stale_preview() {
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+
+    // Tampered digest → 409, nothing executed.
+    let mut wrong = digest.clone();
+    wrong.replace_range(0..1, if digest.starts_with('0') { "1" } else { "0" });
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": wrong})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "tampered digest fails closed"
+    );
+
+    // Edit after preview → old digest is stale → 409 and a fresh preview differs.
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::put()
+            .uri(&format!(
+                "/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}"
+            ))
+            .set_json(json!({"plain_summary": "Changed after preview"}))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = post!(
+        &app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "stale preview fails closed"
+    );
+    let fresh = body_json(get!(&app, preview_uri(ROW_ACTION))).await;
+    assert_ne!(fresh["preview_digest"].as_str().unwrap(), digest);
+
+    // Unknown confirm field rejected.
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": fresh["preview_digest"], "force": true})
+    );
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[actix_web::test]
+async fn confirm_executes_ladder_creates_real_item_and_is_idempotent() {
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+
+    // Bind + assign so the created item is completable by the member.
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let first = body_json(resp).await;
+    let item_id = first["action_item_id"]
+        .as_str()
+        .expect("item id")
+        .to_string();
+    for key in [
+        "plan_record_hash",
+        "application_record_hash",
+        "decision_record_hash",
+    ] {
+        assert_eq!(
+            first[key].as_str().map(str::len),
+            Some(64),
+            "{key} must be a 64-hex real receipt hash: {first}"
+        );
+    }
+
+    // The created action item is a REAL governance record on the normal surface.
+    let resp = get!(&app, format!("/domains/{DOMAIN}/action-items/{item_id}"));
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "created item must be a real record"
+    );
+    let item = body_json(resp).await;
+    assert_eq!(item["status"], "pending");
+
+    // Duplicate confirm: idempotent — same ids, no second item.
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "duplicate confirm is a no-op replay"
+    );
+    let second = body_json(resp).await;
+    assert_eq!(second["action_item_id"], first["action_item_id"]);
+    assert_eq!(second["idempotent"], true);
+    let resp = get!(&app, format!("/domains/{DOMAIN}/action-items"));
+    let listing = body_json(resp).await;
+    let created: Vec<_> = listing
+        .as_array()
+        .map(|a| a.iter().filter(|i| i["id"] == item_id.as_str()).collect())
+        .unwrap_or_default();
+    assert_eq!(
+        created.len(),
+        1,
+        "exactly one item exists after duplicate confirm"
+    );
+}
+
+#[actix_web::test]
+async fn confirm_rejects_unbound_assignee_and_non_action_kinds() {
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+
+    // Seeded action row carries an UNBOUND assignee label → confirm fails closed.
+    let preview = approve_and_preview!(&app);
+    assert_eq!(preview["assignee_bound"], false);
+    assert_eq!(preview["confirmable"], false);
+    let digest = preview["preview_digest"].as_str().unwrap();
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "unbound assignee label must fail closed at confirm"
+    );
+
+    // Non-action-item kinds are reviewable but not executable in this slice.
+    let resp = post!(
+        &app,
+        review_uri(ROW_DECISION),
+        &json!({"decision": "approve"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = get!(&app, preview_uri(ROW_DECISION));
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. Summary endpoint reflects the rehearsal workspace
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[actix_web::test]
+async fn summary_serves_rehearsal_runtime_rows_after_workspace_init() {
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW}"));
+
+    let resp = post!(
+        &app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = get!(&app, "/me/pending-publish-summary");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["origin"], "rehearsal_runtime");
+    let rows = body["rows"].as_array().unwrap();
+    let action = rows
+        .iter()
+        .find(|r| r["id"] == ROW_ACTION)
+        .expect("action row");
+    assert_eq!(
+        action["status"], "approved_for_publish",
+        "summary must reflect live review state"
+    );
+}
+
+#[actix_web::test]
+async fn summary_without_workspace_keeps_committed_fixture_origin_in_rehearsal_mode() {
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let caller = fresh_did();
+    let app = gov_app!(ctx, &caller, READ);
+    let resp = get!(&app, "/me/pending-publish-summary");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(
+        body["origin"], "committed_fixture",
+        "before any workspace exists the static fixture is served, honestly labeled"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. Evidence export + receipts read-back + reset
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[actix_web::test]
+async fn evidence_export_is_value_withheld_hash_bound_and_reflects_outcomes() {
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+
+    // Full loop on the action row.
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let confirm = body_json(resp).await;
+
+    // Reject the decision row so the packet shows a mixed outcome set.
+    post!(
+        &app,
+        review_uri(ROW_DECISION),
+        &json!({"decision": "reject"})
+    );
+
+    let resp = get!(&app, format!("/domains/{DOMAIN}/rehearsal/evidence-export"));
+    assert_eq!(resp.status(), StatusCode::OK);
+    let packet = body_json(resp).await;
+
+    assert_eq!(
+        packet["contract"],
+        "urn:icn:contract:rehearsal-workflow-evidence:v1"
+    );
+    assert_eq!(packet["origin"], "rehearsal_runtime");
+    assert_eq!(packet["hash_algorithm"], "sha256");
+    assert_eq!(packet["packet_hash"].as_str().map(str::len), Some(64));
+
+    // Value-withheld: no DIDs anywhere in the packet.
+    assert!(
+        !packet.to_string().contains("did:"),
+        "evidence packet must contain no DIDs: {packet}"
+    );
+
+    // Outcomes: executed row binds to the plan/application receipt hashes
+    // returned at confirm time.
+    let rows = packet["rows"].as_array().unwrap();
+    let executed = rows.iter().find(|r| r["id"] == ROW_ACTION).unwrap();
+    assert_eq!(executed["outcome"], "executed");
+    assert_eq!(executed["plan_record_hash"], confirm["plan_record_hash"]);
+    assert_eq!(
+        executed["application_record_hash"],
+        confirm["application_record_hash"]
+    );
+    let rejected = rows.iter().find(|r| r["id"] == ROW_DECISION).unwrap();
+    assert_eq!(rejected["outcome"], "rejected");
+
+    // Receipts read-back surface lists the ladder receipts (hashes only).
+    let resp = get!(&app, format!("/domains/{DOMAIN}/rehearsal/receipts"));
+    assert_eq!(resp.status(), StatusCode::OK);
+    let receipts = body_json(resp).await;
+    let classes: Vec<&str> = receipts["receipts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|r| r["class"].as_str())
+        .collect();
+    for expected in [
+        "process_session_opened",
+        "decision_recorded",
+        "process_gate_result",
+        "activation_crossed",
+        "mutation_plan_recorded",
+        "mutation_applied",
+    ] {
+        assert!(
+            classes.contains(&expected),
+            "receipt read-back must include {expected}; got {classes:?}"
+        );
+    }
+    assert!(
+        !receipts.to_string().contains("did:"),
+        "receipt read-back must be value-withheld (no DIDs)"
+    );
+}
+
+#[actix_web::test]
+async fn reset_restores_deterministic_seed_and_bumps_generation() {
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+
+    let resp = post!(
+        &app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["generation"], 2);
+
+    let resp = get!(&app, format!("/domains/{DOMAIN}/rehearsal/pending-publish"));
+    let listing = body_json(resp).await;
+    let action = listing["rows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["id"] == ROW_ACTION)
+        .unwrap()
+        .clone();
+    assert_eq!(
+        action["status"], "pending_review",
+        "reset restores the seed state"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. Cross-domain isolation, rebinding staleness, reset staleness, inert markup
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[actix_web::test]
+async fn member_of_another_domain_cannot_touch_this_domains_workspace() {
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let insider = fresh_did();
+    let outsider = fresh_did();
+    seed_domain(&ctx.manager, vec![insider.clone()]).await;
+    seed_named_domain(&ctx.manager, vec![outsider.clone()], "other-domain").await;
+
+    // The outsider holds full rehearsal scopes and real standing — in the
+    // OTHER domain. The path domain must be the authority context.
+    let app = gov_app!(ctx, &outsider, format!("{READ} {REVIEW} {CONFIRM}"));
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "standing in another domain must not open this domain's workspace"
+    );
+    let resp = post!(&app, review_uri(ROW_ACTION), &json!({"decision": "approve"}));
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[actix_web::test]
+async fn rebinding_a_label_between_preview_and_confirm_invalidates_digest() {
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+
+    // Re-bind the SAME label to a different identity: the mutation the
+    // organizer previewed is no longer the mutation that would execute.
+    let other = fresh_did();
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": other.to_string()})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "a binding change between preview and confirm must fail closed"
+    );
+    let fresh = body_json(get!(&app, preview_uri(ROW_ACTION))).await;
+    assert_ne!(fresh["preview_digest"].as_str().unwrap(), digest);
+}
+
+#[actix_web::test]
+async fn reset_invalidates_previews_from_earlier_generations() {
+    let (app, organizer) = rehearsal_app_reset!(format!("{READ} {REVIEW} {CONFIRM}"));
+
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    let preview = approve_and_preview!(&app);
+    let old_digest = preview["preview_digest"].as_str().unwrap().to_string();
+
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Re-approve in the new generation, then try the pre-reset digest.
+    let fresh = approve_and_preview!(&app);
+    assert_ne!(
+        fresh["preview_digest"].as_str().unwrap(),
+        old_digest,
+        "a new generation must never reproduce an old digest"
+    );
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": old_digest})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "a pre-reset preview digest must be stale after reset"
+    );
+}
+
+#[actix_web::test]
+async fn organizer_supplied_markup_stays_inert_text() {
+    let (app, _o) = rehearsal_app_reset!(format!("{READ} {REVIEW}"));
+    let sneaky = "<script>alert(1)</script> Confirm venue & <b>book</b>";
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::put()
+            .uri(&format!(
+                "/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}"
+            ))
+            .set_json(json!({"plain_summary": sneaky}))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(
+        body["row"]["plain_summary"], sneaky,
+        "markup is stored and returned verbatim as inert JSON text — \
+         never interpreted, never mangled, escaping is the renderer's job"
+    );
+}

--- a/icn/apps/governance/tests/rehearsal_review_workflow.rs
+++ b/icn/apps/governance/tests/rehearsal_review_workflow.rs
@@ -2219,3 +2219,102 @@ async fn broad_governance_write_retains_setup_review_and_confirm() {
     );
     assert_eq!(resp.status(), StatusCode::CREATED, "broad scope confirms");
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 10. Fresh-review-round P2 fixes: reset scan run-scoping + summary
+//     single-domain (no ambiguous cross-domain aggregation)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[actix_web::test]
+async fn reset_scan_matches_only_the_structured_marker_not_a_look_alike() {
+    // The durable retirement scan must match ONLY the structured rehearsal
+    // session marker (`"rehearsal-review session rehearsal-…-gen…"`), never
+    // the loose human prefix a normal caller could put in `meeting_context`.
+    // A normal action item whose context merely starts with the human words
+    // must survive a rehearsal reset.
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let organizer = fresh_did();
+    seed_domain(&ctx.manager, vec![organizer.clone()]).await;
+
+    // Create a normal (non-rehearsal) action item with a look-alike context
+    // via the ordinary create route (broad scope), directly in the domain.
+    let broad_app = gov_app!(ctx.clone(), &organizer, format!("{READ} {BROAD}"));
+    let resp = post!(
+        &broad_app,
+        format!("/domains/{DOMAIN}/action-items"),
+        &json!({
+            "title": "Ordinary item",
+            "priority": "medium",
+            "meeting_context": "rehearsal-review session notes (not a real marker)"
+        })
+    );
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let decoy_id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+    // Designate the rehearsal workspace (the first reset runs the durable
+    // retirement scan over the domain's action items).
+    let setup_app = gov_app!(ctx, &organizer, format!("{READ} {SETUP}"));
+    let resp = post!(
+        &setup_app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // The look-alike item is NOT swept — its marker lacks the structured
+    // `rehearsal-…-gen…` session form.
+    let item = body_json(get!(
+        &broad_app,
+        format!("/domains/{DOMAIN}/action-items/{decoy_id}")
+    ))
+    .await;
+    assert_ne!(
+        item["status"], "cancelled",
+        "a look-alike meeting_context must never be swept by the rehearsal reset scan"
+    );
+}
+
+#[actix_web::test]
+async fn summary_serves_a_single_domain_never_ambiguous_cross_domain_rows() {
+    // A caller who is a member of TWO initialized rehearsal domains must not
+    // receive a concatenated rows array with duplicate seed ids. The summary
+    // falls through to the honest committed_fixture response; the per-domain
+    // routes remain the authoritative surface.
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let member = fresh_did();
+    seed_domain(&ctx.manager, vec![member.clone()]).await;
+    seed_named_domain(
+        &ctx.manager,
+        vec![member.clone()],
+        "second-rehearsal-domain",
+    )
+    .await;
+
+    let app = gov_app!(ctx, &member, format!("{READ} {REVIEW} {SETUP}"));
+    // Designate + approve in BOTH domains.
+    for d in [DOMAIN, "second-rehearsal-domain"] {
+        let resp = post!(&app, format!("/domains/{d}/rehearsal/reset"), &json!({}));
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp = post!(
+            &app,
+            format!("/domains/{d}/rehearsal/pending-publish/{ROW_ACTION}/review"),
+            &json!({"decision": "approve"})
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // Member of two rehearsal domains → summary is NOT the ambiguous
+    // aggregate; it is the honest static fixture.
+    let body = body_json(get!(&app, "/me/pending-publish-summary")).await;
+    assert_eq!(
+        body["origin"], "committed_fixture",
+        "two member-visible workspaces must not aggregate into one rows array"
+    );
+    // No duplicate ids: the fixture set has unique row ids.
+    let rows = body["rows"].as_array().unwrap();
+    let mut ids: Vec<&str> = rows.iter().filter_map(|r| r["id"].as_str()).collect();
+    let n = ids.len();
+    ids.sort();
+    ids.dedup();
+    assert_eq!(ids.len(), n, "summary rows must have unique ids");
+}

--- a/icn/apps/governance/tests/rehearsal_review_workflow.rs
+++ b/icn/apps/governance/tests/rehearsal_review_workflow.rs
@@ -31,8 +31,9 @@ use std::sync::{Arc, Mutex};
 
 use actix_web::{dev::Service as _, http::StatusCode, test, App, HttpMessage};
 use icn_governance::{
-    GovernanceDecisionReceipt, GovernanceDomainId, GovernanceParams, MembershipConfig,
-    MembershipSource, StaticMembershipResolver,
+    ActionItem, ActionItemFilter, ActionItemId, GovernanceDecisionReceipt, GovernanceDomain,
+    GovernanceDomainId, GovernanceParams, InMemoryActionItemStore, MembershipConfig,
+    MembershipResolver, MembershipSource, StaticMembershipResolver,
 };
 use icn_governance_actor::{
     http::{self, GovernanceContext, GovernanceContextBuildMode},
@@ -83,6 +84,17 @@ impl OpaqueUniqueBackend {
     }
     fn clear_failures(&self) {
         self.fail_classes.lock().unwrap().clear();
+    }
+    /// Total persisted entries of one receipt class (append-only chains +
+    /// unique inserts both land in `chains`).
+    fn count_entries(&self, class: &str) -> usize {
+        self.chains
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|((c, _, _), _)| c == class)
+            .map(|(_, chain)| chain.len())
+            .sum()
     }
 }
 
@@ -197,6 +209,61 @@ fn make_ctx(mode: GovernanceContextBuildMode) -> GovernanceContext<NoopEventEmit
     make_ctx_with_backend(mode).0
 }
 
+/// Share one in-memory action-item store across "restarted" managers, the
+/// way the gateway's Sled store survives a daemon restart.
+struct SharedItemStore(Arc<InMemoryActionItemStore>);
+
+impl icn_governance::ActionItemStoreBackend for SharedItemStore {
+    fn save(&self, item: &ActionItem) -> icn_governance::Result<()> {
+        self.0.save(item)
+    }
+    fn get(
+        &self,
+        domain_id: &GovernanceDomainId,
+        id: &ActionItemId,
+    ) -> icn_governance::Result<Option<ActionItem>> {
+        self.0.get(domain_id, id)
+    }
+    fn list(
+        &self,
+        domain_id: &GovernanceDomainId,
+        filter: &ActionItemFilter,
+    ) -> icn_governance::Result<Vec<ActionItem>> {
+        self.0.list(domain_id, filter)
+    }
+    fn delete(
+        &self,
+        domain_id: &GovernanceDomainId,
+        id: &ActionItemId,
+    ) -> icn_governance::Result<bool> {
+        self.0.delete(domain_id, id)
+    }
+    fn count(
+        &self,
+        domain_id: &GovernanceDomainId,
+        filter: &ActionItemFilter,
+    ) -> icn_governance::Result<usize> {
+        self.0.count(domain_id, filter)
+    }
+    fn delete_all(&self, domain_id: &GovernanceDomainId) -> icn_governance::Result<usize> {
+        self.0.delete_all(domain_id)
+    }
+}
+
+/// Like [`make_ctx_on_backend`], but with a durable (shared) action-item
+/// store, so a "restart" test can observe items persisted by a prior manager.
+fn make_ctx_on_backend_with_items(
+    mode: GovernanceContextBuildMode,
+    backend: Arc<OpaqueUniqueBackend>,
+    items: Arc<InMemoryActionItemStore>,
+) -> GovernanceContext<NoopEventEmitter> {
+    let mut ctx = make_ctx_on_backend(mode, backend.clone());
+    let mut manager = GovernanceManager::new().with_receipt_store(backend);
+    manager.set_action_item_store(Box::new(SharedItemStore(items)));
+    ctx.manager = Arc::new(manager);
+    ctx
+}
+
 fn make_ctx_on_backend(
     mode: GovernanceContextBuildMode,
     backend: Arc<OpaqueUniqueBackend>,
@@ -268,6 +335,49 @@ async fn seed_named_domain(
 
 async fn seed_domain(mgr: &GovernanceManager, members: Vec<Did>) -> GovernanceDomainId {
     seed_named_domain(mgr, members, DOMAIN).await
+}
+
+/// A `TrustThreshold` domain: membership is NOT enumerable from the source;
+/// standing exists only if a wired resolver affirms it.
+async fn seed_trust_domain(mgr: &GovernanceManager, name: &str) -> GovernanceDomainId {
+    let domain = GovernanceDomainId::new(name);
+    mgr.create_domain(
+        domain.clone(),
+        format!("Rehearsal Trust Coop ({name})"),
+        "default".to_string(),
+        GovernanceParams {
+            quorum_percentage: 1,
+            approval_threshold_percentage: 51,
+            voting_period_seconds: 86_400,
+            require_deliberation: false,
+            ..GovernanceParams::default()
+        },
+        MembershipConfig {
+            source: MembershipSource::TrustThreshold(0.5),
+        },
+    )
+    .await
+    .expect("create_domain");
+    domain
+}
+
+/// Test resolver with a fixed member set, optionally erroring for one DID
+/// (an INDETERMINATE standing, distinct from a provable non-member).
+struct FixedResolver {
+    members: Vec<Did>,
+    error_for: Option<Did>,
+}
+
+impl MembershipResolver for FixedResolver {
+    fn resolve_members(&self, _domain: &GovernanceDomain) -> anyhow::Result<Vec<Did>> {
+        Ok(self.members.clone())
+    }
+    fn is_member(&self, _domain: &GovernanceDomain, did: &Did) -> anyhow::Result<bool> {
+        if self.error_for.as_ref() == Some(did) {
+            anyhow::bail!("trust graph unavailable for this identity");
+        }
+        Ok(self.members.contains(did))
+    }
 }
 
 macro_rules! gov_app {
@@ -1683,6 +1793,340 @@ async fn confirm_retry_after_applied_failure_resumes_same_item_never_duplicates(
         listing.as_array().map(Vec::len),
         Some(1),
         "an interrupted-then-retried confirm must never duplicate the item"
+    );
+
+    // The retry REUSED the original gate receipt instead of appending a
+    // second observation. This is what keeps the retry working at all: gate
+    // record hashes include recorded_at, so a fresh gate in a later second
+    // would change the activation's gate basis and hard-conflict with the
+    // already-recorded activation (same activation_id, different basis).
+    assert_eq!(
+        backend.count_entries("process_gate_result"),
+        1,
+        "an identical retry must reuse the recorded gate receipt, not append a second"
+    );
+    assert_eq!(
+        backend.count_entries("activation_crossed"),
+        1,
+        "exactly one activation crossing exists after the retry"
+    );
+}
+
+#[actix_web::test]
+async fn rebinding_is_refused_while_an_interrupted_execution_references_the_label() {
+    // If the mutation-applied receipt fails after the item exists, the row
+    // holds pending_item_id and the ONLY forward path is the identical
+    // retry. Rebinding the assignee label now would change the recomputed
+    // digest, turn that retry into a stale-preview 409, and strand the
+    // created item without its applied receipt — so rebinding is refused
+    // (409) until the retry completes or the rehearsal is reset.
+    let (ctx, backend) = make_ctx_with_backend(GovernanceContextBuildMode::Rehearsal);
+    let organizer = fresh_did();
+    let other = fresh_did();
+    seed_domain(&ctx.manager, vec![organizer.clone(), other.clone()]).await;
+    let app = gov_app!(
+        ctx,
+        &organizer,
+        format!("{READ} {REVIEW} {CONFIRM} {SETUP}")
+    );
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    let preview = approve_and_preview!(&app);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+
+    backend.fail_class("mutation_applied");
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+    // Rebinding the label referenced by the interrupted row: refused.
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": other.to_string()})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "rebinding must be refused while an interrupted execution references the label"
+    );
+
+    // An unrelated label may still be bound during the pending state.
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Another member (fictional)", "did": other.to_string()})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "labels not referenced by the interrupted row stay bindable"
+    );
+
+    // The identical retry still resumes and completes.
+    backend.clear_failures();
+    let resp = post!(
+        &app,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "the identical retry must still complete after the refused rebinding"
+    );
+}
+
+#[actix_web::test]
+async fn reset_after_restart_retires_the_prior_runs_persisted_items() {
+    // Action items are DURABLE (Sled in the gateway path) while the review
+    // workspace is node-lifetime memory. After a daemon restart the first
+    // reset has no in-memory record of the prior run — the durable
+    // meeting_context marker is what lets it retire the prior run's
+    // fictional items instead of leaving them active in the member's queue.
+    let backend = Arc::new(OpaqueUniqueBackend::default());
+    let items = Arc::new(InMemoryActionItemStore::new());
+    let organizer = fresh_did();
+
+    // Run 1: full confirm on manager A.
+    let ctx1 = make_ctx_on_backend_with_items(
+        GovernanceContextBuildMode::Rehearsal,
+        backend.clone(),
+        items.clone(),
+    );
+    seed_domain(&ctx1.manager, vec![organizer.clone()]).await;
+    let app1 = gov_app!(
+        ctx1,
+        &organizer,
+        format!("{READ} {REVIEW} {CONFIRM} {SETUP}")
+    );
+    let resp = post!(
+        &app1,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    post!(
+        &app1,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": organizer.to_string()})
+    );
+    post!(
+        &app1,
+        format!("/domains/{DOMAIN}/rehearsal/pending-publish/{ROW_ACTION}/assign"),
+        &json!({"assignee_label": "Example member (fictional)"})
+    );
+    let preview = approve_and_preview!(&app1);
+    let digest = preview["preview_digest"].as_str().unwrap().to_string();
+    let resp = post!(
+        &app1,
+        confirm_uri(ROW_ACTION),
+        &json!({"preview_digest": digest})
+    );
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let item_id = body_json(resp).await["action_item_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // "Restart": manager B shares the durable stores but has NO in-memory
+    // workspace. The first reset (a fresh designation) must find and retire
+    // the prior run's persisted item through the durable marker.
+    let ctx2 =
+        make_ctx_on_backend_with_items(GovernanceContextBuildMode::Rehearsal, backend, items);
+    seed_domain(&ctx2.manager, vec![organizer.clone()]).await;
+    let app2 = gov_app!(ctx2, &organizer, format!("{READ} {SETUP}"));
+    let resp = post!(
+        &app2,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["prior_item_scan"], "complete");
+    assert!(
+        body["cancelled_action_items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v == item_id.as_str()),
+        "post-restart reset must retire the prior run's persisted item: {body}"
+    );
+    let item = body_json(get!(
+        &app2,
+        format!("/domains/{DOMAIN}/action-items/{item_id}")
+    ))
+    .await;
+    assert_eq!(
+        item["status"], "cancelled",
+        "the orphaned fictional item is cancelled, not left active"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. Binding-target membership must be AFFIRMATIVE (fail-closed)
+// ═══════════════════════════════════════════════════════════════════════════
+
+const TRUST_DOMAIN: &str = "rehearsal-trust-domain";
+
+/// The standard deny body: identical for every deny cause, so the response
+/// never distinguishes "provable non-member" from "membership unknowable"
+/// and leaks nothing about hidden identities or foreign domains.
+fn assert_binding_denied_opaquely(status: StatusCode, body: &Value, did: &Did) {
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "binding must be denied: {body}"
+    );
+    assert!(
+        !body.to_string().contains(&did.to_string()),
+        "the deny must not echo the DID: {body}"
+    );
+    assert_eq!(
+        body["error"]
+            .as_str()
+            .map(|s| s.contains("membership standing")),
+        Some(true),
+        "the deny carries only the generic standing message: {body}"
+    );
+}
+
+#[actix_web::test]
+async fn trust_threshold_binding_denies_when_no_resolver_is_wired() {
+    // Rehearsal keeps the permissive CALLER posture for TrustThreshold
+    // domains without a resolver (matching Bootstrap), so the setup caller
+    // reaches the handler — but the BINDING TARGET invariant must still
+    // fail closed: with no resolver, standing cannot be affirmatively
+    // established, so no DID whatsoever may be bound.
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let operator = fresh_did();
+    let target = fresh_did();
+    seed_trust_domain(&ctx.manager, TRUST_DOMAIN).await;
+    let app = gov_app!(ctx, &operator, format!("{READ} {SETUP}"));
+    let resp = post!(
+        &app,
+        format!("/domains/{TRUST_DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "caller-side permissive posture still designates the workspace"
+    );
+    let resp = post!(
+        &app,
+        format!("/domains/{TRUST_DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": target.to_string()})
+    );
+    let status = resp.status();
+    let body = body_json(resp).await;
+    assert_binding_denied_opaquely(status, &body, &target);
+}
+
+#[actix_web::test]
+async fn trust_threshold_binding_requires_affirmative_resolver_confirmation() {
+    let mut ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let operator = fresh_did();
+    let member_target = fresh_did();
+    let non_member = fresh_did();
+    let indeterminate = fresh_did();
+    ctx.membership_resolver = Some(Arc::new(FixedResolver {
+        members: vec![operator.clone(), member_target.clone()],
+        error_for: Some(indeterminate.clone()),
+    }));
+    seed_trust_domain(&ctx.manager, TRUST_DOMAIN).await;
+    let app = gov_app!(ctx, &operator, format!("{READ} {SETUP}"));
+    let resp = post!(
+        &app,
+        format!("/domains/{TRUST_DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Resolver AFFIRMS membership → binding proceeds.
+    let resp = post!(
+        &app,
+        format!("/domains/{TRUST_DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": member_target.to_string()})
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "resolver-confirmed membership must permit the binding"
+    );
+    assert_eq!(body_json(resp).await["bound"], true);
+
+    // Resolver PROVES non-membership → deny.
+    let resp = post!(
+        &app,
+        format!("/domains/{TRUST_DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Second member (fictional)", "did": non_member.to_string()})
+    );
+    let status = resp.status();
+    let deny_non_member = body_json(resp).await;
+    assert_binding_denied_opaquely(status, &deny_non_member, &non_member);
+
+    // Resolver CANNOT DETERMINE standing → deny, indistinguishable from the
+    // provable non-member deny (same status, same error text).
+    let resp = post!(
+        &app,
+        format!("/domains/{TRUST_DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Second member (fictional)", "did": indeterminate.to_string()})
+    );
+    let status = resp.status();
+    let deny_indeterminate = body_json(resp).await;
+    assert_binding_denied_opaquely(status, &deny_indeterminate, &indeterminate);
+    assert_eq!(
+        deny_non_member["error"], deny_indeterminate["error"],
+        "non-member and indeterminate denies must be indistinguishable"
+    );
+}
+
+#[actix_web::test]
+async fn membership_in_another_domain_does_not_permit_binding() {
+    // The target holds REAL standing — in a different domain. The binding
+    // domain's own membership is the only authority context, and the deny
+    // must not reveal that the target exists elsewhere.
+    let ctx = make_ctx(GovernanceContextBuildMode::Rehearsal);
+    let operator = fresh_did();
+    let foreigner = fresh_did();
+    seed_domain(&ctx.manager, vec![operator.clone()]).await;
+    seed_named_domain(&ctx.manager, vec![foreigner.clone()], "other-domain").await;
+    let app = gov_app!(ctx, &operator, format!("{READ} {SETUP}"));
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/reset"),
+        &json!({})
+    );
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp = post!(
+        &app,
+        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+        &json!({"label": "Example member (fictional)", "did": foreigner.to_string()})
+    );
+    let status = resp.status();
+    let body = body_json(resp).await;
+    assert_binding_denied_opaquely(status, &body, &foreigner);
+    assert!(
+        !body.to_string().contains("other-domain"),
+        "the deny must not reveal foreign-domain standing: {body}"
     );
 }
 

--- a/icn/apps/governance/tests/rehearsal_review_workflow.rs
+++ b/icn/apps/governance/tests/rehearsal_review_workflow.rs
@@ -407,13 +407,22 @@ async fn read_scope_cannot_review_edit_assign_confirm_or_reset() {
     let organizer = fresh_did();
     seed_domain(&ctx.manager, vec![organizer.clone()]).await;
     let app = gov_app!(ctx, &organizer, READ);
-    for uri in [
-        format!("/domains/{DOMAIN}/rehearsal/reset"),
-        review_uri(ROW_ACTION),
-        confirm_uri(ROW_ACTION),
-        format!("/domains/{DOMAIN}/rehearsal/bindings"),
+    // Each request carries a schema-valid body for its route, so the
+    // rejection under test is the capability gate (403), not body parsing —
+    // actix extractors run before handler bodies by repo convention.
+    for (uri, body) in [
+        (format!("/domains/{DOMAIN}/rehearsal/reset"), json!({})),
+        (review_uri(ROW_ACTION), json!({"decision": "approve"})),
+        (
+            confirm_uri(ROW_ACTION),
+            json!({"preview_digest": "0".repeat(64)}),
+        ),
+        (
+            format!("/domains/{DOMAIN}/rehearsal/bindings"),
+            json!({"label": "Example member (fictional)", "did": "did:icn:example-not-live"}),
+        ),
     ] {
-        let resp = post!(&app, &uri, &json!({"decision": "approve"}));
+        let resp = post!(&app, &uri, &body);
         assert_eq!(
             resp.status(),
             StatusCode::FORBIDDEN,
@@ -1082,7 +1091,11 @@ async fn member_of_another_domain_cannot_touch_this_domains_workspace() {
         StatusCode::FORBIDDEN,
         "standing in another domain must not open this domain's workspace"
     );
-    let resp = post!(&app, review_uri(ROW_ACTION), &json!({"decision": "approve"}));
+    let resp = post!(
+        &app,
+        review_uri(ROW_ACTION),
+        &json!({"decision": "approve"})
+    );
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 

--- a/icn/crates/icn-gateway/src/validation.rs
+++ b/icn/crates/icn-gateway/src/validation.rs
@@ -10,7 +10,8 @@ use icn_rpc::auth::scopes::{
     GOVERNANCE_ACTION_ITEM_COMPLETE, GOVERNANCE_ACTIVITY_WRITE, GOVERNANCE_CHARTER_WRITE,
     GOVERNANCE_COMMENT_WRITE, GOVERNANCE_FEDERATION_WRITE, GOVERNANCE_MEETING_WRITE,
     GOVERNANCE_PENDING_PUBLISH_CONFIRM, GOVERNANCE_PENDING_PUBLISH_REVIEW,
-    GOVERNANCE_PROCESS_WRITE, GOVERNANCE_PROPOSAL_WRITE, GOVERNANCE_STEWARD_WRITE,
+    GOVERNANCE_PROCESS_WRITE, GOVERNANCE_PROPOSAL_WRITE, GOVERNANCE_REHEARSAL_SETUP,
+    GOVERNANCE_STEWARD_WRITE,
 };
 
 /// Maximum length for cooperative ID
@@ -88,6 +89,7 @@ pub const ALLOWED_SCOPES: &[&str] = &[
     // `test_allowed_scopes_contains_pending_publish_capabilities`.
     GOVERNANCE_PENDING_PUBLISH_REVIEW,
     GOVERNANCE_PENDING_PUBLISH_CONFIRM,
+    GOVERNANCE_REHEARSAL_SETUP,
     // Settlement operations
     "settlements:read",
     "settlements:write",
@@ -947,6 +949,7 @@ mod tests {
                 GOVERNANCE_PENDING_PUBLISH_CONFIRM,
                 "governance:pending-publish:confirm",
             ),
+            (GOVERNANCE_REHEARSAL_SETUP, "governance:rehearsal:setup"),
         ] {
             assert_eq!(scope, wire, "canonical wire string must not drift");
             assert!(

--- a/icn/crates/icn-gateway/src/validation.rs
+++ b/icn/crates/icn-gateway/src/validation.rs
@@ -9,6 +9,7 @@ use crate::error::{GatewayError, Result};
 use icn_rpc::auth::scopes::{
     GOVERNANCE_ACTION_ITEM_COMPLETE, GOVERNANCE_ACTIVITY_WRITE, GOVERNANCE_CHARTER_WRITE,
     GOVERNANCE_COMMENT_WRITE, GOVERNANCE_FEDERATION_WRITE, GOVERNANCE_MEETING_WRITE,
+    GOVERNANCE_PENDING_PUBLISH_CONFIRM, GOVERNANCE_PENDING_PUBLISH_REVIEW,
     GOVERNANCE_PROCESS_WRITE, GOVERNANCE_PROPOSAL_WRITE, GOVERNANCE_STEWARD_WRITE,
 };
 
@@ -80,6 +81,13 @@ pub const ALLOWED_SCOPES: &[&str] = &[
     // from `icn_rpc::auth::scopes`; locked by
     // `test_allowed_scopes_contains_action_item_complete`.
     GOVERNANCE_ACTION_ITEM_COMPLETE,
+    // Rehearsal pending-publish review/confirm capabilities (#1726/#2386):
+    // organizer review decisions and digest-bound confirm on the isolated
+    // Rehearsal Node surface (routes exist only in `rehearsal` build mode).
+    // Sourced from `icn_rpc::auth::scopes`; locked by
+    // `test_allowed_scopes_contains_pending_publish_capabilities`.
+    GOVERNANCE_PENDING_PUBLISH_REVIEW,
+    GOVERNANCE_PENDING_PUBLISH_CONFIRM,
     // Settlement operations
     "settlements:read",
     "settlements:write",
@@ -920,6 +928,42 @@ mod tests {
     /// silently fail at token issuance. It is a *finer* capability than the
     /// class-level `GOVERNANCE_*_WRITE` scopes, so it is deliberately NOT a
     /// member of `GOVERNANCE_CLASS_WRITE`.
+    /// Cross-crate invariant: the rehearsal pending-publish capabilities
+    /// (#1726/#2386) must be issuable by the gateway auth endpoint so the
+    /// Rehearsal Node can mint least-privilege organizer credentials
+    /// (`governance:read` + review + confirm) without falling back to broad
+    /// `governance:write`. Finer capabilities, deliberately NOT members of
+    /// `GOVERNANCE_CLASS_WRITE`.
+    #[test]
+    fn test_allowed_scopes_contains_pending_publish_capabilities() {
+        use icn_rpc::auth::scopes::GOVERNANCE_CLASS_WRITE;
+
+        for (scope, wire) in [
+            (
+                GOVERNANCE_PENDING_PUBLISH_REVIEW,
+                "governance:pending-publish:review",
+            ),
+            (
+                GOVERNANCE_PENDING_PUBLISH_CONFIRM,
+                "governance:pending-publish:confirm",
+            ),
+        ] {
+            assert_eq!(scope, wire, "canonical wire string must not drift");
+            assert!(
+                ALLOWED_SCOPES.contains(&scope),
+                "icn-rpc canonical scope {scope:?} must be in the gateway ALLOWED_SCOPES"
+            );
+            assert!(
+                validate_scopes(&[scope.to_string()]).is_ok(),
+                "icn-rpc canonical scope {scope:?} must pass validate_scopes"
+            );
+            assert!(
+                !GOVERNANCE_CLASS_WRITE.contains(&scope),
+                "rehearsal capabilities must not be members of GOVERNANCE_CLASS_WRITE"
+            );
+        }
+    }
+
     #[test]
     fn test_allowed_scopes_contains_action_item_complete() {
         use icn_rpc::auth::scopes::{GOVERNANCE_ACTION_ITEM_COMPLETE, GOVERNANCE_CLASS_WRITE};

--- a/icn/crates/icn-http-kit/src/auth.rs
+++ b/icn/crates/icn-http-kit/src/auth.rs
@@ -481,18 +481,26 @@ mod tests {
         assert!(require_scope::<BasicClaims>(&req, "governance:read").is_ok());
         let (_c, matched) =
             require_any_scope_matched::<BasicClaims>(&req, &[REVIEW, BROAD]).unwrap();
-        assert_eq!(matched, REVIEW, "evidence must record the review capability");
+        assert_eq!(
+            matched, REVIEW,
+            "evidence must record the review capability"
+        );
         let (_c, matched) =
             require_any_scope_matched::<BasicClaims>(&req, &[CONFIRM, BROAD]).unwrap();
-        assert_eq!(matched, CONFIRM, "evidence must record the confirm capability");
+        assert_eq!(
+            matched, CONFIRM,
+            "evidence must record the confirm capability"
+        );
 
-        // The organizer shape must NOT hold member-completion, creation, or
-        // any broader authority. Siblings never imply each other.
+        // The organizer shape must NOT hold member-completion, creation,
+        // fixture setup (designation/binding), or any broader authority.
+        // Siblings never imply each other.
         for denied in [
             COMPLETE,
             MEETING,
             BROAD,
             CHARTER,
+            "governance:rehearsal:setup",
             "entity:write",
             "coop:admin",
             "coop:write",

--- a/icn/crates/icn-http-kit/src/auth.rs
+++ b/icn/crates/icn-http-kit/src/auth.rs
@@ -460,6 +460,66 @@ mod tests {
         ));
     }
 
+    /// Least-privilege boundary for the rehearsal ORGANIZER credential shape
+    /// (`governance:read governance:pending-publish:review
+    /// governance:pending-publish:confirm`, #1726/#2386). It must satisfy the
+    /// rehearsal review and confirm candidate lists and the read surface, and
+    /// be denied every broader capability — creation via `meeting:write`, the
+    /// completion-only member capability, broad/sibling governance writes,
+    /// entity mutation, and cooperative admin. Also pins that review and
+    /// confirm are mutually non-implying siblings: a review-only credential
+    /// must fail the confirm gate and vice versa.
+    #[test]
+    fn narrow_organizer_rehearsal_shape_cannot_reach_broad_or_member_routes() {
+        const REVIEW: &str = "governance:pending-publish:review";
+        const CONFIRM: &str = "governance:pending-publish:confirm";
+        const COMPLETE: &str = "governance:action-item:complete";
+        let req = req_with_scope(Some(
+            "governance:read governance:pending-publish:review governance:pending-publish:confirm",
+        ));
+
+        assert!(require_scope::<BasicClaims>(&req, "governance:read").is_ok());
+        let (_c, matched) =
+            require_any_scope_matched::<BasicClaims>(&req, &[REVIEW, BROAD]).unwrap();
+        assert_eq!(matched, REVIEW, "evidence must record the review capability");
+        let (_c, matched) =
+            require_any_scope_matched::<BasicClaims>(&req, &[CONFIRM, BROAD]).unwrap();
+        assert_eq!(matched, CONFIRM, "evidence must record the confirm capability");
+
+        // The organizer shape must NOT hold member-completion, creation, or
+        // any broader authority. Siblings never imply each other.
+        for denied in [
+            COMPLETE,
+            MEETING,
+            BROAD,
+            CHARTER,
+            "entity:write",
+            "coop:admin",
+            "coop:write",
+        ] {
+            assert!(
+                matches!(
+                    require_scope::<BasicClaims>(&req, denied).unwrap_err(),
+                    ApiError::Forbidden(_)
+                ),
+                "organizer rehearsal session must NOT grant {denied}"
+            );
+        }
+
+        // Review-only cannot confirm; confirm-only cannot review.
+        let review_only = req_with_scope(Some("governance:read governance:pending-publish:review"));
+        assert!(matches!(
+            require_any_scope::<BasicClaims>(&review_only, &[CONFIRM, BROAD]).unwrap_err(),
+            ApiError::Forbidden(_)
+        ));
+        let confirm_only =
+            req_with_scope(Some("governance:read governance:pending-publish:confirm"));
+        assert!(matches!(
+            require_any_scope::<BasicClaims>(&confirm_only, &[REVIEW, BROAD]).unwrap_err(),
+            ApiError::Forbidden(_)
+        ));
+    }
+
     #[test]
     fn require_any_scope_honors_sub_scope_match() {
         // `governance:write:admin` satisfies the broad `governance:write` candidate.

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -1047,6 +1047,18 @@ pub mod scopes {
     /// confirms.
     pub const GOVERNANCE_PENDING_PUBLISH_CONFIRM: &str = "governance:pending-publish:confirm";
 
+    /// Rehearsal fixture-setup capability (#1726/#2386).
+    ///
+    /// Operator/setup acts on the Rehearsal-Node-only surface: DESIGNATING a
+    /// fictional rehearsal domain (its first workspace initialization) and
+    /// binding human-readable labels to fictional member identities. Held by
+    /// the internal setup credential only — an organizer browser credential
+    /// never carries it, so it can neither turn an arbitrary domain into a
+    /// rehearsal workspace nor bind identities (and never handles a DID).
+    /// A binding grants no authority; bound identities must already hold
+    /// domain membership.
+    pub const GOVERNANCE_REHEARSAL_SETUP: &str = "governance:rehearsal:setup";
+
     // Admin scopes
     pub const ADMIN: &str = "admin";
 

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -1021,15 +1021,17 @@ pub mod scopes {
     /// Rehearsal pending-publish review capability (#1726/#2386).
     ///
     /// Authorizes review decisions (approve / reject / needs-edit /
-    /// needs-more-info), bounded edits, label assignment, label→fictional-DID
-    /// binding, previews, and workspace reset on the rehearsal
-    /// pending-publish surface — routes that exist ONLY on an isolated
-    /// Rehearsal Node (`ICN_GOVERNANCE_BUILD_MODE=rehearsal`). It authorizes
-    /// no mutation of real governance state: reviewing, editing, and
-    /// assigning change only the fictional rehearsal workspace. Reset and
-    /// binding are deliberately part of this capability (repeating the
-    /// fictional rehearsal is an organizer act; a binding grants no
-    /// authority and rebinding invalidates outstanding previews).
+    /// needs-more-info), bounded edits, label assignment (labels only),
+    /// previews, and **re-reset** of an already-designated workspace on the
+    /// rehearsal pending-publish surface — routes that exist ONLY on an
+    /// isolated Rehearsal Node (`ICN_GOVERNANCE_BUILD_MODE=rehearsal`). It
+    /// authorizes no mutation of real governance state: reviewing, editing,
+    /// and assigning change only the fictional rehearsal workspace.
+    ///
+    /// **Not** included here (held by [`GOVERNANCE_REHEARSAL_SETUP`]
+    /// instead): the first workspace designation for a domain and
+    /// label→fictional-DID binding. The organizer browser credential carries
+    /// review+confirm+read only and never binds identities.
     ///
     /// Sibling of the class-level write scopes: it neither implies nor is
     /// implied by `GOVERNANCE_WRITE`; the rehearsal routes accept the broad

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -1018,6 +1018,35 @@ pub mod scopes {
     /// full transition range during the migration.
     pub const GOVERNANCE_ACTION_ITEM_COMPLETE: &str = "governance:action-item:complete";
 
+    /// Rehearsal pending-publish review capability (#1726/#2386).
+    ///
+    /// Authorizes review decisions (approve / reject / needs-edit /
+    /// needs-more-info), bounded edits, label assignment, label→fictional-DID
+    /// binding, previews, and workspace reset on the rehearsal
+    /// pending-publish surface — routes that exist ONLY on an isolated
+    /// Rehearsal Node (`ICN_GOVERNANCE_BUILD_MODE=rehearsal`). It authorizes
+    /// no mutation of real governance state: reviewing, editing, and
+    /// assigning change only the fictional rehearsal workspace. Reset and
+    /// binding are deliberately part of this capability (repeating the
+    /// fictional rehearsal is an organizer act; a binding grants no
+    /// authority and rebinding invalidates outstanding previews).
+    ///
+    /// Sibling of the class-level write scopes: it neither implies nor is
+    /// implied by `GOVERNANCE_WRITE`; the rehearsal routes accept the broad
+    /// scope as a fallback consistent with the sub-capability doctrine.
+    pub const GOVERNANCE_PENDING_PUBLISH_REVIEW: &str = "governance:pending-publish:review";
+
+    /// Rehearsal pending-publish confirm capability (#1726/#2386).
+    ///
+    /// Authorizes executing an approved, digest-bound rehearsal mutation
+    /// (creating ONE real action item through the manager machinery plus the
+    /// ADR-0026 receipt ladder) on the Rehearsal-Node-only confirm route.
+    /// Held separately from `GOVERNANCE_PENDING_PUBLISH_REVIEW` so a
+    /// review-only credential can never mutate governance state and a
+    /// confirm-only credential can never manufacture the review state it
+    /// confirms.
+    pub const GOVERNANCE_PENDING_PUBLISH_CONFIRM: &str = "governance:pending-publish:confirm";
+
     // Admin scopes
     pub const ADMIN: &str = "admin";
 

--- a/sdk/typescript/src/generated/api-types.ts
+++ b/sdk/typescript/src/generated/api-types.ts
@@ -890,7 +890,7 @@ export interface components {
          *     taxonomy so a client can never confuse fixture rehearsal data with live state.
          * @enum {string}
          */
-        PendingPublishOrigin: "live_runtime" | "committed_fixture";
+        PendingPublishOrigin: "live_runtime" | "committed_fixture" | "rehearsal_runtime";
         /**
          * @description Provenance category of a row's source material. Closed taxonomy mirroring the
          *     contract's `source_provenance_ref.category`.
@@ -1604,7 +1604,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Pending-publish preview/review rows for the caller, wrapped in `PendingPublishSummaryResponse` (`{did, origin, rows, non_claims, generated_at}`). Runtime projection of `urn:icn:contract:pending-publish-summary:v1`. Read-only: there is no mutation API on this surface, no authority is granted, and no action card is created. `origin = live_runtime` (production) returns no rows; `origin = committed_fixture` (non-production) returns deterministic, fictional rehearsal rows. Row `kind`, `status`, `risk_level`, `source_provenance`, and `receipt_expected.category` use closed enums. */
+            /** @description Pending-publish preview/review rows for the caller, wrapped in `PendingPublishSummaryResponse` (`{did, origin, rows, non_claims, generated_at}`). Runtime projection of `urn:icn:contract:pending-publish-summary:v1`. Read-only: there is no mutation API on this surface, no authority is granted, and no action card is created. `origin = live_runtime` (production) returns no rows; `origin = committed_fixture` (non-production) returns deterministic, fictional rehearsal rows; `origin = rehearsal_runtime` (rehearsal build mode, after an explicit workspace reset) returns the live rehearsal review workspace rows — still fictional, never production state. Row `kind`, `status`, `risk_level`, `source_provenance`, and `receipt_expected.category` use closed enums. */
             200: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

First real organizer review-and-confirm substrate for the Rehearsal Node (#2386) organizer workflow: a Rehearsal-mode-only pending-publish review surface where an organizer approves/rejects/edits/assigns fictional proposed work, previews a deterministically **bound** mutation, and confirms it — executing the real ADR-0026 receipt ladder and creating one real action item that the existing member completion loop (#2400) can discharge. Refs #1726 #1728 #2386 #1746 (no close keywords; browser surface and appliance wiring follow in separate PRs).

## Changes

**Build-mode boundary (fail-closed).** `GovernanceContextBuildMode::Rehearsal`: opt-in by the exact value `rehearsal` in `ICN_GOVERNANCE_BUILD_MODE` (new `parse()` helper); unknown/missing values keep the historical Bootstrap fallback, and only `Rehearsal` mounts the new routes (`allows_rehearsal_mutation()`), so Production/Bootstrap/Test leave the surface absent (404) and a typo can never open a mutation path. Rehearsal keeps Bootstrap's permissive dependency posture (fixture-only mode); Production validation is unchanged and fail-closed.

**Rehearsal review workspace** (`rehearsal_workspace.rs`, owned by `GovernanceManager` so all gateway workers share one instance): domain-scoped; **designation-gated** (a domain's FIRST workspace initialization requires the new operator capability, so a scoped member cannot turn an arbitrary domain into a rehearsal workspace); deterministic seed from the same in-code fixture generator as the committed-fixture summary; bounded review decisions (approve/reject/needs_edit/needs_more_info) each backed by a real `DecisionRecordedReceipt`; single allowlisted edit field (`plain_summary`, ≤256B) — every edit/assignment invalidates prior approval and previews; assignment by registered human label only. **Restart-safe identifiers:** every persistent receipt id (session/decision/activation/plan/application) carries a per-reset `run_id`, so ids are never reused across resets or daemon restarts against the persistent receipt store (regression-tested with a fresh manager over a shared backend).

**Capabilities** (sub-capability doctrine, #2400) — three non-implying siblings, all in the gateway `ALLOWED_SCOPES` with drift-lock tests and `icn-http-kit` boundary tests:
- `governance:rehearsal:setup` — designation + label→fictional-DID binding, **internal setup credential only**; a binding target must already hold domain membership (422 otherwise); binding grants no authority.
- `governance:pending-publish:review` — review/edit/assign/preview/re-reset. The organizer browser shape (read+review+confirm) **cannot bind identities and never handles a DID**.
- `governance:pending-publish:confirm` — execution only; review-only cannot confirm and confirm-only cannot manufacture review state.
- Broad `governance:write` remains an accepted-also operator fallback (tested end-to-end); browser credentials never carry it.

**Preview→confirm binding.** Preview is a pure GET returning the exact mutation fields plus a domain-separated BLAKE3 digest (`icn:gov:rehearsal_plan:v1`) over the canonical plan document — including workspace generation, run, row version, and the currently bound assignee DID. Confirm recomputes from current state and compares constant-time (`blake3::Hash` eq): any edit, re-review, re-assignment, re-binding, or reset makes the old digest stale (409). Duplicate identical confirm is an idempotent replay; a different digest after execution is a 409 conflict.

**Confirm atomicity.** Confirm walks the real machinery — `ProcessSessionOpened` → `ProcessGateResult` (ScopeConfirmation/Pass) → `ActivationCrossed` (referencing the approving decision + gate hash) → `MutationPlanRecorded` (**body_hash = preview digest**) → one real `create_action_item` → `MutationApplied` (referencing the plan + a result hash binding the created item). The created item is marked in the workspace **before** the applied receipt; if that recording fails, review mutations are blocked and an identical retry **resumes the same item** — failure-injection tests prove a retry can never create a second item (failures before creation leave no item; failures after resume it).

**Summary isolation.** `GET /v1/gov/me/pending-publish-summary` gains origin `rehearsal_runtime`, served **only for workspaces in domains where the caller holds membership standing** — a two-domain test proves another domain's rows, review state, and workspace existence are unobservable (the caller gets the ordinary committed_fixture response). Production still serves no rows. OpenAPI + TS SDK regenerated for the enum.

**Reset = "start a new rehearsal generation."** Explicitly NOT "restore a clean node": receipts are permanent process facts; the prior run's fictional action items are retired through the normal status machinery (cancelled unless already completed, reported in the response) so the member's active queue returns to a deterministic state while history stays inspectable.

**Evidence export** (`GET /domains/{d}/rehearsal/evidence-export`, `urn:icn:contract:rehearsal-workflow-evidence:v1`): derived from actual workspace outcomes (`executed | interrupted-execution | approved-not-executed | rejected | edit-and-resubmit | deferred`), decision log with real receipt hashes, run/generation, binding states (flags only), non-claims, privacy-review result. **Two hashes bind every exported field including `generated_at`** (only the hash fields themselves are outside the canonical content): domain-separated BLAKE3 (ICN convention, primary) + a SHA-256 mirror so a browser steward view can verify via WebCrypto. A reusable validator (`rehearsal_workspace::validate_evidence_packet`) is tamper-tested across rows, decisions, receipt hashes, generation, timestamp, run id, and non-claims. No DIDs, credentials, private values, paths, or topology. A receipts read-back route lists the ladder receipts (ids + hashes only).

**Requests/robustness:** every new body struct is `#[serde(deny_unknown_fields)]`; bounded lengths (summary 256, note 2000, label 120); unknown decision values 400; organizer-supplied markup stays inert JSON text (tested); poisoned-lock recovery instead of panic; backend error details go to logs, clients get plain fail-closed messages.

**Constitutional wording:** receipts and evidence carry explicit non-claims — a facilitator with a trusted narrow capability confirmed fixture work; no collective vote occurred and none is implied; receipts record process facts and grant no authority.

**Contract doc**: `docs/contracts/rehearsal-review-workflow.md` (+ registry entry). The routes are deliberately NOT in the public OpenAPI document (verified: zero occurrences in the regenerated spec) — they never exist on a production surface; the contract doc is their contract.

## Design-audit corrections (two adversarial passes)

**Pass 1** (first green implementation): cross-domain summary leakage → membership-filtered; restart identifier collisions → run-scoped; duplicate-item on interrupted confirm → resume-safe; reset leaving prior items active → retired via the normal transition; organizer-bindable arbitrary DIDs → setup-only + member-bound; unhashed `generated_at` in evidence → bound, BLAKE3-primary, reusable validator.

**Pass 2** (this head — closing the six PR review threads, each with a failing regression test first):
1. **Gate-receipt reuse on retry** — `RehearsalRow.confirm_gate: (row_version, gate_hash)`; a retried confirm reuses the original gate receipt so the activation's `gate_basis` stays byte-identical and does not hard-conflict. Version-keyed (an edit bumps the version → fresh gate); reset clears it. Verified `ActivationCrossedReceipt` identity includes `crossed_by`, so a *different* facilitator retrying post-activation still fails closed.
2. **Fail-closed binding-target membership** — `binding_target_holds_membership` never falls open: `StaticList` from source; `TrustThreshold` requires a wired resolver's affirmative confirmation; missing resolver / resolver error / `Ok(false)` / domain-lookup error all DENY, all with the same opaque 422 (no DID leak, no non-member-vs-unknowable distinction). Caller-side gate keeps the permissive Bootstrap posture; only the binding target is held strict.
3. **Pending-label rebind guard** — rebinding a label referenced by a row with a pending created item is refused (409) so the identical retry's recomputed digest still matches; only referenced labels block; reset/completion clear it.
4. **Restart-aware retirement** — reset scans the durable item store for this surface's stable `meeting_context` marker and cancels only still-active rehearsal-marked items (never unrelated ones), reporting `prior_item_scan: complete|failed` honestly. Cross-restart proof shares a durable item store across two managers.
5. **Constrained conflict classification** — `conflict_or_internal` matches a closed list of the manager's stable leading prefixes with `starts_with`, not substrings; precondition/storage errors stay 500. Four unit tests pin it.
6. **Scope rustdoc** — corrected in `88485ded` to move binding + first designation to `governance:rehearsal:setup`.

**Second review round** (fresh Codex on `902f1408`, fixed in `28a8712a`): (a) reset retirement scan now excludes the newly-installed run and matches only the structured session marker (not the loose human prefix / not client-forgeable look-alikes), so a confirm racing the reset is never swept; (b) the summary serves `rehearsal_runtime` from a single member-visible workspace — a caller in two rehearsal domains gets the honest `committed_fixture` response, never a concatenated array with duplicate seed ids.

**Same-process-only recovery** is now explicit in code and contract: interrupted-*confirm* recovery requires the same running process; the durable scan is the cross-restart reconciliation path for orphaned items, **not** a confirm resume. No cross-restart confirm-resume is claimed.

## Test plan

- `rehearsal_review_workflow.rs`: **37 integration tests** (written first, watched RED) + **4 lib unit tests** for conflict classification. Covers: mode absence (Production/Bootstrap/Test 404 incl. fully-wired Production ctx), capability separation (read/review/confirm/setup shapes + designation + broad-fallback), non-member + cross-domain isolation (routes AND summary), unknown-field/decision/oversized rejection, affirmative binding-target membership (StaticList + TrustThreshold-with/without-resolver + foreign-domain), pending-label rebind guard, preview determinism + approval requirement, stale/tampered/rebind/reset digest failure, idempotent + conflicting confirm, failure-injection atomicity (before/after item creation, gate-reuse retry), restart safety over shared receipt + durable item stores, real-item creation on the normal surface, evidence validator + 6-way tamper matrix, reset retirement (in-memory + cross-restart durable), inert markup.
- Regression: full `icn-governance-actor` (770) + `icn-gateway` (+ `--features sled-storage`) + `icn-rpc` + `icn-http-kit` suites green (incl. the 19-test #2400 completion suite, ladder runtime slices, 3 scope drift locks, http-kit boundary tests).
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- OpenAPI regenerated via `icnctl api export-openapi`; `sdk/typescript` types regenerated; rehearsal routes verified absent from the generated spec.
- Doc-control, compliance, readiness, meaning-firewall, and truth-spine checks clean. Two fresh-context adversarial reviewers (security + receipt/constitutional) ran against this head; dispositions in the review thread.

## Risk

Medium-low. All new mutation routes are structurally absent outside Rehearsal mode; existing routes changed only in the summary handler's origin selection (Production path untouched — locked by existing gate tests). Receipt machinery is reused, not modified. Manager gains one default-initialized field.

## What is real vs fictional

The review workspace and all reviewable rows are fictional, deterministic rehearsal material. The receipts recorded and the action item created on confirm are real governance records on the isolated rehearsal node. No production, pilot, organizer-ready, or live-federation claim. Human gates unchanged and still owed: #2041 (assistive technology), #1703/#1746 (organizer presentation / first operator rehearsal).

## Boundary statement

No private data, secrets, provider topology, NYCN-specific nouns, or unrelated repositories touched. No cookies or credential persistence introduced (bearer-header model unchanged). Regulatory-safe vocabulary maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
