### PR TITLE
refactor(obs): Bring metrics_legacy.rs under cargo fmt coverage

### DIFF
--- a/icn/crates/icn-obs/src/metrics/mod.rs
+++ b/icn/crates/icn-obs/src/metrics/mod.rs
@@ -17,13 +17,13 @@
 //! metrics::gateway::websocket_connections_total_inc();
 //! ```
 
-// Include the legacy metrics file directly
-// This keeps backwards compatibility while allowing gradual migration
+// Declare the legacy metrics file as a module via #[path] rather than include!().
+// This keeps backwards compatibility while allowing gradual migration, and unlike
+// include!() it is traversed by rustfmt, so the file stays under `cargo fmt --all`.
 // Allow missing docs and dead_code for legacy metrics - being migrated to submodules
 #[allow(missing_docs, dead_code)]
-mod legacy {
-    include!("../metrics_legacy.rs");
-}
+#[path = "../metrics_legacy.rs"]
+mod legacy;
 
 pub use legacy::*;
 

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2165,7 +2165,10 @@ pub mod gossip {
     /// DEPRECATED: Per-peer deficit tracking has been removed to avoid high-cardinality
     /// metrics. This function is now a no-op. Callers should aggregate deficit across
     /// all peers and use `total_deficit_bytes_set()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_deficit_bytes_set() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_deficit_bytes_set() instead to avoid high-cardinality metrics"
+    )]
     pub fn peer_deficit_bytes_set(_peer: &str, _deficit: i64) {
         // Intentionally a no-op. Per-peer tracking removed; callers should
         // aggregate and use `total_deficit_bytes_set()` instead.
@@ -2329,8 +2332,7 @@ pub mod scalability {
             .increment(total_downstream_count);
 
         // Track actual invalidations performed (after selective optimization).
-        counter!("icn_trust_cache_actual_invalidations_total")
-            .increment(invalidated_count);
+        counter!("icn_trust_cache_actual_invalidations_total").increment(invalidated_count);
 
         // Record distribution of total downstream fanout for hub detection.
         // Use histogram p99 in Grafana instead of gauge for accurate max tracking.
@@ -2673,7 +2675,8 @@ pub mod governance {
     ///
     /// This metric helps identify performance issues with large delegation graphs.
     pub fn delegation_reconciliation_duration_observe(duration_secs: f64) {
-        histogram!("icn_governance_delegation_reconciliation_duration_seconds").record(duration_secs);
+        histogram!("icn_governance_delegation_reconciliation_duration_seconds")
+            .record(duration_secs);
     }
 
     /// Record when a storage error occurs during scope overlap checking
@@ -3289,7 +3292,10 @@ pub mod gateway {
     ///
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// For auditing specific DIDs, use structured logs. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "DID label removed for cardinality; use logs for audit")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "DID label removed for cardinality; use logs for audit"
+    )]
     pub fn rate_limit_exceeded_inc(_did: &str) {
         counter!("icn_gateway_rate_limit_exceeded_total").increment(1);
     }
@@ -3670,7 +3676,10 @@ pub mod compute {
     /// DEPRECATED: Per-executor load tracking has been removed to avoid high-cardinality
     /// metrics. This function is now a no-op. Callers should compute the aggregate load
     /// across all executors and use `average_executor_load_set()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use average_executor_load_set() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use average_executor_load_set() instead to avoid high-cardinality metrics"
+    )]
     pub fn executor_load_set(_executor_did: &str, _load: f64) {
         // Intentionally a no-op. Per-executor tracking removed; callers should
         // aggregate and use `average_executor_load_set()` instead.
@@ -4194,7 +4203,10 @@ pub mod storage_quotas {
     ///
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Use `exceeded_inc()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use exceeded_inc() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use exceeded_inc() instead to avoid high-cardinality metrics"
+    )]
     pub fn quota_exceeded_inc(_did: &str) {
         counter!("icn_storage_quota_exceeded_total").increment(1);
     }
@@ -4224,7 +4236,10 @@ pub mod storage_quotas {
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Per-DID quota tracking causes unbounded metric growth in large networks.
     /// Use `global_usage_set()` for aggregate tracking. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Per-DID quota tracking removed for cardinality; use global_usage_set()")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Per-DID quota tracking removed for cardinality; use global_usage_set()"
+    )]
     pub fn did_quota_usage_set(_did: &str, _bytes: u64) {
         // No-op: per-DID tracking removed for cardinality
     }
@@ -4234,7 +4249,10 @@ pub mod storage_quotas {
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Per-DID quota tracking causes unbounded metric growth in large networks.
     /// Use `global_usage_percentage_set()` for aggregate tracking. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Per-DID quota tracking removed for cardinality; use global_usage_percentage_set()")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Per-DID quota tracking removed for cardinality; use global_usage_percentage_set()"
+    )]
     pub fn did_quota_percentage_set(_did: &str, _percentage: f64) {
         // No-op: per-DID tracking removed for cardinality
     }
@@ -4322,7 +4340,10 @@ pub mod contribution {
     ///
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Use `total_compute_cpu_seconds_add()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_compute_cpu_seconds_add() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_compute_cpu_seconds_add() instead to avoid high-cardinality metrics"
+    )]
     pub fn compute_cpu_seconds_add(_did: &str, cpu_seconds: u64) {
         counter!("icn_contribution_compute_cpu_seconds_total").increment(cpu_seconds);
     }
@@ -4336,7 +4357,10 @@ pub mod contribution {
     ///
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Use `total_compute_job_completed()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_compute_job_completed() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_compute_job_completed() instead to avoid high-cardinality metrics"
+    )]
     pub fn compute_job_completed(_did: &str, duration_secs: f64) {
         gauge!("icn_contribution_compute_jobs_completed_total").increment(1.0);
         histogram!("icn_contribution_compute_job_duration_seconds").record(duration_secs);
@@ -4354,7 +4378,10 @@ pub mod contribution {
     /// metrics. This function is now a no-op. Callers should aggregate job counts
     /// across all DIDs and use `total_compute_jobs_completed_set()` instead.
     /// See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_compute_jobs_completed_set() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_compute_jobs_completed_set() instead to avoid high-cardinality metrics"
+    )]
     pub fn compute_jobs_completed_set(_did: &str, _count: u64) {
         // Intentionally a no-op. Per-DID tracking removed; callers should
         // aggregate and use `total_compute_jobs_completed_set()` instead.
@@ -4373,7 +4400,10 @@ pub mod contribution {
     ///
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Use `total_storage_byte_seconds_add()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_storage_byte_seconds_add() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_storage_byte_seconds_add() instead to avoid high-cardinality metrics"
+    )]
     pub fn storage_byte_seconds_add(_did: &str, byte_seconds: u64) {
         counter!("icn_contribution_storage_byte_seconds_total").increment(byte_seconds);
     }
@@ -4389,7 +4419,10 @@ pub mod contribution {
     /// metrics. This function is now a no-op. Callers should aggregate replica counts
     /// across all providers and use `total_storage_replicas_healthy_set()` instead.
     /// See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_storage_replicas_healthy_set() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_storage_replicas_healthy_set() instead to avoid high-cardinality metrics"
+    )]
     pub fn storage_replicas_healthy_set(_did: &str, _count: u64) {
         // Intentionally a no-op. Per-provider tracking removed; callers should
         // aggregate and use `total_storage_replicas_healthy_set()` instead.
@@ -4404,7 +4437,10 @@ pub mod contribution {
     ///
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Use `total_storage_replicas_healthy_inc()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_storage_replicas_healthy_inc() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_storage_replicas_healthy_inc() instead to avoid high-cardinality metrics"
+    )]
     pub fn storage_replicas_healthy_inc(_did: &str) {
         gauge!("icn_contribution_storage_replicas_healthy_total").increment(1.0);
     }
@@ -4418,7 +4454,10 @@ pub mod contribution {
     ///
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Use `total_storage_replicas_healthy_dec()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_storage_replicas_healthy_dec() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_storage_replicas_healthy_dec() instead to avoid high-cardinality metrics"
+    )]
     pub fn storage_replicas_healthy_dec(_did: &str) {
         gauge!("icn_contribution_storage_replicas_healthy_total").decrement(1.0);
     }
@@ -4436,7 +4475,10 @@ pub mod contribution {
     ///
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Use `total_bandwidth_bytes_add()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_bandwidth_bytes_add() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_bandwidth_bytes_add() instead to avoid high-cardinality metrics"
+    )]
     pub fn bandwidth_bytes_add(_did: &str, bytes: u64) {
         counter!("icn_contribution_bandwidth_bytes_total").increment(bytes);
     }
@@ -4459,7 +4501,10 @@ pub mod contribution {
     ///
     /// DEPRECATED: The `did` parameter is ignored to avoid high-cardinality metrics.
     /// Use `total_uptime_seconds_add()` instead. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use total_uptime_seconds_add() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use total_uptime_seconds_add() instead to avoid high-cardinality metrics"
+    )]
     pub fn uptime_seconds_add(_did: &str, seconds: u64) {
         counter!("icn_contribution_uptime_seconds_total").increment(seconds);
     }
@@ -4473,7 +4518,10 @@ pub mod contribution {
     ///
     /// DEPRECATED: Per-DID heartbeat tracking causes unbounded metric growth.
     /// Use `heartbeats_received_inc()` for aggregate tracking. See Issue #494.
-    #[deprecated(since = "0.2.0", note = "Use heartbeats_received_inc() instead to avoid high-cardinality metrics")]
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use heartbeats_received_inc() instead to avoid high-cardinality metrics"
+    )]
     pub fn uptime_heartbeat_record(_did: &str, _timestamp: u64) {
         // No-op: per-DID tracking removed for cardinality
         counter!("icn_contribution_uptime_heartbeats_total").increment(1);


### PR DESCRIPTION
## What

Brings `icn/crates/icn-obs/src/metrics_legacy.rs` (5,169 lines) under `cargo fmt --all` coverage,
and applies the resulting one-time reformat.

Two commits, deliberately separated — no behavioral change is mixed with formatting:

| Commit | Contents |
|---|---|
| `chore(obs): apply rustfmt to metrics_legacy.rs` | formatting only — `metrics_legacy.rs` alone, 18 hunks |
| `refactor(obs): declare metrics_legacy via #[path] mod so cargo fmt covers it` | `metrics/mod.rs` alone, 5 lines |

Reformat lands first, so each commit is independently fmt-green.

## Why

`metrics_legacy.rs` was pulled into the crate by `include!("../metrics_legacy.rs")` rather than a
`mod` declaration. rustfmt resolves the **module graph** but does not expand macros, so `include!()`
targets are invisible to it — the file was never visited by `cargo fmt --all --check` (CI Format
Check) and had drifted out of conformance on `main`.

Practical consequence: any editor format-on-save hook reformats the whole file the moment someone
edits it, injecting 86 changed lines of unrelated churn into an unrelated PR's diff. This was hit
and manually reverted during work on #2471 / PR #2474.

## How

The `include!()` was **already wrapped in a private module with a glob re-export**:

```rust
#[allow(missing_docs, dead_code)]
mod legacy {
    include!("../metrics_legacy.rs");
}
pub use legacy::*;
```

so the usual hazard of an `include!` → `mod` conversion — items moving between namespaces, public
paths changing — does not apply. The items already live in `legacy` and are already re-exported by
glob. The replacement is namespace-identical:

```rust
#[allow(missing_docs, dead_code)]
#[path = "../metrics_legacy.rs"]
mod legacy;
```

### Rejected alternative

Keeping `include!()` and adding a second `rustfmt --edition 2021 --check` invocation to the Format
Check step. Rejected because it leaves the file outside `cargo fmt --all`, which is the repo's
documented pre-commit command (`.claude/rules/rust-core.md`). A contributor would get a red CI check
with **no local command that reproduces or repairs it**, and every future `include!()` would have to
be remembered and hand-added to CI.

Also rejected: moving the file to `src/metrics/legacy.rs` with a plain `mod legacy;` — equivalent
outcome, but puts a 5,169-line rename in the same PR as a reformat for no benefit.

## Risk

Low. No behavioral change.

`#[path]` module loading and `include!` splicing produce the same item set here because the include
was already namespace-isolated. The two constructs that *would* behave differently between the forms
are inner attributes (`#![...]`) and path-sensitive macros (`include_str!`, `include_bytes!`,
`file!()`) — `metrics_legacy.rs` contains neither.

The reformat is provably semantics-free: the reformatted file is **byte-identical to the original
once all whitespace is stripped** (`tr -d '[:space:]'`), so no token was added, removed, or
reordered. The 18 hunks are 16 × `#[deprecated(since = ..., note = ...)]` attribute wrapping and
2 × method-chain wrapping.

## Test plan

All run locally against the final tree:

- `cargo fmt --all --check` — green, **and now traverses the file**
- `rustfmt --edition 2021 --check icn/crates/icn-obs/src/metrics_legacy.rs` — green
- `cargo check --workspace --all-targets` — green (confirms the glob re-export's item set is
  unchanged for every downstream consumer of `icn_obs::metrics::*`)
- `cargo clippy -p icn-obs --all-targets -- -D warnings` — green, 0 warnings
- `cargo test -p icn-obs` — 61 passed, 0 failed
- **Negative test**: injecting a deliberate misformat into `metrics_legacy.rs` makes
  `cargo fmt --all --check` fail; reverting makes it pass. The gate genuinely bites now rather than
  merely being green.

## Note — audit for the same blind spot elsewhere

A sweep of all 986 tracked `.rs` files found **exactly one** `include!()` in the repo (this one), no
`#[path]` module declarations, and no `build.rs`. Nothing else has this specific blind spot.

Running `rustfmt --check` on every tracked file individually and diffing against `cargo fmt --all`
coverage did surface 7 other non-conforming files in three unrelated classes — fuzz targets in a
non-member package, examples with no owning package, and two files never declared as `mod` at all
(`icn-ccl/src/governance.rs`, `icn-gateway/src/coop_actor_adapter.rs`, which are therefore not
compiled). Full table is in #2475. Those are out of scope here; the last pair is a dead-code
question deserving its own issue.

Refs #2475
Refs #2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
