### PR TITLE
fix(gateway): fail closed SDIS anchor identity mutations

### DIFF
--- a/docs/reference/project-index/generated/route-inventory.md
+++ b/docs/reference/project-index/generated/route-inventory.md
@@ -1,7 +1,7 @@
 ---
 Status: generated
 Canonical: no
-Generated: 2026-07-21T13:04:39+00:00
+Generated: 2026-07-21T19:44:15+00:00
 ---
 
 # Gateway Route Inventory (generated)
@@ -18,7 +18,7 @@ Generated: 2026-07-21T13:04:39+00:00
 
 ## Snapshot
 
-- Source commit: `b34cd3f670334a2313dc65363fa22e97c6297bc1`
+- Source commit: `cb79ec5ce802053ce0a534b05a9d90ef68c21ea3`
 - Gateway source scanned: `icn/crates/icn-gateway/src/**`
 - OpenAPI spec: `docs/api/openapi.generated.yaml`
 
@@ -379,7 +379,7 @@ Status vocabulary is the existing set from `source-of-truth-map.md`; no new labe
 | GET | `/meetings` | `/v1/registry/meetings` | `icn/crates/icn-gateway/src/api/registry.rs`:564 | `list_meetings` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/meetings` | `/v1/registry/meetings` | `icn/crates/icn-gateway/src/api/registry.rs`:491 | `create_meeting` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/summary` | `/v1/rights/summary` | `icn/crates/icn-gateway/src/api/rights.rs`:12 | `rights_summary` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/devices/add` | `/v1/sdis/devices/add` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:332 | `add_device` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/devices/add` | `/v1/sdis/devices/add` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:309 | `add_device` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/enrollment/complete` | `/v1/sdis/enrollment/complete` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:505 | `complete_enrollment` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/enrollment/start` | `/v1/sdis/enrollment/start` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:281 | `start_enrollment` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/enrollment/verify/level1` | `/v1/sdis/enrollment/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:331 | `verify_level1` | no | L1 | unknown / needs local verification | needs review |
@@ -387,15 +387,15 @@ Status vocabulary is the existing set from `source-of-truth-map.md`; no new labe
 | POST | `/ephemeral/generate` | `/v1/sdis/ephemeral/generate` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:301 | `generate_ephemeral` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/health` | `/v1/sdis/health` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:175 | `sdis_health` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/reject/{enrollment_id}` | `/v1/sdis/reject/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:949 | `reject_enrollment` | no | L1 | unknown / needs local verification | needs review |
-| POST | `/rotate-keys` | `/v1/sdis/rotate-keys` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:271 | `rotate_keys` | no | L1 | unknown / needs local verification | needs review |
+| POST | `/rotate-keys` | `/v1/sdis/rotate-keys` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:274 | `rotate_keys` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/start` | `/v1/sdis/start` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:258 | `start_enrollment` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/start` | `/v1/sdis/start` | `icn/crates/icn-gateway/src/api/sdis/recovery.rs`:216 | `start_recovery` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/verify/level1` | `/v1/sdis/verify/level1` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:189 | `verify_level1` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/verify/level2` | `/v1/sdis/verify/level2` | `icn/crates/icn-gateway/src/api/sdis/mod.rs`:209 | `verify_level2` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/vouch/{enrollment_id}` | `/v1/sdis/vouch/{enrollment_id}` | `icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs`:834 | `steward_vouch` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/{anchor_id}` | `/v1/sdis/{anchor_id}` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:246 | `get_anchor` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/{anchor_id}/devices` | `/v1/sdis/{anchor_id}/devices` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:368 | `list_devices` | no | L1 | unknown / needs local verification | needs review |
-| GET | `/{anchor_id}/history` | `/v1/sdis/{anchor_id}/history` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:311 | `get_rotation_history` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/{anchor_id}` | `/v1/sdis/{anchor_id}` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:245 | `get_anchor` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/{anchor_id}/devices` | `/v1/sdis/{anchor_id}/devices` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:319 | `list_devices` | no | L1 | unknown / needs local verification | needs review |
+| GET | `/{anchor_id}/history` | `/v1/sdis/{anchor_id}/history` | `icn/crates/icn-gateway/src/api/sdis/anchor.rs`:284 | `get_rotation_history` | no | L1 | unknown / needs local verification | needs review |
 | GET | `/{ceremony_id}` | `/v1/sdis/{ceremony_id}` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:294 | `get_enrollment_status` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/{ceremony_id}/approve` | `/v1/sdis/{ceremony_id}/approve` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:368 | `approve_ceremony` | no | L1 | unknown / needs local verification | needs review |
 | POST | `/{ceremony_id}/finalize` | `/v1/sdis/{ceremony_id}/finalize` | `icn/crates/icn-gateway/src/api/sdis/enrollment.rs`:318 | `finalize_enrollment` | no | L1 | unknown / needs local verification | needs review |

--- a/icn/crates/icn-gateway/src/api/sdis/anchor.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/anchor.rs
@@ -272,7 +272,7 @@ pub async fn get_anchor(
 ///
 /// POST /v1/sdis/anchor/rotate-keys
 #[post("/rotate-keys")]
-pub async fn rotate_keys(_req: web::Json<RotateKeysRequest>) -> Result<HttpResponse> {
+pub async fn rotate_keys() -> Result<HttpResponse> {
     Err(GatewayError::Forbidden(
         "Anchor key rotation requires a signed current-key transition; this route is disabled until that authority path is wired".to_string(),
     ))
@@ -307,7 +307,7 @@ pub async fn get_rotation_history(
 ///
 /// POST /v1/sdis/anchor/devices/add
 #[post("/devices/add")]
-pub async fn add_device(_req: web::Json<AddDeviceRequest>) -> Result<HttpResponse> {
+pub async fn add_device() -> Result<HttpResponse> {
     Err(GatewayError::Forbidden(
         "Adding anchor devices requires a signed current-key transition; this route is disabled until that authority path is wired".to_string(),
     ))

--- a/icn/crates/icn-gateway/src/api/sdis/anchor.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/anchor.rs
@@ -6,16 +6,15 @@
 //! # Endpoints
 //!
 //! - GET /v1/sdis/anchor/:anchor_id - Get anchor details
-//! - POST /v1/sdis/anchor/rotate-keys - Rotate keys while keeping anchor
+//! - POST /v1/sdis/anchor/rotate-keys - Disabled until signed current-key rotation is wired
 //! - GET /v1/sdis/anchor/:anchor_id/history - Get key rotation history
-//! - POST /v1/sdis/anchor/devices/add - Add a trusted device
+//! - POST /v1/sdis/anchor/devices/add - Disabled until signed current-key device enrollment is wired
 //! - GET /v1/sdis/anchor/:anchor_id/devices - List trusted devices
 
 use actix_web::{get, post, web, HttpResponse};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
-use uuid::Uuid;
 
 use super::enrollment::{AnchorDto, EnrollmentPathwayDto, KeyBundleDto};
 use crate::error::{GatewayError, Result};
@@ -265,44 +264,18 @@ pub async fn get_anchor(
     Ok(HttpResponse::Ok().json(response))
 }
 
-/// Rotate keys while keeping the same anchor
+/// Rotate keys while keeping the same anchor.
+///
+/// Disabled until this route can verify a signed current-key transition bound to
+/// the exact anchor and replacement key material. Public anchor data is not
+/// authority to mutate an identity root.
 ///
 /// POST /v1/sdis/anchor/rotate-keys
 #[post("/rotate-keys")]
-pub async fn rotate_keys(
-    store: web::Data<Arc<AnchorStore>>,
-    req: web::Json<RotateKeysRequest>,
-) -> Result<HttpResponse> {
-    // Get anchor record
-    let mut record = store
-        .get_anchor(&req.anchor_id)?
-        .ok_or_else(|| GatewayError::NotFound("Anchor not found".to_string()))?;
-
-    // Verify current DID matches
-    if record.current_did != req.current_did {
-        return Err(GatewayError::BadRequest(
-            "Current DID does not match".to_string(),
-        ));
-    }
-
-    // Generate new DID
-    let new_did = format!("did:icn:{}", Uuid::new_v4().to_string().replace("-", ""));
-
-    // Perform rotation
-    let old_did = record.current_did.clone();
-    record.rotate_keys(new_did.clone(), req.reason.clone());
-
-    // Save updated record
-    store.update_anchor(&req.anchor_id, record.clone())?;
-
-    let response = RotateKeysResponse {
-        anchor_id: req.anchor_id.clone(),
-        new_did,
-        keybundle_version: record.keybundle_version,
-        revoked_did: old_did,
-    };
-
-    Ok(HttpResponse::Ok().json(response))
+pub async fn rotate_keys(_req: web::Json<RotateKeysRequest>) -> Result<HttpResponse> {
+    Err(GatewayError::Forbidden(
+        "Anchor key rotation requires a signed current-key transition; this route is disabled until that authority path is wired".to_string(),
+    ))
 }
 
 /// Get key rotation history
@@ -326,40 +299,18 @@ pub async fn get_rotation_history(
     Ok(HttpResponse::Ok().json(response))
 }
 
-/// Add a trusted device to an anchor
+/// Add a trusted device to an anchor.
+///
+/// Disabled until this route can verify a signed current-key transition bound to
+/// the exact anchor and device key. Public anchor data is not authority to
+/// mutate identity authenticators.
 ///
 /// POST /v1/sdis/anchor/devices/add
 #[post("/devices/add")]
-pub async fn add_device(
-    store: web::Data<Arc<AnchorStore>>,
-    req: web::Json<AddDeviceRequest>,
-) -> Result<HttpResponse> {
-    // Get anchor record
-    let mut record = store
-        .get_anchor(&req.anchor_id)?
-        .ok_or_else(|| GatewayError::NotFound("Anchor not found".to_string()))?;
-
-    let now = icn_time::current_timestamp_secs();
-
-    // Create device info
-    let device_id = Uuid::new_v4().to_string();
-    let device = DeviceInfo {
-        device_id: device_id.clone(),
-        device_name: req.device_name.clone(),
-        added_at: now,
-        last_seen: now,
-        device_pubkey: req.device_pubkey.clone(),
-    };
-
-    // Add device
-    record.add_device(device.clone());
-
-    // Save updated record
-    store.update_anchor(&req.anchor_id, record)?;
-
-    let response = AddDeviceResponse { device_id, device };
-
-    Ok(HttpResponse::Ok().json(response))
+pub async fn add_device(_req: web::Json<AddDeviceRequest>) -> Result<HttpResponse> {
+    Err(GatewayError::Forbidden(
+        "Adding anchor devices requires a signed current-key transition; this route is disabled until that authority path is wired".to_string(),
+    ))
 }
 
 /// List devices for an anchor

--- a/icn/crates/icn-gateway/src/api/sdis/mod.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/mod.rs
@@ -16,9 +16,9 @@
 //!
 //! ## Anchor Management
 //! - `GET /v1/sdis/anchor/{id}` - Get anchor details
-//! - `POST /v1/sdis/anchor/rotate-keys` - Rotate keys
+//! - `POST /v1/sdis/anchor/rotate-keys` - Disabled until signed current-key rotation is wired
 //! - `GET /v1/sdis/anchor/{id}/history` - Get rotation history
-//! - `POST /v1/sdis/anchor/devices/add` - Add device
+//! - `POST /v1/sdis/anchor/devices/add` - Disabled until signed current-key device enrollment is wired
 //! - `GET /v1/sdis/anchor/{id}/devices` - List devices
 //!
 //! ## Ephemeral Proofs

--- a/icn/crates/icn-gateway/tests/sdis_anchor_authority.rs
+++ b/icn/crates/icn-gateway/tests/sdis_anchor_authority.rs
@@ -1,0 +1,162 @@
+//! `/v1/sdis/anchor` identity-mutation authority enforcement (issue #2448).
+//!
+//! Anchor reads are intentionally public today. Public anchor values must not be
+//! reusable as authority to mutate that anchor's current DID or device list.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{test, web, App};
+use icn_gateway::api::sdis::anchor::{self, AnchorRecord, AnchorStore};
+use icn_gateway::api::sdis::enrollment::{AnchorDto, EnrollmentPathwayDto};
+
+const ANCHOR_ID: &str = "anchor_test_authority";
+
+fn current_did() -> String {
+    icn_identity::IdentityBundle::generate()
+        .expect("generate identity")
+        .did()
+        .to_string()
+}
+
+fn seeded_store(did: &str) -> Arc<AnchorStore> {
+    let store = Arc::new(AnchorStore::new());
+    let anchor = AnchorDto {
+        anchor_id: ANCHOR_ID.to_string(),
+        created_at: 1_702_425_600,
+        pathway: EnrollmentPathwayDto::Genesis {
+            reason: "test fixture".to_string(),
+        },
+    };
+    store
+        .store_anchor(
+            ANCHOR_ID.to_string(),
+            AnchorRecord::new(anchor, did.to_string()),
+        )
+        .expect("seed anchor");
+    store
+}
+
+#[actix_web::test]
+async fn public_anchor_data_cannot_be_replayed_to_rotate_keys() {
+    let did = current_did();
+    let store = seeded_store(&did);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(store.clone()))
+            .service(web::scope("/v1/sdis").configure(anchor::configure)),
+    )
+    .await;
+
+    let public_read = test::TestRequest::get()
+        .uri(&format!("/v1/sdis/anchor/{ANCHOR_ID}"))
+        .to_request();
+    let body: serde_json::Value = test::call_and_read_body_json(&app, public_read).await;
+    assert_eq!(body["current_did"], did);
+
+    let rotate = test::TestRequest::post()
+        .uri("/v1/sdis/anchor/rotate-keys")
+        .set_json(serde_json::json!({
+            "anchor_id": ANCHOR_ID,
+            "current_did": body["current_did"].as_str().unwrap(),
+            "new_keybundle": {
+                "ed25519_pub": "attacker-ed25519",
+                "ml_dsa_pub": "attacker-ml-dsa",
+                "x25519_pub": "attacker-x25519"
+            },
+            "reason": "replay public anchor data"
+        }))
+        .to_request();
+    let response = test::call_service(&app, rotate).await;
+
+    assert_eq!(
+        response.status().as_u16(),
+        403,
+        "publicly readable anchor fields must not authorize key rotation"
+    );
+    let record = store
+        .get_anchor(ANCHOR_ID)
+        .expect("read anchor")
+        .expect("anchor exists");
+    assert_eq!(record.current_did, did);
+    assert_eq!(record.rotation_count(), 0);
+}
+
+#[actix_web::test]
+async fn anonymous_device_addition_is_refused_and_state_is_unchanged() {
+    let did = current_did();
+    let store = seeded_store(&did);
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(store.clone()))
+            .service(web::scope("/v1/sdis").configure(anchor::configure)),
+    )
+    .await;
+
+    let add_device = test::TestRequest::post()
+        .uri("/v1/sdis/anchor/devices/add")
+        .set_json(serde_json::json!({
+            "anchor_id": ANCHOR_ID,
+            "device_name": "attacker device",
+            "device_pubkey": "attacker-device-pubkey"
+        }))
+        .to_request();
+    let response = test::call_service(&app, add_device).await;
+
+    assert_eq!(
+        response.status().as_u16(),
+        403,
+        "anonymous callers must not attach devices to an anchor"
+    );
+
+    let devices_read = test::TestRequest::get()
+        .uri(&format!("/v1/sdis/anchor/{ANCHOR_ID}/devices"))
+        .to_request();
+    let body: serde_json::Value = test::call_and_read_body_json(&app, devices_read).await;
+    assert_eq!(body["device_count"], 0);
+
+    let record = store
+        .get_anchor(ANCHOR_ID)
+        .expect("read anchor")
+        .expect("anchor exists");
+    assert!(record.devices.is_empty());
+}
+
+#[actix_web::test]
+async fn disabled_anchor_writes_fail_closed_without_store_dependency() {
+    let app =
+        test::init_service(App::new().service(web::scope("/v1/sdis").configure(anchor::configure)))
+            .await;
+
+    let rotate = test::TestRequest::post()
+        .uri("/v1/sdis/anchor/rotate-keys")
+        .set_json(serde_json::json!({
+            "anchor_id": ANCHOR_ID,
+            "current_did": current_did(),
+            "new_keybundle": {
+                "ed25519_pub": "new-ed25519",
+                "ml_dsa_pub": "new-ml-dsa",
+                "x25519_pub": "new-x25519"
+            },
+            "reason": null
+        }))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, rotate).await.status().as_u16(),
+        403
+    );
+
+    let add_device = test::TestRequest::post()
+        .uri("/v1/sdis/anchor/devices/add")
+        .set_json(serde_json::json!({
+            "anchor_id": ANCHOR_ID,
+            "device_name": "phone",
+            "device_pubkey": "device-pubkey"
+        }))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, add_device).await.status().as_u16(),
+        403
+    );
+}

--- a/icn/crates/icn-gateway/tests/sdis_anchor_authority.rs
+++ b/icn/crates/icn-gateway/tests/sdis_anchor_authority.rs
@@ -7,11 +7,39 @@
 
 use std::sync::Arc;
 
-use actix_web::{test, web, App};
+use actix_web::{
+    http::{header, StatusCode},
+    test, web, App,
+};
 use icn_gateway::api::sdis::anchor::{self, AnchorRecord, AnchorStore};
 use icn_gateway::api::sdis::enrollment::{AnchorDto, EnrollmentPathwayDto};
 
 const ANCHOR_ID: &str = "anchor_test_authority";
+const ROTATE_ROUTE: &str = "/v1/sdis/anchor/rotate-keys";
+const ADD_DEVICE_ROUTE: &str = "/v1/sdis/anchor/devices/add";
+
+#[derive(Clone, Copy)]
+enum BodyCase {
+    ValidJson,
+    MalformedJson,
+    EmptyJsonBody,
+    MissingContentType,
+    WrongContentType,
+    ArbitraryBytes,
+    PublicReplay,
+}
+
+impl BodyCase {
+    const ALL: [Self; 7] = [
+        Self::ValidJson,
+        Self::MalformedJson,
+        Self::EmptyJsonBody,
+        Self::MissingContentType,
+        Self::WrongContentType,
+        Self::ArbitraryBytes,
+        Self::PublicReplay,
+    ];
+}
 
 fn current_did() -> String {
     icn_identity::IdentityBundle::generate()
@@ -38,8 +66,115 @@ fn seeded_store(did: &str) -> Arc<AnchorStore> {
     store
 }
 
+fn assert_anchor_state_unchanged(store: &AnchorStore, expected_did: &str) {
+    let record = store
+        .get_anchor(ANCHOR_ID)
+        .expect("read anchor")
+        .expect("anchor exists");
+    assert_eq!(record.current_did, expected_did);
+    assert_eq!(record.rotation_count(), 0);
+    assert!(record.rotation_history.is_empty());
+    assert!(record.devices.is_empty());
+}
+
+fn valid_rotate_json(did: &str) -> serde_json::Value {
+    serde_json::json!({
+        "anchor_id": ANCHOR_ID,
+        "current_did": did,
+        "new_keybundle": {
+            "ed25519_pub": "attacker-ed25519",
+            "ml_dsa_pub": "attacker-ml-dsa",
+            "x25519_pub": "attacker-x25519"
+        },
+        "reason": "replay public anchor data"
+    })
+}
+
+fn valid_device_json() -> serde_json::Value {
+    serde_json::json!({
+        "anchor_id": ANCHOR_ID,
+        "device_name": "attacker device",
+        "device_pubkey": "attacker-device-pubkey"
+    })
+}
+
+fn rotation_request(case: BodyCase, did: &str) -> actix_http::Request {
+    let valid_body = valid_rotate_json(did).to_string();
+    match case {
+        BodyCase::ValidJson | BodyCase::PublicReplay => test::TestRequest::post()
+            .uri(ROTATE_ROUTE)
+            .set_json(valid_rotate_json(did))
+            .to_request(),
+        BodyCase::MalformedJson => test::TestRequest::post()
+            .uri(ROTATE_ROUTE)
+            .insert_header((header::CONTENT_TYPE, "application/json"))
+            .set_payload(r#"{"anchor_id":"anchor_test_authority","#)
+            .to_request(),
+        BodyCase::EmptyJsonBody => test::TestRequest::post()
+            .uri(ROTATE_ROUTE)
+            .insert_header((header::CONTENT_TYPE, "application/json"))
+            .to_request(),
+        BodyCase::MissingContentType => test::TestRequest::post()
+            .uri(ROTATE_ROUTE)
+            .set_payload(valid_body)
+            .to_request(),
+        BodyCase::WrongContentType => test::TestRequest::post()
+            .uri(ROTATE_ROUTE)
+            .insert_header((header::CONTENT_TYPE, "text/plain"))
+            .set_payload(valid_body)
+            .to_request(),
+        BodyCase::ArbitraryBytes => test::TestRequest::post()
+            .uri(ROTATE_ROUTE)
+            .insert_header((header::CONTENT_TYPE, "application/octet-stream"))
+            .set_payload("not-json\0\x01\x02")
+            .to_request(),
+    }
+}
+
+fn add_device_request(case: BodyCase, did: &str) -> actix_http::Request {
+    let valid_body = valid_device_json().to_string();
+    match case {
+        BodyCase::ValidJson => test::TestRequest::post()
+            .uri(ADD_DEVICE_ROUTE)
+            .set_json(valid_device_json())
+            .to_request(),
+        BodyCase::PublicReplay => test::TestRequest::post()
+            .uri(ADD_DEVICE_ROUTE)
+            .set_json(serde_json::json!({
+                "anchor_id": ANCHOR_ID,
+                "current_did": did,
+                "device_name": "attacker device",
+                "device_pubkey": "attacker-device-pubkey"
+            }))
+            .to_request(),
+        BodyCase::MalformedJson => test::TestRequest::post()
+            .uri(ADD_DEVICE_ROUTE)
+            .insert_header((header::CONTENT_TYPE, "application/json"))
+            .set_payload(r#"{"anchor_id":"anchor_test_authority","#)
+            .to_request(),
+        BodyCase::EmptyJsonBody => test::TestRequest::post()
+            .uri(ADD_DEVICE_ROUTE)
+            .insert_header((header::CONTENT_TYPE, "application/json"))
+            .to_request(),
+        BodyCase::MissingContentType => test::TestRequest::post()
+            .uri(ADD_DEVICE_ROUTE)
+            .set_payload(valid_body)
+            .to_request(),
+        BodyCase::WrongContentType => test::TestRequest::post()
+            .uri(ADD_DEVICE_ROUTE)
+            .insert_header((header::CONTENT_TYPE, "text/plain"))
+            .set_payload(valid_body)
+            .to_request(),
+        BodyCase::ArbitraryBytes => test::TestRequest::post()
+            .uri(ADD_DEVICE_ROUTE)
+            .insert_header((header::CONTENT_TYPE, "application/octet-stream"))
+            .set_payload("not-json\0\x01\x02")
+            .to_request(),
+    }
+}
+
 #[actix_web::test]
-async fn public_anchor_data_cannot_be_replayed_to_rotate_keys() {
+async fn disabled_anchor_writes_return_forbidden_without_body_parsing() {
     let did = current_did();
     let store = seeded_store(&did);
     let app = test::init_service(
@@ -52,75 +187,45 @@ async fn public_anchor_data_cannot_be_replayed_to_rotate_keys() {
     let public_read = test::TestRequest::get()
         .uri(&format!("/v1/sdis/anchor/{ANCHOR_ID}"))
         .to_request();
-    let body: serde_json::Value = test::call_and_read_body_json(&app, public_read).await;
+    let response = test::call_service(&app, public_read).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = test::read_body_json(response).await;
     assert_eq!(body["current_did"], did);
+    assert_eq!(body["rotation_count"], 0);
 
-    let rotate = test::TestRequest::post()
-        .uri("/v1/sdis/anchor/rotate-keys")
-        .set_json(serde_json::json!({
-            "anchor_id": ANCHOR_ID,
-            "current_did": body["current_did"].as_str().unwrap(),
-            "new_keybundle": {
-                "ed25519_pub": "attacker-ed25519",
-                "ml_dsa_pub": "attacker-ml-dsa",
-                "x25519_pub": "attacker-x25519"
-            },
-            "reason": "replay public anchor data"
-        }))
+    let history_read = test::TestRequest::get()
+        .uri(&format!("/v1/sdis/anchor/{ANCHOR_ID}/history"))
         .to_request();
-    let response = test::call_service(&app, rotate).await;
-
-    assert_eq!(
-        response.status().as_u16(),
-        403,
-        "publicly readable anchor fields must not authorize key rotation"
-    );
-    let record = store
-        .get_anchor(ANCHOR_ID)
-        .expect("read anchor")
-        .expect("anchor exists");
-    assert_eq!(record.current_did, did);
-    assert_eq!(record.rotation_count(), 0);
-}
-
-#[actix_web::test]
-async fn anonymous_device_addition_is_refused_and_state_is_unchanged() {
-    let did = current_did();
-    let store = seeded_store(&did);
-    let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(store.clone()))
-            .service(web::scope("/v1/sdis").configure(anchor::configure)),
-    )
-    .await;
-
-    let add_device = test::TestRequest::post()
-        .uri("/v1/sdis/anchor/devices/add")
-        .set_json(serde_json::json!({
-            "anchor_id": ANCHOR_ID,
-            "device_name": "attacker device",
-            "device_pubkey": "attacker-device-pubkey"
-        }))
-        .to_request();
-    let response = test::call_service(&app, add_device).await;
-
-    assert_eq!(
-        response.status().as_u16(),
-        403,
-        "anonymous callers must not attach devices to an anchor"
-    );
+    let response = test::call_service(&app, history_read).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = test::read_body_json(response).await;
+    assert_eq!(body["total_count"], 0);
 
     let devices_read = test::TestRequest::get()
         .uri(&format!("/v1/sdis/anchor/{ANCHOR_ID}/devices"))
         .to_request();
-    let body: serde_json::Value = test::call_and_read_body_json(&app, devices_read).await;
+    let response = test::call_service(&app, devices_read).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = test::read_body_json(response).await;
     assert_eq!(body["device_count"], 0);
 
-    let record = store
-        .get_anchor(ANCHOR_ID)
-        .expect("read anchor")
-        .expect("anchor exists");
-    assert!(record.devices.is_empty());
+    for case in BodyCase::ALL {
+        let response = test::call_service(&app, rotation_request(case, &did)).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "disabled key rotation must not parse or accept any request body"
+        );
+        assert_anchor_state_unchanged(&store, &did);
+
+        let response = test::call_service(&app, add_device_request(case, &did)).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "disabled device addition must not parse or accept any request body"
+        );
+        assert_anchor_state_unchanged(&store, &did);
+    }
 }
 
 #[actix_web::test]
@@ -129,34 +234,19 @@ async fn disabled_anchor_writes_fail_closed_without_store_dependency() {
         test::init_service(App::new().service(web::scope("/v1/sdis").configure(anchor::configure)))
             .await;
 
-    let rotate = test::TestRequest::post()
-        .uri("/v1/sdis/anchor/rotate-keys")
-        .set_json(serde_json::json!({
-            "anchor_id": ANCHOR_ID,
-            "current_did": current_did(),
-            "new_keybundle": {
-                "ed25519_pub": "new-ed25519",
-                "ml_dsa_pub": "new-ml-dsa",
-                "x25519_pub": "new-x25519"
-            },
-            "reason": null
-        }))
-        .to_request();
-    assert_eq!(
-        test::call_service(&app, rotate).await.status().as_u16(),
-        403
-    );
-
-    let add_device = test::TestRequest::post()
-        .uri("/v1/sdis/anchor/devices/add")
-        .set_json(serde_json::json!({
-            "anchor_id": ANCHOR_ID,
-            "device_name": "phone",
-            "device_pubkey": "device-pubkey"
-        }))
-        .to_request();
-    assert_eq!(
-        test::call_service(&app, add_device).await.status().as_u16(),
-        403
-    );
+    let did = current_did();
+    for case in BodyCase::ALL {
+        assert_eq!(
+            test::call_service(&app, rotation_request(case, &did))
+                .await
+                .status(),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            test::call_service(&app, add_device_request(case, &did))
+                .await
+                .status(),
+            StatusCode::FORBIDDEN
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Refs #2448.

This PR fails closed the two currently unauthenticated SDIS anchor identity-mutation routes:

- `POST /v1/sdis/anchor/rotate-keys`
- `POST /v1/sdis/anchor/devices/add`

Public anchor reads remain public. Publicly readable anchor IDs, current DIDs, and keybundle-shaped JSON no longer grant mutation authority over an identity root or device list.

## Security invariant

Anchor identity mutation must require proof from the current identity authority, bound to the exact anchor and replacement key or device material. A caller replaying public anchor data must not be able to rotate keys or attach trusted devices.

## Patch strategy

The gateway currently stores `AnchorRecord`/`AnchorDto` state, but does not retain the current `KeyBundlePublic` material needed to verify the canonical `icn_identity::keybundle::RotationRequest` path. Rather than invent an ad hoc signature scheme or treat public `current_did` equality as authority, this PR disables the HTTP mutation routes with 403 responses until signed current-key transition verification is wired.

The internal anchor store/model helpers remain intact; only the exposed HTTP mutation surface is closed.

## Tests

- `cargo test -p icn-gateway --features sled-storage --test sdis_anchor_authority`
- `cargo test -p icn-gateway --features sled-storage --test sdis_route_authority`
- `cargo test -p icn-gateway --features sled-storage --test sdis_anchor_authority --test sdis_route_authority`
- `cargo test -p icn-gateway --features sled-storage anchor::`
- `cargo clippy -p icn-gateway --features sled-storage --all-targets -- -D warnings`
- `cargo test -p icn-gateway --features sled-storage`
- `cargo fmt --all --check`
- `git diff --check`
- `python3 docs/scripts/route_inventory.py --check`
- `bash scripts/check-meaning-firewall.sh` (known transitional gateway trust-import warnings; exits 0)
- `python3 scripts/check-truth-spine.py` (pre-existing stale sprint-state warning; exits 0)
- `python3 .github/scripts/readiness_overclaim_linter.py --repo-root .`
- `python3 scripts/tests/test_public_docs_boundary.py`
- `bash scripts/check-preflight-consistency.sh` (pre-existing skill-copy/legacy-checkout/MCP-root warnings; exits 0)

## Non-goals

This PR does not implement the final signed current-key rotation/device-enrollment protocol, does not change SDIS recovery semantics, does not resolve #2447's generic EntityId enrollment decision, and does not add steward authority as a substitute for current-key control.

Do not merge this PR without fresh human authorization.