### PR TITLE
fix(net): make the outbound signing sequence durable across restarts

### DIFF
--- a/icn/crates/icn-core/src/supervisor/init_send_callback.rs
+++ b/icn/crates/icn-core/src/supervisor/init_send_callback.rs
@@ -7,7 +7,6 @@
 //! - Encryption sequence tracking and cleanup
 //! - Metrics for message types and encryption status
 
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -60,7 +59,15 @@ pub async fn init_send_callback(
     deps: SendCallbackDeps,
     background_tasks: &mut JoinSet<()>,
 ) -> Result<SendCallbackServices> {
-    let sequence_counter = Arc::new(AtomicU64::new(0));
+    // Signing sequence: durable and monotonic across restarts (#2510).
+    // Peers persist their high-water mark for us and reject anything at or below it,
+    // so a counter that restarted at zero would make our own legitimate traffic look
+    // like a replay attack. This is a different sequence space from the encryption
+    // tracker below - see icn_net::signing_sequence.
+    let sequence_counter = Arc::new(
+        icn_net::SigningSequenceCounter::new(deps.gossip_store.clone())
+            .context("Failed to open durable signing sequence counter")?,
+    );
 
     // Create encryption sequence tracker
     let encryption_sequence_tracker = Arc::new(
@@ -118,7 +125,7 @@ fn create_send_callback(
     own_did: Did,
     keypair: KeyPair,
     x25519_secret_bytes: [u8; 32],
-    sequence_counter: Arc<AtomicU64>,
+    sequence_counter: Arc<icn_net::SigningSequenceCounter>,
     encryption_sequence_tracker: Arc<icn_net::OutgoingSequenceTracker>,
     encryption_enabled: bool,
 ) -> SendMessageCallback {
@@ -141,8 +148,16 @@ fn create_send_callback(
 
         // Spawn async task to send message
         tokio::spawn(async move {
-            // Get next sequence number for signed envelope
-            let sequence = sequence_ctr.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            // Get next sequence number for signed envelope.
+            // Fail-closed: if the reservation cannot be persisted we drop the message
+            // rather than emit a sequence a later incarnation could reissue (#2510).
+            let sequence = match sequence_ctr.next_sequence() {
+                Ok(seq) => seq,
+                Err(e) => {
+                    error!("Failed to allocate signing sequence, dropping message: {e}");
+                    return;
+                }
+            };
 
             // Create inner signed envelope with gossip payload
             let inner_envelope = match icn_net::SignedEnvelope::from_payload(

--- a/icn/crates/icn-net/src/lib.rs
+++ b/icn/crates/icn-net/src/lib.rs
@@ -24,6 +24,7 @@ pub mod relay_proxy;
 pub mod replay_guard;
 pub mod sequence_tracker;
 pub mod session;
+pub mod signing_sequence;
 pub mod stun;
 pub mod tls;
 pub mod topology;
@@ -55,6 +56,7 @@ pub use relay_proxy::{ProxyHandle, TurnRelayProxy};
 pub use replay_guard::ReplayGuard;
 pub use sequence_tracker::OutgoingSequenceTracker;
 pub use session::SessionManager;
+pub use signing_sequence::SigningSequenceCounter;
 pub use stun::StunClient;
 pub use topology::{
     FanoutConfig, NeighborLimitsConfig, NeighborMetrics, NeighborSets, NetworkMetrics, NodeRole,

--- a/icn/crates/icn-net/src/signing_sequence.rs
+++ b/icn/crates/icn-net/src/signing_sequence.rs
@@ -1,0 +1,311 @@
+//! Durable signing-sequence counter for outbound [`SignedEnvelope`]s.
+//!
+//! # Why this exists (issue #2510)
+//!
+//! ICN has **two distinct outbound sequence spaces**, and conflating them caused a
+//! security-lifecycle defect:
+//!
+//! | | encryption nonce sequence | signing sequence (this module) |
+//! |---|---|---|
+//! | producer | [`OutgoingSequenceTracker`] | [`SigningSequenceCounter`] |
+//! | scope | per `(sender, recipient)` pair | per sender, shared across all recipients |
+//! | consumed by | ChaCha20-Poly1305 nonce derivation | `ReplayGuard` on the receiving node |
+//!
+//! Only the *signing* sequence is checked by the peer's replay guard. That guard
+//! persists its per-peer high-water mark to disk and reloads it at startup, so it
+//! assumes the sender's counter is durable and monotonic. Before this module, the
+//! signing counter was a process-local `AtomicU64::new(0)`: every restart reset it to
+//! zero, and surviving peers scored the restarted node's legitimate traffic as a replay
+//! attack at severity 1.0.
+//!
+//! The receiver was built against a durable sender that did not exist. This module
+//! supplies the missing half; it deliberately changes no wire format.
+//!
+//! # Durability strategy: block reservation
+//!
+//! [`OutgoingSequenceTracker`] persists on every increment, which is affordable because
+//! it only runs on the encrypted *unicast* path. The signing sequence is consumed by
+//! **every** outbound gossip message, including broadcast, so a disk write per message
+//! would be a hot-path regression.
+//!
+//! Instead we reserve sequences in blocks. The store always holds `reserved_end`, an
+//! exclusive upper bound on the reservation:
+//!
+//! ```text
+//! issued sequences  [.....next.....)  reserved_end
+//!                   ^ handed out      ^ persisted watermark
+//! ```
+//!
+//! The durable invariant is:
+//!
+//! > **every sequence ever issued is strictly less than the persisted `reserved_end`.**
+//!
+//! The watermark is written *before* any sequence in the new block is handed out, so a
+//! crash at any point resumes at or above the highest sequence that could have reached
+//! the network. Crashing mid-block simply skips the unused remainder; gaps are harmless
+//! because the replay guard tracks a high-water mark rather than strict succession.
+//!
+//! [`OutgoingSequenceTracker`]: crate::sequence_tracker::OutgoingSequenceTracker
+//! [`SignedEnvelope`]: crate::envelope::SignedEnvelope
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::{anyhow, Context, Result};
+
+use icn_store::Store;
+
+/// Number of sequences claimed per durable reservation.
+///
+/// Trades restart-time sequence skip against write amplification: one store write per
+/// 1,000 outbound messages, and at most 1,000 sequences skipped per restart. At u64
+/// width the sequence space tolerates ~1.8e16 restarts at this block size.
+const RESERVATION_BLOCK: u64 = 1_000;
+
+/// Storage key holding the exclusive upper bound of the current reservation.
+const SIGNING_SEQUENCE_KEY: &[u8] = b"outgoing_signing_seq_reserved_end";
+
+/// First sequence a fresh counter issues.
+///
+/// Sequence 0 is unusable: `ReplayGuard` rejects `sequence <= floor_seq` and a fresh
+/// per-peer window starts at `floor_seq = 0`, so a message numbered 0 is always scored
+/// as a replay. The previous `AtomicU64::new(0)` + `fetch_add(1)` returned the *old*
+/// value, so every node's first gossip message was silently dropped by every peer.
+const FIRST_SEQUENCE: u64 = 1;
+
+/// Mutable counter state.
+///
+/// Sequences in `[next, reserved_end)` are safe to hand out without touching disk.
+struct State {
+    /// Next sequence to issue.
+    next: u64,
+    /// Exclusive upper bound of the durably reserved range.
+    reserved_end: u64,
+}
+
+/// Per-sender monotonic sequence source for outbound signed envelopes.
+///
+/// Monotonic across process restarts when constructed with [`Self::new`]. Use
+/// [`Self::in_memory`] only for tests and genuinely ephemeral nodes: an in-memory
+/// counter restarts at zero, which is exactly the condition that peers score as a
+/// replay attack.
+pub struct SigningSequenceCounter {
+    state: Mutex<State>,
+    store: Option<Arc<dyn Store>>,
+}
+
+impl SigningSequenceCounter {
+    /// Open a durable counter, resuming past every previously issued sequence.
+    ///
+    /// Reads the persisted reservation watermark and resumes there. Because the
+    /// watermark is always written before the block it covers is used, the first
+    /// sequence issued after a restart is guaranteed to exceed every sequence issued by
+    /// any prior incarnation.
+    pub fn new(store: Arc<dyn Store>) -> Result<Self> {
+        let reserved_end = match store
+            .get(SIGNING_SEQUENCE_KEY)
+            .context("Failed to read persisted signing sequence watermark")?
+        {
+            Some(bytes) => {
+                let raw: [u8; 8] = bytes.as_slice().try_into().map_err(|_| {
+                    anyhow!(
+                        "Corrupt signing sequence watermark: expected 8 bytes, found {}",
+                        bytes.len()
+                    )
+                })?;
+                u64::from_be_bytes(raw)
+            }
+            None => 0,
+        };
+
+        tracing::info!(
+            resumed_at = reserved_end,
+            block = RESERVATION_BLOCK,
+            "Loaded durable signing sequence counter"
+        );
+
+        Ok(SigningSequenceCounter {
+            // Resume at the watermark: everything below it may already be on the wire.
+            // A fresh counter starts at FIRST_SEQUENCE, not zero - see its docs.
+            state: Mutex::new(State {
+                next: reserved_end.max(FIRST_SEQUENCE),
+                reserved_end,
+            }),
+            store: Some(store),
+        })
+    }
+
+    /// Create a non-durable counter for tests and ephemeral nodes.
+    ///
+    /// **Warning**: restarts reset this to zero, which surviving peers classify as a
+    /// replay attack (#2510). Never use on a node with persistent storage.
+    pub fn in_memory() -> Self {
+        SigningSequenceCounter {
+            state: Mutex::new(State {
+                next: FIRST_SEQUENCE,
+                reserved_end: 0,
+            }),
+            store: None,
+        }
+    }
+
+    /// Issue the next sequence number, extending the durable reservation if needed.
+    ///
+    /// Returns an error if the reservation cannot be persisted. Callers must treat that
+    /// as fatal for the message: issuing a sequence we failed to record would let a
+    /// later incarnation reuse it.
+    pub fn next_sequence(&self) -> Result<u64> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow!("Signing sequence counter mutex poisoned"))?;
+
+        if state.next >= state.reserved_end {
+            let new_end = state.next.checked_add(RESERVATION_BLOCK).context(
+                "Signing sequence space exhausted (requires 2^64 messages); \
+                 node identity should be rotated",
+            )?;
+
+            // Persist BEFORE issuing anything from the new block, so a crash between
+            // here and the send resumes above every sequence that could have escaped.
+            // The flush is what makes that claim true rather than aspirational: an
+            // unflushed watermark lost to power failure would let the next incarnation
+            // reissue sequences this one already put on the wire.
+            if let Some(ref store) = self.store {
+                store
+                    .put(SIGNING_SEQUENCE_KEY, &new_end.to_be_bytes())
+                    .context("Failed to persist signing sequence reservation")?;
+                store
+                    .flush()
+                    .context("Failed to flush signing sequence reservation")?;
+            }
+
+            state.reserved_end = new_end;
+        }
+
+        let sequence = state.next;
+        state.next += 1;
+        Ok(sequence)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store() -> Arc<dyn Store> {
+        Arc::new(icn_store::SledStore::temporary().unwrap())
+    }
+
+    #[test]
+    fn issues_monotonically_within_one_incarnation() {
+        let counter = SigningSequenceCounter::new(temp_store()).unwrap();
+
+        let first = counter.next_sequence().unwrap();
+        for expected in 1..2_500u64 {
+            assert_eq!(counter.next_sequence().unwrap(), first + expected);
+        }
+    }
+
+    /// The #2510 invariant: a restart must not reissue a consumed sequence.
+    #[test]
+    fn never_reissues_a_sequence_across_restart() {
+        let store = temp_store();
+        let mut issued = Vec::new();
+
+        // Three incarnations against the same store, each crossing block boundaries.
+        for _ in 0..3 {
+            let counter = SigningSequenceCounter::new(store.clone()).unwrap();
+            for _ in 0..1_500 {
+                issued.push(counter.next_sequence().unwrap());
+            }
+        }
+
+        let mut sorted = issued.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), issued.len(), "a sequence was reissued");
+
+        // Strictly increasing overall, so a peer's high-water mark is never revisited.
+        assert!(
+            issued.windows(2).all(|w| w[1] > w[0]),
+            "sequence regressed across a restart"
+        );
+    }
+
+    /// A crash mid-block must not replay the unused remainder of that block.
+    #[test]
+    fn crash_mid_block_does_not_reuse_reserved_sequences() {
+        let store = temp_store();
+
+        let before = {
+            let counter = SigningSequenceCounter::new(store.clone()).unwrap();
+            // Consume one sequence, abandoning the rest of the reserved block.
+            counter.next_sequence().unwrap()
+        };
+
+        let after = SigningSequenceCounter::new(store.clone())
+            .unwrap()
+            .next_sequence()
+            .unwrap();
+
+        assert!(
+            after >= before + RESERVATION_BLOCK,
+            "resumed at {after}, inside the block reserved by the previous incarnation \
+             starting at {before}"
+        );
+    }
+
+    /// Guards the durability contract itself: the watermark must be written before the
+    /// block it covers is handed out, never lazily afterwards.
+    #[test]
+    fn watermark_is_persisted_before_the_block_is_used() {
+        let store = temp_store();
+        let counter = SigningSequenceCounter::new(store.clone()).unwrap();
+
+        let issued = counter.next_sequence().unwrap();
+
+        let raw = store
+            .get(SIGNING_SEQUENCE_KEY)
+            .unwrap()
+            .expect("watermark must exist immediately after the first issue");
+        let persisted = u64::from_be_bytes(raw.as_slice().try_into().unwrap());
+
+        assert!(
+            persisted > issued,
+            "persisted watermark {persisted} does not cover issued sequence {issued}"
+        );
+    }
+
+    #[test]
+    fn in_memory_counter_starts_at_the_first_usable_sequence() {
+        let counter = SigningSequenceCounter::in_memory();
+        assert_eq!(counter.next_sequence().unwrap(), FIRST_SEQUENCE);
+        assert_eq!(counter.next_sequence().unwrap(), FIRST_SEQUENCE + 1);
+    }
+
+    /// Sequence 0 is always rejected by `ReplayGuard` (`sequence <= floor_seq`, floor
+    /// starts at 0), so it must never be issued by either constructor.
+    #[test]
+    fn never_issues_the_unusable_zero_sequence() {
+        assert_ne!(
+            SigningSequenceCounter::in_memory().next_sequence().unwrap(),
+            0
+        );
+        assert_ne!(
+            SigningSequenceCounter::new(temp_store())
+                .unwrap()
+                .next_sequence()
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn corrupt_watermark_is_rejected_rather_than_silently_reset() {
+        let store = temp_store();
+        store.put(SIGNING_SEQUENCE_KEY, b"garbage").unwrap();
+
+        // Silently restarting at zero here would recreate #2510 on a corrupt store.
+        assert!(SigningSequenceCounter::new(store).is_err());
+    }
+}

--- a/icn/crates/icn-net/src/signing_sequence.rs
+++ b/icn/crates/icn-net/src/signing_sequence.rs
@@ -86,8 +86,8 @@ struct State {
 ///
 /// Monotonic across process restarts when constructed with [`Self::new`]. Use
 /// [`Self::in_memory`] only for tests and genuinely ephemeral nodes: an in-memory
-/// counter restarts at zero, which is exactly the condition that peers score as a
-/// replay attack.
+/// counter restarts from the bottom of the sequence space, which is exactly the
+/// condition that peers score as a replay attack.
 pub struct SigningSequenceCounter {
     state: Mutex<State>,
     store: Option<Arc<dyn Store>>,
@@ -136,8 +136,9 @@ impl SigningSequenceCounter {
 
     /// Create a non-durable counter for tests and ephemeral nodes.
     ///
-    /// **Warning**: restarts reset this to zero, which surviving peers classify as a
-    /// replay attack (#2510). Never use on a node with persistent storage.
+    /// **Warning**: restarts reset this to [`FIRST_SEQUENCE`], far below any high-water
+    /// mark a peer is holding, which surviving peers classify as a replay attack
+    /// (#2510). Never use on a node with persistent storage.
     pub fn in_memory() -> Self {
         SigningSequenceCounter {
             state: Mutex::new(State {
@@ -153,6 +154,18 @@ impl SigningSequenceCounter {
     /// Returns an error if the reservation cannot be persisted. Callers must treat that
     /// as fatal for the message: issuing a sequence we failed to record would let a
     /// later incarnation reuse it.
+    ///
+    /// # Why this is synchronous
+    ///
+    /// The store write happens under the lock, on the caller's thread, rather than via
+    /// `spawn_blocking`. That is deliberate: correctness here depends on "persist, then
+    /// issue from the new block" being atomic. Releasing the lock to await a blocking
+    /// task would let two senders each observe an exhausted reservation and both extend
+    /// it, which is precisely the reuse this type exists to prevent.
+    ///
+    /// The cost is bounded by amortisation - one write per [`RESERVATION_BLOCK`]
+    /// messages, not one per message. The sibling `OutgoingSequenceTracker` already
+    /// persists synchronously from async on *every* encrypted message.
     pub fn next_sequence(&self) -> Result<u64> {
         let mut state = self
             .state

--- a/icn/crates/icn-net/tests/signing_sequence_replay.rs
+++ b/icn/crates/icn-net/tests/signing_sequence_replay.rs
@@ -155,6 +155,45 @@ fn captured_traffic_from_a_previous_incarnation_is_still_rejected() {
     }
 }
 
+/// Demonstrates why "clear the peer's replay state when it reconnects" is NOT a safe
+/// fix for #2510, and must not be reintroduced as a simplification.
+///
+/// The tempting shortcut is to drop a peer's window on a fresh authenticated
+/// connection. This test shows the cost directly: the *same* message that is correctly
+/// refused while the window is held becomes acceptable once the window is dropped.
+///
+/// Note the residual exposure is bounded by the signed timestamp - `verify_age(300)`
+/// rejects anything older than the freshness window regardless. That bound is what
+/// makes the durable-counter fix sufficient without an incarnation field; it is *not*
+/// a licence to clear state on reconnect, because everything inside those 300 seconds
+/// becomes replayable.
+#[test]
+fn clearing_replay_state_on_reconnect_would_reopen_captured_traffic() {
+    let keypair = KeyPair::generate().unwrap();
+    let counter = SigningSequenceCounter::new(temp_store()).unwrap();
+
+    let captured = {
+        let mut guard = persistent_guard(temp_store());
+        let env = envelope(&keypair, counter.next_sequence().unwrap(), b"captured");
+        guard.check(&env).unwrap();
+        assert!(
+            guard.check(&env).is_err(),
+            "precondition: while the window is held, the duplicate must be refused"
+        );
+        env
+    };
+
+    // Model the naive fix: a reconnect drops this peer's replay state, leaving a guard
+    // with no memory of the DID. Everything else is unchanged.
+    let mut cleared = persistent_guard(temp_store());
+
+    assert!(
+        cleared.check(&captured).is_ok(),
+        "expected the cleared-state guard to accept previously-seen traffic; if this \
+         ever fails the demonstration is stale, not fixed"
+    );
+}
+
 /// Ordinary transport churn is not an incarnation boundary.
 ///
 /// The replay guard is keyed by DID alone and holds no connection state, so reconnects

--- a/icn/crates/icn-net/tests/signing_sequence_replay.rs
+++ b/icn/crates/icn-net/tests/signing_sequence_replay.rs
@@ -1,0 +1,240 @@
+//! End-to-end replay behaviour across a sender restart (#2510).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//!
+//! These tests wire the real [`SigningSequenceCounter`] to the real [`ReplayGuard`] so
+//! they exercise the actual production relationship: the sender allocates a signing
+//! sequence, the receiving peer enforces a persisted high-water mark against it.
+//!
+//! The security controls here exist to keep a future refactor from "fixing" a restart
+//! by clearing replay state on reconnect, which would reopen captured traffic.
+
+use std::sync::Arc;
+
+use icn_identity::KeyPair;
+use icn_net::envelope::PayloadType;
+use icn_net::replay_guard::ReplayGuard;
+use icn_net::signing_sequence::SigningSequenceCounter;
+use icn_net::SignedEnvelope;
+use icn_store::Store;
+
+/// One block of the counter's reservation, so tests cross a reservation boundary.
+const OVER_ONE_BLOCK: usize = 1_500;
+
+fn temp_store() -> Arc<dyn Store> {
+    Arc::new(icn_store::SledStore::temporary().unwrap())
+}
+
+/// A receiver that persists replay state, as production does.
+fn persistent_guard(store: Arc<dyn Store>) -> ReplayGuard {
+    let mut guard = ReplayGuard::new_persistent(300, 3600, store);
+    guard.load_and_apply_safety_gap().unwrap();
+    guard
+}
+
+fn envelope(keypair: &KeyPair, sequence: u64, body: &[u8]) -> SignedEnvelope {
+    SignedEnvelope::new(
+        keypair.did(),
+        keypair,
+        sequence,
+        PayloadType::Gossip,
+        body.to_vec(),
+    )
+    .unwrap()
+}
+
+/// The #2510 regression: a peer that restarts must not be scored as a replay attacker.
+///
+/// Fails on the pre-fix implementation, where the signing counter restarted at zero.
+#[test]
+fn restarted_sender_is_accepted_by_a_peer_that_remembers_it() {
+    let sender_store = temp_store();
+    let mut guard = persistent_guard(temp_store());
+    let keypair = KeyPair::generate().unwrap();
+
+    // Incarnation A: enough traffic to push the peer's high-water mark well past zero.
+    {
+        let counter = SigningSequenceCounter::new(sender_store.clone()).unwrap();
+        for _ in 0..OVER_ONE_BLOCK {
+            let seq = counter.next_sequence().unwrap();
+            guard
+                .check(&envelope(&keypair, seq, b"incarnation-a"))
+                .expect("steady-state traffic must be accepted");
+        }
+    }
+
+    let high_water = guard.get_max_seq(keypair.did()).unwrap();
+    assert!(high_water >= OVER_ONE_BLOCK as u64 - 1);
+
+    // Incarnation B: same DID, same disk, brand new process.
+    let counter = SigningSequenceCounter::new(sender_store).unwrap();
+    let seq = counter.next_sequence().unwrap();
+
+    assert!(
+        seq > high_water,
+        "restarted sender issued {seq}, at or below the peer's high-water mark {high_water}"
+    );
+    guard
+        .check(&envelope(&keypair, seq, b"incarnation-b"))
+        .expect("a restarted peer's first message must not be scored as a replay attack");
+}
+
+/// Negative control for the fix itself: an ephemeral counter still reproduces #2510.
+///
+/// This is the pre-fix behaviour, kept executable so the suite proves it can tell the
+/// broken implementation from the fixed one. If someone swaps `new()` for `in_memory()`
+/// in the composition root, the test above fails and this one keeps passing.
+#[test]
+fn ephemeral_counter_reproduces_the_2510_defect() {
+    let mut guard = persistent_guard(temp_store());
+    let keypair = KeyPair::generate().unwrap();
+
+    {
+        let counter = SigningSequenceCounter::in_memory();
+        for _ in 0..OVER_ONE_BLOCK {
+            let seq = counter.next_sequence().unwrap();
+            guard.check(&envelope(&keypair, seq, b"incarnation-a")).ok();
+        }
+    }
+
+    // "Restart" with no durable state: the counter returns to the start of its range,
+    // far below the high-water mark the peer is holding.
+    let counter = SigningSequenceCounter::in_memory();
+    let seq = counter.next_sequence().unwrap();
+    assert!(
+        seq < guard.get_max_seq(keypair.did()).unwrap(),
+        "precondition: the restarted counter must regress below the peer's high-water mark"
+    );
+
+    let result = guard.check(&envelope(&keypair, seq, b"incarnation-b"));
+    assert!(
+        result.is_err(),
+        "an ephemeral counter must still be caught by replay protection - \
+         this test documents the defect the durable counter fixes"
+    );
+}
+
+/// Security control: the fix must not make captured traffic replayable.
+///
+/// A message from the previous incarnation, captured verbatim, stays rejected after the
+/// sender restarts.
+#[test]
+fn captured_traffic_from_a_previous_incarnation_is_still_rejected() {
+    let sender_store = temp_store();
+    let mut guard = persistent_guard(temp_store());
+    let keypair = KeyPair::generate().unwrap();
+
+    let captured = {
+        let counter = SigningSequenceCounter::new(sender_store.clone()).unwrap();
+        let mut captured = Vec::new();
+        for i in 0..OVER_ONE_BLOCK {
+            let seq = counter.next_sequence().unwrap();
+            let env = envelope(&keypair, seq, b"incarnation-a");
+            guard.check(&env).unwrap();
+            // Attacker records a sample of the traffic.
+            if i % 500 == 0 {
+                captured.push(env);
+            }
+        }
+        captured
+    };
+
+    // Sender restarts and is accepted.
+    let counter = SigningSequenceCounter::new(sender_store).unwrap();
+    let seq = counter.next_sequence().unwrap();
+    guard
+        .check(&envelope(&keypair, seq, b"incarnation-b"))
+        .unwrap();
+
+    // Every captured message must still be refused.
+    for env in &captured {
+        assert!(
+            guard.check(env).is_err(),
+            "captured incarnation-A message at sequence {} was accepted after restart",
+            env.sequence
+        );
+    }
+}
+
+/// Ordinary transport churn is not an incarnation boundary.
+///
+/// The replay guard is keyed by DID alone and holds no connection state, so reconnects
+/// cannot reset it. Asserted behaviourally: after repeated reconnect-shaped activity, an
+/// old sequence is still refused.
+#[test]
+fn reconnect_churn_does_not_reset_replay_state() {
+    let sender_store = temp_store();
+    let mut guard = persistent_guard(temp_store());
+    let keypair = KeyPair::generate().unwrap();
+    let counter = SigningSequenceCounter::new(sender_store).unwrap();
+
+    let first = envelope(&keypair, counter.next_sequence().unwrap(), b"first");
+    guard.check(&first).unwrap();
+
+    // Ten "reconnects" within one incarnation: the sequence namespace is unchanged.
+    for _ in 0..10 {
+        let seq = counter.next_sequence().unwrap();
+        guard
+            .check(&envelope(&keypair, seq, b"same-incarnation"))
+            .unwrap();
+
+        assert!(
+            guard.check(&first).is_err(),
+            "replay state was reset by connection churn"
+        );
+    }
+}
+
+/// A receiver restart must keep rejecting pre-restart sequences.
+///
+/// This is the guard's own persistence path, unchanged by #2510; asserted here so the
+/// durable-sender work cannot silently weaken it.
+#[test]
+fn receiver_restart_preserves_replay_protection() {
+    let guard_store = temp_store();
+    let sender_store = temp_store();
+    let keypair = KeyPair::generate().unwrap();
+    let counter = SigningSequenceCounter::new(sender_store).unwrap();
+
+    let old = {
+        let mut guard = persistent_guard(guard_store.clone());
+        // Send several: the guard only persists max_seq when it advances, so a lone
+        // message at sequence 0 would leave nothing on disk to reload.
+        let first = envelope(&keypair, counter.next_sequence().unwrap(), b"before");
+        guard.check(&first).unwrap();
+        for _ in 0..4 {
+            let env = envelope(&keypair, counter.next_sequence().unwrap(), b"before");
+            guard.check(&env).unwrap();
+        }
+        first
+    };
+
+    // Receiver restarts, reloading persisted state.
+    let mut guard = persistent_guard(guard_store);
+    assert!(
+        guard.check(&old).is_err(),
+        "a pre-restart sequence was accepted after the receiver restarted"
+    );
+}
+
+/// Replay state is per-DID: one identity cannot disturb another's window.
+#[test]
+fn traffic_from_one_did_does_not_reset_another_dids_state() {
+    let mut guard = persistent_guard(temp_store());
+    let alice = KeyPair::generate().unwrap();
+    let mallory = KeyPair::generate().unwrap();
+    let counter = SigningSequenceCounter::new(temp_store()).unwrap();
+
+    let alice_msg = envelope(&alice, counter.next_sequence().unwrap(), b"alice");
+    guard.check(&alice_msg).unwrap();
+
+    // Mallory floods low sequences under her own DID.
+    // (From 1: sequence 0 is always rejected, floor_seq starts at 0.)
+    for seq in 1..50 {
+        guard.check(&envelope(&mallory, seq, b"mallory")).unwrap();
+    }
+
+    assert!(
+        guard.check(&alice_msg).is_err(),
+        "another DID's traffic reset Alice's replay window"
+    );
+}


### PR DESCRIPTION
## What

Makes the outbound **signing sequence** durable and monotonic across process restarts, so a restarted peer is no longer scored as a replay attacker. Adds `icn_net::SigningSequenceCounter` and wires it into the send-callback composition root in place of `AtomicU64::new(0)`.

No wire-format change.

## Why

Refs #2510. ICN has two outbound sequence spaces and only the *wrong* one was durable:

|  | encryption nonce sequence | **signing sequence** |
|---|---|---|
| producer | `OutgoingSequenceTracker` | `sequence_counter` |
| initialised | loaded from store, +10,000 restart gap | **`AtomicU64::new(0)`** |
| persisted | yes | **no** |
| checked by peer's `ReplayGuard` | no | **yes** |

The receiving peer persists its per-peer high-water mark and applies a restart safety gap — it was written assuming a durable monotonic sender that did not exist. `replay_guard.rs:58` documents a coupling to `OutgoingSequenceTracker`, but that tracker governs the other sequence space.

Consequence on the rehearsal federation: after a restart, a peer rejected 100% of the restarted node's traffic for a full hour and recorded ~2,000 `severity=1.0` protocol violations against it, until `cleanup()` aged the window out. Verified live; timeline in #2510.

## How

`SigningSequenceCounter` persists a **reservation watermark** instead of every increment, because the signing sequence is consumed by every outbound message including broadcast (per-message writes would be a hot-path regression; the encryption tracker can afford them because it only runs on the encrypted unicast path).

Durable invariant: **every sequence ever issued is strictly less than the persisted `reserved_end`.** The watermark is written *and flushed* before any sequence in the block is handed out, so a crash resumes at or above the highest sequence that could have reached the network. Skipped remainders are harmless — the guard tracks a high-water mark, not strict succession.

Storage key `outgoing_signing_seq_reserved_end` does not collide with the tracker's `outgoing_seq:` prefix scan or its stale-entry cleanup (verified).

### Drive-by, in scope: sequence 0 was never deliverable

`ReplayGuard` rejects `sequence <= floor_seq` and a fresh window starts at `floor_seq: 0`. `fetch_add(1)` returns the pre-increment value, so every node's first-ever gossip message was numbered 0 and dropped as a replay by every peer. Gossip retries masked it. The counter now starts at 1; a unit test pins this.

## Risk

- **Sender loses durable state (disk wipe, snapshot rollback):** sequences regress and are rejected until the peer ages the window out. Fails **closed** — a node that lost its counter is treated as suspect, which is the correct direction for a replay guard. Same exposure class the encryption tracker already carries, where it is strictly worse (nonce reuse).
- **Cloned state directory:** two processes sharing one DID share one counter. Pre-existing class, unchanged by this PR.
- **Store write on the send path:** one flushed write per 1,000 messages, inside the existing `tokio::spawn`. Matches the surrounding `persist_sequence_inner` pattern.
- **Does not retroactively clear a peer's existing high-water mark.** A node upgrading with no persisted counter starts at 1, so its first restart after deployment still waits out one eviction cycle; subsequent restarts are clean.

## Test plan

`cargo test -p icn-net signing_sequence` — unit tests on the counter plus `tests/signing_sequence_replay.rs`, which wires the real counter to the real `ReplayGuard`:

- `restarted_sender_is_accepted_by_a_peer_that_remembers_it` — the #2510 regression
- `ephemeral_counter_reproduces_the_2510_defect` — negative control; proves the suite distinguishes the broken implementation from the fixed one
- `captured_traffic_from_a_previous_incarnation_is_still_rejected` — security control
- `reconnect_churn_does_not_reset_replay_state` — reconnect is not an incarnation boundary
- `receiver_restart_preserves_replay_protection` — guard persistence not weakened
- `traffic_from_one_did_does_not_reset_another_dids_state`
- counter unit tests: monotonic across restarts, no reissue, crash mid-block, watermark-before-use, corrupt watermark rejected, never issues 0

Plus `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, meaning-firewall check, and a live restart acceptance test on the rehearsal federation.
