### PR TITLE
feat(appliance): wire complete rehearsal organizer-to-member loop

### DIFF
--- a/deploy/appliance/DEMO_QUICKSTART.md
+++ b/deploy/appliance/DEMO_QUICKSTART.md
@@ -4,6 +4,14 @@ One VM. One browser. The core ICN loop, honestly labeled:
 
 **standing → action card → discharge → receipt → evidence/audit**
 
+> **Rehearsal Node loop (#2386):** the one-command launcher now opens the
+> **organizer** surface (`?surface=organizer`). The assembled loop is *organizer
+> reviews → confirms one fictional item → the assigned member (a fresh
+> least-privilege session) completes it → steward verifies*
+> (`sudo icn-demo-verify --rehearsal`). See
+> [docs/demo/rehearsal-node-appliance-loop.md](../../docs/demo/rehearsal-node-appliance-loop.md).
+> The legacy member action-item loop below still works as the manual fallback.
+
 ## What this demonstrates
 
 - A real ICN node (`icnd`) booting on a disposable VM and serving its
@@ -136,11 +144,13 @@ ICN_DEMO_VM_IP=192.0.2.50 ICN_DEMO_JUMP=user@dev-host \
 ```
 
 It opens the SSH tunnels (gateway→18080, shell→18090, demo-session→18091),
-then opens your browser to `…/member-shell/?mode=live&demo=launcher`. In the
-page, the gateway is pre-filled and a **Start local demo** button appears —
-select it once and your standing + a sample action card load automatically.
-Nothing is copied or pasted; the credential lives only in the page's memory.
-Press Ctrl-C in the terminal to close the tunnel when you're done.
+then opens your browser to the **organizer** surface
+(`…/member-shell/?mode=live&surface=organizer&demo=launcher`). In the page, the
+gateway is pre-filled and a **Start organizer rehearsal** button appears — select
+it once to review and confirm one fictional item, then "Continue as the assigned
+member" (a fresh least-privilege session) to complete it. Nothing is copied or
+pasted; each credential lives only in the page's memory. Press Ctrl-C in the
+terminal to close the tunnel when you're done.
 
 This needs a demo-profile image (the `icn-demo-session` endpoint ships with
 `ICN_APPLIANCE_DEMO_PROFILE=1`). Everything below is the manual fallback.

--- a/deploy/appliance/README.md
+++ b/deploy/appliance/README.md
@@ -344,11 +344,31 @@ What it adds (and the base image does NOT have):
 |---|---|---|
 | member-shell + pilot-ui fixtures | `/usr/share/icn/static/web/` | static reference client (#2026), fixture + live-local modes |
 | `icn-member-shell.service` | `:8090` | python3 stdlib static server, dev-only |
-| `20-demo-profile.conf` drop-in | `icnd.service.d/` | gateway bind `0.0.0.0:8080` (hostfwd reachability), dev gates (`ICN_ENABLE_ADMIN_ENDPOINTS`, `ICN_GOVERNANCE_BUILD_MODE=test`), `ICN_CORS_ORIGINS` for the shell |
-| `icn-demo-seed` | `/usr/local/sbin/` | seeds NYCN fixture institution + one open action item; prints the dev session JWT + URLs |
-| `icn-demo-verify` | `/usr/local/sbin/` | receipt binding check; `--chain` runs the bundled 13/13 governed receipt-chain rehearsal on an ephemeral in-VM node |
+| `20-demo-profile.conf` drop-in | `icnd.service.d/` | gateway bind `0.0.0.0:8080` (hostfwd reachability), dev gates (`ICN_ENABLE_ADMIN_ENDPOINTS`, `ICN_GOVERNANCE_BUILD_MODE=rehearsal`), `ICN_CORS_ORIGINS` for the shell |
+| `icn-demo-seed` | `/usr/local/sbin/` | legacy: seeds NYCN fixture + one open action item, prints the dev browser JWT. `--session organizer\|member` (#2386): idempotent Rehearsal Node workspace init + fictional label bind, then a least-privilege per-role session JWT (organizer = read+review+confirm; member = read+complete) |
+| `icn-demo-verify` | `/usr/local/sbin/` | receipt binding check; `--chain` runs the bundled 13/13 governed receipt-chain rehearsal; `--rehearsal` (#2386) verifies the organizer→member loop + least-privilege matrix + value-withheld evidence |
 | `icn-demo-reset` | `/usr/local/sbin/` | destructive reset: wipe node state, re-run firstboot, reseed |
 | NYCN package + dogfood kit + 13/13 scripts | `/usr/share/icn/demo/` | fixture institution and bundled evidence tooling |
+
+**Rehearsal Node loop (#2386).** The daemon runs `ICN_GOVERNANCE_BUILD_MODE=rehearsal`
+(a labeled non-production stance, strictly additive over `test` — it mounts the
+organizer review→confirm surface; Production validation is unchanged). The
+loopback demo-session endpoint mints a least-privilege session per **role**
+(`{"role":"organizer"|"member"}` → a fixed `icn-demo-seed --session <role>`
+command; no request bytes reach the command). The no-paste launcher opens the
+organizer surface; the browser's "Continue as the assigned member" link mints a
+**fresh** member session (never a token upgrade). The internal setup credential
+(`governance:read` + `governance:rehearsal:setup`) initializes the workspace and
+binds the fictional `Example member (fictional)` label to the operator DID (a
+StaticList member of `nycn-federation-gov` via the package) — it is never
+returned to the browser. The organizer confirms one fictional item (creating one
+real action item + the ADR-0026 receipt ladder); the member completes it; a
+steward runs `sudo icn-demo-verify --rehearsal` to check the whole loop. Fictional
+data on an isolated node; not production, not a pilot, not live federation. The
+software loop is proven end-to-end against a real rehearsal-mode `icnd`; the full
+assembled-image (KVM) witness is a separate step — see
+[`docs/demo/rehearsal-node-appliance-loop.md`](../../docs/demo/rehearsal-node-appliance-loop.md)
+for the verification status.
 
 Build and smoke it:
 

--- a/deploy/appliance/scripts/icn-demo-seed.sh
+++ b/deploy/appliance/scripts/icn-demo-seed.sh
@@ -5,7 +5,16 @@
 # DEMO PROFILE ONLY. Installed by build-image.sh when
 # ICN_APPLIANCE_DEMO_PROFILE=1. Run as root inside the appliance VM:
 #
-#     sudo icn-demo-seed [--json]
+#     sudo icn-demo-seed [--json]                       # legacy member action-item loop
+#     sudo icn-demo-seed --session organizer [--json]   # Rehearsal Node organizer session (#2386)
+#     sudo icn-demo-seed --session member   [--json]    # Rehearsal Node member session (#2386)
+#
+# The --session path drives the Rehearsal Node organizer review->confirm loop
+# (requires the daemon in ICN_GOVERNANCE_BUILD_MODE=rehearsal). It initializes
+# the rehearsal workspace + binds a fictional assignee label to the operator DID
+# ONCE, then mints a least-privilege per-role browser session (organizer =
+# read+review+confirm; member = read+complete). It does NOT pre-seed an action
+# item — the organizer creates it by confirming, and the member completes it.
 #
 # What it does (all against THIS VM's own gateway on 127.0.0.1:8080):
 #   1. Waits for the gateway to be healthy.
@@ -46,8 +55,11 @@
 #     this command, in your terminal, on request.
 #
 # Idempotency: re-running re-applies the institution package (a no-op when
-# already applied) and creates an additional open action item. For a clean
-# slate use icn-demo-reset.
+# already applied). The default (legacy) path creates an additional open action
+# item each run. The --session (Rehearsal Node) path is idempotent: it
+# initializes the rehearsal workspace + binds the fictional label ONCE (only if
+# absent, so an organizer-created item is never wiped) and mints a fresh
+# least-privilege per-role session. For a clean slate use icn-demo-reset.
 # ============================================================================
 set -uo pipefail
 
@@ -73,11 +85,39 @@ DOMAIN="${ICN_DEMO_DOMAIN:-nycn-federation-gov}"
 # reach broad governance-mutation routes.
 SETUP_SCOPES="governance:meeting:write"
 BROWSER_SCOPES="governance:read,governance:action-item:complete"
+# Rehearsal-loop scope sets (#2386) — narrow, non-write, allowlisted, --local-mint-issuable:
+#   REHEARSAL_SETUP: initializes the workspace + binds fictional labels. INTERNAL — never printed.
+#     governance:read is the minimum genuinely required for the idempotent GET
+#     probe (the read routes need it); governance:rehearsal:setup authorizes the
+#     reset (init) + bindings. It carries NO write/admin/complete class.
+#   ORGANIZER (browser): read + review + confirm. Cannot bind, initialize, complete, or write.
+#   MEMBER (browser): read + completion-only (#2400). Cannot review, confirm, bind, or initialize.
+REHEARSAL_SETUP_SCOPES="governance:read,governance:rehearsal:setup"
+ORGANIZER_SCOPES="governance:read,governance:pending-publish:review,governance:pending-publish:confirm"
+MEMBER_SCOPES="$BROWSER_SCOPES"
+REHEARSAL_LABEL="Example member (fictional)"
+
 JSON_OUT=0
-[ "${1:-}" = "--json" ] && JSON_OUT=1
+SESSION_ROLE=""   # "" = legacy pre-seeded member loop; "organizer"|"member" = Rehearsal Node role session
 
 log(){ [ "$JSON_OUT" = 1 ] || echo "[demo-seed] $*"; }
 fatal(){ echo "[demo-seed] FATAL: $*" >&2; exit 1; }
+
+# Argument parse. A --session role is validated against a CLOSED allowlist and
+# only ever selects a scope constant above — it is never interpolated into any
+# command (preserving the fixed-command safety property).
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --json) JSON_OUT=1; shift ;;
+    --session) shift; SESSION_ROLE="${1:-__missing__}"; [ $# -gt 0 ] && shift ;;
+    --session=*) SESSION_ROLE="${1#--session=}"; shift ;;
+    *) fatal "unknown argument: $1 (usage: icn-demo-seed [--json] [--session organizer|member])" ;;
+  esac
+done
+case "$SESSION_ROLE" in
+  ""|organizer|member) : ;;
+  *) fatal "unknown --session role '$SESSION_ROLE' (allowed: organizer, member)" ;;
+esac
 
 [ "$(id -u)" -eq 0 ] || fatal "run as root: sudo icn-demo-seed"
 [ -f "$ENV_FILE" ]   || fatal "$ENV_FILE missing — has icn-appliance-firstboot run?"
@@ -148,19 +188,57 @@ mint_local_jwt(){
   grep -oE 'eyJ[A-Za-z0-9_.-]+' <<<"$out" | head -1
 }
 
-# SETUP JWT — provisions the demo loop (dev standing-bootstrap + action-item
-# creation). Internal to this root-invoked seed; NEVER printed or returned.
-SETUP_JWT="$(mint_local_jwt "$SETUP_SCOPES")"
-[ -n "$SETUP_JWT" ] || fatal "trusted local SETUP-JWT mint failed (icnctl --local-mint). Check ICN_GATEWAY_JWT_SECRET is present in $ENV_FILE and the keystore unlocks. This path signs with THIS VM's own gateway secret and never uses the public self-asserted /auth/verify flow (issue #2075)."
-AUTH_SETUP="Authorization: Bearer $SETUP_JWT"
+# ---- Rehearsal Node helpers (#2386) ----
+# HTTP status of a rehearsal-route call (curl runs as root against loopback,
+# exactly like the standing-bootstrap / action-item calls below). A JSON body,
+# when present, is built by python json.dumps so labels/DIDs are safely encoded.
+rehearsal_status(){  # $1=METHOD $2=PATH $3=JWT [$4=BODY]
+  local method="$1" path="$2" jwt="$3" body="${4:-}"
+  if [ -n "$body" ]; then
+    curl -s -o /dev/null -m 10 -w '%{http_code}' -X "$method" \
+      -H "Authorization: Bearer $jwt" -H 'Content-Type: application/json' \
+      -d "$body" "$GW$path"
+  else
+    curl -s -o /dev/null -m 10 -w '%{http_code}' -X "$method" \
+      -H "Authorization: Bearer $jwt" "$GW$path"
+  fi
+}
 
-# BROWSER JWT — the narrow, least-privilege credential handed to the member
-# shell (governance:read + the single action-item completion class). The ONLY
-# JWT this seed prints.
-BROWSER_JWT="$(mint_local_jwt "$BROWSER_SCOPES")"
-[ -n "$BROWSER_JWT" ] || fatal "trusted local BROWSER-JWT mint failed (icnctl --local-mint). Check ICN_GATEWAY_JWT_SECRET is present in $ENV_FILE and the keystore unlocks."
-AUTH_BROWSER="Authorization: Bearer $BROWSER_JWT"
-log "minted two trusted-local JWTs: a setup JWT (internal, never printed) and a narrow browser JWT (printed at the end — local VM only)."
+# Idempotent one-time rehearsal setup: initialize the workspace and bind the
+# fictional assignee label to the operator DID (a StaticList member of $DOMAIN
+# via the applied package). Runs init+bind ONLY when the workspace does not
+# already exist, so a re-mint never wipes an organizer-created item (reset =
+# "new generation").
+ensure_rehearsal_workspace(){  # $1=SETUP_JWT
+  local setup="$1" status body
+  status="$(rehearsal_status GET "/v1/gov/domains/$DOMAIN/rehearsal/pending-publish" "$setup")"
+  if [ "$status" = "200" ]; then
+    log "rehearsal workspace already initialized (generation preserved)."
+    return 0
+  fi
+  [ "$status" = "404" ] || fatal "unexpected HTTP $status probing the rehearsal workspace — is icnd in ICN_GOVERNANCE_BUILD_MODE=rehearsal? (rehearsal routes 404 otherwise)"
+  log "initializing the rehearsal workspace for $DOMAIN ..."
+  status="$(rehearsal_status POST "/v1/gov/domains/$DOMAIN/rehearsal/reset" "$setup" '{}')"
+  [ "$status" = "200" ] || fatal "rehearsal workspace init (reset) failed: HTTP $status (setup scope governance:rehearsal:setup)"
+  body="$(python3 -c 'import json,sys; print(json.dumps({"label": sys.argv[1], "did": sys.argv[2]}))' "$REHEARSAL_LABEL" "$DID")"
+  status="$(rehearsal_status POST "/v1/gov/domains/$DOMAIN/rehearsal/bindings" "$setup" "$body")"
+  [ "$status" = "200" ] || fatal "rehearsal label binding failed: HTTP $status (label '$REHEARSAL_LABEL' -> operator DID; the operator must be a domain member — it is, via the package StaticList)"
+  log "rehearsal workspace ready (label '$REHEARSAL_LABEL' bound to the operator DID)."
+}
+
+# ---- internal SETUP credential (scope depends on the path) ----
+# Legacy path: governance:meeting:write (creates the pre-seeded action item).
+# Rehearsal path (#2386): governance:rehearsal:setup (initializes the workspace
+# + binds the fictional label). Either way the SETUP JWT is INTERNAL — never
+# printed or returned.
+if [ -n "$SESSION_ROLE" ]; then
+  SETUP_JWT="$(mint_local_jwt "$REHEARSAL_SETUP_SCOPES")"
+  [ -n "$SETUP_JWT" ] || fatal "trusted local rehearsal-setup JWT mint failed (icnctl --local-mint). Check ICN_GATEWAY_JWT_SECRET is present in $ENV_FILE and the keystore unlocks. This path signs with THIS VM's own gateway secret and never uses the public self-asserted /auth/verify flow (issue #2075)."
+else
+  SETUP_JWT="$(mint_local_jwt "$SETUP_SCOPES")"
+  [ -n "$SETUP_JWT" ] || fatal "trusted local SETUP-JWT mint failed (icnctl --local-mint). Check ICN_GATEWAY_JWT_SECRET is present in $ENV_FILE and the keystore unlocks. This path signs with THIS VM's own gateway secret and never uses the public self-asserted /auth/verify flow (issue #2075)."
+fi
+AUTH_SETUP="Authorization: Bearer $SETUP_JWT"
 
 log "applying NYCN institution package (fictional fixture institution)..."
 as_icn /usr/local/bin/icnctl --data-dir "$DATA_DIR" institution bootstrap apply \
@@ -168,17 +246,82 @@ as_icn /usr/local/bin/icnctl --data-dir "$DATA_DIR" institution bootstrap apply 
   || fatal "institution bootstrap apply failed (see /tmp/icn-demo-seed-bootstrap.log)"
 log "institution package applied."
 
-# Dev-gated standing bootstrap (best-effort; the action-item loop does not
-# strictly require it, but the shell's standing pane is richer with it).
-# The endpoint bootstraps the AUTHENTICATED caller's DID (claims.sub) in the
-# given jurisdiction — the body carries jurisdiction_id only, never a DID
-# (see icn-gateway api/commons dev_bootstrap_standing).
+# Dev-gated standing bootstrap (best-effort; the loops do not strictly require
+# it, but the shell's standing pane is richer with it). The endpoint bootstraps
+# the AUTHENTICATED caller's DID (claims.sub) in the given jurisdiction — the
+# body carries jurisdiction_id only, never a DID.
 standing_note="bootstrap-standing: ok"
 if ! curl -sf -m 5 -X POST -H "$AUTH_SETUP" -H 'Content-Type: application/json' \
       -d "{\"jurisdiction_id\":\"$DOMAIN\"}" "$GW/v1/commons/dev/bootstrap-standing" >/dev/null 2>&1; then
-  standing_note="bootstrap-standing: unavailable (dev gate off or endpoint shape changed) — standing pane may be sparse; action-item loop unaffected"
+  standing_note="bootstrap-standing: unavailable (dev gate off or endpoint shape changed) — standing pane may be sparse; loop unaffected"
   log "WARN: $standing_note"
 fi
+
+# ============================================================================
+# Rehearsal Node organizer->member loop (#2386): idempotent one-time workspace
+# init + a least-privilege per-role session. No pre-seeded action item — the
+# organizer creates it by confirming; the member completes it.
+# ============================================================================
+if [ -n "$SESSION_ROLE" ]; then
+  ensure_rehearsal_workspace "$SETUP_JWT"
+  case "$SESSION_ROLE" in
+    organizer) ROLE_SCOPES="$ORGANIZER_SCOPES" ;;
+    member)    ROLE_SCOPES="$MEMBER_SCOPES" ;;
+  esac
+  ROLE_JWT="$(mint_local_jwt "$ROLE_SCOPES")"
+  [ -n "$ROLE_JWT" ] || fatal "trusted local $SESSION_ROLE-JWT mint failed (icnctl --local-mint)."
+  log "minted a least-privilege $SESSION_ROLE session (the setup JWT stays internal, never printed)."
+  # The organizer opens ?surface=organizer; the member opens the plain member surface.
+  if [ "$SESSION_ROLE" = "organizer" ]; then SHELL_SUFFIX="?mode=live&surface=organizer"; else SHELL_SUFFIX="?mode=live"; fi
+
+  if [ "$JSON_OUT" = 1 ]; then
+    python3 -c 'import json,sys
+print(json.dumps({"did": sys.argv[1], "jwt": sys.argv[2], "role": sys.argv[3],
+                  "surface": sys.argv[3], "domain": sys.argv[4], "gateway": sys.argv[5],
+                  "standing_note": sys.argv[6]}))' \
+      "$DID" "$ROLE_JWT" "$SESSION_ROLE" "$DOMAIN" "$GW" "$standing_note"
+    exit 0
+  fi
+
+  cat <<EOF
+
+===================== ICN REHEARSAL NODE — $SESSION_ROLE session =====================
+ Gateway (in-VM):    $GW
+ Member shell:       http://localhost:8090/member-shell/$SHELL_SUFFIX
+ Operator DID:       $DID
+ Domain:             $DOMAIN   (fictional StaticList rehearsal domain)
+ Bound label:        $REHEARSAL_LABEL  ->  the operator DID
+ $standing_note
+
+ $SESSION_ROLE session JWT (LOCAL VM ONLY — trusted local issuance, this VM's own
+ per-instance gateway secret; least-privilege $ROLE_SCOPES):
+ $ROLE_JWT
+
+ Honesty labels:
+   rehearsal : fictional data on an isolated node. Not a pilot, not live
+               federation. Confirming creates REAL receipts + one action item
+               on THIS VM only; receipts record process facts, grant no authority.
+   NOT real  : no production, no pilot, no federation, no real members.
+
+ Loop: organizer reviews -> confirms one fictional item -> a fresh least-privilege
+ member session completes it -> steward verifies.
+ Verify: sudo icn-demo-verify --rehearsal $DOMAIN
+ Reset:  sudo icn-demo-reset   (then re-run icn-demo-seed --session organizer)
+====================================================================================
+EOF
+  exit 0
+fi
+
+# ============================================================================
+# Legacy pre-seeded member action-item loop (unchanged behavior).
+# ============================================================================
+# BROWSER JWT — the narrow, least-privilege credential handed to the member
+# shell (governance:read + the single action-item completion class). The ONLY
+# JWT this legacy path prints.
+BROWSER_JWT="$(mint_local_jwt "$BROWSER_SCOPES")"
+[ -n "$BROWSER_JWT" ] || fatal "trusted local BROWSER-JWT mint failed (icnctl --local-mint). Check ICN_GATEWAY_JWT_SECRET is present in $ENV_FILE and the keystore unlocks."
+AUTH_BROWSER="Authorization: Bearer $BROWSER_JWT"
+log "minted the narrow browser JWT (governance:read + action-item completion only)."
 
 log "creating one open action item assigned to $DID ..."
 item_json="$(curl -s -m 10 -X POST -H "$AUTH_SETUP" -H 'Content-Type: application/json' \

--- a/deploy/appliance/scripts/icn-demo-session.py
+++ b/deploy/appliance/scripts/icn-demo-session.py
@@ -12,13 +12,17 @@
 # demo" button obtain a fresh DEV/DEMO session with one click — no copy/paste,
 # no JWT in any URL.
 #
-# What it does: on `POST /v1/dev/demo/session` it runs the existing
-# `icn-demo-seed --json` (the same safe, fictional, dev-gated seed an operator
-# could run by hand) and returns its JSON: a short-lived DEV/DEMO session
-# credential, the seeded item/domain/did, and the standing note. The shell
-# holds the credential in page memory only (it is never persisted, never put
-# in a URL). This service adds no privilege the tunnel-holding operator does
-# not already have (they have SSH + sudo on this throwaway VM).
+# What it does: on `POST /v1/dev/demo/session` it reads a CLOSED role intent
+# from the JSON body (`{"role":"organizer"|"member"}`, default member), maps it
+# to one of two FIXED `icn-demo-seed --session <role> --json` commands (the same
+# safe, fictional, dev-gated seed an operator could run by hand), and returns its
+# JSON: a short-lived least-privilege per-role session credential, the domain/did,
+# and the standing note. The role only SELECTS a constant command — no request
+# bytes are ever interpolated into it. The shell holds the credential in page
+# memory only (never persisted, never in a URL). A role transition (organizer ->
+# member) calls back here for a FRESH least-privilege session — it never upgrades
+# a token. This service adds no privilege the tunnel-holding operator does not
+# already have (they have SSH + sudo on this throwaway VM).
 #
 # Safety:
 #   * Binds 127.0.0.1 ONLY (loopback) — reachable solely through the operator's
@@ -48,7 +52,31 @@ _SEED_LOCK = threading.Lock()
 
 BIND_HOST = "127.0.0.1"
 BIND_PORT = int(os.environ.get("ICN_DEMO_SESSION_PORT", "8091"))
-SEED_CMD = ["/usr/local/sbin/icn-demo-seed", "--json"]
+# Two FIXED commands, one per role. The request selects one from this CLOSED set
+# (see resolve_seed_cmd); no request bytes are ever interpolated into a command,
+# so there is no injection surface. Each --session role mints a least-privilege
+# per-role browser JWT (organizer = read+review+confirm; member = read+complete)
+# for the Rehearsal Node loop (#2386). The role transition in the browser calls
+# back here for a FRESH least-privilege session — it never upgrades a token.
+SEED_CMD_ORGANIZER = ["/usr/local/sbin/icn-demo-seed", "--session", "organizer", "--json"]
+SEED_CMD_MEMBER = ["/usr/local/sbin/icn-demo-seed", "--session", "member", "--json"]
+
+
+def resolve_seed_cmd(body_bytes):
+    """Map a CLOSED role intent to one of the two FIXED commands above.
+    Returns (cmd, role) on success, or (None, error_message) on a bad body/role.
+    The role only SELECTS a constant list — it is never spliced into a command."""
+    role = "member"  # default: the member session
+    if body_bytes:
+        try:
+            role = (json.loads(body_bytes.decode("utf-8")).get("role") or "member")
+        except Exception:  # noqa: BLE001
+            return (None, "request body is not valid JSON")
+    if role == "organizer":
+        return (SEED_CMD_ORGANIZER, "organizer")
+    if role == "member":
+        return (SEED_CMD_MEMBER, "member")
+    return (None, "unknown role (allowed: organizer, member)")
 
 # The demo shell is served at 127.0.0.1:8090 in the VM and reached over the
 # operator's tunnel at localhost:18090 (a FIXED host port — open-proxmox-demo.sh
@@ -109,6 +137,14 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         origin = self.headers.get("Origin", "")
+        # Read and bound any request body up front so the socket is drained. The
+        # body may carry a role intent; it is validated against a CLOSED set
+        # (resolve_seed_cmd) and never interpolated into a command.
+        try:
+            length = int(self.headers.get("Content-Length", "0") or "0")
+        except ValueError:
+            length = 0
+        body_bytes = self.rfile.read(min(length, 4096)) if length > 0 else b""
         if self.path.rstrip("/") != "/v1/dev/demo/session":
             return self._json(404, {"error": "not found"}, origin)
         # SERVER-SIDE origin check, before any side effect. CORS response
@@ -122,16 +158,20 @@ class Handler(BaseHTTPRequestHandler):
         if not demo_gated():
             log("refused: dev gates off (ICN_ENABLE_ADMIN_ENDPOINTS / non-production)")
             return self._json(403, {"error": "demo session disabled (not a DEV/DEMO posture)"}, origin)
+        cmd, role = resolve_seed_cmd(body_bytes)
+        if cmd is None:
+            log("refused: %s" % role)  # `role` holds the error string here
+            return self._json(400, {"error": role}, origin)
         # Serialize: never run two seeds at once (see _SEED_LOCK).
         with _SEED_LOCK:
             try:
-                out = subprocess.run(SEED_CMD, capture_output=True, text=True, timeout=120)
+                out = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
             except Exception as e:  # noqa: BLE001 - report any spawn failure plainly
                 log("seed spawn failed: %s" % e)
                 return self._json(500, {"error": "seed failed to start"}, origin)
             if out.returncode != 0:
                 # stderr may name the failure; it does not contain the credential.
-                log("seed exit %d: %s" % (out.returncode, (out.stderr or "").strip()[:200]))
+                log("seed exit %d (%s): %s" % (out.returncode, role, (out.stderr or "").strip()[:200]))
                 return self._json(500, {"error": "seed failed"}, origin)
             try:
                 session = json.loads(out.stdout)
@@ -142,8 +182,7 @@ class Handler(BaseHTTPRequestHandler):
             if note != "bootstrap-standing: ok":
                 log("seed standing degraded: %s" % note)
                 return self._json(500, {"error": "standing bootstrap degraded", "standing_note": note}, origin)
-            log("session seeded ok (item %s) — credential returned to caller, not logged"
-                % session.get("item_id", "?"))
+            log("%s session seeded ok — credential returned to caller, not logged" % role)
             # Return the seed JSON verbatim (it carries the short-lived
             # credential under "jwt"); the shell keeps it in page memory only.
             return self._json(200, session, origin)

--- a/deploy/appliance/scripts/icn-demo-verify.sh
+++ b/deploy/appliance/scripts/icn-demo-verify.sh
@@ -31,6 +31,17 @@
 #       urn:icn:contract:rehearsal-evidence-export:v1 packet and validates it
 #       (fixture-only, offline, no gateway, no writes; fails closed on drift).
 #       Output: /var/lib/icn-demo/pending-publish-evidence/
+#
+#   sudo icn-demo-verify --rehearsal [domain]     (#2386)
+#       Steward-verifies the Rehearsal Node organizer->member loop against THIS
+#       VM's live rehearsal-mode gateway (run after
+#       `sudo icn-demo-seed --session organizer`): the least-privilege capability
+#       matrix (organizer read+review+confirm, canNOT bind/broad-write/complete;
+#       member read+complete, canNOT review/bind), one action item created by
+#       confirmation, the member completion receipt, the process-receipt ladder,
+#       and the value-withheld evidence packet (no DID / no credential). Drives
+#       the loop itself when the browser has not (idempotent on an executed row).
+#       Fictional data on an isolated node; not production, not a pilot.
 # ============================================================================
 set -uo pipefail
 
@@ -89,6 +100,153 @@ if [ "${1:-}" = "--pending-publish" ]; then
     log "evidence copied to $OUT/pending-publish-evidence/"
   fi
   log "OK: pending-publish evidence packet validates against urn:icn:contract:rehearsal-evidence-export:v1"
+  exit 0
+fi
+
+if [ "${1:-}" = "--rehearsal" ]; then
+  # Steward verification of the Rehearsal Node organizer->member loop (#2386):
+  # the least-privilege capability matrix + the end-to-end loop + value-withheld
+  # evidence, against THIS VM's live rehearsal-mode gateway. Run after
+  # `sudo icn-demo-seed --session organizer`. Fail-closed (first mismatch aborts).
+  DOMAIN="${2:-nycn-federation-gov}"
+  [ -f "$ENV_FILE" ] || fatal "$ENV_FILE missing — has firstboot run?"
+  command -v python3 >/dev/null || fatal "python3 missing"
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  [ -n "${ICN_KEYSTORE_PASSPHRASE:-}" ] || fatal "ICN_KEYSTORE_PASSPHRASE not present in $ENV_FILE"
+  [ -n "${ICN_GATEWAY_JWT_SECRET:-}" ] || fatal "ICN_GATEWAY_JWT_SECRET not present in $ENV_FILE — needed for trusted local JWT issuance (icnctl --local-mint)"
+  ICN_PASSPHRASE="$ICN_KEYSTORE_PASSPHRASE"
+  ICN_CHILD_ENV_KEEP="ICN_KEYSTORE_PASSPHRASE ICN_PASSPHRASE ICN_GATEWAY_JWT_SECRET LANG LC_ALL LC_CTYPE TERM"
+
+  # Trusted-local mint (same env-scrub + runuser discipline as the read-JWT below).
+  mint_jwt(){  # $1=scopes -> bare JWT
+    (
+      for _name in $(compgen -e); do
+        case " $ICN_CHILD_ENV_KEEP " in *" $_name "*) : ;; *) unset "$_name" 2>/dev/null || true ;; esac
+      done
+      export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      export ICN_KEYSTORE_PASSPHRASE ICN_PASSPHRASE ICN_GATEWAY_JWT_SECRET
+      runuser -u icn -- /usr/local/bin/icnctl --data-dir "$DATA_DIR" auth token --gateway "$GW" --coop-id "$COOP_ID" -s "$1" --local-mint 2>/dev/null # vocab-ok: icnctl CLI subcommand name
+    ) | grep -oE 'eyJ[A-Za-z0-9_.-]+' | head -1
+  }
+  rstatus(){  # $1=METHOD $2=PATH $3=JWT [$4=BODY] -> HTTP code
+    if [ -n "${4:-}" ]; then
+      curl -s -o /dev/null -m 10 -w '%{http_code}' -X "$1" -H "Authorization: Bearer $3" -H 'Content-Type: application/json' -d "$4" "$GW$2"
+    else
+      curl -s -o /dev/null -m 10 -w '%{http_code}' -X "$1" -H "Authorization: Bearer $3" "$GW$2"
+    fi
+  }
+  rbody(){    # $1=METHOD $2=PATH $3=JWT [$4=BODY] -> body
+    if [ -n "${4:-}" ]; then
+      curl -s -m 10 -X "$1" -H "Authorization: Bearer $3" -H 'Content-Type: application/json' -d "$4" "$GW$2"
+    else
+      curl -s -m 10 -X "$1" -H "Authorization: Bearer $3" "$GW$2"
+    fi
+  }
+  expect(){   # $1=desc $2=want $3=got
+    [ "$3" = "$2" ] && log "  OK   $1 (HTTP $3)" || fatal "$1 — expected HTTP $2, got $3"
+  }
+
+  ORG_JWT="$(mint_jwt "governance:read,governance:pending-publish:review,governance:pending-publish:confirm")"
+  MEM_JWT="$(mint_jwt "governance:read,governance:action-item:complete")"
+  { [ -n "$ORG_JWT" ] && [ -n "$MEM_JWT" ]; } || fatal "trusted local token mint failed (icnctl --local-mint). Check ICN_GATEWAY_JWT_SECRET + keystore."
+  log "minted organizer / member tokens (trusted-local; never printed). Setup/init is the seed's job."
+
+  s="$(rstatus GET "/v1/gov/domains/$DOMAIN/rehearsal/pending-publish" "$ORG_JWT")"
+  [ "$s" = "200" ] || fatal "rehearsal workspace not reachable (HTTP $s) — is icnd in ICN_GOVERNANCE_BUILD_MODE=rehearsal and did 'icn-demo-seed --session organizer' run?"
+  log "rehearsal routes mounted; organizer reads the workspace (HTTP 200)."
+
+  # ---- least-privilege NEGATIVE matrix ----
+  probe_bind="$(python3 -c 'import json;print(json.dumps({"label":"probe-x","did":"did:icn:probe"}))')"
+  expect "organizer canNOT bind labels (setup-only)"          403 "$(rstatus POST "/v1/gov/domains/$DOMAIN/rehearsal/bindings" "$ORG_JWT" "$probe_bind")"
+  expect "organizer canNOT create action items (broad write)" 403 "$(rstatus POST "/v1/gov/domains/$DOMAIN/action-items" "$ORG_JWT" '{"title":"x","description":"x","priority":"low"}')"
+  expect "member canNOT bind labels"                          403 "$(rstatus POST "/v1/gov/domains/$DOMAIN/rehearsal/bindings" "$MEM_JWT" "$probe_bind")"
+
+  # ---- locate the fictional action_item row ----
+  list="$(rbody GET "/v1/gov/domains/$DOMAIN/rehearsal/pending-publish" "$ORG_JWT")"
+  ROW="$(python3 -c 'import json,sys
+d=json.load(sys.stdin)
+for r in d.get("rows",[]):
+    if r.get("kind")=="action_item":
+        print(r["id"]); break' <<<"$list")"
+  [ -n "$ROW" ] || fatal "no action_item row in the rehearsal workspace: $list"
+  expect "member canNOT review a row" 403 "$(rstatus POST "/v1/gov/domains/$DOMAIN/rehearsal/pending-publish/$ROW/review" "$MEM_JWT" '{"decision":"approve"}')"
+
+  # ---- ensure the row is confirmed (drive it if the browser has not) ----
+  detail="$(rbody GET "/v1/gov/domains/$DOMAIN/rehearsal/pending-publish/$ROW" "$ORG_JWT")"
+  AI_ID="$(python3 -c 'import json,sys
+d=json.load(sys.stdin).get("row",{})
+print((d.get("execution") or {}).get("action_item_id","") if d.get("executed") else "")' <<<"$detail")"
+  if [ -z "$AI_ID" ]; then
+    expect "organizer approves the fictional item" 200 "$(rstatus POST "/v1/gov/domains/$DOMAIN/rehearsal/pending-publish/$ROW/review" "$ORG_JWT" '{"decision":"approve"}')"
+    preview="$(rbody GET "/v1/gov/domains/$DOMAIN/rehearsal/pending-publish/$ROW/preview" "$ORG_JWT")"
+    digest="$(python3 -c 'import json,sys;print(json.load(sys.stdin).get("preview_digest",""))' <<<"$preview")"
+    [ -n "$digest" ] || fatal "preview returned no digest (is the assignee label bound? run 'icn-demo-seed --session organizer'): $preview"
+    confirm="$(rbody POST "/v1/gov/domains/$DOMAIN/rehearsal/pending-publish/$ROW/confirm" "$ORG_JWT" "$(python3 -c 'import json,sys;print(json.dumps({"preview_digest":sys.argv[1]}))' "$digest")")"
+    AI_ID="$(python3 -c 'import json,sys;print(json.load(sys.stdin).get("action_item_id",""))' <<<"$confirm")"
+    [ -n "$AI_ID" ] || fatal "confirm did not create an action item: $confirm"
+    log "organizer confirmed -> created one real action item: $AI_ID"
+  else
+    log "action item already confirmed (browser walkthrough): $AI_ID"
+  fi
+
+  # ---- completion: organizer canNOT; member CAN (if not already completed) ----
+  crec="$(rbody GET "/v1/gov/domains/$DOMAIN/action-items/$AI_ID/completion-receipt" "$MEM_JWT")"
+  already="$(python3 -c 'import json,sys
+try:
+    print("1" if json.load(sys.stdin).get("transition")=="completed" else "")
+except Exception:
+    print("")' <<<"$crec")"
+  if [ -z "$already" ]; then
+    expect "organizer canNOT complete the member item" 403 "$(rstatus PUT "/v1/gov/domains/$DOMAIN/action-items/$AI_ID/status" "$ORG_JWT" '{"status":"completed"}')"
+    expect "member completes the assigned item"        200 "$(rstatus PUT "/v1/gov/domains/$DOMAIN/action-items/$AI_ID/status" "$MEM_JWT" '{"status":"completed"}')"
+    crec="$(rbody GET "/v1/gov/domains/$DOMAIN/action-items/$AI_ID/completion-receipt" "$MEM_JWT")"
+  else
+    log "item already completed (browser walkthrough)."
+  fi
+
+  # ---- completion receipt binding check (32-byte record_hash + fields) ----
+  if ! RECEIPT_JSON="$crec" python3 - "$AI_ID" "$DOMAIN" <<'PY'
+import json,os,sys
+r=json.loads(os.environ["RECEIPT_JSON"])
+item,dom=sys.argv[1],sys.argv[2]
+h=r.get("record_hash")
+ok=(isinstance(h,list) and len(h)==32 and all(isinstance(b,int) and 0<=b<=255 for b in h)
+    and r.get("item_id")==item and r.get("domain_id")==dom
+    and r.get("transition")=="completed"
+    and isinstance(r.get("completed_at"),(int,float)) and r.get("completed_at")>0)
+sys.exit(0 if ok else 1)
+PY
+  then fatal "completion receipt failed the 32-byte binding check: $crec"; fi
+  log "member completion receipt validates (32-byte record_hash + field binding)."
+
+  # ---- process receipts + value-withheld evidence (no DID / no credential) ----
+  receipts="$(rbody GET "/v1/gov/domains/$DOMAIN/rehearsal/receipts" "$ORG_JWT")"
+  evidence="$(rbody GET "/v1/gov/domains/$DOMAIN/rehearsal/evidence-export" "$ORG_JWT")"
+  if ! RC="$receipts" EV="$evidence" python3 - <<'PY'
+import json,os,re,sys
+rc=json.loads(os.environ["RC"]); ev=json.loads(os.environ["EV"])
+classes={x.get("class") for x in rc.get("receipts",[])}
+for need in ("process_gate_result","activation_crossed","mutation_plan_recorded","mutation_applied"):
+    if need not in classes: sys.exit("process receipts missing "+need)
+for k in ("contract","run_id","generation","rows","packet_hash","packet_hash_sha256","non_claims","privacy_review_result"):
+    if k not in ev: sys.exit("evidence missing "+k)
+if ev["contract"]!="urn:icn:contract:rehearsal-workflow-evidence:v1": sys.exit("evidence wrong contract")
+blob=json.dumps(rc)+json.dumps(ev)
+if re.search(r'did:icn:',blob): sys.exit("receipts/evidence leaked a did:icn:")
+if re.search(r'eyJ[A-Za-z0-9_-]{20,}\.',blob): sys.exit("receipts/evidence leaked a JWT")
+pr=ev.get("privacy_review",{})
+if pr.get("dids_exported") or pr.get("credentials_exported"): sys.exit("privacy_review flags a leak")
+PY
+  then fatal "process receipts / evidence failed validation or the value-withheld (no-DID / no-credential) check"; fi
+  log "process receipts (gate/activation/plan/applied) + value-withheld evidence validate (no DID, no credential)."
+
+  log "PASS — Rehearsal Node organizer->member loop verified end-to-end on THIS VM:"
+  log "  least-privilege matrix (organizer read+review+confirm, canNOT bind/broad-write/complete;"
+  log "  member read+complete, canNOT review/bind); one action item created by confirm; member"
+  log "  completion receipt + process receipts + value-withheld evidence validate."
+  log "  Fictional data on an isolated node. NOT production, NOT a pilot, NOT federation;"
+  log "  receipts record process facts and grant no authority."
   exit 0
 fi
 

--- a/deploy/appliance/scripts/open-proxmox-demo.sh
+++ b/deploy/appliance/scripts/open-proxmox-demo.sh
@@ -65,7 +65,10 @@ JUMP="${ICN_DEMO_JUMP:-}"
 # Carry the chosen ports to the shell so it talks to the gateway + session
 # endpoint on whatever ports this launcher actually forwarded (honoring the
 # ICN_DEMO_*_PORT overrides), not hard-coded defaults.
-SHELL_URL="http://localhost:${SHELL_PORT}/member-shell/?mode=live&demo=launcher&gw=${GW_PORT}&session=${SESSION_PORT}"
+# The Rehearsal Node headline surface is the organizer review->confirm flow
+# (?surface=organizer). The page's "Continue as the assigned member" link drops
+# surface=organizer and mints a fresh member session from the same launcher ports.
+SHELL_URL="http://localhost:${SHELL_PORT}/member-shell/?mode=live&surface=organizer&demo=launcher&gw=${GW_PORT}&session=${SESSION_PORT}"
 GATEWAY_URL="http://localhost:${GW_PORT}"
 
 log()  { printf '[demo-open] %s\n' "$*"; }
@@ -175,13 +178,15 @@ open_browser() {
 
 cat <<EOF
 
-  ============================ ICN LOCAL DEMO OPEN ============================
-   Member shell : ${SHELL_URL}
-   Gateway      : ${GATEWAY_URL}  (pre-filled in the page; do not type it)
-   In the browser: click "Start local demo" — standing + an action card load.
+  ===================== ICN REHEARSAL NODE — LOCAL OPEN =====================
+   Organizer shell : ${SHELL_URL}
+   Gateway         : ${GATEWAY_URL}  (pre-filled in the page; do not type it)
+   In the browser: click "Start organizer rehearsal" — review one fictional
+   item, confirm it, then "Continue as the assigned member" and complete it.
    No JWT to copy. No gateway to type. No terminal needed after this.
+   Fictional rehearsal data on an isolated node — not a pilot, not federation.
    Stop the demo: press Ctrl-C in this terminal to close the tunnel.
-  ============================================================================
+  ==========================================================================
 
 EOF
 

--- a/deploy/appliance/smoke/demo-seed-auth-check.sh
+++ b/deploy/appliance/smoke/demo-seed-auth-check.sh
@@ -95,6 +95,37 @@ else
     bad "BROWSER_SCOPES is not the expected completion-only set (got: '${browser_scopes:-<unset>}'); it must be governance:read,governance:action-item:complete — no governance:meeting:write, no coop:*, no broad governance:write"
 fi
 
+# 7b. Rehearsal Node (#2386) per-role session scopes are least-privilege.
+organizer_scopes="$(awk -F'"' '/^ORGANIZER_SCOPES=/{print $2; exit}' "$SEED")"
+if [ "$organizer_scopes" = "governance:read,governance:pending-publish:review,governance:pending-publish:confirm" ]; then
+    ok "organizer session is least-privilege: read + pending-publish:review + :confirm"
+else
+    bad "ORGANIZER_SCOPES must be governance:read,governance:pending-publish:review,governance:pending-publish:confirm — no rehearsal:setup, governance:write, meeting:write, action-item:complete, entity:write, or coop:admin (got: '${organizer_scopes:-<unset>}')"
+fi
+member_scopes="$(awk -F'"' '/^MEMBER_SCOPES=/{print $2; exit}' "$SEED")"
+if [ "$member_scopes" = '$BROWSER_SCOPES' ] || [ "$member_scopes" = "governance:read,governance:action-item:complete" ]; then
+    ok "member session is least-privilege: read + action-item:complete (= BROWSER_SCOPES)"
+else
+    bad "MEMBER_SCOPES must be governance:read,governance:action-item:complete (or \$BROWSER_SCOPES) — no organizer or setup authority (got: '${member_scopes:-<unset>}')"
+fi
+# 7c. The internal rehearsal-setup credential carries no write/admin class.
+setup_scopes="$(awk -F'"' '/^REHEARSAL_SETUP_SCOPES=/{print $2; exit}' "$SEED")"
+case "$setup_scopes" in
+  *governance:rehearsal:setup*)
+    case "$setup_scopes" in
+      *governance:write*|*coop:*|*entity:write*|*meeting:write*|*action-item:complete*)
+        bad "REHEARSAL_SETUP_SCOPES must not carry any write/admin/complete class (got: '$setup_scopes')" ;;
+      *) ok "rehearsal-setup credential is read + rehearsal:setup only (internal; never printed)" ;;
+    esac ;;
+  *) bad "REHEARSAL_SETUP_SCOPES must include governance:rehearsal:setup (got: '${setup_scopes:-<unset>}')" ;;
+esac
+# 7d. The per-role session JSON emits the role JWT + role (never the setup JWT).
+if grep -qE '"jwt": sys.argv\[2\]' "$SEED" && grep -qE '"role": sys.argv\[3\]' "$SEED"; then
+    ok "the per-role session JSON emits the role-scoped jwt + role (organizer/member)"
+else
+    bad "the per-role (--session) JSON does not emit a role-scoped jwt"
+fi
+
 # 8. SETUP JWT is internal — only the BROWSER JWT is emitted/printed.
 if grep -qE '"\$BROWSER_JWT"' "$SEED"; then
     ok "the emitted JSON carries the browser JWT (\$BROWSER_JWT)"

--- a/deploy/appliance/systemd/icn-demo-session.service
+++ b/deploy/appliance/systemd/icn-demo-session.service
@@ -25,9 +25,12 @@ ConditionPathExists=/usr/local/sbin/icn-demo-seed
 [Service]
 Type=simple
 # Dev gates passed through so the endpoint's posture check matches icnd's.
+# `rehearsal` (matching the icnd drop-in) keeps the endpoint's non-production
+# gate satisfied AND ensures the seed subprocess it spawns reaches the
+# Rehearsal-mode organizer/member routes on the daemon.
 EnvironmentFile=-/etc/icn/icnd.env
 Environment=ICN_ENABLE_ADMIN_ENDPOINTS=true
-Environment=ICN_GOVERNANCE_BUILD_MODE=test
+Environment=ICN_GOVERNANCE_BUILD_MODE=rehearsal
 ExecStart=/usr/bin/python3 /usr/local/sbin/icn-demo-session.py
 Restart=on-failure
 RestartSec=5

--- a/deploy/appliance/systemd/icnd.service.d/20-demo-profile.conf
+++ b/deploy/appliance/systemd/icnd.service.d/20-demo-profile.conf
@@ -11,12 +11,18 @@
 #    user-net VM, 0.0.0.0 is still host-only exposure (no bridge, no LAN).
 #    JWT auth stays enforced — firstboot's per-instance secret is unchanged.
 #
-# 2. ICN_ENABLE_ADMIN_ENDPOINTS + ICN_GOVERNANCE_BUILD_MODE=test.
+# 2. ICN_ENABLE_ADMIN_ENDPOINTS + ICN_GOVERNANCE_BUILD_MODE=rehearsal.
 #    The dev gate pair behind POST /v1/commons/dev/bootstrap-standing
 #    (same pair the local devnet demo uses — see deploy/devnet and PR #2024).
 #    Used by icn-demo-seed to make member standing visible in the shell and
-#    to unlock the optional proposal/vote demo path. `test` posture is
-#    permissive governance wiring — a labeled non-production stance.
+#    to unlock the optional proposal/vote demo path.
+#    `rehearsal` posture is a labeled non-production stance (like `test`,
+#    permissive governance wiring) that ADDITIONALLY mounts the Rehearsal Node
+#    organizer review→confirm surface (/v1/gov/domains/{d}/rehearsal/*, #2386).
+#    The switch from `test` is strictly additive: the dev gates key on
+#    "not production" (rehearsal passes), Production validation is unchanged
+#    (validate() rejects only Production), and no runtime path keys on == "test".
+#    Rehearsal is the EXACT-match opt-in; a typo falls back to Bootstrap, 404.
 #
 # 3. ICN_CORS_ORIGINS — the member-shell live mode runs in the operator's
 #    browser on the host; its requests carry an Authorization header, which
@@ -31,5 +37,5 @@ ExecStart=/usr/local/bin/icnd \
     --gateway-enable \
     --gateway-bind 0.0.0.0:8080
 Environment=ICN_ENABLE_ADMIN_ENDPOINTS=true
-Environment=ICN_GOVERNANCE_BUILD_MODE=test
+Environment=ICN_GOVERNANCE_BUILD_MODE=rehearsal
 Environment=ICN_CORS_ORIGINS=http://localhost:8090,http://127.0.0.1:8090,http://localhost:18090,http://127.0.0.1:18090

--- a/docs/demo/rehearsal-node-appliance-loop.md
+++ b/docs/demo/rehearsal-node-appliance-loop.md
@@ -1,0 +1,103 @@
+# Assembled Rehearsal Node — organizer → member loop (appliance)
+
+**Status**: descriptive · non-canonical · **Last Reviewed**: 2026-07-12
+
+This is the assembled-appliance wiring of the Rehearsal Node organizer
+review→confirm loop (#2386). It connects, on a single isolated demo-profile VM,
+the browser organizer surface (`web/member-shell/?surface=organizer`, PR #2407)
+to the merged Rehearsal-mode runtime (PR #2406) so a person can run the whole
+loop with **no terminal and no credential paste**:
+
+```text
+one command  →  browser opens the organizer surface
+  →  Start organizer rehearsal  (a fresh least-privilege organizer session)
+  →  review one fictional item · confirm the bound preview
+  →  one real action item + ADR-0026 process receipts are created on THIS VM
+  →  Continue as the assigned member  (a FRESH least-privilege member session)
+  →  complete the action card  →  completion receipt
+  →  steward verifies: sudo icn-demo-verify --rehearsal
+```
+
+Fictional data on an isolated node. **Not production, not a pilot, not live
+federation.** Receipts record process facts and grant no authority.
+
+## What changed to assemble it
+
+- **Governance mode.** The demo-profile daemon runs
+  `ICN_GOVERNANCE_BUILD_MODE=rehearsal` (`20-demo-profile.conf`). This is a
+  labeled non-production stance, **strictly additive** over `test`: it mounts the
+  `/v1/gov/domains/{d}/rehearsal/*` surface and adds rehearsal rows to the
+  pending-publish summary. The dev gates key on "not production" (rehearsal
+  passes); Production validation is unchanged; no runtime path keys on `== test`.
+- **Three credential shapes**, all minted by trusted local issuance
+  (`icnctl --local-mint`, this VM's own instance-local gateway secret — never the
+  public self-asserted `/auth/verify` path, which stays fail-closed on the
+  routable `0.0.0.0` bind, #2075):
+  - **internal setup** — `governance:read` + `governance:rehearsal:setup`
+    (initializes the workspace + binds the fictional label). **Never returned to
+    the browser or logged.**
+  - **organizer browser** — `governance:read` +
+    `governance:pending-publish:review` + `governance:pending-publish:confirm`.
+    No setup / write / meeting:write / action-item:complete / entity:write /
+    coop:admin.
+  - **member browser** — `governance:read` + `governance:action-item:complete`
+    (completion-only, #2400). No organizer or setup authority.
+- **Role sessions.** The loopback demo-session endpoint reads a **closed** role
+  intent (`{"role":"organizer"|"member"}`) and maps it to one of two **fixed**
+  `icn-demo-seed --session <role>` commands — no request bytes reach the command.
+  It returns **one** role's least-privilege session per request. A role
+  transition mints a **fresh** session; it never upgrades a token in the browser.
+- **Deterministic setup.** The seed reuses the fictional NYCN package's
+  `nycn-federation-gov` StaticList domain (whose sole member is the per-instance
+  operator DID), initializes the rehearsal workspace once (idempotent — it never
+  wipes an organizer-created item), and binds `Example member (fictional)` → the
+  operator DID. In a single-operator appliance the organizer and the assigned
+  member are the **same** operator DID wearing different least-privilege tokens.
+  No pre-seeded action item — the organizer creates it by confirming.
+
+## Run it
+
+One-command (from your workstation, tunnels + opens the organizer surface):
+
+```bash
+ICN_DEMO_VM_IP=<node-ip> bash deploy/appliance/scripts/open-proxmox-demo.sh
+```
+
+Steward verification (in-VM, after the organizer session has run):
+
+```bash
+sudo icn-demo-seed --session organizer     # if not already seeded
+sudo icn-demo-verify --rehearsal            # least-privilege matrix + loop + evidence
+```
+
+`icn-demo-verify --rehearsal` asserts, against THIS VM's live gateway: the
+rehearsal routes are mounted; the organizer token can review+confirm but **cannot**
+bind, initialize, complete a member item, or broad-write; the member token can
+complete but **cannot** review/bind; one action item is created by confirmation;
+the member completion receipt binds (32-byte `record_hash`); the process-receipt
+ladder (gate/activation/plan/applied) and the value-withheld evidence packet
+validate with **no DID and no credential**.
+
+## Verification status
+
+- **Software loop — PROVEN end-to-end** against a real rehearsal-mode `icnd`
+  built from this branch (the entire loop above ran green: setup, least-privilege
+  matrix, organizer confirm → item created, member complete, completion receipt +
+  process receipts + value-withheld evidence). This validates the build-mode
+  flip, the seed setup, the role scopes, and the verifier matrix against the
+  actual runtime.
+- **Full assembled-image (KVM) witness — NOT performed in the authoring session.**
+  It requires building a demo-profile `qcow2` from a base image
+  (`build-image.sh --real`) and then `smoke-local.sh --real --demo`; the base
+  image build is a heavy separate step. Per the honesty rule, the appliance
+  tranche is **not** claimed "assembled-image witnessed" until that runs. The KVM
+  smoke path is otherwise ready (qemu + `/dev/kvm` available; the `--demo` flow
+  drives a real browser request path and a no-outbound canary).
+
+## Non-claims
+
+Receipts do not create authority · rehearsal is not a pilot · fictional data is
+not live-federation data · identity binding is a fictional-rehearsal convenience,
+not production enrollment · one local node is not federation · a successful
+software rehearsal is not organizer approval, nor the human assistive-technology
+gate (#2041). The human gates #2041 / #1703 / #1746 remain open.

--- a/web/member-shell/i18n.js
+++ b/web/member-shell/i18n.js
@@ -483,6 +483,9 @@
       "organizer.connect.body": "Enter a locally running ICN gateway started in Rehearsal mode and paste an organizer review credential. It is kept only on this page while it is open, is never saved, and is sent only to the gateway address you enter.",
       "organizer.connect.credentialHelp": "Needs governance:read, governance:pending-publish:review, and governance:pending-publish:confirm. It must not carry setup, write, completion, or admin authority, and it never contains a DID.",
       "organizer.connect.submit": "Connect and load the rehearsal workspace",
+      "organizer.launch.heading": "Start the organizer rehearsal",
+      "organizer.launch.body": "This page was opened by the local Rehearsal Node launcher. Select Start to begin a fresh organizer session — review one fictional item, confirm it, then continue as the assigned member. There is no address to type and no credential to paste. Fictional data on an isolated node; not a pilot, not live federation.",
+      "organizer.launch.start": "Start organizer rehearsal",
 
       "organizer.domain.heading": "Which domain are you rehearsing in?",
       "organizer.domain.explain": "You are a member of more than one domain. Choose the one whose proposed work you are reviewing.",

--- a/web/member-shell/shell.js
+++ b/web/member-shell/shell.js
@@ -2419,16 +2419,36 @@
       byId("nav-demo").setAttribute("aria-current", "true");
       loadDemo();
     } else if (SURFACE === "organizer") {
-      // #2386 organizer rehearsal surface: manual organizer credential, then the
-      // review→confirm workflow against a Rehearsal-mode node. No demo launcher
-      // path — the organizer enters a credential manually in this PR.
+      // #2386 organizer rehearsal surface. Manual organizer credential, OR — on
+      // the assembled appliance (?demo=launcher) — a no-paste organizer session
+      // minted by the loopback demo-session endpoint.
       banner.textContent = t("banner.organizer");
       banner.className = "banner live";
       byId("nav-live").setAttribute("aria-current", "true");
       applyOrganizerConnectCopy();
       wireConnectForm(loadOrganizer);
-      show("connect-section");
-      setSyncChip(t(SYNC.DELAYED), "neutral", t("launcher.notConnected"));
+      if (DEMO_LAUNCHER) {
+        // Point the member-transition link at the MEMBER launcher URL so the
+        // organizer continues as the member via a FRESH least-privilege session
+        // (never a token upgrade), and offer the one-click organizer start.
+        var ml = byId("organizer-member-link");
+        if (ml) {
+          var mp = new URLSearchParams();
+          mp.set("mode", "live"); mp.set("demo", "launcher");
+          if (params.get("gw")) { mp.set("gw", params.get("gw")); }
+          if (params.get("session")) { mp.set("session", params.get("session")); }
+          if (langParam) { mp.set("lang", langParam); }
+          ml.setAttribute("href", "?" + mp.toString());
+        }
+        byId("gateway-url").value = DEMO_GATEWAY;
+        setOrganizerLaunchCopy();
+        show("demo-launch-section");
+        setSyncChip(t(SYNC.DELAYED), "neutral", t("launcher.ready"));
+        wireDemoLaunch("organizer", loadOrganizer);
+      } else {
+        show("connect-section");
+        setSyncChip(t(SYNC.DELAYED), "neutral", t("launcher.notConnected"));
+      }
     } else {
       banner.textContent = t("banner.live");
       banner.className = "banner live";
@@ -2441,12 +2461,22 @@
         byId("gateway-url").value = DEMO_GATEWAY;
         show("demo-launch-section");
         setSyncChip(t(SYNC.DELAYED), "neutral", t("launcher.ready"));
-        wireDemoLaunch();
+        wireDemoLaunch("member", loadLive);
       } else {
         show("connect-section");
         setSyncChip(t(SYNC.DELAYED), "neutral", t("launcher.notConnected"));
       }
     }
+  }
+
+  // On the assembled appliance the organizer launch panel re-uses the demo-launch
+  // section; give it organizer-rehearsal copy (the manual-connect fallback is the
+  // organizer connect form, already wired above).
+  function setOrganizerLaunchCopy() {
+    byId("demo-launch-h").textContent = t("organizer.launch.heading");
+    var body = document.querySelector("#demo-launch-section p[data-i18n=\"demoLaunch.body\"]");
+    if (body) { body.textContent = t("organizer.launch.body"); }
+    byId("demo-launch-button").textContent = t("organizer.launch.start");
   }
 
   // Apply the catalog to every static node carrying data-i18n (textContent)
@@ -2493,7 +2523,11 @@
   // a fresh demo session, hold it in page memory (never persisted, never in a
   // URL), then load standing + cards — the same render path as the manual
   // flow. Falls back to the manual connect form on any failure.
-  function wireDemoLaunch() {
+  // role is the CLOSED session intent ("member" | "organizer"); loader is the
+  // surface loader to run once the session is minted. The manual-connect fallback
+  // uses the connect form already wired for this surface in init().
+  function wireDemoLaunch(role, loader) {
+    loader = loader || loadLive;
     var btn = byId("demo-launch-button");
     var adv = byId("demo-advanced-button");
     var st = byId("demo-launch-status");
@@ -2506,8 +2540,15 @@
     btn.addEventListener("click", function () {
       btn.disabled = true;
       st.textContent = t("launcher.starting");
-      // Simple cross-origin POST (no custom headers) — no preflight needed.
-      fetch(DEMO_SESSION_URL, { method: "POST" }).then(function (resp) {
+      // JSON body carries the CLOSED role intent; the loopback session endpoint
+      // maps it to a fixed command and mints a least-privilege per-role session.
+      // This triggers a CORS preflight, which the endpoint answers for the
+      // demo-shell origin. The credential lives only in page memory.
+      fetch(DEMO_SESSION_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: role })
+      }).then(function (resp) {
         if (!resp.ok) { throw new Error("HTTP " + resp.status); }
         return resp.json();
       }).then(function (session) {
@@ -2519,7 +2560,7 @@
         state.credential = cred;
         hide("demo-launch-section");
         show("connect-section");
-        loadLive();
+        loader();
       }).catch(function (err) {
         btn.disabled = false;
         st.textContent = t("launcher.startFailed", { error: err.message });


### PR DESCRIPTION
## Summary

Assembles the Rehearsal Node organizer→member loop (#2386) on the demo-profile appliance — connecting the browser organizer surface (PR #2407) to the merged Rehearsal-mode runtime (PR #2406) so a person can run the whole loop on one isolated VM with **no terminal and no credential paste**: *Start organizer rehearsal → review → confirm one fictional item → Continue as the assigned member (a fresh least-privilege session) → complete it → steward verifies.* Fictional data on an isolated node; not production, not a pilot, not live federation.

`Refs #1726 #1728 #2386 #1746` (no close keywords — the human gates stay open; see verification status).

## Changes (appliance / session / seed / verification integration)

- **Governance mode.** `ICN_GOVERNANCE_BUILD_MODE` `test` → `rehearsal` on the daemon drop-in + the demo-session unit. A labeled non-production stance, **strictly additive** over `test`: it mounts `/v1/gov/domains/{d}/rehearsal/*`; the dev gates key on "not production" (rehearsal passes); Production validation is unchanged (`validate()` rejects only `Production`); nothing keys on `== "test"` at runtime.
- **Three credential shapes**, all minted by trusted local issuance (`icnctl --local-mint`, this VM's own instance-local secret — never the self-asserted `/auth/verify` path, #2075 untouched; secret stays env-only):
  - internal **setup** — `governance:read` + `governance:rehearsal:setup` (workspace init + label bind). Never returned/logged.
  - organizer **browser** — `read` + `pending-publish:review` + `pending-publish:confirm`. No setup/write/completion/meeting:write/entity:write/coop:admin.
  - member **browser** — `read` + `action-item:complete` (completion-only, #2400). No organizer/setup authority.
- **`icn-demo-seed --session organizer|member`.** Idempotent one-time rehearsal setup (reset only on a 404, so a re-mint never wipes an organizer-created item; bind `Example member (fictional)` → the operator DID, a StaticList member of `nycn-federation-gov` via the fictional package), then a least-privilege per-role browser JWT. **No pre-seeded item** — the organizer creates it by confirming. The legacy action-item path is unchanged.
- **`icn-demo-session.py`.** Reads a **closed** role intent (`{"role":"organizer"|"member"}`) and maps it to one of two **fixed** `icn-demo-seed` commands — no request bytes reach the command. Origin/dev gates, `no-store`, no-credential-logging, and `_SEED_LOCK` serialization intact.
- **`icn-demo-verify --rehearsal`.** Steward verification against the live gateway: the least-privilege matrix (organizer canNOT bind/broad-write/complete; member canNOT review/bind), one action item created by confirm, the completion receipt binding, the process-receipt ladder, and the value-withheld evidence packet (no DID / no credential).
- **Launcher + shell.** `open-proxmox-demo.sh` opens `?surface=organizer`; `wireDemoLaunch(role, loader)` POSTs the role intent; the organizer's "Continue as the assigned member" link mints a **fresh** member session (never a token upgrade). Credential in page memory only; the POST body carries only `{role}`.
- **`demo-seed-auth-check.sh`.** Static assertions that the three role scope sets are least-privilege and the setup token is never emitted.

## Verification status

- **Software loop — PROVEN end-to-end** against a real rehearsal-mode `icnd` built from this branch. The full loop ran green: workspace init + label bind; least-privilege matrix (organizer canNOT bind/broad-write 403, member canNOT bind/review 403); organizer approve 200 → preview `confirmable=true` → confirm → **one real action item created**; organizer canNOT complete 403, member completes 200; completion receipt validates (32-byte `record_hash`); process-receipt ladder (gate/activation/plan/applied) + value-withheld evidence validate (no DID, no credential). This validates the build-mode flip, the seed setup, the role scopes, and the verifier matrix against the actual runtime.
- **Full assembled-image (KVM) witness — NOT performed in this session.** It requires building a demo-profile `qcow2` from a base image (`build-image.sh --real`) then `smoke-local.sh --real --demo`; the base-image build is a heavy separate step. Per the honesty rule, the appliance tranche is **not** claimed "assembled-image witnessed" here. The KVM smoke path is otherwise ready (qemu + `/dev/kvm` available). Documented in `docs/demo/rehearsal-node-appliance-loop.md` § Verification status.
- Static/unit checks green: `bash -n` + `shellcheck` on all scripts; the extended `demo-seed-auth-check.sh`; a `resolve_seed_cmd` unit test (closed-set role mapping, every command a fixed constant); the PR #2407 browser tests still pass (organizer behavioral + axe a11y, 0 violations); doc-control / compliance / readiness / freshness clean.

## Independent review

Two fresh-context adversarial reviewers ran against this diff — **no Critical / High / Medium findings**:
- **Security + shell/script:** fixed-command property holds (role only selects one of two constant lists; no injection); `--local-mint` / #2075 / env-only-secret / origin+dev gates / no-store / no-credential-log all intact; the three role scope sets are correct and narrow; `ensure_rehearsal_workspace` resets only on 404; the build-mode flip is byte-identical-to-`test` behavior (rehearsal ≠ production). Low fixes applied: `--session` with no value now fails closed; the member heredoc no longer hardcodes `surface=organizer`.
- **Constitutional / contract-fidelity:** every route/method/scope/response-field the scripts touch matches the merged runtime contract; the least-privilege 403/200 matrix is runtime-accurate; the honest witness status is stated cleanly; non-claims present; vocabulary clean (no NYCN noun leaked into the generic member-shell copy — `nycn-federation-gov` appears only on package/appliance surfaces). Low fixes applied: dropped the verifier's unused/scope-divergent SETUP token; added the witness-status caveat to the README.

## Risk

Low. Live/demo-profile-only; the daemon change is a build-mode env flip that is strictly additive; the runtime is unmodified; the legacy demo path and its guards are preserved; the auth doctrine (#2075, `--local-mint`, env-only secret) is untouched.

## What is real vs fictional

The workspace and rows are fictional. The action item and ADR-0026 receipts created on confirm are real records on the isolated VM's node.

## Non-claims

Receipts record process facts and grant no authority · rehearsal is not a pilot · fictional data is not live-federation data · identity binding is a fictional-rehearsal convenience, not production enrollment · one local node is not federation · a successful software rehearsal is not organizer approval, nor the human assistive-technology gate. The human gates remain open: #2041 (assistive technology), #1703 (organizer presentation / first operator rehearsal), #1746 (operable-rehearsal milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
