### PR TITLE
fix(website): remove truth drift from demo page, roadmap, and blog

### DIFF
--- a/website/src/components/MemberSurface.astro
+++ b/website/src/components/MemberSurface.astro
@@ -118,7 +118,7 @@ const truthLabel = 'illustrative direction';
         <div class="ms-panel-body">
           <p class="ms-primary"><strong>Recognized member</strong> · Brightworks Collective</p>
           <p class="ms-meta">
-            <span class="ms-chip">Recognized since 2024-11</span>
+            <span class="ms-chip">Standing: recognized (example)</span>
             <span class="ms-chip">Role: Member</span>
           </p>
         </div>

--- a/website/src/content/blog/institution-in-a-box.md
+++ b/website/src/content/blog/institution-in-a-box.md
@@ -1,9 +1,17 @@
 ---
-title: "Institution-in-a-Box: A Live Demo"
-description: "What it looks like when a cooperative actually runs on ICN. A walk-through of the four governance flows that make up our demo."
+title: "The Core Loop, Demonstrated: A Local Devnet Walk-through"
+description: "What the cooperative core loop looks like running on ICN — four flows you can run yourself on a local devnet."
 pubDate: 2026-03-21
 tags: ["demo", "governance", "cooperative"]
 ---
+
+> **Update (July 2026):** this March post described a local devnet
+> walk-through, and its original title oversold that as a "live demo."
+> Everything below runs on your laptop against fictional organizations —
+> it demonstrates real mechanisms, not a deployed network. The current
+> honest map of what is and isn't real is
+> [What's Real Now](/whats-real-now); the current human-facing wedge is
+> the Rehearsal Node.
 
 The most common question we get is: "What does it actually do?"
 
@@ -37,9 +45,9 @@ If your cooperative operates in New York and is required to distribute surplus b
 
 Cooperative A has compute capacity. Cooperative C needs compute. They have a federation agreement.
 
-Cooperative C submits a compute task. The federation protocol routes it to Cooperative A's available nodes. The task executes. An `ExecutionReceipt` comes back. The receipt is linked to the federation agreement that authorized the allocation. Commons credits move between the two cooperatives' accounts, recorded on both sides as signed journal entries.
+Cooperative C submits a compute task. The federation protocol routes it to Cooperative A's available nodes. The task executes. An `ExecutionReceipt` comes back. The receipt is linked to the federation agreement that authorized the allocation, and the allocation is settled between the two cooperatives — recorded on both sides as signed journal entries.
 
-No platform in the middle. No third-party routing compute marketplace. Two organizations that agreed to work together, doing so directly, with a verifiable record on both sides.
+No platform in the middle. No third-party routing compute marketplace. Two fictional organizations on a local devnet, coordinating directly, with a verifiable record on both sides. (No two real cooperatives are federating in production — that distinction matters, and [What's Real Now](/whats-real-now) keeps it explicit.)
 
 ## Flow 4: Audit Report
 
@@ -62,4 +70,4 @@ The demo runs on your laptop. No cloud required. No account required. The crypto
 
 If you want to be part of building what it demonstrates, the issues are labeled, the codebase is open, and we have a Matrix room.
 
-The infrastructure is not theoretical anymore.
+The core loop is real code you can run. What remains between "runs on a laptop" and "carries a real institution" is exactly the part we refuse to hand-wave — [What's Real Now](/whats-real-now) is the running answer.

--- a/website/src/content/blog/sprint-14-closing-the-economic-loop.md
+++ b/website/src/content/blog/sprint-14-closing-the-economic-loop.md
@@ -5,6 +5,11 @@ pubDate: 2026-03-21
 tags: ["development", "sprint", "economics", "governance"]
 ---
 
+> **Update (July 2026):** sprint-number tracking was retired in March 2026 in
+> favor of the sequential Phase 0/1/2 model. This post is kept as a historical
+> record of the work; for current status see
+> [What's Real Now](/whats-real-now).
+
 Every sprint has a theme. Sprint 14's theme was: prove that decisions and their consequences are actually connected.
 
 This sounds obvious. In practice, it is one of the hardest things to build correctly. Most software systems treat governance and execution as separate layers that communicate by convention. Someone decides something. Someone else executes it. The link between the two is a handshake agreement, not a verifiable chain.

--- a/website/src/data/roadmap.json
+++ b/website/src/data/roadmap.json
@@ -9,8 +9,8 @@
       "label": "Current emphasis",
       "badge": "badge-green",
       "markerColor": "var(--accent-green)",
-      "title": "Institution-in-a-box",
-      "description": "The core loop of cooperative life — identity, membership, proposals, decisions, and durable receipts — is the most mature part of the system. Governance-backed provenance and auditable coordination are load-bearing today. This is the part of ICN we are most willing to stand behind in public.",
+      "title": "The institutional core loop",
+      "description": "The core loop of cooperative life — identity, membership, proposals, decisions, and durable receipts — is the most mature part of the system. Governance-backed provenance and auditable coordination are load-bearing today, and the Rehearsal Node packages this loop as a bounded, witnessable rehearsal. This is the part of ICN we are most willing to stand behind in public.",
       "band": "strong"
     },
     {

--- a/website/src/data/roadmap.json
+++ b/website/src/data/roadmap.json
@@ -10,7 +10,7 @@
       "badge": "badge-green",
       "markerColor": "var(--accent-green)",
       "title": "The institutional core loop",
-      "description": "The core loop of cooperative life — identity, membership, proposals, decisions, and durable receipts — is the most mature part of the system. Governance-backed provenance and auditable coordination are load-bearing today, and the Rehearsal Node packages this loop as a bounded, witnessable rehearsal. This is the part of ICN we are most willing to stand behind in public.",
+      "description": "The core loop of cooperative life — identity, membership, proposals, decisions, and durable receipts — is the most mature part of the system. Governance-backed provenance and auditable coordination are load-bearing today. The Rehearsal Node packages one bounded slice of this loop — an organizer reviewing, editing, assigning, and digest-bound-confirming a piece of proposed work, and a member completing it — as a witnessable, non-production rehearsal; proposal and vote surfaces are not part of that rehearsal yet. This is the part of ICN we are most willing to stand behind in public.",
       "band": "strong"
     },
     {

--- a/website/src/pages/docs/demo.astro
+++ b/website/src/pages/docs/demo.astro
@@ -19,9 +19,10 @@ import Layout from '../../layouts/Layout.astro';
         <p class="lead">
           Five fictional demonstration organizations, five scripted end-to-end flows covering
           governance, economics, federation, reporting, and compute. Each flow produces real
-          cryptographic receipts — but it runs on a development deployment the project operates
-          for itself. This is a rehearsal of the mechanisms, not a production service and not a
-          live federation. For what is and isn't real today, see
+          cryptographic receipts. These are developer scripts you run against a development
+          deployment you stand up yourself — a rehearsal of the mechanisms, not a production
+          service, not a live federation, and not a claim that any such deployment is currently
+          running. For what is and isn't real today, see
           <a href="/whats-real-now">What's Real Now</a>.
         </p>
       </div>

--- a/website/src/pages/docs/demo.astro
+++ b/website/src/pages/docs/demo.astro
@@ -14,19 +14,22 @@ import Layout from '../../layouts/Layout.astro';
       </nav>
 
       <div class="demo-header">
-        <span class="badge badge-green">Live on K3s</span>
+        <span class="badge badge-amber">Development demo — not production</span>
         <h1>ICN Demo: Five Cooperative Flows</h1>
         <p class="lead">
-          Five demonstration organizations on a live K3s cluster.
-          Five end-to-end flows covering governance, economics, federation, reporting, and compute.
-          Each flow produces cryptographic receipts — running against real infrastructure, not a sandbox.
+          Five fictional demonstration organizations, five scripted end-to-end flows covering
+          governance, economics, federation, reporting, and compute. Each flow produces real
+          cryptographic receipts — but it runs on a development deployment the project operates
+          for itself. This is a rehearsal of the mechanisms, not a production service and not a
+          live federation. For what is and isn't real today, see
+          <a href="/whats-real-now">What's Real Now</a>.
         </p>
       </div>
 
       <!-- Prerequisites -->
       <div class="prereq-box">
         <h4>Prerequisites</h4>
-        <p>kubectl access to the K3s cluster. Run <code>demo/scripts/reseed-federation-demo.sh</code> before any demo day to seed identity, trust, and state.</p>
+        <p>kubectl access to a development cluster (or the local devnet). Run <code>demo/scripts/reseed-federation-demo.sh</code> before any demo day to seed identity, trust, and state.</p>
         <p>Each flow accepts <code>--present</code> (minimal output, pause on key beats) or <code>--narrated</code> (full explanatory output) flags.</p>
       </div>
 
@@ -113,8 +116,8 @@ import Layout from '../../layouts/Layout.astro';
           <span class="badge badge-green">~8 min</span>
         </div>
         <p>
-          Harbor generates a signed compliance report over its transaction history.
-          The report is anchored to on-chain governance receipts, enabling third-party
+          Harbor generates a signed compliance report over its recorded activity.
+          The report is anchored to signed governance receipts, enabling third-party
           verification without exposing internal financials.
         </p>
         <div class="flow-proves">
@@ -143,9 +146,9 @@ import Layout from '../../layouts/Layout.astro';
           Both pass. The task enters the queue with a Blake3 content hash as its provenance anchor.
         </p>
         <div class="status-note">
-          <strong>Sprint 28 complete:</strong> Gossip fan-out fix enables task dispatch via
-          loopback. CCL executor is live. Tasks move Pending → Completed. Settlement receipts
-          with full provenance chain are generated on completion.
+          <strong>Works end-to-end in the development environment:</strong> task dispatch runs
+          via gossip loopback, the CCL executor completes tasks (Pending → Completed), and
+          settlement receipts with a full provenance chain are generated on completion.
         </div>
         <div class="flow-proves">
           <span class="flow-proves-label">Proves:</span>
@@ -163,7 +166,7 @@ import Layout from '../../layouts/Layout.astro';
         <div class="next-grid">
           <div class="next-item">
             <span class="next-label">Distributed Execution</span>
-            <p>Multi-executor node pool scaling across K3s cluster. Tasks already execute via gossip loopback; this expands to parallel execution across cooperative-contributed nodes.</p>
+            <p>Multi-executor node pool scaling across a multi-node development cluster. Tasks already execute via gossip loopback; this expands to parallel execution across cooperative-contributed nodes.</p>
           </div>
           <div class="next-item">
             <span class="next-label">Mobile UX</span>

--- a/website/src/pages/docs/demo.astro
+++ b/website/src/pages/docs/demo.astro
@@ -29,7 +29,7 @@ import Layout from '../../layouts/Layout.astro';
       <!-- Prerequisites -->
       <div class="prereq-box">
         <h4>Prerequisites</h4>
-        <p>kubectl access to a development cluster (or the local devnet). Run <code>demo/scripts/reseed-federation-demo.sh</code> before any demo day to seed identity, trust, and state.</p>
+        <p>kubectl access to a development Kubernetes cluster. Run <code>demo/scripts/reseed-federation-demo.sh</code> (which port-forwards to the cluster services) before any demo day to seed identity, trust, and state.</p>
         <p>Each flow accepts <code>--present</code> (minimal output, pause on key beats) or <code>--narrated</code> (full explanatory output) flags.</p>
       </div>
 

--- a/website/src/pages/whats-real-now.astro
+++ b/website/src/pages/whats-real-now.astro
@@ -20,12 +20,21 @@ import ReadingLadder from '../components/ReadingLadder.astro';
       </div>
 
       <div class="status-anchor">
-        <span class="status-anchor-label">Reviewed 2026-05-09</span>
+        <span class="status-anchor-label">Reviewed 2026-07-14</span>
         <p>
           ICN is in Phase 2 — Pilot Launch — and Phase 2 is not complete. Phase 0 and Phase 1 are complete.
           The strongest current path is institutional coordination: member standing, action cards, governance actions,
           receipts, and retrievable provenance. The member-facing demo surface is real enough to show the shape of the system,
           but it is still maturing and must not be presented as a finished product.
+        </p>
+        <p>
+          The current bounded wedge is the <strong>Rehearsal Node</strong>: a self-contained,
+          non-production appliance that runs one governed loop end-to-end — an organizer reviews,
+          edits, assigns, previews, and digest-bound-confirms a piece of proposed work; a member
+          completes it; every step leaves a durable receipt and a secret-free evidence export.
+          That loop has been witnessed on an assembled image. Rehearsal before belief: the human
+          gates — a real organizer presentation and a human assistive-technology pass — are still
+          open, and no organizer approval or pilot commitment is claimed.
         </p>
       </div>
     </div>
@@ -154,6 +163,8 @@ import ReadingLadder from '../components/ReadingLadder.astro';
 
       <h2>Where to look directly</h2>
       <ul>
+        <li><a href="/docs/STATE">Project state</a> and <a href="/docs/PHASE_PROGRESS">phase progress</a> — the canonical, truth-synced current-state documents</li>
+        <li><a href="https://github.com/InterCooperative-Network/icn/blob/main/docs/demo/CAPABILITY_HORIZON.md" target="_blank" rel="noopener">Capability horizon</a> — every forward-looking claim with an explicit status label (Demonstrated / Primitive exists / Specified / Horizon)</li>
         <li><a href="/architecture">Architecture reference</a> — the technical deep-dive synced from the repo</li>
         <li><a href="/docs">Documentation</a> — current developer and operator docs</li>
         <li><a href="https://github.com/InterCooperative-Network/icn" target="_blank" rel="noopener">Source on GitHub</a> — the ground truth</li>

--- a/website/src/pages/whats-real-now.astro
+++ b/website/src/pages/whats-real-now.astro
@@ -31,10 +31,11 @@ import ReadingLadder from '../components/ReadingLadder.astro';
           The current bounded wedge is the <strong>Rehearsal Node</strong>: a self-contained,
           non-production appliance that runs one governed loop end-to-end — an organizer reviews,
           edits, assigns, previews, and digest-bound-confirms a piece of proposed work; a member
-          completes it; every step leaves a durable receipt and a secret-free evidence export.
-          That loop has been witnessed on an assembled image. Rehearsal before belief: the human
-          gates — a real organizer presentation and a human assistive-technology pass — are still
-          open, and no organizer approval or pilot commitment is claimed.
+          completes it. The decision points — the organizer's confirm and the member's completion —
+          are recorded as durable process receipts, and the run exports a secret-free evidence
+          summary. That loop has been witnessed on an assembled image. Rehearsal before belief: the
+          human gates — a real organizer presentation and a human assistive-technology pass — are
+          still open, and no organizer approval or pilot commitment is claimed.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## What

Removes the remaining truth drift from the deployed public website (intercooperative.network) and links the maturity pages to the canonical current-state documents.

- `docs/demo.astro` (live at `/docs/demo`): "Live on K3s" badge and "real infrastructure, not a sandbox" lead replaced with honest development-demo framing + a link to What's Real Now; "on-chain" → signed receipts; retired "Sprint 28 complete / CCL executor is live" status note reworded without sprint numbering or "live"; "K3s cluster" scaling claim scoped to a development cluster.
- `roadmap.json` (live at `/roadmap`): stage-A title "Institution-in-a-box" → "The institutional core loop" (retired brand term); description names the Rehearsal Node as the bounded wedge.
- `blog/institution-in-a-box.md`: retitled (was "…A Live Demo"), July-2026 update note added, Flow 3 no longer reads as live federation (explicit "no two real cooperatives are federating in production"), settlement vocabulary instead of accounts/move, closing "not theoretical anymore" overclaim replaced.
- `blog/sprint-14-closing-the-economic-loop.md`: July-2026 note that sprint-number tracking was retired for the Phase 0/1/2 model.
- `whats-real-now.astro`: review stamp 2026-07-14; the Rehearsal Node named as the current bounded wedge with the open human gates stated; "Where to look directly" now links `/docs/STATE`, `/docs/PHASE_PROGRESS`, and the capability horizon (all verified present in the build output).
- `MemberSurface.astro`: fixture chip no longer shows a hardcoded "Recognized since 2024-11" date.

## Why

The 2026-07-13 ecosystem audit's website follow-up: interior pages still carried "Live on K3s / running against real infrastructure", the retired Institution-in-a-Box brand, retired sprint numbering, and live-federation-reading copy — all contradicting `docs/status.toml` NEEDS-OPS-RE-CONFIRMATION and the current doctrine. The homepage and org profile were already clean (verified against the live site).

## How

Copy-only edits; no layout, token, or component-structure changes. The one component change (MemberSurface chip) swaps a hardcoded date string for a label.

## Risk

Content-only; deploys via the existing `website-deploy.yml` GitHub Pages flow on merge to main. Blog slugs unchanged (URLs stable); only titles/copy changed.

## Test plan

- `npm run build`: clean, 967 pages.
- Verified in build output: capability-horizon link renders on `/whats-real-now`; `/docs/STATE` and `/docs/PHASE_PROGRESS` pages exist; new demo-page badge and roadmap title render.
- `readiness_overclaim_linter.py` and `compliance_linter.py` pass.
- Live-site comparison (WebFetch) confirmed the deployed site tracks this repo's `website/` on main.

## What remains unproven

- Post-merge Pages deployment (automatic) should be spot-checked once live.
- The website intentionally does not mention the private LAN rehearsal deployment.

**Standing rule: do not merge without Matt's explicit authorization.**

Refs #2393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
