### PR TITLE
feat(appliance): repository-owned reproducible evaluator package lane

### DIFF
--- a/.github/workflows/evaluator-package.yml
+++ b/.github/workflows/evaluator-package.yml
@@ -1,0 +1,76 @@
+name: Evaluator Package (static)
+
+# Fast, KVM-free static validation of the portable evaluator package lane.
+# This does NOT boot the appliance or assemble the ~1GB image — it validates the
+# repo-owned templates, scripts, spec, generator, and the static validator itself
+# (layout, syntax, ShellCheck, manifest metadata, privacy/forbidden scan,
+# loopback-default binds, archive safety). Assembled-image RUNTIME proof is a
+# separate, KVM-capable concern and is deliberately not claimed here.
+
+on:
+  push:
+    paths:
+      - 'deploy/appliance/evaluator/**'
+      - '.github/workflows/evaluator-package.yml'
+  pull_request:
+    paths:
+      - 'deploy/appliance/evaluator/**'
+      - '.github/workflows/evaluator-package.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Syntax check (bash -n)
+        run: |
+          for s in $(find deploy/appliance/evaluator -type f -name '*.sh'); do
+            bash -n "$s"
+          done
+
+      - name: ShellCheck
+        run: |
+          shellcheck -S warning \
+            deploy/appliance/evaluator/build-evaluator-package.sh \
+            deploy/appliance/evaluator/validate-evaluator-package.sh \
+            deploy/appliance/evaluator/tests/test-evaluator-package.sh \
+            deploy/appliance/evaluator/templates/setup-and-run.sh \
+            deploy/appliance/evaluator/templates/start-icn-demo-vm.sh \
+            deploy/appliance/evaluator/templates/scripts/*.sh
+
+      - name: Validator unit tests (synthetic packages, no image)
+        run: deploy/appliance/evaluator/tests/test-evaluator-package.sh
+
+      - name: Validate template set (no-image, template-derived package)
+        run: |
+          # Assemble a template-only package (no qcow2) and run the full static
+          # validator in --no-image mode, so template/privacy/bind regressions are
+          # caught even without building an image.
+          set -euo pipefail
+          . deploy/appliance/evaluator/package-spec.env
+          PKG_NAME="${PKG_STEM}-${PKG_VERSION}-${PKG_ARCH}"
+          ROOT="$RUNNER_TEMP/$PKG_NAME"; mkdir -p "$ROOT/scripts" "$ROOT/docs"
+          commit=0123456789abcdef0123456789abcdef01234567
+          ish=$(printf 'ci-template-check' | sha256sum | awk '{print $1}')
+          subst() { sed -e "s/@IMAGE_BASENAME@/$IMAGE_BASENAME/g" -e "s/@MANIFEST_BASENAME@/$MANIFEST_BASENAME/g" \
+              -e "s/@PKG_NAME@/$PKG_NAME/g" -e "s/@IMAGE_VERSION@/${PKG_VERSION}-demo/g" \
+              -e "s/@SOURCE_COMMIT@/$commit/g" -e "s/@IMAGE_SHA256@/$ish/g"; }
+          T=deploy/appliance/evaluator/templates
+          for f in README.md setup-and-run.sh start-icn-demo-vm.sh scripts/run-demo.sh scripts/verify.sh \
+                   docs/START-HERE.md docs/RUNBOOK.md docs/WALKTHROUGH.md; do subst < "$T/$f" > "$ROOT/$f"; done
+          chmod 0755 "$ROOT"/setup-and-run.sh "$ROOT"/start-icn-demo-vm.sh "$ROOT"/scripts/*.sh
+          cat > "$ROOT/$MANIFEST_BASENAME" <<EOF
+          { "manifest_version":1, "version":"${PKG_VERSION}-demo", "arch":"$PKG_ARCH",
+            "image_sha256":"$ish", "git_commit":"$commit",
+            "image_path":"$IMAGE_BASENAME", "base_image_path":"base.qcow2",
+            "non_production":true, "signed":false, "demo_profile":true }
+          EOF
+          ( cd "$ROOT" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+          deploy/appliance/evaluator/validate-evaluator-package.sh "$ROOT" --no-image

--- a/deploy/appliance/evaluator/README.md
+++ b/deploy/appliance/evaluator/README.md
@@ -52,10 +52,13 @@ assert provenance against a specific commit (defaults to the manifest's
   `@IMAGE_VERSION@`, `@SOURCE_COMMIT@`, `@IMAGE_SHA256@`) are stamped at generation
   from the actual manifest, so the RUNBOOK's recorded commit/sha are always the
   real ones for the packaged image.
-- **Non-deterministic surface**, documented: the qcow2 bytes (built upstream), the
-  manifest `build_timestamp_utc`, and optional PDFs (generated only when `pandoc`
-  is present — the Markdown doc set is always shipped; PDFs are best-effort).
-  Everything else is a pure function of (templates, spec, image, manifest).
+- **Determinism**: given identical declared inputs (templates, spec, image,
+  manifest), the ZIP is byte-reproducible — entry order is sorted and every
+  entry's mtime is pinned to the manifest `build_timestamp_utc` (fixed-epoch
+  fallback) under `TZ=UTC` with `zip -X`. The only inputs outside that function
+  are the qcow2 bytes (built upstream) and the optional PDFs (generated only when
+  `pandoc` is present; the Markdown doc set always ships, PDFs are best-effort and
+  therefore the one non-reproducible surface if pandoc availability differs).
 
 ## Fail-closed guarantees
 

--- a/deploy/appliance/evaluator/README.md
+++ b/deploy/appliance/evaluator/README.md
@@ -1,0 +1,87 @@
+# Portable evaluator package lane
+
+Repository-owned, reproducible generation of the **portable bootable vertical
+slice** — the downloadable evaluator package an external reviewer runs locally on
+their own Debian/Ubuntu machine to see the current browser-operable
+standing → action card → completion → receipt path.
+
+This lane turns the package from an ad-hoc pile of locally assembled files into a
+declared-input, fail-closed, validated artifact.
+
+## What this is (and is NOT)
+
+- A **portable evaluator** artifact: localhost-only exposure, disposable VM
+  overlay, one-command setup. Unsigned, `non_production`, `demo_profile`.
+- **NOT** the LAN Rehearsal Node (that is the operator-controlled internal
+  single-TLS-origin deployment — a different profile, threat model, and audience;
+  see `deploy/appliance/lan/`). The two profiles are deliberately not collapsed.
+- **NOT** production, pilot, organizer-approved, accessibility-complete, or
+  federated. It demonstrates a bounded slice of what exists today.
+
+## Two-step separation of concerns
+
+1. **Build the image** — `deploy/appliance/build-image.sh` with the demo profile
+   (`ICN_APPLIANCE_DEMO_PROFILE=1`, and NOT `ICN_APPLIANCE_LAN_PROFILE`). It emits
+   the qcow2 + a typed manifest (`icnctl appliance emit-manifest`).
+2. **Assemble the package** — `build-evaluator-package.sh` takes that image +
+   manifest as declared inputs and produces the distributable ZIP. It never builds
+   an image and never bakes a host path into the output.
+
+## Generate
+
+```bash
+deploy/appliance/evaluator/build-evaluator-package.sh \
+  --image   /path/to/icn-appliance-<ver>-demo-amd64.qcow2 \
+  --manifest /path/to/icn-appliance-<ver>-demo-amd64.manifest.json \
+  --out     /path/to/output-dir
+# → output-dir/icn-common-sense-vertical-slice-<ver>-amd64/           (staging tree)
+# → output-dir/icn-common-sense-vertical-slice-<ver>-amd64.zip        (distributable)
+# → output-dir/icn-common-sense-vertical-slice-<ver>-amd64.zip.sha256 (outer checksum)
+```
+
+Add `--no-zip` to stop at the validated staging tree, or `--source-commit SHA` to
+assert provenance against a specific commit (defaults to the manifest's
+`git_commit`).
+
+## Reproducibility contract
+
+- **Identity** is declared once in `package-spec.env` (name, version, arch,
+  profile, image/manifest basenames, required layout, executable set).
+- **Templates** in `templates/` are the repo-owned source for every script and
+  doc. Placeholders (`@PKG_NAME@`, `@IMAGE_BASENAME@`, `@MANIFEST_BASENAME@`,
+  `@IMAGE_VERSION@`, `@SOURCE_COMMIT@`, `@IMAGE_SHA256@`) are stamped at generation
+  from the actual manifest, so the RUNBOOK's recorded commit/sha are always the
+  real ones for the packaged image.
+- **Non-deterministic surface**, documented: the qcow2 bytes (built upstream), the
+  manifest `build_timestamp_utc`, and optional PDFs (generated only when `pandoc`
+  is present — the Markdown doc set is always shipped; PDFs are best-effort).
+  Everything else is a pure function of (templates, spec, image, manifest).
+
+## Fail-closed guarantees
+
+The generator aborts (non-zero) if: the image is missing; the manifest is not
+JSON; `image_sha256 != sha256(image)`; `git_commit != source commit`; the honest-
+posture flags are wrong (`non_production!=true`, `signed!=false`,
+`demo_profile!=true`); version/arch disagree with the spec; a required doc/script
+is absent; a script fails `bash -n`; or the assembled package fails the static
+validator below.
+
+## Static validation (KVM-free)
+
+`validate-evaluator-package.sh <pkg-root> [--no-image] [--expect-commit SHA]`
+checks layout, exec bits, `bash -n` + ShellCheck, `SHA256SUMS`, manifest metadata
+(honest posture, basename-only paths, sha cross-check, commit), a privacy/forbidden
+scan (no host paths, RFC1918 IPs, internal hostnames, tunnel URLs, JWT/PEM/bearer,
+DID literals in scripts, personal names, overclaims), archive safety (no symlinks),
+launcher loopback-default binds, and non-claim wording.
+
+`--no-image` mode runs every non-image check without the ~1GB qcow2, so CI catches
+packaging/script/checksum/manifest/privacy/bind regressions on an ordinary runner.
+`tests/test-evaluator-package.sh` exercises the validator against synthetic clean +
+defective packages.
+
+## What is NOT here
+
+- The qcow2 and the release ZIP are never committed to Git (large, non-source).
+- This lane does not publish a GitHub release. Publishing is a separate,
+  explicitly-authorized manual step after the validator is green.

--- a/deploy/appliance/evaluator/build-evaluator-package.sh
+++ b/deploy/appliance/evaluator/build-evaluator-package.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Reproducible generator for the portable bootable vertical-slice evaluator
+# package. Assembles a distributable ZIP from DECLARED inputs — a built appliance
+# image (a build-image.sh output, demo profile) + its typed manifest + the
+# repo-owned templates in ./templates — and fails closed on any inconsistency.
+#
+# This is the "package assembly + validation + zip" half of the lane. Image
+# BUILDING stays in build-image.sh; this script never builds an image, never
+# reaches into a developer home directory, and bakes no host path into the
+# output (the packaged manifest is rewritten to bare basenames).
+#
+# Usage:
+#   build-evaluator-package.sh --image PATH.qcow2 --manifest PATH.manifest.json \
+#       --out DIR [--source-commit SHA] [--allow-commit-mismatch] [--no-zip]
+#
+# Fails closed if: image missing; manifest not JSON; manifest.image_sha256 !=
+# sha256(image); manifest.git_commit != source commit; honest-posture flags wrong;
+# a required doc/script is absent; a script fails syntax; the assembled package
+# fails the static validator (privacy/bind/checksum/layout).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/package-spec.env"
+TEMPLATES="$SCRIPT_DIR/templates"
+
+IMAGE="" ; MANIFEST_IN="" ; OUTDIR="" ; SOURCE_COMMIT="" ; ALLOW_MISMATCH=0 ; DO_ZIP=1
+log() { printf '[evaluator-pkg] %s\n' "$*"; }
+err() { printf '[evaluator-pkg] ERROR: %s\n' "$*" >&2; }
+die() { err "$*"; exit 1; }
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --image) shift; IMAGE="${1:-}" ;;
+    --manifest) shift; MANIFEST_IN="${1:-}" ;;
+    --out) shift; OUTDIR="${1:-}" ;;
+    --source-commit) shift; SOURCE_COMMIT="${1:-}" ;;
+    --allow-commit-mismatch) ALLOW_MISMATCH=1 ;;
+    --no-zip) DO_ZIP=0 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown arg: $1" ;;
+  esac
+  shift
+done
+
+[ -n "$IMAGE" ] && [ -f "$IMAGE" ] || die "missing/unreadable --image"
+[ -n "$MANIFEST_IN" ] && [ -f "$MANIFEST_IN" ] || die "missing/unreadable --manifest"
+[ -n "$OUTDIR" ] || die "missing --out"
+for t in sha256sum python3 find sed; do command -v "$t" >/dev/null 2>&1 || die "missing tool: $t"; done
+
+PKG_NAME="${PKG_STEM}-${PKG_VERSION}-${PKG_ARCH}"
+log "package: $PKG_NAME (profile=$PKG_PROFILE)"
+
+# ---- read + validate the source manifest ----------------------------------
+log "hashing image (streaming)…"
+IMG_SHA="$(sha256sum "$IMAGE" | awk '{print $1}')"
+
+read -r M_SHA M_COMMIT M_VER M_ARCH M_NP M_SIGNED M_DEMO < <(python3 - "$MANIFEST_IN" <<'PY'
+import json,sys
+d=json.load(open(sys.argv[1]))
+def b(x): return "true" if x is True else "false"
+print(d.get("image_sha256",""), d.get("git_commit",""), d.get("version",""),
+      d.get("arch",""), b(d.get("non_production")), b(d.get("signed")), b(d.get("demo_profile")))
+PY
+)
+
+[ "$M_SHA" = "$IMG_SHA" ] || die "manifest image_sha256 ($M_SHA) != actual image sha ($IMG_SHA)"
+log "image sha matches manifest: OK"
+[ "$M_NP" = "$REQUIRE_NON_PRODUCTION" ] || die "manifest non_production=$M_NP (require $REQUIRE_NON_PRODUCTION)"
+[ "$M_SIGNED" = "$REQUIRE_SIGNED" ] || die "manifest signed=$M_SIGNED (require $REQUIRE_SIGNED)"
+[ "$M_DEMO" = "$REQUIRE_DEMO_PROFILE" ] || die "manifest demo_profile=$M_DEMO (require $REQUIRE_DEMO_PROFILE)"
+[ "${M_VER%%-*}" = "$PKG_VERSION" ] || die "manifest version $M_VER disagrees with spec version $PKG_VERSION"
+[ "$M_ARCH" = "$PKG_ARCH" ] || die "manifest arch $M_ARCH disagrees with spec arch $PKG_ARCH"
+log "honest-posture flags + version/arch: OK"
+
+if [ -z "$SOURCE_COMMIT" ]; then SOURCE_COMMIT="$M_COMMIT"; fi
+if [ "$M_COMMIT" != "$SOURCE_COMMIT" ]; then
+  if [ "$ALLOW_MISMATCH" -eq 1 ]; then
+    log "WARNING: manifest git_commit ($M_COMMIT) != requested source commit ($SOURCE_COMMIT) — allowed by flag"
+  else
+    die "manifest git_commit ($M_COMMIT) != requested source commit ($SOURCE_COMMIT) (use --allow-commit-mismatch to override)"
+  fi
+fi
+echo "$M_COMMIT" | grep -qE '^[0-9a-f]{40}$' || die "manifest git_commit is not a 40-hex sha"
+log "source commit: $M_COMMIT"
+
+# ---- assemble staging tree -------------------------------------------------
+STAGE="$OUTDIR/$PKG_NAME"
+rm -rf "$STAGE"
+mkdir -p "$STAGE/scripts" "$STAGE/docs"
+
+subst() { # substitute placeholders from stdin
+  sed -e "s/@IMAGE_BASENAME@/$IMAGE_BASENAME/g" \
+      -e "s/@MANIFEST_BASENAME@/$MANIFEST_BASENAME/g" \
+      -e "s/@PKG_NAME@/$PKG_NAME/g" \
+      -e "s/@IMAGE_VERSION@/$M_VER/g" \
+      -e "s/@SOURCE_COMMIT@/$M_COMMIT/g" \
+      -e "s/@IMAGE_SHA256@/$IMG_SHA/g"
+}
+
+copy_tmpl() { # $1 rel path under templates/ and stage/
+  [ -f "$TEMPLATES/$1" ] || die "template missing: $1"
+  subst < "$TEMPLATES/$1" > "$STAGE/$1"
+}
+copy_tmpl "README.md"
+copy_tmpl "setup-and-run.sh"
+copy_tmpl "start-icn-demo-vm.sh"
+copy_tmpl "scripts/run-demo.sh"
+copy_tmpl "scripts/verify.sh"
+copy_tmpl "docs/START-HERE.md"
+copy_tmpl "docs/RUNBOOK.md"
+copy_tmpl "docs/WALKTHROUGH.md"
+for ex in "${EXECUTABLE_FILES[@]}"; do chmod 0755 "$STAGE/$ex"; done
+
+# image + sanitized manifest (rewrite host paths to bare basenames)
+cp "$IMAGE" "$STAGE/$IMAGE_BASENAME"
+python3 - "$MANIFEST_IN" "$STAGE/$MANIFEST_BASENAME" "$IMAGE_BASENAME" <<'PY'
+import json,sys,os
+src,dst,image_base=sys.argv[1:4]
+d=json.load(open(src))
+# strip host-specific absolute paths → bare, portable basenames
+if "image_path" in d: d["image_path"]=image_base
+if "base_image_path" in d and d["base_image_path"]:
+    d["base_image_path"]=os.path.basename(str(d["base_image_path"]))
+json.dump(d, open(dst,"w"), indent=2, sort_keys=False)
+open(dst,"a").write("\n")
+PY
+log "assembled tree + sanitized manifest (paths → basenames)"
+
+# ---- optional PDFs (deterministic doc set = md always; pdf best-effort) -----
+PDF_TOOL=""
+if command -v pandoc >/dev/null 2>&1; then PDF_TOOL="pandoc"; fi
+if [ -n "$PDF_TOOL" ]; then
+  for md in "${DOC_MARKDOWN[@]}"; do
+    pdf="${md%.md}.pdf"
+    if pandoc "$STAGE/$md" -o "$STAGE/$pdf" >/dev/null 2>&1; then log "pdf: $pdf"; else log "pdf skipped (convert failed): $pdf"; fi
+  done
+else
+  log "no PDF converter (pandoc) — shipping Markdown only (matching PDFs omitted this build)"
+fi
+
+# ---- syntax gate before checksums -----------------------------------------
+while IFS= read -r -d '' s; do
+  bash -n "$s" || die "script failed syntax: ${s#"$STAGE"/}"
+done < <(find "$STAGE" -type f -name '*.sh' -print0)
+
+# ---- SHA256SUMS over the package (sorted, relative) ------------------------
+( cd "$STAGE" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+log "wrote SHA256SUMS ($(wc -l < "$STAGE/SHA256SUMS") entries)"
+
+# ---- static validation (fail closed) --------------------------------------
+log "running static validator…"
+"$SCRIPT_DIR/validate-evaluator-package.sh" "$STAGE" --expect-commit "$M_COMMIT" \
+  || die "assembled package failed static validation"
+
+# ---- zip + outer checksum --------------------------------------------------
+if [ "$DO_ZIP" -eq 1 ]; then
+  command -v zip >/dev/null 2>&1 || die "missing tool: zip"
+  ZIP="$OUTDIR/${PKG_NAME}.zip"
+  rm -f "$ZIP"
+  ( cd "$OUTDIR" && zip -q -r -X "${PKG_NAME}.zip" "$PKG_NAME" )
+  ( cd "$OUTDIR" && sha256sum "${PKG_NAME}.zip" > "${PKG_NAME}.zip.sha256" )
+  log "wrote $ZIP"
+  log "outer sha256: $(awk '{print $1}' "$OUTDIR/${PKG_NAME}.zip.sha256")"
+else
+  log "staging complete (--no-zip): $STAGE"
+fi
+log "DONE. Non-production, unsigned evaluator package."

--- a/deploy/appliance/evaluator/build-evaluator-package.sh
+++ b/deploy/appliance/evaluator/build-evaluator-package.sh
@@ -158,7 +158,21 @@ if [ "$DO_ZIP" -eq 1 ]; then
   command -v zip >/dev/null 2>&1 || die "missing tool: zip"
   ZIP="$OUTDIR/${PKG_NAME}.zip"
   rm -f "$ZIP"
-  ( cd "$OUTDIR" && zip -q -r -X "${PKG_NAME}.zip" "$PKG_NAME" )
+  # Deterministic archive: identical declared inputs → identical ZIP bytes. Pin
+  # every entry's mtime to the manifest build timestamp (fixed epoch fallback),
+  # feed a sorted entry list, use -X (drop uid/gid/extra fields) under TZ=UTC.
+  # (mtime touch is after SHA256SUMS — those hashes are content-only, unaffected.)
+  REF_EPOCH="$(python3 - "$STAGE/$MANIFEST_BASENAME" <<'PY'
+import json,sys,datetime
+try:
+    ts=json.load(open(sys.argv[1])).get("build_timestamp_utc","")
+    print(int(datetime.datetime.fromisoformat(ts.replace("Z","+00:00")).timestamp()))
+except Exception:
+    print(1577836800)  # 2020-01-01T00:00:00Z fixed fallback
+PY
+)"
+  find "$STAGE" -exec touch -h -d "@$REF_EPOCH" {} +
+  ( cd "$OUTDIR" && find "$PKG_NAME" -print | LC_ALL=C sort | TZ=UTC zip -q -X -@ "${PKG_NAME}.zip" >/dev/null )
   ( cd "$OUTDIR" && sha256sum "${PKG_NAME}.zip" > "${PKG_NAME}.zip.sha256" )
   log "wrote $ZIP"
   log "outer sha256: $(awk '{print $1}' "$OUTDIR/${PKG_NAME}.zip.sha256")"

--- a/deploy/appliance/evaluator/build-evaluator-package.sh
+++ b/deploy/appliance/evaluator/build-evaluator-package.sh
@@ -55,14 +55,20 @@ log "package: $PKG_NAME (profile=$PKG_PROFILE)"
 log "hashing image (streaming)…"
 IMG_SHA="$(sha256sum "$IMAGE" | awk '{print $1}')"
 
-read -r M_SHA M_COMMIT M_VER M_ARCH M_NP M_SIGNED M_DEMO < <(python3 - "$MANIFEST_IN" <<'PY'
+read -r M_SHA M_COMMIT M_VER M_ARCH M_NP M_SIGNED M_DEMO M_FMT < <(python3 - "$MANIFEST_IN" <<'PY'
 import json,sys
 d=json.load(open(sys.argv[1]))
 def b(x): return "true" if x is True else "false"
 print(d.get("image_sha256",""), d.get("git_commit",""), d.get("version",""),
-      d.get("arch",""), b(d.get("non_production")), b(d.get("signed")), b(d.get("demo_profile")))
+      d.get("arch",""), b(d.get("non_production")), b(d.get("signed")), b(d.get("demo_profile")),
+      d.get("image_format","") or "-")
 PY
 )
+
+# The lane packages a qcow2 (the launcher + IMAGE_BASENAME assume it). Reject any
+# other source format so a raw/other image is never shipped under a .qcow2 name.
+[ "$M_FMT" = "qcow2" ] || die "manifest image_format=$M_FMT (this lane only packages qcow2)"
+case "$IMAGE_BASENAME" in *.qcow2) ;; *) die "IMAGE_BASENAME $IMAGE_BASENAME is not a .qcow2 name" ;; esac
 
 [ "$M_SHA" = "$IMG_SHA" ] || die "manifest image_sha256 ($M_SHA) != actual image sha ($IMG_SHA)"
 log "image sha matches manifest: OK"

--- a/deploy/appliance/evaluator/build-evaluator-package.sh
+++ b/deploy/appliance/evaluator/build-evaluator-package.sh
@@ -90,6 +90,18 @@ fi
 echo "$M_COMMIT" | grep -qE '^[0-9a-f]{40}$' || die "manifest git_commit is not a 40-hex sha"
 log "source commit: $M_COMMIT"
 
+# Injection guard: every value interpolated into the sed substitution below MUST
+# be free of sed metacharacters, so a crafted manifest cannot inject a sed command
+# (e.g. GNU sed's `e`, which executes a shell command) to run code on the builder
+# host. The manifest version is only prefix-checked above, so validate the whole
+# string here; git_commit/image_sha are already hex-validated; the spec-derived
+# basenames are checked defensively too. Legit values are [0-9A-Za-z._-] only.
+echo "$M_VER"  | grep -qE '^[0-9A-Za-z._-]+$' || die "manifest version contains unsafe characters — refusing"
+echo "$IMG_SHA" | grep -qE '^[0-9a-f]{64}$'   || die "image sha256 is malformed"
+for _v in "$IMAGE_BASENAME" "$MANIFEST_BASENAME" "$PKG_NAME"; do
+  echo "$_v" | grep -qE '^[0-9A-Za-z._-]+$' || die "spec-derived value has unsafe characters: $_v"
+done
+
 # ---- assemble staging tree -------------------------------------------------
 STAGE="$OUTDIR/$PKG_NAME"
 rm -rf "$STAGE"

--- a/deploy/appliance/evaluator/build-evaluator-package.sh
+++ b/deploy/appliance/evaluator/build-evaluator-package.sh
@@ -158,10 +158,17 @@ if [ "$DO_ZIP" -eq 1 ]; then
   command -v zip >/dev/null 2>&1 || die "missing tool: zip"
   ZIP="$OUTDIR/${PKG_NAME}.zip"
   rm -f "$ZIP"
-  # Deterministic archive: identical declared inputs → identical ZIP bytes. Pin
-  # every entry's mtime to the manifest build timestamp (fixed epoch fallback),
-  # feed a sorted entry list, use -X (drop uid/gid/extra fields) under TZ=UTC.
-  # (mtime touch is after SHA256SUMS — those hashes are content-only, unaffected.)
+  # Deterministic archive: identical declared inputs → identical ZIP bytes.
+  # (1) Canonical modes independent of the caller umask (zip -X still records Unix
+  #     mode bits, so umask 022 vs 077 would otherwise diverge): dirs + executables
+  #     0755, every other file 0644.
+  find "$STAGE" -type d -exec chmod 0755 {} +
+  find "$STAGE" -type f -exec chmod 0644 {} +
+  for ex in "${EXECUTABLE_FILES[@]}"; do chmod 0755 "$STAGE/$ex"; done
+  # (2) Pin every entry's mtime to the manifest build timestamp (fixed epoch
+  #     fallback), feed a sorted entry list, use -X (drop uid/gid/extra fields)
+  #     under TZ=UTC. (mtime/mode changes are after SHA256SUMS — those hashes are
+  #     content-only, unaffected.)
   REF_EPOCH="$(python3 - "$STAGE/$MANIFEST_BASENAME" <<'PY'
 import json,sys,datetime
 try:

--- a/deploy/appliance/evaluator/package-spec.env
+++ b/deploy/appliance/evaluator/package-spec.env
@@ -13,7 +13,11 @@
 # Package identity (drives the package directory name and the outer zip name):
 #   <PKG_STEM>-<PKG_VERSION>-<PKG_ARCH>
 PKG_STEM="icn-common-sense-vertical-slice"
-PKG_VERSION="0.0.2"
+# 0.0.3 = the first package produced by this repository-owned lane from a
+# current-main image. The published 0.0.2 releases were assembled ad hoc from the
+# older 8c0fe926 image; a distinct version keeps the lane's artifact unambiguous
+# and non-conflicting with those tags.
+PKG_VERSION="0.0.3"
 PKG_ARCH="amd64"
 
 # Appliance profile this package ships (portable evaluator = demo profile, NO LAN

--- a/deploy/appliance/evaluator/package-spec.env
+++ b/deploy/appliance/evaluator/package-spec.env
@@ -1,0 +1,63 @@
+# Evaluator package spec — declared inputs for the portable bootable vertical slice.
+#
+# This is the single source of truth for the package IDENTITY and LAYOUT. The
+# generator (build-evaluator-package.sh) and the validator
+# (validate-evaluator-package.sh) both read it. Change values here, not in the
+# scripts.
+#
+# The IMAGE itself is NOT declared here as a path — it is passed to the generator
+# as --image (a build-image.sh output) so no developer home directory is ever
+# baked in. This file declares only what the package must be, not where the
+# build host keeps its files.
+
+# Package identity (drives the package directory name and the outer zip name):
+#   <PKG_STEM>-<PKG_VERSION>-<PKG_ARCH>
+PKG_STEM="icn-common-sense-vertical-slice"
+PKG_VERSION="0.0.2"
+PKG_ARCH="amd64"
+
+# Appliance profile this package ships (portable evaluator = demo profile, NO LAN
+# profile). Recorded for humans + asserted against the manifest's demo_profile flag.
+PKG_PROFILE="demo"
+
+# Expected in-package filenames for the image + its typed manifest. The launcher
+# template resolves the image by this basename; keep them in sync.
+IMAGE_BASENAME="icn-appliance-${PKG_VERSION}-${PKG_PROFILE}-${PKG_ARCH}.qcow2"
+MANIFEST_BASENAME="icn-appliance-${PKG_VERSION}-${PKG_PROFILE}-${PKG_ARCH}.manifest.json"
+
+# Files that MUST be present in a well-formed package (relative to the package root).
+# The validator fails closed if any are missing.
+REQUIRED_FILES=(
+  "README.md"
+  "SHA256SUMS"
+  "setup-and-run.sh"
+  "start-icn-demo-vm.sh"
+  "scripts/verify.sh"
+  "scripts/run-demo.sh"
+  "docs/START-HERE.md"
+  "docs/RUNBOOK.md"
+  "docs/WALKTHROUGH.md"
+  "${IMAGE_BASENAME}"
+  "${MANIFEST_BASENAME}"
+)
+
+# Executable files (must retain the exec bit through packaging + extraction).
+EXECUTABLE_FILES=(
+  "setup-and-run.sh"
+  "start-icn-demo-vm.sh"
+  "scripts/verify.sh"
+  "scripts/run-demo.sh"
+)
+
+# Markdown docs that get an optional matching PDF when a converter is available.
+DOC_MARKDOWN=(
+  "docs/START-HERE.md"
+  "docs/RUNBOOK.md"
+  "docs/WALKTHROUGH.md"
+)
+
+# Honest-posture assertions the manifest MUST satisfy (this is an unsigned,
+# non-production evaluator artifact — never represented otherwise).
+REQUIRE_NON_PRODUCTION="true"
+REQUIRE_SIGNED="false"
+REQUIRE_DEMO_PROFILE="true"

--- a/deploy/appliance/evaluator/templates/README.md
+++ b/deploy/appliance/evaluator/templates/README.md
@@ -1,0 +1,91 @@
+# ICN Common Sense Bootable Vertical Slice
+
+This zip is a self-contained bootable vertical slice of what exists today.
+
+It lets a reviewer boot a local ICN demo VM and see the current browser-facing
+member shell working against services inside that VM.
+
+## Start Here
+
+Open these first:
+
+- `docs/START-HERE.md`
+- `docs/START-HERE.pdf`
+
+Then run:
+
+```bash
+./setup-and-run.sh
+```
+
+On Debian/Ubuntu, that script installs missing host tools, verifies checksums,
+and starts the local VM.
+
+## What Is Included
+
+- `@IMAGE_BASENAME@` - bootable VM image.
+- `@MANIFEST_BASENAME@` - build and provenance manifest.
+- `start-icn-demo-vm.sh` - QEMU launcher.
+- `setup-and-run.sh` - one-command Debian/Ubuntu setup, verify, and run path.
+- `scripts/verify.sh` - verifies every packaged file.
+- `scripts/run-demo.sh` - starts the demo from the package root.
+- `docs/START-HERE.md` and `docs/START-HERE.pdf` - visual setup guide.
+- `docs/RUNBOOK.md` and `docs/RUNBOOK.pdf` - detailed operations runbook.
+- `docs/WALKTHROUGH.md` and `docs/WALKTHROUGH.pdf` - browser click-through.
+- `SHA256SUMS` - checksums for the package contents.
+
+## What This Shows
+
+```text
+download zip
+   |
+   v
+extract package
+   |
+   v
+verify checksums
+   |
+   v
+boot local VM
+   |
+   v
+open member shell in browser
+   |
+   v
+start local demo
+   |
+   v
+complete action card
+   |
+   v
+see receipt
+```
+
+## Scope
+
+This is intentionally narrow:
+
+- it is a bootable vertical slice,
+- it runs locally on the reviewer's machine,
+- it demonstrates the current browser path that exists today,
+- it is not a production federation deployment,
+- it is not a signed release,
+- it is not a claim that the full cooperative storage or distributed compute
+  product is finished.
+
+## Recommended Host
+
+Debian or Ubuntu Linux.
+
+Install host tools:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils openssh-client curl coreutils
+```
+
+Or just run:
+
+```bash
+./setup-and-run.sh
+```

--- a/deploy/appliance/evaluator/templates/README.md
+++ b/deploy/appliance/evaluator/templates/README.md
@@ -7,10 +7,9 @@ member shell working against services inside that VM.
 
 ## Start Here
 
-Open these first:
+Open this first:
 
 - `docs/START-HERE.md`
-- `docs/START-HERE.pdf`
 
 Then run:
 
@@ -29,10 +28,13 @@ and starts the local VM.
 - `setup-and-run.sh` - one-command Debian/Ubuntu setup, verify, and run path.
 - `scripts/verify.sh` - verifies every packaged file.
 - `scripts/run-demo.sh` - starts the demo from the package root.
-- `docs/START-HERE.md` and `docs/START-HERE.pdf` - visual setup guide.
-- `docs/RUNBOOK.md` and `docs/RUNBOOK.pdf` - detailed operations runbook.
-- `docs/WALKTHROUGH.md` and `docs/WALKTHROUGH.pdf` - browser click-through.
+- `docs/START-HERE.md` - visual setup guide.
+- `docs/RUNBOOK.md` - detailed operations runbook.
+- `docs/WALKTHROUGH.md` - browser click-through.
 - `SHA256SUMS` - checksums for the package contents.
+
+The docs are Markdown. A matching `.pdf` for each is included **only when the build
+environment can render one** (best-effort); it is never required to run the demo.
 
 ## What This Shows
 

--- a/deploy/appliance/evaluator/templates/docs/RUNBOOK.md
+++ b/deploy/appliance/evaluator/templates/docs/RUNBOOK.md
@@ -196,21 +196,20 @@ Default ports:
 - `18090` member shell
 - `18091` session service
 
-Alternative ports:
+Alternative ports (SSH, gateway, session only):
 
 ```bash
 ICN_DEMO_SSH_PORT=32222 \
 ICN_DEMO_GW_PORT=28080 \
-ICN_DEMO_SHELL_PORT=28090 \
 ICN_DEMO_SESSION_PORT=28091 \
 ./setup-and-run.sh
 ```
 
-Then open:
-
-```text
-http://localhost:28090/member-shell/?mode=live&demo=launcher&gw=28080&session=28091
-```
+The member-shell port is **fixed at 18090** and cannot be changed: the demo image
+only allowlists the `localhost:18090` browser origin, so the shell must load from
+there or the session/gateway calls fail their origin checks. If `18090` is in use,
+free it (see Troubleshooting) rather than remapping it. The launcher prints the
+exact URL to open; it always uses `localhost:18090`.
 
 ## Troubleshooting
 

--- a/deploy/appliance/evaluator/templates/docs/RUNBOOK.md
+++ b/deploy/appliance/evaluator/templates/docs/RUNBOOK.md
@@ -1,0 +1,265 @@
+# ICN Common Sense Vertical Slice Runbook
+
+## Purpose
+
+This runbook explains how to verify, boot, run, inspect, and stop the ICN
+Common Sense bootable vertical slice.
+
+The package is local after download. It does not require access to the sender's
+LAN or node.
+
+## Recommended Host
+
+Use Debian or Ubuntu Linux.
+
+Minimum practical resources:
+
+- 2 CPU cores,
+- 4 GB RAM,
+- 4 GB free disk space.
+
+## Package Map
+
+```text
+@PKG_NAME@/
+  README.md
+  SHA256SUMS
+  @IMAGE_BASENAME@
+  @MANIFEST_BASENAME@
+  start-icn-demo-vm.sh
+  scripts/
+    run-demo.sh
+    verify.sh
+  docs/
+    START-HERE.md
+    START-HERE.pdf
+    RUNBOOK.md
+    RUNBOOK.pdf
+    WALKTHROUGH.md
+    WALKTHROUGH.pdf
+  setup-and-run.sh
+```
+
+## One-Command Path
+
+On Debian or Ubuntu:
+
+```bash
+./setup-and-run.sh
+```
+
+That script:
+
+```text
+check host tools
+   |
+install missing apt packages with sudo
+   |
+verify checksums
+   |
+start demo VM
+   |
+print browser URL
+```
+
+Useful options:
+
+```bash
+./setup-and-run.sh --setup-only
+./setup-and-run.sh --verify-only
+./setup-and-run.sh --no-install
+```
+
+## Manual Install Requirements
+
+```bash
+sudo apt-get update
+sudo apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils openssh-client curl coreutils
+```
+
+The launcher uses:
+
+- `qemu-system-x86_64`
+- `qemu-img`
+- `cloud-localds`
+- `ssh`
+- `curl`
+- `sha256sum`
+
+## Verify Files
+
+From the package root:
+
+```bash
+./scripts/verify.sh
+```
+
+Expected shape:
+
+```text
+README.md: OK
+docs/START-HERE.md: OK
+docs/START-HERE.pdf: OK
+docs/RUNBOOK.md: OK
+docs/RUNBOOK.pdf: OK
+docs/WALKTHROUGH.md: OK
+docs/WALKTHROUGH.pdf: OK
+@IMAGE_BASENAME@: OK
+...
+```
+
+If any line does not end in `OK`, stop and re-download.
+
+## Start The Demo
+
+```bash
+./setup-and-run.sh
+```
+
+The launcher does this:
+
+```text
+create disposable SSH key
+   |
+create cloud-init seed
+   |
+create throwaway overlay disk
+   |
+boot qcow2 with QEMU
+   |
+wait for SSH
+   |
+wait for firstboot
+   |
+wait for icnd
+   |
+wait for gateway health
+   |
+wait for member shell
+   |
+open local tunnels
+```
+
+When ready, it prints the browser URL.
+
+## Browser URL
+
+Default:
+
+```text
+http://localhost:18090/member-shell/?mode=live&demo=launcher&gw=18080&session=18091
+```
+
+Expected browser path:
+
+```text
+member shell loads
+   |
+click Start local demo
+   |
+review action card
+   |
+complete action
+   |
+receipt appears
+```
+
+## Health Check
+
+After the launcher says ready:
+
+```bash
+curl http://localhost:18080/v1/health
+```
+
+Expected:
+
+```json
+{"status":"ok","version":"0.1.0"}
+```
+
+## Stop The Demo
+
+In the launcher terminal:
+
+```text
+Ctrl-C
+```
+
+The launcher stops the VM and removes the temporary overlay. The source image
+is not modified.
+
+## If Ports Are Busy
+
+Default ports:
+
+- `22222` VM SSH
+- `18080` gateway
+- `18090` member shell
+- `18091` session service
+
+Alternative ports:
+
+```bash
+ICN_DEMO_SSH_PORT=32222 \
+ICN_DEMO_GW_PORT=28080 \
+ICN_DEMO_SHELL_PORT=28090 \
+ICN_DEMO_SESSION_PORT=28091 \
+./setup-and-run.sh
+```
+
+Then open:
+
+```text
+http://localhost:28090/member-shell/?mode=live&demo=launcher&gw=28080&session=28091
+```
+
+## Troubleshooting
+
+### Missing QEMU
+
+Install the host requirements.
+
+### Missing `cloud-localds`
+
+```bash
+sudo apt-get install -y cloud-image-utils
+```
+
+### VM boot is slow
+
+Wait. If hardware virtualization is unavailable, QEMU may use slower emulation.
+
+### Browser does not load
+
+Confirm the launcher printed that the demo VM is ready. Then run the health
+check above.
+
+### Verification fails
+
+Do not run the image. Re-download the zip and verify again.
+
+## Provenance
+
+Image version:
+
+```text
+@IMAGE_VERSION@
+```
+
+Source commit recorded in manifest:
+
+```text
+@SOURCE_COMMIT@
+```
+
+Image SHA256:
+
+```text
+@IMAGE_SHA256@
+```
+
+## Scope
+
+This is a bootable vertical slice of what exists today. It is unsigned,
+fixture-backed, and meant to show the local VM plus browser demo path.

--- a/deploy/appliance/evaluator/templates/docs/RUNBOOK.md
+++ b/deploy/appliance/evaluator/templates/docs/RUNBOOK.md
@@ -32,11 +32,9 @@ Minimum practical resources:
     verify.sh
   docs/
     START-HERE.md
-    START-HERE.pdf
     RUNBOOK.md
-    RUNBOOK.pdf
     WALKTHROUGH.md
-    WALKTHROUGH.pdf
+    (a matching .pdf for each may be present if the build rendered one)
   setup-and-run.sh
 ```
 
@@ -99,14 +97,14 @@ Expected shape:
 ```text
 README.md: OK
 docs/START-HERE.md: OK
-docs/START-HERE.pdf: OK
 docs/RUNBOOK.md: OK
-docs/RUNBOOK.pdf: OK
 docs/WALKTHROUGH.md: OK
-docs/WALKTHROUGH.pdf: OK
 @IMAGE_BASENAME@: OK
 ...
 ```
+
+Every line must end in `OK`. If the package includes `.pdf` docs, they appear as
+additional `OK` lines; if it ships Markdown only, they are simply absent.
 
 If any line does not end in `OK`, stop and re-download.
 

--- a/deploy/appliance/evaluator/templates/docs/START-HERE.md
+++ b/deploy/appliance/evaluator/templates/docs/START-HERE.md
@@ -1,0 +1,157 @@
+# Start Here: ICN Common Sense Bootable Vertical Slice
+
+## What You Have
+
+This package is a self-contained bootable vertical slice.
+
+It contains a VM image and scripts that let you boot ICN locally and see the
+current browser-facing member shell working today.
+
+## The Whole Flow
+
+```text
+1. Extract zip
+      |
+      v
+2. Install host VM tools
+      |
+      v
+3. Run setup-and-run
+      |
+      v
+4. Let it install/check tools
+      |
+      v
+5. It verifies checksums
+      |
+      v
+6. It starts the VM
+      |
+      v
+7. Open the browser URL
+      |
+      v
+8. Click through to receipt
+```
+
+## What You Will See
+
+```text
++----------------------+        +--------------------------+
+| Your machine         |        | Local browser            |
+|                      |        |                          |
+|  QEMU starts VM      | -----> |  Member Shell opens      |
+|  icnd starts in VM   |        |  Start local demo button |
+|  Gateway becomes OK  |        |  Action card             |
+|  Shell is served     |        |  Receipt                 |
++----------------------+        +--------------------------+
+```
+
+## Step 1: Extract
+
+Unzip the package. You should get:
+
+```text
+@PKG_NAME@/
+```
+
+Enter it:
+
+```bash
+cd @PKG_NAME@
+```
+
+## Step 2: Run The One-Command Setup
+
+On Debian or Ubuntu, run:
+
+```bash
+./setup-and-run.sh
+```
+
+The script:
+
+- installs missing host tools with `apt-get`,
+- asks for `sudo` only if needed,
+- verifies checksums,
+- starts the local demo VM.
+
+You may be asked for your system password so the script can install QEMU and
+related VM tools.
+
+## Step 3: Watch For Verification
+
+You want the checksum lines to end with:
+
+```text
+OK
+```
+
+## Step 4: Wait For The VM
+
+Leave the terminal open. The launcher waits until everything inside the VM is
+ready.
+
+## Step 5: Open the Browser
+
+When the launcher says the demo VM is ready, open:
+
+```text
+http://localhost:18090/member-shell/?mode=live&demo=launcher&gw=18080&session=18091
+```
+
+## Step 6: Click Through
+
+In the browser:
+
+```text
+Start local demo -> action card -> complete -> receipt
+```
+
+## Step 7: Stop
+
+Go back to the terminal and press:
+
+```text
+Ctrl-C
+```
+
+## Manual Path
+
+If you do not want the setup script to install packages, run:
+
+```bash
+./setup-and-run.sh --no-install
+```
+
+Or do the steps manually:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y qemu-system-x86 qemu-utils cloud-image-utils openssh-client curl coreutils
+./scripts/verify.sh
+./scripts/run-demo.sh
+```
+
+## What Exists Today In This Slice
+
+This package shows:
+
+- a bootable ICN demo image,
+- `icnd` starting inside the VM,
+- gateway health inside the VM,
+- the current member shell served from the VM,
+- a local browser demo flow,
+- a receipt at the end of the flow.
+
+## What This Does Not Claim
+
+This does not claim:
+
+- production readiness,
+- a signed release,
+- a live public ICN node,
+- completed cooperative storage hosting,
+- completed distributed compute hosting.
+
+It is the working vertical slice that exists today.

--- a/deploy/appliance/evaluator/templates/docs/WALKTHROUGH.md
+++ b/deploy/appliance/evaluator/templates/docs/WALKTHROUGH.md
@@ -1,0 +1,92 @@
+# Browser Walkthrough
+
+## Goal
+
+See what exists today in the browser, running against the local VM.
+
+## Setup Path
+
+```text
+extract zip
+   |
+install host tools
+   |
+run setup-and-run
+   |
+verify checksums automatically
+   |
+VM starts automatically
+   |
+open browser URL printed by launcher
+```
+
+## Browser Path
+
+```text
+member shell
+   |
+Start local demo
+   |
+standing/action card
+   |
+complete
+   |
+receipt
+```
+
+## Step 1: Start The VM
+
+From the package root:
+
+```bash
+./setup-and-run.sh
+```
+
+On Debian/Ubuntu, this installs missing host tools, verifies the package, and
+starts the VM. Wait until the terminal says:
+
+```text
+ICN demo VM is ready.
+```
+
+## Step 2: Open The Member Shell
+
+Open:
+
+```text
+http://localhost:18090/member-shell/?mode=live&demo=launcher&gw=18080&session=18091
+```
+
+## Step 3: Start The Demo
+
+Click:
+
+```text
+Start local demo
+```
+
+## Step 4: Complete The Action
+
+Follow the action card shown in the page.
+
+The intended click-through is:
+
+```text
+standing -> action card -> complete -> receipt
+```
+
+## Step 5: Confirm The Result
+
+The receipt is the visible proof that the local browser flow completed.
+
+## What To Notice
+
+- The browser UI is served from the VM.
+- The gateway health check is from the VM.
+- The demo is local and self-contained after download.
+- The original image remains unchanged because the launcher uses a throwaway
+  overlay.
+
+## Stop
+
+Press `Ctrl-C` in the launcher terminal.

--- a/deploy/appliance/evaluator/templates/scripts/run-demo.sh
+++ b/deploy/appliance/evaluator/templates/scripts/run-demo.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PACKAGE_DIR"
+exec ./start-icn-demo-vm.sh

--- a/deploy/appliance/evaluator/templates/scripts/verify.sh
+++ b/deploy/appliance/evaluator/templates/scripts/verify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PACKAGE_DIR"
+sha256sum -c SHA256SUMS

--- a/deploy/appliance/evaluator/templates/setup-and-run.sh
+++ b/deploy/appliance/evaluator/templates/setup-and-run.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'EOF'
+ICN Common Sense setup-and-run
+
+Usage:
+  ./setup-and-run.sh
+  ./setup-and-run.sh --setup-only
+  ./setup-and-run.sh --verify-only
+  ./setup-and-run.sh --no-install
+
+What it does by default:
+  1. Checks for required host tools.
+  2. Installs missing Debian/Ubuntu packages with apt, using sudo if needed.
+  3. Verifies package checksums.
+  4. Starts the local demo VM.
+
+Notes:
+  - Debian/Ubuntu Linux is the supported one-command path.
+  - On other systems, install the listed tools manually, then run:
+      ./scripts/verify.sh
+      ./scripts/run-demo.sh
+EOF
+}
+
+SETUP_ONLY=0
+VERIFY_ONLY=0
+NO_INSTALL=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --setup-only) SETUP_ONLY=1 ;;
+    --verify-only) VERIFY_ONLY=1 ;;
+    --no-install) NO_INSTALL=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+log() { printf '[icn-setup] %s\n' "$*"; }
+err() { printf '[icn-setup] ERROR: %s\n' "$*" >&2; }
+
+need_cmds=(
+  qemu-system-x86_64
+  qemu-img
+  cloud-localds
+  ssh
+  curl
+  sha256sum
+)
+
+apt_packages=(
+  qemu-system-x86
+  qemu-utils
+  cloud-image-utils
+  openssh-client
+  curl
+  coreutils
+)
+
+missing_cmds() {
+  local missing=()
+  local cmd
+  for cmd in "${need_cmds[@]}"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      missing+=("$cmd")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    printf '%s\n' "${missing[@]}"
+  fi
+}
+
+run_sudo() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    err "Missing sudo. Install these packages manually: ${apt_packages[*]}"
+    exit 3
+  fi
+}
+
+install_missing_tools() {
+  mapfile -t missing < <(missing_cmds)
+  if [ "${#missing[@]}" -eq 0 ]; then
+    log "Host tools are already installed."
+    return 0
+  fi
+
+  log "Missing host tools: ${missing[*]}"
+
+  if [ "$NO_INSTALL" -eq 1 ]; then
+    err "Required tools are missing and --no-install was requested."
+    exit 3
+  fi
+
+  if ! command -v apt-get >/dev/null 2>&1; then
+    err "This one-command installer supports Debian/Ubuntu apt-get only."
+    err "Install these tools manually, then rerun: ${need_cmds[*]}"
+    exit 3
+  fi
+
+  log "Installing Debian/Ubuntu packages. You may be asked for your password."
+  run_sudo apt-get update
+  run_sudo apt-get install -y "${apt_packages[@]}"
+
+  mapfile -t missing_after < <(missing_cmds)
+  if [ "${#missing_after[@]}" -ne 0 ]; then
+    err "Still missing after install: ${missing_after[*]}"
+    exit 3
+  fi
+
+  log "Host tools installed."
+}
+
+verify_package() {
+  log "Verifying package checksums."
+  "$PACKAGE_DIR/scripts/verify.sh"
+  log "Checksums OK."
+}
+
+main() {
+  cd "$PACKAGE_DIR"
+
+  if [ "$VERIFY_ONLY" -eq 1 ]; then
+    verify_package
+    exit 0
+  fi
+
+  install_missing_tools
+
+  if [ "$SETUP_ONLY" -eq 1 ]; then
+    log "Setup complete."
+    exit 0
+  fi
+
+  verify_package
+
+  log "Starting the local ICN browser demo."
+  exec "$PACKAGE_DIR/scripts/run-demo.sh"
+}
+
+main "$@"

--- a/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
+++ b/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
@@ -219,20 +219,35 @@ ssh -N \
   -o UserKnownHostsFile=/dev/null \
   -o StrictHostKeyChecking=no \
   -o ServerAliveInterval=30 \
-  -L "${GW_PORT}:127.0.0.1:8080" \
-  -L "${SHELL_PORT}:127.0.0.1:8090" \
-  -L "${SESSION_PORT}:127.0.0.1:8091" \
+  -o GatewayPorts=no \
+  -L "127.0.0.1:${GW_PORT}:127.0.0.1:8080" \
+  -L "127.0.0.1:${SHELL_PORT}:127.0.0.1:8090" \
+  -L "127.0.0.1:${SESSION_PORT}:127.0.0.1:8091" \
   -i "$KEY" \
   -p "$SSH_PORT" \
   "${SSH_USER}@127.0.0.1" &
 TUNNEL_PID=$!
 
+# The forwards MUST stay loopback-only. Explicit 127.0.0.1 bind addresses plus
+# GatewayPorts=no defeat a host ssh_config that sets `GatewayPorts yes` (which
+# would otherwise bind these on wildcard interfaces and expose the demo to the LAN).
+
+TUNNEL_UP=0
 for _ in $(seq 1 30); do
+  if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
+    err "The browser tunnel exited before it became reachable (a local process may have won the port bind race). Free the ports and rerun."
+    exit 8
+  fi
   if curl -sf -m 3 "http://127.0.0.1:${SHELL_PORT}/member-shell/index.html" >/dev/null 2>&1; then
+    TUNNEL_UP=1
     break
   fi
   sleep 1
 done
+if [ "$TUNNEL_UP" -ne 1 ]; then
+  err "The browser surface did not become reachable at http://127.0.0.1:${SHELL_PORT}; not printing a dead URL."
+  exit 8
+fi
 
 URL="http://localhost:${SHELL_PORT}/member-shell/?mode=live&demo=launcher&gw=${GW_PORT}&session=${SESSION_PORT}"
 

--- a/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
+++ b/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
@@ -11,7 +11,20 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE="${ICN_DEMO_IMAGE:-$SCRIPT_DIR/@IMAGE_BASENAME@}"
-WORK_ROOT="${ICN_DEMO_WORK_ROOT:-/tmp/icn-demo-vm}"
+# Per-run private work dir (holds the disposable SSH key + cloud-init seed). When
+# ICN_DEMO_WORK_ROOT is not set we mktemp a fresh 0700 dir per run and delete it on
+# exit — never a fixed /tmp path that another local user on a shared host could
+# pre-create (predictable-path / pre-seeded-key attack). An explicit override is
+# honored as-is (its lifecycle is the caller's).
+if [ -n "${ICN_DEMO_WORK_ROOT:-}" ]; then
+  WORK_ROOT="$ICN_DEMO_WORK_ROOT"
+  WORK_ROOT_EPHEMERAL=0
+  mkdir -p "$WORK_ROOT"
+  chmod 700 "$WORK_ROOT" 2>/dev/null || true
+else
+  WORK_ROOT="$(mktemp -d -t icn-demo-work.XXXXXX)"
+  WORK_ROOT_EPHEMERAL=1
+fi
 SSH_PORT="${ICN_DEMO_SSH_PORT:-22222}"
 GW_PORT="${ICN_DEMO_GW_PORT:-18080}"
 SHELL_PORT="${ICN_DEMO_SHELL_PORT:-18090}"
@@ -44,6 +57,9 @@ cleanup() {
   fi
   if [ -n "${RUN_DIR:-}" ] && [ -d "$RUN_DIR" ]; then
     rm -rf "$RUN_DIR"
+  fi
+  if [ "${WORK_ROOT_EPHEMERAL:-0}" = "1" ] && [ -n "${WORK_ROOT:-}" ] && [ -d "$WORK_ROOT" ]; then
+    rm -rf "$WORK_ROOT"
   fi
   exit "$rc"
 }

--- a/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
+++ b/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
@@ -27,7 +27,13 @@ else
 fi
 SSH_PORT="${ICN_DEMO_SSH_PORT:-22222}"
 GW_PORT="${ICN_DEMO_GW_PORT:-18080}"
-SHELL_PORT="${ICN_DEMO_SHELL_PORT:-18090}"
+# The member-shell host-forward port is FIXED at 18090 and intentionally not
+# overridable: the demo image's CORS/origin allowlist only permits the fixed
+# localhost:8090/18090 origins, so the browser must load the shell from
+# localhost:18090 for the session mint + authenticated gateway calls to pass.
+# (Gateway/session forward ports are the request TARGETS, not the browser Origin,
+# so those remain overridable.)
+SHELL_PORT=18090
 SESSION_PORT="${ICN_DEMO_SESSION_PORT:-18091}"
 SSH_USER="${ICN_DEMO_SSH_USER:-debian}"
 VM_MEMORY="${ICN_DEMO_VM_MEMORY:-2048}"

--- a/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
+++ b/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
@@ -168,6 +168,11 @@ wait_in_vm() {
 }
 
 [ -f "$IMAGE" ] || { err "Image not found: $IMAGE"; exit 2; }
+# Canonicalize to an absolute path: the overlay is created under RUN_DIR with this
+# image as its qcow2 backing file, and QEMU resolves a relative backing path from
+# the overlay's own directory — so a relative ICN_DEMO_IMAGE (e.g. ./image.qcow2)
+# would pass the check above yet be unfindable at boot.
+IMAGE="$(cd "$(dirname -- "$IMAGE")" && pwd)/$(basename -- "$IMAGE")"
 
 require_tool qemu-system-x86_64
 require_tool qemu-img

--- a/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
+++ b/deploy/appliance/evaluator/templates/start-icn-demo-vm.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Self-contained launcher for the ICN demo appliance image.
+#
+# Put this script next to:
+#   @IMAGE_BASENAME@
+#
+# It boots a clean throwaway overlay, waits for the services, and prints the
+# browser URL. The source image is never modified.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE="${ICN_DEMO_IMAGE:-$SCRIPT_DIR/@IMAGE_BASENAME@}"
+WORK_ROOT="${ICN_DEMO_WORK_ROOT:-/tmp/icn-demo-vm}"
+SSH_PORT="${ICN_DEMO_SSH_PORT:-22222}"
+GW_PORT="${ICN_DEMO_GW_PORT:-18080}"
+SHELL_PORT="${ICN_DEMO_SHELL_PORT:-18090}"
+SESSION_PORT="${ICN_DEMO_SESSION_PORT:-18091}"
+SSH_USER="${ICN_DEMO_SSH_USER:-debian}"
+VM_MEMORY="${ICN_DEMO_VM_MEMORY:-2048}"
+VM_CPUS="${ICN_DEMO_VM_CPUS:-2}"
+VM_TIMEOUT="${ICN_DEMO_VM_TIMEOUT:-420}"
+
+KEY="$WORK_ROOT/demo-key"
+SEED_ISO="$WORK_ROOT/seed.iso"
+RUN_DIR=""
+QEMU_PID=""
+TUNNEL_PID=""
+
+log() { printf '[icn-demo] %s\n' "$*"; }
+err() { printf '[icn-demo] ERROR: %s\n' "$*" >&2; }
+
+cleanup() {
+  local rc=$?
+  if [ -n "${TUNNEL_PID:-}" ] && kill -0 "$TUNNEL_PID" 2>/dev/null; then
+    log "Closing browser tunnels."
+    kill "$TUNNEL_PID" 2>/dev/null || true
+  fi
+  if [ -n "${QEMU_PID:-}" ] && kill -0 "$QEMU_PID" 2>/dev/null; then
+    log "Stopping VM."
+    kill "$QEMU_PID" 2>/dev/null || true
+    sleep 1
+    kill -9 "$QEMU_PID" 2>/dev/null || true
+  fi
+  if [ -n "${RUN_DIR:-}" ] && [ -d "$RUN_DIR" ]; then
+    rm -rf "$RUN_DIR"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    err "Missing required tool: $1"
+    exit 2
+  }
+}
+
+port_free() {
+  local port="$1"
+  if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+    exec 3>&- 3<&- 2>/dev/null || true
+    err "Port $port is already in use. Free it, then rerun this launcher."
+    exit 3
+  fi
+}
+
+prepare_seed() {
+  mkdir -p "$WORK_ROOT"
+  if [ ! -f "$KEY" ]; then
+    log "Creating disposable VM SSH key at $KEY"
+    ssh-keygen -t ed25519 -f "$KEY" -N "" -C icn-demo-vm >/dev/null
+  fi
+
+  local pub user_data meta_data
+  pub="$(cat "$KEY.pub")"
+  user_data="$WORK_ROOT/user-data"
+  meta_data="$WORK_ROOT/meta-data"
+
+  cat >"$user_data" <<EOF_USER_DATA
+#cloud-config
+hostname: icn-demo-vm
+manage_etc_hosts: true
+users:
+  - name: debian
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    shell: /bin/bash
+    lock_passwd: true
+    ssh_authorized_keys:
+      - "$pub"
+ssh_pwauth: false
+disable_root: true
+packages: []
+final_message: |
+  ICN demo VM booted. Non-production demo appliance.
+EOF_USER_DATA
+
+  cat >"$meta_data" <<EOF_META_DATA
+instance-id: icn-demo-vm
+local-hostname: icn-demo-vm
+EOF_META_DATA
+
+  cloud-localds "$SEED_ISO" "$user_data" "$meta_data"
+}
+
+wait_for_ssh() {
+  local deadline=$(( $(date +%s) + VM_TIMEOUT ))
+  log "Waiting for VM SSH on 127.0.0.1:$SSH_PORT ..."
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if ! kill -0 "$QEMU_PID" 2>/dev/null; then
+      err "QEMU exited before SSH became reachable."
+      tail -80 "$RUN_DIR/serial.log" 2>/dev/null || true
+      exit 6
+    fi
+    if ssh "${SSH_OPTS[@]}" "${SSH_USER}@127.0.0.1" "true" 2>/dev/null; then
+      log "VM SSH is ready."
+      return 0
+    fi
+    sleep 3
+  done
+  err "Timed out waiting for SSH."
+  tail -80 "$RUN_DIR/serial.log" 2>/dev/null || true
+  exit 6
+}
+
+run_in_vm() {
+  ssh "${SSH_OPTS[@]}" "${SSH_USER}@127.0.0.1" "$@"
+}
+
+wait_in_vm() {
+  local label="$1"
+  local seconds="$2"
+  local command="$3"
+  local deadline=$(( $(date +%s) + seconds ))
+  log "Waiting for $label ..."
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if run_in_vm "$command" >/dev/null 2>&1; then
+      log "$label ready."
+      return 0
+    fi
+    sleep 3
+  done
+  err "$label did not become ready."
+  exit 7
+}
+
+[ -f "$IMAGE" ] || { err "Image not found: $IMAGE"; exit 2; }
+
+require_tool qemu-system-x86_64
+require_tool qemu-img
+require_tool cloud-localds
+require_tool ssh
+require_tool curl
+require_tool sha256sum
+
+port_free "$SSH_PORT"
+port_free "$GW_PORT"
+port_free "$SHELL_PORT"
+port_free "$SESSION_PORT"
+
+prepare_seed
+
+RUN_DIR="$(mktemp -d -t icn-demo-vm.XXXXXX)"
+OVERLAY="$RUN_DIR/vm-overlay.qcow2"
+log "Creating clean VM overlay."
+qemu-img create -f qcow2 -b "$IMAGE" -F qcow2 "$OVERLAY" >/dev/null
+
+log "Booting ICN demo VM."
+qemu-system-x86_64 \
+  -machine accel=kvm:tcg \
+  -m "$VM_MEMORY" \
+  -smp "$VM_CPUS" \
+  -display none \
+  -serial file:"$RUN_DIR/serial.log" \
+  -drive "if=virtio,format=qcow2,file=$OVERLAY" \
+  -drive "if=virtio,format=raw,file=$SEED_ISO,readonly=on" \
+  -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22" \
+  -device "virtio-net-pci,netdev=net0" \
+  -nographic \
+  >"$RUN_DIR/qemu.stdout" 2>"$RUN_DIR/qemu.stderr" &
+QEMU_PID=$!
+
+SSH_OPTS=(
+  -o UserKnownHostsFile=/dev/null
+  -o StrictHostKeyChecking=no
+  -o PasswordAuthentication=no
+  -o ConnectTimeout=5
+  -o BatchMode=yes
+  -i "$KEY"
+  -p "$SSH_PORT"
+)
+
+wait_for_ssh
+wait_in_vm "firstboot" 120 "sudo test -f /var/lib/icn/.firstboot-complete"
+wait_in_vm "icnd" 120 "systemctl is-active icnd"
+wait_in_vm "gateway health" 60 "curl -sf http://127.0.0.1:8080/v1/health"
+wait_in_vm "member shell" 60 "curl -sf http://127.0.0.1:8090/member-shell/index.html"
+
+log "Opening localhost tunnels to the VM services."
+ssh -N \
+  -o ExitOnForwardFailure=yes \
+  -o UserKnownHostsFile=/dev/null \
+  -o StrictHostKeyChecking=no \
+  -o ServerAliveInterval=30 \
+  -L "${GW_PORT}:127.0.0.1:8080" \
+  -L "${SHELL_PORT}:127.0.0.1:8090" \
+  -L "${SESSION_PORT}:127.0.0.1:8091" \
+  -i "$KEY" \
+  -p "$SSH_PORT" \
+  "${SSH_USER}@127.0.0.1" &
+TUNNEL_PID=$!
+
+for _ in $(seq 1 30); do
+  if curl -sf -m 3 "http://127.0.0.1:${SHELL_PORT}/member-shell/index.html" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+URL="http://localhost:${SHELL_PORT}/member-shell/?mode=live&demo=launcher&gw=${GW_PORT}&session=${SESSION_PORT}"
+
+cat <<EOF_READY
+
+ICN demo VM is ready.
+
+Open this in the browser:
+  $URL
+
+Health check:
+  http://localhost:${GW_PORT}/v1/health
+
+In the page, click "Start local demo".
+Leave this terminal open during the demo. Press Ctrl-C here to stop the VM.
+
+EOF_READY
+
+if [ "${ICN_DEMO_NO_BROWSER:-0}" != "1" ]; then
+  for opener in xdg-open gio open; do
+    if command -v "$opener" >/dev/null 2>&1; then
+      if [ "$opener" = "gio" ]; then
+        "$opener" open "$URL" >/dev/null 2>&1 || true
+      else
+        "$opener" "$URL" >/dev/null 2>&1 || true
+      fi
+      break
+    fi
+  done
+fi
+
+if [ "${ICN_DEMO_SMOKE_ONLY:-0}" = "1" ]; then
+  log "Smoke-only mode complete; stopping VM."
+  exit 0
+fi
+
+wait "$QEMU_PID"

--- a/deploy/appliance/evaluator/tests/test-evaluator-package.sh
+++ b/deploy/appliance/evaluator/tests/test-evaluator-package.sh
@@ -40,10 +40,10 @@ EOF
   ( cd "$root" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
   echo "$root"
 }
-run() { "$VALIDATE" "$1" --no-image >/tmp/v.log 2>&1; }
+run() { "$VALIDATE" "$1" --no-image >"$TMP/v.log" 2>&1; }
 
 # 1. clean package PASSES
-R="$(mkpkg "$TMP/clean")"; if run "$R"; then ok "clean package validates"; else no "clean package should validate"; cat /tmp/v.log; fi
+R="$(mkpkg "$TMP/clean")"; if run "$R"; then ok "clean package validates"; else no "clean package should validate"; cat "$TMP/v.log"; fi
 
 # 2. absolute /home path leak FAILS
 R="$(mkpkg "$TMP/homeleak")"; echo '# see /home/ubuntu/secret/path' >> "$R/docs/RUNBOOK.md"

--- a/deploy/appliance/evaluator/tests/test-evaluator-package.sh
+++ b/deploy/appliance/evaluator/tests/test-evaluator-package.sh
@@ -89,5 +89,25 @@ R="$(mkpkg "$TMP/jwt")"; printf 'token eyJTWVNURVNU.ZmFrZVRFU1Rml4dHVyZQ\n' >> "
 ( cd "$R" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
 if run "$R"; then no "should reject JWT-shaped value"; else ok "rejects JWT-shaped credential"; fi
 
+# 11. GENERATOR command-injection defense: a crafted manifest version that would
+#     inject a GNU sed `e` command must be refused, and the injected command must
+#     NOT run on the builder host. Uses a tiny fake image (no KVM, CI-runnable).
+GEN="$EV/build-evaluator-package.sh"
+FAKEIMG="$TMP/fake.qcow2"; printf 'not-a-real-image' > "$FAKEIMG"
+FSHA="$(sha256sum "$FAKEIMG" | awk '{print $1}')"
+MARKER="$TMP/EVIL_MARKER"; rm -f "$MARKER"
+python3 - "$TMP/craft.json" "$PKG_VERSION" "$PKG_ARCH" "$FSHA" "$IMAGE_BASENAME" "$MARKER" <<'PY'
+import json,sys
+craft,ver,arch,sha,imgbase,marker=sys.argv[1:7]
+# version passes the prefix check (ver-...) but injects a sed `e` command
+d={"manifest_version":1,"version":f"{ver}-x/;e${{IFS}}touch${{IFS}}{marker};#","arch":arch,
+   "image_sha256":sha,"git_commit":"0123456789abcdef0123456789abcdef01234567",
+   "image_path":imgbase,"base_image_path":"b.qcow2","image_format":"qcow2",
+   "non_production":True,"signed":False,"demo_profile":True}
+json.dump(d,open(craft,"w"))
+PY
+"$GEN" --image "$FAKEIMG" --manifest "$TMP/craft.json" --out "$TMP/geninj" --no-zip >/dev/null 2>&1 || true
+if [ -e "$MARKER" ]; then no "generator executed an injected manifest-version command (RCE)"; else ok "generator refuses injected manifest version (no code execution)"; fi
+
 echo "== $PASS passed, $FAILN failed =="
 [ "$FAILN" -eq 0 ]

--- a/deploy/appliance/evaluator/tests/test-evaluator-package.sh
+++ b/deploy/appliance/evaluator/tests/test-evaluator-package.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Unit tests for validate-evaluator-package.sh. Builds synthetic packages in a
+# temp dir (NO qcow2 — runs in --no-image CI mode) and asserts the validator
+# PASSES a clean package and FAILS each injected defect class. No KVM, no big
+# image, so this runs on an ordinary CI runner.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EV="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=/dev/null
+. "$EV/package-spec.env"
+PKG_NAME="${PKG_STEM}-${PKG_VERSION}-${PKG_ARCH}"
+VALIDATE="$EV/validate-evaluator-package.sh"
+TEMPLATES="$EV/templates"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PASS=0 FAILN=0
+ok(){ printf '  PASS  %s\n' "$1"; PASS=$((PASS+1)); }
+no(){ printf '  FAIL  %s\n' "$1"; FAILN=$((FAILN+1)); }
+
+# ---- build a clean synthetic package (no image) ---------------------------
+mkpkg() {
+  local root="$1/$PKG_NAME"; rm -rf "$root"; mkdir -p "$root/scripts" "$root/docs"
+  local commit="0123456789abcdef0123456789abcdef01234567"
+  local ish; ish="$(printf 'synthetic-image' | sha256sum | awk '{print $1}')"
+  subst() { sed -e "s/@IMAGE_BASENAME@/$IMAGE_BASENAME/g" -e "s/@MANIFEST_BASENAME@/$MANIFEST_BASENAME/g" \
+        -e "s/@PKG_NAME@/$PKG_NAME/g" -e "s/@IMAGE_VERSION@/${PKG_VERSION}-demo/g" \
+        -e "s/@SOURCE_COMMIT@/$commit/g" -e "s/@IMAGE_SHA256@/$ish/g"; }
+  for f in README.md setup-and-run.sh start-icn-demo-vm.sh scripts/run-demo.sh scripts/verify.sh \
+           docs/START-HERE.md docs/RUNBOOK.md docs/WALKTHROUGH.md; do
+    subst < "$TEMPLATES/$f" > "$root/$f"
+  done
+  chmod 0755 "$root"/setup-and-run.sh "$root"/start-icn-demo-vm.sh "$root"/scripts/*.sh
+  cat > "$root/$MANIFEST_BASENAME" <<EOF
+{ "manifest_version":1, "version":"${PKG_VERSION}-demo", "arch":"$PKG_ARCH",
+  "image_sha256":"$ish", "git_commit":"$commit",
+  "image_path":"$IMAGE_BASENAME", "base_image_path":"base.qcow2",
+  "non_production":true, "signed":false, "demo_profile":true }
+EOF
+  ( cd "$root" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+  echo "$root"
+}
+run() { "$VALIDATE" "$1" --no-image >/tmp/v.log 2>&1; }
+
+# 1. clean package PASSES
+R="$(mkpkg "$TMP/clean")"; if run "$R"; then ok "clean package validates"; else no "clean package should validate"; cat /tmp/v.log; fi
+
+# 2. absolute /home path leak FAILS
+R="$(mkpkg "$TMP/homeleak")"; echo '# see /home/ubuntu/secret/path' >> "$R/docs/RUNBOOK.md"
+( cd "$R" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+if run "$R"; then no "should reject /home path leak"; else ok "rejects /home path leak"; fi
+
+# 3. RFC1918 IP FAILS  (generic RFC1918 fixture, not a real site address)
+R="$(mkpkg "$TMP/ip")"; echo 'connect to 10.0.0.5 now' >> "$R/README.md"  # sanitize-ok: synthetic test fixture
+( cd "$R" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+if run "$R"; then no "should reject RFC1918 IP"; else ok "rejects RFC1918 IP"; fi
+
+# 4. internal hostname FAILS  (synthetic internal host; triggers rehearsal.icn + .internal)
+R="$(mkpkg "$TMP/host")"; echo 'https://rehearsal.icn.example.internal/' >> "$R/README.md"
+( cd "$R" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+if run "$R"; then no "should reject internal hostname"; else ok "rejects internal hostname"; fi
+
+# 5. non-loopback hostfwd FAILS
+R="$(mkpkg "$TMP/bind")"; sed -i 's/hostfwd=tcp:127\.0\.0\.1:/hostfwd=tcp:0.0.0.0:/' "$R/start-icn-demo-vm.sh"
+( cd "$R" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+if run "$R"; then no "should reject non-loopback hostfwd"; else ok "rejects non-loopback hostfwd"; fi
+
+# 6. broken checksum FAILS
+R="$(mkpkg "$TMP/sum")"; echo 'tampered' >> "$R/README.md"
+if run "$R"; then no "should reject broken checksum"; else ok "rejects broken checksum (README changed after SHA256SUMS)"; fi
+
+# 7. missing required doc FAILS
+R="$(mkpkg "$TMP/missing")"; rm -f "$R/docs/WALKTHROUGH.md"
+( cd "$R" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+if run "$R"; then no "should reject missing doc"; else ok "rejects missing required doc"; fi
+
+# 8. dishonest manifest (signed:true) FAILS
+R="$(mkpkg "$TMP/signed")"; sed -i 's/"signed":false/"signed":true/' "$R/$MANIFEST_BASENAME"
+( cd "$R" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+if run "$R"; then no "should reject signed:true"; else ok "rejects dishonest signed:true"; fi
+
+# 9. host-path manifest (image_path with dir) FAILS
+R="$(mkpkg "$TMP/mpath")"; sed -i "s#\"image_path\":\"$IMAGE_BASENAME\"#\"image_path\":\"/home/ubuntu/out/$IMAGE_BASENAME\"#" "$R/$MANIFEST_BASENAME"
+( cd "$R" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+if run "$R"; then no "should reject non-basename image_path"; else ok "rejects non-basename image_path (host path leak)"; fi
+
+# 10. JWT-shaped credential FAILS  (synthetic non-credential fixture)
+R="$(mkpkg "$TMP/jwt")"; printf 'token eyJTWVNURVNU.ZmFrZVRFU1Rml4dHVyZQ\n' >> "$R/docs/RUNBOOK.md"  # sanitize-ok: synthetic test fixture
+( cd "$R" && find . -type f ! -name SHA256SUMS -printf '%P\0' | sort -z | xargs -0 sha256sum > SHA256SUMS )
+if run "$R"; then no "should reject JWT-shaped value"; else ok "rejects JWT-shaped credential"; fi
+
+echo "== $PASS passed, $FAILN failed =="
+[ "$FAILN" -eq 0 ]

--- a/deploy/appliance/evaluator/validate-evaluator-package.sh
+++ b/deploy/appliance/evaluator/validate-evaluator-package.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Static validator for an assembled evaluator package (portable bootable vertical
+# slice). Fails closed. Designed to run WITHOUT KVM and without the ~1GB qcow2, so
+# CI can catch packaging / script / checksum / manifest / privacy / bind
+# regressions on an ordinary runner.
+#
+# Usage:
+#   validate-evaluator-package.sh <package-root-dir> [--no-image] [--expect-commit SHA]
+#
+#   --no-image        The qcow2 is absent (CI / template-only mode). Image
+#                     presence + image-hash checks are skipped; every other check
+#                     still runs. The manifest's declared image_sha256 is still
+#                     cross-checked against SHA256SUMS when both exist.
+#   --expect-commit   Assert manifest.git_commit == SHA (packaging provenance).
+#
+# Exit non-zero on ANY failure. Never prints a secret-shaped value; findings name
+# the file + class only.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/package-spec.env"
+
+PKG_ROOT="${1:-}"
+NO_IMAGE=0
+EXPECT_COMMIT=""
+shift || true
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-image) NO_IMAGE=1 ;;
+    --expect-commit) shift; EXPECT_COMMIT="${1:-}" ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ -z "$PKG_ROOT" ] || [ ! -d "$PKG_ROOT" ]; then
+  echo "usage: validate-evaluator-package.sh <package-root-dir> [--no-image] [--expect-commit SHA]" >&2
+  exit 2
+fi
+PKG_ROOT="$(cd "$PKG_ROOT" && pwd)"
+
+FAILS=0
+pass() { printf '  ok    %s\n' "$*"; }
+fail() { printf '  FAIL  %s\n' "$*"; FAILS=$((FAILS+1)); }
+note() { printf '  --    %s\n' "$*"; }
+
+echo "== validate evaluator package: $PKG_ROOT =="
+[ "$NO_IMAGE" -eq 1 ] && note "image checks skipped (--no-image)"
+
+# ---- 1. Required layout ----------------------------------------------------
+for rel in "${REQUIRED_FILES[@]}"; do
+  if [ "$NO_IMAGE" -eq 1 ] && { [ "$rel" = "$IMAGE_BASENAME" ]; }; then
+    note "skip (no-image): $rel"; continue
+  fi
+  if [ -e "$PKG_ROOT/$rel" ]; then pass "present: $rel"; else fail "missing required file: $rel"; fi
+done
+
+# ---- 2. Executable bits ----------------------------------------------------
+for rel in "${EXECUTABLE_FILES[@]}"; do
+  if [ -x "$PKG_ROOT/$rel" ]; then pass "executable: $rel"; else fail "not executable: $rel"; fi
+done
+
+# ---- 3. Script syntax + shellcheck ----------------------------------------
+SCRIPTS=()
+while IFS= read -r -d '' s; do SCRIPTS+=("$s"); done < <(find "$PKG_ROOT" -type f -name '*.sh' -print0)
+for s in "${SCRIPTS[@]}"; do
+  if bash -n "$s" 2>/dev/null; then pass "bash -n: ${s#"$PKG_ROOT"/}"; else fail "bash -n FAILED: ${s#"$PKG_ROOT"/}"; fi
+done
+if command -v shellcheck >/dev/null 2>&1; then
+  for s in "${SCRIPTS[@]}"; do
+    if shellcheck -S warning "$s" >/dev/null 2>&1; then pass "shellcheck: ${s#"$PKG_ROOT"/}"; else fail "shellcheck warnings: ${s#"$PKG_ROOT"/}"; fi
+  done
+else
+  note "shellcheck not installed — skipping static analysis (syntax still checked)"
+fi
+
+# ---- 4. Checksums ----------------------------------------------------------
+if [ -f "$PKG_ROOT/SHA256SUMS" ]; then
+  if [ "$NO_IMAGE" -eq 1 ]; then
+    # Verify every listed file that is present (the image line is expected absent).
+    miss=0
+    while read -r _hash rel; do
+      rel="${rel#\*}"
+      [ -z "$rel" ] && continue
+      if [ "$rel" = "$IMAGE_BASENAME" ]; then continue; fi
+      [ -f "$PKG_ROOT/$rel" ] || { fail "SHA256SUMS lists missing file: $rel"; miss=1; }
+    done < "$PKG_ROOT/SHA256SUMS"
+    if [ "$miss" -eq 0 ]; then
+      ( cd "$PKG_ROOT" && grep -v " \*\?$IMAGE_BASENAME\$" SHA256SUMS | sha256sum -c --quiet - ) \
+        && pass "SHA256SUMS verify (non-image entries)" || fail "SHA256SUMS verify failed (non-image entries)"
+    fi
+  else
+    ( cd "$PKG_ROOT" && sha256sum -c --quiet SHA256SUMS ) \
+      && pass "SHA256SUMS verify (all entries)" || fail "SHA256SUMS verify failed"
+  fi
+else
+  fail "SHA256SUMS missing"
+fi
+
+# ---- 5. Manifest metadata + honest posture --------------------------------
+MANIFEST="$PKG_ROOT/$MANIFEST_BASENAME"
+if [ -f "$MANIFEST" ]; then
+  python3 - "$MANIFEST" "$PKG_ROOT" "$NO_IMAGE" "$EXPECT_COMMIT" \
+    "$PKG_VERSION" "$PKG_ARCH" "$REQUIRE_NON_PRODUCTION" "$REQUIRE_SIGNED" \
+    "$REQUIRE_DEMO_PROFILE" "$IMAGE_BASENAME" <<'PY'
+import json, sys, re, os
+mf, root, no_image, expect_commit, ver, arch, req_np, req_signed, req_demo, image_base = sys.argv[1:11]
+no_image = no_image == "1"
+out=[]
+ok=True
+def P(m): out.append("  ok    "+m)
+def F(m):
+    global ok; ok=False; out.append("  FAIL  "+m)
+try:
+    d=json.load(open(mf))
+except Exception as e:
+    print("  FAIL  manifest is not valid JSON"); sys.exit(1)
+# honest posture
+for key,want in (("non_production",req_np=="true"),("signed",req_signed=="true"),("demo_profile",req_demo=="true")):
+    got=d.get(key)
+    if isinstance(got,bool) and got==want: P(f"manifest {key}={got}")
+    else: F(f"manifest {key}={got!r} (expected {want})")
+# version / arch agreement (manifest.version is like '0.0.2-demo')
+mv=str(d.get("version",""))
+if mv.split("-")[0]==ver: P(f"manifest version starts with {ver}")
+else: F(f"manifest version {mv!r} disagrees with spec {ver}")
+if str(d.get("arch",""))==arch: P(f"manifest arch={arch}")
+else: F(f"manifest arch {d.get('arch')!r} disagrees with spec {arch}")
+# paths must be basenames (no leaked host dirs)
+for key in ("image_path","base_image_path"):
+    v=d.get(key)
+    if v is None: P(f"manifest {key} absent (fine)"); continue
+    if "/" in str(v) or "\\" in str(v): F(f"manifest {key} is not a basename (host path leak): contains a path separator")
+    else: P(f"manifest {key} is a bare basename")
+# image_sha256 present + shape
+ish=str(d.get("image_sha256",""))
+if re.fullmatch(r"[0-9a-f]{64}", ish): P("manifest image_sha256 present (64 hex)")
+else: F("manifest image_sha256 missing/malformed")
+# cross-check against SHA256SUMS
+sums=os.path.join(root,"SHA256SUMS")
+if os.path.isfile(sums):
+    want=None
+    for line in open(sums):
+        parts=line.split()
+        if len(parts)>=2 and parts[1].lstrip("*")==image_base:
+            want=parts[0]
+    if want:
+        if want==ish: P("manifest image_sha256 == SHA256SUMS image entry")
+        else: F("manifest image_sha256 disagrees with SHA256SUMS image entry")
+    else:
+        (P if no_image else F)("SHA256SUMS has no image entry" + (" (expected in no-image mode)" if no_image else ""))
+# commit provenance
+gc=str(d.get("git_commit",""))
+if re.fullmatch(r"[0-9a-f]{40}", gc): P("manifest git_commit present (40 hex)")
+else: F("manifest git_commit missing/malformed")
+if expect_commit:
+    if gc==expect_commit: P("manifest git_commit == expected source commit")
+    else: F("manifest git_commit != expected source commit")
+# real image hash when present
+if not no_image:
+    img=os.path.join(root,image_base)
+    if os.path.isfile(img):
+        import hashlib
+        h=hashlib.sha256()
+        with open(img,'rb') as fh:
+            for chunk in iter(lambda: fh.read(1<<20), b''): h.update(chunk)
+        if h.hexdigest()==ish: P("actual qcow2 sha256 == manifest image_sha256")
+        else: F("actual qcow2 sha256 != manifest image_sha256")
+    else:
+        F("image declared but file missing")
+print("\n".join(out))
+sys.exit(0 if ok else 1)
+PY
+  if [ "$?" -eq 0 ]; then pass "manifest checks"; else fail "manifest checks (see above)"; fi
+else
+  fail "manifest missing: $MANIFEST_BASENAME"
+fi
+
+# ---- 6. Privacy / forbidden-value scan (text files only) -------------------
+TEXT=()
+while IFS= read -r -d '' f; do TEXT+=("$f"); done < <(find "$PKG_ROOT" -type f ! -name '*.qcow2' ! -name '*.pdf' -print0)
+scan() { printf '%s\0' "${TEXT[@]}" | xargs -0 grep -lE "$1" 2>/dev/null || true; }
+declare -A FORBID=(
+  ["absolute home/user/root path"]='/home/[a-z]|/Users/|/root/'
+  ["RFC1918 private IP"]='(^|[^0-9])(10\.[0-9]+\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]+\.[0-9]+)([^0-9]|$)'
+  # Generic internal-deployment shapes: the ICN rehearsal service subdomain,
+  # private TLDs, and a deployment VM id. Site-specific internal domains are the
+  # job of the local sanitize deny-list (not hardcoded in this public tool).
+  ["internal hostname / deployment id"]='rehearsal\.icn[.:]|icn-rehearsal|\.(internal|lan|home|corp|localdomain)\b|\b[Vv][Mm][Ii]?[Dd]? ?[0-9]{3}\b'
+  ["temp tunnel URL"]='loca\.lt|ngrok|trycloudflare'
+  ["JWT-shaped credential"]='eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}'
+  ["PEM private key"]='BEGIN [A-Z ]*PRIVATE KEY|BEGIN OPENSSH PRIVATE'
+  ["bearer/authorization literal"]='[Aa]uthorization: *[Bb]earer [A-Za-z0-9._-]{12,}'
+  ["personal name/email"]='([Aa]aron)|@gmail\.com|@icloud\.com'
+  ["overclaim"]='production-ready|pilot-ready|organizer-approved|live federation|accessibility[- ]complete'
+)
+for label in "${!FORBID[@]}"; do
+  hits="$(scan "${FORBID[$label]}")"
+  if [ -z "$hits" ]; then pass "no $label"; else
+    fail "found $label in: $(echo "$hits" | sed "s#$PKG_ROOT/##g" | tr '\n' ' ')"
+  fi
+done
+# DIDs are prohibited in SCRIPTS (a shipped script must never embed an identity);
+# docs may name the did: scheme conceptually, so restrict this one to scripts.
+did_hits="$(printf '%s\0' "${SCRIPTS[@]}" | xargs -0 grep -lE 'did:(icn|key|web):[A-Za-z0-9]' 2>/dev/null || true)"
+if [ -z "$did_hits" ]; then pass "no DID literal in scripts"; else fail "DID literal in scripts: $did_hits"; fi
+
+# ---- 7. Archive safety (tree) ---------------------------------------------
+if find "$PKG_ROOT" -type l | grep -q .; then fail "symlink present in package tree"; else pass "no symlinks in tree"; fi
+
+# ---- 8. Launcher default binds are loopback --------------------------------
+LAUNCHER="$PKG_ROOT/start-icn-demo-vm.sh"
+if [ -f "$LAUNCHER" ]; then
+  # QEMU host forwards must pin 127.0.0.1 (never empty-host tcp::PORT, never 0.0.0.0)
+  if grep -qE 'hostfwd=tcp:(:[0-9]|0\.0\.0\.0:)' "$LAUNCHER"; then
+    fail "launcher hostfwd defaults to a non-loopback bind"
+  else pass "launcher hostfwd bind is loopback-scoped"; fi
+  if grep -qE 'hostfwd=tcp:127\.0\.0\.1:' "$LAUNCHER"; then pass "launcher hostfwd explicitly 127.0.0.1"; else fail "launcher has no explicit 127.0.0.1 hostfwd"; fi
+  # ssh -L forwards must not bind all interfaces; GatewayPorts must not be enabled
+  if grep -qE 'GatewayPorts +yes' "$LAUNCHER"; then fail "launcher enables GatewayPorts (exposes tunnels)"; else pass "launcher does not enable GatewayPorts"; fi
+  if grep -qE -- '-L +(\*|0\.0\.0\.0):' "$LAUNCHER"; then fail "launcher ssh -L binds all interfaces"; else pass "launcher ssh -L is localhost-bound"; fi
+else
+  fail "launcher template missing from package"
+fi
+
+# ---- 9. Non-claim wording present -----------------------------------------
+if grep -rqiE 'not a production|non-production|unsigned|does not claim' "$PKG_ROOT"/README.md "$PKG_ROOT"/docs/*.md 2>/dev/null; then
+  pass "honest non-claim wording present in docs"
+else
+  fail "docs lack explicit non-claim wording"
+fi
+
+echo "== result: $FAILS failure(s) =="
+[ "$FAILS" -eq 0 ]

--- a/deploy/appliance/evaluator/validate-evaluator-package.sh
+++ b/deploy/appliance/evaluator/validate-evaluator-package.sh
@@ -87,7 +87,7 @@ if [ -f "$PKG_ROOT/SHA256SUMS" ]; then
       [ -f "$PKG_ROOT/$rel" ] || { fail "SHA256SUMS lists missing file: $rel"; miss=1; }
     done < "$PKG_ROOT/SHA256SUMS"
     if [ "$miss" -eq 0 ]; then
-      ( cd "$PKG_ROOT" && grep -v " \*\?$IMAGE_BASENAME\$" SHA256SUMS | sha256sum -c --quiet - ) \
+      ( cd "$PKG_ROOT" && grep -vF "$IMAGE_BASENAME" SHA256SUMS | sha256sum -c --quiet - ) \
         && pass "SHA256SUMS verify (non-image entries)" || fail "SHA256SUMS verify failed (non-image entries)"
     fi
   else
@@ -101,7 +101,9 @@ fi
 # ---- 5. Manifest metadata + honest posture --------------------------------
 MANIFEST="$PKG_ROOT/$MANIFEST_BASENAME"
 if [ -f "$MANIFEST" ]; then
-  python3 - "$MANIFEST" "$PKG_ROOT" "$NO_IMAGE" "$EXPECT_COMMIT" \
+  # Run inside `if` so a non-zero exit is captured (not aborted by `set -e`),
+  # letting the remaining privacy/bind/non-claim checks still run + accumulate.
+  if python3 - "$MANIFEST" "$PKG_ROOT" "$NO_IMAGE" "$EXPECT_COMMIT" \
     "$PKG_VERSION" "$PKG_ARCH" "$REQUIRE_NON_PRODUCTION" "$REQUIRE_SIGNED" \
     "$REQUIRE_DEMO_PROFILE" "$IMAGE_BASENAME" <<'PY'
 import json, sys, re, os
@@ -172,7 +174,7 @@ if not no_image:
 print("\n".join(out))
 sys.exit(0 if ok else 1)
 PY
-  if [ "$?" -eq 0 ]; then pass "manifest checks"; else fail "manifest checks (see above)"; fi
+  then pass "manifest checks"; else fail "manifest checks (see above)"; fi
 else
   fail "manifest missing: $MANIFEST_BASENAME"
 fi
@@ -204,7 +206,7 @@ done
 # DIDs are prohibited in SCRIPTS (a shipped script must never embed an identity);
 # docs may name the did: scheme conceptually, so restrict this one to scripts.
 did_hits="$(printf '%s\0' "${SCRIPTS[@]}" | xargs -0 grep -lE 'did:(icn|key|web):[A-Za-z0-9]' 2>/dev/null || true)"
-if [ -z "$did_hits" ]; then pass "no DID literal in scripts"; else fail "DID literal in scripts: $did_hits"; fi
+if [ -z "$did_hits" ]; then pass "no DID literal in scripts"; else fail "DID literal in scripts: $(echo "$did_hits" | sed "s#$PKG_ROOT/##g" | tr '\n' ' ')"; fi
 
 # ---- 7. Archive safety (tree) ---------------------------------------------
 if find "$PKG_ROOT" -type l | grep -q .; then fail "symlink present in package tree"; else pass "no symlinks in tree"; fi

--- a/deploy/appliance/evaluator/validate-evaluator-package.sh
+++ b/deploy/appliance/evaluator/validate-evaluator-package.sh
@@ -219,9 +219,15 @@ if [ -f "$LAUNCHER" ]; then
     fail "launcher hostfwd defaults to a non-loopback bind"
   else pass "launcher hostfwd bind is loopback-scoped"; fi
   if grep -qE 'hostfwd=tcp:127\.0\.0\.1:' "$LAUNCHER"; then pass "launcher hostfwd explicitly 127.0.0.1"; else fail "launcher has no explicit 127.0.0.1 hostfwd"; fi
-  # ssh -L forwards must not bind all interfaces; GatewayPorts must not be enabled
-  if grep -qE 'GatewayPorts +yes' "$LAUNCHER"; then fail "launcher enables GatewayPorts (exposes tunnels)"; else pass "launcher does not enable GatewayPorts"; fi
-  if grep -qE -- '-L +(\*|0\.0\.0\.0):' "$LAUNCHER"; then fail "launcher ssh -L binds all interfaces"; else pass "launcher ssh -L is localhost-bound"; fi
+  # ssh -L forwards must stay loopback-only even when the host ssh_config sets
+  # GatewayPorts on: require an explicit GatewayPorts=no on the tunnel + explicit
+  # 127.0.0.1 -L bind addresses; forbid wildcard binds / enabling GatewayPorts.
+  # Scan code only (strip comment lines) so prose examples don't trip the checks.
+  LCODE="$(grep -vE '^[[:space:]]*#' "$LAUNCHER")"
+  if printf '%s\n' "$LCODE" | grep -qE 'GatewayPorts[ =]+yes'; then fail "launcher enables GatewayPorts (exposes tunnels)"; else pass "launcher does not enable GatewayPorts"; fi
+  if printf '%s\n' "$LCODE" | grep -qE -- '-o +GatewayPorts=no'; then pass "launcher forces GatewayPorts=no on the tunnel"; else fail "launcher does not force GatewayPorts=no (host config could wildcard-bind -L)"; fi
+  if printf '%s\n' "$LCODE" | grep -qE -- '-L +["'\'']?(\*|0\.0\.0\.0):'; then fail "launcher ssh -L binds all interfaces"; else pass "launcher ssh -L is localhost-bound"; fi
+  if printf '%s\n' "$LCODE" | grep -qE -- '-L +["'\'']?127\.0\.0\.1:'; then pass "launcher ssh -L uses explicit 127.0.0.1 bind"; else fail "launcher ssh -L lacks explicit 127.0.0.1 bind address"; fi
 else
   fail "launcher template missing from package"
 fi


### PR DESCRIPTION
## What
Adds `deploy/appliance/evaluator/` — a declared-input, fail-closed, validated,
repository-owned lane that generates the external-evaluator **portable bootable
vertical slice** package. Converts it from an ad-hoc pile of locally-assembled
files into a reproducible artifact + KVM-free static CI.

- `package-spec.env` — single source of truth for package identity + required layout.
- `templates/` — repo-owned source for every script + doc, adopted from the audited,
  ShellCheck-clean published package. Regenerate **byte-identical** to the verified
  originals (proven). Provenance placeholders (`@SOURCE_COMMIT@`/`@IMAGE_SHA256@`/
  `@IMAGE_VERSION@`) are stamped from the actual manifest at generation.
- `build-evaluator-package.sh` — fail-closed generator. Takes a `build-image.sh`
  output (demo-profile qcow2 + typed manifest) as declared inputs. Never builds an
  image, never bakes a host path. **Rewrites the packaged manifest's `image_path`/
  `base_image_path` to bare basenames** (fixes a build-host absolute-path leak found
  in the currently-published package).
- `validate-evaluator-package.sh` — KVM-free static validator (layout, exec bits,
  `bash -n` + ShellCheck, `SHA256SUMS`, manifest metadata incl. basename-only paths +
  honest posture, privacy/forbidden scan, archive safety, loopback-default binds,
  non-claim wording). `--no-image` runs every non-image check without the ~1GB qcow2.
- `tests/test-evaluator-package.sh` — 10 synthetic clean+defective packages.
- `.github/workflows/evaluator-package.yml` — fast static CI on ubuntu-latest.

## Why
The published `common-sense-vertical-slice-0.0.2-amd64-setup` release was assembled
locally with no repo-owned source, no reproducible command, and no regression gate.
This makes the capability maintainable and catches packaging/script/checksum/
manifest/privacy/bind regressions in CI.

## How / evidence
- Published ZIP independently audited: outer sha256 matches
  (`f0128b82…f09b81`), archive-safe (no `../`/absolute/symlink), internal
  `SHA256SUMS` all OK, manifest↔image hash match, `git_commit 8c0fe926` real +
  ancestor of main. Only finding: manifest shipped `/home/ubuntu/...` absolute
  paths — **fixed** by this lane's manifest sanitization.
- Real recipient runtime test (KVM): boots, loopback-only host forwards, disposable
  overlay, source qcow2 unchanged, full slice (standing → organizer-created action
  card → digest-bound confirm incl. wrong-digest→409 → member completion → receipt
  ladder), idempotent retry, clean teardown, repeatable.
- Generator run against the verified image: 0 validator failures; scripts + docs
  regenerate byte-identical; manifest paths sanitized to basenames; 4 fail-closed
  negative tests pass; full ZIP round-trips (outer checksum + exec bits survive).
- 10/10 validator unit tests pass; ShellCheck clean; sanitize gate clean.

## Profile distinction (not collapsed)
This packages the **portable evaluator** (demo profile — QEMU user-net, localhost
forwards, disposable overlay). It is deliberately distinct from the **LAN rehearsal
profile** (`deploy/appliance/lan/`, nginx single TLS origin). Verified: the portable
path does NOT bypass #2424 — that fix addressed a *bridged*-LAN VM; the portable path
uses user-mode networking with loopback-only host forwards.

## Risk
Additive only (new dir + new static workflow). No Rust, no runtime behavior change.
Does not build an image, publish a release, or commit any qcow2/ZIP.

## Non-claims
Unsigned, `non_production` evaluator artifact. NOT production, pilot,
organizer-approved, accessibility-complete, or federated. CI is static validation,
NOT assembled-image runtime proof.

## Note (not in this PR)
`icn-prereview` (local-model pre-review) was unavailable this session — the Zentith
Ollama reverse tunnel was down. Self-review (ShellCheck + 10 unit + 4 negative tests
+ sanitize gate + full round-trip) stands in.