### PR TITLE
fix(net): never admit the local identity as a remote network peer

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -119,6 +119,7 @@ Comprehensive architectural reviews and design decisions:
 - [CELLS_AND_SCOPES.md](architecture/CELLS_AND_SCOPES.md) - Cell-based federation model
 - [SCOPE_BOUNDED_TRUST.md](architecture/SCOPE_BOUNDED_TRUST.md) - Trust scope architecture
 - [KERNEL_APP_SEPARATION.md](architecture/KERNEL_APP_SEPARATION.md) - Kernel/app boundary design
+- [network-identity-self-exclusion.md](architecture/network-identity-self-exclusion.md) - The local node is never a remote peer: where self-exclusion is owned, and why it is identity-based not address-based (#2506)
 - [AUTHORITY_SPINE.md](architecture/AUTHORITY_SPINE.md) - Authority attenuation, expiration, revocation, and capability truth; gateway session-authority boundary (#2436/#2437) implemented, extension to other domains is analysis only
 - [PRIVATE_DATA_DISCLOSURE_BOUNDARY.md](architecture/PRIVATE_DATA_DISCLOSURE_BOUNDARY.md) - Private-data disclosure/access boundary: scoped vaults, opaque receipt storage, disclosure policies, and access/export receipts (#1792, design-only)
 - [ABUSE_CASE_HARDENING_STRATEGY.md](architecture/ABUSE_CASE_HARDENING_STRATEGY.md) - Institutional-failure-mode hardening doctrine

--- a/docs/architecture/network-identity-self-exclusion.md
+++ b/docs/architecture/network-identity-self-exclusion.md
@@ -1,0 +1,81 @@
+# Network identity: the local node is never a remote peer
+
+**Status**: active rule
+**Established**: 2026-08-02 (#2506)
+**Applies to**: `icn-net`, `icn-gossip`, and the supervisor wiring in `icn-core` that feeds them
+
+## The rule
+
+A node's local identity may legitimately appear in **local** state. It must never be admitted into
+state whose semantics are *"a remote network peer"*.
+
+| The local node MAY hold | The local node MUST NOT be |
+|---|---|
+| its own DID and keypair | a remote connection-map entry |
+| its own advertised addresses | a discovered / dialable peer |
+| its own connection candidate | a gossip peer or network-size contributor |
+| its own signing sequence | a replay-guard window |
+| its own outbound gossip nonce | a misbehaviour, quarantine, or ban subject |
+
+The distinguishing test is **identity, never address**. Two nodes legitimately share a source
+address behind NAT, a proxy, a relay, or a shared pod IP; rejecting a peer because its address
+resembles ours would partition exactly those deployments. A remote peer is one whose
+**authenticated DID differs from the local DID**. Discovery metadata alone — an address, an mDNS
+record, a gossiped candidate — is never sufficient to establish that distinction, because all of it
+is either self-authored or attacker-influenced.
+
+## Why it needs stating
+
+Every discovery source in ICN echoes the local node's own advertisement back to it:
+
+- `network:candidates` gossip delivers our own `ConnectionCandidate` to us;
+- mDNS browse resolves the service we ourselves registered on the same multicast group;
+- peer exchange can hand our own entry back in a `Response` or `Announce`.
+
+So "the local identity arrives looking like a peer" is the **normal case**, not an edge case. Absent
+an explicit rule, every layer downstream treats it as remote — and each one is individually
+reasonable in doing so, because none of them knows who "we" are.
+
+## Ownership
+
+**Primary owner — the connection layer** (`icn-net::session`). `SessionManager` holds `local_did`
+and refuses it in both insertion paths (`dial`, `install_incoming_connection`). This is the
+canonical guard because it is the only point where the remote DID is *authenticated* rather than
+claimed: on the Hello path the DID-TLS binding is verified before installation. Refusing here closes
+every downstream path by construction — no connection means no gossip peer, no replay window, no
+misbehaviour subject.
+
+`install_incoming_connection` takes the local DID as a **required parameter** rather than reading it
+from ambient state, so a future caller cannot install a connection without declaring what "self" is.
+
+**Semantic integrity — the receive path** (`icn-net::handlers::signed`). `ReplayGuard` means
+"per-remote-sender sequence high-water" and `MisbehaviorDetector` means "remote peer conduct".
+A self-sourced envelope is dropped before either is touched. This is *not* a blanket "skip security
+checks for our own DID": the message is discarded rather than trusted, and the scope is the network
+receive path, where a self-sourced envelope can only be a self-connection.
+
+**Early exit — discovery sources** (`CandidateCache`, `Discovery`, peer exchange). These prevent
+pointless work rather than providing the guarantee; live, they were ~90% of one node's connection
+handling. `CandidateCache` requires its owning DID at construction and has no `Default`, so a cache
+that cannot recognise its own node is not representable.
+
+## Deliberately not guarded
+
+`MisbehaviorDetector` was **not** given a local-DID bypass. A blanket `if did == self { ignore }`
+there would suppress genuine local faults — a corrupted keystore, a cloned state directory, a
+compromised component signing bad traffic. With the connection guard in place the detector cannot
+see the local DID through the network loop at all; if it ever does, that is a real invariant
+violation and should stay visible. The receive-path guard logs at `WARN` for the same reason.
+
+`AntiEntropy` legitimately keeps a `PeerSyncManager` entry keyed by the local DID to hold its own
+outbound digest nonce. That entry stays; what changed is that `remote_peer_count` excludes it, so
+network size means "other nodes" rather than "map entries".
+
+## When adding networking code
+
+Ask: *does this structure mean "remote peer"?* If yes, it needs the local DID and must refuse it —
+and prefer requiring the identity at construction or in the signature over looking it up, so the
+check cannot be forgotten.
+
+Related: #2504 (restart/rejoin), #2505 (stale connection replacement), #2510 (durable signing
+sequence), #2509 (candidate re-announcement), #2512 (banned-peers metric).

--- a/docs/architecture/network-identity-self-exclusion.md
+++ b/docs/architecture/network-identity-self-exclusion.md
@@ -1,6 +1,10 @@
 # Network identity: the local node is never a remote peer
 
-**Status**: active rule
+**Status:** living — active rule
+**Truth class:** normative
+**Canonical:** yes, for this rule; runtime truth lives in [docs/STATE.md](../STATE.md)
+**Last reviewed:** 2026-08-02
+**Source basis:** traced against `origin/main` @ `72dfed8e` on the live four-node rehearsal federation
 **Established**: 2026-08-02 (#2506)
 **Applies to**: `icn-net`, `icn-gossip`, and the supervisor wiring in `icn-core` that feeds them
 

--- a/docs/registry.toml
+++ b/docs/registry.toml
@@ -818,6 +818,20 @@ depends_on = ["docs/architecture/KERNEL_APP_SEPARATION.md", "docs/strategy/ADR-0
 recommended_action = "keep"
 freshness = "current"
 
+[docs."docs/architecture/network-identity-self-exclusion.md"]
+category = "architecture"
+status = "living"
+truth_class = "normative"
+title = "Network Identity: The Local Node Is Never a Remote Peer"
+description = "Normative rule (#2506) that a node's local identity may hold local state but must never be admitted into state whose semantics are \"remote network peer\" — connection map, discovered/gossip peer, replay window, or misbehaviour/ban subject. Names the connection layer as the canonical invariant owner because it is the only point where the remote DID is authenticated rather than claimed, records why self-exclusion is identity-based and never address-based, and documents the two deliberate non-guards (MisbehaviorDetector, AntiEntropy's own nonce entry)."
+last_updated = "2026-08-02"
+last_reviewed = "2026-08-02"
+owner = "matt"
+audiences = ["architects", "developers"]
+depends_on = ["docs/architecture/KERNEL_APP_SEPARATION.md"]
+recommended_action = "keep"
+freshness = "current"
+
 [docs."docs/architecture/PRIVATE_DATA_DISCLOSURE_BOUNDARY.md"]
 category = "architecture"
 status = "draft"

--- a/icn/crates/icn-core/src/supervisor/init_network.rs
+++ b/icn/crates/icn-core/src/supervisor/init_network.rs
@@ -268,6 +268,7 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
                 handle_peer_exchange(
                     peer_msg,
                     &sender_did,
+                    &own_did,
                     federation_enabled,
                     network_handle_holder.clone(),
                 );
@@ -285,6 +286,7 @@ pub fn create_incoming_handler(deps: MessageHandlerDeps) -> icn_net::IncomingMes
 fn handle_peer_exchange(
     peer_msg: &icn_net::PeerExchangeMessage,
     sender_did: &Did,
+    own_did: &Did,
     federation_enabled: bool,
     network_handle_holder: NetworkHandleHolder,
 ) {
@@ -308,6 +310,9 @@ fn handle_peer_exchange(
                 // the first endpoint of any kind if no public endpoint is available.
                 let peers_to_dial: Vec<_> = peers
                     .iter()
+                    // Peer exchange can hand our own entry back to us; we are not a peer we
+                    // discovered (#2506).
+                    .filter(|p| p.did != own_did.as_str())
                     .filter_map(|p| {
                         use icn_net::candidate::EndpointKind;
                         let addr = p
@@ -361,6 +366,12 @@ fn handle_peer_exchange(
                 "Peer announced by {}: {} at {:?}",
                 sender_did, peer.did, peer.endpoints
             );
+
+            if peer.did == own_did.as_str() {
+                // A peer announcing *us* is not a dial target (#2506).
+                debug!("Ignoring announcement of our own DID as a peer");
+                return;
+            }
 
             if federation_enabled {
                 use icn_net::candidate::EndpointKind;

--- a/icn/crates/icn-core/src/supervisor/init_notifications.rs
+++ b/icn/crates/icn-core/src/supervisor/init_notifications.rs
@@ -465,9 +465,10 @@ pub async fn handle_connection_candidate(
 
             let did = candidate.did.clone();
 
-            // Store the candidate
+            // Store the candidate. The cache refuses our own DID, so this is also what stops us
+            // dialing ourselves after gossip echoes our announcement back (#2506).
             if !candidate_cache.store(candidate.clone()).await {
-                debug!("Ignored stale/older candidate for {}", did);
+                debug!("Ignored candidate for {} (our own, stale, or older)", did);
                 return;
             }
 

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -1450,7 +1450,7 @@ async fn configure_gossip_actor(
     gossip.set_send_callback(send_callback);
 
     // Create candidate cache for NAT traversal
-    let candidate_cache = Arc::new(icn_net::CandidateCache::new());
+    let candidate_cache = Arc::new(icn_net::CandidateCache::new(did.clone()));
     let candidate_cache_for_cleanup = candidate_cache.clone();
 
     // Create profile cache for peer capability discovery

--- a/icn/crates/icn-gossip/src/anti_entropy.rs
+++ b/icn/crates/icn-gossip/src/anti_entropy.rs
@@ -165,7 +165,8 @@ impl GossipActor {
         let scope = topic_obj.scope;
 
         // M2 #484: Calculate adaptive fanout based on network size
-        let network_size = self.peer_sync.peer_count();
+        // Our own nonce-counter entry is not a peer (#2506).
+        let network_size = self.peer_sync.remote_peer_count(&self.own_did);
         let fanout = self
             .adaptive_fanout_config
             .calculate_fanout(network_size, &scope);

--- a/icn/crates/icn-gossip/src/sync.rs
+++ b/icn/crates/icn-gossip/src/sync.rs
@@ -284,7 +284,7 @@ impl PeerSyncManager {
     /// legitimate — but counting it as network size reports `1` for a node that has no peers at
     /// all, and made an isolated node look like it had one (#2506).
     pub fn remote_peer_count(&self, local_did: &Did) -> usize {
-        self.states.keys().filter(|did| *did != local_did).count()
+        self.states.len() - usize::from(self.states.contains_key(local_did))
     }
 
     /// Update backoff settings for a specific peer (based on trust class changes)

--- a/icn/crates/icn-gossip/src/sync.rs
+++ b/icn/crates/icn-gossip/src/sync.rs
@@ -269,8 +269,22 @@ impl PeerSyncManager {
     }
 
     /// Get number of tracked peers
+    ///
+    /// This counts every state entry, including the local node's own — `AntiEntropy` reuses a
+    /// state keyed by the local DID to hold its outbound digest nonce. Use
+    /// [`PeerSyncManager::remote_peer_count`] for anything that means "how many other nodes are
+    /// out there".
     pub fn peer_count(&self) -> usize {
         self.states.len()
+    }
+
+    /// Number of tracked peers that are not this node.
+    ///
+    /// The local node holds a state entry of its own purely as a nonce counter, which is
+    /// legitimate — but counting it as network size reports `1` for a node that has no peers at
+    /// all, and made an isolated node look like it had one (#2506).
+    pub fn remote_peer_count(&self, local_did: &Did) -> usize {
+        self.states.keys().filter(|did| *did != local_did).count()
     }
 
     /// Update backoff settings for a specific peer (based on trust class changes)
@@ -396,6 +410,40 @@ mod tests {
         // Remove peer
         manager.remove(&did1);
         assert_eq!(manager.peer_count(), 1);
+    }
+
+    /// Regression test for #2506.
+    ///
+    /// `AntiEntropy` keeps a peer-sync state keyed by the *local* DID to hold its own outbound
+    /// digest nonce. That is legitimate local state, but counting it as network size reported
+    /// `icn_gossip_network_size_estimate = 1` for a node with no peers at all — which read as
+    /// "one peer" rather than "isolated" and cost real time during the #2504 investigation.
+    #[test]
+    fn test_remote_peer_count_excludes_the_local_node() {
+        let mut manager = PeerSyncManager::new(300, 5000);
+        let own_did = KeyPair::generate().unwrap().did().clone();
+        let peer_did = KeyPair::generate().unwrap().did().clone();
+
+        // The local node's own nonce-counter entry, exactly as `emit_digest` creates it.
+        manager.get_or_create(own_did.clone());
+
+        assert_eq!(
+            manager.remote_peer_count(&own_did),
+            0,
+            "#2506: a node whose only peer-sync entry is its own must report zero peers"
+        );
+
+        manager.get_or_create(peer_did.clone());
+        assert_eq!(
+            manager.remote_peer_count(&own_did),
+            1,
+            "#2506: a real peer must still be counted"
+        );
+        assert_eq!(
+            manager.peer_count(),
+            2,
+            "the raw count still includes the local nonce entry"
+        );
     }
 
     #[test]

--- a/icn/crates/icn-net/src/candidate_cache.rs
+++ b/icn/crates/icn-net/src/candidate_cache.rs
@@ -13,33 +13,53 @@ use tracing::{debug, info};
 /// Default TTL for cached candidates (5 minutes)
 pub const DEFAULT_CANDIDATE_TTL_SECS: u64 = 300;
 
-/// Cache for storing connection candidates from peers
+/// Cache for storing connection candidates from *remote* peers
+///
+/// Entries here are dial targets, so the local node's own candidate has no place in it (#2506):
+/// candidates travel over the `network:candidates` gossip topic, which echoes our own
+/// advertisement straight back to us. The owning DID is required at construction so that a cache
+/// which cannot recognise its own node is not a representable state.
 pub struct CandidateCache {
     /// Cached candidates by DID
     candidates: Arc<RwLock<HashMap<Did, ConnectionCandidate>>>,
 
     /// TTL for candidates in seconds
     ttl_secs: u64,
+
+    /// The DID of the node that owns this cache; never a valid key in `candidates`.
+    local_did: Did,
 }
 
 impl CandidateCache {
-    /// Create a new candidate cache with default TTL
-    pub fn new() -> Self {
-        Self::with_ttl(DEFAULT_CANDIDATE_TTL_SECS)
+    /// Create a new candidate cache with default TTL, owned by `local_did`
+    pub fn new(local_did: Did) -> Self {
+        Self::with_ttl(local_did, DEFAULT_CANDIDATE_TTL_SECS)
     }
 
-    /// Create a new candidate cache with custom TTL
-    pub fn with_ttl(ttl_secs: u64) -> Self {
+    /// Create a new candidate cache with custom TTL, owned by `local_did`
+    pub fn with_ttl(local_did: Did, ttl_secs: u64) -> Self {
         Self {
             candidates: Arc::new(RwLock::new(HashMap::new())),
             ttl_secs,
+            local_did,
         }
     }
 
     /// Store a candidate in the cache
     ///
-    /// Returns true if this is a new or updated candidate, false if ignored (stale)
+    /// Returns true if this is a new or updated candidate, false if ignored (our own, stale, or
+    /// older than what we already hold).
     pub async fn store(&self, candidate: ConnectionCandidate) -> bool {
+        // Our own candidate is not a dial target (#2506). Gossip delivers our own announcement
+        // back to us, and dialing it produces a self-connection that carries real signed traffic
+        // into our own replay guard and misbehaviour detector.
+        if candidate.did == self.local_did {
+            debug!(
+                "Ignoring our own connection candidate; the local node is not a dial target (#2506)"
+            );
+            return false;
+        }
+
         // Check freshness before storing
         if !candidate.is_fresh(self.ttl_secs) {
             debug!(
@@ -154,20 +174,51 @@ impl CandidateCache {
     }
 }
 
-impl Default for CandidateCache {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+// No `Default`: a candidate cache is meaningless without knowing which DID owns it, since that is
+// what lets it refuse to hold the local node as a dial target (#2506).
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use icn_identity::KeyPair;
 
+    /// A cache owned by a freshly generated DID, for tests that only care about remote candidates.
+    fn cache_owned_by_someone_else() -> CandidateCache {
+        CandidateCache::new(KeyPair::generate().unwrap().did().clone())
+    }
+
+    /// Regression test for #2506.
+    ///
+    /// The `network:candidates` topic delivers our own announcement back to us. Storing it makes
+    /// the local node a dial target, and the resulting self-connection carried enough signed
+    /// traffic to trip the node's own replay guard and ban its own DID.
+    #[tokio::test]
+    async fn test_own_candidate_is_not_stored_as_a_dial_target() {
+        let keypair = KeyPair::generate().unwrap();
+        let own_did = keypair.did().clone();
+        let cache = CandidateCache::new(own_did.clone());
+
+        let own_candidate = ConnectionCandidate::new(
+            own_did.clone(),
+            "10.42.2.204:7827".parse().unwrap(),
+            Some("203.0.113.5:39889".parse().unwrap()),
+            None,
+        );
+
+        assert!(
+            !cache.store(own_candidate).await,
+            "#2506: our own connection candidate must be refused"
+        );
+        assert!(
+            cache.get(&own_did).await.is_none(),
+            "#2506: the local DID must never be cached as a dial target"
+        );
+        assert!(cache.is_empty().await);
+    }
+
     #[tokio::test]
     async fn test_candidate_cache_store_and_get() {
-        let cache = CandidateCache::new();
+        let cache = cache_owned_by_someone_else();
         let keypair = KeyPair::generate().unwrap();
         let did = keypair.did().clone();
 
@@ -193,7 +244,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_candidate_cache_stale_rejected() {
-        let cache = CandidateCache::with_ttl(60); // 1 minute TTL
+        let cache = CandidateCache::with_ttl(KeyPair::generate().unwrap().did().clone(), 60); // 1 minute TTL
         let keypair = KeyPair::generate().unwrap();
         let did = keypair.did().clone();
 
@@ -214,7 +265,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_candidate_cache_update_fresher() {
-        let cache = CandidateCache::new();
+        let cache = cache_owned_by_someone_else();
         let keypair = KeyPair::generate().unwrap();
         let did = keypair.did().clone();
 
@@ -246,7 +297,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_candidate_cache_ignore_older() {
-        let cache = CandidateCache::new();
+        let cache = cache_owned_by_someone_else();
         let keypair = KeyPair::generate().unwrap();
         let did = keypair.did().clone();
 
@@ -277,7 +328,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_candidate_cache_cleanup() {
-        let cache = CandidateCache::with_ttl(60); // 1 minute TTL
+        let cache = CandidateCache::with_ttl(KeyPair::generate().unwrap().did().clone(), 60); // 1 minute TTL
         let keypair1 = KeyPair::generate().unwrap();
         let keypair2 = KeyPair::generate().unwrap();
         let did1 = keypair1.did().clone();
@@ -317,7 +368,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_candidate_cache_remove() {
-        let cache = CandidateCache::new();
+        let cache = cache_owned_by_someone_else();
         let keypair = KeyPair::generate().unwrap();
         let did = keypair.did().clone();
 

--- a/icn/crates/icn-net/src/discovery.rs
+++ b/icn/crates/icn-net/src/discovery.rs
@@ -99,6 +99,9 @@ impl Discovery {
 
         // Spawn background task to browse for peers
         let peers = self.peers.clone();
+        // We answer our own multicast advertisement, so the browse task needs to know which DID
+        // is ours in order to skip it (#2506).
+        let own_did = self.own_did.clone();
         let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         tokio::spawn(async move {
@@ -117,7 +120,7 @@ impl Discovery {
                     event = receiver.recv_async() => {
                         match event {
                             Ok(event) => {
-                                Self::handle_mdns_event(event, &peers).await;
+                                Self::handle_mdns_event(event, &peers, own_did.as_ref()).await;
                             }
                             Err(e) => {
                                 warn!("mDNS receiver error: {}", e);
@@ -144,6 +147,7 @@ impl Discovery {
     async fn handle_mdns_event(
         event: mdns_sd::ServiceEvent,
         peers: &Arc<RwLock<HashMap<String, PeerInfo>>>,
+        own_did: Option<&Did>,
     ) {
         use mdns_sd::ServiceEvent;
 
@@ -179,18 +183,7 @@ impl Discovery {
                         .unwrap_or("unknown")
                         .to_string();
 
-                    info!("Discovered peer: {} at {:?}", did.as_str(), addrs);
-
-                    let peer_info = PeerInfo {
-                        did: did.clone(),
-                        addrs,
-                        version,
-                    };
-
-                    peers
-                        .write()
-                        .await
-                        .insert(did.as_str().to_string(), peer_info);
+                    Self::admit_discovered_peer(peers, own_did, did, addrs, version).await;
                 }
             }
             ServiceEvent::ServiceRemoved(_type, instance) => {
@@ -205,6 +198,40 @@ impl Discovery {
             }
             _ => {}
         }
+    }
+
+    /// Record a resolved advertisement in the discovered-peer map.
+    ///
+    /// Split out from the mDNS event plumbing so the admission rule is testable without a live
+    /// multicast daemon (`mdns_sd::ResolvedService` is `#[non_exhaustive]` and cannot be built
+    /// outside its crate).
+    async fn admit_discovered_peer(
+        peers: &Arc<RwLock<HashMap<String, PeerInfo>>>,
+        own_did: Option<&Did>,
+        did: Did,
+        addrs: Vec<SocketAddr>,
+        version: String,
+    ) {
+        // We register our own service on the same multicast group we browse, so our own
+        // advertisement comes straight back to us. Recording it would make the local node a dial
+        // target, and the resulting self-connection pollutes our own replay and ban state (#2506).
+        if own_did.is_some_and(|own| *own == did) {
+            debug!("Skipping our own mDNS advertisement (#2506)");
+            return;
+        }
+
+        info!("Discovered peer: {} at {:?}", did.as_str(), addrs);
+
+        let peer_info = PeerInfo {
+            did: did.clone(),
+            addrs,
+            version,
+        };
+
+        peers
+            .write()
+            .await
+            .insert(did.as_str().to_string(), peer_info);
     }
 
     /// Get all discovered peers
@@ -300,6 +327,58 @@ mod tests {
 
         // Daemon should be cleared
         assert!(discovery.daemon.is_none());
+    }
+
+    /// The advertisement a resolved mDNS service turns into by the time it reaches admission.
+    fn advertised_addrs() -> Vec<SocketAddr> {
+        vec!["127.0.0.1:7827".parse().unwrap()]
+    }
+
+    /// Regression test for #2506.
+    ///
+    /// A node registers its own service on the same multicast group it browses, so it resolves
+    /// its own advertisement. Recording that makes the local node a dial target.
+    #[tokio::test]
+    async fn test_own_mdns_advertisement_is_not_recorded_as_a_peer() {
+        let own_did = KeyPair::generate().unwrap().did().clone();
+        let peers = Arc::new(RwLock::new(HashMap::new()));
+
+        Discovery::admit_discovered_peer(
+            &peers,
+            Some(&own_did),
+            own_did.clone(),
+            advertised_addrs(),
+            "0.1.0".to_string(),
+        )
+        .await;
+
+        assert!(
+            peers.read().await.is_empty(),
+            "#2506: our own mDNS advertisement must not enter the discovered-peer map"
+        );
+    }
+
+    /// The counterpart: a genuinely remote advertisement must still be recorded, so the filter
+    /// cannot be satisfied by simply dropping everything.
+    #[tokio::test]
+    async fn test_remote_mdns_advertisement_is_still_recorded() {
+        let own_did = KeyPair::generate().unwrap().did().clone();
+        let remote_did = KeyPair::generate().unwrap().did().clone();
+        let peers = Arc::new(RwLock::new(HashMap::new()));
+
+        Discovery::admit_discovered_peer(
+            &peers,
+            Some(&own_did),
+            remote_did.clone(),
+            advertised_addrs(),
+            "0.1.0".to_string(),
+        )
+        .await;
+
+        assert!(
+            peers.read().await.contains_key(remote_did.as_str()),
+            "a remote peer's advertisement must still be discovered"
+        );
     }
 
     #[test]

--- a/icn/crates/icn-net/src/handlers/hello.rs
+++ b/icn/crates/icn-net/src/handlers/hello.rs
@@ -207,6 +207,7 @@ impl ConnectionContext {
             let connections_arc = self.session_manager.read().await.connections_arc();
             crate::session::install_incoming_connection(
                 &connections_arc,
+                Some(self.own_did.as_str()),
                 from.to_string(),
                 connection.clone(),
             )

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -22,6 +22,25 @@ impl ConnectionContext {
     /// 4. Byzantine fault recording (on failure)
     /// 5. Forward to handler (on success)
     pub async fn handle_signed(&self, message: NetworkMessage, envelope: &SignedEnvelope) {
+        // Our own DID is not a remote sender (#2506). `ReplayGuard` tracks per-*remote*-peer
+        // sequence high-water marks and `MisbehaviorDetector` scores *remote* peers, so admitting
+        // our own DID into either corrupts what both structures mean — and after a restart it is
+        // self-defeating: our resumed signing sequence sits below our own persisted replay floor,
+        // so we score our own traffic as replay at severity 1.0 and ban ourselves.
+        //
+        // This is deliberately not a blanket "skip security checks for our own DID": it drops the
+        // message rather than trusting it, and it is scoped to the network receive path, where a
+        // self-sourced envelope can only be a self-connection. The connection layer refuses to
+        // register the local DID as a peer, so reaching here means an earlier guard was bypassed.
+        if envelope.from == self.own_did {
+            warn!(
+                sequence = envelope.sequence,
+                "Dropping network message from our own DID without recording remote-peer state; \
+                 a self-connection reached the signed-message path (#2506)"
+            );
+            return;
+        }
+
         // Verify signature and age - use cached PQ key for hybrid envelopes
         let sig_result = self.verify_with_cached_pq_key(envelope, 300).await;
 
@@ -250,6 +269,15 @@ mod tests {
     fn create_test_context(
         misbehavior_detector: Option<Arc<RwLock<MisbehaviorDetector>>>,
     ) -> (ConnectionContext, Arc<AtomicUsize>) {
+        let (ctx, _keypair, count) = create_test_context_with_own_keypair(misbehavior_detector);
+        (ctx, count)
+    }
+
+    /// Same as [`create_test_context`], but also hands back the keypair the context's own DID is
+    /// derived from, so a test can sign traffic *as the local node* (#2506).
+    fn create_test_context_with_own_keypair(
+        misbehavior_detector: Option<Arc<RwLock<MisbehaviorDetector>>>,
+    ) -> (ConnectionContext, KeyPair, Arc<AtomicUsize>) {
         let keypair = KeyPair::generate().unwrap();
         let identity_bundle = IdentityBundle::from_keypair(keypair.clone()).unwrap();
         let own_did = keypair.did().clone();
@@ -281,7 +309,7 @@ mod tests {
             own_did,
         };
 
-        (ctx, forward_count)
+        (ctx, keypair, forward_count)
     }
 
     fn create_signed_envelope(keypair: &KeyPair, sequence: u64) -> SignedEnvelope {
@@ -374,6 +402,47 @@ mod tests {
             violations[0].violation,
             icn_security::Violation::ReplayAttack { sequence: 1, .. }
         ));
+    }
+
+    /// Regression test for #2506.
+    ///
+    /// A signed envelope whose sender is our *own* DID is not remote peer traffic, so it must not
+    /// create replay state or misbehaviour state keyed by the local DID. Live, a node dialed its
+    /// own advertised endpoint, and after a restart its resumed signing sequence sat below its own
+    /// persisted replay floor — so it scored its own messages as replays at severity 1.0,
+    /// quarantined and then banned its own DID, and stopped receiving federation gossip for 26
+    /// minutes until its counter climbed past its own floor.
+    #[tokio::test]
+    async fn test_own_did_envelope_creates_no_replay_or_misbehavior_state() {
+        let detector = Arc::new(RwLock::new(MisbehaviorDetector::new(
+            MisbehaviorThresholds::default(),
+        )));
+        let (ctx, own_keypair, forward_count) =
+            create_test_context_with_own_keypair(Some(detector.clone()));
+        let own_did = own_keypair.did().clone();
+
+        // Two envelopes signed by *us*, arriving over the network on a self-connection. The
+        // second reuses sequence 1, which is exactly what the replay guard exists to catch —
+        // but from our own DID it must not be treated as a remote peer misbehaving.
+        let envelope = create_signed_envelope(&own_keypair, 1);
+        let message = create_network_message(&envelope);
+        ctx.handle_signed(message.clone(), &envelope).await;
+        ctx.handle_signed(message.clone(), &envelope).await;
+
+        assert_eq!(
+            forward_count.load(Ordering::SeqCst),
+            0,
+            "#2506: our own DID's traffic must not be forwarded as remote peer traffic"
+        );
+        assert_eq!(
+            ctx.replay_guard.read().await.peer_count(),
+            0,
+            "#2506: the replay guard must not hold a window keyed by the local DID"
+        );
+        assert!(
+            detector.read().await.get_violations(&own_did).is_empty(),
+            "#2506: the local DID must never accrue misbehaviour violations from a self-loop"
+        );
     }
 
     #[tokio::test]

--- a/icn/crates/icn-net/src/session.rs
+++ b/icn/crates/icn-net/src/session.rs
@@ -84,6 +84,13 @@ pub struct SessionManager {
     /// connection candidates. Required in containerized environments (Docker/K8s) where
     /// the QUIC endpoint binds to `0.0.0.0` but must advertise the container/pod IP.
     advertised_addr: Option<SocketAddr>,
+
+    /// This node's own DID, populated by [`SessionManager::start`].
+    ///
+    /// `connections` maps *remote* peer DIDs to connections, so the local DID is never a valid
+    /// key in it (#2506). Holding the identity here is what lets both insertion paths enforce
+    /// that without each caller having to remember to.
+    local_did: Arc<RwLock<Option<String>>>,
 }
 
 impl SessionManager {
@@ -102,7 +109,25 @@ impl SessionManager {
             shutdown_tx: Some(shutdown_tx),
             _shutdown_rx: shutdown_rx,
             advertised_addr: None,
+            local_did: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Whether `peer_did` is this node's own DID.
+    ///
+    /// Identity, never address: two nodes legitimately share a source address behind NAT, a
+    /// proxy, or a shared pod IP, so an address-based test would partition real deployments.
+    pub(crate) async fn is_local_did(&self, peer_did: &str) -> bool {
+        self.local_did
+            .read()
+            .await
+            .as_deref()
+            .is_some_and(|own| own == peer_did)
+    }
+
+    /// This node's own DID, once [`SessionManager::start`] has run.
+    pub(crate) async fn local_did(&self) -> Option<String> {
+        self.local_did.read().await.clone()
     }
 
     /// Set an explicit advertised address for connection candidates.
@@ -136,7 +161,8 @@ impl SessionManager {
     ) -> Result<()> {
         info!("Session manager starting on {}", listen_addr);
 
-        let _own_did = identity_bundle.did().clone();
+        // Remembered so the connection map can refuse to key on it (#2506).
+        *self.local_did.write().await = Some(identity_bundle.did().as_str().to_string());
 
         // Use TLS certificate from IdentityBundle (already bound to DID)
         // This ensures the cert hash matches what's in BindingInfo
@@ -284,6 +310,18 @@ impl SessionManager {
     ///
     /// Returns a QUIC connection to the peer.
     pub async fn dial(&self, addr: SocketAddr, peer_did: String) -> Result<quinn::Connection> {
+        // Never dial ourselves into our own remote-peer map (#2506). Discovery sources echo our
+        // own advertisement back to us — over `network:candidates`, peer exchange, or mDNS — and
+        // the resulting self-connection carries real signed traffic that trips our own replay
+        // guard. Refuse before spending a connection attempt on it.
+        if self.is_local_did(&peer_did).await {
+            debug!(
+                %addr,
+                "Refusing to dial our own DID as a remote peer (#2506)"
+            );
+            anyhow::bail!("refusing to dial the local DID as a remote peer");
+        }
+
         let endpoint = self
             .endpoint
             .read()
@@ -381,7 +419,14 @@ impl SessionManager {
     /// Replacing a connection that is already closed cannot displace a live session, so this
     /// preserves the anti-connection-confusion property above.
     pub async fn store_incoming_connection(&self, peer_did: String, connection: quinn::Connection) {
-        install_incoming_connection(&self.connections, peer_did, connection).await;
+        let local_did = self.local_did().await;
+        install_incoming_connection(
+            &self.connections,
+            local_did.as_deref(),
+            peer_did,
+            connection,
+        )
+        .await;
     }
 
     /// Get all active connections
@@ -672,6 +717,7 @@ impl SessionManager {
             shutdown_tx: None, // Test clones don't control shutdown
             _shutdown_rx: mpsc::channel(1).1,
             advertised_addr: self.advertised_addr,
+            local_did: self.local_did.clone(),
         }
     }
 }
@@ -734,12 +780,31 @@ fn resolve_local_addr(port: u16) -> Option<SocketAddr> {
 /// Callers must have authenticated `peer_did` first. On the Hello path the DID-TLS binding is
 /// verified before this is reached, so a remote cannot claim another node's DID to displace its
 /// entry.
+/// `local_did` is `None` only before [`SessionManager::start`] has run, when there is no identity
+/// to compare against and therefore no connections either; both production callers pass `Some`.
+/// It is a required parameter rather than ambient state so that a future insertion path cannot
+/// install a connection without first stating which DID is ours (#2506).
 pub(crate) async fn install_incoming_connection(
     connections: &Arc<RwLock<HashMap<String, quinn::Connection>>>,
+    local_did: Option<&str>,
     peer_did: String,
     connection: quinn::Connection,
 ) {
     use std::collections::hash_map::Entry;
+
+    // `connections` is keyed by *remote* peer DID, so our own DID is not a valid key (#2506).
+    // Callers must have authenticated `peer_did` before reaching here, so an authenticated DID
+    // equal to ours means this connection really is a self-loop, not an impostor claiming our
+    // identity — the DID-TLS binding check on the Hello path already rejects the latter.
+    if local_did.is_some_and(|own| own == peer_did) {
+        warn!(
+            remote_addr = %connection.remote_address(),
+            "Refusing to register our own DID as a remote peer (#2506)"
+        );
+        connection.close(0u32.into(), b"self-connection");
+        return;
+    }
+
     let mut connections = connections.write().await;
     match connections.entry(peer_did) {
         Entry::Occupied(mut entry) if entry.get().close_reason().is_some() => {
@@ -1009,7 +1074,7 @@ mod tests {
         let (mut peer_v1, _) = start_manager().await;
         let inbound_v1 = connect(&survivor, &peer_v1, survivor_addr).await;
         let v1_probe = inbound_v1.clone();
-        install_incoming_connection(&map, peer_did.clone(), inbound_v1).await;
+        install_incoming_connection(&map, None, peer_did.clone(), inbound_v1).await;
         assert!(can_reach(&survivor, &peer_did).await);
 
         peer_v1.stop().await.unwrap();
@@ -1019,7 +1084,7 @@ mod tests {
 
         let (mut peer_v2, _) = start_manager().await;
         let inbound_v2 = connect(&survivor, &peer_v2, survivor_addr).await;
-        install_incoming_connection(&map, peer_did.clone(), inbound_v2).await;
+        install_incoming_connection(&map, None, peer_did.clone(), inbound_v2).await;
 
         assert!(
             can_reach(&survivor, &peer_did).await,
@@ -1028,5 +1093,125 @@ mod tests {
 
         peer_v2.stop().await.unwrap();
         survivor.stop().await.unwrap();
+    }
+
+    /// Like `start_manager`, but also returns the identity the manager was started with.
+    async fn start_manager_with_identity() -> (SessionManager, SocketAddr, icn_identity::Did) {
+        let mut manager = SessionManager::new();
+        let identity = icn_identity::IdentityBundle::generate().unwrap();
+        let did = identity.did().clone();
+        manager
+            .start(&identity, "127.0.0.1:0".parse().unwrap(), None, None)
+            .await
+            .unwrap();
+        let addr = manager
+            .endpoint
+            .read()
+            .await
+            .as_ref()
+            .unwrap()
+            .local_addr()
+            .unwrap();
+        (manager, addr, did)
+    }
+
+    /// Regression test for #2506.
+    ///
+    /// A node must never dial itself into its own remote-connection map. Live, a node received
+    /// its own connection candidate back over gossip and dialed both of its own advertised
+    /// endpoints; the resulting self-connection carried signed traffic that tripped the node's
+    /// own replay guard and ended in it banning its own DID.
+    #[tokio::test]
+    async fn test_dial_refuses_local_did() {
+        setup();
+
+        let (mut manager, _addr, own_did) = start_manager_with_identity().await;
+        // A *reachable* target, so the dial cannot fail for transport reasons and the test is
+        // actually exercising the identity check. Live, the reachable target is the node's own
+        // Service/pod address, which hairpins back to its listener — the dial succeeds and the
+        // node registers itself as a remote peer.
+        let (mut target, target_addr) = start_manager().await;
+        let acceptor = target.clone_for_test();
+        let accept_task = tokio::spawn(async move { acceptor.accept().await });
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let result = manager
+            .dial(target_addr, own_did.as_str().to_string())
+            .await;
+        accept_task.abort();
+
+        assert!(
+            result.is_err(),
+            "#2506: a dial that would register our own DID must be refused before connecting"
+        );
+        assert!(
+            !manager
+                .connections()
+                .await
+                .iter()
+                .any(|(did, _)| did == own_did.as_str()),
+            "#2506: the local DID must never become a key in the remote connection map"
+        );
+
+        target.stop().await.unwrap();
+        manager.stop().await.unwrap();
+    }
+
+    /// The inbound counterpart: even an *authenticated* connection whose peer DID equals ours
+    /// must not be registered as a remote peer. On the Hello path the DID-TLS binding is verified
+    /// before installation, so reaching this point with our own DID means the connection really is
+    /// a self-loop rather than an impostor.
+    #[tokio::test]
+    async fn test_store_incoming_connection_refuses_local_did() {
+        setup();
+
+        let (mut manager, addr, own_did) = start_manager_with_identity().await;
+        let (mut other, _) = start_manager().await;
+        let inbound = connect(&manager, &other, addr).await;
+
+        manager
+            .store_incoming_connection(own_did.as_str().to_string(), inbound)
+            .await;
+
+        assert!(
+            !manager
+                .connections()
+                .await
+                .iter()
+                .any(|(did, _)| did == own_did.as_str()),
+            "#2506: an incoming connection claiming our own DID must not be installed"
+        );
+
+        other.stop().await.unwrap();
+        manager.stop().await.unwrap();
+    }
+
+    /// Negative control for #2506: self-exclusion must be *identity*-based, never address-based.
+    ///
+    /// Two nodes legitimately share a source address behind NAT, a proxy, or a shared pod IP.
+    /// Rejecting a peer because its address looks like ours would partition exactly those
+    /// deployments, so a distinct DID arriving from our own address must still be admitted.
+    #[tokio::test]
+    async fn test_remote_peer_from_local_address_is_still_admitted() {
+        setup();
+
+        let (mut manager, addr, _own_did) = start_manager_with_identity().await;
+        let (mut other, _) = start_manager().await;
+
+        // `other` dials over loopback, so the connection manager sees a source address in the
+        // same host as its own listener — the address-based "is this me?" heuristic would fire.
+        let inbound = connect(&manager, &other, addr).await;
+        let remote_did = "did:icn:zLegitimatePeerSharingOurAddress".to_string();
+        manager
+            .store_incoming_connection(remote_did.clone(), inbound)
+            .await;
+
+        assert!(
+            can_reach(&manager, &remote_did).await,
+            "#2506: a distinct DID must still be admitted even when it shares our address"
+        );
+
+        other.stop().await.unwrap();
+        manager.stop().await.unwrap();
     }
 }

--- a/icn/crates/icn-net/tests/nat_traversal_integration.rs
+++ b/icn/crates/icn-net/tests/nat_traversal_integration.rs
@@ -23,8 +23,11 @@ async fn test_candidate_cache_flow() -> Result<()> {
     let did1 = keypair1.did().clone();
     let did2 = keypair2.did().clone();
 
-    // Create candidate cache (as supervisor does)
-    let cache = CandidateCache::new(KeyPair::generate().unwrap().did().clone());
+    // Create candidate cache (as supervisor does: owned by the DID of the node running it).
+    // Here that observing node is a third party watching node 1 and node 2 exchange candidates.
+    let local_keypair = KeyPair::generate()?;
+    let local_did = local_keypair.did().clone();
+    let cache = CandidateCache::new(local_did.clone());
 
     // Node 1 creates and publishes its candidate
     let candidate1 = ConnectionCandidate::new(
@@ -73,6 +76,26 @@ async fn test_candidate_cache_flow() -> Result<()> {
     let candidate2_retrieved = cache.get(&did2).await;
     assert!(candidate2_retrieved.is_some());
     assert!(candidate2_retrieved.unwrap().is_fresh(300));
+
+    // #2506: the same gossip flow also delivers the observing node its *own* candidate, because
+    // `network:candidates` echoes back to the publisher. That one is not a dial target, and it
+    // must not displace or join the two real peers above.
+    let own_candidate = ConnectionCandidate::new(
+        local_did.clone(),
+        "192.168.1.102:5002".parse()?,
+        Some("203.0.113.7:5002".parse()?),
+        None,
+    );
+    assert!(
+        !cache.store(own_candidate).await,
+        "#2506: the cache owner's own candidate must be refused"
+    );
+    assert!(cache.get(&local_did).await.is_none());
+    assert_eq!(
+        cache.len().await,
+        2,
+        "#2506: only the two real peers should be cached"
+    );
 
     Ok(())
 }

--- a/icn/crates/icn-net/tests/nat_traversal_integration.rs
+++ b/icn/crates/icn-net/tests/nat_traversal_integration.rs
@@ -24,7 +24,7 @@ async fn test_candidate_cache_flow() -> Result<()> {
     let did2 = keypair2.did().clone();
 
     // Create candidate cache (as supervisor does)
-    let cache = CandidateCache::new();
+    let cache = CandidateCache::new(KeyPair::generate().unwrap().did().clone());
 
     // Node 1 creates and publishes its candidate
     let candidate1 = ConnectionCandidate::new(
@@ -83,7 +83,7 @@ async fn test_stale_candidate_rejection() -> Result<()> {
     let did = keypair.did().clone();
 
     // Create cache with short TTL (1 second)
-    let cache = CandidateCache::with_ttl(1);
+    let cache = CandidateCache::with_ttl(KeyPair::generate().unwrap().did().clone(), 1);
 
     // Create fresh candidate
     let candidate = ConnectionCandidate::new(
@@ -116,7 +116,7 @@ async fn test_stale_candidate_rejection() -> Result<()> {
 async fn test_candidate_update_priority() -> Result<()> {
     let keypair = KeyPair::generate()?;
     let did = keypair.did().clone();
-    let cache = CandidateCache::new();
+    let cache = CandidateCache::new(KeyPair::generate().unwrap().did().clone());
 
     // Store initial candidate
     let candidate1 =
@@ -155,7 +155,7 @@ async fn test_candidate_update_priority() -> Result<()> {
 
 #[tokio::test]
 async fn test_multiple_peer_candidates() -> Result<()> {
-    let cache = CandidateCache::new();
+    let cache = CandidateCache::new(KeyPair::generate().unwrap().did().clone());
 
     // Simulate receiving candidates from multiple peers
     let mut candidates = Vec::new();


### PR DESCRIPTION
## What

Establishes and enforces one invariant: **a node's local identity may hold local state, but must never be admitted into state whose semantics are "remote network peer."**

Refs #2506. Unblocks #2504.

No wire-format change.

## Why

A node received its own `ConnectionCandidate` back over the `network:candidates` gossip topic, cached it as a dial target, and dialed both of its own advertised endpoints. Traced live on `72dfed8e`:

```
background_tasks:    Connection candidate changed: local=Some(<own pod ip>:7827), public=Some(<public>:39889)
init_notifications:  Received connection candidate from <own did>
candidate_cache:     Updating candidate for <own did>
session:             Dialing peer at <own pod ip>:7827
actor::connection:   Handling connection from <own pod ip>:7827
```

That self-connection carries real signed traffic into the node's own replay guard and misbehaviour detector. It is harmless while the node stays up — but after a restart the resumed signing sequence sits **below** the replay floor the node persisted for its own DID (`own_max_seq + RESTART_SAFETY_GAP`), so the node scores its own messages as replays at severity 1.0, quarantines and then bans its own DID, and stops receiving federation gossip until its own counter climbs past its own floor.

| node | restart | self-replay window | events |
|---|---|---|---|
| alpha | 17:52:05Z | 17:52:53Z → 18:17:51Z (**26m25s**) | 167 |
| beta | 16:44:19Z | 16:45:10Z → 17:44:20Z (**59m**) | 380 |

gamma is the control that isolates the mechanism: **5014 self-connections, zero self-replays, zero self-bans** — it has never restarted. Self-connection is always present; the restart is what weaponises it.

**Correction to the issue as filed.** #2506 attributes self-discovery to mDNS and suggests filtering there. mDNS discovers nothing in this deployment — `icn_network_peers_discovered` is 0 on all four nodes and no node has ever logged `Discovered peer:`. Filtering only mDNS would have shipped a green PR that changed nothing in production, which is the same trap #2505 hit with `store_incoming_connection`.

## How

**Primary owner — the connection layer.** `SessionManager` holds `local_did` (replacing a `let _own_did = …` that was already being discarded at `start()`) and refuses it in both insertion paths, `dial` and `install_incoming_connection`. This is the authoritative point because it is the only one where the remote DID is *authenticated* rather than claimed — the Hello path verifies the DID-TLS binding before installation — and refusing there closes every downstream path by construction.

`install_incoming_connection` takes the local DID as a **required parameter** rather than reading ambient state, so a future insertion path cannot skip the check by omission. #2505 found production had two connection-install paths and only one was fixed; this makes that class of miss a compile error.

**Semantic integrity — the signed receive path.** Envelopes from our own DID are dropped before `ReplayGuard` or `MisbehaviorDetector` see them, so those structures keep meaning "per-remote-sender sequence" and "remote peer conduct".

This is deliberately **not** a blanket "skip security checks for our own DID": the message is dropped rather than trusted, the scope is the network receive path where a self-sourced envelope can only be a self-connection, and it logs at `WARN` because with the connection guard in place it should be unreachable.

**`MisbehaviorDetector` was left without a local-DID exemption on purpose.** An `if did == self { ignore }` there would suppress genuine local faults — a corrupted keystore, a cloned state directory, a compromised component signing bad traffic. With self excluded at the connection layer the detector cannot see the local DID through the network loop at all; if it ever does, that is a real invariant violation and should stay visible.

**Early exits — discovery sources.** `CandidateCache`, mDNS discovery, and peer exchange each filter self. These prevent wasted work rather than providing the guarantee — they were ~90% of alpha's connection handling. `CandidateCache` now requires its owning DID at construction and has no `Default`, so a cache that cannot recognise its own node is unrepresentable.

**Gossip network size.** `AntiEntropy` legitimately keeps a `PeerSyncManager` entry keyed by the local DID as its outbound digest nonce counter — that stays. What changed is `remote_peer_count`, so an isolated node reports `network_size_estimate = 0` rather than `1`. `peer_count` has exactly one production caller, so the blast radius is that call site.

Architectural rule written up in `docs/architecture/network-identity-self-exclusion.md`.

## Identity, never address

Self-exclusion compares DIDs and never addresses. Nodes legitimately share a source address behind NAT, a proxy, a relay, or a shared pod IP, and an address-based test would partition exactly those deployments. `test_remote_peer_from_local_address_is_still_admitted` pins that a distinct DID arriving from our own address is still admitted.

## Risk

- **A remote claiming our DID is refused, not admitted.** The guard rejects; it never grants. It also returns *before* taking the connection-map write lock, so a spoofer cannot evict a legitimate entry — the only connection closed is the caller's own.
- **Bootstrap liveness unchanged.** No node lists itself in `bootstrap_peers`. If an operator misconfigured self, the dial is now refused with a clear log instead of building a self-loop.
- **Pre-existing persisted self-state is left alone.** Nodes that already banned themselves keep those records; the fix stops new self-state rather than rewriting history. The stale own-DID replay window is inert because the receive-path guard runs before the guard is consulted. Deliberately not cleared — that would be making the cluster look healthy rather than being healthy.
- **`network_size_estimate` drops by 1** on every node, which is the correction, but it also feeds `calculate_fanout`. A node with real peers is unaffected in practice; an isolated node now correctly reports 0.

## Test plan

`cargo test -p icn-net -p icn-gossip -p icn-core`: **1334 passed, 0 failed** (84 test binaries). `cargo fmt --all --check`, `cargo clippy --all-targets -D warnings`, and `scripts/check-meaning-firewall.sh` all clean.

New coverage, one per admission point:

| test | pins |
|---|---|
| `test_dial_refuses_local_did` | outbound dial never keys the map on our DID |
| `test_store_incoming_connection_refuses_local_did` | authenticated inbound install refuses our DID |
| `test_remote_peer_from_local_address_is_still_admitted` | **negative control** — same address, distinct DID, still admitted |
| `test_own_did_envelope_creates_no_replay_or_misbehavior_state` | no own-DID replay window, no own-DID violations |
| `test_own_candidate_is_not_stored_as_a_dial_target` | gossip echo of our own candidate is refused |
| `test_own_mdns_advertisement_is_not_recorded_as_a_peer` | our own multicast advertisement is skipped |
| `test_remote_mdns_advertisement_is_still_recorded` | **negative control** — the filter does not drop everything |
| `test_remote_peer_count_excludes_the_local_node` | isolated node reports 0 peers, real peers still counted |

`test_dial_refuses_local_did` was rewritten twice during development because it passed against unfixed code — first because quinn cannot connect to its own endpoint socket, then because nothing was accepting on the target and it errored on timeout. Both were vacuous greens; the final version dials a live acceptor and fails for the intended reason.

Regressions held: #2505 (`test_reconnect_after_peer_restart_replaces_dead_connection`, `test_live_connection_is_not_replaced_by_duplicate_inbound`, `test_hello_path_install_replaces_dead_connection`) and #2510 (`signing_sequence_replay.rs`, 7/7 including `captured_traffic_from_a_previous_incarnation_is_still_rejected`).

## Negative controls

Each guard removed independently; results in a follow-up comment.

## Not in scope

#2507 (undeclared `network:profiles`), #2508 (ban TTL), #2509 (candidate re-announcement), #2512 (banned-peers metric — deliberately not used as evidence anywhere here; all ban counts are log-derived), #2491, #2499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
