### PR TITLE
feat(gateway): Authority Spine Phase 1 — scope attenuation, revocation, and capability truth

### DIFF
--- a/docs/DOCUMENT_REGISTRY.md
+++ b/docs/DOCUMENT_REGISTRY.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-07-18
+Last Reviewed: 2026-07-19
 ---
 
 # ICN Document Registry (human summary)
@@ -41,9 +41,9 @@ python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml
 
 ## Corpus coverage
 
-- **Markdown files under docs/**: 952
+- **Markdown files under docs/**: 953
 - **By truth_class (merged):**
-  - `descriptive`: 555
+  - `descriptive`: 556
   - `draft`: 44
   - `historical`: 80
   - `normative`: 89
@@ -76,5 +76,5 @@ What fails in CI, what warns, what `--strict` adds, and when to promote strict t
 
 ## Registry coverage (this snapshot)
 
-- **Files scanned:** 952 Markdown files under `docs/`
-- **Explicit `[docs."…"]` rows under `docs/`:** 350 (remaining files rely on `[[doc_path_defaults]]` only)
+- **Files scanned:** 953 Markdown files under `docs/`
+- **Explicit `[docs."…"]` rows under `docs/`:** 351 (remaining files rely on `[[doc_path_defaults]]` only)

--- a/docs/DOCUMENT_REGISTRY.md
+++ b/docs/DOCUMENT_REGISTRY.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-07-19
+Last Reviewed: 2026-07-21
 ---
 
 # ICN Document Registry (human summary)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -119,6 +119,7 @@ Comprehensive architectural reviews and design decisions:
 - [CELLS_AND_SCOPES.md](architecture/CELLS_AND_SCOPES.md) - Cell-based federation model
 - [SCOPE_BOUNDED_TRUST.md](architecture/SCOPE_BOUNDED_TRUST.md) - Trust scope architecture
 - [KERNEL_APP_SEPARATION.md](architecture/KERNEL_APP_SEPARATION.md) - Kernel/app boundary design
+- [AUTHORITY_SPINE.md](architecture/AUTHORITY_SPINE.md) - Authority attenuation, expiration, revocation, and capability truth; gateway session-authority boundary (#2436/#2437) implemented, extension to other domains is analysis only
 - [PRIVATE_DATA_DISCLOSURE_BOUNDARY.md](architecture/PRIVATE_DATA_DISCLOSURE_BOUNDARY.md) - Private-data disclosure/access boundary: scoped vaults, opaque receipt storage, disclosure policies, and access/export receipts (#1792, design-only)
 - [ABUSE_CASE_HARDENING_STRATEGY.md](architecture/ABUSE_CASE_HARDENING_STRATEGY.md) - Institutional-failure-mode hardening doctrine
 - [DEBIAN_APPLIANCE_MODEL.md](architecture/DEBIAN_APPLIANCE_MODEL.md) - Debian appliance / installable node image (scaffold-only; not production)

--- a/docs/architecture/AUTHORITY_SPINE.md
+++ b/docs/architecture/AUTHORITY_SPINE.md
@@ -65,14 +65,24 @@ and the fix.
 **Which deployments actually get which profile today**, since a profile
 document that does not say this is exactly the kind of unbacked capability claim
 this note argues against: the profile is *inferred from whether a revocation
-store was supplied*, not declared by operator configuration. The daemon always
-supplies one, so **every daemon deployment — including the portable evaluator
-appliance — runs `Institutional`**. `PortableEvaluator` is reached only by
-embedded/test callers that construct a `GatewayServer` without a store. Two
-consequences worth naming: the evaluator appliance does get durable revocation
-(it has a real store), and a deployment whose keystore fails to unlock takes a
-path that supplies no store, silently *downgrading* the authority guarantee.
-Making the profile an operator-declared configuration value is a follow-up.
+store was supplied*, not declared by operator configuration. The supply is
+conditional, not guaranteed — `revocation_store` is an `Option` on the gateway
+handles (`supervisor/lifecycle.rs`) that `init_gateway` consumes with `if let
+Some(..)`. A daemon startup that completes the component set opens
+`<store_path>/auth-revocation` and supplies it, so **a fully started daemon —
+including the portable evaluator appliance — runs `Institutional` with durable
+revocation**.
+
+The consequence to state plainly, because the inference is silent: `Institutional`
+is not a property of *being* a daemon. Any path that does not reach that
+assignment leaves the handle `None` and yields `PortableEvaluator` — embedded and
+test callers that construct a `GatewayServer` without a store, and equally a
+daemon run that never gets that far, such as one whose keystore does not unlock.
+In that case a daemon *downgrades* its own authority guarantee without an
+operator asking for it, and the only thing that says so is the capability report.
+Making the profile an operator-declared configuration value — so that a
+deployment which asked for `Institutional` fails instead of quietly becoming
+disposable — is a follow-up.
 
 Precisely what "refuses" means today: the gateway does not come up, and the
 daemon logs the error and continues running without a gateway. The supervisor

--- a/docs/architecture/AUTHORITY_SPINE.md
+++ b/docs/architecture/AUTHORITY_SPINE.md
@@ -39,16 +39,17 @@ authority rather than a bearer secret.
 | Invariant | Statement | Where enforced |
 |---|---|---|
 | **Attenuation** | `issued ⊆ issuer ∩ flow_allowed ∩ requested` — every term a ceiling, never a grant | `session_authority::attenuate_scopes` |
-| **Expiration** | The *configured* lifetime bounds the credentials actually issued; misconfiguration is refused, not clamped | `TokenLifetimePolicy`, `AuthManager::with_token_ttl` |
-| **Revocation** | An issued credential can be individually withdrawn and is rejected thereafter on every surface that accepted it | `RevocationAuthority`, consulted in `jwt_auth` |
+| **Expiration** | The *configured* lifetime bounds the credentials actually issued and accepted; client responses report that same lifetime, without hidden verification leeway | `TokenLifetimePolicy`, `AuthManager::with_token_ttl`, auth/invite/session responses |
+| **Revocation** | An issued credential can be individually withdrawn and is revalidated before each protected operation on every surface that accepted it | `RevocationAuthority`, HTTP middleware, WebSocket operations, RPC verification |
 | **Truth** | The runtime reports which of the above it actually installed, and a profile that *requires* a guarantee refuses to **serve** without it | `AuthorityCapabilities`, `AuthorityProfile::validate` |
 
 Two design rules make these hold under failure:
 
-- **Fail closed at the boundary, not per-caller.** `jwt_auth` resolves the
-  authority from `app_data` and refuses to authenticate if it is absent. A route
-  cannot opt out by forgetting to check, and a misassembly cannot silently
-  restore signature-only verification.
+- **Fail closed at the boundary, not per-caller.** Issuance handlers and
+  `jwt_auth` resolve the same `SessionAuthority` from `app_data`; the runtime no
+  longer registers a separate bare issuer. A route cannot opt out by forgetting
+  to check, and a misassembly cannot silently restore signature-only
+  verification.
 - **Unreadable state is not authorization.** A revocation lookup that errors
   denies the request. "We could not determine whether this was revoked" must
   never resolve to "not revoked".
@@ -74,13 +75,36 @@ path that supplies no store, silently *downgrading* the authority guarantee.
 Making the profile an operator-declared configuration value is a follow-up.
 
 Precisely what "refuses" means today: the gateway does not come up, and the
-daemon logs the error and continues running without a gateway. It is fail-closed
-— no request is ever served under an unmet guarantee — but it is *not* a process
-abort, and an operator watching only for a crash would miss it. Making an unmet
-authority profile fail the whole daemon is a deliberate follow-up decision, not
-an oversight. An institution that cannot make a withdrawal survive a
-restart does not have revocation, and the software should not claim otherwise on
-its behalf.
+daemon logs the error and continues running without a gateway. The supervisor
+waits for the gateway's initialization-and-bind acknowledgement and marks the
+gateway actor active only after that acknowledgement; failed startup is reported
+inactive. This is fail-closed — no request is ever served under an unmet
+guarantee — but it is *not* a process abort. Making an unmet authority profile
+fail the whole daemon is a deliberate follow-up decision. An institution that
+cannot make a withdrawal survive a restart does not have revocation, and the
+software should not claim otherwise on its behalf.
+
+### Current lifetime and continuing-authorization semantics
+
+- The canonical unconfigured session lifetime is 24 hours across
+  `AuthManager`, `TokenLifetimePolicy`, embedded gateways, and daemon
+  `GatewayConfig`. Explicit configuration replaces that value; authority
+  assembly rejects a mismatch between the issuer and the reported policy.
+- `/auth/verify`, invite join, and QR-session responses derive their reported
+  lifetime from the installed authority. Verification uses the credential's
+  exact `exp` boundary; the JWT library's default expiry leeway is disabled.
+- HTTP bearer routes revalidate on every request. WebSockets retain the
+  credential, revalidate after asynchronous subscription setup, and revalidate
+  before every protected event and every backfill operation/event. A revoked or
+  expired socket is stopped before protected delivery. An idle socket may remain
+  connected until its next protected operation; it retains no protected access
+  during that idle period.
+- Gateway and RPC revocation caches are positive-only. A miss consults the
+  shared durable store, so a revocation written by either surface is visible to
+  the other without restart. Store and cache errors deny verification.
+- This means verification of a non-revoked credential performs one point read
+  from the revocation store. No negative cache is installed: no demonstrated
+  bottleneck currently justifies a stale-revocation window.
 
 ## 4. Extending the pattern (analysis — not implemented)
 

--- a/docs/architecture/AUTHORITY_SPINE.md
+++ b/docs/architecture/AUTHORITY_SPINE.md
@@ -1,0 +1,133 @@
+---
+Status: descriptive
+Canonical: no
+Last Reviewed: 2026-07-19
+---
+
+# The Authority Spine
+
+How ICN makes the powers of an assembled runtime provable: where authority came
+from, what bounds it, how it is withdrawn, and what the runtime will honestly
+say about itself.
+
+> **Truth status.** This note describes a pattern **implemented for gateway
+> session authority only** (issues #2436, #2437). Every other domain named in
+> §4 is *analysis*: the extension is proposed, not built. Nothing here asserts
+> production operation, pilot readiness, or institutional adoption.
+
+## 1. The problem this answers
+
+A recurring failure shape across the codebase: a capability is implemented in a
+crate, unit-tested against a miniature composition, and then **not installed**
+in the assembled runtime — while documentation describes the library capability
+as though it were a runtime guarantee. Verified instances at the time of writing
+included RPC token revocation (machinery complete, constructed as `None` in the
+daemon), the gateway session lifetime (`token_expiry_hours` parsed, tested, and
+never applied), credit-policy enforcement on gateway-owned ledgers, ledger
+inbound sync, invariant gates, and hybrid blob storage.
+
+The common cause is not carelessness. It is that **composition is not a
+first-class value**: optional capabilities are exposed as setter seams, the
+composition root takes the minimal default at each seam, and nothing compares
+"built and tested" against "installed here".
+
+## 2. The invariants
+
+Four properties, enforced together, are what turn a credential into accountable
+authority rather than a bearer secret.
+
+| Invariant | Statement | Where enforced |
+|---|---|---|
+| **Attenuation** | `issued ⊆ issuer ∩ flow_allowed ∩ requested` — every term a ceiling, never a grant | `session_authority::attenuate_scopes` |
+| **Expiration** | The *configured* lifetime bounds the credentials actually issued; misconfiguration is refused, not clamped | `TokenLifetimePolicy`, `AuthManager::with_token_ttl` |
+| **Revocation** | An issued credential can be individually withdrawn and is rejected thereafter on every surface that accepted it | `RevocationAuthority`, consulted in `jwt_auth` |
+| **Truth** | The runtime reports which of the above it actually installed, and a profile that *requires* a guarantee refuses to start without it | `AuthorityCapabilities`, `AuthorityProfile::validate` |
+
+Two design rules make these hold under failure:
+
+- **Fail closed at the boundary, not per-caller.** `jwt_auth` resolves the
+  authority from `app_data` and refuses to authenticate if it is absent. A route
+  cannot opt out by forgetting to check, and a misassembly cannot silently
+  restore signature-only verification.
+- **Unreadable state is not authorization.** A revocation lookup that errors
+  denies the request. "We could not determine whether this was revoked" must
+  never resolve to "not revoked".
+
+## 3. What a deployment profile means
+
+A profile is a **requirement**, not a description. `PortableEvaluator` may run
+volatile revocation because the deployment is disposable — and says so in its
+capability report. `Institutional` requires durable revocation and **aborts
+startup** when it is missing, naming the capability, the reason, the refused
+fallback, and the fix. An institution that cannot make a withdrawal survive a
+restart does not have revocation, and the software should not claim otherwise on
+its behalf.
+
+## 4. Extending the pattern (analysis — not implemented)
+
+Authority is not only about people. A compute worker, a storage provider, a
+model endpoint, and a federation peer each hold *powers* over cooperative
+infrastructure, and each currently follows the same failure shape the session
+work just corrected. The same lifecycle applies:
+
+```text
+advertised → discovered → attested → institutionally authorized
+   → allocated → invoked → metered → receipt-producing
+   → revocable → degraded → unavailable/withdrawn
+```
+
+The load-bearing distinction is between three things that are routinely
+conflated:
+
+1. **Technical capacity** — the machine can do it.
+2. **Institutional legitimacy** — someone with standing authorized it.
+3. **Current availability** — it works right now.
+
+A capability report must never let (1) or (3) stand in for (2). Concretely:
+
+- A machine may **advertise** compute without being **authorized** to execute
+  protected workloads.
+- A storage node may be **reachable** without being **authorized** to retain
+  member evidence.
+- A model may be **callable** without being **approved** for a given data class.
+- A federation peer may **authenticate** a message without holding **authority**
+  to alter institutional state. (This is a live gap: inbound institutional-state
+  application is currently ambient — see #2441.)
+- A ledger implementation may **exist** without the runtime **enforcing** the
+  institution's credit policy — see #2438, the same "installed?" question in the
+  economic domain.
+
+For each such domain, the extension is the same three moves this work made:
+give the subsystem one explicit composition value; make the profile's required
+guarantees a startup invariant; and derive the capability report from the
+constructed object rather than a hand-maintained list.
+
+## 5. What this pattern does NOT decide
+
+It enforces technical ceilings on authority. It does not decide who is
+legitimate. Which DIDs may approve a session, which scopes a role carries, how
+long an institution wants credentials to live, who may revoke whose authority,
+and what recourse a member has — these are institutional questions that belong
+to charter and governance policy above this layer, and several of them are
+unanswered today:
+
+| Question | Status |
+|---|---|
+| Who may approve a session on another member's behalf? | Open — currently any credential holder for the cooperative, attenuated to their own scopes |
+| Who may revoke, and on whose authority? | Open — the revocation *mechanism* exists; the institutional act does not |
+| What evidence should a revocation leave? | Open — no revocation receipt yet; belongs with the ADR-0026 ladder |
+| How is authority recovered when an administrator disappears? | Open — operator succession is unaddressed |
+| How does a member contest a revocation? | Open — challenge paths are weaker than institutional action paths |
+
+Recording these as open is deliberate. A system whose authority cannot be
+revoked, contested, or understood by its members does not meet ICN's purpose,
+and naming the gap is more useful than a mechanism that implies it is closed.
+
+## 6. References
+
+- `icn/crates/icn-gateway/src/session_authority.rs` — the composition boundary
+- `icn/crates/icn-gateway/tests/session_authority_enforcement.rs` — enforcement
+  proof through the real middleware
+- Issues #2436 (attenuation), #2437 (revocation + lifetime), #2421 (production
+  route assembly not test-constructible — the remaining gap between "this
+  boundary is tested" and "every mounted route is tested")

--- a/docs/architecture/AUTHORITY_SPINE.md
+++ b/docs/architecture/AUTHORITY_SPINE.md
@@ -61,6 +61,18 @@ capability report. `Institutional` requires durable revocation and **refuses to
 assemble** without it, naming the capability, the reason, the refused fallback,
 and the fix.
 
+**Which deployments actually get which profile today**, since a profile
+document that does not say this is exactly the kind of unbacked capability claim
+this note argues against: the profile is *inferred from whether a revocation
+store was supplied*, not declared by operator configuration. The daemon always
+supplies one, so **every daemon deployment — including the portable evaluator
+appliance — runs `Institutional`**. `PortableEvaluator` is reached only by
+embedded/test callers that construct a `GatewayServer` without a store. Two
+consequences worth naming: the evaluator appliance does get durable revocation
+(it has a real store), and a deployment whose keystore fails to unlock takes a
+path that supplies no store, silently *downgrading* the authority guarantee.
+Making the profile an operator-declared configuration value is a follow-up.
+
 Precisely what "refuses" means today: the gateway does not come up, and the
 daemon logs the error and continues running without a gateway. It is fail-closed
 — no request is ever served under an unmet guarantee — but it is *not* a process

--- a/docs/architecture/AUTHORITY_SPINE.md
+++ b/docs/architecture/AUTHORITY_SPINE.md
@@ -41,7 +41,7 @@ authority rather than a bearer secret.
 | **Attenuation** | `issued ⊆ issuer ∩ flow_allowed ∩ requested` — every term a ceiling, never a grant | `session_authority::attenuate_scopes` |
 | **Expiration** | The *configured* lifetime bounds the credentials actually issued; misconfiguration is refused, not clamped | `TokenLifetimePolicy`, `AuthManager::with_token_ttl` |
 | **Revocation** | An issued credential can be individually withdrawn and is rejected thereafter on every surface that accepted it | `RevocationAuthority`, consulted in `jwt_auth` |
-| **Truth** | The runtime reports which of the above it actually installed, and a profile that *requires* a guarantee refuses to start without it | `AuthorityCapabilities`, `AuthorityProfile::validate` |
+| **Truth** | The runtime reports which of the above it actually installed, and a profile that *requires* a guarantee refuses to **serve** without it | `AuthorityCapabilities`, `AuthorityProfile::validate` |
 
 Two design rules make these hold under failure:
 
@@ -57,9 +57,16 @@ Two design rules make these hold under failure:
 
 A profile is a **requirement**, not a description. `PortableEvaluator` may run
 volatile revocation because the deployment is disposable — and says so in its
-capability report. `Institutional` requires durable revocation and **aborts
-startup** when it is missing, naming the capability, the reason, the refused
-fallback, and the fix. An institution that cannot make a withdrawal survive a
+capability report. `Institutional` requires durable revocation and **refuses to
+assemble** without it, naming the capability, the reason, the refused fallback,
+and the fix.
+
+Precisely what "refuses" means today: the gateway does not come up, and the
+daemon logs the error and continues running without a gateway. It is fail-closed
+— no request is ever served under an unmet guarantee — but it is *not* a process
+abort, and an operator watching only for a crash would miss it. Making an unmet
+authority profile fail the whole daemon is a deliberate follow-up decision, not
+an oversight. An institution that cannot make a withdrawal survive a
 restart does not have revocation, and the software should not claim otherwise on
 its behalf.
 

--- a/docs/architecture/AUTHORITY_SPINE.md
+++ b/docs/architecture/AUTHORITY_SPINE.md
@@ -39,7 +39,7 @@ authority rather than a bearer secret.
 | Invariant | Statement | Where enforced |
 |---|---|---|
 | **Attenuation** | `issued ⊆ issuer ∩ flow_allowed ∩ requested` — every term a ceiling, never a grant | `session_authority::attenuate_scopes` |
-| **Expiration** | The *configured* lifetime bounds the credentials actually issued and accepted; client responses report that same lifetime, without hidden verification leeway | `TokenLifetimePolicy`, `AuthManager::with_token_ttl`, `SessionAuthority::verify` (acceptance bound), auth/invite/session responses |
+| **Expiration** | The *configured* lifetime bounds the **gateway session** credentials actually issued and accepted; client responses report that same lifetime, without hidden verification leeway. The RPC surface is **not** bounded — see below | `TokenLifetimePolicy`, `AuthManager::with_token_ttl`, `SessionAuthority::verify` (acceptance bound), auth/invite/session responses |
 | **Revocation** | An issued credential can be individually withdrawn and is revalidated before each protected operation on every surface that accepted it | `RevocationAuthority`, HTTP middleware, WebSocket operations, RPC verification |
 | **Truth** | The runtime reports which of the above it actually installed, and a profile that *requires* a guarantee refuses to **serve** without it | `AuthorityCapabilities`, `AuthorityProfile::validate` |
 
@@ -105,6 +105,23 @@ software should not claim otherwise on its behalf.
   mint takes `--expiry-hours`, validated through the same
   `TokenLifetimePolicy` the gateway applies to its own configuration, for
   deployments configured shorter than the canonical default.
+- **The acceptance bound covers the gateway surface only.** The daemon derives
+  the RPC signing key from the same `gateway.jwt_secret`
+  (`supervisor/init_rpc.rs`), and `RpcTokenClaims` does not reject unknown
+  fields, so a gateway-issued credential is structurally verifiable on the RPC
+  surface. `icn-rpc`'s `verify_token` checks signature, `exp`, and revocation —
+  it applies no configured-lifetime bound, and its own issuance lifetime is a
+  hardcoded 24 hours that never reads `token_expiry_hours`. Verified by direct
+  test on this branch: on a deployment configured for one-hour sessions, a
+  24-hour co-issued credential is refused by `SessionAuthority::verify` and
+  **accepted** by `RpcAuthManager::verify_token`. Consequence an operator must
+  know: lowering `token_expiry_hours` shortens gateway sessions immediately but
+  does not shorten already-issued credentials on the RPC surface; revocation,
+  which *is* shared, remains the instrument that reaches both. Closing this
+  requires bounding RPC acceptance **and** issuance together — bounding
+  acceptance alone would refuse the RPC manager's own freshly-minted tokens —
+  which is a separate change with its own credential-invalidation migration,
+  tracked in #2445.
 - HTTP bearer routes revalidate on every request. WebSockets retain the
   credential, revalidate after asynchronous subscription setup, and revalidate
   before every protected event and every backfill operation/event. A revoked or

--- a/docs/architecture/AUTHORITY_SPINE.md
+++ b/docs/architecture/AUTHORITY_SPINE.md
@@ -1,7 +1,7 @@
 ---
 Status: descriptive
 Canonical: no
-Last Reviewed: 2026-07-19
+Last Reviewed: 2026-07-21
 ---
 
 # The Authority Spine
@@ -39,7 +39,7 @@ authority rather than a bearer secret.
 | Invariant | Statement | Where enforced |
 |---|---|---|
 | **Attenuation** | `issued ⊆ issuer ∩ flow_allowed ∩ requested` — every term a ceiling, never a grant | `session_authority::attenuate_scopes` |
-| **Expiration** | The *configured* lifetime bounds the credentials actually issued and accepted; client responses report that same lifetime, without hidden verification leeway | `TokenLifetimePolicy`, `AuthManager::with_token_ttl`, auth/invite/session responses |
+| **Expiration** | The *configured* lifetime bounds the credentials actually issued and accepted; client responses report that same lifetime, without hidden verification leeway | `TokenLifetimePolicy`, `AuthManager::with_token_ttl`, `SessionAuthority::verify` (acceptance bound), auth/invite/session responses |
 | **Revocation** | An issued credential can be individually withdrawn and is revalidated before each protected operation on every surface that accepted it | `RevocationAuthority`, HTTP middleware, WebSocket operations, RPC verification |
 | **Truth** | The runtime reports which of the above it actually installed, and a profile that *requires* a guarantee refuses to **serve** without it | `AuthorityCapabilities`, `AuthorityProfile::validate` |
 
@@ -93,6 +93,18 @@ software should not claim otherwise on its behalf.
 - `/auth/verify`, invite join, and QR-session responses derive their reported
   lifetime from the installed authority. Verification uses the credential's
   exact `exp` boundary; the JWT library's default expiry leeway is disabled.
+- The configured lifetime bounds **acceptance**, not just issuance. Every
+  gateway mint already carries exactly the configured lifetime, but a co-issuer
+  holding the signing secret — `icnctl auth token --local-mint` is the
+  supported one — signs whatever expiry it chooses. `SessionAuthority::verify`
+  therefore refuses a credential whose `exp - iat` exceeds the configured
+  lifetime (loudly, naming the bound — not clamped, which would silently
+  shorten a session the holder was told was longer), and independently refuses
+  any credential whose expiry lies more than one configured lifetime from now,
+  so a fabricated or forward-dated `iat` cannot buy extra validity. The local
+  mint takes `--expiry-hours`, validated through the same
+  `TokenLifetimePolicy` the gateway applies to its own configuration, for
+  deployments configured shorter than the canonical default.
 - HTTP bearer routes revalidate on every request. WebSockets retain the
   credential, revalidate after asynchronous subscription setup, and revalidate
   before every protected event and every backfill operation/event. A revoked or

--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-07-02T22:22:44+00:00
+Generated: 2026-07-20T01:33:38+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -18,20 +18,20 @@ Generated: 2026-07-02T22:22:44+00:00
 
 ## Snapshot
 
-- Source commit: `6a1f00aed433a8c80862f6742f081129ceeb323e`
+- Source commit: `708cb0004402dc298abd448ab84604d4d2f9933d`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
 ## Coverage summary
 
-- **Discovered gateway route macros: 287** (DELETE 17 · GET 131 · POST 125 · PUT 14)
-- **OpenAPI documented paths: 5**
+- **Discovered gateway route macros: 286** (DELETE 17 · GET 131 · POST 124 · PUT 14)
+- **OpenAPI documented paths: 6**
 - Matched as documented (best-effort method+path match): 2
-- Not matched to OpenAPI (best-effort): 285 (~99% of discovered)
+- Not matched to OpenAPI (best-effort): 284 (~99% of discovered)
 - Documented share of discovered routes: ~0.7%
-- **OpenAPI operations (method + path) not matched to a discovered gateway route: 3** (see section below)
-- **Governance app route-registration candidates (separate surface, not gateway macros): 86** (see section below)
-- **Proof level: every tabulated route row is recorded at `L1`** (287 gateway macros + 86 governance candidates + 3 OpenAPI-unmatched operations) — a declaration/contract/registration exists in source; the static scan asserts no level above L1. The 4 unparsed `web::resource`/`.route` candidates are flagged leads (not parsed into routes) and carry no proof level.
+- **OpenAPI operations (method + path) not matched to a discovered gateway route: 4** (see section below)
+- **Governance app route-registration candidates (separate surface, not gateway macros): 87** (see section below)
+- **Proof level: every tabulated route row is recorded at `L1`** (286 gateway macros + 87 governance candidates + 4 OpenAPI-unmatched operations) — a declaration/contract/registration exists in source; the static scan asserts no level above L1. The 4 unparsed `web::resource`/`.route` candidates are flagged leads (not parsed into routes) and carry no proof level.
 
 > The gap is structural: only handlers hand-annotated for utoipa reach the OpenAPI spec. Of the OpenAPI paths, several belong to `icn-governance-actor` HTTP handlers that live outside the gateway crate and are not captured by this macro scan — so the documented/undocumented counts here are a best-effort comparison, while the two headline counts (discovered macros, OpenAPI paths) are the robust measured facts.
 
@@ -41,102 +41,104 @@ These OpenAPI-documented paths did **not** mechanically match any discovered gat
 
 | Method | OpenAPI path | Matched gateway route | Governance registration candidate | Proof | Status | Claim safety |
 |---|---|---|---|---|---|---|
-| GET | `/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | no | `get_action_item_completion_receipt` @ `icn/apps/governance/src/http/configure.rs`:682 | L1 | unknown / needs local verification | needs review |
-| GET | `/gov/me/action-cards` | no | `get_my_action_cards` @ `icn/apps/governance/src/http/configure.rs`:871 | L1 | unknown / needs local verification | needs review |
-| GET | `/gov/me/standing` | no | `get_my_standing` @ `icn/apps/governance/src/http/configure.rs`:867 | L1 | unknown / needs local verification | needs review |
+| GET | `/gov/domains/{domain_id}/action-items/{item_id}/completion-receipt` | no | `get_action_item_completion_receipt` @ `icn/apps/governance/src/http/configure.rs`:726 | L1 | unknown / needs local verification | needs review |
+| GET | `/gov/me/action-cards` | no | `get_my_action_cards` @ `icn/apps/governance/src/http/configure.rs`:915 | L1 | unknown / needs local verification | needs review |
+| GET | `/gov/me/pending-publish-summary` | no | `get_my_pending_publish_summary` @ `icn/apps/governance/src/http/configure.rs`:919 | L1 | unknown / needs local verification | needs review |
+| GET | `/gov/me/standing` | no | `get_my_standing` @ `icn/apps/governance/src/http/configure.rs`:911 | L1 | unknown / needs local verification | needs review |
 
 ## Governance app route-registration candidates
 
-The governance app (`icn-governance-actor` = `icn/apps/governance`) registers its HTTP routes via `web::resource("…").route(web::<verb>().to(handlers::…))` in `apps/governance/src/http/configure.rs`, mounted under the gateway's `web::scope("/gov")` (the served path is `/gov` + the relative path below). It uses **no route attribute macros**, so the gateway macro scan above never sees these: they are a **separate registration surface**, listed here as candidates and **not** counted among the 287 gateway macros. This is why the unmatched `/gov/*` OpenAPI operations have no gateway-macro match — their handlers are registered here. The scan is mechanical (one `configure.rs`, one pattern); a registration site does **not** prove correctness, auth, mounting health, tests, or production readiness, so candidates stay `unknown / needs local verification`. `OpenAPI documented` = this candidate's `(verb, /gov + path)` matches a generated OpenAPI operation.
+The governance app (`icn-governance-actor` = `icn/apps/governance`) registers its HTTP routes via `web::resource("…").route(web::<verb>().to(handlers::…))` in `apps/governance/src/http/configure.rs`, mounted under the gateway's `web::scope("/gov")` (the served path is `/gov` + the relative path below). It uses **no route attribute macros**, so the gateway macro scan above never sees these: they are a **separate registration surface**, listed here as candidates and **not** counted among the 286 gateway macros. This is why the unmatched `/gov/*` OpenAPI operations have no gateway-macro match — their handlers are registered here. The scan is mechanical (one `configure.rs`, one pattern); a registration site does **not** prove correctness, auth, mounting health, tests, or production readiness, so candidates stay `unknown / needs local verification`. `OpenAPI documented` = this candidate's `(verb, /gov + path)` matches a generated OpenAPI operation.
 
 | Method | Path (relative, under `/gov`) | Source | Handler | OpenAPI documented | Proof | Status | Claim safety |
 |---|---|---|---|---|---|---|---|
-| GET | `/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:744 | `get_activity` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/charters` | `icn/apps/governance/src/http/configure.rs`:587 | `activate_charter` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/delegations` | `icn/apps/governance/src/http/configure.rs`:654 | `list_delegations` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/delegations` | `icn/apps/governance/src/http/configure.rs`:653 | `create_delegation` | no | L1 | unknown / needs local verification | needs review |
-| DELETE | `/delegations/{delegation_id}` | `icn/apps/governance/src/http/configure.rs`:658 | `revoke_delegation` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/digest` | `icn/apps/governance/src/http/configure.rs`:864 | `get_digest` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/domains` | `icn/apps/governance/src/http/configure.rs`:576 | `list_domains` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains` | `icn/apps/governance/src/http/configure.rs`:575 | `create_domain` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}` | `icn/apps/governance/src/http/configure.rs`:579 | `get_domain` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/action-items` | `icn/apps/governance/src/http/configure.rs`:664 | `list_action_items` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/action-items` | `icn/apps/governance/src/http/configure.rs`:663 | `create_action_item` | no | L1 | unknown / needs local verification | needs review |
-| DELETE | `/domains/{domain_id}/action-items/{item_id}` | `icn/apps/governance/src/http/configure.rs`:670 | `delete_action_item` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/action-items/{item_id}` | `icn/apps/governance/src/http/configure.rs`:668 | `get_action_item` | no | L1 | unknown / needs local verification | needs review |
-| PUT | `/domains/{domain_id}/action-items/{item_id}` | `icn/apps/governance/src/http/configure.rs`:669 | `update_action_item` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `icn/apps/governance/src/http/configure.rs`:682 | `get_action_item_completion_receipt` | yes | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/action-items/{item_id}/notes` | `icn/apps/governance/src/http/configure.rs`:678 | `add_action_item_note` | no | L1 | unknown / needs local verification | needs review |
-| PUT | `/domains/{domain_id}/action-items/{item_id}/status` | `icn/apps/governance/src/http/configure.rs`:674 | `update_action_item_status` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/domain-policy/adopt` | `icn/apps/governance/src/http/configure.rs`:714 | `adopt_domain_policy` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/institutional-domain/declare` | `icn/apps/governance/src/http/configure.rs`:719 | `declare_institutional_domain` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:795 | `list_meetings` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:794 | `create_meeting` | no | L1 | unknown / needs local verification | needs review |
-| DELETE | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:584 | `remove_domain_member` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:583 | `add_domain_member` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/process-sessions/{session_id}/decisions/{decision_id}/record` | `icn/apps/governance/src/http/configure.rs`:709 | `record_decision` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/process-sessions/{session_id}/deliberation-entries/{entry_id}/record` | `icn/apps/governance/src/http/configure.rs`:701 | `record_deliberation_entry` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/process-sessions/{session_id}/gate-results` | `icn/apps/governance/src/http/configure.rs`:687 | `record_process_gate_result` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/process-sessions/{session_id}/open` | `icn/apps/governance/src/http/configure.rs`:693 | `open_process_session` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:750 | `list_programs_by_domain` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:749 | `create_program` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:740 | `list_activities` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:739 | `create_activity` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:725 | `list_structures` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:724 | `create_structure` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/me/action-cards` | `icn/apps/governance/src/http/configure.rs`:871 | `get_my_action_cards` | yes | L1 | unknown / needs local verification | needs review |
-| GET | `/me/scopes` | `icn/apps/governance/src/http/configure.rs`:866 | `get_my_scopes` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/me/standing` | `icn/apps/governance/src/http/configure.rs`:867 | `get_my_standing` | yes | L1 | unknown / needs local verification | needs review |
-| GET | `/me/work` | `icn/apps/governance/src/http/configure.rs`:868 | `get_my_work` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/meetings/{meeting_id}` | `icn/apps/governance/src/http/configure.rs`:799 | `get_meeting` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/agenda` | `icn/apps/governance/src/http/configure.rs`:819 | `add_agenda_item` | no | L1 | unknown / needs local verification | needs review |
-| PUT | `/meetings/{meeting_id}/agenda/{item_id}` | `icn/apps/governance/src/http/configure.rs`:823 | `update_agenda_item` | no | L1 | unknown / needs local verification | needs review |
-| PUT | `/meetings/{meeting_id}/attendance` | `icn/apps/governance/src/http/configure.rs`:815 | `mark_attendance` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/attendees` | `icn/apps/governance/src/http/configure.rs`:811 | `add_attendee` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/end` | `icn/apps/governance/src/http/configure.rs`:807 | `end_meeting` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/meetings/{meeting_id}/start` | `icn/apps/governance/src/http/configure.rs`:803 | `start_meeting` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:780 | `get_milestone` | no | L1 | unknown / needs local verification | needs review |
-| PATCH | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:781 | `update_milestone_status` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}/history` | `icn/apps/governance/src/http/configure.rs`:789 | `get_milestone_history` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/milestones/{milestone_id}/preview` | `icn/apps/governance/src/http/configure.rs`:785 | `preview_milestone` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}` | `icn/apps/governance/src/http/configure.rs`:754 | `get_program` | no | L1 | unknown / needs local verification | needs review |
-| DELETE | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:776 | `unlink_activity_from_program` | no | L1 | unknown / needs local verification | needs review |
-| PUT | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:775 | `link_activity_to_program` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/dashboard` | `icn/apps/governance/src/http/configure.rs`:762 | `get_program_dashboard` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:771 | `list_milestones_by_program` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:770 | `create_milestone` | no | L1 | unknown / needs local verification | needs review |
-| PATCH | `/programs/{program_id}/status` | `icn/apps/governance/src/http/configure.rs`:758 | `update_program_status` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/programs/{program_id}/summary` | `icn/apps/governance/src/http/configure.rs`:766 | `get_program_summary` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/proposals` | `icn/apps/governance/src/http/configure.rs`:592 | `list_proposals` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals` | `icn/apps/governance/src/http/configure.rs`:591 | `create_proposal` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/clearing/establish` | `icn/apps/governance/src/http/configure.rs`:836 | `create_establish_clearing_proposal` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/clearing/terminate` | `icn/apps/governance/src/http/configure.rs`:840 | `create_terminate_clearing_proposal` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/join` | `icn/apps/governance/src/http/configure.rs`:828 | `create_join_federation_proposal` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/leave` | `icn/apps/governance/src/http/configure.rs`:832 | `create_leave_federation_proposal` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/policy` | `icn/apps/governance/src/http/configure.rs`:852 | `create_update_federation_policy_proposal` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/vouch` | `icn/apps/governance/src/http/configure.rs`:844 | `create_vouch_proposal` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/federation/vouch/revoke` | `icn/apps/governance/src/http/configure.rs`:848 | `create_revoke_vouch_proposal` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/sdis/appoint-steward` | `icn/apps/governance/src/http/configure.rs`:857 | `create_appoint_steward_proposal` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/sdis/remove-steward` | `icn/apps/governance/src/http/configure.rs`:861 | `create_remove_steward_proposal` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/proposals/{proposal_id}` | `icn/apps/governance/src/http/configure.rs`:596 | `get_proposal` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/proposals/{proposal_id}/chain` | `icn/apps/governance/src/http/configure.rs`:620 | `get_chain` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/{proposal_id}/close` | `icn/apps/governance/src/http/configure.rs`:604 | `close_proposal` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/proposals/{proposal_id}/deliberation` | `icn/apps/governance/src/http/configure.rs`:624 | `get_proposal_deliberation` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/proposals/{proposal_id}/discussion` | `icn/apps/governance/src/http/configure.rs`:633 | `get_discussion` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/proposals/{proposal_id}/discussion/comments` | `icn/apps/governance/src/http/configure.rs`:638 | `list_comments` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/{proposal_id}/discussion/comments` | `icn/apps/governance/src/http/configure.rs`:637 | `add_comment` | no | L1 | unknown / needs local verification | needs review |
-| DELETE | `/proposals/{proposal_id}/discussion/comments/{comment_id}` | `icn/apps/governance/src/http/configure.rs`:643 | `delete_comment` | no | L1 | unknown / needs local verification | needs review |
-| PUT | `/proposals/{proposal_id}/discussion/comments/{comment_id}` | `icn/apps/governance/src/http/configure.rs`:642 | `edit_comment` | no | L1 | unknown / needs local verification | needs review |
-| DELETE | `/proposals/{proposal_id}/discussion/comments/{comment_id}/reactions` | `icn/apps/governance/src/http/configure.rs`:648 | `remove_reaction` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/{proposal_id}/discussion/comments/{comment_id}/reactions` | `icn/apps/governance/src/http/configure.rs`:647 | `add_reaction` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/proposals/{proposal_id}/effects` | `icn/apps/governance/src/http/configure.rs`:628 | `list_proposal_effects` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/{proposal_id}/open` | `icn/apps/governance/src/http/configure.rs`:600 | `open_proposal` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/proposals/{proposal_id}/proof` | `icn/apps/governance/src/http/configure.rs`:616 | `get_proof` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/proposals/{proposal_id}/tally` | `icn/apps/governance/src/http/configure.rs`:612 | `get_vote_tally` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/proposals/{proposal_id}/vote` | `icn/apps/governance/src/http/configure.rs`:608 | `cast_vote` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/structures/{structure_id}` | `icn/apps/governance/src/http/configure.rs`:729 | `get_structure` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:734 | `list_roles` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:733 | `assign_role` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:788 | `get_activity` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/charters` | `icn/apps/governance/src/http/configure.rs`:631 | `activate_charter` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/delegations` | `icn/apps/governance/src/http/configure.rs`:698 | `list_delegations` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/delegations` | `icn/apps/governance/src/http/configure.rs`:697 | `create_delegation` | no | L1 | unknown / needs local verification | needs review |
+| DELETE | `/delegations/{delegation_id}` | `icn/apps/governance/src/http/configure.rs`:702 | `revoke_delegation` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/digest` | `icn/apps/governance/src/http/configure.rs`:908 | `get_digest` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/domains` | `icn/apps/governance/src/http/configure.rs`:620 | `list_domains` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains` | `icn/apps/governance/src/http/configure.rs`:619 | `create_domain` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}` | `icn/apps/governance/src/http/configure.rs`:623 | `get_domain` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/action-items` | `icn/apps/governance/src/http/configure.rs`:708 | `list_action_items` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/action-items` | `icn/apps/governance/src/http/configure.rs`:707 | `create_action_item` | no | L1 | unknown / needs local verification | needs review |
+| DELETE | `/domains/{domain_id}/action-items/{item_id}` | `icn/apps/governance/src/http/configure.rs`:714 | `delete_action_item` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/action-items/{item_id}` | `icn/apps/governance/src/http/configure.rs`:712 | `get_action_item` | no | L1 | unknown / needs local verification | needs review |
+| PUT | `/domains/{domain_id}/action-items/{item_id}` | `icn/apps/governance/src/http/configure.rs`:713 | `update_action_item` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/action-items/{item_id}/completion-receipt` | `icn/apps/governance/src/http/configure.rs`:726 | `get_action_item_completion_receipt` | yes | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/action-items/{item_id}/notes` | `icn/apps/governance/src/http/configure.rs`:722 | `add_action_item_note` | no | L1 | unknown / needs local verification | needs review |
+| PUT | `/domains/{domain_id}/action-items/{item_id}/status` | `icn/apps/governance/src/http/configure.rs`:718 | `update_action_item_status` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/domain-policy/adopt` | `icn/apps/governance/src/http/configure.rs`:758 | `adopt_domain_policy` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/institutional-domain/declare` | `icn/apps/governance/src/http/configure.rs`:763 | `declare_institutional_domain` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:839 | `list_meetings` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/meetings` | `icn/apps/governance/src/http/configure.rs`:838 | `create_meeting` | no | L1 | unknown / needs local verification | needs review |
+| DELETE | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:628 | `remove_domain_member` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/members` | `icn/apps/governance/src/http/configure.rs`:627 | `add_domain_member` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/process-sessions/{session_id}/decisions/{decision_id}/record` | `icn/apps/governance/src/http/configure.rs`:753 | `record_decision` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/process-sessions/{session_id}/deliberation-entries/{entry_id}/record` | `icn/apps/governance/src/http/configure.rs`:745 | `record_deliberation_entry` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/process-sessions/{session_id}/gate-results` | `icn/apps/governance/src/http/configure.rs`:731 | `record_process_gate_result` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/process-sessions/{session_id}/open` | `icn/apps/governance/src/http/configure.rs`:737 | `open_process_session` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:794 | `list_programs_by_domain` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/domains/{domain_id}/programs` | `icn/apps/governance/src/http/configure.rs`:793 | `create_program` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:784 | `list_activities` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/activities` | `icn/apps/governance/src/http/configure.rs`:783 | `create_activity` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:769 | `list_structures` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/entities/{entity_id}/structures` | `icn/apps/governance/src/http/configure.rs`:768 | `create_structure` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/me/action-cards` | `icn/apps/governance/src/http/configure.rs`:915 | `get_my_action_cards` | yes | L1 | unknown / needs local verification | needs review |
+| GET | `/me/pending-publish-summary` | `icn/apps/governance/src/http/configure.rs`:919 | `get_my_pending_publish_summary` | yes | L1 | unknown / needs local verification | needs review |
+| GET | `/me/scopes` | `icn/apps/governance/src/http/configure.rs`:910 | `get_my_scopes` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/me/standing` | `icn/apps/governance/src/http/configure.rs`:911 | `get_my_standing` | yes | L1 | unknown / needs local verification | needs review |
+| GET | `/me/work` | `icn/apps/governance/src/http/configure.rs`:912 | `get_my_work` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/meetings/{meeting_id}` | `icn/apps/governance/src/http/configure.rs`:843 | `get_meeting` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/agenda` | `icn/apps/governance/src/http/configure.rs`:863 | `add_agenda_item` | no | L1 | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/agenda/{item_id}` | `icn/apps/governance/src/http/configure.rs`:867 | `update_agenda_item` | no | L1 | unknown / needs local verification | needs review |
+| PUT | `/meetings/{meeting_id}/attendance` | `icn/apps/governance/src/http/configure.rs`:859 | `mark_attendance` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/attendees` | `icn/apps/governance/src/http/configure.rs`:855 | `add_attendee` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/end` | `icn/apps/governance/src/http/configure.rs`:851 | `end_meeting` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/meetings/{meeting_id}/start` | `icn/apps/governance/src/http/configure.rs`:847 | `start_meeting` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:824 | `get_milestone` | no | L1 | unknown / needs local verification | needs review |
+| PATCH | `/milestones/{milestone_id}` | `icn/apps/governance/src/http/configure.rs`:825 | `update_milestone_status` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/history` | `icn/apps/governance/src/http/configure.rs`:833 | `get_milestone_history` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/milestones/{milestone_id}/preview` | `icn/apps/governance/src/http/configure.rs`:829 | `preview_milestone` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}` | `icn/apps/governance/src/http/configure.rs`:798 | `get_program` | no | L1 | unknown / needs local verification | needs review |
+| DELETE | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:820 | `unlink_activity_from_program` | no | L1 | unknown / needs local verification | needs review |
+| PUT | `/programs/{program_id}/activities/{activity_id}` | `icn/apps/governance/src/http/configure.rs`:819 | `link_activity_to_program` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/dashboard` | `icn/apps/governance/src/http/configure.rs`:806 | `get_program_dashboard` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:815 | `list_milestones_by_program` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/programs/{program_id}/milestones` | `icn/apps/governance/src/http/configure.rs`:814 | `create_milestone` | no | L1 | unknown / needs local verification | needs review |
+| PATCH | `/programs/{program_id}/status` | `icn/apps/governance/src/http/configure.rs`:802 | `update_program_status` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/programs/{program_id}/summary` | `icn/apps/governance/src/http/configure.rs`:810 | `get_program_summary` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/proposals` | `icn/apps/governance/src/http/configure.rs`:636 | `list_proposals` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals` | `icn/apps/governance/src/http/configure.rs`:635 | `create_proposal` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/establish` | `icn/apps/governance/src/http/configure.rs`:880 | `create_establish_clearing_proposal` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/clearing/terminate` | `icn/apps/governance/src/http/configure.rs`:884 | `create_terminate_clearing_proposal` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/join` | `icn/apps/governance/src/http/configure.rs`:872 | `create_join_federation_proposal` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/leave` | `icn/apps/governance/src/http/configure.rs`:876 | `create_leave_federation_proposal` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/policy` | `icn/apps/governance/src/http/configure.rs`:896 | `create_update_federation_policy_proposal` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch` | `icn/apps/governance/src/http/configure.rs`:888 | `create_vouch_proposal` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/federation/vouch/revoke` | `icn/apps/governance/src/http/configure.rs`:892 | `create_revoke_vouch_proposal` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/appoint-steward` | `icn/apps/governance/src/http/configure.rs`:901 | `create_appoint_steward_proposal` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/sdis/remove-steward` | `icn/apps/governance/src/http/configure.rs`:905 | `create_remove_steward_proposal` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}` | `icn/apps/governance/src/http/configure.rs`:640 | `get_proposal` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/chain` | `icn/apps/governance/src/http/configure.rs`:664 | `get_chain` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/close` | `icn/apps/governance/src/http/configure.rs`:648 | `close_proposal` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/deliberation` | `icn/apps/governance/src/http/configure.rs`:668 | `get_proposal_deliberation` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/discussion` | `icn/apps/governance/src/http/configure.rs`:677 | `get_discussion` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/discussion/comments` | `icn/apps/governance/src/http/configure.rs`:682 | `list_comments` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/discussion/comments` | `icn/apps/governance/src/http/configure.rs`:681 | `add_comment` | no | L1 | unknown / needs local verification | needs review |
+| DELETE | `/proposals/{proposal_id}/discussion/comments/{comment_id}` | `icn/apps/governance/src/http/configure.rs`:687 | `delete_comment` | no | L1 | unknown / needs local verification | needs review |
+| PUT | `/proposals/{proposal_id}/discussion/comments/{comment_id}` | `icn/apps/governance/src/http/configure.rs`:686 | `edit_comment` | no | L1 | unknown / needs local verification | needs review |
+| DELETE | `/proposals/{proposal_id}/discussion/comments/{comment_id}/reactions` | `icn/apps/governance/src/http/configure.rs`:692 | `remove_reaction` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/discussion/comments/{comment_id}/reactions` | `icn/apps/governance/src/http/configure.rs`:691 | `add_reaction` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/effects` | `icn/apps/governance/src/http/configure.rs`:672 | `list_proposal_effects` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/open` | `icn/apps/governance/src/http/configure.rs`:644 | `open_proposal` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/proof` | `icn/apps/governance/src/http/configure.rs`:660 | `get_proof` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/proposals/{proposal_id}/tally` | `icn/apps/governance/src/http/configure.rs`:656 | `get_vote_tally` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/proposals/{proposal_id}/vote` | `icn/apps/governance/src/http/configure.rs`:652 | `cast_vote` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}` | `icn/apps/governance/src/http/configure.rs`:773 | `get_structure` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:778 | `list_roles` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/structures/{structure_id}/roles` | `icn/apps/governance/src/http/configure.rs`:777 | `assign_role` | no | L1 | unknown / needs local verification | needs review |
 
 ## Limitations
 
@@ -378,19 +380,19 @@ Status vocabulary is the existing set from `source-of-truth-map.md`; no new labe
 | POST | `/meetings` | `/v1/registry/meetings` | `icn/crates/icn-gateway/src/api/registry.rs`:491 | `create_meeting` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/summary` | `/v1/rights/summary` | `icn/crates/icn-gateway/src/api/rights.rs`:12 | `rights_summary` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/devices/add` | `/v1/sdis/devices/add` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:332 | `add_device` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/enrollment/complete` | `/v1/sdis/enrollment/complete` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:501 | `complete_enrollment` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/enrollment/complete` | `/v1/sdis/enrollment/complete` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:505 | `complete_enrollment` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/enrollment/start` | `/v1/sdis/enrollment/start` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:281 | `start_enrollment` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/enrollment/verify/level1` | `/v1/sdis/enrollment/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:331 | `verify_level1` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/enrollment/verify/level2` | `/v1/sdis/enrollment/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:406 | `verify_level2` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/ephemeral/generate` | `/v1/sdis/ephemeral/generate` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:301 | `generate_ephemeral` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/health` | `/v1/sdis/health` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:175 | `sdis_health` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/reject/{enrollment_id}` | `/v1/sdis/reject/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:913 | `reject_enrollment` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/reject/{enrollment_id}` | `/v1/sdis/reject/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:917 | `reject_enrollment` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/rotate-keys` | `/v1/sdis/rotate-keys` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:271 | `rotate_keys` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/start` | `/v1/sdis/start` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:258 | `start_enrollment` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/start` | `/v1/sdis/start` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:216 | `start_recovery` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/verify/level1` | `/v1/sdis/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:189 | `verify_level1` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/verify/level2` | `/v1/sdis/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:209 | `verify_level2` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/vouch/{enrollment_id}` | `/v1/sdis/vouch/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:824 | `steward_vouch` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/vouch/{enrollment_id}` | `/v1/sdis/vouch/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:828 | `steward_vouch` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/{anchor_id}` | `/v1/sdis/{anchor_id}` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:246 | `get_anchor` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/{anchor_id}/devices` | `/v1/sdis/{anchor_id}/devices` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:368 | `list_devices` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/{anchor_id}/history` | `/v1/sdis/{anchor_id}/history` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:311 | `get_rotation_history` | no | L1 | unknown / needs local verification | needs review |
@@ -405,9 +407,8 @@ Status vocabulary is the existing set from `source-of-truth-map.md`; no new labe
 | GET | `/discover` | `/v1/services/discover` | `icn/crates/icn-gateway/src/api/services.rs`:388 | `discover_services` | no | L1 | unknown / needs local verification | needs review |
 | DELETE | `/{service_id}` | `/v1/services/{service_id}` | `icn/crates/icn-gateway/src/api/services.rs`:347 | `withdraw_service` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/{service_id}` | `/v1/services/{service_id}` | `icn/crates/icn-gateway/src/api/services.rs`:550 | `get_service` | no | L1 | unknown / needs local verification | needs review |
-| POST | `(empty)` | `/v1/sessions` | `icn/crates/icn-gateway/src/api/sessions.rs`:137 | `create_session` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/{session_id}` | `/v1/sessions/{session_id}` | `icn/crates/icn-gateway/src/api/sessions.rs`:184 | `get_session_status` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/{session_id}/approve` | `/v1/sessions/{session_id}/approve` | `icn/crates/icn-gateway/src/api/sessions.rs`:251 | `approve_session` | no | L1 | unknown / needs local verification | needs review |
+| POST | `(empty)` | `/v1/sessions` | `icn/crates/icn-gateway/src/api/sessions.rs`:158 | `create_session` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/{session_id}` | `/v1/sessions/{session_id}` | `icn/crates/icn-gateway/src/api/sessions.rs`:205 | `get_session_status` | no | L1 | unknown / needs local verification | needs review |
 | GET | `(empty)` | `/v1/steward` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:170 | `list_stewards` | no | L1 | unknown / needs local verification | needs review |
 | POST | `(empty)` | `/v1/steward` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:72 | `register_steward` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/attesters` | `/v1/steward/attesters` | `icn/crates/icn-gateway/src/api/steward/mod.rs`:195 | `list_attesters` | no | L1 | unknown / needs local verification | needs review |
@@ -448,6 +449,6 @@ Beyond attribute macros, Actix can also register routes via `web::resource("…"
 |---|---|---|
 | `web::resource` | `/notifications/register` | `icn/crates/icn-gateway/src/api/notifications.rs`:315 |
 | `.route` | — | `icn/crates/icn-gateway/src/api/notifications.rs`:316 |
-| `web::resource` | `/{session_id}/approve` | `icn/crates/icn-gateway/src/server.rs`:2011 |
-| `.route` | — | `icn/crates/icn-gateway/src/server.rs`:2012 |
+| `web::resource` | `/{session_id}/approve` | `icn/crates/icn-gateway/src/server.rs`:2129 |
+| `.route` | — | `icn/crates/icn-gateway/src/server.rs`:2130 |
 

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -714,7 +714,7 @@ category = "reference"
 status = "living"
 title = "ICN Document Registry (human summary)"
 description = "Auto-generated summary companion to registry.toml; run doc_control_check.py to refresh"
-last_updated = "2026-07-17"
+last_updated = "2026-07-21"
 owner = "matt"
 audiences = ["contributors", "agents"]
 truth_class = "descriptive"
@@ -723,7 +723,7 @@ canonical = "no"
 freshness = "current"
 domain_tags = ["registry", "documentation-control"]
 recommended_action = "keep"
-last_reviewed = "2026-07-17"
+last_reviewed = "2026-07-21"
 
 [docs."docs/planning/documentation-namespace-resolution.md"]
 category = "strategy"

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -908,7 +908,7 @@ category = "architecture"
 status = "living"
 title = "The Authority Spine"
 description = "How ICN proves the powers of an assembled runtime: attenuation, expiration, revocation, and capability truth. Documents the gateway session-authority composition boundary implemented for #2436/#2437, the deployment-profile startup invariants, and — as analysis only — how the same lifecycle would extend to compute, storage, economics, federation, policy, and evidence. Explicitly separates technical capacity, institutional legitimacy, and current availability; records the institutional questions (who may approve, who may revoke, what recourse a member has) that remain open."
-last_updated = "2026-07-19"
+last_updated = "2026-07-21"
 owner = "matt"
 audiences = ["developers", "architects"]
 truth_class = "descriptive"
@@ -917,7 +917,7 @@ canonical = "no"
 freshness = "current"
 domain_tags = ["architecture", "security"]
 recommended_action = "keep"
-last_reviewed = "2026-07-19"
+last_reviewed = "2026-07-21"
 
 [docs."docs/architecture/KERNEL_APP_SEPARATION.md"]
 category = "architecture"

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -903,6 +903,22 @@ depends_on = ["docs/architecture/COOPERATIVE_DOMAIN_INFRASTRUCTURE.md", "docs/rf
 recommended_action = "keep"
 freshness = "current"
 
+[docs."docs/architecture/AUTHORITY_SPINE.md"]
+category = "architecture"
+status = "living"
+title = "The Authority Spine"
+description = "How ICN proves the powers of an assembled runtime: attenuation, expiration, revocation, and capability truth. Documents the gateway session-authority composition boundary implemented for #2436/#2437, the deployment-profile startup invariants, and — as analysis only — how the same lifecycle would extend to compute, storage, economics, federation, policy, and evidence. Explicitly separates technical capacity, institutional legitimacy, and current availability; records the institutional questions (who may approve, who may revoke, what recourse a member has) that remain open."
+last_updated = "2026-07-19"
+owner = "matt"
+audiences = ["developers", "architects"]
+truth_class = "descriptive"
+role = "architecture"
+canonical = "no"
+freshness = "current"
+domain_tags = ["architecture", "security"]
+recommended_action = "keep"
+last_reviewed = "2026-07-19"
+
 [docs."docs/architecture/KERNEL_APP_SEPARATION.md"]
 category = "architecture"
 status = "living"

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -185,6 +185,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-tls"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6176099de3f58fbddac916a7f8c6db297e021d706e7a6b99947785fee14abe9f"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "impl-more",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +627,39 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "awc"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7dc0207013c5059ddce268fe12045bd12b2e919318ee660c891bfe297a54f1f"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-rt",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "itoa",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -3202,6 +3254,7 @@ dependencies = [
  "actix-web-prom",
  "anyhow",
  "async-trait",
+ "awc",
  "base64 0.22.1",
  "blake3",
  "chrono",

--- a/icn/bins/icnctl/src/institution_bootstrap.rs
+++ b/icn/bins/icnctl/src/institution_bootstrap.rs
@@ -1325,6 +1325,10 @@ async fn get_bootstrap_gateway_token(
                 "governance:read".to_string(),
                 "governance:write".to_string(),
             ],
+            // Canonical default lifetime. The bootstrap token is consumed
+            // immediately; a deployment configured shorter than the default
+            // refuses it at acceptance with a message naming the bound.
+            None,
         )?;
         return Ok(BootstrapAuthContext {
             token,

--- a/icn/bins/icnctl/src/institution_bootstrap.rs
+++ b/icn/bins/icnctl/src/institution_bootstrap.rs
@@ -1743,7 +1743,7 @@ mod tests {
         use actix_web_httpauth::middleware::HttpAuthentication;
         use icn_gateway::{
             api, auth::AuthManager, entity_audit::EntityAuditManager, entity_mgr::EntityManager,
-            middleware::jwt_auth, rate_limit::IpRateLimiter,
+            middleware::jwt_auth, rate_limit::IpRateLimiter, session_authority::SessionAuthority,
         };
         use icn_governance_actor::{
             events::NoopEventEmitter,
@@ -1759,6 +1759,7 @@ mod tests {
         {
             let jwt_secret = b"bootstrap-apply-integration-test!".to_vec();
             let auth_mgr = Arc::new(AuthManager::new(jwt_secret).with_self_asserted_coop(true));
+            let authority = Arc::new(SessionAuthority::evaluator(auth_mgr));
             let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
             let entity_mgr = Arc::new(EntityManager::new());
             let store = Arc::new(SledStore::temporary().expect("temp sled store"));
@@ -1780,7 +1781,7 @@ mod tests {
                 build_mode: icn_governance_actor::http::GovernanceContextBuildMode::Test,
             };
 
-            let auth_mgr2 = auth_mgr.clone();
+            let authority2 = authority.clone();
             let ip2 = ip_limiter.clone();
             let entity2 = entity_mgr.clone();
             let audit2 = audit_mgr.clone();
@@ -1792,7 +1793,7 @@ mod tests {
             let server = HttpServer::new(move || {
                 let auth_mw = HttpAuthentication::bearer(jwt_auth);
                 App::new()
-                    .app_data(web::Data::new(auth_mgr2.clone()))
+                    .app_data(web::Data::new(authority2.clone()))
                     .app_data(web::Data::new(ip2.clone()))
                     .app_data(web::Data::new(entity2.clone()))
                     .app_data(web::Data::new(audit2.clone()))

--- a/icn/bins/icnctl/src/main.rs
+++ b/icn/bins/icnctl/src/main.rs
@@ -584,6 +584,14 @@ enum AuthCommands {
         /// (issue #2075), which stays fail-closed on routable binds.
         #[arg(long, default_value_t = false)]
         local_mint: bool,
+
+        /// Session lifetime in hours for --local-mint. Defaults to the
+        /// canonical 24-hour lifetime. The gateway ACCEPTS only credentials
+        /// whose lifetime is within its configured `token_expiry_hours`; on a
+        /// deployment configured shorter than 24 hours, pass a matching (or
+        /// shorter) value or the minted credential will be refused.
+        #[arg(long, requires = "local_mint")]
+        expiry_hours: Option<u64>,
     },
 }
 
@@ -7647,6 +7655,7 @@ pub(crate) fn mint_trusted_token_with_secret(
     did: &icn_identity::Did,
     coop_id: &str,
     scopes: Vec<String>,
+    expiry_hours: Option<u64>,
 ) -> Result<String> {
     if secret.is_empty() {
         bail!("gateway JWT secret is empty");
@@ -7664,7 +7673,22 @@ pub(crate) fn mint_trusted_token_with_secret(
     // bytes, verbatim, never hex/base64-decoded. This is what makes a token minted
     // here verify on this VM's live gateway (the divergence bug caught in review
     // of #2396 is now structurally impossible — one function, both call sites).
-    icn_gateway::auth::AuthManager::from_secret_string(secret)
+    let manager = icn_gateway::auth::AuthManager::from_secret_string(secret);
+    // An explicit lifetime goes through the SAME validation the gateway applies
+    // to its own configured `token_expiry_hours` (`TokenLifetimePolicy`), so the
+    // co-issuer and the gateway cannot drift in what a legal lifetime is. The
+    // gateway ACCEPTS only credentials within its configured lifetime, so on a
+    // deployment configured shorter than the canonical default this knob is how
+    // a trusted-local mint stays acceptable.
+    let manager = match expiry_hours {
+        Some(hours) => {
+            let policy = icn_gateway::session_authority::TokenLifetimePolicy::from_hours(hours)
+                .map_err(|e| anyhow::anyhow!("invalid --expiry-hours: {e}"))?;
+            manager.with_token_ttl(policy.ttl())
+        }
+        None => manager,
+    };
+    manager
         .issue_token(did, coop_id, scopes)
         .context("trusted local token mint failed")
 }
@@ -7677,6 +7701,7 @@ pub(crate) fn mint_local_trusted_token(
     did: &icn_identity::Did,
     coop_id: &str,
     scopes: Vec<String>,
+    expiry_hours: Option<u64>,
 ) -> Result<String> {
     let secret = std::env::var("ICN_GATEWAY_JWT_SECRET").map_err(|_| {
         anyhow::anyhow!(
@@ -7692,7 +7717,7 @@ pub(crate) fn mint_local_trusted_token(
     // daemon does (see `icn_gateway::auth::signing_key_bytes`). icnd stores
     // ICN_GATEWAY_JWT_SECRET verbatim, so the minted JWT verifies on the live
     // gateway.
-    mint_trusted_token_with_secret(&secret, did, coop_id, scopes)
+    mint_trusted_token_with_secret(&secret, did, coop_id, scopes, expiry_hours)
 }
 
 #[cfg(test)]
@@ -7712,6 +7737,7 @@ mod trusted_local_mint_tests {
             bundle.did(),
             "nycn",
             vec!["governance:read".to_string(), "coop:admin".to_string()],
+            None,
         )
         .unwrap();
         let claims = icn_gateway::auth::AuthManager::from_secret_string(secret)
@@ -7737,6 +7763,7 @@ mod trusted_local_mint_tests {
             bundle.did(),
             "nycn",
             vec!["governance:read".to_string()],
+            None,
         )
         .unwrap();
         assert!(
@@ -7751,7 +7778,7 @@ mod trusted_local_mint_tests {
     #[test]
     fn local_mint_rejects_empty_secret() {
         let bundle = icn_identity::IdentityBundle::generate().unwrap();
-        assert!(mint_trusted_token_with_secret("", bundle.did(), "nycn", vec![]).is_err());
+        assert!(mint_trusted_token_with_secret("", bundle.did(), "nycn", vec![], None).is_err());
     }
 
     /// The gateway builds its signing key as `config.jwt_secret.into_bytes()`
@@ -7768,6 +7795,7 @@ mod trusted_local_mint_tests {
             bundle.did(),
             "nycn",
             vec!["governance:read".to_string()],
+            None,
         )
         .unwrap();
         // The gateway (raw string-byte key, via the shared `from_secret_string`)
@@ -7785,6 +7813,78 @@ mod trusted_local_mint_tests {
         );
     }
 
+    /// The local mint applies a requested session lifetime, so an operator on a
+    /// deployment configured for shorter sessions can mint within that bound —
+    /// the gateway REFUSES any credential whose lifetime exceeds its configured
+    /// `token_expiry_hours` (#2442 acceptance bound).
+    #[test]
+    fn local_mint_applies_a_requested_expiry() {
+        let secret = "instance-local-gateway-secret";
+        let bundle = icn_identity::IdentityBundle::generate().unwrap();
+        let token = mint_trusted_token_with_secret(
+            secret,
+            bundle.did(),
+            "nycn",
+            vec!["governance:read".to_string()],
+            Some(1),
+        )
+        .unwrap();
+        let claims = icn_gateway::auth::AuthManager::from_secret_string(secret)
+            .verify_token(&token)
+            .unwrap();
+        assert_eq!(
+            claims.exp - claims.iat,
+            3600,
+            "an explicit --expiry-hours must be the lifetime actually minted"
+        );
+    }
+
+    /// Without an explicit lifetime the mint carries the canonical default —
+    /// the same lifetime an unconfigured gateway both issues and accepts.
+    #[test]
+    fn local_mint_defaults_to_the_canonical_lifetime() {
+        let secret = "instance-local-gateway-secret";
+        let bundle = icn_identity::IdentityBundle::generate().unwrap();
+        let token = mint_trusted_token_with_secret(
+            secret,
+            bundle.did(),
+            "nycn",
+            vec!["governance:read".to_string()],
+            None,
+        )
+        .unwrap();
+        let claims = icn_gateway::auth::AuthManager::from_secret_string(secret)
+            .verify_token(&token)
+            .unwrap();
+        assert_eq!(
+            claims.exp - claims.iat,
+            icn_gateway::session_authority::DEFAULT_TOKEN_TTL.as_secs(),
+            "the unconfigured mint and the unconfigured gateway must share one canonical lifetime"
+        );
+    }
+
+    /// A zero or absurd lifetime is rejected through the SAME validation the
+    /// gateway applies to its own configured lifetime (`TokenLifetimePolicy`),
+    /// so the two surfaces cannot drift in what they consider a legal lifetime.
+    #[test]
+    fn local_mint_rejects_zero_and_excessive_expiry() {
+        let secret = "instance-local-gateway-secret";
+        let bundle = icn_identity::IdentityBundle::generate().unwrap();
+        for hours in [0u64, 100_000] {
+            assert!(
+                mint_trusted_token_with_secret(
+                    secret,
+                    bundle.did(),
+                    "nycn",
+                    vec!["governance:read".to_string()],
+                    Some(hours),
+                )
+                .is_err(),
+                "lifetime of {hours} hours must be rejected up front"
+            );
+        }
+    }
+
     /// The local mint runs the same input validation as /auth/verify: a malformed
     /// coop_id or an unknown scope is rejected up front, not minted into a token
     /// that only 403s later at the endpoint.
@@ -7793,7 +7893,8 @@ mod trusted_local_mint_tests {
         let secret = "instance-local-gateway-secret";
         let bundle = icn_identity::IdentityBundle::generate().unwrap();
         assert!(
-            mint_trusted_token_with_secret(secret, bundle.did(), "bad@coop#id!", vec![]).is_err(),
+            mint_trusted_token_with_secret(secret, bundle.did(), "bad@coop#id!", vec![], None)
+                .is_err(),
             "malformed coop_id must be rejected up front"
         );
         assert!(
@@ -7802,6 +7903,7 @@ mod trusted_local_mint_tests {
                 bundle.did(),
                 "nycn",
                 vec!["governance:read".to_string(), "totally:bogus".to_string()],
+                None,
             )
             .is_err(),
             "an unknown scope must be rejected up front"
@@ -7817,6 +7919,7 @@ async fn handle_auth_command(cmd: AuthCommands, data_dir: &Path) -> Result<()> {
             coop_id,
             scopes,
             local_mint,
+            expiry_hours,
         } => {
             // Get keystore path and unlock
             let keystore_path = get_keystore_path(data_dir);
@@ -7848,7 +7951,8 @@ async fn handle_auth_command(cmd: AuthCommands, data_dir: &Path) -> Result<()> {
                 // secret in-process — no network call, no /auth/verify. Print
                 // ONLY the token (callers / the demo seed capture it from
                 // stdout); the signing secret is never printed.
-                let token = mint_local_trusted_token(keypair.did(), &coop_id, scope_list)?;
+                let token =
+                    mint_local_trusted_token(keypair.did(), &coop_id, scope_list, expiry_hours)?;
                 println!("{token}");
                 return Ok(());
             }

--- a/icn/crates/icn-core/src/config/gateway.rs
+++ b/icn/crates/icn-core/src/config/gateway.rs
@@ -64,7 +64,7 @@ fn default_gateway_bind_addr() -> String {
 }
 
 fn default_token_expiry_hours() -> u64 {
-    24
+    icn_gateway::session_authority::DEFAULT_TOKEN_TTL.as_secs() / 3600
 }
 
 fn default_challenge_ttl_minutes() -> u64 {

--- a/icn/crates/icn-core/src/supervisor/actors.rs
+++ b/icn/crates/icn-core/src/supervisor/actors.rs
@@ -61,6 +61,10 @@ pub struct GatewayActorHandles {
     /// execution records instead of re-opening the (exclusively locked) sled
     /// path and falling back to an empty temporary store.
     pub execution_query_store: Option<Arc<dyn icn_store::Store>>,
+    /// Runtime-owned session-revocation store, shared with the RPC auth manager
+    /// so a revoked credential is rejected on both authenticated surfaces
+    /// (issue #2437).
+    pub revocation_store: Option<Arc<dyn icn_store::Store>>,
     /// Best-effort execution-record retention cleanup, deferred to run *after*
     /// the gateway's dispatch-evidence backfill (Issue #1987 follow-up). Pruning
     /// terminal execution records before the backfill could delete a record

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -96,8 +96,13 @@ pub struct GatewayHandles {
 /// The gateway runs in a dedicated thread with its own tokio runtime
 /// because actix-web has specific runtime requirements.
 ///
-/// Returns true if the gateway was spawned, false if disabled or failed.
-pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: GatewayHandles) -> bool {
+/// Returns true only after the gateway has initialized and bound its socket;
+/// returns false if disabled or if startup fails before readiness.
+pub async fn spawn_gateway(
+    config: &GatewayConfig,
+    data_dir: PathBuf,
+    handles: GatewayHandles,
+) -> bool {
     if !config.enabled {
         debug!("Gateway API disabled in configuration");
         return false;
@@ -122,8 +127,27 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
         warn!("Gateway enabled but JWT secret not configured - gateway will not start");
         warn!("Set jwt_secret in config or ICN_GATEWAY_JWT_SECRET environment variable");
         icn_obs::metrics::supervisor::error_inc("gateway_jwt_secret_missing");
+        icn_obs::metrics::supervisor::actor_active_set("gateway", false);
         return false;
     }
+
+    // Validate security-sensitive policy before creating a thread. The server
+    // receives the already-validated value, so invalid configuration cannot
+    // race ahead of the supervisor's startup report.
+    let token_lifetime = match icn_gateway::session_authority::TokenLifetimePolicy::from_hours(
+        config.token_expiry_hours,
+    ) {
+        Ok(lifetime) => lifetime,
+        Err(error) => {
+            warn!(
+                "Gateway not started: invalid token_expiry_hours — {}",
+                error
+            );
+            icn_obs::metrics::supervisor::error_inc("gateway_token_lifetime_invalid");
+            icn_obs::metrics::supervisor::actor_active_set("gateway", false);
+            return false;
+        }
+    };
 
     info!("Gateway JWT secret verified, spawning server...");
 
@@ -166,20 +190,25 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let revocation_store = handles.revocation_store;
     let post_backfill_cleanup = handles.post_backfill_cleanup;
     let default_trust_score = config.default_trust_score;
-    // The configured session lifetime now reaches the issuer (issue #2437):
-    // before this, `token_expiry_hours` was parsed and tested but never applied,
-    // so every credential lived one hour regardless of configuration.
-    let token_expiry_hours = config.token_expiry_hours;
     // Dev/demo posture (issue #2075): carried by config (set for the loopback
     // `--insecure-gateway-no-jwt` hatch) instead of an env var, so it does not
     // race threads reading the environment after the runtime has started.
     let dev_self_serve_auth = config.dev_self_serve_auth;
 
-    // Spawn gateway in a dedicated thread (actix-web has its own runtime)
+    // Spawn gateway in a dedicated thread (actix-web has its own runtime). The
+    // supervisor waits for an explicit post-bind acknowledgement before marking
+    // the actor active.
+    let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();
+    let (activation_tx, activation_rx) = tokio::sync::oneshot::channel();
     std::thread::spawn(move || {
-        // SAFETY: Runtime creation only fails with invalid config or resource exhaustion
-        #[allow(clippy::unwrap_used)]
-        let rt = tokio::runtime::Runtime::new().unwrap();
+        let rt = match tokio::runtime::Runtime::new() {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                warn!("Failed to create gateway async runtime: {}", error);
+                icn_obs::metrics::supervisor::error_inc("gateway_server");
+                return;
+            }
+        };
         rt.block_on(async move {
             let mut gateway_server = if let Some(broadcaster) = broadcaster_for_gateway {
                 icn_gateway::GatewayServer::new_with_broadcaster(
@@ -296,36 +325,71 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
                         icn_gateway::session_authority::AuthorityProfile::Institutional,
                     );
             }
-            match icn_gateway::session_authority::TokenLifetimePolicy::from_hours(
-                token_expiry_hours,
-            ) {
-                Ok(lifetime) => {
-                    gateway_server = gateway_server.with_token_lifetime(lifetime);
-                }
-                Err(e) => {
-                    // Misconfigured lifetime is an operator error: refuse to
-                    // start rather than silently fall back to a different
-                    // lifetime than the one configured.
-                    warn!("Gateway not started: invalid token_expiry_hours — {}", e);
-                    icn_obs::metrics::supervisor::error_inc("gateway_server");
-                    return;
-                }
-            }
+            gateway_server = gateway_server.with_token_lifetime(token_lifetime);
 
             if let Some(cleanup) = post_backfill_cleanup {
                 gateway_server = gateway_server.with_post_backfill_cleanup(cleanup);
             }
 
-            if let Err(e) = gateway_server.run().await {
+            let result = gateway_server
+                .run_with_startup_signal(startup_tx, activation_rx)
+                .await;
+            icn_obs::metrics::supervisor::actor_active_set("gateway", false);
+            if let Err(e) = result {
                 warn!("Gateway server error: {}", e);
                 icn_obs::metrics::supervisor::error_inc("gateway_server");
             }
         });
     });
 
-    icn_obs::metrics::supervisor::actor_spawned_inc("gateway");
-    icn_obs::metrics::supervisor::actor_active_set("gateway", true);
-    info!("Gateway API spawned on {}", gateway_addr);
+    match startup_rx.await {
+        Ok(()) => {
+            icn_obs::metrics::supervisor::actor_spawned_inc("gateway");
+            icn_obs::metrics::supervisor::actor_active_set("gateway", true);
+            if activation_tx.send(()).is_err() {
+                icn_obs::metrics::supervisor::error_inc("gateway_activation_ack");
+                icn_obs::metrics::supervisor::actor_active_set("gateway", false);
+                warn!("Gateway exited before supervisor acknowledged activation");
+                false
+            } else {
+                info!("Gateway API ready on {}", gateway_addr);
+                true
+            }
+        }
+        Err(error) => {
+            icn_obs::metrics::supervisor::error_inc("gateway_startup_ack");
+            icn_obs::metrics::supervisor::actor_active_set("gateway", false);
+            warn!(
+                "Gateway startup thread exited without reporting readiness: {}",
+                error
+            );
+            false
+        }
+    }
+}
 
-    true
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_token_lifetime_is_rejected_before_gateway_spawn() {
+        let config = GatewayConfig {
+            enabled: true,
+            jwt_secret: "a".repeat(32),
+            token_expiry_hours: 0,
+            ..GatewayConfig::default()
+        };
+        let data_dir = tempfile::tempdir().expect("temporary gateway data directory");
+
+        assert!(
+            !spawn_gateway(
+                &config,
+                data_dir.path().to_path_buf(),
+                GatewayHandles::default()
+            )
+            .await,
+            "invalid authority policy must not report a ready gateway actor"
+        );
+    }
 }

--- a/icn/crates/icn-core/src/supervisor/init_gateway.rs
+++ b/icn/crates/icn-core/src/supervisor/init_gateway.rs
@@ -79,6 +79,12 @@ pub struct GatewayHandles {
     /// Shared into the gateway receipt-chain read API so audit reads see real
     /// execution records instead of an empty temp-store fallback (Gap C).
     pub execution_query_store: Option<Arc<dyn icn_store::Store>>,
+    /// Persistent store backing session revocation (issue #2437).
+    ///
+    /// Shared with the RPC auth manager so a credential revoked on one
+    /// authenticated surface is rejected on the other. Its presence is what
+    /// lets the gateway assemble the institutional authority profile.
+    pub revocation_store: Option<Arc<dyn icn_store::Store>>,
     /// Execution-record retention cleanup deferred to run after the gateway's
     /// dispatch-evidence backfill (Issue #1987 follow-up), so pruning cannot
     /// delete a terminal record whose evidence the backfill still needs to heal.
@@ -157,8 +163,13 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
     let settlement_engine_handle = handles.settlement_engine;
     let dispatch_evidence_sink_installer = handles.dispatch_evidence_sink_installer;
     let execution_query_store = handles.execution_query_store;
+    let revocation_store = handles.revocation_store;
     let post_backfill_cleanup = handles.post_backfill_cleanup;
     let default_trust_score = config.default_trust_score;
+    // The configured session lifetime now reaches the issuer (issue #2437):
+    // before this, `token_expiry_hours` was parsed and tested but never applied,
+    // so every credential lived one hour regardless of configuration.
+    let token_expiry_hours = config.token_expiry_hours;
     // Dev/demo posture (issue #2075): carried by config (set for the loopback
     // `--insecure-gateway-no-jwt` hatch) instead of an env var, so it does not
     // race threads reading the environment after the runtime has started.
@@ -271,6 +282,34 @@ pub fn spawn_gateway(config: &GatewayConfig, data_dir: PathBuf, handles: Gateway
 
             if let Some(store) = execution_query_store {
                 gateway_server = gateway_server.with_execution_query_store(store);
+            }
+
+            // Session authority (issues #2436, #2437). A daemon deployment is an
+            // operator-run node, so it declares the institutional profile: the
+            // gateway then refuses to start unless durable revocation is
+            // actually installed, rather than serving requests whose credentials
+            // cannot be withdrawn across a restart.
+            if let Some(store) = revocation_store {
+                gateway_server = gateway_server
+                    .with_revocation_store(store)
+                    .with_authority_profile(
+                        icn_gateway::session_authority::AuthorityProfile::Institutional,
+                    );
+            }
+            match icn_gateway::session_authority::TokenLifetimePolicy::from_hours(
+                token_expiry_hours,
+            ) {
+                Ok(lifetime) => {
+                    gateway_server = gateway_server.with_token_lifetime(lifetime);
+                }
+                Err(e) => {
+                    // Misconfigured lifetime is an operator error: refuse to
+                    // start rather than silently fall back to a different
+                    // lifetime than the one configured.
+                    warn!("Gateway not started: invalid token_expiry_hours — {}", e);
+                    icn_obs::metrics::supervisor::error_inc("gateway_server");
+                    return;
+                }
             }
 
             if let Some(cleanup) = post_backfill_cleanup {

--- a/icn/crates/icn-core/src/supervisor/init_rpc.rs
+++ b/icn/crates/icn-core/src/supervisor/init_rpc.rs
@@ -49,6 +49,13 @@ pub struct RpcConfig {
     pub jwt_secret: Option<Vec<u8>>,
     /// Enable trust-based rate limiting
     pub enable_trust_rate_limiting: bool,
+    /// Persistent store backing RPC token revocation (issue #2437).
+    ///
+    /// Supplied by the daemon; `None` leaves revocation uninstalled, which is
+    /// logged explicitly rather than presented as revocation support. Opened by
+    /// the caller (not derived here) so the store path stays with the rest of
+    /// the daemon's store layout in `lifecycle`.
+    pub revocation_store: Option<Arc<icn_store::SledStore>>,
 }
 
 impl RpcConfig {
@@ -70,7 +77,14 @@ impl RpcConfig {
             addr: rpc_addr,
             jwt_secret,
             enable_trust_rate_limiting: true,
+            revocation_store: None,
         }
+    }
+
+    /// Attach the persistent store that backs RPC token revocation.
+    pub fn with_revocation_store(mut self, store: Arc<icn_store::SledStore>) -> Self {
+        self.revocation_store = Some(store);
+        self
     }
 }
 
@@ -81,14 +95,45 @@ pub fn spawn_rpc_server(
     config: RpcConfig,
     deps: RpcDeps,
     background_tasks: &mut tokio::task::JoinSet<()>,
-) -> ComputeHandle {
+) -> anyhow::Result<ComputeHandle> {
     // Create RPC server with optional auth
     let mut rpc_server = if let Some(ref jwt_secret) = config.jwt_secret {
-        info!("RPC server auth enabled (using gateway JWT secret)");
         RpcServer::new_with_auth(config.addr, jwt_secret.clone())
     } else {
         RpcServer::new(config.addr)
     };
+
+    // Install the store-backed auth manager so token revocation actually exists
+    // in the assembled daemon (issue #2437).
+    //
+    // `new_with_auth` alone constructs `revocation_list: None`, which made the
+    // `auth.revoke` RPC method answer "Token revocation not available" at
+    // runtime even though the full `TokenRevocationList` machinery was
+    // implemented and tested — the library had the capability, the daemon did
+    // not install it. Wiring is fail-closed: if the revocation store cannot be
+    // opened we refuse to start rather than serve RPC with silently
+    // unrevocable credentials.
+    if let Some(ref jwt_secret) = config.jwt_secret {
+        match config.revocation_store.clone() {
+            Some(store) => {
+                rpc_server
+                    .set_auth_manager_with_store(jwt_secret.clone(), store)
+                    .map_err(|e| {
+                        anyhow::anyhow!("failed to install RPC token revocation store: {e}")
+                    })?;
+                info!("RPC server auth enabled with durable token revocation");
+            }
+            None => {
+                // Only reachable for callers that build an RpcConfig without a
+                // store (tests, embedded uses). Say so plainly rather than
+                // implying revocation exists.
+                warn!(
+                    "RPC server auth enabled WITHOUT a revocation store: issued credentials \
+                     cannot be revoked (auth.revoke will report revocation unavailable)"
+                );
+            }
+        }
+    }
 
     // Wire up all handles
     rpc_server.set_network_handle(deps.network_handle);
@@ -151,7 +196,7 @@ pub fn spawn_rpc_server(
     icn_obs::metrics::supervisor::actor_active_set("rpc_server", true);
     info!("RPC server spawned on {}", rpc_addr);
 
-    compute_handle_for_gateway
+    Ok(compute_handle_for_gateway)
 }
 
 /// Configuration for Gateway server

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -181,7 +181,8 @@ pub async fn run_supervisor(
             revocation_store: gateway_handles.revocation_store,
             post_backfill_cleanup: gateway_handles.post_backfill_cleanup,
         },
-    );
+    )
+    .await;
 
     // Set supervisor state to running
     icn_obs::metrics::supervisor::state_set(2);

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -178,6 +178,7 @@ pub async fn run_supervisor(
             settlement_engine: gateway_handles.settlement_engine,
             dispatch_evidence_sink_installer: gateway_handles.dispatch_evidence_sink_installer,
             execution_query_store: gateway_handles.execution_query_store,
+            revocation_store: gateway_handles.revocation_store,
             post_backfill_cleanup: gateway_handles.post_backfill_cleanup,
         },
     );
@@ -1044,8 +1045,19 @@ async fn spawn_actors_with_identity(
     // SchedulingPolicy proposals will be handled by ProtocolService when implemented.
     info!("✓ Compute integration active");
 
+    // Session-authority revocation store (issue #2437).
+    //
+    // One store backs both authenticated surfaces: the RPC `auth.revoke` path
+    // and the gateway's session revocation. Sharing it is deliberate — a
+    // credential revoked through one API must not remain valid on the other,
+    // which two independent stores would allow.
+    let revocation_store_path = config.store_path().join("auth-revocation");
+    let revocation_store: Arc<icn_store::SledStore> =
+        Arc::new(icn_store::SledStore::open(&revocation_store_path)?);
+
     // Spawn RPC server with OracleRegistry-backed trust-based rate limiting
-    let rpc_config = super::init_rpc::RpcConfig::from_daemon_config(config);
+    let rpc_config = super::init_rpc::RpcConfig::from_daemon_config(config)
+        .with_revocation_store(revocation_store.clone());
     let rpc_compute_handle = super::init_rpc::spawn_rpc_server(
         rpc_config,
         super::init_rpc::RpcDeps {
@@ -1062,9 +1074,10 @@ async fn spawn_actors_with_identity(
             policy_oracle: Some(oracle_for_components.clone()),
         },
         background_tasks,
-    );
+    )?;
     gateway_handles.compute = Some(rpc_compute_handle);
     gateway_handles.settlement_engine = Some(compute_services.settlement_engine.clone());
+    gateway_handles.revocation_store = Some(revocation_store);
 
     // Extract LedgerService for background tasks (resource enforcer)
     let ledger_service_for_bg: Option<Arc<dyn icn_kernel_api::services::LedgerService>> =

--- a/icn/crates/icn-gateway/Cargo.toml
+++ b/icn/crates/icn-gateway/Cargo.toml
@@ -113,6 +113,7 @@ reqwest = { workspace = true }
 lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder"] }
 
 [dev-dependencies]
+awc = "3"
 futures = "0.3"
 reqwest = { workspace = true }
 tempfile = "3"

--- a/icn/crates/icn-gateway/src/api/auth.rs
+++ b/icn/crates/icn-gateway/src/api/auth.rs
@@ -4,10 +4,10 @@ use actix_web::{post, web, HttpRequest, HttpResponse};
 use std::sync::Arc;
 
 use crate::audit::AuditLogger;
-use crate::auth::AuthManager;
 use crate::error::Result;
 use crate::models::{ChallengeRequest, ChallengeResponse, TokenResponse, VerifyRequest};
 use crate::rate_limit::IpRateLimiter;
+use crate::session_authority::SessionAuthority;
 use crate::validation;
 use icn_obs::metrics::gateway;
 
@@ -38,7 +38,7 @@ fn get_client_ip(req: &HttpRequest) -> String {
 #[post("/auth/challenge")]
 pub async fn challenge(
     http_req: HttpRequest,
-    auth: web::Data<Arc<AuthManager>>,
+    authority: web::Data<Arc<SessionAuthority>>,
     ip_limiter: web::Data<Arc<IpRateLimiter>>,
     req: web::Json<ChallengeRequest>,
 ) -> Result<HttpResponse> {
@@ -51,7 +51,7 @@ pub async fn challenge(
         .parse()
         .map_err(|e| crate::error::GatewayError::BadRequest(format!("Invalid DID: {e}")))?;
 
-    let nonce = auth.create_challenge(&did)?;
+    let nonce = authority.auth_manager().create_challenge(&did)?;
 
     // Increment challenge metric
     gateway::auth_challenges_inc();
@@ -68,7 +68,7 @@ pub async fn challenge(
 #[post("/auth/verify")]
 pub async fn verify(
     http_req: HttpRequest,
-    auth: web::Data<Arc<AuthManager>>,
+    authority: web::Data<Arc<SessionAuthority>>,
     ip_limiter: web::Data<Arc<IpRateLimiter>>,
     req: web::Json<VerifyRequest>,
 ) -> Result<HttpResponse> {
@@ -113,7 +113,8 @@ pub async fn verify(
         )));
     }
 
-    let token = auth
+    let token = authority
+        .auth_manager()
         .verify_challenge(&did, &signature, &req.coop_id, req.scopes.clone())
         .inspect_err(|e| {
             gateway::auth_failures_inc("verification_failed");
@@ -129,7 +130,7 @@ pub async fn verify(
 
     let response = TokenResponse {
         token,
-        expires_in: 3600, // 1 hour
+        expires_in: authority.lifetime().ttl().as_secs(),
     };
 
     Ok(HttpResponse::Ok().json(response))
@@ -138,8 +139,13 @@ pub async fn verify(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::AuthManager;
     use actix_web::{test, App};
     use icn_identity::IdentityBundle;
+
+    fn evaluator(auth: Arc<AuthManager>) -> Arc<SessionAuthority> {
+        Arc::new(SessionAuthority::evaluator(auth))
+    }
 
     #[actix_web::test]
     async fn test_challenge_endpoint() {
@@ -147,7 +153,7 @@ mod tests {
         let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
         let app = test::init_service(
             App::new()
-                .app_data(web::Data::new(auth))
+                .app_data(web::Data::new(evaluator(auth)))
                 .app_data(web::Data::new(ip_limiter))
                 .service(challenge),
         )
@@ -169,10 +175,13 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn test_verify_endpoint_success() {
+    async fn test_verify_endpoint_reports_issued_non_default_lifetime() {
         // Dev/demo self-service issuance: caller supplies its own coop_id (#2075).
-        let auth =
-            Arc::new(AuthManager::new(b"test_secret".to_vec()).with_self_asserted_coop(true));
+        let auth = Arc::new(
+            AuthManager::new(b"test_secret".to_vec())
+                .with_self_asserted_coop(true)
+                .with_token_ttl(std::time::Duration::from_secs(2 * 3600)),
+        );
         let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
         let bundle = IdentityBundle::generate().unwrap();
 
@@ -188,7 +197,7 @@ mod tests {
 
         let app = test::init_service(
             App::new()
-                .app_data(web::Data::new(auth))
+                .app_data(web::Data::new(evaluator(auth.clone())))
                 .app_data(web::Data::new(ip_limiter))
                 .service(verify),
         )
@@ -208,7 +217,13 @@ mod tests {
 
         let resp: TokenResponse = test::call_and_read_body_json(&app, req).await;
         assert!(!resp.token.is_empty());
-        assert_eq!(resp.expires_in, 3600);
+        assert_eq!(resp.expires_in, 2 * 3600);
+        let claims = auth.verify_token(&resp.token).unwrap();
+        assert_eq!(
+            claims.exp - claims.iat,
+            resp.expires_in,
+            "client-visible lifetime must equal the issued credential claims"
+        );
     }
 
     #[actix_web::test]
@@ -222,7 +237,7 @@ mod tests {
 
         let app = test::init_service(
             App::new()
-                .app_data(web::Data::new(auth))
+                .app_data(web::Data::new(evaluator(auth)))
                 .app_data(web::Data::new(ip_limiter))
                 .service(verify),
         )
@@ -254,7 +269,7 @@ mod tests {
 
         let app = test::init_service(
             App::new()
-                .app_data(web::Data::new(auth))
+                .app_data(web::Data::new(evaluator(auth)))
                 .app_data(web::Data::new(ip_limiter))
                 .service(verify),
         )
@@ -287,7 +302,7 @@ mod tests {
 
         let app = test::init_service(
             App::new()
-                .app_data(web::Data::new(auth))
+                .app_data(web::Data::new(evaluator(auth)))
                 .app_data(web::Data::new(ip_limiter))
                 .service(verify),
         )
@@ -316,7 +331,7 @@ mod tests {
         let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
         let app = test::init_service(
             App::new()
-                .app_data(web::Data::new(auth))
+                .app_data(web::Data::new(evaluator(auth)))
                 .app_data(web::Data::new(ip_limiter))
                 .service(challenge),
         )
@@ -378,7 +393,7 @@ mod tests {
 
         let app = test::init_service(
             App::new()
-                .app_data(web::Data::new(auth.clone()))
+                .app_data(web::Data::new(evaluator(auth.clone())))
                 .app_data(web::Data::new(ip_limiter))
                 .service(verify),
         )

--- a/icn/crates/icn-gateway/src/api/commons/mod.rs
+++ b/icn/crates/icn-gateway/src/api/commons/mod.rs
@@ -653,6 +653,7 @@ mod tests {
             exp: 9_999_999_999,
             coop_id: "test-coop".to_string(),
             scopes: vec![],
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri(&format!("/v1/commons/holder/{did}"))

--- a/icn/crates/icn-gateway/src/api/coops.rs
+++ b/icn/crates/icn-gateway/src/api/coops.rs
@@ -406,6 +406,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["coop:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -426,6 +427,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["coop:read".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::get()
@@ -484,6 +486,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["coop:admin".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -551,6 +554,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["coop:read".to_string()], // Wrong scope!
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -577,6 +581,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["coop:read".to_string()], // Wrong scope!
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::put()
@@ -615,6 +620,7 @@ mod tests {
             coop_id: "alice-coop".to_string(),
             scopes: vec!["coop:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -699,6 +705,7 @@ mod tests {
             coop_id: "coop-food".to_string(),
             scopes: vec!["coop:read".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::get()
@@ -724,6 +731,7 @@ mod tests {
             coop_id: "coop-food".to_string(), // Alice's token is for coop-food
             scopes: vec!["coop:admin".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::put()

--- a/icn/crates/icn-gateway/src/api/escrow.rs
+++ b/icn/crates/icn-gateway/src/api/escrow.rs
@@ -391,6 +391,7 @@ mod tests {
             coop_id: coop.to_string(),
             // Validly scoped, so the coop binding is the only thing under test.
             scopes: vec!["settlements:write".to_string()],
+            jti: None,
         }
     }
 

--- a/icn/crates/icn-gateway/src/api/federation.rs
+++ b/icn/crates/icn-gateway/src/api/federation.rs
@@ -1472,6 +1472,7 @@ mod tests {
             coop_id: "coop-alpha".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/clearing/agr-001/position")
@@ -1519,6 +1520,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/clearing/nonexistent-agreement/position")
@@ -1697,6 +1699,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/coops")
@@ -1744,6 +1747,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/coops")
@@ -1784,6 +1788,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
 
         // Known coop → 200
@@ -1829,6 +1834,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/coops/any-coop/vouches")
@@ -1872,6 +1878,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/clearing")
@@ -1923,6 +1930,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
 
         // Known agreement → 200 with correct shape
@@ -1970,6 +1978,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/clearing")
@@ -2011,6 +2020,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/coops")
@@ -2051,6 +2061,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/coops/governance-coop")
@@ -2090,6 +2101,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/coops/any-coop/vouches")
@@ -2129,6 +2141,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/clearing")
@@ -2169,6 +2182,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/clearing/agr-gov-001")
@@ -2233,6 +2247,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:write".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::post()
             .uri("/v1/federation/clearing/does-not-exist/propose-adoption")
@@ -2329,6 +2344,7 @@ mod tests {
             coop_id: "coop-alpha".to_string(),
             scopes: vec!["federation:write".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::post()
             .uri("/v1/federation/clearing/agr-dm-001/propose-adoption")
@@ -2462,6 +2478,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/topology")
@@ -2671,6 +2688,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/topology")
@@ -2740,6 +2758,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/topology")
@@ -2795,6 +2814,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["federation:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
         let req = test::TestRequest::get()
             .uri("/v1/federation/topology")

--- a/icn/crates/icn-gateway/src/api/flow_c.rs
+++ b/icn/crates/icn-gateway/src/api/flow_c.rs
@@ -178,6 +178,7 @@ mod tests {
             coop_id: coop_id.to_string(),
             scopes: scopes.into_iter().map(|s| s.to_string()).collect(),
             exp: 9999999999,
+            jti: None,
         }
     }
 

--- a/icn/crates/icn-gateway/src/api/invites.rs
+++ b/icn/crates/icn-gateway/src/api/invites.rs
@@ -214,6 +214,7 @@ mod tests {
             exp: 9_999_999_999,
             coop_id: coop.to_string(),
             scopes: vec!["coop:admin".to_string(), "coop:read".to_string()],
+            jti: None,
         }
     }
 

--- a/icn/crates/icn-gateway/src/api/invites.rs
+++ b/icn/crates/icn-gateway/src/api/invites.rs
@@ -5,7 +5,6 @@
 use actix_web::{get, post, web, HttpRequest, HttpResponse};
 use std::sync::Arc;
 
-use crate::auth::AuthManager;
 use crate::commons_mgr::CommonsManager;
 use crate::error::Result;
 use crate::invite::InviteManager;
@@ -13,6 +12,7 @@ use crate::middleware::{get_claims, require_coop_access, require_scope};
 use crate::models::{
     CreateInviteRequest, InviteInfo, InviteListResponse, InviteResponse, JoinRequest, JoinResponse,
 };
+use crate::session_authority::SessionAuthority;
 use crate::validation;
 use icn_identity::Did;
 use icn_obs::metrics::gateway;
@@ -146,7 +146,7 @@ pub async fn list_invites(
 #[post("/join")]
 pub async fn join_via_invite(
     invite_mgr: web::Data<Arc<InviteManager>>,
-    auth_mgr: web::Data<Arc<AuthManager>>,
+    authority: web::Data<Arc<SessionAuthority>>,
     req: web::Json<JoinRequest>,
 ) -> Result<HttpResponse> {
     // Validate invite code
@@ -177,7 +177,8 @@ pub async fn join_via_invite(
         "ledger:transact".to_string(),
     ];
 
-    let token = auth_mgr
+    let token = authority
+        .auth_manager()
         .issue_token(&did, &invite.coop_id, scopes)
         .map_err(|e| {
             crate::error::GatewayError::InternalError(format!("Failed to generate token: {e}"))
@@ -189,7 +190,7 @@ pub async fn join_via_invite(
     Ok(HttpResponse::Ok().json(JoinResponse {
         did: did.to_string(),
         token,
-        token_expires_in: 86400, // 24 hours
+        token_expires_in: authority.lifetime().ttl().as_secs(),
         coop_id: invite.coop_id,
         role: invite.role,
         private_key: String::new(), // Client generates their own keypair
@@ -199,7 +200,7 @@ pub async fn join_via_invite(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::auth::TokenClaims;
+    use crate::auth::{AuthManager, TokenClaims};
     use crate::commons_mgr::CommonsManager;
     use crate::invite::InviteManager;
     use actix_web::http::StatusCode;
@@ -290,5 +291,43 @@ mod tests {
 
         assert_eq!(run("coopA", "coopA").await, StatusCode::OK);
         assert_eq!(run("coopA", "coopB").await, StatusCode::FORBIDDEN);
+    }
+
+    #[actix_web::test]
+    async fn join_reports_the_installed_non_default_token_lifetime() {
+        let invite_mgr = Arc::new(InviteManager::new());
+        let creator = icn_identity::KeyPair::generate().unwrap().did().clone();
+        let invite = invite_mgr
+            .create_invite("coopA".to_string(), "member".to_string(), creator, 3600)
+            .await
+            .unwrap();
+        let auth = Arc::new(
+            AuthManager::new(b"invite-lifetime-test-secret-32b".to_vec())
+                .with_token_ttl(std::time::Duration::from_secs(2 * 3600)),
+        );
+        let authority = Arc::new(SessionAuthority::evaluator(auth.clone()));
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(web::Data::new(invite_mgr))
+                .app_data(web::Data::new(authority))
+                .service(join_via_invite),
+        )
+        .await;
+        let member = icn_identity::KeyPair::generate().unwrap().did().clone();
+        let request = actix_test::TestRequest::post()
+            .uri("/join")
+            .set_json(JoinRequest {
+                invite_code: invite.code,
+                did: member.to_string(),
+            })
+            .to_request();
+
+        let response = actix_test::call_service(&app, request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let response: JoinResponse = actix_test::read_body_json(response).await;
+
+        assert_eq!(response.token_expires_in, 2 * 3600);
+        let claims = auth.verify_token(&response.token).unwrap();
+        assert_eq!(claims.exp - claims.iat, response.token_expires_in);
     }
 }

--- a/icn/crates/icn-gateway/src/api/ledger.rs
+++ b/icn/crates/icn-gateway/src/api/ledger.rs
@@ -747,6 +747,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -768,6 +769,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:read".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::get().uri(&uri).to_request();
@@ -815,6 +817,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:read".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::get()
@@ -904,6 +907,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:read".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let uri = format!(
@@ -971,6 +975,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:read".to_string()], // Wrong scope!
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -992,6 +997,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()], // Wrong scope!
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::get().uri(&uri).to_request();
@@ -1048,6 +1054,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1124,6 +1131,7 @@ mod tests {
             coop_id: "coop-food".to_string(), // Token for coop-food
             scopes: vec!["ledger:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1144,6 +1152,7 @@ mod tests {
             coop_id: "coop-food".to_string(), // Token for coop-food
             scopes: vec!["ledger:read".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let uri = format!("/ledger/coop-tech/position/{}", bob.did()); // Accessing coop-tech
@@ -1208,6 +1217,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1259,6 +1269,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1309,6 +1320,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1360,6 +1372,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:read".to_string()], // Wrong scope!
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1399,6 +1412,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:read".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1451,6 +1465,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1507,6 +1522,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1569,6 +1585,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:read".to_string()],
             exp: 9999999999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1662,6 +1679,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
 
         let req = test::TestRequest::post()
@@ -1747,6 +1765,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["ledger:write".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
 
         // No Authorization header — the extraction path must store "http-auth-missing",

--- a/icn/crates/icn-gateway/src/api/members.rs
+++ b/icn/crates/icn-gateway/src/api/members.rs
@@ -201,6 +201,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: scopes.iter().map(|s| s.to_string()).collect(),
             exp: 9999999999,
+            jti: None,
         }
     }
 

--- a/icn/crates/icn-gateway/src/api/recurring_settlements.rs
+++ b/icn/crates/icn-gateway/src/api/recurring_settlements.rs
@@ -436,6 +436,7 @@ mod tests {
             exp: 9_999_999_999,
             coop_id: coop.to_string(),
             scopes: vec!["settlements:write".to_string()],
+            jti: None,
         }
     }
 
@@ -545,6 +546,7 @@ mod tests {
             exp: 9_999_999_999,
             coop_id: "coopA".to_string(),
             scopes: vec!["settlements:read".to_string()],
+            jti: None,
         };
         let req = actix_test::TestRequest::get()
             .uri("/settlements/recurring")

--- a/icn/crates/icn-gateway/src/api/registry.rs
+++ b/icn/crates/icn-gateway/src/api/registry.rs
@@ -1049,6 +1049,7 @@ mod tests {
                 exp: 9_999_999_999,
                 coop_id: "did:icn:test123".to_string(),
                 scopes: vec![scope.to_string()],
+                jti: None,
             };
             let req = actix_test::TestRequest::post()
                 .uri("/registry/meetings")
@@ -1119,6 +1120,7 @@ mod tests {
                 // Validly scoped: passes the scope gate so the coop binding is the
                 // only thing under test.
                 scopes: vec!["governance:meeting:write".to_string()],
+                jti: None,
             };
             let req = actix_test::TestRequest::post()
                 .uri("/registry/meetings")
@@ -1189,6 +1191,7 @@ mod tests {
                 exp: 9_999_999_999,
                 coop_id: "did:icn:test123".to_string(),
                 scopes: vec![scope.to_string()],
+                jti: None,
             };
             let req = actix_test::TestRequest::post()
                 .uri("/registry/decisions")
@@ -1245,6 +1248,7 @@ mod tests {
                 // Validly scoped: passes the scope gate so the coop binding is the
                 // only thing under test.
                 scopes: vec!["governance:proposal:write".to_string()],
+                jti: None,
             };
             let req = actix_test::TestRequest::post()
                 .uri("/registry/decisions")
@@ -1601,6 +1605,7 @@ mod tests {
             coop_id: "did:icn:test123".to_string(),
             scopes: vec!["governance:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
 
         let req = actix_test::TestRequest::get()
@@ -1678,6 +1683,7 @@ mod tests {
             coop_id: coop_id.clone(),
             scopes: vec!["governance:read".to_string(), "ledger:read".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         };
 
         let req = actix_test::TestRequest::get()

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -55,7 +55,6 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::api::sessions::get_gateway_url;
-use crate::auth::AuthManager;
 use crate::error::{GatewayError, Result};
 use crate::session_authority::SessionAuthority;
 use crate::steward_mgr::StewardManager;
@@ -506,7 +505,7 @@ pub async fn verify_level2(
 #[post("/enrollment/complete")]
 pub async fn complete_enrollment(
     store: web::Data<Arc<EnrollmentStore>>,
-    auth: web::Data<Arc<AuthManager>>,
+    authority: web::Data<Arc<SessionAuthority>>,
     trust_mgr: web::Data<Arc<TrustManager>>,
     commons_mgr: web::Data<Arc<crate::commons_mgr::CommonsManager>>,
     steward_mgr: web::Data<Option<Arc<StewardManager>>>,
@@ -734,7 +733,7 @@ pub async fn complete_enrollment(
     // This eliminates the race condition identified in Issue #397.
 
     // Issue auth token for the new identity
-    let auth_token = auth.issue_token(
+    let auth_token = authority.auth_manager().issue_token(
         &ephemeral_did,
         &coop_id,
         vec!["ledger:read".to_string(), "ledger:write".to_string()],

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -57,6 +57,7 @@ use uuid::Uuid;
 use crate::api::sessions::get_gateway_url;
 use crate::auth::AuthManager;
 use crate::error::{GatewayError, Result};
+use crate::session_authority::SessionAuthority;
 use crate::steward_mgr::StewardManager;
 use crate::trust_mgr::TrustManager;
 
@@ -407,7 +408,7 @@ const STEWARD_MIN_TRUST_SCORE: f64 = 0.4;
 pub async fn verify_level2(
     http_req: HttpRequest,
     store: web::Data<Arc<EnrollmentStore>>,
-    auth: web::Data<Arc<AuthManager>>,
+    authority: web::Data<Arc<SessionAuthority>>,
     trust_mgr: web::Data<Arc<TrustManager>>,
     req: web::Json<VerifyLevel2Request>,
 ) -> Result<HttpResponse> {
@@ -424,7 +425,11 @@ pub async fn verify_level2(
         GatewayError::AuthenticationFailed("Invalid Authorization format".to_string())
     })?;
 
-    let claims = auth.verify_token(token)?;
+    // Verify through the session authority: this scope is mounted WITHOUT the
+    // `jwt_auth` middleware and authenticates by hand, so using the bare
+    // AuthManager here would honor revoked credentials that every wrapped route
+    // rejects (issue #2437).
+    let claims = authority.verify(token)?;
     let steward_did: Did = claims
         .sub
         .parse()
@@ -969,7 +974,7 @@ pub struct RejectRequest {
 pub async fn get_steward_stats(
     http_req: HttpRequest,
     store: web::Data<Arc<EnrollmentStore>>,
-    auth: web::Data<Arc<AuthManager>>,
+    authority: web::Data<Arc<SessionAuthority>>,
     trust_mgr: web::Data<Arc<TrustManager>>,
 ) -> Result<HttpResponse> {
     // Extract steward DID from Bearer token
@@ -985,7 +990,11 @@ pub async fn get_steward_stats(
         GatewayError::AuthenticationFailed("Invalid Authorization format".to_string())
     })?;
 
-    let claims = auth.verify_token(token)?;
+    // Verify through the session authority: this scope is mounted WITHOUT the
+    // `jwt_auth` middleware and authenticates by hand, so using the bare
+    // AuthManager here would honor revoked credentials that every wrapped route
+    // rejects (issue #2437).
+    let claims = authority.verify(token)?;
     let steward_did: Did = claims
         .sub
         .parse()

--- a/icn/crates/icn-gateway/src/api/sessions.rs
+++ b/icn/crates/icn-gateway/src/api/sessions.rs
@@ -12,7 +12,6 @@
 use actix_web::{get, post, web, HttpRequest, HttpResponse};
 use std::sync::Arc;
 
-use crate::auth::AuthManager;
 use crate::error::{GatewayError, Result};
 use crate::middleware::get_claims;
 use crate::models::{
@@ -20,8 +19,30 @@ use crate::models::{
 };
 use crate::rate_limit::IpRateLimiter;
 use crate::session::{SessionManager, SessionStatus};
+use crate::session_authority::SessionAuthority;
 use crate::validation;
 use icn_identity::Did;
+
+/// The widest authority this flow may ever delegate to an approved web session.
+///
+/// This is a **ceiling, not a grant** (issue #2436). The scopes actually issued
+/// are this set intersected with the approving credential's own scopes, so a
+/// read-only wallet approves a read-only web session. Before attenuation, this
+/// list was issued verbatim to any caller holding any valid credential for the
+/// cooperative, which let a narrowly-scoped member credential mint
+/// `governance:write` for itself.
+///
+/// The ceiling is deliberately unchanged from the historical list: narrowing it
+/// further is a product decision about what a wallet-approved web session is
+/// *for*, not a security fix, and attenuation already removes the escalation.
+const WEB_SESSION_SCOPE_CEILING: &[&str] = &[
+    "coop:read",
+    "coop:write",
+    "ledger:read",
+    "ledger:transact",
+    "governance:read",
+    "governance:write",
+];
 
 /// Extract client IP address from request (for rate limiting)
 fn get_client_ip(req: &HttpRequest) -> String {
@@ -246,84 +267,20 @@ pub async fn get_session_status(
 
 /// POST /v1/sessions/{session_id}/approve - Approve a login session (AUTHENTICATED)
 ///
-/// Called by the mobile wallet to approve a web login session.
-/// Requires valid JWT token from the wallet.
-#[post("/{session_id}/approve")]
-pub async fn approve_session(
-    http_req: HttpRequest,
-    session_mgr: web::Data<Arc<SessionManager>>,
-    auth_mgr: web::Data<Arc<AuthManager>>,
-    path: web::Path<String>,
-) -> Result<HttpResponse> {
-    // session_id comes from the path parameter /{session_id}/approve
-    let session_id = path.into_inner();
-
-    // Get authenticated DID from JWT claims
-    let claims = get_claims(&http_req)
-        .ok_or_else(|| GatewayError::AuthenticationFailed("Authentication required".to_string()))?;
-
-    let did: Did = claims
-        .sub
-        .parse()
-        .map_err(|e| GatewayError::BadRequest(format!("Invalid DID in token: {e}")))?;
-
-    // Get session to validate coop_id
-    let session = session_mgr
-        .get_session(&session_id)
-        .await
-        .map_err(|e| GatewayError::InternalError(format!("Failed to get session: {e}")))?
-        .ok_or_else(|| GatewayError::NotFound("Session not found or expired".to_string()))?;
-
-    // Verify the wallet's token is for the same cooperative
-    if claims.coop_id != session.coop_id {
-        return Err(GatewayError::AuthorizationFailed(format!(
-            "Token coop_id '{}' does not match session coop_id '{}'",
-            claims.coop_id, session.coop_id
-        )));
-    }
-
-    // Issue a new token for the web session
-    // Use standard web session scopes
-    let scopes = vec![
-        "coop:read".to_string(),
-        "coop:write".to_string(),
-        "ledger:read".to_string(),
-        "ledger:transact".to_string(),
-        "governance:read".to_string(),
-        "governance:write".to_string(),
-    ];
-
-    let token = auth_mgr
-        .issue_token(&did, &session.coop_id, scopes.clone())
-        .map_err(|e| GatewayError::InternalError(format!("Failed to issue token: {e}")))?;
-
-    // Approve the session
-    session_mgr
-        .approve_session(&session_id, did.clone(), token, 3600, scopes)
-        .await
-        .map_err(|e| GatewayError::BadRequest(format!("Failed to approve session: {e}")))?;
-
-    tracing::info!(
-        session_id = %session_id,
-        did = %did,
-        coop_id = %session.coop_id,
-        "QR login session approved"
-    );
-
-    Ok(HttpResponse::Ok().json(serde_json::json!({
-        "success": true,
-        "message": "Session approved. Web login will complete shortly."
-    })))
-}
-
-/// Handler wrapper for approve_session (for use with web::resource().to())
+/// Called by the mobile wallet to approve a web login session. Requires a valid
+/// credential from the wallet, and issues a web-session credential **attenuated
+/// to the approver's own authority** (issue #2436): matching `coop_id` alone is
+/// not authorization to mint arbitrary scopes.
+///
+/// This is the only mounted approval handler (`server.rs`, `/sessions` scope).
+/// A second, byte-identical copy carrying the same defect existed here as
+/// unmounted dead code and was removed rather than fixed twice.
 pub async fn approve_session_handler(
     http_req: HttpRequest,
     session_mgr: web::Data<Arc<SessionManager>>,
-    auth_mgr: web::Data<Arc<AuthManager>>,
+    authority: web::Data<Arc<SessionAuthority>>,
     path: web::Path<String>,
 ) -> Result<HttpResponse> {
-    // Delegate to the main implementation
     let session_id = path.into_inner();
 
     // Get authenticated DID from JWT claims
@@ -342,7 +299,8 @@ pub async fn approve_session_handler(
         .map_err(|e| GatewayError::InternalError(format!("Failed to get session: {e}")))?
         .ok_or_else(|| GatewayError::NotFound("Session not found or expired".to_string()))?;
 
-    // Verify the wallet's token is for the same cooperative
+    // Same-cooperative is a NECESSARY condition, not a sufficient one: the
+    // authority actually delegated is bounded by the approver's scopes below.
     if claims.coop_id != session.coop_id {
         return Err(GatewayError::AuthorizationFailed(format!(
             "Token coop_id '{}' does not match session coop_id '{}'",
@@ -350,23 +308,28 @@ pub async fn approve_session_handler(
         )));
     }
 
-    // Issue a new token for the web session
-    let scopes = vec![
-        "coop:read".to_string(),
-        "coop:write".to_string(),
-        "ledger:read".to_string(),
-        "ledger:transact".to_string(),
-        "governance:read".to_string(),
-        "governance:write".to_string(),
-    ];
+    // Attenuate: issued ⊆ approver's scopes ∩ this flow's ceiling. An approver
+    // holding none of the ceiling's scopes has nothing to delegate and is told
+    // so (403) rather than handed a broad credential.
+    let (token, scopes) = authority.issue_delegated(
+        &claims,
+        &did,
+        &session.coop_id,
+        WEB_SESSION_SCOPE_CEILING,
+        None,
+    )?;
 
-    let token = auth_mgr
-        .issue_token(&did, &session.coop_id, scopes.clone())
-        .map_err(|e| GatewayError::InternalError(format!("Failed to issue token: {e}")))?;
+    let session_ttl_secs = authority.lifetime().ttl().as_secs();
 
     // Approve the session
     session_mgr
-        .approve_session(&session_id, did.clone(), token, 3600, scopes)
+        .approve_session(
+            &session_id,
+            did.clone(),
+            token,
+            session_ttl_secs,
+            scopes.clone(),
+        )
         .await
         .map_err(|e| GatewayError::BadRequest(format!("Failed to approve session: {e}")))?;
 
@@ -374,7 +337,8 @@ pub async fn approve_session_handler(
         session_id = %session_id,
         did = %did,
         coop_id = %session.coop_id,
-        "QR login session approved"
+        granted_scopes = ?scopes,
+        "QR login session approved (attenuated to approver authority)"
     );
 
     Ok(HttpResponse::Ok().json(serde_json::json!({

--- a/icn/crates/icn-gateway/src/api/treasury.rs
+++ b/icn/crates/icn-gateway/src/api/treasury.rs
@@ -1464,6 +1464,7 @@ mod tests {
             coop_id: coop_id.to_string(),
             scopes: vec!["treasury:read".to_string(), "treasury:write".to_string()],
             exp: 9999999999,
+            jti: None,
         }
     }
 
@@ -1795,6 +1796,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["treasury:read".to_string()], // No write scope
             exp: 9999999999,
+            jti: None,
         };
         req.extensions_mut().insert(claims);
 
@@ -1901,6 +1903,7 @@ mod tests {
             coop_id: "test-coop".to_string(),
             scopes: vec!["treasury:write".to_string()],
             exp: 9_999_999_999,
+            jti: None,
         });
 
         let _resp: serde_json::Value = test::call_and_read_body_json(&app, req).await;

--- a/icn/crates/icn-gateway/src/api/websocket.rs
+++ b/icn/crates/icn-gateway/src/api/websocket.rs
@@ -4,8 +4,8 @@ use actix_web::{get, web, Error, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
 use std::sync::Arc;
 
-use crate::auth::AuthManager;
 use crate::events::EventBroadcaster;
+use crate::session_authority::SessionAuthority;
 use crate::websocket::WsSession;
 
 /// GET /ws/:coop_id - WebSocket connection for real-time updates
@@ -14,12 +14,12 @@ pub async fn websocket(
     req: HttpRequest,
     stream: web::Payload,
     coop_id: web::Path<String>,
-    auth_manager: web::Data<Arc<AuthManager>>,
+    authority: web::Data<Arc<SessionAuthority>>,
     event_broadcaster: web::Data<Arc<EventBroadcaster>>,
 ) -> Result<HttpResponse, Error> {
     let session = WsSession::new(
         coop_id.into_inner(),
-        auth_manager.get_ref().clone(),
+        authority.get_ref().clone(),
         event_broadcaster.get_ref().clone(),
     );
     ws::start(session, &req, stream)
@@ -32,12 +32,13 @@ mod tests {
 
     #[actix_web::test]
     async fn test_websocket_endpoint() {
-        let auth_manager = Arc::new(AuthManager::new(b"test_secret".to_vec()));
+        let auth_manager = Arc::new(crate::auth::AuthManager::new(b"test_secret".to_vec()));
+        let authority = Arc::new(SessionAuthority::evaluator(auth_manager));
         let event_broadcaster = Arc::new(EventBroadcaster::new());
 
         let app = test::init_service(
             actix_web::App::new()
-                .app_data(web::Data::new(auth_manager))
+                .app_data(web::Data::new(authority))
                 .app_data(web::Data::new(event_broadcaster))
                 .service(websocket),
         )

--- a/icn/crates/icn-gateway/src/auth.rs
+++ b/icn/crates/icn-gateway/src/auth.rs
@@ -202,7 +202,7 @@ impl AuthManager {
             challenges: Arc::new(RwLock::new(HashMap::new())),
             jwt_secret,
             challenge_ttl: Duration::from_secs(300), // 5 minutes
-            token_ttl: Duration::from_secs(3600),    // 1 hour
+            token_ttl: crate::session_authority::DEFAULT_TOKEN_TTL,
             allow_self_asserted_coop: false,
         }
     }
@@ -424,7 +424,11 @@ impl AuthManager {
 
     /// Verify a JWT token and extract claims
     pub fn verify_token(&self, token: &str) -> Result<TokenClaims> {
-        let validation = Validation::default();
+        let mut validation = Validation::default();
+        // The configured lifetime is an authorization bound, not a hint. The
+        // jsonwebtoken default permits a 60-second expiry leeway, which would
+        // silently extend every issued credential beyond its reported `exp`.
+        validation.leeway = 0;
 
         let token_data = decode::<TokenClaims>(
             token,
@@ -442,18 +446,29 @@ impl AuthManager {
     /// minted for the same subject in the same second are still independently
     /// revocable, and so an id reveals nothing about issuance order or volume.
     fn generate_jti() -> String {
-        use rand::Rng;
-        let mut rng = rand::rng();
-        let bytes: [u8; 16] = rng.random();
-        hex::encode(bytes)
+        hex::encode(Self::cryptographic_random_bytes::<16>())
     }
 
     /// Generate cryptographically random nonce (32 bytes, hex-encoded)
     fn generate_nonce(&self) -> ChallengeNonce {
-        use rand::Rng;
+        hex::encode(Self::cryptographic_random_bytes::<32>())
+    }
+
+    /// Generate bytes from rand's cryptographic thread-local generator.
+    ///
+    /// Under the pinned rand 0.9 contract, `rand::rng()` is ChaCha12,
+    /// automatically seeded and periodically reseeded from `OsRng`. The
+    /// compile-time `CryptoRng` bound prevents a future API substitution with a
+    /// non-cryptographic generator from silently weakening credential IDs or
+    /// challenge nonces.
+    fn cryptographic_random_bytes<const N: usize>() -> [u8; N] {
+        use rand::{CryptoRng, Rng};
+
+        fn require_crypto_rng<R: CryptoRng + ?Sized>(_rng: &R) {}
+
         let mut rng = rand::rng();
-        let nonce_bytes: [u8; 32] = rng.random();
-        hex::encode(nonce_bytes)
+        require_crypto_rng(&rng);
+        rng.random()
     }
 
     /// Get current Unix timestamp

--- a/icn/crates/icn-gateway/src/auth.rs
+++ b/icn/crates/icn-gateway/src/auth.rs
@@ -136,6 +136,23 @@ pub struct TokenClaims {
     /// back-compatible contract as `entity_id`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub entity_type: Option<String>,
+
+    /// Unique credential id, enabling individual revocation (issue #2437).
+    ///
+    /// Minted by [`AuthManager::issue_entity_token`] — the one function every
+    /// gateway mint path bottoms out in — so all issuance paths (sessions,
+    /// invites, enrollment, `icnctl --local-mint`) produce revocable
+    /// credentials without call-site changes.
+    ///
+    /// `Option` for wire compatibility: credentials minted before this claim
+    /// existed still decode. A missing `jti` means *not individually
+    /// revocable*, which
+    /// [`SessionAuthority::verify`](crate::session_authority::SessionAuthority::verify)
+    /// refuses under profiles that require durable revocation. Because every
+    /// mint path now sets it, that population drains within one token lifetime
+    /// of an upgrade.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jti: Option<String>,
 }
 
 /// Authentication manager
@@ -214,6 +231,24 @@ impl AuthManager {
     pub fn with_self_asserted_coop(mut self, enabled: bool) -> Self {
         self.allow_self_asserted_coop = enabled;
         self
+    }
+
+    /// Apply a deployment-configured session lifetime to issued credentials.
+    ///
+    /// Before this existed, `GatewayConfig::token_expiry_hours` was parsed and
+    /// tested but never reached the issuer, so every credential lived exactly
+    /// one hour regardless of configuration (issue #2437). A configuration field
+    /// that does not change behavior is worse than no field at all: it creates
+    /// false operational confidence. The bound itself is validated by
+    /// [`TokenLifetimePolicy`](crate::session_authority::TokenLifetimePolicy).
+    pub fn with_token_ttl(mut self, ttl: Duration) -> Self {
+        self.token_ttl = ttl;
+        self
+    }
+
+    /// The lifetime applied to credentials this manager issues.
+    pub fn token_ttl(&self) -> Duration {
+        self.token_ttl
     }
 
     /// Generate a challenge for a DID
@@ -374,6 +409,7 @@ impl AuthManager {
             scopes,
             entity_id: entity_id.map(|id| id.to_string()),
             entity_type,
+            jti: Some(Self::generate_jti()),
         };
 
         let token = encode(
@@ -398,6 +434,18 @@ impl AuthManager {
         .map_err(|e| GatewayError::AuthenticationFailed(format!("Invalid token: {e}")))?;
 
         Ok(token_data.claims)
+    }
+
+    /// Generate a unique credential id (`jti`, 16 random bytes hex-encoded).
+    ///
+    /// Randomness — not a counter or a hash of the claims — so two credentials
+    /// minted for the same subject in the same second are still independently
+    /// revocable, and so an id reveals nothing about issuance order or volume.
+    fn generate_jti() -> String {
+        use rand::Rng;
+        let mut rng = rand::rng();
+        let bytes: [u8; 16] = rng.random();
+        hex::encode(bytes)
     }
 
     /// Generate cryptographically random nonce (32 bytes, hex-encoded)

--- a/icn/crates/icn-gateway/src/lib.rs
+++ b/icn/crates/icn-gateway/src/lib.rs
@@ -65,6 +65,7 @@ pub mod security;
 pub mod server;
 pub mod service_discovery_mgr;
 pub mod session;
+pub mod session_authority;
 pub mod steward_mgr;
 pub mod token_authority;
 pub mod treasury_mgr;

--- a/icn/crates/icn-gateway/src/middleware.rs
+++ b/icn/crates/icn-gateway/src/middleware.rs
@@ -10,8 +10,9 @@ use std::future::{ready, Ready};
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::auth::{AuthManager, TokenClaims};
+use crate::auth::TokenClaims;
 use crate::error::GatewayError;
+use crate::session_authority::SessionAuthority;
 use icn_obs::metrics::gateway;
 
 /// Extract and verify JWT token from Authorization header
@@ -19,11 +20,22 @@ pub async fn jwt_auth(
     req: ServiceRequest,
     credentials: BearerAuth,
 ) -> Result<ServiceRequest, (Error, ServiceRequest)> {
-    // Get auth manager
-    let auth_manager = match req.app_data::<actix_web::web::Data<Arc<AuthManager>>>() {
-        Some(mgr) => mgr.clone(),
+    // Verify through the session authority — the composition boundary that owns
+    // signature, expiry AND revocation (issue #2437). Resolving it here, at the
+    // single middleware every authenticated route is wrapped with, is what makes
+    // revocation unavoidable: a route cannot opt out by forgetting to check.
+    //
+    // Fail closed when it is absent. Falling back to a bare `AuthManager` would
+    // silently restore the pre-#2437 behavior (valid signature ⇒ authorized) in
+    // exactly the misassembly this work exists to prevent.
+    let authority = match req.app_data::<actix_web::web::Data<Arc<SessionAuthority>>>() {
+        Some(authority) => authority.clone(),
         None => {
-            let err = GatewayError::InternalError("AuthManager not found".to_string());
+            let err = GatewayError::InternalError(
+                "SessionAuthority not installed: refusing to authenticate without \
+                 revocation enforcement"
+                    .to_string(),
+            );
             return Err((Error::from(err), req));
         }
     };
@@ -42,7 +54,7 @@ pub async fn jwt_auth(
         }
     }
 
-    match auth_manager.verify_token(token) {
+    match authority.verify(token) {
         Ok(claims) => {
             // Insert BasicClaims first so apps/governance handlers can extract them
             // without depending on gateway-internal TokenClaims type.
@@ -264,6 +276,7 @@ mod tests {
             scopes: scopes.iter().map(|s| s.to_string()).collect(),
             entity_id: None,
             entity_type: None,
+            jti: None,
         });
         req
     }
@@ -486,6 +499,7 @@ mod tests {
             scopes: vec!["ledger:write".to_string()],
             entity_id: None,
             entity_type: None,
+            jti: None,
         });
 
         assert!(matches!(
@@ -510,6 +524,7 @@ mod tests {
             scopes: vec!["ledger:write".to_string()],
             entity_id: Some("entity:icn:cooperative:coop-b".to_string()),
             entity_type: Some("cooperative".to_string()),
+            jti: None,
         });
 
         // Decision follows coop_id, not the (mismatched) entity_id.

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -682,8 +682,31 @@ impl GatewayServer {
         self
     }
 
-    /// Run the gateway server
+    /// Run the gateway server.
     pub async fn run(self) -> Result<()> {
+        self.run_inner(None).await
+    }
+
+    /// Run the gateway and acknowledge only after initialization and socket bind.
+    ///
+    /// The supervisor uses this handshake so it cannot report the gateway actor
+    /// active while authority assembly, storage initialization, or binding has
+    /// already failed.
+    pub async fn run_with_startup_signal(
+        self,
+        startup: tokio::sync::oneshot::Sender<()>,
+        supervisor_ack: tokio::sync::oneshot::Receiver<()>,
+    ) -> Result<()> {
+        self.run_inner(Some((startup, supervisor_ack))).await
+    }
+
+    async fn run_inner(
+        self,
+        startup: Option<(
+            tokio::sync::oneshot::Sender<()>,
+            tokio::sync::oneshot::Receiver<()>,
+        )>,
+    ) -> Result<()> {
         info!("Starting ICN Gateway on {}", self.bind_addr);
 
         // Initialize server start time for health check uptime reporting
@@ -2019,10 +2042,9 @@ impl GatewayServer {
                         .url("/api-docs/openapi.json", openapi.clone()),
                 )
                 // Shared state
-                .app_data(web::Data::new(auth_manager.clone()))
-                // Authority composition boundary: every authenticated request
-                // verifies through this (see `middleware::jwt_auth`), so
-                // revocation cannot be bypassed by a route that forgets it.
+                // Authority composition boundary: issuance handlers and every
+                // authenticated request resolve this one object, so a router
+                // cannot install a bare issuer without revocation enforcement.
                 .app_data(web::Data::new(session_authority.clone()))
                 .app_data(web::Data::new(coop_manager.clone()))
                 .app_data(web::Data::new(community_manager.clone()))
@@ -2513,6 +2535,19 @@ impl GatewayServer {
         .bind(self.bind_addr)?
         .run();
 
+        if let Some((startup, supervisor_ack)) = startup {
+            startup.send(()).map_err(|_| {
+                GatewayError::InternalError(
+                    "gateway supervisor dropped startup acknowledgement channel".to_string(),
+                )
+            })?;
+            supervisor_ack.await.map_err(|_| {
+                GatewayError::InternalError(
+                    "gateway supervisor did not acknowledge actor activation".to_string(),
+                )
+            })?;
+        }
+
         // Wait for server to complete and then signal cleanup task to shutdown
         let result = server.await;
 
@@ -2597,6 +2632,24 @@ mod tests {
         assert!(
             err_msg.contains("empty JWT secret"),
             "Expected empty JWT secret error, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_signal_reports_failure_before_readiness() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let server = GatewayServer::new(addr, vec![]);
+        let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();
+        let (_supervisor_ack_tx, supervisor_ack_rx) = tokio::sync::oneshot::channel();
+
+        let result = server
+            .run_with_startup_signal(startup_tx, supervisor_ack_rx)
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            startup_rx.await.is_err(),
+            "a failed server must never acknowledge readiness"
         );
     }
 

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -37,6 +37,10 @@ use crate::rate_limit::{
     IpRateLimiter, RateLimitConfig, RateLimiter, VelocityLimitConfig, VelocityLimiter,
 };
 use crate::security::{configure_cors, SecurityConfig, SecurityHeaders};
+use crate::session_authority::{
+    AuthorityProfile, InMemoryRevocationAuthority, RevocationAuthority, SessionAuthority,
+    StoreRevocationAuthority, TokenLifetimePolicy,
+};
 use crate::treasury_mgr::{GatewayTreasuryManager, LedgerHandle, TreasuryHandle};
 use crate::trust_mgr::TrustManager;
 use anyhow::Context;
@@ -82,6 +86,16 @@ impl Default for AuditPruneConfig {
 pub struct GatewayServer {
     bind_addr: SocketAddr,
     jwt_secret: Vec<u8>,
+    /// Deployment profile governing which authority guarantees are REQUIRED.
+    /// Defaults to the disposable-evaluator posture; the daemon sets the
+    /// institutional profile when a persistent deployment is configured.
+    authority_profile: AuthorityProfile,
+    /// Persistent store backing session revocation. `None` yields volatile
+    /// revocation, which only the evaluator profile may run (see
+    /// [`AuthorityProfile::validate`]).
+    revocation_store: Option<Arc<dyn icn_store::Store>>,
+    /// Configured session lifetime; `None` uses the default.
+    token_lifetime: Option<TokenLifetimePolicy>,
     data_dir: Option<std::path::PathBuf>,
     event_broadcaster: Option<Arc<EventBroadcaster>>,
     security_config: SecurityConfig,
@@ -190,6 +204,13 @@ impl GatewayServer {
         GatewayServer {
             bind_addr,
             jwt_secret,
+            // Safe-by-default: assume the disposable posture until a deployment
+            // declares itself institutional. Declaring the stronger profile
+            // without the machinery to back it fails at startup rather than
+            // shipping an authority claim the runtime cannot honor.
+            authority_profile: AuthorityProfile::PortableEvaluator,
+            revocation_store: None,
+            token_lifetime: None,
             data_dir: None,
             event_broadcaster: None,
             security_config: SecurityConfig::development(), // Permissive for tests
@@ -242,6 +263,9 @@ impl GatewayServer {
         GatewayServer {
             bind_addr,
             jwt_secret,
+            authority_profile: AuthorityProfile::PortableEvaluator,
+            revocation_store: None,
+            token_lifetime: None,
             data_dir: Some(data_dir),
             event_broadcaster: None,
             security_config,
@@ -295,6 +319,9 @@ impl GatewayServer {
         GatewayServer {
             bind_addr,
             jwt_secret,
+            authority_profile: AuthorityProfile::PortableEvaluator,
+            revocation_store: None,
+            token_lifetime: None,
             data_dir,
             event_broadcaster: Some(event_broadcaster),
             security_config,
@@ -614,6 +641,32 @@ impl GatewayServer {
     /// real records (keyed `exec:<decision_hash>`). Standalone/test gateways
     /// that have no runtime store leave this `None` and keep the path-open
     /// fallback (Gap C).
+    /// Install a persistent store for session revocation.
+    ///
+    /// Without this, revocation is in-memory and is lost on restart — a posture
+    /// only [`AuthorityProfile::PortableEvaluator`] may run. Supplying the store
+    /// is what makes [`AuthorityProfile::Institutional`] assemblable.
+    pub fn with_revocation_store(mut self, store: Arc<dyn icn_store::Store>) -> Self {
+        self.revocation_store = Some(store);
+        self
+    }
+
+    /// Declare the deployment profile whose authority guarantees must hold.
+    ///
+    /// A profile is a *requirement*, not a description: declaring
+    /// [`AuthorityProfile::Institutional`] without durable revocation aborts
+    /// startup with an actionable error rather than degrading silently.
+    pub fn with_authority_profile(mut self, profile: AuthorityProfile) -> Self {
+        self.authority_profile = profile;
+        self
+    }
+
+    /// Apply the deployment-configured session lifetime (`token_expiry_hours`).
+    pub fn with_token_lifetime(mut self, lifetime: TokenLifetimePolicy) -> Self {
+        self.token_lifetime = Some(lifetime);
+        self
+    }
+
     pub fn with_execution_query_store(mut self, store: Arc<dyn icn_store::Store>) -> Self {
         self.execution_query_store = Some(store);
         self
@@ -697,9 +750,48 @@ impl GatewayServer {
                 self.bind_addr
             );
         }
+        // ---- Session authority composition (issues #2436, #2437) ----------
+        //
+        // The authority subsystem is assembled as ONE explicit value rather than
+        // an implicit set of defaults, so what this deployment guarantees is
+        // constructible, inspectable, and testable through the same path
+        // production uses. `SessionAuthority::new` runs the profile's startup
+        // invariants and refuses to assemble a deployment whose required
+        // guarantees are missing.
+        let lifetime = self.token_lifetime.unwrap_or_default();
         let auth_manager = Arc::new(
-            AuthManager::new(self.jwt_secret).with_self_asserted_coop(allow_self_asserted_coop),
+            AuthManager::new(self.jwt_secret)
+                .with_self_asserted_coop(allow_self_asserted_coop)
+                .with_token_ttl(lifetime.ttl()),
         );
+
+        // Durable when the daemon supplied a revocation store; volatile
+        // otherwise. The profile decides whether volatile is acceptable — it is
+        // never silently upgraded to "revocation supported".
+        let revocation: Arc<dyn RevocationAuthority> = match self.revocation_store.clone() {
+            Some(store) => Arc::new(StoreRevocationAuthority::new(store)?),
+            None => Arc::new(InMemoryRevocationAuthority::new()),
+        };
+
+        let session_authority = Arc::new(SessionAuthority::new(
+            auth_manager.clone(),
+            revocation,
+            lifetime,
+            self.authority_profile,
+        )?);
+
+        let authority_caps = session_authority.capabilities();
+        info!(
+            profile = authority_caps.profile,
+            revocation = ?authority_caps.revocation,
+            revocation_durability = authority_caps.revocation_durability,
+            revocation_backend = authority_caps.revocation_backend,
+            token_ttl_secs = authority_caps.token_ttl_secs,
+            "Session authority assembled"
+        );
+        for note in &authority_caps.notes {
+            warn!("Session authority: {}", note);
+        }
 
         // Create cooperative manager (uses actor if handle available, otherwise in-memory)
         let coop_manager: Arc<CoopManager> = if let Some(handle) = self.coop_handle {
@@ -1928,6 +2020,10 @@ impl GatewayServer {
                 )
                 // Shared state
                 .app_data(web::Data::new(auth_manager.clone()))
+                // Authority composition boundary: every authenticated request
+                // verifies through this (see `middleware::jwt_auth`), so
+                // revocation cannot be bypassed by a route that forgets it.
+                .app_data(web::Data::new(session_authority.clone()))
                 .app_data(web::Data::new(coop_manager.clone()))
                 .app_data(web::Data::new(community_manager.clone()))
                 .app_data(web::Data::new(steward_manager.clone()))

--- a/icn/crates/icn-gateway/src/session_authority.rs
+++ b/icn/crates/icn-gateway/src/session_authority.rs
@@ -59,8 +59,12 @@ const REVOKED_JTI_PREFIX: &[u8] = b"auth:revoked:";
 /// a new credential rather than extending an old one.
 pub const MAX_TOKEN_TTL: Duration = Duration::from_secs(30 * 24 * 3600);
 
-/// Fallback lifetime when a deployment supplies no configuration.
-pub const DEFAULT_TOKEN_TTL: Duration = Duration::from_secs(3600);
+/// Canonical session-credential lifetime when no explicit configuration is supplied.
+///
+/// The daemon's `GatewayConfig`, embedded gateways, and direct [`AuthManager`]
+/// construction all use this value. Keeping one default prevents an embedded
+/// router from silently issuing shorter-lived credentials than the daemon.
+pub const DEFAULT_TOKEN_TTL: Duration = Duration::from_secs(24 * 3600);
 
 // ---------------------------------------------------------------------------
 // Scope attenuation
@@ -508,6 +512,13 @@ impl SessionAuthority {
         profile: AuthorityProfile,
     ) -> Result<Self> {
         profile.validate(revocation.durability())?;
+        if auth.token_ttl() != lifetime.ttl() {
+            return Err(GatewayError::InternalError(format!(
+                "session authority lifetime mismatch: issuer uses {} seconds but policy reports {} seconds",
+                auth.token_ttl().as_secs(),
+                lifetime.ttl().as_secs()
+            )));
+        }
         Ok(Self {
             auth,
             revocation,
@@ -812,6 +823,13 @@ mod tests {
     }
 
     #[test]
+    fn unconfigured_issuer_and_policy_share_the_canonical_default() {
+        let auth = AuthManager::new(vec![7u8; 32]);
+        assert_eq!(auth.token_ttl(), DEFAULT_TOKEN_TTL);
+        assert_eq!(TokenLifetimePolicy::default().ttl(), DEFAULT_TOKEN_TTL);
+    }
+
+    #[test]
     fn zero_and_excessive_lifetimes_are_rejected() {
         assert!(TokenLifetimePolicy::from_hours(0).is_err());
         assert!(TokenLifetimePolicy::from_hours(24 * 31).is_err());
@@ -855,6 +873,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn assembly_rejects_an_issuer_policy_lifetime_mismatch() {
+        let auth = Arc::new(AuthManager::new(vec![7u8; 32]));
+        let result = SessionAuthority::new(
+            auth,
+            Arc::new(InMemoryRevocationAuthority::new()),
+            TokenLifetimePolicy::from_hours(2).unwrap(),
+            AuthorityProfile::PortableEvaluator,
+        );
+        let error = match result {
+            Ok(_) => panic!("mismatched lifetime truth must fail assembly"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("lifetime mismatch"));
+    }
+
     // -- revocation --------------------------------------------------------
 
     #[test]
@@ -869,11 +903,12 @@ mod tests {
 
     #[test]
     fn capability_report_reflects_actual_assembly() {
-        let auth = Arc::new(AuthManager::new(vec![7u8; 32]));
+        let lifetime = TokenLifetimePolicy::from_hours(2).unwrap();
+        let auth = Arc::new(AuthManager::new(vec![7u8; 32]).with_token_ttl(lifetime.ttl()));
         let authority = SessionAuthority::new(
             auth,
             Arc::new(InMemoryRevocationAuthority::new()),
-            TokenLifetimePolicy::from_hours(2).unwrap(),
+            lifetime,
             AuthorityProfile::PortableEvaluator,
         )
         .unwrap();

--- a/icn/crates/icn-gateway/src/session_authority.rs
+++ b/icn/crates/icn-gateway/src/session_authority.rs
@@ -21,7 +21,7 @@
 //! 3. **Revocation** — an issued credential can be individually withdrawn and is
 //!    rejected thereafter ([`RevocationAuthority`]).
 //! 4. **Truth** — what is installed is reportable, and a profile that requires a
-//!    guarantee refuses to start without it ([`AuthorityCapabilities`],
+//!    guarantee refuses to assemble without it ([`AuthorityCapabilities`],
 //!    [`AuthorityProfile::validate`]).
 //!
 //! # What this module deliberately does NOT decide
@@ -42,7 +42,15 @@ use crate::auth::{AuthManager, TokenClaims};
 use crate::error::{GatewayError, Result};
 
 /// Key prefix for persisted revocation entries.
-const REVOKED_JTI_PREFIX: &[u8] = b"gateway:revoked_jti:";
+///
+/// **Deliberately identical to `icn-rpc`'s `TokenRevocationList` prefix.** The
+/// gateway and the RPC server are signed with the same secret and their claim
+/// shapes are mutually decodable, so a credential presented to one surface can
+/// be presented to the other. Namespacing the two revocation lists separately
+/// would mean "revoked" on the gateway and "valid" on RPC for the same
+/// credential — the exact divergence sharing a store is meant to prevent. The
+/// key IS the revocation fact; the value is advisory metadata.
+const REVOKED_JTI_PREFIX: &[u8] = b"auth:revoked:";
 
 /// Upper bound on any configured session lifetime.
 ///
@@ -211,10 +219,19 @@ pub trait RevocationAuthority: Send + Sync {
 
 /// Durable revocation backed by a persistent [`icn_store::Store`].
 ///
-/// Reads are served from an in-memory set so the request hot path stays a
-/// hash lookup; writes go to the store first and are only cached after the
-/// durable write succeeds, so a cached "revoked" always implies a persisted
-/// "revoked" (never the reverse).
+/// # Read semantics: cache is a fast YES, the store is the authority
+///
+/// A cache hit answers "revoked" immediately. A cache *miss* falls through to
+/// the store rather than answering "not revoked", because the cache only knows
+/// about revocations this process performed or loaded at startup — a credential
+/// revoked through the RPC `auth.revoke` surface (which shares this store) would
+/// otherwise stay valid on the gateway until a restart. The one-sided fallthrough
+/// keeps the dangerous answer authoritative while leaving the common path a
+/// single hash lookup plus one point read.
+///
+/// Writes go to the store first and are cached only after the durable write
+/// succeeds, so a cached "revoked" always implies a persisted "revoked" — never
+/// the reverse.
 pub struct StoreRevocationAuthority {
     store: Arc<dyn icn_store::Store>,
     cache: RwLock<HashSet<String>>,
@@ -255,18 +272,51 @@ impl StoreRevocationAuthority {
 
 impl RevocationAuthority for StoreRevocationAuthority {
     fn is_revoked(&self, jti: &str) -> Result<bool> {
-        let cache = self.cache.read().map_err(|_| {
-            GatewayError::InternalError("gateway revocation cache lock poisoned".to_string())
+        {
+            let cache = self.cache.read().map_err(|_| {
+                GatewayError::InternalError("gateway revocation cache lock poisoned".to_string())
+            })?;
+            if cache.contains(jti) {
+                return Ok(true);
+            }
+        }
+
+        // Cache miss is not proof of validity: the RPC surface shares this store
+        // and revokes without touching this process's cache. Consult the store,
+        // and propagate read failures so the caller fails closed.
+        let present = self.store.get(&Self::key(jti)).map_err(|e| {
+            GatewayError::InternalError(format!("failed to read revocation state: {e}"))
         })?;
-        Ok(cache.contains(jti))
+
+        if present.is_some() {
+            if let Ok(mut cache) = self.cache.write() {
+                cache.insert(jti.to_string());
+            }
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     fn revoke(&self, jti: &str, expires_at: u64) -> Result<()> {
-        self.store
-            .put(&Self::key(jti), &expires_at.to_be_bytes())
-            .map_err(|e| {
-                GatewayError::InternalError(format!("failed to persist gateway revocation: {e}"))
-            })?;
+        // Value shape mirrors `icn-rpc`'s `RevokedToken` so the RPC server's
+        // startup cache load (which deserializes values and skips entries it
+        // cannot parse) honors revocations written here. The KEY is the
+        // authoritative revocation fact for this side; the value carries the
+        // expiry that both sides use to reclaim entries after the credential
+        // would have expired anyway.
+        let value = serde_json::json!({
+            "jti": jti,
+            "subject": "",
+            "revoked_at": icn_time::current_timestamp_secs(),
+            "original_expiry": expires_at,
+            "reason": "revoked via gateway session authority",
+        });
+        let encoded = serde_json::to_vec(&value).map_err(|e| {
+            GatewayError::InternalError(format!("failed to encode revocation entry: {e}"))
+        })?;
+        self.store.put(&Self::key(jti), &encoded).map_err(|e| {
+            GatewayError::InternalError(format!("failed to persist gateway revocation: {e}"))
+        })?;
         let mut cache = self.cache.write().map_err(|_| {
             GatewayError::InternalError("gateway revocation cache lock poisoned".to_string())
         })?;
@@ -538,8 +588,14 @@ impl SessionAuthority {
             // A credential minted before revocable ids existed cannot be
             // individually withdrawn. Institutions must not accept an
             // unrevocable credential; disposable evaluators may (they have no
-            // durable revocation to contradict anyway). Every mint path now sets
-            // `jti`, so this drains within one token lifetime of an upgrade.
+            // durable revocation to contradict anyway).
+            //
+            // MIGRATION (breaking): because the daemon declares the
+            // institutional profile whenever it has a revocation store, every
+            // credential outstanding at upgrade time is rejected *immediately*,
+            // not gradually — holders must re-authenticate. The appliance
+            // re-mints during seeding; browser sessions held elsewhere die at
+            // upgrade.
             if self.profile.requires_durable_revocation() {
                 return Err(GatewayError::AuthenticationFailed(
                     "credential predates revocable session ids and cannot be withdrawn; \
@@ -600,10 +656,24 @@ impl SessionAuthority {
             ));
         }
 
+        // Attenuation is DEGRADED, not enforced, and saying so is the whole
+        // point of this report. `issue_delegated` is the only attenuating mint
+        // path; the invite, SDIS-enrollment and trusted-local (`icnctl
+        // --local-mint`) paths still issue fixed scope sets chosen by the flow
+        // rather than bounded by the issuer's own authority. Reporting
+        // `Enforced` here would be precisely the failure this subsystem exists
+        // to make impossible: a capability claim the assembled runtime does not
+        // back on every path.
+        notes.push(
+            "scope attenuation is enforced only for delegated session approval; the invite, \
+             SDIS-enrollment and trusted-local mint paths still issue flow-chosen scope sets"
+                .to_string(),
+        );
+
         AuthorityCapabilities {
             profile: self.profile.as_str(),
             session_issuance: CapabilityState::Enforced,
-            scope_attenuation: CapabilityState::Enforced,
+            scope_attenuation: CapabilityState::Degraded,
             revocation,
             revocation_durability: durability.as_str(),
             revocation_backend: self.revocation.backend(),
@@ -814,7 +884,17 @@ mod tests {
         assert_eq!(caps.revocation_durability, "volatile");
         assert_eq!(caps.revocation_backend, "memory");
         assert_eq!(caps.token_ttl_secs, 7200);
-        assert_eq!(caps.scope_attenuation, CapabilityState::Enforced);
+        // Attenuation is Degraded, not Enforced: only delegated session approval
+        // attenuates today. Pinning the honest value here so a future change that
+        // upgrades the claim has to also upgrade the reality.
+        assert_eq!(caps.scope_attenuation, CapabilityState::Degraded);
+        assert!(
+            caps.notes
+                .iter()
+                .any(|n| n.contains("enforced only for delegated session approval")),
+            "partial attenuation must be reported honestly: {:?}",
+            caps.notes
+        );
         assert!(
             caps.notes.iter().any(|n| n.contains("valid again after")),
             "degraded revocation must be reported honestly: {:?}",

--- a/icn/crates/icn-gateway/src/session_authority.rs
+++ b/icn/crates/icn-gateway/src/session_authority.rs
@@ -1,0 +1,824 @@
+//! Session authority — the gateway's authority composition boundary.
+//!
+//! # Why this module exists
+//!
+//! Gateway session authority was previously assembled implicitly: [`AuthManager`]
+//! was constructed inline in `GatewayServer::run`, minting was reachable from
+//! five call sites, verification consulted nothing but the JWT signature, and
+//! the configured token lifetime never reached the issuer. Nothing in the
+//! runtime could answer "which authority guarantees does this deployment
+//! actually have?" — the library contained revocation machinery (in `icn-rpc`)
+//! that the assembled daemon never installed (issues #2436, #2437).
+//!
+//! [`SessionAuthority`] is the single value through which the gateway issues and
+//! verifies session credentials. It owns four responsibilities that were
+//! previously scattered or absent:
+//!
+//! 1. **Attenuation** — no delegation may mint authority its issuer lacks
+//!    ([`attenuate_scopes`]).
+//! 2. **Lifetime** — the *configured* TTL bounds the credentials actually issued
+//!    ([`TokenLifetimePolicy`]).
+//! 3. **Revocation** — an issued credential can be individually withdrawn and is
+//!    rejected thereafter ([`RevocationAuthority`]).
+//! 4. **Truth** — what is installed is reportable, and a profile that requires a
+//!    guarantee refuses to start without it ([`AuthorityCapabilities`],
+//!    [`AuthorityProfile::validate`]).
+//!
+//! # What this module deliberately does NOT decide
+//!
+//! It enforces *technical* bounds on authority; it does not decide who is
+//! institutionally legitimate. Which DIDs may approve a session, which scopes a
+//! role carries, and how long a cooperative wants sessions to live are
+//! institutional questions that belong to governance/charter policy above this
+//! layer. This module guarantees only that whatever the institution decides
+//! cannot be *exceeded* by the software: attenuation is a ceiling, never a
+//! grant. See `docs/architecture/AUTHORITY_SPINE.md`.
+
+use std::collections::{BTreeSet, HashSet};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use crate::auth::{AuthManager, TokenClaims};
+use crate::error::{GatewayError, Result};
+
+/// Key prefix for persisted revocation entries.
+const REVOKED_JTI_PREFIX: &[u8] = b"gateway:revoked_jti:";
+
+/// Upper bound on any configured session lifetime.
+///
+/// A credential that cannot be revoked for longer than this is an unbounded
+/// liability; 30 days is the outer edge at which an operator should be issuing
+/// a new credential rather than extending an old one.
+pub const MAX_TOKEN_TTL: Duration = Duration::from_secs(30 * 24 * 3600);
+
+/// Fallback lifetime when a deployment supplies no configuration.
+pub const DEFAULT_TOKEN_TTL: Duration = Duration::from_secs(3600);
+
+// ---------------------------------------------------------------------------
+// Scope attenuation
+// ---------------------------------------------------------------------------
+
+/// Compute the scopes a delegation may legitimately mint.
+///
+/// The attenuation rule, in one line:
+///
+/// ```text
+/// issued ⊆ issuer ∩ flow_allowed ∩ (requested, when the caller asks for a subset)
+/// ```
+///
+/// Every term is a *ceiling*. An issuer can only pass on authority it already
+/// holds; a flow can only pass on authority its design permits; a caller may ask
+/// for less but never for more. This is the invariant that makes #2436
+/// structurally impossible rather than patched: there is no argument to this
+/// function that yields a scope the issuer did not hold.
+///
+/// Returns [`GatewayError::AuthorizationFailed`] when the intersection is empty
+/// — an issuer with nothing to delegate must be told so, not handed a valid
+/// credential carrying no authority (which reads as success to a client and
+/// fails confusingly later).
+///
+/// Duplicates and ordering are normalized; unknown scope strings are not
+/// special-cased because an unknown scope cannot survive intersection with the
+/// issuer's set unless the issuer already held it.
+pub fn attenuate_scopes(
+    issuer_scopes: &[String],
+    flow_allowed: &[&str],
+    requested: Option<&[String]>,
+) -> Result<Vec<String>> {
+    let issuer: BTreeSet<&str> = issuer_scopes.iter().map(String::as_str).collect();
+    let allowed: BTreeSet<&str> = flow_allowed.iter().copied().collect();
+
+    let mut granted: BTreeSet<&str> = issuer.intersection(&allowed).copied().collect();
+
+    if let Some(req) = requested {
+        // An explicit request narrows further. Asking for something outside the
+        // ceiling is not an error the caller can exploit — it is simply dropped —
+        // but a request that survives to an empty set is reported below.
+        let req_set: BTreeSet<&str> = req.iter().map(String::as_str).collect();
+        granted = granted.intersection(&req_set).copied().collect();
+    }
+
+    if granted.is_empty() {
+        return Err(GatewayError::AuthorizationFailed(
+            "no delegable authority: the approving credential holds none of the \
+             scopes this flow may grant"
+                .to_string(),
+        ));
+    }
+
+    Ok(granted.into_iter().map(str::to_string).collect())
+}
+
+// ---------------------------------------------------------------------------
+// Token lifetime
+// ---------------------------------------------------------------------------
+
+/// The lifetime actually applied to issued credentials.
+///
+/// Constructed from deployment configuration and *consumed* by the issuer, so a
+/// configured value can never again be silently ignored (the prior state of
+/// `token_expiry_hours`, issue #2437).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenLifetimePolicy {
+    ttl: Duration,
+}
+
+impl TokenLifetimePolicy {
+    /// Build a policy from a configured hour count.
+    ///
+    /// Rejects `0` (a credential expiring at issuance is a misconfiguration that
+    /// would otherwise present as "auth is broken") and anything beyond
+    /// [`MAX_TOKEN_TTL`]. Both are reported rather than clamped: silently
+    /// shortening an operator's configured lifetime is the same class of bug as
+    /// silently ignoring it.
+    pub fn from_hours(hours: u64) -> Result<Self> {
+        if hours == 0 {
+            return Err(GatewayError::InternalError(
+                "token_expiry_hours = 0 would issue already-expired credentials; \
+                 set a positive lifetime"
+                    .to_string(),
+            ));
+        }
+        let ttl = Duration::from_secs(hours.saturating_mul(3600));
+        if ttl > MAX_TOKEN_TTL {
+            return Err(GatewayError::InternalError(format!(
+                "token_expiry_hours = {hours} exceeds the {} hour maximum session lifetime",
+                MAX_TOKEN_TTL.as_secs() / 3600
+            )));
+        }
+        Ok(Self { ttl })
+    }
+
+    /// The applied lifetime.
+    pub fn ttl(&self) -> Duration {
+        self.ttl
+    }
+}
+
+impl Default for TokenLifetimePolicy {
+    fn default() -> Self {
+        Self {
+            ttl: DEFAULT_TOKEN_TTL,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Revocation
+// ---------------------------------------------------------------------------
+
+/// Whether revocation state survives a restart.
+///
+/// This distinction is load-bearing: a volatile revocation authority silently
+/// resurrects every revoked credential on restart, which is acceptable for a
+/// disposable offline evaluator and unacceptable for an institution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevocationDurability {
+    /// Survives process restart (persistent store).
+    Durable,
+    /// Lost on restart (process memory only).
+    Volatile,
+}
+
+impl RevocationDurability {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Durable => "durable",
+            Self::Volatile => "volatile",
+        }
+    }
+}
+
+/// Authority to withdraw an issued credential.
+///
+/// Implementations MUST return `Err` rather than `Ok(false)` when they cannot
+/// determine revocation state. Callers treat an error as "assume revoked" — an
+/// unreadable revocation store must never read as authorization.
+pub trait RevocationAuthority: Send + Sync {
+    /// Is this credential id revoked?
+    fn is_revoked(&self, jti: &str) -> Result<bool>;
+
+    /// Withdraw a credential until `expires_at` (unix seconds), after which the
+    /// entry may be reclaimed because the credential is expired anyway.
+    fn revoke(&self, jti: &str, expires_at: u64) -> Result<()>;
+
+    /// Whether this authority's state survives restart.
+    fn durability(&self) -> RevocationDurability;
+
+    /// Implementation name, for the capability report.
+    fn backend(&self) -> &'static str;
+}
+
+/// Durable revocation backed by a persistent [`icn_store::Store`].
+///
+/// Reads are served from an in-memory set so the request hot path stays a
+/// hash lookup; writes go to the store first and are only cached after the
+/// durable write succeeds, so a cached "revoked" always implies a persisted
+/// "revoked" (never the reverse).
+pub struct StoreRevocationAuthority {
+    store: Arc<dyn icn_store::Store>,
+    cache: RwLock<HashSet<String>>,
+}
+
+impl StoreRevocationAuthority {
+    /// Open a durable revocation authority, loading existing revocations.
+    ///
+    /// A store that cannot be scanned at startup is a hard error: booting with
+    /// an unreadable revocation list would mean serving requests while unable to
+    /// honor prior revocations.
+    pub fn new(store: Arc<dyn icn_store::Store>) -> Result<Self> {
+        let entries = store.scan(REVOKED_JTI_PREFIX).map_err(|e| {
+            GatewayError::InternalError(format!("failed to load gateway revocation list: {e}"))
+        })?;
+
+        let cache = entries
+            .into_iter()
+            .filter_map(|(key, _)| {
+                key.strip_prefix(REVOKED_JTI_PREFIX)
+                    .and_then(|raw| std::str::from_utf8(raw).ok())
+                    .map(str::to_string)
+            })
+            .collect::<HashSet<String>>();
+
+        Ok(Self {
+            store,
+            cache: RwLock::new(cache),
+        })
+    }
+
+    fn key(jti: &str) -> Vec<u8> {
+        let mut k = REVOKED_JTI_PREFIX.to_vec();
+        k.extend_from_slice(jti.as_bytes());
+        k
+    }
+}
+
+impl RevocationAuthority for StoreRevocationAuthority {
+    fn is_revoked(&self, jti: &str) -> Result<bool> {
+        let cache = self.cache.read().map_err(|_| {
+            GatewayError::InternalError("gateway revocation cache lock poisoned".to_string())
+        })?;
+        Ok(cache.contains(jti))
+    }
+
+    fn revoke(&self, jti: &str, expires_at: u64) -> Result<()> {
+        self.store
+            .put(&Self::key(jti), &expires_at.to_be_bytes())
+            .map_err(|e| {
+                GatewayError::InternalError(format!("failed to persist gateway revocation: {e}"))
+            })?;
+        let mut cache = self.cache.write().map_err(|_| {
+            GatewayError::InternalError("gateway revocation cache lock poisoned".to_string())
+        })?;
+        cache.insert(jti.to_string());
+        Ok(())
+    }
+
+    fn durability(&self) -> RevocationDurability {
+        RevocationDurability::Durable
+    }
+
+    fn backend(&self) -> &'static str {
+        "store"
+    }
+}
+
+/// Volatile revocation for disposable deployments.
+///
+/// Honest about what it is: revocations are lost on restart. Permitted only by
+/// profiles that explicitly accept that (see [`AuthorityProfile`]).
+#[derive(Default)]
+pub struct InMemoryRevocationAuthority {
+    revoked: RwLock<HashSet<String>>,
+}
+
+impl InMemoryRevocationAuthority {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl RevocationAuthority for InMemoryRevocationAuthority {
+    fn is_revoked(&self, jti: &str) -> Result<bool> {
+        let revoked = self.revoked.read().map_err(|_| {
+            GatewayError::InternalError("gateway revocation lock poisoned".to_string())
+        })?;
+        Ok(revoked.contains(jti))
+    }
+
+    fn revoke(&self, jti: &str, _expires_at: u64) -> Result<()> {
+        let mut revoked = self.revoked.write().map_err(|_| {
+            GatewayError::InternalError("gateway revocation lock poisoned".to_string())
+        })?;
+        revoked.insert(jti.to_string());
+        Ok(())
+    }
+
+    fn durability(&self) -> RevocationDurability {
+        RevocationDurability::Volatile
+    }
+
+    fn backend(&self) -> &'static str {
+        "memory"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deployment profile
+// ---------------------------------------------------------------------------
+
+/// What a deployment *requires* of its authority subsystem.
+///
+/// Profile names follow the appliance's existing vocabulary
+/// (`deploy/appliance/evaluator` = the portable demo profile;
+/// `deploy/appliance/lan` = the operator-controlled node).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorityProfile {
+    /// Disposable, offline, single-reviewer evaluator. Volatile revocation is
+    /// permitted because the whole deployment is discarded after use — but it is
+    /// reported as a degraded guarantee, never as revocation support.
+    PortableEvaluator,
+    /// Operator-controlled or institutional deployment. Durable revocation is
+    /// required: an institution that cannot make a withdrawal stick across a
+    /// restart does not have revocation.
+    Institutional,
+}
+
+impl AuthorityProfile {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::PortableEvaluator => "portable-evaluator",
+            Self::Institutional => "institutional",
+        }
+    }
+
+    /// Does this profile require revocation to survive restart?
+    pub fn requires_durable_revocation(&self) -> bool {
+        matches!(self, Self::Institutional)
+    }
+
+    /// Startup invariant: refuse to run with guarantees this profile requires
+    /// but the assembled runtime does not provide.
+    ///
+    /// The error names the missing capability, why the profile requires it, the
+    /// unsafe fallback that was refused, and what to supply — an operator should
+    /// not have to read this source file to fix their deployment.
+    pub fn validate(&self, installed: RevocationDurability) -> Result<()> {
+        if self.requires_durable_revocation() && installed == RevocationDurability::Volatile {
+            return Err(GatewayError::InternalError(format!(
+                "SECURITY: deployment profile '{}' requires durable session revocation, but only \
+                 volatile (in-memory) revocation is installed.\n\
+                 Why: volatile revocation is lost on restart, so every credential revoked before a \
+                 restart silently becomes valid again — an institution cannot withdraw authority.\n\
+                 Refused fallback: starting with in-memory revocation and reporting it as \
+                 revocation support.\n\
+                 To fix: supply a persistent revocation store to the gateway \
+                 (`GatewayServer::with_revocation_store`), or run the \
+                 '{}' profile if this deployment really is disposable.",
+                self.as_str(),
+                Self::PortableEvaluator.as_str(),
+            )));
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Capability truth
+// ---------------------------------------------------------------------------
+
+/// How real a capability is in *this* runtime.
+///
+/// The distinction the campaign found missing everywhere: code existing in a
+/// crate is not a runtime guarantee. Only [`CapabilityState::Enforced`] means a
+/// request path cannot bypass it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityState {
+    /// Installed and on the enforcing request path.
+    Enforced,
+    /// Installed but with explicitly reduced guarantees (see the report's notes).
+    Degraded,
+    /// Not installed in this runtime.
+    Absent,
+}
+
+/// Machine-checkable description of the authority subsystem this runtime
+/// actually assembled.
+///
+/// Derived from the constructed [`SessionAuthority`] — not hand-maintained — so
+/// it cannot drift from the composition the way a checked-in inventory would.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AuthorityCapabilities {
+    /// Deployment profile in force.
+    pub profile: &'static str,
+    /// Session credential issuance.
+    pub session_issuance: CapabilityState,
+    /// Delegation scope attenuation (issuer ceiling).
+    pub scope_attenuation: CapabilityState,
+    /// Individual credential revocation.
+    pub revocation: CapabilityState,
+    /// Whether revocation survives restart.
+    pub revocation_durability: &'static str,
+    /// Revocation backend implementation name.
+    pub revocation_backend: &'static str,
+    /// The lifetime actually applied to issued credentials.
+    pub token_ttl_secs: u64,
+    /// Human-readable qualifications on the states above.
+    pub notes: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// SessionAuthority
+// ---------------------------------------------------------------------------
+
+/// The gateway's authority composition boundary.
+///
+/// Production (`GatewayServer::run`) and integration tests construct this the
+/// same way, so a test that exercises `SessionAuthority` is exercising the
+/// object the daemon serves requests with.
+pub struct SessionAuthority {
+    auth: Arc<AuthManager>,
+    revocation: Arc<dyn RevocationAuthority>,
+    lifetime: TokenLifetimePolicy,
+    profile: AuthorityProfile,
+}
+
+impl SessionAuthority {
+    /// Assemble the session authority, enforcing the profile's startup
+    /// invariants.
+    ///
+    /// Fails closed: a profile whose required guarantees are not installed does
+    /// not start. This is the mechanism that stops an authority capability from
+    /// silently disappearing from a deployment.
+    pub fn new(
+        auth: Arc<AuthManager>,
+        revocation: Arc<dyn RevocationAuthority>,
+        lifetime: TokenLifetimePolicy,
+        profile: AuthorityProfile,
+    ) -> Result<Self> {
+        profile.validate(revocation.durability())?;
+        Ok(Self {
+            auth,
+            revocation,
+            lifetime,
+            profile,
+        })
+    }
+
+    /// Assemble the disposable-evaluator posture: volatile revocation, default
+    /// lifetime, [`AuthorityProfile::PortableEvaluator`].
+    ///
+    /// This is the honest minimum an authenticated surface needs in order to
+    /// serve at all — it enforces attenuation and revocation-within-a-run while
+    /// reporting that revocation does not survive restart. It exists so that
+    /// callers which legitimately have no persistent store (the portable
+    /// evaluator, and tests that build their own routers) get a real authority
+    /// rather than a bypass. Deployments that must withdraw authority durably
+    /// use [`SessionAuthority::new`] with a store-backed authority and the
+    /// institutional profile.
+    pub fn evaluator(auth: Arc<AuthManager>) -> Self {
+        let lifetime = TokenLifetimePolicy {
+            ttl: auth.token_ttl(),
+        };
+        Self {
+            auth,
+            revocation: Arc::new(InMemoryRevocationAuthority::new()),
+            lifetime,
+            profile: AuthorityProfile::PortableEvaluator,
+        }
+    }
+
+    /// The underlying credential issuer/verifier.
+    pub fn auth_manager(&self) -> &Arc<AuthManager> {
+        &self.auth
+    }
+
+    /// Applied session lifetime.
+    pub fn lifetime(&self) -> TokenLifetimePolicy {
+        self.lifetime
+    }
+
+    /// Deployment profile in force.
+    pub fn profile(&self) -> AuthorityProfile {
+        self.profile
+    }
+
+    /// Issue a credential **delegated from an existing one**, attenuated to the
+    /// issuer's own authority.
+    ///
+    /// This is the path a session-approval flow must use. `flow_allowed` is the
+    /// ceiling the flow itself may ever grant; `requested` lets a caller ask for
+    /// less. Neither can raise the issuer's authority.
+    pub fn issue_delegated(
+        &self,
+        issuer: &TokenClaims,
+        subject: &icn_identity::Did,
+        coop_id: &str,
+        flow_allowed: &[&str],
+        requested: Option<&[String]>,
+    ) -> Result<(String, Vec<String>)> {
+        let granted = attenuate_scopes(&issuer.scopes, flow_allowed, requested)?;
+        let token = self.auth.issue_token(subject, coop_id, granted.clone())?;
+        Ok((token, granted))
+    }
+
+    /// Verify a presented credential: signature and expiry, then revocation.
+    ///
+    /// Ordering is deliberate — revocation state is only consulted for a
+    /// credential that is otherwise valid, so an attacker cannot use this path to
+    /// probe which identifiers exist.
+    ///
+    /// Fails closed on revocation-store errors: an authority that cannot read its
+    /// revocation state denies rather than admits.
+    pub fn verify(&self, token: &str) -> Result<TokenClaims> {
+        let claims = self.auth.verify_token(token)?;
+
+        let Some(jti) = claims.jti.as_deref() else {
+            // A credential minted before revocable ids existed cannot be
+            // individually withdrawn. Institutions must not accept an
+            // unrevocable credential; disposable evaluators may (they have no
+            // durable revocation to contradict anyway). Every mint path now sets
+            // `jti`, so this drains within one token lifetime of an upgrade.
+            if self.profile.requires_durable_revocation() {
+                return Err(GatewayError::AuthenticationFailed(
+                    "credential predates revocable session ids and cannot be withdrawn; \
+                     re-authenticate to obtain a current credential"
+                        .to_string(),
+                ));
+            }
+            return Ok(claims);
+        };
+
+        if self.revocation.is_revoked(jti).map_err(|e| {
+            // Do not leak store internals to the client; the operator gets the
+            // detail in logs.
+            tracing::error!(error = %e, "revocation lookup failed; denying request (fail-closed)");
+            GatewayError::AuthenticationFailed("credential could not be validated".to_string())
+        })? {
+            return Err(GatewayError::AuthenticationFailed(
+                "credential has been revoked".to_string(),
+            ));
+        }
+
+        Ok(claims)
+    }
+
+    /// Withdraw a credential by its claims.
+    pub fn revoke(&self, claims: &TokenClaims) -> Result<()> {
+        let jti = claims.jti.as_deref().ok_or_else(|| {
+            GatewayError::BadRequest(
+                "credential carries no revocable id; it cannot be individually withdrawn"
+                    .to_string(),
+            )
+        })?;
+        self.revocation.revoke(jti, claims.exp)
+    }
+
+    /// Report what this runtime actually assembled.
+    pub fn capabilities(&self) -> AuthorityCapabilities {
+        let durability = self.revocation.durability();
+        let mut notes = Vec::new();
+
+        let revocation = match durability {
+            RevocationDurability::Durable => CapabilityState::Enforced,
+            RevocationDurability::Volatile => {
+                notes.push(
+                    "revocation is in-memory: credentials revoked before a restart become valid \
+                     again after it"
+                        .to_string(),
+                );
+                CapabilityState::Degraded
+            }
+        };
+
+        if !self.profile.requires_durable_revocation() {
+            notes.push(format!(
+                "profile '{}' does not require durable revocation; this deployment is not an \
+                 institutional authority",
+                self.profile.as_str()
+            ));
+        }
+
+        AuthorityCapabilities {
+            profile: self.profile.as_str(),
+            session_issuance: CapabilityState::Enforced,
+            scope_attenuation: CapabilityState::Enforced,
+            revocation,
+            revocation_durability: durability.as_str(),
+            revocation_backend: self.revocation.backend(),
+            token_ttl_secs: self.lifetime.ttl().as_secs(),
+            notes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scopes(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    // -- attenuation -------------------------------------------------------
+
+    #[test]
+    fn attenuation_never_exceeds_issuer_authority() {
+        // The #2436 defect, expressed as an invariant: a read-only issuer cannot
+        // produce write authority no matter what the flow permits.
+        let issuer = scopes(&["governance:read"]);
+        let flow = ["coop:write", "ledger:transact", "governance:write"];
+        let err = attenuate_scopes(&issuer, &flow, None).unwrap_err();
+        assert!(matches!(err, GatewayError::AuthorizationFailed(_)));
+    }
+
+    #[test]
+    fn attenuation_yields_the_intersection() {
+        let issuer = scopes(&["governance:read", "governance:write", "ledger:read"]);
+        let flow = ["governance:read", "governance:write", "coop:write"];
+        let granted = attenuate_scopes(&issuer, &flow, None).unwrap();
+        assert_eq!(granted, scopes(&["governance:read", "governance:write"]));
+    }
+
+    #[test]
+    fn requested_scopes_can_only_narrow() {
+        let issuer = scopes(&["governance:read", "governance:write"]);
+        let flow = ["governance:read", "governance:write"];
+        // Asking for more than the ceiling does not raise it.
+        let granted = attenuate_scopes(
+            &issuer,
+            &flow,
+            Some(&scopes(&[
+                "governance:read",
+                "ledger:transact",
+                "coop:write",
+            ])),
+        )
+        .unwrap();
+        assert_eq!(granted, scopes(&["governance:read"]));
+    }
+
+    #[test]
+    fn duplicate_and_unordered_scopes_normalize() {
+        let issuer = scopes(&["b:write", "a:read", "b:write", "a:read"]);
+        let flow = ["a:read", "b:write", "a:read"];
+        let granted = attenuate_scopes(&issuer, &flow, None).unwrap();
+        assert_eq!(granted, scopes(&["a:read", "b:write"]));
+    }
+
+    #[test]
+    fn empty_issuer_or_flow_grants_nothing() {
+        assert!(attenuate_scopes(&[], &["a:read"], None).is_err());
+        assert!(attenuate_scopes(&scopes(&["a:read"]), &[], None).is_err());
+        assert!(attenuate_scopes(&scopes(&["a:read"]), &["a:read"], Some(&[])).is_err());
+    }
+
+    #[test]
+    fn unknown_scopes_cannot_be_conjured() {
+        // An unknown/garbage scope only survives if the issuer already held it,
+        // in which case it is the issuer's own authority, not an escalation.
+        let issuer = scopes(&["weird::scope\u{0}"]);
+        let flow = ["governance:write"];
+        assert!(attenuate_scopes(&issuer, &flow, None).is_err());
+    }
+
+    /// Exhaustive attenuation invariant over the real gateway scope vocabulary:
+    /// for every issuer subset and every requested subset, the granted set is
+    /// always a subset of the issuer's set. This is the property that closes
+    /// #2436 for all inputs, not just the reported one.
+    #[test]
+    fn granted_is_always_a_subset_of_issuer_authority() {
+        let vocab = [
+            "coop:read",
+            "coop:write",
+            "ledger:read",
+            "ledger:transact",
+            "governance:read",
+            "governance:write",
+        ];
+        let flow: Vec<&str> = vocab.to_vec();
+
+        for issuer_mask in 0u32..(1 << vocab.len()) {
+            let issuer: Vec<String> = vocab
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| issuer_mask & (1 << i) != 0)
+                .map(|(_, s)| s.to_string())
+                .collect();
+
+            for req_mask in 0u32..(1 << vocab.len()) {
+                let requested: Vec<String> = vocab
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| req_mask & (1 << i) != 0)
+                    .map(|(_, s)| s.to_string())
+                    .collect();
+
+                if let Ok(granted) = attenuate_scopes(&issuer, &flow, Some(&requested)) {
+                    for scope in &granted {
+                        assert!(
+                            issuer.contains(scope),
+                            "escalation: granted {scope:?} not held by issuer {issuer:?}"
+                        );
+                        assert!(
+                            requested.contains(scope),
+                            "granted {scope:?} beyond request {requested:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // -- lifetime ----------------------------------------------------------
+
+    #[test]
+    fn configured_lifetime_is_applied() {
+        assert_eq!(
+            TokenLifetimePolicy::from_hours(24).unwrap().ttl(),
+            Duration::from_secs(86_400)
+        );
+    }
+
+    #[test]
+    fn zero_and_excessive_lifetimes_are_rejected() {
+        assert!(TokenLifetimePolicy::from_hours(0).is_err());
+        assert!(TokenLifetimePolicy::from_hours(24 * 31).is_err());
+        assert!(TokenLifetimePolicy::from_hours(24 * 30).is_ok());
+    }
+
+    // -- profile / startup -------------------------------------------------
+
+    #[test]
+    fn institutional_profile_refuses_volatile_revocation() {
+        let err = AuthorityProfile::Institutional
+            .validate(RevocationDurability::Volatile)
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("durable session revocation"), "{msg}");
+        assert!(msg.contains("To fix"), "{msg}");
+    }
+
+    #[test]
+    fn portable_evaluator_may_run_volatile() {
+        assert!(AuthorityProfile::PortableEvaluator
+            .validate(RevocationDurability::Volatile)
+            .is_ok());
+        assert!(AuthorityProfile::Institutional
+            .validate(RevocationDurability::Durable)
+            .is_ok());
+    }
+
+    #[test]
+    fn assembly_fails_closed_when_profile_requirements_are_unmet() {
+        let auth = Arc::new(AuthManager::new(vec![7u8; 32]));
+        let result = SessionAuthority::new(
+            auth,
+            Arc::new(InMemoryRevocationAuthority::new()),
+            TokenLifetimePolicy::default(),
+            AuthorityProfile::Institutional,
+        );
+        assert!(
+            result.is_err(),
+            "institutional profile must not assemble with volatile revocation"
+        );
+    }
+
+    // -- revocation --------------------------------------------------------
+
+    #[test]
+    fn in_memory_revocation_round_trips() {
+        let rev = InMemoryRevocationAuthority::new();
+        assert!(!rev.is_revoked("abc").unwrap());
+        rev.revoke("abc", 0).unwrap();
+        assert!(rev.is_revoked("abc").unwrap());
+        assert!(!rev.is_revoked("other").unwrap());
+        assert_eq!(rev.durability(), RevocationDurability::Volatile);
+    }
+
+    #[test]
+    fn capability_report_reflects_actual_assembly() {
+        let auth = Arc::new(AuthManager::new(vec![7u8; 32]));
+        let authority = SessionAuthority::new(
+            auth,
+            Arc::new(InMemoryRevocationAuthority::new()),
+            TokenLifetimePolicy::from_hours(2).unwrap(),
+            AuthorityProfile::PortableEvaluator,
+        )
+        .unwrap();
+
+        let caps = authority.capabilities();
+        assert_eq!(caps.profile, "portable-evaluator");
+        assert_eq!(caps.revocation, CapabilityState::Degraded);
+        assert_eq!(caps.revocation_durability, "volatile");
+        assert_eq!(caps.revocation_backend, "memory");
+        assert_eq!(caps.token_ttl_secs, 7200);
+        assert_eq!(caps.scope_attenuation, CapabilityState::Enforced);
+        assert!(
+            caps.notes.iter().any(|n| n.contains("valid again after")),
+            "degraded revocation must be reported honestly: {:?}",
+            caps.notes
+        );
+    }
+}

--- a/icn/crates/icn-gateway/src/session_authority.rs
+++ b/icn/crates/icn-gateway/src/session_authority.rs
@@ -584,7 +584,8 @@ impl SessionAuthority {
         Ok((token, granted))
     }
 
-    /// Verify a presented credential: signature and expiry, then revocation.
+    /// Verify a presented credential: signature and expiry, then the configured
+    /// lifetime bound, then revocation.
     ///
     /// Ordering is deliberate — revocation state is only consulted for a
     /// credential that is otherwise valid, so an attacker cannot use this path to
@@ -594,6 +595,42 @@ impl SessionAuthority {
     /// revocation state denies rather than admits.
     pub fn verify(&self, token: &str) -> Result<TokenClaims> {
         let claims = self.auth.verify_token(token)?;
+
+        // The configured lifetime bounds ACCEPTANCE, not just issuance. Every
+        // gateway mint already carries exactly the configured lifetime, but a
+        // co-issuer holding the signing secret — `icnctl auth token
+        // --local-mint` is the supported one — signs whatever expiry it
+        // chooses, and a signature check alone would honor it. Two checks,
+        // guarding different failures:
+        //
+        // 1. `exp - iat` beyond the bound: an issuer that never learned this
+        //    deployment's configured lifetime. Refused loudly and immediately
+        //    (not clamped, not accepted-later), so the operator re-mints
+        //    within policy instead of discovering a silently shortened
+        //    session.
+        // 2. `exp` further than one lifetime from now: independent of what
+        //    `iat` claims, no accepted credential can have more than one
+        //    configured lifetime of validity remaining. This holds even for a
+        //    fabricated or forward-dated `iat`, which check 1 alone would
+        //    trust.
+        //
+        // No leeway on either check, matching the zero-leeway expiry stance:
+        // the trusted-local co-issuer runs on this same host and clock.
+        let bound = self.lifetime.ttl().as_secs();
+        if claims.exp.saturating_sub(claims.iat) > bound {
+            return Err(GatewayError::AuthenticationFailed(format!(
+                "credential lifetime exceeds this deployment's configured session \
+                 lifetime ({bound} seconds); re-mint within the configured bound"
+            )));
+        }
+        let now = icn_time::current_timestamp_secs();
+        if claims.exp > now.saturating_add(bound) {
+            return Err(GatewayError::AuthenticationFailed(
+                "credential expiry lies further away than the configured session \
+                 lifetime permits"
+                    .to_string(),
+            ));
+        }
 
         let Some(jti) = claims.jti.as_deref() else {
             // A credential minted before revocable ids existed cannot be
@@ -935,5 +972,81 @@ mod tests {
             "degraded revocation must be reported honestly: {:?}",
             caps.notes
         );
+    }
+
+    // -- lifetime acceptance bound (#2442 review: trusted-local co-issuer) --
+
+    fn hour_authority() -> SessionAuthority {
+        let lifetime = TokenLifetimePolicy::from_hours(1).unwrap();
+        let auth = Arc::new(AuthManager::new(vec![7u8; 32]).with_token_ttl(lifetime.ttl()));
+        SessionAuthority::new(
+            auth,
+            Arc::new(InMemoryRevocationAuthority::new()),
+            lifetime,
+            AuthorityProfile::PortableEvaluator,
+        )
+        .unwrap()
+    }
+
+    fn test_did() -> icn_identity::Did {
+        icn_identity::IdentityBundle::generate()
+            .expect("generate test identity")
+            .did()
+            .clone()
+    }
+
+    /// A co-issuer holding the signing secret but not the deployment's
+    /// configuration (the `icnctl auth token --local-mint` shape) mints with
+    /// the canonical 24-hour default. A one-hour deployment must refuse that
+    /// credential at acceptance: the configured lifetime is an authorization
+    /// bound on what is ACCEPTED, not advice applied only at issuance.
+    #[test]
+    fn acceptance_rejects_a_lifetime_beyond_the_configured_bound() {
+        let authority = hour_authority();
+        let co_issuer = AuthManager::new(vec![7u8; 32]); // canonical 24h default
+        let token = co_issuer
+            .issue_token(&test_did(), "test-coop", scopes(&["coop:read"]))
+            .unwrap();
+        let err = authority.verify(&token).unwrap_err();
+        assert!(matches!(err, GatewayError::AuthenticationFailed(_)));
+    }
+
+    /// The bound is exact, not fuzzy: a credential carrying precisely the
+    /// configured lifetime — what every gateway mint produces — is accepted.
+    #[test]
+    fn acceptance_admits_exactly_the_configured_lifetime() {
+        let authority = hour_authority();
+        let token = authority
+            .auth_manager()
+            .issue_token(&test_did(), "test-coop", scopes(&["coop:read"]))
+            .unwrap();
+        assert!(authority.verify(&token).is_ok());
+    }
+
+    /// A forward-dated `iat` cannot smuggle extra validity: even when
+    /// `exp - iat` respects the configured lifetime, a credential whose expiry
+    /// lies further than one configured lifetime from now is refused.
+    #[test]
+    fn forward_dated_credentials_cannot_outlive_the_configured_bound() {
+        let authority = hour_authority();
+        let now = icn_time::current_timestamp_secs();
+        let claims = crate::auth::TokenClaims {
+            sub: test_did().to_string(),
+            iat: now + 7200,
+            exp: now + 7200 + 3600, // exp - iat == configured ttl, but 3h out
+            coop_id: "test-coop".to_string(),
+            scopes: scopes(&["coop:read"]),
+            entity_id: None,
+            entity_type: None,
+            jti: Some("forward-dated-test".to_string()),
+        };
+        let token = jsonwebtoken::encode(
+            &jsonwebtoken::Header::default(),
+            &claims,
+            &jsonwebtoken::EncodingKey::from_secret(&[7u8; 32]),
+        )
+        .unwrap();
+        let err = authority.verify(&token).unwrap_err();
+        assert!(matches!(err, GatewayError::AuthenticationFailed(_)));
     }
 }

--- a/icn/crates/icn-gateway/src/websocket.rs
+++ b/icn/crates/icn-gateway/src/websocket.rs
@@ -63,11 +63,11 @@ pub enum ServerMessage {
 pub struct WsSession {
     /// Cooperative ID this session is subscribed to
     coop_id: String,
-    /// Authenticated DID (None until authenticated)
-    did: Option<Did>,
+    /// Credential retained for continuing authorization (None until authenticated).
+    authenticated: Option<AuthenticatedCredential>,
     /// Last heartbeat timestamp
     last_heartbeat: Instant,
-    /// Authentication manager
+    /// Session authority used for initial and continuing authorization
     authority: Arc<SessionAuthority>,
     /// Event broadcaster
     event_broadcaster: Arc<EventBroadcaster>,
@@ -79,6 +79,11 @@ pub struct WsSession {
     connection_tracked: bool,
 }
 
+struct AuthenticatedCredential {
+    token: String,
+    did: Did,
+}
+
 impl WsSession {
     /// Create a new WebSocket session
     pub fn new(
@@ -88,7 +93,7 @@ impl WsSession {
     ) -> Self {
         Self {
             coop_id,
-            did: None,
+            authenticated: None,
             last_heartbeat: Instant::now(),
             authority,
             event_broadcaster,
@@ -129,7 +134,10 @@ impl WsSession {
                 // Parse DID from claims
                 match claims.sub.parse::<Did>() {
                     Ok(did) => {
-                        self.did = Some(did.clone());
+                        self.authenticated = Some(AuthenticatedCredential {
+                            token: token.to_string(),
+                            did,
+                        });
 
                         // Get current sequence for reconnection support
                         let current_seq = self.event_broadcaster.current_sequence();
@@ -143,16 +151,21 @@ impl WsSession {
                             .map(move |rx_opt, act, ctx| {
                                 match rx_opt {
                                     Some(rx) => {
+                                        // Revocation or expiry may occur while the
+                                        // asynchronous subscription is being created.
+                                        if !act.enforce_continuing_authorization(ctx) {
+                                            return;
+                                        }
                                         act.event_rx = Some(rx);
                                         // Start polling for events
                                         act.poll_events(ctx);
 
                                         // Send success message with current sequence
-                                        // SAFETY: did was set above when auth succeeded
-                                        #[allow(clippy::unwrap_used)]
-                                        let did_str = act.did.as_ref().unwrap().to_string();
+                                        let Some(authenticated) = act.authenticated.as_ref() else {
+                                            return;
+                                        };
                                         let msg = ServerMessage::AuthOk {
-                                            did: did_str,
+                                            did: authenticated.did.to_string(),
                                             current_seq,
                                         };
                                         act.send_message(msg, ctx);
@@ -191,10 +204,45 @@ impl WsSession {
         }
     }
 
+    /// Revalidate the retained credential before each protected operation.
+    ///
+    /// This is deliberately operation-level rather than timer-level: there is no
+    /// stale-revocation window in which polling or backfill may continue merely
+    /// because the next periodic check has not fired.
+    fn continuing_authorization_is_valid(&self) -> bool {
+        let Some(authenticated) = self.authenticated.as_ref() else {
+            return false;
+        };
+
+        self.authority
+            .verify(&authenticated.token)
+            .map(|claims| {
+                claims.coop_id == self.coop_id && claims.sub == authenticated.did.to_string()
+            })
+            .unwrap_or(false)
+    }
+
+    fn enforce_continuing_authorization(&mut self, ctx: &mut <Self as Actor>::Context) -> bool {
+        if self.continuing_authorization_is_valid() {
+            return true;
+        }
+
+        self.authenticated = None;
+        self.event_rx = None;
+        self.send_message(
+            ServerMessage::AuthError {
+                message: "Authentication expired or revoked".to_string(),
+            },
+            ctx,
+        );
+        ctx.stop();
+        false
+    }
+
     /// Poll for events from the event broadcaster
     /// SECURITY: Drains ALL available events per poll to prevent unbounded channel growth
     fn poll_events(&mut self, ctx: &mut <Self as Actor>::Context) {
-        if let Some(ref mut rx) = self.event_rx {
+        if self.event_rx.is_some() {
             // CRITICAL FIX: Drain ALL available events in this poll cycle
             // Previous code only processed ONE event per 100ms, causing unbounded buffer growth
             // when events arrived faster than 10/second (e.g., 100 payments/sec × 1000 subscribers)
@@ -202,8 +250,15 @@ impl WsSession {
             const MAX_EVENTS_PER_POLL: usize = 1000; // Safety limit to prevent starvation
 
             loop {
-                match rx.try_recv() {
+                let Some(event_rx) = self.event_rx.as_mut() else {
+                    return;
+                };
+                let next_event = event_rx.try_recv();
+                match next_event {
                     Ok(sequenced_event) => {
+                        if !self.enforce_continuing_authorization(ctx) {
+                            return;
+                        }
                         // Forward sequenced event to client
                         let msg = ServerMessage::Event {
                             seq: sequenced_event.seq,
@@ -251,12 +306,8 @@ impl WsSession {
     }
 
     /// Handle backfill request
-    fn handle_backfill(&self, after_seq: u64, ctx: &mut <Self as Actor>::Context) {
-        if self.did.is_none() {
-            let msg = ServerMessage::Error {
-                message: "Must authenticate before requesting backfill".to_string(),
-            };
-            self.send_message(msg, ctx);
+    fn handle_backfill(&mut self, after_seq: u64, ctx: &mut <Self as Actor>::Context) {
+        if !self.enforce_continuing_authorization(ctx) {
             return;
         }
 
@@ -266,15 +317,22 @@ impl WsSession {
         let fut = async move { event_broadcaster.get_backfill(&coop_id, after_seq).await }
             .into_actor(self)
             .map(|events, act, ctx| {
-                let count = events.len();
+                let mut count = 0;
                 // Send all backfill events
                 for sequenced in events {
+                    if !act.enforce_continuing_authorization(ctx) {
+                        return;
+                    }
                     let msg = ServerMessage::Event {
                         seq: sequenced.seq,
                         event: sequenced.event,
                     };
                     act.send_message(msg, ctx);
                     gateway::websocket_messages_sent_inc();
+                    count += 1;
+                }
+                if !act.enforce_continuing_authorization(ctx) {
+                    return;
                 }
                 // Send completion message
                 let msg = ServerMessage::BackfillComplete { count };
@@ -334,7 +392,7 @@ impl Actor for WsSession {
         // SECURITY: Enforce authentication deadline (Bug #30 fix)
         // Close connection if not authenticated within 10 seconds
         ctx.run_later(Duration::from_secs(10), |act, ctx| {
-            if act.did.is_none() {
+            if act.authenticated.is_none() {
                 tracing::warn!(
                     "WebSocket authentication timeout for coop '{}' (no auth within 10s)",
                     act.coop_id
@@ -422,6 +480,29 @@ impl StreamHandler<std::result::Result<ws::Message, ws::ProtocolError>> for WsSe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::AuthManager;
+    use icn_identity::IdentityBundle;
+
+    fn authenticated_session(
+        ttl: Duration,
+    ) -> (WsSession, Arc<SessionAuthority>, crate::auth::TokenClaims) {
+        let auth = Arc::new(
+            AuthManager::new(b"websocket-continuing-auth-test".to_vec()).with_token_ttl(ttl),
+        );
+        let authority = Arc::new(SessionAuthority::evaluator(auth.clone()));
+        let broadcaster = Arc::new(EventBroadcaster::new());
+        let bundle = IdentityBundle::generate().unwrap();
+        let token = auth
+            .issue_token(bundle.did(), "test-coop", vec!["coop:read".to_string()])
+            .unwrap();
+        let claims = auth.verify_token(&token).unwrap();
+        let mut session = WsSession::new("test-coop".to_string(), authority.clone(), broadcaster);
+        session.authenticated = Some(AuthenticatedCredential {
+            token,
+            did: bundle.did().clone(),
+        });
+        (session, authority, claims)
+    }
 
     #[test]
     fn test_create_session() {
@@ -431,7 +512,33 @@ mod tests {
 
         let session = WsSession::new("test-coop".to_string(), authority, broadcaster);
         assert_eq!(session.coop_id, "test-coop");
-        assert!(session.did.is_none());
+        assert!(session.authenticated.is_none());
+    }
+
+    #[test]
+    fn protected_operations_reject_a_revoked_retained_credential() {
+        let (session, authority, claims) = authenticated_session(Duration::from_secs(3600));
+        assert!(session.continuing_authorization_is_valid());
+
+        authority.revoke(&claims).unwrap();
+
+        assert!(
+            !session.continuing_authorization_is_valid(),
+            "event polling and backfill must reject a credential revoked after initial auth"
+        );
+    }
+
+    #[actix_web::test]
+    async fn protected_operations_reject_an_expired_retained_credential() {
+        let (session, _authority, _claims) = authenticated_session(Duration::from_secs(1));
+        assert!(session.continuing_authorization_is_valid());
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        assert!(
+            !session.continuing_authorization_is_valid(),
+            "event polling and backfill must reject a credential expired after initial auth"
+        );
     }
 
     #[test]

--- a/icn/crates/icn-gateway/src/websocket.rs
+++ b/icn/crates/icn-gateway/src/websocket.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
-use crate::auth::AuthManager;
 use crate::events::{EventBroadcaster, SequencedEvent};
+use crate::session_authority::SessionAuthority;
 use icn_identity::Did;
 use icn_obs::metrics::gateway;
 
@@ -68,7 +68,7 @@ pub struct WsSession {
     /// Last heartbeat timestamp
     last_heartbeat: Instant,
     /// Authentication manager
-    auth_manager: Arc<AuthManager>,
+    authority: Arc<SessionAuthority>,
     /// Event broadcaster
     event_broadcaster: Arc<EventBroadcaster>,
     /// Event receiver (subscribed after authentication)
@@ -83,14 +83,14 @@ impl WsSession {
     /// Create a new WebSocket session
     pub fn new(
         coop_id: String,
-        auth_manager: Arc<AuthManager>,
+        authority: Arc<SessionAuthority>,
         event_broadcaster: Arc<EventBroadcaster>,
     ) -> Self {
         Self {
             coop_id,
             did: None,
             last_heartbeat: Instant::now(),
-            auth_manager,
+            authority,
             event_broadcaster,
             event_rx: None,
             connection_tracked: false,
@@ -111,7 +111,11 @@ impl WsSession {
 
     /// Authenticate user with JWT token
     fn authenticate(&mut self, token: &str, ctx: &mut <Self as Actor>::Context) {
-        match self.auth_manager.verify_token(token) {
+        // Verify through the session authority, NOT the bare AuthManager: this
+        // surface is mounted outside `jwt_auth` and authenticates in-band, so
+        // without this it would honor revoked and jti-less credentials that
+        // every wrapped HTTP route rejects (issue #2437).
+        match self.authority.verify(token) {
             Ok(claims) => {
                 // Verify token is for this cooperative
                 if claims.coop_id != self.coop_id {
@@ -421,10 +425,11 @@ mod tests {
 
     #[test]
     fn test_create_session() {
-        let auth = Arc::new(AuthManager::new(b"test_secret".to_vec()));
+        let auth = Arc::new(crate::auth::AuthManager::new(b"test_secret".to_vec()));
+        let authority = Arc::new(SessionAuthority::evaluator(auth));
         let broadcaster = Arc::new(EventBroadcaster::new());
 
-        let session = WsSession::new("test-coop".to_string(), auth, broadcaster);
+        let session = WsSession::new("test-coop".to_string(), authority, broadcaster);
         assert_eq!(session.coop_id, "test-coop");
         assert!(session.did.is_none());
     }

--- a/icn/crates/icn-gateway/tests/demo_member_standing_bootstrap.rs
+++ b/icn/crates/icn-gateway/tests/demo_member_standing_bootstrap.rs
@@ -179,6 +179,12 @@ async fn build_app(
     test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
+++ b/icn/crates/icn-gateway/tests/dev_standing_bootstrap_gate.rs
@@ -165,6 +165,12 @@ async fn build_app(
     test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter))
             .app_data(web::Data::new(commons_mgr))
             .service(

--- a/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
+++ b/icn/crates/icn-gateway/tests/e2e_close_time_revalidation.rs
@@ -233,7 +233,13 @@ async fn build_app_with_proposal(
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(auth_manager))
+            .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_create_delegation_gate.rs
@@ -297,6 +297,12 @@ async fn test_suspended_member_cannot_create_delegation() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")
@@ -532,6 +538,12 @@ async fn test_suspended_member_cannot_create_blanket_delegation() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test builds
+            // its own router, so it installs the same authority production installs —
+            // `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
+++ b/icn/crates/icn-gateway/tests/e2e_institutional_flow.rs
@@ -334,6 +334,12 @@ async fn test_e2e_freeze_member_suspends_commons_affiliation() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")
@@ -593,6 +599,12 @@ async fn test_e2e_unfreeze_member_reinstates_commons_affiliation() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test builds
+            // its own router, so it installs the same authority production installs —
+            // `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")
@@ -944,6 +956,12 @@ async fn test_e2e_appoint_steward_scoped_to_chartered_domain() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test builds
+            // its own router, so it installs the same authority production installs —
+            // `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_ledger_freeze_enforcement.rs
@@ -250,6 +250,12 @@ async fn test_freeze_member_blocks_ledger_entries_after_governance_acceptance() 
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_member_standing_gate.rs
@@ -146,6 +146,12 @@ async fn build_app(
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_open_proposal_gate.rs
@@ -235,6 +235,12 @@ async fn test_suspended_member_cannot_open_proposal() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_proposal_submission_gate.rs
@@ -269,6 +269,12 @@ async fn test_suspended_member_cannot_submit_proposals() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_steward_standing_gate.rs
@@ -145,7 +145,13 @@ async fn build_app(
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
     test::init_service(
         App::new()
-            .app_data(web::Data::new(auth_manager))
+            .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/e2e_trust_threshold_close_time_enforcement.rs
@@ -188,6 +188,12 @@ async fn build_app_with_trust_resolver(
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
+++ b/icn/crates/icn-gateway/tests/e2e_vote_standing_gate.rs
@@ -168,7 +168,13 @@ async fn build_app_with_open_proposal(
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(auth_manager))
+            .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter))
             .service(
                 web::scope("/v1")
@@ -422,7 +428,13 @@ async fn build_app_with_suspension_checker(
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
     let app = test::init_service(
         App::new()
-            .app_data(web::Data::new(auth_manager))
+            .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test builds
+            // its own router, so it installs the same authority production installs —
+            // `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/entity_dissolution_integration.rs
+++ b/icn/crates/icn-gateway/tests/entity_dissolution_integration.rs
@@ -35,6 +35,7 @@ fn create_test_claims(did: &str, scopes: Vec<&str>) -> TokenClaims {
         coop_id: "test-coop".to_string(),
         scopes: scopes.iter().map(|s| s.to_string()).collect(),
         exp: 9999999999,
+        jti: None,
     }
 }
 

--- a/icn/crates/icn-gateway/tests/entity_integration.rs
+++ b/icn/crates/icn-gateway/tests/entity_integration.rs
@@ -44,6 +44,7 @@ fn create_test_claims(did: &str, scopes: Vec<&str>) -> TokenClaims {
         coop_id: "test-coop".to_string(),
         scopes: scopes.iter().map(|s| s.to_string()).collect(),
         exp: 9999999999,
+        jti: None,
     }
 }
 

--- a/icn/crates/icn-gateway/tests/governance_proof.rs
+++ b/icn/crates/icn-gateway/tests/governance_proof.rs
@@ -89,6 +89,12 @@ async fn test_governance_proposal_full_lifecycle_with_real_auth() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter.clone()))
             .service(
                 web::scope("/v1")
@@ -343,6 +349,12 @@ async fn test_auth_rejects_invalid_signature() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test builds
+            // its own router, so it installs the same authority production installs —
+            // `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter))
             .service(
                 web::scope("/v1")
@@ -406,6 +418,12 @@ async fn test_governance_endpoints_require_auth() {
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test builds
+            // its own router, so it installs the same authority production installs —
+            // `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(ip_limiter))
             .service(
                 web::scope("/v1")

--- a/icn/crates/icn-gateway/tests/services_auth_boundary.rs
+++ b/icn/crates/icn-gateway/tests/services_auth_boundary.rs
@@ -99,7 +99,13 @@ async fn build_app(
     let auth = HttpAuthentication::bearer(jwt_auth);
     test::init_service(
         App::new()
-            .app_data(web::Data::new(auth_manager))
+            .app_data(web::Data::new(auth_manager.clone()))
+            // Authority composition boundary (issues #2436/#2437): this test
+            // builds its own router, so it must install the same authority the
+            // production composition installs — `jwt_auth` fails closed without it.
+            .app_data(web::Data::new(std::sync::Arc::new(
+                icn_gateway::session_authority::SessionAuthority::evaluator(auth_manager.clone()),
+            )))
             .app_data(web::Data::new(mgr))
             .service(
                 web::scope("/v1").service(

--- a/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
@@ -31,6 +31,7 @@ use icn_gateway::session_authority::{
     SessionAuthority, StoreRevocationAuthority, TokenLifetimePolicy,
 };
 use icn_identity::Did;
+use icn_store::Store;
 
 const SECRET: &[u8] = b"session-authority-enforcement-test-secret-32b";
 
@@ -273,10 +274,8 @@ async fn expired_credentials_are_rejected_at_the_boundary() {
 
     // Comfortably in the future: accepted.
     assert_eq!(get_protected(&app, &mint(now + 3600)).await, 200);
-    // Already past: rejected. (jsonwebtoken applies a small default leeway, so
-    // the "expired" case is placed clearly outside it rather than at exp-1,
-    // which would assert against library leeway rather than our behavior.)
-    assert_eq!(get_protected(&app, &mint(now - 3600)).await, 401);
+    // One second past the claim boundary: rejected without hidden leeway.
+    assert_eq!(get_protected(&app, &mint(now - 1)).await, 401);
 }
 
 // ---------------------------------------------------------------------------
@@ -482,14 +481,20 @@ async fn capability_report_matches_the_assembled_dependencies() {
 #[actix_web::test]
 async fn revocation_is_visible_across_both_authenticated_surfaces() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let store: Arc<dyn icn_store::Store> =
-        Arc::new(icn_store::SledStore::open(dir.path()).expect("open store"));
+    let store = Arc::new(icn_store::SledStore::open(dir.path()).expect("open store"));
+    let gateway_store: Arc<dyn icn_store::Store> = store.clone();
 
     let authority = authority(
-        Arc::new(StoreRevocationAuthority::new(store.clone()).unwrap()),
+        Arc::new(StoreRevocationAuthority::new(gateway_store).unwrap()),
         AuthorityProfile::Institutional,
         1,
     );
+    // Construct RPC before either revocation so its startup cache is empty. The
+    // assertions below therefore require live cache-miss store reads, not a
+    // reconstruction that happens to reload the persisted entry.
+    let rpc_auth =
+        icn_rpc::auth::RpcAuthManager::new_with_store(SECRET.to_vec(), true, store.clone())
+            .expect("RPC auth manager");
     let app = protected_app!(authority.clone());
 
     // -- direction 1: gateway revoke must be written where RPC looks for it --
@@ -513,18 +518,19 @@ async fn revocation_is_visible_across_both_authenticated_surfaces() {
         decoded["original_expiry"].as_u64().is_some(),
         "RPC's loader drops entries without a usable original_expiry"
     );
+    assert!(
+        matches!(
+            rpc_auth.verify_token(&token),
+            Err(icn_rpc::auth::AuthError::TokenRevoked)
+        ),
+        "a live RPC verifier must reject a gateway-revoked credential without restart"
+    );
 
-    // -- direction 2: an RPC-style revoke must be honored by the gateway ------
+    // -- direction 2: an RPC revoke must be honored by the gateway ------------
     let other = authority
         .auth_manager()
         .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
         .expect("mint");
-    let other_jti = authority
-        .auth_manager()
-        .verify_token(&other)
-        .unwrap()
-        .jti
-        .expect("jti");
 
     assert_eq!(
         get_protected(&app, &other).await,
@@ -532,22 +538,9 @@ async fn revocation_is_visible_across_both_authenticated_surfaces() {
         "precondition: valid before the out-of-process revoke"
     );
 
-    // Written directly to the store, as the RPC surface would — this process's
-    // cache knows nothing about it.
-    store
-        .put(
-            format!("auth:revoked:{other_jti}").as_bytes(),
-            serde_json::to_vec(&serde_json::json!({
-                "jti": other_jti,
-                "subject": "",
-                "revoked_at": 1,
-                "original_expiry": u64::MAX,
-                "reason": "revoked via RPC",
-            }))
-            .unwrap()
-            .as_slice(),
-        )
-        .expect("store write");
+    rpc_auth
+        .revoke_token_string(&other, Some("revoked via RPC".to_string()))
+        .expect("RPC revoke");
 
     assert_eq!(
         get_protected(&app, &other).await,

--- a/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
@@ -437,16 +437,27 @@ async fn authenticated_routes_refuse_to_serve_without_the_authority_installed() 
     // The misassembly guard: if `SessionAuthority` is not registered, the
     // middleware must fail closed rather than fall back to signature-only
     // verification (which is exactly the pre-#2437 behavior).
+    //
+    // A usable `AuthManager` is deliberately registered here, in both shapes a
+    // reintroduction would plausibly take. Omitting it would only prove the
+    // middleware fails when nothing can verify; the regression worth guarding
+    // is the one where something *can* — a refactor adding an `.or_else(..)`
+    // fallback to a bare issuer would restore "valid signature ⇒ authorized"
+    // while every route still looked wrapped. Production registers no
+    // `AuthManager` in `app_data` at all; these entries must stay inert.
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
     let app = test::init_service(
-        App::new().service(
-            web::scope("/v1")
-                .route(
-                    "/protected",
-                    web::get().to(|| async { HttpResponse::Ok().body("ok") }),
-                )
-                .wrap(auth_mw),
-        ),
+        App::new()
+            .app_data(web::Data::new(AuthManager::new(SECRET.to_vec())))
+            .app_data(web::Data::new(Arc::new(AuthManager::new(SECRET.to_vec()))))
+            .service(
+                web::scope("/v1")
+                    .route(
+                        "/protected",
+                        web::get().to(|| async { HttpResponse::Ok().body("ok") }),
+                    )
+                    .wrap(auth_mw),
+            ),
     )
     .await;
 

--- a/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
@@ -1,0 +1,622 @@
+//! Authority-spine enforcement tests (issues #2436, #2437).
+//!
+//! # What these tests exercise
+//!
+//! These are not unit tests around an isolated struct. Every case below drives
+//! HTTP requests through the **real `jwt_auth` middleware** wrapping routes, with
+//! the **same `SessionAuthority` value the production composition registers** as
+//! `app_data` in `GatewayServer::run`. The middleware resolves the authority out
+//! of `app_data` exactly as it does in production, so a regression that removed
+//! revocation from the request path would fail here.
+//!
+//! # What they do NOT prove
+//!
+//! They do not construct the full production router — the gateway's route tree
+//! is still assembled inside a closure in `GatewayServer::run` that no test can
+//! call (issue #2421). What is shared with production is the authority object,
+//! the middleware, and the enforcement ordering; what is not shared is the route
+//! table. Closing that gap is #2421's job, and until it lands "the auth path is
+//! tested" is a claim about this boundary, not about every mounted route.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{test, web, App, HttpResponse};
+use actix_web_httpauth::middleware::HttpAuthentication;
+use icn_gateway::auth::{AuthManager, TokenClaims};
+use icn_gateway::middleware::jwt_auth;
+use icn_gateway::session_authority::{
+    attenuate_scopes, AuthorityProfile, InMemoryRevocationAuthority, RevocationAuthority,
+    SessionAuthority, StoreRevocationAuthority, TokenLifetimePolicy,
+};
+use icn_identity::Did;
+
+const SECRET: &[u8] = b"session-authority-enforcement-test-secret-32b";
+
+/// A real generated DID — `Did` validates that the encoded key is a genuine
+/// 32-byte Ed25519 public key, so a hand-written placeholder is not usable.
+fn did() -> Did {
+    use std::sync::OnceLock;
+    static DID: OnceLock<Did> = OnceLock::new();
+    DID.get_or_init(|| {
+        icn_identity::IdentityBundle::generate()
+            .expect("generate test identity")
+            .did()
+            .clone()
+    })
+    .clone()
+}
+
+fn scopes(list: &[&str]) -> Vec<String> {
+    list.iter().map(|s| s.to_string()).collect()
+}
+
+/// Build a session authority the way production does, with a caller-chosen
+/// revocation backend and profile.
+fn authority(
+    revocation: Arc<dyn RevocationAuthority>,
+    profile: AuthorityProfile,
+    ttl_hours: u64,
+) -> Arc<SessionAuthority> {
+    let auth = Arc::new(
+        AuthManager::new(SECRET.to_vec())
+            .with_token_ttl(TokenLifetimePolicy::from_hours(ttl_hours).unwrap().ttl()),
+    );
+    Arc::new(
+        SessionAuthority::new(
+            auth,
+            revocation,
+            TokenLifetimePolicy::from_hours(ttl_hours).unwrap(),
+            profile,
+        )
+        .expect("authority assembles"),
+    )
+}
+
+/// A protected app wired the way production wires authenticated scopes:
+/// `jwt_auth` middleware reading `SessionAuthority` from `app_data`.
+macro_rules! protected_app {
+    ($authority:expr) => {{
+        let auth_mw = HttpAuthentication::bearer(jwt_auth);
+        test::init_service(
+            App::new().app_data(web::Data::new($authority)).service(
+                web::scope("/v1")
+                    .route(
+                        "/protected",
+                        web::get().to(|| async { HttpResponse::Ok().body("ok") }),
+                    )
+                    .wrap(auth_mw),
+            ),
+        )
+        .await
+    }};
+}
+
+async fn get_protected(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    token: &str,
+) -> u16 {
+    let req = test::TestRequest::get()
+        .uri("/v1/protected")
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .to_request();
+    test::call_service(app, req).await.status().as_u16()
+}
+
+// ---------------------------------------------------------------------------
+// 1–2. Valid before revocation, rejected after — through the real middleware
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn credential_is_accepted_before_revocation_and_rejected_after() {
+    let authority = authority(
+        Arc::new(InMemoryRevocationAuthority::new()),
+        AuthorityProfile::PortableEvaluator,
+        1,
+    );
+    let app = protected_app!(authority.clone());
+
+    let token = authority
+        .auth_manager()
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .expect("mint");
+
+    assert_eq!(
+        get_protected(&app, &token).await,
+        200,
+        "valid before revoke"
+    );
+
+    let claims = authority.auth_manager().verify_token(&token).unwrap();
+    authority.revoke(&claims).expect("revoke");
+
+    assert_eq!(
+        get_protected(&app, &token).await,
+        401,
+        "revoked credential must be rejected on the enforcing request path"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Revocation survives application reconstruction over the same durable state
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn revocation_survives_restart_with_durable_state() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store: Arc<dyn icn_store::Store> =
+        Arc::new(icn_store::SledStore::open(dir.path()).expect("open store"));
+
+    let first = authority(
+        Arc::new(StoreRevocationAuthority::new(store.clone()).unwrap()),
+        AuthorityProfile::Institutional,
+        1,
+    );
+    let token = first
+        .auth_manager()
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .expect("mint");
+    let claims = first.auth_manager().verify_token(&token).unwrap();
+    first.revoke(&claims).expect("revoke");
+
+    // Simulate a restart: a brand-new authority + app over the SAME store.
+    drop(first);
+    let restarted = authority(
+        Arc::new(StoreRevocationAuthority::new(store).unwrap()),
+        AuthorityProfile::Institutional,
+        1,
+    );
+    let app = protected_app!(restarted);
+
+    assert_eq!(
+        get_protected(&app, &token).await,
+        401,
+        "durable revocation must still reject after reconstruction"
+    );
+}
+
+/// The same scenario on a volatile authority: the credential comes back to life.
+/// This is the degraded behavior the evaluator profile accepts and the
+/// institutional profile refuses to assemble — asserted so the difference can
+/// never be quietly erased.
+#[actix_web::test]
+async fn volatile_revocation_is_lost_across_restart_as_documented() {
+    let first = authority(
+        Arc::new(InMemoryRevocationAuthority::new()),
+        AuthorityProfile::PortableEvaluator,
+        1,
+    );
+    let token = first
+        .auth_manager()
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .expect("mint");
+    let claims = first.auth_manager().verify_token(&token).unwrap();
+    first.revoke(&claims).unwrap();
+    drop(first);
+
+    let restarted = authority(
+        Arc::new(InMemoryRevocationAuthority::new()),
+        AuthorityProfile::PortableEvaluator,
+        1,
+    );
+    let app = protected_app!(restarted.clone());
+    assert_eq!(
+        get_protected(&app, &token).await,
+        200,
+        "volatile revocation is lost on restart — the honest degraded behavior"
+    );
+    let caps = restarted.capabilities();
+    assert_eq!(caps.revocation_durability, "volatile");
+    assert!(caps.notes.iter().any(|n| n.contains("valid again after")));
+}
+
+// ---------------------------------------------------------------------------
+// 5–6. Configured lifetime is the applied lifetime; expiry boundary
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn configured_lifetime_changes_actual_expiration() {
+    for hours in [1u64, 24, 72] {
+        let authority = authority(
+            Arc::new(InMemoryRevocationAuthority::new()),
+            AuthorityProfile::PortableEvaluator,
+            hours,
+        );
+        let token = authority
+            .auth_manager()
+            .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+            .expect("mint");
+        let claims = authority.auth_manager().verify_token(&token).unwrap();
+        assert_eq!(
+            claims.exp - claims.iat,
+            hours * 3600,
+            "issued credential must carry the CONFIGURED lifetime, not a hardcoded one"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn expired_credentials_are_rejected_at_the_boundary() {
+    let authority = authority(
+        Arc::new(InMemoryRevocationAuthority::new()),
+        AuthorityProfile::PortableEvaluator,
+        1,
+    );
+    let app = protected_app!(authority.clone());
+    let now = icn_time::current_timestamp_secs();
+
+    // Hand-mint claims around the expiry boundary using the same secret the
+    // authority verifies with.
+    let mint = |exp: u64| {
+        let claims = TokenClaims {
+            sub: did().to_string(),
+            iat: now - 10,
+            exp,
+            coop_id: "test-coop".to_string(),
+            scopes: scopes(&["coop:read"]),
+            entity_id: None,
+            entity_type: None,
+            jti: Some("boundary-test-jti".to_string()),
+        };
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::default(),
+            &claims,
+            &jsonwebtoken::EncodingKey::from_secret(SECRET),
+        )
+        .expect("encode")
+    };
+
+    // Comfortably in the future: accepted.
+    assert_eq!(get_protected(&app, &mint(now + 3600)).await, 200);
+    // Already past: rejected. (jsonwebtoken applies a small default leeway, so
+    // the "expired" case is placed clearly outside it rather than at exp-1,
+    // which would assert against library leeway rather than our behavior.)
+    assert_eq!(get_protected(&app, &mint(now - 3600)).await, 401);
+}
+
+// ---------------------------------------------------------------------------
+// 7–8. Attenuation: a delegation cannot exceed its issuer
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn delegation_cannot_grant_more_than_the_issuer_holds() {
+    let authority = authority(
+        Arc::new(InMemoryRevocationAuthority::new()),
+        AuthorityProfile::PortableEvaluator,
+        1,
+    );
+
+    // The #2436 scenario: a narrowly-scoped member credential approving a
+    // session that historically minted six broad scopes.
+    let member = TokenClaims {
+        sub: did().to_string(),
+        iat: 0,
+        exp: u64::MAX,
+        coop_id: "test-coop".to_string(),
+        scopes: scopes(&["governance:read", "governance:action-item:complete"]),
+        entity_id: None,
+        entity_type: None,
+        jti: Some("member".to_string()),
+    };
+
+    let ceiling = [
+        "coop:read",
+        "coop:write",
+        "ledger:read",
+        "ledger:transact",
+        "governance:read",
+        "governance:write",
+    ];
+
+    let (token, granted) = authority
+        .issue_delegated(&member, &did(), "test-coop", &ceiling, None)
+        .expect("delegation of the issuer's own authority succeeds");
+
+    assert_eq!(
+        granted,
+        scopes(&["governance:read"]),
+        "only the issuer's own overlap with the flow ceiling may be delegated"
+    );
+    for forbidden in ["coop:write", "ledger:transact", "governance:write"] {
+        assert!(
+            !granted.contains(&forbidden.to_string()),
+            "escalation to {forbidden} must be impossible"
+        );
+    }
+
+    // And the minted credential really carries only the attenuated scopes.
+    let claims = authority.auth_manager().verify_token(&token).unwrap();
+    assert_eq!(claims.scopes, scopes(&["governance:read"]));
+}
+
+#[actix_web::test]
+async fn issuer_with_no_delegable_authority_is_refused() {
+    let authority = authority(
+        Arc::new(InMemoryRevocationAuthority::new()),
+        AuthorityProfile::PortableEvaluator,
+        1,
+    );
+    let outsider = TokenClaims {
+        sub: did().to_string(),
+        iat: 0,
+        exp: u64::MAX,
+        coop_id: "test-coop".to_string(),
+        scopes: scopes(&["some:unrelated:scope"]),
+        entity_id: None,
+        entity_type: None,
+        jti: Some("outsider".to_string()),
+    };
+    assert!(
+        authority
+            .issue_delegated(&outsider, &did(), "test-coop", &["coop:write"], None)
+            .is_err(),
+        "an issuer holding none of the ceiling's scopes must be refused, not handed a token"
+    );
+}
+
+#[actix_web::test]
+async fn excess_scope_requests_are_narrowed_not_granted() {
+    let issuer = scopes(&["governance:read"]);
+    let granted = attenuate_scopes(
+        &issuer,
+        &["governance:read", "governance:write"],
+        Some(&scopes(&["governance:read", "governance:write"])),
+    )
+    .expect("intersection is non-empty");
+    assert_eq!(granted, scopes(&["governance:read"]));
+}
+
+// ---------------------------------------------------------------------------
+// 9, 12. Missing required machinery fails startup rather than degrading
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn institutional_profile_refuses_to_assemble_without_durable_revocation() {
+    let auth = Arc::new(AuthManager::new(SECRET.to_vec()));
+    let result = SessionAuthority::new(
+        auth,
+        Arc::new(InMemoryRevocationAuthority::new()),
+        TokenLifetimePolicy::default(),
+        AuthorityProfile::Institutional,
+    );
+    let err = result.err().expect("must not assemble").to_string();
+    assert!(err.contains("durable session revocation"), "{err}");
+    assert!(err.contains("To fix"), "actionable message required: {err}");
+}
+
+#[actix_web::test]
+async fn authenticated_routes_refuse_to_serve_without_the_authority_installed() {
+    // The misassembly guard: if `SessionAuthority` is not registered, the
+    // middleware must fail closed rather than fall back to signature-only
+    // verification (which is exactly the pre-#2437 behavior).
+    let auth_mw = HttpAuthentication::bearer(jwt_auth);
+    let app = test::init_service(
+        App::new().service(
+            web::scope("/v1")
+                .route(
+                    "/protected",
+                    web::get().to(|| async { HttpResponse::Ok().body("ok") }),
+                )
+                .wrap(auth_mw),
+        ),
+    )
+    .await;
+
+    let token = AuthManager::new(SECRET.to_vec())
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .expect("mint");
+
+    let status = get_protected(&app, &token).await;
+    assert_eq!(
+        status, 500,
+        "a cryptographically valid credential must NOT be honored when revocation \
+         enforcement is not installed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 11. The capability report agrees with what was actually assembled
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn capability_report_matches_the_assembled_dependencies() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store: Arc<dyn icn_store::Store> =
+        Arc::new(icn_store::SledStore::open(dir.path()).expect("open store"));
+
+    let durable = authority(
+        Arc::new(StoreRevocationAuthority::new(store).unwrap()),
+        AuthorityProfile::Institutional,
+        24,
+    );
+    let caps = durable.capabilities();
+    assert_eq!(caps.profile, "institutional");
+    assert_eq!(caps.revocation_durability, "durable");
+    assert_eq!(caps.revocation_backend, "store");
+    assert_eq!(caps.token_ttl_secs, 86_400);
+    assert!(
+        caps.notes.is_empty(),
+        "a fully-satisfied institutional profile should carry no degradation notes: {:?}",
+        caps.notes
+    );
+
+    let volatile = authority(
+        Arc::new(InMemoryRevocationAuthority::new()),
+        AuthorityProfile::PortableEvaluator,
+        1,
+    );
+    let caps = volatile.capabilities();
+    assert_eq!(caps.revocation_backend, "memory");
+    assert!(!caps.notes.is_empty(), "degradation must be reported");
+}
+
+// ---------------------------------------------------------------------------
+// 13. A failing revocation store denies; it never authorizes
+// ---------------------------------------------------------------------------
+
+/// A revocation authority whose backing state cannot be read.
+struct FailingRevocationAuthority;
+
+impl RevocationAuthority for FailingRevocationAuthority {
+    fn is_revoked(&self, _jti: &str) -> icn_gateway::error::Result<bool> {
+        Err(icn_gateway::error::GatewayError::InternalError(
+            "revocation store unavailable".to_string(),
+        ))
+    }
+    fn revoke(&self, _jti: &str, _expires_at: u64) -> icn_gateway::error::Result<()> {
+        Ok(())
+    }
+    fn durability(&self) -> icn_gateway::session_authority::RevocationDurability {
+        icn_gateway::session_authority::RevocationDurability::Durable
+    }
+    fn backend(&self) -> &'static str {
+        "failing"
+    }
+}
+
+#[actix_web::test]
+async fn revocation_store_failure_denies_rather_than_authorizes() {
+    let authority = authority(
+        Arc::new(FailingRevocationAuthority),
+        AuthorityProfile::Institutional,
+        1,
+    );
+    let app = protected_app!(authority.clone());
+    let token = authority
+        .auth_manager()
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .expect("mint");
+
+    assert_eq!(
+        get_protected(&app, &token).await,
+        401,
+        "an unreadable revocation store must never read as authorization"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Migration: credentials minted before revocable ids existed
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn pre_jti_credentials_are_refused_by_institutional_profiles() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store: Arc<dyn icn_store::Store> =
+        Arc::new(icn_store::SledStore::open(dir.path()).expect("open store"));
+    let authority = authority(
+        Arc::new(StoreRevocationAuthority::new(store).unwrap()),
+        AuthorityProfile::Institutional,
+        1,
+    );
+    let app = protected_app!(authority);
+
+    // A legacy credential: valid signature, valid expiry, no `jti`.
+    let now = icn_time::current_timestamp_secs();
+    let legacy = TokenClaims {
+        sub: did().to_string(),
+        iat: now,
+        exp: now + 3600,
+        coop_id: "test-coop".to_string(),
+        scopes: scopes(&["coop:read"]),
+        entity_id: None,
+        entity_type: None,
+        jti: None,
+    };
+    let token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::default(),
+        &legacy,
+        &jsonwebtoken::EncodingKey::from_secret(SECRET),
+    )
+    .expect("encode");
+
+    assert_eq!(
+        get_protected(&app, &token).await,
+        401,
+        "an institution must not accept a credential it cannot withdraw"
+    );
+}
+
+#[actix_web::test]
+async fn every_mint_path_now_produces_a_revocable_credential() {
+    // `issue_token` and `issue_entity_token` are the two public mint entry
+    // points; every gateway call site (sessions, invites, enrollment,
+    // icnctl --local-mint) bottoms out in them.
+    let mgr = AuthManager::new(SECRET.to_vec());
+
+    let plain = mgr
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .unwrap();
+    let plain_claims = mgr.verify_token(&plain).unwrap();
+    assert!(plain_claims.jti.is_some(), "issue_token must set a jti");
+
+    let entity = mgr
+        .issue_entity_token(&did(), "test-coop", None, scopes(&["coop:read"]))
+        .unwrap();
+    let entity_claims = mgr.verify_token(&entity).unwrap();
+    assert!(
+        entity_claims.jti.is_some(),
+        "issue_entity_token must set a jti"
+    );
+
+    assert_ne!(
+        plain_claims.jti, entity_claims.jti,
+        "credential ids must be unique so they are individually revocable"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 14. Concurrent verification and revocation behave safely
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn concurrent_verification_and_revocation_are_safe() {
+    let authority = authority(
+        Arc::new(InMemoryRevocationAuthority::new()),
+        AuthorityProfile::PortableEvaluator,
+        1,
+    );
+
+    let tokens: Vec<String> = (0..32)
+        .map(|_| {
+            authority
+                .auth_manager()
+                .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+                .expect("mint")
+        })
+        .collect();
+
+    // Revoke half while verifying all, from many threads.
+    let mut handles = Vec::new();
+    for (i, token) in tokens.iter().cloned().enumerate() {
+        let authority = authority.clone();
+        handles.push(std::thread::spawn(move || {
+            if i % 2 == 0 {
+                let claims = authority.auth_manager().verify_token(&token).unwrap();
+                authority.revoke(&claims).expect("revoke");
+            }
+            // Verification must never panic or poison the lock regardless of
+            // interleaving; the outcome is checked deterministically below.
+            let _ = authority.verify(&token);
+        }));
+    }
+    for h in handles {
+        h.join().expect("no thread panicked or poisoned a lock");
+    }
+
+    for (i, token) in tokens.iter().enumerate() {
+        let verified = authority.verify(token);
+        if i % 2 == 0 {
+            assert!(
+                verified.is_err(),
+                "revoked credential {i} must stay revoked"
+            );
+        } else {
+            assert!(verified.is_ok(), "untouched credential {i} must stay valid");
+        }
+    }
+}

--- a/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
@@ -272,10 +272,54 @@ async fn expired_credentials_are_rejected_at_the_boundary() {
         .expect("encode")
     };
 
-    // Comfortably in the future: accepted.
-    assert_eq!(get_protected(&app, &mint(now + 3600)).await, 200);
+    // Comfortably in the future, and carrying EXACTLY the configured lifetime
+    // (iat is 10s in the past, so exp - iat == 3600): accepted. This also pins
+    // the acceptance-bound equality case through the real middleware — one
+    // second longer and the lifetime bound would refuse it.
+    assert_eq!(get_protected(&app, &mint(now + 3590)).await, 200);
     // One second past the claim boundary: rejected without hidden leeway.
     assert_eq!(get_protected(&app, &mint(now - 1)).await, 401);
+}
+
+// ---------------------------------------------------------------------------
+// 6b. The configured lifetime bounds ACCEPTANCE, not just issuance
+// ---------------------------------------------------------------------------
+
+/// `icnctl auth token --local-mint` holds the gateway's signing secret but not
+/// its configuration. If it mints with the canonical 24-hour default against a
+/// deployment configured for one-hour sessions, the middleware must refuse the
+/// credential: deployment policy is a ceiling on what is ACCEPTED, not advice
+/// to well-behaved issuers.
+#[actix_web::test]
+async fn co_issued_credential_exceeding_the_configured_lifetime_is_rejected() {
+    let authority = authority(
+        Arc::new(InMemoryRevocationAuthority::new()),
+        AuthorityProfile::PortableEvaluator,
+        1,
+    );
+    let app = protected_app!(authority.clone());
+
+    // The local-mint shape: same secret, canonical default (24h) lifetime.
+    let over_long = AuthManager::new(SECRET.to_vec())
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .expect("mint");
+    assert_eq!(
+        get_protected(&app, &over_long).await,
+        401,
+        "a credential outliving the deployment's configured session lifetime \
+         must be refused at the enforcing boundary"
+    );
+
+    // The same co-issuer, minting within the configured bound, is accepted.
+    let bounded = AuthManager::new(SECRET.to_vec())
+        .with_token_ttl(TokenLifetimePolicy::from_hours(1).unwrap().ttl())
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .expect("mint");
+    assert_eq!(
+        get_protected(&app, &bounded).await,
+        200,
+        "a co-issued credential within the configured bound is accepted"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/session_authority_enforcement.rs
@@ -439,9 +439,20 @@ async fn capability_report_matches_the_assembled_dependencies() {
     assert_eq!(caps.revocation_durability, "durable");
     assert_eq!(caps.revocation_backend, "store");
     assert_eq!(caps.token_ttl_secs, 86_400);
+    // Revocation is fully satisfied here, so no revocation-degradation note —
+    // but attenuation is still partial and must say so even under the strongest
+    // profile. A capability report that goes quiet when the profile is strong is
+    // exactly the overclaim this subsystem exists to prevent.
     assert!(
-        caps.notes.is_empty(),
-        "a fully-satisfied institutional profile should carry no degradation notes: {:?}",
+        !caps.notes.iter().any(|n| n.contains("valid again after")),
+        "durable revocation must not carry a volatility note: {:?}",
+        caps.notes
+    );
+    assert!(
+        caps.notes
+            .iter()
+            .any(|n| n.contains("enforced only for delegated session approval")),
+        "partial attenuation must be reported even on the institutional profile: {:?}",
         caps.notes
     );
 
@@ -453,6 +464,96 @@ async fn capability_report_matches_the_assembled_dependencies() {
     let caps = volatile.capabilities();
     assert_eq!(caps.revocation_backend, "memory");
     assert!(!caps.notes.is_empty(), "degradation must be reported");
+}
+
+// ---------------------------------------------------------------------------
+// 15. One surface cannot be used to bypass the other
+// ---------------------------------------------------------------------------
+
+/// The gateway and the RPC server are signed with the same secret and share one
+/// revocation store, so a credential revoked on either surface must be rejected
+/// on both. This pins the shared key format: writing the entry the way `icn-rpc`
+/// writes it, and reading revocation state from the store rather than only from
+/// this process's cache.
+///
+/// Both directions are asserted because they fail differently: gateway→RPC
+/// depends on the key prefix and value shape, RPC→gateway depends on the
+/// cache-miss fallthrough to the store.
+#[actix_web::test]
+async fn revocation_is_visible_across_both_authenticated_surfaces() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store: Arc<dyn icn_store::Store> =
+        Arc::new(icn_store::SledStore::open(dir.path()).expect("open store"));
+
+    let authority = authority(
+        Arc::new(StoreRevocationAuthority::new(store.clone()).unwrap()),
+        AuthorityProfile::Institutional,
+        1,
+    );
+    let app = protected_app!(authority.clone());
+
+    // -- direction 1: gateway revoke must be written where RPC looks for it --
+    let token = authority
+        .auth_manager()
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .expect("mint");
+    let claims = authority.auth_manager().verify_token(&token).unwrap();
+    let jti = claims.jti.clone().expect("minted credential carries a jti");
+    authority.revoke(&claims).expect("revoke");
+
+    let rpc_key = format!("auth:revoked:{jti}").into_bytes();
+    let entry = store
+        .get(&rpc_key)
+        .expect("store read")
+        .expect("gateway revocation must be written under the shared RPC key prefix");
+    let decoded: serde_json::Value =
+        serde_json::from_slice(&entry).expect("entry must be JSON the RPC loader can parse");
+    assert_eq!(decoded["jti"], jti);
+    assert!(
+        decoded["original_expiry"].as_u64().is_some(),
+        "RPC's loader drops entries without a usable original_expiry"
+    );
+
+    // -- direction 2: an RPC-style revoke must be honored by the gateway ------
+    let other = authority
+        .auth_manager()
+        .issue_token(&did(), "test-coop", scopes(&["coop:read"]))
+        .expect("mint");
+    let other_jti = authority
+        .auth_manager()
+        .verify_token(&other)
+        .unwrap()
+        .jti
+        .expect("jti");
+
+    assert_eq!(
+        get_protected(&app, &other).await,
+        200,
+        "precondition: valid before the out-of-process revoke"
+    );
+
+    // Written directly to the store, as the RPC surface would — this process's
+    // cache knows nothing about it.
+    store
+        .put(
+            format!("auth:revoked:{other_jti}").as_bytes(),
+            serde_json::to_vec(&serde_json::json!({
+                "jti": other_jti,
+                "subject": "",
+                "revoked_at": 1,
+                "original_expiry": u64::MAX,
+                "reason": "revoked via RPC",
+            }))
+            .unwrap()
+            .as_slice(),
+        )
+        .expect("store write");
+
+    assert_eq!(
+        get_protected(&app, &other).await,
+        401,
+        "a credential revoked on the other surface must not remain valid here"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/icn/crates/icn-gateway/tests/websocket_authority_enforcement.rs
+++ b/icn/crates/icn-gateway/tests/websocket_authority_enforcement.rs
@@ -1,0 +1,178 @@
+//! Assembled WebSocket continuing-authorization regression tests.
+//!
+//! These use a real TCP listener, the production WebSocket handler, and the
+//! production `WsSession` actor. They prove that retaining a connection after
+//! initial authentication does not retain protected event or backfill access.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::fmt::Debug;
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::time::Duration;
+
+use actix_web::{web, App, HttpServer};
+use awc::ws::{Frame, Message};
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use icn_gateway::auth::{AuthManager, TokenClaims};
+use icn_gateway::events::{EventBroadcaster, GatewayEvent};
+use icn_gateway::session_authority::SessionAuthority;
+use icn_identity::IdentityBundle;
+
+const SECRET: &[u8] = b"websocket-authority-integration-secret";
+const COOP_ID: &str = "test-coop";
+
+fn authority_and_token(ttl: Duration) -> (Arc<SessionAuthority>, String, TokenClaims) {
+    let auth = Arc::new(AuthManager::new(SECRET.to_vec()).with_token_ttl(ttl));
+    let authority = Arc::new(SessionAuthority::evaluator(auth.clone()));
+    let identity = IdentityBundle::generate().expect("test identity");
+    let token = auth
+        .issue_token(identity.did(), COOP_ID, vec!["coop:read".to_string()])
+        .expect("test token");
+    let claims = auth.verify_token(&token).expect("test claims");
+    (authority, token, claims)
+}
+
+async fn start_server(
+    authority: Arc<SessionAuthority>,
+    broadcaster: Arc<EventBroadcaster>,
+) -> (actix_web::dev::ServerHandle, String) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+    let address = listener.local_addr().expect("test server address");
+    let server = HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(authority.clone()))
+            .app_data(web::Data::new(broadcaster.clone()))
+            .service(icn_gateway::api::websocket::websocket)
+    })
+    .listen(listener)
+    .expect("listen on test socket")
+    .run();
+    let handle = server.handle();
+    actix_web::rt::spawn(server);
+    (handle, format!("ws://{address}/ws/{COOP_ID}"))
+}
+
+async fn authenticate<S, E>(socket: &mut S, token: &str)
+where
+    S: Sink<Message, Error = E> + Stream<Item = Result<Frame, E>> + Unpin,
+    E: Debug,
+{
+    socket
+        .send(Message::Text(
+            serde_json::json!({ "type": "Auth", "token": token })
+                .to_string()
+                .into(),
+        ))
+        .await
+        .expect("send auth frame");
+    let response = next_text(socket).await;
+    assert!(
+        response.contains("\"type\":\"AuthOk\""),
+        "expected AuthOk, received {response}"
+    );
+}
+
+async fn next_text<S, E>(socket: &mut S) -> String
+where
+    S: Stream<Item = Result<Frame, E>> + Unpin,
+    E: Debug,
+{
+    let frame = tokio::time::timeout(Duration::from_secs(3), socket.next())
+        .await
+        .expect("timed out waiting for WebSocket frame")
+        .expect("WebSocket stream ended")
+        .expect("WebSocket protocol error");
+    match frame {
+        Frame::Text(bytes) => String::from_utf8(bytes.to_vec()).expect("UTF-8 server message"),
+        other => panic!("expected text frame, received {other:?}"),
+    }
+}
+
+fn protected_event() -> GatewayEvent {
+    GatewayEvent::MemberAdded {
+        coop_id: COOP_ID.to_string(),
+        did: "did:icn:protected-member".to_string(),
+        role: "member".to_string(),
+    }
+}
+
+#[actix_web::test]
+async fn revoked_connection_receives_no_live_event() {
+    let (authority, token, claims) = authority_and_token(Duration::from_secs(3600));
+    let broadcaster = Arc::new(EventBroadcaster::new());
+    let (server, url) = start_server(authority.clone(), broadcaster.clone()).await;
+    let (_response, mut socket) = awc::Client::new()
+        .ws(url)
+        .connect()
+        .await
+        .expect("connect WebSocket");
+    authenticate(&mut socket, &token).await;
+
+    authority.revoke(&claims).expect("revoke credential");
+    broadcaster.broadcast(COOP_ID, protected_event()).await;
+
+    let response = next_text(&mut socket).await;
+    assert!(
+        response.contains("\"type\":\"AuthError\""),
+        "revoked socket must close before event delivery: {response}"
+    );
+    assert!(!response.contains("\"type\":\"Event\""));
+    server.stop(true).await;
+}
+
+#[actix_web::test]
+async fn revoked_connection_receives_no_backfill() {
+    let (authority, token, claims) = authority_and_token(Duration::from_secs(3600));
+    let broadcaster = Arc::new(EventBroadcaster::new());
+    broadcaster.broadcast(COOP_ID, protected_event()).await;
+    let (server, url) = start_server(authority.clone(), broadcaster).await;
+    let (_response, mut socket) = awc::Client::new()
+        .ws(url)
+        .connect()
+        .await
+        .expect("connect WebSocket");
+    authenticate(&mut socket, &token).await;
+
+    authority.revoke(&claims).expect("revoke credential");
+    socket
+        .send(Message::Text(
+            serde_json::json!({ "type": "Backfill", "after_seq": 0 })
+                .to_string()
+                .into(),
+        ))
+        .await
+        .expect("send backfill request");
+
+    let response = next_text(&mut socket).await;
+    assert!(
+        response.contains("\"type\":\"AuthError\""),
+        "revoked socket must close before backfill delivery: {response}"
+    );
+    assert!(!response.contains("\"type\":\"Event\""));
+    server.stop(true).await;
+}
+
+#[actix_web::test]
+async fn expired_connection_receives_no_live_event() {
+    let (authority, token, _claims) = authority_and_token(Duration::from_secs(1));
+    let broadcaster = Arc::new(EventBroadcaster::new());
+    let (server, url) = start_server(authority, broadcaster.clone()).await;
+    let (_response, mut socket) = awc::Client::new()
+        .ws(url)
+        .connect()
+        .await
+        .expect("connect WebSocket");
+    authenticate(&mut socket, &token).await;
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    broadcaster.broadcast(COOP_ID, protected_event()).await;
+
+    let response = next_text(&mut socket).await;
+    assert!(
+        response.contains("\"type\":\"AuthError\""),
+        "expired socket must close before event delivery: {response}"
+    );
+    assert!(!response.contains("\"type\":\"Event\""));
+    server.stop(true).await;
+}

--- a/icn/crates/icn-obs/src/metrics/rpc.rs
+++ b/icn/crates/icn-obs/src/metrics/rpc.rs
@@ -13,7 +13,7 @@ pub fn init_descriptions() {
     );
     describe_counter!(
         "icn_rpc_revocation_hits_total",
-        "Total number of revocation checks that found a revoked token (cache hits)"
+        "Total number of revocation checks that found a revoked token"
     );
     describe_gauge!(
         "icn_rpc_revoked_tokens_total",

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -210,6 +210,11 @@ impl<S: Store> TokenRevocationList<S> {
             .read()
             .map(|cache| cache.contains(jti))
             .map_err(|e| {
+                // Counted, not just returned: `icn_rpc_revocation_errors_total`
+                // is described as covering lock errors, and a fail-closed denial
+                // that never reaches a metric is invisible exactly when an
+                // operator is trying to explain a wave of 401s.
+                counter!("icn_rpc_revocation_errors_total").increment(1);
                 AuthError::InternalError(format!("Revocation cache lock poisoned: {e}"))
             })?;
 
@@ -225,6 +230,7 @@ impl<S: Store> TokenRevocationList<S> {
 
         if present.is_some() {
             let mut cache = self.cache.write().map_err(|e| {
+                counter!("icn_rpc_revocation_errors_total").increment(1);
                 AuthError::InternalError(format!("Revocation cache lock poisoned: {e}"))
             })?;
             cache.insert(jti.to_string());

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -196,30 +196,44 @@ impl<S: Store> TokenRevocationList<S> {
         Ok(())
     }
 
-    /// Check if a token ID has been revoked
+    /// Check if a token ID has been revoked.
     ///
-    /// Returns `false` on cache lock errors (fail-open). This is intentional:
-    /// - Lock poisoning is extremely rare (requires a panic while holding the lock)
-    /// - Failing closed (rejecting all tokens) creates a DoS vector
-    /// - The persistent storage is the source of truth; cache is only a performance optimization
-    /// - Better to allow one potentially-revoked token through than reject all valid tokens
-    pub fn is_revoked(&self, jti: &str) -> bool {
+    /// A cache hit is sufficient, but a miss is not proof of validity: the
+    /// gateway shares this store and may have written the revocation after this
+    /// RPC process loaded its cache. Store and lock errors are returned so token
+    /// verification fails closed.
+    pub fn is_revoked(&self, jti: &str) -> Result<bool, AuthError> {
         counter!("icn_rpc_revocation_checks_total").increment(1);
 
-        let is_revoked = self
+        let cached = self
             .cache
             .read()
             .map(|cache| cache.contains(jti))
-            .unwrap_or_else(|e| {
-                tracing::warn!(error = %e, jti = %jti, "Cache lock poisoned in is_revoked, failing open");
-                false
-            });
+            .map_err(|e| {
+                AuthError::InternalError(format!("Revocation cache lock poisoned: {e}"))
+            })?;
 
-        if is_revoked {
+        if cached {
             counter!("icn_rpc_revocation_hits_total").increment(1);
+            return Ok(true);
         }
 
-        is_revoked
+        let present = self.store.get(&Self::make_key(jti)).map_err(|e| {
+            counter!("icn_rpc_revocation_errors_total").increment(1);
+            AuthError::InternalError(format!("Failed to read token revocation state: {e}"))
+        })?;
+
+        if present.is_some() {
+            let mut cache = self.cache.write().map_err(|e| {
+                AuthError::InternalError(format!("Revocation cache lock poisoned: {e}"))
+            })?;
+            cache.insert(jti.to_string());
+            counter!("icn_rpc_revocation_hits_total").increment(1);
+            gauge!("icn_rpc_revoked_tokens_total").set(cache.len() as f64);
+            return Ok(true);
+        }
+
+        Ok(false)
     }
 
     /// Revoke a token
@@ -704,7 +718,11 @@ impl<S: Store + 'static> RpcAuthManager<S> {
     /// 2. Token has not expired
     /// 3. Token has not been revoked (if revocation list is enabled)
     pub fn verify_token(&self, token: &str) -> Result<RpcTokenClaims, AuthError> {
-        let validation = Validation::default();
+        let mut validation = Validation::default();
+        // Credential expiry is an authority bound. Do not inherit
+        // jsonwebtoken's default 60-second leeway and silently extend access
+        // beyond the token's reported `exp`.
+        validation.leeway = 0;
 
         let token_data = decode::<RpcTokenClaims>(
             token,
@@ -715,7 +733,7 @@ impl<S: Store + 'static> RpcAuthManager<S> {
 
         // Check if token has been revoked
         if let Some(ref trl) = self.revocation_list {
-            if trl.is_revoked(&token_data.claims.jti) {
+            if trl.is_revoked(&token_data.claims.jti)? {
                 return Err(AuthError::TokenRevoked);
             }
         }
@@ -797,11 +815,12 @@ impl<S: Store + 'static> RpcAuthManager<S> {
 
     /// Check if a specific token (by JTI) has been revoked
     ///
-    /// Returns `false` if revocation is not enabled or on cache errors (fail-open).
-    pub fn is_token_revoked(&self, jti: &str) -> bool {
+    /// Returns `Ok(false)` if revocation is not enabled. Store and cache errors
+    /// are surfaced so callers can fail closed.
+    pub fn is_token_revoked(&self, jti: &str) -> Result<bool, AuthError> {
         match &self.revocation_list {
             Some(trl) => trl.is_revoked(jti),
-            None => false,
+            None => Ok(false),
         }
     }
 
@@ -1626,7 +1645,7 @@ mod tests {
             ));
 
             // Check by JTI directly
-            assert!(auth2.is_token_revoked(&jti));
+            assert!(auth2.is_token_revoked(&jti).unwrap());
         }
     }
 
@@ -1682,8 +1701,27 @@ mod tests {
         trl.revoke("new-jti", "did:icn:test", future_expiry, None)
             .unwrap();
         assert_eq!(trl.count(), 1);
-        assert!(trl.is_revoked("new-jti"));
-        assert!(!trl.is_revoked("old-jti"));
+        assert!(trl.is_revoked("new-jti").unwrap());
+        assert!(!trl.is_revoked("old-jti").unwrap());
+    }
+
+    #[test]
+    fn cache_miss_observes_revocation_written_by_another_surface() {
+        let store = Arc::new(icn_store::SledStore::temporary().unwrap());
+        let trl = TokenRevocationList::new(Arc::clone(&store)).unwrap();
+        let jti = "gateway-written-jti";
+
+        store
+            .put(
+                &TokenRevocationList::<icn_store::SledStore>::make_key(jti),
+                b"{}",
+            )
+            .unwrap();
+
+        assert!(
+            trl.is_revoked(jti).unwrap(),
+            "a live RPC verifier must consult shared storage after a cache miss"
+        );
     }
 
     /// Test concurrent token revocation from multiple threads.
@@ -1741,14 +1779,17 @@ mod tests {
 
         // Token should be revoked exactly once in the cache
         assert_eq!(trl.count(), 1, "Token should be in cache exactly once");
-        assert!(trl.is_revoked(jti), "Token should be marked as revoked");
+        assert!(
+            trl.is_revoked(jti).unwrap(),
+            "Token should be marked as revoked"
+        );
 
         // Verify concurrent reads don't cause issues
         let read_handles: Vec<_> = (0..num_threads)
             .map(|_| {
                 let trl = Arc::clone(&trl);
                 let jti = jti.to_string();
-                thread::spawn(move || trl.is_revoked(&jti))
+                thread::spawn(move || trl.is_revoked(&jti).unwrap())
             })
             .collect();
 

--- a/icn/crates/icn-rpc/src/handler/auth.rs
+++ b/icn/crates/icn-rpc/src/handler/auth.rs
@@ -314,14 +314,25 @@ pub async fn handle_auth_revoke(
     };
 
     // Check if token was already revoked (idempotent operation)
-    if auth_manager.is_token_revoked(&claims.jti) {
-        return RpcResponse::success(
-            id,
-            serde_json::json!({
-                "revoked": true,
-                "message": "Token was already revoked"
-            }),
-        );
+    match auth_manager.is_token_revoked(&claims.jti) {
+        Ok(true) => {
+            return RpcResponse::success(
+                id,
+                serde_json::json!({
+                    "revoked": true,
+                    "message": "Token was already revoked"
+                }),
+            );
+        }
+        Ok(false) => {}
+        Err(error) => {
+            tracing::error!(error = %error, "Unable to verify existing revocation; refusing revoke request");
+            return RpcResponse::error(
+                id,
+                -32603,
+                "Unable to verify token revocation state".to_string(),
+            );
+        }
     }
 
     // Authorization check: only the token owner or an admin can revoke


### PR DESCRIPTION
## What

Authority Spine Phase 1. Introduces `SessionAuthority` — one explicit, test-constructible composition boundary owning gateway session authority — and lands #2436 and #2437 through it rather than as isolated patches.

## Why

Both issues are instances of one structural failure: a capability exists in a crate, is unit-tested against a miniature composition, and is not installed in the assembled runtime, while docs describe library capability as a runtime guarantee. RPC revocation machinery was constructed as `None`; `token_expiry_hours` was parsed but every gateway credential lived one hour.

## Invariants enforced by this branch

- **Attenuation:** `issued ⊆ issuer ∩ flow_allowed ∩ requested`; every term is a ceiling, never a grant.
- **Expiration:** the configured lifetime bounds both issuance and acceptance **on the gateway surface** — `SessionAuthority::verify` refuses a credential whose `exp − iat` exceeds the configured lifetime and, independently, one whose expiry lies more than one lifetime from now (a forward-dated `iat` buys nothing); client-visible lifetime fields report the installed authority lifetime; JWT expiry has no hidden leeway. This is **not** a universal cross-surface lifetime bound — the RPC surface shares the signing secret and is not bounded; see "What this does not do".
- **Revocation:** a credential can be individually withdrawn and is revalidated on HTTP requests, RPC requests, and every protected WebSocket event/backfill operation.
- **Truth:** capability reports derive from the constructed authority; required guarantees fail assembly; gateway actor-active state is set only after initialization and bind acknowledgement and is cleared on termination.

## #2436 — QR session-approve privilege escalation

`POST /v1/sessions/{id}/approve` previously checked only matching `coop_id`, then minted six broad scopes. The flow ceiling is now intersected with the approver's own scopes through `SessionAuthority::issue_delegated`. A holder with no delegable scope receives 403. The unmounted duplicate approval handler was removed.

The route remains attenuated rather than deleted. Requiring a dedicated approval capability is an institutional policy decision outside this PR.

## #2437 — revocation and lifetime

- Every gateway mint path bottoms out in `issue_entity_token`, which now emits a random `jti`.
- HTTP bearer middleware, in-band WebSocket auth, and hand-authenticated SDIS paths verify through `SessionAuthority` and fail closed when it is absent or revocation state is unreadable.
- The daemon installs RPC revocation with the same durable store used by the gateway.
- Gateway and RPC positive caches fall through to the shared store on misses, so cross-surface revocation is visible without restart; errors deny.
- The canonical unconfigured/default session lifetime is 24 hours across `AuthManager`, `TokenLifetimePolicy`, embedded gateways, and daemon `GatewayConfig`. Authority assembly rejects issuer/policy lifetime divergence.
- `/auth/verify`, invite join, and QR-session responses derive lifetime from the installed authority.
- WebSockets retain the credential and revalidate after subscription setup and before each protected event and backfill event. Revocation or expiry closes the socket before protected delivery.

## Operator-visible changes

1. **BREAKING:** a daemon with the durable revocation store runs the institutional profile and rejects pre-`jti` credentials immediately; holders must re-authenticate.
2. Default session lifetime changes from the formerly effective 1 hour to the configured/canonical 24 hours. Set `token_expiry_hours = 1` to retain one-hour sessions.
3. New boot dependency: `<store_path>/auth-revocation`. Failure to open or read required revocation state is fail-closed.
4. A gateway startup failure does not abort the daemon, but the supervisor now waits for readiness and reports the gateway actor inactive rather than claiming it started.
5. Verification of a non-revoked credential performs a point read from the shared revocation store. No negative cache is used because it would create a stale-revocation window.
6. A credential whose lifetime exceeds the deployment's configured session lifetime is refused at acceptance with a message naming the bound (previously the signed expiration was honored). This applies to trusted-local mints and to credentials issued before an operator lowered `token_expiry_hours`. `icnctl auth token --local-mint` takes `--expiry-hours` — validated through the same `TokenLifetimePolicy` as the gateway's own configuration — for deployments configured shorter than the canonical 24-hour default.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Full `icn-gateway --features sled-storage`: 712 unit tests plus all integration suites, including three real-TCP production-handler WebSocket revocation/expiry tests.
- Full `icn-core`, `icn-rpc`, `icnctl`, and `icn-obs` package suites.
- NYCN `nycn_bootstrap_apply_round_trip` executes and passes through the corrected router.
- `session_authority_enforcement`: 17 middleware/composition cases, including live gateway↔RPC revocation in both directions and exact expiry boundary.
- OpenAPI drift comparison, route-inventory check, agent-context-spine check, doc control, compliance, and readiness-overclaim checks pass.
- Repository freshness currently reports unchanged sections that crossed their age threshold; current `main` reproduces that pre-existing documentation debt. It is not papered over here.

## What this does not do

- Does not extract the full production router; #2421 remains the production-assembly closure.
- Does not add a gateway HTTP revocation route; revocation is reached through RPC `auth.revoke`.
- Does not decide who may approve or revoke, what evidence revocation leaves, or member recourse.
- Attenuation is enforced for delegated session approval; invite, SDIS enrollment, and trusted-local mint remain flow-chosen and capability reporting stays `Degraded` rather than overclaiming.
- Does not introduce a speculative revocation-store performance redesign. The correctness-preserving point read remains until evidence justifies a coherent invalidation mechanism.
- **Does not make the lifetime bound universal across surfaces.** The daemon derives the RPC signing key from the same `gateway.jwt_secret` (`supervisor/init_rpc.rs`), `RpcTokenClaims` does not reject unknown fields, and every field it requires is present in a gateway `TokenClaims` — so a gateway credential is structurally verifiable on the RPC surface. `icn-rpc`'s `verify_token` checks signature, `exp`, and revocation but applies no configured-lifetime bound, and its own issuance lifetime is a hardcoded 24 hours. Proven directly on this branch: against a one-hour deployment, a validly signed 24-hour co-issued credential is refused by `SessionAuthority::verify` and accepted by `RpcAuthManager::verify_token`. This is **pre-existing on `main`** — before this branch neither surface applied an acceptance bound — and is not a regression introduced here, but it means lowering `token_expiry_hours` shortens gateway acceptance without shortening an already-issued credential on RPC. Shared revocation, which *did* land here, remains the instrument that invalidates a credential on both surfaces. Closing it requires bounding RPC acceptance **and** issuance together (bounding acceptance alone would refuse the RPC manager's own freshly minted tokens) with an explicit credential-invalidation migration. Tracked in #2445.

## Review disposition

Commit `7cf8c478` addresses startup truth, client-visible TTL truth, WebSocket continuing authorization, bootstrap-router composition, split defaults, and live cross-surface RPC/gateway revocation. The JTI path retains `rand::rng()` because pinned rand 0.9 contractually provides a ChaCha12 `CryptoRng` seeded/reseeded from `OsRng`; a compile-time `CryptoRng` bound and code documentation now make that guarantee explicit. The non-revoked store read is retained deliberately for correctness.

Commit `9287b79e` closes the remaining P2 (local-mint lifetime): the configured lifetime is now an acceptance bound enforced at `SessionAuthority::verify` — both the `exp − iat` check and the remaining-window check — and the trusted-local mint gained `--expiry-hours` (validated through the shared `TokenLifetimePolicy`) so it stays usable on shorter-lifetime deployments. Regression matrix: co-issued 24-hour credential vs a 1-hour deployment → 401 through the real `jwt_auth` middleware, bounded re-mint → 200; exact-equality boundary; forward-dated `iat`; icnctl knob applies/defaults/rejects-invalid. The `Compare Against Base` failure is disposed as measurement noise with a code-path non-overlap analysis in the PR conversation; the revocation point read is not weakened.

Commit `a846a3dd` is a claims-boundary correction with no behavior change. An independent adversarial closure review found the Expiration invariant was stated as a universal cross-surface guarantee when it holds on the gateway surface only; the architecture note and this description now say so, and the RPC gap is tracked in #2445. The gateway invariant itself was re-verified rather than assumed: attenuation is a true double intersection that errors on the empty set; the acceptance bound was probed at `exp = u64::MAX`, `iat = 0`, `iat > exp`, `iat = u64::MAX`, exact equality, and one second over — no `iat` manipulation can yield an accepted window longer than the configured lifetime, and malformed orderings fail short rather than long; the only production JWT verification in the gateway crate is inside `SessionAuthority::verify`, so HTTP, WebSocket revalidation, and the hand-authenticated SDIS paths all inherit the bound.

Refs #2436 #2437 #2421 #2445


