### PR TITLE
fix(ops): make icn-ops doctor detect a stale checkout and stop swallowing worktree-root errors

### DIFF
--- a/.github/workflows/mcp-portability.yml
+++ b/.github/workflows/mcp-portability.yml
@@ -39,3 +39,10 @@ jobs:
         run: npm run build
       - name: Validate MCP package entrypoint
         run: test -f ops/mcp/dist/index.js
+      # Without this step the ops/mcp suite is compiled and never executed:
+      # `npm test` was referenced by no workflow, so every test under
+      # ops/mcp/src/tests/ could pass, fail, or be deleted with CI still green.
+      # The freshness check added here is only load-bearing if its tests run.
+      - name: Test MCP server
+        working-directory: ops/mcp
+        run: npm test

--- a/ops/mcp/src/diagnostics/doctor.ts
+++ b/ops/mcp/src/diagnostics/doctor.ts
@@ -17,6 +17,67 @@ export type DoctorReport = {
   suggested_repairs: string[];
 };
 
+/**
+ * A checkout on `main` that is behind its own `origin/main` is serving stale
+ * truth: every canonical doc it exposes (STATE.md, ARCHITECTURE.md, AGENTS.md,
+ * ops/state/truth/*) is that many commits out of date. Escalate to `error` past
+ * this many commits — at that point the tree is not "slightly behind", it is a
+ * different repository state than the one it claims to represent.
+ */
+export const MAIN_STALE_ERROR_COMMITS = 25;
+
+/**
+ * A feature branch is *expected* to sit behind main while work is in progress,
+ * so behind-ness is only worth mentioning once the branch base is old enough
+ * that a rebase is genuinely overdue.
+ */
+export const FEATURE_BASE_STALE_WARN_COMMITS = 50;
+
+/**
+ * Classify how stale a checkout is relative to origin/main.
+ *
+ * `behindCount` of NaN means origin/main could not be resolved (no remote ref,
+ * not a repo) — that is "unknown", never "fine".
+ */
+export function classifyTreeFreshness(
+  branch: string | null,
+  behindCount: number
+): { severity: DoctorCheck["severity"]; message: string; detail?: string; repair?: string } {
+  if (!Number.isFinite(behindCount)) {
+    return {
+      severity: "ok",
+      message: "origin/main not resolvable here; freshness check skipped.",
+    };
+  }
+  if (behindCount === 0) {
+    return { severity: "ok", message: "Checkout is level with origin/main." };
+  }
+  if (branch === "main") {
+    const stale = behindCount >= MAIN_STALE_ERROR_COMMITS;
+    return {
+      severity: stale ? "error" : "warn",
+      message: `Checkout is on main but ${behindCount} commit(s) behind origin/main — canonical docs and ops/state served from here are stale.`,
+      ...(stale
+        ? {
+            detail: `At or past ${MAIN_STALE_ERROR_COMMITS} commits this tree no longer represents main; treat anything read from it as unverified.`,
+          }
+        : {}),
+      repair: "git pull --ff-only  # re-sync the tree serving canonical docs",
+    };
+  }
+  if (behindCount >= FEATURE_BASE_STALE_WARN_COMMITS) {
+    return {
+      severity: "warn",
+      message: `Branch base is ${behindCount} commit(s) behind origin/main; a rebase is overdue.`,
+      repair: "git fetch origin && git rebase origin/main",
+    };
+  }
+  return {
+    severity: "ok",
+    message: `Feature branch ${behindCount} commit(s) behind origin/main (expected during active work).`,
+  };
+}
+
 function maxSeverity(
   a: DoctorReport["severity"],
   b: DoctorCheck["severity"]
@@ -189,6 +250,34 @@ export async function buildDoctorReport(repoRoot: string): Promise<DoctorReport>
       message: "Worktree clean.",
     });
   }
+
+  // Tree freshness. `dirty_tree` above answers "are there uncommitted edits?",
+  // which is trivially "no" for a checkout nobody has touched in weeks — so a
+  // clean tree is, on its own, an inverted signal for the staleness we care
+  // about. This check asks the question that actually matters for a host that
+  // serves canonical docs: how far behind origin/main is this checkout?
+  //
+  // No fetch is performed (doctor is read-only diagnosis), so `origin/main` is
+  // whatever the local object store last saw. That makes this a LOWER BOUND on
+  // staleness, never an overestimate.
+  const behindProbe = await runCommand(
+    "git",
+    ["rev-list", "--count", "HEAD..origin/main"],
+    { cwd: repoRoot, timeoutMs: 5_000, maxStdoutBytes: 256 }
+  );
+  const behindCount = behindProbe.ok
+    ? Number.parseInt(behindProbe.stdout.trim(), 10)
+    : Number.NaN;
+
+  const freshness = classifyTreeFreshness(env.git.branch, behindCount);
+  checks.push({
+    id: "tree_freshness",
+    severity: freshness.severity,
+    message: freshness.message,
+    ...(freshness.detail ? { detail: freshness.detail } : {}),
+  });
+  if (freshness.repair) suggested.push(freshness.repair);
+  top = maxSeverity(top, freshness.severity);
 
   const runnerProbes: [string, Awaited<ReturnType<typeof runCommand>>][] = [
     ["git", await runCommand("git", ["--version"], { cwd: repoRoot, timeoutMs: 4000, maxStdoutBytes: 256 })],

--- a/ops/mcp/src/diagnostics/doctor.ts
+++ b/ops/mcp/src/diagnostics/doctor.ts
@@ -79,9 +79,14 @@ export function classifyTreeFreshness(
       repair: "git fetch origin && git rebase origin/main",
     };
   }
+  // A detached checkout reports "HEAD" (or null) and is not claiming to be a
+  // feature branch — describe what it is rather than mislabelling it. Both are
+  // held to the same rule; only the wording differs.
+  const what =
+    branch === null || branch === "HEAD" ? "Detached checkout is" : "Feature branch is";
   return {
     severity: "ok",
-    message: `Feature branch ${behindCount} commit(s) behind origin/main (expected during active work).`,
+    message: `${what} ${behindCount} commit(s) behind origin/main (expected during active work).`,
   };
 }
 

--- a/ops/mcp/src/diagnostics/doctor.ts
+++ b/ops/mcp/src/diagnostics/doctor.ts
@@ -44,9 +44,16 @@ export function classifyTreeFreshness(
   behindCount: number
 ): { severity: DoctorCheck["severity"]; message: string; detail?: string; repair?: string } {
   if (!Number.isFinite(behindCount)) {
+    // `warn`, not `ok`. The top-level report folds only `severity` (see
+    // maxSeverity), so returning "ok" here with an explanatory message would
+    // still render the whole environment as "healthy" — reintroducing, one
+    // level down, the exact defect this check exists to remove: a confident
+    // health verdict over truth nobody verified. Unverifiable is not fine.
     return {
-      severity: "ok",
-      message: "origin/main not resolvable here; freshness check skipped.",
+      severity: "warn",
+      message:
+        "origin/main not resolvable here; checkout freshness is UNVERIFIED (not confirmed current).",
+      repair: "git fetch origin  # let doctor resolve origin/main and verify freshness",
     };
   }
   if (behindCount === 0) {

--- a/ops/mcp/src/tests/doctor-freshness.test.ts
+++ b/ops/mcp/src/tests/doctor-freshness.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyTreeFreshness,
+  MAIN_STALE_ERROR_COMMITS,
+  FEATURE_BASE_STALE_WARN_COMMITS,
+} from "../diagnostics/doctor.js";
+
+describe("classifyTreeFreshness", () => {
+  it("is ok when level with origin/main", () => {
+    expect(classifyTreeFreshness("main", 0).severity).toBe("ok");
+    expect(classifyTreeFreshness("feat/x", 0).severity).toBe("ok");
+  });
+
+  it("treats an unresolvable origin/main as skipped, not healthy-by-default", () => {
+    const r = classifyTreeFreshness("main", Number.NaN);
+    expect(r.severity).toBe("ok");
+    expect(r.message).toMatch(/skipped/);
+  });
+
+  describe("a checkout claiming to be main", () => {
+    it("warns as soon as it is behind at all", () => {
+      const r = classifyTreeFreshness("main", 1);
+      expect(r.severity).toBe("warn");
+      expect(r.repair).toMatch(/ff-only/);
+    });
+
+    it("escalates to error past the staleness threshold", () => {
+      expect(classifyTreeFreshness("main", MAIN_STALE_ERROR_COMMITS).severity).toBe("error");
+      expect(classifyTreeFreshness("main", MAIN_STALE_ERROR_COMMITS - 1).severity).toBe("warn");
+    });
+
+    it("errors on the real regression this check exists for", () => {
+      // The icn-ops MCP served ops/state + canonical docs from a `main`
+      // checkout 75 commits behind origin/main while icn_ops_doctor reported
+      // severity "ok" — repo_status already knew the number and nothing
+      // consulted it. Any tree this far behind must not read as healthy.
+      const r = classifyTreeFreshness("main", 75);
+      expect(r.severity).toBe("error");
+      expect(r.message).toContain("75");
+      expect(r.message).toMatch(/stale/);
+    });
+  });
+
+  describe("a feature branch", () => {
+    it("does not complain about the ordinary lag of active work", () => {
+      expect(classifyTreeFreshness("feat/x", 5).severity).toBe("ok");
+      expect(
+        classifyTreeFreshness("feat/x", FEATURE_BASE_STALE_WARN_COMMITS - 1).severity
+      ).toBe("ok");
+    });
+
+    it("warns once the branch base is genuinely overdue for a rebase", () => {
+      const r = classifyTreeFreshness("feat/x", FEATURE_BASE_STALE_WARN_COMMITS);
+      expect(r.severity).toBe("warn");
+      expect(r.repair).toMatch(/rebase/);
+    });
+
+    it("holds a detached checkout to the feature-branch rule, not the main rule", () => {
+      // env.git.branch is "HEAD" (or null) on a detached checkout; it is not
+      // claiming to be main, so it must not trip the main-staleness error.
+      expect(classifyTreeFreshness("HEAD", 30).severity).toBe("ok");
+      expect(classifyTreeFreshness(null, 30).severity).toBe("ok");
+    });
+  });
+});

--- a/ops/mcp/src/tests/doctor-freshness.test.ts
+++ b/ops/mcp/src/tests/doctor-freshness.test.ts
@@ -67,5 +67,16 @@ describe("classifyTreeFreshness", () => {
       expect(classifyTreeFreshness("HEAD", 30).severity).toBe("ok");
       expect(classifyTreeFreshness(null, 30).severity).toBe("ok");
     });
+
+    it("does not describe a detached checkout as a feature branch", () => {
+      // Same rule, honest wording: a detached HEAD is not a branch, and this
+      // report is read by agents deciding whether to trust the tree.
+      for (const branch of ["HEAD", null]) {
+        const r = classifyTreeFreshness(branch, 3);
+        expect(r.message).not.toMatch(/Feature branch/);
+        expect(r.message).toMatch(/Detached checkout/);
+      }
+      expect(classifyTreeFreshness("feat/x", 3).message).toMatch(/Feature branch/);
+    });
   });
 });

--- a/ops/mcp/src/tests/doctor-freshness.test.ts
+++ b/ops/mcp/src/tests/doctor-freshness.test.ts
@@ -11,10 +11,16 @@ describe("classifyTreeFreshness", () => {
     expect(classifyTreeFreshness("feat/x", 0).severity).toBe("ok");
   });
 
-  it("treats an unresolvable origin/main as skipped, not healthy-by-default", () => {
+  it("reports an unresolvable origin/main as unverified, NOT as healthy", () => {
+    // The whole point of this check is that a confident health verdict must
+    // never be issued over unverified truth. `severity` is the only field
+    // maxSeverity folds into the top-level report, so "ok" here — however
+    // well-worded the message — makes the report say "Environment looks
+    // healthy" about a tree whose freshness nobody established.
     const r = classifyTreeFreshness("main", Number.NaN);
-    expect(r.severity).toBe("ok");
-    expect(r.message).toMatch(/skipped/);
+    expect(r.severity).toBe("warn");
+    expect(r.severity).not.toBe("ok");
+    expect(r.message).toMatch(/UNVERIFIED/);
   });
 
   describe("a checkout claiming to be main", () => {

--- a/ops/mcp/src/tests/repos.test.ts
+++ b/ops/mcp/src/tests/repos.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveBranch } from "../tools/repos.js";
+import { resolveBranch, readWorktreeDirs } from "../tools/repos.js";
 
 describe("resolveBranch", () => {
   it("falls back to main when HEAD is detached", () => {
@@ -20,5 +20,31 @@ describe("resolveBranch", () => {
 
   it("trims surrounding whitespace", () => {
     expect(resolveBranch("  release/1.2 \n")).toBe("release/1.2");
+  });
+});
+
+describe("readWorktreeDirs", () => {
+  it("lists worktrees and hides dotfiles", () => {
+    const r = readWorktreeDirs("/wt", () => ["alpha", ".git", "beta", ".DS_Store"]);
+    expect(r.dirs).toEqual(["alpha", "beta"]);
+    expect(r.error).toBeNull();
+  });
+
+  it("distinguishes a genuinely empty root from an unreadable one", () => {
+    const empty = readWorktreeDirs("/wt", () => []);
+    expect(empty.dirs).toEqual([]);
+    expect(empty.error).toBeNull();
+  });
+
+  it("reports an unreadable worktree root instead of returning an empty list", () => {
+    // Regression: a misconfigured/absent root used to be swallowed by `catch {
+    // dirs = [] }`, which is indistinguishable from "no worktrees exist" and
+    // reads as success. That is how a wrong root stayed invisible.
+    const r = readWorktreeDirs("/nope", () => {
+      throw new Error("ENOENT: no such file or directory");
+    });
+    expect(r.dirs).toEqual([]);
+    expect(r.error).toContain("/nope");
+    expect(r.error).toContain("ICN_WT_ROOT");
   });
 });

--- a/ops/mcp/src/tools/repos.ts
+++ b/ops/mcp/src/tools/repos.ts
@@ -61,7 +61,11 @@ async function repoStatus(repoPath: string, name: string) {
     return {
       name,
       resolved: false,
-      error: `Not a readable git repository at ${repoPath}`,
+      // Say what was observed, not a diagnosis. `gitLine` returns "" for any
+      // failure — missing git, timeout, permissions, or genuinely not a repo —
+      // so naming one cause would be asserting more than we checked, which is
+      // the habit this whole change exists to remove.
+      error: `Could not resolve a git branch at ${repoPath} (not a repository, or git failed there); treat this repo's status as unknown, not clean`,
       branch: null,
       dirty: null,
       dirtyFiles: null,

--- a/ops/mcp/src/tools/repos.ts
+++ b/ops/mcp/src/tools/repos.ts
@@ -29,12 +29,19 @@ export function resolveBranch(rawBranch: string): string {
 }
 
 /**
- * Enumerate worktree directories under `wtRoot`.
+ * Enumerate candidate worktree entries under `wtRoot`.
  *
  * Returns the failure instead of swallowing it: an unreadable worktree root
  * previously collapsed to `[]`, which is indistinguishable from "no worktrees
  * exist" and reads as success. That is how a misconfigured root stayed
  * invisible while dozens of worktrees went unreported.
+ *
+ * The only filter applied is dotfile exclusion — entries are NOT stat'd, so a
+ * stray non-directory file under `wtRoot` is returned as a candidate. That is
+ * deliberate and consistent with the rule above: the caller resolves each entry
+ * and reports what it finds, so a stray entry surfaces as a visible per-worktree
+ * error rather than being silently filtered out of the listing. Hiding entries
+ * here would reintroduce the same class of defect one level down.
  */
 export function readWorktreeDirs(
   wtRoot: string,

--- a/ops/mcp/src/tools/repos.ts
+++ b/ops/mcp/src/tools/repos.ts
@@ -28,8 +28,48 @@ export function resolveBranch(rawBranch: string): string {
   return branch === "" || branch === "HEAD" ? "main" : branch;
 }
 
+/**
+ * Enumerate worktree directories under `wtRoot`.
+ *
+ * Returns the failure instead of swallowing it: an unreadable worktree root
+ * previously collapsed to `[]`, which is indistinguishable from "no worktrees
+ * exist" and reads as success. That is how a misconfigured root stayed
+ * invisible while dozens of worktrees went unreported.
+ */
+export function readWorktreeDirs(
+  wtRoot: string,
+  readdir: (p: string) => string[]
+): { dirs: string[]; error: string | null } {
+  try {
+    return { dirs: readdir(wtRoot).filter((d) => !d.startsWith(".")), error: null };
+  } catch (e) {
+    return {
+      dirs: [],
+      error: `Worktree root unreadable at ${wtRoot}: ${
+        e instanceof Error ? e.message : String(e)
+      }. Set ICN_WT_ROOT or fix ops/state/config/repo-map.json#worktrees.root.`,
+    };
+  }
+}
+
 async function repoStatus(repoPath: string, name: string) {
   const branch = await gitLine(repoPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  // An unresolvable path yields "" here and 0 for every counter below, which
+  // renders as a clean, up-to-date repo. Report it as unresolved instead —
+  // a repo we cannot see is not a repo that is fine.
+  if (branch === "") {
+    return {
+      name,
+      resolved: false,
+      error: `Not a readable git repository at ${repoPath}`,
+      branch: null,
+      dirty: null,
+      dirtyFiles: null,
+      ahead: null,
+      behind: null,
+      lastCommit: null,
+    };
+  }
   const dirty = await gitLine(repoPath, ["status", "--porcelain"]);
   let ahead = await gitLine(repoPath, ["rev-list", "@{u}..HEAD", "--count"]);
   if (!ahead) ahead = "0";
@@ -40,6 +80,8 @@ async function repoStatus(repoPath: string, name: string) {
   const behindN = parseInt(behind, 10);
   return {
     name,
+    resolved: true,
+    error: null,
     branch,
     dirty: dirty !== "",
     dirtyFiles: dirty.split("\n").filter(Boolean).length,
@@ -80,13 +122,10 @@ export function registerRepoTools(
       const icnPath = join(ICN_ROOT, "icn");
       const mainHash = await gitLine(icnPath, ["rev-parse", "origin/main"]);
 
-      let dirs: string[] = [];
-      try {
-        const { readdirSync } = await import("fs");
-        dirs = readdirSync(wtRoot).filter((d) => !d.startsWith("."));
-      } catch {
-        dirs = [];
-      }
+      const { readdirSync } = await import("fs");
+      const { dirs, error: wtRootError } = readWorktreeDirs(wtRoot, (p) =>
+        readdirSync(p)
+      );
 
       const results = await Promise.all(
         dirs.map(async (dir) => {
@@ -126,10 +165,14 @@ export function registerRepoTools(
           {
             type: "text",
             text: JSON.stringify(
-              results.map((r) => ({
-                ...r,
-                claimedBy: sessionMap[r.name] ?? null,
-              })),
+              {
+                worktreeRoot: wtRoot,
+                error: wtRootError,
+                worktrees: results.map((r) => ({
+                  ...r,
+                  claimedBy: sessionMap[r.name] ?? null,
+                })),
+              },
               null,
               2
             ),

--- a/ops/mcp/vitest.config.ts
+++ b/ops/mcp/vitest.config.ts
@@ -4,5 +4,13 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/tests/**/*.test.ts"],
+    // Several diagnostics tests (buildDoctorReport, buildNextStepsReport) spawn
+    // real subprocesses — git, python3, and probes for kubectl/gh — sequentially
+    // against a bare temp dir. On this VM that costs ~0.7–1.3s; on a GitHub
+    // runner, where those binaries are cold or absent, the same tests exceed
+    // vitest's 5s default and time out. The tests are correct; the default is
+    // just too tight for a suite that shells out. Raised so CI measures the
+    // behaviour rather than the runner's process-spawn latency.
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## What

Four changes to the icn-ops MCP so it can no longer report itself healthy while serving stale truth:

- **New `tree_freshness` doctor check**, implemented as a pure, tested `classifyTreeFreshness`.
- **`readWorktreeDirs`** returns an enumeration failure instead of swallowing it; `worktree_status` now reports `worktreeRoot` and `error` alongside the list.
- **`repoStatus`** reports `resolved: false` + an error for an unreadable path, instead of a zero-counter row that renders as a clean, up-to-date repo.
- **`mcp-portability` now runs `npm test`.** The suite existed but no workflow executed it (see *CI* below).

## Why

The MCP served canonical docs (`STATE.md`, `ARCHITECTURE.md`, `AGENTS.md`, `ops/state/truth/*`) from a checkout **75 commits behind `origin/main`** while `icn_ops_doctor` returned `severity: "ok"` / *"Environment looks healthy."* Three defects combined:

1. The doctor had 14 checks and **none looked at freshness**. Worse, its `dirty_tree` check reports *"Worktree clean."* for exactly that tree — an abandoned checkout has no uncommitted edits, so **cleanliness is inversely correlated with the risk**.
2. `repo_status` **already computed `behind: 75`**. Nothing consulted it.
3. `worktree_status` collapsed an unreadable worktree root to `[]` via a bare `catch`. An empty array is indistinguishable from *"no worktrees exist"* and reads as success — so a misconfigured root stayed invisible and the existing `stale: behindMain > 10` flag could never fire.

The net effect was a control plane that simultaneously *knew* it was stale and *reported* that it was healthy — it computed repository staleness and then discarded it before the health decision. Agents following the documented startup ritual received confident, three-week-old answers.

## How

`classifyTreeFreshness(branch, behindCount)` is pure and separately tested:

| Situation | Verdict |
|---|---|
| level with `origin/main` | ok |
| `origin/main` **unresolvable** | **warn** — freshness is UNVERIFIED, never "fine" |
| on `main`, behind at all | **warn** |
| on `main`, behind ≥ `MAIN_STALE_ERROR_COMMITS` (25) | **error** — past this the tree is a different repository state than the one it claims to represent |
| feature branch, behind < `FEATURE_BASE_STALE_WARN_COMMITS` (50) | ok — ordinary lag of active work |
| feature branch, behind ≥ 50 | **warn** — rebase overdue |

The unresolvable row is **warn, not ok**. The top-level report folds only `severity`, so returning `ok` with an explanatory message would still render the environment "healthy" — reintroducing the exact defect this check exists to remove, one level down. Unverifiable is not fine.

No fetch is performed (the doctor stays read-only diagnosis), so the count is a **lower bound** on staleness, never an overestimate. A detached checkout follows the feature-branch thresholds but is *described* as a detached checkout, not mislabelled a feature branch.

## CI — the suite is now actually executed

`mcp-portability.yml` is the only workflow covering `ops/mcp/**`, and it previously ran `npm ci` + `npm run build` + an entrypoint check with **no `npm test` step**. The MCP's entire test suite had never been executed by CI.

This PR adds the `npm test` step. Enabling it immediately surfaced a real CI-only failure mode: several diagnostics tests (`buildDoctorReport`, `buildNextStepsReport`) spawn real subprocesses — `git`, `python3`, probes for `kubectl`/`gh` — sequentially against a bare temp dir. On this VM that costs ~0.7–1.3s; on a GitHub runner, where those binaries are cold or absent, the same tests exceeded vitest's 5s default and timed out. The tests are correct; the default is too tight for a suite that shells out. `vitest.config.ts` now sets `testTimeout: 30_000` so CI measures the behaviour rather than the runner's process-spawn latency.

**Note on gating:** `mcp-portability` is a **non-required** check (it is not in branch protection's required contexts) and is `paths`-filtered to `ops/mcp/**` and friends. So the suite now runs and is visible, but it does not by itself block merge. Promoting it to required is a separate repo-policy decision, not made here.

## Risk

- **Low, but `icn_ops_doctor` can now return `severity: "error"`** where it previously returned `ok`. That is the intended behaviour change; anything consuming the severity will start seeing a stale host flagged.
- `worktree_status` return shape changed from a bare array to `{ worktreeRoot, error, worktrees }`. Checked: it has no programmatic consumer — the result is rendered to text for the agent.
- `repo_status` rows gain `resolved` / `error`, and unresolvable rows now carry `null` counters instead of `0`. This is the point: `homelab-inventory` resolves to nothing on the dev VM and previously reported `behind: 0`.
- No Rust, protocol, auth, or deployment paths touched.

## Test plan

- `npm run build` — clean (`tsc`, exit 0).
- **Local: 98/98 tests pass across 10 files** (2.16s), including the new `doctor-freshness.test.ts` and the extended `repos.test.ts`, with a regression test pinned to the real 75-commit case.
- **CI: 98/98 tests pass across 10 files** in the `mcp-portability` job — first time the suite has ever run in CI.
- The 23 `better-sqlite3` native-binding failures reported in an earlier revision of this description were a local fresh-worktree artifact (*"Could not locate the bindings file"*). They do not reproduce now, locally or in CI; the current suite is fully green with no skips.

## Review threads

All five review threads are addressed in the commits above or answered inline with source evidence:

- **`branch` may carry a trailing newline** → *refuted*. `runCommand` (`ops/mcp/src/utils/commands.ts`) applies `.trim()` to stdout before returning, so `env.git.branch` is `"main"`, never `"main\n"`, and `branch === "main"` matches.
- **detached checkout mislabelled "Feature branch"** → fixed (`23f66645`).
- **`gitLine()` error wording overstates "not a readable git repository"** → fixed (`23f66645`).
- **sparse-temp-repo test timing out** → fixed (`af4d9d10`, `testTimeout: 30_000`).
- **`readWorktreeDirs` doc says "directories" but does not stat entries** → doc corrected to describe the actual contract, and to record why surfacing a stray entry is preferred over silently filtering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
