### PR TITLE
fix(gateway): contain credential-holder escalation to arbitrary-coop ledger:write

### DIFF
--- a/docs/sdis/SDIS_QUICK_START.md
+++ b/docs/sdis/SDIS_QUICK_START.md
@@ -3,6 +3,21 @@
 > Snapshot guidance: this document contains both currently wired endpoints and forward-looking flows.
 > Verify live behavior against `icn/crates/icn-gateway/src/api/sdis/mod.rs` and `docs/sdis/SDIS_STATUS.md`.
 
+> **Self-serve enrollment is not mounted by default.** The
+> `POST /v1/sdis/enrollment/*` routes are unauthenticated by construction and end
+> in a credential mint, so they are registered only when the operator sets
+> `ICN_ENABLE_SELF_SERVE_ENROLLMENT=true` to declare an isolated rehearsal
+> deployment. **No shipped deployment profile sets it** — on production, LAN,
+> evaluator and demo images these routes return 404. Steward and moderation
+> routes under `/v1/sdis` are unaffected and remain mounted behind `jwt_auth`.
+>
+> Two further constraints apply wherever enrollment *is* mounted: a level-2 vouch
+> requires a credential issued for the same cooperative as the enrollment, and
+> completion fails rather than minting a credential if any required institutional
+> write (anchor, holder, jurisdiction join, membership approval) fails. This is a
+> containment tranche, not the final SDIS enrollment authority model — see
+> [`ADR-0085`](../adr/) for the open decision.
+
 ## 🚀 Getting Started with SDIS
 
 SDIS (Secure Distributed Identity System) enables secure multi-device identity management and recovery for ICN.

--- a/docs/sdis/SDIS_QUICK_START.md
+++ b/docs/sdis/SDIS_QUICK_START.md
@@ -8,8 +8,12 @@
 > in a credential mint, so they are registered only when the operator sets
 > `ICN_ENABLE_SELF_SERVE_ENROLLMENT=true` to declare an isolated rehearsal
 > deployment. **No shipped deployment profile sets it** — on production, LAN,
-> evaluator and demo images these routes return 404. Steward and moderation
-> routes under `/v1/sdis` are unaffected and remain mounted behind `jwt_auth`.
+> evaluator and demo images these routes are absent, returning **404 or 401
+> depending on route fallthrough**: the `/v1/sdis` scope nests an authenticated
+> sub-scope that matches remaining paths, so an unmounted enrollment path may be
+> rejected by `jwt_auth` before routing rather than 404'ing. Either way no
+> enrollment handler runs. Steward and moderation routes under `/v1/sdis` are
+> unaffected and remain mounted behind `jwt_auth`.
 >
 > Two further constraints apply wherever enrollment *is* mounted: a level-2 vouch
 > requires a credential issued for the same cooperative as the enrollment, and

--- a/docs/sdis/SDIS_QUICK_START.md
+++ b/docs/sdis/SDIS_QUICK_START.md
@@ -19,8 +19,11 @@
 > requires a credential issued for the same cooperative as the enrollment, and
 > completion fails rather than minting a credential if any required institutional
 > write (anchor, holder, jurisdiction join, membership approval) fails. This is a
-> containment tranche, not the final SDIS enrollment authority model — see
-> [`ADR-0085`](../adr/) for the open decision.
+> containment tranche, not the final SDIS enrollment authority model. That decision —
+> whether vouching authority derives from the trust graph or from a governance
+> capability — is still open and has no accepted ADR. The live proposal is the **draft
+> PR** [InterCooperative-Network/icn#2450](https://github.com/InterCooperative-Network/icn/pull/2450),
+> *"docs(architecture): propose institution-scoped SDIS vouch authority"*.
 
 ## 🚀 Getting Started with SDIS
 

--- a/icn/apps/trust-app/src/service_tokio.rs
+++ b/icn/apps/trust-app/src/service_tokio.rs
@@ -396,6 +396,31 @@ impl TrustService for TrustServiceImplTokio {
             return Ok(()); // Silently reject expired attestations
         }
 
+        // Refuse self-attestation on the gossip ingestion boundary (F-P0-1).
+        //
+        // This is the third authorization boundary, and the one most easily missed:
+        // a peer can correctly self-sign an attestation whose issuer equals its
+        // subject. The signature verifies, the expiry check passes, and the edge
+        // would then be persisted as a genuine incoming vouch — which is exactly
+        // what the level-2 enrollment gate averages when deciding who may vouch.
+        //
+        // A remote peer must not be able to raise its own standing by asserting it.
+        // Checked here rather than in `TrustGraph::add_edge` for the same reason as
+        // the HTTP and RPC paths: that storage primitive must keep accepting the
+        // deliberate `own_did -> own_did` genesis seed `icnd` writes under
+        // `ICN_DEV_SELF_TRUST`.
+        if attestation.issuer == attestation.subject {
+            tracing::warn!(
+                source = %source,
+                "Rejected self-attestation from gossip: {} -> {}",
+                attestation.issuer, attestation.subject,
+            );
+            return Err(icn_trust::SelfAttestationRejected {
+                did: attestation.issuer.to_string(),
+            }
+            .to_string());
+        }
+
         // Save sequence info before converting (attestation is consumed)
         let att_issuer = attestation.issuer.clone();
         let att_sequence = attestation.sequence;
@@ -782,6 +807,84 @@ mod tests {
             keypair,
             store,
         )
+    }
+
+    /// A peer may not raise its own standing by gossiping a self-signed
+    /// self-attestation (F-P0-1, gossip ingress boundary).
+    ///
+    /// The signature on such an attestation is perfectly valid — the peer really
+    /// does own the key — so signature verification alone does not refuse it. The
+    /// resulting edge would be persisted as a genuine incoming vouch, which is
+    /// exactly what the level-2 enrollment gate averages when deciding who may
+    /// vouch. `TrustGraph::add_edge` deliberately accepts self-edges (it must, for
+    /// `icnd`'s `ICN_DEV_SELF_TRUST` genesis seed), so the refusal has to happen
+    /// here.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ingest_rejects_self_attestation_from_gossip() {
+        let (graph, keypair, store) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph.clone(), keypair, store);
+
+        // A remote peer, self-signing an attestation for itself.
+        let peer = icn_identity::KeyPair::generate().unwrap();
+        let peer_did = peer.did().clone();
+        let mut attestation =
+            icn_trust::TrustAttestation::new(peer_did.clone(), peer_did.clone(), 1.0);
+        attestation
+            .sign(&peer)
+            .expect("peer signs its own attestation");
+        attestation
+            .verify()
+            .expect("the signature is genuinely valid");
+
+        let bytes = serde_json::to_vec(&attestation).expect("serialize");
+        let source = icn_kernel_api::types::Did::from(peer_did.to_string());
+
+        let err = service
+            .ingest_attestation(&bytes, &source)
+            .expect_err("a self-attestation must be refused at the gossip boundary");
+        assert!(
+            err.contains("self-attestation"),
+            "expected a typed self-attestation refusal, got: {err}"
+        );
+
+        // And nothing was persisted.
+        let incoming = graph
+            .read()
+            .await
+            .get_incoming_edges(&peer_did)
+            .expect("read incoming edges");
+        assert!(
+            incoming.is_empty(),
+            "a refused self-attestation must not be stored"
+        );
+    }
+
+    /// The guard is specific to self-edges: an ordinary peer-to-peer attestation
+    /// still ingests normally.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ingest_accepts_normal_peer_attestation() {
+        let (graph, keypair, store) = create_test_graph();
+        let service = TrustServiceImplTokio::new(graph.clone(), keypair, store);
+
+        let issuer = icn_identity::KeyPair::generate().unwrap();
+        let subject = icn_identity::KeyPair::generate().unwrap();
+        let mut attestation =
+            icn_trust::TrustAttestation::new(issuer.did().clone(), subject.did().clone(), 0.6);
+        attestation.sign(&issuer).expect("sign");
+
+        let bytes = serde_json::to_vec(&attestation).expect("serialize");
+        let source = icn_kernel_api::types::Did::from(issuer.did().to_string());
+
+        service
+            .ingest_attestation(&bytes, &source)
+            .expect("a normal peer attestation must still ingest");
+
+        let incoming = graph
+            .read()
+            .await
+            .get_incoming_edges(subject.did())
+            .expect("read incoming edges");
+        assert_eq!(incoming.len(), 1, "the normal edge must be stored");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/icn/apps/trust-app/src/service_tokio.rs
+++ b/icn/apps/trust-app/src/service_tokio.rs
@@ -620,6 +620,26 @@ impl TrustService for TrustServiceImplTokio {
             .parse()
             .map_err(|e| format!("Invalid target DID: {e}"))?;
 
+        // Refuse self-attestation on the RPC path (F-P0-1).
+        //
+        // This is an authorization boundary: a caller reaches it through
+        // `trust.add`, and the edge it writes is read by every trust threshold
+        // in the system — including the one deciding who may vouch on the
+        // enrollment surface. A self-edge is indistinguishable from a real
+        // vouch to those consumers, so one at score 1.0 satisfies any
+        // incoming-trust gate permanently.
+        //
+        // The guard is here rather than in `TrustGraph::add_edge` because that
+        // storage primitive has no caller to reason about, and because `icnd`
+        // seeds a deliberate `own_did -> own_did` genesis edge under the
+        // `ICN_DEV_SELF_TRUST` dev gate that must keep working.
+        if self.own_did == target_did {
+            return Err(icn_trust::SelfAttestationRejected {
+                did: target_did.to_string(),
+            }
+            .to_string());
+        }
+
         let trust_score =
             icn_trust::TrustScore::new(score).map_err(|e| format!("Invalid trust score: {e}"))?;
         let mut edge = icn_trust::TrustEdge::new(self.own_did.clone(), target_did, trust_score);

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -460,7 +460,10 @@ pub async fn verify_level2(
     // makes the vouch an institution-scoped decision, using the same
     // credential-to-coop binding every other coop-scoped route enforces. It does
     // not decide the larger question of where vouching authority ought to come
-    // from — that is ADR-0085's, and is deliberately left open here.
+    // from — trust graph or governance capability — which is deliberately left
+    // open here. There is no accepted ADR for that decision yet; the live
+    // proposal is the draft PR #2450, "propose institution-scoped SDIS vouch
+    // authority".
     if claims.coop_id != session.coop_id {
         return Err(GatewayError::AuthorizationFailed(format!(
             "credential is for cooperative '{}' and cannot vouch for an enrollment into '{}'",

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -446,6 +446,28 @@ pub async fn verify_level2(
         ));
     }
 
+    // Bind the vouch to the cooperative the enrollment names.
+    //
+    // The session's `coop_id` arrives unauthenticated from `start_enrollment`,
+    // and completion turns it into the `coop_id` of a minted credential that
+    // `require_coop_access` then honors by string equality. Without this check
+    // the trust threshold below is the only thing standing between *any* valid
+    // credential and membership in an *arbitrary* cooperative — and a trust
+    // score says nothing about which institution the holder belongs to
+    // (F-P0-1, links 4 and 6).
+    //
+    // Requiring the voucher to already hold authority in the same cooperative
+    // makes the vouch an institution-scoped decision, using the same
+    // credential-to-coop binding every other coop-scoped route enforces. It does
+    // not decide the larger question of where vouching authority ought to come
+    // from — that is ADR-0085's, and is deliberately left open here.
+    if claims.coop_id != session.coop_id {
+        return Err(GatewayError::AuthorizationFailed(format!(
+            "credential is for cooperative '{}' and cannot vouch for an enrollment into '{}'",
+            claims.coop_id, session.coop_id
+        )));
+    }
+
     // Verify steward has sufficient trust
     // Stewards need a trust score of at least 0.4 (Partner level) to vouch
     // Self-trust is 1.0, so we check from steward's own perspective
@@ -659,71 +681,88 @@ pub async fn complete_enrollment(
         None
     };
 
-    // Create PersonhoodAnchor and CommonsHolderRecord for the new identity
-    let (anchor_id, holder_id) = match commons_mgr
+    // Create PersonhoodAnchor and CommonsHolderRecord for the new identity.
+    //
+    // FAIL-CLOSED (F-P0-1, link 9). Every step from here to the mint was
+    // previously `warn!`-and-continue, so a completion whose anchor, holder,
+    // jurisdiction join and membership approval had *all* failed still returned
+    // a signed credential carrying `ledger:read`/`ledger:write` for the
+    // cooperative. That credential asserts an institutional standing no durable
+    // record supports, and `require_coop_access` cannot tell the difference — it
+    // sees only the `coop_id` string. A credential that claims authority must
+    // not outlive the writes that justify it, so each failure below aborts the
+    // enrollment instead of degrading it.
+    let anchor = commons_mgr
         .create_anchor_from_enrollment(&ephemeral_did, steward_did_opt.as_ref())
         .await
-    {
-        Ok(anchor) => {
-            let anchor_id_hex = hex::encode(anchor.id());
-            // Get or create holder from anchor (idempotent - safe to call multiple times)
-            match commons_mgr
-                .get_or_create_holder(
-                    &anchor_id_hex,
-                    &ephemeral_did,
-                    Some(session.identity_name.clone()),
-                )
-                .await
-            {
-                Ok(holder) => (Some(anchor_id_hex), Some(hex::encode(holder.id()))),
-                Err(e) => {
-                    tracing::warn!("Failed to create holder for {}: {}", did, e);
-                    (Some(anchor_id_hex), None)
-                }
-            }
-        }
-        Err(e) => {
-            tracing::warn!("Failed to create anchor for {}: {}", did, e);
-            (None, None)
-        }
-    };
+        .map_err(|e| {
+            tracing::error!("Failed to create anchor for {}: {}", did, e);
+            GatewayError::InternalError(
+                "Enrollment failed: identity anchor could not be recorded".to_string(),
+            )
+        })?;
+    let anchor_id_hex = hex::encode(anchor.id());
+
+    // Get or create holder from anchor (idempotent - safe to call multiple times)
+    let holder = commons_mgr
+        .get_or_create_holder(
+            &anchor_id_hex,
+            &ephemeral_did,
+            Some(session.identity_name.clone()),
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to create holder for {}: {}", did, e);
+            GatewayError::InternalError(
+                "Enrollment failed: holder record could not be recorded".to_string(),
+            )
+        })?;
+    let holder_id_hex = hex::encode(holder.id());
 
     // Auto-affiliate the new holder with their enrollment coop
-    let membership_status = if let Some(ref holder_id_hex) = holder_id {
-        let jurisdiction = JurisdictionId::new(format!("coop:{}", session.coop_id));
-        let initial_capabilities = vec![MembershipCapability::Transact, MembershipCapability::Vote];
+    let jurisdiction = JurisdictionId::new(format!("coop:{}", session.coop_id));
+    let initial_capabilities = vec![MembershipCapability::Transact, MembershipCapability::Vote];
 
-        match commons_mgr
-            .join_jurisdiction(holder_id_hex, jurisdiction.clone(), initial_capabilities)
-            .await
-        {
-            Ok(_affiliation) => {
-                // If steward vouched, auto-approve (skip candidate → provisional)
-                if steward_did_opt.is_some() {
-                    if let Err(e) = commons_mgr
-                        .approve_membership(holder_id_hex, &jurisdiction)
-                        .await
-                    {
-                        tracing::warn!("Failed to auto-approve membership: {}", e);
-                    }
-                    Some("provisional".to_string())
-                } else {
-                    Some("candidate".to_string())
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to auto-affiliate {} with coop {}: {}",
-                    holder_id_hex,
-                    session.coop_id,
-                    e
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
+    commons_mgr
+        .join_jurisdiction(&holder_id_hex, jurisdiction.clone(), initial_capabilities)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to affiliate {} with coop {}: {}",
+                holder_id_hex,
+                session.coop_id,
+                e
+            );
+            GatewayError::InternalError(
+                "Enrollment failed: cooperative membership could not be recorded".to_string(),
+            )
+        })?;
+
+    // A level-2 session always carries a steward vouch, so approval is the normal
+    // path. The one way to reach this with no steward is an unparseable
+    // `session.steward_did` above — in which case the enrollment is in a state no
+    // durable record supports, and minting a credential for an unapproved
+    // candidate is exactly the failure this containment exists to prevent.
+    if steward_did_opt.is_none() {
+        return Err(GatewayError::InternalError(
+            "Enrollment failed: level-2 session carried no usable steward vouch".to_string(),
+        ));
+    }
+    commons_mgr
+        .approve_membership(&holder_id_hex, &jurisdiction)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to approve membership for {}: {}", holder_id_hex, e);
+            GatewayError::InternalError(
+                "Enrollment failed: membership approval could not be recorded".to_string(),
+            )
+        })?;
+
+    // Every institutional write above succeeded, so these are no longer "best
+    // effort" fields that may be absent in a successful response.
+    let anchor_id = Some(anchor_id_hex);
+    let holder_id = Some(holder_id_hex);
+    let membership_status = Some("provisional".to_string());
 
     // Capture coop_id before dropping session
     let coop_id = session.coop_id.clone();

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -1235,8 +1235,15 @@ pub struct HistoryQuery {
 /// protected `/vouch/{id}` — it sets `level = 2`, `steward_vouch`,
 /// `steward_did`, and `vouched_at` — but authorizes it with a trust-graph gate
 /// (`effective_trust >= STEWARD_MIN_TRUST_SCORE`) rather than a steward
-/// capability, and applies no cooperative binding. Moving `/vouch/{id}` behind
-/// a capability therefore does not make vouching capability-gated in general.
+/// capability. Moving `/vouch/{id}` behind a capability therefore does not make
+/// vouching capability-gated in general.
+///
+/// Note what *is* now bound and what is not. Since F-P0-1, `/enrollment/verify/level2`
+/// **does** enforce a cooperative binding: the voucher's credential must name the
+/// same `coop_id` as the enrollment, so a credential for coop A can no longer
+/// advance an enrollment into coop B. What remains unreconciled is the
+/// *capability model* — trust-graph gate here versus steward capability on
+/// `/vouch/{id}` — not the cooperative scope.
 /// Reconciling the two authority models is an institutional decision (does
 /// vouching authority derive from the trust graph or from a governance
 /// capability?), deliberately not made here — see the PR discussion for #2443.

--- a/icn/crates/icn-gateway/src/api/trust.rs
+++ b/icn/crates/icn-gateway/src/api/trust.rs
@@ -2,9 +2,12 @@
 
 use crate::error::{GatewayError, Result};
 use crate::events::{EventBroadcaster, GatewayEvent};
-use crate::trust_mgr::{TrustManager, TRUST_ISOLATED_MAX, TRUST_KNOWN_MAX, TRUST_PARTNER_MAX};
-use actix_web::{get, post, web, HttpResponse};
+use crate::trust_mgr::{
+    TrustManager, TrustMutationError, TRUST_ISOLATED_MAX, TRUST_KNOWN_MAX, TRUST_PARTNER_MAX,
+};
+use actix_web::{get, post, web, HttpRequest, HttpResponse};
 use icn_identity::Did;
+use icn_rpc::auth::scopes::TRUST_WRITE;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
@@ -100,13 +103,28 @@ pub async fn get_trust_edges(
 /// POST /v1/trust/attest - Create a trust attestation
 ///
 /// Creates a trust edge from the authenticated DID to another DID.
+///
+/// # Authority
+///
+/// Requires the [`TRUST_WRITE`] capability. Authentication alone is deliberately
+/// **not** sufficient: this was the only mutating gateway route reachable with
+/// any valid credential and no capability, and the edge it writes feeds the
+/// trust threshold that decides who may vouch on the enrollment surface. A
+/// holder of an arbitrary credential could therefore raise its own standing to
+/// the vouching threshold (F-P0-1, links 1–3).
+///
+/// `from` is the authenticated subject and is never taken from the body, so the
+/// capability authorizes attesting *as yourself*, not as anyone else.
 #[post("/trust/attest")]
 pub async fn create_trust_attestation(
+    http_req: HttpRequest,
     req: web::Json<CreateTrustEdgeRequest>,
     from_did: web::ReqData<Did>,
     trust_manager: web::Data<Arc<TrustManager>>,
     event_broadcaster: web::Data<Arc<EventBroadcaster>>,
 ) -> Result<HttpResponse> {
+    crate::middleware::require_scope(&http_req, TRUST_WRITE)?;
+
     let to_did = req
         .to
         .parse::<Did>()
@@ -117,7 +135,16 @@ pub async fn create_trust_attestation(
     trust_manager
         .add_edge_with_score(from.clone(), to_did.clone(), req.score, req.memo.clone())
         .await
-        .map_err(|e| GatewayError::BadRequest(format!("Invalid trust score: {}", e)))?;
+        .map_err(|e| match e {
+            // A self-edge refusal is an authorization outcome, not bad input:
+            // the request is well-formed and the caller is simply not permitted
+            // to be both ends of its own attestation.
+            TrustMutationError::SelfAttestation { .. } => {
+                GatewayError::AuthorizationFailed(e.to_string())
+            }
+            TrustMutationError::InvalidScore(_) => GatewayError::BadRequest(e.to_string()),
+            TrustMutationError::Storage(_) => GatewayError::InternalError(e.to_string()),
+        })?;
 
     // Broadcast event to target DID (they received a trust attestation)
     // Use target's DID as the "coop_id" for personal notifications

--- a/icn/crates/icn-gateway/src/server.rs
+++ b/icn/crates/icn-gateway/src/server.rs
@@ -211,6 +211,125 @@ fn admin_endpoints_allowed(opt_in: bool, bind_addr: &SocketAddr) -> bool {
     opt_in && bind_addr.ip().is_loopback()
 }
 
+/// Environment variable that mounts the self-serve SDIS enrollment route tree.
+///
+/// Its own variable on purpose. It is **not** `ICN_ENABLE_ADMIN_ENDPOINTS`,
+/// which the demo appliance profile sets
+/// (`deploy/appliance/systemd/icnd.service.d/20-demo-profile.conf`); reusing it
+/// would mount this surface on an image a stranger runs and reaches over a
+/// hostfwd.
+pub(crate) const SELF_SERVE_ENROLLMENT_ENV: &str = "ICN_ENABLE_SELF_SERVE_ENROLLMENT";
+
+/// Decide whether the self-serve SDIS enrollment route tree
+/// (`/v1/sdis/enrollment/*`, plus the unauthenticated status/stats reads) may be
+/// mounted.
+///
+/// # Why this does not test the bind address
+///
+/// Every other dev/escape-hatch gate here pairs an opt-in with
+/// `bind_addr.ip().is_loopback()`, and for those it is the right invariant. It
+/// is the **wrong** invariant for this surface, because a loopback bind is not
+/// evidence of external unreachability once a reverse proxy is in front of it:
+///
+/// - the LAN rehearsal profile binds `127.0.0.1:8080`
+///   (`deploy/appliance/lan/icnd-30-lan-origin.conf.in`) and nginx proxies the
+///   whole of `/v1/` to it from the LAN TLS origin
+///   (`deploy/appliance/lan/nginx-icn-rehearsal-https.conf.in`). `is_loopback()`
+///   is `true` there — on the profile with the *highest* external reachability.
+/// - the demo profile binds `0.0.0.0:8080`, where `is_loopback()` is `false`,
+///   even though that deployment is host-only.
+///
+/// A loopback-keyed gate is therefore inverted with respect to real exposure.
+/// The gate is instead a single explicit declaration by the operator, defaulting
+/// to absent, and **no shipped deployment profile sets it** — so the route tree
+/// is absent on production, LAN, evaluator and demo alike. Setting it is an
+/// assertion that the deployment is an isolated rehearsal, which only the
+/// operator composing the topology can make.
+///
+/// Exact `true` match (case-insensitive, trimmed), matching the surrounding
+/// opt-ins: a typo falls back to absent rather than to mounted.
+fn self_serve_enrollment_allowed(opt_in: Option<&str>) -> bool {
+    opt_in
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Which conditionally-mounted routes the `/v1/sdis` scope should include.
+///
+/// Both default to `false`: a caller that forgets a field gets the closed
+/// posture, not the open one.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SdisMountFlags {
+    /// Mount the self-serve enrollment route tree (`/enrollment/*`, plus the
+    /// unauthenticated status and stats reads). See
+    /// [`self_serve_enrollment_allowed`].
+    pub self_serve_enrollment: bool,
+    /// Mount the recovery steward-approval simulation. See
+    /// [`admin_endpoints_allowed`].
+    pub admin_recovery: bool,
+}
+
+/// Build the `/v1/sdis` scope exactly as the running gateway mounts it.
+///
+/// Extracted from the `HttpServer` closure so a test can assemble the **real**
+/// scope — same routes, same nesting order, same `jwt_auth` middleware, same
+/// mount conditions — instead of hand-rebuilding an approximation of it. The
+/// architecture campaign's finding that no gateway test reaches the production
+/// router (#2421) is what makes that distinction matter: a parallel test router
+/// can agree with itself while diverging from what actually serves traffic. This
+/// closes that gap for the SDIS surface only; the rest of the route tree is
+/// still assembled inline and remains #2421's job.
+///
+/// The scope is deliberately split by authority (issue #2443): public
+/// verification stays reachable without a credential, while steward and
+/// moderation routes are mounted behind `jwt_auth` so they inherit signature
+/// validation, the configured lifetime ceiling, durable revocation, and
+/// fail-closed authority construction.
+pub fn sdis_scope(flags: SdisMountFlags) -> actix_web::Scope {
+    let SdisMountFlags {
+        self_serve_enrollment,
+        admin_recovery,
+    } = flags;
+
+    web::scope("/sdis")
+        .service(api::sdis::sdis_health)
+        .service(api::sdis::generate_ephemeral)
+        .service(api::sdis::verify_level1)
+        .service(api::sdis::verify_level2)
+        // Self-serve enrollment is mounted ONLY on an explicit
+        // isolated-rehearsal declaration. It is unauthenticated by construction
+        // and terminates in a credential mint, so on every ordinary profile the
+        // route tree is absent (404) rather than present-and-guarded — there is
+        // no handler left to forget a check. The steward surface in
+        // `configure_protected` below is unaffected.
+        .configure(move |cfg| {
+            if self_serve_enrollment {
+                api::sdis::simple_enrollment::configure(cfg);
+            }
+        })
+        // Note: enrollment::configure disabled - using simple_enrollment as primary API
+        // .configure(api::sdis::enrollment::configure)
+        .configure(api::sdis::recovery::configure)
+        .configure(api::sdis::anchor::configure)
+        // Steward/moderation surface: same `/sdis` prefix, authenticated. Nested
+        // last so the public routes above keep their unwrapped behavior.
+        // Recovery steward-approval joins the enrollment steward acts behind
+        // `jwt_auth`.
+        .service(
+            web::scope("")
+                .wrap(HttpAuthentication::bearer(crate::middleware::jwt_auth))
+                .configure(api::sdis::simple_enrollment::configure_protected)
+                // Recovery steward-approval is a dev/test escape hatch: mounted
+                // only on an explicit opt-in AND loopback bind (#2075).
+                // Off-loopback it is absent.
+                .configure(move |cfg| {
+                    if admin_recovery {
+                        api::sdis::recovery::configure_protected(cfg);
+                    }
+                }),
+        )
+}
+
 impl GatewayServer {
     /// Create a new gateway server (uses temporary storage for testing)
     pub fn new(bind_addr: SocketAddr, jwt_secret: Vec<u8>) -> Self {
@@ -806,6 +925,25 @@ impl GatewayServer {
             .map(|v| v.trim().eq_ignore_ascii_case("true"))
             .unwrap_or(false);
         let mount_admin_recovery = admin_endpoints_allowed(admin_opt_in, &self.bind_addr);
+
+        // Self-serve SDIS enrollment: absent unless the operator explicitly
+        // declares an isolated rehearsal deployment. See
+        // `self_serve_enrollment_allowed` for why this gate is not bind-keyed.
+        let self_serve_enrollment_env = std::env::var(SELF_SERVE_ENROLLMENT_ENV).ok();
+        let mount_self_serve_enrollment =
+            self_serve_enrollment_allowed(self_serve_enrollment_env.as_deref());
+        if mount_self_serve_enrollment {
+            warn!(
+                "⚠️  {}=true — the self-serve SDIS enrollment route tree \
+                 (/v1/sdis/enrollment/*) is MOUNTED WITHOUT AUTHENTICATION on bind {}. \
+                 This surface mints cooperative-scoped credentials for callers who present no \
+                 credential; it is safe only on a deployment that is genuinely unreachable from \
+                 any untrusted network, which a loopback bind alone does NOT establish when a \
+                 reverse proxy fronts the gateway. Never set this on production, LAN or \
+                 evaluator deployments.",
+                SELF_SERVE_ENROLLMENT_ENV, self.bind_addr
+            );
+        }
         if admin_opt_in && !mount_admin_recovery {
             warn!(
                 "ICN_ENABLE_ADMIN_ENDPOINTS is set but the gateway is bound to \
@@ -2210,46 +2348,10 @@ impl GatewayServer {
                         )
                         // Public cooperative statistics (no auth required)
                         .service(api::coops::get_coop_stats)
-                        // SDIS endpoints. The scope is deliberately split by
-                        // authority (issue #2443): public verification and
-                        // enrollment initiation stay reachable without a
-                        // credential, while steward and moderation routes are
-                        // mounted behind `jwt_auth` so they inherit signature
-                        // validation, the configured lifetime ceiling, durable
-                        // revocation, and fail-closed authority construction.
-                        .service(
-                            web::scope("/sdis")
-                                .service(api::sdis::sdis_health)
-                                .service(api::sdis::generate_ephemeral)
-                                .service(api::sdis::verify_level1)
-                                .service(api::sdis::verify_level2)
-                                .configure(api::sdis::simple_enrollment::configure)
-                                // Note: enrollment::configure disabled - using simple_enrollment as primary API
-                                // .configure(api::sdis::enrollment::configure)
-                                .configure(api::sdis::recovery::configure)
-                                .configure(api::sdis::anchor::configure)
-                                // Steward/moderation surface: same `/sdis`
-                                // prefix, authenticated. Nested last so the
-                                // public routes above keep their unwrapped
-                                // behavior. Recovery steward-approval joins the
-                                // enrollment steward acts behind `jwt_auth`.
-                                .service(
-                                    web::scope("")
-                                        .wrap(auth.clone())
-                                        .configure(
-                                            api::sdis::simple_enrollment::configure_protected,
-                                        )
-                                        // Recovery steward-approval is a dev/test
-                                        // escape hatch: mounted only on an
-                                        // explicit opt-in AND loopback bind
-                                        // (#2075). Off-loopback it is absent.
-                                        .configure(move |cfg| {
-                                            if mount_admin_recovery {
-                                                api::sdis::recovery::configure_protected(cfg);
-                                            }
-                                        }),
-                                ),
-                        )
+                        .service(sdis_scope(SdisMountFlags {
+                            self_serve_enrollment: mount_self_serve_enrollment,
+                            admin_recovery: mount_admin_recovery,
+                        }))
                         // Protected coop endpoints (auth + rate limiting)
                         .service(
                             web::scope("/coops")
@@ -2703,6 +2805,55 @@ mod tests {
         // no dev opt-in => disabled regardless of bind
         assert!(!self_serve_coop_allowed(false, &loopback_v4));
         assert!(!self_serve_coop_allowed(false, &all_ifaces));
+    }
+
+    /// SECURITY (F-P0-1): the self-serve SDIS enrollment tree is absent unless
+    /// the operator explicitly declares an isolated rehearsal deployment.
+    ///
+    /// Absent by default is the property that matters: this surface is
+    /// unauthenticated by construction and terminates in a credential mint, so
+    /// "not declared" must mean "no route", not "route with a check".
+    #[test]
+    fn self_serve_enrollment_requires_explicit_declaration() {
+        // Unset => absent. This is what every shipped deployment profile produces.
+        assert!(!self_serve_enrollment_allowed(None));
+
+        // Explicit declaration => mounted.
+        assert!(self_serve_enrollment_allowed(Some("true")));
+        assert!(self_serve_enrollment_allowed(Some("TRUE")));
+        assert!(self_serve_enrollment_allowed(Some("  true  ")));
+
+        // Anything else => absent. A typo must fall back to closed, never open.
+        for v in ["", "1", "yes", "on", "false", "ture", "enabled"] {
+            assert!(
+                !self_serve_enrollment_allowed(Some(v)),
+                "{v:?} must not mount the self-serve enrollment tree"
+            );
+        }
+    }
+
+    /// The gate must NOT be a loopback test.
+    ///
+    /// The LAN rehearsal profile binds `127.0.0.1:8080` and fronts it with an
+    /// nginx that proxies all of `/v1/` from the LAN TLS origin, so a loopback
+    /// bind is the *most* externally reachable configuration, not the least.
+    /// Keying this surface on `is_loopback()` — as the architecture campaign
+    /// originally proposed — would mount it exactly there. This test pins the
+    /// decision to the declaration alone so a later refactor cannot quietly
+    /// reintroduce a bind-address condition.
+    #[test]
+    fn self_serve_enrollment_gate_ignores_bind_address() {
+        // Same answer regardless of what the process is bound to: the predicate
+        // takes no bind argument at all, and that is deliberate.
+        assert!(self_serve_enrollment_allowed(Some("true")));
+        assert!(!self_serve_enrollment_allowed(None));
+
+        // And the environment variable is its own, not the demo profile's.
+        assert_ne!(
+            SELF_SERVE_ENROLLMENT_ENV, "ICN_ENABLE_ADMIN_ENDPOINTS",
+            "the demo appliance profile sets ICN_ENABLE_ADMIN_ENDPOINTS; reusing it would \
+             mount self-serve enrollment on an image strangers run"
+        );
     }
 
     /// SECURITY (#2075): the admin/dev SDIS recovery-approval simulation may be

--- a/icn/crates/icn-gateway/src/trust_mgr.rs
+++ b/icn/crates/icn-gateway/src/trust_mgr.rs
@@ -61,6 +61,29 @@ use tracing::{debug, warn};
 /// 3. The target DID has no trust edges (neither direct nor transitive)
 pub const DEFAULT_TRUST_SCORE: f64 = 0.5;
 
+/// Why a trust-edge mutation was refused.
+///
+/// Typed rather than a `String` so the API layer can map each cause to the
+/// status code it actually deserves. The distinction that matters for F-P0-1 is
+/// [`Self::SelfAttestation`] vs [`Self::InvalidScore`]: the old signature
+/// returned `String` for both and the handler mapped everything to 400, so a
+/// refusal to grant authority would have been reported as malformed input.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TrustMutationError {
+    /// The score was out of range, NaN, or infinite. Invalid input (400).
+    #[error("invalid trust score: {0}")]
+    InvalidScore(String),
+    /// Source and target were the same DID. An authorization outcome (403).
+    #[error("self-attestation is not permitted: {did} may not vouch for itself")]
+    SelfAttestation {
+        /// The DID that appeared as both source and target.
+        did: String,
+    },
+    /// The underlying edge store failed (500).
+    #[error("trust edge storage failed: {0}")]
+    Storage(String),
+}
+
 // Trust class thresholds (single source of truth)
 // These define the trust score boundaries for rate limiting
 /// Threshold below which a peer is considered "Isolated" (untrusted)
@@ -317,12 +340,28 @@ impl TrustManager {
     }
 
     /// Add or update a trust edge (async version)
-    pub async fn add_edge_async(&self, edge: TrustEdge) -> Result<(), String> {
+    pub async fn add_edge_async(&self, edge: TrustEdge) -> Result<(), TrustMutationError> {
+        // Refuse self-attestation before dispatching to either backend.
+        //
+        // `icn_trust::TrustGraph::add_edge` carries the same guard, but this
+        // manager has a second backend: when no `TrustGraph` handle is
+        // installed, edges go straight into the in-memory `edges` map below and
+        // never reach the domain layer. That fallback is the configuration the
+        // gateway actually runs in when trust is served by a `TrustService`
+        // (`with_trust_service` leaves `trust_graph` as `None`), so a
+        // domain-only guard would leave the live path open — which is precisely
+        // how F-P0-1 reached a 1.0 self-edge.
+        if edge.source == edge.target {
+            return Err(TrustMutationError::SelfAttestation {
+                did: edge.source.to_string(),
+            });
+        }
+
         if let Some(ref handle) = self.trust_graph {
             let mut graph = handle.write().await;
             let result = graph
                 .add_edge(edge)
-                .map_err(|e| format!("TrustGraph error: {e}"));
+                .map_err(|e| TrustMutationError::Storage(format!("TrustGraph error: {e}")));
             if result.is_ok() {
                 self.bump_generation();
             }
@@ -339,22 +378,22 @@ impl TrustManager {
     ///
     /// # Errors
     ///
-    /// Returns `Err(String)` if:
-    /// - `score` is outside the valid range [0.0, 1.0]
-    /// - `score` is NaN or infinite
-    /// - The underlying edge storage fails (actor-backed mode only)
-    ///
-    /// These errors should be mapped to HTTP 400 Bad Request at the API layer,
-    /// as they represent invalid user input.
+    /// - [`TrustMutationError::InvalidScore`] if `score` is outside [0.0, 1.0],
+    ///   NaN, or infinite — invalid input, map to 400 at the API layer.
+    /// - [`TrustMutationError::SelfAttestation`] if `from == to` — an
+    ///   authorization outcome, map to 403, not 400.
+    /// - [`TrustMutationError::Storage`] if the underlying edge storage fails
+    ///   (actor-backed mode only) — map to 500.
     pub async fn add_edge_with_score(
         &self,
         from: Did,
         to: Did,
         score: f64,
         memo: Option<String>,
-    ) -> Result<(), String> {
+    ) -> Result<(), TrustMutationError> {
         // TrustScore::new validates the score is in [0.0, 1.0] range
-        let trust_score = TrustScore::new(score).map_err(|e| e.to_string())?;
+        let trust_score =
+            TrustScore::new(score).map_err(|e| TrustMutationError::InvalidScore(e.to_string()))?;
         let mut edge = TrustEdge::new(from, to, trust_score);
 
         if let Some(memo_str) = memo {

--- a/icn/crates/icn-gateway/src/trust_mgr.rs
+++ b/icn/crates/icn-gateway/src/trust_mgr.rs
@@ -320,6 +320,20 @@ impl TrustManager {
         note = "Use add_edge_async for async contexts to avoid blocking worker threads"
     )]
     pub fn add_edge(&self, edge: TrustEdge) -> Result<(), String> {
+        // Same self-attestation refusal as `add_edge_async` (F-P0-1).
+        //
+        // This deprecated twin currently has no production caller — both call
+        // sites are inside `#[cfg(test)]` modules. It is guarded anyway rather
+        // than left to be "safe because nobody calls it": a `pub` unguarded twin
+        // of a guarded method is precisely the shape that turns into a live
+        // bypass the first time someone reaches for the sync API.
+        if edge.source == edge.target {
+            return Err(TrustMutationError::SelfAttestation {
+                did: edge.source.to_string(),
+            }
+            .to_string());
+        }
+
         if let Some(ref handle) = self.trust_graph {
             tokio::task::block_in_place(|| {
                 let mut graph = handle.blocking_write();

--- a/icn/crates/icn-gateway/src/validation.rs
+++ b/icn/crates/icn-gateway/src/validation.rs
@@ -11,7 +11,7 @@ use icn_rpc::auth::scopes::{
     GOVERNANCE_COMMENT_WRITE, GOVERNANCE_FEDERATION_WRITE, GOVERNANCE_MEETING_WRITE,
     GOVERNANCE_PENDING_PUBLISH_CONFIRM, GOVERNANCE_PENDING_PUBLISH_REVIEW,
     GOVERNANCE_PROCESS_WRITE, GOVERNANCE_PROPOSAL_WRITE, GOVERNANCE_REHEARSAL_SETUP,
-    GOVERNANCE_STEWARD_WRITE,
+    GOVERNANCE_STEWARD_WRITE, TRUST_WRITE,
 };
 
 /// Maximum length for cooperative ID
@@ -90,6 +90,13 @@ pub const ALLOWED_SCOPES: &[&str] = &[
     GOVERNANCE_PENDING_PUBLISH_REVIEW,
     GOVERNANCE_PENDING_PUBLISH_CONFIRM,
     GOVERNANCE_REHEARSAL_SETUP,
+    // Trust-graph mutation. The scope already existed in `icn_rpc::auth::scopes`
+    // and the RPC transport already required it for `trust.add`/`trust.remove`;
+    // it was missing from this allowlist, so no gateway credential could carry
+    // it and `POST /v1/trust/attest` enforced nothing instead (F-P0-1).
+    // Referenced through the constant so the allowlist and the RPC vocabulary
+    // cannot drift; locked by `test_allowed_scopes_contains_trust_write`.
+    TRUST_WRITE,
     // Settlement operations
     "settlements:read",
     "settlements:write",
@@ -895,6 +902,26 @@ mod tests {
     ///
     /// This test asserts membership both at the constant-list level
     /// (`ALLOWED_SCOPES`) and at the public-API level (`validate_scopes`).
+    /// `trust:write` must be issuable at the gateway.
+    ///
+    /// The scope already existed in `icn_rpc::auth::scopes` and the RPC
+    /// transport already required it for `trust.add`/`trust.remove`, but it was
+    /// missing from this allowlist — so no gateway credential could carry it,
+    /// and `POST /v1/trust/attest` enforced nothing instead (F-P0-1). If this
+    /// entry is ever removed, the route becomes permanently unusable rather than
+    /// permanently open, but the divergence returns either way.
+    #[test]
+    fn test_allowed_scopes_contains_trust_write() {
+        assert!(
+            ALLOWED_SCOPES.contains(&TRUST_WRITE),
+            "icn-rpc canonical scope {TRUST_WRITE:?} must be in the gateway ALLOWED_SCOPES"
+        );
+        assert!(
+            validate_scopes(&[TRUST_WRITE.to_string()]).is_ok(),
+            "a credential request for {TRUST_WRITE:?} must validate"
+        );
+    }
+
     #[test]
     fn test_allowed_scopes_contains_governance_class_write() {
         use icn_rpc::auth::scopes::GOVERNANCE_CLASS_WRITE;

--- a/icn/crates/icn-gateway/tests/fp01_credential_holder_escalation.rs
+++ b/icn/crates/icn-gateway/tests/fp01_credential_holder_escalation.rs
@@ -1,0 +1,776 @@
+//! Regression proof for F-P0-1 — credential-holder self-elevation to
+//! arbitrary-cooperative membership and `ledger:write`.
+//!
+//! # The chain these tests close
+//!
+//! A holder of **one** valid gateway credential — any scope, any cooperative —
+//! could:
+//!
+//! 1. `POST /v1/trust/attest` with `{to: <self>, score: 1.0}`. The route was
+//!    authenticated but carried no capability check, and the trust-edge mutation
+//!    had no self-edge guard, so the caller wrote an edge asserting that it
+//!    vouched for itself.
+//! 2. That self-edge is an *incoming* edge to the caller, so the level-2 vouch
+//!    gate (`effective_trust >= 0.4`, averaged over incoming edges) was
+//!    satisfied permanently and for free.
+//! 3. `POST /v1/sdis/enrollment/verify/level2` accepted any valid credential as
+//!    a steward, with no capability and no binding to the cooperative the
+//!    enrollment named.
+//! 4. `POST /v1/sdis/enrollment/complete` was mounted on the bare `/sdis` scope
+//!    outside the auth wrapper and minted a credential carrying
+//!    `ledger:read`+`ledger:write` scoped to the caller-supplied `coop_id` —
+//!    even when every institutional write behind it had failed.
+//! 5. `require_coop_access` then compared that `coop_id` by string equality and
+//!    let the credential through.
+//!
+//! # Why these tests build the real scope
+//!
+//! The route tree is assembled inside a closure in `GatewayServer::run`, and the
+//! campaign found that no gateway test reaches it (#2421) — a parallel test
+//! router can agree with itself while diverging from what serves traffic, which
+//! is how a mounted-outside-auth route survived review. These cases therefore
+//! call [`icn_gateway::server::sdis_scope`], the same constructor the running
+//! gateway calls, with the same mount flags, rather than rebuilding an
+//! approximation of `/sdis`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use actix_web::{test, web, App};
+use ed25519_dalek::{Signer, SigningKey};
+use icn_gateway::api::sdis::simple_enrollment::{EnrollmentSession, EnrollmentStore};
+use icn_gateway::auth::AuthManager;
+use icn_gateway::commons_mgr::CommonsManager;
+use icn_gateway::server::{sdis_scope, SdisMountFlags};
+use icn_gateway::session_authority::{
+    AuthorityProfile, InMemoryRevocationAuthority, SessionAuthority, TokenLifetimePolicy,
+};
+use icn_gateway::steward_mgr::StewardManager;
+use icn_gateway::trust_mgr::{TrustManager, TrustMutationError};
+use icn_identity::{Did, IdentityBundle};
+
+const SECRET: &[u8] = b"fp01-containment-regression-secret-32b";
+
+/// The trust-attestation route as the assembled router actually serves it.
+///
+/// Note the doubled segment. The handler macro is `#[post("/trust/attest")]`
+/// *and* `GatewayServer::run` mounts it inside `web::scope("/trust")`, so the
+/// live path is `/v1/trust/trust/attest` — not the `/v1/trust/attest` that the
+/// docs and the architecture campaign both name. The same doubling applies to
+/// every route in that scope. That is a separate (cosmetic) defect; this
+/// containment deliberately does not renumber the API, and pins the real path
+/// here so the capability check is proven against the route that actually
+/// serves traffic rather than against a 404.
+const ATTEST_URI: &str = "/v1/trust/trust/attest";
+
+/// The cooperative an honest credential in these tests belongs to.
+const HOME_COOP: &str = "home-coop";
+/// A cooperative the caller has no relationship with — the escalation target.
+const VICTIM_COOP: &str = "victim-coop";
+
+fn authority() -> Arc<SessionAuthority> {
+    let lifetime = TokenLifetimePolicy::from_hours(1).unwrap();
+    let auth = Arc::new(AuthManager::new(SECRET.to_vec()).with_token_ttl(lifetime.ttl()));
+    Arc::new(
+        SessionAuthority::new(
+            auth,
+            Arc::new(InMemoryRevocationAuthority::new()),
+            lifetime,
+            AuthorityProfile::PortableEvaluator,
+        )
+        .expect("authority assembles"),
+    )
+}
+
+fn scopes(list: &[&str]) -> Vec<String> {
+    list.iter().map(|s| s.to_string()).collect()
+}
+
+fn mint(authority: &SessionAuthority, did: &Did, coop: &str, scope_list: &[&str]) -> String {
+    authority
+        .auth_manager()
+        .issue_token(did, coop, scopes(scope_list))
+        .expect("mint")
+}
+
+/// Assemble `/v1/sdis` exactly as `GatewayServer::run` does, with the given
+/// mount flags and the app data the enrollment handlers resolve.
+macro_rules! sdis_app {
+    ($authority:expr, $trust:expr, $flags:expr) => {{
+        test::init_service(
+            App::new()
+                .app_data(web::Data::new($authority.clone()))
+                .app_data(web::Data::new($trust.clone()))
+                .app_data(web::Data::new(Arc::new(EnrollmentStore::new())))
+                .app_data(web::Data::new(Arc::new(CommonsManager::new())))
+                .app_data(web::Data::new(None::<Arc<StewardManager>>))
+                .service(web::scope("/v1").service(sdis_scope($flags))),
+        )
+        .await
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// 1. The trust-attestation route: capability check, and the dead extractor.
+// ---------------------------------------------------------------------------
+
+/// `POST /v1/trust/trust/attest` is UNREACHABLE on current `main`, and that
+/// disproves link 2 of the reported chain.
+///
+/// `create_trust_attestation` takes `from_did: web::ReqData<Did>`. `ReqData<T>`
+/// resolves `T` out of the request extensions — and **nothing in the gateway
+/// ever inserts a bare `Did`**. `jwt_auth` inserts `icn_http_kit::auth::BasicClaims`
+/// and the gateway's `TokenClaims` (`middleware.rs`); the trust rate limiter only
+/// *reads* `TokenClaims`. So the extractor fails and the request 500s before the
+/// handler body — including before the `require_scope` this containment added.
+///
+/// Consequences, recorded here because they are easy to lose:
+///
+/// * The self-edge write that the architecture campaign described as link 2 of
+///   F-P0-1 **cannot happen over this route**. The campaign traced the handler
+///   body without checking whether its extractor could resolve.
+/// * The same defect kills `get_trust_score`, `revoke_trust_attestation`
+///   (`api/trust.rs`) and seven handlers in `api/notifications.rs`.
+/// * The chain is still reachable by another route — see
+///   `enrollment_vouch_edge_clears_the_threshold_without_any_attestation` below.
+///
+/// This case pins the current behaviour deliberately. Repairing the extractor is
+/// a surface-*expanding* change (it turns a dead write path into a live one) and
+/// is intentionally not done in a containment tranche. Whoever repairs it will
+/// see this test fail, and must keep the `require_scope` that is already in the
+/// handler.
+#[actix_web::test]
+async fn trust_attest_route_is_unreachable_because_its_extractor_is_never_populated() {
+    use actix_web_httpauth::middleware::HttpAuthentication;
+
+    let authority = authority();
+    let trust = Arc::new(TrustManager::new());
+    let caller = IdentityBundle::generate().unwrap().did().clone();
+    let target = IdentityBundle::generate().unwrap().did().clone();
+
+    // A credential carrying the capability the route requires. Even this fails.
+    let token = mint(&authority, &caller, HOME_COOP, &["trust:write"]);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(authority.clone()))
+            .app_data(web::Data::new(trust.clone()))
+            .app_data(web::Data::new(Arc::new(
+                icn_gateway::events::EventBroadcaster::new(),
+            )))
+            .service(
+                web::scope("/v1").service(
+                    web::scope("/trust")
+                        .service(icn_gateway::api::trust::create_trust_attestation)
+                        .wrap(HttpAuthentication::bearer(
+                            icn_gateway::middleware::jwt_auth,
+                        )),
+                ),
+            ),
+    )
+    .await;
+
+    let status = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(ATTEST_URI)
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .set_json(serde_json::json!({ "to": target.to_string(), "score": 0.6 }))
+            .to_request(),
+    )
+    .await
+    .status()
+    .as_u16();
+
+    assert_eq!(
+        status, 500,
+        "the route is expected to be dead: ReqData<Did> is never populated. \
+         If this now returns 200/403, the extractor was repaired — keep the \
+         require_scope(TRUST_WRITE) check in create_trust_attestation and update \
+         this test to assert 403-without-capability / 200-with."
+    );
+
+    // The decisive part: no edge was written, so no self-elevation is possible here.
+    assert!(
+        trust.get_incoming_edges_async(&target).await.is_empty(),
+        "a 500'd attestation must not have written an edge"
+    );
+}
+
+/// The reachable replacement for the disproved link 2.
+///
+/// `complete_enrollment` writes a steward→member trust edge at **0.5**, labelled
+/// `enrollment-vouch`. The level-2 gate admits anyone whose average *incoming*
+/// trust is >= 0.4. So a member who completed enrollment can immediately vouch
+/// for further enrollments — no `trust/attest` call, and no self-edge, required.
+///
+/// That is why the cooperative binding on `verify_level2` is the load-bearing
+/// control in this containment rather than the capability on `trust/attest`:
+/// the trust threshold is satisfiable through an entirely legitimate path.
+#[tokio::test]
+async fn enrollment_vouch_edge_clears_the_threshold_without_any_attestation() {
+    let trust = TrustManager::new();
+    let steward = IdentityBundle::generate().unwrap().did().clone();
+    let member = IdentityBundle::generate().unwrap().did().clone();
+
+    // Exactly what complete_enrollment writes.
+    trust
+        .add_edge_async(
+            icn_trust::TrustEdge::new(
+                steward,
+                member.clone(),
+                icn_trust::TrustScore::unchecked(0.5),
+            )
+            .with_label("enrollment-vouch"),
+        )
+        .await
+        .expect("the enrollment vouch edge is a normal, non-self edge");
+
+    let incoming = trust.get_incoming_edges_async(&member).await;
+    let avg = incoming.iter().map(|e| e.score.value()).sum::<f64>() / incoming.len() as f64;
+
+    assert!(
+        avg >= 0.4,
+        "an enrolled member already clears the vouching threshold ({avg}) — the chain \
+         does not depend on the dead trust/attest route"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Self-attestation is rejected at the domain layer, not just over HTTP.
+// ---------------------------------------------------------------------------
+
+/// The guard must live below the transport so another caller cannot recreate the
+/// bypass. This calls the manager directly, with no HTTP involved.
+#[tokio::test]
+async fn self_edge_rejected_at_the_mutation_layer() {
+    let trust = TrustManager::new();
+    let did = IdentityBundle::generate().unwrap().did().clone();
+
+    let err = trust
+        .add_edge_with_score(did.clone(), did.clone(), 1.0, None)
+        .await
+        .expect_err("self-attestation must be refused by the mutation layer itself");
+
+    assert!(
+        matches!(err, TrustMutationError::SelfAttestation { .. }),
+        "the refusal must be a stable typed error, got {err:?}"
+    );
+
+    assert!(
+        trust.get_incoming_edges_async(&did).await.is_empty(),
+        "a rejected self-edge must not be silently stored"
+    );
+}
+
+/// A self-edge is what made the level-2 gate unfireable. With the edge refused,
+/// the caller's incoming-trust average stays at zero — below the 0.4 threshold.
+#[tokio::test]
+async fn refused_self_edge_leaves_the_vouch_threshold_unmet() {
+    let trust = TrustManager::new();
+    let did = IdentityBundle::generate().unwrap().did().clone();
+
+    let _ = trust
+        .add_edge_with_score(did.clone(), did.clone(), 1.0, None)
+        .await;
+
+    let incoming = trust.get_incoming_edges_async(&did).await;
+    let avg = if incoming.is_empty() {
+        0.0
+    } else {
+        incoming.iter().map(|e| e.score.value()).sum::<f64>() / incoming.len() as f64
+    };
+    assert!(
+        avg < 0.4,
+        "self-attestation must not lift the caller to the 0.4 vouching threshold (got {avg})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3 & 5. The enrollment route tree is absent on every non-rehearsal profile.
+// ---------------------------------------------------------------------------
+
+/// With self-serve enrollment not declared — the default, and what every shipped
+/// deployment profile produces — the whole enrollment tree is absent. A caller
+/// cannot enroll into an arbitrary cooperative because there is no route to.
+#[actix_web::test]
+async fn enrollment_tree_absent_without_explicit_declaration() {
+    let authority = authority();
+    let trust = Arc::new(TrustManager::new());
+    let app = sdis_app!(authority, trust, SdisMountFlags::default());
+
+    for (method, uri) in [
+        ("POST", "/v1/sdis/enrollment/start"),
+        ("POST", "/v1/sdis/enrollment/verify/level1"),
+        ("POST", "/v1/sdis/enrollment/verify/level2"),
+        ("POST", "/v1/sdis/enrollment/complete"),
+    ] {
+        let req = match method {
+            "POST" => test::TestRequest::post()
+                .uri(uri)
+                .set_json(serde_json::json!({})),
+            _ => test::TestRequest::get().uri(uri),
+        };
+        let status = test::call_service(&app, req.to_request())
+            .await
+            .status()
+            .as_u16();
+        // 404 (no such route) or 401 (the request fell through to the nested
+        // authenticated `/sdis` scope, which matches any remaining path and
+        // rejects an anonymous caller before routing). Either proves the same
+        // thing: no enrollment handler ran. What must never appear is 2xx.
+        assert!(
+            status == 404 || status == 401,
+            "{uri} must not be served when self-serve enrollment is undeclared (got {status})"
+        );
+    }
+}
+
+/// The containment must not take the steward surface with it: those routes are
+/// mounted unconditionally and stay behind `jwt_auth`, answering 401 to an
+/// anonymous caller rather than 404.
+#[actix_web::test]
+async fn steward_surface_survives_the_containment() {
+    let authority = authority();
+    let trust = Arc::new(TrustManager::new());
+    let app = sdis_app!(authority, trust, SdisMountFlags::default());
+
+    let req = test::TestRequest::post()
+        .uri("/v1/sdis/vouch/some-enrollment")
+        .set_json(serde_json::json!({ "vouch_statement": "x" }))
+        .to_request();
+
+    let status = test::call_service(&app, req).await.status().as_u16();
+    assert_eq!(
+        status, 401,
+        "the protected steward surface must remain mounted and authenticated, not removed"
+    );
+}
+
+/// The declared isolated-rehearsal profile still serves the surface — the gate
+/// is a mount decision, not a removal of the feature.
+#[actix_web::test]
+async fn enrollment_tree_present_under_explicit_declaration() {
+    let authority = authority();
+    let trust = Arc::new(TrustManager::new());
+    let app = sdis_app!(
+        authority,
+        trust,
+        SdisMountFlags {
+            self_serve_enrollment: true,
+            admin_recovery: false,
+        }
+    );
+
+    let req = test::TestRequest::post()
+        .uri("/v1/sdis/enrollment/start")
+        .set_json(serde_json::json!({
+            "identity_name": "Ada",
+            "coop_id": HOME_COOP,
+        }))
+        .to_request();
+
+    let status = test::call_service(&app, req).await.status().as_u16();
+    assert_eq!(
+        status, 200,
+        "the declared rehearsal profile must still serve enrollment initiation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3 (cont). Even where mounted, the vouch is bound to the cooperative.
+// ---------------------------------------------------------------------------
+
+/// Drive the real chain on the rehearsal profile: start an enrollment naming a
+/// cooperative the caller has nothing to do with, then try to vouch for it with
+/// a credential issued for a different cooperative.
+///
+/// This is the step that stops a caller-supplied `coop_id` from becoming
+/// enforceable authority: the trust threshold says nothing about *which*
+/// institution the voucher belongs to.
+#[actix_web::test]
+async fn vouch_denied_for_a_foreign_cooperative() {
+    let authority = authority();
+    let trust = Arc::new(TrustManager::new());
+    let app = sdis_app!(
+        authority,
+        trust,
+        SdisMountFlags {
+            self_serve_enrollment: true,
+            admin_recovery: false,
+        }
+    );
+
+    // Start an enrollment into the victim cooperative (unauthenticated, as designed).
+    let start = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/start")
+            .set_json(serde_json::json!({
+                "identity_name": "Mallory",
+                "coop_id": VICTIM_COOP,
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(start.status().as_u16(), 200);
+    let start: serde_json::Value = test::read_body_json(start).await;
+    let enrollment_id = start["enrollment_id"].as_str().unwrap().to_string();
+
+    // Level 1: device proof over the enrollment id.
+    let signing = SigningKey::from_bytes(&[7u8; 32]);
+    let ephemeral = Did::from_public_key(&signing.verifying_key());
+    let sig = signing.sign(enrollment_id.as_bytes());
+    let l1 = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/verify/level1")
+            .set_json(serde_json::json!({
+                "enrollment_id": enrollment_id,
+                "device_proof": {
+                    "ephemeral_did": ephemeral.to_string(),
+                    "signature": hex::encode(sig.to_bytes()),
+                }
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(l1.status().as_u16(), 200, "level 1 should succeed");
+
+    // Level 2 with a credential for HOME_COOP, and enough trust to clear the
+    // threshold by honest means (an edge from someone else).
+    let attacker = IdentityBundle::generate().unwrap().did().clone();
+    let voucher = IdentityBundle::generate().unwrap().did().clone();
+    trust
+        .add_edge_with_score(voucher, attacker.clone(), 1.0, None)
+        .await
+        .expect("honest edge");
+    let token = mint(
+        &authority,
+        &attacker,
+        HOME_COOP,
+        &["governance:steward:write"],
+    );
+
+    let l2 = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/verify/level2")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .set_json(serde_json::json!({
+                "enrollment_id": enrollment_id,
+                "vouch_statement": "I vouch",
+            }))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(
+        l2.status().as_u16(),
+        403,
+        "a credential for '{HOME_COOP}' must not advance an enrollment into '{VICTIM_COOP}', \
+         even with sufficient trust"
+    );
+}
+
+/// Completion cannot be reached while the enrollment is stuck at level 1, so no
+/// credential is minted for the foreign cooperative.
+#[actix_web::test]
+async fn completion_denied_while_vouch_is_unbound() {
+    let authority = authority();
+    let trust = Arc::new(TrustManager::new());
+    let app = sdis_app!(
+        authority,
+        trust,
+        SdisMountFlags {
+            self_serve_enrollment: true,
+            admin_recovery: false,
+        }
+    );
+
+    let start = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/start")
+            .set_json(serde_json::json!({
+                "identity_name": "Mallory",
+                "coop_id": VICTIM_COOP,
+            }))
+            .to_request(),
+    )
+    .await;
+    let start: serde_json::Value = test::read_body_json(start).await;
+    let enrollment_id = start["enrollment_id"].as_str().unwrap().to_string();
+
+    let signing = SigningKey::from_bytes(&[9u8; 32]);
+    let ephemeral = Did::from_public_key(&signing.verifying_key());
+    let sig = signing.sign(format!("complete:{enrollment_id}").as_bytes());
+
+    let done = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/complete")
+            .set_json(serde_json::json!({
+                "enrollment_id": enrollment_id,
+                "ephemeral_did": ephemeral.to_string(),
+                "ephemeral_signature": hex::encode(sig.to_bytes()),
+                "device_info": { "device_type": "t", "os": "o", "app_version": "v" },
+            }))
+            .to_request(),
+    )
+    .await;
+
+    let status = done.status().as_u16();
+    assert_ne!(
+        status, 200,
+        "completion must not mint a credential for an enrollment that never cleared a bound vouch"
+    );
+
+    let body: serde_json::Value = test::read_body_json(done).await;
+    assert!(
+        body.get("auth_token").is_none(),
+        "no credential may be returned: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4 & 7. Fail-closed mint, and the legitimate flow still works.
+// ---------------------------------------------------------------------------
+
+/// Drive one full, legitimate enrollment on the declared rehearsal profile.
+///
+/// `seed` distinguishes the device keypair; `coop` is both the enrollment's
+/// cooperative and the voucher's, so the vouch is properly bound. Returns the
+/// completion response status and body.
+async fn run_enrollment(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    authority: &SessionAuthority,
+    trust: &TrustManager,
+    coop: &str,
+    seed: u8,
+) -> (u16, serde_json::Value) {
+    let start = test::call_service(
+        app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/start")
+            .set_json(serde_json::json!({ "identity_name": "Ada", "coop_id": coop }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(start.status().as_u16(), 200, "enrollment start");
+    let start: serde_json::Value = test::read_body_json(start).await;
+    let enrollment_id = start["enrollment_id"].as_str().unwrap().to_string();
+
+    let signing = SigningKey::from_bytes(&[seed; 32]);
+    let ephemeral = Did::from_public_key(&signing.verifying_key());
+
+    let l1 = test::call_service(
+        app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/verify/level1")
+            .set_json(serde_json::json!({
+                "enrollment_id": enrollment_id,
+                "device_proof": {
+                    "ephemeral_did": ephemeral.to_string(),
+                    "signature": hex::encode(signing.sign(enrollment_id.as_bytes()).to_bytes()),
+                }
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(l1.status().as_u16(), 200, "level 1");
+
+    // A steward who belongs to the same cooperative and has honest incoming trust.
+    let steward = IdentityBundle::generate().unwrap().did().clone();
+    let voucher = IdentityBundle::generate().unwrap().did().clone();
+    trust
+        .add_edge_with_score(voucher, steward.clone(), 1.0, None)
+        .await
+        .expect("honest trust edge");
+    let token = mint(authority, &steward, coop, &["governance:steward:write"]);
+
+    let l2 = test::call_service(
+        app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/verify/level2")
+            .insert_header(("Authorization", format!("Bearer {token}")))
+            .set_json(serde_json::json!({
+                "enrollment_id": enrollment_id,
+                "vouch_statement": "I vouch for Ada",
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        l2.status().as_u16(),
+        200,
+        "a same-cooperative steward with real trust must still be able to vouch"
+    );
+
+    let done = test::call_service(
+        app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/complete")
+            .set_json(serde_json::json!({
+                "enrollment_id": enrollment_id,
+                "ephemeral_did": ephemeral.to_string(),
+                "ephemeral_signature":
+                    hex::encode(
+                        signing.sign(format!("complete:{enrollment_id}").as_bytes()).to_bytes()
+                    ),
+                "device_info": { "device_type": "t", "os": "o", "app_version": "v" },
+            }))
+            .to_request(),
+    )
+    .await;
+
+    let status = done.status().as_u16();
+    let body: serde_json::Value = test::read_body_json(done).await;
+    (status, body)
+}
+
+/// The legitimate flow still completes end to end and still mints a credential —
+/// the containment denies unauthorized callers, it does not disable enrollment
+/// on the profile that declares it.
+#[actix_web::test]
+async fn legitimate_enrollment_still_completes() {
+    let authority = authority();
+    let trust = Arc::new(TrustManager::new());
+    let app = sdis_app!(
+        authority,
+        trust,
+        SdisMountFlags {
+            self_serve_enrollment: true,
+            admin_recovery: false,
+        }
+    );
+
+    let (status, body) = run_enrollment(&app, &authority, &trust, HOME_COOP, 21).await;
+
+    assert_eq!(status, 200, "legitimate enrollment must complete: {body}");
+    assert!(
+        body["auth_token"].as_str().is_some(),
+        "a legitimate completion mints a credential: {body}"
+    );
+    assert_eq!(
+        body["membership_status"].as_str(),
+        Some("provisional"),
+        "membership must be durably recorded, not reported as absent: {body}"
+    );
+    assert!(
+        body["anchor_id"].as_str().is_some() && body["holder_id"].as_str().is_some(),
+        "anchor and holder must both exist: {body}"
+    );
+}
+
+/// A completion whose required institutional write fails must not mint.
+///
+/// # How this reproduces the original defect deterministically
+///
+/// A level-2 session records the vouching steward's DID as a string. If that
+/// string is not a parseable DID, `complete_enrollment` derives
+/// `steward_did_opt = None`, and the anchor is then created on the `Genesis`
+/// pathway rather than `WebOfTrust` — which attests `POPLevel::Weak` instead of
+/// `Strong`. `join_jurisdiction` refuses a holder below `Strong`, so the
+/// cooperative membership write **fails**.
+///
+/// Before the containment that failure was a `warn!` and execution continued to
+/// the mint: the caller received a signed credential carrying
+/// `ledger:read`+`ledger:write` for the cooperative, alongside
+/// `membership_status: null` — authority asserted over institutional state that
+/// was never written, which `require_coop_access` cannot distinguish from the
+/// real thing because it only compares the `coop_id` string.
+///
+/// The session is injected through the store's public `insert` rather than
+/// driven through `verify_level2`, because `verify_level2` can only ever record
+/// a well-formed subject DID. The point under test is the completion handler's
+/// behaviour when a required write fails, not how the session got that way.
+#[actix_web::test]
+async fn no_credential_is_minted_when_a_required_write_fails() {
+    let authority = authority();
+    let trust = Arc::new(TrustManager::new());
+    let store = Arc::new(EnrollmentStore::new());
+
+    let app = test::init_service(
+        App::new()
+            .app_data(web::Data::new(authority.clone()))
+            .app_data(web::Data::new(trust.clone()))
+            .app_data(web::Data::new(store.clone()))
+            .app_data(web::Data::new(Arc::new(CommonsManager::new())))
+            .app_data(web::Data::new(None::<Arc<StewardManager>>))
+            .service(web::scope("/v1").service(sdis_scope(SdisMountFlags {
+                self_serve_enrollment: true,
+                admin_recovery: false,
+            }))),
+    )
+    .await;
+
+    let signing = SigningKey::from_bytes(&[57u8; 32]);
+    let ephemeral = Did::from_public_key(&signing.verifying_key());
+    let enrollment_id = "fp01-required-write-fails".to_string();
+    let now = icn_time::current_timestamp_secs();
+
+    store
+        .insert(
+            enrollment_id.clone(),
+            EnrollmentSession {
+                enrollment_id: enrollment_id.clone(),
+                identity_name: "Ada".to_string(),
+                coop_id: VICTIM_COOP.to_string(),
+                verification_code: "VERIFY-0000".to_string(),
+                level: 2,
+                created_at: now,
+                expires_at: now + 86_400,
+                ephemeral_did: Some(ephemeral.to_string()),
+                steward_vouch: Some("I vouch".to_string()),
+                // Not a parseable DID ⇒ the anchor is created without a voucher
+                // ⇒ Weak POP ⇒ the jurisdiction join fails.
+                steward_did: Some("not-a-parseable-did".to_string()),
+                vouched_at: Some(now),
+                rejected: false,
+                rejection_reason: None,
+                rejected_at: None,
+                rejected_by: None,
+            },
+        )
+        .await;
+
+    let done = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/sdis/enrollment/complete")
+            .set_json(serde_json::json!({
+                "enrollment_id": enrollment_id,
+                "ephemeral_did": ephemeral.to_string(),
+                "ephemeral_signature": hex::encode(
+                    signing.sign(format!("complete:{enrollment_id}").as_bytes()).to_bytes()
+                ),
+                "device_info": { "device_type": "t", "os": "o", "app_version": "v" },
+            }))
+            .to_request(),
+    )
+    .await;
+
+    let status = done.status().as_u16();
+    let body: serde_json::Value = test::read_body_json(done).await;
+
+    assert_ne!(
+        status, 200,
+        "a completion whose institutional writes failed must not succeed: {body}"
+    );
+    assert!(
+        body.get("auth_token").is_none(),
+        "no credential may be minted when a required institutional write failed: {body}"
+    );
+    assert!(
+        body.get("membership_status")
+            .and_then(|v| v.as_str())
+            .is_none(),
+        "no membership may be reported: {body}"
+    );
+}

--- a/icn/crates/icn-gateway/tests/sdis_route_authority.rs
+++ b/icn/crates/icn-gateway/tests/sdis_route_authority.rs
@@ -11,17 +11,16 @@
 //!
 //! These cases drive the protected routes through the **real `jwt_auth`
 //! middleware** over the **same `SessionAuthority`** the production composition
-//! registers, mounted the way `GatewayServer::run` mounts them: one public
-//! `/sdis` scope for enrollment initiation and status, and one wrapped scope for
-//! the steward/moderation surface.
+//! registers, and — since the F-P0-1 containment — through
+//! `icn_gateway::server::sdis_scope`, the same `/sdis` constructor
+//! `GatewayServer::run` calls. The route set, nesting order, middleware and
+//! mount conditions are therefore production's, not a test-local rebuild.
 //!
 //! # What they do NOT prove
 //!
-//! They do not construct the full production router — the gateway's route tree
-//! is still assembled inside a closure in `GatewayServer::run` that no test can
-//! call (issue #2421). What is shared with production is the authority object,
-//! the middleware, the scope vocabulary, and the public/protected split; what is
-//! not shared is the surrounding route table. Closing that gap is #2421's job.
+//! They do not construct the full production router: the *surrounding* route
+//! table is still assembled inline in `GatewayServer::run` (issue #2421). The
+//! `/sdis` subtree is now shared; the rest is not.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -32,6 +31,7 @@ use actix_web_httpauth::middleware::HttpAuthentication;
 use icn_gateway::api::sdis::simple_enrollment::{self, EnrollmentStore};
 use icn_gateway::auth::AuthManager;
 use icn_gateway::middleware::jwt_auth;
+use icn_gateway::server::{sdis_scope, SdisMountFlags};
 use icn_gateway::session_authority::{
     AuthorityProfile, InMemoryRevocationAuthority, SessionAuthority, TokenLifetimePolicy,
 };
@@ -69,24 +69,24 @@ fn authority(ttl_hours: u64) -> Arc<SessionAuthority> {
     )
 }
 
-/// Mount `/sdis` the way production does: the public enrollment surface
-/// unwrapped, the steward/moderation surface behind `jwt_auth`.
+/// Mount `/sdis` the way production does, by calling the same constructor
+/// `GatewayServer::run` calls.
+///
+/// These cases are about *steward* authority, so they declare the isolated
+/// rehearsal profile (`self_serve_enrollment: true`) — that is the only profile
+/// on which the enrollment routes exist at all after F-P0-1 containment. On
+/// every shipped profile the tree is absent; that boundary is proven in
+/// `fp01_credential_holder_escalation.rs`, not here.
 macro_rules! sdis_app {
     ($authority:expr) => {{
-        let auth_mw = HttpAuthentication::bearer(jwt_auth);
         test::init_service(
             App::new()
                 .app_data(web::Data::new($authority))
                 .app_data(web::Data::new(Arc::new(EnrollmentStore::new())))
-                .service(
-                    web::scope("/v1/sdis")
-                        .configure(simple_enrollment::configure)
-                        .service(
-                            web::scope("")
-                                .wrap(auth_mw)
-                                .configure(simple_enrollment::configure_protected),
-                        ),
-                ),
+                .service(web::scope("/v1").service(sdis_scope(SdisMountFlags {
+                    self_serve_enrollment: true,
+                    admin_recovery: false,
+                }))),
         )
         .await
     }};
@@ -547,8 +547,15 @@ async fn restricted_reads_require_steward_capability() {
 // ---------------------------------------------------------------------------
 
 /// The point of a route-authority boundary is not to make enrollment
-/// impossible. A person beginning enrollment has no ICN credential yet, so
-/// initiation must remain reachable anonymously.
+/// impossible. A person beginning enrollment has no ICN credential yet, so on a
+/// profile that mounts enrollment at all, initiation must remain reachable
+/// anonymously.
+///
+/// Scope note (F-P0-1): "mounts enrollment at all" now means an explicitly
+/// declared isolated rehearsal deployment, which `sdis_app!` selects. This case
+/// proves the authority split did not break anonymous initiation *there*; it
+/// deliberately says nothing about whether the tree should be mounted on any
+/// other profile, which is a mount decision, not a route-authority one.
 #[actix_web::test]
 async fn public_enrollment_initiation_remains_anonymous() {
     let authority = authority(1);

--- a/icn/crates/icn-rpc/src/auth.rs
+++ b/icn/crates/icn-rpc/src/auth.rs
@@ -972,6 +972,14 @@ pub mod scopes {
     pub const GOVERNANCE_WRITE: &str = "governance:write";
     pub const COMPUTE_WRITE: &str = "compute:write";
     pub const POLICY_WRITE: &str = "policy:write";
+    /// Authority to mutate the trust graph — create or revise a trust edge
+    /// attesting that one DID vouches for another.
+    ///
+    /// Already enforced on the RPC transport: `method_required_scopes` maps
+    /// `trust.add`/`trust.remove` to this scope. The gateway's
+    /// `POST /v1/trust/attest` performed the same mutation with no capability at
+    /// all until F-P0-1 — the two transports had diverged on the same effect,
+    /// and the unguarded one was reachable with any valid credential.
     pub const TRUST_WRITE: &str = "trust:write";
     pub const RECOVERY_WRITE: &str = "recovery:write";
     pub const DISPUTE_WRITE: &str = "dispute:write";

--- a/icn/crates/icn-trust/src/lib.rs
+++ b/icn/crates/icn-trust/src/lib.rs
@@ -109,9 +109,13 @@ use tracing::{debug, info, instrument, warn};
 ///
 /// Stable and typed so callers can distinguish "you may not vouch for yourself"
 /// (an authorization outcome) from "that score is out of range" (bad input) and
-/// from a storage failure, without matching on message text. Returned through
-/// `anyhow` by [`TrustGraph::add_edge`]; recover it with
-/// `err.downcast_ref::<SelfAttestationRejected>()`.
+/// from a storage failure, without matching on message text.
+///
+/// Returned by the *authorization* boundaries — `TrustService::submit_attestation`
+/// in `apps/trust-app`, and (as its own typed variant) the gateway's
+/// `TrustManager`. [`TrustGraph::add_edge`] deliberately does not raise it; see
+/// that method's docs for why the policy does not live in the storage layer.
+/// Recover it with `err.downcast_ref::<SelfAttestationRejected>()`.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("self-attestation rejected: a trust edge may not have {did} as both source and target")]
 pub struct SelfAttestationRejected {
@@ -446,27 +450,26 @@ impl TrustGraph {
 
     /// Add or update a trust edge
     ///
-    /// # Errors
+    /// # Self-edges
     ///
-    /// Returns [`SelfAttestationRejected`] if `edge.source == edge.target`. A
-    /// self-edge is not a weaker attestation, it is a *counterfeit* one: every
-    /// consumer of this graph reads an edge as "somebody else vouched", and the
-    /// scoring paths that average incoming edges cannot distinguish the two. One
-    /// self-edge at score 1.0 therefore satisfies any incoming-trust threshold
-    /// permanently and for free (F-P0-1, link 3).
+    /// This method does **not** refuse `source == target`. Refusing a self-edge
+    /// is an *authorization* decision about who asked, and this type is the
+    /// storage primitive — it has no caller identity to reason about. Encoding
+    /// that policy here also breaks a deliberate, composition-root-level
+    /// bootstrap: `icnd` seeds a genesis `own_did -> own_did` edge under the
+    /// explicit `ICN_DEV_SELF_TRUST` dev gate (`bins/icnd/src/main.rs`), which
+    /// the documented live-local receipt-chain proof depends on.
     ///
-    /// The guard lives here rather than in a handler because every wrapper
-    /// (`TrustGraphFacade`, `TypedTrustGraph`, `MultiTrustGraph`) funnels into
-    /// this method — a transport added later inherits the rejection instead of
-    /// having to remember it.
+    /// The self-attestation guard therefore lives at each *authorization*
+    /// boundary instead, where a caller exists to be refused:
+    /// - the gateway's `TrustManager::add_edge_async` (HTTP `/trust/attest`),
+    /// - `TrustService::submit_attestation` in `apps/trust-app` (the RPC
+    ///   `trust.add` path).
+    ///
+    /// Callers that legitimately need a self-edge reach this method directly and
+    /// are, by construction, composition roots rather than request handlers.
+    /// See [`SelfAttestationRejected`] for the error those boundaries return.
     pub fn add_edge(&mut self, edge: TrustEdge) -> Result<()> {
-        if edge.source == edge.target {
-            return Err(SelfAttestationRejected {
-                did: edge.source.to_string(),
-            }
-            .into());
-        }
-
         info!(
             "Adding trust edge: {} -> {} (score: {}, prefix: {})",
             edge.source, edge.target, edge.score, self.storage_prefix

--- a/icn/crates/icn-trust/src/lib.rs
+++ b/icn/crates/icn-trust/src/lib.rs
@@ -105,6 +105,20 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, info, instrument, warn};
 
+/// A trust-edge mutation was refused because its source and target are the same DID.
+///
+/// Stable and typed so callers can distinguish "you may not vouch for yourself"
+/// (an authorization outcome) from "that score is out of range" (bad input) and
+/// from a storage failure, without matching on message text. Returned through
+/// `anyhow` by [`TrustGraph::add_edge`]; recover it with
+/// `err.downcast_ref::<SelfAttestationRejected>()`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("self-attestation rejected: a trust edge may not have {did} as both source and target")]
+pub struct SelfAttestationRejected {
+    /// The DID that appeared as both source and target.
+    pub did: String,
+}
+
 /// Threshold for logging high-fanout cache invalidation events.
 ///
 /// When a trust edge change triggers invalidation of >= this many downstream
@@ -431,7 +445,28 @@ impl TrustGraph {
     }
 
     /// Add or update a trust edge
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SelfAttestationRejected`] if `edge.source == edge.target`. A
+    /// self-edge is not a weaker attestation, it is a *counterfeit* one: every
+    /// consumer of this graph reads an edge as "somebody else vouched", and the
+    /// scoring paths that average incoming edges cannot distinguish the two. One
+    /// self-edge at score 1.0 therefore satisfies any incoming-trust threshold
+    /// permanently and for free (F-P0-1, link 3).
+    ///
+    /// The guard lives here rather than in a handler because every wrapper
+    /// (`TrustGraphFacade`, `TypedTrustGraph`, `MultiTrustGraph`) funnels into
+    /// this method — a transport added later inherits the rejection instead of
+    /// having to remember it.
     pub fn add_edge(&mut self, edge: TrustEdge) -> Result<()> {
+        if edge.source == edge.target {
+            return Err(SelfAttestationRejected {
+                did: edge.source.to_string(),
+            }
+            .into());
+        }
+
         info!(
             "Adding trust edge: {} -> {} (score: {}, prefix: {})",
             edge.source, edge.target, edge.score, self.storage_prefix

--- a/icn/crates/icn-trust/src/lib.rs
+++ b/icn/crates/icn-trust/src/lib.rs
@@ -107,15 +107,32 @@ use tracing::{debug, info, instrument, warn};
 
 /// A trust-edge mutation was refused because its source and target are the same DID.
 ///
-/// Stable and typed so callers can distinguish "you may not vouch for yourself"
-/// (an authorization outcome) from "that score is out of range" (bad input) and
-/// from a storage failure, without matching on message text.
+/// # What this type is, and what it is not
 ///
-/// Returned by the *authorization* boundaries — `TrustService::submit_attestation`
-/// in `apps/trust-app`, and (as its own typed variant) the gateway's
-/// `TrustManager`. [`TrustGraph::add_edge`] deliberately does not raise it; see
-/// that method's docs for why the policy does not live in the storage layer.
-/// Recover it with `err.downcast_ref::<SelfAttestationRejected>()`.
+/// It is the **canonical wording** of the self-attestation refusal, so every
+/// ingress reports the same thing and the message is defined in one place.
+///
+/// It is **not** recoverable as a typed value across the `TrustService`
+/// boundary. `TrustService::submit_attestation` and
+/// `TrustService::ingest_attestation` (`apps/trust-app/src/service_tokio.rs`)
+/// both return `Result<_, String>` — a signature owned by the
+/// `icn_kernel_api::services::TrustService` trait — so they construct this type
+/// and immediately `.to_string()` it. The type is erased at that boundary.
+/// **Do not attempt `downcast_ref::<SelfAttestationRejected>()` on a
+/// `TrustService` error; there is no error object to downcast.** A caller that
+/// must distinguish this refusal from other trust failures at that layer has
+/// only the message text today. Giving `TrustService` a typed error is an
+/// API change across the trait and all its implementors, deliberately not made
+/// in the F-P0-1 containment.
+///
+/// Contrast the gateway, where the refusal **is** genuinely typed:
+/// `TrustManager::add_edge_async` returns
+/// `Result<(), crate::trust_mgr::TrustMutationError>`, and the HTTP layer
+/// matches on `TrustMutationError::SelfAttestation` to answer 403 rather than
+/// 400. That path never stringifies until the response is built.
+///
+/// [`TrustGraph::add_edge`] deliberately does not raise this at all — see that
+/// method's docs for why the policy does not live in the storage layer.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("self-attestation rejected: a trust edge may not have {did} as both source and target")]
 pub struct SelfAttestationRejected {

--- a/icn/crates/icn-trust/src/lib.rs
+++ b/icn/crates/icn-trust/src/lib.rs
@@ -461,10 +461,14 @@ impl TrustGraph {
     /// the documented live-local receipt-chain proof depends on.
     ///
     /// The self-attestation guard therefore lives at each *authorization*
-    /// boundary instead, where a caller exists to be refused:
+    /// boundary instead, where a caller exists to be refused. There are three,
+    /// and all three must carry it — a self-edge accepted at any one of them is
+    /// indistinguishable downstream from a genuine vouch:
     /// - the gateway's `TrustManager::add_edge_async` (HTTP `/trust/attest`),
-    /// - `TrustService::submit_attestation` in `apps/trust-app` (the RPC
-    ///   `trust.add` path).
+    /// - `TrustService::submit_attestation` in `apps/trust-app` (RPC `trust.add`),
+    /// - `TrustService::ingest_attestation` in `apps/trust-app` (**gossip ingress**
+    ///   — a peer can correctly self-sign an attestation whose issuer equals its
+    ///   subject, so signature verification alone does not refuse it).
     ///
     /// Callers that legitimately need a self-edge reach this method directly and
     /// are, by construction, composition roots rather than request handlers.

--- a/icn/crates/icn-trust/tests/trust_integration.rs
+++ b/icn/crates/icn-trust/tests/trust_integration.rs
@@ -1306,47 +1306,36 @@ fn test_fanout_threshold_logging() {
     assert!(score >= 0.0);
 }
 
-/// A trust edge may not have the same DID as source and target (F-P0-1).
+/// `TrustGraph::add_edge` deliberately ACCEPTS a self-edge (F-P0-1 follow-up).
 ///
-/// This is the domain-layer half of the containment. The gateway carries its own
-/// guard because its in-memory backend never reaches `TrustGraph`, but every
-/// graph wrapper — `TrustGraphFacade`, `TypedTrustGraph`, `MultiTrustGraph` —
-/// funnels into `TrustGraph::add_edge`, so a transport added later inherits the
-/// refusal rather than having to remember it.
+/// Refusing `source == target` is an authorization decision, and this type is
+/// the storage primitive — it has no caller to reason about. Two things depend
+/// on that separation:
 ///
-/// A self-edge is not a weaker attestation, it is a counterfeit one: consumers
-/// read an edge as "somebody else vouched", and the scoring paths that average
-/// incoming edges cannot tell the difference. One self-edge at 1.0 therefore
-/// satisfies any incoming-trust threshold permanently and for free.
+/// 1. `icnd` seeds a genesis `own_did -> own_did` edge under the explicit
+///    `ICN_DEV_SELF_TRUST` dev gate (`bins/icnd/src/main.rs`), which the
+///    documented live-local receipt-chain proof requires. A guard here would
+///    fail the daemon at startup.
+/// 2. `icn-core`'s `ledger_gossip_trust_integration` seeds trust for every node
+///    including itself; a guard here would fail that test.
+///
+/// The self-attestation refusal lives at the authorization boundaries instead —
+/// the gateway's `TrustManager::add_edge_async` and `TrustService::submit_attestation`.
+/// This test pins the separation so a future change does not quietly move policy
+/// back down into storage.
 #[test]
-fn self_edge_is_rejected_with_a_typed_error() {
-    use icn_trust::SelfAttestationRejected;
-
+fn trust_graph_accepts_self_edges_policy_lives_above() {
     let store = Arc::new(SledStore::temporary().unwrap());
     let alice = KeyPair::generate().unwrap();
     let mut graph = TrustGraph::new(store, alice.did().clone());
 
-    let err = graph
+    graph
         .add_edge(TrustEdge::new(
             alice.did().clone(),
             alice.did().clone(),
             TrustScore::new(1.0).unwrap(),
         ))
-        .expect_err("TrustGraph must refuse a self-edge");
-
-    assert!(
-        err.downcast_ref::<SelfAttestationRejected>().is_some(),
-        "the refusal must be recoverable as a stable typed error, got: {err}"
-    );
-
-    // And nothing was written: the edge must not be silently stored.
-    assert!(
-        graph
-            .get_incoming_edges(alice.did())
-            .expect("read incoming edges")
-            .is_empty(),
-        "a rejected self-edge must leave the graph unchanged"
-    );
+        .expect("the storage layer must accept a self-edge; policy belongs above it");
 
     // An ordinary edge between two distinct DIDs still works.
     let bob = KeyPair::generate().unwrap();

--- a/icn/crates/icn-trust/tests/trust_integration.rs
+++ b/icn/crates/icn-trust/tests/trust_integration.rs
@@ -1305,3 +1305,56 @@ fn test_fanout_threshold_logging() {
     let score = multi.social().compute_trust_score(hub.did()).unwrap();
     assert!(score >= 0.0);
 }
+
+/// A trust edge may not have the same DID as source and target (F-P0-1).
+///
+/// This is the domain-layer half of the containment. The gateway carries its own
+/// guard because its in-memory backend never reaches `TrustGraph`, but every
+/// graph wrapper — `TrustGraphFacade`, `TypedTrustGraph`, `MultiTrustGraph` —
+/// funnels into `TrustGraph::add_edge`, so a transport added later inherits the
+/// refusal rather than having to remember it.
+///
+/// A self-edge is not a weaker attestation, it is a counterfeit one: consumers
+/// read an edge as "somebody else vouched", and the scoring paths that average
+/// incoming edges cannot tell the difference. One self-edge at 1.0 therefore
+/// satisfies any incoming-trust threshold permanently and for free.
+#[test]
+fn self_edge_is_rejected_with_a_typed_error() {
+    use icn_trust::SelfAttestationRejected;
+
+    let store = Arc::new(SledStore::temporary().unwrap());
+    let alice = KeyPair::generate().unwrap();
+    let mut graph = TrustGraph::new(store, alice.did().clone());
+
+    let err = graph
+        .add_edge(TrustEdge::new(
+            alice.did().clone(),
+            alice.did().clone(),
+            TrustScore::new(1.0).unwrap(),
+        ))
+        .expect_err("TrustGraph must refuse a self-edge");
+
+    assert!(
+        err.downcast_ref::<SelfAttestationRejected>().is_some(),
+        "the refusal must be recoverable as a stable typed error, got: {err}"
+    );
+
+    // And nothing was written: the edge must not be silently stored.
+    assert!(
+        graph
+            .get_incoming_edges(alice.did())
+            .expect("read incoming edges")
+            .is_empty(),
+        "a rejected self-edge must leave the graph unchanged"
+    );
+
+    // An ordinary edge between two distinct DIDs still works.
+    let bob = KeyPair::generate().unwrap();
+    graph
+        .add_edge(TrustEdge::new(
+            alice.did().clone(),
+            bob.did().clone(),
+            TrustScore::new(0.8).unwrap(),
+        ))
+        .expect("a normal edge must still be accepted");
+}

--- a/scripts/test-mobile-app-e2e.sh
+++ b/scripts/test-mobile-app-e2e.sh
@@ -176,8 +176,22 @@ if [ "$enroll_status" = "200" ] || [ "$enroll_status" = "201" ]; then
     echo -e "${GREEN}✓${NC}"
     enrollment_id=$(echo "$enroll_body" | jq -r '.enrollment_id' 2>/dev/null)
     echo "  Enrollment ID: $enrollment_id"
+elif [ "$enroll_status" = "404" ] || [ "$enroll_status" = "401" ]; then
+    # Self-serve enrollment is absent unless the operator declares an isolated
+    # rehearsal deployment (ICN_ENABLE_SELF_SERVE_ENROLLMENT=true). No shipped
+    # profile sets it, so this is the EXPECTED default, not a failure.
+    #
+    # Report it as SKIPPED rather than a warning: this section previously
+    # printed a warning and carried on, so a run against a default gateway
+    # reported the enrollment flow as exercised when no enrollment happened.
+    echo -e "${YELLOW}SKIPPED${NC} ($enroll_status — self-serve enrollment not mounted)"
+    echo "  This is the expected default: no shipped profile sets"
+    echo "  ICN_ENABLE_SELF_SERVE_ENROLLMENT=true. To exercise this flow, point"
+    echo "  the script at a gateway that has explicitly declared an isolated"
+    echo "  rehearsal deployment."
+    enrollment_id=""
 else
-    echo -e "${YELLOW}⚠${NC} ($enroll_status)"
+    echo -e "${RED}✗${NC} ($enroll_status)"
     echo "  Response: $enroll_body" | head -c 200
 fi
 echo ""

--- a/scripts/test-mobile-app-e2e.sh
+++ b/scripts/test-mobile-app-e2e.sh
@@ -156,6 +156,10 @@ echo ""
 echo -e "${BLUE}Step 4: Test SDIS Enrollment Flow${NC}"
 echo "----------------------------------------"
 
+# Outcome of the enrollment section, consumed by the final summary.
+# Default to "failed" so an unforeseen path cannot silently read as success.
+enrollment_result="failed"
+
 echo -n "Starting SDIS enrollment... "
 enroll_response=$(curl -s -w "\n%{http_code}" \
     -H "Content-Type: application/json" \
@@ -173,9 +177,18 @@ enroll_status=$(echo "$enroll_response" | tail -n1)
 enroll_body=$(echo "$enroll_response" | head -n-1)
 
 if [ "$enroll_status" = "200" ] || [ "$enroll_status" = "201" ]; then
-    echo -e "${GREEN}✓${NC}"
     enrollment_id=$(echo "$enroll_body" | jq -r '.enrollment_id' 2>/dev/null)
-    echo "  Enrollment ID: $enrollment_id"
+    if [ -z "$enrollment_id" ] || [ "$enrollment_id" = "null" ]; then
+        # 2xx but no usable enrollment_id: a malformed response is a real
+        # failure, not a skip.
+        echo -e "${RED}✗${NC} ($enroll_status, no enrollment_id in response)"
+        echo "  Response: $enroll_body" | head -c 200
+        enrollment_result="failed"
+    else
+        echo -e "${GREEN}✓${NC}"
+        echo "  Enrollment ID: $enrollment_id"
+        enrollment_result="operational"
+    fi
 elif [ "$enroll_status" = "404" ] || [ "$enroll_status" = "401" ]; then
     # Self-serve enrollment is absent unless the operator declares an isolated
     # rehearsal deployment (ICN_ENABLE_SELF_SERVE_ENROLLMENT=true). No shipped
@@ -190,9 +203,11 @@ elif [ "$enroll_status" = "404" ] || [ "$enroll_status" = "401" ]; then
     echo "  the script at a gateway that has explicitly declared an isolated"
     echo "  rehearsal deployment."
     enrollment_id=""
+    enrollment_result="skipped"
 else
     echo -e "${RED}✗${NC} ($enroll_status)"
     echo "  Response: $enroll_body" | head -c 200
+    enrollment_result="failed"
 fi
 echo ""
 
@@ -205,9 +220,31 @@ echo -e "${GREEN}✓ Authentication Flow${NC} - Challenge-response working"
 echo -e "${GREEN}✓ Token Generation${NC} - JWT tokens being issued"
 echo -e "${GREEN}✓ Ledger Endpoints${NC} - Balance and history accessible"
 echo -e "${GREEN}✓ Governance Endpoints${NC} - Domains and proposals accessible"
-echo -e "${GREEN}✓ SDIS Enrollment${NC} - Enrollment system operational"
-echo ""
-echo "🎉 Mobile app backend is fully operational!"
+
+# The enrollment line must reflect what actually happened. Self-serve enrollment
+# is absent on every shipped profile, so on a default gateway this section is
+# skipped — and a skipped section must never be summarised as "operational",
+# nor support an unconditional "fully operational" conclusion.
+case "$enrollment_result" in
+    operational)
+        echo -e "${GREEN}✓ SDIS Enrollment${NC} - Enrollment system operational"
+        echo ""
+        echo "🎉 Mobile app backend is fully operational!"
+        ;;
+    skipped)
+        echo -e "${YELLOW}⊘ SDIS Enrollment${NC} - SKIPPED (self-serve enrollment not enabled on this gateway)"
+        echo ""
+        echo "✅ Mobile app backend checks passed, EXCEPT SDIS enrollment, which was not exercised."
+        echo "   Self-serve enrollment is absent unless the operator sets"
+        echo "   ICN_ENABLE_SELF_SERVE_ENROLLMENT=true. That is the expected default and is"
+        echo "   not a failure — but this run does NOT demonstrate that the enrollment flow works."
+        ;;
+    *)
+        echo -e "${RED}✗ SDIS Enrollment${NC} - FAILED"
+        echo ""
+        echo "❌ Mobile app backend is NOT fully operational: SDIS enrollment failed."
+        ;;
+esac
 echo ""
 echo "To run CoopWallet mobile app:"
 echo "  cd /home/matt/projects/icn/sdk/react-native/examples/CoopWallet"
@@ -219,3 +256,8 @@ echo ""
 
 # Cleanup
 rm -rf "$TEST_DATA_DIR"
+
+# A genuine enrollment failure must fail the run. A skip must not.
+if [ "$enrollment_result" = "failed" ]; then
+    exit 1
+fi

--- a/scripts/test-mobile-app-e2e.sh
+++ b/scripts/test-mobile-app-e2e.sh
@@ -157,6 +157,20 @@ echo -e "${BLUE}Step 4: Test SDIS Enrollment Flow${NC}"
 echo "----------------------------------------"
 
 # Outcome of the enrollment section, consumed by the final summary.
+#
+# States:
+#   completed        the full flow ran and completion returned a credential
+#   initiation_only  /enrollment/start responded, nothing further was exercised
+#   skipped          401/404 — self-serve enrollment is not mounted (the default)
+#   failed           unexpected status, malformed 2xx, or a failed completion
+#
+# NOTE: this script exercises ONLY /enrollment/start. It performs no level-1
+# device proof, no level-2 vouch, and no completion, so it cannot reach
+# "completed". The state exists so the summary can never imply completion was
+# tested, and so a future version that does exercise the full flow has an
+# honest value to set. Reaching completion needs Ed25519 device signing over
+# `complete:{enrollment_id}`; duplicating that in shell is out of scope here.
+#
 # Default to "failed" so an unforeseen path cannot silently read as success.
 enrollment_result="failed"
 
@@ -185,9 +199,15 @@ if [ "$enroll_status" = "200" ] || [ "$enroll_status" = "201" ]; then
         echo "  Response: $enroll_body" | head -c 200
         enrollment_result="failed"
     else
-        echo -e "${GREEN}✓${NC}"
+        # A usable enrollment ID proves the START endpoint answered. It proves
+        # nothing about level-1 verification, level-2 vouching, completion,
+        # credential minting, or the durable anchor/holder/membership records.
+        # Report exactly that.
+        echo -e "${GREEN}✓${NC} (initiation only)"
         echo "  Enrollment ID: $enrollment_id"
-        enrollment_result="operational"
+        echo "  NOTE: completion was NOT exercised — no level-1 proof, no level-2"
+        echo "        vouch, no /enrollment/complete call."
+        enrollment_result="initiation_only"
     fi
 elif [ "$enroll_status" = "404" ] || [ "$enroll_status" = "401" ]; then
     # Self-serve enrollment is absent unless the operator declares an isolated
@@ -226,10 +246,18 @@ echo -e "${GREEN}✓ Governance Endpoints${NC} - Domains and proposals accessibl
 # skipped — and a skipped section must never be summarised as "operational",
 # nor support an unconditional "fully operational" conclusion.
 case "$enrollment_result" in
-    operational)
-        echo -e "${GREEN}✓ SDIS Enrollment${NC} - Enrollment system operational"
+    completed)
+        echo -e "${GREEN}✓ SDIS Enrollment${NC} - Enrollment system operational (completion verified)"
         echo ""
         echo "🎉 Mobile app backend is fully operational!"
+        ;;
+    initiation_only)
+        echo -e "${YELLOW}◐ SDIS Enrollment${NC} - PARTIAL: initiation endpoint available; completion NOT exercised"
+        echo ""
+        echo "✅ Mobile app backend checks passed, with SDIS enrollment only PARTIALLY exercised."
+        echo "   /enrollment/start responded, but this run performed no level-1 device"
+        echo "   proof, no level-2 vouch, and no completion — so it does NOT demonstrate"
+        echo "   credential minting, membership creation, or completion reliability."
         ;;
     skipped)
         echo -e "${YELLOW}⊘ SDIS Enrollment${NC} - SKIPPED (self-serve enrollment not enabled on this gateway)"

--- a/scripts/test-sdis-enrollment.sh
+++ b/scripts/test-sdis-enrollment.sh
@@ -37,16 +37,38 @@ fi
 echo ""
 
 # Step 2: Start Enrollment
+#
+# NOTE: self-serve enrollment is absent unless the gateway operator has declared
+# an isolated rehearsal deployment with ICN_ENABLE_SELF_SERVE_ENROLLMENT=true.
+# No shipped deployment profile sets it, so against a default gateway these
+# routes are simply not mounted and answer 404 (or 401, if the request falls
+# through to the authenticated /sdis sub-scope). That is the expected posture,
+# not a regression — this script requires a gateway that has opted in.
 echo -e "${YELLOW}Step 2: Start Enrollment${NC}"
-ENROLLMENT_RESPONSE=$(curl -s -X POST "$GATEWAY_URL/v1/sdis/enrollment/start" \
+ENROLLMENT_HTTP=$(curl -s -o /tmp/icn-enroll-start.$$ -w "%{http_code}" \
+    -X POST "$GATEWAY_URL/v1/sdis/enrollment/start" \
     -H "Content-Type: application/json" \
     -d "{\"identity_name\":\"$IDENTITY_NAME\",\"coop_id\":\"$COOP_ID\"}")
+ENROLLMENT_RESPONSE=$(cat /tmp/icn-enroll-start.$$ 2>/dev/null)
+rm -f /tmp/icn-enroll-start.$$
+
+if [ "$ENROLLMENT_HTTP" = "404" ] || [ "$ENROLLMENT_HTTP" = "401" ]; then
+    echo -e "${YELLOW}⊘ Self-serve enrollment is not mounted on this gateway (HTTP $ENROLLMENT_HTTP)${NC}"
+    echo ""
+    echo "  This is the expected default. The route tree mounts only when the"
+    echo "  operator sets ICN_ENABLE_SELF_SERVE_ENROLLMENT=true to declare an"
+    echo "  isolated rehearsal deployment, and no shipped profile sets it."
+    echo ""
+    echo "  To run this script, point it at a gateway that has opted in."
+    echo "  Skipping the enrollment flow rather than reporting a false result."
+    exit 0
+fi
 
 ENROLLMENT_ID=$(echo "$ENROLLMENT_RESPONSE" | jq -r '.enrollment_id // empty')
 
 if [ -z "$ENROLLMENT_ID" ]; then
-    echo -e "${RED}✗ Enrollment start failed${NC}"
-    echo "$ENROLLMENT_RESPONSE" | jq .
+    echo -e "${RED}✗ Enrollment start failed (HTTP $ENROLLMENT_HTTP)${NC}"
+    echo "$ENROLLMENT_RESPONSE" | jq . 2>/dev/null || echo "$ENROLLMENT_RESPONSE"
     exit 1
 else
     echo -e "${GREEN}✓ Enrollment started${NC}"


### PR DESCRIPTION
## Summary

An unauthenticated caller could complete an SDIS enrollment naming an **arbitrary** cooperative and receive a signed credential carrying `ledger:read`+`ledger:write` for it, plus an auto-approved `coop:{arbitrary}` membership with `Transact` and `Vote` — **even when every institutional write behind that credential had failed**.

### Preconditions

- The enrollment routes had to be mounted. On `main` they are mounted **unconditionally on every profile**, including production and the LAN rehearsal node.
- `verify_level2` required a valid credential — any scope, any cooperative — whose average **incoming** trust was ≥ 0.4.
- `start_enrollment` and `complete_enrollment` required **no credential at all**.

### Why arbitrary cooperative authority could be minted

`start_enrollment` is unauthenticated and stores the caller-supplied `coop_id` verbatim. `verify_level2` hand-authenticated a bearer token but applied no capability and no cooperative binding, so any credential could vouch for an enrollment into any cooperative. `complete_enrollment` was mounted on the bare `/sdis` scope **outside** the auth wrapper — its signature has no `HttpRequest`, so it structurally could not 401 — and minted `ledger:read`/`ledger:write` against the session's `coop_id` unconditionally; anchor, holder, `join_jurisdiction` and `approve_membership` failures were all `warn!`-and-continue. `require_coop_access` then honored that `coop_id` by **pure string equality**.

### Correction to the originally reported entry step

The architecture campaign named `POST /v1/trust/attest` with `{to: self, score: 1.0}` as the way in. **That route cannot execute.** `create_trust_attestation` takes `from_did: web::ReqData<Did>`, and nothing in the gateway ever inserts a bare `Did` into request extensions — `jwt_auth` inserts `BasicClaims` and `TokenClaims`; the trust rate limiter only reads `TokenClaims`. Extraction fails and the request 500s before the handler body. Verified empirically: a live test service mounting the real handler behind the real `jwt_auth`, given a credential carrying `trust:write`, returns 500. The same defect affects `get_trust_score`, `revoke_trust_attestation`, and seven handlers in `api/notifications.rs`. (The live path is also `/v1/trust/`**`trust`**`/attest` — the handler macro and the scope both contribute `/trust`.)

**The finding survives the correction.** `complete_enrollment` itself writes a steward→member edge at **0.5** labelled `enrollment-vouch`, and the level-2 gate admits ≥ 0.4 — so any member who completed an enrollment could already vouch. The self-edge was a shortcut, not the key. Severity is unchanged; only the entry step moves. This is why the **cooperative binding**, not the capability check, is the load-bearing control here.

## Final controls

1. **Self-serve enrollment is absent unless explicitly declared.** The route tree mounts only when `ICN_ENABLE_SELF_SERVE_ENROLLMENT=true` (exact match, trimmed, case-insensitive). **No shipped deployment profile sets it.** Absent means no handler exists — not present-and-guarded.
2. **A level-2 vouch is bound to the cooperative.** A credential issued for coop A can no longer advance an enrollment into coop B, using the same credential-to-coop binding every other coop-scoped route enforces.
3. **The credential mint is fail-closed.** Anchor creation, holder creation, jurisdiction join and membership approval each abort the enrollment on failure. A credential can no longer outlive the writes that justify it.
4. **`POST /v1/trust/attest` requires `trust:write`.** The scope already existed in `icn_rpc::auth::scopes` and the RPC transport already enforced it for `trust.add`/`trust.remove`; it was missing from the gateway's `ALLOWED_SCOPES`, so no gateway credential could carry it and the route enforced nothing instead. No new vocabulary was minted. (Currently unreachable behind the dead extractor above; in place for when that is repaired.)
5. **Self-attestation is rejected at every untrusted trust-ingress boundary** — there are three, and a self-edge accepted at any one is indistinguishable downstream from a genuine vouch:

   | Boundary | Location |
   |---|---|
   | HTTP `/trust/attest` | `TrustManager::add_edge_async` (+ the deprecated sync twin) |
   | RPC `trust.add` | `TrustService::submit_attestation` |
   | Gossip ingestion | `TrustService::ingest_attestation` |

   The gossip one matters most: a peer can **correctly self-sign** an attestation whose `issuer == subject`, so signature verification alone does not refuse it.
6. **The privileged dev bootstrap keeps working.** `icnd` seeds a deliberate `own_did → own_did` genesis edge under `ICN_DEV_SELF_TRUST`, which the documented live-local 13/13 receipt-chain proof requires.

## Architecture boundary

`TrustGraph` is a **storage primitive**. It has no caller identity to reason about, so it cannot make authorization decisions, and it deliberately **accepts** self-edges — that is what lets a composition root express the explicitly privileged bootstrap edge above.

Caller authorization belongs at **ingress**, where a caller exists to be refused. Hence the three-boundary table rather than one guard in the graph. `TrustGraph::add_edge`'s doc comment now states this and enumerates all three, and an `icn-trust` integration test pins the separation in the opposite direction — storage *must* accept self-edges — so a future change cannot quietly move policy back down into the graph and reintroduce the daemon-startup failure.

The distinction in one line: **the graph may represent a privileged bootstrap edge; untrusted ingress may not introduce one.**

## Deployment behavior

- **No shipped profile enables self-serve enrollment.** Verified: `ICN_ENABLE_SELF_SERVE_ENROLLMENT` appears in no file under `deploy/`, `scripts/`, or any compose file.
- **A loopback bind is not treated as isolation.** The LAN rehearsal profile binds `127.0.0.1:8080` and nginx proxies all of `/v1/` to it from the LAN TLS origin, while the demo profile binds `0.0.0.0:8080` and is host-only — so `is_loopback()` is *true* where exposure is highest and *false* where it is lowest. The gate takes no bind argument at all, and a unit test pins that so a refactor cannot reintroduce one.
- **Absent routes may return 404 or 401.** The `/sdis` scope nests an authenticated sub-scope that matches remaining paths, so an unmounted enrollment path may be rejected by `jwt_auth` before routing. **Neither status means the self-serve handlers are mounted** — in both cases no enrollment handler runs.
- Steward and moderation routes under `/v1/sdis` are unaffected and remain mounted behind `jwt_auth`.

## Tests

Tested SHA: see the final head on this PR. Totals at time of writing: **2052 passed, 0 failed** across `icn-gateway`, `icn-trust`, `icn-trust-app`, `icn-core`; `cargo fmt --all --check` exit 0; `cargo clippy --all-targets -- -D warnings` across five packages, **0 diagnostics**.

`icn/crates/icn-gateway/tests/fp01_credential_holder_escalation.rs` builds `/v1/sdis` through `icn_gateway::server::sdis_scope` — **the same constructor `GatewayServer::run` calls** — rather than a parallel test router, which is the divergence the architecture campaign flagged as #2421.

Coverage:

| Case | Kind |
|---|---|
| HTTP self-edge refused at the mutation layer | negative |
| RPC self-edge refused (`submit_attestation`) | negative |
| Gossip self-signed self-attestation refused (`ingest_attestation`) | negative |
| Legitimate peer-A-about-peer-B attestation still ingests and stores | positive |
| Dev bootstrap self-edge still accepted by `TrustGraph` | positive |
| Foreign-cooperative voucher denied, *even with* sufficient trust | negative |
| Completion mints nothing when a required institutional write fails | negative |
| Legitimate same-cooperative enrollment completes, mints, records `provisional` | positive |
| Enrollment tree absent under default mount flags | negative |
| Steward surface still 401s (not removed) | positive |

**Every guard was verified red-green** — neutralised, observed failing, restored. The fail-closed mint required removing **all four** of its overlapping guards before its test went red, at which point it emitted the exploit artifact: HTTP 200 with a signed JWT for `coop_id: victim-coop` carrying `ledger:read`+`ledger:write` for an enrollment whose institutional writes had all failed.

## Deferred limitations

| Limitation | Owner |
|---|---|
| VUI reservation is not released when a required write fails, so a failed enrollment cannot be retried | **#2468** |
| `web::ReqData<Did>` never resolves ⇒ `/v1/trust/*` and seven `api/notifications.rs` handlers return 500; `/v1/trust/trust/*` path doubling | **untracked** — repair is surface-expanding and deliberately excluded here; a test pins the current 500 so a future repair fails loudly and must keep the capability check |
| Vouch-authority model unresolved — trust-derived vs governance-capability-derived | draft PR **[#2450](https://github.com/InterCooperative-Network/icn/pull/2450)**. Note: **no ADR-0085 exists** — not on this branch and not on `main`. The decision has a proposal, not an accepted record. |
| POP attestations created during enrollment are unsigned | **#133** |
| The enrollment mint grants `ledger:write` where invite redemption grants the narrower `ledger:transact` | untracked |
| The steward daily-vouch limiter is not reinstated — zero non-test callers, no durable state at the call site, key is a caller-generated DID, fails open when `steward_mgr` is `None` | untracked; reinstating it would ship the appearance of a control |

## Nonclaims

This PR does **not**:

- adopt ADR-0086, or create/adopt any ADR for the SDIS vouch-authority model (no ADR-0085 exists; the live proposal is draft PR #2450);
- make SDIS production-ready;
- prove self-serve enrollment reliable (see #2468);
- resolve the duplicate SDIS authority model;
- fix sender-blind governance replication;
- prove federation;
- perform independent recovery;
- modify the two-node proof or gossip topics;
- resume B1 or begin B2;
- touch private infrastructure;
- demonstrate an executed exploit against a live deployment — this is a source-traced reachability and authorization analysis, closed by regression tests.

---

*Findings originate in the ICN architecture campaign of 2026-07-28 (audited `e389e35e`). Every link was independently re-verified against `main` before any change was made; two links did not survive that re-verification and are corrected above. Development history, including three intermediate designs and the review exchanges that corrected them, is preserved in this PR's comments.*

