### PR TITLE
docs(net): repoint the NetworkMessage.from limitation from #2469 to #2480

### DIFF
--- a/docs/reference/api/topic-subscriptions-api.md
+++ b/docs/reference/api/topic-subscriptions-api.md
@@ -451,8 +451,10 @@ authority.
 
 **What this does not provide.** None of the above authenticates gossip. A peer may still
 subscribe and unsubscribe itself under any DID it asserts, and may still grow a topic's
-subscriber list up to `MAX_SUBSCRIBERS_PER_TOPIC`. Authenticating the requests is tracked
-separately (issue #2469).
+subscriber list up to `MAX_SUBSCRIBERS_PER_TOPIC`. Authenticating the requests — binding
+`NetworkMessage.from` to the authenticated identity of the connection that delivered it — is
+tracked separately as issue #2480. Issue #2469 covers the distinct question of authenticating
+`GossipEntry.author` on the governance apply path; neither primitive supplies the other.
 
 ---
 

--- a/icn/crates/icn-core/src/supervisor/init_network.rs
+++ b/icn/crates/icn-core/src/supervisor/init_network.rs
@@ -75,7 +75,7 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                         // `sender_did` is `NetworkMessage.from` — self-declared, not
                         // authenticated. `subscribe_from_network` refuses any claim of
                         // this node's own DID (#2471); a peer subscribing itself is
-                        // still allowed, and still unauthenticated (#2469).
+                        // still allowed, and still unauthenticated (#2480).
                         match gossip
                             .subscribe_from_network(topic, sender_did.clone())
                             .await

--- a/icn/crates/icn-gossip/src/subscriptions.rs
+++ b/icn/crates/icn-gossip/src/subscriptions.rs
@@ -298,7 +298,9 @@ impl GossipActor {
     /// copy away from reopening the hole.
     ///
     /// This is containment, not authentication: it does not verify that the claimed peer
-    /// DID belongs to the sender. Authenticated gossip remains unresolved (#2469).
+    /// DID belongs to the sender. Binding `NetworkMessage.from` to the authenticated
+    /// identity of the delivering connection remains unresolved (#2480). The separate
+    /// question of authenticating `GossipEntry.author` on the apply path is #2469.
     pub async fn subscribe_from_network(
         &mut self,
         topic: &str,


### PR DESCRIPTION
## Summary

Repoints three references that cite **#2469** for a limitation #2469 does not own.

#2474 landed the containment for unauthenticated gossip subscription control and correctly recorded its residual limitation — that `NetworkMessage.from` is self-declared and unbound to any authenticated connection identity. It attributed that limitation to #2469. #2480 was subsequently opened to own exactly that gap, after an audit established the two are distinct primitives at different layers:

| Identity | Where | Owner |
|---|---|---|
| `NetworkMessage.from` | transport envelope — the claimed sender of a `Subscribe`/`Unsubscribe`/`Gossip` message | **#2480** |
| `GossipEntry.author` | inside the gossip payload — the claimed author of a replicated entry | **#2469** |

#2469's own body scopes it to `GossipEntry.author` on the governance apply path: *"`GossipEntry` … carries a claimed `author` DID and no signature binding that DID to the entry contents."* It says nothing about the transport envelope. Neither primitive supplies the other — transport-peer authentication does not authenticate a forwarded entry's author, and per-entry signatures do not authenticate a subscription request.

## Changes

Comment and documentation text only. Three sites, all introduced by #2474:

- `icn/crates/icn-core/src/supervisor/init_network.rs` — the comment reading "`sender_did` is `NetworkMessage.from` — self-declared, not authenticated … still unauthenticated (#2469)" now cites #2480.
- `icn/crates/icn-gossip/src/subscriptions.rs` — the `subscribe_from_network` doc comment now names the actual gap ("binding `NetworkMessage.from` to the authenticated identity of the delivering connection", #2480) and explicitly points the `GossipEntry.author` question at #2469.
- `docs/reference/api/topic-subscriptions-api.md` — the **What this does not provide** section now attributes request authentication to #2480 and distinguishes #2469's scope.

The two surviving `#2469` mentions are deliberate: they now describe #2469's real scope rather than misattributing the envelope gap to it.

## Why separately

Kept out of #2478 (orphaned-module removal) on the one-phase-one-branch rule. #2478 was a build-graph cleanup; this is a cross-reference correction to code #2474 introduced.

## Risk

None. No executable code changes — the Rust edits are a line comment and a doc comment. No behaviour, schema, API, or public-surface change.

## Test plan

```
python3 docs/scripts/doc_control_check.py --repo . --registry docs/registry.toml   exit=0
python3 .github/scripts/compliance_linter.py --repo-root .                         exit=0
python3 .github/scripts/readiness_overclaim_linter.py --repo-root .                exit=0
bash scripts/check-meaning-firewall.sh                                             exit=0
git diff --check                                                                   exit=0
cargo fmt --all --check                                                            exit=0
cargo clippy -p icn-gossip --all-targets -- -D warnings                           exit=0
cargo clippy -p icn-core   --all-targets -- -D warnings                           exit=0
cargo test -p icn-gossip --lib                exit=0   226 passed, 0 failed, 1 ignored
```

Refs #2480, #2469, #2471, #2474
