### PR TITLE
docs(architecture): record the #2514 live proof and the migration invariant

### DIFF
--- a/docs/architecture/replay-state-restart-invariants.md
+++ b/docs/architecture/replay-state-restart-invariants.md
@@ -258,7 +258,39 @@ is a prerequisite for signed-envelope freshness**, and therefore for replay-stat
   discovered.
 - **Failed `put` or `flush`.** Fail closed, per §6.
 
-## 9. Connection lifetime vs replay lifetime
+## 9. Migration: these invariants describe state created under the corrected protocol
+
+Every invariant above governs replay state **created by this code**. None of them repair state that
+was written, or is remembered by a peer, under earlier sequence semantics. That is a separate
+invariant and it is not yet satisfied.
+
+The distinction is sharp enough to be worth stating as a rule:
+
+> **Correct steady-state protocol semantics and safe migration from previously persisted or
+> distributed semantics are separate invariants.** Establishing the first does not establish the
+> second, and a faithful restore of a legacy value is still wrong.
+
+Two known instances, both live-observed:
+
+- **Sender side (#2517).** `SigningSequenceCounter` initialises its durable counter without any
+  bridge from the ephemeral counter it replaced, so a first upgrade can resume *below* the
+  high-water its peers already recorded. Observed: a sender resumed at `10001` while a long-lived
+  peer still remembered `15915` for it, and rejected every legitimate sequence in between.
+- **Receiver side (#2514).** §6 restores the durable high-water *exactly*. If that value was
+  written by the pre-fix loader — which persisted `stored + 1000` on every load — the exactness is
+  faithful to a number that was already inflated. Nothing in §6 detects this.
+
+Both currently "heal" the same way: the peer window ages out under §7 after `max_peer_age_secs` of
+no **accepted** traffic, because rejections never refresh liveness. That is recovery by timeout,
+which is precisely what the restart/rejoin work exists to eliminate, and it costs thousands of false
+misbehaviour and ban events on the way.
+
+A bridge is **not** designed here. The shape of the problem — a persisted record whose meaning
+changed without its format changing — suggests versioning the records so a reader can tell
+old-regime data from new and treat old-regime entries as untrusted rather than authoritative, which
+would cover both instances with one mechanism. That is for #2517 to decide, not this document.
+
+## 10. Connection lifetime vs replay lifetime
 
 Replay state is keyed by peer **DID**, not by connection. Reconnects, stale-connection replacement
 (#2505), and transport churn do not reset it. Conversely, the local identity is never admitted as a

--- a/docs/architecture/restart-rejoin-investigation-2504.md
+++ b/docs/architecture/restart-rejoin-investigation-2504.md
@@ -16,18 +16,35 @@ at 4 and kept gossiping normally. Rollback did not recover it, because rollback 
 
 ## Causal decomposition
 
-Four independent defects, each masked by the one before it:
+Four independent defects, each masked by the one before it — plus a fifth of a different kind:
 
 ```
 peer restart
-  → stale QUIC connection cache        #2505  fixed  adb9d07d
-  → ephemeral outbound signing seq     #2510  fixed  72dfed8e (PR #2511)
-  → local identity admitted as remote  #2506  fixed  045fa9e9 (PR #2513)
-  → receiver restart replay floor      #2514  OPEN — current blocker
+  → stale QUIC connection cache        #2505  fixed   adb9d07d
+  → ephemeral outbound signing seq     #2510  fixed   72dfed8e (PR #2511)
+  → local identity admitted as remote  #2506  fixed   045fa9e9 (PR #2513)
+  → receiver restart replay floor      #2514  fixed   e3c14c4d (PR #2516)
+  → legacy sequence-state migration    #2517  ACTIVE  — not a steady-state defect
 ```
 
 **The masking is the important part.** Each fix made the next defect reachable for the first time,
 so a newly appearing blocker is evidence the previous fix worked, not that it was wrong.
+
+**#2517 is a different kind of finding and breaks the pattern.** The first four are steady-state
+protocol defects. #2517 is a *migration* defect: #2510's durable sender counter is correct going
+forward, but its first initialisation had no bridge from the ephemeral counter it replaced, so an
+upgraded sender can resume below the high-water its peers already recorded. The protocol is right;
+the transition into it is not.
+
+> **Correct steady-state protocol semantics and safe migration from previously persisted or
+> distributed semantics are separate invariants.** Proving the first does not prove the second.
+
+This matters for #2514 specifically: its invariant is *restore exactly what was accepted*, which is
+faithful — including to a legacy value that was already wrong. A receiver holding a pre-fix inflated
+high-water, or a legacy ephemeral-regime high-water, restores it precisely and still rejects
+legitimate traffic. Both currently resolve only when the peer window ages out after
+`max_peer_age_secs` of no accepted traffic, i.e. **recovery by timeout** — the property this whole
+investigation exists to eliminate.
 
 - #2505 kept traffic from flowing at all, so nobody could observe #2510's sequence regression.
 - #2510 caused peers to reject 100 % of a restarted node's traffic, which hid #2506's inbound cost.
@@ -98,6 +115,29 @@ The compounding behaviour (`+1000` per restart, encoded in
 each load. No incident, test, or comment justified a positive gap, the value 1000, or compounding.
 
 Full invariant statement: [replay-state-restart-invariants.md](replay-state-restart-invariants.md).
+
+**Live proof, 2026-08-03.** Merged `e3c14c4d`, image digest
+`sha256:c94f6535e4e6b4434f20b899d6c9d2baf51cbf13c38b2502fd5fc1e51966271d` from the cluster
+registry, deployed to alpha only. Beta ran continuously throughout (`restarts=0`, up since `00:17:15Z`);
+gamma and delta were not touched. Three alpha restarts — one migration deploy and two deliberate
+receiver-only restarts — with **zero** replay rejections in every case:
+
+```
+restart #1  06:51:58.795  command
+            06:52:13.206  replay state loaded (no safety_gap field — pre-fix code gone)
+            06:52:13.260  connected to beta            (+54 ms)
+            ~06:52:15     digests flowing              recovery < 25 s
+
+restart #2  06:56:59.582  command
+            06:57:12.333  replay state loaded
+            06:57:12.396  connected to beta            (+63 ms)
+            06:58:13      6 digests received           no compounding
+```
+
+Against the pre-fix behaviour on the same pair — 566 rejections, 566 severity-1.0 events, 566 bans,
+and zero digests for a full hour — recovery is now bounded by connection setup rather than by
+sender sequence burn or `cleanup()` timeout. The second restart is the compounding control: the old
+code added another `+1000` per restart, and here the boundary did not move at all.
 
 ## Disproved hypotheses
 

--- a/docs/architecture/restart-rejoin-investigation-2504.md
+++ b/docs/architecture/restart-rejoin-investigation-2504.md
@@ -37,7 +37,11 @@ upgraded sender can resume below the high-water its peers already recorded. The 
 the transition into it is not.
 
 > **Correct steady-state protocol semantics and safe migration from previously persisted or
-> distributed semantics are separate invariants.** Proving the first does not prove the second.
+> distributed semantics are separate invariants.** Establishing the first does not establish the
+> second, and a faithful restore of a legacy value is still wrong.
+
+That wording is owned by [replay-state-restart-invariants.md](replay-state-restart-invariants.md)
+and is quoted verbatim here; change it there first.
 
 This matters for #2514 specifically: its invariant is *restore exactly what was accepted*, which is
 faithful — including to a legacy value that was already wrong. A receiver holding a pre-fix inflated
@@ -119,8 +123,10 @@ Full invariant statement: [replay-state-restart-invariants.md](replay-state-rest
 **Live proof, 2026-08-03.** Merged `e3c14c4d`, image digest
 `sha256:c94f6535e4e6b4434f20b899d6c9d2baf51cbf13c38b2502fd5fc1e51966271d` from the cluster
 registry, deployed to alpha only. Beta ran continuously throughout (`restarts=0`, up since `00:17:15Z`);
-gamma and delta were not touched. Three alpha restarts — one migration deploy and two deliberate
-receiver-only restarts — with **zero** replay rejections in every case:
+gamma and delta were not touched. Three alpha restarts — the migration deploy that rolled the image,
+then two deliberate receiver-only restarts — with **zero** replay rejections in every case. The
+deploy restart is the one that crossed the code boundary and so has no comparable pre-fix timing
+line; the two deliberate restarts, both entirely on the fixed image, are timed below:
 
 ```
 restart #1  06:51:58.795  command


### PR DESCRIPTION
## What

Documentation only. Records the alpha-only live acceptance evidence for the merged #2514 fix (`e3c14c4d`), and adds a migration section stating an invariant this investigation surfaced.

## Live proof

Merged image deployed to alpha only. Beta ran continuously throughout (`restarts=0`, up since `00:17:15Z`); gamma and delta untouched. Three alpha restarts — one migration deploy and two deliberate receiver-only restarts — **zero replay rejections in every case**.

```
restart #1  06:51:58.795  command
            06:52:13.206  replay state loaded (no safety_gap field - pre-fix code gone)
            06:52:13.260  connected to beta            (+54 ms)
            ~06:52:15     digests flowing              recovery < 25 s

restart #2  06:56:59.582  command
            06:57:12.333  replay state loaded
            06:57:12.396  connected to beta            (+63 ms)
            06:58:13      6 digests received           no compounding
```

Against pre-fix behaviour on the same pair — 566 rejections, 566 severity-1.0 events, 566 bans, zero digests for a full hour — recovery is now bounded by connection setup rather than sender sequence burn or `cleanup()` timeout. Restart #2 is the compounding control: the old code added another `+1000` per restart, and the boundary did not move at all.

## The migration invariant

The more durable finding, and the reason this is a doc change rather than a note on the issue:

> Correct steady-state protocol semantics and safe migration from previously persisted or distributed semantics are **separate invariants**. Proving the first does not prove the second.

#2514's invariant is *restore exactly what was accepted*. That is faithful — including to a number written under earlier semantics that is already wrong. Two live instances are recorded: #2517 (sender's durable counter resumes below the ephemeral high-water peers recorded) and #2514's own upgrade case (a pre-fix inflated value is restored precisely). Both currently resolve only by peer-window timeout, which is the property #2504 exists to eliminate.

No bridge is designed here — that is #2517.

## Risk

None to running code. Registry host address omitted per the address-scrub rule; image identified by digest only.

Refs #2514, #2504, #2517

🤖 Generated with [Claude Code](https://claude.com/claude-code)