### PR TITLE
fix(governance): refuse unauthenticated remote governance state application

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,6 +220,14 @@ Every ICN node provides these eight primitives. Apps compose them into instituti
 
 **Governance coordination:** Proposals and votes gossip. Each node tallies votes independently. Once a threshold is reached, the governance oracle executes the decision. No central authority needed.
 
+> **Current status — governance replication is suspended.** The design above describes the
+> intended model, not present behavior. Governance messages received over gossip are
+> refused before they are applied to governance state: `GossipEntry` carries a claimed
+> author DID but no signature binding it to the entry contents, so a replicated governance
+> message is indistinguishable from a forged one and applying it was an unauthenticated
+> write primitive. Locally originated governance is unaffected; cross-node governance
+> convergence does not currently occur. Authenticated replication is tracked in issue #2469.
+
 **Crate:** `icn-gossip`, `icn-ledger` (deterministic merge), `icn-governance` (proposal dispatch), `icn-protocol` (message ordering)
 
 <!-- truth: descriptive -->

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -838,7 +838,9 @@ Uses kernel primitives: State, Communication, Coordination, Authorization, Time
 Cooperatives need to make decisions collectively. ICN provides:
 - State: Proposal ledger
 - Communication: Announce proposals, gossip votes
-- Coordination: Tally votes across peers (no consensus needed, just gossip)
+- Coordination: Tally votes across peers (no consensus needed, just gossip) — **note:**
+  inbound governance replication is currently refused, so votes do not propagate between
+  nodes today; tallying is per-node over locally recorded votes. See §4.7 and issue #2469
 - Authorization: Gates voting by membership
 - Time: Voting period (block numbers, not wall time)
 

--- a/docs/design/governance/governance.md
+++ b/docs/design/governance/governance.md
@@ -857,12 +857,12 @@ Timer expires OR icnctl gov proposal close
 
 | Use Case | Component | Notes |
 |----------|-----------|-------|
-| Production deployment | GovernanceActor | Full gossip, persistence, scheduling |
+| Production deployment | GovernanceActor | Persistence, scheduling, **outbound** gossip publication. Inbound governance replication is refused — see §11.3 note and issue #2469 |
 | CLI operations | RPC → GovernanceActor | Via `icnctl gov` commands |
 | Gateway REST API (dev) | GovernanceManager | Quick testing, no persistence |
 | Gateway REST API (prod) | Gateway + Actor handle | Future: full integration |
 | Unit tests | InMemoryGovernanceStore | Direct store operations |
-| Integration tests | GovernanceActor | Multi-node gossip validation |
+| Integration tests | GovernanceActor | Single-node validation. Multi-node governance convergence does not currently occur (inbound replication refused) |
 
 ### 11.5 Source of Truth
 

--- a/docs/design/governance/governance.md
+++ b/docs/design/governance/governance.md
@@ -766,10 +766,19 @@ let governance_handle = GovernanceActor::spawn(
 ```
 
 This mode provides:
-- **Gossip-based synchronization**: `governance:proposal` topic
+- **Gossip-based synchronization**: `governance:proposal` topic — **outbound only at present;
+  see the note below**
 - **Persistent storage**: Domains, proposals, votes in Sled
 - **Auto-close scheduling**: Background task closes proposals when voting period ends
 - **Event bus integration**: `ProposalAccepted` events trigger ledger transactions
+
+> **Inbound governance replication is suspended.** Locally originated governance is still
+> published to the `governance:proposal` topic, but governance messages *received* over
+> gossip are refused before they are applied. `GossipEntry` carries a claimed author DID
+> and no signature binding it to the entry contents, so a peer could claim any DID;
+> applying those messages was an unauthenticated write into governance state. Nodes
+> therefore do not currently converge on each other's domains, proposals, votes or
+> delegations. Authenticated replication is tracked in issue #2469.
 
 RPC clients use `governance.*` methods which delegate to `GovernanceHandle`:
 ```bash

--- a/docs/guides/operations/runbooks/02-data-recovery.md
+++ b/docs/guides/operations/runbooks/02-data-recovery.md
@@ -143,22 +143,49 @@ icnctl gov domain list
 # Proposals per domain (repeat for each expected domain)
 icnctl gov proposal list --domain-id "coop:your-domain"
 
-# Votes and delegations are stored independently of proposals -- a backup can hold every
-# expected domain and proposal while missing later votes or delegations.
-icnctl gov vote show --proposal-id "<id>"   # repeat for each still-open proposal
-icnctl gov vote delegations                 # delegations given and received
 ```
+
+> **These two listings are partial checks, not proof of completeness.** Votes
+> (`gov:vote:*`) and delegations (`gov:delegation:*`) are persisted independently of the
+> proposals they belong to, so a backup can hold every expected domain and proposal while
+> silently omitting later votes or delegations. **There is currently no supported way to
+> verify that a restored governance store contains every vote and delegation** — see the
+> limitation below.
 
 If any of these is short or empty against the expected set, **stop and do not treat the
 recovery as complete**: the backup predates those records, or the governance store was not
 included. Stop the node again and restore from a governance-bearing backup — waiting for
 peers to fill the gap will not work.
 
-Votes and delegations matter beyond completeness. They are persisted separately from the
-proposals they belong to, so a backup can restore every expected domain and proposal while
-silently omitting later votes or delegations. A still-open proposal restored that way will
-close on an **incorrect tally or delegation weight** — a wrong governance outcome, not just
-missing data. Check them before allowing any restored proposal to reach its deadline.
+### Governance completeness cannot currently be verified
+
+**The available CLI and RPC surfaces cannot prove a restored governance store holds every
+vote and delegation.** Verified against the implementation, not the command definitions:
+
+| Surface | Why it does not work |
+|---|---|
+| `icnctl gov vote show --proposal-id` | Unimplemented — exits with "Vote show command not yet supported via RPC" |
+| `icnctl gov vote delegations` | Returns only the **authenticated caller's own** delegations; delegations between other members are invisible |
+| `GET /gov/delegations` | Same caller-scoped restriction |
+| votes over RPC / gateway | No such method or route exists |
+
+Tracked in **#2472**.
+
+**What this means operationally.** A restore that silently omits votes or delegations leaves
+a still-open proposal to close on an **incorrect tally or delegation weight** — a wrong
+governance outcome that looks like a normal decision, not an error. Inbound replication is
+refused (#2469), so peers will not refill the gap, and nothing above will detect it.
+
+**Required policy until #2472 lands:**
+
+1. Restore governance only from a **known-complete governance-bearing backup** whose
+   provenance and completeness were established *before* the failure — not inferred
+   afterwards from the restored node.
+2. If backup completeness is uncertain, **do not use that node to resume or close
+   still-open proposals.** Recovery from an unverified backup is not supported for open
+   governance processes.
+3. Treat the domain and proposal listings above as useful partial checks only. They can
+   prove state is *missing*; they cannot prove it is *complete*.
 
 ## Replay from Peers
 
@@ -178,9 +205,9 @@ If backup is old or unavailable, some data can be recovered from peers via gossi
 > **Consequence for recovery:** a node restored from an old or missing backup will come
 > back with *silently incomplete* governance state — it will not error, it will simply
 > never learn the governance records it is missing. **Governance state must be recovered
-> from a backup.** Treat the governance store as backup-only until #2469 lands, and verify
-> it explicitly after any restore — see the governance check in Step 7 (after the daemon is
-> back up) and the governance items in the Verification Checklist.
+> from a backup.** Treat the governance store as backup-only until #2469 lands. Note that
+> vote and delegation completeness cannot currently be verified after a restore (#2472), so
+> backup provenance must be established beforehand — see Step 7 and the Verification Checklist.
 
 ```bash
 # After starting with keystore only:
@@ -203,12 +230,10 @@ watch -n5 'curl -s http://localhost:9100/metrics | grep -E "icn_ledger_entries|i
 - [ ] Governance domains match the expected set (`icnctl gov domain list`) — these do **not**
       replay from peers, so a short list means data loss, not a pending sync
 - [ ] Governance proposals present per domain (`icnctl gov proposal list --domain-id <id>`)
-- [ ] Votes present on each still-open proposal (`icnctl gov vote show --proposal-id <id>`) —
-      stored separately from proposals, so a backup can hold the proposal but not its votes
-- [ ] Delegations present (`icnctl gov vote delegations`) — a missing delegation silently
-      changes voting weight
-- [ ] No restored proposal is allowed to close before the two checks above pass — an
-      incomplete tally produces a wrong outcome, not an obvious failure
+- [ ] Backup provenance established **before** the failure as governance-complete — vote and
+      delegation completeness **cannot be verified after the fact** with current surfaces (#2472)
+- [ ] If backup completeness is uncertain: this node is **not** used to resume or close
+      still-open proposals (an incomplete tally produces a wrong outcome, not a visible failure)
 
 ## Rollback
 

--- a/docs/guides/operations/runbooks/02-data-recovery.md
+++ b/docs/guides/operations/runbooks/02-data-recovery.md
@@ -99,6 +99,23 @@ ICN_PASSPHRASE="your-passphrase" icnctl --data-dir ~/.icn id show
 icnctl verify-backup /path/to/backup.tar --verify-ledger
 ```
 
+**Governance state must be checked explicitly.** It does not replay from peers (see
+"Replay from Peers" below), and a node with missing governance state starts cleanly and
+reports healthy — the absence is silent. Compare against what this node is expected to
+hold *before* declaring the restore complete:
+
+```bash
+# Domains this node should know about
+icnctl gov domain list
+
+# Proposals per domain (repeat for each expected domain)
+icnctl gov proposal list --domain-id "coop:your-domain"
+```
+
+If either list is short or empty against the expected set, **stop**: the backup predates
+those records, or the governance store was not included. Restore from a governance-bearing
+backup rather than starting the node and waiting for peers to fill the gap — they will not.
+
 ### Step 6: Restart Node
 
 **Kubernetes**:
@@ -125,6 +142,7 @@ watch -n5 'curl -s http://localhost:9100/metrics | grep icn_gossip'
 # Verify expected data present
 icnctl ledger balance  # If had transactions
 icnctl trust list      # If had trust edges
+icnctl gov domain list # Governance domains -- must match the pre-restore expectation
 ```
 
 ## Replay from Peers
@@ -146,7 +164,8 @@ If backup is old or unavailable, some data can be recovered from peers via gossi
 > back with *silently incomplete* governance state — it will not error, it will simply
 > never learn the governance records it is missing. **Governance state must be recovered
 > from a backup.** Treat the governance store as backup-only until #2469 lands, and verify
-> it explicitly after any restore (see the verification step above).
+> it explicitly after any restore — see the governance check in Step 5 and the governance
+> items in the Verification Checklist.
 
 ```bash
 # After starting with keystore only:
@@ -166,6 +185,9 @@ watch -n5 'curl -s http://localhost:9100/metrics | grep -E "icn_ledger_entries|i
 - [ ] Gossip connecting to peers
 - [ ] Ledger balance correct (if applicable)
 - [ ] Trust edges present (if applicable)
+- [ ] Governance domains match the expected set (`icnctl gov domain list`) — these do **not**
+      replay from peers, so a short list means data loss, not a pending sync
+- [ ] Governance proposals present per domain (`icnctl gov proposal list --domain-id <id>`)
 
 ## Rollback
 

--- a/docs/guides/operations/runbooks/02-data-recovery.md
+++ b/docs/guides/operations/runbooks/02-data-recovery.md
@@ -142,12 +142,23 @@ icnctl gov domain list
 
 # Proposals per domain (repeat for each expected domain)
 icnctl gov proposal list --domain-id "coop:your-domain"
+
+# Votes and delegations are stored independently of proposals -- a backup can hold every
+# expected domain and proposal while missing later votes or delegations.
+icnctl gov vote show --proposal-id "<id>"   # repeat for each still-open proposal
+icnctl gov vote delegations                 # delegations given and received
 ```
 
-If either list is short or empty against the expected set, **stop and do not treat the
+If any of these is short or empty against the expected set, **stop and do not treat the
 recovery as complete**: the backup predates those records, or the governance store was not
 included. Stop the node again and restore from a governance-bearing backup — waiting for
 peers to fill the gap will not work.
+
+Votes and delegations matter beyond completeness. They are persisted separately from the
+proposals they belong to, so a backup can restore every expected domain and proposal while
+silently omitting later votes or delegations. A still-open proposal restored that way will
+close on an **incorrect tally or delegation weight** — a wrong governance outcome, not just
+missing data. Check them before allowing any restored proposal to reach its deadline.
 
 ## Replay from Peers
 
@@ -192,6 +203,12 @@ watch -n5 'curl -s http://localhost:9100/metrics | grep -E "icn_ledger_entries|i
 - [ ] Governance domains match the expected set (`icnctl gov domain list`) — these do **not**
       replay from peers, so a short list means data loss, not a pending sync
 - [ ] Governance proposals present per domain (`icnctl gov proposal list --domain-id <id>`)
+- [ ] Votes present on each still-open proposal (`icnctl gov vote show --proposal-id <id>`) —
+      stored separately from proposals, so a backup can hold the proposal but not its votes
+- [ ] Delegations present (`icnctl gov vote delegations`) — a missing delegation silently
+      changes voting weight
+- [ ] No restored proposal is allowed to close before the two checks above pass — an
+      incomplete tally produces a wrong outcome, not an obvious failure
 
 ## Rollback
 

--- a/docs/guides/operations/runbooks/02-data-recovery.md
+++ b/docs/guides/operations/runbooks/02-data-recovery.md
@@ -99,22 +99,9 @@ ICN_PASSPHRASE="your-passphrase" icnctl --data-dir ~/.icn id show
 icnctl verify-backup /path/to/backup.tar --verify-ledger
 ```
 
-**Governance state must be checked explicitly.** It does not replay from peers (see
-"Replay from Peers" below), and a node with missing governance state starts cleanly and
-reports healthy — the absence is silent. Compare against what this node is expected to
-hold *before* declaring the restore complete:
-
-```bash
-# Domains this node should know about
-icnctl gov domain list
-
-# Proposals per domain (repeat for each expected domain)
-icnctl gov proposal list --domain-id "coop:your-domain"
-```
-
-If either list is short or empty against the expected set, **stop**: the backup predates
-those records, or the governance store was not included. Restore from a governance-bearing
-backup rather than starting the node and waiting for peers to fill the gap — they will not.
+> **Governance state also needs checking, but not here.** `icnctl gov ...` talks to the
+> daemon over RPC and the node is still stopped at this point. The governance verification
+> is in Step 7, after the restart.
 
 ### Step 6: Restart Node
 
@@ -142,8 +129,25 @@ watch -n5 'curl -s http://localhost:9100/metrics | grep icn_gossip'
 # Verify expected data present
 icnctl ledger balance  # If had transactions
 icnctl trust list      # If had trust edges
-icnctl gov domain list # Governance domains -- must match the pre-restore expectation
 ```
+
+**Verify governance state explicitly.** It does not replay from peers (see "Replay from
+Peers" below), and a node with missing governance state starts cleanly and reports healthy —
+the absence is silent, so nothing above will surface it. Compare against what this node is
+expected to hold:
+
+```bash
+# Domains this node should know about
+icnctl gov domain list
+
+# Proposals per domain (repeat for each expected domain)
+icnctl gov proposal list --domain-id "coop:your-domain"
+```
+
+If either list is short or empty against the expected set, **stop and do not treat the
+recovery as complete**: the backup predates those records, or the governance store was not
+included. Stop the node again and restore from a governance-bearing backup — waiting for
+peers to fill the gap will not work.
 
 ## Replay from Peers
 
@@ -164,8 +168,8 @@ If backup is old or unavailable, some data can be recovered from peers via gossi
 > back with *silently incomplete* governance state — it will not error, it will simply
 > never learn the governance records it is missing. **Governance state must be recovered
 > from a backup.** Treat the governance store as backup-only until #2469 lands, and verify
-> it explicitly after any restore — see the governance check in Step 5 and the governance
-> items in the Verification Checklist.
+> it explicitly after any restore — see the governance check in Step 7 (after the daemon is
+> back up) and the governance items in the Verification Checklist.
 
 ```bash
 # After starting with keystore only:

--- a/docs/guides/operations/runbooks/02-data-recovery.md
+++ b/docs/guides/operations/runbooks/02-data-recovery.md
@@ -129,13 +129,24 @@ icnctl trust list      # If had trust edges
 
 ## Replay from Peers
 
-If backup is old or unavailable, data can be recovered from peers via gossip:
+If backup is old or unavailable, some data can be recovered from peers via gossip:
 
 1. **Start fresh node** with same identity (keystore)
 2. **Connect to peers** - they will sync:
    - Ledger entries (via gossip)
    - Trust edges (via gossip)
-   - Governance proposals (via gossip)
+
+> **Governance state does NOT replay from peers.** Domains, proposals, votes and
+> delegations arriving over gossip are refused before they are applied, because a
+> `GossipEntry` carries no signature binding its claimed author to its contents, so a
+> replicated governance message cannot be distinguished from a forged one. See
+> issue #2469 for the authenticated-replication work that will restore this.
+>
+> **Consequence for recovery:** a node restored from an old or missing backup will come
+> back with *silently incomplete* governance state — it will not error, it will simply
+> never learn the governance records it is missing. **Governance state must be recovered
+> from a backup.** Treat the governance store as backup-only until #2469 lands, and verify
+> it explicitly after any restore (see the verification step above).
 
 ```bash
 # After starting with keystore only:

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -3932,19 +3932,20 @@ fn refuse_replicated_governance_message(
     let effect = replicated_state_effect(msg);
 
     if effect == ReplicatedStateEffect::WouldMutateGovernanceState {
-        // A node's own publications loop back through this ingress: every local
-        // `GovernanceCommand` persists and then calls `GossipActor::publish`, which
-        // calls `store_entry`, which fires this callback. Without separating them the
-        // quarantine counter would be nonzero during ordinary local governance and
-        // useless as an exploitation signal, and healthy single-node operation would
-        // emit a warning per command.
+        // Every refusal is counted and warned, including this node's own publications
+        // looping back (each local `GovernanceCommand` persists, then calls
+        // `GossipActor::publish`, which calls `store_entry`, which fires this callback).
         //
-        // The split is on the entry's *claimed* author, which is telemetry
-        // classification only — never authentication, and never an input to the
-        // refusal, which is unconditional. A peer may claim this node's DID, so it can
-        // land its entries in the `self` bucket; the counter is therefore a floor for
-        // remote traffic, not a total. Both buckets are still counted, so an unexplained
-        // rise in `self` beyond local command volume remains visible.
+        // The `claimed_origin` label is descriptive only and is derived from
+        // `entry.author`, which the sending peer chooses. It is therefore **not** a
+        // trustworthy local/remote split: a peer can land its entries in the `self`
+        // bucket by claiming this node's DID. Do not alert on one bucket alone — a
+        // reliable split needs trusted ingress provenance from the gossip layer, which
+        // the notification callback does not currently carry (see issue #2469).
+        //
+        // Counting and warning on both buckets keeps a forged entry visible no matter
+        // which DID it claims. Local publications contribute a low, operator-driven
+        // baseline: one per local governance command.
         let claimed_origin = if claimed_author == local_did {
             "self"
         } else {
@@ -3958,20 +3959,13 @@ fn refuse_replicated_governance_message(
             claimed_origin,
         );
 
-        if claimed_origin == "peer" {
-            warn!(
-                local_did = %local_did,
-                claimed_author = %claimed_author,
-                message_type = msg.message_type(),
-                "{REPLICATION_QUARANTINE_REASON}"
-            );
-        } else {
-            debug!(
-                message_type = msg.message_type(),
-                "Local governance publication looped back through the replication \
-                 ingress and was not re-applied (state was already persisted locally)"
-            );
-        }
+        warn!(
+            local_did = %local_did,
+            claimed_author = %claimed_author,
+            claimed_origin,
+            message_type = msg.message_type(),
+            "{REPLICATION_QUARANTINE_REASON}"
+        );
     } else {
         debug!(
             message_type = msg.message_type(),

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1277,7 +1277,7 @@ impl GovernanceActor {
         {
             let mut g = gossip.write().await;
             g.add_notification_callback(Arc::new(move |topic, entry, subscriber_did| {
-                if !governance_replication_delivery_applies(&topic, &subscriber_did, &did_notify) {
+                if !should_handle_governance_notification(&topic, &subscriber_did, &did_notify) {
                     return;
                 }
 
@@ -3815,34 +3815,45 @@ pub const REPLICATION_QUARANTINE_REASON: &str =
     "refused: unauthenticated governance replication — the entry's claimed author is not \
      verified and carries no authority over the affected governance domain";
 
-/// Whether the governance replication ingress should act on a given gossip notification.
+/// Whether this gossip notification is the one this node should handle.
 ///
-/// Two conditions, both dispatch/observability concerns rather than authorization — the
-/// refusal in [`refuse_replicated_governance_message`] is unconditional either way:
+/// **This decides dispatch, never authority.** Neither condition authenticates anything
+/// or authorizes any state change: the refusal in
+/// [`refuse_replicated_governance_message`] is unconditional for every message that gets
+/// past this point. A subscriber DID is as attacker-influenced as any other gossip field
+/// and must never be read as governance authority.
 ///
-/// 1. **Topic.** The entry must be on the governance topic or a federation governance
-///    topic (`federation:governance` or `federation:governance:<fed_id>`).
-/// 2. **Once per entry, not once per subscriber.** `GossipActor::store_entry` invokes
-///    every notification callback inside its per-subscriber loop, and a peer can add
-///    arbitrary DIDs to that list with an unauthenticated `Subscribe` (up to
-///    `MAX_SUBSCRIBERS_PER_TOPIC`). Without this, one received entry would be refused
-///    once per subscriber, letting a remote peer inflate the quarantine counter and the
-///    warning volume by orders of magnitude. Subscriber DIDs are deduplicated on insert,
-///    so matching the local DID yields exactly one invocation per entry.
+/// 1. **Deduplication.** `GossipActor::store_entry` invokes every notification callback
+///    inside its per-subscriber loop, and a peer can add arbitrary DIDs to that list with
+///    an unauthenticated `Subscribe` (up to `MAX_SUBSCRIBERS_PER_TOPIC`). Without this,
+///    one received entry would be handled once per subscriber, letting a remote peer
+///    inflate the quarantine counter and the warning volume by orders of magnitude.
+///    Subscriber DIDs are deduplicated on insert, so matching the local DID yields
+///    exactly one handling per entry.
+/// 2. **Topic.** The entry must be on the governance topic, or on
+///    `federation:governance` / `federation:governance:<federation-id>`.
 ///
 /// Extracted as a pure function so both conditions are directly testable; inline in the
 /// closure they could only be exercised indirectly.
-pub fn governance_replication_delivery_applies(
+fn should_handle_governance_notification(
     topic: &str,
     subscriber_did: &Did,
     local_did: &Did,
 ) -> bool {
-    let federation_root = icn_federation::TOPIC_FEDERATION_GOVERNANCE;
-    let is_governance_topic = topic == GOVERNANCE_TOPIC
-        || topic == federation_root
-        || topic.starts_with(&format!("{federation_root}:"));
+    // Subscriber first. This is the cheapest check and it discards the amplified
+    // per-subscriber invocations before any topic comparison or allocation.
+    if subscriber_did != local_did {
+        return false;
+    }
 
-    is_governance_topic && subscriber_did == local_did
+    let federation_root = icn_federation::TOPIC_FEDERATION_GOVERNANCE;
+    topic == GOVERNANCE_TOPIC
+        || topic == federation_root
+        // `federation:governance:<federation-id>` only. Matching on the bare prefix
+        // would also admit look-alikes such as `federation:governanceX`.
+        || topic
+            .strip_prefix(federation_root)
+            .is_some_and(|rest| rest.starts_with(':'))
 }
 
 /// Classify what a replicated governance message would have mutated.
@@ -4129,7 +4140,7 @@ mod tests {
         // Governance topics, this node's own subscription -> act.
         for topic in [GOVERNANCE_TOPIC, fed, fed_scoped.as_str()] {
             assert!(
-                governance_replication_delivery_applies(topic, &local, &local),
+                should_handle_governance_notification(topic, &local, &local),
                 "should act on {topic} for the local subscription"
             );
         }
@@ -4139,7 +4150,7 @@ mod tests {
         // can add arbitrary DIDs, and each one re-invokes this callback for one entry.
         for topic in [GOVERNANCE_TOPIC, fed, fed_scoped.as_str()] {
             assert!(
-                !governance_replication_delivery_applies(topic, &other, &local),
+                !should_handle_governance_notification(topic, &other, &local),
                 "must not act a second time for a non-local subscriber on {topic}"
             );
         }
@@ -4152,8 +4163,24 @@ mod tests {
             "federation",
         ] {
             assert!(
-                !governance_replication_delivery_applies(topic, &local, &local),
+                !should_handle_governance_notification(topic, &local, &local),
                 "must not act on unrelated topic {topic}"
+            );
+        }
+
+        // Look-alikes must not slip through on a bare prefix match.
+        let fed_lookalike = format!("{fed}X");
+        let fed_suffix = format!("{fed}-shadow");
+        for topic in [
+            "governance:proposals",
+            "governance:proposal:extra",
+            "xgovernance:proposal",
+            fed_lookalike.as_str(),
+            fed_suffix.as_str(),
+        ] {
+            assert!(
+                !should_handle_governance_notification(topic, &local, &local),
+                "must not act on look-alike topic {topic}"
             );
         }
     }

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1266,8 +1266,12 @@ impl GovernanceActor {
             g.subscribe(GOVERNANCE_TOPIC, did.clone()).await?;
         }
 
-        // Set up notification callback for incoming messages
-        let store_notify = store.clone();
+        // Set up notification callback for incoming messages.
+        //
+        // F-P0-2 containment: this closure deliberately captures **no**
+        // `GovernanceStateStore` handle. A replicated entry therefore cannot reach
+        // governance state by construction, not merely by passing a check that a
+        // later edit could bypass. See `refuse_replicated_governance_message`.
         let did_notify = did.clone();
 
         {
@@ -1284,16 +1288,7 @@ impl GovernanceActor {
 
                 match GovernanceMessage::from_bytes(&entry.data) {
                     Ok(msg) => {
-                        info!(
-                            "[{}] Received governance message: {}",
-                            did_notify,
-                            msg.message_type()
-                        );
-                        if let Err(e) =
-                            handle_incoming(store_notify.as_ref(), msg, Some(&entry.author))
-                        {
-                            warn!("Failed to handle incoming governance message: {}", e);
-                        }
+                        refuse_replicated_governance_message(&msg, &entry.author, &did_notify);
                     }
                     Err(e) => {
                         warn!("Failed to deserialize governance message: {}", e);
@@ -3792,245 +3787,132 @@ impl GovernanceActor {
     }
 }
 
-/// Handle incoming governance messages from gossip.
+// ---- Governance replication ingress (F-P0-2 containment) ----
+
+/// What a replicated [`GovernanceMessage`] would have written to durable
+/// governance state before the F-P0-2 containment.
 ///
-/// `sender` is the `GossipEntry::author` DID of the peer that published the message.
-/// For delegation messages, the sender must match the delegator (or `revoked_by`) to
-/// prevent any peer from injecting or revoking delegations they do not own.
-/// If `sender` is `None` (e.g. in tests that don't have a real gossip entry), delegation
-/// sender validation is skipped.
-fn handle_incoming(
-    store: &dyn GovernanceStateStore,
-    msg: GovernanceMessage,
-    sender: Option<&icn_identity::Did>,
-) -> Result<()> {
+/// This distinction is **diagnostic only, never an authorization decision**. No
+/// replicated message is applied, whatever its variant — see
+/// [`refuse_replicated_governance_message`]. The classification decides only
+/// whether a refusal is worth reporting (a would-be mutation was stopped) or is
+/// indistinguishable from the previous behavior (the variant already wrote
+/// nothing). Keeping the security property unconditional means a misclassification
+/// here cannot create a bypass.
+///
+/// The match in [`replicated_state_effect`] is exhaustive on purpose: a new
+/// `GovernanceMessage` variant must not silently become an unguarded mutation, so
+/// adding one fails the build until it is classified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplicatedStateEffect {
+    /// Applying this variant wrote durable governance state.
+    WouldMutateGovernanceState,
+    /// Applying this variant wrote nothing.
+    NoStateEffect,
+}
+
+/// Fixed diagnostic emitted when a replicated governance mutation is refused.
+///
+/// Deliberately a constant, so the message body carries no attacker-supplied
+/// content. The author is attached as a separate structured field and is always
+/// described as *claimed*, never authenticated.
+pub const REPLICATION_QUARANTINE_REASON: &str =
+    "refused: unauthenticated governance replication — the entry's claimed author is not \
+     verified and carries no authority over the affected governance domain";
+
+/// Classify what a replicated governance message would have mutated.
+///
+/// See [`ReplicatedStateEffect`] — this is observability, not authorization.
+pub fn replicated_state_effect(msg: &GovernanceMessage) -> ReplicatedStateEffect {
+    use ReplicatedStateEffect::{NoStateEffect, WouldMutateGovernanceState};
+
     match msg {
-        GovernanceMessage::DomainCreated { domain } => {
-            store.save_domain(&domain)?;
-        }
+        // These arms wrote durable governance state through the pre-containment
+        // ingress: domains, proposals, votes, delegations and close outcomes.
+        GovernanceMessage::DomainCreated { .. }
+        | GovernanceMessage::DomainUpdated { .. }
+        | GovernanceMessage::ProposalCreated { .. }
+        | GovernanceMessage::ProposalOpened { .. }
+        | GovernanceMessage::VoteCast { .. }
+        | GovernanceMessage::ProposalClosed { .. }
+        | GovernanceMessage::DelegationCreated { .. }
+        | GovernanceMessage::DelegationRevoked { .. } => WouldMutateGovernanceState,
 
-        GovernanceMessage::DomainUpdated { domain } => {
-            // Update existing domain with new config
-            store.save_domain(&domain)?;
-            info!("Domain config updated via gossip: {}", domain.id.0);
-        }
+        // These arms reached the ingress but wrote nothing.
+        GovernanceMessage::ProposalCancelled { .. }
+        | GovernanceMessage::DeliberationStarted { .. }
+        | GovernanceMessage::DeliberationEnded { .. }
+        | GovernanceMessage::CommentCreated { .. }
+        | GovernanceMessage::CommentEdited { .. }
+        | GovernanceMessage::CommentDeleted { .. }
+        | GovernanceMessage::ReactionAdded { .. }
+        | GovernanceMessage::ReactionRemoved { .. } => NoStateEffect,
+    }
+}
 
-        GovernanceMessage::ProposalCreated { proposal } => {
-            store.save_proposal(&proposal)?;
-        }
+/// Governance replication ingress — refuses to apply remote governance state.
+///
+/// ## Why transport acceptance and state-application authority are separate
+///
+/// Permission to transport or replicate bytes is not permission to apply those
+/// bytes as governance state.
+///
+/// A [`icn_gossip::GossipEntry`] carries a claimed `author` DID and **no
+/// signature binding that DID to the entry contents**. The receive path
+/// (`GossipActor::store_entry`) neither recomputes the entry hash — it dedups on
+/// the sender-supplied `entry.hash` — nor enforces the topic ACL, and the
+/// transport-level policy gate above it evaluates a self-declared sender DID with
+/// no threshold attached. Every value that reaches this function is therefore
+/// attacker-chosen *input*, not authenticated authority. Comparing anything
+/// against `entry.author` is not an authorization check: a peer that wants to be
+/// treated as some DID simply writes that DID into the field.
+///
+/// So this ingress applies nothing. Until authenticated governance replication
+/// exists (issue #2469), a message that arrives here is *observed*, not *obeyed*.
+/// Entries are
+/// still accepted, stored, clock-merged and gossiped by the generic gossip layer;
+/// only the application of remote governance state is suspended.
+///
+/// ## Why this does not break local governance
+///
+/// `GossipActor::store_entry` fires notification callbacks identically for
+/// locally published entries and for entries received from the network, and no
+/// field distinguishes them — `publish()` sets `author` to the local DID, but a
+/// remote peer may claim that same DID. There is no trustworthy local/remote
+/// discriminator at this layer, so the containment does not try to invent one.
+///
+/// It does not need one: every local `GovernanceCommand` persists through
+/// `GovernanceActor`'s command path *before* it publishes (the delegation arms say
+/// so outright — "failure doesn't roll back the local write"). The loopback copy
+/// this ingress also receives is a redundant re-application of state the node
+/// already wrote, so refusing it costs local governance nothing.
+///
+/// Returns the classification so callers and tests can observe the disposition.
+fn refuse_replicated_governance_message(
+    msg: &GovernanceMessage,
+    claimed_author: &Did,
+    local_did: &Did,
+) -> ReplicatedStateEffect {
+    let effect = replicated_state_effect(msg);
 
-        GovernanceMessage::ProposalOpened {
-            id,
-            opened_at,
-            closes_at,
-        } => {
-            // Load, update state, persist
-            if let Some(proposal) = store.get_proposal(&id)? {
-                // Force state to Open (idempotent for convergence)
-                let updated = Proposal {
-                    state: ProposalState::Open {
-                        opened_at,
-                        closes_at,
-                    },
-                    updated_at: now_seconds(),
-                    ..proposal
-                };
-                store.save_proposal(&updated)?;
-            }
-        }
-
-        GovernanceMessage::VoteCast { vote, .. } => {
-            store.save_vote(&vote.proposal_id.clone(), &vote)?;
-        }
-
-        GovernanceMessage::ProposalClosed {
-            id,
-            outcome,
-            closed_at,
-            proof_bytes,
-            ..
-        } => {
-            if let Some(mut proposal) = store.get_proposal(&id)? {
-                let new_state = match outcome {
-                    ProposalOutcome::Accepted => ProposalState::Accepted { closed_at },
-                    ProposalOutcome::Rejected => ProposalState::Rejected { closed_at },
-                    ProposalOutcome::NoQuorum => ProposalState::NoQuorum { closed_at },
-                };
-                proposal.close(new_state)?;
-                store.save_proposal(&proposal)?;
-            }
-            // Persist proof from remote node (if included and valid)
-            if let Some(bytes) = proof_bytes {
-                // Validate remote proof before storing (untrusted gossip input)
-                let incoming_v2 = match serde_json::from_slice::<icn_governance::GovernanceProofV2>(
-                    &bytes,
-                ) {
-                    Ok(proof) => match validate_secure_v2_proof_for_proposal(&proof, &id) {
-                        Ok(()) => Some(proof),
-                        Err(reason) => {
-                            warn!("Rejected remote proof for proposal {} — {}", id.0, reason);
-                            None
-                        }
-                    },
-                    Err(_) => {
-                        match serde_json::from_slice::<icn_governance::GovernanceProof>(&bytes) {
-                            Ok(legacy) => {
-                                // Legacy proofs must still verify cryptographically. We reject them
-                                // for storage because they cannot carry canonical V2 attestations.
-                                if !legacy.verify_binding() {
-                                    warn!(
-                                    "Rejected legacy remote proof for proposal {} — invalid binding",
-                                    id.0
-                                );
-                                } else {
-                                    match Did::from_str(&legacy.signer_did)
-                                    .and_then(|did| did.to_verifying_key())
-                                {
-                                    Ok(vk) if legacy.verify_signature(&vk) => warn!(
-                                        "Rejected legacy remote proof for proposal {} — missing canonical attestations",
-                                        id.0
-                                    ),
-                                    Ok(_) => warn!(
-                                        "Rejected legacy remote proof for proposal {} — invalid signature",
-                                        id.0
-                                    ),
-                                    Err(e) => warn!(
-                                        "Rejected legacy remote proof for proposal {} — cannot resolve signer DID: {}",
-                                        id.0, e
-                                    ),
-                                }
-                                }
-                                None
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Rejected remote proof for proposal {} — invalid JSON: {}",
-                                    id.0, e
-                                );
-                                None
-                            }
-                        }
-                    }
-                };
-
-                if let Some(proof) = incoming_v2 {
-                    let should_store = match store.get_proof_bytes(&id)? {
-                        Some(existing_bytes) => {
-                            match serde_json::from_slice::<icn_governance::GovernanceProofV2>(
-                                &existing_bytes,
-                            ) {
-                                Ok(existing)
-                                    if validate_secure_v2_proof_for_proposal(&existing, &id)
-                                        .is_ok() =>
-                                {
-                                    debug!(
-                                        "Skipping remote proof for proposal {} — valid proof already exists",
-                                        id.0
-                                    );
-                                    false
-                                }
-                                _ => true,
-                            }
-                        }
-                        None => true,
-                    };
-
-                    if should_store {
-                        let canonical_bytes = serde_json::to_vec(&proof)?;
-                        store.save_proof_bytes(&id, &canonical_bytes)?;
-                        info!(
-                            "Stored validated governance proof from remote for proposal {}",
-                            id.0
-                        );
-                    }
-                }
-            }
-        }
-
-        GovernanceMessage::DelegationCreated { delegation } => {
-            // Security: verify the gossip sender is the delegator.
-            // Any peer that can publish to the governance topic could otherwise inject
-            // delegations on behalf of DIDs they don't control.
-            if let Some(sender_did) = sender {
-                if *sender_did != delegation.delegator {
-                    warn!(
-                        "DelegationCreated gossip rejected: sender {} does not match delegator {} \
-                         (delegation {})",
-                        sender_did, delegation.delegator, delegation.id.0
-                    );
-                    return Ok(());
-                }
-            }
-            match store.get_delegation(&delegation.id)? {
-                None => {
-                    store.save_delegation(&delegation)?;
-                    info!(
-                        "Delegation synced via gossip: {} -> {} (scope: {:?})",
-                        delegation.delegator, delegation.delegate, delegation.scope
-                    );
-                }
-                Some(existing) => {
-                    let existing_bytes = serde_json::to_vec(&existing)?;
-                    let incoming_bytes = serde_json::to_vec(&delegation)?;
-                    if existing_bytes == incoming_bytes {
-                        debug!(
-                            "Delegation gossip replay ignored (already stored): {} -> {} (scope: {:?})",
-                            delegation.delegator, delegation.delegate, delegation.scope
-                        );
-                    } else {
-                        warn!(
-                            "Delegation gossip conflict ignored: incoming {} differs from stored — possible tampering",
-                            delegation.id.0
-                        );
-                    }
-                }
-            }
-        }
-
-        GovernanceMessage::DelegationRevoked {
-            id,
-            revoked_at,
-            revoked_by,
-        } => {
-            if let Some(delegation) = store.get_delegation(&id)? {
-                // Security: verify the gossip sender is the original delegator.
-                // The `revoked_by` field in the message must also match the stored delegator,
-                // preventing a third party from revoking a delegation they don't own.
-                if let Some(sender_did) = sender {
-                    if *sender_did != delegation.delegator {
-                        warn!(
-                            "DelegationRevoked gossip rejected: sender {} does not match stored \
-                             delegator {} (delegation {})",
-                            sender_did, delegation.delegator, id.0
-                        );
-                        return Ok(());
-                    }
-                }
-                if revoked_by != delegation.delegator {
-                    warn!(
-                        "DelegationRevoked gossip rejected: revoked_by {} does not match stored \
-                         delegator {} (delegation {})",
-                        revoked_by, delegation.delegator, id.0
-                    );
-                    return Ok(());
-                }
-                store.save_revoked_delegation(&delegation, revoked_at)?;
-                info!("Delegation revocation synced via gossip: {}", id.0);
-            } else {
-                // May arrive before the DelegationCreated gossip — log and ignore.
-                debug!(
-                    "DelegationRevoked gossip for unknown delegation {} — ignoring",
-                    id.0
-                );
-            }
-        }
-
-        _ => {
-            // Ignore other message types for now (future: DomainUpdated, ProposalCancelled)
-        }
+    if effect == ReplicatedStateEffect::WouldMutateGovernanceState {
+        // `message_type()` is a `&'static str`, so it is safe both as a log field
+        // and as a metric label — an attacker cannot inflate label cardinality.
+        icn_obs::metrics::governance::replication_quarantined_inc(msg.message_type());
+        warn!(
+            local_did = %local_did,
+            claimed_author = %claimed_author,
+            message_type = msg.message_type(),
+            "{REPLICATION_QUARANTINE_REASON}"
+        );
+    } else {
+        debug!(
+            message_type = msg.message_type(),
+            "Replicated governance message observed; this variant applies no state"
+        );
     }
 
-    Ok(())
+    effect
 }
 
 // ---- Utility functions ----
@@ -4039,6 +3921,13 @@ fn now_seconds() -> u64 {
     icn_time::current_timestamp_secs()
 }
 
+/// Validate a stored `GovernanceProofV2` before it is served to a reader.
+///
+/// This is a **read-path** check on locally stored proofs (see
+/// `GovernanceHandle::get_proof`). It verifies the receipt and each attestation
+/// signature, but it does not establish that any signer held authority over the
+/// proposal, so it is not an authentication of governance authority and is
+/// deliberately not used to admit replicated state.
 fn validate_secure_v2_proof_for_proposal(
     proof: &icn_governance::GovernanceProofV2,
     proposal_id: &ProposalId,
@@ -4077,200 +3966,143 @@ fn validate_secure_v2_proof_for_proposal(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_governance::{Delegation, DelegationScope};
+    use icn_governance::{CommentId, Delegation, DelegationScope, GovernanceProfileId, Proposal};
     use icn_identity::KeyPair;
-    use icn_store::SledStore;
-
-    fn make_store() -> SledGovernanceStateStore {
-        SledGovernanceStateStore::new(Arc::new(SledStore::temporary().expect("temp store")))
-    }
 
     fn did() -> Did {
         KeyPair::generate().unwrap().did().clone()
     }
 
-    /// DelegationCreated gossip → delegation is persisted and readable.
-    #[test]
-    fn test_delegation_created_persisted() {
-        let store = make_store();
-        let d = Delegation::new(did(), did(), DelegationScope::Blanket);
-
-        handle_incoming(
-            &store,
-            GovernanceMessage::delegation_created(d.clone()),
-            None,
+    fn sample_domain() -> icn_governance::GovernanceDomain {
+        icn_governance::GovernanceDomain::new(
+            "sample".to_string(),
+            icn_governance::GovernanceConfig::new(
+                GovernanceProfileId::builtin("cooperative_default"),
+                icn_governance::MembershipConfig::static_list(vec![did()]),
+                GovernanceParams::new(50, 50, 3600),
+            ),
         )
-        .unwrap();
-
-        let loaded = store
-            .get_delegation(&d.id)
-            .unwrap()
-            .expect("delegation not persisted");
-        assert_eq!(loaded.id, d.id);
-        assert_eq!(loaded.delegator, d.delegator);
-        assert_eq!(loaded.delegate, d.delegate);
-        assert!(loaded.revoked_at.is_none());
     }
 
-    /// Repeated DelegationCreated with the same delegation is idempotent — no error, same result.
-    #[test]
-    fn test_delegation_created_idempotent() {
-        let store = make_store();
-        let d = Delegation::new(did(), did(), DelegationScope::Blanket);
-
-        handle_incoming(
-            &store,
-            GovernanceMessage::delegation_created(d.clone()),
-            None,
+    fn sample_proposal() -> Proposal {
+        Proposal::new(
+            GovernanceDomainId("d".to_string()),
+            did(),
+            "t".to_string(),
+            "d".to_string(),
+            ProposalPayload::Text {
+                body: "b".to_string(),
+            },
         )
-        .unwrap();
-        // Second application of the same message must not error.
-        handle_incoming(
-            &store,
-            GovernanceMessage::delegation_created(d.clone()),
-            None,
-        )
-        .unwrap();
-
-        let loaded = store.get_delegation(&d.id).unwrap().unwrap();
-        assert_eq!(loaded.id, d.id);
-        assert!(loaded.revoked_at.is_none());
     }
 
-    /// DelegationRevoked gossip after a DelegationCreated → revoked_at is set.
-    #[test]
-    fn test_delegation_revoked_sets_revoked_at() {
-        let store = make_store();
-        let delegator = did();
-        let d = Delegation::new(delegator.clone(), did(), DelegationScope::Blanket);
-
-        // Persist first so the revoke handler finds it.
-        store.save_delegation(&d).unwrap();
-
-        let revoke_ts: Timestamp = 999_999;
-        handle_incoming(
-            &store,
-            GovernanceMessage::delegation_revoked(d.id.clone(), delegator, revoke_ts),
-            None,
-        )
-        .unwrap();
-
-        let loaded = store.get_delegation(&d.id).unwrap().unwrap();
-        assert_eq!(loaded.revoked_at, Some(revoke_ts));
-    }
-
-    /// DelegationRevoked gossip for an unknown delegation is silently ignored (no error).
+    /// Every variant that the pre-containment ingress persisted must still be
+    /// reported as a would-be mutation, so the refusal is visible to operators.
     ///
-    /// This covers the out-of-order gossip case where the revoke arrives before the create.
+    /// These eight arms replace the delegation-replication tests that previously
+    /// asserted gossip *could* create and revoke delegations. That behavior was the
+    /// vulnerability: those arms compared the delegation owner against
+    /// `GossipEntry::author`, which is attacker-chosen, so "correct sender accepted"
+    /// only ever meant "correct sender successfully impersonated".
     #[test]
-    fn test_delegation_revoked_before_create_is_ignored() {
-        let store = make_store();
-        let delegator = did();
-        let d = Delegation::new(delegator.clone(), did(), DelegationScope::Blanket);
-
-        // Do NOT persist the delegation — simulate out-of-order gossip.
-        let result = handle_incoming(
-            &store,
-            GovernanceMessage::delegation_revoked(d.id.clone(), delegator, 1234),
-            None,
-        );
-
-        assert!(result.is_ok(), "out-of-order revoke must not error");
-        assert!(
-            store.get_delegation(&d.id).unwrap().is_none(),
-            "unknown delegation must not be created by revoke"
-        );
-    }
-
-    /// DelegationCreated gossip with wrong sender is rejected (security: #1340).
-    #[test]
-    fn test_delegation_created_wrong_sender_rejected() {
-        let store = make_store();
-        let delegator = did();
-        let attacker = did();
-        let d = Delegation::new(delegator.clone(), did(), DelegationScope::Blanket);
-
-        // Attacker tries to inject a delegation owned by `delegator`.
-        let result = handle_incoming(
-            &store,
+    fn mutating_variants_are_reported_as_would_be_mutations() {
+        let d = Delegation::new(did(), did(), DelegationScope::Blanket);
+        let mutating = vec![
+            GovernanceMessage::domain_created(sample_domain()),
+            GovernanceMessage::domain_updated(sample_domain()),
+            GovernanceMessage::proposal_created(sample_proposal()),
+            GovernanceMessage::proposal_opened(ProposalId("p".to_string()), 1, 2),
+            GovernanceMessage::vote_cast(
+                Vote::new(ProposalId("p".to_string()), did(), VoteChoice::For),
+                None,
+            ),
+            GovernanceMessage::proposal_closed(
+                ProposalId("p".to_string()),
+                ProposalOutcome::Accepted,
+                3,
+                TallySnapshot::new(1, 0, 0, 1),
+                None,
+            ),
             GovernanceMessage::delegation_created(d.clone()),
-            Some(&attacker),
-        );
+            GovernanceMessage::delegation_revoked(d.id.clone(), d.delegator.clone(), 4),
+        ];
 
-        assert!(result.is_ok(), "wrong-sender rejection must not error");
-        assert!(
-            store.get_delegation(&d.id).unwrap().is_none(),
-            "delegation from wrong sender must not be persisted"
+        for msg in mutating {
+            assert_eq!(
+                replicated_state_effect(&msg),
+                ReplicatedStateEffect::WouldMutateGovernanceState,
+                "{} must be reported as a would-be governance mutation",
+                msg.message_type()
+            );
+        }
+    }
+
+    /// Variants the ingress never applied stay classified as inert, so the refusal
+    /// diagnostic does not cry wolf on ordinary deliberation traffic.
+    #[test]
+    fn inert_variants_are_reported_as_no_state_effect() {
+        let inert = vec![
+            GovernanceMessage::deliberation_started(ProposalId("p".to_string()), 1, 2),
+            GovernanceMessage::comment_deleted(
+                ProposalId("p".to_string()),
+                CommentId("c".to_string()),
+                1,
+            ),
+            GovernanceMessage::reaction_removed(
+                ProposalId("p".to_string()),
+                CommentId("c".to_string()),
+                did(),
+                "+1".to_string(),
+            ),
+        ];
+
+        for msg in inert {
+            assert_eq!(
+                replicated_state_effect(&msg),
+                ReplicatedStateEffect::NoStateEffect,
+                "{} must be reported as applying no state",
+                msg.message_type()
+            );
+        }
+    }
+
+    /// The refusal itself must not depend on the classification: both dispositions
+    /// return without touching governance state. `refuse_replicated_governance_message`
+    /// has no store handle at all, which is what makes that unconditional.
+    #[test]
+    fn refusal_returns_the_classification_for_both_dispositions() {
+        let local = did();
+        let claimed = did();
+
+        assert_eq!(
+            refuse_replicated_governance_message(
+                &GovernanceMessage::domain_created(sample_domain()),
+                &claimed,
+                &local,
+            ),
+            ReplicatedStateEffect::WouldMutateGovernanceState
+        );
+        assert_eq!(
+            refuse_replicated_governance_message(
+                &GovernanceMessage::deliberation_started(ProposalId("p".to_string()), 1, 2),
+                &claimed,
+                &local,
+            ),
+            ReplicatedStateEffect::NoStateEffect
         );
     }
 
-    /// DelegationCreated gossip with correct sender is accepted (security: #1340).
+    /// The operator-facing reason must describe the author as *claimed* and must
+    /// never imply the sender was authenticated.
     #[test]
-    fn test_delegation_created_correct_sender_accepted() {
-        let store = make_store();
-        let delegator = did();
-        let d = Delegation::new(delegator.clone(), did(), DelegationScope::Blanket);
-
-        handle_incoming(
-            &store,
-            GovernanceMessage::delegation_created(d.clone()),
-            Some(&delegator),
-        )
-        .unwrap();
-
+    fn quarantine_reason_calls_the_author_claimed() {
+        let reason = REPLICATION_QUARANTINE_REASON.to_ascii_lowercase();
         assert!(
-            store.get_delegation(&d.id).unwrap().is_some(),
-            "delegation from correct sender must be persisted"
+            reason.contains("claimed"),
+            "{REPLICATION_QUARANTINE_REASON}"
         );
-    }
-
-    /// DelegationRevoked gossip with wrong sender is rejected (security: #1340).
-    #[test]
-    fn test_delegation_revoked_wrong_sender_rejected() {
-        let store = make_store();
-        let delegator = did();
-        let attacker = did();
-        let d = Delegation::new(delegator.clone(), did(), DelegationScope::Blanket);
-
-        store.save_delegation(&d).unwrap();
-
-        let result = handle_incoming(
-            &store,
-            GovernanceMessage::delegation_revoked(d.id.clone(), delegator.clone(), 1234),
-            Some(&attacker),
-        );
-
-        assert!(result.is_ok(), "wrong-sender rejection must not error");
-        // revoked_at should still be None — revocation was dropped
-        let loaded = store.get_delegation(&d.id).unwrap().unwrap();
-        assert!(
-            loaded.revoked_at.is_none(),
-            "delegation revoked by wrong sender must not be revoked"
-        );
-    }
-
-    /// DelegationRevoked with mismatched revoked_by field is rejected (security: #1340).
-    #[test]
-    fn test_delegation_revoked_mismatched_revoked_by_rejected() {
-        let store = make_store();
-        let delegator = did();
-        let impersonator = did();
-        let d = Delegation::new(delegator.clone(), did(), DelegationScope::Blanket);
-
-        store.save_delegation(&d).unwrap();
-
-        // Sender matches delegator but revoked_by is a different DID.
-        let result = handle_incoming(
-            &store,
-            GovernanceMessage::delegation_revoked(d.id.clone(), impersonator.clone(), 1234),
-            Some(&delegator),
-        );
-
-        assert!(result.is_ok(), "mismatched revoked_by must not error");
-        let loaded = store.get_delegation(&d.id).unwrap().unwrap();
-        assert!(
-            loaded.revoked_at.is_none(),
-            "delegation with mismatched revoked_by must not be revoked"
-        );
+        assert!(!reason.contains("authenticated sender"));
+        assert!(!reason.contains("verified author"));
+        assert!(REPLICATION_QUARANTINE_REASON.len() < 256);
     }
 }

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1271,22 +1271,33 @@ impl GovernanceActor {
         // F-P0-2 containment: this closure deliberately captures **no**
         // `GovernanceStateStore` handle. A replicated entry therefore cannot reach
         // governance state by construction, not merely by passing a check that a
-        // later edit could bypass. See `refuse_replicated_governance_message`.
+        // later edit could bypass. See `observe_replicated_governance_message`.
         let did_notify = did.clone();
 
         {
             let mut g = gossip.write().await;
-            g.add_notification_callback(Arc::new(move |topic, entry, subscriber_did| {
-                if !should_handle_governance_notification(&topic, &subscriber_did, &did_notify) {
+            g.add_notification_callback(Arc::new(move |topic, entry, _subscriber_did| {
+                // Accept the governance topic and any federation governance topic
+                // (federation topics have format "federation:governance:<fed_id>").
+                //
+                // This filter is dispatch, never authority: it only decides whether the
+                // diagnostic below is worth emitting. The containment does not depend on
+                // it, because this closure captures no `GovernanceStateStore` and so has
+                // no path to governance state on any topic.
+                let federation_root = icn_federation::TOPIC_FEDERATION_GOVERNANCE;
+                let is_governance_topic = topic == GOVERNANCE_TOPIC
+                    || topic == federation_root
+                    || topic
+                        .strip_prefix(federation_root)
+                        .is_some_and(|rest| rest.starts_with(':'));
+                if !is_governance_topic {
                     return;
                 }
 
                 match GovernanceMessage::from_bytes(&entry.data) {
-                    Ok(msg) => {
-                        refuse_replicated_governance_message(&msg, &entry.author, &did_notify);
-                    }
+                    Ok(msg) => observe_replicated_governance_message(&msg, &did_notify),
                     Err(e) => {
-                        warn!("Failed to deserialize governance message: {}", e);
+                        debug!("Failed to deserialize governance message: {}", e);
                     }
                 }
             }));
@@ -3784,207 +3795,59 @@ impl GovernanceActor {
 
 // ---- Governance replication ingress (F-P0-2 containment) ----
 
-/// What a replicated [`GovernanceMessage`] would have written to durable
-/// governance state before the F-P0-2 containment.
-///
-/// This distinction is **diagnostic only, never an authorization decision**. No
-/// replicated message is applied, whatever its variant — see
-/// [`refuse_replicated_governance_message`]. The classification decides only
-/// whether a refusal is worth reporting (a would-be mutation was stopped) or is
-/// indistinguishable from the previous behavior (the variant already wrote
-/// nothing). Keeping the security property unconditional means a misclassification
-/// here cannot create a bypass.
-///
-/// The match in [`replicated_state_effect`] is exhaustive on purpose: a new
-/// `GovernanceMessage` variant must not silently become an unguarded mutation, so
-/// adding one fails the build until it is classified.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ReplicatedStateEffect {
-    /// Applying this variant wrote durable governance state.
-    WouldMutateGovernanceState,
-    /// Applying this variant wrote nothing.
-    NoStateEffect,
-}
-
-/// Fixed diagnostic emitted when a replicated governance mutation is refused.
-///
-/// Deliberately a constant, so the message body carries no attacker-supplied
-/// content. The author is attached as a separate structured field and is always
-/// described as *claimed*, never authenticated.
-pub const REPLICATION_QUARANTINE_REASON: &str =
-    "refused: unauthenticated governance replication — the entry's claimed author is not \
-     verified and carries no authority over the affected governance domain";
-
-/// Whether this gossip notification is the one this node should handle.
-///
-/// **This decides dispatch, never authority.** Neither condition authenticates anything
-/// or authorizes any state change: the refusal in
-/// [`refuse_replicated_governance_message`] is unconditional for every message that gets
-/// past this point. A subscriber DID is as attacker-influenced as any other gossip field
-/// and must never be read as governance authority.
-///
-/// 1. **Deduplication.** `GossipActor::store_entry` invokes every notification callback
-///    inside its per-subscriber loop, and a peer can add arbitrary DIDs to that list with
-///    an unauthenticated `Subscribe` (up to `MAX_SUBSCRIBERS_PER_TOPIC`). Without this,
-///    one received entry would be handled once per subscriber, letting a remote peer
-///    inflate the quarantine counter and the warning volume by orders of magnitude.
-///    Subscriber DIDs are deduplicated on insert, so matching the local DID yields
-///    exactly one handling per entry.
-///
-///    **The subscription list is peer-mutable, so this dedup is not tamper-proof.**
-///    `Unsubscribe` also acts on a self-declared DID (issue #2471), so a peer can drop
-///    this node's own subscription and suppress the quarantine counter and warning
-///    entirely. State containment is unaffected — with no local subscriber the callback
-///    simply never runs, and nothing is applied either way — but the *telemetry* can be
-///    silenced. Do not describe this ingress's detection as tamper-proof.
-///
-///    Neither the subscriber DID nor any other field consulted here is treated as
-///    governance authority. They select *which notification to handle*; the refusal
-///    below is unconditional for everything that reaches it.
-/// 2. **Topic.** The entry must be on the governance topic, or on
-///    `federation:governance` / `federation:governance:<federation-id>`.
-///
-/// Extracted as a pure function so both conditions are directly testable; inline in the
-/// closure they could only be exercised indirectly.
-fn should_handle_governance_notification(
-    topic: &str,
-    subscriber_did: &Did,
-    local_did: &Did,
-) -> bool {
-    // Subscriber first. This is the cheapest check and it discards the amplified
-    // per-subscriber invocations before any topic comparison or allocation.
-    if subscriber_did != local_did {
-        return false;
-    }
-
-    let federation_root = icn_federation::TOPIC_FEDERATION_GOVERNANCE;
-    topic == GOVERNANCE_TOPIC
-        || topic == federation_root
-        // `federation:governance:<federation-id>` only. Matching on the bare prefix
-        // would also admit look-alikes such as `federation:governanceX`.
-        || topic
-            .strip_prefix(federation_root)
-            .is_some_and(|rest| rest.starts_with(':'))
-}
-
-/// Classify what a replicated governance message would have mutated.
-///
-/// See [`ReplicatedStateEffect`] — this is observability, not authorization.
-pub fn replicated_state_effect(msg: &GovernanceMessage) -> ReplicatedStateEffect {
-    use ReplicatedStateEffect::{NoStateEffect, WouldMutateGovernanceState};
-
-    match msg {
-        // These arms wrote durable governance state through the pre-containment
-        // ingress: domains, proposals, votes, delegations and close outcomes.
-        GovernanceMessage::DomainCreated { .. }
-        | GovernanceMessage::DomainUpdated { .. }
-        | GovernanceMessage::ProposalCreated { .. }
-        | GovernanceMessage::ProposalOpened { .. }
-        | GovernanceMessage::VoteCast { .. }
-        | GovernanceMessage::ProposalClosed { .. }
-        | GovernanceMessage::DelegationCreated { .. }
-        | GovernanceMessage::DelegationRevoked { .. } => WouldMutateGovernanceState,
-
-        // These arms reached the ingress but wrote nothing.
-        GovernanceMessage::ProposalCancelled { .. }
-        | GovernanceMessage::DeliberationStarted { .. }
-        | GovernanceMessage::DeliberationEnded { .. }
-        | GovernanceMessage::CommentCreated { .. }
-        | GovernanceMessage::CommentEdited { .. }
-        | GovernanceMessage::CommentDeleted { .. }
-        | GovernanceMessage::ReactionAdded { .. }
-        | GovernanceMessage::ReactionRemoved { .. } => NoStateEffect,
-    }
-}
-
-/// Governance replication ingress — refuses to apply remote governance state.
+/// Governance replication ingress — applies nothing.
 ///
 /// ## Why transport acceptance and state-application authority are separate
 ///
-/// Permission to transport or replicate bytes is not permission to apply those
-/// bytes as governance state.
+/// Permission to transport or replicate bytes is not permission to apply those bytes as
+/// governance state.
 ///
-/// A [`icn_gossip::GossipEntry`] carries a claimed `author` DID and **no
-/// signature binding that DID to the entry contents**. The receive path
-/// (`GossipActor::store_entry`) neither recomputes the entry hash — it dedups on
-/// the sender-supplied `entry.hash` — nor enforces the topic ACL, and the
-/// transport-level policy gate above it evaluates a self-declared sender DID with
-/// no threshold attached. Every value that reaches this function is therefore
-/// attacker-chosen *input*, not authenticated authority. Comparing anything
-/// against `entry.author` is not an authorization check: a peer that wants to be
-/// treated as some DID simply writes that DID into the field.
+/// A [`icn_gossip::GossipEntry`] carries a claimed `author` DID and **no signature binding
+/// that DID to the entry contents**. The receive path (`GossipActor::store_entry`) neither
+/// recomputes the entry hash — it dedups on the sender-supplied `entry.hash` — nor enforces
+/// the topic ACL, and the transport-level policy gate above it evaluates a self-declared
+/// sender DID with no threshold attached. Every value that reaches this function is
+/// attacker-chosen *input*, not authenticated authority. Comparing anything against
+/// `entry.author` is not an authorization check: a peer that wants to be treated as some DID
+/// simply writes that DID into the field.
 ///
-/// So this ingress applies nothing. Until authenticated governance replication
-/// exists (issue #2469), a message that arrives here is *observed*, not *obeyed*.
-/// Entries are
-/// still accepted, stored, clock-merged and gossiped by the generic gossip layer;
-/// only the application of remote governance state is suspended.
+/// So this ingress applies nothing. Until authenticated governance replication exists
+/// (issue #2469), a message that arrives here is *observed*, not *obeyed*. Entries are still
+/// accepted, stored, clock-merged and gossiped by the generic gossip layer; only the
+/// application of remote governance state is suspended.
+///
+/// ## The containment is structural, not procedural
+///
+/// The registered callback captures **no `GovernanceStateStore` handle**, so a replicated
+/// entry has no path to governance state regardless of what this function does, whether it
+/// runs at all, or how often. Nothing here — not the decode, not this diagnostic, not the
+/// topic the entry arrived on, not the subscriber it was dispatched for, not the claimed
+/// author — is an authorization decision. There is deliberately no telemetry to evade,
+/// because there is deliberately nothing to gate.
 ///
 /// ## Why this does not break local governance
 ///
-/// `GossipActor::store_entry` fires notification callbacks identically for
-/// locally published entries and for entries received from the network, and no
-/// field distinguishes them — `publish()` sets `author` to the local DID, but a
-/// remote peer may claim that same DID. There is no trustworthy local/remote
-/// discriminator at this layer, so the containment does not try to invent one.
+/// `GossipActor::store_entry` fires notification callbacks identically for locally published
+/// entries and for entries received from the network, and no field distinguishes them —
+/// `publish()` sets `author` to the local DID, but a remote peer may claim that same DID.
+/// There is no trustworthy local/remote discriminator at this layer, so the containment does
+/// not try to invent one.
 ///
 /// It does not need one: every local `GovernanceCommand` persists through
-/// `GovernanceActor`'s command path *before* it publishes (the delegation arms say
-/// so outright — "failure doesn't roll back the local write"). The loopback copy
-/// this ingress also receives is a redundant re-application of state the node
-/// already wrote, so refusing it costs local governance nothing.
-///
-/// Returns the classification so callers and tests can observe the disposition.
-fn refuse_replicated_governance_message(
-    msg: &GovernanceMessage,
-    claimed_author: &Did,
-    local_did: &Did,
-) -> ReplicatedStateEffect {
-    let effect = replicated_state_effect(msg);
-
-    if effect == ReplicatedStateEffect::WouldMutateGovernanceState {
-        // Every refusal is counted and warned, including this node's own publications
-        // looping back (each local `GovernanceCommand` persists, then calls
-        // `GossipActor::publish`, which calls `store_entry`, which fires this callback).
-        //
-        // The `claimed_origin` label is descriptive only and is derived from
-        // `entry.author`, which the sending peer chooses. It is therefore **not** a
-        // trustworthy local/remote split: a peer can land its entries in the `self`
-        // bucket by claiming this node's DID. Do not alert on one bucket alone — a
-        // reliable split needs trusted ingress provenance from the gossip layer, which
-        // the notification callback does not currently carry (see issue #2469).
-        //
-        // Counting and warning on both buckets keeps a forged entry visible no matter
-        // which DID it claims. Local publications contribute a low, operator-driven
-        // baseline: one per local governance command.
-        let claimed_origin = if claimed_author == local_did {
-            "self"
-        } else {
-            "peer"
-        };
-
-        // `message_type()` is a `&'static str` and `claimed_origin` is one of two fixed
-        // values, so neither label lets a remote peer inflate cardinality.
-        icn_obs::metrics::governance::replication_quarantined_inc(
-            msg.message_type(),
-            claimed_origin,
-        );
-
-        warn!(
-            local_did = %local_did,
-            claimed_author = %claimed_author,
-            claimed_origin,
-            message_type = msg.message_type(),
-            "{REPLICATION_QUARANTINE_REASON}"
-        );
-    } else {
-        debug!(
-            message_type = msg.message_type(),
-            "Replicated governance message observed; this variant applies no state"
-        );
-    }
-
-    effect
+/// `GovernanceActor`'s command path *before* it publishes (the delegation arms say so
+/// outright — "failure doesn't roll back the local write"). The loopback copy this ingress
+/// also receives is a redundant re-application of state the node already wrote, so refusing
+/// it costs local governance nothing.
+fn observe_replicated_governance_message(msg: &GovernanceMessage, local_did: &Did) {
+    // Bounded and deliberately low-severity: `message_type()` is a `&'static str` over a
+    // fixed variant set, and this path fires for ordinary local governance too (each local
+    // command persists, then publishes, and `publish` calls `store_entry`, which calls this
+    // callback). It is a diagnostic, not a security signal — see the note above.
+    debug!(
+        local_did = %local_did,
+        message_type = msg.message_type(),
+        "Replicated governance state application is disabled; message not applied"
+    );
 }
 
 // ---- Utility functions ----
@@ -4038,7 +3901,7 @@ fn validate_secure_v2_proof_for_proposal(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icn_governance::{CommentId, Delegation, DelegationScope, GovernanceProfileId, Proposal};
+    use icn_governance::{Delegation, DelegationScope, GovernanceProfileId, Proposal};
     use icn_identity::KeyPair;
 
     fn did() -> Did {
@@ -4068,18 +3931,25 @@ mod tests {
         )
     }
 
-    /// Every variant that the pre-containment ingress persisted must still be
-    /// reported as a would-be mutation, so the refusal is visible to operators.
+    /// The replication ingress observes and returns; it must not touch governance state
+    /// for any variant, including the eight that the pre-containment ingress persisted.
     ///
-    /// These eight arms replace the delegation-replication tests that previously
-    /// asserted gossip *could* create and revoke delegations. That behavior was the
-    /// vulnerability: those arms compared the delegation owner against
-    /// `GossipEntry::author`, which is attacker-chosen, so "correct sender accepted"
-    /// only ever meant "correct sender successfully impersonated".
+    /// This replaces the delegation-replication tests that previously asserted gossip
+    /// *could* create and revoke delegations. That behavior was the vulnerability: those
+    /// arms compared the delegation owner against `GossipEntry::author`, which is
+    /// attacker-chosen, so "correct sender accepted" only ever meant "correct sender
+    /// successfully impersonated".
+    ///
+    /// The real containment is structural and is proven at the production boundary in
+    /// `tests/fp02_governance_replication_containment.rs`: the registered callback
+    /// captures no `GovernanceStateStore`, so no replicated entry has a path to
+    /// governance state whatever this function does.
     #[test]
-    fn mutating_variants_are_reported_as_would_be_mutations() {
+    fn observing_a_replicated_message_is_side_effect_free() {
+        let local = did();
         let d = Delegation::new(did(), did(), DelegationScope::Blanket);
-        let mutating = vec![
+
+        let messages = vec![
             GovernanceMessage::domain_created(sample_domain()),
             GovernanceMessage::domain_updated(sample_domain()),
             GovernanceMessage::proposal_created(sample_proposal()),
@@ -4099,139 +3969,11 @@ mod tests {
             GovernanceMessage::delegation_revoked(d.id.clone(), d.delegator.clone(), 4),
         ];
 
-        for msg in mutating {
-            assert_eq!(
-                replicated_state_effect(&msg),
-                ReplicatedStateEffect::WouldMutateGovernanceState,
-                "{} must be reported as a would-be governance mutation",
-                msg.message_type()
-            );
+        // The function takes no store and returns nothing: there is no value to assert on
+        // and no state to inspect. Exercising every mutating variant pins that it stays
+        // that way — if a future edit reintroduces a store parameter, this stops compiling.
+        for msg in &messages {
+            observe_replicated_governance_message(msg, &local);
         }
-    }
-
-    /// Variants the ingress never applied stay classified as inert, so the refusal
-    /// diagnostic does not cry wolf on ordinary deliberation traffic.
-    #[test]
-    fn inert_variants_are_reported_as_no_state_effect() {
-        let inert = vec![
-            GovernanceMessage::deliberation_started(ProposalId("p".to_string()), 1, 2),
-            GovernanceMessage::comment_deleted(
-                ProposalId("p".to_string()),
-                CommentId("c".to_string()),
-                1,
-            ),
-            GovernanceMessage::reaction_removed(
-                ProposalId("p".to_string()),
-                CommentId("c".to_string()),
-                did(),
-                "+1".to_string(),
-            ),
-        ];
-
-        for msg in inert {
-            assert_eq!(
-                replicated_state_effect(&msg),
-                ReplicatedStateEffect::NoStateEffect,
-                "{} must be reported as applying no state",
-                msg.message_type()
-            );
-        }
-    }
-
-    /// The refusal itself must not depend on the classification: both dispositions
-    /// return without touching governance state. `refuse_replicated_governance_message`
-    /// has no store handle at all, which is what makes that unconditional.
-    #[test]
-    fn refusal_returns_the_classification_for_both_dispositions() {
-        let local = did();
-        let claimed = did();
-
-        assert_eq!(
-            refuse_replicated_governance_message(
-                &GovernanceMessage::domain_created(sample_domain()),
-                &claimed,
-                &local,
-            ),
-            ReplicatedStateEffect::WouldMutateGovernanceState
-        );
-        assert_eq!(
-            refuse_replicated_governance_message(
-                &GovernanceMessage::deliberation_started(ProposalId("p".to_string()), 1, 2),
-                &claimed,
-                &local,
-            ),
-            ReplicatedStateEffect::NoStateEffect
-        );
-    }
-
-    /// The ingress must act on governance topics only, and exactly once per entry
-    /// rather than once per subscriber.
-    #[test]
-    fn delivery_predicate_is_topic_scoped_and_once_per_entry() {
-        let local = did();
-        let other = did();
-        let fed = icn_federation::TOPIC_FEDERATION_GOVERNANCE;
-        let fed_scoped = format!("{fed}:fed-1");
-
-        // Governance topics, this node's own subscription -> act.
-        for topic in [GOVERNANCE_TOPIC, fed, fed_scoped.as_str()] {
-            assert!(
-                should_handle_governance_notification(topic, &local, &local),
-                "should act on {topic} for the local subscription"
-            );
-        }
-
-        // Same entry, some other subscriber's notification -> do not act again.
-        // This is the per-subscriber amplification guard: an unauthenticated `Subscribe`
-        // can add arbitrary DIDs, and each one re-invokes this callback for one entry.
-        for topic in [GOVERNANCE_TOPIC, fed, fed_scoped.as_str()] {
-            assert!(
-                !should_handle_governance_notification(topic, &other, &local),
-                "must not act a second time for a non-local subscriber on {topic}"
-            );
-        }
-
-        // Unrelated topics are not ours, even for the local subscription.
-        for topic in [
-            "ledger:entries",
-            "trust:attestations",
-            "governance",
-            "federation",
-        ] {
-            assert!(
-                !should_handle_governance_notification(topic, &local, &local),
-                "must not act on unrelated topic {topic}"
-            );
-        }
-
-        // Look-alikes must not slip through on a bare prefix match.
-        let fed_lookalike = format!("{fed}X");
-        let fed_suffix = format!("{fed}-shadow");
-        for topic in [
-            "governance:proposals",
-            "governance:proposal:extra",
-            "xgovernance:proposal",
-            fed_lookalike.as_str(),
-            fed_suffix.as_str(),
-        ] {
-            assert!(
-                !should_handle_governance_notification(topic, &local, &local),
-                "must not act on look-alike topic {topic}"
-            );
-        }
-    }
-
-    /// The operator-facing reason must describe the author as *claimed* and must
-    /// never imply the sender was authenticated.
-    #[test]
-    fn quarantine_reason_calls_the_author_claimed() {
-        let reason = REPLICATION_QUARANTINE_REASON.to_ascii_lowercase();
-        assert!(
-            reason.contains("claimed"),
-            "{REPLICATION_QUARANTINE_REASON}"
-        );
-        assert!(!reason.contains("authenticated sender"));
-        assert!(!reason.contains("verified author"));
-        assert!(REPLICATION_QUARANTINE_REASON.len() < 256);
     }
 }

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -3830,6 +3830,17 @@ pub const REPLICATION_QUARANTINE_REASON: &str =
 ///    inflate the quarantine counter and the warning volume by orders of magnitude.
 ///    Subscriber DIDs are deduplicated on insert, so matching the local DID yields
 ///    exactly one handling per entry.
+///
+///    **The subscription list is peer-mutable, so this dedup is not tamper-proof.**
+///    `Unsubscribe` also acts on a self-declared DID (issue #2471), so a peer can drop
+///    this node's own subscription and suppress the quarantine counter and warning
+///    entirely. State containment is unaffected — with no local subscriber the callback
+///    simply never runs, and nothing is applied either way — but the *telemetry* can be
+///    silenced. Do not describe this ingress's detection as tamper-proof.
+///
+///    Neither the subscriber DID nor any other field consulted here is treated as
+///    governance authority. They select *which notification to handle*; the refusal
+///    below is unconditional for everything that reaches it.
 /// 2. **Topic.** The entry must be on the governance topic, or on
 ///    `federation:governance` / `federation:governance:<federation-id>`.
 ///

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -1276,13 +1276,8 @@ impl GovernanceActor {
 
         {
             let mut g = gossip.write().await;
-            g.add_notification_callback(Arc::new(move |topic, entry, _subscriber_did| {
-                // Accept local governance topic and any federation governance topic
-                // (federation topics have format "federation:governance:<fed_id>")
-                let is_federation_gov = topic == icn_federation::TOPIC_FEDERATION_GOVERNANCE
-                    || topic
-                        .starts_with(&format!("{}:", icn_federation::TOPIC_FEDERATION_GOVERNANCE));
-                if topic != GOVERNANCE_TOPIC && !is_federation_gov {
+            g.add_notification_callback(Arc::new(move |topic, entry, subscriber_did| {
+                if !governance_replication_delivery_applies(&topic, &subscriber_did, &did_notify) {
                     return;
                 }
 
@@ -3820,6 +3815,36 @@ pub const REPLICATION_QUARANTINE_REASON: &str =
     "refused: unauthenticated governance replication — the entry's claimed author is not \
      verified and carries no authority over the affected governance domain";
 
+/// Whether the governance replication ingress should act on a given gossip notification.
+///
+/// Two conditions, both dispatch/observability concerns rather than authorization — the
+/// refusal in [`refuse_replicated_governance_message`] is unconditional either way:
+///
+/// 1. **Topic.** The entry must be on the governance topic or a federation governance
+///    topic (`federation:governance` or `federation:governance:<fed_id>`).
+/// 2. **Once per entry, not once per subscriber.** `GossipActor::store_entry` invokes
+///    every notification callback inside its per-subscriber loop, and a peer can add
+///    arbitrary DIDs to that list with an unauthenticated `Subscribe` (up to
+///    `MAX_SUBSCRIBERS_PER_TOPIC`). Without this, one received entry would be refused
+///    once per subscriber, letting a remote peer inflate the quarantine counter and the
+///    warning volume by orders of magnitude. Subscriber DIDs are deduplicated on insert,
+///    so matching the local DID yields exactly one invocation per entry.
+///
+/// Extracted as a pure function so both conditions are directly testable; inline in the
+/// closure they could only be exercised indirectly.
+pub fn governance_replication_delivery_applies(
+    topic: &str,
+    subscriber_did: &Did,
+    local_did: &Did,
+) -> bool {
+    let federation_root = icn_federation::TOPIC_FEDERATION_GOVERNANCE;
+    let is_governance_topic = topic == GOVERNANCE_TOPIC
+        || topic == federation_root
+        || topic.starts_with(&format!("{federation_root}:"));
+
+    is_governance_topic && subscriber_did == local_did
+}
+
 /// Classify what a replicated governance message would have mutated.
 ///
 /// See [`ReplicatedStateEffect`] — this is observability, not authorization.
@@ -4090,6 +4115,47 @@ mod tests {
             ),
             ReplicatedStateEffect::NoStateEffect
         );
+    }
+
+    /// The ingress must act on governance topics only, and exactly once per entry
+    /// rather than once per subscriber.
+    #[test]
+    fn delivery_predicate_is_topic_scoped_and_once_per_entry() {
+        let local = did();
+        let other = did();
+        let fed = icn_federation::TOPIC_FEDERATION_GOVERNANCE;
+        let fed_scoped = format!("{fed}:fed-1");
+
+        // Governance topics, this node's own subscription -> act.
+        for topic in [GOVERNANCE_TOPIC, fed, fed_scoped.as_str()] {
+            assert!(
+                governance_replication_delivery_applies(topic, &local, &local),
+                "should act on {topic} for the local subscription"
+            );
+        }
+
+        // Same entry, some other subscriber's notification -> do not act again.
+        // This is the per-subscriber amplification guard: an unauthenticated `Subscribe`
+        // can add arbitrary DIDs, and each one re-invokes this callback for one entry.
+        for topic in [GOVERNANCE_TOPIC, fed, fed_scoped.as_str()] {
+            assert!(
+                !governance_replication_delivery_applies(topic, &other, &local),
+                "must not act a second time for a non-local subscriber on {topic}"
+            );
+        }
+
+        // Unrelated topics are not ours, even for the local subscription.
+        for topic in [
+            "ledger:entries",
+            "trust:attestations",
+            "governance",
+            "federation",
+        ] {
+            assert!(
+                !governance_replication_delivery_applies(topic, &local, &local),
+                "must not act on unrelated topic {topic}"
+            );
+        }
     }
 
     /// The operator-facing reason must describe the author as *claimed* and must

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -3932,15 +3932,46 @@ fn refuse_replicated_governance_message(
     let effect = replicated_state_effect(msg);
 
     if effect == ReplicatedStateEffect::WouldMutateGovernanceState {
-        // `message_type()` is a `&'static str`, so it is safe both as a log field
-        // and as a metric label — an attacker cannot inflate label cardinality.
-        icn_obs::metrics::governance::replication_quarantined_inc(msg.message_type());
-        warn!(
-            local_did = %local_did,
-            claimed_author = %claimed_author,
-            message_type = msg.message_type(),
-            "{REPLICATION_QUARANTINE_REASON}"
+        // A node's own publications loop back through this ingress: every local
+        // `GovernanceCommand` persists and then calls `GossipActor::publish`, which
+        // calls `store_entry`, which fires this callback. Without separating them the
+        // quarantine counter would be nonzero during ordinary local governance and
+        // useless as an exploitation signal, and healthy single-node operation would
+        // emit a warning per command.
+        //
+        // The split is on the entry's *claimed* author, which is telemetry
+        // classification only — never authentication, and never an input to the
+        // refusal, which is unconditional. A peer may claim this node's DID, so it can
+        // land its entries in the `self` bucket; the counter is therefore a floor for
+        // remote traffic, not a total. Both buckets are still counted, so an unexplained
+        // rise in `self` beyond local command volume remains visible.
+        let claimed_origin = if claimed_author == local_did {
+            "self"
+        } else {
+            "peer"
+        };
+
+        // `message_type()` is a `&'static str` and `claimed_origin` is one of two fixed
+        // values, so neither label lets a remote peer inflate cardinality.
+        icn_obs::metrics::governance::replication_quarantined_inc(
+            msg.message_type(),
+            claimed_origin,
         );
+
+        if claimed_origin == "peer" {
+            warn!(
+                local_did = %local_did,
+                claimed_author = %claimed_author,
+                message_type = msg.message_type(),
+                "{REPLICATION_QUARANTINE_REASON}"
+            );
+        } else {
+            debug!(
+                message_type = msg.message_type(),
+                "Local governance publication looped back through the replication \
+                 ingress and was not re-applied (state was already persisted locally)"
+            );
+        }
     } else {
         debug!(
             message_type = msg.message_type(),

--- a/icn/apps/governance/src/state_store.rs
+++ b/icn/apps/governance/src/state_store.rs
@@ -278,7 +278,7 @@ impl SledGovernanceStateStore {
     ///
     /// This used to name the gossip ingress (`handle_incoming`) as the motivating
     /// caller. That ingress no longer applies replicated state and holds no store
-    /// handle at all — see `actor::refuse_replicated_governance_message`.
+    /// handle at all — see `actor::observe_replicated_governance_message`.
     pub fn as_store(&self) -> &dyn Store {
         self.store.as_ref()
     }

--- a/icn/apps/governance/src/state_store.rs
+++ b/icn/apps/governance/src/state_store.rs
@@ -274,8 +274,11 @@ impl SledGovernanceStateStore {
         Self { store }
     }
 
-    /// Expose the inner store for callers that still need raw KV access
-    /// (e.g. `handle_incoming` which operates on a `&dyn Store`).
+    /// Expose the inner store for callers that still need raw KV access.
+    ///
+    /// This used to name the gossip ingress (`handle_incoming`) as the motivating
+    /// caller. That ingress no longer applies replicated state and holds no store
+    /// handle at all — see `actor::refuse_replicated_governance_message`.
     pub fn as_store(&self) -> &dyn Store {
         self.store.as_ref()
     }

--- a/icn/apps/governance/tests/fp02_governance_replication_containment.rs
+++ b/icn/apps/governance/tests/fp02_governance_replication_containment.rs
@@ -79,7 +79,7 @@ struct Node {
     /// Without this, every negative test below would still pass if the ingress stopped
     /// being reached at all — a renamed topic filter, a dropped subscription or a
     /// decode regression would leave the suite green while testing nothing.
-    observed: Arc<std::sync::Mutex<Vec<String>>>,
+    observed: Arc<std::sync::Mutex<Vec<(String, Did)>>>,
     /// Distinguishes otherwise-identical injections. `store_entry` dedups on the
     /// sender-supplied `entry.hash`, so replays must carry distinct claimed hashes to
     /// reach the ingress independently — which is exactly the attacker's capability.
@@ -112,17 +112,19 @@ impl Node {
         .await
         .expect("init_governance_actor");
 
-        let observed: Arc<std::sync::Mutex<Vec<String>>> =
+        let observed: Arc<std::sync::Mutex<Vec<(String, Did)>>> =
             Arc::new(std::sync::Mutex::new(Vec::new()));
         {
             let obs = observed.clone();
             gossip.write().await.add_notification_callback(Arc::new(
-                move |topic: String, entry: GossipEntry, _| {
+                move |topic: String, entry: GossipEntry, subscriber_did: Did| {
                     let is_gov = topic == GOVERNANCE_TOPIC
                         || topic.starts_with(icn_federation::TOPIC_FEDERATION_GOVERNANCE);
                     if is_gov {
                         if let Ok(msg) = GovernanceMessage::from_bytes(&entry.data) {
-                            obs.lock().unwrap().push(msg.message_type().to_string());
+                            obs.lock()
+                                .unwrap()
+                                .push((msg.message_type().to_string(), subscriber_did));
                         }
                     }
                 },
@@ -157,7 +159,7 @@ impl Node {
         wire_sender: &Did,
         msg: &GovernanceMessage,
     ) {
-        let before = self.observed.lock().unwrap().len();
+        let before = self.local_deliveries();
         self.inject_forged_bytes(topic, claimed_author, wire_sender, msg.to_bytes().unwrap())
             .await;
 
@@ -165,14 +167,28 @@ impl Node {
         // replication ingress rather than being dropped upstream (topic filter, dedup,
         // missing subscription, decode failure). A refusal is only meaningful if the
         // message got there to be refused.
-        let seen = self.observed.lock().unwrap();
         assert_eq!(
-            seen.len(),
+            self.local_deliveries(),
             before + 1,
-            "injected {} never reached the governance replication ingress",
+            "injected {} never reached the governance replication ingress exactly once",
             msg.message_type()
         );
-        assert_eq!(seen.last().map(String::as_str), Some(msg.message_type()));
+    }
+
+    /// Invocations whose `subscriber_did` matches this node — the same predicate the
+    /// production ingress filters on, so this counts real ingress deliveries rather
+    /// than the raw per-subscriber fan-out.
+    fn local_deliveries(&self) -> usize {
+        self.observed
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(_, sub)| *sub == self.did)
+            .count()
+    }
+
+    fn total_fanout(&self) -> usize {
+        self.observed.lock().unwrap().len()
     }
 
     async fn inject_forged_bytes(
@@ -804,4 +820,53 @@ async fn federation_governance_topic_is_contained_too() {
         node.state.get_domain(&domain_id).unwrap().is_none(),
         "a forged DomainCreated on the federation governance topic created a domain"
     );
+}
+
+// ---------------------------------------------------------------------------
+// 14. One entry is refused once, regardless of how many subscribers a peer adds
+// ---------------------------------------------------------------------------
+
+/// `GossipActor::store_entry` invokes notification callbacks inside a per-subscriber
+/// loop, and an unauthenticated network `Subscribe` can add arbitrary DIDs to that
+/// list. Without a per-entry filter, one forged entry would be refused once per
+/// subscriber, letting a remote peer inflate `icn_governance_replication_quarantined_total`
+/// and the warning volume by up to `MAX_SUBSCRIBERS_PER_TOPIC`.
+#[tokio::test(flavor = "current_thread")]
+async fn one_entry_is_refused_once_regardless_of_subscriber_count() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+
+    // Simulate what an unauthenticated remote `Subscribe` does.
+    for _ in 0..3 {
+        node.gossip
+            .write()
+            .await
+            .subscribe(GOVERNANCE_TOPIC, attacker())
+            .await
+            .expect("subscribe");
+    }
+
+    let domain = make_domain("fanout-check", vec![mallory.clone()]);
+    let domain_id = domain.id.clone();
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::domain_created(domain),
+    )
+    .await;
+
+    // The raw gossip fan-out really does hit every subscriber (local + 3 attacker DIDs)...
+    assert_eq!(
+        node.total_fanout(),
+        4,
+        "expected the gossip layer to fan out to every subscriber"
+    );
+    // ...but the governance ingress must act exactly once for the entry.
+    assert_eq!(
+        node.local_deliveries(),
+        1,
+        "the ingress must act once per entry, not once per subscriber"
+    );
+    assert!(node.state.get_domain(&domain_id).unwrap().is_none());
 }

--- a/icn/apps/governance/tests/fp02_governance_replication_containment.rs
+++ b/icn/apps/governance/tests/fp02_governance_replication_containment.rs
@@ -72,6 +72,18 @@ struct Node {
     gossip: Arc<tokio::sync::RwLock<GossipActor>>,
     ops: GovernanceManager,
     state: SledGovernanceStateStore,
+    /// Positive control. Registered on the same fan-out seam as the production
+    /// governance callback (`add_notification_callback`), so if this observer records
+    /// a message the production ingress was invoked for it in the same dispatch loop.
+    ///
+    /// Without this, every negative test below would still pass if the ingress stopped
+    /// being reached at all — a renamed topic filter, a dropped subscription or a
+    /// decode regression would leave the suite green while testing nothing.
+    observed: Arc<std::sync::Mutex<Vec<String>>>,
+    /// Distinguishes otherwise-identical injections. `store_entry` dedups on the
+    /// sender-supplied `entry.hash`, so replays must carry distinct claimed hashes to
+    /// reach the ingress independently — which is exactly the attacker's capability.
+    seq: std::sync::atomic::AtomicU64,
 }
 
 impl Node {
@@ -100,6 +112,23 @@ impl Node {
         .await
         .expect("init_governance_actor");
 
+        let observed: Arc<std::sync::Mutex<Vec<String>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        {
+            let obs = observed.clone();
+            gossip.write().await.add_notification_callback(Arc::new(
+                move |topic: String, entry: GossipEntry, _| {
+                    let is_gov = topic == GOVERNANCE_TOPIC
+                        || topic.starts_with(icn_federation::TOPIC_FEDERATION_GOVERNANCE);
+                    if is_gov {
+                        if let Ok(msg) = GovernanceMessage::from_bytes(&entry.data) {
+                            obs.lock().unwrap().push(msg.message_type().to_string());
+                        }
+                    }
+                },
+            ));
+        }
+
         let state = SledGovernanceStateStore::new(services.governance_store.clone());
         let ops = GovernanceManager::with_handle(
             Arc::new(services.governance_handle) as Arc<dyn GovernanceOps + Send + Sync>
@@ -111,6 +140,8 @@ impl Node {
             gossip,
             ops,
             state,
+            observed,
+            seq: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -126,8 +157,22 @@ impl Node {
         wire_sender: &Did,
         msg: &GovernanceMessage,
     ) {
+        let before = self.observed.lock().unwrap().len();
         self.inject_forged_bytes(topic, claimed_author, wire_sender, msg.to_bytes().unwrap())
-            .await
+            .await;
+
+        // Positive control: prove this injection actually reached the governance
+        // replication ingress rather than being dropped upstream (topic filter, dedup,
+        // missing subscription, decode failure). A refusal is only meaningful if the
+        // message got there to be refused.
+        let seen = self.observed.lock().unwrap();
+        assert_eq!(
+            seen.len(),
+            before + 1,
+            "injected {} never reached the governance replication ingress",
+            msg.message_type()
+        );
+        assert_eq!(seen.last().map(String::as_str), Some(msg.message_type()));
     }
 
     async fn inject_forged_bytes(
@@ -138,11 +183,15 @@ impl Node {
         data: Vec<u8>,
     ) {
         // The attacker picks the hash freely: `store_entry` dedups on this field and
-        // never recomputes it from `data`.
+        // never recomputes it from `data`. Mixing in a per-injection counter models that
+        // freedom and keeps repeated injections of identical bytes from being silently
+        // deduped away before they reach the ingress.
+        let nonce = self.seq.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let mut hash = [0u8; 32];
-        for (i, b) in data.iter().take(32).enumerate() {
+        for (i, b) in data.iter().take(24).enumerate() {
             hash[i] = *b ^ 0xA5;
         }
+        hash[24..32].copy_from_slice(&nonce.to_le_bytes());
 
         let entry = GossipEntry {
             hash,
@@ -698,9 +747,10 @@ async fn replayed_unauthenticated_messages_remain_non_mutating() {
     let vote = Vote::new(proposal_id.clone(), victim.clone(), VoteChoice::Against);
     let msg = GovernanceMessage::vote_cast(vote, None);
 
-    // Same bytes, replayed. `store_entry` dedups on the attacker-chosen hash, so a
-    // replay carrying a different claimed hash is *not* deduped — each one reaches
-    // the ingress independently.
+    // Same payload, replayed three times, each carrying a *different* claimed hash —
+    // which is what an attacker does to defeat `store_entry`'s dedup. Each injection
+    // therefore reaches the ingress independently (asserted by the positive control in
+    // `inject_forged`), and each must still be refused.
     for _ in 0..3 {
         node.inject_forged(GOVERNANCE_TOPIC, &victim, &mallory, &msg)
             .await;

--- a/icn/apps/governance/tests/fp02_governance_replication_containment.rs
+++ b/icn/apps/governance/tests/fp02_governance_replication_containment.rs
@@ -80,10 +80,10 @@ struct Node {
     /// a dropped subscription, an uncreated topic or a decode regression would leave the
     /// suite green while testing nothing.
     ///
-    /// **What it does not prove:** this observer cannot see how many times the production
-    /// refusal function runs. It records callback invocations, not ingress actions. The
-    /// production dispatch decision is pinned directly by the
-    /// `should_handle_governance_notification` unit tests in `actor.rs`.
+    /// **What it does not prove:** this observer cannot see the production ingress at all.
+    /// That ingress deliberately has no observable effect — it captures no store and emits
+    /// only a bounded `debug!` — which is precisely why the containment holds. The negative
+    /// assertions below inspect durable governance state directly.
     observed: Arc<std::sync::Mutex<Vec<(String, Did)>>>,
     /// Distinguishes otherwise-identical injections. `store_entry` dedups on the
     /// sender-supplied `entry.hash`, so replays must carry distinct claimed hashes to
@@ -164,7 +164,7 @@ impl Node {
         wire_sender: &Did,
         msg: &GovernanceMessage,
     ) {
-        let before = self.local_deliveries();
+        let before = self.deliveries_to_this_node();
         self.inject_forged_bytes(topic, claimed_author, wire_sender, msg.to_bytes().unwrap())
             .await;
 
@@ -173,7 +173,7 @@ impl Node {
         // missing subscription, decode failure). A refusal is only meaningful if the
         // message got there to be refused.
         assert_eq!(
-            self.local_deliveries(),
+            self.deliveries_to_this_node(),
             before + 1,
             "injected {} was not delivered exactly once on the local subscription",
             msg.message_type()
@@ -182,19 +182,16 @@ impl Node {
 
     /// Callback invocations whose `subscriber_did` is this node's own.
     ///
-    /// This is the subset of the raw fan-out that is *eligible* for handling. It is not a
-    /// count of production refusals — the observer cannot see those.
-    fn local_deliveries(&self) -> usize {
+    /// Used only to prove the injection was delivered. It counts *this test's* observer,
+    /// not the production ingress — the production ingress has no observable effect by
+    /// design, which is the point of the containment.
+    fn deliveries_to_this_node(&self) -> usize {
         self.observed
             .lock()
             .unwrap()
             .iter()
             .filter(|(_, sub)| *sub == self.did)
             .count()
-    }
-
-    fn total_fanout(&self) -> usize {
-        self.observed.lock().unwrap().len()
     }
 
     async fn inject_forged_bytes(
@@ -714,48 +711,6 @@ async fn quarantine_does_not_stop_generic_gossip_transport() {
 }
 
 // ---------------------------------------------------------------------------
-// 11. A quarantined message yields a bounded, observable disposition
-// ---------------------------------------------------------------------------
-
-#[test]
-fn quarantine_disposition_is_bounded_and_marks_the_author_as_claimed() {
-    use icn_governance_actor::actor::{
-        replicated_state_effect, ReplicatedStateEffect, REPLICATION_QUARANTINE_REASON,
-    };
-
-    let mallory = attacker();
-    let domain = make_domain("d", vec![mallory]);
-
-    // State-mutating variants are reported as such.
-    assert_eq!(
-        replicated_state_effect(&GovernanceMessage::domain_created(domain)),
-        ReplicatedStateEffect::WouldMutateGovernanceState
-    );
-    // Variants that applied nothing before containment stay quiet.
-    assert_eq!(
-        replicated_state_effect(&GovernanceMessage::comment_deleted(
-            ProposalId("p".to_string()),
-            icn_governance::CommentId("c".to_string()),
-            1,
-        )),
-        ReplicatedStateEffect::NoStateEffect
-    );
-
-    // The diagnostic never describes the claimed author as authenticated.
-    let reason = REPLICATION_QUARANTINE_REASON.to_ascii_lowercase();
-    assert!(
-        reason.contains("claimed"),
-        "quarantine reason must call the author claimed: {REPLICATION_QUARANTINE_REASON}"
-    );
-    assert!(
-        !reason.contains("authenticated sender") && !reason.contains("verified author"),
-        "quarantine reason must not imply the author was authenticated: {REPLICATION_QUARANTINE_REASON}"
-    );
-    // Bounded: a fixed-size constant, not attacker-controlled content.
-    assert!(REPLICATION_QUARANTINE_REASON.len() < 256);
-}
-
-// ---------------------------------------------------------------------------
 // 12. Replay of the same unauthenticated message remains non-mutating
 // ---------------------------------------------------------------------------
 
@@ -826,57 +781,4 @@ async fn federation_governance_topic_is_contained_too() {
         node.state.get_domain(&domain_id).unwrap().is_none(),
         "a forged DomainCreated on the federation governance topic created a domain"
     );
-}
-
-// ---------------------------------------------------------------------------
-// 14. One entry is refused once, regardless of how many subscribers a peer adds
-// ---------------------------------------------------------------------------
-
-/// `GossipActor::store_entry` invokes notification callbacks inside a per-subscriber
-/// loop, and an unauthenticated network `Subscribe` can add arbitrary DIDs to that
-/// list. Without a per-entry filter, one forged entry would be refused once per
-/// subscriber, letting a remote peer inflate `icn_governance_replication_quarantined_total`
-/// and the warning volume by up to `MAX_SUBSCRIBERS_PER_TOPIC`.
-#[tokio::test(flavor = "current_thread")]
-async fn one_entry_is_refused_once_regardless_of_subscriber_count() {
-    let node = Node::spawn().await;
-    let mallory = attacker();
-
-    // Simulate what an unauthenticated remote `Subscribe` does.
-    for _ in 0..3 {
-        node.gossip
-            .write()
-            .await
-            .subscribe(GOVERNANCE_TOPIC, attacker())
-            .await
-            .expect("subscribe");
-    }
-
-    let domain = make_domain("fanout-check", vec![mallory.clone()]);
-    let domain_id = domain.id.clone();
-    node.inject_forged(
-        GOVERNANCE_TOPIC,
-        &mallory,
-        &mallory,
-        &GovernanceMessage::domain_created(domain),
-    )
-    .await;
-
-    // The raw gossip fan-out really does invoke callbacks once per subscriber
-    // (local + 3 attacker DIDs) — the amplification this guards against is real...
-    assert_eq!(
-        node.total_fanout(),
-        4,
-        "expected the gossip layer to fan out to every subscriber"
-    );
-    // ...while exactly one of those invocations carries this node's own subscriber DID,
-    // which is the only one `should_handle_governance_notification` admits. That predicate
-    // is tested directly in `actor.rs`; this assertion establishes the input it sees, not
-    // the number of times the production refusal function ran.
-    assert_eq!(
-        node.local_deliveries(),
-        1,
-        "exactly one invocation should be eligible for handling"
-    );
-    assert!(node.state.get_domain(&domain_id).unwrap().is_none());
 }

--- a/icn/apps/governance/tests/fp02_governance_replication_containment.rs
+++ b/icn/apps/governance/tests/fp02_governance_replication_containment.rs
@@ -1,0 +1,757 @@
+//! F-P0-2 containment: unauthenticated remote governance messages must never be
+//! applied to governance state.
+//!
+//! ## The invariant
+//!
+//! Institutional governance state must only be mutated by a party whose authority
+//! over the affected governance domain has been authenticated and verified.
+//! Permission to transport or replicate bytes is not permission to apply those
+//! bytes as governance state.
+//!
+//! ## The mechanism these tests exercise
+//!
+//! `GossipEntry` (`icn-gossip/src/types.rs`) carries a claimed `author` DID but
+//! **no signature binding that DID to the entry contents**, and the receive path
+//! (`GossipActor::store_entry`) neither recomputes the entry hash nor enforces the
+//! topic ACL. So any peer that can reach the node may publish an entry claiming
+//! *any* author. The governance replication ingress therefore receives an
+//! attacker-chosen DID, not an authenticated one — comparing anything against it
+//! is not an authorization check.
+//!
+//! Every negative test below uses a genuinely attacker-controlled `entry.author`.
+//! A test that merely passes `None` would not exercise the real vulnerability.
+//!
+//! ## Test boundary
+//!
+//! These tests drive the **production** wiring, not a reimplementation:
+//!
+//! * `icn_governance_actor::init::init_governance_actor` is the exact function the
+//!   `icnd` supervisor calls (`icn-core/src/supervisor/init_governance.rs`). It
+//!   creates the `governance:proposal` topic, opens the real Sled-backed store,
+//!   spawns the real `GovernanceActor`, and registers the real notification callback.
+//! * Forged entries are injected through the real remote ingress
+//!   `GossipActor::handle_message(sender, GossipMessage::Response { entry })`, which
+//!   dispatches to `handle_response` → `store_entry` → notification callbacks —
+//!   the same path a `Response` off the wire takes.
+//!
+//! Local governance is driven through `GovernanceManager`, the same ops surface the
+//! HTTP/RPC handlers use.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use icn_gossip::{GossipActor, GossipEntry, GossipMessage, VectorClock};
+use icn_governance::{
+    Delegation, DelegationScope, GovernanceConfig, GovernanceDomain, GovernanceDomainId,
+    GovernanceMessage, GovernanceOps, GovernanceParams, GovernanceProfileId, MembershipConfig,
+    Proposal, ProposalId, ProposalOutcome, ProposalPayload, ProposalScope, ProposalState,
+    TallySnapshot, Vote, VoteChoice,
+};
+use icn_governance_actor::init::{init_governance_actor, GovernanceActorDeps};
+use icn_governance_actor::manager::GovernanceManager;
+use icn_governance_actor::state_store::{GovernanceStateStore, SledGovernanceStateStore};
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::events::{EventEmitter, SystemEvent};
+
+const GOVERNANCE_TOPIC: &str = "governance:proposal";
+
+/// Kernel event bus stub — this suite asserts on durable governance state, not events.
+struct NoopKernelEvents;
+
+#[async_trait::async_trait]
+impl EventEmitter for NoopKernelEvents {
+    async fn emit(&self, _event: SystemEvent) {}
+}
+
+/// A node assembled the way `icnd` assembles one, plus a typed read handle on the
+/// governance store so assertions can inspect durable state directly.
+struct Node {
+    _tmp: tempfile::TempDir,
+    did: Did,
+    gossip: Arc<tokio::sync::RwLock<GossipActor>>,
+    ops: GovernanceManager,
+    state: SledGovernanceStateStore,
+}
+
+impl Node {
+    async fn spawn() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bundle = IdentityBundle::generate().expect("IdentityBundle::generate");
+        let did = bundle.did().clone();
+
+        let gossip = Arc::new(tokio::sync::RwLock::new(GossipActor::new(
+            did.clone(),
+            None,
+        )));
+
+        // The production entry point: creates the topic, opens the store, spawns the
+        // actor, and registers the governance notification callback.
+        let services = init_governance_actor(
+            tmp.path(),
+            did.clone(),
+            GovernanceActorDeps {
+                gossip_handle: gossip.clone(),
+                event_bus: Arc::new(NoopKernelEvents),
+                signing_key: None,
+                trust_service: None,
+            },
+        )
+        .await
+        .expect("init_governance_actor");
+
+        let state = SledGovernanceStateStore::new(services.governance_store.clone());
+        let ops = GovernanceManager::with_handle(
+            Arc::new(services.governance_handle) as Arc<dyn GovernanceOps + Send + Sync>
+        );
+
+        Self {
+            _tmp: tmp,
+            did,
+            gossip,
+            ops,
+            state,
+        }
+    }
+
+    /// Inject a governance message over the real remote gossip ingress, with an
+    /// attacker-chosen `entry.author` and an attacker-chosen `entry.hash`.
+    ///
+    /// `claimed_author` is what the attacker writes into the entry; `wire_sender` is
+    /// the DID the connection claims. Neither is authenticated anywhere.
+    async fn inject_forged(
+        &self,
+        topic: &str,
+        claimed_author: &Did,
+        wire_sender: &Did,
+        msg: &GovernanceMessage,
+    ) {
+        self.inject_forged_bytes(topic, claimed_author, wire_sender, msg.to_bytes().unwrap())
+            .await
+    }
+
+    async fn inject_forged_bytes(
+        &self,
+        topic: &str,
+        claimed_author: &Did,
+        wire_sender: &Did,
+        data: Vec<u8>,
+    ) {
+        // The attacker picks the hash freely: `store_entry` dedups on this field and
+        // never recomputes it from `data`.
+        let mut hash = [0u8; 32];
+        for (i, b) in data.iter().take(32).enumerate() {
+            hash[i] = *b ^ 0xA5;
+        }
+
+        let entry = GossipEntry {
+            hash,
+            author: claimed_author.clone(),
+            clock: VectorClock::new(),
+            topic: topic.to_string(),
+            data,
+            compressed: false,
+            timestamp: 1_700_000_000,
+            replica_offered: None,
+        };
+
+        let mut gossip = self.gossip.write().await;
+        gossip
+            .handle_message(wire_sender, GossipMessage::Response { entry })
+            .await
+            .expect("gossip transport must keep accepting the entry");
+    }
+}
+
+fn attacker() -> Did {
+    IdentityBundle::generate()
+        .expect("attacker identity")
+        .did()
+        .clone()
+}
+
+fn make_domain(id: &str, members: Vec<Did>) -> GovernanceDomain {
+    GovernanceDomain::with_id(
+        GovernanceDomainId(id.to_string()),
+        format!("Domain {id}"),
+        GovernanceConfig::new(
+            GovernanceProfileId::builtin("cooperative_default"),
+            MembershipConfig::static_list(members),
+            GovernanceParams::new(50, 50, 3600),
+        ),
+    )
+}
+
+/// Establish a domain + open proposal through the legitimate local path.
+async fn seed_open_proposal(node: &Node) -> (GovernanceDomainId, ProposalId) {
+    let domain_id = GovernanceDomainId("fp02-domain".to_string());
+    node.ops
+        .create_domain(
+            domain_id.clone(),
+            "FP02 Domain".to_string(),
+            "cooperative_default".to_string(),
+            GovernanceParams::new(50, 50, 3600),
+            MembershipConfig::static_list(vec![node.did.clone()]),
+        )
+        .await
+        .expect("create_domain");
+
+    let proposal_id = node
+        .ops
+        .create_proposal(
+            ProposalId("_ignored".to_string()),
+            domain_id.clone(),
+            node.did.clone(),
+            "Seed proposal".to_string(),
+            "Legitimately created locally".to_string(),
+            ProposalPayload::Text {
+                body: "seed".to_string(),
+            },
+            ProposalScope::Local,
+        )
+        .await
+        .expect("create_proposal");
+
+    node.ops
+        .open_proposal(proposal_id.clone(), 3600)
+        .await
+        .expect("open_proposal");
+
+    (domain_id, proposal_id)
+}
+
+// ---------------------------------------------------------------------------
+// 1. Forged DomainCreated cannot create a domain
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn forged_domain_created_cannot_create_a_domain() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+
+    let domain = make_domain("forged-domain", vec![mallory.clone()]);
+    let domain_id = domain.id.clone();
+
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::domain_created(domain),
+    )
+    .await;
+
+    assert!(
+        node.state.get_domain(&domain_id).unwrap().is_none(),
+        "a forged DomainCreated created a governance domain"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Forged DomainUpdated cannot modify a domain
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn forged_domain_updated_cannot_modify_a_domain() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+    let (domain_id, _) = seed_open_proposal(&node).await;
+
+    let before = node
+        .state
+        .get_domain(&domain_id)
+        .unwrap()
+        .expect("seeded domain");
+
+    // Attacker rewrites the membership to themselves and slashes the thresholds.
+    let mut tampered = before.clone();
+    tampered.config.membership = MembershipConfig::static_list(vec![mallory.clone()]);
+    tampered.config.params = GovernanceParams::new(1, 1, 1);
+
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::domain_updated(tampered),
+    )
+    .await;
+
+    let after = node
+        .state
+        .get_domain(&domain_id)
+        .unwrap()
+        .expect("domain still present");
+    assert_eq!(
+        serde_json::to_value(&before).unwrap(),
+        serde_json::to_value(&after).unwrap(),
+        "a forged DomainUpdated modified the domain"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Forged ProposalCreated cannot create a proposal
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn forged_proposal_created_cannot_create_a_proposal() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+    let (domain_id, _) = seed_open_proposal(&node).await;
+
+    let forged_id = ProposalId("forged-proposal".to_string());
+    let mut proposal = Proposal::new(
+        domain_id,
+        mallory.clone(),
+        "Forged proposal".to_string(),
+        "Injected over gossip".to_string(),
+        ProposalPayload::Text {
+            body: "forged".to_string(),
+        },
+    );
+    proposal.id = forged_id.clone();
+
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::proposal_created(proposal),
+    )
+    .await;
+
+    assert!(
+        node.state.get_proposal(&forged_id).unwrap().is_none(),
+        "a forged ProposalCreated created a proposal"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Forged VoteCast cannot record or alter a vote
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn forged_vote_cast_cannot_record_a_vote() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+    let (_, proposal_id) = seed_open_proposal(&node).await;
+
+    // The attacker casts a vote *as the legitimate member* — the strongest form of
+    // the attack, since `entry.author` is set to that member's DID as well.
+    let victim = node.did.clone();
+    let vote = Vote::new(proposal_id.clone(), victim.clone(), VoteChoice::Against);
+
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &victim,
+        &mallory,
+        &GovernanceMessage::vote_cast(vote, None),
+    )
+    .await;
+
+    assert!(
+        node.state
+            .get_vote(&proposal_id, &victim)
+            .unwrap()
+            .is_none(),
+        "a forged VoteCast recorded a vote under the victim's DID"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Forged ProposalOpened cannot reopen a closed proposal
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn forged_proposal_opened_cannot_reopen_a_closed_proposal() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+    let (_, proposal_id) = seed_open_proposal(&node).await;
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+    node.ops
+        .close_proposal(proposal_id.clone())
+        .await
+        .expect("close_proposal");
+
+    let closed = node
+        .state
+        .get_proposal(&proposal_id)
+        .unwrap()
+        .expect("closed proposal");
+    assert!(
+        !closed.state.is_open(),
+        "precondition: proposal must be closed before the reopen attempt"
+    );
+
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::proposal_opened(proposal_id.clone(), 1, 999_999_999),
+    )
+    .await;
+
+    let after = node
+        .state
+        .get_proposal(&proposal_id)
+        .unwrap()
+        .expect("proposal still present");
+    assert!(
+        !after.state.is_open(),
+        "a forged ProposalOpened reopened a closed proposal"
+    );
+    assert_eq!(
+        serde_json::to_value(&closed.state).unwrap(),
+        serde_json::to_value(&after.state).unwrap(),
+        "a forged ProposalOpened altered the terminal proposal state"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Forged ProposalOpened → ProposalClosed cannot replace a decided outcome
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn forged_reopen_then_close_cannot_replace_a_decided_outcome() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+    let (_, proposal_id) = seed_open_proposal(&node).await;
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+    node.ops
+        .close_proposal(proposal_id.clone())
+        .await
+        .expect("close_proposal");
+
+    let decided = node
+        .state
+        .get_proposal(&proposal_id)
+        .unwrap()
+        .expect("decided proposal");
+    assert!(
+        matches!(decided.state, ProposalState::Accepted { .. }),
+        "precondition: proposal should be Accepted, got {:?}",
+        decided.state
+    );
+
+    // Step 1: force the proposal back to Open (defeats `Proposal::close`'s
+    // `is_open()` guard). Step 2: re-finalize with the attacker's chosen outcome.
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::proposal_opened(proposal_id.clone(), 1, 999_999_999),
+    )
+    .await;
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::proposal_closed(
+            proposal_id.clone(),
+            ProposalOutcome::Rejected,
+            2,
+            TallySnapshot::new(0, 99, 0, 99),
+            None,
+        ),
+    )
+    .await;
+
+    let after = node
+        .state
+        .get_proposal(&proposal_id)
+        .unwrap()
+        .expect("proposal still present");
+    assert!(
+        matches!(after.state, ProposalState::Accepted { .. }),
+        "the forged reopen→close sequence replaced the decided outcome: {:?}",
+        after.state
+    );
+    assert_eq!(
+        serde_json::to_value(&decided.state).unwrap(),
+        serde_json::to_value(&after.state).unwrap(),
+        "the forged reopen→close sequence altered the decided outcome"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Claiming a legitimate party's DID confers no authority
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn claiming_a_legitimate_did_confers_no_authority() {
+    let node = Node::spawn().await;
+    let _ = seed_open_proposal(&node).await;
+
+    // The node's own DID is the domain's sole member, the proposal's proposer, and
+    // the delegator below. Claiming it in `entry.author` must still grant nothing.
+    let victim = node.did.clone();
+    let delegate = attacker();
+    let delegation = Delegation::new(victim.clone(), delegate, DelegationScope::Blanket);
+
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &victim,
+        &victim,
+        &GovernanceMessage::delegation_created(delegation.clone()),
+    )
+    .await;
+
+    assert!(
+        node.state.get_delegation(&delegation.id).unwrap().is_none(),
+        "claiming the delegator's DID in entry.author created a delegation"
+    );
+
+    // Same for the reverse operation on a delegation the node does hold.
+    let real = Delegation::new(victim.clone(), attacker(), DelegationScope::Blanket);
+    node.state.save_delegation(&real).unwrap();
+
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &victim,
+        &victim,
+        &GovernanceMessage::delegation_revoked(real.id.clone(), victim.clone(), 42),
+    )
+    .await;
+
+    let after = node
+        .state
+        .get_delegation(&real.id)
+        .unwrap()
+        .expect("delegation still present");
+    assert!(
+        after.revoked_at.is_none(),
+        "claiming the delegator's DID in entry.author revoked a delegation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Malformed / unknown messages remain safely handled
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn malformed_and_unknown_messages_are_handled_safely() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+
+    // Not valid JSON at all.
+    node.inject_forged_bytes(GOVERNANCE_TOPIC, &mallory, &mallory, vec![0xff; 64])
+        .await;
+    // Valid JSON, unknown shape.
+    node.inject_forged_bytes(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        br#"{"NotAVariant":{"x":1}}"#.to_vec(),
+    )
+    .await;
+    // Empty payload.
+    node.inject_forged_bytes(GOVERNANCE_TOPIC, &mallory, &mallory, Vec::new())
+        .await;
+
+    // The actor survives and local governance still works afterwards.
+    let (domain_id, _) = seed_open_proposal(&node).await;
+    assert!(node.state.get_domain(&domain_id).unwrap().is_some());
+}
+
+// ---------------------------------------------------------------------------
+// 9. Local authorized governance operations continue to work
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn local_authorized_governance_still_works_end_to_end() {
+    let node = Node::spawn().await;
+    let (domain_id, proposal_id) = seed_open_proposal(&node).await;
+
+    assert!(
+        node.state.get_domain(&domain_id).unwrap().is_some(),
+        "local create_domain must still persist"
+    );
+    let opened = node
+        .state
+        .get_proposal(&proposal_id)
+        .unwrap()
+        .expect("proposal");
+    assert!(
+        opened.state.is_open(),
+        "local open_proposal must still persist"
+    );
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+    assert!(
+        node.state
+            .get_vote(&proposal_id, &node.did)
+            .unwrap()
+            .is_some(),
+        "local cast_vote must still persist"
+    );
+
+    node.ops
+        .close_proposal(proposal_id.clone())
+        .await
+        .expect("close_proposal");
+    let closed = node
+        .state
+        .get_proposal(&proposal_id)
+        .unwrap()
+        .expect("proposal");
+    assert!(
+        matches!(closed.state, ProposalState::Accepted { .. }),
+        "local close_proposal must still decide the proposal, got {:?}",
+        closed.state
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 10. Quarantine does not stop the generic gossip actor
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn quarantine_does_not_stop_generic_gossip_transport() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+
+    let domain = make_domain("transport-check", vec![mallory.clone()]);
+    let domain_id = domain.id.clone();
+    let msg = GovernanceMessage::domain_created(domain);
+
+    // `inject_forged` already asserts `handle_message` returns Ok — transport accepted
+    // the entry. Confirm the entry was retained by the gossip layer for observability.
+    node.inject_forged(GOVERNANCE_TOPIC, &mallory, &mallory, &msg)
+        .await;
+
+    let entries = node.gossip.read().await.get_entries(GOVERNANCE_TOPIC);
+    assert!(
+        entries.iter().any(|e| e.author == mallory),
+        "the quarantined entry must still be stored by the gossip layer"
+    );
+
+    // And the actor keeps serving further traffic.
+    node.inject_forged(GOVERNANCE_TOPIC, &mallory, &mallory, &msg)
+        .await;
+    assert!(
+        node.state.get_domain(&domain_id).unwrap().is_none(),
+        "transport retention must not become state application"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 11. A quarantined message yields a bounded, observable disposition
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quarantine_disposition_is_bounded_and_marks_the_author_as_claimed() {
+    use icn_governance_actor::actor::{
+        replicated_state_effect, ReplicatedStateEffect, REPLICATION_QUARANTINE_REASON,
+    };
+
+    let mallory = attacker();
+    let domain = make_domain("d", vec![mallory]);
+
+    // State-mutating variants are reported as such.
+    assert_eq!(
+        replicated_state_effect(&GovernanceMessage::domain_created(domain)),
+        ReplicatedStateEffect::WouldMutateGovernanceState
+    );
+    // Variants that applied nothing before containment stay quiet.
+    assert_eq!(
+        replicated_state_effect(&GovernanceMessage::comment_deleted(
+            ProposalId("p".to_string()),
+            icn_governance::CommentId("c".to_string()),
+            1,
+        )),
+        ReplicatedStateEffect::NoStateEffect
+    );
+
+    // The diagnostic never describes the claimed author as authenticated.
+    let reason = REPLICATION_QUARANTINE_REASON.to_ascii_lowercase();
+    assert!(
+        reason.contains("claimed"),
+        "quarantine reason must call the author claimed: {REPLICATION_QUARANTINE_REASON}"
+    );
+    assert!(
+        !reason.contains("authenticated sender") && !reason.contains("verified author"),
+        "quarantine reason must not imply the author was authenticated: {REPLICATION_QUARANTINE_REASON}"
+    );
+    // Bounded: a fixed-size constant, not attacker-controlled content.
+    assert!(REPLICATION_QUARANTINE_REASON.len() < 256);
+}
+
+// ---------------------------------------------------------------------------
+// 12. Replay of the same unauthenticated message remains non-mutating
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn replayed_unauthenticated_messages_remain_non_mutating() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+    let (_, proposal_id) = seed_open_proposal(&node).await;
+
+    let victim = node.did.clone();
+    let vote = Vote::new(proposal_id.clone(), victim.clone(), VoteChoice::Against);
+    let msg = GovernanceMessage::vote_cast(vote, None);
+
+    // Same bytes, replayed. `store_entry` dedups on the attacker-chosen hash, so a
+    // replay carrying a different claimed hash is *not* deduped — each one reaches
+    // the ingress independently.
+    for _ in 0..3 {
+        node.inject_forged(GOVERNANCE_TOPIC, &victim, &mallory, &msg)
+            .await;
+    }
+
+    assert!(
+        node.state
+            .get_vote(&proposal_id, &victim)
+            .unwrap()
+            .is_none(),
+        "a replayed forged VoteCast recorded a vote"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 13. The federation governance topic shares the same containment
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+async fn federation_governance_topic_is_contained_too() {
+    let node = Node::spawn().await;
+    let mallory = attacker();
+
+    let fed_topic = format!("{}:fed-1", icn_federation::TOPIC_FEDERATION_GOVERNANCE);
+    node.gossip
+        .write()
+        .await
+        .create_topic(icn_gossip::Topic::new(
+            fed_topic.clone(),
+            icn_gossip::AccessControl::Public,
+        ));
+    node.gossip
+        .write()
+        .await
+        .subscribe(&fed_topic, node.did.clone())
+        .await
+        .expect("subscribe");
+
+    let domain = make_domain("fed-forged", vec![mallory.clone()]);
+    let domain_id = domain.id.clone();
+
+    node.inject_forged(
+        &fed_topic,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::domain_created(domain),
+    )
+    .await;
+
+    assert!(
+        node.state.get_domain(&domain_id).unwrap().is_none(),
+        "a forged DomainCreated on the federation governance topic created a domain"
+    );
+}

--- a/icn/apps/governance/tests/fp02_governance_replication_containment.rs
+++ b/icn/apps/governance/tests/fp02_governance_replication_containment.rs
@@ -72,13 +72,18 @@ struct Node {
     gossip: Arc<tokio::sync::RwLock<GossipActor>>,
     ops: GovernanceManager,
     state: SledGovernanceStateStore,
-    /// Positive control. Registered on the same fan-out seam as the production
-    /// governance callback (`add_notification_callback`), so if this observer records
-    /// a message the production ingress was invoked for it in the same dispatch loop.
+    /// Positive control on *delivery*, recorded as `(message_type, subscriber_did)`.
     ///
-    /// Without this, every negative test below would still pass if the ingress stopped
-    /// being reached at all — a renamed topic filter, a dropped subscription or a
-    /// decode regression would leave the suite green while testing nothing.
+    /// Registered on the same `add_notification_callback` fan-out seam the production
+    /// governance callback uses, so it observes the same dispatch loop. Without it, every
+    /// negative test below would still pass if entries stopped being delivered at all —
+    /// a dropped subscription, an uncreated topic or a decode regression would leave the
+    /// suite green while testing nothing.
+    ///
+    /// **What it does not prove:** this observer cannot see how many times the production
+    /// refusal function runs. It records callback invocations, not ingress actions. The
+    /// production dispatch decision is pinned directly by the
+    /// `should_handle_governance_notification` unit tests in `actor.rs`.
     observed: Arc<std::sync::Mutex<Vec<(String, Did)>>>,
     /// Distinguishes otherwise-identical injections. `store_entry` dedups on the
     /// sender-supplied `entry.hash`, so replays must carry distinct claimed hashes to
@@ -163,21 +168,22 @@ impl Node {
         self.inject_forged_bytes(topic, claimed_author, wire_sender, msg.to_bytes().unwrap())
             .await;
 
-        // Positive control: prove this injection actually reached the governance
-        // replication ingress rather than being dropped upstream (topic filter, dedup,
+        // Positive control: prove this injection was actually delivered on this node's
+        // own subscription rather than being dropped upstream (topic filter, dedup,
         // missing subscription, decode failure). A refusal is only meaningful if the
         // message got there to be refused.
         assert_eq!(
             self.local_deliveries(),
             before + 1,
-            "injected {} never reached the governance replication ingress exactly once",
+            "injected {} was not delivered exactly once on the local subscription",
             msg.message_type()
         );
     }
 
-    /// Invocations whose `subscriber_did` matches this node — the same predicate the
-    /// production ingress filters on, so this counts real ingress deliveries rather
-    /// than the raw per-subscriber fan-out.
+    /// Callback invocations whose `subscriber_did` is this node's own.
+    ///
+    /// This is the subset of the raw fan-out that is *eligible* for handling. It is not a
+    /// count of production refusals — the observer cannot see those.
     fn local_deliveries(&self) -> usize {
         self.observed
             .lock()
@@ -856,17 +862,21 @@ async fn one_entry_is_refused_once_regardless_of_subscriber_count() {
     )
     .await;
 
-    // The raw gossip fan-out really does hit every subscriber (local + 3 attacker DIDs)...
+    // The raw gossip fan-out really does invoke callbacks once per subscriber
+    // (local + 3 attacker DIDs) — the amplification this guards against is real...
     assert_eq!(
         node.total_fanout(),
         4,
         "expected the gossip layer to fan out to every subscriber"
     );
-    // ...but the governance ingress must act exactly once for the entry.
+    // ...while exactly one of those invocations carries this node's own subscriber DID,
+    // which is the only one `should_handle_governance_notification` admits. That predicate
+    // is tested directly in `actor.rs`; this assertion establishes the input it sees, not
+    // the number of times the production refusal function ran.
     assert_eq!(
         node.local_deliveries(),
         1,
-        "the ingress must act once per entry, not once per subscriber"
+        "exactly one invocation should be eligible for handling"
     );
     assert!(node.state.get_domain(&domain_id).unwrap().is_none());
 }

--- a/icn/crates/icn-obs/src/metrics/governance.rs
+++ b/icn/crates/icn-obs/src/metrics/governance.rs
@@ -52,6 +52,13 @@ pub fn init_descriptions() {
         "Number of proposals scanned in last cleanup run"
     );
 
+    // Replication containment metrics (F-P0-2)
+    describe_counter!(
+        "icn_governance_replication_quarantined_total",
+        "Total replicated governance messages refused because the gossip entry's claimed \
+         author is unauthenticated and carries no governance authority (by message_type label)"
+    );
+
     // Domain metrics
     describe_counter!(
         "icn_governance_domains_created_total",
@@ -193,6 +200,22 @@ pub fn votes_cast_inc(vote_type: &str) {
 /// Increment delegated votes counter
 pub fn delegated_votes_inc() {
     counter!("icn_governance_delegated_votes_total").increment(1);
+}
+
+// Replication containment metrics (F-P0-2)
+
+/// Increment the counter of replicated governance messages refused for lack of
+/// authenticated authority.
+///
+/// `message_type` must be a fixed variant name (e.g. `GovernanceMessage::message_type`,
+/// which returns `&'static str`) — never an attacker-supplied value, which would let a
+/// remote peer inflate label cardinality.
+pub fn replication_quarantined_inc(message_type: &str) {
+    counter!(
+        "icn_governance_replication_quarantined_total",
+        "message_type" => message_type.to_string()
+    )
+    .increment(1);
 }
 
 // Cleanup metrics

--- a/icn/crates/icn-obs/src/metrics/governance.rs
+++ b/icn/crates/icn-obs/src/metrics/governance.rs
@@ -223,6 +223,16 @@ pub fn delegated_votes_inc() {
 /// bucket. A node's own publications loop back through this ingress and contribute a low,
 /// operator-driven baseline of one per local governance command. A reliable split requires
 /// trusted ingress provenance from the gossip layer (issue #2469).
+///
+/// This counter can also be **silenced** by a peer: gossip dispatch is driven by a
+/// peer-mutable subscription list, and an unauthenticated `Unsubscribe` can drop this
+/// node's own subscription (issue #2471), after which this ingress stops being invoked.
+/// Absence of this metric is therefore not evidence of absence of forged governance
+/// traffic. State containment is unaffected either way: the ingress callback captures no
+/// governance store, so no replicated governance state is applied whether or not the
+/// callback runs, and no unauthenticated field is ever treated as governance authority.
+///
+/// Treat this as best-effort diagnostic telemetry, not a non-evadable exploitation measure.
 pub fn replication_quarantined_inc(message_type: &str, claimed_origin: &str) {
     counter!(
         "icn_governance_replication_quarantined_total",

--- a/icn/crates/icn-obs/src/metrics/governance.rs
+++ b/icn/crates/icn-obs/src/metrics/governance.rs
@@ -57,8 +57,11 @@ pub fn init_descriptions() {
         "icn_governance_replication_quarantined_total",
         "Total governance messages refused at the replication ingress because the gossip \
          entry's claimed author is unauthenticated and carries no governance authority. \
-         Labels: message_type, and claimed_origin (self|peer). Local publications loop \
-         back through the same ingress and are labelled self; alert on claimed_origin=peer."
+         Labels: message_type, and claimed_origin (self|peer). claimed_origin is derived \
+         from the entry's attacker-chosen author and is descriptive only -- a peer can \
+         claim this node's DID -- so alert on the TOTAL, not on one bucket. Local \
+         publications loop back through this ingress and contribute a low baseline of \
+         one per local governance command."
     );
 
     // Domain metrics
@@ -214,10 +217,12 @@ pub fn delegated_votes_inc() {
 /// remote peer inflate label cardinality.
 ///
 /// `claimed_origin` is `"self"` or `"peer"` — nothing else, so cardinality stays bounded.
-/// It reflects the entry's *claimed* author and is telemetry classification only, never an
-/// authentication or authorization decision. A node's own publications loop back through
-/// the same ingress, so without this label the counter would be nonzero during ordinary
-/// local governance and useless as an exploitation signal. Alert on `claimed_origin="peer"`.
+/// It is derived from the entry's *claimed* author, which the sending peer chooses, so it
+/// is **descriptive only and not a trustworthy origin split**: a peer can land entries in
+/// the `self` bucket by claiming this node's DID. **Alert on the total**, not on one
+/// bucket. A node's own publications loop back through this ingress and contribute a low,
+/// operator-driven baseline of one per local governance command. A reliable split requires
+/// trusted ingress provenance from the gossip layer (issue #2469).
 pub fn replication_quarantined_inc(message_type: &str, claimed_origin: &str) {
     counter!(
         "icn_governance_replication_quarantined_total",

--- a/icn/crates/icn-obs/src/metrics/governance.rs
+++ b/icn/crates/icn-obs/src/metrics/governance.rs
@@ -52,18 +52,6 @@ pub fn init_descriptions() {
         "Number of proposals scanned in last cleanup run"
     );
 
-    // Replication containment metrics (F-P0-2)
-    describe_counter!(
-        "icn_governance_replication_quarantined_total",
-        "Total governance messages refused at the replication ingress because the gossip \
-         entry's claimed author is unauthenticated and carries no governance authority. \
-         Labels: message_type, and claimed_origin (self|peer). claimed_origin is derived \
-         from the entry's attacker-chosen author and is descriptive only -- a peer can \
-         claim this node's DID -- so alert on the TOTAL, not on one bucket. Local \
-         publications loop back through this ingress and contribute a low baseline of \
-         one per local governance command."
-    );
-
     // Domain metrics
     describe_counter!(
         "icn_governance_domains_created_total",
@@ -205,41 +193,6 @@ pub fn votes_cast_inc(vote_type: &str) {
 /// Increment delegated votes counter
 pub fn delegated_votes_inc() {
     counter!("icn_governance_delegated_votes_total").increment(1);
-}
-
-// Replication containment metrics (F-P0-2)
-
-/// Increment the counter of governance messages refused at the replication ingress for
-/// lack of authenticated authority.
-///
-/// `message_type` must be a fixed variant name (e.g. `GovernanceMessage::message_type`,
-/// which returns `&'static str`) — never an attacker-supplied value, which would let a
-/// remote peer inflate label cardinality.
-///
-/// `claimed_origin` is `"self"` or `"peer"` — nothing else, so cardinality stays bounded.
-/// It is derived from the entry's *claimed* author, which the sending peer chooses, so it
-/// is **descriptive only and not a trustworthy origin split**: a peer can land entries in
-/// the `self` bucket by claiming this node's DID. **Alert on the total**, not on one
-/// bucket. A node's own publications loop back through this ingress and contribute a low,
-/// operator-driven baseline of one per local governance command. A reliable split requires
-/// trusted ingress provenance from the gossip layer (issue #2469).
-///
-/// This counter can also be **silenced** by a peer: gossip dispatch is driven by a
-/// peer-mutable subscription list, and an unauthenticated `Unsubscribe` can drop this
-/// node's own subscription (issue #2471), after which this ingress stops being invoked.
-/// Absence of this metric is therefore not evidence of absence of forged governance
-/// traffic. State containment is unaffected either way: the ingress callback captures no
-/// governance store, so no replicated governance state is applied whether or not the
-/// callback runs, and no unauthenticated field is ever treated as governance authority.
-///
-/// Treat this as best-effort diagnostic telemetry, not a non-evadable exploitation measure.
-pub fn replication_quarantined_inc(message_type: &str, claimed_origin: &str) {
-    counter!(
-        "icn_governance_replication_quarantined_total",
-        "message_type" => message_type.to_string(),
-        "claimed_origin" => claimed_origin.to_string()
-    )
-    .increment(1);
 }
 
 // Cleanup metrics

--- a/icn/crates/icn-obs/src/metrics/governance.rs
+++ b/icn/crates/icn-obs/src/metrics/governance.rs
@@ -55,8 +55,10 @@ pub fn init_descriptions() {
     // Replication containment metrics (F-P0-2)
     describe_counter!(
         "icn_governance_replication_quarantined_total",
-        "Total replicated governance messages refused because the gossip entry's claimed \
-         author is unauthenticated and carries no governance authority (by message_type label)"
+        "Total governance messages refused at the replication ingress because the gossip \
+         entry's claimed author is unauthenticated and carries no governance authority. \
+         Labels: message_type, and claimed_origin (self|peer). Local publications loop \
+         back through the same ingress and are labelled self; alert on claimed_origin=peer."
     );
 
     // Domain metrics
@@ -204,16 +206,23 @@ pub fn delegated_votes_inc() {
 
 // Replication containment metrics (F-P0-2)
 
-/// Increment the counter of replicated governance messages refused for lack of
-/// authenticated authority.
+/// Increment the counter of governance messages refused at the replication ingress for
+/// lack of authenticated authority.
 ///
 /// `message_type` must be a fixed variant name (e.g. `GovernanceMessage::message_type`,
 /// which returns `&'static str`) — never an attacker-supplied value, which would let a
 /// remote peer inflate label cardinality.
-pub fn replication_quarantined_inc(message_type: &str) {
+///
+/// `claimed_origin` is `"self"` or `"peer"` — nothing else, so cardinality stays bounded.
+/// It reflects the entry's *claimed* author and is telemetry classification only, never an
+/// authentication or authorization decision. A node's own publications loop back through
+/// the same ingress, so without this label the counter would be nonzero during ordinary
+/// local governance and useless as an exploitation signal. Alert on `claimed_origin="peer"`.
+pub fn replication_quarantined_inc(message_type: &str, claimed_origin: &str) {
     counter!(
         "icn_governance_replication_quarantined_total",
-        "message_type" => message_type.to_string()
+        "message_type" => message_type.to_string(),
+        "claimed_origin" => claimed_origin.to_string()
     )
     .increment(1);
 }


### PR DESCRIPTION
**This PR contains unauthenticated governance state application by structurally removing the replicated entry's path to `GovernanceStateStore`. It deliberately does not provide reliable exploitation telemetry. Generic gossip still stores and propagates entries.**

Authenticated governance replication remains #2469; unauthenticated subscription control remains #2471; governance backup-integrity tooling remains #2472; the sibling institutional-state paths remain #2441.

---

## Current-main vulnerability trace (re-derived at `26eb6fe1`)

The transport layer changed substantially since this PR was opened. **The vulnerability did not.** The accurate current statement is a chain of three distinct properties, only the first of which exists:

> **authenticated transport peer ≠ authenticated content author ≠ institutional governance authority**

### 1. The transport peer *is* authenticated — this is no longer the defect

`icn-net/src/handlers/hello.rs:44-108` binds the claimed DID to the live TLS session before anything derived from `from` is stored, requiring all three of:

1. the binding names the DID that sent this Hello (`did == from`);
2. that DID's key signed the binding (Ed25519 over the certificate hash);
3. the signed hash is of the certificate **this connection is actually presenting**.

A connection presenting no peer certificate is refused outright (`hello.rs:62`), which is what makes `client_auth_mandatory() == false` at `icn-net/src/tls.rs:44` survivable: TLS is still TOFU, but Hello — not TLS — is the authentication boundary, and it fails closed. On success, `record_authenticated_peer(from)` (`hello.rs:108`) publishes the identity as `ConnectionContext::authenticated_peer()` (`icn-net/src/handlers/mod.rs:78`).

**Earlier revisions of this PR described the transport as proving nothing about the peer. That description is obsolete and has been removed from the trace below.** See GHSA-c22h-qr8j-g639 / #2520 for the binding, and #2535 for a handler that correctly consumes it.

### 2. That authenticated identity is discarded before the gossip decision

`authenticated_peer()` is consulted where it has been wired deliberately — e.g. `icn-net/src/handlers/peer_exchange.rs:96` refuses to proceed without it. **The gossip ingress does not consult it.** The canonical `icnd` handler reads the per-message envelope field instead:

```rust
// icn-core/src/supervisor/init_network.rs:59
let sender_did = net_msg.from.clone();
...
// :62-71
icn_net::MessagePayload::Gossip(gossip_msg) => {
    ... gossip.handle_message(&sender, gossip_msg).await ...
}
```

`NetworkMessage.from` is self-declared per message and is never rebound to the Hello identity — stated in-tree at `icn-gossip/src/subscriptions.rs:288-291`: *"The claimed subscriber comes from `NetworkMessage.from`, which is self-declared … nothing rebinds a per-message `from` to the Hello identity."*

So the system computes an authenticated peer identity and then does not use it at this seam.

### 3. Even the transport sender is the wrong principal — governance keys off an unsigned author

Closing (2) would still not close the hole, because governance authority is not derived from the sender at all. It is derived from `GossipEntry.author`:

```rust
// icn/apps/governance/src/actor.rs:1293
handle_incoming(store_notify.as_ref(), msg, Some(&entry.author))   // ← durable state mutation
```

`GossipEntry` (`icn-gossip/src/types.rs:116-140`) carries `author: Did` and **no signature field whatsoever** — an `awk`-scoped scan of the struct returns zero matches for `signature`. The author is attacker-chosen and cryptographically unbound to the entry contents. `Did`'s deserializer validates the string is a well-formed Ed25519 DID — that proves syntactic validity of a public key, **not** possession of the private half, and not that the named party wrote this entry.

### 4. No institutional authority check exists

Nothing between ingress and mutation establishes that the (unauthenticated) author holds authority over the affected governance domain. `validate_secure_v2_proof_for_proposal` verifies attestation signatures but does not establish domain authority, and is not on this path (see *What this PR does not claim*).

### 5. The path is live in the canonical composition

`icn-core/src/supervisor/lifecycle.rs:801` calls `init_governance::init_governance_services(...)` **unconditionally** — no config gate. Governance ingress is present in every assembled `icnd`.

### Pre-containment behavior by variant

| Variant | Pre-containment behavior |
|---|---|
| `DomainCreated`, `DomainUpdated`, `ProposalCreated`, `VoteCast` | applied with **no author check of any kind** |
| `DelegationCreated`, `DelegationRevoked` | compared the owner against the **unsigned, spoofable** `entry.author` |
| `ProposalOpened` | **force-reset** proposal state to `Open` regardless of current state |
| `ProposalClosed` | `Proposal::close()`'s `is_open()` guard is real, but a forged `ProposalOpened` first defeats it |

The last two compose into a two-message bypass that re-finalizes an already-decided proposal with an attacker-chosen outcome.

---

## Historical defect discovery (retained for provenance)

This section records how the defect was found and which earlier explanations were **refuted**. It is not a description of current main.

- **Refuted:** an earlier campaign claimed the bypass was `sender == None` skipping optional checks. The only production call site always passed `Some(&entry.author)`.
- **Refuted (by the transport work that landed since):** the original July trace attributed the defect to the transport — `client_auth_mandatory() = false` and a `verify_client_cert` that accepts any certificate, therefore "connecting proves nothing." The TLS facts are still literally true, but the conclusion no longer holds: Hello now authenticates the peer (§1 above). **The defect was never actually transport-shaped.** It is a content-authority defect that the transport gap was masking, which is why hardening the transport did not fix it.
- **Original trace, as re-derived at base `99b8e0b3`** (superseded by §1–§5):

```
untrusted peer
  → icn-net TLS: client_auth_mandatory()=false; verify_client_cert accepts any cert
  → NetworkMessage.from is self-declared
  → icn-gossip protocol.rs: PolicyRequest::new(..) carries no context, so
       required_trust_threshold() is None and the oracle's deny branch is unreachable
  → GossipActor::store_entry — three callers: local publish, handlers/push.rs,
       handlers/pull.rs. Dedups on the sender-supplied entry.hash; no ACL on receipt
  → notification callbacks
  → apps/governance/src/actor.rs: GovernanceMessage::from_bytes
       (the ONLY production consumer in the workspace)
  → handle_incoming(store, msg, Some(&entry.author))   ← state mutation
```

The same callback also serves `federation:governance*`, so that topic shared the identical defect. Federation has no separate `GovernanceMessage` apply path.

---

## What this PR proves

- **The production path allows unauthenticated governance state application.** Traced end to end above against current main.
- **The exploit is reproduced through production wiring.** The containment suite drives `init_governance_actor` — the exact function the `icnd` supervisor reaches via `lifecycle.rs:801` — and injects forged entries via the real remote ingress `GossipActor::handle_message(sender, GossipMessage::Response { entry })`. Against unpatched behavior it fails, including a forged reopen→close sequence flipping an **Accepted** proposal to `Rejected { closed_at: 2 }` and a forged `VoteCast` recorded under the victim's DID.
- **The final callback captures no governance store.** The registered closure captures only the local DID. A replicated entry has no path to `GovernanceStateStore` regardless of what the callback does, whether it runs, or how often. The unauthenticated apply arms are deleted, not gated — `actor.rs` is a net **−297** lines.
- **Forged replicated governance messages cannot mutate governance state.** All eight previously-mutating variants are inert, structurally rather than by per-variant checks.
- **Local governance remains functional.** Every local `GovernanceCommand` persists through the actor command path *before* it publishes; the diff touches none of those lines. The gossip loopback was a redundant re-application.
- **Generic gossip behavior is unchanged.** Entries are still accepted, stored, clock-merged and served by anti-entropy; `icn-gossip` and `icn-net` are untouched by this PR.

## What this PR intentionally breaks

**Legitimate multi-node governance convergence is suspended.** A node no longer learns proposals, votes, domains or delegations created on another node. This is the intended effect: that convergence *was* the unauthenticated write primitive, and legitimate entries cannot currently be distinguished from forged ones — precisely because `GossipEntry.author` carries no signature. Single-node and local/API-driven governance are unaffected.

No prior test covered cross-node governance convergence — every pre-existing test that uses the real `GovernanceActor` spawns exactly one node — so nothing broke. That absence is itself notable and is recorded in #2469.

## What this PR does not claim

- **Not** authenticated governance replication (#2469). Closing this properly requires binding content authorship — either signing `GossipEntry`, or rebinding the ingress to `authenticated_peer()` and requiring sender-authored entries.
- **Not** a transport fix. The transport is already authenticated (§1); that is not what was broken.
- **Not** secure federation governance.
- **Not** trustworthy exploitation telemetry — see below.
- **Not** a live-cluster or live-federation exploit demonstration. Evidence is deterministic production-wired integration tests.
- **Not** deployment readiness.
- **Not** proof-signer institutional authority. `validate_secure_v2_proof_for_proposal` is retained for its single remaining caller, `GovernanceHandle::get_proof`, a read path that validates stored proofs before serving them. It verifies attestation signatures but does **not** establish that any signer held authority over the domain, and is deliberately not used to admit replicated state.
- **Not** a fix for #2441, #2471, or #2472.

## No exploitation telemetry, deliberately

An earlier revision of this PR added a quarantine counter and warning. It was removed, because it could not be made trustworthy at this layer:

- local governance publications loop back through the same ingress and inflated it;
- its origin label derived from the attacker-chosen `entry.author`;
- entries compressed above the gossip threshold fail to decode before reaching it;
- an unauthenticated `Unsubscribe` claiming this node's DID removes the local subscription and silences the callback entirely (#2471).

A signal with those properties is worse than none: its absence proves nothing, and an operator alerting on it is misled. The ingress now emits one bounded `debug!`. **None of this ever affected the containment**, which is structural rather than procedural.

## Documentation updated

- `docs/guides/operations/runbooks/02-data-recovery.md` — "Replay from Peers" listed governance proposals as recoverable after an old or missing backup. They are not, and the failure is **silent**. The runbook now requires a known-complete governance-bearing backup whose provenance was established before the failure, states that an uncertain backup must not be used to resume or close still-open proposals, and places the domain/proposal listings in **Step 7** (after the daemon restart — those commands reach the daemon over RPC and Step 1 stops it). It records that vote and delegation completeness **cannot** be verified with current surfaces (#2472): `icnctl gov vote show` is unimplemented, and `icnctl gov vote delegations` / `GET /gov/delegations` return only the authenticated caller's own delegations.
- `docs/ARCHITECTURE.md` §4.7 — annotated as intended model, not current behavior.
- `docs/design/governance/governance.md` — gossip synchronization marked outbound-only; the "Which to Use?" table no longer advertises full gossip or multi-node validation.

## Deployment impact

Multi-node governance replication stops converging, as above. Single-node and local/API-driven governance are unaffected. Governance state must be recovered from backup, not from peers.

## Rollback

Revert the branch. That restores the previous behavior — including the unauthenticated write primitive — so it should only be done alongside a compensating control.

## Benchmarks

`Compare Against Base` (non-required) reports regressions across `icn-compute`, `icn-gateway`, `icn-gossip` and `icn-net`. This PR touches none of them — its only Rust changes are in `icn/apps/governance`, which has no benchmarks. `icn-net` and `icn-gossip` have no dependency edge to the changed crate yet regressed the most. The workflow runs base and PR benchmarks sequentially on the same runner, base first, at Criterion's minimum sample size, which biases the second half. Filed as **#2473**. `perf-regression-ok` has **not** been applied.

Refs #2469 #2471 #2472 #2441 #2473
