### PR TITLE
architecture: reconcile meaning-firewall taxonomy and enforcement (Tranche A1)

### DIFF
--- a/.claude/hooks/firewall-guard.sh
+++ b/.claude/hooks/firewall-guard.sh
@@ -2,6 +2,9 @@
 # Hook: PreToolUse guard for meaning firewall violations
 # Blocks Edit/Write to kernel crates if the content introduces domain imports
 #
+# Crate lists come from kernel-crates.conf, which is sync-checked against the
+# single-source taxonomy (scripts/firewall-taxonomy.toml) in CI.
+#
 # Receives JSON on stdin with tool_input containing file_path and content
 
 INPUT=$(cat)
@@ -12,15 +15,18 @@ if [[ -z "$FILE_PATH" ]]; then
   exit 0
 fi
 
-# Load kernel crate list from centralized config, with hardcoded fallback
+# Load kernel + domain crate lists from centralized config, with hardcoded fallback
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONF_FILE="${HOOK_DIR}/kernel-crates.conf"
-FALLBACK_KERNEL_CRATES="icn-net|icn-gateway|icn-gossip|icn-ledger|icn-core|icn-store|icn-kernel-api"
+FALLBACK_KERNEL_CRATES="icn-core|icn-net|icn-gossip|icn-store|icn-kernel-api"
+FALLBACK_DOMAIN_CRATES="icn-trust|icn-governance|icn-ledger|icn-ccl|icn-compute|icn-entity|icn-community|icn-federation|icn-steward|icn-coop|icn-commons|icn-zkp"
 if [[ -f "$CONF_FILE" ]]; then
   KERNEL_CRATES=$(sed -n '/^\[kernel\]/,/^\[/p' "$CONF_FILE" | grep -v '^\[' | grep -v '^#' | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
+  DOMAIN_CRATES=$(sed -n '/^\[domain\]/,/^\[/p' "$CONF_FILE" | grep -v '^\[' | grep -v '^#' | grep -v '^$' | tr '\n' '|' | sed 's/|$//')
 fi
-# Fallback if config absent or [kernel] section empty/malformed
+# Fallback if config absent or sections empty/malformed
 KERNEL_CRATES="${KERNEL_CRATES:-$FALLBACK_KERNEL_CRATES}"
+DOMAIN_CRATES="${DOMAIN_CRATES:-$FALLBACK_DOMAIN_CRATES}"
 
 # Check if file is in a kernel crate
 if ! echo "$FILE_PATH" | grep -qE "crates/(${KERNEL_CRATES})/"; then
@@ -32,8 +38,16 @@ if [[ "$FILE_PATH" != *.rs ]]; then
   exit 0
 fi
 
-# Exclude test files — integration tests legitimately use domain crates as dev-dependencies
-if echo "$FILE_PATH" | grep -qE '/tests/|#\[cfg\(test\)\]'; then
+# Exclude integration-test paths — they legitimately use domain crates as
+# dev-dependencies. (In-file #[cfg(test)] modules cannot be detected from the
+# path; the ratchet tests own that surface.)
+if echo "$FILE_PATH" | grep -qE '/tests/'; then
+  exit 0
+fi
+
+# Exclude the ratchet-test file itself — it necessarily contains forbidden
+# patterns as string literals (same exclusion its own counter applies).
+if [[ "$(basename "$FILE_PATH")" == "meaning_firewall.rs" ]]; then
   exit 0
 fi
 
@@ -44,24 +58,16 @@ if [[ -z "$NEW_CONTENT" ]]; then
   exit 0
 fi
 
-# Check for forbidden domain imports
+# Check for forbidden domain imports — one pattern per [domain] crate.
 VIOLATIONS=""
 
-if echo "$NEW_CONTENT" | grep -qE 'use icn_trust::'; then
-  VIOLATIONS="${VIOLATIONS}\n  - imports icn_trust (domain crate) in kernel code"
-fi
-
-if echo "$NEW_CONTENT" | grep -qE 'use icn_governance::'; then
-  VIOLATIONS="${VIOLATIONS}\n  - imports icn_governance (domain crate) in kernel code"
-fi
-
-if echo "$NEW_CONTENT" | grep -qE 'use icn_ccl::'; then
-  VIOLATIONS="${VIOLATIONS}\n  - imports icn_ccl (domain crate) in kernel code"
-fi
-
-if echo "$NEW_CONTENT" | grep -qE 'use icn_coop::'; then
-  VIOLATIONS="${VIOLATIONS}\n  - imports icn_coop (domain crate) in kernel code"
-fi
+IFS='|' read -ra DOMAIN_LIST <<< "$DOMAIN_CRATES"
+for crate in "${DOMAIN_LIST[@]}"; do
+  module="${crate//-/_}"
+  if echo "$NEW_CONTENT" | grep -qE "use ${module}::"; then
+    VIOLATIONS="${VIOLATIONS}\n  - imports ${module} (domain crate) in kernel code"
+  fi
+done
 
 if echo "$NEW_CONTENT" | grep -qE 'TrustClass|TrustGraph|GovernanceRole'; then
   VIOLATIONS="${VIOLATIONS}\n  - references domain types (TrustClass/TrustGraph/GovernanceRole) in kernel code"
@@ -70,6 +76,7 @@ fi
 if [[ -n "$VIOLATIONS" ]]; then
   echo "MEANING FIREWALL VIOLATION in ${FILE_PATH}:${VIOLATIONS}" >&2
   echo "Kernel crates must not reference domain types. Use ConstraintSet and PolicyOracle instead." >&2
+  echo "Crate classes: scripts/firewall-taxonomy.toml (single source of truth)." >&2
   exit 2
 fi
 

--- a/.claude/hooks/kernel-crates.conf
+++ b/.claude/hooks/kernel-crates.conf
@@ -1,17 +1,23 @@
 # ICN Kernel/Domain Crate Lists
 # Used by: firewall-guard.sh (blocking hook)
-# Single source of truth — update here when crates are added or removed.
+# SYNC-CHECKED against scripts/firewall-taxonomy.toml (the single source of
+# truth) by .github/scripts/test_firewall_taxonomy.py — edit the taxonomy
+# first; this file must mirror it exactly or CI fails.
 #
-# Verified against: cargo metadata --no-deps (2026-04-15)
-# Cross-checked with: .claude/rules/kernel-boundary.md
+# 2026-07-22 reconciliation:
+# - icn-ledger moved kernel→domain. Public evidence: both CI dependency gates
+#   already denylisted it; its trust/governance deps are dev-only (its own
+#   Cargo.toml); its public surface is settlement/credit/treasury semantics and
+#   all reverse-deps consume those economic symbols. See the taxonomy header.
+# - icn-gateway is class api-shell (not kernel): it hosts domain routes during
+#   the transition; its coupling is pinned in the taxonomy [shells] + ratchets.
+# - icn-store, icn-kernel-api retained; icn-commons/icn-zkp added to [domain].
 
 # Kernel crates — domain imports are forbidden in these crates
 [kernel]
 icn-core
 icn-net
-icn-gateway
 icn-gossip
-icn-ledger
 icn-store
 icn-kernel-api
 
@@ -19,6 +25,13 @@ icn-kernel-api
 [domain]
 icn-trust
 icn-governance
+icn-ledger
 icn-ccl
-icn-coop
+icn-compute
+icn-entity
 icn-community
+icn-federation
+icn-steward
+icn-coop
+icn-commons
+icn-zkp

--- a/.claude/rules/kernel-boundary.md
+++ b/.claude/rules/kernel-boundary.md
@@ -11,11 +11,16 @@ paths:
 
 # Kernel Crate Boundary Rules
 
-These crates are KERNEL crates. The meaning firewall applies strictly.
+Kernel crates are `icn-core`, `icn-net`, `icn-gossip`, `icn-store`,
+`icn-kernel-api` — the class of record is `scripts/firewall-taxonomy.toml`
+(single source of truth; sync-checked in CI). `icn-gateway`/`icn-rpc`/`icn-api`
+are API-SHELL class (pinned, shrink-only domain coupling); `icn-ledger` is
+DOMAIN class (2026-07-22 reclassification). The meaning firewall applies
+strictly to kernel crates.
 
 ## Forbidden
 
-- **NEVER** import domain crates: `icn-trust`, `icn-governance`, `icn-ccl`, `icn-coop`, `icn-community`
+- **NEVER** import domain crates (full list in the taxonomy): `icn-trust`, `icn-governance`, `icn-ledger`, `icn-ccl`, `icn-compute`, `icn-entity`, `icn-community`, `icn-federation`, `icn-steward`, `icn-coop`, `icn-commons`, `icn-zkp`
 - **NEVER** reference domain types: `TrustClass`, `TrustGraph`, `GovernanceRole`, `MembershipTier`
 - **NEVER** hardcode domain thresholds: `if score >= 0.7`, `if tier == "premium"`
 - **NEVER** reconstruct domain semantics from `ConstraintSet` fields
@@ -40,7 +45,15 @@ let value = decision.constraints()
 ## Quick Verification
 
 ```bash
-# Should produce NO output:
-grep -rn 'use icn_trust::' icn/crates/icn-{net,gateway,gossip,ledger,core}/src/
-grep -rn 'TrustClass\|TrustGraph' icn/crates/icn-{gossip,net,gateway,ledger,core}/src/
+# Honest, taxonomy-driven check (fails on violations):
+bash scripts/check-meaning-firewall.sh
+
+# Raw grep equivalent — should produce NO output (kernel class only;
+# meaning_firewall.rs is excluded because it holds pattern literals):
+grep -rn --exclude=meaning_firewall.rs 'use icn_trust::' icn/crates/icn-{net,gossip,store,kernel-api,core}/src/
 ```
+
+Note: the pre-2026-07-22 version of this block grepped icn-gateway and
+icn-ledger as kernel — icn-gateway has 3 real `use icn_trust::` imports
+(api-shell class, pinned in `strict_shell_import_violations`), so that
+"should produce NO output" claim was failing the whole time.

--- a/.github/scripts/firewall_denylist.py
+++ b/.github/scripts/firewall_denylist.py
@@ -2,68 +2,38 @@
 """
 Firewall Denylist Checker - CI Script
 
-Verifies that kernel crates do not depend on domain/app crates (directly or transitively).
-This enforces the Meaning Firewall contract described in docs/architecture/KERNEL_APP_SEPARATION.md.
+Verifies the Meaning Firewall contract described in
+docs/architecture/KERNEL_APP_SEPARATION.md, driven entirely by the
+single-source taxonomy at scripts/firewall-taxonomy.toml:
+
+  1. Kernel-class crates must not depend on domain/app crates (directly or
+     transitively). Existing violations are pinned as [[exception]] entries.
+  2. STALE-EXCEPTION DETECTION: an exception whose edge no longer exists FAILS
+     the check until the entry is removed. `kind = "direct"` entries must remain
+     direct production deps; `transitive-or-dev` entries must remain in the
+     metadata closure.
+  3. API-SHELL PINS: each shell's DIRECT domain/app dependencies must equal the
+     pinned set in [shells.*] — new domain coupling on shells fails CI.
 
 Usage:
     python3 .github/scripts/firewall_denylist.py
 
 Exit codes:
-    0: No violations detected (firewall is intact)
-    1: Violations detected (kernel imports forbidden domain crates)
-    2: Script error (e.g., cargo or JSON parsing failure)
+    0: contract holds (all violations pinned, no stale entries, shells match pins)
+    1: violations detected
+    2: script error (cargo/JSON/taxonomy failure)
 
-Tracking Issue: #1007 (Wave 1 Firewall Contract)
+Tracking Issue: #1007 (Wave 1 Firewall Contract); taxonomy introduced 2026-07-22.
 """
 
 import json
 import subprocess
 import sys
-from typing import Set, Dict, List
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
 
-# Kernel crates that MUST NOT depend on domain/app crates
-KERNEL_CRATES = [
-    "icn-core",
-    "icn-kernel-api",
-    "icn-net",
-    "icn-gossip",
-    "icn-store",
-]
-
-# Domain/app crates that kernel MUST NOT depend on
-DENYLISTED_CRATES = [
-    # Domain crates (internals)
-    "icn-trust",
-    "icn-governance",
-    "icn-ledger",
-    "icn-ccl",
-    "icn-compute",
-    "icn-entity",
-    "icn-community",
-    "icn-federation",
-    "icn-steward",
-    "icn-coop",
-    # App crates (anything under apps/)
-    # Note: These would be listed if they exist as separate crates
-]
-
-# Known violations that are being tracked for migration
-# These are allowed temporarily until the kernel/app separation is complete
-# Tracked in: docs/architecture/KERNEL_APP_SEPARATION.md
-KNOWN_VIOLATIONS = {
-    # icn-core currently depends on domain crates for app bootstrapping
-    # Migration tracked in Wave 2-6 of the kernel separation roadmap
-    ("icn-core", "icn-ccl"),
-    ("icn-core", "icn-community"),
-    ("icn-core", "icn-compute"),
-    ("icn-core", "icn-coop"),
-    ("icn-core", "icn-entity"),
-    ("icn-core", "icn-federation"),
-    ("icn-core", "icn-governance"),
-    ("icn-core", "icn-ledger"),
-    ("icn-core", "icn-steward"),
-    ("icn-core", "icn-trust"),
-}
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import firewall_taxonomy as taxonomy  # noqa: E402
 
 
 def get_cargo_metadata(manifest_path: str = "icn/Cargo.toml") -> Dict:
@@ -86,156 +56,256 @@ def get_cargo_metadata(manifest_path: str = "icn/Cargo.toml") -> Dict:
 
 
 def get_package_id(metadata: Dict, crate_name: str) -> str | None:
-    """Find the package ID for a crate by name."""
     for package in metadata["packages"]:
         if package["name"] == crate_name:
             return package["id"]
     return None
 
 
-def get_dependencies(metadata: Dict, package_id: str) -> Set[str]:
-    """
-    Get the transitive dependency closure for a package.
-    
-    Returns a set of package names (not IDs).
-    """
-    # Build dependency graph
-    dep_graph = {}
-    id_to_name = {}
-    
+def get_transitive_deps(metadata: Dict, package_id: str) -> Set[str]:
+    """Transitive dependency closure (all dep kinds) as package names."""
+    dep_graph: Dict[str, Set[str]] = {}
+    id_to_name: Dict[str, str] = {}
+
     for package in metadata["packages"]:
-        pkg_id = package["id"]
-        pkg_name = package["name"]
-        id_to_name[pkg_id] = pkg_name
-        
-        # Extract dependencies from resolve graph
-        dep_graph[pkg_id] = set()
-    
-    # Parse the resolve graph
+        id_to_name[package["id"]] = package["name"]
+        dep_graph[package["id"]] = set()
+
     if "resolve" in metadata and metadata["resolve"]:
         for node in metadata["resolve"]["nodes"]:
-            node_id = node["id"]
-            # Dependencies are listed as package IDs
-            deps = set(node.get("dependencies", []))
-            dep_graph[node_id] = deps
-    
-    # BFS to find transitive closure
-    visited = set()
+            dep_graph[node["id"]] = set(node.get("dependencies", []))
+
+    visited: Set[str] = set()
     queue = [package_id]
-    
     while queue:
         current = queue.pop(0)
         if current in visited:
             continue
         visited.add(current)
-        
-        if current in dep_graph:
-            for dep in dep_graph[current]:
-                if dep not in visited:
-                    queue.append(dep)
-    
-    # Convert IDs to names
-    dep_names = set()
-    for pkg_id in visited:
-        if pkg_id in id_to_name:
-            dep_names.add(id_to_name[pkg_id])
-    
-    return dep_names
+        for dep in dep_graph.get(current, ()):
+            if dep not in visited:
+                queue.append(dep)
+
+    return {id_to_name[p] for p in visited if p in id_to_name}
 
 
-def check_firewall(metadata: Dict) -> tuple[List[str], List[str]]:
+def get_direct_prod_deps(metadata: Dict, crate_name: str) -> Set[str]:
+    """Direct [dependencies] (+target deps) names for a workspace crate."""
+    for package in metadata["packages"]:
+        if package["name"] == crate_name:
+            return {
+                d["name"]
+                for d in package.get("dependencies", [])
+                if d.get("kind") in (None, "normal")
+            }
+    return set()
+
+
+def check_completeness(metadata: Dict, tax: Dict) -> List[str]:
+    """Every workspace member must be classified in exactly one taxonomy class.
+
+    Prevents a new crate from evading the firewall by staying unlisted, and
+    forces removal of taxonomy rows when a crate leaves the workspace.
     """
-    Check kernel crates for forbidden dependencies.
-    
-    Returns a tuple of (new_violations, known_violations).
-    - new_violations: violations that are NOT in KNOWN_VIOLATIONS (fails CI)
-    - known_violations: violations that ARE in KNOWN_VIOLATIONS (tracked, passes CI)
+    members = {p["name"] for p in metadata["packages"] if p["id"] in _workspace_ids(metadata)}
+    classified = taxonomy.all_classified(tax)
+    problems: List[str] = []
+    for missing in sorted(members - classified):
+        problems.append(
+            f"workspace member '{missing}' is UNCLASSIFIED — add it to a class in "
+            f"scripts/firewall-taxonomy.toml (new crates must be classified)"
+        )
+    for phantom in sorted(classified - members):
+        problems.append(
+            f"taxonomy lists '{phantom}' which is not a workspace member — remove it"
+        )
+    return problems
+
+
+def _workspace_ids(metadata: Dict) -> Set[str]:
+    return set(metadata.get("workspace_members", []))
+
+
+def check_tool_isolation(metadata: Dict, tax: Dict) -> List[str]:
+    """Tool-class crates must not be production deps of any restricted member."""
+    tools = taxonomy.tool_crates(tax)
+    unrestricted = taxonomy.unrestricted_crates(tax)
+    problems: List[str] = []
+    for package in metadata["packages"]:
+        name = package["name"]
+        if package["id"] not in _workspace_ids(metadata) or name in unrestricted:
+            continue
+        hits = get_direct_prod_deps(metadata, name) & tools
+        for hit in sorted(hits):
+            problems.append(
+                f"{name} -> {hit} (tool-class crate used as a PRODUCTION dependency; "
+                f"tools are test/dev support only — use a dev-dependency or reclassify)"
+            )
+    return problems
+
+
+def check_kernel(metadata: Dict, tax: Dict) -> Tuple[List[str], List[str], List[str]]:
+    """Returns (new_violations, known_violations, stale_exceptions).
+
+    Scans the ENFORCED classes (kernel + substrate) — the taxonomy's substrate
+    prohibition is real, not prose: all substrate crates were verified clean at
+    introduction (2026-07-22), so no substrate exceptions exist or are accepted
+    by the loader.
     """
-    new_violations = []
-    known_violations = []
-    
-    for kernel_crate in KERNEL_CRATES:
+    kernel = taxonomy.enforced_crates(tax)
+    denylist = set(taxonomy.denylisted_crates(tax))
+    known: Set[Tuple[str, str]] = taxonomy.exceptions(tax)
+    exception_kind = {
+        (e["from"], e["to"]): e["kind"] for e in taxonomy.exception_entries(tax)
+    }
+
+    new_violations: List[str] = []
+    known_violations: List[str] = []
+    observed_any: Set[Tuple[str, str]] = set()
+    observed_direct: Set[Tuple[str, str]] = set()
+
+    for kernel_crate in kernel:
         pkg_id = get_package_id(metadata, kernel_crate)
         if not pkg_id:
-            print(f"Warning: Kernel crate '{kernel_crate}' not found in workspace", file=sys.stderr)
+            print(f"Warning: kernel crate '{kernel_crate}' not found in workspace", file=sys.stderr)
             continue
-        
-        # Get transitive dependencies
-        deps = get_dependencies(metadata, pkg_id)
-        
-        # Check for denylisted dependencies
-        forbidden_deps = deps.intersection(DENYLISTED_CRATES)
-        
-        if forbidden_deps:
-            for forbidden in sorted(forbidden_deps):
-                violation = (kernel_crate, forbidden)
-                if violation in KNOWN_VIOLATIONS:
-                    known_violations.append(f"{kernel_crate} -> {forbidden}")
-                else:
-                    new_violations.append(f"{kernel_crate} -> {forbidden}")
-    
-    return new_violations, known_violations
+        for forbidden in sorted(get_direct_prod_deps(metadata, kernel_crate) & denylist):
+            observed_direct.add((kernel_crate, forbidden))
+        deps = get_transitive_deps(metadata, pkg_id)
+        for forbidden in sorted(deps.intersection(denylist)):
+            edge = (kernel_crate, forbidden)
+            observed_any.add(edge)
+            if edge in known:
+                known_violations.append(f"{kernel_crate} -> {forbidden}")
+            else:
+                new_violations.append(f"{kernel_crate} -> {forbidden}")
+
+    stale: List[str] = []
+    for edge in sorted(known):
+        kind = exception_kind[edge]
+        if kind == "direct":
+            if edge not in observed_direct:
+                stale.append(f"{edge[0]} -> {edge[1]} [direct edge absent]")
+        elif edge not in observed_any:
+            stale.append(f"{edge[0]} -> {edge[1]} [{kind} edge absent]")
+    return new_violations, known_violations, stale
 
 
-def main():
+def check_shells(metadata: Dict, tax: Dict) -> List[str]:
+    """Each api-shell's DIRECT domain/app deps must equal its pinned set."""
+    denylist = set(taxonomy.denylisted_crates(tax))
+    problems: List[str] = []
+    for shell, pins in taxonomy.shell_pins(tax).items():
+        actual = get_direct_prod_deps(metadata, shell) & denylist
+        pinned = pins["domain"] | pins["app"]
+        for extra in sorted(actual - pinned):
+            problems.append(
+                f"{shell} -> {extra} (NEW direct domain/app dep on an api-shell; "
+                f"add via review to [shells.{shell}] or remove the dep)"
+            )
+        for gone in sorted(pinned - actual):
+            problems.append(
+                f"{shell} -> {gone} (pinned but no longer a direct dep; "
+                f"update [shells.{shell}] — pins must track reality)"
+            )
+    return problems
+
+
+def main() -> int:
     print("=" * 70)
     print("Firewall Denylist Check - Enforcing Kernel/App Separation")
     print("=" * 70)
     print()
-    
-    # Get cargo metadata
+
+    try:
+        tax = taxonomy.load()
+    except taxonomy.TaxonomyError as e:
+        print(f"TAXONOMY ERROR: {e}", file=sys.stderr)
+        return 2
+
+    print(f"Taxonomy: scripts/firewall-taxonomy.toml v{tax['meta']['version']}")
+    print(f"Enforced crates (kernel+substrate): {', '.join(taxonomy.enforced_crates(tax))}")
+    print(f"Denylisted classes: domain + app ({len(taxonomy.denylisted_crates(tax))} crates)")
+    print()
+
     print("Running cargo metadata...")
     metadata = get_cargo_metadata()
     print(f"Found {len(metadata['packages'])} packages in workspace")
     print()
-    
-    # Check for violations
-    print("Checking kernel crates for forbidden dependencies...")
-    print(f"Kernel crates: {', '.join(KERNEL_CRATES)}")
-    print(f"Denylisted crates: {', '.join(DENYLISTED_CRATES)}")
-    print()
-    
-    new_violations, known_violations = check_firewall(metadata)
-    
-    # Report known violations (tracked, not blocking)
+
+    new_violations, known_violations, stale = check_kernel(metadata, tax)
+    shell_problems = check_shells(metadata, tax)
+    completeness_problems = check_completeness(metadata, tax)
+    tool_problems = check_tool_isolation(metadata, tax)
+
+    failed = False
+
     if known_violations:
-        print(f"📋 KNOWN VIOLATIONS ({len(known_violations)} tracked for migration):")
+        print(f"📋 KNOWN VIOLATIONS ({len(known_violations)} pinned for migration):")
+        for v in known_violations:
+            print(f"  • {v}")
         print()
-        for violation in known_violations:
-            print(f"  • {violation}")
+        print("Pinned in scripts/firewall-taxonomy.toml [[exception]]; removed as the")
+        print("kernel/app separation migration proceeds (Phases B–H).")
         print()
-        print("These violations are tracked in KNOWN_VIOLATIONS and will be fixed")
-        print("as part of the kernel/app separation migration (Waves 2-6).")
-        print("See docs/architecture/KERNEL_APP_SEPARATION.md for roadmap.")
-        print()
-    
-    # Report new violations (blocking)
+
     if new_violations:
+        failed = True
         print("❌ NEW FIREWALL VIOLATIONS DETECTED:")
+        for v in new_violations:
+            print(f"  • {v}")
         print()
-        for violation in new_violations:
-            print(f"  • {violation}")
+        print("These edges are NOT in the taxonomy exceptions. To fix:")
+        print("  1. Remove the dependency (preferred), or")
+        print("  2. If temporarily unavoidable, add a reviewed [[exception]] with")
+        print("     tracking + expiry to scripts/firewall-taxonomy.toml")
         print()
-        print("These are NEW dependencies that violate the Meaning Firewall contract.")
-        print("See docs/architecture/KERNEL_APP_SEPARATION.md for details.")
+
+    if stale:
+        failed = True
+        print("❌ STALE EXCEPTIONS (edge no longer exists — remove the entry):")
+        for v in stale:
+            print(f"  • {v}")
         print()
-        print("To fix:")
-        print("  1. Remove direct imports of domain crates from kernel code")
-        print("  2. Use PolicyOracle pattern to receive constraints from apps")
-        print("  3. See migration examples in the docs")
+        print("An exception may only describe a live edge. Delete these entries from")
+        print("scripts/firewall-taxonomy.toml so the contract only shrinks honestly.")
         print()
+
+    if shell_problems:
+        failed = True
+        print("❌ API-SHELL PIN MISMATCHES:")
+        for v in shell_problems:
+            print(f"  • {v}")
+        print()
+
+    if completeness_problems:
+        failed = True
+        print("❌ TAXONOMY COMPLETENESS FAILURES:")
+        for v in completeness_problems:
+            print(f"  • {v}")
+        print()
+
+    if tool_problems:
+        failed = True
+        print("❌ TOOL-CRATE ISOLATION FAILURES:")
+        for v in tool_problems:
+            print(f"  • {v}")
+        print()
+
+    if failed:
         return 1
-    
-    if known_violations:
-        print("✅ No NEW firewall violations detected!")
-        print()
-        print(f"Migration progress: {len(KNOWN_VIOLATIONS) - len(known_violations)}/{len(KNOWN_VIOLATIONS)} violations resolved")
-        return 0
-    else:
-        print("✅ No firewall violations detected!")
-        print()
-        print("All kernel crates maintain proper separation from domain/app crates.")
-        return 0
+
+    print("✅ Firewall dependency contract holds:")
+    print(f"  • no NEW unpinned kernel/substrate violations")
+    print(f"  • pinned firewall debt remains: {len(known_violations)} kernel exception edges (shrinking)")
+    print("  • no stale exceptions (direct entries verified against direct deps)")
+    print("  • api-shell direct domain/app deps match pins exactly")
+    print("  • every workspace member classified; tool crates isolated")
+    print()
+    print("NOTE: this proves the DEPENDENCY contract only — kernel-api semantic")
+    print("purity and reference-level coupling are owned by the Rust ratchets")
+    print("(icn-core meaning_firewall.rs); see the taxonomy header ownership map.")
+    return 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/firewall_denylist.py
+++ b/.github/scripts/firewall_denylist.py
@@ -151,6 +151,18 @@ def check_kernel(metadata: Dict, tax: Dict) -> Tuple[List[str], List[str], List[
     prohibition is real, not prose: all substrate crates were verified clean at
     introduction (2026-07-22), so no substrate exceptions exist or are accepted
     by the loader.
+
+    A declared direct normal dependency is architectural coupling REGARDLESS of
+    whether its feature is currently activated. `get_transitive_deps` walks
+    `metadata["resolve"]["nodes"]`, which is the ACTIVATED feature graph — an
+    optional (or target-specific, currently-inactive-target) normal dependency
+    on a denylisted crate can be declared in Cargo.toml and pass every gate
+    unnoticed if it never appears in the resolve graph for the current
+    feature/target selection. `observed_direct` (declared deps, independent of
+    activation) is therefore folded into violation reporting, not just stale-
+    exception detection — a single pass over `observed_any` (the union of
+    direct + resolved-transitive edges) drives both NEW/KNOWN classification
+    and guarantees each edge is reported exactly once.
     """
     kernel = taxonomy.enforced_crates(tax)
     denylist = set(taxonomy.denylisted_crates(tax))
@@ -159,8 +171,6 @@ def check_kernel(metadata: Dict, tax: Dict) -> Tuple[List[str], List[str], List[
         (e["from"], e["to"]): e["kind"] for e in taxonomy.exception_entries(tax)
     }
 
-    new_violations: List[str] = []
-    known_violations: List[str] = []
     observed_any: Set[Tuple[str, str]] = set()
     observed_direct: Set[Tuple[str, str]] = set()
 
@@ -169,16 +179,23 @@ def check_kernel(metadata: Dict, tax: Dict) -> Tuple[List[str], List[str], List[
         if not pkg_id:
             print(f"Warning: kernel crate '{kernel_crate}' not found in workspace", file=sys.stderr)
             continue
-        for forbidden in sorted(get_direct_prod_deps(metadata, kernel_crate) & denylist):
-            observed_direct.add((kernel_crate, forbidden))
-        deps = get_transitive_deps(metadata, pkg_id)
-        for forbidden in sorted(deps.intersection(denylist)):
-            edge = (kernel_crate, forbidden)
-            observed_any.add(edge)
-            if edge in known:
-                known_violations.append(f"{kernel_crate} -> {forbidden}")
-            else:
-                new_violations.append(f"{kernel_crate} -> {forbidden}")
+
+        direct_edges = {(kernel_crate, dep) for dep in get_direct_prod_deps(metadata, kernel_crate) & denylist}
+        observed_direct |= direct_edges
+
+        transitive_deps = get_transitive_deps(metadata, pkg_id)
+        transitive_edges = {(kernel_crate, dep) for dep in transitive_deps & denylist}
+
+        observed_any |= direct_edges | transitive_edges
+
+    new_violations: List[str] = []
+    known_violations: List[str] = []
+    for edge in sorted(observed_any):
+        label = f"{edge[0]} -> {edge[1]}"
+        if edge in known:
+            known_violations.append(label)
+        else:
+            new_violations.append(label)
 
     stale: List[str] = []
     for edge in sorted(known):

--- a/.github/scripts/firewall_taxonomy.py
+++ b/.github/scripts/firewall_taxonomy.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Loader for the meaning-firewall taxonomy.
+
+scripts/firewall-taxonomy.toml is the single AUTHORITATIVE DECLARATION of crate
+classes and boundary exceptions. Enforcement mechanisms either load it at
+runtime through this module (so they cannot drift) or hold mirrored copies that
+test_firewall_taxonomy.py drift-checks in CI. See the taxonomy file header for
+the exact ownership map.
+
+CLI:
+    python3 .github/scripts/firewall_taxonomy.py --bash
+        Emit bash array definitions (KERNEL_CRATES, FORBIDDEN, ALLOWED_EDGES)
+        for the ci.yml kernel-deps step.
+    python3 .github/scripts/firewall_taxonomy.py --summary
+        Human-readable dump.
+
+Env:
+    ICN_FIREWALL_TAXONOMY — override the taxonomy path (used by the
+    failure-path tests to run the real checkers against doctored fixtures;
+    never set in CI enforcement jobs).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+# Repo root = two levels up from this file (.github/scripts/ -> repo root)
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TAXONOMY_PATH = Path(
+    os.environ.get(
+        "ICN_FIREWALL_TAXONOMY", REPO_ROOT / "scripts" / "firewall-taxonomy.toml"
+    )
+)
+
+REQUIRED_CLASSES = (
+    "kernel",
+    "substrate",
+    "api-shell",
+    "domain",
+    "app",
+    "facade",
+    "tool",
+    "bin",
+)
+EXCEPTION_KINDS = ("direct", "transitive-or-dev")
+
+
+class TaxonomyError(RuntimeError):
+    pass
+
+
+def load(path: Path | None = None) -> dict:
+    """Load and validate the taxonomy. Returns the parsed dict."""
+    p = path or TAXONOMY_PATH
+    try:
+        with open(p, "rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError as e:
+        raise TaxonomyError(f"taxonomy file missing: {p}") from e
+    except tomllib.TOMLDecodeError as e:
+        raise TaxonomyError(f"taxonomy file unparseable: {p}: {e}") from e
+
+    classes = data.get("classes", {})
+    for cls in REQUIRED_CLASSES:
+        if cls not in classes or not isinstance(classes[cls], list):
+            raise TaxonomyError(f"taxonomy missing class list: [classes].{cls}")
+
+    # A crate must appear in exactly one class, and names must be shell-safe:
+    # the --bash emitter's output is eval'd by two consumers, so restrict the
+    # charset rather than trusting quoting alone.
+    name_re = re.compile(r"^[A-Za-z0-9_-]+$")
+    seen: dict[str, str] = {}
+    for cls in REQUIRED_CLASSES:
+        for crate in classes[cls]:
+            if not name_re.match(crate):
+                raise TaxonomyError(f"invalid crate name (shell-unsafe): {crate!r}")
+            if crate in seen:
+                raise TaxonomyError(
+                    f"crate '{crate}' classified twice: {seen[crate]} and {cls}"
+                )
+            seen[crate] = cls
+
+    denylisted = set(classes["domain"]) | set(classes["app"])
+    exception_edges: set[tuple[str, str]] = set()
+    for exc in data.get("exception", []):
+        for field in ("from", "to", "kind", "tracking", "expiry"):
+            if field not in exc:
+                raise TaxonomyError(f"exception entry missing '{field}': {exc}")
+        if exc["kind"] not in EXCEPTION_KINDS:
+            raise TaxonomyError(
+                f"unsupported exception kind '{exc['kind']}' "
+                f"(expected one of {', '.join(EXCEPTION_KINDS)}): {exc}"
+            )
+        if exc["expiry"] != "edge-absent":
+            raise TaxonomyError(
+                f"unsupported expiry '{exc['expiry']}' (only 'edge-absent'): {exc}"
+            )
+        if exc["from"] not in classes["kernel"]:
+            raise TaxonomyError(
+                f"exception 'from' must be a kernel crate (got {exc['from']})"
+            )
+        if exc["to"] not in denylisted:
+            raise TaxonomyError(
+                f"exception 'to' must be a domain/app crate (got {exc['to']})"
+            )
+        edge = (exc["from"], exc["to"])
+        if edge in exception_edges:
+            raise TaxonomyError(f"duplicate exception edge: {exc['from']} -> {exc['to']}")
+        exception_edges.add(edge)
+    return data
+
+
+def kernel_crates(data: dict) -> list[str]:
+    return list(data["classes"]["kernel"])
+
+
+def enforced_crates(data: dict) -> list[str]:
+    """Crates under the no-domain/app-deps prohibition: kernel + substrate."""
+    return list(data["classes"]["kernel"]) + list(data["classes"]["substrate"])
+
+
+def all_classified(data: dict) -> set[str]:
+    out: set[str] = set()
+    for cls in REQUIRED_CLASSES:
+        out |= set(data["classes"][cls])
+    return out
+
+
+def tool_crates(data: dict) -> set[str]:
+    return set(data["classes"]["tool"])
+
+
+def unrestricted_crates(data: dict) -> set[str]:
+    """Classes with no dependency restrictions (tool + bin)."""
+    return set(data["classes"]["tool"]) | set(data["classes"]["bin"])
+
+
+def denylisted_crates(data: dict) -> list[str]:
+    """Crates that kernel-class crates must not depend on: domain + app."""
+    return list(data["classes"]["domain"]) + list(data["classes"]["app"])
+
+
+def exceptions(data: dict) -> set[tuple[str, str]]:
+    return {(e["from"], e["to"]) for e in data.get("exception", [])}
+
+
+def exception_entries(data: dict) -> list[dict]:
+    return list(data.get("exception", []))
+
+
+def shell_pins(data: dict) -> dict[str, dict[str, set[str]]]:
+    out = {}
+    for shell, pins in data.get("shells", {}).items():
+        out[shell] = {
+            "domain": set(pins.get("domain", [])),
+            "app": set(pins.get("app", [])),
+        }
+    return out
+
+
+def emit_bash(data: dict) -> str:
+    """Bash lists for the ci.yml kernel-deps step (direct-edge scope).
+
+    Every element is double-quoted: edge entries contain `->`, which bash
+    would otherwise parse as a redirection.
+    """
+
+    def arr(items) -> str:
+        return " ".join(f'"{i}"' for i in items)
+
+    kernel = arr(kernel_crates(data))
+    forbidden = arr(denylisted_crates(data))
+    allowed = arr(f"{f}->{t}" for f, t in sorted(exceptions(data)))
+    return (
+        f"KERNEL_CRATES=({kernel})\n"
+        f"FORBIDDEN=({forbidden})\n"
+        f"ALLOWED_EDGES=({allowed})\n"
+    )
+
+
+def main() -> int:
+    data = load()
+    if "--bash" in sys.argv:
+        sys.stdout.write(emit_bash(data))
+        return 0
+    # --summary / default
+    print(f"taxonomy {data['meta']['version']} ({data['meta']['updated']})")
+    for cls in REQUIRED_CLASSES:
+        print(f"  {cls}: {', '.join(data['classes'][cls])}")
+    print(f"  exceptions: {len(data.get('exception', []))}")
+    for shell, pins in shell_pins(data).items():
+        print(f"  shell {shell}: {len(pins['domain'])} domain / {len(pins['app'])} app pins")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except TaxonomyError as e:
+        print(f"TAXONOMY ERROR: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/.github/scripts/test_firewall_taxonomy.py
+++ b/.github/scripts/test_firewall_taxonomy.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Self-test + cross-mechanism sync check for the meaning-firewall taxonomy.
+
+Run in CI (firewall-contract job) BEFORE firewall_denylist.py. Fails when any
+enforcement mechanism's embedded crate lists drift from
+scripts/firewall-taxonomy.toml (the single source of truth), or when the
+taxonomy itself is malformed.
+
+Checks:
+  1. Taxonomy loads and validates (loader invariants incl. one-class-per-crate).
+  2. Loader negative fixtures: duplicate classification, malformed exception
+     shape, and non-kernel exception 'from' are rejected.
+  3. .claude/hooks/kernel-crates.conf [kernel]/[domain] == taxonomy classes.
+  4. icn-core meaning_firewall.rs KERNEL_CRATES/DOMAIN_CRATES consts == taxonomy.
+  5. scripts/check-meaning-firewall.sh + .github/workflows/ci.yml kernel-deps
+     step actually source their lists from the taxonomy (marker check — they
+     load at runtime, so content cannot drift; absence of the marker means
+     someone reintroduced a hardcoded list).
+  6. scripts/forbidden-deps-allowlist.txt stays retired (no live edge entries;
+     exceptions live only in the taxonomy).
+
+Exit codes: 0 ok / 1 drift or malformed / 2 script error.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import firewall_taxonomy as taxonomy  # noqa: E402
+
+REPO = taxonomy.REPO_ROOT
+FAILURES: list[str] = []
+
+
+def fail(msg: str) -> None:
+    FAILURES.append(msg)
+
+
+def parse_conf_section(text: str, section: str) -> list[str]:
+    """Parse a [section] crate list from kernel-crates.conf."""
+    lines = []
+    in_section = False
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("["):
+            in_section = s == f"[{section}]"
+            continue
+        if in_section and s and not s.startswith("#"):
+            lines.append(s)
+    return lines
+
+
+def parse_rust_const(text: str, name: str) -> list[str]:
+    """Parse `const NAME: &[&str] = &[ ... ];` from meaning_firewall.rs."""
+    m = re.search(rf"const {name}: &\[&str\] = &\[(.*?)\];", text, re.S)
+    if not m:
+        return []
+    return re.findall(r'"([^"]+)"', m.group(1))
+
+
+def run_denylist(taxonomy_path: Path) -> tuple[int, str]:
+    """Run the REAL firewall_denylist.py against a doctored taxonomy fixture."""
+    import os
+    import subprocess
+
+    env = dict(os.environ)
+    env["ICN_FIREWALL_TAXONOMY"] = str(taxonomy_path)
+    p = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent / "firewall_denylist.py")],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=REPO,
+    )
+    return p.returncode, p.stdout + p.stderr
+
+
+def failure_path_tests() -> None:
+    """Prove the gates actually FAIL on real violations (not just pattern checks).
+
+    Uses doctored copies of the live taxonomy against the real cargo metadata,
+    plus an isolated fixture repo for the shell scanner. Leaves the repository
+    untouched.
+    """
+    import re as _re
+    import shutil
+    import stat
+    import subprocess
+    import tempfile
+
+    real = (REPO / "scripts" / "firewall-taxonomy.toml").read_text()
+
+    with tempfile.TemporaryDirectory() as td:
+        tdir = Path(td)
+
+        # F1: removing a live exception must surface it as a NEW violation.
+        doctored = _re.sub(
+            r"\n\[\[exception\]\][^\[]*?to = \"icn-ledger\"\n[^\[]*?expiry = \"edge-absent\"\n",
+            "\n",
+            real,
+            count=1,
+        )
+        assert doctored != real, "F1 fixture surgery failed to remove the entry"
+        f1 = tdir / "f1.toml"
+        f1.write_text(doctored)
+        rc, out = run_denylist(f1)
+        if rc != 1 or "NEW FIREWALL VIOLATIONS" not in out or "icn-core -> icn-ledger" not in out:
+            fail(f"F1 failure-path: removing the icn-ledger exception did not fail as a NEW violation (rc={rc})")
+
+        # F2: a transitive-only edge pinned as kind="direct" must be STALE
+        # (transitive/dev residue must not satisfy a direct exception).
+        doctored = real.replace(
+            'to = "icn-zkp"\nkind = "transitive-or-dev"',
+            'to = "icn-zkp"\nkind = "direct"',
+            1,
+        )
+        assert doctored != real, "F2 fixture surgery failed"
+        f2 = tdir / "f2.toml"
+        f2.write_text(doctored)
+        rc, out = run_denylist(f2)
+        if rc != 1 or "direct edge absent" not in out:
+            fail(f"F2 failure-path: direct-kind exception satisfied by transitive residue (rc={rc})")
+
+        # F3: an unpinned api-shell domain dep must fail the shell pins.
+        doctored = real.replace(', "icn-ledger"]\napp = []\n\n[shells.icn-api]', ']\napp = []\n\n[shells.icn-api]', 1)
+        assert doctored != real, "F3 fixture surgery failed"
+        f3 = tdir / "f3.toml"
+        f3.write_text(doctored)
+        rc, out = run_denylist(f3)
+        if rc != 1 or "NEW direct domain/app dep on an api-shell" not in out:
+            fail(f"F3 failure-path: unpinned shell domain dep did not fail (rc={rc})")
+
+        # F6: an UNCLASSIFIED workspace member must fail completeness.
+        doctored = real.replace('bin = ["icnd", "icnctl", "icn-console"]', 'bin = ["icnd", "icnctl"]', 1)
+        assert doctored != real, "F6 fixture surgery failed"
+        f6 = tdir / "f6.toml"
+        f6.write_text(doctored)
+        rc, out = run_denylist(f6)
+        if rc != 1 or "UNCLASSIFIED" not in out:
+            fail(f"F6 failure-path: unclassified member did not fail completeness (rc={rc})")
+
+        # F5: the shell scanner must fail on a real new import in an
+        # exception-free kernel crate — proven in an isolated fixture repo.
+        fx = tdir / "fixture-repo"
+        (fx / "scripts").mkdir(parents=True)
+        (fx / ".github" / "scripts").mkdir(parents=True)
+        (fx / "icn" / "crates" / "icn-net" / "src").mkdir(parents=True)
+        shutil.copy(REPO / ".github" / "scripts" / "firewall_taxonomy.py", fx / ".github" / "scripts")
+        script_dst = fx / "scripts" / "check-meaning-firewall.sh"
+        shutil.copy(REPO / "scripts" / "check-meaning-firewall.sh", script_dst)
+        script_dst.chmod(script_dst.stat().st_mode | stat.S_IEXEC)
+        (fx / "scripts" / "firewall-taxonomy.toml").write_text(
+            '[meta]\nversion="fixture"\nupdated="fixture"\nowner="t"\nadr="t"\n'
+            '[classes]\nkernel=["icn-net"]\nsubstrate=[]\napi-shell=[]\n'
+            'domain=["icn-trust"]\napp=[]\nfacade=[]\ntool=[]\nbin=[]\n'
+        )
+        clean_env = {k: v for k, v in __import__("os").environ.items() if k != "ICN_FIREWALL_TAXONOMY"}
+        (fx / "icn" / "crates" / "icn-net" / "src" / "lib.rs").write_text("pub fn ok() {}\n")
+        p = subprocess.run(["bash", str(script_dst)], capture_output=True, text=True, env=clean_env)
+        if p.returncode != 0:
+            fail(f"F5a failure-path: clean fixture repo should pass (rc={p.returncode}): {p.stdout}{p.stderr}")
+        (fx / "icn" / "crates" / "icn-net" / "src" / "lib.rs").write_text(
+            "use icn_trust::TrustGraph;\npub fn bad() {}\n"
+        )
+        p = subprocess.run(["bash", str(script_dst)], capture_output=True, text=True, env=clean_env)
+        if p.returncode != 1 or "NEW violation" not in p.stdout:
+            fail(f"F5b failure-path: violating fixture repo did not fail (rc={p.returncode}): {p.stdout}{p.stderr}")
+
+
+def main() -> int:
+    # 1. Load + validate
+    try:
+        tax = taxonomy.load()
+    except taxonomy.TaxonomyError as e:
+        print(f"FAIL: taxonomy invalid: {e}")
+        return 1
+
+    kernel = taxonomy.kernel_crates(tax)
+    domain = list(tax["classes"]["domain"])
+
+    # 2. Negative fixtures (loader must reject malformed taxonomies).
+    # Every fixture declares ALL required classes so it fails for its INTENDED
+    # reason, not for a missing class list.
+    import tempfile
+
+    BASE_CLASSES = 'api-shell=[]\napp=[]\nfacade=[]\ntool=[]\nbin=[]\n'
+    bad_dup = (
+        '[meta]\nversion="0"\nupdated="0"\nowner="t"\nadr="t"\n'
+        '[classes]\nkernel=["icn-core"]\nsubstrate=["icn-core"]\n'
+        'domain=[]\n' + BASE_CLASSES
+    )
+    bad_from = (
+        '[meta]\nversion="0"\nupdated="0"\nowner="t"\nadr="t"\n'
+        '[classes]\nkernel=["icn-core"]\nsubstrate=[]\n'
+        'domain=["icn-trust"]\n' + BASE_CLASSES +
+        '[[exception]]\nfrom="icn-trust"\nto="icn-core"\nkind="direct"\ntracking="t"\nexpiry="edge-absent"\n'
+    )
+    bad_kind = (
+        '[meta]\nversion="0"\nupdated="0"\nowner="t"\nadr="t"\n'
+        '[classes]\nkernel=["icn-core"]\nsubstrate=[]\n'
+        'domain=["icn-trust"]\n' + BASE_CLASSES +
+        '[[exception]]\nfrom="icn-core"\nto="icn-trust"\nkind="maybe"\ntracking="t"\nexpiry="edge-absent"\n'
+    )
+    bad_to = (
+        '[meta]\nversion="0"\nupdated="0"\nowner="t"\nadr="t"\n'
+        '[classes]\nkernel=["icn-core"]\nsubstrate=["icn-time"]\n'
+        'domain=["icn-trust"]\n' + BASE_CLASSES +
+        '[[exception]]\nfrom="icn-core"\nto="icn-time"\nkind="direct"\ntracking="t"\nexpiry="edge-absent"\n'
+    )
+    for label, content in (
+        ("duplicate-class", bad_dup),
+        ("non-kernel-from", bad_from),
+        ("bad-exception-kind", bad_kind),
+        ("non-denylisted-to", bad_to),
+    ):
+        with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as f:
+            f.write(content)
+            tmp = Path(f.name)
+        try:
+            taxonomy.load(tmp)
+            fail(f"negative fixture '{label}' was ACCEPTED (loader too permissive)")
+        except taxonomy.TaxonomyError:
+            pass
+        finally:
+            tmp.unlink()
+
+    # 3. Hook conf sync
+    conf_path = REPO / ".claude" / "hooks" / "kernel-crates.conf"
+    if conf_path.exists():
+        conf = conf_path.read_text()
+        conf_kernel = parse_conf_section(conf, "kernel")
+        conf_domain = parse_conf_section(conf, "domain")
+        if sorted(conf_kernel) != sorted(kernel):
+            fail(
+                f"kernel-crates.conf [kernel] drift: {sorted(conf_kernel)} != taxonomy {sorted(kernel)}"
+            )
+        if sorted(conf_domain) != sorted(domain):
+            fail(
+                f"kernel-crates.conf [domain] drift: {sorted(conf_domain)} != taxonomy {sorted(domain)}"
+            )
+    else:
+        fail("missing .claude/hooks/kernel-crates.conf")
+
+    # 4. Ratchet consts sync
+    mf_path = REPO / "icn" / "crates" / "icn-core" / "src" / "meaning_firewall.rs"
+    if mf_path.exists():
+        mf = mf_path.read_text()
+        rust_kernel = parse_rust_const(mf, "KERNEL_CRATES")
+        rust_domain = parse_rust_const(mf, "DOMAIN_CRATES")
+        if sorted(rust_kernel) != sorted(kernel):
+            fail(
+                f"meaning_firewall.rs KERNEL_CRATES drift: {sorted(rust_kernel)} != taxonomy {sorted(kernel)}"
+            )
+        if sorted(rust_domain) != sorted(domain):
+            fail(
+                f"meaning_firewall.rs DOMAIN_CRATES drift: {sorted(rust_domain)} != taxonomy {sorted(domain)}"
+            )
+        rust_shell = parse_rust_const(mf, "API_SHELL_CRATES")
+        rust_app = parse_rust_const(mf, "APP_CRATES")
+        if sorted(rust_shell) != sorted(tax["classes"]["api-shell"]):
+            fail(
+                f"meaning_firewall.rs API_SHELL_CRATES drift: {sorted(rust_shell)} != taxonomy {sorted(tax['classes']['api-shell'])}"
+            )
+        if sorted(rust_app) != sorted(tax["classes"]["app"]):
+            fail(
+                f"meaning_firewall.rs APP_CRATES drift: {sorted(rust_app)} != taxonomy {sorted(tax['classes']['app'])}"
+            )
+    else:
+        fail("missing icn/crates/icn-core/src/meaning_firewall.rs")
+
+    # 5. Runtime-loading markers
+    script = REPO / "scripts" / "check-meaning-firewall.sh"
+    if script.exists():
+        if "firewall_taxonomy.py" not in script.read_text():
+            fail("check-meaning-firewall.sh no longer loads the taxonomy (hardcoded list reintroduced?)")
+    else:
+        fail("missing scripts/check-meaning-firewall.sh")
+
+    ci = REPO / ".github" / "workflows" / "ci.yml"
+    if ci.exists():
+        ci_text = ci.read_text()
+        if "firewall_taxonomy.py --bash" not in ci_text:
+            fail("ci.yml kernel-deps step no longer sources lists from the taxonomy")
+    else:
+        fail("missing .github/workflows/ci.yml")
+
+    # 6. Retired allowlist stays retired
+    allow = REPO / "scripts" / "forbidden-deps-allowlist.txt"
+    if allow.exists():
+        live = [
+            l
+            for l in allow.read_text().splitlines()
+            if l.strip() and not l.strip().startswith("#")
+        ]
+        if live:
+            fail(
+                "forbidden-deps-allowlist.txt has live entries; it is RETIRED — "
+                "exceptions belong in scripts/firewall-taxonomy.toml: " + ", ".join(live)
+            )
+
+    # 7. Failure-path battery: the real checkers must go RED on real violations.
+    failure_path_tests()
+
+    if FAILURES:
+        print("❌ FIREWALL TAXONOMY SYNC FAILURES:")
+        for f_ in FAILURES:
+            print(f"  • {f_}")
+        print()
+        print("Fix by updating the drifted mechanism to match scripts/firewall-taxonomy.toml")
+        print("(or update the taxonomy via review if the change is intentional).")
+        return 1
+
+    print("✅ taxonomy valid; all mechanisms in sync (hook conf, ratchet consts,")
+    print("   script+CI runtime loading, allowlist retired); negative fixtures")
+    print("   rejected; failure-path battery green (new-edge / stale-direct /")
+    print("   shell-pin / shell-scan violations all provably fail).")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:  # noqa: BLE001
+        print(f"SCRIPT ERROR: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/.github/scripts/test_firewall_taxonomy.py
+++ b/.github/scripts/test_firewall_taxonomy.py
@@ -18,6 +18,15 @@ Checks:
      someone reintroduced a hardcoded list).
   6. scripts/forbidden-deps-allowlist.txt stays retired (no live edge entries;
      exceptions live only in the taxonomy).
+  7. Failure-path battery (F1/F2/F3/F5/F6): the real checkers actually go RED
+     on new/stale/unpinned/unclassified violations.
+  8. D1-D5: optional/direct-vs-resolved dependency semantics in
+     firewall_denylist.check_kernel — a declared direct normal dependency
+     (including optional and target-specific ones) is reported even when
+     inactive in the resolved feature graph; direct+resolved duplicates
+     collapse to one report; transitive-only edges are still detected but
+     never populate observed_direct; a direct exception over a since-removed
+     direct edge with lingering transitive residue is STALE.
 
 Exit codes: 0 ok / 1 drift or malformed / 2 script error.
 """
@@ -30,6 +39,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import firewall_taxonomy as taxonomy  # noqa: E402
+import firewall_denylist as denylist  # noqa: E402
 
 REPO = taxonomy.REPO_ROOT
 FAILURES: list[str] = []
@@ -76,6 +86,142 @@ def run_denylist(taxonomy_path: Path) -> tuple[int, str]:
         cwd=REPO,
     )
     return p.returncode, p.stdout + p.stderr
+
+
+def _synthetic_taxonomy(exceptions: list[dict] | None = None) -> dict:
+    """Minimal one-kernel-crate / one-domain-crate taxonomy for check_kernel unit tests."""
+    return {
+        "classes": {
+            "kernel": ["kernel-a"],
+            "substrate": [],
+            "api-shell": [],
+            "domain": ["domain-a"],
+            "app": [],
+            "facade": [],
+            "tool": [],
+            "bin": [],
+        },
+        "exception": list(exceptions) if exceptions else [],
+        "shells": {},
+    }
+
+
+def _direct_exception(kind: str = "direct") -> dict:
+    return {
+        "from": "kernel-a",
+        "to": "domain-a",
+        "kind": kind,
+        "tracking": "t",
+        "expiry": "edge-absent",
+    }
+
+
+def optional_direct_dependency_tests() -> None:
+    """D1-D5: prove check_kernel's optional/direct-vs-resolved semantics directly
+    against synthetic cargo-metadata fixtures (unit-level, no workspace mutation).
+
+    Root cause under test: `get_transitive_deps` walks the ACTIVATED resolve
+    graph; a declared-but-currently-inactive optional (or target-specific)
+    normal dependency on a denylisted crate is architectural coupling that must
+    still be reported — this is exactly what firewall_denylist.check_kernel's
+    `observed_direct | observed_any` union now guarantees.
+    """
+
+    # D1: unpinned optional direct dep, NOT in the resolve graph -> NEW violation.
+    metadata_d1 = {
+        "packages": [
+            {
+                "id": "kernel-a 0.1.0",
+                "name": "kernel-a",
+                "dependencies": [
+                    {"name": "domain-a", "kind": None, "optional": True, "target": None}
+                ],
+            },
+            {"id": "domain-a 0.1.0", "name": "domain-a", "dependencies": []},
+        ],
+        "workspace_members": ["kernel-a 0.1.0", "domain-a 0.1.0"],
+        "resolve": {
+            "nodes": [
+                {"id": "kernel-a 0.1.0", "dependencies": []},  # optional dep INACTIVE
+                {"id": "domain-a 0.1.0", "dependencies": []},
+            ]
+        },
+    }
+    new_v, known_v, stale = denylist.check_kernel(metadata_d1, _synthetic_taxonomy())
+    if new_v != ["kernel-a -> domain-a"] or known_v or stale:
+        fail(f"D1: unpinned optional direct dep not reported as NEW (new={new_v} known={known_v} stale={stale})")
+
+    # D2: SAME metadata, but now pinned with a direct-kind exception ->
+    # KNOWN (not new), not stale, not duplicated.
+    tax_d2 = _synthetic_taxonomy([_direct_exception()])
+    new_v, known_v, stale = denylist.check_kernel(metadata_d1, tax_d2)
+    if new_v or known_v != ["kernel-a -> domain-a"] or stale:
+        fail(f"D2: pinned optional direct dep mishandled (new={new_v} known={known_v} stale={stale})")
+
+    # D3: direct dep ALSO present in the resolved closure (the common real-world
+    # case, e.g. icn-core -> icn-ledger) -> exactly one report, no duplicate.
+    metadata_d3 = {
+        "packages": [
+            {
+                "id": "kernel-a 0.1.0",
+                "name": "kernel-a",
+                "dependencies": [
+                    {"name": "domain-a", "kind": None, "optional": False, "target": None}
+                ],
+            },
+            {"id": "domain-a 0.1.0", "name": "domain-a", "dependencies": []},
+        ],
+        "workspace_members": ["kernel-a 0.1.0", "domain-a 0.1.0"],
+        "resolve": {
+            "nodes": [
+                {"id": "kernel-a 0.1.0", "dependencies": ["domain-a 0.1.0"]},  # activated
+                {"id": "domain-a 0.1.0", "dependencies": []},
+            ]
+        },
+    }
+    new_v, known_v, stale = denylist.check_kernel(metadata_d3, _synthetic_taxonomy())
+    total_reports = new_v.count("kernel-a -> domain-a") + known_v.count("kernel-a -> domain-a")
+    if total_reports != 1:
+        fail(f"D3: direct+resolved duplicate edge reported {total_reports} times, expected exactly 1 (new={new_v} known={known_v})")
+
+    # D4: domain-a reachable ONLY transitively (via mid-b), never a direct dep
+    # of kernel-a -> still detected via the resolved closure, and confirmed
+    # absent from observed_direct (white-box: get_direct_prod_deps directly).
+    metadata_d4 = {
+        "packages": [
+            {"id": "kernel-a 0.1.0", "name": "kernel-a", "dependencies": [
+                {"name": "mid-b", "kind": None, "optional": False, "target": None}
+            ]},
+            {"id": "mid-b 0.1.0", "name": "mid-b", "dependencies": [
+                {"name": "domain-a", "kind": None, "optional": False, "target": None}
+            ]},
+            {"id": "domain-a 0.1.0", "name": "domain-a", "dependencies": []},
+        ],
+        "workspace_members": ["kernel-a 0.1.0", "mid-b 0.1.0", "domain-a 0.1.0"],
+        "resolve": {
+            "nodes": [
+                {"id": "kernel-a 0.1.0", "dependencies": ["mid-b 0.1.0"]},
+                {"id": "mid-b 0.1.0", "dependencies": ["domain-a 0.1.0"]},
+                {"id": "domain-a 0.1.0", "dependencies": []},
+            ]
+        },
+    }
+    new_v, known_v, stale = denylist.check_kernel(metadata_d4, _synthetic_taxonomy())
+    if new_v != ["kernel-a -> domain-a"]:
+        fail(f"D4: transitive-only edge not detected via resolved closure (new={new_v})")
+    direct_only = denylist.get_direct_prod_deps(metadata_d4, "kernel-a")
+    if "domain-a" in direct_only:
+        fail(f"D4: transitive-only edge incorrectly present in direct deps: {direct_only}")
+
+    # D5: the Codex correction, preserved — a direct-kind exception whose direct
+    # edge was REMOVED (kernel-a no longer declares domain-a directly) but a
+    # transitive path lingers (via mid-b) -> STALE (transitive residue must not
+    # satisfy a "direct" exception), even though the edge is still `known`
+    # (detected) via the resolved closure.
+    tax_d5 = _synthetic_taxonomy([_direct_exception()])
+    new_v, known_v, stale = denylist.check_kernel(metadata_d4, tax_d5)
+    if known_v != ["kernel-a -> domain-a"] or stale != ["kernel-a -> domain-a [direct edge absent]"]:
+        fail(f"D5: direct exception over a now-transitive-only edge not marked stale (known={known_v} stale={stale})")
 
 
 def failure_path_tests() -> None:
@@ -223,7 +369,9 @@ def main() -> int:
             taxonomy.load(tmp)
             fail(f"negative fixture '{label}' was ACCEPTED (loader too permissive)")
         except taxonomy.TaxonomyError:
-            pass
+            # Expected: each negative fixture must be rejected by the loader.
+            # No further action needed — reaching this branch IS the pass case.
+            continue
         finally:
             tmp.unlink()
 
@@ -304,6 +452,11 @@ def main() -> int:
     # 7. Failure-path battery: the real checkers must go RED on real violations.
     failure_path_tests()
 
+    # 8. D1-D5: optional/direct-vs-resolved dependency semantics (unit-level,
+    # synthetic metadata — the review-follow-up regression for the
+    # optional-direct-dependency reporting gap).
+    optional_direct_dependency_tests()
+
     if FAILURES:
         print("❌ FIREWALL TAXONOMY SYNC FAILURES:")
         for f_ in FAILURES:
@@ -316,7 +469,8 @@ def main() -> int:
     print("✅ taxonomy valid; all mechanisms in sync (hook conf, ratchet consts,")
     print("   script+CI runtime loading, allowlist retired); negative fixtures")
     print("   rejected; failure-path battery green (new-edge / stale-direct /")
-    print("   shell-pin / shell-scan violations all provably fail).")
+    print("   shell-pin / shell-scan violations all provably fail); D1-D5")
+    print("   optional/direct-vs-resolved dependency semantics verified.")
     return 0
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ env:
   GATE_RATCHET_PHASE_COMPLIANCE: blocking
   GATE_RATCHET_PHASE_READINESS: warning
   # Scope controls for staged boundary enforcement
-  GATE_RATCHET_KERNEL_DEPS_SCOPE: core-only
+  # all-kernel = the full taxonomy kernel class (scripts/firewall-taxonomy.toml).
+  # Advanced from core-only 2026-07-22: net/gossip/store/kernel-api verified clean
+  # (firewall_denylist.py transitive check passes with zero exceptions for them).
+  GATE_RATCHET_KERNEL_DEPS_SCOPE: all-kernel
 
 permissions:
   contents: read
@@ -182,36 +185,41 @@ jobs:
       - name: Check kernel crates for forbidden deps (bash version)
         run: |
           set -euo pipefail
+          # Lists come from the single-source taxonomy (scripts/firewall-taxonomy.toml)
+          # via the loader — defines KERNEL_CRATES, FORBIDDEN, ALLOWED_EDGES.
+          # FAIL-CLOSED: capture via bare assignment first — `eval "$(cmd)"` would
+          # swallow a loader failure (empty eval is a no-op → step passes with
+          # ZERO crates checked). Bare assignment propagates the exit code under set -e.
+          TAXONOMY_LISTS="$(python3 ../.github/scripts/firewall_taxonomy.py --bash)"
+          eval "$TAXONOMY_LISTS"
+          if [ "${#KERNEL_CRATES[@]}" -eq 0 ] || [ "${#FORBIDDEN[@]}" -eq 0 ]; then
+            echo "::error title=Taxonomy load produced empty lists::refusing to pass with nothing checked"
+            exit 1
+          fi
           SCOPE="${GATE_RATCHET_KERNEL_DEPS_SCOPE}"
           case "$SCOPE" in
             core-only)
               KERNEL_CRATES=("icn-core")
               ;;
             all-kernel)
-              KERNEL_CRATES=("icn-core" "icn-net" "icn-gossip")
+              : # full taxonomy kernel class, as loaded
               ;;
             *)
               echo "Unknown GATE_RATCHET_KERNEL_DEPS_SCOPE: $SCOPE"
               exit 1
               ;;
           esac
-          FORBIDDEN=("icn-trust" "icn-governance" "icn-ledger" "icn-ccl" "icn-compute" "icn-entity" "icn-community" "icn-federation" "icn-steward")
           PHASE="${GATE_RATCHET_PHASE_KERNEL_DEPS}"
-          ALLOWLIST_FILE="../scripts/forbidden-deps-allowlist.txt"
           violations=()
           echo "Ratchet phase: $PHASE"
           echo "Kernel dependency check scope: $SCOPE (${KERNEL_CRATES[*]})"
-          echo "Accepted scopes: core-only | all-kernel"
-          echo "Rollout: Wave 2 (core-only) enforcement active when scope=core-only and phase=blocking"
-          if [ -f "$ALLOWLIST_FILE" ]; then
-            # Read allowlist, filtering out comments and empty lines
-            mapfile -t ALLOWLIST < <(grep -v '^\s*#' "$ALLOWLIST_FILE" | grep -v '^\s*$')
-          else
-            ALLOWLIST=()
-          fi
+          echo "Accepted scopes: core-only | all-kernel (lists from scripts/firewall-taxonomy.toml)"
+          ALLOWLIST=("${ALLOWED_EDGES[@]}")
           for crate in "${KERNEL_CRATES[@]}"; do
             for dep in "${FORBIDDEN[@]}"; do
-              if cargo tree -p "$crate" --edges normal | grep -q "\\b${dep}\\b"; then
+              # Anchor on the version column: `\b${dep}\b` alone false-matches
+              # icn-ledger inside icn-ledger-app (hyphen is a \b boundary).
+              if cargo tree -p "$crate" --edges normal | grep -qE "\\b${dep} v[0-9]"; then
                 entry="${crate}->${dep}"
                 if printf '%s\n' "${ALLOWLIST[@]}" | grep -qx "$entry"; then
                   echo "Allowed dependency (allowlist): ${entry}"
@@ -237,7 +245,7 @@ jobs:
             echo "Remediation order:"
             echo "  1) Remove the dependency from icn-core (preferred)"
             echo "  2) Move the dependency behind a kernel API/service boundary"
-            echo "  3) If this edge is temporarily unavoidable, add a scoped entry to: $ALLOWLIST_FILE"
+            echo "  3) If this edge is temporarily unavoidable, add a reviewed [[exception]] to scripts/firewall-taxonomy.toml"
             echo
             echo "Reference: docs/ci/GATE_RATCHET_PLAN.md"
             echo
@@ -260,6 +268,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Taxonomy self-test + cross-mechanism sync check
+        run: python3 .github/scripts/test_firewall_taxonomy.py
 
       - name: Run firewall denylist check
         run: |

--- a/docs/architecture/KERNEL_APP_SEPARATION.md
+++ b/docs/architecture/KERNEL_APP_SEPARATION.md
@@ -33,6 +33,16 @@ These invariants are mechanically enforced to ensure the kernel remains semantic
 
 **Rationale**: Direct imports create compile-time coupling. If kernel code can import `TrustGraph`, it can call domain-specific methods, violating the meaning firewall.
 
+**Crate classes of record**: `scripts/firewall-taxonomy.toml` is the single source of
+truth for kernel/substrate/api-shell/domain/app/facade classification and for the
+pinned boundary exceptions (each with a machine-checked edge-absent expiry). All
+enforcement mechanisms load it or are sync-checked against it
+(`.github/scripts/test_firewall_taxonomy.py`). Where older prose in this document
+disagrees with the taxonomy, the taxonomy wins — e.g. the §2.1 diagram below
+historically listed `icn-obs` in the kernel column; `icn-obs` is SUBSTRATE class
+(same prohibition, different list), and `icn-gateway`/`icn-rpc`/`icn-api` are
+API-SHELL class, not kernel.
+
 **Enforcement**: CI checks dependency closure via `cargo metadata` (see `.github/scripts/firewall_denylist.py`).
 
 **Example Violation**:
@@ -500,7 +510,7 @@ icn-obs          ← Metrics, tracing           icn-community ← Membership
              │
 ```
 
-**CI Enforcement**: The `kernel-deps` CI job checks that kernel crates don't depend on forbidden domain crates:
+**CI Enforcement**: The `kernel-deps` CI job checks that kernel crates don't depend on forbidden domain crates. (The snippet below is illustrative and predates 2026-07-22 — the live step now sources its crate lists from `scripts/firewall-taxonomy.toml` via `firewall_taxonomy.py --bash` and fails closed if the taxonomy cannot load; see the workflow for current truth.)
 
 ```yaml
 # From .github/workflows/ci.yml

--- a/icn/crates/icn-core/src/meaning_firewall.rs
+++ b/icn/crates/icn-core/src/meaning_firewall.rs
@@ -23,25 +23,51 @@
 
 use std::path::PathBuf;
 
-/// Core kernel crates that must not depend on domain crates.
-const KERNEL_CRATES: &[&str] = &["icn-net", "icn-gateway", "icn-gossip", "icn-ledger"];
+// Crate classes below MIRROR scripts/firewall-taxonomy.toml (the single source
+// of truth). .github/scripts/test_firewall_taxonomy.py fails CI if these
+// constants drift from the taxonomy — edit the taxonomy first.
 
-/// Domain-specific crates that kernel must not depend on directly.
-const DOMAIN_CRATES: &[&str] = &["icn-trust", "icn-governance"];
+/// Kernel-class crates that must not depend on domain crates.
+const KERNEL_CRATES: &[&str] = &[
+    "icn-core",
+    "icn-net",
+    "icn-gossip",
+    "icn-store",
+    "icn-kernel-api",
+];
 
-/// Forbidden import patterns in kernel crates.
-/// Used as reference for what constitutes a Meaning Firewall violation.
-/// The strict_*_import_violations tests use `use icn_*::` patterns directly;
-/// bare type names here are too broad for automated scanning (appear in docs).
+/// Domain-class crates that kernel crates must not depend on directly.
+const DOMAIN_CRATES: &[&str] = &[
+    "icn-trust",
+    "icn-governance",
+    "icn-ledger",
+    "icn-ccl",
+    "icn-compute",
+    "icn-entity",
+    "icn-community",
+    "icn-federation",
+    "icn-steward",
+    "icn-coop",
+    "icn-commons",
+    "icn-zkp",
+];
+
+/// API-shell crates: HTTP/RPC hosting layers. Their domain coupling is
+/// EXPECTED during the kernel/app migration and is pinned exactly (Cargo pins
+/// in the taxonomy `[shells]`; import pins in the shell ratchets below).
 #[allow(dead_code)]
-const FORBIDDEN_IMPORTS: &[&str] = &[
-    "use icn_trust::",
-    "icn_trust::",
-    "TrustGraph",
-    "TrustClass",
-    "TrustScore",
-    "GovernanceRules",
-    "MembershipCriteria",
+const API_SHELL_CRATES: &[&str] = &["icn-gateway", "icn-rpc", "icn-api"];
+
+/// App crates (apps/): the kernel must not depend on applications. Current
+/// violations are pinned in `strict_core_app_crate_deps` (migration B10).
+const APP_CRATES: &[&str] = &[
+    "icn-charter-app",
+    "icn-governance-actor",
+    "icn-governance-app",
+    "icn-ledger-actor",
+    "icn-ledger-app",
+    "icn-membership-app",
+    "icn-trust-app",
 ];
 
 /// Allowed kernel-api types that kernel crates CAN use.
@@ -160,18 +186,26 @@ mod tests {
     /// Update these when violations are removed. Adding new violations
     /// will cause this test to fail.
     ///
-    /// Current state (2026-02-15):
-    /// - icn-gossip: CLEAN
-    /// - icn-net: CLEAN
-    /// - icn-gateway: 2 (icn-trust + icn-governance in prod deps)
-    /// - icn-ledger: CLEAN (icn-trust + icn-governance are dev-deps only)
+    /// Current state (2026-07-22, taxonomy reconciliation):
+    /// - icn-net / icn-gossip / icn-store / icn-kernel-api: CLEAN against all
+    ///   12 domain crates.
+    /// - icn-core: carries pinned domain deps — covered by
+    ///   `strict_core_cargo_domain_deps` (finer-grained), excluded here.
+    /// - icn-gateway/icn-rpc/icn-api are API-SHELL class, not kernel: their
+    ///   Cargo domain deps are pinned in scripts/firewall-taxonomy.toml
+    ///   `[shells]` and enforced by firewall_denylist.py.
+    /// - icn-ledger is DOMAIN class (2026-07-22 reclassification) — no longer
+    ///   scanned as kernel. Public evidence: both CI dependency gates already
+    ///   denylisted it; its own trust/governance deps are dev-only; its public
+    ///   surface is settlement/credit/treasury semantics (see the taxonomy
+    ///   header's rules-of-change note).
     #[test]
     fn strict_cargo_dependency_violations() {
         let expected: &[(&str, usize)] = &[
-            ("icn-gossip", 0),  // CLEAN ✅
-            ("icn-net", 0),     // CLEAN ✅
-            ("icn-gateway", 2), // icn-trust + icn-governance
-            ("icn-ledger", 0),  // CLEAN ✅ (domain crates are dev-deps only)
+            ("icn-gossip", 0),     // CLEAN ✅
+            ("icn-net", 0),        // CLEAN ✅
+            ("icn-store", 0),      // CLEAN ✅
+            ("icn-kernel-api", 0), // CLEAN ✅
         ];
 
         for &(crate_name, expected_count) in expected {
@@ -207,18 +241,19 @@ mod tests {
     /// Update these when imports are removed. Adding new imports
     /// will cause this test to fail.
     ///
-    /// Current state (2026-01-30):
-    /// - icn-gossip: CLEAN
-    /// - icn-net: CLEAN (no source imports, only had Cargo.toml dev-dep)
-    /// - icn-gateway: 3 (trust_mgr.rs:2, api/trust.rs:1)
-    /// - icn-ledger: 3 (credit_policy.rs:1, ledger.rs:1, fork_resolution.rs:1)
+    /// Current state (2026-07-22, taxonomy reconciliation): ALL kernel-class
+    /// crates are at ZERO trust imports (icn-core's remaining trust coupling is
+    /// dev-dependency/test-only; `count_imports_in_crate` scans src/).
+    /// icn-gateway's 3 imports moved to `strict_shell_import_violations`
+    /// (api-shell class); icn-ledger is domain class and no longer scanned.
     #[test]
     fn strict_trust_import_violations() {
         let expected: &[(&str, usize)] = &[
+            ("icn-core", 0), // CLEAN ✅ in src/ (trust is a dev-dep; its uses live in tests/, outside the scan)
             ("icn-gossip", 0), // CLEAN ✅
-            ("icn-net", 0),    // CLEAN ✅
-            ("icn-gateway", 3),
-            ("icn-ledger", 0), // CLEAN ✅ (imports removed by #970)
+            ("icn-net", 0),  // CLEAN ✅
+            ("icn-store", 0), // CLEAN ✅
+            ("icn-kernel-api", 0), // CLEAN ✅
         ];
 
         for &(crate_name, expected_count) in expected {
@@ -266,13 +301,20 @@ mod tests {
     /// - receipt_store.rs: +5 `use icn_governance::{Mandate, MandateId, AuthorityGrant,
     ///   AuthorityGrantId, ...}` for sled-backed ADR-0014 authorization-side storage (#1575)
     /// - icn-gateway: 17
+    ///
+    /// Current state (2026-07-22, taxonomy reconciliation): kernel class is at
+    /// ZERO governance imports across the board (icn-core reached 0 earlier —
+    /// see `strict_core_governance_reference_ratchet`). icn-gateway's 17 moved
+    /// to `strict_shell_import_violations` (api-shell class); icn-ledger is
+    /// domain class and no longer scanned here.
     #[test]
     fn strict_governance_import_violations() {
         let expected: &[(&str, usize)] = &[
-            ("icn-net", 0),      // CLEAN ✅
-            ("icn-gossip", 0),   // CLEAN ✅
-            ("icn-ledger", 0),   // CLEAN ✅
-            ("icn-gateway", 17), // +5 ADR-0014 Mandate/AuthorityGrant storage in receipt_store.rs (#1575)
+            ("icn-core", 0),       // CLEAN ✅
+            ("icn-net", 0),        // CLEAN ✅
+            ("icn-gossip", 0),     // CLEAN ✅
+            ("icn-store", 0),      // CLEAN ✅
+            ("icn-kernel-api", 0), // CLEAN ✅
         ];
 
         for &(crate_name, expected_count) in expected {
@@ -372,7 +414,10 @@ mod tests {
 
     /// Domain crates that icn-core should eventually stop depending on.
     /// These are crates whose types leak into the supervisor/wiring layer.
-    const CORE_DOMAIN_DEPS: &[&str] = &["icn-ledger", "icn-ccl", "icn-governance"];
+    /// (Full DOMAIN_CRATES class since 2026-07-22 — previously only 3 of the
+    /// 8 live edges were tracked; compute/federation/coop/steward/entity/
+    /// community/commons had NO ratchet coverage.)
+    const CORE_DOMAIN_DEPS: &[&str] = DOMAIN_CRATES;
 
     /// Pinned count of ALL `icn_ledger::` references in icn-core source.
     ///
@@ -508,10 +553,14 @@ mod tests {
 
     /// Pinned Cargo.toml domain dependency count for icn-core.
     ///
-    /// icn-core currently depends on 3 domain crates (icn-ledger, icn-ccl,
-    /// icn-governance). As extraction proceeds, these should be removed.
+    /// Now measured against the FULL domain class (12 crates). icn-core's
+    /// production deps as of 2026-07-22: icn-ledger, icn-ccl, icn-compute,
+    /// icn-entity, icn-community, icn-federation, icn-steward, icn-coop,
+    /// icn-commons (9). icn-trust/icn-governance are dev-deps only; icn-zkp
+    /// is transitive-only. Each edge has an [[exception]] in
+    /// scripts/firewall-taxonomy.toml with an edge-absent expiry.
     ///
-    /// Target state: 0 after all domain crate extraction completes.
+    /// Target state: 0 after all domain crate extraction completes (Phases B0–B9).
     #[test]
     fn strict_core_cargo_domain_deps() {
         let cargo_toml = read_cargo_toml("icn-core").expect("Could not read icn-core/Cargo.toml");
@@ -523,7 +572,7 @@ mod tests {
             }
         }
 
-        let expected: usize = 2; // icn-ledger + icn-ccl (icn-governance moved to dev-deps only)
+        let expected: usize = 9; // ledger,ccl,compute,entity,community,federation,steward,coop,commons
 
         assert!(
             actual <= expected,
@@ -539,6 +588,170 @@ mod tests {
                  (was pinned at {expected}). Update the pinned count in \
                  meaning_firewall.rs::strict_core_cargo_domain_deps()."
             );
+        }
+    }
+
+    /// Pinned count of ALL references for the icn-core domain edges that had
+    /// NO ratchet coverage before 2026-07-22 (214 references could grow
+    /// silently). Same semantics as the ledger/ccl/governance ratchets:
+    /// counts `use` statements AND inline qualified paths, src/ only,
+    /// excluding this file.
+    ///
+    /// Baselines measured 2026-07-22 at 767ece63. Target: 0 per edge as the
+    /// corresponding migration tranche (B0–B9) lands.
+    #[test]
+    fn strict_core_remaining_domain_reference_ratchets() {
+        let expected: &[(&str, usize)] = &[
+            ("icn_compute::", 86),    // migration B8
+            ("icn_federation::", 48), // migration B6
+            ("icn_coop::", 34),       // migration B5
+            ("icn_steward::", 32),    // migration B4
+            ("icn_entity::", 14),     // migration B3
+            ("icn_commons::", 10),    // migration B9
+            ("icn_community::", 7),   // migration B0
+        ];
+
+        for &(pattern, expected_count) in expected {
+            let actual = count_imports_in_crate("icn-core", pattern);
+
+            assert!(
+                actual <= expected_count,
+                "REGRESSION: icn-core has {actual} `{pattern}` references \
+                 (expected at most {expected_count}). \
+                 Do not add new domain references to icn-core — \
+                 use kernel-api traits or BootstrapHandles instead. \
+                 See docs/architecture/KERNEL_APP_SEPARATION.md for extraction guidance."
+            );
+
+            if actual < expected_count {
+                panic!(
+                    "✅ PROGRESS: icn-core now has only {actual} `{pattern}` references \
+                     (was pinned at {expected_count}). Update the pinned count in \
+                     meaning_firewall.rs::strict_core_remaining_domain_reference_ratchets()."
+                );
+            }
+        }
+    }
+
+    /// Pinned Cargo.toml APP-crate dependency count for icn-core.
+    ///
+    /// The kernel must not depend on applications; these edges were on NO
+    /// denylist before 2026-07-22 (undetectable bypass, now closed). Each has
+    /// an [[exception]] in scripts/firewall-taxonomy.toml.
+    ///
+    /// Current: icn-trust-app, icn-governance-actor, icn-ledger-actor (3).
+    /// Target: 0 after migration B10 (composition moves to bins/icnd).
+    #[test]
+    fn strict_core_app_crate_deps() {
+        let cargo_toml = read_cargo_toml("icn-core").expect("Could not read icn-core/Cargo.toml");
+
+        let mut actual = 0;
+        for app_crate in APP_CRATES {
+            if has_dependency(&cargo_toml, app_crate) {
+                actual += 1;
+            }
+        }
+
+        let expected: usize = 3; // icn-trust-app + icn-governance-actor + icn-ledger-actor
+
+        assert!(
+            actual <= expected,
+            "REGRESSION: icn-core has {actual} app-crate Cargo.toml deps \
+             (expected at most {expected}). \
+             The kernel must not gain new dependencies on apps/ crates — \
+             register apps from the composition root (bins/icnd) instead."
+        );
+
+        if actual < expected {
+            panic!(
+                "✅ PROGRESS: icn-core now has only {actual} app-crate deps \
+                 (was pinned at {expected}). Update the pinned count in \
+                 meaning_firewall.rs::strict_core_app_crate_deps()."
+            );
+        }
+    }
+
+    /// Pinned domain-import counts for API-SHELL crates (icn-gateway, icn-rpc,
+    /// icn-api). Shells host domain routes during the transition, so their
+    /// coupling is EXPECTED — but pinned exactly so it can only shrink.
+    /// Compensates for the edit hook no longer treating icn-gateway as kernel
+    /// (2026-07-22 taxonomy reconciliation).
+    ///
+    /// Baselines measured 2026-07-22 at 767ece63.
+    #[test]
+    fn strict_shell_import_violations() {
+        let expected: &[(&str, &str, usize)] = &[
+            ("icn-gateway", "use icn_trust::", 3), // trust_mgr.rs:2, api/trust.rs:1
+            ("icn-gateway", "use icn_governance::", 17), // see strict_governance history above
+            ("icn-rpc", "use icn_trust::", 0),
+            ("icn-rpc", "use icn_governance::", 2),
+            ("icn-api", "use icn_trust::", 0),
+            ("icn-api", "use icn_governance::", 1),
+        ];
+
+        for &(crate_name, pattern, expected_count) in expected {
+            let actual = count_imports_in_crate(crate_name, pattern);
+
+            assert!(
+                actual <= expected_count,
+                "REGRESSION: {crate_name} has {actual} `{pattern}` imports \
+                 (expected at most {expected_count}). \
+                 API-shell domain coupling may only shrink — new handlers belong \
+                 in apps/ crates mounted as route plugins."
+            );
+
+            if actual < expected_count {
+                panic!(
+                    "✅ PROGRESS: {crate_name} now has only {actual} `{pattern}` \
+                     imports (was pinned at {expected_count}). Update the pinned count in \
+                     meaning_firewall.rs::strict_shell_import_violations()."
+                );
+            }
+        }
+    }
+
+    /// Pinned DOMAIN-TOKEN counts inside icn-kernel-api (the boundary contract
+    /// crate itself). icn-kernel-api was scanned by NOTHING before 2026-07-22,
+    /// while natively defining a domain service layer (services.rs) — domain
+    /// meaning that no Cargo-dependency check can see.
+    ///
+    /// These pins are the honest baseline for the kernel-api purification
+    /// (migration Phase A2/F; layer-contract ADR pending — HD-9). Counts are
+    /// raw token occurrences in icn-kernel-api/src, measured 2026-07-22.
+    /// They may only DECREASE; new domain vocabulary in kernel-api fails here.
+    #[test]
+    fn kernel_api_domain_surface_ratchet() {
+        let expected: &[(&str, usize)] = &[
+            ("TrustClass", 18),              // native enum + thresholds (services.rs)
+            ("MembershipService", 2),        // domain service trait
+            ("FederationService", 6),        // domain service trait
+            ("SdisService", 3),              // domain service trait
+            ("GovernanceService", 5),        // domain service trait
+            ("LedgerService", 8),            // domain service trait
+            ("ControlService", 2),           // domain service trait
+            ("TreasuryOperationType", 28),   // operation enum driving match logic
+            ("FederationOperationType", 10), // operation enum
+            ("AssetType", 65),               // operation enum
+        ];
+
+        for &(token, expected_count) in expected {
+            let actual = count_imports_in_crate("icn-kernel-api", token);
+
+            assert!(
+                actual <= expected_count,
+                "REGRESSION: icn-kernel-api has {actual} `{token}` occurrences \
+                 (expected at most {expected_count}). \
+                 The kernel contract crate must not GROW domain vocabulary — \
+                 domain service contracts belong in per-app api crates."
+            );
+
+            if actual < expected_count {
+                panic!(
+                    "✅ PROGRESS: icn-kernel-api now has only {actual} `{token}` \
+                     occurrences (was pinned at {expected_count}). Update the pinned \
+                     count in meaning_firewall.rs::kernel_api_domain_surface_ratchet()."
+                );
+            }
         }
     }
 
@@ -595,13 +808,15 @@ mod tests {
     /// Verify kernel-api does NOT expose domain-specific types.
     #[test]
     fn kernel_api_no_domain_types() {
+        // NOTE (2026-07-22): this test previously scanned for the literal
+        // "pub struct TrustClass" — a FALSE NEGATIVE, because the real
+        // definition is `pub enum TrustClass` (services.rs). TrustClass and
+        // the rest of kernel-api's existing domain surface are now honestly
+        // pinned (shrink-only) in `kernel_api_domain_surface_ratchet`; this
+        // test keeps only the absolute never-present assertions.
         for file in list_rust_files("icn-kernel-api") {
             if let Ok(content) = std::fs::read_to_string(&file) {
-                for pattern in &[
-                    "struct TrustGraph",
-                    "pub struct TrustClass",
-                    "GovernanceRules",
-                ] {
+                for pattern in &["struct TrustGraph", "enum TrustGraph", "GovernanceRules"] {
                     assert!(
                         !content.contains(pattern),
                         "icn-kernel-api should not define domain type: {pattern}"

--- a/kernel_surface.toml
+++ b/kernel_surface.toml
@@ -1,5 +1,12 @@
 # ICN Kernel Surface Inventory
 #
+# ⚠️ CLASSIFICATION SUPERSEDED (2026-07-22): crate CLASSES (kernel/substrate/
+# api-shell/domain/app/facade) are now owned by scripts/firewall-taxonomy.toml,
+# which is sync-checked across all enforcement mechanisms. This file's per-crate
+# `status` fields (clean/infected) remain as a HISTORICAL infection inventory
+# (last audited 2026-02) — useful context, not classification truth. Where this
+# file and the taxonomy disagree (e.g. icn-ledger), the taxonomy wins.
+#
 # This file lists every public API exposed by kernel crates and tracks
 # their "infection" status - whether they contain domain-specific logic
 # that should be extracted to apps.

--- a/scripts/check-meaning-firewall.sh
+++ b/scripts/check-meaning-firewall.sh
@@ -1,59 +1,107 @@
 #!/bin/bash
-# Meaning Firewall Check - CI Script
+# Meaning Firewall Check - CI Script (honest, fail-capable rewrite 2026-07-22)
 #
-# This script verifies that kernel crates don't directly import domain-specific types.
-# Run this in CI to catch accidental firewall breaches.
+# Verifies that EXCEPTION-FREE kernel-class crates contain no domain-crate
+# imports in src/. Crate classes come from the single-source taxonomy
+# (scripts/firewall-taxonomy.toml); nothing is hardcoded here.
+#
+# Kernel crates that carry [[exception]] entries (today: icn-core) are covered
+# by the finer-grained ratchet tests (icn-core meaning_firewall.rs) and the
+# Cargo-level checks (firewall_denylist.py) — this script enforces the crates
+# whose debt is ZERO, so they can never regress silently.
+#
+# History: the previous version always exited 0 ("allow CI pass during active
+# refactoring") — a required branch-protection check that structurally could
+# not fail. That defect is what this rewrite removes.
 #
 # Usage: ./scripts/check-meaning-firewall.sh
-#
-# Exit codes:
-#   0: No violations detected (firewall is clean)
-#   1: Violations detected (expected before Phase 2 completes)
-#
-# Tracking Issues:
-#   - #865: Gateway trust manager → oracle
-#   - #866: Gossip topic access control → oracle
-#   - #867: Ledger entry validation → oracle
+# Exit codes: 0 = clean; 1 = violations; 2 = environment/taxonomy error
 
-set -e
+set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-KERNEL_CRATES="icn-net icn-gateway icn-gossip icn-ledger"
+if ! command -v python3 >/dev/null; then
+    echo "ERROR: python3 required (taxonomy loader)" >&2
+    exit 2
+fi
+
+# Load kernel/domain lists + exception edges from the taxonomy.
+# FAIL-CLOSED: capture first — `eval "$(cmd)"` swallows the loader's exit code
+# (empty eval is a no-op), which would skip the check silently.
+if ! TAXONOMY_LISTS="$(python3 .github/scripts/firewall_taxonomy.py --bash)"; then
+    echo "ERROR: failed to load scripts/firewall-taxonomy.toml" >&2
+    exit 2
+fi
+eval "$TAXONOMY_LISTS"
+if [ "${#KERNEL_CRATES[@]}" -eq 0 ]; then
+    echo "ERROR: taxonomy produced an empty kernel list — refusing to pass with nothing scanned" >&2
+    exit 2
+fi
+
+# Kernel crates with at least one exception entry (they carry pinned debt and
+# are enforced by ratchets instead).
+declare -A HAS_EXCEPTION=()
+for edge in "${ALLOWED_EDGES[@]:-}"; do
+    # Guard the empty expansion a zero-exception taxonomy produces under set -u
+    # (an empty key is a bad associative-array subscript — found by the
+    # failure-path battery's clean-fixture case).
+    [ -n "$edge" ] || continue
+    HAS_EXCEPTION["${edge%%->*}"]=1
+done
+
 VIOLATIONS=0
 
-echo "=== Meaning Firewall Check ==="
+echo "=== Meaning Firewall Check (taxonomy-driven) ==="
+echo ""
+echo "Kernel class: ${KERNEL_CRATES[*]}"
 echo ""
 
-# Check for icn_trust imports in kernel crate source files
-echo "Checking for forbidden imports in kernel crates..."
-for crate in $KERNEL_CRATES; do
+for crate in "${KERNEL_CRATES[@]}"; do
     CRATE_DIR="icn/crates/$crate/src"
-    if [ -d "$CRATE_DIR" ]; then
-        COUNT=$(grep -rE "use icn_trust::" "$CRATE_DIR" 2>/dev/null | wc -l || true)
-        if [ "$COUNT" -gt 0 ]; then
-            echo "  ⚠️  $crate: $COUNT icn_trust imports"
-            VIOLATIONS=$((VIOLATIONS + COUNT))
-        else
-            echo "  ✅ $crate: clean"
-        fi
+    if [ ! -d "$CRATE_DIR" ]; then
+        echo "  ⚠️  $crate: no src directory found" >&2
+        continue
     fi
+    if [ -n "${HAS_EXCEPTION[$crate]:-}" ]; then
+        echo "  ⏭  $crate: has pinned exceptions — enforced by ratchet tests + firewall_denylist.py"
+        continue
+    fi
+    CRATE_HITS=0
+    for dep in "${FORBIDDEN[@]}"; do
+        PATTERN="use ${dep//-/_}::"
+        # meaning_firewall.rs holds pattern literals for the ratchet tests.
+        COUNT=$(grep -r --include='*.rs' --exclude='meaning_firewall.rs' -E "$PATTERN" "$CRATE_DIR" 2>/dev/null | wc -l || true)
+        if [ "$COUNT" -gt 0 ]; then
+            echo "  ❌ $crate: $COUNT \`$PATTERN\` import(s)"
+            # `|| true`: head closing the pipe early SIGPIPEs grep under pipefail.
+            { grep -rn --include='*.rs' --exclude='meaning_firewall.rs' -E "$PATTERN" "$CRATE_DIR" | head -5 | sed 's/^/       /'; } || true
+            CRATE_HITS=$((CRATE_HITS + COUNT))
+        fi
+    done
+    if [ "$CRATE_HITS" -eq 0 ]; then
+        echo "  ✅ $crate: clean"
+    fi
+    VIOLATIONS=$((VIOLATIONS + CRATE_HITS))
 done
 
 echo ""
 if [ "$VIOLATIONS" -gt 0 ]; then
-    echo "RESULT: $VIOLATIONS violation(s) detected"
+    echo "RESULT: $VIOLATIONS NEW violation(s) detected in exception-free kernel crates"
     echo ""
-    echo "This is expected until Phase 2 completes."
-    echo "After Phase 2, this script should report 0 violations."
-    echo ""
-    echo "To see detailed violations, run:"
-    echo "  cargo test -p icn-core --lib meaning_firewall -- --nocapture"
-    # TODO: Re-enable strict check (exit 1) after Phase 2 completes.
-    # Currently allowing violations as meaningful progress is tracked via issues.
-    echo "WARNING: Exiting 0 to allow CI pass during active refactoring."
-    exit 0
-else
-    echo "RESULT: Firewall is clean! 🎉"
-    exit 0
+    echo "Exception-free kernel crates must stay free of domain imports."
+    echo "Remediation:"
+    echo "  1) Remove the import — use PolicyOracle/ConstraintSet or kernel-api traits"
+    echo "  2) If unavoidable, add a reviewed [[exception]] to scripts/firewall-taxonomy.toml"
+    echo "     (that moves the crate to ratchet-based enforcement — a tracked, shrinking state)"
+    echo "Reference: docs/architecture/KERNEL_APP_SEPARATION.md, docs/ci/GATE_RATCHET_PLAN.md"
+    exit 1
 fi
+
+# Honest claim boundary: this script proves only the slice it scans.
+echo "RESULT: No new unpinned domain imports in exception-free kernel crates."
+echo "Pinned firewall debt remains elsewhere: ${#ALLOWED_EDGES[@]} kernel exception edges"
+echo "(tracked in scripts/firewall-taxonomy.toml; enforced by firewall_denylist.py"
+echo "and the icn-core meaning_firewall.rs ratchets). The firewall is NOT 'done' —"
+echo "this gate only proves no NEW debt entered its scan scope."
+exit 0

--- a/scripts/firewall-taxonomy.toml
+++ b/scripts/firewall-taxonomy.toml
@@ -1,0 +1,248 @@
+# ICN Meaning-Firewall Taxonomy — the single AUTHORITATIVE DECLARATION of crate
+# classes and boundary exceptions.
+#
+# Truth mechanism (precise): drift is structurally prevented or CI-detected —
+#   RUNTIME LOADERS (cannot drift; they read this file on every run):
+#     - .github/scripts/firewall_taxonomy.py   (loader; emits bash lists)
+#     - .github/scripts/firewall_denylist.py   (CI: Firewall Contract Enforcement)
+#     - .github/workflows/ci.yml kernel-deps   (CI: Kernel Forbidden Dependencies)
+#     - scripts/check-meaning-firewall.sh      (CI: Meaning Firewall Check)
+#   MIRRORED COPIES (drift-checked in CI by .github/scripts/test_firewall_taxonomy.py):
+#     - .claude/hooks/kernel-crates.conf            (edit hook; hooks can't run python)
+#     - icn/crates/icn-core/src/meaning_firewall.rs (KERNEL_CRATES/DOMAIN_CRATES consts)
+#
+# ENFORCEMENT OWNERSHIP (each mechanism owns a distinct slice; none proves the whole):
+#   - firewall_denylist.py  — Cargo DEPENDENCY EDGES: kernel+substrate transitive
+#     closure vs domain+app; exception staleness (direct vs transitive-or-dev);
+#     api-shell direct-dep pins; taxonomy completeness vs workspace members;
+#     tool-crate isolation.
+#   - ci.yml kernel-deps    — redundant direct/cargo-tree view of the same edges
+#     (defense in depth; catches metadata-vs-tree skew).
+#   - check-meaning-firewall.sh — SOURCE `use <domain>::` imports in exception-free
+#     kernel-class crates only (explicit-import form; qualified paths/aliases/macros
+#     are owned by the Rust ratchets).
+#   - meaning_firewall.rs ratchets — per-edge REFERENCE COUNTS (imports + qualified
+#     paths) in icn-core; api-shell import pins; kernel-api domain-token baseline.
+#   - firewall-guard.sh hook — best-effort edit-time guard (agent sessions only).
+#   None of these proves semantic purity; that is migration Phase A2/F + review.
+#
+# Classes (see docs/architecture/KERNEL_APP_SEPARATION.md; layer-contract ADR pending):
+#   kernel     — domain-blind runtime/contract crates. Domain/app deps FORBIDDEN
+#                (exceptions below, each with a machine-checkable expiry).
+#   substrate  — generic infrastructure. Same prohibition, enforced by
+#                firewall_denylist.py; zero exceptions (verified 2026-07-22).
+#   api-shell  — HTTP/RPC hosting crates. Domain deps are EXPECTED during the
+#                transition and pinned exactly in [shells]; NEW domain/app deps fail CI.
+#   domain     — meaning lives here. May depend on kernel/substrate + peer domain crates.
+#   app        — apps/ crates (actors + PolicyOracle facades).
+#   facade     — re-export shells; audited in migration Phase G.
+#   tool       — test/fixture/dev-support crates. May depend on anything; must NOT
+#                be a production dependency of any non-tool, non-bin member (enforced).
+#   bin        — binaries/composition roots (icnd, icnctl, icn-console). Unrestricted
+#                by design: the composition root is the one place allowed to know
+#                the full app roster.
+#   Every workspace member MUST be classified (completeness enforced vs cargo
+#   metadata) — a new crate cannot evade the firewall by staying unlisted.
+#
+# RULES OF CHANGE:
+#   - Removing an exception requires the edge to be GONE (checker fails on stale entries).
+#   - Adding an exception requires a tracking reference and is a reviewed event.
+#   - Class moves are reviewed events. icn-ledger's 2026-07-22 move from
+#     (contradictory kernel/domain listings) to domain rests on public, checkable
+#     facts: both CI dependency gates already denylisted it; its own icn-trust/
+#     icn-governance deps are dev-only (icn/crates/icn-ledger/Cargo.toml); its
+#     public surface is settlement/credit/treasury semantics (icn/crates/
+#     icn-ledger/src/ledger.rs validate_entry enforces credit policy); and every
+#     workspace reverse-dependency consumes those economic symbols. The PR
+#     introducing this file carries the full evidence summary.
+
+[meta]
+version = "1.0.0"
+updated = "2026-07-22"
+owner = "core-arch"
+adr = "pending (HD-9 layer-contract ADR)"
+
+[classes]
+kernel = ["icn-core", "icn-net", "icn-gossip", "icn-store", "icn-kernel-api"]
+substrate = [
+  "icn-identity", "icn-time", "icn-snapshot", "icn-encoding", "icn-obs",
+  "icn-security", "icn-privacy", "icn-crypto-pq", "icn-naming", "icn-http-kit",
+  "icn-authz", "icn-appliance", "icn-boundary",
+]
+api-shell = ["icn-gateway", "icn-rpc", "icn-api"]
+domain = [
+  "icn-trust", "icn-governance", "icn-ledger", "icn-ccl", "icn-compute",
+  "icn-entity", "icn-community", "icn-federation", "icn-steward", "icn-coop",
+  "icn-commons", "icn-zkp",
+]
+app = [
+  "icn-charter-app", "icn-governance-actor", "icn-governance-app",
+  "icn-ledger-actor", "icn-ledger-app", "icn-membership-app", "icn-trust-app",
+]
+facade = ["icn-protocol", "icn-services", "icn-crypto"]
+tool = ["icn-testkit", "icn-baseline-lock"]
+bin = ["icnd", "icnctl", "icn-console"]
+
+# Classification annotations (NOT enforcement changes; candidates for future review):
+# - icn-ccl: engine is arguably substrate (deterministic evaluation); its domain
+#   stdlib is app material. Kept in `domain` because every current enforcement
+#   mechanism forbids kernel->ccl; reclassification is a Phase-E decision.
+# - icn-identity: carries ~36% domain modules (commons/personhood/vui) — extraction
+#   tracked as migration Phase E1; stays substrate meanwhile.
+# - api-shell crates appear in icn-core's transitive closure (core->gateway/rpc);
+#   shedding those edges is migration Phase B11 — tracked, not yet enforced.
+# - kernel vs substrate binning of icn-net/icn-gossip/icn-store follows the
+#   CURRENT enforcement lists (both classes carry the same prohibition, so the
+#   split is enforcement-neutral today); the target architecture treats them as
+#   substrate — re-binned, if at all, at migration Phase G.
+# - Exception lifecycle nuance: the 9 direct domain edges are ALSO reachable
+#   transitively via core->icn-gateway. When a B-tranche deletes a DIRECT edge,
+#   the stale detector fires on the `direct` entry — the entry is then CONVERTED
+#   to kind="transitive-or-dev" (reviewed event), and fully removed only when
+#   B11 sheds the shell edges. Tranche labels below name the direct-edge removal.
+
+# ---------------------------------------------------------------------------
+# Exceptions: kernel-crate boundary violations that exist TODAY, pinned exactly.
+# expiry = "edge-absent": the checker FAILS when the edge no longer exists,
+# forcing removal of the entry (no silent staleness, I11) — and FAILS on any
+# kernel->domain/app edge NOT listed here (no silent growth, I1).
+# ---------------------------------------------------------------------------
+
+# --- icn-core direct production deps (Cargo [dependencies]) ---
+[[exception]] # supervisor/lifecycle constructs ledger-backed services; B1 tranche removes
+from = "icn-core"
+to = "icn-ledger"
+kind = "direct"
+tracking = "#914"
+expiry = "edge-absent"
+
+[[exception]] # contract execution + dispute actor wiring (32 refs); Phase B7
+from = "icn-core"
+to = "icn-ccl"
+kind = "direct"
+tracking = "#912-family / migration B7"
+expiry = "edge-absent"
+
+[[exception]] # compute/settlement wiring (86 refs); Phase B8
+from = "icn-core"
+to = "icn-compute"
+kind = "direct"
+tracking = "migration B8"
+expiry = "edge-absent"
+
+[[exception]]
+from = "icn-core"
+to = "icn-entity"
+kind = "direct"
+tracking = "migration B3"
+expiry = "edge-absent"
+
+[[exception]]
+from = "icn-core"
+to = "icn-community"
+kind = "direct"
+tracking = "migration B0"
+expiry = "edge-absent"
+
+[[exception]]
+from = "icn-core"
+to = "icn-federation"
+kind = "direct"
+tracking = "migration B6"
+expiry = "edge-absent"
+
+[[exception]]
+from = "icn-core"
+to = "icn-steward"
+kind = "direct"
+tracking = "migration B4"
+expiry = "edge-absent"
+
+[[exception]]
+from = "icn-core"
+to = "icn-coop"
+kind = "direct"
+tracking = "migration B5"
+expiry = "edge-absent"
+
+[[exception]] # on NO prior list (bypass closed 2026-07-22); imports icn-governance
+from = "icn-core"
+to = "icn-commons"
+kind = "direct"
+tracking = "migration B9"
+expiry = "edge-absent"
+
+# --- icn-core direct deps on app crates (bypass closed 2026-07-22) ---
+[[exception]] # supervisor constructs the trust app; Phase B10
+from = "icn-core"
+to = "icn-trust-app"
+kind = "direct"
+tracking = "migration B10"
+expiry = "edge-absent"
+
+[[exception]] # kernel depends on the governance app (wrong direction); Phase B10
+from = "icn-core"
+to = "icn-governance-actor"
+kind = "direct"
+tracking = "migration B10"
+expiry = "edge-absent"
+
+[[exception]] # lifecycle.rs:889 create_stores; Phase B10
+from = "icn-core"
+to = "icn-ledger-actor"
+kind = "direct"
+tracking = "migration B10"
+expiry = "edge-absent"
+
+# --- icn-core transitive-only edges (via dev-deps and via icn-commons/gateway) ---
+[[exception]] # dev-dep only (tests); prod edge gone since #970-era cleanups
+from = "icn-core"
+to = "icn-trust"
+kind = "transitive-or-dev"
+tracking = "test-architecture; migration Phase A2+"
+expiry = "edge-absent"
+
+[[exception]] # dev-dep + transitive via icn-commons->icn-governance
+from = "icn-core"
+to = "icn-governance"
+kind = "transitive-or-dev"
+tracking = "resolved by B9 (commons) + test-architecture"
+expiry = "edge-absent"
+
+[[exception]] # transitive via api-shell edges (core->gateway->zkp); B11 removes
+from = "icn-core"
+to = "icn-zkp"
+kind = "transitive-or-dev"
+tracking = "migration B11"
+expiry = "edge-absent"
+
+[[exception]] # transitive via api-shell edges (gateway->ledger-app et al); B11
+from = "icn-core"
+to = "icn-ledger-app"
+kind = "transitive-or-dev"
+tracking = "migration B11"
+expiry = "edge-absent"
+
+
+
+
+# ---------------------------------------------------------------------------
+# API-shell pins: the EXACT set of direct domain/app deps each shell may have.
+# A new domain/app dep on a shell fails CI; a removed one fails until the pin
+# is updated (same no-silent-change rule as exceptions).
+# ---------------------------------------------------------------------------
+[shells.icn-gateway]
+domain = [
+  "icn-ccl", "icn-commons", "icn-community", "icn-compute", "icn-coop",
+  "icn-entity", "icn-federation", "icn-governance", "icn-ledger", "icn-steward",
+  "icn-trust", "icn-zkp",
+]
+app = ["icn-governance-actor", "icn-ledger-app"]
+
+[shells.icn-rpc]
+domain = ["icn-ccl", "icn-compute", "icn-coop", "icn-federation", "icn-governance", "icn-ledger"]
+app = []
+
+[shells.icn-api]
+domain = ["icn-compute", "icn-governance", "icn-ledger"]
+app = []

--- a/scripts/forbidden-deps-allowlist.txt
+++ b/scripts/forbidden-deps-allowlist.txt
@@ -1,22 +1,13 @@
-# Kernel/App boundary violations to be resolved in future waves
-# Each entry represents a dependency that should be removed as part of
-# the kernel/app separation refactor (see docs/ARCHITECTURE.md)
+# RETIRED (2026-07-22) — do not add entries here.
 #
-# COMPLETED - Wave 1A (icn-gossip, icn-net cleaned):
-# - icn-net->icn-trust: REMOVED
-# - icn-gossip->icn-trust: REMOVED
-# - icn-net->icn-ledger: REMOVED
-# - icn-net->icn-entity: REMOVED
+# The kernel/app boundary exception list moved to the single-source taxonomy:
+#   scripts/firewall-taxonomy.toml   ([[exception]] entries, with stale-entry
+#   detection enforced by .github/scripts/firewall_denylist.py)
 #
-# Wave 2 targets: supervisor refactoring (icn-core)
-# These will be removed when supervisor uses AppRuntime instead of direct init
-icn-core->icn-trust
-icn-core->icn-governance
-icn-core->icn-ledger
-icn-core->icn-ccl
-icn-core->icn-compute
-icn-core->icn-entity
-icn-core->icn-community
-icn-core->icn-federation
-icn-core->icn-steward
-icn-core->icn-coop
+# Every edge formerly listed here is preserved there (nothing was un-excepted);
+# the CI kernel-deps job now sources its lists from the taxonomy via
+#   python3 .github/scripts/firewall_taxonomy.py --bash
+#
+# This file remains only so historical references (e.g. ADR-0014 prose,
+# generated file inventories) do not dangle. test_firewall_taxonomy.py fails CI
+# if live entries reappear here.


### PR DESCRIPTION
## What

**Tranche A1 — Firewall truth reconciliation.** One authoritative crate taxonomy now drives every meaning-firewall mechanism, all known boundary debt is measured and pinned, and the gates are honest and fail-closed. **No runtime behavior changes. No dependency edge is removed. Kernel/app separation is NOT completed by this PR — it is truthfully measured.**

## Why (problem)

The firewall's enforcement mechanisms disagreed about reality (17 hand-copied crate-list variants across hooks, CI, tests, and docs):
- `icn-ledger` was classified **kernel in 5 mechanisms and forbidden-domain in 6** — including CLAUDE.md contradicting itself.
- The required **"Meaning Firewall Check" could not fail**: its script unconditionally `exit 0`'d ("allow CI pass during active refactoring") behind branch protection since 2026-03-24.
- The ratchet's TrustClass scan had a **false negative** (grepped `pub struct TrustClass`; the real definition is `pub enum`).
- The bash job's FORBIDDEN array **omitted icn-coop** while both exception lists included it.
- `icn-core`'s deps on **app crates** (`icn-trust-app`, `icn-governance-actor`, `icn-ledger-actor`) and on **icn-commons** (which itself imports icn-governance) were on **no denylist at all**.
- `icn-gateway` (called "kernel" by hooks/docs) was **scanned by neither blocking CI job** while carrying 12 domain deps.
- The exception lists' expiry premise ("removed when supervisor uses AppRuntime") could never fire — AppRuntime has no in-workspace consumers — making the exceptions structurally permanent.
- Only 3 of 8 live `icn-core` domain edges had ratchet coverage (214 references could grow silently).

## How (mechanisms changed)

- **`scripts/firewall-taxonomy.toml`** (new): the authoritative declaration — 8 classes (`kernel/substrate/api-shell/domain/app/facade/tool/bin`), all 48 workspace members classified (completeness enforced against cargo metadata), 16 `[[exception]]` entries with `kind` + `tracking` + machine-checkable `expiry = "edge-absent"`, api-shell pins, and an enforcement-ownership map. Runtime consumers **load it**; the two mirrored copies (hook conf, Rust consts) are **drift-checked in CI**.
- **`firewall_denylist.py`** (rewritten): taxonomy-driven; scans **kernel + substrate** transitively; **stale-exception detection** — `kind="direct"` must remain a *direct production dep* (a lingering transitive/dev path cannot mask a removed direct edge); `transitive-or-dev` checked against the full metadata closure; api-shell pin equality; workspace completeness; tool-crate isolation.
- **`check-meaning-firewall.sh`** (rewritten): fail-capable for the first time; scans exception-free kernel crates; **fails closed** if the taxonomy can't load; output states pinned debt explicitly and never claims the firewall "clean/done".
- **`ci.yml`**: `kernel-deps` sources its lists from the taxonomy (icn-coop desync fixed mechanically), scope advanced `core-only → all-kernel` (net/gossip/store/kernel-api verified clean), **fail-closed capture** of the loader (a load failure can no longer pass with zero crates checked), version-anchored grep (no `icn-ledger`-inside-`icn-ledger-app` false matches); taxonomy self-test added to the firewall-contract job. **All three check names unchanged** (branch protection untouched).
- **`meaning_firewall.rs`** (all `#[cfg(test)]` — zero runtime footprint): consts mirror the taxonomy (CI-locked, incl. APP/API-shell consts); ratchets for **all 8 live core domain edges** (compute 86, federation 48, coop 34, steward 32, entity 14, commons 10, community 7 + existing ledger 5/ccl 32/governance 0); app-crate dep pin (3); shell import pins (gateway trust 3/governance 17, rpc 2, api 1); **kernel-api domain-token baseline** (TrustClass=18, the six domain service traits, three operation enums — shrink-only); TrustClass false-negative fixed honestly (pinned known, not pattern-matched away).
- **`test_firewall_taxonomy.py`** (new): sync checks + 4 malformed-taxonomy fixtures + a **failure-path battery** proving the gates actually go red: new unpinned edge (F1), transitive residue masquerading as direct (F2), unpinned shell dep (F3), unclassified member (F6), and a real `use icn_trust::` violation in an isolated fixture repo (F5) — plus clean-fixture green. The battery found and fixed a real crash (empty-exception taxonomy → bad array subscript).
- Edit hook + `kernel-crates.conf`: taxonomy-mirrored lists, dynamic domain patterns, ratchet-file exclusion. `kernel_surface.toml`: supersession banner (historical inventory, not classification truth). `KERNEL_APP_SEPARATION.md`/`kernel-boundary.md`: taxonomy pointer, self-contradiction fixes. `forbidden-deps-allowlist.txt`: retired to an empty tombstone (entries live in the taxonomy; sync test enforces it stays empty; kept so ADR-0014 prose/generated inventories don't dangle).

## Key classification decisions (public evidence)

- **icn-ledger → domain**: both CI dependency gates already denylisted it; its own trust/governance deps are dev-only (`icn/crates/icn-ledger/Cargo.toml`); its public surface is settlement/credit/treasury semantics (`ledger.rs::validate_entry` enforces credit policy); every workspace reverse-dependency consumes those economic symbols.
- **icn-gateway/icn-rpc/icn-api → api-shell**: they host domain routes during the migration; their exact direct domain/app dep sets are now **pinned** (gateway 12+2, rpc 6, api 3) — a net CI strengthening, since neither blocking job scanned gateway before.
- 16 pinned exceptions = 9 direct domain + 3 app-crate + 4 transitive-or-dev edges from `icn-core`, each with tracking and edge-absent expiry. Direct-edge removals convert entries to `transitive-or-dev` until B11 sheds the shell path (documented in the taxonomy header).

## Independent review

Three fresh reviewers on the final diff: **Opus adversarial** (10 questions: no blockers; 6 minors — all applied or adjudicated; confirmed the module is test-gated, counts exact by independent grep, and gateway reclassification net-strengthens CI), **Sonnet implementation** (1 HIGH: the fail-open eval in `kernel-deps` — **fixed + repro-verified fail-closed**; 3 moderates — all fixed: script eval contract, `\b` grep false-positive, loader charset validation), **Haiku mechanical scan** (9/9 pass: 48/48 classified, three list copies identical, zero private-path references, zero stale language).

## Validation

Local (all exact commands + rcs recorded in session VERIFICATION.md): taxonomy sync + failure battery ✅ · firewall_denylist ✅ (16 pinned/0 new/0 stale) · shell gate ✅ · CI-style kernel-deps simulation: 0 unlisted violations ✅ · fail-closed repros (missing taxonomy → rc≠0) ✅ · `cargo test -p icn-core --lib meaning_firewall` 16/16 ✅ · `cargo fmt --all --check` ✅ · scoped `cargo clippy -p icn-core --all-targets -D warnings` ✅ · python `py_compile` ✅ · `git diff --check` ✅.

**Local limitations**: `actionlint` unavailable (no repo-pinned installer) — strongest local check was YAML parse + marker checks; **this PR's own CI run is the workflow witness**. Full workspace test suite intentionally not run (change is tooling/config + one test-only Rust module); not claimed.

## Risk / rollback

Tooling, tests, config, and docs only; single-revert rollback; no state, storage, or wire impact. Behavior of the three required checks is intentionally stricter-and-honest; all current reality is pinned, so this branch must be green on its own gates — if a required check fails here, that is signal, not noise.

## Claims boundary (explicit)

This PR does **not** prove: kernel domain-neutrality (icn-core keeps 9 domain + 3 app prod deps — pinned), icn-kernel-api semantic cleanliness (its domain service layer is **pinned, not removed**), composition-root unification (icnd + supervisor/lifecycle.rs both construct), AppRuntime adoption, api-shell domain-freedom, removal of any of the 16 edges, or anything about authority/receipts/custody/deployment. Those are Phases B–H of the migration program plus the authority lane (ADR-0085, #2447, #2448 — unchanged here).

## Follow-up (next tranche)

**B0**: invert the `icn-core → icn-community` edge (7 refs — smallest composition-pattern prover), then **B1**: remove the `icn-core → icn-ledger` edge via the existing kernel-api `LedgerService` seam (5 syntactic refs, M-size plumbing through init_rpc/init_notifications/init_gateway), landing the ServiceKey visibility manifest with it. Draft issue bodies for these + 11 more exist in the session record.

Refs #1007, #914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
