### PR TITLE
fix(gateway): require steward authority for /v1/sdis institutional acts

### DIFF
--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-07-20T01:33:38+00:00
+Generated: 2026-07-21T13:04:39+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -18,7 +18,7 @@ Generated: 2026-07-20T01:33:38+00:00
 
 ## Snapshot
 
-- Source commit: `708cb0004402dc298abd448ab84604d4d2f9933d`
+- Source commit: `b34cd3f670334a2313dc65363fa22e97c6297bc1`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -386,13 +386,13 @@ Status vocabulary is the existing set from `source-of-truth-map.md`; no new labe
 | POST | `/enrollment/verify/level2` | `/v1/sdis/enrollment/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:406 | `verify_level2` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/ephemeral/generate` | `/v1/sdis/ephemeral/generate` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:301 | `generate_ephemeral` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/health` | `/v1/sdis/health` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:175 | `sdis_health` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/reject/{enrollment_id}` | `/v1/sdis/reject/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:917 | `reject_enrollment` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/reject/{enrollment_id}` | `/v1/sdis/reject/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:949 | `reject_enrollment` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/rotate-keys` | `/v1/sdis/rotate-keys` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:271 | `rotate_keys` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/start` | `/v1/sdis/start` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:258 | `start_enrollment` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/start` | `/v1/sdis/start` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:216 | `start_recovery` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/verify/level1` | `/v1/sdis/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:189 | `verify_level1` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/verify/level2` | `/v1/sdis/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:209 | `verify_level2` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/vouch/{enrollment_id}` | `/v1/sdis/vouch/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:828 | `steward_vouch` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/vouch/{enrollment_id}` | `/v1/sdis/vouch/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:834 | `steward_vouch` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/{anchor_id}` | `/v1/sdis/{anchor_id}` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:246 | `get_anchor` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/{anchor_id}/devices` | `/v1/sdis/{anchor_id}/devices` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:368 | `list_devices` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/{anchor_id}/history` | `/v1/sdis/{anchor_id}/history` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:311 | `get_rotation_history` | no | L1 | unknown / needs local verification | needs review |

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -1236,9 +1236,14 @@ pub fn configure_protected(cfg: &mut web::ServiceConfig) {
 /// accepted alongside it during the #1868 capability decomposition — the same
 /// pair `assign_role` uses in `apps/governance`, so the enrollment surface does
 /// not invent a second, divergent notion of steward authority.
+/// Both are referenced through `icn_rpc::auth::scopes` rather than spelled as
+/// literals: the broad scope is slated for retirement "once no production code
+/// references it", and a string literal is invisible to the constant-reference
+/// search that decision will be made from — this call site would be missed and
+/// the accepted-also fallback would silently survive its own retirement.
 const STEWARD_ACT_SCOPES: &[&str] = &[
     icn_rpc::auth::scopes::GOVERNANCE_STEWARD_WRITE,
-    "governance:write",
+    icn_rpc::auth::scopes::GOVERNANCE_WRITE,
 ];
 
 /// Authorize a steward/moderation act and return the DID to RECORD as its actor.

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -797,8 +797,14 @@ fn format_timestamp(ts: u64) -> String {
 /// GET /pending - List pending enrollments for stewards
 #[actix_web::get("/pending")]
 pub async fn list_pending_enrollments(
+    http_req: HttpRequest,
     store: web::Data<Arc<EnrollmentStore>>,
 ) -> Result<HttpResponse> {
+    // The pending queue lists applicant names and cooperatives for people who
+    // have not been admitted to anything yet. It is steward working state, not
+    // public information (issue #2443).
+    authorize_steward_act(&http_req, None)?;
+
     let enrollments = store.enrollments.read().await;
     let now = icn_time::current_timestamp_secs();
 
@@ -827,14 +833,39 @@ pub async fn list_pending_enrollments(
 /// POST /vouch/{enrollment_id} - Steward vouches for an enrollment
 #[post("/vouch/{enrollment_id}")]
 pub async fn steward_vouch(
+    http_req: HttpRequest,
     store: web::Data<Arc<EnrollmentStore>>,
     enrollment_id: web::Path<String>,
     req: web::Json<StewardVouchRequest>,
 ) -> Result<HttpResponse> {
+    // Vouching is an institutional act of standing. Authorize BEFORE touching
+    // enrollment state, and take the actor from the credential rather than the
+    // body (issue #2443).
+    let steward_did = authorize_steward_act(&http_req, req.steward_did.as_deref())?;
+
     let mut enrollments = store.enrollments.write().await;
     let session = enrollments
         .get_mut(enrollment_id.as_str())
         .ok_or_else(|| GatewayError::NotFound("Enrollment not found".to_string()))?;
+
+    // Steward authority is scoped to an organization, not global: a steward of
+    // one must not vouch someone into another's membership. Checked before any
+    // state validation so a cross-organization caller is refused outright
+    // rather than told about the enrollment's progress.
+    //
+    // SCOPE NOTE: this surface is **cooperative-only by construction**, not
+    // organization-generic. `complete_enrollment` builds the membership
+    // jurisdiction as `format!("coop:{}", session.coop_id)`, and the `coop_id`
+    // claim is the cooperative namespace. Communities are a distinct entity
+    // type (`icn_entity::EntityType::Community`) addressed by a separate
+    // `community:*` scope family in `api/communities.rs` — which does not use
+    // this check, and whose scopes are not in `validation::ALLOWED_SCOPES`, so
+    // no gateway credential can carry them today. Enrolling into a community
+    // therefore is not a supported flow here; generalizing it belongs with the
+    // flat-`coop_id` → `EntityId` migration (#2082/#2080), not with this
+    // authorization fix. Until then, binding on `coop_id` matches exactly what
+    // the surface actually creates.
+    crate::middleware::require_coop_access(&http_req, &session.coop_id)?;
 
     // Must be level 1 first
     if session.level < 1 {
@@ -849,10 +880,11 @@ pub async fn steward_vouch(
         return Err(GatewayError::BadRequest("Enrollment expired".to_string()));
     }
 
-    // Record the vouch
+    // Record the vouch. `steward_did` is the VERIFIED credential subject, never
+    // the request body's assertion.
     session.level = 2;
     session.steward_vouch = Some(req.vouch_statement.clone());
-    session.steward_did = req.steward_did.clone();
+    session.steward_did = Some(steward_did);
     session.vouched_at = Some(now);
 
     // Release lock and persist
@@ -916,14 +948,23 @@ pub async fn get_enrollment_status(
 /// POST /reject/{enrollment_id} - Steward rejects an enrollment
 #[post("/reject/{enrollment_id}")]
 pub async fn reject_enrollment(
+    http_req: HttpRequest,
     store: web::Data<Arc<EnrollmentStore>>,
     enrollment_id: web::Path<String>,
     req: web::Json<RejectRequest>,
 ) -> Result<HttpResponse> {
+    // Rejection is an institutional moderation decision; same binding as
+    // vouching (issue #2443).
+    let rejected_by = authorize_steward_act(&http_req, req.steward_did.as_deref())?;
+
     let mut enrollments = store.enrollments.write().await;
     let session = enrollments
         .get_mut(enrollment_id.as_str())
         .ok_or_else(|| GatewayError::NotFound("Enrollment not found".to_string()))?;
+
+    // Same cooperative binding as vouching: moderation authority does not cross
+    // cooperative boundaries.
+    crate::middleware::require_coop_access(&http_req, &session.coop_id)?;
 
     // Check not already rejected
     if session.rejected {
@@ -945,7 +986,8 @@ pub async fn reject_enrollment(
     session.rejected = true;
     session.rejection_reason = Some(req.reason.clone());
     session.rejected_at = Some(now);
-    session.rejected_by = req.steward_did.clone();
+    // The VERIFIED subject, never the body's assertion.
+    session.rejected_by = Some(rejected_by);
 
     // Release lock and persist
     let id = enrollment_id.clone();
@@ -1069,9 +1111,15 @@ pub async fn get_steward_stats(
 /// GET /steward/history - Get vouch history
 #[actix_web::get("/steward/history")]
 pub async fn get_vouch_history(
+    http_req: HttpRequest,
     store: web::Data<Arc<EnrollmentStore>>,
     query: web::Query<HistoryQuery>,
 ) -> Result<HttpResponse> {
+    // Unlike `/steward/stats`, this history is NOT self-scoped: it discloses
+    // applicant identities together with which steward vouched for each of
+    // them, across every enrollment. Steward authority required (issue #2443).
+    authorize_steward_act(&http_req, None)?;
+
     let limit = query.limit.unwrap_or(50).min(100);
     let offset = query.offset.unwrap_or(0);
 
@@ -1124,17 +1172,104 @@ pub struct HistoryQuery {
 // Configuration
 // ============================================================================
 
+/// Public and self-authenticating enrollment routes.
+///
+/// Mounted WITHOUT `jwt_auth`. Two different reasons live here, and conflating
+/// them is how the #2443 defect happened:
+///
+/// - **Public initiation** (`/enrollment/start`, `/enrollment/verify/level1`,
+///   `/status/{id}`): a person beginning enrollment does not yet hold an ICN
+///   credential, so requiring one would make enrollment impossible.
+/// - **Bearer-authenticating by hand** (`/enrollment/verify/level2`,
+///   `/steward/stats`): these verify a bearer credential through
+///   [`SessionAuthority`], so they already honor revocation and the configured
+///   lifetime (#2437). They stay here rather than moving under the middleware,
+///   which would double-verify the same credential.
+/// - **Applicant-signature authenticating** (`/enrollment/complete`): this one
+///   takes no `Authorization` header at all. It authenticates the *applicant's*
+///   device signature over `complete:{enrollment_id}` and then **mints** a
+///   credential. It is a credential-issuing endpoint, not a credential-gated
+///   one — do not read its `SessionAuthority` parameter as an access check.
+///
+/// CAVEAT worth stating explicitly, because it bounds what this split fixes:
+/// `/enrollment/verify/level2` performs the *same* state transition as the
+/// protected `/vouch/{id}` — it sets `level = 2`, `steward_vouch`,
+/// `steward_did`, and `vouched_at` — but authorizes it with a trust-graph gate
+/// (`effective_trust >= STEWARD_MIN_TRUST_SCORE`) rather than a steward
+/// capability, and applies no cooperative binding. Moving `/vouch/{id}` behind
+/// a capability therefore does not make vouching capability-gated in general.
+/// Reconciling the two authority models is an institutional decision (does
+/// vouching authority derive from the trust graph or from a governance
+/// capability?), deliberately not made here — see the PR discussion for #2443.
+///
+/// Institutional acts do NOT belong in this set — see [`configure_protected`].
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(start_enrollment)
         .service(verify_level1)
         .service(verify_level2)
         .service(complete_enrollment)
-        .service(list_pending_enrollments)
-        .service(steward_vouch)
         .service(get_enrollment_status)
+        .service(get_steward_stats);
+}
+
+/// Steward and moderation routes, which record institutional acts or disclose
+/// applicant state.
+///
+/// Mounted BEHIND `jwt_auth` (issue #2443). Registering a route here is what
+/// gives it signature validation, the configured lifetime ceiling, durable
+/// revocation, and fail-closed authority construction — a handler cannot opt
+/// out of them by forgetting a check, which is precisely how `steward_vouch`
+/// came to accept an anonymous POST that named its own actor.
+///
+/// Authentication alone is not sufficient for these routes: each handler
+/// additionally requires steward authority through [`authorize_steward_act`].
+pub fn configure_protected(cfg: &mut web::ServiceConfig) {
+    cfg.service(list_pending_enrollments)
+        .service(steward_vouch)
         .service(reject_enrollment)
-        .service(get_steward_stats)
         .service(get_vouch_history);
+}
+
+/// Capabilities that authorize an institutional act on the enrollment surface.
+///
+/// The narrowed steward class scope first, with the broad `governance:write`
+/// accepted alongside it during the #1868 capability decomposition — the same
+/// pair `assign_role` uses in `apps/governance`, so the enrollment surface does
+/// not invent a second, divergent notion of steward authority.
+const STEWARD_ACT_SCOPES: &[&str] = &[
+    icn_rpc::auth::scopes::GOVERNANCE_STEWARD_WRITE,
+    "governance:write",
+];
+
+/// Authorize a steward/moderation act and return the DID to RECORD as its actor.
+///
+/// The recorded actor is always the verified credential subject. A request body
+/// may still carry a steward DID (the field predates this check and remains in
+/// the wire format), but it may only *agree* with the verified subject — it can
+/// never determine the actor. Disagreement is refused rather than silently
+/// overridden, so a client that believes it is acting as someone else is told
+/// so instead of having its claim quietly rewritten.
+fn authorize_steward_act(http_req: &HttpRequest, body_did: Option<&str>) -> Result<String> {
+    crate::middleware::require_any_scope(http_req, STEWARD_ACT_SCOPES)?;
+
+    let claims = crate::middleware::get_claims(http_req).ok_or_else(|| {
+        // Unreachable while these routes are mounted behind `jwt_auth`; if a
+        // future composition drops the middleware, deny rather than proceed
+        // with an unauthenticated actor.
+        GatewayError::AuthenticationFailed(
+            "no verified credential on an institutional route".to_string(),
+        )
+    })?;
+
+    if let Some(supplied) = body_did {
+        if supplied != claims.sub {
+            return Err(GatewayError::AuthorizationFailed(
+                "steward_did does not match the authenticated credential subject".to_string(),
+            ));
+        }
+    }
+
+    Ok(claims.sub)
 }
 
 #[cfg(test)]

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -2152,7 +2152,13 @@ impl GatewayServer {
                         )
                         // Public cooperative statistics (no auth required)
                         .service(api::coops::get_coop_stats)
-                        // Public SDIS endpoints (verification + enrollment)
+                        // SDIS endpoints. The scope is deliberately split by
+                        // authority (issue #2443): public verification and
+                        // enrollment initiation stay reachable without a
+                        // credential, while steward and moderation routes are
+                        // mounted behind `jwt_auth` so they inherit signature
+                        // validation, the configured lifetime ceiling, durable
+                        // revocation, and fail-closed authority construction.
                         .service(
                             web::scope("/sdis")
                                 .service(api::sdis::sdis_health)
@@ -2163,7 +2169,16 @@ impl GatewayServer {
                                 // Note: enrollment::configure disabled - using simple_enrollment as primary API
                                 // .configure(api::sdis::enrollment::configure)
                                 .configure(api::sdis::recovery::configure)
-                                .configure(api::sdis::anchor::configure),
+                                .configure(api::sdis::anchor::configure)
+                                // Steward/moderation surface: same `/sdis`
+                                // prefix, authenticated. Nested last so the
+                                // public routes above keep their unwrapped
+                                // behavior.
+                                .service(
+                                    web::scope("").wrap(auth.clone()).configure(
+                                        api::sdis::simple_enrollment::configure_protected,
+                                    ),
+                                ),
                         )
                         // Protected coop endpoints (auth + rate limiting)
                         .service(

--- a/icn/crates/icn-gateway/tests/sdis_route_authority.rs
+++ b/icn/crates/icn-gateway/tests/sdis_route_authority.rs
@@ -240,11 +240,14 @@ async fn revoked_credential_is_refused() {
     let token = mint(&authority, &did, &[STEWARD_SCOPE]);
     let body = serde_json::json!({ "vouch_statement": "x" });
 
-    // Sanity: accepted before revocation (not a 401).
+    // Sanity before revoking: the credential authenticates and authorizes, so
+    // the only thing left to refuse it is the nonexistent enrollment. Pinning
+    // 404 exactly (rather than "not 401") keeps this precondition from passing
+    // on a 500 and making the revocation assertion below vacuous.
     let before = post_vouch(&app, Some(&token), body.clone()).await;
-    assert_ne!(
-        before, 401,
-        "credential should authenticate before revocation"
+    assert_eq!(
+        before, 404,
+        "credential should authenticate and authorize before revocation"
     );
 
     let claims = authority.auth_manager().verify_token(&token).unwrap();
@@ -299,10 +302,15 @@ async fn steward_capability_and_broad_governance_scope_are_both_accepted() {
             serde_json::json!({ "vouch_statement": "I vouch", "steward_did": did.to_string() }),
         )
         .await;
-        assert_ne!(status, 401, "scope {scope} must authenticate");
-        assert_ne!(
-            status, 403,
-            "scope {scope} must carry steward authority (got {status})"
+        // 404 is the precise success signal: the enrollment id is deliberately
+        // nonexistent, so reaching the handler's own NotFound proves
+        // authentication AND authorization both passed. Asserting merely
+        // "not 401/403" would also pass on a 500 and mask an unrelated
+        // regression.
+        assert_eq!(
+            status, 404,
+            "scope {scope} must authenticate and carry steward authority, \
+             leaving only the missing enrollment to refuse it (got {status})"
         );
     }
 }
@@ -487,11 +495,14 @@ async fn matching_body_did_is_accepted_and_records_the_same_subject() {
         }),
     )
     .await;
-    assert_ne!(
-        status, 403,
-        "a body DID equal to the subject must be accepted"
+    // As above, 404 is the exact expected outcome: authorization passed and only
+    // the nonexistent enrollment remains. A bare "not 403" would also accept a
+    // 500 and hide an unrelated failure.
+    assert_eq!(
+        status, 404,
+        "a body DID equal to the verified subject must be accepted, leaving \
+         only the missing enrollment to refuse it (got {status})"
     );
-    assert_ne!(status, 401, "the credential is valid");
 }
 
 // ---------------------------------------------------------------------------

--- a/icn/crates/icn-gateway/tests/sdis_route_authority.rs
+++ b/icn/crates/icn-gateway/tests/sdis_route_authority.rs
@@ -1,0 +1,687 @@
+//! `/v1/sdis` route-authority enforcement (issue #2443).
+//!
+//! # What these tests exercise
+//!
+//! The `/v1/sdis` scope is mounted **without** the general `jwt_auth` middleware,
+//! so several institutional routes historically authenticated nothing at all:
+//! `steward_vouch` recorded a vouch attributed to a DID taken from the request
+//! body, `reject_enrollment` recorded a moderation decision the same way, and
+//! the pending-queue and vouch-history reads disclosed applicant state to
+//! anonymous callers.
+//!
+//! These cases drive the protected routes through the **real `jwt_auth`
+//! middleware** over the **same `SessionAuthority`** the production composition
+//! registers, mounted the way `GatewayServer::run` mounts them: one public
+//! `/sdis` scope for enrollment initiation and status, and one wrapped scope for
+//! the steward/moderation surface.
+//!
+//! # What they do NOT prove
+//!
+//! They do not construct the full production router — the gateway's route tree
+//! is still assembled inside a closure in `GatewayServer::run` that no test can
+//! call (issue #2421). What is shared with production is the authority object,
+//! the middleware, the scope vocabulary, and the public/protected split; what is
+//! not shared is the surrounding route table. Closing that gap is #2421's job.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{test, web, App};
+use actix_web_httpauth::middleware::HttpAuthentication;
+use icn_gateway::api::sdis::simple_enrollment::{self, EnrollmentStore};
+use icn_gateway::auth::AuthManager;
+use icn_gateway::middleware::jwt_auth;
+use icn_gateway::session_authority::{
+    AuthorityProfile, InMemoryRevocationAuthority, SessionAuthority, TokenLifetimePolicy,
+};
+use icn_identity::Did;
+
+const SECRET: &[u8] = b"sdis-route-authority-test-secret-32-bytes";
+
+/// The canonical steward capability (`icn_rpc::auth::scopes`), and the broad
+/// governance scope accepted alongside it during the #1868 decomposition.
+const STEWARD_SCOPE: &str = "governance:steward:write";
+const BROAD_GOVERNANCE_SCOPE: &str = "governance:write";
+
+fn generated_did() -> Did {
+    icn_identity::IdentityBundle::generate()
+        .expect("generate test identity")
+        .did()
+        .clone()
+}
+
+fn scopes(list: &[&str]) -> Vec<String> {
+    list.iter().map(|s| s.to_string()).collect()
+}
+
+fn authority(ttl_hours: u64) -> Arc<SessionAuthority> {
+    let lifetime = TokenLifetimePolicy::from_hours(ttl_hours).unwrap();
+    let auth = Arc::new(AuthManager::new(SECRET.to_vec()).with_token_ttl(lifetime.ttl()));
+    Arc::new(
+        SessionAuthority::new(
+            auth,
+            Arc::new(InMemoryRevocationAuthority::new()),
+            lifetime,
+            AuthorityProfile::PortableEvaluator,
+        )
+        .expect("authority assembles"),
+    )
+}
+
+/// Mount `/sdis` the way production does: the public enrollment surface
+/// unwrapped, the steward/moderation surface behind `jwt_auth`.
+macro_rules! sdis_app {
+    ($authority:expr) => {{
+        let auth_mw = HttpAuthentication::bearer(jwt_auth);
+        test::init_service(
+            App::new()
+                .app_data(web::Data::new($authority))
+                .app_data(web::Data::new(Arc::new(EnrollmentStore::new())))
+                .service(
+                    web::scope("/v1/sdis")
+                        .configure(simple_enrollment::configure)
+                        .service(
+                            web::scope("")
+                                .wrap(auth_mw)
+                                .configure(simple_enrollment::configure_protected),
+                        ),
+                ),
+        )
+        .await
+    }};
+}
+
+async fn post_vouch(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    token: Option<&str>,
+    body: serde_json::Value,
+) -> u16 {
+    let mut req = test::TestRequest::post()
+        .uri("/v1/sdis/vouch/enrollment-under-test")
+        .set_json(body);
+    if let Some(t) = token {
+        req = req.insert_header(("Authorization", format!("Bearer {t}")));
+    }
+    test::call_service(app, req.to_request())
+        .await
+        .status()
+        .as_u16()
+}
+
+async fn get_status(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    uri: &str,
+    token: Option<&str>,
+) -> u16 {
+    let mut req = test::TestRequest::get().uri(uri);
+    if let Some(t) = token {
+        req = req.insert_header(("Authorization", format!("Bearer {t}")));
+    }
+    test::call_service(app, req.to_request())
+        .await
+        .status()
+        .as_u16()
+}
+
+fn mint(authority: &SessionAuthority, did: &Did, scope_list: &[&str]) -> String {
+    authority
+        .auth_manager()
+        .issue_token(did, "test-coop", scopes(scope_list))
+        .expect("mint")
+}
+
+// ---------------------------------------------------------------------------
+// 1. Authentication: the institutional write surface refuses anonymous callers
+// ---------------------------------------------------------------------------
+
+/// The #2443 defect, expressed as an invariant: an anonymous POST could record a
+/// vouch attributed to any steward DID. It must now be refused before reaching
+/// the handler.
+#[actix_web::test]
+async fn anonymous_caller_cannot_record_a_steward_vouch() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+
+    let status = post_vouch(
+        &app,
+        None,
+        serde_json::json!({
+            "vouch_statement": "I vouch for this applicant",
+            "steward_did": "did:icn:zSomeoneElse",
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        status, 401,
+        "an unauthenticated caller must not be able to record an institutional vouch"
+    );
+}
+
+#[actix_web::test]
+async fn malformed_and_expired_credentials_are_refused() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+    let body = serde_json::json!({ "vouch_statement": "x" });
+
+    assert_eq!(
+        post_vouch(&app, Some("not.a.jwt"), body.clone()).await,
+        401,
+        "malformed credential"
+    );
+
+    // Hand-mint an already-expired credential with the authority's own secret.
+    let now = icn_time::current_timestamp_secs();
+    let expired = icn_gateway::auth::TokenClaims {
+        sub: generated_did().to_string(),
+        iat: now - 7200,
+        exp: now - 1,
+        coop_id: "test-coop".to_string(),
+        scopes: scopes(&[STEWARD_SCOPE]),
+        entity_id: None,
+        entity_type: None,
+        jti: Some("expired-jti".to_string()),
+    };
+    let expired_token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::default(),
+        &expired,
+        &jsonwebtoken::EncodingKey::from_secret(SECRET),
+    )
+    .unwrap();
+    assert_eq!(
+        post_vouch(&app, Some(&expired_token), body).await,
+        401,
+        "expired credential"
+    );
+}
+
+/// The protected surface inherits the #2442 lifetime acceptance bound: a
+/// credential minted by a co-issuer that never learned this deployment's
+/// configured lifetime is refused here exactly as it is on every other
+/// authority-bearing route.
+#[actix_web::test]
+async fn credential_exceeding_the_configured_lifetime_is_refused() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+
+    // Same signing secret, canonical 24h default -> exceeds the 1h deployment.
+    let overlong = AuthManager::new(SECRET.to_vec())
+        .issue_token(&generated_did(), "test-coop", scopes(&[STEWARD_SCOPE]))
+        .expect("mint");
+
+    assert_eq!(
+        post_vouch(
+            &app,
+            Some(&overlong),
+            serde_json::json!({ "vouch_statement": "x" })
+        )
+        .await,
+        401,
+        "the configured lifetime ceiling must bound this surface too"
+    );
+}
+
+/// Revocation reaches the SDIS surface: a credential withdrawn through the
+/// shared authority stops working on the next request.
+#[actix_web::test]
+async fn revoked_credential_is_refused() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+    let did = generated_did();
+    let token = mint(&authority, &did, &[STEWARD_SCOPE]);
+    let body = serde_json::json!({ "vouch_statement": "x" });
+
+    // Sanity: accepted before revocation (not a 401).
+    let before = post_vouch(&app, Some(&token), body.clone()).await;
+    assert_ne!(
+        before, 401,
+        "credential should authenticate before revocation"
+    );
+
+    let claims = authority.auth_manager().verify_token(&token).unwrap();
+    authority.revoke(&claims).expect("revoke");
+
+    assert_eq!(
+        post_vouch(&app, Some(&token), body).await,
+        401,
+        "a revoked credential must not act on the institutional surface"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Authorization: authentication alone is not steward authority
+// ---------------------------------------------------------------------------
+
+/// Authentication without authorization is not closure. A valid member
+/// credential that holds no steward capability must not be able to vouch.
+#[actix_web::test]
+async fn authenticated_member_without_steward_capability_is_refused() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+    let token = mint(
+        &authority,
+        &generated_did(),
+        &["coop:read", "governance:read"],
+    );
+
+    assert_eq!(
+        post_vouch(
+            &app,
+            Some(&token),
+            serde_json::json!({ "vouch_statement": "x" })
+        )
+        .await,
+        403,
+        "any authenticated user is NOT a steward"
+    );
+}
+
+#[actix_web::test]
+async fn steward_capability_and_broad_governance_scope_are_both_accepted() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+
+    for scope in [STEWARD_SCOPE, BROAD_GOVERNANCE_SCOPE] {
+        let did = generated_did();
+        let token = mint(&authority, &did, &[scope]);
+        let status = post_vouch(
+            &app,
+            Some(&token),
+            serde_json::json!({ "vouch_statement": "I vouch", "steward_did": did.to_string() }),
+        )
+        .await;
+        assert_ne!(status, 401, "scope {scope} must authenticate");
+        assert_ne!(
+            status, 403,
+            "scope {scope} must carry steward authority (got {status})"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Identity binding: the body cannot name the actor
+// ---------------------------------------------------------------------------
+
+/// A steward credential must not be usable to attribute a vouch to somebody
+/// else. The recorded actor is the verified subject; a body-supplied DID that
+/// disagrees is refused rather than silently overridden.
+#[actix_web::test]
+async fn body_supplied_steward_did_must_match_the_verified_subject() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+    let token = mint(&authority, &generated_did(), &[STEWARD_SCOPE]);
+
+    let status = post_vouch(
+        &app,
+        Some(&token),
+        serde_json::json!({
+            "vouch_statement": "I vouch",
+            "steward_did": generated_did().to_string(), // a different steward
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        status, 403,
+        "a credential must not attribute an institutional act to another DID"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3b. Cooperative binding: steward authority is not global
+// ---------------------------------------------------------------------------
+
+/// A steward credential carries the cooperative it was issued for. Holding
+/// steward authority in one cooperative must not authorize an institutional act
+/// on another's enrollment — the recurring "broad scope + caller coop_id"
+/// bypass class (#2052/#2056/#2058), applied here through the canonical
+/// `require_coop_access`.
+#[actix_web::test]
+async fn steward_cannot_act_on_another_cooperatives_enrollment() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+
+    // Seed an enrollment belonging to "coop-a" through the real public
+    // initiation route rather than a test-only backdoor into the store.
+    let start = test::TestRequest::post()
+        .uri("/v1/sdis/enrollment/start")
+        .set_json(serde_json::json!({
+            "identity_name": "Applicant",
+            "coop_id": "coop-a",
+        }))
+        .to_request();
+    let started: serde_json::Value = test::call_and_read_body_json(&app, start).await;
+    let enrollment_id = started["enrollment_id"]
+        .as_str()
+        .expect("enrollment_id in start response")
+        .to_string();
+
+    // A genuine steward — but of "coop-b".
+    let did = generated_did();
+    let token = authority
+        .auth_manager()
+        .issue_token(&did, "coop-b", scopes(&[STEWARD_SCOPE]))
+        .expect("mint");
+
+    let req = test::TestRequest::post()
+        .uri(&format!("/v1/sdis/vouch/{enrollment_id}"))
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .set_json(serde_json::json!({ "vouch_statement": "I vouch" }))
+        .to_request();
+
+    assert_eq!(
+        test::call_service(&app, req).await.status().as_u16(),
+        403,
+        "steward authority in one cooperative must not reach another's enrollment"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3c. The success path, and what it actually records
+// ---------------------------------------------------------------------------
+
+/// Drive a real enrollment to level 1 through the public routes, then vouch as
+/// a same-cooperative steward and assert the act SUCCEEDS and is attributed to
+/// the verified credential subject.
+///
+/// Without this, every protected-route case is a refusal: a regression that
+/// restored `session.steward_did = req.steward_did.clone()` would keep the
+/// refusal tests green while silently recording the body's assertion again, and
+/// a mismatch between the enrollment's `coop_id` and the credential's would
+/// lock out every legitimate steward with no test noticing.
+#[actix_web::test]
+async fn same_coop_steward_vouch_succeeds_and_records_the_verified_subject() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+
+    // Public initiation.
+    let start = test::TestRequest::post()
+        .uri("/v1/sdis/enrollment/start")
+        .set_json(serde_json::json!({ "identity_name": "Applicant", "coop_id": "coop-a" }))
+        .to_request();
+    let started: serde_json::Value = test::call_and_read_body_json(&app, start).await;
+    let enrollment_id = started["enrollment_id"].as_str().unwrap().to_string();
+
+    // Level 1: the applicant's device signs the enrollment_id challenge.
+    let device = icn_identity::IdentityBundle::generate().unwrap();
+    let signature = device.keypair().unwrap().sign(enrollment_id.as_bytes());
+    let level1 = test::TestRequest::post()
+        .uri("/v1/sdis/enrollment/verify/level1")
+        .set_json(serde_json::json!({
+            "enrollment_id": enrollment_id,
+            "device_proof": {
+                "ephemeral_did": device.did().to_string(),
+                "signature": hex::encode(signature.to_bytes()),
+            }
+        }))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, level1).await.status().as_u16(),
+        200,
+        "public level-1 device verification must still work"
+    );
+
+    // A steward of the SAME cooperative vouches.
+    let steward = generated_did();
+    let token = authority
+        .auth_manager()
+        .issue_token(&steward, "coop-a", scopes(&[STEWARD_SCOPE]))
+        .expect("mint");
+    let vouch = test::TestRequest::post()
+        .uri(&format!("/v1/sdis/vouch/{enrollment_id}"))
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .set_json(serde_json::json!({ "vouch_statement": "I vouch for this applicant" }))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, vouch).await.status().as_u16(),
+        200,
+        "a same-cooperative steward with the capability must be able to vouch"
+    );
+
+    // The recorded actor is the credential subject — read back through the
+    // steward-authenticated history surface.
+    let history = test::TestRequest::get()
+        .uri("/v1/sdis/steward/history")
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .to_request();
+    let body: serde_json::Value = test::call_and_read_body_json(&app, history).await;
+    let recorded = body["vouches"][0]["steward_did"]
+        .as_str()
+        .unwrap_or_default();
+    assert_eq!(
+        recorded,
+        steward.to_string(),
+        "the recorded vouching steward must be the verified credential subject"
+    );
+}
+
+/// The body cannot redirect attribution even when it names a *real* steward:
+/// agreement is required, and agreement records the same subject.
+#[actix_web::test]
+async fn matching_body_did_is_accepted_and_records_the_same_subject() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+    let steward = generated_did();
+    let token = authority
+        .auth_manager()
+        .issue_token(&steward, "coop-a", scopes(&[STEWARD_SCOPE]))
+        .expect("mint");
+
+    // Nonexistent enrollment: we only assert the authorization verdict, which
+    // is decided before the lookup's 404.
+    let status = post_vouch(
+        &app,
+        Some(&token),
+        serde_json::json!({
+            "vouch_statement": "I vouch",
+            "steward_did": steward.to_string(),
+        }),
+    )
+    .await;
+    assert_ne!(
+        status, 403,
+        "a body DID equal to the subject must be accepted"
+    );
+    assert_ne!(status, 401, "the credential is valid");
+}
+
+// ---------------------------------------------------------------------------
+// 4. Restricted reads: applicant state is not public
+// ---------------------------------------------------------------------------
+
+#[actix_web::test]
+async fn restricted_reads_are_unreachable_anonymously() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+
+    for uri in ["/v1/sdis/pending", "/v1/sdis/steward/history"] {
+        assert_eq!(
+            get_status(&app, uri, None).await,
+            401,
+            "{uri} discloses applicant state and must require a credential"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn restricted_reads_require_steward_capability() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+    let token = mint(
+        &authority,
+        &generated_did(),
+        &["coop:read", "governance:read"],
+    );
+
+    for uri in ["/v1/sdis/pending", "/v1/sdis/steward/history"] {
+        assert_eq!(
+            get_status(&app, uri, Some(&token)).await,
+            403,
+            "{uri} must require steward authority, not merely authentication"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Public enrollment initiation is preserved
+// ---------------------------------------------------------------------------
+
+/// The point of a route-authority boundary is not to make enrollment
+/// impossible. A person beginning enrollment has no ICN credential yet, so
+/// initiation must remain reachable anonymously.
+#[actix_web::test]
+async fn public_enrollment_initiation_remains_anonymous() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+
+    let req = test::TestRequest::post()
+        .uri("/v1/sdis/enrollment/start")
+        .set_json(serde_json::json!({
+            "identity_name": "Applicant",
+            "coop_id": "test-coop",
+        }))
+        .to_request();
+    let status = test::call_service(&app, req).await.status().as_u16();
+
+    assert_ne!(
+        status, 401,
+        "enrollment initiation must not require a credential the applicant cannot have"
+    );
+    assert_ne!(
+        status, 403,
+        "enrollment initiation must not require authority"
+    );
+}
+
+/// Public status reads stay public, but the *institutional* surface does not
+/// become reachable through the public scope.
+#[actix_web::test]
+async fn public_scope_does_not_expose_the_steward_surface() {
+    let authority = authority(1);
+    let app = sdis_app!(authority.clone());
+
+    // No credential: the moderation write is refused, not merely 404'd away.
+    let req = test::TestRequest::post()
+        .uri("/v1/sdis/reject/enrollment-under-test")
+        .set_json(serde_json::json!({ "reason": "spam" }))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, req).await.status().as_u16(),
+        401,
+        "moderation write must be refused without a credential"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5b. The nested protected scope does not shadow its siblings
+// ---------------------------------------------------------------------------
+
+/// The protected surface is mounted as a nested empty-prefix scope so it can
+/// carry `jwt_auth` under the same `/sdis` prefix. An empty prefix matches
+/// everything, so the structural risk is that it swallows or shadows the
+/// sibling routes registered beside it — turning public verification endpoints
+/// into 401s, or into 404s.
+///
+/// This mounts the siblings the way `GatewayServer::run` does, in the same
+/// order, and asserts they still resolve unauthenticated.
+#[actix_web::test]
+async fn nested_protected_scope_does_not_shadow_sibling_routes() {
+    let authority = authority(1);
+    let auth_mw = HttpAuthentication::bearer(jwt_auth);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(authority))
+            .app_data(web::Data::new(Arc::new(EnrollmentStore::new())))
+            .service(
+                web::scope("/v1/sdis")
+                    .service(icn_gateway::api::sdis::sdis_health)
+                    .configure(simple_enrollment::configure)
+                    .service(
+                        web::scope("")
+                            .wrap(auth_mw)
+                            .configure(simple_enrollment::configure_protected),
+                    ),
+            ),
+    )
+    .await;
+
+    // A sibling registered BEFORE the nested scope still resolves, and is still
+    // public.
+    let req = test::TestRequest::get().uri("/v1/sdis/health").to_request();
+    assert_eq!(
+        test::call_service(&app, req).await.status().as_u16(),
+        200,
+        "the nested authenticated scope must not shadow sibling public routes"
+    );
+
+    // And the protected surface is still protected in the same composition.
+    assert_eq!(
+        post_vouch(&app, None, serde_json::json!({ "vouch_statement": "x" })).await,
+        401,
+        "protected routes must remain protected alongside siblings"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Misassembly fails closed
+// ---------------------------------------------------------------------------
+
+/// A composition that forgets to register `SessionAuthority` must refuse, and
+/// must keep refusing even when a perfectly usable bare `AuthManager` is
+/// present. Registering nothing would only prove "fails when nothing can
+/// verify"; an `.or_else(..)` fallback to signature-only verification would slip
+/// straight through such a test.
+#[actix_web::test]
+async fn misassembly_without_session_authority_refuses_even_with_a_usable_auth_manager() {
+    let bare = AuthManager::new(SECRET.to_vec());
+    let token = bare
+        .issue_token(&generated_did(), "test-coop", scopes(&[STEWARD_SCOPE]))
+        .expect("mint");
+
+    let auth_mw = HttpAuthentication::bearer(jwt_auth);
+    let app = test::init_service(
+        App::new()
+            // Deliberately NO SessionAuthority. Both plausible shapes of a bare
+            // issuer are registered and are individually sufficient to verify
+            // this token.
+            .app_data(web::Data::new(AuthManager::new(SECRET.to_vec())))
+            .app_data(web::Data::new(Arc::new(AuthManager::new(SECRET.to_vec()))))
+            .app_data(web::Data::new(Arc::new(EnrollmentStore::new())))
+            .service(
+                web::scope("/v1/sdis")
+                    .configure(simple_enrollment::configure)
+                    .service(
+                        web::scope("")
+                            .wrap(auth_mw)
+                            .configure(simple_enrollment::configure_protected),
+                    ),
+            ),
+    )
+    .await;
+
+    // 500, not 401: a missing `SessionAuthority` is a server-side wiring error,
+    // not a bad credential. Reporting 401 would blame the caller's token while
+    // hiding the misassembly. This matches the guard in
+    // `session_authority_enforcement.rs`; what both pin is that a
+    // cryptographically valid credential is NOT honored when revocation
+    // enforcement is absent.
+    assert_eq!(
+        post_vouch(
+            &app,
+            Some(&token),
+            serde_json::json!({ "vouch_statement": "x" })
+        )
+        .await,
+        500,
+        "a misassembled runtime must refuse rather than fall back to signature-only auth"
+    );
+}

--- a/icn/crates/icn-gateway/tests/sdis_route_authority.rs
+++ b/icn/crates/icn-gateway/tests/sdis_route_authority.rs
@@ -563,13 +563,15 @@ async fn public_enrollment_initiation_remains_anonymous() {
         .to_request();
     let status = test::call_service(&app, req).await.status().as_u16();
 
-    assert_ne!(
-        status, 401,
-        "enrollment initiation must not require a credential the applicant cannot have"
-    );
-    assert_ne!(
-        status, 403,
-        "enrollment initiation must not require authority"
+    // Pinned to 200, not merely "not 401/403". This test exists to prove the
+    // scope split did not break enrollment for people who have no credential
+    // yet — if it accepted any non-auth status, initiation could be failing
+    // outright and this case would still pass, proving nothing about the one
+    // thing it guards.
+    assert_eq!(
+        status, 200,
+        "enrollment initiation must remain anonymous AND working: an applicant \
+         has no credential to present"
     );
 }
 


### PR DESCRIPTION
## What

Establishes one authority boundary for the `/v1/sdis` enrollment surface. The scope is split by *authority* rather than left flat: public initiation stays reachable without a credential, and steward/moderation routes move behind `jwt_auth` — so they inherit the Authority Spine guarantees (#2442) instead of each handler deciding for itself.

## Why

`/v1/sdis` is mounted without the general `jwt_auth` middleware. Some handlers authenticated by hand; four did not authenticate at all:

- `steward_vouch` took the vouching steward's DID **from the request body** and recorded an institutional act of standing. Any unauthenticated caller who knew an `enrollment_id` could advance an enrollment to level 2 and attribute it to an arbitrary steward.
- `reject_enrollment` recorded a moderation decision the same way (`rejected_by` from the body).
- `list_pending_enrollments` and `get_vouch_history` disclosed applicant names and cooperative ids — and, for the history, which steward vouched for whom — to anonymous callers.

## Route matrix

Every route mounted under `/v1/sdis`, classified. Only the four in **bold** change behavior.

| Route | Class | Before | After |
|---|---|---|---|
| `GET /health` | public status read | none | unchanged |
| `POST /verify/level1`, `/verify/level2`, `/ephemeral/generate` | verification | none | unchanged |
| `POST /enrollment/start` | public initiation | none | unchanged (**must** stay public) |
| `POST /enrollment/verify/level1` | public initiation | proves key possession by signature | unchanged |
| `GET /status/{id}` | applicant continuation | none | unchanged |
| `POST /enrollment/verify/level2` | **steward act by a second authority model** | hand-auth via `SessionAuthority` + trust gate, no capability, no coop binding | unchanged — see parallel-path section |
| `POST /enrollment/complete` | applicant continuation, credential-**issuing** | applicant device signature; takes no `Authorization` header | unchanged |
| `GET /steward/stats` | authenticated, self-scoped | hand-auth via `SessionAuthority` | unchanged |
| **`POST /vouch/{id}`** | **steward act** | **none** | `jwt_auth` + steward capability + coop binding + identity binding |
| **`POST /reject/{id}`** | **moderator act** | **none** | same |
| **`GET /pending`** | **restricted read** | **none** | `jwt_auth` + steward capability |
| **`GET /steward/history`** | **restricted read** | **none** | `jwt_auth` + steward capability |
| `/recovery/*`, `/anchor/*` | out of scope | none | unchanged — see "Not in this PR" |

`/enrollment/verify/level2` and `/steward/stats` stay in the public `configure` because they already verify a bearer credential through `SessionAuthority`; moving them under the middleware would double-verify the same credential. `/enrollment/complete` stays because it is not credential-gated at all — it authenticates the applicant's device signature and *mints* a credential. Worth stating precisely: it takes a `SessionAuthority` parameter, which reads like an access check and is not one.

## Invariants

- **Capability.** `authorize_steward_act` requires `governance:steward:write`, accepting the broad `governance:write` alongside it — the same pair `assign_role` uses in `apps/governance`, so the enrollment surface does not invent a second notion of steward authority. Authentication alone is not sufficient: an authenticated member without steward capability gets 403.
- **Identity binding.** The recorded actor is always the verified credential subject. `steward_did`/`rejected_by` come from `claims.sub`, never the body. The body field remains in the wire format but may only *agree*; disagreement is 403 rather than a silent override.
- **Cooperative binding.** Steward authority is not global. `require_coop_access` binds the act to the enrollment's own `coop_id`, applying the recurring "broad scope + caller coop_id" lesson (#2052/#2056/#2058) to these routes. Checked before any state validation, so a cross-cooperative caller is refused outright. **This binds `/vouch/{id}` and `/reject/{id}` only — see the parallel-path finding below; it does not make vouching coop-bound in general.**
- **Inherited from #2442.** Because the routes sit behind `jwt_auth`, they get signature validation, the configured lifetime ceiling, durable revocation, and fail-closed authority construction without restating any of it.

## Public behavior deliberately preserved

Enrollment initiation is anonymous by design — an applicant has no ICN credential yet, so requiring one would make enrollment impossible. `POST /enrollment/start`, `/enrollment/verify/level1`, and `GET /status/{id}` are unchanged and tested to remain reachable without a credential.

## Tests

`icn/crates/icn-gateway/tests/sdis_route_authority.rs` — 16 cases through the **real `jwt_auth` middleware** over the **same `SessionAuthority`** production registers: anonymous → 401; malformed → 401; expired → 401; lifetime beyond the configured ceiling → 401; revoked → 401; authenticated non-steward → 403; body DID ≠ verified subject → 403; cross-cooperative steward → 403; both accepted capabilities pass; restricted reads unreachable anonymously and by non-stewards; public initiation still anonymous; the nested scope does not shadow sibling routes; misassembly refuses.

Crucially the suite includes a **success path**, not only refusals: an enrollment is driven to level 1 through the real public routes (the applicant's device signs the challenge), a same-cooperative steward vouches → 200, and the vouch is read back to assert `steward_did` equals the verified credential subject. Without it every protected case was a refusal, and a regression restoring `session.steward_did = req.steward_did.clone()` would have kept the suite green while silently recording the body's assertion again — and a `coop_id`-shape mismatch would have locked out every legitimate steward unnoticed.

The misassembly guard registers a **usable** bare `AuthManager` in both plausible shapes while omitting `SessionAuthority`, so an `.or_else(..)` fallback to signature-only verification would fail it — registering nothing would only prove "fails when nothing can verify".

## Parallel path: `/enrollment/verify/level2` reaches the same state by a weaker route

Found by adversarial review of this branch, and it bounds what this PR fixes — stating it here rather than letting the diff imply more than it delivers.

`POST /v1/sdis/enrollment/verify/level2` performs the **identical institutional write** as the now-protected `/vouch/{id}`: it sets `level = 2`, `steward_vouch`, `steward_did`, `vouched_at`, and its response says "Steward vouch recorded successfully". Its authorization is different:

| | `/vouch/{id}` (this PR) | `/enrollment/verify/level2` (unchanged) |
|---|---|---|
| Authentication | `jwt_auth` → `SessionAuthority` | hand-verified bearer → `SessionAuthority` |
| Capability | `governance:steward:write` ∨ `governance:write` | **none** |
| Cooperative binding | `require_coop_access` | **none** |
| Other gate | — | trust graph: `effective_trust >= STEWARD_MIN_TRUST_SCORE` (0.4) |

Attribution is sound on both (each records `claims.sub`, not a body field), so the impersonation defect is closed on both paths. What remains is that **capability and cooperative gating are bypassable** via the level2 route by any authenticated credential meeting the trust threshold.

I did not close this here, deliberately. The two routes encode **two different theories of vouching authority** — one capability-based, one trust-graph-based — and choosing between them is an institutional decision, not a mechanical fix. Forcing the capability onto the trust path would silently retire a deliberate trust-based design; adding a cooperative binding there may contradict it, since ICN's trust graph is explicitly cross-organizational. That decision needs a human; tracked in #2447.

Reviewers should also note the level2 route carries a pre-existing `TODO(#396)` for steward-vouch rate limiting, and that the new protected scope is the only authenticated write scope under `/v1` mounted without `trust_rate_limit_middleware` (`/v1/coops` and `/v1/members` both wrap it).

## Not in this PR

- **`/recovery/*` and `/anchor/*` have no authentication of any kind** — no bearer, no signature — including `POST /anchor/rotate-keys` and `POST /anchor/devices/add`. Verified, not inferred. That is a different institutional question (identity-recovery and device authority, not steward vouching); tracked in #2448 with the specific finding that `rotate-keys` gates only on a DID string readable from the public `GET /anchor/{id}`.
- **The restricted reads remain cross-cooperative**: a steward of coop A can still list coop B's pending applicants and vouch history. Narrowing them means filtering results by the caller's cooperative, which changes what the endpoint returns — a product decision, not a security patch.
- **This surface is cooperative-only, not organization-generic.** Worth stating because the binding invites the question "coop or community?". Today it is unambiguously cooperative: `complete_enrollment` builds the membership jurisdiction as `format!("coop:{}", session.coop_id)`, and `coop_id` is documented as the cooperative namespace. Communities are a distinct entity type (`EntityType::Community`, which can itself contain cooperatives) addressed by a separate `community:*` scope family in `api/communities.rs` that never uses `require_coop_access` — and those scopes are absent from `validation::ALLOWED_SCOPES`, so no gateway credential can legally carry them and the community surface is unreachable with gateway auth. Binding on `coop_id` therefore matches exactly what this surface creates and excludes no working flow. If enrollment should serve communities too, that is the flat-`coop_id` → `EntityId` migration (#2082/#2080), not an authorization patch.
- **Self-vouching is not prevented.** A naive `ephemeral_did == claims.sub` check would be security theater: the applicant's ephemeral enrollment DID and a steward's durable credential subject would essentially never match even for a genuine self-vouch. Real prevention needs a link between ephemeral enrollment identity and durable member identity — an identity-model question.
- Does not extract the production router (#2421), so these tests share production's authority object, middleware, and public/protected split, but not its surrounding route table.

## Claims boundary

Implemented and wired into the production composition in `server.rs`; automatically tested at the middleware/composition boundary. **Not** runtime-witnessed, **not** human-reviewed, **not** institutionally accepted, **not** production-verified. No organizer or steward has approved this authority model — the capability choice is a mechanical reuse of the existing canonical scope, and who may vouch remains an institutional question.

Refs #2443
