### PR TITLE
fix(net): replace a closed connection when a restarted peer reconnects

### DIFF
--- a/icn/crates/icn-net/src/handlers/hello.rs
+++ b/icn/crates/icn-net/src/handlers/hello.rs
@@ -15,7 +15,6 @@ use crate::topology::{NeighborLimitsConfig, PeerId, TopologyInfo};
 use anyhow::Context;
 use anyhow::Result;
 use icn_identity::Did;
-use std::collections::hash_map::Entry;
 use tracing::{debug, info, warn};
 
 impl ConnectionContext {
@@ -202,26 +201,16 @@ impl ConnectionContext {
 
         // Store the incoming QUIC connection in session_manager
         {
+            // Route through the canonical installer so the replace-if-closed rule cannot drift
+            // between this path and `SessionManager::store_incoming_connection` (#2504). The
+            // DID-TLS binding above has already been verified, so `from` is authenticated here.
             let connections_arc = self.session_manager.read().await.connections_arc();
-            let peer_did = from.to_string();
-            let mut connections = connections_arc.write().await;
-            match connections.entry(peer_did) {
-                Entry::Occupied(entry) => {
-                    info!(
-                        "Connection already exists for {}, not overwriting with incoming connection from {}",
-                        entry.key(),
-                        connection.remote_address()
-                    );
-                }
-                Entry::Vacant(entry) => {
-                    info!(
-                        "Storing incoming connection from {} at {}",
-                        entry.key(),
-                        connection.remote_address()
-                    );
-                    entry.insert(connection.clone());
-                }
-            }
+            crate::session::install_incoming_connection(
+                &connections_arc,
+                from.to_string(),
+                connection.clone(),
+            )
+            .await;
         }
 
         // Add peer to neighbor sets if topology is enabled

--- a/icn/crates/icn-net/src/session.rs
+++ b/icn/crates/icn-net/src/session.rs
@@ -381,30 +381,7 @@ impl SessionManager {
     /// Replacing a connection that is already closed cannot displace a live session, so this
     /// preserves the anti-connection-confusion property above.
     pub async fn store_incoming_connection(&self, peer_did: String, connection: quinn::Connection) {
-        use std::collections::hash_map::Entry;
-        let mut connections = self.connections.write().await;
-        match connections.entry(peer_did) {
-            Entry::Occupied(mut entry) if entry.get().close_reason().is_some() => {
-                info!(
-                    "Replacing closed connection for {} with incoming connection from {}",
-                    entry.key(),
-                    connection.remote_address()
-                );
-                entry.insert(connection);
-            }
-            Entry::Occupied(entry) => {
-                info!("Connection already exists for {}, not overwriting with incoming connection from {}",
-                      entry.key(), connection.remote_address());
-            }
-            Entry::Vacant(entry) => {
-                info!(
-                    "Storing incoming connection from {} at {}",
-                    entry.key(),
-                    connection.remote_address()
-                );
-                entry.insert(connection);
-            }
-        }
+        install_incoming_connection(&self.connections, peer_did, connection).await;
     }
 
     /// Get all active connections
@@ -735,6 +712,62 @@ fn resolve_local_addr(port: u16) -> Option<SocketAddr> {
     None
 }
 
+/// Install an inbound connection for `peer_did`, replacing an entry that is already closed.
+///
+/// This is the single decision point for inbound connection installation. Both the
+/// `SessionManager::store_incoming_connection` helper and the Hello handler (which holds the
+/// connection map directly via `connections_arc`) route through here, so the replacement rule
+/// cannot drift between the two paths.
+///
+/// The rule is:
+///
+/// * a **live** existing connection wins — a duplicate inbound connection never displaces it,
+///   which is the anti-connection-confusion property;
+/// * a **closed** existing connection is treated as absent and replaced.
+///
+/// Map occupancy is not proof of liveness. When a peer restarts, our cached connection to it is
+/// dead and the peer's reconnect is the only signal we get; keeping the dead entry made every
+/// subsequent send to that peer fail — permanently, and in one direction only — until this
+/// process itself restarted (#2504). Replacing an already-closed connection cannot displace a
+/// live session, so recovery is bought without weakening duplicate suppression.
+///
+/// Callers must have authenticated `peer_did` first. On the Hello path the DID-TLS binding is
+/// verified before this is reached, so a remote cannot claim another node's DID to displace its
+/// entry.
+pub(crate) async fn install_incoming_connection(
+    connections: &Arc<RwLock<HashMap<String, quinn::Connection>>>,
+    peer_did: String,
+    connection: quinn::Connection,
+) {
+    use std::collections::hash_map::Entry;
+    let mut connections = connections.write().await;
+    match connections.entry(peer_did) {
+        Entry::Occupied(mut entry) if entry.get().close_reason().is_some() => {
+            info!(
+                "Replacing closed connection for {} with incoming connection from {}",
+                entry.key(),
+                connection.remote_address()
+            );
+            entry.insert(connection);
+        }
+        Entry::Occupied(entry) => {
+            info!(
+                "Connection already exists for {}, not overwriting with incoming connection from {}",
+                entry.key(),
+                connection.remote_address()
+            );
+        }
+        Entry::Vacant(entry) => {
+            info!(
+                "Storing incoming connection from {} at {}",
+                entry.key(),
+                connection.remote_address()
+            );
+            entry.insert(connection);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -877,7 +910,7 @@ mod tests {
     async fn test_reconnect_after_peer_restart_replaces_dead_connection() {
         setup();
 
-        let (survivor, survivor_addr) = start_manager().await;
+        let (mut survivor, survivor_addr) = start_manager().await;
         let peer_did = "did:icn:zRestartingPeer".to_string();
 
         // --- peer's first incarnation connects and is registered ---
@@ -918,6 +951,7 @@ mod tests {
         );
 
         peer_v2.stop().await.unwrap();
+        survivor.stop().await.unwrap();
     }
 
     /// A *live* connection must still win over a duplicate inbound one.
@@ -928,7 +962,7 @@ mod tests {
     async fn test_live_connection_is_not_replaced_by_duplicate_inbound() {
         setup();
 
-        let (survivor, survivor_addr) = start_manager().await;
+        let (mut survivor, survivor_addr) = start_manager().await;
         let peer_did = "did:icn:zChattyPeer".to_string();
 
         let (mut peer, _) = start_manager().await;
@@ -957,5 +991,42 @@ mod tests {
         );
 
         peer.stop().await.unwrap();
+        survivor.stop().await.unwrap();
+    }
+
+    /// The Hello handler does not call `store_incoming_connection`; it holds the connection map
+    /// directly via `connections_arc()`. That is the path a real peer's reconnect takes, so it
+    /// gets its own coverage against the same invariant — a fix that only reached the helper
+    /// would have left production untouched (#2504).
+    #[tokio::test]
+    async fn test_hello_path_install_replaces_dead_connection() {
+        setup();
+
+        let (mut survivor, survivor_addr) = start_manager().await;
+        let peer_did = "did:icn:zHelloPathPeer".to_string();
+        let map = survivor.connections_arc();
+
+        let (mut peer_v1, _) = start_manager().await;
+        let inbound_v1 = connect(&survivor, &peer_v1, survivor_addr).await;
+        let v1_probe = inbound_v1.clone();
+        install_incoming_connection(&map, peer_did.clone(), inbound_v1).await;
+        assert!(can_reach(&survivor, &peer_did).await);
+
+        peer_v1.stop().await.unwrap();
+        tokio::time::timeout(tokio::time::Duration::from_secs(5), v1_probe.closed())
+            .await
+            .expect("cached connection should observe closure");
+
+        let (mut peer_v2, _) = start_manager().await;
+        let inbound_v2 = connect(&survivor, &peer_v2, survivor_addr).await;
+        install_incoming_connection(&map, peer_did.clone(), inbound_v2).await;
+
+        assert!(
+            can_reach(&survivor, &peer_did).await,
+            "#2504: the Hello-handler install path must also replace a dead cached connection"
+        );
+
+        peer_v2.stop().await.unwrap();
+        survivor.stop().await.unwrap();
     }
 }

--- a/icn/crates/icn-net/src/session.rs
+++ b/icn/crates/icn-net/src/session.rs
@@ -302,17 +302,31 @@ impl SessionManager {
 
         info!("Connected to peer at {}", addr);
 
-        // Store connection, or return existing one if we already have it
+        // Store connection, or return the existing one if we already have a *live* one.
+        //
+        // A closed entry must never win over a freshly dialed connection: after a peer restarts,
+        // our cached connection to it is dead, and preferring it would make every send fail
+        // until this process restarts (#2504).
         let mut connections = self.connections.write().await;
         if let Some(existing) = connections.get(&peer_did) {
-            info!(
-                "Connection already exists for {} (from incoming), returning existing connection and closing new one",
-                peer_did
-            );
-            let existing_conn = existing.clone();
-            drop(connections); // Release lock before closing
-            connection.close(0u32.into(), b"duplicate");
-            return Ok(existing_conn);
+            match existing.close_reason() {
+                None => {
+                    info!(
+                        "Connection already exists for {} (from incoming), returning existing connection and closing new one",
+                        peer_did
+                    );
+                    let existing_conn = existing.clone();
+                    drop(connections); // Release lock before closing
+                    connection.close(0u32.into(), b"duplicate");
+                    return Ok(existing_conn);
+                }
+                Some(reason) => {
+                    info!(
+                        "Replacing closed connection for {} ({}) with the connection we just dialed",
+                        peer_did, reason
+                    );
+                }
+            }
         }
         connections.insert(peer_did, connection.clone());
         drop(connections);
@@ -356,13 +370,28 @@ impl SessionManager {
     /// This is called when we receive a Hello message from a peer on an incoming
     /// connection, allowing us to send messages back on that connection.
     ///
-    /// Note: If a connection already exists for this peer (e.g., from a dial we made),
+    /// Note: If a *live* connection already exists for this peer (e.g., from a dial we made),
     /// we don't overwrite it to avoid connection confusion. Both connections will
     /// have handlers running, but we prefer the connection we dialed.
+    ///
+    /// A **closed** entry is replaced. Map occupancy is not proof of liveness: when a peer
+    /// restarts, our cached connection to it is dead, and the peer's reconnect is the only
+    /// signal we get. Keeping the dead entry made every subsequent send to that peer fail —
+    /// permanently and in one direction only — until this process itself restarted (#2504).
+    /// Replacing a connection that is already closed cannot displace a live session, so this
+    /// preserves the anti-connection-confusion property above.
     pub async fn store_incoming_connection(&self, peer_did: String, connection: quinn::Connection) {
         use std::collections::hash_map::Entry;
         let mut connections = self.connections.write().await;
         match connections.entry(peer_did) {
+            Entry::Occupied(mut entry) if entry.get().close_reason().is_some() => {
+                info!(
+                    "Replacing closed connection for {} with incoming connection from {}",
+                    entry.key(),
+                    connection.remote_address()
+                );
+                entry.insert(connection);
+            }
             Entry::Occupied(entry) => {
                 info!("Connection already exists for {}, not overwriting with incoming connection from {}",
                       entry.key(), connection.remote_address());
@@ -787,5 +816,146 @@ mod tests {
         // Cleanup
         client_manager.stop().await.unwrap();
         server_manager.stop().await.unwrap();
+    }
+
+    /// Start a manager on an ephemeral loopback port and return it with its bound address.
+    async fn start_manager() -> (SessionManager, SocketAddr) {
+        let mut manager = SessionManager::new();
+        let identity = icn_identity::IdentityBundle::generate().unwrap();
+        manager
+            .start(&identity, "127.0.0.1:0".parse().unwrap(), None, None)
+            .await
+            .unwrap();
+        let addr = manager
+            .endpoint
+            .read()
+            .await
+            .as_ref()
+            .unwrap()
+            .local_addr()
+            .unwrap();
+        (manager, addr)
+    }
+
+    /// Have `dialer` connect to `listener`, returning the connection `listener` accepted.
+    async fn connect(
+        listener: &SessionManager,
+        dialer: &SessionManager,
+        addr: SocketAddr,
+    ) -> quinn::Connection {
+        let listener_clone = listener.clone_for_test();
+        let accept_task = tokio::spawn(async move { listener_clone.accept().await });
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        dialer.dial(addr, "listener".to_string()).await.unwrap();
+        accept_task.await.unwrap().unwrap().unwrap()
+    }
+
+    /// Whether `manager` can actually open a stream on the connection it holds for `peer_did`.
+    ///
+    /// This is the property that matters operationally: `send_message_to_peer` resolves peers by
+    /// DID lookup into this map and then calls `open_bi()`, so a dead entry means every send fails.
+    async fn can_reach(manager: &SessionManager, peer_did: &str) -> bool {
+        let Some((_, conn)) = manager
+            .connections()
+            .await
+            .into_iter()
+            .find(|(did, _)| did == peer_did)
+        else {
+            return false;
+        };
+        conn.open_bi().await.is_ok()
+    }
+
+    /// Regression test for #2504.
+    ///
+    /// When a peer restarts, the surviving node holds a dead `quinn::Connection` for that peer's
+    /// DID. The restarted peer reconnects with the same DID, but `store_incoming_connection`
+    /// treated map occupancy as proof of liveness and discarded the live connection — so every
+    /// subsequent send to that peer failed, permanently and one-way, until the survivor itself
+    /// restarted.
+    #[tokio::test]
+    async fn test_reconnect_after_peer_restart_replaces_dead_connection() {
+        setup();
+
+        let (survivor, survivor_addr) = start_manager().await;
+        let peer_did = "did:icn:zRestartingPeer".to_string();
+
+        // --- peer's first incarnation connects and is registered ---
+        let (mut peer_v1, _) = start_manager().await;
+        let inbound_v1 = connect(&survivor, &peer_v1, survivor_addr).await;
+        let v1_probe = inbound_v1.clone();
+        survivor
+            .store_incoming_connection(peer_did.clone(), inbound_v1)
+            .await;
+        assert!(
+            can_reach(&survivor, &peer_did).await,
+            "precondition: survivor should reach the peer's first incarnation"
+        );
+
+        // --- the peer restarts: its process goes away ---
+        peer_v1.stop().await.unwrap();
+        tokio::time::timeout(tokio::time::Duration::from_secs(5), v1_probe.closed())
+            .await
+            .expect("survivor's connection to the peer should observe closure");
+        assert!(
+            !can_reach(&survivor, &peer_did).await,
+            "precondition: the survivor's cached connection is now dead"
+        );
+
+        // --- the peer comes back with the SAME DID and reconnects ---
+        let (mut peer_v2, _) = start_manager().await;
+        let inbound_v2 = connect(&survivor, &peer_v2, survivor_addr).await;
+        survivor
+            .store_incoming_connection(peer_did.clone(), inbound_v2)
+            .await;
+
+        // The regression: the survivor must be able to send to the peer again, without
+        // restarting the survivor and without operator intervention.
+        assert!(
+            can_reach(&survivor, &peer_did).await,
+            "#2504: survivor still holds the dead connection after the peer reconnected, \
+             so every send to it will fail until the survivor restarts"
+        );
+
+        peer_v2.stop().await.unwrap();
+    }
+
+    /// A *live* connection must still win over a duplicate inbound one.
+    ///
+    /// This is the anti-connection-confusion property the original code was protecting; the
+    /// #2504 fix must not trade it away to make reconnection work.
+    #[tokio::test]
+    async fn test_live_connection_is_not_replaced_by_duplicate_inbound() {
+        setup();
+
+        let (survivor, survivor_addr) = start_manager().await;
+        let peer_did = "did:icn:zChattyPeer".to_string();
+
+        let (mut peer, _) = start_manager().await;
+        let first = connect(&survivor, &peer, survivor_addr).await;
+        let first_id = first.stable_id();
+        survivor
+            .store_incoming_connection(peer_did.clone(), first)
+            .await;
+
+        // A second, concurrent inbound connection from the same peer must not evict the first.
+        let second = connect(&survivor, &peer, survivor_addr).await;
+        survivor
+            .store_incoming_connection(peer_did.clone(), second)
+            .await;
+
+        let held = survivor
+            .connections()
+            .await
+            .into_iter()
+            .find(|(did, _)| *did == peer_did)
+            .map(|(_, c)| c.stable_id());
+        assert_eq!(
+            held,
+            Some(first_id),
+            "a live connection must not be displaced by a duplicate inbound connection"
+        );
+
+        peer.stop().await.unwrap();
     }
 }


### PR DESCRIPTION
## What

`SessionManager` now treats a connection whose `close_reason()` is `Some` as absent, in both `store_incoming_connection` and `dial`. A dead cached connection no longer wins over a live one.

## Why

A restarted node could not rejoin the federation, and no amount of retrying or rolling back fixed it. Root cause traced in #2504:

`SessionManager.connections: HashMap<peer_did, quinn::Connection>` treated **map occupancy as proof of liveness**, and nothing evicts a connection that dies on its own — the only `connections.remove()` is `disconnect_peer`, documented as *"primarily intended for testing and administrative use"*.

So when a node restarts, every surviving peer keeps a dead connection for that node's DID:

- `store_incoming_connection` saw `Entry::Occupied` and **discarded the live inbound connection**;
- `dial` returned the stale entry and closed the freshly dialed one as a `"duplicate"`.

`send_message_to_peer` resolves peers by DID lookup into that same map, so every send failed at `open_bi()`. The restarted node's own map was empty, so its *outbound* traffic worked fine — producing a one-way partition.

Observed live on the four-node rehearsal federation, all nodes on an identical image:

| node | uptime | `network_size_estimate` | `digests_received` |
|---|---|---|---|
| alpha (restarted) | 34 m | **1** | counter never incremented |
| beta (restarted) | 45 m | **1** | counter never incremented |
| gamma | 8 h 21 m | 4 | 7,906 |
| delta | 8 h 21 m | 4 | 7,981 |

with the healthy peer logging `Failed to send gossip message: Failed to send message` (×146) and `Detected 1 partitioned peers`. This also explains why **rollback did not recover the node** — rollback restarts the *broken* node, but the stale entries live in its *peers*.

## How

Both sites check `close_reason()` before preferring the cached connection. Replacing an already-closed connection cannot displace a live session, so the anti-connection-confusion property the original code was protecting is preserved intact.

No change to authentication, rate limiting, ban/misbehavior handling, replay protection, or gossip deduplication. A reconnecting peer still completes the full Hello/authentication path; this only decides which socket a *already-authenticated* DID maps to.

In production, a connection to a vanished peer reaches the closed state via the existing 60 s `max_idle_timeout` (30 s keep-alive), so recovery happens automatically on the existing redial cadence — **without restarting any healthy peer**.

## Risk

Low, and bounded to connection bookkeeping.

- Could a hostile peer evict a live connection? No — replacement only happens when the existing connection is *already closed*, which means it carries no traffic.
- Could this cause connection churn? No — the live-connection path is unchanged; the second test pins it.
- Unbounded peer-state growth? Unchanged: this replaces an entry in place rather than adding one.

## Test plan

Two tests added to `icn-net/src/session.rs`:

1. `test_reconnect_after_peer_restart_replaces_dead_connection` — the regression. Survivor registers peer v1, peer restarts, peer v2 reconnects with the same DID; asserts the survivor can actually `open_bi()` to that DID again. **Verified failing on `38c9a048` before the fix**, with:
   ```
   #2504: survivor still holds the dead connection after the peer reconnected,
   so every send to it will fail until the survivor restarts
   ```
   Both preconditions pass on unfixed main (survivor reaches v1; the cached connection is confirmed dead), so the test fails for the right reason.

2. `test_live_connection_is_not_replaced_by_duplicate_inbound` — the negative case: a live connection must still win over a duplicate inbound one.

Gates run locally on this branch:

- `cargo test -p icn-net --lib` → **263 passed, 0 failed**
- `cargo fmt --all --check` → clean
- `cargo clippy -p icn-net --all-targets --all-features -- -D warnings` → clean

Live verification on the rehearsal federation (alpha first, healthy controls untouched) is tracked in #2504 and will be posted there.

## Notes — out of scope, filed separately

Found while tracing, deliberately **not** bundled here:

1. A node discovers and dials **itself** (mDNS), then trips its own replay guard and bans its own DID.
2. Ban state is persisted and reloaded on restart with no TTL — `is_banned` never consults the stored timestamp. (The #2504 issue body's claim that bans are memory-only is incorrect on this image.)
3. A restarted node cannot re-announce its connection candidate: its own trust score is 0 against a 0.1 threshold.
4. `network:profiles` is published but never declared → `Rejecting publish to undeclared topic`.

Refs #2504
