### PR TITLE
fix(demo): evidence packet validator privacy/redaction leak scan (#2422)

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -257,6 +257,11 @@ jobs:
           # output (deterministic apart from recorded_at), so a fixture edit cannot
           # silently drift the committed packet. Offline, fail-closed.
           python3 scripts/rehearsal_pending_publish_evidence.py --check
+          # #2422: the evidence packet validator now runs a privacy/redaction
+          # value scan (did:icn / JWT / PEM / private-path / private-IP) on top
+          # of structural schema validation. Adversarial suite must stay green
+          # so a structurally-valid-but-leaky packet can never pass. Offline.
+          python3 docs/scripts/tests/test_rehearsal_evidence_leak_scan.py
         continue-on-error: false
 
   bridge_conformance:

--- a/docs/contracts/rehearsal-evidence-export.md
+++ b/docs/contracts/rehearsal-evidence-export.md
@@ -86,13 +86,17 @@ The schema declares `additionalProperties: false` so unknown fields are rejected
 - accommodation or access needs tied to an identifiable person
 - raw attendee or member rolls
 - API tokens, secrets, signed URLs, or session credentials
+- JWT / bearer-shaped credentials (e.g. `eyJ…` tokens)
+- PEM private keys
 - private Drive / Groups / Sheets paths or content
+- private filesystem paths (e.g. `/home`, `/root`, `/Users`, Windows user profiles)
 - private overlay contents
+- private-network or loopback IP addresses / internal topology
 - live partner operational details
 - any field that implies formal pilot approval or production deployment
 - DIDs of unconsented participants
 
-This list is also captured in the schema's `x-icn-must-not-include` extension so machine consumers (linters, partner CI) can read it without parsing this prose.
+This list is also captured in the schema's `x-icn-must-not-include` extension so machine consumers (linters, partner CI) can read it without parsing this prose. The last six of these (DIDs, JWT/bearer credentials, PEM keys, private paths, private/loopback IPs) are the ones the bundled validator's privacy scan (§"Validation is two distinct layers") enforces at the value level, since JSON Schema structure cannot see them.
 
 ## Validation is two distinct layers (not four)
 

--- a/docs/contracts/rehearsal-evidence-export.md
+++ b/docs/contracts/rehearsal-evidence-export.md
@@ -94,9 +94,23 @@ The schema declares `additionalProperties: false` so unknown fields are rejected
 
 This list is also captured in the schema's `x-icn-must-not-include` extension so machine consumers (linters, partner CI) can read it without parsing this prose.
 
+## Validation is two distinct layers (not four)
+
+The bundled validator (`docs/scripts/validate-rehearsal-evidence.py`) enforces **two** of the four concerns; keep them distinct when reasoning about what a "valid" packet proves:
+
+- **(a) Structural** — draft-2020-12 JSON Schema: shape, required fields, enums, `additionalProperties:false`. Structure alone cannot see a leaked identifier hidden inside an otherwise-valid free-text field.
+- **(b) Privacy / redaction** — a deterministic value scan (added for [#2422](https://github.com/InterCooperative-Network/icn/issues/2422)) for the identifier classes §"What this schema MUST NOT carry" forbids but that structure cannot catch: `did:icn:` DIDs, JWT/bearer-shaped credentials, PEM private keys, private filesystem paths, and private-network / loopback IPs (topology). This asserts the packet's *content* is repo-safe; it does **not** prove redaction is complete. Diagnostics name the field and class only — never the offending value.
+
+Not performed by this validator, and not implied by a passing result:
+
+- **(c) Cryptographic verification** (digest / signature / `packet_hash`) — a separate concern.
+- **(d) Institutional truth** (approval, pilot status, authority) — a valid, repo-safe packet still grants zero authority.
+
+A passing validation means *structurally valid AND free of the scanned identifier classes* — nothing more.
+
 ## Validation guidance for package repos
 
-1. Validate every example or evidence packet that will live in a **public repository** against `rehearsal-evidence-export.schema.json` before committing. Use the bundled validator (`docs/scripts/validate-rehearsal-evidence.py`) or any draft-2020-12 JSON Schema validator. Pin to the URN.
+1. Validate every example or evidence packet that will live in a **public repository** against `rehearsal-evidence-export.schema.json` **and** the privacy scan before committing. Use the bundled validator (`docs/scripts/validate-rehearsal-evidence.py`, which runs both layers) — a bare draft-2020-12 JSON Schema validator only covers layer (a). Pin to the URN. Adversarial coverage lives at `docs/scripts/tests/test_rehearsal_evidence_leak_scan.py` (offline, CI-run).
 2. Do **not** add partner-specific nouns to this schema. Bind local meaning in package docs.
 3. **Partner-internal overlays do not validate against this schema and must not be committed.** This schema is for the repo-safe export path only.
 4. Prefer regulatory-safe vocabulary in human-language fields: **obligation**, **allocation**, **settlement**, **unit**, **position**, **receipt**, **provenance**, **evidence** — not payment / wallet / balance / currency framing for substrate flows.

--- a/docs/contracts/rehearsal-evidence-export.schema.json
+++ b/docs/contracts/rehearsal-evidence-export.schema.json
@@ -28,8 +28,12 @@
     "accommodation or access needs tied to an identifiable person",
     "raw attendee or member rolls",
     "API tokens, secrets, signed URLs, or session credentials",
+    "JWT / bearer-shaped credentials (e.g. eyJ… tokens)",
+    "PEM private keys",
     "private Drive / Groups / Sheets paths or content",
+    "private filesystem paths (e.g. /home, /root, /Users, Windows user profiles)",
     "private overlay contents",
+    "private-network or loopback IP addresses / internal topology",
     "live partner operational details",
     "any field that implies formal pilot approval or production deployment",
     "DIDs of unconsented participants"

--- a/docs/scripts/tests/test_rehearsal_evidence_leak_scan.py
+++ b/docs/scripts/tests/test_rehearsal_evidence_leak_scan.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Adversarial tests for the rehearsal evidence packet privacy leak scan
+(docs/scripts/validate-rehearsal-evidence.py, issue #2422).
+
+These are standalone assertions — no pytest dependency — so CI can run them
+with a bare `python3 docs/scripts/tests/test_rehearsal_evidence_leak_scan.py`
+alongside the other docs-freshness validators. Exit 0 = all pass, 1 = a
+failure.
+
+They exercise the distinction the fix rests on:
+  * STRUCTURALLY VALID BUT PRIVACY-INVALID packets must be rejected by the
+    privacy scan even though the JSON Schema accepts them — this is the whole
+    point of #2422.
+  * a valid, redacted packet must still pass.
+  * legitimate public identifiers (contract URNs, opaque public row ids,
+    public issue URLs) must NOT be flagged.
+"""
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VALIDATOR = REPO_ROOT / "docs" / "scripts" / "validate-rehearsal-evidence.py"
+SCHEMA = REPO_ROOT / "docs" / "contracts" / "rehearsal-evidence-export.schema.json"
+EXAMPLE = REPO_ROOT / "docs" / "contracts" / "rehearsal-evidence-export.example.json"
+
+# Import the validator module (hyphenated filename → importlib).
+_spec = importlib.util.spec_from_file_location("rev", VALIDATOR)
+rev = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rev)
+
+_failures = []
+
+
+def check(name, cond):
+    status = "ok  " if cond else "FAIL"
+    print(f"[{status}] {name}")
+    if not cond:
+        _failures.append(name)
+
+
+def leaks(packet):
+    """(count, categories) from the importable scan."""
+    f = rev.privacy_leak_findings(packet)
+    return len(f), sorted({c for _, c in f})
+
+
+def run_cli(packet_dict, extra=None):
+    """Run the validator end-to-end on a temp packet; return exit code."""
+    import tempfile
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump(packet_dict, fh)
+        p = fh.name
+    cmd = [sys.executable, str(VALIDATOR), p, "--schema", str(SCHEMA)]
+    if extra:
+        cmd += extra
+    rc = subprocess.run(cmd, capture_output=True, text=True)
+    Path(p).unlink(missing_ok=True)
+    return rc.returncode, (rc.stdout + rc.stderr)
+
+
+def main():
+    base = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+
+    # -- Baseline: the bundled redacted example is clean end-to-end. --------
+    n, _ = leaks(base)
+    check("valid redacted example: privacy scan finds nothing", n == 0)
+    rc, _ = run_cli(base)
+    check("valid redacted example: CLI exit 0", rc == 0)
+
+    # -- Injected private DID (the reported #2422 case) --------------------
+    p = copy.deepcopy(base)
+    p["privacy_review"]["notes"] = "leaked did:icn:zTAMPERzzzzzzzzzzzzzzzzzzzzzzzzzz here"
+    n, cats = leaks(p)
+    check("injected DID in privacy_review.notes: flagged", n >= 1 and "did:icn identifier" in cats)
+    rc, out = run_cli(p)
+    check("injected DID: CLI exit 1 with [privacy] tag", rc == 1 and "[privacy]" in out)
+    check("injected DID: value not echoed in diagnostics", "zTAMPER" not in out)
+
+    # -- Injected JWT / bearer credential ----------------------------------
+    p = copy.deepcopy(base)
+    p["decision_outcomes"][0]["plain_summary"] = (
+        "token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.sig embedded"  # sanitize-ok: fabricated JWT-shape test fixture (decodes to {"alg":"HS256"}.{"sub":"a"})
+    )
+    n, cats = leaks(p)
+    check("injected JWT in plain_summary: flagged", "JWT / bearer-shaped credential" in cats)
+
+    # -- Injected private / loopback IP (topology) -------------------------
+    # Use a generic RFC1918 address (10.0.0.0/8), NOT any real homelab address,
+    # so the fixture exercises the scanner without recording live topology.
+    p = copy.deepcopy(base)
+    p["source_material"][0]["summary"] = "served from 10.0.0.5 internal host"
+    n, cats = leaks(p)
+    check("injected private IP: flagged", "private / loopback IP (topology)" in cats)
+    # public / version-like dotted numbers must NOT trip the IP rule
+    p2 = copy.deepcopy(base)
+    p2["source_material"][0]["summary"] = "schema draft 2020.12.1.0 revision"
+    _, cats2 = leaks(p2)
+    check("version-like dotted number: NOT flagged as IP",
+          "private / loopback IP (topology)" not in cats2)
+
+    # -- Injected private filesystem path ----------------------------------
+    p = copy.deepcopy(base)
+    p["warnings"] = ["/home/ubuntu/icn-dev/private/secret.json referenced"]
+    n, cats = leaks(p)
+    check("injected private path in warnings: flagged", "private filesystem path" in cats)
+
+    # -- PEM private key ---------------------------------------------------
+    p = copy.deepcopy(base)
+    p["rehearsal_label"] = "-----BEGIN EC PRIVATE KEY----- ..."  # sanitize-ok: bare PEM header string, no key material — leak-scan test fixture
+    n, cats = leaks(p)
+    check("injected PEM private key: flagged", "PEM private key" in cats)
+
+    # -- Nested / array-contained leakage ----------------------------------
+    p = copy.deepcopy(base)
+    p["follow_ups"] = [{
+        "title": "ok",
+        "url": "https://github.com/InterCooperative-Network/icn/issues/2422",
+        "notes": "assignee did:icn:zNESTEDzzzzzzzzzzzzzzzzzzzzzzzzz",
+    }]
+    n, cats = leaks(p)
+    check("DID nested in follow_ups[].notes: flagged", "did:icn identifier" in cats)
+    # the legitimate public github URL in the same object must NOT be flagged
+    check("public github URL alongside: only one finding (the DID)", n == 1)
+
+    # -- privacy_review flags themselves declare a leak --------------------
+    p = copy.deepcopy(base)
+    p["privacy_review"]["dids_exported"] = True
+    _, cats = leaks(p)
+    check("privacy_review.dids_exported=true: flagged",
+          any("dids_exported" in c for c in cats))
+
+    # -- Legitimate public identifiers are NOT rejected --------------------
+    p = copy.deepcopy(base)
+    p["proof_loop_references"][0]["public_id_or_category"] = "pending-row-action-item-001"
+    p["source_material"][0]["summary"] = "contract urn:icn:contract:rehearsal-evidence-export:v1"
+    n, _ = leaks(p)
+    check("public row id + contract URN: NOT flagged", n == 0)
+
+    # -- Layer separation: --skip-privacy-scan still passes structurally,
+    #    but a DID-injected packet passes structurally and fails on privacy. -
+    p = copy.deepcopy(base)
+    p["privacy_review"]["notes"] = "did:icn:zLAYERzzzzzzzzzzzzzzzzzzzzzzzzzz"
+    rc_struct, out_struct = run_cli(p, extra=["--skip-privacy-scan"])
+    check("DID packet is STRUCTURALLY valid (schema can't see it)", rc_struct == 0)
+    rc_priv, _ = run_cli(p)
+    check("same DID packet FAILS with privacy scan on", rc_priv == 1)
+
+    print()
+    if _failures:
+        print(f"FAILED: {len(_failures)} case(s): {_failures}", file=sys.stderr)
+        return 1
+    print("ALL PRIVACY-SCAN TESTS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/scripts/validate-rehearsal-evidence.py
+++ b/docs/scripts/validate-rehearsal-evidence.py
@@ -1,12 +1,35 @@
 #!/usr/bin/env python3
 """
 Validate a rehearsal evidence export packet against the substrate-level
-JSON Schema at docs/contracts/rehearsal-evidence-export.schema.json.
+JSON Schema at docs/contracts/rehearsal-evidence-export.schema.json, and
+then scan its string values for identifiers the value-withheld contract
+forbids (DIDs, credentials, private paths, private-network addresses).
 
 The schema is identified by a non-DNS URN ($id =
 urn:icn:contract:rehearsal-evidence-export:v1). The repo-relative path
 is a distribution hint, not authority. See
 docs/contracts/rehearsal-evidence-export.md for the rationale.
+
+TWO DISTINCT VALIDATION LAYERS (this tool covers a and b; NOT c or d):
+  (a) STRUCTURAL  — JSON Schema: shape, required fields, enums,
+      additionalProperties:false. Structure alone cannot catch a leaked
+      identifier hidden inside an otherwise-valid free-text field, which is
+      exactly why layer (b) exists (issue #2422).
+  (b) PRIVACY / REDACTION — a deterministic value scan for the identifier
+      classes the schema's `x-icn-must-not-include` forbids but that
+      structure cannot see: `did:icn:` DIDs, JWT/bearer-shaped credentials,
+      PEM private keys, private filesystem paths, and private-network /
+      loopback IPs (topology). This asserts repo-safety of the packet's
+      *content*; it does not prove completeness of redaction.
+  (c) CRYPTOGRAPHIC verification (digest / signature / `packet_hash`) is a
+      SEPARATE concern and is NOT performed here.
+  (d) INSTITUTIONAL TRUTH (approval, pilot status, authority) is NOT
+      asserted by validation — a valid, repo-safe packet still grants zero
+      authority.
+
+A passing result means: structurally valid AND free of the scanned
+identifier classes. It does NOT mean cryptographically verified, redaction-
+complete, approved, or authoritative.
 
 Usage:
     python3 docs/scripts/validate-rehearsal-evidence.py
@@ -19,21 +42,114 @@ Usage:
         # Validates against an alternate schema (rarely needed; intended
         # for partner repositories that pin a different version URN).
 
+    python3 docs/scripts/validate-rehearsal-evidence.py --skip-privacy-scan packet.json
+        # Structural (schema) validation only. Use only to isolate a schema
+        # failure; the privacy scan is on by default and CI must keep it on.
+
 Exit codes:
-    0: packet validates
-    1: packet fails validation (or input file is missing/invalid)
+    0: packet validates (structural + privacy)
+    1: packet fails validation, or input file is missing/invalid
 
 Requires: Python 3.11+ and the `jsonschema` library.
 """
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SCHEMA = REPO_ROOT / "docs" / "contracts" / "rehearsal-evidence-export.schema.json"
 DEFAULT_PACKET = REPO_ROOT / "docs" / "contracts" / "rehearsal-evidence-export.example.json"
+
+# ---------------------------------------------------------------------------
+# Privacy / redaction scan (layer b).
+#
+# These patterns target ONLY identifier classes that are never legitimate in a
+# value-withheld evidence packet (schema `x-icn-must-not-include`). They do NOT
+# match — and must not reject — public identifiers that ARE legitimate:
+#   * urn:icn:contract:... contract URNs (the packet's own identity),
+#   * opaque public row ids like "pending-row-action-item-001",
+#   * public issue/PR URLs, closed-taxonomy enum values.
+# The `did:icn:` pattern is the load-bearing one for #2422; it mirrors the
+# in-VM icn-demo-verify.sh leak scan so both layers agree.
+# ---------------------------------------------------------------------------
+_DID_RE = re.compile(r"did:icn:[A-Za-z0-9]+")
+# JWT / bearer-shaped: base64url header.payload (two dot-separated segments).
+_JWT_RE = re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}")
+_PEM_RE = re.compile(r"-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----")
+# Private filesystem paths (POSIX home/root, Windows user profile).
+_PRIV_PATH_RE = re.compile(r"(?:/home/|/root/|/Users/|[A-Za-z]:\\Users\\)", re.IGNORECASE)
+# Dotted-quad candidate; range-checked in _is_private_ip so we only flag
+# private / loopback / link-local addresses (topology), never version strings.
+_IPV4_RE = re.compile(r"\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b")
+
+
+def _is_private_ip(a: int, b: int, c: int, d: int) -> bool:
+    if not all(0 <= x <= 255 for x in (a, b, c, d)):
+        return False  # not a valid dotted-quad — treat as ordinary text
+    if a == 10:
+        return True
+    if a == 127:
+        return True
+    if a == 192 and b == 168:
+        return True
+    if a == 172 and 16 <= b <= 31:
+        return True
+    if a == 169 and b == 254:  # link-local
+        return True
+    return False
+
+
+def _string_findings(value: str, path: str) -> list:
+    """Return (path, category) findings for a single string. Diagnostics never
+    echo the offending value — only its JSON path and category — so the tool's
+    own output can never become a leak vector."""
+    out = []
+    if _DID_RE.search(value):
+        out.append((path, "did:icn identifier"))
+    if _JWT_RE.search(value):
+        out.append((path, "JWT / bearer-shaped credential"))
+    if _PEM_RE.search(value):
+        out.append((path, "PEM private key"))
+    if _PRIV_PATH_RE.search(value):
+        out.append((path, "private filesystem path"))
+    for m in _IPV4_RE.finditer(value):
+        if _is_private_ip(*(int(g) for g in m.groups())):
+            out.append((path, "private / loopback IP (topology)"))
+            break
+    return out
+
+
+def privacy_leak_findings(packet) -> list:
+    """Walk every string value in the packet and return a list of
+    (json_path, category) findings for forbidden identifier classes. Empty
+    list == privacy-clean. Also honors the packet's own privacy_review flags:
+    a truthy dids_exported / credentials_exported is itself a declared leak."""
+    findings = []
+
+    def walk(node, path):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                walk(v, f"{path}.{k}" if path else str(k))
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                walk(v, f"{path}[{i}]")
+        elif isinstance(node, str):
+            findings.extend(_string_findings(node, path or "<root>"))
+
+    walk(packet, "")
+
+    if isinstance(packet, dict):
+        pr = packet.get("privacy_review")
+        if isinstance(pr, dict):
+            if pr.get("dids_exported"):
+                findings.append(("privacy_review.dids_exported", "packet declares dids_exported=true"))
+            if pr.get("credentials_exported"):
+                findings.append(("privacy_review.credentials_exported", "packet declares credentials_exported=true"))
+
+    return findings
 
 
 def load_json(path: Path, label: str) -> dict:
@@ -52,6 +168,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("packet", nargs="?", type=Path, default=DEFAULT_PACKET, help="Packet JSON file to validate (defaults to the bundled example).")
     parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA, help="Schema JSON file to validate against (defaults to the bundled schema).")
+    parser.add_argument("--skip-privacy-scan", action="store_true", help="Run structural (schema) validation only. CI must NOT set this.")
     args = parser.parse_args()
 
     try:
@@ -63,20 +180,36 @@ def main() -> int:
     schema = load_json(args.schema, "schema")
     Draft202012Validator.check_schema(schema)
     validator = Draft202012Validator(schema)
-
     packet = load_json(args.packet, "packet")
+
+    rel = args.packet.relative_to(REPO_ROOT) if args.packet.is_relative_to(REPO_ROOT) else args.packet
+    contract = schema.get("$id", "<unknown>")
+
+    # Layer (a): structural / schema.
     errors = sorted(validator.iter_errors(packet), key=lambda e: list(e.path))
+    if errors:
+        print(f"FAIL [structural]: {rel} did not validate against {contract}", file=sys.stderr)
+        for err in errors:
+            loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+            print(f"  at {loc}: {err.message}", file=sys.stderr)
+        return 1
 
-    if not errors:
-        contract = schema.get("$id", "<unknown>")
-        print(f"OK: {args.packet.relative_to(REPO_ROOT) if args.packet.is_relative_to(REPO_ROOT) else args.packet} validates against {contract}")
-        return 0
-
-    print(f"FAIL: {args.packet} did not validate against {schema.get('$id', '<unknown>')}", file=sys.stderr)
-    for err in errors:
-        loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
-        print(f"  at {loc}: {err.message}", file=sys.stderr)
-    return 1
+    # Layer (b): privacy / redaction value scan (unless explicitly skipped).
+    if not args.skip_privacy_scan:
+        leaks = privacy_leak_findings(packet)
+        if leaks:
+            print(f"FAIL [privacy]: {rel} is structurally valid but leaks forbidden identifiers "
+                  f"(value-withheld contract {contract}):", file=sys.stderr)
+            for loc, category in leaks:
+                print(f"  at {loc}: {category}", file=sys.stderr)
+            print("  (diagnostics name the field and class only; the offending value is never echoed)", file=sys.stderr)
+            return 1
+        print(f"OK: {rel} validates against {contract} — structural + privacy scan pass "
+              f"(NOT cryptographic verification, redaction-completeness, approval, or authority).")
+    else:
+        print(f"OK [structural only]: {rel} validates against {contract} "
+              f"(privacy scan SKIPPED — do not use for a repo-safety decision).")
+    return 0
 
 
 if __name__ == "__main__":

--- a/docs/scripts/validate-rehearsal-evidence.py
+++ b/docs/scripts/validate-rehearsal-evidence.py
@@ -172,14 +172,17 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        from jsonschema import Draft202012Validator
+        from jsonschema import Draft202012Validator, FormatChecker
     except ImportError:
         print("ERROR: the `jsonschema` Python package is required (pip install jsonschema).", file=sys.stderr)
         return 1
 
     schema = load_json(args.schema, "schema")
     Draft202012Validator.check_schema(schema)
-    validator = Draft202012Validator(schema)
+    # Register a format checker so `format: date-time` / `format: uri`
+    # annotations are actually enforced (stdlib-only checks), matching the
+    # sibling contract validators (validate-preview-review.py / -action-card.py).
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
     packet = load_json(args.packet, "packet")
 
     rel = args.packet.relative_to(REPO_ROOT) if args.packet.is_relative_to(REPO_ROOT) else args.packet


### PR DESCRIPTION
## What

Closes the #2422 gap: `docs/scripts/validate-rehearsal-evidence.py` did **structural** (JSON Schema) validation only, so a packet whose free-text fields carried a real `did:icn:` / JWT / private path passed as long as its *shape* was valid. (Schema tampering was already caught; identifier leakage was not.)

Adds a second, **contract-driven** validation layer — a deterministic value scan over every string in the packet for the identifier classes the schema's `x-icn-must-not-include` forbids but structure cannot see:
- `did:icn:` DIDs (never legitimate in a value-withheld export)
- JWT / bearer-shaped credentials
- PEM private keys
- private filesystem paths (`/home`, `/root`, `/Users`, Windows profiles)
- private / loopback / link-local IPs (topology)
- plus the packet's own `privacy_review.dids_exported` / `credentials_exported` flags

## Why it's contract-driven, not a fragile blacklist

The scan enforces the schema's declared `x-icn-must-not-include` classes, not the single observed string. Legitimate **public** identifiers are explicitly **not** rejected — `urn:icn:contract:` URNs, opaque public row ids (`pending-row-action-item-001`), public issue/PR URLs, enum values. The IP rule range-checks a full dotted-quad so version-like numbers (`2020.12.1.0`) aren't flagged.

## Layer honesty (kept explicit)

The tool covers **(a) structural** and **(b) privacy/redaction**. It does **not** perform **(c) cryptographic** verification (digest/signature/`packet_hash`) or assert **(d) institutional truth** (approval/pilot/authority). A pass means *structurally valid AND free of the scanned identifier classes* — nothing more. The validator's output, its docstring, and `docs/contracts/rehearsal-evidence-export.md` all state this. Diagnostics name the field + class only — the offending value is never echoed (the tool cannot itself become a leak vector).

## Adversarial tests

New standalone suite `docs/scripts/tests/test_rehearsal_evidence_leak_scan.py` (16 cases), wired into the `docs-freshness` CI job:
- injected private DID (the reported case), JWT, PEM private key, private path, private IP
- nested / array-contained leakage (`follow_ups[].notes`)
- schema-valid-but-privacy-invalid must fail; `--skip-privacy-scan` shows it passes structurally then fails with the scan on (layer separation)
- false-positive guards: public github URL alongside a DID yields one finding; a contract URN + public row id yields none; a version-like dotted number isn't flagged as an IP
- `privacy_review.dids_exported=true` is itself flagged

Test fixtures use fabricated/generic values (a synthetic JWT that decodes to `{"alg":"HS256"}`, a generic RFC1918 `10.0.0.5`, a bare PEM header) — no real credentials or homelab addresses.

## Risk

Validator-tooling only; no runtime/gateway change. The committed example packet, the generated `pending-publish-evidence-export.json` fixture, the generator `--check`, and the shell-fixtures validator (which shells out to this validator) all still pass. `--skip-privacy-scan` exists to isolate a schema failure but CI keeps the scan on.

## Test plan

- `python3 docs/scripts/validate-rehearsal-evidence.py` (example) → OK; adversarial suite → 16/16 pass.
- generator `--check`, `validate-rehearsal-shell-fixtures.py` → pass.
- doc-control, compliance, readiness-overclaim → green; workflow YAML parses.

## Note (follow-up, not in this PR)

The in-VM `icn-demo-verify.sh` has a sibling inline `did:icn:`/JWT scan over the **runtime** `rehearsal-workflow-evidence:v1` export (a different contract/URN). Unifying both scans on one shared implementation is a reasonable later cleanup; kept out to keep this PR narrow.

**Standing rule: do not merge without Matt's explicit authorization.**

Refs #2422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
