### PR TITLE
fix(net): stop reporting address-derived placeholder keys as authenticated DIDs

### DIFF
--- a/icn/crates/icn-core/src/supervisor/bridge.rs
+++ b/icn/crates/icn-core/src/supervisor/bridge.rs
@@ -16,15 +16,22 @@ use tracing::debug;
 pub enum BootstrapPeer {
     /// Full peer with known DID: `icn://did:icn:PUBKEY@HOST:PORT`
     KnownDid { did: Did, addr: SocketAddr },
-    /// Address-only hint — DID learned from handshake: `icn://HOST:PORT`
+    /// Address-only hint — no DID is known up front: `icn://HOST:PORT`.
+    /// Dialing one of these keys the connection by an address-derived
+    /// placeholder; the peer's authenticated DID is established separately by
+    /// the Hello handshake.
     AddrOnly { addr: SocketAddr },
 }
 
 /// Parse bootstrap peer URL.
 ///
 /// Supported formats:
-/// - `icn://did:icn:PUBKEY@HOST:PORT` — verified peer (DID known)
-/// - `icn://HOST:PORT` — bootstrap hint (DID learned from handshake)
+/// - `icn://did:icn:PUBKEY@HOST:PORT` — DID supplied by configuration
+/// - `icn://HOST:PORT` — address-only hint; no DID until the Hello handshake
+///
+/// Neither form authenticates the peer: parsing yields configuration, and the
+/// peer's identity is proven only by DID-TLS binding verification in the Hello
+/// handler.
 ///
 /// Supports both IP addresses and DNS hostnames.
 pub async fn parse_bootstrap_peer(url: &str) -> Result<BootstrapPeer> {

--- a/icn/crates/icn-core/src/supervisor/bridge.rs
+++ b/icn/crates/icn-core/src/supervisor/bridge.rs
@@ -10,8 +10,9 @@ use icn_identity::Did;
 use std::net::SocketAddr;
 use tracing::debug;
 
-/// Parsed bootstrap peer — either with a known DID or address-only
-/// (DID learned from QUIC/DID-TLS handshake).
+/// Parsed bootstrap peer — either with a DID supplied by configuration or
+/// address-only. Neither form authenticates the peer; identity is proven only
+/// by DID-TLS binding verification during the Hello handshake.
 #[derive(Debug, Clone)]
 pub enum BootstrapPeer {
     /// Full peer with known DID: `icn://did:icn:PUBKEY@HOST:PORT`

--- a/icn/crates/icn-core/src/supervisor/init_bootstrap.rs
+++ b/icn/crates/icn-core/src/supervisor/init_bootstrap.rs
@@ -52,7 +52,11 @@ impl BootstrapConfig {
 
 /// Dial bootstrap peers and optionally request peer exchange
 ///
-/// Returns the list of successfully connected peer DIDs.
+/// Returns the list of connection keys for peers we reached. For `KnownDid`
+/// bootstrap entries (`icn://did:icn:PUBKEY@HOST:PORT`) these are the
+/// configured DIDs. For `AddrOnly` entries (`icn://HOST:PORT`) they are
+/// address-derived **placeholders**, not authenticated peer identities — see
+/// [`icn_net::NetworkHandle::dial_addr`] and #2530.
 pub async fn dial_bootstrap_peers(
     config: &BootstrapConfig,
     network_handle: &NetworkHandle,
@@ -86,14 +90,18 @@ pub async fn dial_bootstrap_peers(
             }
             Ok(super::bridge::BootstrapPeer::AddrOnly { addr: peer_addr }) => {
                 info!("Connecting to bootstrap peer (addr-only): {}", peer_addr);
-                // Dial without known DID — DID will be learned from QUIC/TLS handshake
+                // Dial without a known DID. The value returned here is a
+                // placeholder derived from the address, NOT the peer's
+                // identity; the peer's authenticated DID is established
+                // separately by the Hello handshake.
                 match network_handle.dial_addr(peer_addr).await {
-                    Ok(peer_did) => {
+                    Ok(placeholder_did) => {
                         info!(
-                            "✓ Connected to bootstrap peer: {} (learned from handshake)",
-                            peer_did
+                            "✓ Connected to bootstrap peer at {} (placeholder key {}; \
+                             peer identity not yet authenticated — awaiting Hello)",
+                            peer_addr, placeholder_did
                         );
-                        connected_peers.push(peer_did);
+                        connected_peers.push(placeholder_did);
                     }
                     Err(e) => {
                         warn!(

--- a/icn/crates/icn-net/src/actor/mod.rs
+++ b/icn/crates/icn-net/src/actor/mod.rs
@@ -231,9 +231,13 @@ impl NetworkHandle {
     /// cryptographic attribution. It is derived deterministically from `addr`
     /// alone by `derive_placeholder_did`, and is needed because the session
     /// manager's connection map is keyed by DID string while the peer's real
-    /// DID is unknown until the Hello handshake completes. It is computable by
-    /// anyone from the address alone, has no corresponding private key, and is
-    /// produced even when the dial never reaches a peer at all.
+    /// DID is unknown until the Hello handshake completes. It has no
+    /// corresponding private key, and is computed from the address *before* the
+    /// dial is attempted, so it is derivable offline by anyone who knows the
+    /// address and carries no evidence that a peer answered.
+    ///
+    /// (`dial_addr` itself still returns `Err` when the dial fails; the point is
+    /// that the value's derivation is independent of the dial's outcome.)
     ///
     /// The peer's authenticated DID is recorded separately by the Hello
     /// handler, into `peer_connections`, after DID-TLS binding verification.

--- a/icn/crates/icn-net/src/actor/mod.rs
+++ b/icn/crates/icn-net/src/actor/mod.rs
@@ -225,11 +225,23 @@ impl NetworkHandle {
         );
     }
 
-    /// Dial a peer by address only (DID learned from Hello handshake).
+    /// Dial a peer by address only, returning a **placeholder connection key**.
     ///
-    /// Uses a deterministic placeholder DID derived from the address as a
-    /// temporary connection key. The peer's actual DID is learned during
-    /// the Hello handshake and the connection map is updated accordingly.
+    /// The returned value is not the peer's identity and carries no
+    /// cryptographic attribution. It is derived deterministically from `addr`
+    /// alone by `derive_placeholder_did`, and is needed because the session
+    /// manager's connection map is keyed by DID string while the peer's real
+    /// DID is unknown until the Hello handshake completes. It is computable by
+    /// anyone from the address alone, has no corresponding private key, and is
+    /// produced even when the dial never reaches a peer at all.
+    ///
+    /// The peer's authenticated DID is recorded separately by the Hello
+    /// handler, into `peer_connections`, after DID-TLS binding verification.
+    /// The placeholder entry in the session manager's connection map is
+    /// **not** re-keyed or evicted — see #2530.
+    ///
+    /// Callers must not treat the returned `Did` as an authenticated peer
+    /// identity, and must not report it as one.
     pub async fn dial_addr(&self, addr: SocketAddr) -> Result<Did> {
         let temp_did = derive_placeholder_did(addr)?;
         self.dial(addr, temp_did.clone()).await?;
@@ -924,8 +936,12 @@ impl NetworkHandle {
 fn derive_placeholder_did(addr: SocketAddr) -> Result<Did> {
     // Derive a deterministic placeholder key from the address using SHA-256.
     // The resulting 32 bytes are used as an Ed25519 "public key" for connection
-    // tracking only — this is NOT a real key and will be replaced by the peer's
-    // actual DID after the Hello handshake.
+    // tracking only. This is NOT a real key: it is a function of the address
+    // alone, so it is identical for every node that dials the same address and
+    // is produced even when nothing is listening there.
+    //
+    // The peer's authenticated DID is recorded separately by the Hello handler.
+    // This placeholder is not currently replaced or evicted — see #2530.
     use sha2::{Digest, Sha256};
     let addr_hash = Sha256::digest(format!("bootstrap:{addr}").as_bytes());
     let hash_bytes: [u8; 32] = addr_hash.into();
@@ -1440,6 +1456,59 @@ mod tests {
             did, did_again,
             "fallback mapping should remain deterministic"
         );
+    }
+
+    /// Characterization test for #2529: the placeholder is scoped to the
+    /// *address*, not to the peer, so one host reached by several routes
+    /// yields several unrelated placeholders — none of which is its identity.
+    ///
+    /// This is what made #2529 look like an identity anomaly: a node dialed
+    /// gamma's ClusterIP and logged a DID that was not gamma's. If a future
+    /// change makes this value look peer-scoped (host-keyed, or sourced from
+    /// the peer's certificate) without also making it authenticated, this test
+    /// fails and forces that decision to be explicit.
+    #[test]
+    fn test_placeholder_did_is_address_scoped_not_peer_scoped() {
+        // Three routes to one hypothetical peer: pod IP, service IP, node port.
+        // The node address uses RFC 5737 documentation space; the cluster-internal
+        // ones are the shapes a pod and a ClusterIP actually take.
+        let pod_ip: SocketAddr = "10.42.1.208:7825".parse().unwrap();
+        let service_ip: SocketAddr = "10.43.12.70:7825".parse().unwrap();
+        let node_port: SocketAddr = "192.0.2.10:30825".parse().unwrap();
+
+        let via_pod = derive_placeholder_did(pod_ip).unwrap();
+        let via_service = derive_placeholder_did(service_ip).unwrap();
+        let via_node_port = derive_placeholder_did(node_port).unwrap();
+
+        assert_ne!(
+            via_pod, via_service,
+            "same peer via a different address must not be assumed to be the same peer"
+        );
+        assert_ne!(via_service, via_node_port);
+        assert_ne!(via_pod, via_node_port);
+
+        // Even the port alone changes it, so this cannot stand in for a host,
+        // let alone an identity.
+        let other_port: SocketAddr = "10.43.12.70:7826".parse().unwrap();
+        assert_ne!(via_service, derive_placeholder_did(other_port).unwrap());
+    }
+
+    /// The placeholder requires no peer, no connection, and no handshake — it
+    /// is a pure function of the address. This is the concrete reason the old
+    /// "learned from handshake" log line was false: nodes emitted this value
+    /// for addresses whose dial timed out without any peer ever responding.
+    #[test]
+    fn test_placeholder_did_needs_no_peer_or_handshake() {
+        // Reserved-for-documentation address (RFC 5737); nothing can answer.
+        let unreachable: SocketAddr = "192.0.2.1:7825".parse().unwrap();
+
+        let did = derive_placeholder_did(unreachable).unwrap();
+        assert!(did.as_str().starts_with("did:icn:"));
+
+        // Any party can recompute it offline from the address alone, which is
+        // precisely why it must never be reported as an authenticated identity.
+        let recomputed = derive_placeholder_did(unreachable).unwrap();
+        assert_eq!(did, recomputed);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Observation

During #2517 live validation, delta dialled gamma's Service address `10.43.12.70:7825` and logged:

```
✓ Connected to bootstrap peer: did:icn:zxAdpRHW5n2MeVdbHCXuH7TfVDXTa17YiRwCSE9pZmWo (learned from handshake)
```

That DID belongs to no node in the federation.

## Root cause

An addr-only bootstrap entry (`icn://HOST:PORT`) has no peer DID yet, but the session connection map
is keyed by DID string. So `dial_addr` synthesises a placeholder key — `SHA-256("bootstrap:{addr}")`
reinterpreted as an Ed25519 public key — and **returns it**. The supervisor then logged that value as
if a handshake had produced it.

All four such DIDs across the federation reproduce exactly from the address string alone, offline,
with no key material:

| Address dialled | Logged DID | Reproduced |
|---|---|---|
| `10.43.12.70:7825` (gamma) | `zxAdpRHW5n2Me…` | yes |
| `10.43.110.197:7831` (delta) | `z7P72raZD1nfk…` | yes |
| `10.43.97.80:7827` (alpha) | `zGVqszhUboikN…` | yes |
| `10.43.194.7:7834` (beta) | `z9rnPayL7fHuW…` | yes (fallback branch) |

## Decisive proof

Beta produced the **same** `zxAdpRHW…` for gamma's address on a dial that **timed out after 30
seconds** — no QUIC handshake, no certificate, no Hello, no peer response. A value that appears when
the peer never answers cannot have been learned from the peer.

## Real identity

Gamma's authenticated DID is `did:icn:zyWqWVqGERfRvUz4LVGd4coCZDuNhnufxRpNVTR1BBA7`, established
through Hello and recorded separately in `peer_connections` after DID-TLS binding verification. Delta
authenticated it 11 seconds after the misleading log line.

## Routing

Kubernetes was correct throughout. EndpointSlice `icn-gamma-nl9wj` has exactly one address,
`10.42.1.208`, `ready: true`, `targetRef: icn-gamma-…`. No second endpoint, no stale entry, no
sidecar, no hostNetwork.

## Fix

Observability and API contracts only:

- the bootstrap log leads with the **address** and labels the DID a placeholder awaiting Hello
- `dial_addr`, `derive_placeholder_did`, `dial_bootstrap_peers` and `parse_bootstrap_peer` docs no
  longer claim a handshake origin, and no longer claim a connection-map re-keying that does not exist
- the `KnownDid` bootstrap form is no longer described as a "verified peer" — configuration is not
  verification
- two characterization tests pin the semantics: the placeholder is address-scoped rather than
  peer-scoped, and requires no peer or handshake

No runtime behaviour changes. The only non-comment edits are a local binding rename and adding the
address to a log format string.

## Security result

**No #2520 bypass and no impersonation.** The placeholder has no private key, so nothing can sign a
`BindingInfo` for it and the #2520 checks fail closed. Live: 0 Hello binding rejections on gamma and
delta. The placeholder never enters `peer_connections`, so it has no X25519 key, no capability flags,
and is invisible to encrypted send, capability checks, and replay/sequence state (which key off
inbound `message.from`).

## Risk

Low. Comments, docs, one log string, two pure-function tests.

## Test plan

`cargo fmt --all --check` clean; `cargo clippy -p icn-net -p icn-core --all-targets --all-features -D warnings`
clean (0 warnings); `cargo test -p icn-net -p icn-core` → 1080 passed / 36 ignored across 67 suites.
Source hashes were captured before and after the gate run and were identical, so the gated bytes are
the committed bytes.

One unrelated failure: `a_fused_accept_cancelled_after_one_poll_destroys_the_handshake` (the #2521
regression test). Characterized as a pre-existing timing flake on this VM — **4 pass / 1 fail over 5
runs on byte-identical source**, and this diff cannot reach the accept loop. Its assertion is a
self-consistency guard that trips when the handshake completes faster than the test's premise allows.

## Follow-up

Refs #2529. #2530 tracks the substantive defect this investigation uncovered: the placeholder is
never evicted from the session connection map, and `handle_peer_exchange_request` advertises it to
other nodes as a known peer paired with a real reachable endpoint. Latent today because federation is
disabled in the coop configs. Deliberately not addressed here.
