### PR TITLE
fix(gateway): authenticate SDIS recovery steward-approval; loopback-gate the dev sim

### DIFF
--- a/icn/crates/icn-gateway/src/api/sdis/mod.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/mod.rs
@@ -53,6 +53,9 @@ use crate::error::{GatewayError, Result};
 pub use ephemeral::{Channel, EphemeralBinding, EphemeralProof, VerifyResult};
 pub use qr::{decode_from_qr, encode_for_qr, QrEstimate};
 pub use verify::EphemeralVerifier;
+// Shared steward-authority check for SDIS institutional acts. Recovery reuses the
+// exact helper enrollment uses (one notion of steward authority, not a parallel one).
+pub(crate) use simple_enrollment::authorize_steward_act;
 
 // ============================================================================
 // Request/Response Models

--- a/icn/crates/icn-gateway/src/api/sdis/recovery.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/recovery.rs
@@ -11,7 +11,7 @@
 //! 4. Once threshold reached, new KeyBundle is authorized
 //! 5. Client receives new DID (same Anchor, new keys)
 
-use actix_web::{get, post, web, HttpResponse};
+use actix_web::{get, post, web, HttpRequest, HttpResponse};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
@@ -213,7 +213,7 @@ impl RecoveryCeremony {
 /// Start a new recovery ceremony
 ///
 /// POST /v1/sdis/recovery/start
-#[post("/start")]
+#[post("/recovery/start")]
 pub async fn start_recovery(
     store: web::Data<Arc<RecoveryStore>>,
     req: web::Json<StartRecoveryRequest>,
@@ -249,7 +249,7 @@ pub async fn start_recovery(
 /// Get recovery ceremony status
 ///
 /// GET /v1/sdis/recovery/{recovery_id}
-#[get("/{recovery_id}")]
+#[get("/recovery/{recovery_id}")]
 pub async fn get_recovery_status(
     store: web::Data<Arc<RecoveryStore>>,
     recovery_id: web::Path<String>,
@@ -272,7 +272,7 @@ pub async fn get_recovery_status(
 /// Complete recovery and receive new DID
 ///
 /// POST /v1/sdis/recovery/{recovery_id}/complete
-#[post("/{recovery_id}/complete")]
+#[post("/recovery/{recovery_id}/complete")]
 pub async fn complete_recovery(
     store: web::Data<Arc<RecoveryStore>>,
     recovery_id: web::Path<String>,
@@ -320,22 +320,42 @@ pub async fn complete_recovery(
     Ok(HttpResponse::Ok().json(response))
 }
 
-/// Simulate steward approval (for testing/development only)
+/// Record a steward approval on a recovery ceremony.
 ///
 /// POST /v1/sdis/recovery/{recovery_id}/approve
 ///
-/// **WARNING**: This endpoint should NOT be enabled in production.
-/// Set environment variable `ICN_ENABLE_ADMIN_ENDPOINTS=false` to disable.
-#[post("/{recovery_id}/approve")]
+/// A recovery approval is a steward institutional act: advancing it toward the
+/// approval threshold authorizes rotating an Anchor's keys (see the
+/// start -> approve -> complete chain). It is therefore mounted behind `jwt_auth`
+/// via [`configure_protected`] and requires steward authority — the approving
+/// steward is the VERIFIED credential subject, never a request-body field.
+///
+/// This endpoint SIMULATES a single steward approval (it advances the counter
+/// without the steward-network identity-proof ceremony), so it additionally stays
+/// an explicit, fail-closed dev/test escape hatch behind `ICN_ENABLE_ADMIN_ENDPOINTS`.
+/// It is NOT the production recovery-authority path: it has no cooperative binding
+/// (the ceremony carries no `coop_id`) and does not enforce distinct approvers.
+/// Production recovery authority is an owed institutional decision (see #2447 /
+/// ADR-0085), not established here.
+#[post("/recovery/{recovery_id}/approve")]
 pub async fn approve_recovery(
+    http_req: HttpRequest,
     store: web::Data<Arc<RecoveryStore>>,
     recovery_id: web::Path<String>,
 ) -> Result<HttpResponse> {
-    // Production guard: check environment variable
+    // Authority first: require verified steward authority (fail-closed if the
+    // `jwt_auth` middleware is ever dropped from this route). There is no body on
+    // this endpoint, so the actor is unambiguously the verified credential subject.
+    // Checked before the admin gate so the gate cannot be probed unauthenticated.
+    let steward_did = super::authorize_steward_act(&http_req, None)?;
+
+    // Defense in depth: this is a dev/test simulation of steward approval, so it
+    // stays fail-closed unless admin endpoints are explicitly enabled. Parsed the
+    // same way as the construction-time mount gate (`admin_endpoints_allowed` in
+    // server.rs) so the two never disagree on a padded/mixed-case value.
     let admin_enabled = std::env::var("ICN_ENABLE_ADMIN_ENDPOINTS")
-        .unwrap_or_else(|_| "false".to_string())
-        .to_lowercase()
-        == "true";
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
 
     if !admin_enabled {
         return Err(GatewayError::Forbidden(
@@ -352,6 +372,8 @@ pub async fn approve_recovery(
 
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "status": "approved",
+        // Attribution comes from the verified credential subject, not the body.
+        "approved_by": steward_did,
         "approvals": ceremony.steward_approvals,
         "required": ceremony.required_stewards
     })))
@@ -386,14 +408,27 @@ fn validate_recovery_request(req: &StartRecoveryRequest) -> Result<()> {
 // Configuration Function
 // ============================================================================
 
+/// Public recovery routes (holder-side flow). Non-institutional: ceremony intake,
+/// status read, and holder-side completion (which is gated by prior steward
+/// approval). Steward approval itself is NOT here — see [`configure_protected`].
+///
+/// Registered as FLAT full-path services (not a `web::scope("/recovery")`), the
+/// same shape as `simple_enrollment::configure`: a prefix scope here would
+/// greedily match `/recovery/{id}/approve` and shadow the sibling protected
+/// scope, 404-ing the authenticated route before its middleware ran.
 pub fn configure(cfg: &mut web::ServiceConfig) {
-    cfg.service(
-        web::scope("/recovery")
-            .service(start_recovery)
-            .service(get_recovery_status)
-            .service(complete_recovery)
-            .service(approve_recovery), // Guarded by ICN_ENABLE_ADMIN_ENDPOINTS env var
-    );
+    cfg.service(start_recovery)
+        .service(get_recovery_status)
+        .service(complete_recovery);
+}
+
+/// Institutional (steward) recovery routes. The caller mounts this INSIDE the
+/// `jwt_auth`-wrapped scope (see `server.rs`), so `approve_recovery` always runs
+/// with a verified credential and cannot be reached unauthenticated. Registered
+/// flat (full-path macro) for the same reason as [`configure`]; the path is
+/// identical to the pre-existing mount (`/v1/sdis/recovery/{id}/approve`).
+pub fn configure_protected(cfg: &mut web::ServiceConfig) {
+    cfg.service(approve_recovery);
 }
 
 #[cfg(test)]

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -1254,7 +1254,10 @@ const STEWARD_ACT_SCOPES: &[&str] = &[
 /// never determine the actor. Disagreement is refused rather than silently
 /// overridden, so a client that believes it is acting as someone else is told
 /// so instead of having its claim quietly rewritten.
-fn authorize_steward_act(http_req: &HttpRequest, body_did: Option<&str>) -> Result<String> {
+pub(crate) fn authorize_steward_act(
+    http_req: &HttpRequest,
+    body_did: Option<&str>,
+) -> Result<String> {
     crate::middleware::require_any_scope(http_req, STEWARD_ACT_SCOPES)?;
 
     let claims = crate::middleware::get_claims(http_req).ok_or_else(|| {

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -198,6 +198,19 @@ fn self_serve_coop_allowed(dev_opt_in: bool, bind_addr: &SocketAddr) -> bool {
     dev_opt_in && bind_addr.ip().is_loopback()
 }
 
+/// Decide whether the admin/dev SDIS endpoints (currently the recovery-approval
+/// simulation) may be mounted (issue #2075).
+///
+/// Same safe-by-construction rule as [`self_serve_coop_allowed`]: BOTH an explicit
+/// opt-in (`ICN_ENABLE_ADMIN_ENDPOINTS`) AND a loopback bind. The loopback
+/// condition is the invariant — a dev/test escape hatch can never be reached from
+/// a routable interface even if the opt-in is mistakenly set on an all-interfaces
+/// listener. Off-loopback the route is simply not registered. Kept as a free
+/// function so the invariant is unit-tested directly.
+fn admin_endpoints_allowed(opt_in: bool, bind_addr: &SocketAddr) -> bool {
+    opt_in && bind_addr.ip().is_loopback()
+}
+
 impl GatewayServer {
     /// Create a new gateway server (uses temporary storage for testing)
     pub fn new(bind_addr: SocketAddr, jwt_secret: Vec<u8>) -> Self {
@@ -756,6 +769,23 @@ impl GatewayServer {
             .unwrap_or(false);
         let dev_opt_in = self.dev_self_serve_auth || dev_mode_env;
         let allow_self_asserted_coop = self_serve_coop_allowed(dev_opt_in, &self.bind_addr);
+
+        // Admin/dev SDIS endpoints (recovery-approval simulation) require an
+        // explicit opt-in AND a loopback bind. Computed once here (bind-address
+        // based, not a per-request IP heuristic) and used to decide whether the
+        // protected recovery route is mounted at all (#2075).
+        let admin_opt_in = std::env::var("ICN_ENABLE_ADMIN_ENDPOINTS")
+            .map(|v| v.trim().eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let mount_admin_recovery = admin_endpoints_allowed(admin_opt_in, &self.bind_addr);
+        if admin_opt_in && !mount_admin_recovery {
+            warn!(
+                "ICN_ENABLE_ADMIN_ENDPOINTS is set but the gateway is bound to \
+                 non-loopback {} — the SDIS recovery-approval simulation stays \
+                 UNMOUNTED (fail-closed). Bind to loopback for local dev (#2075).",
+                self.bind_addr
+            );
+        }
         if allow_self_asserted_coop {
             warn!(
                 "⚠️  self-asserted cooperative authority is ENABLED at /auth/verify on loopback \
@@ -2173,11 +2203,23 @@ impl GatewayServer {
                                 // Steward/moderation surface: same `/sdis`
                                 // prefix, authenticated. Nested last so the
                                 // public routes above keep their unwrapped
-                                // behavior.
+                                // behavior. Recovery steward-approval joins the
+                                // enrollment steward acts behind `jwt_auth`.
                                 .service(
-                                    web::scope("").wrap(auth.clone()).configure(
-                                        api::sdis::simple_enrollment::configure_protected,
-                                    ),
+                                    web::scope("")
+                                        .wrap(auth.clone())
+                                        .configure(
+                                            api::sdis::simple_enrollment::configure_protected,
+                                        )
+                                        // Recovery steward-approval is a dev/test
+                                        // escape hatch: mounted only on an
+                                        // explicit opt-in AND loopback bind
+                                        // (#2075). Off-loopback it is absent.
+                                        .configure(move |cfg| {
+                                            if mount_admin_recovery {
+                                                api::sdis::recovery::configure_protected(cfg);
+                                            }
+                                        }),
                                 ),
                         )
                         // Protected coop endpoints (auth + rate limiting)
@@ -2633,6 +2675,29 @@ mod tests {
         // no dev opt-in => disabled regardless of bind
         assert!(!self_serve_coop_allowed(false, &loopback_v4));
         assert!(!self_serve_coop_allowed(false, &all_ifaces));
+    }
+
+    /// SECURITY (#2075): the admin/dev SDIS recovery-approval simulation may be
+    /// mounted only with BOTH an explicit opt-in AND a loopback bind — never on a
+    /// routable/all-interfaces listener, and never without the opt-in.
+    #[test]
+    fn admin_endpoints_require_optin_and_loopback() {
+        let loopback_v4: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        let loopback_v6: SocketAddr = "[::1]:8080".parse().unwrap();
+        let all_ifaces: SocketAddr = "0.0.0.0:8080".parse().unwrap();
+        let routable: SocketAddr = "10.0.0.5:8080".parse().unwrap();
+
+        // opt-in + loopback => mountable
+        assert!(admin_endpoints_allowed(true, &loopback_v4));
+        assert!(admin_endpoints_allowed(true, &loopback_v6));
+
+        // opt-in but NOT loopback => not mounted (the #2075 exposure guard)
+        assert!(!admin_endpoints_allowed(true, &all_ifaces));
+        assert!(!admin_endpoints_allowed(true, &routable));
+
+        // no opt-in => not mounted regardless of bind
+        assert!(!admin_endpoints_allowed(false, &loopback_v4));
+        assert!(!admin_endpoints_allowed(false, &all_ifaces));
     }
 
     #[tokio::test]

--- a/icn/crates/icn-gateway/tests/sdis_recovery_authority.rs
+++ b/icn/crates/icn-gateway/tests/sdis_recovery_authority.rs
@@ -1,0 +1,424 @@
+//! `/v1/sdis/recovery/{id}/approve` route-authority enforcement.
+//!
+//! # What these tests exercise
+//!
+//! Recovery steward-approval is a steward institutional act: advancing a recovery
+//! ceremony to its approval threshold authorizes rotating an Anchor's keys (the
+//! public `start` -> steward `approve` -> public `complete` chain). Historically
+//! `approve_recovery` was mounted as an **unwrapped** sibling under `/sdis`,
+//! authenticated nothing, and was reachable by any caller whenever
+//! `ICN_ENABLE_ADMIN_ENDPOINTS=true` — the same defect class PR #2446 fixed for
+//! enrollment vouch, omitted for recovery.
+//!
+//! These cases drive `approve_recovery` through the **real `jwt_auth` middleware**
+//! over the **same `SessionAuthority`** production registers, mounted the way
+//! `GatewayServer::run` mounts it: the public recovery surface unwrapped, the
+//! steward approval behind `jwt_auth` via `recovery::configure_protected`.
+//!
+//! # What they do NOT prove
+//!
+//! They do not construct the full production router (#2421), and — because the
+//! recovery ceremony carries no cooperative binding — they do not prove
+//! cooperative-scoped authorization (an owed institutional decision; see #2447 /
+//! ADR-0085). What they prove is that the approval is unreachable without a
+//! verified steward credential and stays fail-closed as a dev/test simulation.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use actix_web::{test, web, App};
+use actix_web_httpauth::middleware::HttpAuthentication;
+use icn_gateway::api::sdis::recovery::{self, RecoveryStore};
+use icn_gateway::auth::AuthManager;
+use icn_gateway::middleware::jwt_auth;
+use icn_gateway::session_authority::{
+    AuthorityProfile, InMemoryRevocationAuthority, SessionAuthority, TokenLifetimePolicy,
+};
+use icn_identity::Did;
+
+const SECRET: &[u8] = b"sdis-recovery-authority-test-secret-32b";
+
+/// The canonical steward capability, and the broad governance scope accepted
+/// alongside it during the #1868 decomposition (mirrors `STEWARD_ACT_SCOPES`).
+const STEWARD_SCOPE: &str = "governance:steward:write";
+const BROAD_GOVERNANCE_SCOPE: &str = "governance:write";
+
+/// Serializes mutation of the process-global `ICN_ENABLE_ADMIN_ENDPOINTS` the
+/// approval gate reads (same approach as `dev_standing_bootstrap_gate.rs`).
+static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Sets `ICN_ENABLE_ADMIN_ENDPOINTS` for the test's lifetime and restores the
+/// previous value on drop, under a shared lock so parallel tests don't race.
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    prior_admin: Option<String>,
+}
+
+impl EnvGuard {
+    fn acquire(admin: Option<&str>) -> Self {
+        let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prior_admin = std::env::var("ICN_ENABLE_ADMIN_ENDPOINTS").ok();
+        set_or_clear("ICN_ENABLE_ADMIN_ENDPOINTS", admin);
+        Self {
+            _lock: lock,
+            prior_admin,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        set_or_clear("ICN_ENABLE_ADMIN_ENDPOINTS", self.prior_admin.as_deref());
+    }
+}
+
+fn set_or_clear(key: &str, value: Option<&str>) {
+    match value {
+        Some(v) => std::env::set_var(key, v),
+        None => std::env::remove_var(key),
+    }
+}
+
+fn generated_did() -> Did {
+    icn_identity::IdentityBundle::generate()
+        .expect("generate test identity")
+        .did()
+        .clone()
+}
+
+fn scopes(list: &[&str]) -> Vec<String> {
+    list.iter().map(|s| s.to_string()).collect()
+}
+
+fn authority(ttl_hours: u64) -> Arc<SessionAuthority> {
+    let lifetime = TokenLifetimePolicy::from_hours(ttl_hours).unwrap();
+    let auth = Arc::new(AuthManager::new(SECRET.to_vec()).with_token_ttl(lifetime.ttl()));
+    Arc::new(
+        SessionAuthority::new(
+            auth,
+            Arc::new(InMemoryRevocationAuthority::new()),
+            lifetime,
+            AuthorityProfile::PortableEvaluator,
+        )
+        .expect("authority assembles"),
+    )
+}
+
+fn mint(authority: &SessionAuthority, did: &Did, scope_list: &[&str]) -> String {
+    authority
+        .auth_manager()
+        .issue_token(did, "test-coop", scopes(scope_list))
+        .expect("mint")
+}
+
+/// Mount `/sdis` recovery the way production does: the public recovery surface
+/// (start/status/complete) unwrapped, steward approval behind `jwt_auth`.
+macro_rules! recovery_app {
+    ($authority:expr) => {{
+        let auth_mw = HttpAuthentication::bearer(jwt_auth);
+        test::init_service(
+            App::new()
+                .app_data(web::Data::new($authority))
+                .app_data(web::Data::new(Arc::new(RecoveryStore::new())))
+                .service(
+                    web::scope("/v1/sdis")
+                        .configure(recovery::configure)
+                        .service(
+                            web::scope("")
+                                .wrap(auth_mw)
+                                .configure(recovery::configure_protected),
+                        ),
+                ),
+        )
+        .await
+    }};
+}
+
+/// Start a real recovery ceremony through the public route and return its id.
+async fn start_recovery_ceremony(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+) -> String {
+    let start = test::TestRequest::post()
+        .uri("/v1/sdis/recovery/start")
+        .set_json(serde_json::json!({
+            "anchor_id": "anchor-under-recovery",
+            "verification_data": { "type": "selfie" },
+            "new_keybundle": {
+                "ed25519_pub": "ed25519-new",
+                "ml_dsa_pub": "ml-dsa-new",
+                "x25519_pub": "x25519-new",
+            },
+        }))
+        .to_request();
+    let started: serde_json::Value = test::call_and_read_body_json(app, start).await;
+    started["recovery_id"]
+        .as_str()
+        .expect("recovery_id in start response")
+        .to_string()
+}
+
+async fn post_approve(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    recovery_id: &str,
+    token: Option<&str>,
+) -> u16 {
+    let mut req =
+        test::TestRequest::post().uri(&format!("/v1/sdis/recovery/{recovery_id}/approve"));
+    if let Some(t) = token {
+        req = req.insert_header(("Authorization", format!("Bearer {t}")));
+    }
+    test::call_service(app, req.to_request())
+        .await
+        .status()
+        .as_u16()
+}
+
+// ---------------------------------------------------------------------------
+// 1. Authentication: the approval surface refuses anonymous callers
+// ---------------------------------------------------------------------------
+
+/// The core defect: an anonymous POST could advance a steward-approval counter.
+/// It must be refused before the handler — and, crucially, refused EVEN WITH the
+/// admin flag enabled, proving the fix is authentication, not merely the env gate.
+#[actix_web::test]
+async fn anonymous_caller_cannot_approve_recovery_even_with_admin_enabled() {
+    let _env = EnvGuard::acquire(Some("true"));
+    let authority = authority(1);
+    let app = recovery_app!(authority.clone());
+
+    assert_eq!(
+        post_approve(&app, "any-recovery-id", None).await,
+        401,
+        "an unauthenticated caller must not be able to record a steward approval"
+    );
+}
+
+/// The recovery approval route inherits the shared authority's revocation: a
+/// credential withdrawn through `SessionAuthority` stops working on the next call.
+#[actix_web::test]
+async fn revoked_credential_is_refused_on_recovery_approval() {
+    let _env = EnvGuard::acquire(Some("true"));
+    let authority = authority(1);
+    let app = recovery_app!(authority.clone());
+    let did = generated_did();
+    let token = mint(&authority, &did, &[STEWARD_SCOPE]);
+
+    // Before revoking, the credential authenticates + authorizes + passes the
+    // admin gate, so only the missing ceremony refuses it (404). Pinning 404
+    // keeps the revocation assertion below from passing vacuously on a 500.
+    assert_eq!(
+        post_approve(&app, "no-such-ceremony", Some(&token)).await,
+        404,
+        "a live steward credential should reach the handler before revocation"
+    );
+
+    let claims = authority.auth_manager().verify_token(&token).unwrap();
+    authority.revoke(&claims).expect("revoke");
+
+    assert_eq!(
+        post_approve(&app, "no-such-ceremony", Some(&token)).await,
+        401,
+        "a revoked credential must not approve recovery"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Authorization: authentication alone is not steward authority
+// ---------------------------------------------------------------------------
+
+/// A valid member credential with no steward capability must be refused (403),
+/// even with admin endpoints enabled — authentication is not authorization.
+#[actix_web::test]
+async fn authenticated_member_without_steward_capability_is_refused() {
+    let _env = EnvGuard::acquire(Some("true"));
+    let authority = authority(1);
+    let app = recovery_app!(authority.clone());
+    let token = mint(
+        &authority,
+        &generated_did(),
+        &["coop:read", "governance:read"],
+    );
+
+    assert_eq!(
+        post_approve(&app, "any-recovery-id", Some(&token)).await,
+        403,
+        "any authenticated user is NOT a steward"
+    );
+}
+
+/// Both the narrow steward capability and the broad governance scope carry
+/// steward authority (mirrors the enrollment surface — one notion of steward
+/// authority, not a second divergent one).
+#[actix_web::test]
+async fn steward_capability_and_broad_governance_scope_are_both_accepted() {
+    let _env = EnvGuard::acquire(Some("true"));
+    let authority = authority(1);
+    let app = recovery_app!(authority.clone());
+
+    for scope in [STEWARD_SCOPE, BROAD_GOVERNANCE_SCOPE] {
+        let token = mint(&authority, &generated_did(), &[scope]);
+        // Nonexistent ceremony: 404 is the precise success signal — reaching the
+        // handler's own NotFound proves authentication, authorization, AND the
+        // admin gate all passed. "not 401/403" would also pass on a 500.
+        assert_eq!(
+            post_approve(&app, "no-such-ceremony", Some(&token)).await,
+            404,
+            "scope {scope} must authenticate and carry steward authority"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Dev/test simulation stays fail-closed
+// ---------------------------------------------------------------------------
+
+/// Even a genuine steward cannot use this dev/test simulation when admin
+/// endpoints are disabled: the endpoint is fail-closed by default. (Auth is
+/// checked first, so this 403 is the admin gate, reached only by a real steward.)
+#[actix_web::test]
+async fn steward_is_refused_when_admin_endpoints_disabled() {
+    let _env = EnvGuard::acquire(None); // admin flag unset -> disabled
+    let authority = authority(1);
+    let app = recovery_app!(authority.clone());
+    let token = mint(&authority, &generated_did(), &[STEWARD_SCOPE]);
+
+    assert_eq!(
+        post_approve(&app, "no-such-ceremony", Some(&token)).await,
+        403,
+        "the dev/test approval simulation must be fail-closed by default"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. The success path, and what it records
+// ---------------------------------------------------------------------------
+
+/// An authorized steward, with admin enabled, on a real ceremony started through
+/// the public route: the approval SUCCEEDS, the counter advances, and the
+/// recorded approver is the VERIFIED credential subject (there is no body field
+/// that could redirect attribution).
+#[actix_web::test]
+async fn authorized_steward_approval_succeeds_and_records_verified_subject() {
+    let _env = EnvGuard::acquire(Some("true"));
+    let authority = authority(1);
+    let app = recovery_app!(authority.clone());
+
+    let recovery_id = start_recovery_ceremony(&app).await;
+
+    let steward = generated_did();
+    let token = mint(&authority, &steward, &[STEWARD_SCOPE]);
+    let req = test::TestRequest::post()
+        .uri(&format!("/v1/sdis/recovery/{recovery_id}/approve"))
+        .insert_header(("Authorization", format!("Bearer {token}")))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "a steward with the capability must be able to approve when enabled"
+    );
+
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(
+        body["approved_by"].as_str().unwrap_or_default(),
+        steward.to_string(),
+        "the recorded approver must be the verified credential subject"
+    );
+    assert_eq!(
+        body["approvals"].as_u64().unwrap_or_default(),
+        1,
+        "the approval must advance the ceremony's steward counter"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Scope ordering: the public surface is preserved, approval is not exposed
+// ---------------------------------------------------------------------------
+
+/// The scope split must not break the holder-side flow: starting a recovery has
+/// no credential yet and must stay anonymous — while steward approval on the same
+/// `/recovery` prefix is unreachable without a credential (no unwrapped path).
+#[actix_web::test]
+async fn public_recovery_flow_preserved_and_approval_not_exposed() {
+    let _env = EnvGuard::acquire(Some("true"));
+    let authority = authority(1);
+    let app = recovery_app!(authority.clone());
+
+    // Public initiation stays anonymous AND working (pinned 200, not "not 401").
+    let start = test::TestRequest::post()
+        .uri("/v1/sdis/recovery/start")
+        .set_json(serde_json::json!({
+            "anchor_id": "anchor-x",
+            "verification_data": {},
+            "new_keybundle": {
+                "ed25519_pub": "e", "ml_dsa_pub": "m", "x25519_pub": "x"
+            },
+        }))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, start).await.status().as_u16(),
+        200,
+        "public recovery initiation must remain anonymous and working"
+    );
+
+    // Steward approval on the same prefix is NOT reachable through the public
+    // scope: refused with 401, not merely 404'd away.
+    assert_eq!(
+        post_approve(&app, "any-recovery-id", None).await,
+        401,
+        "steward approval must be refused without a credential"
+    );
+}
+
+/// The off-loopback / opt-out composition: when `recovery::configure_protected`
+/// is NOT mounted (the server's `mount_admin_recovery` gate is false — see
+/// `admin_endpoints_allowed` in server.rs, unit-tested there), the approve route
+/// is absent entirely and cannot reach `approve_by_steward`. This asserts the
+/// safe-by-construction claim end-to-end: the public routes still resolve, but
+/// approval returns 404 (no such route) rather than existing-but-forbidden.
+#[actix_web::test]
+async fn approve_route_absent_when_protected_config_not_mounted() {
+    let authority = authority(1);
+    // Public recovery routes only — mirrors the mounting when the loopback+opt-in
+    // gate is not satisfied, so `configure_protected` is never applied.
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(authority))
+            .app_data(web::Data::new(Arc::new(RecoveryStore::new())))
+            .service(web::scope("/v1/sdis").configure(recovery::configure)),
+    )
+    .await;
+
+    // A public route still resolves (200) — the composition is otherwise intact.
+    let start = test::TestRequest::post()
+        .uri("/v1/sdis/recovery/start")
+        .set_json(serde_json::json!({
+            "anchor_id": "anchor-y",
+            "verification_data": {},
+            "new_keybundle": { "ed25519_pub": "e", "ml_dsa_pub": "m", "x25519_pub": "x" },
+        }))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, start).await.status().as_u16(),
+        200,
+        "public recovery routes must still work when the admin route is unmounted"
+    );
+
+    // The approve route does not exist in this composition -> 404, never reaching
+    // the steward-approval handler. The route is absent regardless of credential,
+    // so no token is needed to demonstrate it.
+    assert_eq!(
+        post_approve(&app, "any-recovery-id", None).await,
+        404,
+        "an unmounted approve route must be absent (404), not reachable"
+    );
+}


### PR DESCRIPTION
## What

Bounded security containment for an **unauthenticated SDIS recovery steward-approval**
path. This is **not** a production recovery system — it authenticates and loopback-gates
an explicitly-enabled dev/test simulation. Draft; do not merge without human review.

## The vulnerability (origin/main `cb79ec5c`)

`POST /v1/sdis/recovery/{recovery_id}/approve` (`approve_recovery`) recorded a **steward
institutional act** — `ceremony.approve_by_steward()`, advancing an account key-recovery
ceremony toward its approval threshold — with **no authentication**. It was mounted as an
**unwrapped sibling** under `web::scope("/sdis")` (`server.rs`), gated only by the env var
`ICN_ENABLE_ADMIN_ENDPOINTS`. No JWT, no steward attribution, no cooperative binding, no
loopback restriction.

Full takeover chain, reachable whenever admin endpoints were enabled on a routable bind:

```
public start_recovery  (attacker picks anchor_id + attacker-controlled new_keybundle)
  -> approve_recovery x3   (UNAUTHENTICATED — the steward gate that authenticated nothing)
  -> public complete_recovery
  -> new DID issued for the target anchor
```

This is the same defect class **#2446** fixed for enrollment vouch (`configure_protected`
behind `jwt_auth`); recovery was omitted. Distinct from **#2448/#2449** (anchor
rotation/device-add) and **#2447** (vouch authority duality).

## The correction

1. **Authenticated protected mount.** `approve_recovery` moved out of the public
   `recovery::configure` into a new `recovery::configure_protected`, mounted inside the
   existing `web::scope("").wrap(auth.clone())` `jwt_auth` scope in `server.rs` — the same
   composition #2446 used for enrollment. It now requires steward authority via the
   **shared** `authorize_steward_act` helper (`governance:steward:write` OR
   `governance:write`) — one notion of steward authority, not a parallel one.
2. **Verified-subject attribution.** The approving steward is the verified credential
   subject (`claims.sub`); the response records `approved_by`. There is no request body on
   this endpoint, so nothing can forge the actor. Auth is checked **before** the admin
   flag, so the flag cannot be probed unauthenticated.
3. **Routing fix.** Recovery routes are now registered as flat full-path services (like
   `simple_enrollment::configure`) instead of a `web::scope("/recovery")`. A same-prefix
   sibling scope greedily shadows `/recovery/{id}/approve` and 404s the authenticated route
   before its middleware runs — caught by the regression tests. Paths are byte-identical.
4. **Loopback posture (#2075).** The dev/test approval simulation is mounted only when
   `admin_endpoints_allowed(opt_in, bind) = opt_in && bind.ip().is_loopback()` — a
   construction-time, bind-address-based gate (sibling of `self_serve_coop_allowed`), not a
   per-request IP heuristic. Off-loopback the route is **not registered** (safe-by-
   construction). The in-handler `ICN_ENABLE_ADMIN_ENDPOINTS` check is retained as
   defense-in-depth.

## Tests & results (local, `icn-gateway`, pinned toolchain)

- `cargo fmt --check` — pass (exit 0)
- `cargo clippy -p icn-gateway --all-targets --all-features -- -D warnings` — pass (exit 0)
- `cargo test -p icn-gateway --lib` — **713 passed / 0 failed** (incl. new
  `admin_endpoints_require_optin_and_loopback` unit test)
- `tests/sdis_recovery_authority.rs` — **8 passed / 0 failed**: anonymous→401 (even with
  admin enabled), revoked→401, authenticated non-steward→403, both steward scopes→404 on a
  missing ceremony, steward+admin-disabled→403, authorized steward→200 with `approved_by` =
  verified subject and counter advanced, public flow preserved + approval not exposed, and
  `approve_route_absent_when_protected_config_not_mounted` proving the protected approval
  route is absent (404, not mounted) off-loopback.
- `tests/sdis_route_authority.rs` (enrollment regression) — **16 passed / 0 failed** (the
  `authorize_steward_act` visibility change did not regress enrollment).
- No `Cargo.lock` / `rust-toolchain.toml` change. No forbidden domain imports.

## What this does NOT do (claims boundary)

**Unauthenticated recovery approval contained; production cooperative-bound recovery
authority remains an unresolved institutional design.**

- **No cooperative binding.** `RecoveryCeremony` carries no `coop_id`, so this cannot
  enforce that the approving steward governs the anchor's cooperative — a
  `governance:steward:write` holder of any cooperative could approve when the dev sim is
  enabled on loopback. This is the same unresolved question as **#2447 / ADR-0085**.
- **No distinct-approver enforcement.** `approve_by_steward()` only increments a counter;
  one authenticated steward can still approve repeatedly to reach the threshold. A
  production-authority limitation, not solved here.
- This endpoint remains an explicit **dev/test simulation** that bypasses the real
  steward-network identity-proof ceremony; it is not the production recovery-authority path.

Production recovery authority (cooperative binding + approver set + receipt) needs
**ADR-0085 or an equivalent institutionally-adopted recovery policy**. See the follow-up
notes for the DEAD `enrollment::approve_ceremony` sibling, the `complete_recovery`
recovery_id bearer-capability question, and loopback-hardening the shared admin-endpoint
class.

## Risk

Small, gateway-only, auth-hardening change. Worst case if the loopback mount gate is
misconfigured is that an *authenticated steward* can drive the dev simulation — the
unauthenticated bypass (the actual vulnerability) is closed by the auth check regardless of
mount. No production authority path is created or claimed.

## Independent verification

A fresh-context, read-only security verifier traced the route from registration to
state mutation against source. **Verdict: the patch closes the original
unauthenticated-approval vulnerability.** Findings:

- `approve_by_steward()` has exactly one non-test caller (`approve_recovery`), reachable
  only through the `jwt_auth`-wrapped, loopback+opt-in-gated route; `authorize_steward_act`
  runs before any env read or store access. No unwrapped alias anywhere in `icn/**`.
- The greedy-scope defect is genuinely fixed (flat services), not relocated; `POST
  /recovery/{id}/approve` cannot be captured by the public flat routes.
- Loopback gate is bind-address based (not per-request IP), env-only (not config-file
  settable); off-loopback the route is absent, not merely 403. `0.0.0.0` treated as
  non-loopback.
- Attribution is unforgeable (no body extractor; actor = verified `claims.sub`).
- No new same-scope defect. The coop-binding and distinct-approver items were confirmed
  as the intended boundary, not defects.

Two non-defect refinements the verifier raised were addressed in this branch: the
in-handler env parse was aligned to the mount gate's (`.trim().eq_ignore_ascii_case`),
and an integration test was added proving the unmounted (off-loopback) composition makes
the approve route absent (404), not reachable.

The verifier separately flagged, as **out of scope**, that `anchor::configure`
(`rotate-keys` / `devices/add`) is unauthenticated — this is the **#2448 / #2449**
surface (a distinct store, pre-existing on main, untouched here), not part of the
recovery-approval chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

