### PR TITLE
feat(obs): observe-only outcome counter for subscription-control ingress

### DIFF
--- a/docs/reference/api/topic-subscriptions-api.md
+++ b/docs/reference/api/topic-subscriptions-api.md
@@ -486,17 +486,44 @@ The subscription system exports Prometheus metrics:
 - Description: Total SubscribeAck messages sent
 - Increments: When supervisor sends SubscribeAck
 
+**`icn_gossip_subscription_control_spoof_rejected_total`**
+- Type: Counter
+- Description: Network Subscribe/Unsubscribe requests refused for claiming this node's own DID (#2471)
+- Increments: Per topic, when the own-DID guard refuses a request
+
+**`icn_gossip_subscription_control_outcome_total{action, outcome}`**
+- Type: Counter
+- Description: How each topic of a received subscription-control request resolved (#2482)
+- Increments: Per **topic**, after the accept/reject decision — unlike the `*_received_total`
+  counters above, which increment once per **message**
+- Labels (closed sets; never a DID, topic name, or address):
+  - `action`: `subscribe` | `unsubscribe`
+  - `outcome`:
+    - `processed` — the handler returned success. **This does not mean the subscriber set
+      changed**: unsubscribing a DID that was not subscribed, and subscribing one that already
+      was, both return success and are counted here.
+    - `rejected_own_did` — refused by the own-DID guard (also counted by the spoof counter above)
+    - `rejected_or_error` — any other non-success: topic-ACL denial, unknown topic, per-topic
+      capacity refusal, or a genuine fault. Expected policy denials and faults are not
+      distinguished, because the underlying refusals are untyped error strings.
+
 ### Querying Metrics
 
 ```bash
-# View all subscription metrics
-curl http://localhost:9100/metrics | grep icn_gossip_subscribe
+# View all subscription metrics.
+# Note the `subscri` prefix: it matches both the `subscribe*` and `subscription*`
+# metric families. `grep icn_gossip_subscribe` alone would miss the control metrics.
+curl http://localhost:9100/metrics | grep icn_gossip_subscri
 
 # Example output:
 # icn_gossip_subscriptions_total 15
 # icn_gossip_subscribes_received_total 42
 # icn_gossip_unsubscribes_received_total 7
 # icn_gossip_subscribe_acks_sent_total 38
+# icn_gossip_subscription_control_spoof_rejected_total 3
+# icn_gossip_subscription_control_outcome_total{action="subscribe",outcome="processed"} 39
+# icn_gossip_subscription_control_outcome_total{action="subscribe",outcome="rejected_own_did"} 3
+# icn_gossip_subscription_control_outcome_total{action="unsubscribe",outcome="processed"} 7
 ```
 
 ---

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3124,6 +3124,7 @@ dependencies = [
  "icn-trust",
  "icn-trust-app",
  "metrics",
+ "metrics-util 0.19.1",
  "portpicker",
  "rand 0.9.4",
  "rand_core 0.6.4",

--- a/icn/crates/icn-core/Cargo.toml
+++ b/icn/crates/icn-core/Cargo.toml
@@ -71,6 +71,9 @@ reqwest.workspace = true
 rand_core = { workspace = true }
 # Enable test-util for time mocking in integration tests
 tokio = { version = "1.49", features = ["test-util"] }
+# Test-only metrics recorder, matching the pattern already used by icn-ledger
+# (crates/icn-ledger/Cargo.toml) for asserting counter values in tests.
+metrics-util = { version = "0.19", features = ["debugging"] }
 
 [features]
 default = []

--- a/icn/crates/icn-core/src/supervisor/init_network.rs
+++ b/icn/crates/icn-core/src/supervisor/init_network.rs
@@ -4,9 +4,24 @@
 //! providing a cleaner separation of concerns for network message routing.
 
 use icn_identity::Did;
+use icn_obs::metrics::gossip::{SubscriptionControlAction, SubscriptionControlOutcome};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
+
+/// Record how one topic of a network subscription-control request resolved (#2482).
+///
+/// Deliberately a single choke point so the observe-only property is stated once and is
+/// obvious at every call site: this runs **after** the accept/reject decision has already
+/// been made, takes no locks, returns nothing, and cannot influence the outcome it
+/// describes. Both arguments are closed enums, so no DID, topic name, or error string can
+/// reach the metric.
+fn record_subscription_control_outcome(
+    action: SubscriptionControlAction,
+    outcome: SubscriptionControlOutcome,
+) {
+    icn_obs::metrics::gossip::subscription_control_outcome_inc(action, outcome);
+}
 
 /// Type alias for the gossip handle used in message routing
 pub type GossipHandle = Arc<RwLock<icn_gossip::GossipActor>>;
@@ -83,6 +98,10 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                             Ok(_) => {
                                 info!("Subscribed {} to topic: {}", sender_did, topic);
                                 acked_topics.push(topic.clone());
+                                record_subscription_control_outcome(
+                                    SubscriptionControlAction::Subscribe,
+                                    SubscriptionControlOutcome::Accepted,
+                                );
                             }
                             Err(e)
                                 if icn_gossip::GossipActor::is_subscription_control_spoof(&e) =>
@@ -92,11 +111,19 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                                 // the operational warn! path; the durable signal is
                                 // icn_gossip_subscription_control_spoof_rejected_total.
                                 debug!("{}", e);
+                                record_subscription_control_outcome(
+                                    SubscriptionControlAction::Subscribe,
+                                    SubscriptionControlOutcome::RejectedOwnDid,
+                                );
                             }
                             Err(e) => {
                                 warn!(
                                     "Failed to subscribe {} to topic {}: {}",
                                     sender_did, topic, e
+                                );
+                                record_subscription_control_outcome(
+                                    SubscriptionControlAction::Subscribe,
+                                    SubscriptionControlOutcome::Error,
                                 );
                             }
                         }
@@ -135,6 +162,10 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                         match gossip.unsubscribe_from_network(topic, &sender_did) {
                             Ok(_) => {
                                 info!("Unsubscribed {} from topic: {}", sender_did, topic);
+                                record_subscription_control_outcome(
+                                    SubscriptionControlAction::Unsubscribe,
+                                    SubscriptionControlOutcome::Accepted,
+                                );
                             }
                             Err(e)
                                 if icn_gossip::GossipActor::is_subscription_control_spoof(&e) =>
@@ -142,11 +173,19 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                                 // See the Subscribe arm: remotely triggerable, so it must
                                 // not be able to drive warning-level log volume.
                                 debug!("{}", e);
+                                record_subscription_control_outcome(
+                                    SubscriptionControlAction::Unsubscribe,
+                                    SubscriptionControlOutcome::RejectedOwnDid,
+                                );
                             }
                             Err(e) => {
                                 warn!(
                                     "Failed to unsubscribe {} from topic {}: {}",
                                     sender_did, topic, e
+                                );
+                                record_subscription_control_outcome(
+                                    SubscriptionControlAction::Unsubscribe,
+                                    SubscriptionControlOutcome::Error,
                                 );
                             }
                         }

--- a/icn/crates/icn-core/src/supervisor/init_network.rs
+++ b/icn/crates/icn-core/src/supervisor/init_network.rs
@@ -100,7 +100,7 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                                 acked_topics.push(topic.clone());
                                 record_subscription_control_outcome(
                                     SubscriptionControlAction::Subscribe,
-                                    SubscriptionControlOutcome::Accepted,
+                                    SubscriptionControlOutcome::Processed,
                                 );
                             }
                             Err(e)
@@ -123,7 +123,7 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                                 );
                                 record_subscription_control_outcome(
                                     SubscriptionControlAction::Subscribe,
-                                    SubscriptionControlOutcome::Error,
+                                    SubscriptionControlOutcome::RejectedOrError,
                                 );
                             }
                         }
@@ -164,7 +164,7 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                                 info!("Unsubscribed {} from topic: {}", sender_did, topic);
                                 record_subscription_control_outcome(
                                     SubscriptionControlAction::Unsubscribe,
-                                    SubscriptionControlOutcome::Accepted,
+                                    SubscriptionControlOutcome::Processed,
                                 );
                             }
                             Err(e)
@@ -185,7 +185,7 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                                 );
                                 record_subscription_control_outcome(
                                     SubscriptionControlAction::Unsubscribe,
-                                    SubscriptionControlOutcome::Error,
+                                    SubscriptionControlOutcome::RejectedOrError,
                                 );
                             }
                         }

--- a/icn/crates/icn-core/tests/subscription_control_metrics.rs
+++ b/icn/crates/icn-core/tests/subscription_control_metrics.rs
@@ -1,0 +1,375 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Behaviour-level tests for the subscription-control outcome counter (issue #2482).
+//!
+//! These drive the **production** handler
+//! (`icn_core::supervisor::init_network::create_incoming_handler`) against a real
+//! `GossipActor` and assert on what the metrics recorder actually observed. Asserting
+//! only that the label enums map to the right strings would not catch a counter call
+//! deleted, duplicated, or wired into the wrong match arm — which is the whole point.
+//!
+//! ## Why a manually built current-thread runtime
+//!
+//! The handler dispatches onto `tokio::spawn`, and `metrics::with_local_recorder`
+//! installs a **thread-local** recorder. On a multi-thread runtime the spawned task runs
+//! on a worker thread that cannot see it, and every assertion would read zero. A
+//! current-thread runtime polls spawned tasks on the calling thread, inside the
+//! `with_local_recorder` closure, so the recorder is in scope when the counter fires.
+//!
+//! The recorder is local, not global, so these tests do not interfere with each other.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use icn_core::supervisor::init_network::{create_incoming_handler, MessageHandlerDeps};
+use icn_gossip::{AccessControl, GossipActor, Topic};
+use icn_identity::{Did, KeyPair};
+use icn_net::{IncomingMessageHandler, NetworkMessage};
+use metrics::with_local_recorder;
+use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+use tokio::sync::RwLock;
+
+const OUTCOME_METRIC: &str = "icn_gossip_subscription_control_outcome_total";
+const SPOOF_METRIC: &str = "icn_gossip_subscription_control_spoof_rejected_total";
+const SUBSCRIBES_RECEIVED: &str = "icn_gossip_subscribes_received_total";
+const UNSUBSCRIBES_RECEIVED: &str = "icn_gossip_unsubscribes_received_total";
+
+const TOPIC: &str = "coop:updates";
+/// Never created on the actor, so subscribing/unsubscribing to it fails for a
+/// non-spoof reason.
+const ABSENT_TOPIC: &str = "coop:does-not-exist";
+
+fn did() -> Did {
+    KeyPair::generate().expect("keypair").did().clone()
+}
+
+/// Sum a counter restricted to one `(action, outcome)` label pair.
+///
+/// Label-aware on purpose: summing across all label sets (as the icn-ledger helper does)
+/// would let a call recorded under the wrong labels still satisfy the assertion.
+fn outcome_count(snapshotter: &Snapshotter, action: &str, outcome: &str) -> u64 {
+    snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter_map(|(key, _, _, value)| {
+            let k = key.key();
+            if k.name() != OUTCOME_METRIC {
+                return None;
+            }
+            let mut got_action = None;
+            let mut got_outcome = None;
+            for label in k.labels() {
+                match label.key() {
+                    "action" => got_action = Some(label.value()),
+                    "outcome" => got_outcome = Some(label.value()),
+                    _ => {}
+                }
+            }
+            if got_action == Some(action) && got_outcome == Some(outcome) {
+                match value {
+                    DebugValue::Counter(v) => Some(v),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        })
+        .sum()
+}
+
+/// Total for an unlabelled counter, across every label set.
+fn plain_count(snapshotter: &Snapshotter, name: &str) -> u64 {
+    snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter_map(|(key, _, _, value)| {
+            if key.key().name() == name {
+                match value {
+                    DebugValue::Counter(v) => Some(v),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        })
+        .sum()
+}
+
+/// Every emitted series for the outcome metric, as `(action, outcome, value)`.
+///
+/// Used to assert that a scenario produced *nothing except* what was expected — a plain
+/// per-label assertion would pass even if a stray call landed under other labels.
+fn all_outcome_series(snapshotter: &Snapshotter) -> Vec<(String, String, u64)> {
+    let mut out: Vec<(String, String, u64)> = snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter_map(|(key, _, _, value)| {
+            let k = key.key();
+            if k.name() != OUTCOME_METRIC {
+                return None;
+            }
+            let mut a = String::new();
+            let mut o = String::new();
+            for label in k.labels() {
+                match label.key() {
+                    "action" => a = label.value().to_string(),
+                    "outcome" => o = label.value().to_string(),
+                    _ => {}
+                }
+            }
+            match value {
+                DebugValue::Counter(v) => Some((a, o, v)),
+                _ => None,
+            }
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+async fn harness(own: &Did) -> (Arc<RwLock<GossipActor>>, IncomingMessageHandler) {
+    let gossip = Arc::new(RwLock::new(GossipActor::new(own.clone(), None)));
+    gossip
+        .write()
+        .await
+        .create_topic(Topic::new(TOPIC.to_string(), AccessControl::Public));
+
+    let handler = create_incoming_handler(MessageHandlerDeps {
+        gossip_handle: gossip.clone(),
+        network_handle_holder: Arc::new(RwLock::new(None)),
+        own_did: own.clone(),
+        federation_enabled: false,
+    });
+
+    (gossip, handler)
+}
+
+/// Run `body` with a thread-local recorder installed and a current-thread runtime, then
+/// hand back the snapshotter.
+///
+/// `body` gets the handler and the actor. After it returns, the runtime is driven a
+/// little longer so the handler's spawned task reaches its counter call.
+fn with_recorder<F>(body: F) -> Snapshotter
+where
+    F: FnOnce(&Did, &Did, IncomingMessageHandler, Arc<RwLock<GossipActor>>),
+{
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    with_local_recorder(&recorder, || {
+        rt.block_on(async {
+            let own = did();
+            let peer = did();
+            let (gossip, handler) = harness(&own).await;
+            body(&own, &peer, handler, gossip);
+            // Let the spawned task run to completion. 200 * 5ms mirrors the settle()
+            // budget in gossip_subscription_control.rs.
+            for _ in 0..200 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        });
+    });
+
+    snapshotter
+}
+
+// ---------------------------------------------------------------------------
+// Subscribe: all three outcomes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accepted_subscribe_emits_exactly_one_processed() {
+    let snap = with_recorder(|own, peer, handler, _g| {
+        handler(NetworkMessage::subscribe(
+            peer.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+    });
+
+    assert_eq!(outcome_count(&snap, "subscribe", "processed"), 1);
+    assert_eq!(
+        all_outcome_series(&snap),
+        vec![("subscribe".into(), "processed".into(), 1)],
+        "a successful subscribe must emit exactly one series and nothing else"
+    );
+}
+
+#[test]
+fn forged_own_did_subscribe_emits_exactly_one_rejected_own_did() {
+    let snap = with_recorder(|own, _peer, handler, _g| {
+        // `from` claims the receiving node's own DID — the #2471 attack.
+        handler(NetworkMessage::subscribe(
+            own.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+    });
+
+    assert_eq!(outcome_count(&snap, "subscribe", "rejected_own_did"), 1);
+    assert_eq!(outcome_count(&snap, "subscribe", "processed"), 0);
+    // The #2474 security counter must still fire, independently of this one.
+    assert_eq!(
+        plain_count(&snap, SPOOF_METRIC),
+        1,
+        "the pre-existing spoof counter must remain intact and independent"
+    );
+}
+
+#[test]
+fn non_spoof_subscribe_failure_emits_exactly_one_rejected_or_error() {
+    let snap = with_recorder(|own, peer, handler, _g| {
+        // Topic was never created on this actor: a genuine, non-spoof refusal.
+        handler(NetworkMessage::subscribe(
+            peer.clone(),
+            own.clone(),
+            vec![ABSENT_TOPIC.to_string()],
+        ));
+    });
+
+    assert_eq!(outcome_count(&snap, "subscribe", "rejected_or_error"), 1);
+    assert_eq!(outcome_count(&snap, "subscribe", "rejected_own_did"), 0);
+    assert_eq!(
+        plain_count(&snap, SPOOF_METRIC),
+        0,
+        "a non-spoof failure must not touch the spoof counter"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unsubscribe: all three outcomes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accepted_unsubscribe_emits_exactly_one_processed() {
+    let snap = with_recorder(|own, peer, handler, _g| {
+        handler(NetworkMessage::subscribe(
+            peer.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+        handler(NetworkMessage::unsubscribe(
+            peer.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+    });
+
+    assert_eq!(outcome_count(&snap, "unsubscribe", "processed"), 1);
+    assert_eq!(outcome_count(&snap, "subscribe", "processed"), 1);
+}
+
+#[test]
+fn forged_own_did_unsubscribe_emits_exactly_one_rejected_own_did() {
+    let snap = with_recorder(|own, _peer, handler, _g| {
+        handler(NetworkMessage::unsubscribe(
+            own.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+    });
+
+    assert_eq!(outcome_count(&snap, "unsubscribe", "rejected_own_did"), 1);
+    assert_eq!(outcome_count(&snap, "unsubscribe", "processed"), 0);
+    assert_eq!(plain_count(&snap, SPOOF_METRIC), 1);
+}
+
+#[test]
+fn non_spoof_unsubscribe_failure_emits_exactly_one_rejected_or_error() {
+    let snap = with_recorder(|own, peer, handler, _g| {
+        // `unsubscribe` errors with "Topic not found" for a topic that was never created.
+        handler(NetworkMessage::unsubscribe(
+            peer.clone(),
+            own.clone(),
+            vec![ABSENT_TOPIC.to_string()],
+        ));
+    });
+
+    assert_eq!(outcome_count(&snap, "unsubscribe", "rejected_or_error"), 1);
+    assert_eq!(outcome_count(&snap, "unsubscribe", "rejected_own_did"), 0);
+    assert_eq!(plain_count(&snap, SPOOF_METRIC), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Per-topic accounting, isolation, and non-interference
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multi_topic_request_increments_once_per_topic() {
+    let snap = with_recorder(|own, peer, handler, _g| {
+        // Three topics in ONE message: one that exists, two that do not.
+        handler(NetworkMessage::subscribe(
+            peer.clone(),
+            own.clone(),
+            vec![
+                TOPIC.to_string(),
+                ABSENT_TOPIC.to_string(),
+                "coop:also-absent".to_string(),
+            ],
+        ));
+    });
+
+    assert_eq!(
+        outcome_count(&snap, "subscribe", "processed"),
+        1,
+        "one existing topic -> exactly one processed"
+    );
+    assert_eq!(
+        outcome_count(&snap, "subscribe", "rejected_or_error"),
+        2,
+        "two absent topics -> exactly two refusals; the counter is per-topic, not per-message"
+    );
+    assert_eq!(
+        plain_count(&snap, SUBSCRIBES_RECEIVED),
+        1,
+        "arrival is per-message and must NOT be inflated to per-topic by this change"
+    );
+}
+
+#[test]
+fn subscribe_ack_and_unrelated_payloads_do_not_touch_the_outcome_counter() {
+    let snap = with_recorder(|own, peer, handler, _g| {
+        handler(NetworkMessage::subscribe_ack(
+            peer.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+        handler(NetworkMessage::ping(peer.clone(), own.clone()));
+    });
+
+    assert!(
+        all_outcome_series(&snap).is_empty(),
+        "SubscribeAck and Ping must emit no subscription-control outcome series, got {:?}",
+        all_outcome_series(&snap)
+    );
+}
+
+#[test]
+fn arrival_counters_are_not_double_counted() {
+    let snap = with_recorder(|own, peer, handler, _g| {
+        handler(NetworkMessage::subscribe(
+            peer.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+        handler(NetworkMessage::unsubscribe(
+            peer.clone(),
+            own.clone(),
+            vec![TOPIC.to_string()],
+        ));
+    });
+
+    // Each arrival counter fires exactly once per received message, unchanged by #2482.
+    assert_eq!(plain_count(&snap, SUBSCRIBES_RECEIVED), 1);
+    assert_eq!(plain_count(&snap, UNSUBSCRIBES_RECEIVED), 1);
+    // And the new counter is additional, not a replacement.
+    assert_eq!(outcome_count(&snap, "subscribe", "processed"), 1);
+    assert_eq!(outcome_count(&snap, "unsubscribe", "processed"), 1);
+}

--- a/icn/crates/icn-core/tests/subscription_control_metrics.rs
+++ b/icn/crates/icn-core/tests/subscription_control_metrics.rs
@@ -4,8 +4,14 @@
 //! These drive the **production** handler
 //! (`icn_core::supervisor::init_network::create_incoming_handler`) against a real
 //! `GossipActor` and assert on what the metrics recorder actually observed. Asserting
-//! only that the label enums map to the right strings would not catch a counter call
-//! deleted, duplicated, or wired into the wrong match arm — which is the whole point.
+//! only that the enums map to the right label strings would not catch a counter call
+//! deleted, duplicated, or wired into the wrong match arm — which is the point.
+//!
+//! ## Exact-series assertions
+//!
+//! Every scenario asserts the **complete** set of emitted outcome series, not just that
+//! the expected one equals 1. A per-label assertion would pass even if a stray call
+//! landed under different labels; `assert_eq!` on the whole sorted vector cannot.
 //!
 //! ## Why a manually built current-thread runtime
 //!
@@ -15,7 +21,7 @@
 //! current-thread runtime polls spawned tasks on the calling thread, inside the
 //! `with_local_recorder` closure, so the recorder is in scope when the counter fires.
 //!
-//! The recorder is local, not global, so these tests do not interfere with each other.
+//! The recorder is local, not global, so tests do not interfere with each other.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -35,19 +41,23 @@ const UNSUBSCRIBES_RECEIVED: &str = "icn_gossip_unsubscribes_received_total";
 
 const TOPIC: &str = "coop:updates";
 /// Never created on the actor, so subscribing/unsubscribing to it fails for a
-/// non-spoof reason.
+/// non-spoof reason (`Topic not found`).
 const ABSENT_TOPIC: &str = "coop:does-not-exist";
+
+/// Bounded settle budget: the handler dispatches onto `tokio::spawn`, so the counter
+/// fires after the call returns. 200 * 5ms mirrors the `settle()` budget already used by
+/// `gossip_subscription_control.rs`, but unlike that helper this one exits as soon as the
+/// expected number of events is observed rather than always sleeping the full budget.
+const SETTLE_TICKS: u32 = 200;
+const SETTLE_TICK: Duration = Duration::from_millis(5);
 
 fn did() -> Did {
     KeyPair::generate().expect("keypair").did().clone()
 }
 
-/// Sum a counter restricted to one `(action, outcome)` label pair.
-///
-/// Label-aware on purpose: summing across all label sets (as the icn-ledger helper does)
-/// would let a call recorded under the wrong labels still satisfy the assertion.
-fn outcome_count(snapshotter: &Snapshotter, action: &str, outcome: &str) -> u64 {
-    snapshotter
+/// Every emitted series for the outcome metric, as sorted `(action, outcome, value)`.
+fn outcome_series(snapshotter: &Snapshotter) -> Vec<(String, String, u64)> {
+    let mut out: Vec<(String, String, u64)> = snapshotter
         .snapshot()
         .into_vec()
         .into_iter()
@@ -56,25 +66,28 @@ fn outcome_count(snapshotter: &Snapshotter, action: &str, outcome: &str) -> u64 
             if k.name() != OUTCOME_METRIC {
                 return None;
             }
-            let mut got_action = None;
-            let mut got_outcome = None;
+            let mut action = String::new();
+            let mut outcome = String::new();
             for label in k.labels() {
                 match label.key() {
-                    "action" => got_action = Some(label.value()),
-                    "outcome" => got_outcome = Some(label.value()),
+                    "action" => action = label.value().to_string(),
+                    "outcome" => outcome = label.value().to_string(),
                     _ => {}
                 }
             }
-            if got_action == Some(action) && got_outcome == Some(outcome) {
-                match value {
-                    DebugValue::Counter(v) => Some(v),
-                    _ => None,
-                }
-            } else {
-                None
+            match value {
+                DebugValue::Counter(v) => Some((action, outcome, v)),
+                _ => None,
             }
         })
-        .sum()
+        .collect();
+    out.sort();
+    out
+}
+
+/// Total outcome increments observed, across every label set.
+fn outcome_event_total(snapshotter: &Snapshotter) -> u64 {
+    outcome_series(snapshotter).iter().map(|(_, _, v)| v).sum()
 }
 
 /// Total for an unlabelled counter, across every label set.
@@ -96,37 +109,14 @@ fn plain_count(snapshotter: &Snapshotter, name: &str) -> u64 {
         .sum()
 }
 
-/// Every emitted series for the outcome metric, as `(action, outcome, value)`.
-///
-/// Used to assert that a scenario produced *nothing except* what was expected — a plain
-/// per-label assertion would pass even if a stray call landed under other labels.
-fn all_outcome_series(snapshotter: &Snapshotter) -> Vec<(String, String, u64)> {
-    let mut out: Vec<(String, String, u64)> = snapshotter
-        .snapshot()
-        .into_vec()
-        .into_iter()
-        .filter_map(|(key, _, _, value)| {
-            let k = key.key();
-            if k.name() != OUTCOME_METRIC {
-                return None;
-            }
-            let mut a = String::new();
-            let mut o = String::new();
-            for label in k.labels() {
-                match label.key() {
-                    "action" => a = label.value().to_string(),
-                    "outcome" => o = label.value().to_string(),
-                    _ => {}
-                }
-            }
-            match value {
-                DebugValue::Counter(v) => Some((a, o, v)),
-                _ => None,
-            }
-        })
+/// Convenience for building the expected exact-series vector.
+fn series(items: &[(&str, &str, u64)]) -> Vec<(String, String, u64)> {
+    let mut v: Vec<(String, String, u64)> = items
+        .iter()
+        .map(|(a, o, n)| (a.to_string(), o.to_string(), *n))
         .collect();
-    out.sort();
-    out
+    v.sort();
+    v
 }
 
 async fn harness(own: &Did) -> (Arc<RwLock<GossipActor>>, IncomingMessageHandler) {
@@ -146,15 +136,22 @@ async fn harness(own: &Did) -> (Arc<RwLock<GossipActor>>, IncomingMessageHandler
     (gossip, handler)
 }
 
-/// Run `body` with a thread-local recorder installed and a current-thread runtime, then
-/// hand back the snapshotter.
+/// Run `act` under a thread-local recorder on a current-thread runtime, waiting until
+/// `expected_events` outcome increments have been observed.
 ///
-/// `body` gets the handler and the actor. After it returns, the runtime is driven a
-/// little longer so the handler's spawned task reaches its counter call.
-fn with_recorder<F>(body: F) -> Snapshotter
-where
-    F: FnOnce(&Did, &Did, IncomingMessageHandler, Arc<RwLock<GossipActor>>),
-{
+/// `seed_subscribed` subscribes `peer` to `TOPIC` through the **actor API** rather than
+/// the network handler. That path records no outcome (the counter lives only in the
+/// supervisor handler), so a test needing pre-existing subscription state still observes
+/// exactly one series — its own. That is why unsubscribe tests do not have to assert a
+/// two-series vector containing an unrelated setup subscribe.
+///
+/// When `expected_events` is 0 the full budget is waited out, because "nothing happened"
+/// cannot be detected early.
+fn run_observed(
+    seed_subscribed: bool,
+    expected_events: u64,
+    act: impl FnOnce(&Did, &Did, &IncomingMessageHandler),
+) -> Snapshotter {
     let recorder = DebuggingRecorder::new();
     let snapshotter = recorder.snapshotter();
 
@@ -168,11 +165,35 @@ where
             let own = did();
             let peer = did();
             let (gossip, handler) = harness(&own).await;
-            body(&own, &peer, handler, gossip);
-            // Let the spawned task run to completion. 200 * 5ms mirrors the settle()
-            // budget in gossip_subscription_control.rs.
-            for _ in 0..200 {
-                tokio::time::sleep(Duration::from_millis(5)).await;
+
+            if seed_subscribed {
+                gossip
+                    .write()
+                    .await
+                    .subscribe(TOPIC, peer.clone())
+                    .await
+                    .expect("seed subscribe");
+                assert_eq!(
+                    outcome_event_total(&snapshotter),
+                    0,
+                    "seeding via the actor API must not emit an outcome series"
+                );
+            }
+
+            act(&own, &peer, &handler);
+
+            for _ in 0..SETTLE_TICKS {
+                if expected_events > 0 && outcome_event_total(&snapshotter) >= expected_events {
+                    return;
+                }
+                tokio::time::sleep(SETTLE_TICK).await;
+            }
+
+            if expected_events > 0 {
+                panic!(
+                    "timed out waiting for {expected_events} outcome event(s); observed {:?}",
+                    outcome_series(&snapshotter)
+                );
             }
         });
     });
@@ -181,12 +202,12 @@ where
 }
 
 // ---------------------------------------------------------------------------
-// Subscribe: all three outcomes
+// Subscribe: all three outcomes, each asserted as the COMPLETE emitted set
 // ---------------------------------------------------------------------------
 
 #[test]
-fn accepted_subscribe_emits_exactly_one_processed() {
-    let snap = with_recorder(|own, peer, handler, _g| {
+fn subscribe_success_emits_only_one_processed_series() {
+    let snap = run_observed(false, 1, |own, peer, handler| {
         handler(NetworkMessage::subscribe(
             peer.clone(),
             own.clone(),
@@ -194,17 +215,16 @@ fn accepted_subscribe_emits_exactly_one_processed() {
         ));
     });
 
-    assert_eq!(outcome_count(&snap, "subscribe", "processed"), 1);
     assert_eq!(
-        all_outcome_series(&snap),
-        vec![("subscribe".into(), "processed".into(), 1)],
-        "a successful subscribe must emit exactly one series and nothing else"
+        outcome_series(&snap),
+        series(&[("subscribe", "processed", 1)])
     );
+    assert_eq!(plain_count(&snap, SPOOF_METRIC), 0);
 }
 
 #[test]
-fn forged_own_did_subscribe_emits_exactly_one_rejected_own_did() {
-    let snap = with_recorder(|own, _peer, handler, _g| {
+fn subscribe_forged_own_did_emits_only_one_rejected_own_did_series() {
+    let snap = run_observed(false, 1, |own, _peer, handler| {
         // `from` claims the receiving node's own DID — the #2471 attack.
         handler(NetworkMessage::subscribe(
             own.clone(),
@@ -213,8 +233,10 @@ fn forged_own_did_subscribe_emits_exactly_one_rejected_own_did() {
         ));
     });
 
-    assert_eq!(outcome_count(&snap, "subscribe", "rejected_own_did"), 1);
-    assert_eq!(outcome_count(&snap, "subscribe", "processed"), 0);
+    assert_eq!(
+        outcome_series(&snap),
+        series(&[("subscribe", "rejected_own_did", 1)])
+    );
     // The #2474 security counter must still fire, independently of this one.
     assert_eq!(
         plain_count(&snap, SPOOF_METRIC),
@@ -224,9 +246,8 @@ fn forged_own_did_subscribe_emits_exactly_one_rejected_own_did() {
 }
 
 #[test]
-fn non_spoof_subscribe_failure_emits_exactly_one_rejected_or_error() {
-    let snap = with_recorder(|own, peer, handler, _g| {
-        // Topic was never created on this actor: a genuine, non-spoof refusal.
+fn subscribe_non_spoof_failure_emits_only_one_rejected_or_error_series() {
+    let snap = run_observed(false, 1, |own, peer, handler| {
         handler(NetworkMessage::subscribe(
             peer.clone(),
             own.clone(),
@@ -234,8 +255,10 @@ fn non_spoof_subscribe_failure_emits_exactly_one_rejected_or_error() {
         ));
     });
 
-    assert_eq!(outcome_count(&snap, "subscribe", "rejected_or_error"), 1);
-    assert_eq!(outcome_count(&snap, "subscribe", "rejected_own_did"), 0);
+    assert_eq!(
+        outcome_series(&snap),
+        series(&[("subscribe", "rejected_or_error", 1)])
+    );
     assert_eq!(
         plain_count(&snap, SPOOF_METRIC),
         0,
@@ -244,17 +267,13 @@ fn non_spoof_subscribe_failure_emits_exactly_one_rejected_or_error() {
 }
 
 // ---------------------------------------------------------------------------
-// Unsubscribe: all three outcomes
+// Unsubscribe: all three outcomes, each asserted as the COMPLETE emitted set
 // ---------------------------------------------------------------------------
 
 #[test]
-fn accepted_unsubscribe_emits_exactly_one_processed() {
-    let snap = with_recorder(|own, peer, handler, _g| {
-        handler(NetworkMessage::subscribe(
-            peer.clone(),
-            own.clone(),
-            vec![TOPIC.to_string()],
-        ));
+fn unsubscribe_success_emits_only_one_processed_series() {
+    // Seeded through the actor API, so the recorder observes only the unsubscribe.
+    let snap = run_observed(true, 1, |own, peer, handler| {
         handler(NetworkMessage::unsubscribe(
             peer.clone(),
             own.clone(),
@@ -262,13 +281,16 @@ fn accepted_unsubscribe_emits_exactly_one_processed() {
         ));
     });
 
-    assert_eq!(outcome_count(&snap, "unsubscribe", "processed"), 1);
-    assert_eq!(outcome_count(&snap, "subscribe", "processed"), 1);
+    assert_eq!(
+        outcome_series(&snap),
+        series(&[("unsubscribe", "processed", 1)])
+    );
+    assert_eq!(plain_count(&snap, SPOOF_METRIC), 0);
 }
 
 #[test]
-fn forged_own_did_unsubscribe_emits_exactly_one_rejected_own_did() {
-    let snap = with_recorder(|own, _peer, handler, _g| {
+fn unsubscribe_forged_own_did_emits_only_one_rejected_own_did_series() {
+    let snap = run_observed(false, 1, |own, _peer, handler| {
         handler(NetworkMessage::unsubscribe(
             own.clone(),
             own.clone(),
@@ -276,15 +298,17 @@ fn forged_own_did_unsubscribe_emits_exactly_one_rejected_own_did() {
         ));
     });
 
-    assert_eq!(outcome_count(&snap, "unsubscribe", "rejected_own_did"), 1);
-    assert_eq!(outcome_count(&snap, "unsubscribe", "processed"), 0);
+    assert_eq!(
+        outcome_series(&snap),
+        series(&[("unsubscribe", "rejected_own_did", 1)])
+    );
     assert_eq!(plain_count(&snap, SPOOF_METRIC), 1);
 }
 
 #[test]
-fn non_spoof_unsubscribe_failure_emits_exactly_one_rejected_or_error() {
-    let snap = with_recorder(|own, peer, handler, _g| {
-        // `unsubscribe` errors with "Topic not found" for a topic that was never created.
+fn unsubscribe_non_spoof_failure_emits_only_one_rejected_or_error_series() {
+    let snap = run_observed(false, 1, |own, peer, handler| {
+        // `unsubscribe` errors with "Topic not found" for a topic never created.
         handler(NetworkMessage::unsubscribe(
             peer.clone(),
             own.clone(),
@@ -292,8 +316,10 @@ fn non_spoof_unsubscribe_failure_emits_exactly_one_rejected_or_error() {
         ));
     });
 
-    assert_eq!(outcome_count(&snap, "unsubscribe", "rejected_or_error"), 1);
-    assert_eq!(outcome_count(&snap, "unsubscribe", "rejected_own_did"), 0);
+    assert_eq!(
+        outcome_series(&snap),
+        series(&[("unsubscribe", "rejected_or_error", 1)])
+    );
     assert_eq!(plain_count(&snap, SPOOF_METRIC), 0);
 }
 
@@ -303,7 +329,7 @@ fn non_spoof_unsubscribe_failure_emits_exactly_one_rejected_or_error() {
 
 #[test]
 fn multi_topic_request_increments_once_per_topic() {
-    let snap = with_recorder(|own, peer, handler, _g| {
+    let snap = run_observed(false, 3, |own, peer, handler| {
         // Three topics in ONE message: one that exists, two that do not.
         handler(NetworkMessage::subscribe(
             peer.clone(),
@@ -317,14 +343,12 @@ fn multi_topic_request_increments_once_per_topic() {
     });
 
     assert_eq!(
-        outcome_count(&snap, "subscribe", "processed"),
-        1,
-        "one existing topic -> exactly one processed"
-    );
-    assert_eq!(
-        outcome_count(&snap, "subscribe", "rejected_or_error"),
-        2,
-        "two absent topics -> exactly two refusals; the counter is per-topic, not per-message"
+        outcome_series(&snap),
+        series(&[
+            ("subscribe", "processed", 1),
+            ("subscribe", "rejected_or_error", 2),
+        ]),
+        "the outcome counter is per-topic, not per-message"
     );
     assert_eq!(
         plain_count(&snap, SUBSCRIBES_RECEIVED),
@@ -334,8 +358,8 @@ fn multi_topic_request_increments_once_per_topic() {
 }
 
 #[test]
-fn subscribe_ack_and_unrelated_payloads_do_not_touch_the_outcome_counter() {
-    let snap = with_recorder(|own, peer, handler, _g| {
+fn subscribe_ack_and_unrelated_payloads_emit_no_outcome_series() {
+    let snap = run_observed(false, 0, |own, peer, handler| {
         handler(NetworkMessage::subscribe_ack(
             peer.clone(),
             own.clone(),
@@ -344,16 +368,16 @@ fn subscribe_ack_and_unrelated_payloads_do_not_touch_the_outcome_counter() {
         handler(NetworkMessage::ping(peer.clone(), own.clone()));
     });
 
-    assert!(
-        all_outcome_series(&snap).is_empty(),
-        "SubscribeAck and Ping must emit no subscription-control outcome series, got {:?}",
-        all_outcome_series(&snap)
+    assert_eq!(
+        outcome_series(&snap),
+        Vec::new(),
+        "SubscribeAck and Ping must emit no subscription-control outcome series"
     );
 }
 
 #[test]
 fn arrival_counters_are_not_double_counted() {
-    let snap = with_recorder(|own, peer, handler, _g| {
+    let snap = run_observed(false, 2, |own, peer, handler| {
         handler(NetworkMessage::subscribe(
             peer.clone(),
             own.clone(),
@@ -366,10 +390,15 @@ fn arrival_counters_are_not_double_counted() {
         ));
     });
 
+    // Exactly the two expected series and nothing else.
+    assert_eq!(
+        outcome_series(&snap),
+        series(&[
+            ("subscribe", "processed", 1),
+            ("unsubscribe", "processed", 1),
+        ])
+    );
     // Each arrival counter fires exactly once per received message, unchanged by #2482.
     assert_eq!(plain_count(&snap, SUBSCRIBES_RECEIVED), 1);
     assert_eq!(plain_count(&snap, UNSUBSCRIBES_RECEIVED), 1);
-    // And the new counter is additional, not a replacement.
-    assert_eq!(outcome_count(&snap, "subscribe", "processed"), 1);
-    assert_eq!(outcome_count(&snap, "unsubscribe", "processed"), 1);
 }

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2135,6 +2135,79 @@ pub mod gossip {
         counter!("icn_gossip_subscription_control_spoof_rejected_total").increment(1);
     }
 
+    /// Which subscription-control verb a network request carried (#2482).
+    ///
+    /// A closed enum, not a string: the label set is fixed at compile time so no
+    /// caller-controlled value can ever reach the metric.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum SubscriptionControlAction {
+        /// A received `Subscribe` request.
+        Subscribe,
+        /// A received `Unsubscribe` request.
+        Unsubscribe,
+    }
+
+    impl SubscriptionControlAction {
+        /// Fixed label value for this action.
+        pub fn as_label(self) -> &'static str {
+            match self {
+                Self::Subscribe => "subscribe",
+                Self::Unsubscribe => "unsubscribe",
+            }
+        }
+    }
+
+    /// How this node resolved one topic of a network subscription-control request (#2482).
+    ///
+    /// Closed for the same reason as [`SubscriptionControlAction`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum SubscriptionControlOutcome {
+        /// The request was applied for that topic.
+        Accepted,
+        /// Refused because it claimed this node's own DID (#2471 guard).
+        RejectedOwnDid,
+        /// Any other failure — ACL denial, unknown topic, capacity, storage.
+        Error,
+    }
+
+    impl SubscriptionControlOutcome {
+        /// Fixed label value for this outcome.
+        pub fn as_label(self) -> &'static str {
+            match self {
+                Self::Accepted => "accepted",
+                Self::RejectedOwnDid => "rejected_own_did",
+                Self::Error => "error",
+            }
+        }
+    }
+
+    /// Record how one topic of a network subscription-control request resolved (#2482).
+    ///
+    /// **Observe-only.** Calling this never changes an authorization, subscription,
+    /// delivery, or persistence outcome; it is called after the decision is made.
+    ///
+    /// `icn_gossip_subscribes_received_total` / `icn_gossip_unsubscribes_received_total`
+    /// already count *arrival*. This counts *resolution*, which is what distinguishes a
+    /// peer being served from a peer whose every request is refused — the evidence #2480
+    /// needs before unsigned subscription control can be rejected.
+    ///
+    /// # Privacy budget
+    ///
+    /// Both labels are `&'static str` drawn from closed enums. No DID, topic name, peer
+    /// address, payload, or error string is ever recorded. Maximum cardinality is
+    /// 2 actions x 3 outcomes = 6 series.
+    pub fn subscription_control_outcome_inc(
+        action: SubscriptionControlAction,
+        outcome: SubscriptionControlOutcome,
+    ) {
+        counter!(
+            "icn_gossip_subscription_control_outcome_total",
+            "action" => action.as_label(),
+            "outcome" => outcome.as_label()
+        )
+        .increment(1);
+    }
+
     pub fn digests_sent_inc() {
         counter!("icn_gossip_digests_sent_total").increment(1);
     }
@@ -2272,6 +2345,73 @@ pub mod gossip {
     /// Issue #181: Record gossip message processing latency
     pub fn message_latency_record(latency_secs: f64) {
         histogram!("icn_gossip_message_latency_seconds").record(latency_secs);
+    }
+
+    // Must remain the LAST item in this module: `clippy::items_after_test_module`
+    // rejects a `#[cfg(test)]` module with siblings declared after it.
+    #[cfg(test)]
+    mod subscription_control_label_tests {
+        use super::{SubscriptionControlAction, SubscriptionControlOutcome};
+
+        /// The label strings are wire-visible in Prometheus, so pin them: renaming one
+        /// silently breaks every dashboard and alert built on it.
+        #[test]
+        fn labels_are_stable() {
+            assert_eq!(SubscriptionControlAction::Subscribe.as_label(), "subscribe");
+            assert_eq!(
+                SubscriptionControlAction::Unsubscribe.as_label(),
+                "unsubscribe"
+            );
+            assert_eq!(SubscriptionControlOutcome::Accepted.as_label(), "accepted");
+            assert_eq!(
+                SubscriptionControlOutcome::RejectedOwnDid.as_label(),
+                "rejected_own_did"
+            );
+            assert_eq!(SubscriptionControlOutcome::Error.as_label(), "error");
+        }
+
+        /// Cardinality is bounded by construction: 2 actions x 3 outcomes = 6 series.
+        /// If a variant is added, this fails and forces a deliberate budget decision.
+        #[test]
+        fn cardinality_is_bounded_and_labels_distinct() {
+            let actions = [
+                SubscriptionControlAction::Subscribe,
+                SubscriptionControlAction::Unsubscribe,
+            ];
+            let outcomes = [
+                SubscriptionControlOutcome::Accepted,
+                SubscriptionControlOutcome::RejectedOwnDid,
+                SubscriptionControlOutcome::Error,
+            ];
+
+            let series: std::collections::HashSet<(&str, &str)> = actions
+                .iter()
+                .flat_map(|a| outcomes.iter().map(move |o| (a.as_label(), o.as_label())))
+                .collect();
+
+            assert_eq!(series.len(), 6, "expected exactly 6 label combinations");
+        }
+
+        /// Privacy budget: no label may carry a DID, topic name, or address. Every value
+        /// is a `&'static str` from a closed enum, so this holds by construction — assert
+        /// it anyway so the intent survives refactoring.
+        #[test]
+        fn labels_carry_no_caller_controlled_data() {
+            for label in [
+                SubscriptionControlAction::Subscribe.as_label(),
+                SubscriptionControlAction::Unsubscribe.as_label(),
+                SubscriptionControlOutcome::Accepted.as_label(),
+                SubscriptionControlOutcome::RejectedOwnDid.as_label(),
+                SubscriptionControlOutcome::Error.as_label(),
+            ] {
+                assert!(!label.contains("did:"), "label leaked a DID: {label}");
+                assert!(!label.contains(':'), "label looks structured: {label}");
+                assert!(
+                    label.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                    "label is not a closed snake_case token: {label}"
+                );
+            }
+        }
     }
 }
 

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2159,24 +2159,42 @@ pub mod gossip {
 
     /// How this node resolved one topic of a network subscription-control request (#2482).
     ///
-    /// Closed for the same reason as [`SubscriptionControlAction`].
+    /// Closed for the same reason as [`SubscriptionControlAction`]. The vocabulary is
+    /// deliberately conservative: these strings become a public operational surface the
+    /// moment they are scraped, so each one claims only what the code actually guarantees.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum SubscriptionControlOutcome {
-        /// The request was applied for that topic.
-        Accepted,
-        /// Refused because it claimed this node's own DID (#2471 guard).
+        /// The handler returned success for that topic.
+        ///
+        /// **Success does not imply the subscriber set changed**, which is why this is
+        /// `processed` and not `accepted`. `GossipActor::subscribe` skips the insert when
+        /// the DID is already subscribed, and `GossipActor::unsubscribe` returns `Ok(())`
+        /// having removed nothing when the DID was not subscribed. Both are counted here.
+        Processed,
+        /// Refused because the request claimed this node's own DID (the #2471 guard).
+        ///
+        /// The only non-success distinguished by a *type* rather than by message text:
+        /// it is matched via `GossipActor::is_subscription_control_spoof`.
         RejectedOwnDid,
-        /// Any other failure — ACL denial, unknown topic, capacity, storage.
-        Error,
+        /// Every other non-success — expected policy denials and operational failures alike.
+        ///
+        /// Covers topic-ACL denial, unknown topic, and per-topic capacity refusal as well
+        /// as genuine faults. These are deliberately **not** split: the denial paths in
+        /// `GossipActor::subscribe` use `anyhow::bail!` with format strings rather than
+        /// typed `GossipError` variants, so separating "policy said no" from "something
+        /// broke" would require matching on error text — brittle, and it would silently
+        /// reclassify on any rewording. If those paths are ever given typed variants, this
+        /// can be split then, with the cardinality cost paid deliberately.
+        RejectedOrError,
     }
 
     impl SubscriptionControlOutcome {
         /// Fixed label value for this outcome.
         pub fn as_label(self) -> &'static str {
             match self {
-                Self::Accepted => "accepted",
+                Self::Processed => "processed",
                 Self::RejectedOwnDid => "rejected_own_did",
-                Self::Error => "error",
+                Self::RejectedOrError => "rejected_or_error",
             }
         }
     }
@@ -2362,12 +2380,18 @@ pub mod gossip {
                 SubscriptionControlAction::Unsubscribe.as_label(),
                 "unsubscribe"
             );
-            assert_eq!(SubscriptionControlOutcome::Accepted.as_label(), "accepted");
+            assert_eq!(
+                SubscriptionControlOutcome::Processed.as_label(),
+                "processed"
+            );
             assert_eq!(
                 SubscriptionControlOutcome::RejectedOwnDid.as_label(),
                 "rejected_own_did"
             );
-            assert_eq!(SubscriptionControlOutcome::Error.as_label(), "error");
+            assert_eq!(
+                SubscriptionControlOutcome::RejectedOrError.as_label(),
+                "rejected_or_error"
+            );
         }
 
         /// Cardinality is bounded by construction: 2 actions x 3 outcomes = 6 series.
@@ -2379,9 +2403,9 @@ pub mod gossip {
                 SubscriptionControlAction::Unsubscribe,
             ];
             let outcomes = [
-                SubscriptionControlOutcome::Accepted,
+                SubscriptionControlOutcome::Processed,
                 SubscriptionControlOutcome::RejectedOwnDid,
-                SubscriptionControlOutcome::Error,
+                SubscriptionControlOutcome::RejectedOrError,
             ];
 
             let series: std::collections::HashSet<(&str, &str)> = actions
@@ -2400,9 +2424,9 @@ pub mod gossip {
             for label in [
                 SubscriptionControlAction::Subscribe.as_label(),
                 SubscriptionControlAction::Unsubscribe.as_label(),
-                SubscriptionControlOutcome::Accepted.as_label(),
+                SubscriptionControlOutcome::Processed.as_label(),
                 SubscriptionControlOutcome::RejectedOwnDid.as_label(),
-                SubscriptionControlOutcome::Error.as_label(),
+                SubscriptionControlOutcome::RejectedOrError.as_label(),
             ] {
                 assert!(!label.contains("did:"), "label leaked a DID: {label}");
                 assert!(!label.contains(':'), "label looks structured: {label}");


### PR DESCRIPTION
## Summary

Adds `icn_gossip_subscription_control_outcome_total{action,outcome}`, recorded from the two subscription-control ingress arms in the supervisor. Closes #2482.

**Observe-only.** No enforcement, no wire change, no authorization change. The metric authenticates nothing — it exists to answer whether anything actually exercises this path, which is the evidence gate #2480 needs.

## Why this is narrower than #2480's costing suggested

#2480 recommended an observe-only counter distinguishing **signed vs unsigned** ingress. Checking the tree first, most of that already existed, so this PR deliberately builds less:

| Already instrumented | Where |
|---|---|
| `icn_gossip_subscribes_received_total` | `init_network.rs` |
| `icn_gossip_unsubscribes_received_total` | `init_network.rs` |
| `icn_gossip_subscription_control_spoof_rejected_total` | `reject_own_did_claim` (#2471) |

Arrival volume was **already** answerable with no code change. A `signed`/`unsigned` label would also be a **constant** — subscription control cannot arrive signed today (the supervisor's `MessagePayload::Signed` arm matches only `PayloadType::Gossip` before `_ =>`, and `PayloadType` has no subscription variant). That dimension belongs with the signed path, not ahead of it.

**The genuine gap was outcome.** Nothing distinguished *served* from *refused*; only the own-DID spoof case had a counter.

## Metric taxonomy — derived from the code, not from intent

These strings become a public operational surface once scraped, so each claims only what the code guarantees.

| Label | Meaning |
|---|---|
| `action` | `subscribe` \| `unsubscribe` |
| **`processed`** | The handler returned success for that topic. **Does not imply the subscriber set changed** — `GossipActor::unsubscribe` returns `Ok(())` having removed nothing when the DID was not subscribed, and `subscribe` guards its insert with `if !subscribers.contains(..)` and still returns `Ok`. Hence `processed`, not `accepted`. |
| **`rejected_own_did`** | The typed #2471/#2474 own-DID spoof guard refused it — the only non-success distinguished by a **type** (`is_subscription_control_spoof`) rather than message text. |
| **`rejected_or_error`** | Any other non-success: expected ACL denial, unknown topic, per-topic capacity, and genuine faults. **Deliberately not split** — those paths use `anyhow::bail!` with format strings rather than the typed `GossipError` variants beside them, so separating "policy said no" from "something broke" would require matching on error text. `error` would also have implied malfunction where the common case is policy working correctly. |

Cardinality: **6 series**, bounded by construction. Labels are `&'static str` from closed enums, so no caller-controlled value can reach the metric — enforced by the compiler, not convention. No DID, topic name, address, payload, or error string is ever recorded.

If those `bail!` sites ever gain typed variants, the split becomes cheap and the cardinality can be paid deliberately. That reasoning is recorded in the enum doc comment.

## Changes — 6 files, +640 / −2

| File | Role |
|---|---|
| `icn-obs/src/metrics_legacy.rs` (+164) | `SubscriptionControlAction`, `SubscriptionControlOutcome`, `subscription_control_outcome_inc`, plus label-pinning / cardinality / privacy unit tests |
| `icn-core/src/supervisor/init_network.rs` (+39, **−0**) | Six call sites (one per match arm) via a single `record_subscription_control_outcome` choke point |
| `icn-core/tests/subscription_control_metrics.rs` (+404, new) | Behaviour-level handler tests |
| `icn-core/Cargo.toml` (+3) | **`metrics-util` in `[dev-dependencies]` only** — the recorder already used by `icn-ledger`. No runtime dependency added. |
| `icn/Cargo.lock` (+1) | Corresponding lock entry |
| `docs/reference/api/topic-subscriptions-api.md` (+29/−2) | Operator reference entry for this counter and the #2474 spoof counter; corrected query example (review round, below) |

## Behaviour-level acceptance tests

Label/enum tests cannot show a call is present, unique, and in the right arm. These drive the **production** `create_incoming_handler` against a real `GossipActor` and assert on an installed recorder (`metrics::with_local_recorder` + `metrics_util::debugging`, the pattern already in `icn-ledger/src/settlement.rs`) — 9 tests:

| Test | Asserts |
|---|---|
| `subscribe_success_emits_only_one_processed_series` | complete set == `[(subscribe, processed, 1)]` |
| `subscribe_forged_own_did_emits_only_one_rejected_own_did_series` | complete set == `[(subscribe, rejected_own_did, 1)]`; spoof counter == 1 |
| `subscribe_non_spoof_failure_emits_only_one_rejected_or_error_series` | complete set == `[(subscribe, rejected_or_error, 1)]`; spoof counter == 0 |
| `unsubscribe_success_emits_only_one_processed_series` | complete set == `[(unsubscribe, processed, 1)]` |
| `unsubscribe_forged_own_did_emits_only_one_rejected_own_did_series` | complete set == `[(unsubscribe, rejected_own_did, 1)]`; spoof counter == 1 |
| `unsubscribe_non_spoof_failure_emits_only_one_rejected_or_error_series` | complete set == `[(unsubscribe, rejected_or_error, 1)]`; spoof counter == 0 |
| `multi_topic_request_increments_once_per_topic` | 3 topics in one message → complete set == `[(subscribe, processed, 1), (subscribe, rejected_or_error, 2)]`, arrival still 1 |
| `subscribe_ack_and_unrelated_payloads_emit_no_outcome_series` | complete set is **empty** |
| `arrival_counters_are_not_double_counted` | complete set == the two expected series; both arrival counters == 1 |

Every scenario asserts the **complete sorted set** of emitted outcome series, not merely that the expected one equals 1 — a per-label assertion would pass even if a stray call landed under different labels.

Unsubscribe tests seed subscription state through the **actor API**, which records no outcome (the counter lives only in the supervisor handler), so the recorder observes exactly one series — the unsubscribe under test. The seed asserts zero outcome events before acting, so that assumption is checked rather than trusted.

**Implementation note:** the handler dispatches onto `tokio::spawn`, and `with_local_recorder` installs a **thread-local** recorder. On a multi-thread runtime the spawned task runs where the recorder is invisible and every assertion reads zero. The tests build a **current-thread** runtime explicitly. Settling is a bounded predicate on the recorder (200 × 5 ms ceiling, early exit, panics with the observed series on timeout so a timeout can never read as a pass).

### Negative controls (run with real exit codes, then reverted)

| Mutation | `cargo test` exit | Result |
|---|---|---|
| Counter call **removed** from the subscribe `Ok` arm | **101** | 3 failed |
| Counter call **duplicated** | **101** | 3 failed |
| Counter call in the **wrong arm** (unsubscribe spoof arm recording `processed`) | **101** | 1 failed |

Exit status captured before any filtering. The wrong-arm case failing exactly one test is the exact-series assertion doing its job. All mutations reverted; the production file is byte-identical to its committed state and the branch carries none of them.

## Risk

Minimal. The production diff adds an import, one helper, and six counter calls placed **after** each accept/reject decision — **zero deletions, no condition changed**. The #2474 own-DID guard is untouched and its 9-test suite passes **unmodified**.

## Test plan

Exit codes captured directly, no pipelines:

```
bash scripts/check-meaning-firewall.sh                        exit=0
git diff --check                                              exit=0
cargo fmt --all --check                                       exit=0
cargo check --workspace --all-targets                         exit=0
cargo clippy -p icn-obs  --all-targets -- -D warnings         exit=0
cargo clippy -p icn-core --all-targets -- -D warnings         exit=0
cargo test -p icn-obs                                         exit=0   64 passed
cargo test -p icn-core --test subscription_control_metrics    exit=0    9 passed
cargo test -p icn-core --test gossip_subscription_control     exit=0    9 passed (unmodified)
cargo test -p icn-core --lib                                  exit=0  420 passed
```

Zero failures across all suites.

## Known-red non-required checks — not addressed here, deliberately

- **`Security Audit`** — fails on **`origin/main` itself**. `cargo audit` at `c015310a` exits 1 with `RUSTSEC-2026-0222` (wasmtime 36.0.8, severity 3.8 low). Pre-existing, unrelated to this diff, and **not** a branch-protection required check. Tracked and fixed separately in **#2484**. Deliberately not bundled here.
- **`Compare Against Base`** — benchmark noise spanning unrelated serialization, ledger, hashing, and message-size benchmarks. This diff adds counter calls reached only during subscription-control handling; it cannot alter compile-time message sizes or unrelated ledger/task serialization. No `perf-regression-ok` label, no no-op commit, no production change to quiet it.

## Invariants

- [x] No panics introduced in protocol paths — additive counter calls only
- [x] Determinism preserved — metrics feed no decision
- [x] Canonical encodings unchanged — no wire change
- [x] Trust gates not weakened — #2474 guard untouched, suite passes unmodified
- [x] Kernel/app boundaries respected — `check-meaning-firewall.sh` exit 0

## Documentation

- [x] N/A — no API, schema, or OpenAPI surface change. Metric and label semantics are documented in doc comments on the enums.

## Review note

Automated review has **not** run on this PR — Copilot reported quota exhaustion on every attempt. **Zero inline review threads must not be read as review approval.** This PR has had no independent code review.

## Review round

Codex raised two P2 findings after this went ready. Both were checked against source before deciding.

**Document the counter in the subscription reference — valid, fixed in `67210283`.** The reference listed four counters and omitted this one, and the query example `grep icn_gossip_subscribe` genuinely cannot match `icn_gossip_subscription_control_outcome_total` (`subscribe` and `subscription` diverge at the eighth character). Added the counter with its label semantics — spelling out that `processed` does not mean the subscriber set changed, and that this counter is per **topic** while the neighbouring `*_received_total` counters are per **message** — plus the #2474 spoof counter, which had the identical gap. Query example corrected to `grep icn_gossip_subscri`.

**Register the counter with `init_descriptions` — not adopted; premise does not hold.** The finding stated that `init_descriptions()` registers the neighbouring subscription counters but not this one. It registers none of them: the file has 314 `describe_counter!` calls and **zero** describe any `icn_gossip_*` metric — all 28, including #2474's spoof counter, are undescribed. Describing only this one would make it the single described gossip metric out of 28. The cited anchor (`AGENTS.md:L345-348`) is the "Repo-provided agent rules" section and contains no metric-registration procedure. Adding `HELP` metadata across the gossip family is a reasonable separate change; doing it for one counter here would create the inconsistency the finding aims to prevent.

Both threads answered and resolved.

Refs #2482, #2480, #2474, #2471, #2484

