### PR TITLE
fix(net): contain unauthenticated gossip subscription control

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -289,7 +289,10 @@ Three-layer security model:
 3. Subscribe in relevant actor: `gossip.subscribe(topic, access_control)`
 4. Implement message serialization (use `bincode` or `serde_json`)
 5. Set up notification callback to receive new entries
-6. Handle incoming messages in gossip actor's message handler
+6. Handle incoming messages in gossip actor's message handler. Handlers for a *received*
+   `Subscribe`/`Unsubscribe` must call `subscribe_from_network`/`unsubscribe_from_network`,
+   never the local `subscribe`/`unsubscribe` — `NetworkMessage.from` is self-declared
+   (see `docs/reference/api/topic-subscriptions-api.md`, issue #2471)
 
 ### Adding Metrics
 

--- a/docs/reference/api/topic-subscriptions-api.md
+++ b/docs/reference/api/topic-subscriptions-api.md
@@ -17,8 +17,9 @@ Topic subscriptions allow peers to express interest in specific gossip topics an
 2. [Network Protocol](#network-protocol)
 3. [Usage Examples](#usage-examples)
 4. [Access Control](#access-control)
-5. [Metrics](#metrics)
-6. [Testing](#testing)
+5. [Security: network-originated requests](#security-network-originated-requests)
+6. [Metrics](#metrics)
+7. [Testing](#testing)
 
 ---
 
@@ -31,6 +32,11 @@ pub fn subscribe(&mut self, topic: &str, subscriber: Did) -> Result<Subscription
 ```
 
 Subscribe a DID to a topic. Performs ACL checks based on the topic's `AccessControl` policy.
+
+> **This is the LOCAL API.** It acts on whatever DID the caller supplies and is how a node
+> subscribes **itself**. Handlers processing a *received* `Subscribe` must use
+> [`subscribe_from_network`](#handle-a-received-subscribe) instead — see
+> [Security](#security-network-originated-requests).
 
 **Parameters:**
 - `topic`: Topic name (e.g., "global:identity", "contract:abc123")
@@ -158,6 +164,45 @@ if gossip.is_subscribed("global:identity", &peer_did) {
 
 ---
 
+### Handle a Received Subscribe
+
+```rust
+pub async fn subscribe_from_network(
+    &mut self,
+    topic: &str,
+    claimed_subscriber: Did,
+) -> Result<Subscription>
+```
+
+The **only** entry point a network message handler may use for a received `Subscribe`.
+Refuses any request whose claimed subscriber is this node's own DID, then delegates to
+`subscribe`. A peer subscribing itself is unaffected.
+
+**Returns:**
+- `Ok(Subscription)`: as `subscribe`
+- `Err(GossipError::SubscriptionControlSpoofRejected)`: the request claimed this node's own
+  DID. Match with `GossipActor::is_subscription_control_spoof()` and log at `debug!`.
+- `Err(_)`: any ordinary subscribe failure (topic missing, ACL, policy, capacity)
+
+### Handle a Received Unsubscribe
+
+```rust
+pub fn unsubscribe_from_network(&mut self, topic: &str, claimed_subscriber: &Did) -> Result<()>
+```
+
+The network-facing counterpart to `unsubscribe`, with the same own-DID refusal.
+
+### Check This Node's Own Subscription
+
+```rust
+pub fn is_locally_subscribed(&self, topic: &str) -> bool
+```
+
+Whether this node subscribed **itself** to `topic`. This is the gate on local notification
+delivery. Unlike `is_subscribed`, it cannot be influenced by any network message.
+
+---
+
 ## Network Protocol
 
 ### Subscribe Message
@@ -178,7 +223,9 @@ network_handle.send_message(peer_did, subscribe_msg).await?;
 1. Node A sends `Subscribe {topics: [...]}` to Node B
 2. Node B's supervisor receives message
 3. For each topic:
-   - Call `gossip.subscribe(topic, sender_did)`
+   - Call `gossip.subscribe_from_network(topic, sender_did)` — **never** the local
+     `gossip.subscribe`; see [Security](#security-network-originated-requests) below
+   - Refused outright if `sender_did` claims Node B's own DID
    - ACL check performed
    - Add to subscribers if authorized
 4. Send `SubscribeAck {topics: [...]}` back with successful subscriptions
@@ -203,7 +250,9 @@ network_handle.send_message(peer_did, unsubscribe_msg).await?;
 1. Node A sends `Unsubscribe {topics: [...]}` to Node B
 2. Node B's supervisor receives message
 3. For each topic:
-   - Call `gossip.unsubscribe(topic, &sender_did)`
+   - Call `gossip.unsubscribe_from_network(topic, &sender_did)` — **never** the local
+     `gossip.unsubscribe`; see [Security](#security-network-originated-requests) below
+   - Refused outright if `sender_did` claims Node B's own DID
    - Remove from subscribers
 4. No acknowledgment sent for unsubscribe
 
@@ -261,8 +310,16 @@ let incoming_handler = Arc::new(move |net_msg| {
                 let mut acked_topics = Vec::new();
 
                 for topic in &topics {
-                    match gossip.subscribe(topic, sender.clone()).await {
+                    // `sender` is `NetworkMessage.from` — self-declared and unauthenticated.
+                    // Network handlers MUST use `subscribe_from_network`, which refuses any
+                    // request claiming this node's own DID (#2471). Using the local
+                    // `gossip.subscribe` here reintroduces the spoofing vulnerability.
+                    match gossip.subscribe_from_network(topic, sender.clone()).await {
                         Ok(_) => acked_topics.push(topic.clone()),
+                        Err(e) if GossipActor::is_subscription_control_spoof(&e) => {
+                            // Remotely triggerable and repeatable — keep it out of `warn!`.
+                            debug!("{}", e);
+                        }
                         Err(e) => warn!("Subscription denied for {}: {}", topic, e),
                     }
                 }
@@ -351,6 +408,51 @@ gossip.create_topic(topic);
 gossip.subscribe("contract:abc123", alice_did)?; // Succeeds
 gossip.subscribe("contract:abc123", charlie_did)?; // Fails - not in whitelist
 ```
+
+---
+
+## Security: network-originated requests
+
+`NetworkMessage.from` is **self-declared**. TLS is TOFU with
+`client_auth_mandatory() = false`, and nothing rebinds a per-message `from` to the identity
+established by the `Hello` exchange. A syntactically valid DID is not proof that the sender
+holds its private key, and a transport connection is not subscription authority.
+
+Therefore:
+
+| Caller | Use | Never use |
+|---|---|---|
+| Local code subscribing **this node** | `subscribe` / `unsubscribe` | — |
+| A handler processing a **received** `Subscribe`/`Unsubscribe` | `subscribe_from_network` / `unsubscribe_from_network` | `subscribe` / `unsubscribe` |
+
+`subscribe_from_network` and `unsubscribe_from_network` refuse any request whose claimed
+subscriber is this node's own DID. A peer subscribing or unsubscribing **itself** is
+unaffected — that is the intended protocol. Without the guard, a peer could send
+`Unsubscribe` with `from` set to the receiving node's own DID and drop that node's own
+subscription (issue #2471).
+
+Refusals increment `icn_gossip_subscription_control_spoof_rejected_total` and return
+`GossipError::SubscriptionControlSpoofRejected`. Match it with
+`GossipActor::is_subscription_control_spoof()` and log at `debug!`: the trigger is remote and
+repeatable, and a single forged request can batch many topics, so routing it to `warn!` lets a
+peer drive log volume.
+
+### Local delivery is not the subscriber list
+
+Notification callbacks fire **once per accepted stored entry per callback**, gated on
+`is_locally_subscribed(topic)` — this node's own subscription record, which no network message
+can write. The subscriber list returned by `get_subscribers` is network/propagation
+bookkeeping; it is peer-mutable and must never gate local delivery. Registering a callback
+without also subscribing this node's own DID to the topic yields no local delivery.
+
+The third callback argument is this node's own DID — the local delivery target. It is not the
+entry's author, not the forwarding peer, and carries no authentication. Never treat it as
+authority.
+
+**What this does not provide.** None of the above authenticates gossip. A peer may still
+subscribe and unsubscribe itself under any DID it asserts, and may still grow a topic's
+subscriber list up to `MAX_SUBSCRIBERS_PER_TOPIC`. Authenticating the requests is tracked
+separately (issue #2469).
 
 ---
 

--- a/icn/crates/icn-core/src/supervisor/init_network.rs
+++ b/icn/crates/icn-core/src/supervisor/init_network.rs
@@ -84,6 +84,15 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                                 info!("Subscribed {} to topic: {}", sender_did, topic);
                                 acked_topics.push(topic.clone());
                             }
+                            Err(e)
+                                if icn_gossip::GossipActor::is_subscription_control_spoof(&e) =>
+                            {
+                                // Expected, remotely triggerable and repeatable — a peer
+                                // can batch many topics per forged request. Keep it out of
+                                // the operational warn! path; the durable signal is
+                                // icn_gossip_subscription_control_spoof_rejected_total.
+                                debug!("{}", e);
+                            }
                             Err(e) => {
                                 warn!(
                                     "Failed to subscribe {} to topic {}: {}",
@@ -126,6 +135,13 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                         match gossip.unsubscribe_from_network(topic, &sender_did) {
                             Ok(_) => {
                                 info!("Unsubscribed {} from topic: {}", sender_did, topic);
+                            }
+                            Err(e)
+                                if icn_gossip::GossipActor::is_subscription_control_spoof(&e) =>
+                            {
+                                // See the Subscribe arm: remotely triggerable, so it must
+                                // not be able to drive warning-level log volume.
+                                debug!("{}", e);
                             }
                             Err(e) => {
                                 warn!(

--- a/icn/crates/icn-core/src/supervisor/init_network.rs
+++ b/icn/crates/icn-core/src/supervisor/init_network.rs
@@ -72,7 +72,14 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                     let mut acked_topics = Vec::new();
 
                     for topic in &topics {
-                        match gossip.subscribe(topic, sender_did.clone()).await {
+                        // `sender_did` is `NetworkMessage.from` — self-declared, not
+                        // authenticated. `subscribe_from_network` refuses any claim of
+                        // this node's own DID (#2471); a peer subscribing itself is
+                        // still allowed, and still unauthenticated (#2469).
+                        match gossip
+                            .subscribe_from_network(topic, sender_did.clone())
+                            .await
+                        {
                             Ok(_) => {
                                 info!("Subscribed {} to topic: {}", sender_did, topic);
                                 acked_topics.push(topic.clone());
@@ -114,7 +121,9 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                 tokio::spawn(async move {
                     let mut gossip = gossip.write().await;
                     for topic in &topics {
-                        match gossip.unsubscribe(topic, &sender_did) {
+                        // Guarded for the same reason as Subscribe above: a peer must not
+                        // be able to drop this node's own subscription (#2471).
+                        match gossip.unsubscribe_from_network(topic, &sender_did) {
                             Ok(_) => {
                                 info!("Unsubscribed {} from topic: {}", sender_did, topic);
                             }

--- a/icn/crates/icn-core/src/supervisor/init_notifications.rs
+++ b/icn/crates/icn-core/src/supervisor/init_notifications.rs
@@ -82,9 +82,13 @@ pub struct NotificationDeps {
 }
 
 /// Handle trust attestation entries via TrustService
+///
+/// `local_recipient` is the local delivery target from entry-driven gossip dispatch
+/// (this node's own DID, #2471). It is unauthenticated and is used only as a log label —
+/// every authorization decision here rests on the attestation's own signature.
 pub async fn handle_trust_attestation_via_service(
     entry: &GossipEntry,
-    forwarding_peer: &str,
+    local_recipient: &str,
     trust_service: &Arc<dyn icn_kernel_api::services::TrustService>,
     rate_limiter: &AttestationRateLimiterHandle,
 ) {
@@ -126,16 +130,19 @@ pub async fn handle_trust_attestation_via_service(
         }
     }
 
-    let source = forwarding_peer.to_string();
+    let source = local_recipient.to_string();
     if let Err(e) = trust_service.ingest_attestation(&data, &source) {
         warn!("Failed to ingest trust attestation: {}", e);
     }
 }
 
 /// Handle trust revocation entries via TrustService
+///
+/// `local_recipient` carries the same meaning and the same non-authority as in
+/// [`handle_trust_attestation_via_service`].
 pub async fn handle_trust_revocation_via_service(
     entry: &GossipEntry,
-    forwarding_peer: &str,
+    local_recipient: &str,
     trust_service: &Arc<dyn icn_kernel_api::services::TrustService>,
 ) {
     // Extract data from gossip entry
@@ -147,7 +154,7 @@ pub async fn handle_trust_revocation_via_service(
         }
     };
 
-    let source = forwarding_peer.to_string();
+    let source = local_recipient.to_string();
     if let Err(e) = trust_service.ingest_revocation(&data, &source) {
         warn!("Failed to ingest trust revocation: {}", e);
     }
@@ -873,7 +880,10 @@ pub async fn handle_resource_revocation(entry_data: Vec<u8>) {
 pub fn create_notification_callback(
     deps: NotificationDeps,
 ) -> icn_gossip::EntryNotificationCallback {
-    Arc::new(move |topic, entry, subscriber_did| {
+    // `recipient_did` is the local delivery target supplied by entry-driven gossip
+    // dispatch (#2471) — this node's own DID. It is not the forwarding peer and is not
+    // authenticated; it is passed through to the trust service purely as a log label.
+    Arc::new(move |topic, entry, recipient_did| {
         // Clone dependencies for the async task
         let deps = deps.clone();
         let topic = topic.to_string();
@@ -897,19 +907,24 @@ pub fn create_notification_callback(
         if topic == crate::trust_propagation::TRUST_ATTESTATIONS_TOPIC {
             if let Some(trust_svc) = deps.trust_service.clone() {
                 let rate_limiter = deps.attestation_rate_limiter.clone();
-                let peer = subscriber_did.to_string();
+                let recipient = recipient_did.to_string();
                 tokio::spawn(async move {
-                    handle_trust_attestation_via_service(&entry, &peer, &trust_svc, &rate_limiter)
-                        .await;
+                    handle_trust_attestation_via_service(
+                        &entry,
+                        &recipient,
+                        &trust_svc,
+                        &rate_limiter,
+                    )
+                    .await;
                 });
             } else {
                 warn!("Trust attestation received but no TrustService available");
             }
         } else if topic == crate::trust_propagation::TRUST_REVOCATIONS_TOPIC {
             if let Some(trust_svc) = deps.trust_service.clone() {
-                let peer = subscriber_did.to_string();
+                let recipient = recipient_did.to_string();
                 tokio::spawn(async move {
-                    handle_trust_revocation_via_service(&entry, &peer, &trust_svc).await;
+                    handle_trust_revocation_via_service(&entry, &recipient, &trust_svc).await;
                 });
             } else {
                 warn!("Trust revocation received but no TrustService available");

--- a/icn/crates/icn-core/tests/devnet_integration.rs
+++ b/icn/crates/icn-core/tests/devnet_integration.rs
@@ -244,9 +244,17 @@ async fn test_three_node_gossip_convergence() {
     node_b.create_topic(topic).await;
     node_c.create_topic(topic).await;
 
-    // B and C subscribe on A (so A's notification callback fires for them)
+    // B and C register as remote subscribers on A — this is A's propagation state.
     node_a.add_subscriber(topic, &node_b.did).await;
     node_a.add_subscriber(topic, &node_c.did).await;
+
+    // Each node also subscribes itself. Since #2471 that, and only that, is what
+    // enables a node's own notification callbacks: local delivery is entry-driven
+    // and gated on the node's own locally-owned subscription, never on the
+    // peer-mutable remote subscriber list.
+    node_a.add_subscriber(topic, &node_a.did).await;
+    node_b.add_subscriber(topic, &node_b.did).await;
+    node_c.add_subscriber(topic, &node_c.did).await;
 
     // Verify subscriptions
     let subs = node_a.get_subscribers(topic).await;
@@ -301,13 +309,27 @@ async fn test_three_node_gossip_convergence() {
     assert_eq!(b_entry.author, node_a.did, "B's entry author should be A");
     assert_eq!(c_entry.author, node_a.did, "C's entry author should be A");
 
-    // Verify notifications fired on A (from store_entry when publishing).
-    // A has subscribers B and C, so store_entry fires notifications for them.
-    let a_notifications = node_a.notification_count().await;
-    assert!(
-        a_notifications >= 2,
-        "A should have fired at least 2 notifications (for B and C), got {}",
-        a_notifications
+    // Exactly one local notification per node for the one entry that converged.
+    //
+    // Before #2471 A fired one notification *per remote subscriber* — two here, and
+    // up to MAX_SUBSCRIBERS_PER_TOPIC (10000) for an attacker willing to send that
+    // many unauthenticated Subscribe messages. Dispatch is now per accepted entry,
+    // so the count tracks entries rather than peer-controlled subscriber state.
+    assert_eq!(
+        node_a.notification_count().await,
+        1,
+        "A published one entry and must observe exactly one local notification, \
+         independent of how many remote subscribers it has"
+    );
+    assert_eq!(
+        node_b.notification_count().await,
+        1,
+        "B stored the converged entry once and must be notified exactly once"
+    );
+    assert_eq!(
+        node_c.notification_count().await,
+        1,
+        "C stored the converged entry once and must be notified exactly once"
     );
 }
 

--- a/icn/crates/icn-core/tests/entity_gossip_convergence.rs
+++ b/icn/crates/icn-core/tests/entity_gossip_convergence.rs
@@ -134,7 +134,7 @@ impl TestNode {
                         let mut acked_topics = Vec::new();
 
                         for topic in &topics {
-                            match gossip.subscribe(topic, sender.clone()).await {
+                            match gossip.subscribe_from_network(topic, sender.clone()).await {
                                 Ok(_) => acked_topics.push(topic.clone()),
                                 Err(e) => {
                                     warn!("Failed to subscribe {} to {}: {}", sender, topic, e)

--- a/icn/crates/icn-core/tests/gossip_subscription_control.rs
+++ b/icn/crates/icn-core/tests/gossip_subscription_control.rs
@@ -1,0 +1,522 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Gossip subscription-control containment (issue #2471).
+//!
+//! These tests drive the **production** incoming-message handler
+//! (`icn_core::supervisor::init_network::create_incoming_handler`) against a real
+//! `GossipActor`, because that is the code path a remote peer actually reaches:
+//! `NetworkMessage` -> `connection.rs` catch-all arm -> supervisor handler ->
+//! `GossipActor::{subscribe,unsubscribe}` -> `store_entry` -> notification callbacks.
+//!
+//! Threat model: `NetworkMessage.from` is self-declared. TLS is TOFU with
+//! `client_auth_mandatory() = false`, and nothing rebinds per-message `from` to the
+//! Hello identity. So every `from` below is simply what an attacker chose to write.
+//!
+//! These tests do **not** assert that gossip is authenticated. They assert two
+//! containment properties that hold *despite* gossip being unauthenticated:
+//!
+//! 1. A received message cannot add or remove the receiving node's own subscription.
+//! 2. Peer-controlled subscriber state cannot multiply or suppress local callback delivery.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use icn_core::supervisor::init_network::{create_incoming_handler, MessageHandlerDeps};
+use icn_gossip::{
+    AccessControl, EntryNotificationCallback, GossipActor, GossipEntry, GossipMessage, Topic,
+    VectorClock,
+};
+use icn_identity::{Did, KeyPair};
+use icn_net::{IncomingMessageHandler, NetworkMessage};
+use tokio::sync::RwLock;
+
+const TOPIC: &str = "coop:updates";
+
+fn did() -> Did {
+    KeyPair::generate().expect("keypair").did().clone()
+}
+
+/// Build a gossip actor with `TOPIC` created, plus the production incoming handler wired to it.
+async fn harness(own: &Did) -> (Arc<RwLock<GossipActor>>, IncomingMessageHandler) {
+    let gossip = Arc::new(RwLock::new(GossipActor::new(own.clone(), None)));
+    gossip
+        .write()
+        .await
+        .create_topic(Topic::new(TOPIC.to_string(), AccessControl::Public));
+
+    let handler = create_incoming_handler(MessageHandlerDeps {
+        gossip_handle: gossip.clone(),
+        network_handle_holder: Arc::new(RwLock::new(None)),
+        own_did: own.clone(),
+        federation_enabled: false,
+    });
+
+    (gossip, handler)
+}
+
+/// The production handler dispatches onto `tokio::spawn`. Poll until `cond` or give up.
+///
+/// Returns the final observed value either way, so callers assert on it rather than on
+/// this helper — a timeout must never be reported as a pass.
+async fn settle<F>(mut cond: F) -> bool
+where
+    F: FnMut() -> bool,
+{
+    for _ in 0..200 {
+        if cond() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    cond()
+}
+
+/// Counting callback plus its counter.
+fn counting_callback() -> (EntryNotificationCallback, Arc<Mutex<u32>>) {
+    let count = Arc::new(Mutex::new(0u32));
+    let c = count.clone();
+    let cb: EntryNotificationCallback = Arc::new(move |_topic, _entry, _recipient| {
+        *c.lock().expect("counter") += 1;
+    });
+    (cb, count)
+}
+
+/// A well-formed entry that did not come from us. `author` and `hash` are attacker-chosen;
+/// `hash` is never recomputed by the receiver, so it is not an identity of anything.
+fn remote_entry(author: &Did, marker: u8) -> GossipEntry {
+    GossipEntry {
+        hash: [marker; 32],
+        author: author.clone(),
+        clock: VectorClock::new(),
+        topic: TOPIC.to_string(),
+        data: b"remote entry".to_vec(),
+        compressed: false,
+        timestamp: 1_700_000_000_000,
+        replica_offered: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Forged local unsubscribe
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn forged_unsubscribe_claiming_local_did_cannot_remove_local_subscription() {
+    let own = did();
+    let attacker = did();
+    let (gossip, handler) = harness(&own).await;
+
+    // A real local subscription, created through the legitimate internal path.
+    gossip
+        .write()
+        .await
+        .subscribe(TOPIC, own.clone())
+        .await
+        .expect("local subscribe");
+    assert!(
+        gossip.read().await.is_subscribed(TOPIC, &own),
+        "precondition: local node is subscribed"
+    );
+
+    // Attacker sends Unsubscribe with `from` spoofed to the victim's own DID.
+    handler(NetworkMessage::unsubscribe(
+        own.clone(),
+        attacker.clone(),
+        vec![TOPIC.to_string()],
+    ));
+
+    // Give the spawned task a chance to do damage before asserting it did not.
+    let removed = settle(|| {
+        let g = gossip.try_read();
+        matches!(g, Ok(ref g) if !g.is_subscribed(TOPIC, &own))
+    })
+    .await;
+
+    assert!(
+        !removed,
+        "a received Unsubscribe claiming the local DID must not remove the local subscription"
+    );
+    assert!(
+        gossip.read().await.is_subscribed(TOPIC, &own),
+        "local subscription must survive a forged Unsubscribe"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Forged local subscribe
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn forged_subscribe_claiming_local_did_cannot_create_local_subscription() {
+    let own = did();
+    let attacker = did();
+    let (gossip, handler) = harness(&own).await;
+
+    assert!(
+        !gossip.read().await.is_subscribed(TOPIC, &own),
+        "precondition: local node has not subscribed"
+    );
+
+    handler(NetworkMessage::subscribe(
+        own.clone(),
+        attacker.clone(),
+        vec![TOPIC.to_string()],
+    ));
+
+    let created = settle(|| {
+        let g = gossip.try_read();
+        matches!(g, Ok(ref g) if g.is_subscribed(TOPIC, &own))
+    })
+    .await;
+
+    assert!(
+        !created,
+        "a received Subscribe claiming the local DID must not create a local subscription"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Delivery survives the attack
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn local_callback_delivery_survives_forged_unsubscribe() {
+    let own = did();
+    let attacker = did();
+    let (gossip, handler) = harness(&own).await;
+
+    let (cb_a, count_a) = counting_callback();
+    let (cb_b, count_b) = counting_callback();
+    {
+        let mut g = gossip.write().await;
+        g.add_notification_callback(cb_a);
+        g.add_notification_callback(cb_b);
+        g.subscribe(TOPIC, own.clone()).await.expect("subscribe");
+    }
+
+    // Attack first...
+    handler(NetworkMessage::unsubscribe(
+        own.clone(),
+        attacker.clone(),
+        vec![TOPIC.to_string()],
+    ));
+    settle(|| false).await; // let the spawned task run to completion
+
+    // ...then a validly formed entry arrives from a peer.
+    gossip
+        .write()
+        .await
+        .handle_message(
+            &attacker,
+            GossipMessage::Response {
+                entry: remote_entry(&attacker, 1),
+            },
+        )
+        .await
+        .expect("handle Response");
+
+    assert_eq!(
+        *count_a.lock().unwrap(),
+        1,
+        "first callback must receive the entry exactly once after a forged Unsubscribe"
+    );
+    assert_eq!(
+        *count_b.lock().unwrap(),
+        1,
+        "second callback must receive the entry exactly once after a forged Unsubscribe"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Amplification
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn attacker_subscribers_cannot_multiply_local_callback_delivery() {
+    let own = did();
+    let (gossip, handler) = harness(&own).await;
+
+    let (cb_a, count_a) = counting_callback();
+    let (cb_b, count_b) = counting_callback();
+    {
+        let mut g = gossip.write().await;
+        g.add_notification_callback(cb_a);
+        g.add_notification_callback(cb_b);
+        g.subscribe(TOPIC, own.clone()).await.expect("subscribe");
+    }
+
+    // 25 distinct attacker-controlled peers each subscribe themselves. Every one of these
+    // is a *legitimate* remote subscribe under current protocol semantics — the point is
+    // that none of them may influence how often local callbacks run.
+    let attackers: Vec<Did> = (0..25).map(|_| did()).collect();
+    for a in &attackers {
+        handler(NetworkMessage::subscribe(
+            a.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+    }
+    let all_subscribed = settle(|| match gossip.try_read() {
+        Ok(g) => attackers.iter().all(|a| g.is_subscribed(TOPIC, a)),
+        Err(_) => false,
+    })
+    .await;
+    assert!(
+        all_subscribed,
+        "attacker peers should have subscribed themselves"
+    );
+
+    // Exactly one entry is stored.
+    gossip
+        .write()
+        .await
+        .handle_message(
+            &attackers[0],
+            GossipMessage::Response {
+                entry: remote_entry(&attackers[0], 2),
+            },
+        )
+        .await
+        .expect("handle Response");
+
+    assert_eq!(
+        *count_a.lock().unwrap(),
+        1,
+        "one stored entry must produce exactly one invocation of the first callback, \
+         regardless of how many remote subscribers exist"
+    );
+    assert_eq!(
+        *count_b.lock().unwrap(),
+        1,
+        "one stored entry must produce exactly one invocation of the second callback"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Legitimate remote behavior is preserved
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn remote_peer_can_still_subscribe_and_unsubscribe_itself() {
+    let own = did();
+    let peer = did();
+    let (gossip, handler) = harness(&own).await;
+
+    handler(NetworkMessage::subscribe(
+        peer.clone(),
+        own.clone(),
+        vec![TOPIC.to_string()],
+    ));
+    let subscribed = settle(|| match gossip.try_read() {
+        Ok(g) => g.is_subscribed(TOPIC, &peer),
+        Err(_) => false,
+    })
+    .await;
+    assert!(
+        subscribed,
+        "a remote peer must still be able to subscribe itself"
+    );
+
+    handler(NetworkMessage::unsubscribe(
+        peer.clone(),
+        own.clone(),
+        vec![TOPIC.to_string()],
+    ));
+    let unsubscribed = settle(|| match gossip.try_read() {
+        Ok(g) => !g.is_subscribed(TOPIC, &peer),
+        Err(_) => false,
+    })
+    .await;
+    assert!(
+        unsubscribed,
+        "a remote peer must still be able to unsubscribe itself"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. No-remote-subscriber behavior
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn local_delivery_does_not_depend_on_remote_subscribers_existing() {
+    let own = did();
+    let sender = did();
+    let (gossip, _handler) = harness(&own).await;
+
+    let (cb, count) = counting_callback();
+    {
+        let mut g = gossip.write().await;
+        g.add_notification_callback(cb);
+        g.subscribe(TOPIC, own.clone()).await.expect("subscribe");
+    }
+
+    assert_eq!(
+        gossip.read().await.get_subscribers(TOPIC),
+        vec![own.clone()],
+        "precondition: the only subscriber is the local node itself"
+    );
+
+    gossip
+        .write()
+        .await
+        .handle_message(
+            &sender,
+            GossipMessage::Response {
+                entry: remote_entry(&sender, 3),
+            },
+        )
+        .await
+        .expect("handle Response");
+
+    assert_eq!(
+        *count.lock().unwrap(),
+        1,
+        "local delivery must not disappear merely because no remote peer subscribed"
+    );
+}
+
+/// A topic the local node never subscribed to must not deliver into local callbacks —
+/// entry-driven dispatch must stay gated on the node's own, locally-owned subscription.
+#[tokio::test]
+async fn entries_on_never_subscribed_topics_do_not_reach_local_callbacks() {
+    let own = did();
+    let sender = did();
+    let (gossip, _handler) = harness(&own).await;
+
+    let (cb, count) = counting_callback();
+    gossip.write().await.add_notification_callback(cb);
+    // deliberately no local subscribe
+
+    gossip
+        .write()
+        .await
+        .handle_message(
+            &sender,
+            GossipMessage::Response {
+                entry: remote_entry(&sender, 4),
+            },
+        )
+        .await
+        .expect("handle Response");
+
+    assert_eq!(
+        *count.lock().unwrap(),
+        0,
+        "a topic the node never subscribed to must not deliver into local callbacks"
+    );
+    assert_eq!(
+        gossip.read().await.get_entries(TOPIC).len(),
+        1,
+        "the entry is still stored — storage is independent of local delivery"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Generic gossip behavior is preserved
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn storage_and_vector_clock_merge_survive_subscription_attacks() {
+    let own = did();
+    let attacker = did();
+    let (gossip, handler) = harness(&own).await;
+
+    gossip
+        .write()
+        .await
+        .subscribe(TOPIC, own.clone())
+        .await
+        .expect("subscribe");
+
+    handler(NetworkMessage::unsubscribe(
+        own.clone(),
+        attacker.clone(),
+        vec![TOPIC.to_string()],
+    ));
+    settle(|| false).await;
+
+    let mut clock = VectorClock::new();
+    clock.increment(&attacker);
+    clock.increment(&attacker);
+    let mut entry = remote_entry(&attacker, 5);
+    entry.clock = clock;
+
+    gossip
+        .write()
+        .await
+        .handle_message(&attacker, GossipMessage::Response { entry })
+        .await
+        .expect("handle Response");
+
+    let g = gossip.read().await;
+    assert_eq!(g.get_entries(TOPIC).len(), 1, "entry must still be stored");
+    assert_eq!(
+        g.get_clock().get(&attacker),
+        2,
+        "the remote vector clock must still be merged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 8. Malformed and adversarial input
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn malformed_and_repeated_subscription_control_stays_bounded() {
+    let own = did();
+    let peer = did();
+    let (gossip, handler) = harness(&own).await;
+
+    gossip
+        .write()
+        .await
+        .subscribe(TOPIC, own.clone())
+        .await
+        .expect("subscribe");
+
+    // Unknown, empty, oversized and control-character topics must not panic the handler.
+    let junk = vec![
+        String::new(),
+        "no:such:topic".to_string(),
+        "\u{0}\u{1}\u{7f}".to_string(),
+        "x".repeat(64 * 1024),
+    ];
+    handler(NetworkMessage::subscribe(
+        peer.clone(),
+        own.clone(),
+        junk.clone(),
+    ));
+    handler(NetworkMessage::unsubscribe(peer.clone(), own.clone(), junk));
+
+    // Repeated identical requests must not grow the subscriber list without bound,
+    // and repeated forged own-DID requests must never take effect.
+    for _ in 0..50 {
+        handler(NetworkMessage::subscribe(
+            peer.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+        handler(NetworkMessage::subscribe(
+            own.clone(),
+            peer.clone(),
+            vec![TOPIC.to_string()],
+        ));
+        handler(NetworkMessage::unsubscribe(
+            own.clone(),
+            peer.clone(),
+            vec![TOPIC.to_string()],
+        ));
+    }
+    settle(|| false).await;
+
+    let g = gossip.read().await;
+    let subs = g.get_subscribers(TOPIC);
+    assert!(
+        subs.len() <= 2,
+        "repeated subscribe requests must be deduplicated, got {} subscribers",
+        subs.len()
+    );
+    assert!(
+        g.is_subscribed(TOPIC, &own),
+        "repeated forged own-DID Unsubscribe must never remove the local subscription"
+    );
+}

--- a/icn/crates/icn-core/tests/multi_node_gossip_convergence.rs
+++ b/icn/crates/icn-core/tests/multi_node_gossip_convergence.rs
@@ -119,7 +119,7 @@ impl TestNode {
                         let mut acked_topics = Vec::new();
 
                         for topic in &topics {
-                            match gossip.subscribe(topic, sender.clone()).await {
+                            match gossip.subscribe_from_network(topic, sender.clone()).await {
                                 Ok(_) => {
                                     info!("Subscribed {} to topic: {}", sender, topic);
                                     acked_topics.push(topic.clone());
@@ -161,7 +161,7 @@ impl TestNode {
                     tokio::spawn(async move {
                         let mut gossip = gossip_handle.write().await;
                         for topic in &topics {
-                            if let Err(e) = gossip.unsubscribe(topic, &sender) {
+                            if let Err(e) = gossip.unsubscribe_from_network(topic, &sender) {
                                 warn!(
                                     "Failed to unsubscribe {} from topic {}: {}",
                                     sender, topic, e

--- a/icn/crates/icn-core/tests/subscription_integration.rs
+++ b/icn/crates/icn-core/tests/subscription_integration.rs
@@ -83,7 +83,7 @@ impl TestNode {
                         let mut acked_topics = Vec::new();
 
                         for topic in &topics {
-                            match gossip.subscribe(topic, sender.clone()).await {
+                            match gossip.subscribe_from_network(topic, sender.clone()).await {
                                 Ok(_) => {
                                     info!("Subscribed {} to topic: {}", sender, topic);
                                     acked_topics.push(topic.clone());
@@ -125,7 +125,7 @@ impl TestNode {
                     tokio::spawn(async move {
                         let mut gossip = gossip_handle.write().await;
                         for topic in &topics {
-                            match gossip.unsubscribe(topic, &sender) {
+                            match gossip.unsubscribe_from_network(topic, &sender) {
                                 Ok(_) => {
                                     info!("Unsubscribed {} from topic: {}", sender, topic);
                                 }

--- a/icn/crates/icn-gossip/src/error.rs
+++ b/icn/crates/icn-gossip/src/error.rs
@@ -20,6 +20,14 @@ pub enum GossipError {
         actual: String,
     },
 
+    /// A network-originated subscription-control request claimed this node's own DID.
+    ///
+    /// Distinct from an operational subscribe/unsubscribe failure so callers can log it
+    /// at a level a remote peer cannot use to drive log volume. `NetworkMessage.from` is
+    /// self-declared, so this is fully remote-triggerable and repeatable.
+    #[error("refusing network {action} claiming this node's own DID for topic {topic}")]
+    SubscriptionControlSpoofRejected { topic: String, action: &'static str },
+
     /// Entry not found
     #[error("entry not found: {0}")]
     EntryNotFound(String),

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -2363,6 +2363,25 @@ mod tests {
         );
         assert!(gossip.is_subscribed("test:guard", &owner));
 
+        // The refusal is typed, so handlers can keep this remotely-triggerable rejection
+        // out of their operational `warn!` path instead of letting a peer drive log volume.
+        let spoof = gossip
+            .subscribe_from_network("test:guard", owner.clone())
+            .await
+            .unwrap_err();
+        assert!(
+            GossipActor::is_subscription_control_spoof(&spoof),
+            "spoof rejection must be distinguishable from an operational failure"
+        );
+        let operational = gossip
+            .subscribe_from_network("no:such:topic", peer.clone())
+            .await
+            .unwrap_err();
+        assert!(
+            !GossipActor::is_subscription_control_spoof(&operational),
+            "an ordinary subscribe failure must not be classified as a spoof rejection"
+        );
+
         // A peer acting on itself is unaffected.
         gossip
             .subscribe_from_network("test:guard", peer.clone())

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -2346,6 +2346,65 @@ mod tests {
         );
     }
 
+    /// A peer can fill a public topic's subscriber list to `MAX_SUBSCRIBERS_PER_TOPIC` with
+    /// distinct claimed DIDs. That must not be able to make the node's own later subscribe
+    /// fail, which would leave local delivery unset — the same remote suppression this
+    /// change closes, arriving via the capacity check instead of via `Unsubscribe`.
+    #[tokio::test]
+    async fn test_filled_topic_cannot_block_the_local_nodes_own_subscription() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+        let mut gossip = GossipActor::new(owner.clone(), create_test_oracle());
+        gossip.create_topic(Topic::new("test:filled".to_string(), AccessControl::Public));
+
+        // Saturate the topic with peer-claimed DIDs, as an unauthenticated peer could.
+        {
+            let subscribers = gossip.subscriptions.get_mut("test:filled").unwrap();
+            while subscribers.len() < MAX_SUBSCRIBERS_PER_TOPIC {
+                subscribers.push(KeyPair::generate().unwrap().did().clone());
+            }
+        }
+        assert_eq!(
+            gossip.get_subscribers("test:filled").len(),
+            MAX_SUBSCRIBERS_PER_TOPIC
+        );
+
+        // A further *peer* subscribe is still refused — the cap still does its job.
+        let peer = KeyPair::generate().unwrap().did().clone();
+        assert!(
+            gossip
+                .subscribe_from_network("test:filled", peer)
+                .await
+                .is_err(),
+            "the per-topic cap must still bound peer-driven growth"
+        );
+
+        // The node's own subscribe must still succeed and must establish local delivery.
+        gossip
+            .subscribe("test:filled", owner.clone())
+            .await
+            .expect("a saturated subscriber list must not block our own subscription");
+        assert!(
+            gossip.is_locally_subscribed("test:filled"),
+            "a peer must not be able to suppress local delivery by filling the topic"
+        );
+
+        // And delivery actually happens.
+        let count = Arc::new(std::sync::Mutex::new(0u32));
+        let c = count.clone();
+        gossip.add_notification_callback(Arc::new(move |_, _, _| {
+            *c.lock().unwrap() += 1;
+        }));
+        gossip
+            .publish("test:filled", b"payload".to_vec())
+            .await
+            .unwrap();
+        assert_eq!(
+            *count.lock().unwrap(),
+            1,
+            "exactly one local notification, despite 10000 remote subscribers"
+        );
+    }
+
     /// A snapshot written by a pre-fix node can contain an own-DID subscription that a peer
     /// forged over the unauthenticated Subscribe path. Restoring it must not enable local
     /// delivery for that topic, or the upgrade would launder the compromise past the guard.

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -21,9 +21,20 @@ use tracing::{debug, info, instrument, warn};
 /// If recipient_did is None, broadcast to all peers
 pub type SendMessageCallback = Arc<dyn Fn(Option<Did>, GossipMessage) + Send + Sync>;
 
-/// Callback for notifying subscribers of new entries
-/// Parameters: (topic, entry, subscriber_did)
-/// Called when a new entry is stored in a topic that has subscribers
+/// Callback for local notification of newly stored entries.
+///
+/// Parameters: `(topic, entry, recipient_did)`.
+///
+/// Dispatch is **entry-driven**: each accepted stored entry invokes each registered
+/// callback exactly once, provided this node has locally subscribed to the topic
+/// (see [`GossipActor::is_locally_subscribed`]). `recipient_did` is therefore always
+/// this node's own DID — it identifies the local delivery target, not the entry's
+/// author and not the peer that forwarded it.
+///
+/// Before #2471 this fired once *per subscriber per callback*, which let any peer
+/// both multiply and zero local delivery by mutating the (unauthenticated) subscriber
+/// list. Callbacks must not treat the third argument as an authority or as a peer
+/// identity; it carries no authentication.
 pub type EntryNotificationCallback = Arc<dyn Fn(String, GossipEntry, Did) + Send + Sync>;
 
 /// Callback for sampling peers based on scope
@@ -88,8 +99,24 @@ pub struct GossipActor {
     /// Bloom filters (topic -> filter)
     pub(crate) bloom_filters: HashMap<String, BloomFilter>,
 
-    /// Subscriptions (topic -> subscribers)
+    /// Network subscription state (topic -> subscribers).
+    ///
+    /// This list is peer-mutable by design: a remote peer may add or remove **itself**
+    /// via `Subscribe`/`Unsubscribe`, and `NetworkMessage.from` is self-declared. It
+    /// drives propagation/network bookkeeping only. It must never be the sole gate on
+    /// local notification delivery — see [`GossipActor::local_topic_subscriptions`].
     pub(crate) subscriptions: HashMap<String, Vec<Did>>,
+
+    /// Topics this node has subscribed **itself** to, via the local
+    /// [`GossipActor::subscribe`] path or snapshot restore.
+    ///
+    /// Deliberately separate from [`GossipActor::subscriptions`] (#2471). Every mutation
+    /// of this set is guarded by `subscriber == self.own_did`, and the network-facing
+    /// entry points ([`GossipActor::subscribe_from_network`] /
+    /// [`GossipActor::unsubscribe_from_network`]) refuse any request claiming this node's
+    /// own DID. So no peer-supplied DID can reach this set, and local notification
+    /// delivery cannot be suppressed or amplified from the network.
+    pub(crate) local_topic_subscriptions: HashSet<String>,
 
     /// Policy Oracle for authorization and resource limits
     pub(crate) oracle: Option<Arc<dyn PolicyOracle>>,
@@ -176,6 +203,7 @@ impl GossipActor {
             entries: HashMap::new(),
             bloom_filters: HashMap::new(),
             subscriptions: HashMap::new(),
+            local_topic_subscriptions: HashSet::new(),
             oracle,
             send_callback: None,
             notification_callbacks: Vec::new(),
@@ -1058,18 +1086,25 @@ impl GossipActor {
         // Merge vector clock
         self.clock.merge(&entry.clock);
 
-        // Notify subscribers about the new entry (fan-out to all registered callbacks)
-        if !self.notification_callbacks.is_empty() {
-            if let Some(subscribers) = self.subscriptions.get(topic) {
-                for subscriber in subscribers {
-                    debug!(
-                        "Notifying subscriber {} about new entry in topic {}",
-                        subscriber, topic
-                    );
-                    for callback in &self.notification_callbacks {
-                        callback(topic.clone(), entry.clone(), subscriber.clone());
-                    }
-                }
+        // Local notification dispatch is **entry-driven** (#2471): one accepted entry
+        // invokes each registered callback exactly once.
+        //
+        // It is gated on `local_topic_subscriptions` — this node's own, locally-owned
+        // record of what it subscribed itself to — and never on `self.subscriptions`,
+        // which any peer can mutate by sending an unauthenticated Subscribe/Unsubscribe.
+        // Gating on the peer-mutable list is what let a peer both multiply local work by
+        // the subscriber count and silence delivery entirely by removing our own entry.
+        //
+        // Storage and vector-clock merge above are deliberately unconditional: an entry
+        // is retained and propagated whether or not anything locally observes it.
+        if self.local_topic_subscriptions.contains(topic) {
+            debug!(
+                topic = %topic,
+                callbacks = self.notification_callbacks.len(),
+                "Dispatching local entry notification"
+            );
+            for callback in &self.notification_callbacks {
+                callback(topic.clone(), entry.clone(), self.own_did.clone());
             }
         }
 
@@ -1372,12 +1407,20 @@ impl GossipActor {
                 let did =
                     Did::from_str(&sub_str).context("Failed to parse DID from subscription")?;
 
+                // Restore the locally-owned delivery record too, so local notification
+                // dispatch survives a restart (#2471). Only our own DID qualifies.
+                let is_own = did == self.own_did;
+
                 // Ensure subscription list exists for this topic (create if missing)
                 let sub_list = self.subscriptions.entry(topic.clone()).or_default();
 
                 // Add subscription without access control check (we trust persisted state)
                 if !sub_list.contains(&did) {
                     sub_list.push(did.clone());
+                }
+
+                if is_own {
+                    self.local_topic_subscriptions.insert(topic.clone());
                 }
             }
         }
@@ -2182,8 +2225,15 @@ mod tests {
         );
     }
 
+    /// Local notification dispatch is entry-driven, not subscriber-driven (#2471).
+    ///
+    /// This test previously asserted one notification *per subscriber*. That shape made
+    /// local delivery a function of `subscriptions`, which any peer can mutate with an
+    /// unauthenticated `Subscribe`/`Unsubscribe` — so remote peers could multiply local
+    /// callback work and, by removing our own entry, silence it. Delivery now depends
+    /// only on this node's own locally-owned subscription, and fires once per entry.
     #[tokio::test]
-    async fn test_subscription_notifications() {
+    async fn test_entry_notification_is_once_per_entry_not_per_subscriber() {
         use std::sync::Mutex;
 
         let owner = KeyPair::generate().unwrap().did().clone();
@@ -2203,13 +2253,19 @@ mod tests {
         let notifications_clone = notifications.clone();
 
         // Set up notification callback
-        let callback: EntryNotificationCallback = Arc::new(move |topic, entry, subscriber| {
+        let callback: EntryNotificationCallback = Arc::new(move |topic, entry, recipient| {
             let mut notifs = notifications_clone.lock().unwrap();
-            notifs.push((topic, entry.hash, subscriber));
+            notifs.push((topic, entry.hash, recipient));
         });
         gossip.add_notification_callback(callback);
 
-        // Subscribe both users to the topic
+        // This node subscribes itself — this, and only this, enables local delivery.
+        gossip
+            .subscribe("test:notifications", owner.clone())
+            .await
+            .unwrap();
+
+        // Two remote peers also subscribe. They affect propagation bookkeeping only.
         gossip
             .subscribe("test:notifications", subscriber1.clone())
             .await
@@ -2223,30 +2279,104 @@ mod tests {
         let data = b"Test notification".to_vec();
         let hash = gossip.publish("test:notifications", data).await.unwrap();
 
-        // Verify both subscribers were notified
         let notifs = notifications.lock().unwrap();
         assert_eq!(
             notifs.len(),
-            2,
-            "Should have 2 notifications (one per subscriber)"
+            1,
+            "one stored entry must produce exactly one notification per callback, \
+             independent of the remote subscriber count"
         );
 
-        // Check that both subscribers received the notification
-        let subscriber_dids: Vec<_> = notifs.iter().map(|(_, _, did)| did.clone()).collect();
-        assert!(
-            subscriber_dids.contains(&subscriber1),
-            "subscriber1 should be notified"
+        let (topic, notif_hash, recipient) = &notifs[0];
+        assert_eq!(topic, "test:notifications");
+        assert_eq!(*notif_hash, hash);
+        assert_eq!(
+            recipient, &owner,
+            "the recipient argument identifies the local delivery target"
         );
-        assert!(
-            subscriber_dids.contains(&subscriber2),
-            "subscriber2 should be notified"
-        );
+    }
 
-        // Verify all notifications are for the correct topic and hash
-        for (topic, notif_hash, _) in notifs.iter() {
-            assert_eq!(topic, "test:notifications");
-            assert_eq!(*notif_hash, hash);
-        }
+    /// Remote subscribers alone must not enable local delivery: without this node's own
+    /// subscription there is nothing locally interested in the topic, and the remote
+    /// subscriber list is attacker-writable.
+    #[tokio::test]
+    async fn test_remote_subscribers_alone_do_not_enable_local_delivery() {
+        use std::sync::Mutex;
+
+        let owner = KeyPair::generate().unwrap().did().clone();
+        let remote = KeyPair::generate().unwrap().did().clone();
+
+        let mut gossip = GossipActor::new(owner.clone(), create_test_oracle());
+        gossip.create_topic(Topic::new(
+            "test:remote-only".to_string(),
+            AccessControl::Public,
+        ));
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c = count.clone();
+        gossip.add_notification_callback(Arc::new(move |_, _, _| {
+            *c.lock().unwrap() += 1;
+        }));
+
+        gossip
+            .subscribe("test:remote-only", remote.clone())
+            .await
+            .unwrap();
+        assert!(gossip.is_subscribed("test:remote-only", &remote));
+        assert!(!gossip.is_locally_subscribed("test:remote-only"));
+
+        gossip
+            .publish("test:remote-only", b"payload".to_vec())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *count.lock().unwrap(),
+            0,
+            "a remote subscriber must not by itself trigger local callbacks"
+        );
+    }
+
+    /// The network-facing entry points refuse requests claiming this node's own DID,
+    /// while still allowing a peer to subscribe and unsubscribe itself.
+    #[tokio::test]
+    async fn test_network_subscription_control_refuses_own_did_claim() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+        let peer = KeyPair::generate().unwrap().did().clone();
+
+        let mut gossip = GossipActor::new(owner.clone(), create_test_oracle());
+        gossip.create_topic(Topic::new("test:guard".to_string(), AccessControl::Public));
+
+        gossip.subscribe("test:guard", owner.clone()).await.unwrap();
+
+        // Spoofed subscribe/unsubscribe claiming our own DID: both refused.
+        assert!(gossip
+            .subscribe_from_network("test:guard", owner.clone())
+            .await
+            .is_err());
+        assert!(gossip
+            .unsubscribe_from_network("test:guard", &owner)
+            .is_err());
+        assert!(
+            gossip.is_locally_subscribed("test:guard"),
+            "a forged network request must not touch the local subscription record"
+        );
+        assert!(gossip.is_subscribed("test:guard", &owner));
+
+        // A peer acting on itself is unaffected.
+        gossip
+            .subscribe_from_network("test:guard", peer.clone())
+            .await
+            .unwrap();
+        assert!(gossip.is_subscribed("test:guard", &peer));
+        gossip
+            .unsubscribe_from_network("test:guard", &peer)
+            .unwrap();
+        assert!(!gossip.is_subscribed("test:guard", &peer));
+        assert!(
+            gossip.is_locally_subscribed("test:guard"),
+            "peer activity must not disturb the local subscription record"
+        );
     }
 
     #[tokio::test]
@@ -2324,11 +2454,17 @@ mod tests {
 
         let mut gossip = GossipActor::new(owner.clone(), create_test_oracle());
 
-        // Create topic and subscribe
+        // Create topic and subscribe. This node subscribes itself — that is what enables
+        // local delivery (#2471). The extra remote subscriber is present to prove it does
+        // not change the notification count.
         gossip.create_topic(Topic::new(
             "test:response".to_string(),
             AccessControl::Public,
         ));
+        gossip
+            .subscribe("test:response", owner.clone())
+            .await
+            .unwrap();
         gossip
             .subscribe("test:response", subscriber.clone())
             .await
@@ -2377,16 +2513,19 @@ mod tests {
             .await;
         assert!(result.is_ok(), "Response handler should succeed");
 
-        // Verify notification was sent to subscriber
+        // Verify exactly one local notification was dispatched for the stored entry
         let notifs = notifications.lock().unwrap();
         assert_eq!(
             notifs.len(),
             1,
-            "Should have 1 notification for the subscriber"
+            "Should have exactly 1 notification for the stored entry"
         );
         assert_eq!(notifs[0].0, "test:response");
         assert_eq!(notifs[0].1, hash);
-        assert_eq!(notifs[0].2, subscriber);
+        assert_eq!(
+            notifs[0].2, owner,
+            "the recipient argument is the local node, not a remote subscriber"
+        );
     }
 
     #[tokio::test]

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -1280,6 +1280,16 @@ impl GossipActor {
         icn_snapshot::GossipState {
             vector_clock,
             subscriptions,
+            // Persisted separately from `subscriptions` because only this set has
+            // provenance: it is written solely by local `subscribe(topic, own_did)`
+            // calls (#2471). Restoring it is what keeps local notification delivery
+            // alive across a restart for embeddings and runtime-created topics, which
+            // have no subsystem-startup re-subscribe to fall back on.
+            local_subscriptions: {
+                let mut v: Vec<String> = self.local_topic_subscriptions.iter().cloned().collect();
+                v.sort(); // deterministic snapshot output
+                v
+            },
             topics,
         }
     }
@@ -1418,20 +1428,27 @@ impl GossipActor {
                 // Deliberately NOT promoted into `local_topic_subscriptions`, even when
                 // `did == self.own_did` (#2471).
                 //
-                // Snapshot subscription records carry no provenance: a snapshot taken by a
-                // node running the pre-fix handler can contain an own-DID entry that a peer
-                // forged via the unauthenticated Subscribe path. Promoting it here would
-                // launder that record across the upgrade and permanently enable local
-                // delivery for an attacker-chosen topic — the exact request the patched
-                // network path now refuses.
+                // Records in `subscriptions` carry no provenance: a snapshot taken by a node
+                // running the pre-fix handler can contain an own-DID entry that a peer forged
+                // via the unauthenticated Subscribe path. Promoting it here would launder
+                // that record across the upgrade and permanently enable local delivery for an
+                // attacker-chosen topic — the exact request the patched network path refuses.
                 //
-                // Nothing is lost by dropping it: restore runs before subsystem startup
-                // (`init_gossip.rs` restore_state -> `lifecycle.rs` subscribe_standard_topics
-                // and the per-subsystem init_* subscribes), so every legitimately configured
-                // topic re-establishes its own local subscription on this boot. The local
-                // set therefore derives only from code-path decisions made now, never from
-                // persisted peer-influenced state.
+                // The genuinely-local set is restored from `state.local_subscriptions` below,
+                // which is written only from `local_topic_subscriptions` and therefore only
+                // ever from a local `subscribe(topic, own_did)` call.
             }
+        }
+
+        // Restore this node's own subscriptions from the provenance-safe field.
+        //
+        // A pre-#2471 snapshot has no such field and deserializes to empty, so a legacy
+        // (possibly forged) own-DID record grants nothing. A post-fix snapshot restores
+        // exactly what this node subscribed itself to — which matters for embeddings and
+        // runtime-created topics, where there is no subsystem startup to re-subscribe and
+        // entries would otherwise be stored silently without ever being processed.
+        for topic in state.local_subscriptions {
+            self.local_topic_subscriptions.insert(topic);
         }
 
         info!("✅ Gossip state restored successfully");
@@ -2405,6 +2422,64 @@ mod tests {
         );
     }
 
+    /// A post-#2471 snapshot must carry this node's own subscriptions and restore local
+    /// delivery across a restart. Embeddings and runtime-created topics have no
+    /// subsystem-startup re-subscribe to fall back on, so without this an entry would be
+    /// stored after restart and silently never processed.
+    #[tokio::test]
+    async fn test_own_subscriptions_survive_snapshot_round_trip_and_still_deliver() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+        let sender = KeyPair::generate().unwrap().did().clone();
+
+        let mut before = GossipActor::new(owner.clone(), create_test_oracle());
+        before.create_topic(Topic::new(
+            "runtime:created".to_string(),
+            AccessControl::Public,
+        ));
+        before
+            .subscribe("runtime:created", owner.clone())
+            .await
+            .unwrap();
+        assert!(before.is_locally_subscribed("runtime:created"));
+
+        // (The JSON-level back-compat of this field — a legacy snapshot lacking it
+        // deserializing to empty — is pinned in icn-snapshot, which owns the format.)
+        let state = before.export_state();
+
+        let mut after = GossipActor::new(owner.clone(), create_test_oracle());
+        after.restore_state(state).unwrap();
+        assert!(
+            after.is_locally_subscribed("runtime:created"),
+            "this node's own subscription must survive a snapshot round trip"
+        );
+
+        // And delivery actually resumes.
+        let count = Arc::new(std::sync::Mutex::new(0u32));
+        let c = count.clone();
+        after.add_notification_callback(Arc::new(move |_, _, _| {
+            *c.lock().unwrap() += 1;
+        }));
+        let entry = GossipEntry {
+            hash: [9u8; 32],
+            author: sender.clone(),
+            clock: VectorClock::new(),
+            topic: "runtime:created".to_string(),
+            data: b"after restart".to_vec(),
+            compressed: false,
+            timestamp: 1_700_000_000_000,
+            replica_offered: None,
+        };
+        after
+            .handle_message(&sender, GossipMessage::Response { entry })
+            .await
+            .unwrap();
+        assert_eq!(
+            *count.lock().unwrap(),
+            1,
+            "local delivery must resume after restore, exactly once for the entry"
+        );
+    }
+
     /// A snapshot written by a pre-fix node can contain an own-DID subscription that a peer
     /// forged over the unauthenticated Subscribe path. Restoring it must not enable local
     /// delivery for that topic, or the upgrade would launder the compromise past the guard.
@@ -2423,7 +2498,10 @@ mod tests {
             .subscribe("attacker:chosen", owner.clone())
             .await
             .unwrap();
-        let state = victim.export_state();
+        let mut state = victim.export_state();
+        // A pre-#2471 snapshot has no `local_subscriptions` field at all; serde's default
+        // gives an empty vec on load. Reproduce that exactly.
+        state.local_subscriptions.clear();
         assert!(
             state.subscriptions["attacker:chosen"].contains(&owner.to_string()),
             "precondition: the forged own-DID record is in the snapshot"
@@ -2435,8 +2513,8 @@ mod tests {
 
         assert!(
             !upgraded.is_locally_subscribed("attacker:chosen"),
-            "a snapshot subscription record must never establish local delivery — it has no \
-             provenance separating a local subscribe from a forged network one"
+            "a legacy snapshot subscription record must never establish local delivery — it \
+             has no provenance separating a local subscribe from a forged network one"
         );
 
         // The legitimate path still works: subsystem startup re-subscribes after restore.
@@ -3018,6 +3096,7 @@ mod tests {
         let state = GossipState {
             vector_clock: HashMap::new(),
             subscriptions,
+            local_subscriptions: Vec::new(),
             topics: HashMap::new(), // No topics in snapshot
         };
 

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -1407,10 +1407,6 @@ impl GossipActor {
                 let did =
                     Did::from_str(&sub_str).context("Failed to parse DID from subscription")?;
 
-                // Restore the locally-owned delivery record too, so local notification
-                // dispatch survives a restart (#2471). Only our own DID qualifies.
-                let is_own = did == self.own_did;
-
                 // Ensure subscription list exists for this topic (create if missing)
                 let sub_list = self.subscriptions.entry(topic.clone()).or_default();
 
@@ -1419,9 +1415,22 @@ impl GossipActor {
                     sub_list.push(did.clone());
                 }
 
-                if is_own {
-                    self.local_topic_subscriptions.insert(topic.clone());
-                }
+                // Deliberately NOT promoted into `local_topic_subscriptions`, even when
+                // `did == self.own_did` (#2471).
+                //
+                // Snapshot subscription records carry no provenance: a snapshot taken by a
+                // node running the pre-fix handler can contain an own-DID entry that a peer
+                // forged via the unauthenticated Subscribe path. Promoting it here would
+                // launder that record across the upgrade and permanently enable local
+                // delivery for an attacker-chosen topic — the exact request the patched
+                // network path now refuses.
+                //
+                // Nothing is lost by dropping it: restore runs before subsystem startup
+                // (`init_gossip.rs` restore_state -> `lifecycle.rs` subscribe_standard_topics
+                // and the per-subsystem init_* subscribes), so every legitimately configured
+                // topic re-establishes its own local subscription on this boot. The local
+                // set therefore derives only from code-path decisions made now, never from
+                // persisted peer-influenced state.
             }
         }
 
@@ -2334,6 +2343,51 @@ mod tests {
             *count.lock().unwrap(),
             0,
             "a remote subscriber must not by itself trigger local callbacks"
+        );
+    }
+
+    /// A snapshot written by a pre-fix node can contain an own-DID subscription that a peer
+    /// forged over the unauthenticated Subscribe path. Restoring it must not enable local
+    /// delivery for that topic, or the upgrade would launder the compromise past the guard.
+    #[tokio::test]
+    async fn test_restore_does_not_promote_snapshot_own_did_to_local_subscription() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+
+        // Build a snapshot as a pre-fix node would have written it: the attacker forged
+        // `Subscribe { from: owner }` for a topic the node never subscribed itself to.
+        let mut victim = GossipActor::new(owner.clone(), create_test_oracle());
+        victim.create_topic(Topic::new(
+            "attacker:chosen".to_string(),
+            AccessControl::Public,
+        ));
+        victim
+            .subscribe("attacker:chosen", owner.clone())
+            .await
+            .unwrap();
+        let state = victim.export_state();
+        assert!(
+            state.subscriptions["attacker:chosen"].contains(&owner.to_string()),
+            "precondition: the forged own-DID record is in the snapshot"
+        );
+
+        // Upgraded node restores that snapshot.
+        let mut upgraded = GossipActor::new(owner.clone(), create_test_oracle());
+        upgraded.restore_state(state).unwrap();
+
+        assert!(
+            !upgraded.is_locally_subscribed("attacker:chosen"),
+            "a snapshot subscription record must never establish local delivery — it has no \
+             provenance separating a local subscribe from a forged network one"
+        );
+
+        // The legitimate path still works: subsystem startup re-subscribes after restore.
+        upgraded
+            .subscribe("attacker:chosen", owner.clone())
+            .await
+            .unwrap();
+        assert!(
+            upgraded.is_locally_subscribed("attacker:chosen"),
+            "an explicit local subscribe after restore must establish local delivery"
         );
     }
 

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -296,6 +296,12 @@ impl GossipActor {
         );
         self.entries.insert(topic.name.clone(), HashMap::new());
         self.subscriptions.insert(topic.name.clone(), Vec::new());
+        // Recreating a topic already resets its subscriber list, so it must reset this
+        // node's own subscription too (#2471) — otherwise `is_locally_subscribed` would
+        // stay true while `is_subscribed(topic, own_did)` went false, and local delivery
+        // would continue under a replacement ACL that might now deny us. Re-subscribing
+        // after a recreate is explicit, and goes through the ACL like any other subscribe.
+        self.local_topic_subscriptions.remove(&topic.name);
         self.topics.insert(topic.name.clone(), topic);
     }
 
@@ -2419,6 +2425,73 @@ mod tests {
             *count.lock().unwrap(),
             1,
             "exactly one local notification, despite 10000 remote subscribers"
+        );
+    }
+
+    /// Recreating a topic resets its subscriber list, so it must reset this node's own
+    /// subscription too — otherwise local delivery would continue under a replacement ACL
+    /// that has not authorised it, and the two records would disagree.
+    #[tokio::test]
+    async fn test_recreating_a_topic_clears_local_delivery() {
+        let owner = KeyPair::generate().unwrap().did().clone();
+        let mut gossip = GossipActor::new(owner.clone(), create_test_oracle());
+
+        gossip.create_topic(Topic::new("reconfig:me".to_string(), AccessControl::Public));
+        gossip
+            .subscribe("reconfig:me", owner.clone())
+            .await
+            .unwrap();
+        assert!(gossip.is_locally_subscribed("reconfig:me"));
+
+        let count = Arc::new(std::sync::Mutex::new(0u32));
+        let c = count.clone();
+        gossip.add_notification_callback(Arc::new(move |_, _, _| {
+            *c.lock().unwrap() += 1;
+        }));
+
+        // Recreate under a different ACL, as runtime reconfiguration would.
+        gossip.create_topic(Topic::new(
+            "reconfig:me".to_string(),
+            AccessControl::Participants(vec![]),
+        ));
+
+        assert!(
+            !gossip.is_subscribed("reconfig:me", &owner),
+            "precondition: recreating already resets the subscriber list"
+        );
+        assert!(
+            !gossip.is_locally_subscribed("reconfig:me"),
+            "recreating a topic must also reset this node's own subscription, so the two \
+             records cannot disagree"
+        );
+
+        // Deliver through the receive path — the case that matters, and one the replacement
+        // ACL does not gate (`store_entry` accepts entries regardless of publish rights).
+        let sender = KeyPair::generate().unwrap().did().clone();
+        let entry = GossipEntry {
+            hash: [11u8; 32],
+            author: sender.clone(),
+            clock: VectorClock::new(),
+            topic: "reconfig:me".to_string(),
+            data: b"after recreate".to_vec(),
+            compressed: false,
+            timestamp: 1_700_000_000_000,
+            replica_offered: None,
+        };
+        gossip
+            .handle_message(&sender, GossipMessage::Response { entry })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *count.lock().unwrap(),
+            0,
+            "local delivery must not continue under a replacement ACL without a fresh subscribe"
+        );
+        assert_eq!(
+            gossip.get_entries("reconfig:me").len(),
+            1,
+            "the entry is still stored — only local delivery is gated"
         );
     }
 

--- a/icn/crates/icn-gossip/src/subscriptions.rs
+++ b/icn/crates/icn-gossip/src/subscriptions.rs
@@ -10,13 +10,28 @@
 //! 3. **Rate limits** - Per-peer subscription limits (trust-weighted)
 //! 4. **Capacity limits** - Per-topic subscriber limits
 //!
+//! # Local vs network entry points (#2471)
+//!
+//! [`GossipActor::subscribe`] and [`GossipActor::unsubscribe`] are the **local** API:
+//! they act on whatever DID the caller supplies and are how this node subscribes itself.
+//!
+//! [`GossipActor::subscribe_from_network`] and [`GossipActor::unsubscribe_from_network`]
+//! are the **only** entry points a network message handler may use. They refuse any
+//! request claiming this node's own DID, because `NetworkMessage.from` is self-declared
+//! and no peer has a legitimate reason to alter our subscriptions.
+//!
+//! Neither pair authenticates anything. The DIDs here are claims, not proofs.
+//!
 //! # Key Functions
 //!
 //! - [`GossipActor::subscribe`] - Subscribe a DID to a topic (with authorization)
 //! - [`GossipActor::unsubscribe`] - Remove a subscription
+//! - [`GossipActor::subscribe_from_network`] - Network-originated subscribe (own-DID guarded)
+//! - [`GossipActor::unsubscribe_from_network`] - Network-originated unsubscribe (own-DID guarded)
 //! - [`GossipActor::get_subscribers`] - List subscribers for a topic
 //! - [`GossipActor::get_subscriptions`] - List topics a DID is subscribed to
 //! - [`GossipActor::is_subscribed`] - Check if a DID is subscribed to a topic
+//! - [`GossipActor::is_locally_subscribed`] - Check this node's own, non-peer-mutable subscription
 
 use crate::gossip::{spawn_violation_recording, GossipActor, MAX_SUBSCRIBERS_PER_TOPIC};
 use crate::types::{AccessControl, ResourceLimits, Subscription};
@@ -26,7 +41,7 @@ use icn_kernel_api::authz::{
     ActionKind, Domain, PolicyContext, PolicyDecision, PolicyRequest, PolicyRequestCore,
 };
 use std::sync::Arc;
-use tracing::{info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 impl GossipActor {
     /// Subscribe to a topic
@@ -214,6 +229,13 @@ impl GossipActor {
             self.update_gauge_metrics();
         }
 
+        // Record the locally-owned delivery gate (#2471). `is_own_did` was computed from
+        // `self.own_did`, so this set can only ever be reached by a caller that passed our
+        // own DID — and `subscribe_from_network` refuses exactly that from the wire.
+        if is_own_did {
+            self.local_topic_subscriptions.insert(topic.to_string());
+        }
+
         Ok(Subscription {
             topic: topic.to_string(),
             subscriber,
@@ -222,6 +244,8 @@ impl GossipActor {
 
     /// Unsubscribe from a topic
     pub fn unsubscribe(&mut self, topic: &str, subscriber: &Did) -> Result<()> {
+        let is_own_did = *subscriber == self.own_did;
+
         let subscribers = self
             .subscriptions
             .get_mut(topic)
@@ -240,7 +264,74 @@ impl GossipActor {
             self.update_gauge_metrics();
         }
 
+        if is_own_did {
+            self.local_topic_subscriptions.remove(topic);
+        }
+
         Ok(())
+    }
+
+    /// Handle a `Subscribe` request that arrived over the network.
+    ///
+    /// **This is the only entry point network message handlers may use.** The claimed
+    /// subscriber comes from `NetworkMessage.from`, which is self-declared: TLS is TOFU
+    /// with `client_auth_mandatory() = false`, and nothing rebinds a per-message `from`
+    /// to the Hello identity. A syntactically valid DID is not proof of key possession.
+    ///
+    /// A peer subscribing **itself** remains supported — that is the intended protocol.
+    /// What is refused is a request claiming *this node's own DID*, for which no peer has
+    /// any legitimate reason. Enforced here rather than in the handler because the same
+    /// handler shape is reimplemented in several places (`icn-core`'s supervisor,
+    /// `icn-testkit`, integration harnesses); a per-caller guard would be one forgotten
+    /// copy away from reopening the hole.
+    ///
+    /// This is containment, not authentication: it does not verify that the claimed peer
+    /// DID belongs to the sender. Authenticated gossip remains unresolved (#2469).
+    pub async fn subscribe_from_network(
+        &mut self,
+        topic: &str,
+        claimed_subscriber: Did,
+    ) -> Result<Subscription> {
+        self.reject_own_did_claim(topic, &claimed_subscriber, "subscribe")?;
+        self.subscribe(topic, claimed_subscriber).await
+    }
+
+    /// Handle an `Unsubscribe` request that arrived over the network.
+    ///
+    /// See [`GossipActor::subscribe_from_network`] for why the guard lives here.
+    pub fn unsubscribe_from_network(
+        &mut self,
+        topic: &str,
+        claimed_subscriber: &Did,
+    ) -> Result<()> {
+        self.reject_own_did_claim(topic, claimed_subscriber, "unsubscribe")?;
+        self.unsubscribe(topic, claimed_subscriber)
+    }
+
+    /// Refuse a network-originated subscription-control request that claims this node's DID.
+    ///
+    /// Observability is a counter plus a `debug!` line: this is remotely triggerable, so it
+    /// must not be able to drive log volume. The counter is the durable signal.
+    fn reject_own_did_claim(&self, topic: &str, claimed: &Did, action: &str) -> Result<()> {
+        if *claimed != self.own_did {
+            return Ok(());
+        }
+
+        icn_obs::metrics::gossip::subscription_control_spoof_rejected_inc();
+        debug!(
+            topic = %topic,
+            action = %action,
+            "Refused network subscription-control request claiming this node's own DID"
+        );
+        bail!("Refusing network {action} claiming this node's own DID for topic {topic}")
+    }
+
+    /// Whether this node has subscribed **itself** to `topic`.
+    ///
+    /// This is the gate on local notification delivery. Unlike
+    /// [`GossipActor::is_subscribed`], it cannot be influenced by any network message.
+    pub fn is_locally_subscribed(&self, topic: &str) -> bool {
+        self.local_topic_subscriptions.contains(topic)
     }
 
     /// Get all subscribers for a topic

--- a/icn/crates/icn-gossip/src/subscriptions.rs
+++ b/icn/crates/icn-gossip/src/subscriptions.rs
@@ -33,6 +33,7 @@
 //! - [`GossipActor::is_subscribed`] - Check if a DID is subscribed to a topic
 //! - [`GossipActor::is_locally_subscribed`] - Check this node's own, non-peer-mutable subscription
 
+use crate::error::GossipError;
 use crate::gossip::{spawn_violation_recording, GossipActor, MAX_SUBSCRIBERS_PER_TOPIC};
 use crate::types::{AccessControl, ResourceLimits, Subscription};
 use anyhow::{bail, Context as _, Result};
@@ -310,9 +311,13 @@ impl GossipActor {
 
     /// Refuse a network-originated subscription-control request that claims this node's DID.
     ///
-    /// Observability is a counter plus a `debug!` line: this is remotely triggerable, so it
-    /// must not be able to drive log volume. The counter is the durable signal.
-    fn reject_own_did_claim(&self, topic: &str, claimed: &Did, action: &str) -> Result<()> {
+    /// Observability is a counter plus a `debug!` line: this is remotely triggerable and
+    /// repeatable, so it must not be able to drive log volume. The counter is the durable
+    /// signal. The returned error is the typed
+    /// [`GossipError::SubscriptionControlSpoofRejected`] rather than an opaque one,
+    /// specifically so callers can tell a spoof rejection apart from an operational
+    /// subscribe/unsubscribe failure and avoid re-logging it at `warn!`.
+    fn reject_own_did_claim(&self, topic: &str, claimed: &Did, action: &'static str) -> Result<()> {
         if *claimed != self.own_did {
             return Ok(());
         }
@@ -323,7 +328,24 @@ impl GossipActor {
             action = %action,
             "Refused network subscription-control request claiming this node's own DID"
         );
-        bail!("Refusing network {action} claiming this node's own DID for topic {topic}")
+        Err(GossipError::SubscriptionControlSpoofRejected {
+            topic: topic.to_string(),
+            action,
+        }
+        .into())
+    }
+
+    /// Whether `err` is the spoof rejection from [`GossipActor::subscribe_from_network`] or
+    /// [`GossipActor::unsubscribe_from_network`].
+    ///
+    /// Network message handlers use this to keep a remotely-triggerable, expected rejection
+    /// out of their operational `warn!` paths — otherwise a peer can batch many topics per
+    /// forged request and drive warning-level log volume.
+    pub fn is_subscription_control_spoof(err: &anyhow::Error) -> bool {
+        matches!(
+            err.downcast_ref::<GossipError>(),
+            Some(GossipError::SubscriptionControlSpoofRejected { .. })
+        )
     }
 
     /// Whether this node has subscribed **itself** to `topic`.

--- a/icn/crates/icn-gossip/src/subscriptions.rs
+++ b/icn/crates/icn-gossip/src/subscriptions.rs
@@ -186,8 +186,19 @@ impl GossipActor {
         let subscribers = self.subscriptions.entry(topic.to_string()).or_default();
 
         if !subscribers.contains(&subscriber) {
-            // Check per-topic subscriber limit to prevent unbounded growth
-            if subscribers.len() >= MAX_SUBSCRIBERS_PER_TOPIC {
+            // Check per-topic subscriber limit to prevent unbounded growth.
+            //
+            // The local node's own DID is exempt, matching the per-peer limit above
+            // (#2471). This list is fillable by unauthenticated peers: `Subscribe` accepts
+            // any claimed DID, so a peer can push it to MAX_SUBSCRIBERS_PER_TOPIC with
+            // distinct claimed DIDs. Without the exemption, that peer could make the
+            // node's own later `subscribe` — during subsystem startup, or for a topic
+            // created at runtime — fail, leaving `local_topic_subscriptions` unset and
+            // silencing local delivery. That is the same remote suppression this change
+            // exists to close, arriving through the capacity check instead of through
+            // `Unsubscribe`. The exemption costs at most one entry over the cap, for our
+            // own DID only.
+            if !is_own_did && subscribers.len() >= MAX_SUBSCRIBERS_PER_TOPIC {
                 // Record misbehavior violation (fire-and-forget, non-blocking)
                 if let Some(ref detector) = self.misbehavior_detector {
                     use sha2::{Digest, Sha256};

--- a/icn/crates/icn-kernel-api/src/services.rs
+++ b/icn/crates/icn-kernel-api/src/services.rs
@@ -254,9 +254,11 @@ pub trait TrustService: Send + Sync {
     /// but the trust service owns deserialization, signature verification,
     /// and state updates.
     ///
-    /// `source` is the DID of the peer that forwarded this attestation
-    /// (the gossip subscriber, not necessarily the attestation issuer).
-    /// The trust service decides whether to accept or reject it.
+    /// `source` is the local delivery target reported by the gossip notification —
+    /// this node's own DID. It is **not** the forwarding peer and **not** the issuer,
+    /// and it carries no authentication. Treat it as a log label only; authorization
+    /// must come from the attestation's own signature. (Before #2471 this was the
+    /// gossip subscriber DID, which any peer could set.)
     ///
     /// Default implementation does nothing (no attestation support).
     fn ingest_attestation(&self, _bytes: &[u8], _source: &Did) -> Result<(), String> {
@@ -269,9 +271,9 @@ pub trait TrustService: Send + Sync {
     /// The trust service owns deserialization, signature verification,
     /// supersedence checks, and edge removal.
     ///
-    /// `source` is the DID of the peer that forwarded this revocation
-    /// (the gossip subscriber, not necessarily the revocation issuer).
-    /// The trust service decides whether to accept or reject it.
+    /// `source` is the local delivery target reported by the gossip notification —
+    /// this node's own DID, not the forwarding peer and not the issuer. It carries no
+    /// authentication; treat it as a log label only. (See `ingest_attestation`, #2471.)
     ///
     /// Default implementation does nothing (no revocation support).
     fn ingest_revocation(&self, _bytes: &[u8], _source: &Did) -> Result<(), String> {

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2128,6 +2128,13 @@ pub mod gossip {
         counter!("icn_gossip_subscribe_acks_sent_total").increment(1);
     }
 
+    /// A network-originated Subscribe/Unsubscribe claimed this node's own DID and was
+    /// refused (#2471). Non-zero means a peer attempted subscription-control spoofing;
+    /// it is a counter rather than a log line because the trigger is remote.
+    pub fn subscription_control_spoof_rejected_inc() {
+        counter!("icn_gossip_subscription_control_spoof_rejected_total").increment(1);
+    }
+
     pub fn digests_sent_inc() {
         counter!("icn_gossip_digests_sent_total").increment(1);
     }

--- a/icn/crates/icn-snapshot/src/lib.rs
+++ b/icn/crates/icn-snapshot/src/lib.rs
@@ -174,7 +174,25 @@ pub struct GossipState {
     pub vector_clock: HashMap<String, u64>,
 
     /// Topic subscriptions (topic name -> list of subscriber DID strings)
+    ///
+    /// Peer-influenced: remote peers add and remove themselves here, and on nodes predating
+    /// #2471 a peer could also forge an entry under the node's own DID. Records here carry
+    /// **no provenance** and must never be treated as evidence that this node subscribed
+    /// itself — see [`GossipState::local_subscriptions`].
     pub subscriptions: HashMap<String, Vec<String>>,
+
+    /// Topics this node subscribed **itself** to (#2471).
+    ///
+    /// Written only from `GossipActor::local_topic_subscriptions`, which by construction can
+    /// only be reached by a caller passing the node's own DID — the network-facing entry
+    /// points refuse exactly that. So unlike [`GossipState::subscriptions`] this field is
+    /// provenance-safe, and it is what restores local notification delivery.
+    ///
+    /// `#[serde(default)]` handles legacy snapshots: one written before #2471 has no such
+    /// field and deserializes to empty, so its possibly-forged own-DID records in
+    /// `subscriptions` grant no local delivery. Old snapshots still load.
+    #[serde(default)]
+    pub local_subscriptions: Vec<String>,
 
     /// Topic metadata (topic name -> TopicMetadata)
     pub topics: HashMap<String, TopicMetadata>,
@@ -923,6 +941,7 @@ mod tests {
                 .cloned()
                 .collect(),
             topics: HashMap::new(),
+            local_subscriptions: Vec::new(),
         });
 
         // Save
@@ -1328,6 +1347,7 @@ mod tests {
                         scope,
                     })
                 }).collect(),
+                local_subscriptions: Vec::new(),
             }
         }
     }
@@ -1483,6 +1503,7 @@ mod tests {
                 vector_clock: HashMap::new(),
                 subscriptions: HashMap::new(),
                 topics: HashMap::new(),
+                local_subscriptions: Vec::new(),
             };
 
             // Create large vector clock
@@ -1534,6 +1555,7 @@ mod tests {
             vector_clock: HashMap::new(),
             subscriptions: HashMap::new(),
             topics: HashMap::new(),
+            local_subscriptions: Vec::new(),
         });
         snapshot.network_state = Some(NetworkState {
             peer_connections: HashMap::new(),
@@ -1619,6 +1641,7 @@ mod tests {
             vector_clock: HashMap::new(),
             subscriptions: HashMap::new(),
             topics: HashMap::new(),
+            local_subscriptions: Vec::new(),
         };
 
         let long_did = "a".repeat(10000);
@@ -1891,6 +1914,7 @@ mod tests {
             vector_clock: HashMap::new(),
             subscriptions: HashMap::new(),
             topics: HashMap::new(),
+            local_subscriptions: Vec::new(),
         });
 
         // Save
@@ -1903,5 +1927,52 @@ mod tests {
 
         // Cleanup
         std::fs::remove_dir_all(&temp).unwrap();
+    }
+
+    /// A snapshot written before #2471 has no `local_subscriptions` field. It must still
+    /// load, and must deserialize to an empty local set — so its own-DID records in
+    /// `subscriptions`, which a peer could have forged over the unauthenticated Subscribe
+    /// path, grant the upgraded node no local notification delivery.
+    #[test]
+    fn legacy_gossip_state_without_local_subscriptions_loads_as_empty() {
+        let legacy_json = r#"{
+            "vector_clock": {"did:icn:alice": 7},
+            "subscriptions": {"coop:updates": ["did:icn:victim"]},
+            "topics": {}
+        }"#;
+
+        let state: GossipState =
+            serde_json::from_str(legacy_json).expect("a pre-#2471 snapshot must still load");
+
+        assert_eq!(state.vector_clock.get("did:icn:alice"), Some(&7));
+        assert_eq!(
+            state.subscriptions.get("coop:updates").map(Vec::len),
+            Some(1),
+            "the legacy subscriber record still loads into the propagation list"
+        );
+        assert!(
+            state.local_subscriptions.is_empty(),
+            "a legacy snapshot must grant no local delivery"
+        );
+    }
+
+    /// Round trip: a post-#2471 snapshot carries the local set through serialization.
+    #[test]
+    fn local_subscriptions_survive_json_round_trip() {
+        let mut state = GossipState {
+            vector_clock: HashMap::new(),
+            subscriptions: HashMap::new(),
+            local_subscriptions: Vec::new(),
+            topics: HashMap::new(),
+        };
+        state.local_subscriptions = vec!["coop:updates".to_string(), "entity:updates".to_string()];
+
+        let json = serde_json::to_string(&state).expect("serialize");
+        let back: GossipState = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(
+            back.local_subscriptions,
+            vec!["coop:updates".to_string(), "entity:updates".to_string()]
+        );
     }
 }

--- a/icn/crates/icn-testkit/src/node.rs
+++ b/icn/crates/icn-testkit/src/node.rs
@@ -550,6 +550,25 @@ impl TestNode {
 
     /// Subscribe to a topic on a remote node
     pub async fn subscribe_to(&self, topic: &str, remote: &TestNode) -> Result<()> {
+        // Establish our own local subscription first. Since #2471 local notification
+        // dispatch is gated on `local_topic_subscriptions`, which only the node itself
+        // can write; telling a *remote* peer we are interested does not make our own
+        // callbacks fire. Production does both too — every subsystem subscribes its own
+        // DID alongside registering its callback — so doing only the network half here
+        // would leave tests silently observing nothing.
+        //
+        // Best-effort: the topic may not exist locally in tests that only mirror a
+        // remote's topic, and that is not a reason to fail the subscribe.
+        {
+            let mut g = self.gossip.write().await;
+            if let Err(e) = g.subscribe(topic, self.did.clone()).await {
+                debug!(
+                    "Local subscribe to {} failed (continuing with remote subscribe): {}",
+                    topic, e
+                );
+            }
+        }
+
         let msg = NetworkMessage::subscribe(
             self.did.clone(),
             remote.did.clone(),

--- a/icn/crates/icn-testkit/src/node.rs
+++ b/icn/crates/icn-testkit/src/node.rs
@@ -289,7 +289,9 @@ impl TestNode {
                                 let mut g = gossip.write().await;
                                 let mut acked = Vec::new();
                                 for topic in &topics {
-                                    if g.subscribe(topic, sender.clone()).await.is_ok() {
+                                    // Network-originated: must use the own-DID-guarded
+                                    // entry point so the harness matches production (#2471).
+                                    if g.subscribe_from_network(topic, sender.clone()).await.is_ok() {
                                         acked.push(topic.clone());
                                     }
                                 }
@@ -343,7 +345,7 @@ impl TestNode {
                             _ = async {
                                 let mut g = gossip.write().await;
                                 for topic in &topics {
-                                    if let Err(e) = g.unsubscribe(topic, &sender) {
+                                    if let Err(e) = g.unsubscribe_from_network(topic, &sender) {
                                         debug!("Failed to unsubscribe {} from {}: {}", sender, topic, e);
                                     }
                                 }


### PR DESCRIPTION
Contains the unauthenticated gossip subscription-control defect in #2471. Follows #2470
(F-P0-2 governance replication containment), which is independent and untouched by this PR.

## The exploit, before this change

`NetworkMessage.from` is self-declared. TLS is TOFU with `client_auth_mandatory() = false`
(`icn-net/src/tls.rs:44`), the Hello handler verifies only a self-consistent binding
(`verify_did_matches_binding`, not `verify_binding_info` against the real peer cert), and
nothing rebinds a per-message `from` to the Hello identity. `Subscribe`/`Unsubscribe` have no
arm in the connection dispatcher, so they fall to `_ => handler(message)`
(`icn-net/src/actor/connection.rs:329`) and reach the supervisor with `from` exactly as written.

`init_network.rs` then passed that value straight through as the subscriber identity, and
`GossipActor::unsubscribe` removed whichever DID it was handed:

```rust
if let Some(pos) = subscribers.iter().position(|did| did == subscriber) {
    subscribers.remove(pos);
}
```

**Suppression.** A peer sends `Unsubscribe { topics: [T] }` with `from` set to the *victim's own
DID*. The victim drops its own subscription. `store_entry` then finds no local subscriber and
fires no callback — while still storing the entry and merging the clock, so nothing looks wrong.

**Amplification.** `store_entry` dispatched `subscribers x callbacks`:

```rust
for subscriber in subscribers { for callback in &self.notification_callbacks { ... } }
```

`Subscribe` is equally unauthenticated, so a peer could inflate local callback work up to
`MAX_SUBSCRIBERS_PER_TOPIC = 10000` per entry, per callback.

Both directions are topic-agnostic. Affected lifecycle topics are every topic the node
subscribes itself to: `trust:attestations`, `trust:revocations`, `coop:updates`,
`entity:updates`, `community:updates`, `governance:proposals`, `contracts:deploy`,
`contracts:revoke`, `identity:recovery`, `network:candidates`, `snapshot:coordinate`,
`node:profiles`, `compute:submit` / `:claim` / `:result`, `disputes:file`, `upgrade:*`,
service-discovery announce/query, and the five `federation:*` topics.

## Structural containment

Two layers, both in `icn-gossip`, which owns the state.

**1. Network-facing entry points.** `subscribe_from_network` / `unsubscribe_from_network` are the
only entry points a message handler may use. They refuse any request claiming this node's own DID.
A peer subscribing *itself* is unchanged — that is the intended protocol.

The guard is in the gossip crate rather than in the handler because the handler shape is
reimplemented in **five** places (the supervisor, `icn-testkit`, and three integration harnesses).
A per-caller guard would have been one forgotten copy from reopening the hole. All five now use
the guarded entry points.

**2. Entry-driven local dispatch.** One accepted stored entry invokes each registered callback
exactly once, gated on `local_topic_subscriptions` — a new, locally-owned set that only ever
records `subscriber == self.own_did`. No peer-supplied DID can reach it, so local delivery is
structurally independent of the peer-mutable subscriber list.

Gating was kept rather than dispatching unconditionally: production subscriptions are the
per-subsystem feature gate (federation topics only when `federation_enabled`, etc.), so an
ungated firehose would have routed entries into subsystems that never subscribed — trading one
defect for another. `entries_on_never_subscribed_topics_do_not_reach_local_callbacks` pins that.

Observability is a counter, `icn_gossip_subscription_control_spoof_rejected_total`, plus a
`debug!` line. The trigger is remote, so it must not be able to drive log volume — the refusal is
the typed `GossipError::SubscriptionControlSpoofRejected`, and both supervisor arms match it via
`GossipActor::is_subscription_control_spoof()` so it never reaches the operational `warn!` path.
(The first push got this wrong: the guard returned an opaque error that fell into the existing
per-topic `warn!` branch, so a peer batching topics could still pin the log at warning level.
Caught in review, fixed in `5fb97b83`.)

## Callback dispatch semantics: before and after

| | Before | After |
|---|---|---|
| Dispatch unit | once per subscriber, per callback | once per accepted entry, per callback |
| Gate | `subscriptions[topic]` non-empty (peer-mutable both directions) | `local_topic_subscriptions.contains(topic)` (not reachable from the network) |
| 3rd callback arg | the subscriber DID | this node's own DID — the local delivery target |

**This is a real semantic change.** Auditing every production `EntryNotificationCallback`
registration first:

| Registration | Uses the 3rd argument? |
|---|---|
| `apps/governance/src/actor.rs:1275` | `_subscriber_did` — ignored |
| `icn-community/src/gossip_sync.rs:93` (via `icnd/community_wiring.rs`) | `_subscriber_did` — ignored |
| `icn-core/supervisor/init_steward.rs:96` | `_subscriber_did` — ignored |
| `icn-core/supervisor/init_notifications.rs:876` (lifecycle dispatcher) | **used**, two sites |

The two uses pass it to `handle_trust_{attestation,revocation}_via_service` → `TrustService::ingest_*`,
where `apps/trust-app/src/service_tokio.rs` uses it **only in `tracing` format args and error
strings**. Rate limiting keys on the attestation's own issuer/subject; authorization is the
attestation signature, the sequence tracker, and the self-attestation refusal. Nothing
load-bearing depends on it.

It was also already wrong: in production the node subscribes itself, so the value was already
`own_did`, not "the DID of the peer that forwarded this" as the `TrustService` docs claimed. Those
docs are corrected here, and `peer`/`forwarding_peer` renamed to `recipient`/`local_recipient`.

## Red / green evidence

Negative control in a **disposable** worktree detached at `99b8e0b3`, base source pristine
(`git status` showed only the added test file), running the test file exactly as committed:

```
test result: FAILED. 4 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out
  attacker_subscribers_cannot_multiply_local_callback_delivery   FAILED  left: 26, right: 1
  local_callback_delivery_survives_forged_unsubscribe            FAILED  left: 0,  right: 1
  forged_unsubscribe_claiming_local_did_cannot_remove_local_subscription  FAILED
  forged_subscribe_claiming_local_did_cannot_create_local_subscription    FAILED
  malformed_and_repeated_subscription_control_stays_bounded      FAILED
```

Same file on this branch:

```
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The four that pass on both sides are preservation tests and are the point of them: a remote peer
can still subscribe and unsubscribe itself; local delivery does not depend on any remote
subscriber existing; a never-subscribed topic still does not deliver locally; entries are still
stored and vector clocks still merged while under attack.

The tests drive `create_incoming_handler` — the real supervisor handler — against a real
`GossipActor`, not an extracted helper.

## Validation

All exit codes observed, not inferred.

| Command | Result |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo test --workspace --lib` | exit 0 — **6573 passed, 0 failed, 1 ignored** |
| `cargo test --workspace --test '*' -- --test-threads=1` | exit 0 — **1833 passed, 0 failed, 52 ignored** |
| `cargo test -p icn-core --test '*' -- --test-threads=1` | exit 0 — 278 passed, 0 failed, 36 ignored |
| `cargo test -p icn-gossip` / `-p icn-net` / `-p icn-obs -p icn-kernel-api -p icn-testkit` | exit 0 |
| `git diff --check` | exit 0 |
| `check-meaning-firewall.sh` | exit 0 — no new unpinned domain imports |
| `doc_control_check.py`, `compliance_linter.py`, `readiness_overclaim_linter.py` | exit 0 |
| `freshness-check.py` | **exit 1** — 7 pre-existing stale sections, none in files this PR touches. Advisory in CI (`continue-on-error: true` in `docs-freshness.yml`), and the `Check Documentation Freshness` check is green. This corrects an earlier claim in this description that it exited 0: that reading came from a shell pipeline, so `$?` was the pipeline tail's status, not the script's. |

One existing test changed semantics deliberately, called out rather than quietly adjusted:
`devnet_integration::test_three_node_gossip_convergence` asserted `a_notifications >= 2` with the
comment "A has subscribers B and C, so store_entry fires notifications for them" — i.e. it pinned
the amplification mechanism. It now asserts exactly one notification per node, and additionally
checks B and C, which the old test did not. Two `icn-gossip` unit tests were repointed the same
way. The convergence subject of each test is unchanged.

## Deployment impact

- **Wire format unchanged.** No new message types, no field changes, no migration. A patched node
  and an unpatched node interoperate.
- A patched node stops honouring `Subscribe`/`Unsubscribe` that claim its own DID. No legitimate
  peer sends those.
- Subsystems that register a notification callback but never subscribe the node's own DID to the
  topic will stop receiving callbacks they previously received only when some *remote* peer
  happened to be subscribed. Every production subsystem subscribes its own DID alongside
  registering its callback; the audit above lists all four registration sites.
- Per-entry callback work drops from O(subscribers) to O(1).

## Rollback

Reverting restores both directions of the defect: any connected peer can silence every
lifecycle-routed topic on a node by claiming its DID in an `Unsubscribe`, and can multiply local
callback work by up to 10000x per entry. There is no partial rollback — the guard and the dispatch
change close different halves of the same hole, and reverting only the dispatch change leaves
amplification live.

## What this does not do

- **It does not authenticate gossip.** It does not verify that a claimed peer DID belongs to the
  sender. Any peer can still subscribe and unsubscribe *itself* under any DID it cares to assert,
  and can still inflate the remote subscriber list up to `MAX_SUBSCRIBERS_PER_TOPIC`. That list is
  now propagation bookkeeping only, but it is still unauthenticated. The missing primitive —
  nothing binds `NetworkMessage.from` to a key — is #2469, and is unresolved.
- It does not redesign topic access control, TLS, or peer identity, and does not touch governance
  replication.
- It makes no deployment-readiness claim.
- `entry.hash` is sender-supplied and never recomputed on receipt. This change deliberately does
  not use it as a security identity; that remains a separate pre-existing property.

## Review follow-ups

Two findings from automated review, both real, both fixed in `5fb97b83`:

1. **Spoof rejections could drive warn-level log volume** — described above.
2. **`TestNode::subscribe_to` only did the network half.** It sent a Subscribe to the remote but
   never established the caller's own local subscription, so a test subscribing and awaiting
   notifications observed nothing. Not a regression — `subscribe_to` never touched the caller's own
   `subscriptions` entry at base either, so the old empty-list loop also produced zero callbacks.
   Fixed anyway, because local subscription is now explicit and load-bearing and the harness should
   model production, where every subsystem subscribes its own DID alongside registering its callback.
3. **Snapshot restore laundered pre-fix compromise** (P1, `cacc0d8e`). Restore promoted own-DID
   entries from the snapshot into `local_topic_subscriptions`. Snapshot subscription records carry
   no provenance, so a snapshot written by a *pre-fix* node could contain an own-DID entry a peer
   forged over the unauthenticated Subscribe path — and restoring it permanently enabled local
   delivery for an attacker-chosen topic, i.e. the guard held for live traffic and lost to a
   snapshot. The promotion turned out to be unnecessary: `restore_state` (`init_gossip.rs:383`)
   runs strictly before `subscribe_standard_topics` and the per-subsystem `init_*` subscribes
   (`lifecycle.rs:641` -> `:1434`), so every configured topic re-establishes its own local
   subscription on this boot anyway. Dropping it gives a stronger property than versioning the
   snapshot — `local_topic_subscriptions` now derives only from code-path decisions made on this
   boot, never from persisted peer-influenceable state — and needs no format change or migration.
   An upgrade test pins it.
4. **A filled topic could block our own subscription** (P2, `d7babf62`). `Subscribe` accepts any
   claimed DID, so a peer can push a public topic's subscriber list to
   `MAX_SUBSCRIBERS_PER_TOPIC` (10000) and make the node's own later subscribe hit the cap and
   bail *before* the `local_topic_subscriptions` insert — the same suppression, reached through
   the capacity check instead of through `Unsubscribe`. The own DID is now exempt from that cap,
   matching the per-peer limit immediately above, which already exempts it for the same reason.
   The cap still bounds peer-driven growth; the exemption costs at most one entry, for our own
   DID. Deliberately *not* decoupled from `subscribe` success entirely — an oracle or ACL refusal
   is a legitimate local decision and should still leave delivery off.

**Note on residual unauthenticated behaviour, updated:** a peer can still grow the remote
subscriber list to the cap. That list is now propagation bookkeeping only, no longer influences
local delivery, and can no longer block the node's own subscription — but it is still memory an
unauthenticated peer can consume. Authenticating the requests is #2469.

5. **Documentation still taught the vulnerable handler** (P2, `c23171ad`).
   `docs/reference/api/topic-subscriptions-api.md` — the canonical subscription guide — told
   handlers to call the unguarded `gossip.subscribe`/`gossip.unsubscribe`, in both its flow
   descriptions and its complete handler example. Documentation was effectively a sixth copy of
   that handler, and an integrator following it would have recreated the spoofing path. The guide
   now requires the guarded entry points, gains a "Security: network-originated requests" section,
   and documents `subscribe_from_network` / `unsubscribe_from_network` / `is_locally_subscribed`.
   `.github/copilot-instructions.md` gets the same one-line rule. Dated session records under
   `docs/development/sessions/2025-11/` are left as historical.

6. **…but dropping the snapshot promotion broke restore for embeddings** (P2, `6b3d4454`).
   Finding 3's fix regressed the other way: an embedding, or a topic created at runtime, has no
   subsystem startup to re-subscribe, so local delivery silently stopped across a restart —
   entries stored, callbacks never invoked. Reconciled with a separate, provenance-safe field:
   `GossipState.local_subscriptions` is written only from `local_topic_subscriptions`, which
   only a caller passing our own DID can reach. `#[serde(default)]` does the versioning — a
   pre-#2471 snapshot has no such field, loads as empty, and still grants no local delivery, so
   a forged own-DID record cannot survive the upgrade. Additive and backward compatible: no
   format version bump, no migration, nothing changes on the network wire.

**On the shape of this review round.** Six findings, and five were the *same* property failing
through a path the original guard did not cover — an opaque error routed into `warn!`, a snapshot
restore, a peer-fillable resource cap, the documentation, and then the restore path again from the
opposite direction. Closing the obvious write path was not the same as closing the property.

Refs #2471 #2470 #2469 #2441
