### PR TITLE
fix(net): register a PolicyOracle for the "net" domain and honor configured rate tiers

### DIFF
--- a/icn/crates/icn-core/src/config/mod.rs
+++ b/icn/crates/icn-core/src/config/mod.rs
@@ -348,8 +348,33 @@ impl Config {
         }
 
         // Rate limiting validation
-        if self.rate_limiting.enabled && self.rate_limiting.refill_interval_ms == 0 {
-            errors.push("rate_limiting.refill_interval_ms cannot be 0".to_string());
+        if self.rate_limiting.enabled {
+            if self.rate_limiting.refill_interval_ms == 0 {
+                errors.push("rate_limiting.refill_interval_ms cannot be 0".to_string());
+            }
+
+            // A burst capacity of 0 means the bucket can never hold a whole token,
+            // so every message is denied forever regardless of the configured rate
+            // — the node silently stops peering. Rejected explicitly rather than
+            // left as a silent brick.
+            //
+            // A configured *rate* of 0 is left valid: since #2503 it honestly means
+            // "no sustained replenishment, burst is a one-time allowance". It used
+            // to be inflated to the limiter's one-token-per-interval floor
+            // (10 msg/s at the default interval), which was the misleading case.
+            for (name, tier) in [
+                ("isolated", &self.rate_limiting.isolated),
+                ("known", &self.rate_limiting.known),
+                ("partner", &self.rate_limiting.partner),
+                ("federated", &self.rate_limiting.federated),
+                ("fallback", &self.rate_limiting.fallback),
+            ] {
+                if tier.burst_capacity == 0 {
+                    errors.push(format!(
+                        "rate_limiting.{name}.burst_capacity cannot be 0                          (a zero bucket denies every message permanently)"
+                    ));
+                }
+            }
         }
 
         // Topology validation

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -283,11 +283,12 @@ pub async fn run_supervisor(
 /// and the query site bound to one symbol so they cannot drift apart again.
 fn register_core_oracles(
     oracle_registry: &icn_kernel_api::OracleRegistry,
-    trust_oracle: Option<std::sync::Arc<dyn icn_kernel_api::authz::PolicyOracle>>,
+    trust_service: Option<std::sync::Arc<dyn icn_kernel_api::services::TrustService>>,
     charter_oracle: Option<std::sync::Arc<dyn icn_kernel_api::authz::PolicyOracle>>,
-    network_rate_ceiling: &crate::config::TrustClassRateLimitConfig,
+    rate_limiting: &crate::config::RateLimitingConfig,
 ) {
-    if let Some(trust_oracle) = trust_oracle {
+    if let Some(trust_service) = trust_service {
+        let trust_oracle = trust_service.oracle();
         let trust_domain = trust_oracle.domain();
         oracle_registry.register(trust_domain.clone(), trust_oracle.clone());
         info!(
@@ -299,25 +300,35 @@ fn register_core_oracles(
         // its own domain as "trust", so registering by `domain()` alone leaves
         // "net" unregistered — see this function's doc comment.
         //
-        // Wrapped in a ceiling because the rate limiter keys on the *unauthenticated*
+        // It is not registered raw. `NetworkRateLimitOracle` replaces the trust
+        // oracle's hard-coded 5/20/100/unlimited ladder with the operator's
+        // configured per-tier limits (#2496), and clamps the result to the
+        // highest configured tier as an absolute ceiling. The ceiling matters
+        // because the rate limiter keys on the *unauthenticated*
         // `NetworkMessage.from`: the tier is chosen from a DID the sender merely
-        // claims, and the top trust tier is `RateLimit::unlimited()` (u32::MAX).
-        // Without the cap, naming a well-trusted DID buys an unbounded budget for
-        // pre-authentication work. The cap is the operator's configured maximum.
+        // claims, so no tier may be an unbounded pre-authentication budget
+        // (defence in depth for #2491, which is a separate protocol change).
         let network_domain = icn_kernel_api::authz::Domain::new(icn_net::NETWORK_DOMAIN);
+        let tiers = super::network_policy::NetworkRateLimitTiers::from_config(rate_limiting);
+        let ceiling = super::network_policy::rate_limit_from_config(&rate_limiting.federated);
         let network_oracle: std::sync::Arc<dyn icn_kernel_api::authz::PolicyOracle> =
-            std::sync::Arc::new(super::network_policy::CappedRateLimitOracle::new(
+            std::sync::Arc::new(super::network_policy::NetworkRateLimitOracle::new(
                 trust_oracle,
+                trust_service,
                 network_domain.clone(),
-                network_rate_ceiling.max_messages_per_second,
-                network_rate_ceiling.burst_capacity,
+                tiers,
+                ceiling.clone(),
             ));
         oracle_registry.register(network_domain.clone(), network_oracle);
         info!(
-            max_messages_per_second = network_rate_ceiling.max_messages_per_second,
-            burst_capacity = network_rate_ceiling.burst_capacity,
+            isolated = ?rate_limiting.isolated,
+            known = ?rate_limiting.known,
+            partner = ?rate_limiting.partner,
+            federated = ?rate_limiting.federated,
+            ceiling_messages_per_second = ceiling.messages_per_second,
+            ceiling_burst = ceiling.burst_size,
             "Registered network PolicyOracle with OracleRegistry for domain '{}' \
-             (rate limits capped at the configured maximum)",
+             (operator-configured tier per trust class, clamped to the ceiling)",
             network_domain
         );
     }
@@ -403,12 +414,11 @@ async fn spawn_actors_with_identity(
 
     register_core_oracles(
         &oracle_registry,
-        trust_service_from_registry
-            .as_ref()
-            .map(|trust_service| trust_service.oracle()),
+        trust_service_from_registry.clone(),
         service_registry.and_then(|r| r.charter_oracle().cloned()),
-        // Highest configured tier: no peer may exceed what the operator allowed.
-        &config.rate_limiting.federated,
+        // All four tiers: the network oracle selects per trust class, and uses
+        // the highest configured tier as an absolute ceiling.
+        &config.rate_limiting,
     );
 
     // Transition to CoreApps phase: first-party oracles are registered.
@@ -1777,11 +1787,78 @@ mod core_oracle_registration_tests {
         }
     }
 
+    /// Stand-in for the trust service: hands out `oracle` and a fixed score.
+    ///
+    /// `register_core_oracles` now takes the service rather than just its oracle,
+    /// because selecting an operator-configured tier needs the peer's trust
+    /// *class*, and the class comes from the service — never from arithmetic on
+    /// the oracle's constraint values (#2496).
+    struct FakeTrust {
+        oracle: Arc<dyn PolicyOracle>,
+        score: f64,
+    }
+
+    impl FakeTrust {
+        fn arc(oracle: Arc<dyn PolicyOracle>, score: f64) -> Arc<dyn icn_kernel_api::TrustService> {
+            Arc::new(Self { oracle, score })
+        }
+    }
+
+    impl icn_kernel_api::TrustService for FakeTrust {
+        fn oracle(&self) -> Arc<dyn PolicyOracle> {
+            Arc::clone(&self.oracle)
+        }
+
+        fn trust_score(&self, _actor: &icn_kernel_api::types::Did) -> f64 {
+            self.score
+        }
+
+        fn record_event(
+            &self,
+            _actor: &icn_kernel_api::types::Did,
+            _event: icn_kernel_api::services::TrustEvent,
+        ) {
+        }
+    }
+
     /// Mirrors the deployed `[rate_limiting.federated]` values.
     fn ceiling() -> crate::config::TrustClassRateLimitConfig {
         crate::config::TrustClassRateLimitConfig {
             max_messages_per_second: 200,
             burst_capacity: 50,
+        }
+    }
+
+    /// Four deliberately distinct tiers, none of which coincides with the trust
+    /// oracle's hard-coded 5/20/100/unlimited ladder.
+    fn tiered_rate_limiting() -> crate::config::RateLimitingConfig {
+        let tier = |rate, burst| crate::config::TrustClassRateLimitConfig {
+            max_messages_per_second: rate,
+            burst_capacity: burst,
+        };
+        crate::config::RateLimitingConfig {
+            isolated: tier(1, 2),
+            known: tier(7, 9),
+            partner: tier(11, 13),
+            federated: tier(200, 50),
+            ..Default::default()
+        }
+    }
+
+    /// The `[rate_limiting]` section whose `federated` tier is the deployed ceiling.
+    fn rate_limiting_with_ceiling() -> crate::config::RateLimitingConfig {
+        crate::config::RateLimitingConfig {
+            federated: ceiling(),
+            ..Default::default()
+        }
+    }
+
+    fn rate_limit_of(decision: PolicyDecision) -> RateLimit {
+        match decision {
+            PolicyDecision::Allow { constraints, .. } => {
+                constraints.rate_limit.clone().expect("rate limit present")
+            }
+            PolicyDecision::Deny { .. } => panic!("domain must be registered"),
         }
     }
 
@@ -1801,9 +1878,9 @@ mod core_oracle_registration_tests {
         let registry = OracleRegistry::new();
         register_core_oracles(
             &registry,
-            Some(Arc::new(FakeOracle("trust"))),
+            Some(FakeTrust::arc(Arc::new(FakeOracle("trust")), 1.0)),
             None,
-            &ceiling(),
+            &rate_limiting_with_ceiling(),
         );
         registry.set_phase(BootstrapPhase::Running);
 
@@ -1824,9 +1901,9 @@ mod core_oracle_registration_tests {
         let registry = OracleRegistry::new();
         register_core_oracles(
             &registry,
-            Some(Arc::new(FakeOracle("trust"))),
+            Some(FakeTrust::arc(Arc::new(FakeOracle("trust")), 1.0)),
             Some(Arc::new(FakeOracle("charter"))),
-            &ceiling(),
+            &rate_limiting_with_ceiling(),
         );
         registry.set_phase(BootstrapPhase::Running);
 
@@ -1851,7 +1928,12 @@ mod core_oracle_registration_tests {
     #[test]
     fn network_domain_rate_limits_are_capped_at_the_configured_maximum() {
         let registry = OracleRegistry::new();
-        register_core_oracles(&registry, Some(Arc::new(UnlimitedOracle)), None, &ceiling());
+        register_core_oracles(
+            &registry,
+            Some(FakeTrust::arc(Arc::new(UnlimitedOracle), 1.0)),
+            None,
+            &rate_limiting_with_ceiling(),
+        );
         registry.set_phase(BootstrapPhase::Running);
 
         let decision = registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN));
@@ -1871,12 +1953,77 @@ mod core_oracle_registration_tests {
         );
     }
 
+    /// Every operator-configured tier reaches the registry (#2496).
+    ///
+    /// The earlier wiring passed only `rate_limiting.federated` as a ceiling and
+    /// let the trust oracle's hard-coded 5/20/100/unlimited through underneath,
+    /// so lowering `isolated`, `known` or `partner` changed nothing. This drives
+    /// the real `register_core_oracles`, not the wrapper in isolation.
+    #[test]
+    fn every_configured_network_tier_reaches_the_registry() {
+        // (score, class, expected rate, expected burst)
+        let cases = [
+            (0.0, "Isolated", 1, 2),
+            (0.2, "Known", 7, 9),
+            (0.5, "Partner", 11, 13),
+            (0.9, "Federated", 200, 50),
+        ];
+
+        for (score, class, expected_rate, expected_burst) in cases {
+            let registry = OracleRegistry::new();
+            register_core_oracles(
+                &registry,
+                // The inner oracle offers `unlimited()` for everyone, exactly as
+                // the real trust oracle does at score >= 0.7.
+                Some(FakeTrust::arc(Arc::new(UnlimitedOracle), score)),
+                None,
+                &tiered_rate_limiting(),
+            );
+            registry.set_phase(BootstrapPhase::Running);
+
+            let limit = rate_limit_of(registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN)));
+
+            assert_eq!(
+                (limit.messages_per_second, limit.burst_size),
+                (expected_rate, expected_burst),
+                "{class} (score {score}) must get its configured tier through the \
+                 real composition root"
+            );
+        }
+    }
+
+    /// The exact regression named in the #2496 review, asserted end to end.
+    #[test]
+    fn a_configured_isolated_burst_of_two_survives_the_composition_root() {
+        let registry = OracleRegistry::new();
+        register_core_oracles(
+            &registry,
+            Some(FakeTrust::arc(Arc::new(UnlimitedOracle), 0.0)),
+            None,
+            &tiered_rate_limiting(),
+        );
+        registry.set_phase(BootstrapPhase::Running);
+
+        let limit = rate_limit_of(registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN)));
+
+        assert_eq!(
+            limit.burst_size, 2,
+            "configured isolated burst = 2 must produce effective burst = 2; 5 \
+             would mean `RateLimit::restricted()` leaked through the wiring"
+        );
+    }
+
     /// The trust domain itself is NOT capped — the ceiling is specific to the
     /// network path, where the actor is unauthenticated.
     #[test]
     fn the_trust_domain_itself_is_not_capped() {
         let registry = OracleRegistry::new();
-        register_core_oracles(&registry, Some(Arc::new(UnlimitedOracle)), None, &ceiling());
+        register_core_oracles(
+            &registry,
+            Some(FakeTrust::arc(Arc::new(UnlimitedOracle), 1.0)),
+            None,
+            &rate_limiting_with_ceiling(),
+        );
         registry.set_phase(BootstrapPhase::Running);
 
         let decision = registry.evaluate(&request_for("trust"));
@@ -1903,9 +2050,9 @@ mod core_oracle_registration_tests {
         let registry = OracleRegistry::new();
         register_core_oracles(
             &registry,
-            Some(Arc::new(FakeOracle("trust"))),
+            Some(FakeTrust::arc(Arc::new(FakeOracle("trust")), 1.0)),
             None,
-            &ceiling(),
+            &rate_limiting_with_ceiling(),
         );
         registry.set_phase(BootstrapPhase::Running);
 
@@ -1923,7 +2070,7 @@ mod core_oracle_registration_tests {
     #[test]
     fn without_a_trust_oracle_the_network_domain_is_not_registered() {
         let registry = OracleRegistry::new();
-        register_core_oracles(&registry, None, None, &ceiling());
+        register_core_oracles(&registry, None, None, &rate_limiting_with_ceiling());
         registry.set_phase(BootstrapPhase::Running);
 
         let decision = registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN));

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -1836,10 +1836,14 @@ mod core_oracle_registration_tests {
             max_messages_per_second: rate,
             burst_capacity: burst,
         };
+        // Rates are whole multiples of the refill granularity (>= 10/s at the
+        // default 100 ms interval). `RateLimiter` quantises with
+        // `(rate * interval).max(1.0)`, so asserting on a sub-granularity rate
+        // would imply a precision the limiter cannot deliver.
         crate::config::RateLimitingConfig {
-            isolated: tier(1, 2),
-            known: tier(7, 9),
-            partner: tier(11, 13),
+            isolated: tier(10, 2),
+            known: tier(30, 9),
+            partner: tier(70, 13),
             federated: tier(200, 50),
             ..Default::default()
         }
@@ -1963,9 +1967,9 @@ mod core_oracle_registration_tests {
     fn every_configured_network_tier_reaches_the_registry() {
         // (score, class, expected rate, expected burst)
         let cases = [
-            (0.0, "Isolated", 1, 2),
-            (0.2, "Known", 7, 9),
-            (0.5, "Partner", 11, 13),
+            (0.0, "Isolated", 10, 2),
+            (0.2, "Known", 30, 9),
+            (0.5, "Partner", 70, 13),
             (0.9, "Federated", 200, 50),
         ];
 

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -310,7 +310,10 @@ fn register_core_oracles(
         // (defence in depth for #2491, which is a separate protocol change).
         let network_domain = icn_kernel_api::authz::Domain::new(icn_net::NETWORK_DOMAIN);
         let tiers = super::network_policy::NetworkRateLimitTiers::from_config(rate_limiting);
-        let ceiling = super::network_policy::rate_limit_from_config(&rate_limiting.federated);
+        // Maximum across all four tiers, not the federated tier: an operator may
+        // legitimately configure a burstier local `partner` tier than the WAN
+        // `federated` one, and a federated-derived ceiling would silently clamp it.
+        let ceiling = tiers.ceiling();
         let network_oracle: std::sync::Arc<dyn icn_kernel_api::authz::PolicyOracle> =
             std::sync::Arc::new(super::network_policy::NetworkRateLimitOracle::new(
                 trust_oracle,

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -262,6 +262,60 @@ pub async fn run_supervisor(
     Ok(())
 }
 
+/// Register every first-party oracle with the `OracleRegistry`.
+///
+/// This is the composition root's complete set of domain registrations. It is a
+/// standalone function so that the set can be asserted in tests: once the registry
+/// reaches [`BootstrapPhase::Running`], any domain that is *not* registered here is
+/// denied by default, so an omission silently disables a whole subsystem rather
+/// than failing loudly.
+///
+/// That is exactly how #2488 happened. Oracles were registered by
+/// `oracle.domain()`, which covered `trust` and `charter` but never `net` — the
+/// domain `icn-net`'s rate limiter queries. Every inbound network message was
+/// denied, reported as an ordinary rate-limit rejection, and no node could peer.
+///
+/// The network layer is a kernel component: it asks for a `ConstraintSet` and
+/// enforces it without knowing where the numbers came from. Choosing *which*
+/// oracle answers for the network domain is a composition-root decision, which is
+/// why it lives here and not in `icn-net`. Registering under
+/// [`icn_net::NETWORK_DOMAIN`] rather than a local string literal keeps this site
+/// and the query site bound to one symbol so they cannot drift apart again.
+fn register_core_oracles(
+    oracle_registry: &icn_kernel_api::OracleRegistry,
+    trust_oracle: Option<std::sync::Arc<dyn icn_kernel_api::authz::PolicyOracle>>,
+    charter_oracle: Option<std::sync::Arc<dyn icn_kernel_api::authz::PolicyOracle>>,
+) {
+    if let Some(trust_oracle) = trust_oracle {
+        let trust_domain = trust_oracle.domain();
+        oracle_registry.register(trust_domain.clone(), trust_oracle.clone());
+        info!(
+            "Registered TrustPolicyOracle with OracleRegistry for domain '{}'",
+            trust_domain
+        );
+
+        // Serve the network domain from the same oracle. The trust oracle reports
+        // its own domain as "trust", so registering by `domain()` alone leaves
+        // "net" unregistered — see this function's doc comment.
+        let network_domain = icn_kernel_api::authz::Domain::new(icn_net::NETWORK_DOMAIN);
+        oracle_registry.register(network_domain.clone(), trust_oracle);
+        info!(
+            "Registered network PolicyOracle with OracleRegistry for domain '{}'",
+            network_domain
+        );
+    }
+
+    // Register charter oracle with OracleRegistry if available (Phase 1 charter engine).
+    if let Some(charter_oracle) = charter_oracle {
+        let charter_domain = charter_oracle.domain();
+        oracle_registry.register(charter_domain.clone(), charter_oracle);
+        info!(
+            "Registered CharterPolicyOracle with OracleRegistry for domain '{}'",
+            charter_domain
+        );
+    }
+}
+
 /// Spawn all actors when identity bundle is available
 #[allow(clippy::too_many_arguments)]
 async fn spawn_actors_with_identity(
@@ -330,27 +384,13 @@ async fn spawn_actors_with_identity(
     // Get TrustService from ServiceRegistry for ReplicationManager and oracle registration.
     let trust_service_from_registry = service_registry.and_then(|r| r.trust().cloned());
 
-    // Register trust PolicyOracle with OracleRegistry if available.
-    // This replaces the direct PolicyOracle passing and provides phase-aware authorization.
-    if let Some(ref trust_service) = trust_service_from_registry {
-        let trust_oracle = trust_service.oracle();
-        let trust_domain = trust_oracle.domain();
-        oracle_registry.register(trust_domain.clone(), trust_oracle);
-        info!(
-            "Registered TrustPolicyOracle with OracleRegistry for domain '{}'",
-            trust_domain
-        );
-    }
-
-    // Register charter oracle with OracleRegistry if available (Phase 1 charter engine).
-    if let Some(charter_oracle) = service_registry.and_then(|r| r.charter_oracle().cloned()) {
-        let charter_domain = charter_oracle.domain();
-        oracle_registry.register(charter_domain.clone(), charter_oracle);
-        info!(
-            "Registered CharterPolicyOracle with OracleRegistry for domain '{}'",
-            charter_domain
-        );
-    }
+    register_core_oracles(
+        &oracle_registry,
+        trust_service_from_registry
+            .as_ref()
+            .map(|trust_service| trust_service.oracle()),
+        service_registry.and_then(|r| r.charter_oracle().cloned()),
+    );
 
     // Transition to CoreApps phase: first-party oracles are registered.
     oracle_registry.set_phase(icn_kernel_api::bootstrap::BootstrapPhase::CoreApps);
@@ -1672,5 +1712,118 @@ async fn spawn_background_tasks(
         }
     } else {
         info!("Resource access enforcer disabled by configuration");
+    }
+}
+
+#[cfg(test)]
+mod core_oracle_registration_tests {
+    use super::register_core_oracles;
+    use icn_kernel_api::authz::{
+        ActionKind, ConstraintSet, Domain, PolicyDecision, PolicyOracle, PolicyRequest, RateLimit,
+    };
+    use icn_kernel_api::bootstrap::BootstrapPhase;
+    use icn_kernel_api::OracleRegistry;
+    use std::sync::Arc;
+
+    /// Reports a domain that is NOT the network domain, exactly as the real trust
+    /// and charter oracles do. That mismatch is the whole bug (#2488): registering
+    /// oracles by `domain()` alone never covers `net`.
+    #[derive(Debug)]
+    struct FakeOracle(&'static str);
+
+    impl PolicyOracle for FakeOracle {
+        fn evaluate(&self, _request: &PolicyRequest) -> PolicyDecision {
+            PolicyDecision::allow_with(
+                ConstraintSet::new().with_rate_limit(RateLimit::restricted()),
+            )
+        }
+
+        fn domain(&self) -> Domain {
+            Domain::new(self.0)
+        }
+    }
+
+    fn request_for(domain: &str) -> PolicyRequest {
+        PolicyRequest::new(
+            "did:icn:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK".to_string(),
+            ActionKind::Custom("network_message".to_string()),
+            Domain::new(domain),
+        )
+    }
+
+    /// The regression guard: the composition root MUST register the domain that
+    /// `icn-net` queries. If the `net` registration is ever removed from
+    /// `register_core_oracles`, this fails.
+    #[test]
+    fn registers_the_domain_icn_net_queries() {
+        let registry = OracleRegistry::new();
+        register_core_oracles(&registry, Some(Arc::new(FakeOracle("trust"))), None);
+        registry.set_phase(BootstrapPhase::Running);
+
+        let decision = registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN));
+
+        assert!(
+            matches!(decision, PolicyDecision::Allow { .. }),
+            "the composition root must register an oracle for '{}' — without it the \
+             registry denies every inbound network message in Running phase and the \
+             node cannot peer (#2488); got {decision:?}",
+            icn_net::NETWORK_DOMAIN
+        );
+    }
+
+    /// The trust domain keeps working; the net registration is additive.
+    #[test]
+    fn still_registers_the_trust_and_charter_domains() {
+        let registry = OracleRegistry::new();
+        register_core_oracles(
+            &registry,
+            Some(Arc::new(FakeOracle("trust"))),
+            Some(Arc::new(FakeOracle("charter"))),
+        );
+        registry.set_phase(BootstrapPhase::Running);
+
+        for domain in ["trust", "charter"] {
+            assert!(
+                matches!(
+                    registry.evaluate(&request_for(domain)),
+                    PolicyDecision::Allow { .. }
+                ),
+                "domain '{domain}' must remain registered"
+            );
+        }
+    }
+
+    /// Registration is scoped: unrelated domains still deny by default. Guards
+    /// against a "fix" that makes the registry permissive across the board.
+    #[test]
+    fn does_not_make_unrelated_domains_permissive() {
+        let registry = OracleRegistry::new();
+        register_core_oracles(&registry, Some(Arc::new(FakeOracle("trust"))), None);
+        registry.set_phase(BootstrapPhase::Running);
+
+        let decision = registry.evaluate(&request_for("some-unregistered-domain"));
+
+        assert!(
+            matches!(decision, PolicyDecision::Deny { .. }),
+            "deny-by-default must still hold for domains nobody registered; got {decision:?}"
+        );
+    }
+
+    /// Without a trust service there is no network oracle, so the network domain
+    /// stays denied. Documents the residual exposure rather than hiding it: a node
+    /// with no trust service cannot peer, and that is fail-closed by construction.
+    #[test]
+    fn without_a_trust_oracle_the_network_domain_is_not_registered() {
+        let registry = OracleRegistry::new();
+        register_core_oracles(&registry, None, None);
+        registry.set_phase(BootstrapPhase::Running);
+
+        let decision = registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN));
+
+        assert!(
+            matches!(decision, PolicyDecision::Deny { .. }),
+            "with no trust oracle the network domain has no provider and must \
+             fail closed; got {decision:?}"
+        );
     }
 }

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -285,6 +285,7 @@ fn register_core_oracles(
     oracle_registry: &icn_kernel_api::OracleRegistry,
     trust_oracle: Option<std::sync::Arc<dyn icn_kernel_api::authz::PolicyOracle>>,
     charter_oracle: Option<std::sync::Arc<dyn icn_kernel_api::authz::PolicyOracle>>,
+    network_rate_ceiling: &crate::config::TrustClassRateLimitConfig,
 ) {
     if let Some(trust_oracle) = trust_oracle {
         let trust_domain = trust_oracle.domain();
@@ -297,10 +298,26 @@ fn register_core_oracles(
         // Serve the network domain from the same oracle. The trust oracle reports
         // its own domain as "trust", so registering by `domain()` alone leaves
         // "net" unregistered — see this function's doc comment.
+        //
+        // Wrapped in a ceiling because the rate limiter keys on the *unauthenticated*
+        // `NetworkMessage.from`: the tier is chosen from a DID the sender merely
+        // claims, and the top trust tier is `RateLimit::unlimited()` (u32::MAX).
+        // Without the cap, naming a well-trusted DID buys an unbounded budget for
+        // pre-authentication work. The cap is the operator's configured maximum.
         let network_domain = icn_kernel_api::authz::Domain::new(icn_net::NETWORK_DOMAIN);
-        oracle_registry.register(network_domain.clone(), trust_oracle);
+        let network_oracle: std::sync::Arc<dyn icn_kernel_api::authz::PolicyOracle> =
+            std::sync::Arc::new(super::network_policy::CappedRateLimitOracle::new(
+                trust_oracle,
+                network_domain.clone(),
+                network_rate_ceiling.max_messages_per_second,
+                network_rate_ceiling.burst_capacity,
+            ));
+        oracle_registry.register(network_domain.clone(), network_oracle);
         info!(
-            "Registered network PolicyOracle with OracleRegistry for domain '{}'",
+            max_messages_per_second = network_rate_ceiling.max_messages_per_second,
+            burst_capacity = network_rate_ceiling.burst_capacity,
+            "Registered network PolicyOracle with OracleRegistry for domain '{}' \
+             (rate limits capped at the configured maximum)",
             network_domain
         );
     }
@@ -390,6 +407,8 @@ async fn spawn_actors_with_identity(
             .as_ref()
             .map(|trust_service| trust_service.oracle()),
         service_registry.and_then(|r| r.charter_oracle().cloned()),
+        // Highest configured tier: no peer may exceed what the operator allowed.
+        &config.rate_limiting.federated,
     );
 
     // Transition to CoreApps phase: first-party oracles are registered.
@@ -1743,6 +1762,29 @@ mod core_oracle_registration_tests {
         }
     }
 
+    /// Returns the unbounded top tier, as the real trust oracle does for a peer
+    /// scoring >= 0.7.
+    #[derive(Debug)]
+    struct UnlimitedOracle;
+
+    impl PolicyOracle for UnlimitedOracle {
+        fn evaluate(&self, _request: &PolicyRequest) -> PolicyDecision {
+            PolicyDecision::allow_with(ConstraintSet::new().with_rate_limit(RateLimit::unlimited()))
+        }
+
+        fn domain(&self) -> Domain {
+            Domain::trust()
+        }
+    }
+
+    /// Mirrors the deployed `[rate_limiting.federated]` values.
+    fn ceiling() -> crate::config::TrustClassRateLimitConfig {
+        crate::config::TrustClassRateLimitConfig {
+            max_messages_per_second: 200,
+            burst_capacity: 50,
+        }
+    }
+
     fn request_for(domain: &str) -> PolicyRequest {
         PolicyRequest::new(
             "did:icn:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK".to_string(),
@@ -1757,7 +1799,12 @@ mod core_oracle_registration_tests {
     #[test]
     fn registers_the_domain_icn_net_queries() {
         let registry = OracleRegistry::new();
-        register_core_oracles(&registry, Some(Arc::new(FakeOracle("trust"))), None);
+        register_core_oracles(
+            &registry,
+            Some(Arc::new(FakeOracle("trust"))),
+            None,
+            &ceiling(),
+        );
         registry.set_phase(BootstrapPhase::Running);
 
         let decision = registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN));
@@ -1779,6 +1826,7 @@ mod core_oracle_registration_tests {
             &registry,
             Some(Arc::new(FakeOracle("trust"))),
             Some(Arc::new(FakeOracle("charter"))),
+            &ceiling(),
         );
         registry.set_phase(BootstrapPhase::Running);
 
@@ -1793,12 +1841,72 @@ mod core_oracle_registration_tests {
         }
     }
 
+    /// The composition root must cap what it registers for the network domain.
+    ///
+    /// `icn-net` rate-limits on the *unauthenticated* `NetworkMessage.from`, so the
+    /// tier comes from a DID the sender merely claims. If the top tier reaches the
+    /// limiter as `u32::MAX`, naming a well-trusted DID buys an unbounded budget
+    /// for pre-authentication work. This asserts the wiring — not just the wrapper
+    /// in isolation — actually applies the operator's ceiling.
+    #[test]
+    fn network_domain_rate_limits_are_capped_at_the_configured_maximum() {
+        let registry = OracleRegistry::new();
+        register_core_oracles(&registry, Some(Arc::new(UnlimitedOracle)), None, &ceiling());
+        registry.set_phase(BootstrapPhase::Running);
+
+        let decision = registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN));
+
+        let rate_limit = match decision {
+            PolicyDecision::Allow { constraints, .. } => {
+                constraints.rate_limit.clone().expect("rate limit present")
+            }
+            PolicyDecision::Deny { .. } => panic!("network domain must be registered"),
+        };
+
+        assert_eq!(
+            (rate_limit.messages_per_second, rate_limit.burst_size),
+            (200, 50),
+            "an unlimited trust tier must be clamped to the configured maximum before \
+             it reaches the rate limiter, not passed through as u32::MAX"
+        );
+    }
+
+    /// The trust domain itself is NOT capped — the ceiling is specific to the
+    /// network path, where the actor is unauthenticated.
+    #[test]
+    fn the_trust_domain_itself_is_not_capped() {
+        let registry = OracleRegistry::new();
+        register_core_oracles(&registry, Some(Arc::new(UnlimitedOracle)), None, &ceiling());
+        registry.set_phase(BootstrapPhase::Running);
+
+        let decision = registry.evaluate(&request_for("trust"));
+
+        let rate_limit = match decision {
+            PolicyDecision::Allow { constraints, .. } => {
+                constraints.rate_limit.clone().expect("rate limit present")
+            }
+            PolicyDecision::Deny { .. } => panic!("trust domain must be registered"),
+        };
+
+        assert_eq!(
+            rate_limit.messages_per_second,
+            u32::MAX,
+            "the cap must apply to the network registration only, leaving other \
+             consumers of the trust oracle unchanged"
+        );
+    }
+
     /// Registration is scoped: unrelated domains still deny by default. Guards
     /// against a "fix" that makes the registry permissive across the board.
     #[test]
     fn does_not_make_unrelated_domains_permissive() {
         let registry = OracleRegistry::new();
-        register_core_oracles(&registry, Some(Arc::new(FakeOracle("trust"))), None);
+        register_core_oracles(
+            &registry,
+            Some(Arc::new(FakeOracle("trust"))),
+            None,
+            &ceiling(),
+        );
         registry.set_phase(BootstrapPhase::Running);
 
         let decision = registry.evaluate(&request_for("some-unregistered-domain"));
@@ -1815,7 +1923,7 @@ mod core_oracle_registration_tests {
     #[test]
     fn without_a_trust_oracle_the_network_domain_is_not_registered() {
         let registry = OracleRegistry::new();
-        register_core_oracles(&registry, None, None);
+        register_core_oracles(&registry, None, None, &ceiling());
         registry.set_phase(BootstrapPhase::Running);
 
         let decision = registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN));

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -266,9 +266,9 @@ pub async fn run_supervisor(
 ///
 /// This is the composition root's complete set of domain registrations. It is a
 /// standalone function so that the set can be asserted in tests: once the registry
-/// reaches [`BootstrapPhase::Running`], any domain that is *not* registered here is
-/// denied by default, so an omission silently disables a whole subsystem rather
-/// than failing loudly.
+/// reaches [`icn_kernel_api::bootstrap::BootstrapPhase::Running`], any domain that
+/// is *not* registered here is denied by default, so an omission silently disables
+/// a whole subsystem rather than failing loudly.
 ///
 /// That is exactly how #2488 happened. Oracles were registered by
 /// `oracle.domain()`, which covered `trust` and `charter` but never `net` — the

--- a/icn/crates/icn-core/src/supervisor/mod.rs
+++ b/icn/crates/icn-core/src/supervisor/mod.rs
@@ -35,6 +35,7 @@ pub mod init_snapshot;
 pub mod init_steward;
 pub mod lifecycle;
 pub mod nat_dial;
+pub mod network_policy;
 pub mod shutdown;
 pub mod version_tracker;
 

--- a/icn/crates/icn-core/src/supervisor/network_policy.rs
+++ b/icn/crates/icn-core/src/supervisor/network_policy.rs
@@ -1,0 +1,261 @@
+//! Operator-configured ceiling on network rate-limit constraints.
+//!
+//! # Why this exists
+//!
+//! `icn-net`'s rate limiter is keyed on `NetworkMessage.from`, which is
+//! **self-asserted and not yet authenticated** when the check runs — the Hello
+//! binding proof and `SignedEnvelope` verification both happen after dispatch
+//! (`icn-net/src/actor/connection.rs`). DIDs are public, so a sender can name any
+//! DID it likes and receive whatever tier that DID's trust score maps to.
+//!
+//! On its own that is a pre-existing weakness bounded by whatever the tier
+//! allows. It stops being bounded when the tier is `RateLimit::unlimited()`,
+//! which is `u32::MAX` for both rate and burst: a sender that claims a
+//! well-trusted DID gets no effective limit at all, and can force repeated
+//! deserialization, binding checks, and signature verification for free.
+//!
+//! [`CappedRateLimitOracle`] closes that by clamping whatever the inner oracle
+//! returns to the operator's configured maximum. It is a numeric ceiling and
+//! nothing more: it does not read trust scores, infer a tier, or reconstruct any
+//! domain meaning from the `ConstraintSet` — doing so inside a kernel crate would
+//! violate the meaning firewall. It only enforces "no peer, however it is
+//! classified, exceeds what the operator configured."
+//!
+//! The deeper fix — applying trust-derived tiers only after the connection is
+//! bound to a verified DID — is a protocol change tracked separately.
+
+use std::sync::Arc;
+
+use icn_kernel_api::authz::{
+    ConstraintSet, Domain, PolicyDecision, PolicyOracle, PolicyRequest, RateLimit,
+};
+
+/// Wraps a `PolicyOracle` and caps any rate-limit constraint it returns.
+pub struct CappedRateLimitOracle {
+    inner: Arc<dyn PolicyOracle>,
+    domain: Domain,
+    max_messages_per_second: u32,
+    max_burst: u32,
+}
+
+// Hand-written: `Arc<dyn PolicyOracle>` is not `Debug`, and the trait does not
+// require it.
+impl std::fmt::Debug for CappedRateLimitOracle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CappedRateLimitOracle")
+            .field("domain", &self.domain)
+            .field("max_messages_per_second", &self.max_messages_per_second)
+            .field("max_burst", &self.max_burst)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CappedRateLimitOracle {
+    /// Serve `domain` from `inner`, clamping rate limits to the given ceiling.
+    pub fn new(
+        inner: Arc<dyn PolicyOracle>,
+        domain: Domain,
+        max_messages_per_second: u32,
+        max_burst: u32,
+    ) -> Self {
+        Self {
+            inner,
+            domain,
+            max_messages_per_second,
+            max_burst,
+        }
+    }
+
+    fn cap(&self, rate_limit: &RateLimit) -> RateLimit {
+        RateLimit {
+            messages_per_second: rate_limit
+                .messages_per_second
+                .min(self.max_messages_per_second),
+            burst_size: rate_limit.burst_size.min(self.max_burst),
+        }
+    }
+}
+
+impl PolicyOracle for CappedRateLimitOracle {
+    fn evaluate(&self, request: &PolicyRequest) -> PolicyDecision {
+        match self.inner.evaluate(request) {
+            PolicyDecision::Allow { constraints, .. } => {
+                // A decision with no rate-limit constraint is left alone: the
+                // caller falls back to its configured default, which is already
+                // operator-controlled.
+                let capped = match &constraints.rate_limit {
+                    Some(rate_limit) => {
+                        let mut next = ConstraintSet::clone(&constraints);
+                        next.rate_limit = Some(self.cap(rate_limit));
+                        next
+                    }
+                    None => constraints,
+                };
+                PolicyDecision::allow_with(capped)
+            }
+            // Denials pass through untouched — capping must never turn a deny
+            // into an allow.
+            deny => deny,
+        }
+    }
+
+    fn domain(&self) -> Domain {
+        self.domain.clone()
+    }
+
+    fn cache_ttl(&self) -> std::time::Duration {
+        self.inner.cache_ttl()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_kernel_api::authz::ActionKind;
+
+    #[derive(Debug)]
+    struct FixedOracle(Option<RateLimit>);
+
+    impl PolicyOracle for FixedOracle {
+        fn evaluate(&self, _request: &PolicyRequest) -> PolicyDecision {
+            match &self.0 {
+                Some(rate_limit) => PolicyDecision::allow_with(
+                    ConstraintSet::new().with_rate_limit(rate_limit.clone()),
+                ),
+                None => PolicyDecision::allow_with(ConstraintSet::new()),
+            }
+        }
+
+        fn domain(&self) -> Domain {
+            Domain::trust()
+        }
+    }
+
+    #[derive(Debug)]
+    struct DenyOracle;
+
+    impl PolicyOracle for DenyOracle {
+        fn evaluate(&self, _request: &PolicyRequest) -> PolicyDecision {
+            PolicyDecision::deny("nope".to_string())
+        }
+
+        fn domain(&self) -> Domain {
+            Domain::trust()
+        }
+    }
+
+    fn request() -> PolicyRequest {
+        PolicyRequest::new(
+            "did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9".to_string(),
+            ActionKind::Custom("network_message".to_string()),
+            Domain::new("net"),
+        )
+    }
+
+    fn rate_limit_of(decision: &PolicyDecision) -> Option<RateLimit> {
+        match decision {
+            PolicyDecision::Allow { constraints, .. } => constraints.rate_limit.clone(),
+            PolicyDecision::Deny { .. } => None,
+        }
+    }
+
+    /// The security case: an unlimited tier must not survive the cap.
+    ///
+    /// `RateLimit::unlimited()` is `u32::MAX`, and the DID it was derived from is
+    /// unauthenticated at check time, so without this an attacker naming a
+    /// well-trusted DID gets no bound at all.
+    #[test]
+    fn unlimited_is_capped_to_the_configured_ceiling() {
+        let oracle = CappedRateLimitOracle::new(
+            Arc::new(FixedOracle(Some(RateLimit::unlimited()))),
+            Domain::new("net"),
+            200,
+            50,
+        );
+
+        let limit = rate_limit_of(&oracle.evaluate(&request())).expect("rate limit present");
+
+        assert_eq!(
+            (limit.messages_per_second, limit.burst_size),
+            (200, 50),
+            "an unlimited tier must be clamped to the operator's configured maximum"
+        );
+    }
+
+    /// Limits already below the ceiling are untouched — the cap is a ceiling, not
+    /// an override that would silently *raise* a restrictive tier.
+    #[test]
+    fn limits_below_the_ceiling_are_left_alone() {
+        let oracle = CappedRateLimitOracle::new(
+            Arc::new(FixedOracle(Some(RateLimit::restricted()))),
+            Domain::new("net"),
+            200,
+            50,
+        );
+
+        let limit = rate_limit_of(&oracle.evaluate(&request())).expect("rate limit present");
+
+        assert_eq!(
+            (limit.messages_per_second, limit.burst_size),
+            (5, 5),
+            "restricted() is already under the ceiling and must pass through unchanged"
+        );
+    }
+
+    /// Each field is capped independently.
+    #[test]
+    fn each_field_is_capped_independently() {
+        let oracle = CappedRateLimitOracle::new(
+            Arc::new(FixedOracle(Some(RateLimit {
+                messages_per_second: 10,
+                burst_size: u32::MAX,
+            }))),
+            Domain::new("net"),
+            200,
+            50,
+        );
+
+        let limit = rate_limit_of(&oracle.evaluate(&request())).expect("rate limit present");
+
+        assert_eq!(
+            (limit.messages_per_second, limit.burst_size),
+            (10, 50),
+            "a low rate with an unbounded burst must keep the rate and cap the burst"
+        );
+    }
+
+    /// Capping must never convert a denial into an allow.
+    #[test]
+    fn denials_pass_through_untouched() {
+        let oracle = CappedRateLimitOracle::new(Arc::new(DenyOracle), Domain::new("net"), 200, 50);
+
+        assert!(
+            matches!(oracle.evaluate(&request()), PolicyDecision::Deny { .. }),
+            "a deny from the inner oracle must remain a deny"
+        );
+    }
+
+    /// No rate-limit constraint means the caller's configured fallback applies;
+    /// the wrapper must not invent one.
+    #[test]
+    fn absent_rate_limit_is_not_fabricated() {
+        let oracle =
+            CappedRateLimitOracle::new(Arc::new(FixedOracle(None)), Domain::new("net"), 200, 50);
+
+        assert!(
+            rate_limit_of(&oracle.evaluate(&request())).is_none(),
+            "the wrapper must not synthesise a rate limit where the inner oracle gave none"
+        );
+    }
+
+    /// The wrapper reports the domain it was registered for, not the inner
+    /// oracle's — that mismatch is what #2488 was about.
+    #[test]
+    fn reports_the_domain_it_serves_not_the_inner_domain() {
+        let oracle =
+            CappedRateLimitOracle::new(Arc::new(FixedOracle(None)), Domain::new("net"), 200, 50);
+
+        assert_eq!(oracle.domain(), Domain::new("net"));
+        assert_ne!(oracle.domain(), Domain::trust());
+    }
+}

--- a/icn/crates/icn-core/src/supervisor/network_policy.rs
+++ b/icn/crates/icn-core/src/supervisor/network_policy.rs
@@ -14,87 +14,196 @@
 //! well-trusted DID gets no effective limit at all, and can force repeated
 //! deserialization, binding checks, and signature verification for free.
 //!
-//! [`CappedRateLimitOracle`] closes that by clamping whatever the inner oracle
-//! returns to the operator's configured maximum. It is a numeric ceiling and
-//! nothing more: it does not read trust scores, infer a tier, or reconstruct any
-//! domain meaning from the `ConstraintSet` — doing so inside a kernel crate would
-//! violate the meaning firewall. It only enforces "no peer, however it is
-//! classified, exceeds what the operator configured."
+//! # What this does
 //!
-//! The deeper fix — applying trust-derived tiers only after the connection is
-//! bound to a verified DID — is a protocol change tracked separately.
+//! [`NetworkRateLimitOracle`] serves the network domain by selecting the
+//! operator-configured limit for the peer's trust class, then clamping it to an
+//! absolute ceiling.
+//!
+//! ## Honouring every configured tier (#2496)
+//!
+//! Operators configure four tiers — `rate_limiting.{isolated,known,partner,federated}`.
+//! Routing `net` straight at the trust oracle ignored all of them: that oracle
+//! emits its own hard-coded 5/20/100/`unlimited()` ladder, so a configured
+//! `isolated` burst of 2 still produced 5. Passing only the `federated` values as
+//! a ceiling fixed the top of the range and left the rest untouched.
+//!
+//! The selection happens **here**, at the composition root, because this is the
+//! only layer that holds both halves: the neutral [`TrustClass`] classification
+//! (via [`TrustService`], an `icn-kernel-api` trait) and the operator's
+//! configuration. The flow is
+//!
+//! ```text
+//! domain trust score -> neutral TrustClass -> operator-configured tier -> ceiling
+//! ```
+//!
+//! It never inspects the inner oracle's numbers to work out which tier they came
+//! from. Reconstructing "5 msg/s means Isolated" from a generic `ConstraintSet`
+//! would be exactly the meaning-firewall violation the kernel/app split exists to
+//! prevent; the class comes from the trust service, not from arithmetic.
+//!
+//! ## The absolute ceiling
+//!
+//! Tier selection does not replace the ceiling — both apply. The ceiling is
+//! defence in depth for #2491: since the tier is chosen from an unauthenticated
+//! DID, a misconfigured or overly generous tier must not become an unbounded
+//! pre-authentication budget. #2491 itself (binding the tier to a *verified*
+//! identity) is a protocol change tracked separately and deliberately not solved
+//! here.
+//!
+//! ## Cost
+//!
+//! Selecting the tier costs one `TrustService::trust_score` call per *allowed*
+//! message, on top of the one the inner oracle already makes. That is the price
+//! of not inferring the class from the constraint values; denials short-circuit
+//! before it.
 
 use std::sync::Arc;
 
 use icn_kernel_api::authz::{
     ConstraintSet, Domain, PolicyDecision, PolicyOracle, PolicyRequest, RateLimit,
 };
+use icn_kernel_api::services::{TrustClass, TrustService};
 
-/// Wraps a `PolicyOracle` and caps any rate-limit constraint it returns.
-pub struct CappedRateLimitOracle {
+/// The operator-configured network rate limit for each trust class.
+///
+/// Mirrors `rate_limiting.{isolated,known,partner,federated}` from the daemon
+/// config. Held as a struct rather than a map so adding a [`TrustClass`] variant
+/// is a compile error here rather than a silently missing tier.
+#[derive(Debug, Clone)]
+pub struct NetworkRateLimitTiers {
+    /// Limit for peers classified [`TrustClass::Isolated`].
+    pub isolated: RateLimit,
+    /// Limit for peers classified [`TrustClass::Known`].
+    pub known: RateLimit,
+    /// Limit for peers classified [`TrustClass::Partner`].
+    pub partner: RateLimit,
+    /// Limit for peers classified [`TrustClass::Federated`].
+    pub federated: RateLimit,
+}
+
+impl NetworkRateLimitTiers {
+    /// The configured limit for a trust class.
+    pub fn for_class(&self, class: TrustClass) -> &RateLimit {
+        match class {
+            TrustClass::Isolated => &self.isolated,
+            TrustClass::Known => &self.known,
+            TrustClass::Partner => &self.partner,
+            TrustClass::Federated => &self.federated,
+        }
+    }
+}
+
+/// Read one configured tier as a kernel [`RateLimit`].
+///
+/// The config type is the daemon's; the kernel only ever sees the two numbers.
+pub fn rate_limit_from_config(config: &crate::config::TrustClassRateLimitConfig) -> RateLimit {
+    RateLimit {
+        messages_per_second: config.max_messages_per_second,
+        burst_size: config.burst_capacity,
+    }
+}
+
+impl NetworkRateLimitTiers {
+    /// Build the tier table from the daemon's `[rate_limiting]` section.
+    ///
+    /// This is the whole of the operator's half of the mapping. The trust half
+    /// arrives separately, as a [`TrustClass`]; the two meet in
+    /// [`NetworkRateLimitOracle::configured_limit_for`] and nowhere else.
+    pub fn from_config(config: &crate::config::RateLimitingConfig) -> Self {
+        Self {
+            isolated: rate_limit_from_config(&config.isolated),
+            known: rate_limit_from_config(&config.known),
+            partner: rate_limit_from_config(&config.partner),
+            federated: rate_limit_from_config(&config.federated),
+        }
+    }
+}
+
+/// Serves the network domain: selects the operator-configured tier for a peer's
+/// trust class, then clamps it to an absolute ceiling.
+pub struct NetworkRateLimitOracle {
     inner: Arc<dyn PolicyOracle>,
+    trust: Arc<dyn TrustService>,
     domain: Domain,
-    max_messages_per_second: u32,
-    max_burst: u32,
+    tiers: NetworkRateLimitTiers,
+    ceiling: RateLimit,
 }
 
 // Hand-written: `Arc<dyn PolicyOracle>` is not `Debug`, and the trait does not
 // require it.
-impl std::fmt::Debug for CappedRateLimitOracle {
+impl std::fmt::Debug for NetworkRateLimitOracle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CappedRateLimitOracle")
+        f.debug_struct("NetworkRateLimitOracle")
             .field("domain", &self.domain)
-            .field("max_messages_per_second", &self.max_messages_per_second)
-            .field("max_burst", &self.max_burst)
+            .field("tiers", &self.tiers)
+            .field("ceiling", &self.ceiling)
             .finish_non_exhaustive()
     }
 }
 
-impl CappedRateLimitOracle {
-    /// Serve `domain` from `inner`, clamping rate limits to the given ceiling.
+impl NetworkRateLimitOracle {
+    /// Serve `domain` from `inner`, replacing its rate limit with the configured
+    /// tier for the peer's trust class and clamping that to `ceiling`.
     pub fn new(
         inner: Arc<dyn PolicyOracle>,
+        trust: Arc<dyn TrustService>,
         domain: Domain,
-        max_messages_per_second: u32,
-        max_burst: u32,
+        tiers: NetworkRateLimitTiers,
+        ceiling: RateLimit,
     ) -> Self {
         Self {
             inner,
+            trust,
             domain,
-            max_messages_per_second,
-            max_burst,
+            tiers,
+            ceiling,
         }
+    }
+
+    /// The configured limit for `actor`, clamped to the absolute ceiling.
+    ///
+    /// The class comes from the trust service and is mapped through the neutral
+    /// [`TrustClass`]; it is never derived from the inner oracle's numbers.
+    fn configured_limit_for(&self, actor: &icn_kernel_api::types::Did) -> RateLimit {
+        let class = TrustClass::from_score(self.trust.trust_score(actor));
+        self.cap(self.tiers.for_class(class))
     }
 
     fn cap(&self, rate_limit: &RateLimit) -> RateLimit {
         RateLimit {
             messages_per_second: rate_limit
                 .messages_per_second
-                .min(self.max_messages_per_second),
-            burst_size: rate_limit.burst_size.min(self.max_burst),
+                .min(self.ceiling.messages_per_second),
+            burst_size: rate_limit.burst_size.min(self.ceiling.burst_size),
         }
     }
 }
 
-impl PolicyOracle for CappedRateLimitOracle {
+impl PolicyOracle for NetworkRateLimitOracle {
     fn evaluate(&self, request: &PolicyRequest) -> PolicyDecision {
         match self.inner.evaluate(request) {
             PolicyDecision::Allow { constraints, .. } => {
                 // A decision with no rate-limit constraint is left alone: the
                 // caller falls back to its configured default, which is already
-                // operator-controlled.
-                let capped = match &constraints.rate_limit {
-                    Some(rate_limit) => {
+                // operator-controlled. Synthesising one here would override that
+                // fallback for oracles that deliberately abstain.
+                let resolved = match &constraints.rate_limit {
+                    Some(_) => {
+                        // The inner oracle's own number is *replaced*, not
+                        // clamped. Clamping alone was #2496: it bounded the top
+                        // of the range and let the hard-coded ladder through
+                        // everywhere below it.
                         let mut next = ConstraintSet::clone(&constraints);
-                        next.rate_limit = Some(self.cap(rate_limit));
+                        next.rate_limit = Some(self.configured_limit_for(&request.core.actor));
                         next
                     }
                     None => constraints,
                 };
-                PolicyDecision::allow_with(capped)
+                PolicyDecision::allow_with(resolved)
             }
-            // Denials pass through untouched — capping must never turn a deny
-            // into an allow.
+            // Denials pass through untouched — neither tier selection nor
+            // capping may turn a deny into an allow.
             deny => deny,
         }
     }
@@ -159,18 +268,132 @@ mod tests {
         }
     }
 
-    /// The security case: an unlimited tier must not survive the cap.
-    ///
-    /// `RateLimit::unlimited()` is `u32::MAX`, and the DID it was derived from is
-    /// unauthenticated at check time, so without this an attacker naming a
-    /// well-trusted DID gets no bound at all.
-    #[test]
-    fn unlimited_is_capped_to_the_configured_ceiling() {
-        let oracle = CappedRateLimitOracle::new(
+    /// Stand-in for the trust service: reports a fixed score for any actor.
+    struct FixedScoreTrust(f64);
+
+    impl icn_kernel_api::services::TrustService for FixedScoreTrust {
+        fn oracle(&self) -> Arc<dyn PolicyOracle> {
+            Arc::new(FixedOracle(None))
+        }
+
+        fn trust_score(&self, _actor: &icn_kernel_api::types::Did) -> f64 {
+            self.0
+        }
+
+        fn record_event(
+            &self,
+            _actor: &icn_kernel_api::types::Did,
+            _event: icn_kernel_api::services::TrustEvent,
+        ) {
+        }
+    }
+
+    /// The four configured tiers, deliberately distinct from the trust oracle's
+    /// hard-coded 5/20/100/unlimited so a passing test cannot be an accident.
+    fn configured_tiers() -> NetworkRateLimitTiers {
+        NetworkRateLimitTiers {
+            isolated: RateLimit {
+                messages_per_second: 1,
+                burst_size: 2,
+            },
+            known: RateLimit {
+                messages_per_second: 7,
+                burst_size: 9,
+            },
+            partner: RateLimit {
+                messages_per_second: 11,
+                burst_size: 13,
+            },
+            federated: RateLimit {
+                messages_per_second: 17,
+                burst_size: 19,
+            },
+        }
+    }
+
+    fn tiered_oracle(score: f64) -> NetworkRateLimitOracle {
+        NetworkRateLimitOracle::new(
+            // The inner oracle offers `unlimited()` for every actor, exactly as
+            // the real trust oracle does at score >= 0.7. If the tier table is
+            // ignored, that value is what comes out.
             Arc::new(FixedOracle(Some(RateLimit::unlimited()))),
+            Arc::new(FixedScoreTrust(score)),
             Domain::new("net"),
-            200,
-            50,
+            configured_tiers(),
+            RateLimit {
+                messages_per_second: 200,
+                burst_size: 50,
+            },
+        )
+    }
+
+    /// Every configured tier is honoured, not just the federated one.
+    ///
+    /// This is #2496. The previous wiring passed only `rate_limiting.federated`
+    /// as a ceiling and let the trust oracle's hard-coded 5/20/100/unlimited
+    /// through underneath it, so lowering `isolated` or `partner` did nothing.
+    #[test]
+    fn each_configured_tier_is_honoured() {
+        // (trust score, expected rate, expected burst) — one per class boundary.
+        let cases = [
+            (0.0, 1, 2),    // Isolated
+            (0.05, 1, 2),   // Isolated, just below the Known threshold
+            (0.1, 7, 9),    // Known, exactly at the threshold
+            (0.39, 7, 9),   // Known
+            (0.4, 11, 13),  // Partner, exactly at the threshold
+            (0.69, 11, 13), // Partner
+            (0.7, 17, 19),  // Federated, exactly at the threshold
+            (1.0, 17, 19),  // Federated
+        ];
+
+        for (score, expected_rate, expected_burst) in cases {
+            let limit = rate_limit_of(&tiered_oracle(score).evaluate(&request()))
+                .expect("rate limit present");
+
+            assert_eq!(
+                (limit.messages_per_second, limit.burst_size),
+                (expected_rate, expected_burst),
+                "score {score} must select its operator-configured tier"
+            );
+        }
+    }
+
+    /// The exact regression from the #2496 review: a configured isolated burst of
+    /// 2 must produce an effective burst of 2, not the trust oracle's hard-coded 5.
+    #[test]
+    fn configured_isolated_burst_of_two_is_not_widened_to_five() {
+        let limit =
+            rate_limit_of(&tiered_oracle(0.0).evaluate(&request())).expect("rate limit present");
+
+        assert_eq!(
+            limit.burst_size, 2,
+            "configured isolated burst = 2 must produce effective burst = 2; a 5 \
+             here means the trust oracle's `RateLimit::restricted()` leaked through"
+        );
+        assert_ne!(
+            limit.burst_size, 5,
+            "5 is `RateLimit::restricted()`'s burst - the value this bug shipped"
+        );
+    }
+
+    /// The absolute ceiling still binds, as defence in depth for #2491.
+    ///
+    /// The rate limiter keys on an unauthenticated `NetworkMessage.from`, so a
+    /// misconfigured tier must not become an unbounded pre-auth budget.
+    #[test]
+    fn a_tier_above_the_absolute_ceiling_is_still_clamped() {
+        let oracle = NetworkRateLimitOracle::new(
+            Arc::new(FixedOracle(Some(RateLimit::unlimited()))),
+            Arc::new(FixedScoreTrust(1.0)),
+            Domain::new("net"),
+            NetworkRateLimitTiers {
+                federated: RateLimit::unlimited(),
+                ..configured_tiers()
+            },
+            RateLimit {
+                messages_per_second: 200,
+                burst_size: 50,
+            },
         );
 
         let limit = rate_limit_of(&oracle.evaluate(&request())).expect("rate limit present");
@@ -178,41 +401,54 @@ mod tests {
         assert_eq!(
             (limit.messages_per_second, limit.burst_size),
             (200, 50),
-            "an unlimited tier must be clamped to the operator's configured maximum"
+            "no configured tier may exceed the operator's absolute ceiling"
         );
     }
 
-    /// Limits already below the ceiling are untouched — the cap is a ceiling, not
-    /// an override that would silently *raise* a restrictive tier.
+    /// The inner oracle's own numbers never reach the caller.
+    ///
+    /// This is the difference between #2490's first cut and the fix. Clamping the
+    /// inner value meant its hard-coded ladder still decided everything below the
+    /// ceiling; replacing it means the operator's table decides. The inner oracle
+    /// here says `unlimited()` for every actor and none of it survives.
     #[test]
-    fn limits_below_the_ceiling_are_left_alone() {
-        let oracle = CappedRateLimitOracle::new(
-            Arc::new(FixedOracle(Some(RateLimit::restricted()))),
-            Domain::new("net"),
-            200,
-            50,
-        );
+    fn the_inner_oracles_own_numbers_never_reach_the_caller() {
+        for score in [0.0, 0.2, 0.5, 0.9] {
+            let limit = rate_limit_of(&tiered_oracle(score).evaluate(&request()))
+                .expect("rate limit present");
 
-        let limit = rate_limit_of(&oracle.evaluate(&request())).expect("rate limit present");
-
-        assert_eq!(
-            (limit.messages_per_second, limit.burst_size),
-            (5, 5),
-            "restricted() is already under the ceiling and must pass through unchanged"
-        );
+            assert_ne!(
+                limit.messages_per_second,
+                u32::MAX,
+                "the inner oracle's unlimited() must never survive"
+            );
+            assert!(
+                [1, 7, 11, 17].contains(&limit.messages_per_second),
+                "the effective limit must come from the configured tier table, \
+                 got {} msg/s",
+                limit.messages_per_second
+            );
+        }
     }
 
-    /// Each field is capped independently.
+    /// The ceiling clamps each field independently.
     #[test]
-    fn each_field_is_capped_independently() {
-        let oracle = CappedRateLimitOracle::new(
-            Arc::new(FixedOracle(Some(RateLimit {
-                messages_per_second: 10,
-                burst_size: u32::MAX,
-            }))),
+    fn the_ceiling_clamps_each_field_independently() {
+        let oracle = NetworkRateLimitOracle::new(
+            Arc::new(FixedOracle(Some(RateLimit::unlimited()))),
+            Arc::new(FixedScoreTrust(1.0)),
             Domain::new("net"),
-            200,
-            50,
+            NetworkRateLimitTiers {
+                federated: RateLimit {
+                    messages_per_second: 10,
+                    burst_size: u32::MAX,
+                },
+                ..configured_tiers()
+            },
+            RateLimit {
+                messages_per_second: 200,
+                burst_size: 50,
+            },
         );
 
         let limit = rate_limit_of(&oracle.evaluate(&request())).expect("rate limit present");
@@ -220,14 +456,24 @@ mod tests {
         assert_eq!(
             (limit.messages_per_second, limit.burst_size),
             (10, 50),
-            "a low rate with an unbounded burst must keep the rate and cap the burst"
+            "a configured tier with a low rate and an unbounded burst must keep \
+             the rate and clamp only the burst"
         );
     }
 
-    /// Capping must never convert a denial into an allow.
+    /// Neither tier selection nor capping may convert a denial into an allow.
     #[test]
     fn denials_pass_through_untouched() {
-        let oracle = CappedRateLimitOracle::new(Arc::new(DenyOracle), Domain::new("net"), 200, 50);
+        let oracle = NetworkRateLimitOracle::new(
+            Arc::new(DenyOracle),
+            Arc::new(FixedScoreTrust(1.0)),
+            Domain::new("net"),
+            configured_tiers(),
+            RateLimit {
+                messages_per_second: 200,
+                burst_size: 50,
+            },
+        );
 
         assert!(
             matches!(oracle.evaluate(&request()), PolicyDecision::Deny { .. }),
@@ -237,10 +483,21 @@ mod tests {
 
     /// No rate-limit constraint means the caller's configured fallback applies;
     /// the wrapper must not invent one.
+    ///
+    /// An oracle that deliberately abstains is not the same as one that grants a
+    /// tier, and `icn-net`'s fallback is itself operator-configured.
     #[test]
     fn absent_rate_limit_is_not_fabricated() {
-        let oracle =
-            CappedRateLimitOracle::new(Arc::new(FixedOracle(None)), Domain::new("net"), 200, 50);
+        let oracle = NetworkRateLimitOracle::new(
+            Arc::new(FixedOracle(None)),
+            Arc::new(FixedScoreTrust(1.0)),
+            Domain::new("net"),
+            configured_tiers(),
+            RateLimit {
+                messages_per_second: 200,
+                burst_size: 50,
+            },
+        );
 
         assert!(
             rate_limit_of(&oracle.evaluate(&request())).is_none(),
@@ -252,8 +509,16 @@ mod tests {
     /// oracle's — that mismatch is what #2488 was about.
     #[test]
     fn reports_the_domain_it_serves_not_the_inner_domain() {
-        let oracle =
-            CappedRateLimitOracle::new(Arc::new(FixedOracle(None)), Domain::new("net"), 200, 50);
+        let oracle = NetworkRateLimitOracle::new(
+            Arc::new(FixedOracle(None)),
+            Arc::new(FixedScoreTrust(1.0)),
+            Domain::new("net"),
+            configured_tiers(),
+            RateLimit {
+                messages_per_second: 200,
+                burst_size: 50,
+            },
+        );
 
         assert_eq!(oracle.domain(), Domain::new("net"));
         assert_ne!(oracle.domain(), Domain::trust());

--- a/icn/crates/icn-core/src/supervisor/network_policy.rs
+++ b/icn/crates/icn-core/src/supervisor/network_policy.rs
@@ -290,22 +290,31 @@ mod tests {
 
     /// The four configured tiers, deliberately distinct from the trust oracle's
     /// hard-coded 5/20/100/unlimited so a passing test cannot be an accident.
+    ///
+    /// Every rate here is a whole multiple of the token bucket's refill
+    /// granularity (>= 1 / `refill_interval`, i.e. >= 10/s at the default 100 ms).
+    /// Sub-granularity rates are deliberately avoided: `RateLimiter` computes
+    /// `(rate * interval).max(1.0)` (`icn-net/src/rate_limit.rs:394`), so a
+    /// configured 1/s would be *quantised up* to 10/s by the consumer. Asserting
+    /// on such a value here would imply this layer can deliver a rate the limiter
+    /// cannot honour. See the floor test in
+    /// `tests/network_domain_oracle_registration.rs` and the tracking issue.
     fn configured_tiers() -> NetworkRateLimitTiers {
         NetworkRateLimitTiers {
             isolated: RateLimit {
-                messages_per_second: 1,
+                messages_per_second: 10,
                 burst_size: 2,
             },
             known: RateLimit {
-                messages_per_second: 7,
+                messages_per_second: 30,
                 burst_size: 9,
             },
             partner: RateLimit {
-                messages_per_second: 11,
+                messages_per_second: 70,
                 burst_size: 13,
             },
             federated: RateLimit {
-                messages_per_second: 17,
+                messages_per_second: 170,
                 burst_size: 19,
             },
         }
@@ -336,14 +345,14 @@ mod tests {
     fn each_configured_tier_is_honoured() {
         // (trust score, expected rate, expected burst) — one per class boundary.
         let cases = [
-            (0.0, 1, 2),    // Isolated
-            (0.05, 1, 2),   // Isolated, just below the Known threshold
-            (0.1, 7, 9),    // Known, exactly at the threshold
-            (0.39, 7, 9),   // Known
-            (0.4, 11, 13),  // Partner, exactly at the threshold
-            (0.69, 11, 13), // Partner
-            (0.7, 17, 19),  // Federated, exactly at the threshold
-            (1.0, 17, 19),  // Federated
+            (0.0, 10, 2),   // Isolated
+            (0.05, 10, 2),  // Isolated, just below the Known threshold
+            (0.1, 30, 9),   // Known, exactly at the threshold
+            (0.39, 30, 9),  // Known
+            (0.4, 70, 13),  // Partner, exactly at the threshold
+            (0.69, 70, 13), // Partner
+            (0.7, 170, 19), // Federated, exactly at the threshold
+            (1.0, 170, 19), // Federated
         ];
 
         for (score, expected_rate, expected_burst) in cases {
@@ -423,7 +432,7 @@ mod tests {
                 "the inner oracle's unlimited() must never survive"
             );
             assert!(
-                [1, 7, 11, 17].contains(&limit.messages_per_second),
+                [10, 30, 70, 170].contains(&limit.messages_per_second),
                 "the effective limit must come from the configured tier table, \
                  got {} msg/s",
                 limit.messages_per_second

--- a/icn/crates/icn-core/src/supervisor/network_policy.rs
+++ b/icn/crates/icn-core/src/supervisor/network_policy.rs
@@ -83,6 +83,32 @@ pub struct NetworkRateLimitTiers {
 }
 
 impl NetworkRateLimitTiers {
+    /// The absolute ceiling implied by this configuration.
+    ///
+    /// The maximum over all four tiers — deliberately *not* the federated tier.
+    ///
+    /// Using `federated` as a global ceiling silently clamped any tier an operator
+    /// configured above it, which is a legitimate shape: a burstier local
+    /// `partner` tier alongside a tighter WAN `federated` tier. Config validation
+    /// imposes no monotonic ordering, so such a configuration is accepted and was
+    /// then quietly overridden.
+    ///
+    /// Taking the maximum keeps the ceiling's actual purpose — bounding anything
+    /// that is *not* an operator-configured tier, so no trust-derived value can
+    /// exceed what the operator allowed — while guaranteeing it can never clamp a
+    /// configured tier.
+    pub fn ceiling(&self) -> RateLimit {
+        let tiers = [&self.isolated, &self.known, &self.partner, &self.federated];
+        RateLimit {
+            messages_per_second: tiers
+                .iter()
+                .map(|t| t.messages_per_second)
+                .max()
+                .unwrap_or(0),
+            burst_size: tiers.iter().map(|t| t.burst_size).max().unwrap_or(0),
+        }
+    }
+
     /// The configured limit for a trust class.
     pub fn for_class(&self, class: TrustClass) -> &RateLimit {
         match class {
@@ -382,6 +408,78 @@ mod tests {
         assert_ne!(
             limit.burst_size, 5,
             "5 is `RateLimit::restricted()`'s burst - the value this bug shipped"
+        );
+    }
+
+    /// A tier configured above the federated tier is not clamped.
+    ///
+    /// Regression for the review finding that used `rate_limiting.federated` as a
+    /// global ceiling. A burstier local `partner` tier alongside a tighter WAN
+    /// `federated` tier is a legitimate configuration, config validation imposes
+    /// no monotonic ordering, and the ceiling silently overrode it.
+    #[test]
+    fn a_tier_configured_above_the_federated_tier_is_not_clamped() {
+        let tiers = NetworkRateLimitTiers {
+            // Partner is deliberately burstier and faster than federated.
+            partner: RateLimit {
+                messages_per_second: 500,
+                burst_size: 90,
+            },
+            federated: RateLimit {
+                messages_per_second: 200,
+                burst_size: 50,
+            },
+            ..configured_tiers()
+        };
+        let ceiling = tiers.ceiling();
+
+        let oracle = NetworkRateLimitOracle::new(
+            Arc::new(FixedOracle(Some(RateLimit::unlimited()))),
+            Arc::new(FixedScoreTrust(0.5)), // Partner
+            Domain::new("net"),
+            tiers,
+            ceiling,
+        );
+
+        let limit = rate_limit_of(&oracle.evaluate(&request())).expect("rate limit present");
+
+        assert_eq!(
+            (limit.messages_per_second, limit.burst_size),
+            (500, 90),
+            "a partner tier configured above the federated tier must be honoured, \
+             not clamped down to the federated values"
+        );
+    }
+
+    /// The derived ceiling is the maximum across all tiers.
+    #[test]
+    fn the_ceiling_is_the_maximum_across_all_tiers() {
+        let tiers = NetworkRateLimitTiers {
+            isolated: RateLimit {
+                messages_per_second: 10,
+                burst_size: 99,
+            },
+            known: RateLimit {
+                messages_per_second: 30,
+                burst_size: 9,
+            },
+            partner: RateLimit {
+                messages_per_second: 700,
+                burst_size: 13,
+            },
+            federated: RateLimit {
+                messages_per_second: 200,
+                burst_size: 50,
+            },
+        };
+
+        let ceiling = tiers.ceiling();
+
+        assert_eq!(
+            (ceiling.messages_per_second, ceiling.burst_size),
+            (700, 99),
+            "each field takes the maximum independently, so no configured tier can \
+             be clamped in either dimension"
         );
     }
 

--- a/icn/crates/icn-core/tests/network_domain_oracle_registration.rs
+++ b/icn/crates/icn-core/tests/network_domain_oracle_registration.rs
@@ -83,9 +83,14 @@ fn registry_without_network_domain() -> Arc<OracleRegistry> {
 }
 
 /// The same, plus the network-domain registration that `#2488` adds.
+///
+/// Both domains are served by the *same* oracle instance, as production does —
+/// using two instances here would hide any state or caching the oracle carries
+/// across domains.
 fn registry_with_network_domain() -> Arc<OracleRegistry> {
-    let registry = registry_without_network_domain();
+    let registry = Arc::new(OracleRegistry::new());
     let oracle: Arc<dyn PolicyOracle> = Arc::new(TrustLikeOracle);
+    registry.register(oracle.domain(), oracle.clone());
     registry.register(Domain::new(NETWORK_DOMAIN), oracle);
     registry
 }

--- a/icn/crates/icn-core/tests/network_domain_oracle_registration.rs
+++ b/icn/crates/icn-core/tests/network_domain_oracle_registration.rs
@@ -1,0 +1,243 @@
+// Matches the convention already used across `icn-core/tests/` (see
+// backup_restore_integration.rs, app_runtime_integration.rs, and others).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Regression tests for the network-domain oracle registration (#2488).
+//!
+//! # What broke
+//!
+//! `icn-net`'s `RateLimiter` asks the `OracleRegistry` for per-peer constraints
+//! under the `net` domain. The composition root registered the trust oracle by
+//! `oracle.domain()`, which is `"trust"` — so `"net"` was never registered.
+//!
+//! Once the registry reaches `BootstrapPhase::Running`, an unregistered domain is
+//! denied by default. `RateLimiter::check_rate_limit` returns `false` for that
+//! denial, and the caller in `actor/connection.rs` logs it as
+//! `"Rate limited message from … (per-DID limit exceeded)"` and drops the message.
+//!
+//! Net effect: every inbound network message was dropped, no peer could ever be
+//! registered, and the failure was indistinguishable from ordinary rate limiting.
+//! A four-node cluster reported 22,577 "rate limited" messages and zero accepted
+//! ones, while `icn_network_messages_rate_limited_by_rate` — which only the token
+//! bucket increments — never registered at all.
+//!
+//! These tests pin the *observable* behaviour (messages flow / do not flow), not
+//! the registration call itself, so they still fail if the wiring is removed.
+
+use std::sync::Arc;
+
+use icn_identity::Did;
+use icn_kernel_api::authz::{ActionKind, Domain, PolicyDecision, PolicyOracle, PolicyRequest};
+use icn_kernel_api::bootstrap::BootstrapPhase;
+use icn_kernel_api::OracleRegistry;
+use icn_net::{RateLimitConfig, RateLimiter, NETWORK_DOMAIN};
+
+/// Stand-in for the trust oracle: reports domain "trust" (as the real one does)
+/// but answers any request with trust-derived constraints.
+#[derive(Debug)]
+struct TrustLikeOracle;
+
+impl PolicyOracle for TrustLikeOracle {
+    fn evaluate(&self, _request: &PolicyRequest) -> PolicyDecision {
+        use icn_kernel_api::authz::{ConstraintSet, RateLimit};
+        PolicyDecision::allow_with(ConstraintSet::new().with_rate_limit(RateLimit::restricted()))
+    }
+
+    fn domain(&self) -> Domain {
+        Domain::trust()
+    }
+}
+
+fn peer() -> Did {
+    // Fixed, valid DID: the trust path parses the actor, and an unparseable one
+    // would take a different branch than the one under test.
+    Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9")
+        .expect("test DID must parse")
+}
+
+fn network_request(actor: &Did) -> PolicyRequest {
+    PolicyRequest::new(
+        actor.to_string(),
+        ActionKind::Custom("network_message".to_string()),
+        Domain::new(NETWORK_DOMAIN),
+    )
+}
+
+/// A generous fallback, so that anything this test observes being blocked is
+/// blocked by the oracle decision and not by the token bucket.
+fn generous_fallback() -> RateLimitConfig {
+    RateLimitConfig {
+        max_messages_per_second: 1000,
+        burst_capacity: 1000,
+        ..RateLimitConfig::default()
+    }
+}
+
+/// Registry wired the way the composition root wires it: trust oracle registered
+/// under its own `domain()` only.
+fn registry_without_network_domain() -> Arc<OracleRegistry> {
+    let registry = Arc::new(OracleRegistry::new());
+    let oracle: Arc<dyn PolicyOracle> = Arc::new(TrustLikeOracle);
+    registry.register(oracle.domain(), oracle);
+    registry
+}
+
+/// The same, plus the network-domain registration that `#2488` adds.
+fn registry_with_network_domain() -> Arc<OracleRegistry> {
+    let registry = registry_without_network_domain();
+    let oracle: Arc<dyn PolicyOracle> = Arc::new(TrustLikeOracle);
+    registry.register(Domain::new(NETWORK_DOMAIN), oracle);
+    registry
+}
+
+/// The bug, at the registry level: `Running` + unregistered `net` = deny.
+///
+/// This is the test that fails against the pre-fix composition root.
+#[test]
+fn running_phase_denies_unregistered_network_domain() {
+    let registry = registry_without_network_domain();
+    registry.set_phase(BootstrapPhase::Running);
+
+    let decision = registry.evaluate(&network_request(&peer()));
+
+    assert!(
+        matches!(decision, PolicyDecision::Deny { .. }),
+        "an unregistered 'net' domain must deny in Running phase — this is the \
+         behaviour that silently dropped every inbound message; got {decision:?}"
+    );
+}
+
+/// Registering the network domain makes the same request allowed.
+#[test]
+fn registered_network_domain_is_allowed_in_running_phase() {
+    let registry = registry_with_network_domain();
+    registry.set_phase(BootstrapPhase::Running);
+
+    let decision = registry.evaluate(&network_request(&peer()));
+
+    assert!(
+        matches!(decision, PolicyDecision::Allow { .. }),
+        "registering an oracle for '{NETWORK_DOMAIN}' must allow network policy \
+         requests; got {decision:?}"
+    );
+}
+
+/// Registering under the trust domain alone is NOT sufficient.
+///
+/// Guards against a "fix" that re-registers the trust oracle by `domain()` and
+/// assumes that covers the network layer.
+#[test]
+fn trust_domain_registration_does_not_cover_network_domain() {
+    let registry = registry_without_network_domain();
+    registry.set_phase(BootstrapPhase::Running);
+
+    let trust_decision = registry.evaluate(&PolicyRequest::new(
+        peer().to_string(),
+        ActionKind::Custom("network_message".to_string()),
+        Domain::trust(),
+    ));
+    let net_decision = registry.evaluate(&network_request(&peer()));
+
+    assert!(
+        matches!(trust_decision, PolicyDecision::Allow { .. }),
+        "trust domain is registered and must be allowed"
+    );
+    assert!(
+        matches!(net_decision, PolicyDecision::Deny { .. }),
+        "'{NETWORK_DOMAIN}' must still be denied — the two domains are distinct \
+         registry keys and registering one does not register the other"
+    );
+}
+
+/// End-to-end through the real `RateLimiter`: the user-visible symptom.
+///
+/// This is the strongest test — it exercises exactly the call the connection
+/// handler makes, so it fails for the same reason production failed.
+#[tokio::test]
+async fn rate_limiter_drops_every_message_when_network_domain_unregistered() {
+    let registry = registry_without_network_domain();
+    registry.set_phase(BootstrapPhase::Running);
+
+    let limiter = RateLimiter::new_with_oracle(registry, generous_fallback());
+    let peer = peer();
+
+    // Well under any configured rate: a token bucket would allow all of these.
+    for attempt in 1..=5 {
+        assert!(
+            !limiter.check_rate_limit(&peer).await,
+            "message {attempt} was allowed, but with '{NETWORK_DOMAIN}' unregistered \
+             every message must be rejected"
+        );
+    }
+}
+
+/// With the domain registered, the same sequence flows.
+#[tokio::test]
+async fn rate_limiter_admits_messages_when_network_domain_registered() {
+    let registry = registry_with_network_domain();
+    registry.set_phase(BootstrapPhase::Running);
+
+    let limiter = RateLimiter::new_with_oracle(registry, generous_fallback());
+    let peer = peer();
+
+    for attempt in 1..=5 {
+        assert!(
+            limiter.check_rate_limit(&peer).await,
+            "message {attempt} was rejected; with '{NETWORK_DOMAIN}' registered and an \
+             unexhausted bucket the message must be admitted"
+        );
+    }
+}
+
+/// Registration restores enforcement, it does not disable it.
+///
+/// `RateLimit::restricted()` is 5 msg/s with burst 5, so a burst well past that
+/// must still be cut off. Without this, a "fix" that always allows would pass
+/// every other test here.
+#[tokio::test]
+async fn registered_network_domain_still_enforces_a_finite_bound() {
+    let registry = registry_with_network_domain();
+    registry.set_phase(BootstrapPhase::Running);
+
+    // Fallback is deliberately generous; the bound must come from the oracle's
+    // constraints, not from the fallback.
+    let limiter = RateLimiter::new_with_oracle(registry, generous_fallback());
+    let peer = peer();
+
+    let mut allowed = 0usize;
+    for _ in 0..100 {
+        if limiter.check_rate_limit(&peer).await {
+            allowed += 1;
+        }
+    }
+
+    assert!(
+        allowed > 0,
+        "the peer must be able to send something — otherwise this is the bug again"
+    );
+    assert!(
+        allowed < 100,
+        "a burst of 100 must not be fully admitted; the isolated-tier bound has to \
+         still apply after registration (allowed {allowed}/100)"
+    );
+}
+
+/// Bootstrap phases keep their permissive behaviour.
+///
+/// A node must be able to peer while still coming up; the deny only appears at
+/// `Running`. Pins the phase semantics the fix relies on.
+#[test]
+fn bootstrap_phases_allow_network_domain_before_running() {
+    for phase in [BootstrapPhase::Genesis, BootstrapPhase::CoreApps] {
+        let registry = registry_without_network_domain();
+        registry.set_phase(phase);
+
+        let decision = registry.evaluate(&network_request(&peer()));
+
+        assert!(
+            matches!(decision, PolicyDecision::Allow { .. }),
+            "{phase:?} must allow an unregistered '{NETWORK_DOMAIN}' domain; \
+             got {decision:?}"
+        );
+    }
+}

--- a/icn/crates/icn-core/tests/network_domain_oracle_registration.rs
+++ b/icn/crates/icn-core/tests/network_domain_oracle_registration.rs
@@ -27,6 +27,7 @@
 use std::sync::Arc;
 
 use icn_identity::Did;
+use icn_kernel_api::authz::RateLimit;
 use icn_kernel_api::authz::{ActionKind, Domain, PolicyDecision, PolicyOracle, PolicyRequest};
 use icn_kernel_api::bootstrap::BootstrapPhase;
 use icn_kernel_api::OracleRegistry;
@@ -92,6 +93,34 @@ fn registry_with_network_domain() -> Arc<OracleRegistry> {
     let oracle: Arc<dyn PolicyOracle> = Arc::new(TrustLikeOracle);
     registry.register(oracle.domain(), oracle.clone());
     registry.register(Domain::new(NETWORK_DOMAIN), oracle);
+    registry
+}
+
+/// The same, but serving the network domain with an explicit configured tier.
+///
+/// Mirrors what `register_core_oracles` produces after #2496: the `net` domain is
+/// answered with the operator's configured `RateLimit`, not the trust oracle's
+/// hard-coded ladder. Used to prove the limiter honours that number end to end.
+fn registry_with_network_domain_tier(tier: RateLimit) -> Arc<OracleRegistry> {
+    #[derive(Debug)]
+    struct ConfiguredTierOracle(RateLimit);
+
+    impl PolicyOracle for ConfiguredTierOracle {
+        fn evaluate(&self, _request: &PolicyRequest) -> PolicyDecision {
+            use icn_kernel_api::authz::ConstraintSet;
+            PolicyDecision::allow_with(ConstraintSet::new().with_rate_limit(self.0.clone()))
+        }
+
+        fn domain(&self) -> Domain {
+            Domain::new(NETWORK_DOMAIN)
+        }
+    }
+
+    let registry = Arc::new(OracleRegistry::new());
+    let trust: Arc<dyn PolicyOracle> = Arc::new(TrustLikeOracle);
+    registry.register(trust.domain(), trust);
+    let net: Arc<dyn PolicyOracle> = Arc::new(ConfiguredTierOracle(tier));
+    registry.register(Domain::new(NETWORK_DOMAIN), net);
     registry
 }
 
@@ -247,53 +276,99 @@ fn bootstrap_phases_allow_network_domain_before_running() {
     }
 }
 
-/// The consuming limiter quantises sub-granularity rates upward — pinned, not hidden.
+/// An operator-configured rate below the refill granularity is actually enforced.
 ///
-/// `RateLimiter::do_rate_limit_check` computes
-/// `(max_messages_per_second * refill_interval).max(1.0)` tokens per interval
-/// (`icn-net/src/rate_limit.rs:394`). At the default 100 ms interval that floor is
-/// **one token per 100 ms = 10 messages/s**, so every configured rate below 10/s
-/// collapses to 10/s.
+/// This is the end-to-end form of #2503, driven through the real [`RateLimiter`].
 ///
-/// This is a property of the limiter, not of the oracle wiring, and it predates
-/// the tier-selection fix: the previously hard-coded isolated tier was
-/// `RateLimit::restricted()` = 5/s, which this floor already inflated to 10/s.
-/// Selecting the operator's configured tier does not introduce it and does not
-/// worsen it — but it does make it *reachable*, because an operator can now
-/// actually put a sub-10 number into effect and be misled about the result.
+/// The limiter used to compute `(rate * interval).max(1.0)` tokens per interval.
+/// At the default 100 ms interval that floor is 10 messages/s, so a configured
+/// 1 msg/s silently became 10 msg/s. #2496 made the operator's number reach the
+/// limiter; without this fix the limiter then ignored it, and the guarantee
+/// "configured limits control behaviour" was false at the last hop.
 ///
-/// Burst is unaffected: `capacity` is used verbatim, which is why the #2496
-/// regression (configured burst 2 must not become 5) is genuinely fixed.
+/// # Why this test sleeps
 ///
-/// Asserted here rather than left as a comment so that if the floor is ever
-/// removed, this test fails and the tier tests can be tightened accordingly.
-#[test]
-fn configured_rates_below_the_refill_granularity_are_quantised_up() {
+/// An earlier version hammered the limiter in a tight loop and asserted the
+/// admitted count. That version could not fail: the loop finishes inside one
+/// refill interval, so no replenishment happens with *or* without the floor, and
+/// only the burst gets through either way. Discriminating the defect requires
+/// real elapsed time, because the limiter reads `std::time::Instant` directly and
+/// so is not affected by `tokio::time::pause`.
+///
+/// The 150 ms probe is the discriminator: under the old floor one whole token had
+/// arrived by then (10 msg/s); at a correctly-enforced 1 msg/s only 0.15 tokens
+/// have.
+#[tokio::test]
+async fn a_configured_sub_granularity_rate_is_enforced_by_the_limiter() {
     use std::time::Duration;
 
-    let refill_interval = Duration::from_millis(100);
-    let granularity = 1.0 / refill_interval.as_secs_f64(); // 10 messages/s
+    // Isolated tier: 1 msg/s sustained, burst 2 — deliberately below the old
+    // 10 msg/s floor.
+    let registry = registry_with_network_domain_tier(RateLimit {
+        messages_per_second: 1,
+        burst_size: 2,
+    });
+    registry.set_phase(BootstrapPhase::Running);
 
-    for configured in [1u32, 5, 9] {
-        let tokens_per_interval = (configured as f64 * refill_interval.as_secs_f64()).max(1.0);
-        let effective = tokens_per_interval / refill_interval.as_secs_f64();
+    let limiter = RateLimiter::new_with_oracle(registry, generous_fallback());
+    let peer = peer();
 
-        assert_eq!(
-            effective, granularity,
-            "a configured {configured} msg/s is quantised up to {granularity} msg/s \
-             by the limiter's `.max(1.0)` floor - the operator's number does not \
-             take effect below the refill granularity"
+    // Spend the burst.
+    for n in 1..=2 {
+        assert!(
+            limiter.check_rate_limit(&peer).await,
+            "burst message {n} of 2 must be admitted"
         );
     }
+    assert!(
+        !limiter.check_rate_limit(&peer).await,
+        "the burst of 2 must be exhausted after two messages"
+    );
 
-    // At and above the granularity the configured value is exact.
-    for configured in [10u32, 30, 70, 200] {
-        let tokens_per_interval = (configured as f64 * refill_interval.as_secs_f64()).max(1.0);
-        let effective = tokens_per_interval / refill_interval.as_secs_f64();
+    // 150 ms is more than one refill interval but far less than the one second a
+    // correctly-enforced 1 msg/s needs.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(
+        !limiter.check_rate_limit(&peer).await,
+        "after 150 ms a configured 1 msg/s has accrued only ~0.15 tokens, so no \
+         message may be admitted. Admitting one here means the limiter is still \
+         applying its old one-token-per-interval floor, i.e. 10 msg/s"
+    );
 
-        assert_eq!(
-            effective, configured as f64,
-            "at or above the refill granularity the configured rate must be exact"
-        );
+    // But the rate is a rate, not a ban: a full second must replenish one token.
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    assert!(
+        limiter.check_rate_limit(&peer).await,
+        "after ~1.15 s at 1 msg/s at least one token must have accrued - the fix \
+         must enforce the configured rate, not suppress traffic entirely"
+    );
+}
+
+/// Burst is exact, independently of the sustained rate.
+///
+/// The #2496 headline regression: a configured burst of 2 must be 2, not the
+/// trust oracle's hard-coded `RateLimit::restricted()` burst of 5.
+#[tokio::test]
+async fn a_configured_burst_of_two_admits_two_not_five() {
+    let registry = registry_with_network_domain_tier(RateLimit {
+        messages_per_second: 1,
+        burst_size: 2,
+    });
+    registry.set_phase(BootstrapPhase::Running);
+
+    let limiter = RateLimiter::new_with_oracle(registry, generous_fallback());
+    let peer = peer();
+
+    let mut allowed = 0usize;
+    for _ in 0..5 {
+        if limiter.check_rate_limit(&peer).await {
+            allowed += 1;
+        }
     }
+
+    assert_eq!(
+        allowed, 2,
+        "five immediate attempts against a burst of 2 must admit exactly 2; \
+         5 would mean restricted()'s burst leaked through"
+    );
 }

--- a/icn/crates/icn-core/tests/network_domain_oracle_registration.rs
+++ b/icn/crates/icn-core/tests/network_domain_oracle_registration.rs
@@ -246,3 +246,54 @@ fn bootstrap_phases_allow_network_domain_before_running() {
         );
     }
 }
+
+/// The consuming limiter quantises sub-granularity rates upward — pinned, not hidden.
+///
+/// `RateLimiter::do_rate_limit_check` computes
+/// `(max_messages_per_second * refill_interval).max(1.0)` tokens per interval
+/// (`icn-net/src/rate_limit.rs:394`). At the default 100 ms interval that floor is
+/// **one token per 100 ms = 10 messages/s**, so every configured rate below 10/s
+/// collapses to 10/s.
+///
+/// This is a property of the limiter, not of the oracle wiring, and it predates
+/// the tier-selection fix: the previously hard-coded isolated tier was
+/// `RateLimit::restricted()` = 5/s, which this floor already inflated to 10/s.
+/// Selecting the operator's configured tier does not introduce it and does not
+/// worsen it — but it does make it *reachable*, because an operator can now
+/// actually put a sub-10 number into effect and be misled about the result.
+///
+/// Burst is unaffected: `capacity` is used verbatim, which is why the #2496
+/// regression (configured burst 2 must not become 5) is genuinely fixed.
+///
+/// Asserted here rather than left as a comment so that if the floor is ever
+/// removed, this test fails and the tier tests can be tightened accordingly.
+#[test]
+fn configured_rates_below_the_refill_granularity_are_quantised_up() {
+    use std::time::Duration;
+
+    let refill_interval = Duration::from_millis(100);
+    let granularity = 1.0 / refill_interval.as_secs_f64(); // 10 messages/s
+
+    for configured in [1u32, 5, 9] {
+        let tokens_per_interval = (configured as f64 * refill_interval.as_secs_f64()).max(1.0);
+        let effective = tokens_per_interval / refill_interval.as_secs_f64();
+
+        assert_eq!(
+            effective, granularity,
+            "a configured {configured} msg/s is quantised up to {granularity} msg/s \
+             by the limiter's `.max(1.0)` floor - the operator's number does not \
+             take effect below the refill granularity"
+        );
+    }
+
+    // At and above the granularity the configured value is exact.
+    for configured in [10u32, 30, 70, 200] {
+        let tokens_per_interval = (configured as f64 * refill_interval.as_secs_f64()).max(1.0);
+        let effective = tokens_per_interval / refill_interval.as_secs_f64();
+
+        assert_eq!(
+            effective, configured as f64,
+            "at or above the refill granularity the configured rate must be exact"
+        );
+    }
+}

--- a/icn/crates/icn-net/src/lib.rs
+++ b/icn/crates/icn-net/src/lib.rs
@@ -50,7 +50,7 @@ pub use protocol::{
     write_message_compressed, write_message_negotiated, CompressionFormat, EncodingFormat,
     KnownPeer, MessagePayload, NetworkMessage, PeerExchangeMessage, COMPRESSION_THRESHOLD,
 };
-pub use rate_limit::{RateLimitConfig, RateLimiter};
+pub use rate_limit::{RateLimitConfig, RateLimiter, NETWORK_DOMAIN};
 pub use relay_proxy::{ProxyHandle, TurnRelayProxy};
 pub use replay_guard::ReplayGuard;
 pub use sequence_tracker::OutgoingSequenceTracker;

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -129,6 +129,39 @@ impl Default for AnchorRateLimitConfig {
     }
 }
 
+/// Tokens added per refill interval for a configured rate.
+///
+/// # Why this is not floored at one token (#2503)
+///
+/// This used to end in `.max(1.0)`, forcing at least one token per interval.
+/// With the default 100 ms interval that is 10 messages/s, so **every** configured
+/// rate below 10/s was silently raised to 10/s — including a configured `0`, which
+/// reads as "deny sustained traffic" and instead produced the floor. An operator
+/// tightening a pre-authentication DoS cap got 10x what they asked for, with no
+/// warning. That made #2496's guarantee — operator-configured limits control
+/// behaviour — untrue at the last hop, however correct the policy mapping was.
+///
+/// Fractional rates need no special handling: [`TokenBucket::tokens`] is `f64` and
+/// [`TokenBucket::refill`] adds `intervals * refill_rate` where `intervals` is
+/// itself fractional, so 0.1 tokens per 100 ms accumulates to one token per second.
+/// Removing the floor is therefore sufficient — the accumulation machinery was
+/// already correct, and the identity
+///
+/// ```text
+/// intervals * refill_rate
+///   == (elapsed / interval) * (rate * interval)
+///   == elapsed * rate
+/// ```
+///
+/// means the existing interval mechanism already computes exactly
+/// "elapsed time x configured rate", with no additional quantisation.
+///
+/// A configured rate of `0` now yields `0`, so the bucket never replenishes and
+/// burst is a one-time allowance. That is the honest reading of the number.
+fn refill_rate_per_interval(config: &RateLimitConfig) -> f64 {
+    config.max_messages_per_second as f64 * config.refill_interval.as_secs_f64()
+}
+
 /// Token bucket for a single peer
 #[derive(Debug)]
 struct TokenBucket {
@@ -391,8 +424,7 @@ impl RateLimiter {
         config: &RateLimitConfig,
     ) -> bool {
         // Calculate refill rate: tokens per interval
-        let refill_rate =
-            (config.max_messages_per_second as f64 * config.refill_interval.as_secs_f64()).max(1.0);
+        let refill_rate = refill_rate_per_interval(config);
 
         let capacity = config.burst_capacity as f64;
         let refill_interval = config.refill_interval;
@@ -1206,5 +1238,218 @@ mod tests {
         );
         assert_eq!(EnforcementMode::parse("unknown"), EnforcementMode::Enforce);
         // Default
+    }
+}
+
+/// Refill semantics of the production token bucket (#2503).
+///
+/// # The contract
+///
+/// 1. `burst_capacity` is the immediately-available token count.
+/// 2. `max_messages_per_second` is the long-run replenishment rate, independent
+///    of burst.
+/// 3. A configured rate below `1 / refill_interval` is still representable — it
+///    refills fractionally rather than being rounded up.
+/// 4. Fractional refill accumulates; it is never discarded.
+/// 5. No configured rate is ever silently *increased*.
+/// 6. Capacity remains the upper bound, however long the gap.
+/// 7. A configured rate of zero means no replenishment: burst is a one-time
+///    allowance, not a floor.
+///
+/// # What was wrong
+///
+/// `refill_rate_per_interval` used to end in `.max(1.0)`, forcing at least one
+/// token per interval. At the default 100 ms interval that is 10 messages/s, so
+/// every configured rate below 10/s — including 0 — was silently raised to 10/s.
+///
+/// These tests drive `TokenBucket` itself and control time by rewinding
+/// `last_refill`, so they are deterministic: no `sleep`, no wall-clock races.
+#[cfg(test)]
+mod refill_semantics_tests {
+    use super::*;
+
+    /// Build a bucket the way production does, via the real refill-rate formula.
+    fn bucket(rate: u32, burst: u32, interval_ms: u64) -> TokenBucket {
+        let interval = Duration::from_millis(interval_ms);
+        let config = RateLimitConfig {
+            max_messages_per_second: rate,
+            burst_capacity: burst,
+            refill_interval: interval,
+        };
+        TokenBucket::new(burst as f64, refill_rate_per_interval(&config), interval)
+    }
+
+    /// Tolerance for token-count assertions.
+    ///
+    /// `refill()` reads `Instant::now()` itself, so rewinding `last_refill` gives
+    /// "at least `d` elapsed", not exactly `d` — a few microseconds of real time
+    /// leak in. At the highest rate under test (20 msg/s) a microsecond is 2e-5
+    /// tokens, so this bound is ~50x looser than the jitter and ~500x tighter
+    /// than the 0.5-token differences being distinguished.
+    const TOKEN_EPSILON: f64 = 1e-3;
+
+    /// Rewind `last_refill` so the bucket believes `d` has elapsed.
+    fn advance(b: &mut TokenBucket, d: Duration) {
+        b.last_refill = b
+            .last_refill
+            .checked_sub(d)
+            .expect("test durations stay within Instant range");
+    }
+
+    /// Drain every token so subsequent behaviour is pure refill.
+    fn drain(b: &mut TokenBucket) {
+        while b.try_consume() {}
+        assert!(!b.try_consume(), "bucket must be empty after draining");
+    }
+
+    /// A configured 1 msg/s must take ~1 s to yield a token, not 100 ms.
+    ///
+    /// This is the operator-visible defect: someone tightening a
+    /// pre-authentication DoS cap to 1/s was silently given 10/s.
+    #[test]
+    fn one_message_per_second_is_not_inflated_to_ten() {
+        let mut b = bucket(1, 1, 100);
+        drain(&mut b);
+
+        advance(&mut b, Duration::from_millis(100));
+        assert!(
+            !b.try_consume(),
+            "at 1 msg/s, 100 ms must NOT yield a token - that would be 10 msg/s"
+        );
+
+        // 900 ms more brings the total to a full second.
+        advance(&mut b, Duration::from_millis(900));
+        assert!(
+            b.try_consume(),
+            "at 1 msg/s, one full second must yield exactly one token"
+        );
+    }
+
+    /// A configured 5 msg/s refills in ~200 ms, not ~100 ms.
+    #[test]
+    fn five_messages_per_second_needs_two_hundred_millis_per_token() {
+        let mut b = bucket(5, 1, 100);
+        drain(&mut b);
+
+        advance(&mut b, Duration::from_millis(100));
+        assert!(
+            !b.try_consume(),
+            "at 5 msg/s, one 100 ms interval yields only 0.5 tokens"
+        );
+
+        advance(&mut b, Duration::from_millis(100));
+        assert!(
+            b.try_consume(),
+            "two 100 ms intervals accumulate 0.5 + 0.5 = 1 token"
+        );
+    }
+
+    /// Fractional refills accumulate rather than being discarded per interval.
+    ///
+    /// Stated separately from the timing tests because "0.5 tokens twice" is the
+    /// property a naive rounding implementation would break while still passing a
+    /// single-interval check.
+    #[test]
+    fn fractional_refills_accumulate_across_intervals() {
+        let mut b = bucket(5, 4, 100);
+        drain(&mut b);
+
+        for _ in 0..2 {
+            advance(&mut b, Duration::from_millis(100));
+            b.refill();
+        }
+
+        assert!(
+            (b.tokens - 1.0).abs() < TOKEN_EPSILON,
+            "two 0.5-token refills must accumulate to exactly 1.0, got {}",
+            b.tokens
+        );
+    }
+
+    /// At the granularity boundary the configured rate is exact.
+    #[test]
+    fn ten_messages_per_second_is_one_token_per_interval() {
+        let mut b = bucket(10, 5, 100);
+        drain(&mut b);
+
+        advance(&mut b, Duration::from_millis(100));
+        b.refill();
+
+        assert!(
+            (b.tokens - 1.0).abs() < TOKEN_EPSILON,
+            "10 msg/s at a 100 ms interval is exactly 1 token per interval, got {}",
+            b.tokens
+        );
+    }
+
+    /// Above the granularity the rate scales linearly.
+    #[test]
+    fn twenty_messages_per_second_is_two_tokens_per_interval() {
+        let mut b = bucket(20, 5, 100);
+        drain(&mut b);
+
+        advance(&mut b, Duration::from_millis(100));
+        b.refill();
+
+        assert!(
+            (b.tokens - 2.0).abs() < TOKEN_EPSILON,
+            "20 msg/s at a 100 ms interval is exactly 2 tokens per interval, got {}",
+            b.tokens
+        );
+    }
+
+    /// Burst capacity does not change the long-run rate.
+    ///
+    /// Burst and sustained rate are independent knobs; a bigger bucket must not
+    /// refill faster.
+    #[test]
+    fn burst_capacity_does_not_alter_the_configured_rate() {
+        for burst in [1u32, 2, 5, 50] {
+            let mut b = bucket(5, burst, 100);
+            drain(&mut b);
+
+            advance(&mut b, Duration::from_millis(100));
+            b.refill();
+
+            assert!(
+                (b.tokens - 0.5).abs() < TOKEN_EPSILON,
+                "burst {burst} must not change the 0.5 tokens/interval implied by \
+                 5 msg/s, got {}",
+                b.tokens
+            );
+        }
+    }
+
+    /// A long gap refills only up to capacity.
+    #[test]
+    fn a_long_gap_refills_only_to_capacity() {
+        let mut b = bucket(200, 5, 100);
+        drain(&mut b);
+
+        advance(&mut b, Duration::from_secs(3600));
+        b.refill();
+
+        assert!(
+            (b.tokens - 5.0).abs() < TOKEN_EPSILON,
+            "an hour of accrual must clamp at the burst capacity of 5, got {}",
+            b.tokens
+        );
+    }
+
+    /// A configured rate of zero does not replenish.
+    ///
+    /// Previously `.max(1.0)` turned a configured 0 into 10 msg/s — the most
+    /// surprising case of the floor, since 0 reads as "deny sustained traffic".
+    #[test]
+    fn zero_rate_does_not_replenish() {
+        let mut b = bucket(0, 2, 100);
+        drain(&mut b);
+
+        advance(&mut b, Duration::from_secs(60));
+        assert!(
+            !b.try_consume(),
+            "a configured 0 msg/s must not replenish - burst is a one-time \
+             allowance, not a floor"
+        );
     }
 }

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -37,7 +37,16 @@ impl fmt::Display for HexDisplay<'_> {
 }
 
 const NETWORK_MESSAGE_ACTION: &str = "network_message";
-const NETWORK_DOMAIN: &str = "net";
+
+/// Policy domain under which the network layer requests per-peer constraints.
+///
+/// The composition root MUST register a `PolicyOracle` for this domain. Once the
+/// `OracleRegistry` reaches `BootstrapPhase::Running`, an unregistered domain is
+/// denied by default, and [`RateLimiter::check_rate_limit`] reports that denial
+/// the same way it reports a token-bucket rejection — so a missing registration
+/// silently drops every inbound message. Exported so the registration site and
+/// this query site share one symbol instead of two string literals that can drift.
+pub const NETWORK_DOMAIN: &str = "net";
 
 /// Configuration for rate limiting
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## What

Registers a `PolicyOracle` for the `net` domain, and makes it honor every operator-configured rate-limit tier.

Closes #2488. Closes #2496.

## Why

**#2488 — every inbound message was denied.** `icn-net`'s `RateLimiter` asks the `OracleRegistry` for per-peer constraints under the `net` domain. The composition root registered oracles by `oracle.domain()`, which yields `trust` and `charter` — `net` was never registered. Once the registry reaches `BootstrapPhase::Running`, an unregistered domain denies by default, and `check_rate_limit` reports that denial as ordinary throttling.

Net effect: no peer could ever be registered, and the failure was indistinguishable from rate limiting. A four-node cluster logged 22,577 "rate limited" messages and zero accepted ones, while `icn_network_messages_rate_limited_by_rate` — which only the token bucket increments — never fired at all. That absent counter is what localised the branch.

**#2496 — the operator's configuration was ignored.** Routing `net` at the trust oracle brought its hard-coded ladder along: 5 / 20 / 100 / `unlimited()`. The first cut clamped that against `rate_limiting.federated` only, so:

| Configured | Effective (before) |
|---|---|
| `isolated` burst = 2 | **5** |
| `partner` = 10 msg/s | **100** |
| `federated` | honored |

Silently ignoring a configured DoS cap is worse than not offering one.

## How

`NetworkRateLimitOracle` (formerly `CappedRateLimitOracle`) **replaces** the inner oracle's rate limit with the operator-configured tier for the peer's trust class, then applies the highest configured tier as an absolute ceiling.

Selection happens at the composition root because that is the only layer holding both halves of the mapping — the neutral `TrustClass` (via `TrustService`, an `icn-kernel-api` trait) and the `[rate_limiting]` config:

```
domain trust score -> neutral TrustClass -> configured tier -> ceiling
```

**What is deliberately not done:** inferring the tier from the inner oracle's numbers. Reconstructing "5 msg/s means Isolated" from a generic `ConstraintSet` inside a kernel crate is exactly the meaning-firewall violation the kernel/app split exists to prevent. The class comes from the trust service, never from arithmetic on constraint values. `check-meaning-firewall.sh` reports no new debt.

Registration uses `icn_net::NETWORK_DOMAIN` rather than a string literal, so the registration site and the query site are bound to one symbol and cannot drift apart again.

Preserved:
- denials pass through as denials — neither tier selection nor capping may upgrade one to an allow
- an absent rate-limit constraint is not fabricated, so `icn-net`'s operator-configured fallback still applies
- the `trust` domain itself is uncapped; the ceiling is specific to the network path

## The limiter now honours those numbers too (#2503)

Final review found that delivering the operator's number to the limiter was not enough: `refill_rate_per_interval` ended in `.max(1.0)`, forcing at least one token per refill interval. At the default 100 ms interval that is 10 messages/s, so **every configured rate below 10/s was silently raised**:

| configured | old effective | now |
|---|---|---|
| 0 msg/s | 10 msg/s | 0 (no replenishment) |
| 1 msg/s | 10 msg/s | 1 msg/s |
| 5 msg/s | 10 msg/s | 5 msg/s |
| 10 msg/s | 10 msg/s | 10 msg/s |
| 20 msg/s | 20 msg/s | 20 msg/s |

That made this PR's central claim false at the last hop, so it is fixed here rather than deferred.

Removing the floor was sufficient — no new machinery. `tokens` is already `f64` and `refill()` already adds `intervals * refill_rate` with fractional `intervals`, and `intervals * refill_rate == (elapsed / interval) * (rate * interval) == elapsed * rate`, so the existing mechanism already computed "elapsed time × configured rate". The `if intervals >= 1.0` gate was checked as a possible second floor and is not one: when it does not fire it leaves `last_refill` untouched, so no elapsed time is lost.

## Ceiling is no longer derived from the federated tier

Review also found that using `rate_limiting.federated` as a global ceiling silently clamped any tier configured above it — and a burstier local `partner` tier alongside a tighter WAN `federated` tier is legitimate, with no monotonic ordering enforced by validation.

The ceiling is now the **maximum across all four tiers**. It keeps its purpose (bounding anything that is not an operator-configured tier) while becoming structurally incapable of clamping one.

## Config validation

`burst_capacity == 0` is now rejected per tier: a zero bucket can never hold a whole token, so it denies every message forever regardless of rate — previously a silent brick. A configured rate of `0` stays valid now that it honestly means "no sustained replenishment".

## Risk## Risk

`register_core_oracles` now takes `Arc<dyn TrustService>` instead of `Arc<dyn PolicyOracle>` — it needs the class, not just the decision.

Cost: one extra `TrustService::trust_score` call per **allowed** message. `trust_score` is not cached at the service level, so this roughly doubles trust-graph read-lock acquisitions on the accept path. That is the price of not inferring the class from constraint values; denials short-circuit before it.

## #2491 is NOT solved here

The tier is still selected from an unauthenticated `NetworkMessage.from` — Hello binding and `SignedEnvelope` verification both run after dispatch. Binding the tier to a *verified* identity is a protocol change, not a wiring change.

The absolute ceiling is retained as defence in depth: a spoofed federated DID buys the operator's ceiling, not `u32::MAX`. **#2491 remains open** and is referenced from the code comment at the registration site.

## Test plan

Per-tier coverage at and around every class boundary, both directly on the oracle and end-to-end through the real `register_core_oracles`:

| Trust score | Class | Configured | Asserted effective |
|---|---|---|---|
| 0.0, 0.05 | Isolated | 10 / 2 | 10 / 2 |
| 0.1, 0.39 | Known | 30 / 9 | 30 / 9 |
| 0.4, 0.69 | Partner | 70 / 13 | 70 / 13 |
| 0.7, 1.0 | Federated | 170 / 19 | 170 / 19 |

The test tiers are deliberately distinct from the trust oracle's 5/20/100/unlimited so a pass cannot be an accident, and the inner oracle returns `unlimited()` for *every* actor — if the tier table is ignored, that is what comes out.

Named regression: `configured_isolated_burst_of_two_is_not_widened_to_five` asserts burst = 2 and explicitly `assert_ne!(burst, 5)`.

Also covered: the ceiling still clamps a tier above it, each field clamps independently, denials survive, absent limits are not fabricated, the wrapper reports the domain it serves, and the observable `RateLimiter` behaviour (messages flow / do not flow) with the domain registered and unregistered.

Gates: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` (exit 0, zero warnings), `cargo test -p icn-core` (436 lib + 121 supervisor + 7 integration, 0 failed), `scripts/check-meaning-firewall.sh` (no new debt).


