### PR TITLE
fix(net): keep outbound connections provisional until Hello authenticates peer identity

### DIFF
--- a/icn/crates/icn-core/src/supervisor/init_bootstrap.rs
+++ b/icn/crates/icn-core/src/supervisor/init_bootstrap.rs
@@ -6,6 +6,7 @@
 //! - Announcing connection candidates for NAT traversal
 //! - Publishing node profile for peer capability discovery
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -50,24 +51,26 @@ impl BootstrapConfig {
     }
 }
 
-/// Dial bootstrap peers and optionally request peer exchange
+/// Dial bootstrap peers.
 ///
-/// Returns the DIDs we can address peers by. Only `KnownDid` bootstrap entries
-/// (`icn://did:icn:PUBKEY@HOST:PORT`) contribute: for `AddrOnly` entries
-/// (`icn://HOST:PORT`) the peer's identity is not known until Hello completes, and the
-/// address-derived placeholder is not a peer identity and not a usable send target — see
-/// [`icn_net::NetworkHandle::dial_addr`] and #2530. Those peers are picked up from
-/// [`icn_net::NetworkHandle::connected_peers`] once they authenticate.
+/// Returns the **addresses** transport was established to, not peer identities. Neither
+/// bootstrap form authenticates anyone: `parse_bootstrap_peer` yields configuration, and a
+/// peer's identity is proven only by DID-TLS binding verification in the Hello handler. A
+/// configured `KnownDid` is therefore an expectation, and the `AddrOnly` placeholder is not
+/// even that — see [`icn_net::NetworkHandle::dial_addr`] and #2530.
+///
+/// The addresses are what lets [`request_peer_exchange`] find *these* peers once they
+/// authenticate, without widening to every peer the node happens to be connected to.
 pub async fn dial_bootstrap_peers(
     config: &BootstrapConfig,
     network_handle: &NetworkHandle,
-) -> Vec<Did> {
+) -> Vec<SocketAddr> {
     if config.bootstrap_peers.is_empty() {
         return Vec::new();
     }
 
     info!("Dialing {} bootstrap peers", config.bootstrap_peers.len());
-    let mut connected_peers = Vec::new();
+    let mut dialed_endpoints = Vec::new();
 
     for peer_url in &config.bootstrap_peers {
         match super::bridge::parse_bootstrap_peer(peer_url).await {
@@ -81,8 +84,14 @@ pub async fn dial_bootstrap_peers(
                 );
                 match network_handle.dial(peer_addr, peer_did.clone()).await {
                     Ok(_) => {
-                        info!("✓ Connected to bootstrap peer: {}", peer_did);
-                        connected_peers.push(peer_did);
+                        // The configured DID is an expectation, not a result: this records
+                        // that transport came up, and the peer is named only once Hello
+                        // authenticates it (#2530).
+                        info!(
+                            "✓ Reached bootstrap peer at {} (expected {}; awaiting Hello)",
+                            peer_addr, peer_did
+                        );
+                        dialed_endpoints.push(peer_addr);
                     }
                     Err(e) => {
                         warn!("Failed to connect to bootstrap peer {}: {}", peer_did, e)
@@ -97,14 +106,12 @@ pub async fn dial_bootstrap_peers(
                 // separately by the Hello handshake.
                 match network_handle.dial_addr(peer_addr).await {
                     Ok(placeholder_did) => {
-                        // Deliberately not added to `connected_peers`: the placeholder
-                        // names no peer and addresses nothing. This peer becomes
-                        // addressable once Hello authenticates it (#2530).
                         info!(
                             "✓ Connected to bootstrap peer at {} (placeholder key {}; \
                              peer identity not yet authenticated — awaiting Hello)",
                             peer_addr, placeholder_did
                         );
+                        dialed_endpoints.push(peer_addr);
                     }
                     Err(e) => {
                         warn!(
@@ -123,16 +130,55 @@ pub async fn dial_bootstrap_peers(
         }
     }
 
-    connected_peers
+    dialed_endpoints
 }
 
-/// Request peer exchange from connected bootstrap peers
+/// Which peers this bootstrap operation may request peer exchange from.
+///
+/// A target must satisfy both halves: it authenticated (so it came from
+/// `connected_peer_endpoints`, whose entries exist only after Hello proved a DID against the
+/// connection's certificate), **and** it is reachable at an endpoint this bootstrap
+/// operation actually dialed. Either half alone is wrong — a configured DID that never
+/// authenticated is not a peer, and an authenticated peer we never dialed is not a bootstrap
+/// peer.
+///
+/// Matching on the dialed address is sound here because bootstrap dialing is direct-only:
+/// `NetworkHandle::dial` passes `peer_relay_addr: None`, so `handle_dial` cannot take the
+/// TURN branch, and the connection's remote address is the address we dialed. (Under
+/// Kubernetes DNAT the client still observes the service address it sent to, because
+/// conntrack rewrites the reply source back.) If bootstrap ever gains relay fallback, a
+/// relayed connection's remote address is the local proxy's, and this correlation would need
+/// revisiting.
+fn select_peer_exchange_targets(
+    dialed_endpoints: &[SocketAddr],
+    authenticated_peers: Vec<(Did, SocketAddr)>,
+) -> Vec<Did> {
+    let mut targets: Vec<Did> = Vec::new();
+    for (did, addr) in authenticated_peers {
+        if dialed_endpoints.contains(&addr) && !targets.contains(&did) {
+            targets.push(did);
+        }
+    }
+    targets
+}
+
+/// Request peer exchange from the bootstrap peers that authenticated.
+///
+/// Targets are resolved *after* the handshake window, by matching live authenticated
+/// sessions against the addresses we actually dialed. A bootstrap entry names an endpoint
+/// and, at most, an expectation about who is there; only Hello says who is really there, so
+/// a configured DID must not become a peer-exchange target on its own (#2530, and the
+/// "configuration is not verification" principle settled in #2529).
+///
+/// Matching on the dialed address keeps this scoped to bootstrap peers. Asking only for
+/// "every connected peer" would quietly turn this into a request to the whole neighbourhood
+/// — including inbound peers this node never chose to bootstrap from.
 pub async fn request_peer_exchange(
     config: &BootstrapConfig,
     network_handle: &NetworkHandle,
-    connected_peers: Vec<Did>,
+    dialed_endpoints: Vec<SocketAddr>,
 ) {
-    if !config.federation_enabled {
+    if !config.federation_enabled || dialed_endpoints.is_empty() {
         return;
     }
 
@@ -143,28 +189,24 @@ pub async fn request_peer_exchange(
     };
 
     let peer_exchange_delay = Duration::from_millis(config.peer_exchange_delay_ms);
-
-    // Wait out the handshake window before choosing targets. Address-only bootstrap peers
-    // have no addressable identity until Hello completes, so they can only be named after
-    // authenticating — asking the network handle afterwards is what picks them up (#2530).
     tokio::time::sleep(peer_exchange_delay).await;
 
-    let mut targets = connected_peers;
-    for authenticated in network_handle.connected_peers().await {
-        if !targets.contains(&authenticated) {
-            targets.push(authenticated);
-        }
-    }
+    let targets = select_peer_exchange_targets(
+        &dialed_endpoints,
+        network_handle.connected_peer_endpoints().await,
+    );
 
     if targets.is_empty() {
         info!(
-            "Federation enabled - no authenticated bootstrap peers to request peer exchange from"
+            "Federation enabled - none of the {} bootstrap endpoints has an authenticated peer yet; \
+             not requesting peer exchange",
+            dialed_endpoints.len()
         );
         return;
     }
 
     info!(
-        "Federation enabled - requesting peer exchange from {} bootstrap peers",
+        "Federation enabled - requesting peer exchange from {} authenticated bootstrap peers",
         targets.len()
     );
 
@@ -291,4 +333,87 @@ pub async fn run_bootstrap(
 
     // Announce node profile
     announce_node_profile(gossip_handle, did, node_profile).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn did(s: &str) -> Did {
+        // Real Ed25519-derived DIDs: the selection rule compares identities, so seeding
+        // from distinct keys keeps the fixtures distinct the same way production ones are.
+        let seed = {
+            let mut bytes = [0u8; 32];
+            for (i, b) in s.bytes().enumerate().take(32) {
+                bytes[i] = b;
+            }
+            bytes
+        };
+        Did::from_public_key(&ed25519_dalek::SigningKey::from_bytes(&seed).verifying_key())
+    }
+
+    fn addr(port: u16) -> SocketAddr {
+        format!("10.0.0.1:{port}").parse().expect("valid addr")
+    }
+
+    /// Peer exchange goes only to peers that both authenticated **and** sit at an endpoint
+    /// this bootstrap operation dialed.
+    ///
+    /// The two exclusions are the ones that matter. An endpoint we dialed but that never
+    /// authenticated contributes nothing: transport success is not identity, so there is no
+    /// DID to address (#2530). And an authenticated peer at some other endpoint is a peer of
+    /// this node but not a *bootstrap* peer — including it would silently turn a bootstrap
+    /// step into a request to the whole neighbourhood, including inbound peers this node
+    /// never chose.
+    #[test]
+    fn targets_are_authenticated_peers_at_endpoints_we_dialed() {
+        let bootstrap_a = addr(7001);
+        let bootstrap_b = addr(7002);
+        let unrelated_c = addr(7003);
+
+        let targets = select_peer_exchange_targets(
+            &[bootstrap_a, bootstrap_b],
+            vec![
+                (did("PeerA"), bootstrap_a),
+                // C authenticated, but we never dialed it as a bootstrap peer.
+                (did("PeerC"), unrelated_c),
+            ],
+        );
+
+        assert_eq!(
+            targets,
+            vec![did("PeerA")],
+            "only the authenticated peer at a dialed bootstrap endpoint may be a target"
+        );
+        // B was dialed but nobody authenticated there, so it contributes no DID at all.
+        assert!(!targets.iter().any(|t| t.as_str().contains("PeerB")));
+    }
+
+    /// A DID reachable at two dialed endpoints is requested from once.
+    ///
+    /// Bootstrap lists legitimately name the same node twice — a service address and a
+    /// direct one, or an IPv4 and IPv6 entry — and the peer that answers both is one peer.
+    #[test]
+    fn targets_are_deduplicated_across_endpoints() {
+        let first = addr(7001);
+        let second = addr(7002);
+
+        let targets = select_peer_exchange_targets(
+            &[first, second, first],
+            vec![(did("SamePeer"), first), (did("SamePeer"), second)],
+        );
+
+        assert_eq!(targets, vec![did("SamePeer")]);
+    }
+
+    /// With nothing dialed, nothing is a bootstrap target — not even a live peer.
+    #[test]
+    fn no_dialed_endpoints_means_no_targets() {
+        let targets =
+            select_peer_exchange_targets(&[], vec![(did("SomeConnectedPeer"), addr(7009))]);
+        assert!(
+            targets.is_empty(),
+            "an authenticated peer we did not dial is not a bootstrap peer"
+        );
+    }
 }

--- a/icn/crates/icn-core/src/supervisor/init_bootstrap.rs
+++ b/icn/crates/icn-core/src/supervisor/init_bootstrap.rs
@@ -52,11 +52,12 @@ impl BootstrapConfig {
 
 /// Dial bootstrap peers and optionally request peer exchange
 ///
-/// Returns the list of connection keys for peers we reached. For `KnownDid`
-/// bootstrap entries (`icn://did:icn:PUBKEY@HOST:PORT`) these are the
-/// configured DIDs. For `AddrOnly` entries (`icn://HOST:PORT`) they are
-/// address-derived **placeholders**, not authenticated peer identities — see
-/// [`icn_net::NetworkHandle::dial_addr`] and #2530.
+/// Returns the DIDs we can address peers by. Only `KnownDid` bootstrap entries
+/// (`icn://did:icn:PUBKEY@HOST:PORT`) contribute: for `AddrOnly` entries
+/// (`icn://HOST:PORT`) the peer's identity is not known until Hello completes, and the
+/// address-derived placeholder is not a peer identity and not a usable send target — see
+/// [`icn_net::NetworkHandle::dial_addr`] and #2530. Those peers are picked up from
+/// [`icn_net::NetworkHandle::connected_peers`] once they authenticate.
 pub async fn dial_bootstrap_peers(
     config: &BootstrapConfig,
     network_handle: &NetworkHandle,
@@ -96,12 +97,14 @@ pub async fn dial_bootstrap_peers(
                 // separately by the Hello handshake.
                 match network_handle.dial_addr(peer_addr).await {
                     Ok(placeholder_did) => {
+                        // Deliberately not added to `connected_peers`: the placeholder
+                        // names no peer and addresses nothing. This peer becomes
+                        // addressable once Hello authenticates it (#2530).
                         info!(
                             "✓ Connected to bootstrap peer at {} (placeholder key {}; \
                              peer identity not yet authenticated — awaiting Hello)",
                             peer_addr, placeholder_did
                         );
-                        connected_peers.push(placeholder_did);
                     }
                     Err(e) => {
                         warn!(
@@ -129,14 +132,9 @@ pub async fn request_peer_exchange(
     network_handle: &NetworkHandle,
     connected_peers: Vec<Did>,
 ) {
-    if !config.federation_enabled || connected_peers.is_empty() {
+    if !config.federation_enabled {
         return;
     }
-
-    info!(
-        "Federation enabled - requesting peer exchange from {} bootstrap peers",
-        connected_peers.len()
-    );
 
     let network_filter = if config.network_name != "icn-mainnet" {
         Some(config.network_name.clone())
@@ -146,10 +144,31 @@ pub async fn request_peer_exchange(
 
     let peer_exchange_delay = Duration::from_millis(config.peer_exchange_delay_ms);
 
-    for peer_did in connected_peers {
-        // Small delay to allow Hello handshake to complete
-        tokio::time::sleep(peer_exchange_delay).await;
+    // Wait out the handshake window before choosing targets. Address-only bootstrap peers
+    // have no addressable identity until Hello completes, so they can only be named after
+    // authenticating — asking the network handle afterwards is what picks them up (#2530).
+    tokio::time::sleep(peer_exchange_delay).await;
 
+    let mut targets = connected_peers;
+    for authenticated in network_handle.connected_peers().await {
+        if !targets.contains(&authenticated) {
+            targets.push(authenticated);
+        }
+    }
+
+    if targets.is_empty() {
+        info!(
+            "Federation enabled - no authenticated bootstrap peers to request peer exchange from"
+        );
+        return;
+    }
+
+    info!(
+        "Federation enabled - requesting peer exchange from {} bootstrap peers",
+        targets.len()
+    );
+
+    for peer_did in targets {
         match network_handle
             .request_peer_exchange(
                 &peer_did,

--- a/icn/crates/icn-net/src/actor/messages.rs
+++ b/icn/crates/icn-net/src/actor/messages.rs
@@ -19,12 +19,11 @@
 use anyhow::{Context, Result};
 use icn_identity::Did;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 use tracing::{info, instrument, warn};
 
 use crate::{
     protocol::{write_message, write_message_negotiated, NetworkMessage},
-    NetworkMsg, NetworkStats, SessionManager, TraversalMode,
+    NetworkMsg, NetworkStats, TraversalMode,
 };
 
 use super::NetworkActor;
@@ -45,6 +44,15 @@ impl NetworkActor {
                 response,
             } => {
                 let result = self.handle_dial(addr, did, peer_relay_addr).await;
+                let _ = response.send(result);
+            }
+
+            NetworkMsg::DialProvisional {
+                addr,
+                placeholder,
+                response,
+            } => {
+                let result = self.handle_dial_provisional(addr, placeholder).await;
                 let _ = response.send(result);
             }
 
@@ -92,6 +100,47 @@ impl NetworkActor {
                 let _ = tx.send(status);
             }
         }
+    }
+
+    /// Dial an address whose peer identity is not yet known.
+    ///
+    /// The connection is established and wired for traffic, but is **not** registered in
+    /// the session manager's connection map. That map's readers treat every key as an
+    /// authenticated peer — peer exchange republishes them to other nodes, broadcast opens
+    /// a stream per entry, `connections_active` counts them — and the only key available
+    /// here is derived from the address, so no peer could ever authenticate as it and
+    /// nothing would ever evict it (#2530).
+    ///
+    /// The connection becomes addressable when Hello proves who is on it.
+    ///
+    /// No relay fallback: an address-only dial has no peer relay candidate to fall back to,
+    /// which is why the previous implementation passed `None` for it.
+    async fn handle_dial_provisional(
+        &mut self,
+        addr: std::net::SocketAddr,
+        placeholder: Did,
+    ) -> Result<()> {
+        let dial_timeout = std::time::Duration::from_millis(
+            self.dial_timeout_ms
+                .load(std::sync::atomic::Ordering::Relaxed),
+        );
+
+        let connection = tokio::time::timeout(dial_timeout, {
+            let sm = self.session_manager.clone();
+            async move { sm.read().await.connect_unregistered(addr).await }
+        })
+        .await
+        .context("Timeout dialing peer (provisional)")
+        .and_then(|r| r)?;
+
+        {
+            let mut ns = self.nat_status.write().await;
+            ns.last_traversal_mode = TraversalMode::Direct;
+            ns.last_direct_error = None;
+        }
+
+        self.wire_new_connection(connection, &placeholder);
+        Ok(())
     }
 
     /// Handle a dial request with direct-then-relay fallback.
@@ -260,7 +309,15 @@ impl NetworkActor {
 
     /// Wire up a newly-established connection: stats, connection handler, Hello message.
     ///
-    /// This is called for both direct and relayed connections.
+    /// This is called for both direct and relayed connections, and for provisional
+    /// address-only dials that have no authenticated peer identity yet.
+    ///
+    /// `did` addresses the outgoing Hello and labels logs. It is **not** required to be
+    /// an authenticated identity and is never used to look the connection up: the Hello
+    /// is written straight to `connection`. That is what lets a provisional dial stay out
+    /// of the session manager's authenticated connection map entirely (#2530) — the map
+    /// lookup this used to perform was the only thing that forced an unauthenticated key
+    /// to be registered before the handshake could run.
     fn wire_new_connection(&self, connection: quinn::Connection, did: &Did) {
         // Increment connection counter
         let stats = self.stats.clone();
@@ -283,10 +340,11 @@ impl NetworkActor {
             let misbehavior_detector = self.misbehavior_detector.clone();
             let identity_bundle = self.identity_bundle.clone();
             let own_did = self.own_did.clone();
+            let handler_connection = connection.clone();
 
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_connection(
-                    connection.clone(),
+                    handler_connection,
                     handler,
                     rate_limiter,
                     replay_guard,
@@ -363,12 +421,14 @@ impl NetworkActor {
 
         match hello_msg_result {
             Ok(hello_msg) => {
-                let session_mgr = self.session_manager.clone();
+                // Write the Hello to the connection we were just handed, rather than
+                // looking it up by DID. On an address-only dial there is no authenticated
+                // DID to look up, and inventing a placeholder key for the map is what
+                // created the phantom peer entries in #2530.
+                let hello_connection = connection.clone();
                 let did_clone = did.clone();
                 tokio::spawn(async move {
-                    if let Err(e) =
-                        send_handshake_internal(session_mgr, &did_clone, hello_msg).await
-                    {
+                    if let Err(e) = send_handshake_on(&hello_connection, hello_msg).await {
                         warn!("Failed to send Hello to {}: {}", did_clone, e);
                     }
                 });
@@ -527,19 +587,17 @@ impl NetworkActor {
     }
 }
 
-/// Send handshake message to a peer
-pub(super) async fn send_handshake_internal(
-    session_manager: Arc<RwLock<SessionManager>>,
-    peer_did: &Did,
+/// Send a handshake message directly on an established connection.
+///
+/// Deliberately takes the connection rather than a DID. The Hello handshake is what
+/// *establishes* the peer's identity, so requiring an identity to address it inverted the
+/// dependency: an address-only dial had to register a synthetic, address-derived key in
+/// the authenticated connection map just so this lookup could succeed, and that key then
+/// outlived the handshake and leaked into peer-facing topology (#2530).
+pub(super) async fn send_handshake_on(
+    connection: &quinn::Connection,
     handshake_msg: NetworkMessage,
 ) -> Result<()> {
-    let connections = session_manager.read().await.connections().await;
-    let connection = connections
-        .iter()
-        .find(|(did, _)| did == peer_did.as_str())
-        .map(|(_, conn)| conn.clone())
-        .context("No connection to peer")?;
-
     let (mut send, _recv) = connection
         .open_bi()
         .await
@@ -547,6 +605,9 @@ pub(super) async fn send_handshake_internal(
     write_message(&mut send, &handshake_msg).await?;
     send.finish().context("Failed to finish stream")?;
 
-    info!("Sent handshake to {}", peer_did);
+    info!(
+        remote_addr = %connection.remote_address(),
+        "Sent handshake"
+    );
     Ok(())
 }

--- a/icn/crates/icn-net/src/actor/messages.rs
+++ b/icn/crates/icn-net/src/actor/messages.rs
@@ -47,15 +47,6 @@ impl NetworkActor {
                 let _ = response.send(result);
             }
 
-            NetworkMsg::DialProvisional {
-                addr,
-                placeholder,
-                response,
-            } => {
-                let result = self.handle_dial_provisional(addr, placeholder).await;
-                let _ = response.send(result);
-            }
-
             NetworkMsg::SendMessage {
                 did,
                 message,
@@ -100,47 +91,6 @@ impl NetworkActor {
                 let _ = tx.send(status);
             }
         }
-    }
-
-    /// Dial an address whose peer identity is not yet known.
-    ///
-    /// The connection is established and wired for traffic, but is **not** registered in
-    /// the session manager's connection map. That map's readers treat every key as an
-    /// authenticated peer — peer exchange republishes them to other nodes, broadcast opens
-    /// a stream per entry, `connections_active` counts them — and the only key available
-    /// here is derived from the address, so no peer could ever authenticate as it and
-    /// nothing would ever evict it (#2530).
-    ///
-    /// The connection becomes addressable when Hello proves who is on it.
-    ///
-    /// No relay fallback: an address-only dial has no peer relay candidate to fall back to,
-    /// which is why the previous implementation passed `None` for it.
-    async fn handle_dial_provisional(
-        &mut self,
-        addr: std::net::SocketAddr,
-        placeholder: Did,
-    ) -> Result<()> {
-        let dial_timeout = std::time::Duration::from_millis(
-            self.dial_timeout_ms
-                .load(std::sync::atomic::Ordering::Relaxed),
-        );
-
-        let connection = tokio::time::timeout(dial_timeout, {
-            let sm = self.session_manager.clone();
-            async move { sm.read().await.connect_unregistered(addr).await }
-        })
-        .await
-        .context("Timeout dialing peer (provisional)")
-        .and_then(|r| r)?;
-
-        {
-            let mut ns = self.nat_status.write().await;
-            ns.last_traversal_mode = TraversalMode::Direct;
-            ns.last_direct_error = None;
-        }
-
-        self.wire_new_connection(connection, &placeholder);
-        Ok(())
     }
 
     /// Handle a dial request with direct-then-relay fallback.
@@ -261,12 +211,13 @@ impl NetworkActor {
 
                 match relay_result {
                     Ok(connection) => {
-                        // Store the connection in session manager so send_message works
-                        self.session_manager
-                            .read()
-                            .await
-                            .store_incoming_connection(did.as_str().to_string(), connection.clone())
-                            .await;
+                        // Not registered as a peer here. Reaching a peer through a relay is
+                        // still only transport: `did` is the identity we expected to find,
+                        // and the relayed connection earns its place in the connection map
+                        // the same way a direct one does — when Hello binds a DID to this
+                        // connection's certificate. Registering it here called the
+                        // *authenticated* installer with an unauthenticated DID, which is
+                        // precisely the precondition that installer documents (#2530).
 
                         // Store proxy handle so it stays alive
                         self.relay_proxies.write().await.insert(did.clone(), proxy);

--- a/icn/crates/icn-net/src/actor/mod.rs
+++ b/icn/crates/icn-net/src/actor/mod.rs
@@ -94,19 +94,6 @@ pub enum NetworkMsg {
         response: oneshot::Sender<Result<()>>,
     },
 
-    /// Dial an address whose peer identity is not yet known.
-    ///
-    /// Distinct from [`NetworkMsg::Dial`] because the connection must **not** be
-    /// registered as a peer until Hello authenticates one: there is no identity to
-    /// register it under, and a stand-in derived from the address is not one (#2530).
-    DialProvisional {
-        addr: SocketAddr,
-        /// Address-derived key used to address the outgoing Hello and label logs.
-        /// Local bookkeeping only — never an authenticated identity.
-        placeholder: Did,
-        response: oneshot::Sender<Result<()>>,
-    },
-
     /// Send a network message to a specific peer
     SendMessage {
         did: Did,
@@ -256,27 +243,19 @@ impl NetworkHandle {
     /// handler, after DID-TLS binding verification, and *that* is the identity
     /// the connection is registered under.
     ///
-    /// The placeholder is never registered as a peer: it addresses the outgoing
-    /// Hello and labels logs, and then it is done. Until the handshake proves an
-    /// identity the connection is deliberately not addressable by DID, so a peer
-    /// that answers on the wire but never authenticates leaves nothing behind
-    /// (#2530).
+    /// The placeholder is never registered as a peer. Nor is the DID passed to
+    /// an ordinary [`Self::dial`]: no outbound path writes to the connection map,
+    /// because transport success says nothing about who answered. Until Hello
+    /// proves an identity the connection is deliberately not addressable by DID,
+    /// so a peer that answers on the wire but never authenticates leaves nothing
+    /// behind (#2530).
     ///
     /// Callers must not treat the returned `Did` as an authenticated peer
     /// identity, must not report it as one, and must not use it as a send
     /// target — sending to it will fail, because no such peer exists.
     pub async fn dial_addr(&self, addr: SocketAddr) -> Result<Did> {
         let placeholder = derive_placeholder_did(addr)?;
-        let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(NetworkMsg::DialProvisional {
-                addr,
-                placeholder: placeholder.clone(),
-                response: tx,
-            })
-            .await
-            .context("Network actor closed")?;
-        rx.await.context("Response channel closed")??;
+        self.dial(addr, placeholder.clone()).await?;
         Ok(placeholder)
     }
 
@@ -421,17 +400,20 @@ impl NetworkHandle {
             .map(|info| info.x25519_key)
     }
 
-    /// DIDs of peers we currently hold a live, authenticated session with.
+    /// Peers we currently hold a live, authenticated session with, and the address each is
+    /// reachable at.
     ///
-    /// Every key in the session manager's connection map is an authenticated peer DID:
-    /// entries are installed only after Hello verifies the DID-TLS binding (#2520), and a
-    /// provisional address-only dial is deliberately not registered until then (#2530). So
-    /// this is the authenticated view, and it is the right source for anything that needs
-    /// to *name* a peer.
+    /// Every key in the session manager's connection map is an authenticated peer DID.
+    /// That is true because `install_incoming_connection` is the map's only insertion path
+    /// and it runs after Hello has bound the DID to this connection's certificate (#2520);
+    /// no outbound dial registers anything, since neither an address nor a caller-supplied
+    /// DID is proof of who answered (#2530). If a future writer inserts before
+    /// authentication, this method silently starts reporting unauthenticated identities —
+    /// so that invariant belongs to the map, not to this accessor.
     ///
     /// Closed connections are filtered out: map occupancy is not proof of liveness, since a
     /// peer's restart leaves a dead entry behind until something replaces it (#2504).
-    pub async fn connected_peers(&self) -> Vec<Did> {
+    pub async fn connected_peer_endpoints(&self) -> Vec<(Did, SocketAddr)> {
         self.session_manager
             .read()
             .await
@@ -439,7 +421,18 @@ impl NetworkHandle {
             .await
             .into_iter()
             .filter(|(_, conn)| conn.close_reason().is_none())
-            .filter_map(|(did, _)| did.parse::<Did>().ok())
+            .filter_map(|(did, conn)| Some((did.parse::<Did>().ok()?, conn.remote_address())))
+            .collect()
+    }
+
+    /// DIDs of peers we currently hold a live, authenticated session with.
+    ///
+    /// See [`Self::connected_peer_endpoints`] for why these are authenticated.
+    pub async fn connected_peers(&self) -> Vec<Did> {
+        self.connected_peer_endpoints()
+            .await
+            .into_iter()
+            .map(|(did, _)| did)
             .collect()
     }
 

--- a/icn/crates/icn-net/src/actor/mod.rs
+++ b/icn/crates/icn-net/src/actor/mod.rs
@@ -94,6 +94,19 @@ pub enum NetworkMsg {
         response: oneshot::Sender<Result<()>>,
     },
 
+    /// Dial an address whose peer identity is not yet known.
+    ///
+    /// Distinct from [`NetworkMsg::Dial`] because the connection must **not** be
+    /// registered as a peer until Hello authenticates one: there is no identity to
+    /// register it under, and a stand-in derived from the address is not one (#2530).
+    DialProvisional {
+        addr: SocketAddr,
+        /// Address-derived key used to address the outgoing Hello and label logs.
+        /// Local bookkeeping only — never an authenticated identity.
+        placeholder: Did,
+        response: oneshot::Sender<Result<()>>,
+    },
+
     /// Send a network message to a specific peer
     SendMessage {
         did: Did,
@@ -240,16 +253,31 @@ impl NetworkHandle {
     /// that the value's derivation is independent of the dial's outcome.)
     ///
     /// The peer's authenticated DID is recorded separately by the Hello
-    /// handler, into `peer_connections`, after DID-TLS binding verification.
-    /// The placeholder entry in the session manager's connection map is
-    /// **not** re-keyed or evicted — see #2530.
+    /// handler, after DID-TLS binding verification, and *that* is the identity
+    /// the connection is registered under.
+    ///
+    /// The placeholder is never registered as a peer: it addresses the outgoing
+    /// Hello and labels logs, and then it is done. Until the handshake proves an
+    /// identity the connection is deliberately not addressable by DID, so a peer
+    /// that answers on the wire but never authenticates leaves nothing behind
+    /// (#2530).
     ///
     /// Callers must not treat the returned `Did` as an authenticated peer
-    /// identity, and must not report it as one.
+    /// identity, must not report it as one, and must not use it as a send
+    /// target — sending to it will fail, because no such peer exists.
     pub async fn dial_addr(&self, addr: SocketAddr) -> Result<Did> {
-        let temp_did = derive_placeholder_did(addr)?;
-        self.dial(addr, temp_did.clone()).await?;
-        Ok(temp_did)
+        let placeholder = derive_placeholder_did(addr)?;
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(NetworkMsg::DialProvisional {
+                addr,
+                placeholder: placeholder.clone(),
+                response: tx,
+            })
+            .await
+            .context("Network actor closed")?;
+        rx.await.context("Response channel closed")??;
+        Ok(placeholder)
     }
 
     /// Send a network message to a specific peer
@@ -391,6 +419,28 @@ impl NetworkHandle {
             .await
             .get(did)
             .map(|info| info.x25519_key)
+    }
+
+    /// DIDs of peers we currently hold a live, authenticated session with.
+    ///
+    /// Every key in the session manager's connection map is an authenticated peer DID:
+    /// entries are installed only after Hello verifies the DID-TLS binding (#2520), and a
+    /// provisional address-only dial is deliberately not registered until then (#2530). So
+    /// this is the authenticated view, and it is the right source for anything that needs
+    /// to *name* a peer.
+    ///
+    /// Closed connections are filtered out: map occupancy is not proof of liveness, since a
+    /// peer's restart leaves a dead entry behind until something replaces it (#2504).
+    pub async fn connected_peers(&self) -> Vec<Did> {
+        self.session_manager
+            .read()
+            .await
+            .connections()
+            .await
+            .into_iter()
+            .filter(|(_, conn)| conn.close_reason().is_none())
+            .filter_map(|(did, _)| did.parse::<Did>().ok())
+            .collect()
     }
 
     /// Get this node's connection candidate for NAT traversal

--- a/icn/crates/icn-net/src/session.rs
+++ b/icn/crates/icn-net/src/session.rs
@@ -306,43 +306,26 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Open a QUIC connection to `addr` **without** registering it as a peer.
+    /// Dial `addr`, expecting to reach `peer_did`.
     ///
-    /// This is the transport half of dialling: it establishes the connection and hands it
-    /// back, leaving the caller to drive the handshake. Nothing is written to
-    /// [`Self::connections`], because at this point nothing is known about who is on the
-    /// other end — only that something at `addr` completed a QUIC/TLS handshake.
+    /// Returns a QUIC connection to the peer. The connection is **not** registered as a
+    /// peer: `peer_did` is what the caller *expects* to find there, and expectation is not
+    /// proof. It comes from operator configuration, from a DID another node advertised over
+    /// peer exchange, or from a discovery candidate — none of which is a cryptographic
+    /// statement about who will answer. Registration happens in
+    /// [`install_incoming_connection`], once Hello has bound a DID to this connection's
+    /// certificate (#2520).
     ///
-    /// Address-only bootstrap dials use this directly. Their only available key would be a
-    /// placeholder derived from the address, which no peer can ever authenticate as and
-    /// which therefore could never be reconciled, replaced or evicted; registering one made
-    /// a single physical connection appear as two peers and published a synthetic identity
-    /// through peer exchange (#2530). The connection becomes addressable when — and only
-    /// when — Hello proves who is on it.
-    pub async fn connect_unregistered(&self, addr: SocketAddr) -> Result<quinn::Connection> {
-        let endpoint = self
-            .endpoint
-            .read()
-            .await
-            .as_ref()
-            .context("Session manager not started")?
-            .clone();
-
-        info!("Dialing peer at {} (identity not yet known)", addr);
-
-        let connection = endpoint
-            .connect(addr, "localhost")?
-            .await
-            .context("Failed to connect to peer")?;
-
-        info!("Connected to peer at {} (awaiting Hello)", addr);
-
-        Ok(connection)
-    }
-
-    /// Dial a peer at the given address
+    /// `peer_did` is still load-bearing here: it suppresses duplicate connections to a peer
+    /// we already hold a live session with, and it is what the outgoing Hello is addressed
+    /// to. It just never becomes an entry in the connection map (#2530).
     ///
-    /// Returns a QUIC connection to the peer.
+    /// **The caller owns the returned connection.** Dropping it closes the QUIC connection,
+    /// because nothing else holds it: registering the dial in the connection map used to
+    /// keep it alive as a side effect, and that is exactly the pre-authentication entry this
+    /// no longer creates. In production `NetworkActor::handle_dial` hands it to
+    /// `wire_new_connection`, which moves it into the spawned connection handler — the task
+    /// that reads from it — and that task is its owner until Hello registers it or it closes.
     pub async fn dial(&self, addr: SocketAddr, peer_did: String) -> Result<quinn::Connection> {
         // Never dial ourselves into our own remote-peer map (#2506). Discovery sources echo our
         // own advertisement back to us — over `network:candidates`, peer exchange, or mDNS — and
@@ -374,34 +357,42 @@ impl SessionManager {
 
         info!("Connected to peer at {}", addr);
 
-        // Store connection, or return the existing one if we already have a *live* one.
+        // Return the existing connection instead if we already hold a *live, authenticated*
+        // session with the peer we expected to reach, so a redundant dial does not displace
+        // a working session with a second one.
         //
         // A closed entry must never win over a freshly dialed connection: after a peer restarts,
         // our cached connection to it is dead, and preferring it would make every send fail
-        // until this process restarts (#2504).
-        let mut connections = self.connections.write().await;
-        if let Some(existing) = connections.get(&peer_did) {
-            match existing.close_reason() {
-                None => {
-                    info!(
-                        "Connection already exists for {} (from incoming), returning existing connection and closing new one",
-                        peer_did
-                    );
-                    let existing_conn = existing.clone();
-                    drop(connections); // Release lock before closing
-                    connection.close(0u32.into(), b"duplicate");
-                    return Ok(existing_conn);
+        // until this process restarts (#2504). So a closed entry is simply passed over here —
+        // the peer's Hello on the new connection replaces it.
+        //
+        // This only *reads* the map. Nothing is inserted: `peer_did` is the caller's
+        // expectation, and a connection becomes a peer when Hello proves an identity for it,
+        // not when the transport comes up (#2530).
+        let existing_live = {
+            let connections = self.connections.read().await;
+            match connections.get(&peer_did) {
+                Some(existing) if existing.close_reason().is_none() => Some(existing.clone()),
+                Some(existing) => {
+                    if let Some(reason) = existing.close_reason() {
+                        info!(
+                            "Existing connection for {} is closed ({}); using the connection we just dialed",
+                            peer_did, reason
+                        );
+                    }
+                    None
                 }
-                Some(reason) => {
-                    info!(
-                        "Replacing closed connection for {} ({}) with the connection we just dialed",
-                        peer_did, reason
-                    );
-                }
+                None => None,
             }
+        };
+        if let Some(existing_conn) = existing_live {
+            info!(
+                "Live session already exists for {}, returning it and closing the connection we just dialed",
+                peer_did
+            );
+            connection.close(0u32.into(), b"duplicate");
+            return Ok(existing_conn);
         }
-        connections.insert(peer_did, connection.clone());
-        drop(connections);
 
         Ok(connection)
     }
@@ -1034,6 +1025,15 @@ mod tests {
     }
 
     /// Have `dialer` connect to `listener`, returning the connection `listener` accepted.
+    /// Dialer-side connections, kept alive for the lifetime of the test binary.
+    ///
+    /// `SessionManager::dial` transfers ownership of the connection to its caller, so
+    /// dropping it closes the QUIC connection and tears down the listener side these tests
+    /// are about to assert on. Production keeps it alive by moving it into the spawned
+    /// connection handler; there is no such handler here, so the test binary holds it.
+    static DIALER_SIDE: std::sync::Mutex<Vec<quinn::Connection>> =
+        std::sync::Mutex::new(Vec::new());
+
     async fn connect(
         listener: &SessionManager,
         dialer: &SessionManager,
@@ -1042,7 +1042,11 @@ mod tests {
         let listener_clone = listener.clone_for_test();
         let accept_task = tokio::spawn(async move { listener_clone.accept().await });
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        dialer.dial(addr, "listener".to_string()).await.unwrap();
+        let dialer_side = dialer.dial(addr, "listener".to_string()).await.unwrap();
+        DIALER_SIDE
+            .lock()
+            .expect("dialer-side lock poisoned")
+            .push(dialer_side);
         accept_task.await.unwrap().unwrap().unwrap()
     }
 
@@ -1060,6 +1064,86 @@ mod tests {
             return false;
         };
         conn.open_bi().await.is_ok()
+    }
+
+    /// Regression test for #2530: installing an authenticated DID collapses any other key
+    /// standing for the same physical connection.
+    ///
+    /// No outbound path registers a connection any more, so nothing in production *should*
+    /// be able to create such an alias. This asserts the installer's own invariant directly
+    /// rather than through a path that happens to produce one, so the guarantee survives a
+    /// future writer that reintroduces a pre-authentication key — which is exactly how the
+    /// placeholder got in.
+    #[tokio::test]
+    async fn test_install_evicts_other_keys_for_the_same_connection() {
+        setup();
+
+        let (survivor, survivor_addr) = start_manager().await;
+        let (peer, _) = start_manager().await;
+        let inbound = connect(&survivor, &peer, survivor_addr).await;
+
+        // A key standing in for the peer before it authenticated: an address-derived
+        // placeholder, a configured DID, a DID some other node advertised — the installer
+        // does not care which, only that it is not the DID that just authenticated.
+        let provisional = "did:icn:zProvisionalStandIn".to_string();
+        let authenticated = "did:icn:zAuthenticatedPeer".to_string();
+        survivor
+            .connections
+            .write()
+            .await
+            .insert(provisional.clone(), inbound.clone());
+
+        install_incoming_connection(
+            &survivor.connections,
+            survivor.local_did().await.as_deref(),
+            authenticated.clone(),
+            inbound.clone(),
+        )
+        .await;
+
+        let keys: Vec<String> = survivor.connections.read().await.keys().cloned().collect();
+        assert_eq!(
+            keys,
+            vec![authenticated],
+            "one physical connection must end up under exactly one identity; {provisional} \
+             survived alongside it (#2530)"
+        );
+    }
+
+    /// A key for a *different* connection must survive the alias collapse.
+    ///
+    /// The eviction matches on connection identity, not on the key, so it must never be
+    /// able to unregister a peer that simply happens to be in the map at the time — the
+    /// "removal of the wrong connection" hazard.
+    #[tokio::test]
+    async fn test_install_does_not_evict_keys_for_other_connections() {
+        setup();
+
+        let (survivor, survivor_addr) = start_manager().await;
+        let (peer_a, _) = start_manager().await;
+        let (peer_b, _) = start_manager().await;
+        let conn_a = connect(&survivor, &peer_a, survivor_addr).await;
+        let conn_b = connect(&survivor, &peer_b, survivor_addr).await;
+
+        let unrelated = "did:icn:zUnrelatedLivePeer".to_string();
+        survivor
+            .connections
+            .write()
+            .await
+            .insert(unrelated.clone(), conn_a);
+
+        install_incoming_connection(
+            &survivor.connections,
+            survivor.local_did().await.as_deref(),
+            "did:icn:zNewlyAuthenticated".to_string(),
+            conn_b,
+        )
+        .await;
+
+        assert!(
+            survivor.connections.read().await.contains_key(&unrelated),
+            "installing one connection must not unregister a different, live connection"
+        );
     }
 
     /// Regression test for #2504.

--- a/icn/crates/icn-net/src/session.rs
+++ b/icn/crates/icn-net/src/session.rs
@@ -306,6 +306,40 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Open a QUIC connection to `addr` **without** registering it as a peer.
+    ///
+    /// This is the transport half of dialling: it establishes the connection and hands it
+    /// back, leaving the caller to drive the handshake. Nothing is written to
+    /// [`Self::connections`], because at this point nothing is known about who is on the
+    /// other end — only that something at `addr` completed a QUIC/TLS handshake.
+    ///
+    /// Address-only bootstrap dials use this directly. Their only available key would be a
+    /// placeholder derived from the address, which no peer can ever authenticate as and
+    /// which therefore could never be reconciled, replaced or evicted; registering one made
+    /// a single physical connection appear as two peers and published a synthetic identity
+    /// through peer exchange (#2530). The connection becomes addressable when — and only
+    /// when — Hello proves who is on it.
+    pub async fn connect_unregistered(&self, addr: SocketAddr) -> Result<quinn::Connection> {
+        let endpoint = self
+            .endpoint
+            .read()
+            .await
+            .as_ref()
+            .context("Session manager not started")?
+            .clone();
+
+        info!("Dialing peer at {} (identity not yet known)", addr);
+
+        let connection = endpoint
+            .connect(addr, "localhost")?
+            .await
+            .context("Failed to connect to peer")?;
+
+        info!("Connected to peer at {} (awaiting Hello)", addr);
+
+        Ok(connection)
+    }
+
     /// Dial a peer at the given address
     ///
     /// Returns a QUIC connection to the peer.
@@ -817,6 +851,10 @@ fn resolve_local_addr(port: u16) -> Option<SocketAddr> {
 /// to compare against and therefore no connections either; both production callers pass `Some`.
 /// It is a required parameter rather than ambient state so that a future insertion path cannot
 /// install a connection without first stating which DID is ours (#2506).
+///
+/// On return, no key other than `peer_did` maps to `connection`: this is the point at which a
+/// connection acquires its single canonical identity, so any provisional key that was standing in
+/// for it beforehand is dropped here (#2530).
 pub(crate) async fn install_incoming_connection(
     connections: &Arc<RwLock<HashMap<String, quinn::Connection>>>,
     local_did: Option<&str>,
@@ -839,6 +877,33 @@ pub(crate) async fn install_incoming_connection(
     }
 
     let mut connections = connections.write().await;
+
+    // One physical connection, one identity. Any *other* key mapping to this same
+    // connection is an alias left over from before the peer authenticated — a placeholder
+    // from an address-only dial, or a DID that was configured for this address but turned
+    // out not to be who answered. Consumers read this map as authenticated peer topology:
+    // peer exchange publishes its keys to other nodes, broadcast opens a stream per entry,
+    // and `connections_active` counts entries as peers. So an alias is not a duplicate
+    // record, it is a phantom peer (#2530).
+    //
+    // Matching on `stable_id` compares connection *identity*, not address or key, so this
+    // can only ever drop an alias of the connection in hand — never a different, newer
+    // connection to the same peer. Done under the same write guard as the insert below, so
+    // no reader observes both keys.
+    let alias_id = connection.stable_id();
+    connections.retain(|key, existing| {
+        let is_alias = key != &peer_did && existing.stable_id() == alias_id;
+        if is_alias {
+            info!(
+                evicted_key = %key,
+                authenticated_did = %peer_did,
+                remote_addr = %connection.remote_address(),
+                "Evicting provisional connection key superseded by the authenticated DID (#2530)"
+            );
+        }
+        !is_alias
+    });
+
     match connections.entry(peer_did) {
         Entry::Occupied(mut entry) if entry.get().close_reason().is_some() => {
             info!(

--- a/icn/crates/icn-net/tests/provisional_connection_lifecycle.rs
+++ b/icn/crates/icn-net/tests/provisional_connection_lifecycle.rs
@@ -34,8 +34,25 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
 
+/// Ports already handed out in this process.
+///
+/// `pick_unused_port` binds, closes, and returns the port, so two tests running
+/// concurrently can be handed the same one — the port is genuinely free at each moment it
+/// is checked. Remembering what we issued removes that race within the process; callers
+/// still retry, because nothing can rule out another process taking it in between.
+static ISSUED_PORTS: std::sync::Mutex<Option<std::collections::HashSet<u16>>> =
+    std::sync::Mutex::new(None);
+
 fn pick_port() -> u16 {
-    portpicker::pick_unused_port().expect("no free port")
+    let mut guard = ISSUED_PORTS.lock().expect("issued-port lock poisoned");
+    let issued = guard.get_or_insert_with(std::collections::HashSet::new);
+    for _ in 0..200 {
+        let port = portpicker::pick_unused_port().expect("no free port");
+        if issued.insert(port) {
+            return port;
+        }
+    }
+    panic!("could not find an unissued free port");
 }
 
 fn init() {
@@ -66,33 +83,45 @@ async fn spawn_node_counting(
     counter: Arc<AtomicUsize>,
     variant: &'static str,
 ) -> Result<(NetworkHandle, SocketAddr, Guard)> {
-    let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
     let (shutdown_tx, _) = broadcast::channel(1);
     let handler: IncomingMessageHandler = Arc::new(move |msg: NetworkMessage| {
         if !variant.is_empty() && msg.payload.variant_name() == variant {
             counter.fetch_add(1, Ordering::SeqCst);
         }
     });
-    let handle = NetworkActor::spawn(
-        bundle,
-        addr,
-        shutdown_tx.clone(),
-        Some(handler),
-        None, // oracle
-        None, // fallback_config
-        None, // topology_config
-        None, // stun_servers
-        None, // turn_config
-        None, // misbehavior_detector
-        None, // store
-        None, // personhood_store
-        None, // anchor_rate_config
-        None, // advertised_addr
-    )
-    .await?;
-    // Let the endpoint bind before anyone dials it.
-    tokio::time::sleep(Duration::from_millis(300)).await;
-    Ok((handle, addr, Guard(shutdown_tx)))
+
+    // Binding is setup, not the property under test, so it retries: a port reported free can
+    // still be taken by another process before we bind it.
+    let mut last_err = None;
+    for _ in 0..8 {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        match NetworkActor::spawn(
+            bundle.clone(),
+            addr,
+            shutdown_tx.clone(),
+            Some(handler.clone()),
+            None, // oracle
+            None, // fallback_config
+            None, // topology_config
+            None, // stun_servers
+            None, // turn_config
+            None, // misbehavior_detector
+            None, // store
+            None, // personhood_store
+            None, // anchor_rate_config
+            None, // advertised_addr
+        )
+        .await
+        {
+            Ok(handle) => {
+                // Let the endpoint bind before anyone dials it.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                return Ok((handle, addr, Guard(shutdown_tx)));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
 }
 
 /// Keeps a node's shutdown sender alive for the duration of a test.
@@ -294,17 +323,24 @@ async fn peer_exchange_must_not_advertise_address_derived_placeholders() -> Resu
     Ok(())
 }
 
-/// A dial keyed on a DID that turns out not to be who answered must not leave that DID
-/// behind as a peer.
+/// When the supplied DID is not who answered, only the DID that authenticated becomes
+/// canonical — and the supplied one is never exposed as a peer.
 ///
-/// `SessionManager::dial` registers the caller's *claimed* key before any handshake has
-/// happened, so a bootstrap entry carrying a stale or wrong DID for an address registers a
-/// peer that does not exist. Hello then authenticates whoever actually answered and
-/// registers them too, leaving one connection under two identities — the same aliasing the
-/// address-only path produces, reached by a different route. This is what the eviction in
-/// `install_incoming_connection` covers, independently of where the stale key came from.
+/// This pins the **hint** semantics, which is what ICN actually implements: per
+/// `parse_bootstrap_peer`, a supplied DID "yields configuration", and identity "is proven
+/// only by DID-TLS binding verification in the Hello handler". Nothing anywhere compares
+/// the supplied DID against the authenticated one, so a supplied DID is *not* a
+/// cryptographic pin, and this test deliberately does not assert that a mismatch is
+/// rejected.
+///
+/// What it does assert is the part that is a trust boundary either way: the unproven DID
+/// must never appear as authenticated topology, and one physical connection must end up
+/// under exactly one identity. Making a supplied DID an enforced pin is a separate design
+/// decision with real operational consequences — a stale bootstrap entry would become a
+/// hard connectivity failure rather than a degraded one — tracked in #2533.
 #[tokio::test]
-async fn dial_keyed_on_the_wrong_did_does_not_leave_a_phantom_peer() -> Result<()> {
+async fn only_the_authenticated_did_becomes_canonical_when_the_supplied_did_differs() -> Result<()>
+{
     init();
     let dialer = IdentityBundle::generate()?;
     let dialer_did = dialer.did().clone();
@@ -331,6 +367,13 @@ async fn dial_keyed_on_the_wrong_did_does_not_leave_a_phantom_peer() -> Result<(
         "the connection must be held under the DID that authenticated, not also under the \
          DID we guessed; found {} entries, so {wrong_did} survived as a phantom peer (#2530)",
         stats.connections_active
+    );
+
+    let authenticated = dialer_handle.connected_peers().await;
+    assert_eq!(
+        authenticated,
+        vec![listener_did.clone()],
+        "only the DID proven by Hello may be reported as an authenticated peer (#2530)"
     );
 
     let client = WireClient::connect(&interrogator, dialer_addr).await?;
@@ -429,38 +472,9 @@ async fn addr_only_dial_that_never_authenticates_leaves_no_peer_identity() -> Re
     let silent = IdentityBundle::generate()?;
 
     let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+    let silent = SilentPeer::spawn(&silent)?;
 
-    // A bare QUIC listener: completes the handshake, accepts the connection, and then
-    // says nothing. No Hello, so the dialer never learns an authenticated identity.
-    let silent_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
-    let server_config =
-        icn_net::tls::create_server_config(vec![silent.tls_cert().clone()], silent.tls_key())?;
-    let mut quic_server = quinn::ServerConfig::with_crypto(Arc::new(
-        quinn::crypto::rustls::QuicServerConfig::try_from(server_config)?,
-    ));
-    quic_server.transport_config(Arc::new({
-        let mut t = quinn::TransportConfig::default();
-        t.max_idle_timeout(Some(Duration::from_secs(60).try_into()?));
-        t
-    }));
-    let silent_endpoint = Endpoint::server(quic_server, silent_addr)?;
-    let accepted = tokio::spawn({
-        let endpoint = silent_endpoint.clone();
-        async move {
-            // Hold the accepted connection open; dropping it would close the connection
-            // and let the dialer clean up for the wrong reason.
-            let mut held = Vec::new();
-            while let Some(incoming) = endpoint.accept().await {
-                if let Ok(conn) = incoming.await {
-                    held.push(conn);
-                }
-            }
-            held
-        }
-    });
-    tokio::time::sleep(Duration::from_millis(300)).await;
-
-    let placeholder = dialer_handle.dial_addr(silent_addr).await?;
+    let placeholder = dialer_handle.dial_addr(silent.addr).await?;
 
     // Give the dialer ample opportunity to have registered something. There is no
     // observable "authentication finished" event here — that is the point — so this
@@ -476,6 +490,224 @@ async fn addr_only_dial_that_never_authenticates_leaves_no_peer_identity() -> Re
         stats.connections_active
     );
 
-    accepted.abort();
     Ok(())
+}
+
+/// A **DID-supplied** dial whose peer never authenticates must leave nothing behind either.
+///
+/// This is the same rule as the address-only case, reached through the ordinary
+/// `dial(addr, did)` path. A supplied DID is configuration or, worse, a claim relayed by
+/// another node through peer exchange — `init_network`'s auto-dial feeds
+/// `KnownPeer.did` straight into this path. `parse_bootstrap_peer` is explicit that
+/// neither bootstrap form authenticates anything: "parsing yields configuration, and the
+/// peer's identity is proven only by DID-TLS binding verification in the Hello handler."
+///
+/// So transport success must not promote the supplied DID into authenticated peer state.
+/// Otherwise any node can name an arbitrary DID at a reachable address and have every
+/// receiver adopt it as a peer, then re-advertise it — the placeholder was one instance of
+/// this, not the whole of it (#2530).
+#[tokio::test]
+async fn did_supplied_dial_that_never_authenticates_leaves_no_peer_identity() -> Result<()> {
+    init();
+    let dialer = IdentityBundle::generate()?;
+    let silent_identity = IdentityBundle::generate()?;
+
+    // The DID a caller claims lives at that address. Nothing has proven it.
+    let claimed_did = IdentityBundle::generate()?.did().clone();
+
+    let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+    let silent = SilentPeer::spawn(&silent_identity)?;
+
+    dialer_handle.dial(silent.addr, claimed_did.clone()).await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let stats = dialer_handle.get_stats().await?;
+    assert_eq!(
+        stats.connections_active, 0,
+        "QUIC success is not authentication: the claimed DID {claimed_did} must not become \
+         an active peer without an authenticated Hello; found {} entries (#2530)",
+        stats.connections_active
+    );
+
+    let authenticated = dialer_handle.connected_peers().await;
+    assert!(
+        authenticated.is_empty(),
+        "connected_peers() reports authenticated peers, so an unauthenticated claimed DID \
+         must never appear in it; got {authenticated:?} (#2530)"
+    );
+
+    Ok(())
+}
+
+/// A peer whose Hello fails the #2520 binding checks must not become authenticated state.
+///
+/// The dial supplies a DID and the peer answers with a Hello, so both of the inputs that
+/// could tempt an implementation into registering something are present — but the Hello is
+/// bound to a different certificate than the one on this connection, so it proves nothing.
+/// Neither the supplied DID nor the DID the Hello claims may end up as a peer, and #2530
+/// must not have opened a path that installs before verification.
+#[tokio::test]
+async fn peer_whose_hello_fails_binding_verification_becomes_no_ones_peer() -> Result<()> {
+    init();
+    let dialer = IdentityBundle::generate()?;
+    // Presents this identity's certificate on the wire...
+    let wire_identity = IdentityBundle::generate()?;
+    // ...but claims to be this one, with that one's own (valid, but wrong-cert) binding.
+    let impersonated = IdentityBundle::generate()?;
+    let impersonated_did = impersonated.did().clone();
+    let claimed_did = IdentityBundle::generate()?.did().clone();
+
+    let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+    let liar = SilentPeer::spawn_replying_with_hello(
+        &wire_identity,
+        NetworkMessage::hello(
+            impersonated_did.clone(),
+            claimed_did.clone(),
+            impersonated.binding_info(),
+            icn_net::VersionInfo::new("icnd-liar".to_string()),
+            None,
+            *impersonated.x25519_public_bytes(),
+            None,
+            None,
+        ),
+    )?;
+
+    dialer_handle.dial(liar.addr, claimed_did.clone()).await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let stats = dialer_handle.get_stats().await?;
+    assert_eq!(
+        stats.connections_active, 0,
+        "a Hello bound to a different certificate proves nothing, so neither the supplied \
+         DID {claimed_did} nor the claimed DID {impersonated_did} may become a peer; found \
+         {} entries (#2520, #2530)",
+        stats.connections_active
+    );
+    assert!(
+        dialer_handle
+            .get_peer_connection_info(&impersonated_did)
+            .await
+            .is_none(),
+        "a rejected Hello must not populate authenticated peer info (#2520)"
+    );
+
+    Ok(())
+}
+
+/// Positive control for the test above: the same scripted-peer harness, with a Hello whose
+/// binding *does* match the certificate it is presenting, must authenticate.
+///
+/// Without this, `peer_whose_hello_fails_binding_verification_becomes_no_ones_peer` would
+/// pass for free if the harness silently failed to deliver a Hello at all — the assertion
+/// there is an absence, and an absence proves nothing unless presence is reachable.
+#[tokio::test]
+async fn scripted_peer_with_a_matching_binding_does_authenticate() -> Result<()> {
+    init();
+    let dialer = IdentityBundle::generate()?;
+    let honest = IdentityBundle::generate()?;
+    let honest_did = honest.did().clone();
+    let claimed_did = IdentityBundle::generate()?.did().clone();
+
+    let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+    let peer = SilentPeer::spawn_replying_with_hello(
+        &honest,
+        NetworkMessage::hello(
+            honest_did.clone(),
+            claimed_did.clone(),
+            honest.binding_info(),
+            icn_net::VersionInfo::new("icnd-honest".to_string()),
+            None,
+            *honest.x25519_public_bytes(),
+            None,
+            None,
+        ),
+    )?;
+
+    dialer_handle.dial(peer.addr, claimed_did.clone()).await?;
+
+    assert!(
+        wait_until_authenticated(&dialer_handle, &honest_did, Duration::from_secs(20)).await,
+        "the harness must be able to deliver an acceptable Hello, otherwise the rejection \
+         test above proves nothing"
+    );
+    assert_eq!(
+        dialer_handle.connected_peers().await,
+        vec![honest_did],
+        "only the authenticated DID becomes a peer — not the DID we dialed with"
+    );
+
+    Ok(())
+}
+
+/// A bare QUIC listener that completes the handshake and then says nothing.
+///
+/// No Hello, so a dialer never learns an authenticated identity from it. It holds accepted
+/// connections open: dropping them would close the connection and let the dialer clean up
+/// for the wrong reason, which would make the assertions pass vacuously.
+struct SilentPeer {
+    addr: SocketAddr,
+    accept_task: tokio::task::JoinHandle<Vec<quinn::Connection>>,
+}
+
+impl SilentPeer {
+    fn spawn(identity: &IdentityBundle) -> Result<Self> {
+        Self::spawn_inner(identity, None)
+    }
+
+    /// Same, but answers each accepted connection with `hello` on a fresh stream.
+    fn spawn_replying_with_hello(identity: &IdentityBundle, hello: NetworkMessage) -> Result<Self> {
+        Self::spawn_inner(identity, Some(hello))
+    }
+
+    fn spawn_inner(identity: &IdentityBundle, hello: Option<NetworkMessage>) -> Result<Self> {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        let server_config = icn_net::tls::create_server_config(
+            vec![identity.tls_cert().clone()],
+            identity.tls_key(),
+        )?;
+        let mut quic_server = quinn::ServerConfig::with_crypto(Arc::new(
+            quinn::crypto::rustls::QuicServerConfig::try_from(server_config)?,
+        ));
+        quic_server.transport_config(Arc::new({
+            let mut t = quinn::TransportConfig::default();
+            t.max_idle_timeout(Some(Duration::from_secs(60).try_into()?));
+            t
+        }));
+        // Same retry rationale as `spawn_node_counting`.
+        let mut endpoint = None;
+        let mut addr = addr;
+        for _ in 0..8 {
+            match Endpoint::server(quic_server.clone(), addr) {
+                Ok(ep) => {
+                    endpoint = Some(ep);
+                    break;
+                }
+                Err(_) => addr = format!("127.0.0.1:{}", pick_port()).parse()?,
+            }
+        }
+        let endpoint = endpoint.context("could not bind the scripted peer")?;
+        let accept_task = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Some(incoming) = endpoint.accept().await {
+                if let Ok(conn) = incoming.await {
+                    if let Some(ref hello) = hello {
+                        if let Ok((mut send, _recv)) = conn.open_bi().await {
+                            let _ = icn_net::protocol::write_message(&mut send, hello).await;
+                            let _ = send.finish();
+                        }
+                    }
+                    held.push(conn);
+                }
+            }
+            held
+        });
+        std::thread::sleep(Duration::from_millis(300));
+        Ok(Self { addr, accept_task })
+    }
+}
+
+impl Drop for SilentPeer {
+    fn drop(&mut self) {
+        self.accept_task.abort();
+    }
 }

--- a/icn/crates/icn-net/tests/provisional_connection_lifecycle.rs
+++ b/icn/crates/icn-net/tests/provisional_connection_lifecycle.rs
@@ -1,0 +1,481 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! An address-only bootstrap dial must not leave a second, unauthenticated identity
+//! behind once the peer authenticates.
+//!
+//! `dial_addr` has no authenticated remote DID to key on, so it derives a placeholder
+//! from the socket address alone (`derive_placeholder_did`). That placeholder is local
+//! transport bookkeeping: it has no private key, nobody can ever authenticate as it, and
+//! it is computable offline by anyone who knows the address. The peer's real DID arrives
+//! later, on the Hello handshake, verified against the certificate of *this* connection
+//! (#2520).
+//!
+//! The session manager's connection map is documented as mapping *authenticated remote
+//! peer DIDs* to connections — `install_incoming_connection` states the precondition
+//! outright — and its readers act on that: peer exchange publishes its keys to other
+//! nodes as topology, broadcast opens one stream per entry, and `connections_active`
+//! counts entries as peers. So a placeholder that survives past Hello is not a cosmetic
+//! duplicate; it is an unauthenticated key sitting in an authenticated-only structure.
+//!
+//! These tests pin the lifecycle through the production composition path — two real
+//! `NetworkActor`s, real QUIC/TLS, real dispatch loop, real `handle_hello` — and assert
+//! on observable surfaces (`get_stats`, the peer-exchange wire response) rather than on
+//! private state. See #2530.
+
+use anyhow::{Context, Result};
+use icn_identity::{Did, IdentityBundle};
+use icn_net::{
+    IncomingMessageHandler, MessagePayload, NetworkActor, NetworkHandle, NetworkMessage,
+    PeerExchangeMessage,
+};
+use quinn::{ClientConfig, Endpoint};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+fn pick_port() -> u16 {
+    portpicker::pick_unused_port().expect("no free port")
+}
+
+fn init() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+}
+
+/// Spawn a real node on the production stack.
+///
+/// The handler is required, not optional: `NetworkActor::spawn` only starts the inbound
+/// accept loop when `incoming_handler` is `Some`, and it is also what makes
+/// `wire_new_connection` spawn a dispatch loop for an *outbound* connection. Without it
+/// the dialer would never process the peer's Hello response, so nothing in this file
+/// would authenticate and every assertion would pass or fail for the wrong reason.
+async fn spawn_node(bundle: IdentityBundle) -> Result<(NetworkHandle, SocketAddr, Guard)> {
+    spawn_node_counting(bundle, Arc::new(AtomicUsize::new(0)), "").await
+}
+
+/// Spawn a real node whose handler counts inbound messages of one payload variant.
+///
+/// Counting at the *handler* — the far end of the receiver's dispatch loop — is what makes
+/// the broadcast assertion meaningful: it counts messages that actually arrived and were
+/// decoded, not streams the sender believes it opened.
+async fn spawn_node_counting(
+    bundle: IdentityBundle,
+    counter: Arc<AtomicUsize>,
+    variant: &'static str,
+) -> Result<(NetworkHandle, SocketAddr, Guard)> {
+    let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let handler: IncomingMessageHandler = Arc::new(move |msg: NetworkMessage| {
+        if !variant.is_empty() && msg.payload.variant_name() == variant {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+    let handle = NetworkActor::spawn(
+        bundle,
+        addr,
+        shutdown_tx.clone(),
+        Some(handler),
+        None, // oracle
+        None, // fallback_config
+        None, // topology_config
+        None, // stun_servers
+        None, // turn_config
+        None, // misbehavior_detector
+        None, // store
+        None, // personhood_store
+        None, // anchor_rate_config
+        None, // advertised_addr
+    )
+    .await?;
+    // Let the endpoint bind before anyone dials it.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    Ok((handle, addr, Guard(shutdown_tx)))
+}
+
+/// Keeps a node's shutdown sender alive for the duration of a test.
+struct Guard(broadcast::Sender<()>);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+/// Poll until `observer` has authenticated `did`, or the deadline passes.
+///
+/// `peer_connections` is written only by `handle_hello`, after the #2520 DID-TLS binding
+/// checks pass, so this returning `true` is proof the handshake completed and the peer's
+/// real identity is known — the exact moment after which a provisional key has no reason
+/// to exist. Synchronising on that observable, rather than sleeping, is what keeps the
+/// negative assertions below non-vacuous: "placeholder already evicted" and "Hello not
+/// processed yet" would otherwise look identical.
+async fn wait_until_authenticated(observer: &NetworkHandle, did: &Did, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if observer.get_peer_connection_info(did).await.is_some() {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// A raw QUIC client that speaks the wire protocol without being an ICN node.
+///
+/// Used to interrogate a node's peer-exchange surface from outside: what a *remote* node
+/// is told is the property under test, and reading it off the wire keeps the assertion
+/// independent of how the responder happens to store its connections.
+struct WireClient {
+    _endpoint: Endpoint,
+    connection: quinn::Connection,
+}
+
+impl WireClient {
+    async fn connect(identity: &IdentityBundle, target: SocketAddr) -> Result<Self> {
+        let rustls_client = icn_net::tls::create_tofu_client_config(
+            vec![identity.tls_cert().clone()],
+            identity.tls_key(),
+        )?;
+        let mut endpoint = Endpoint::client("127.0.0.1:0".parse()?)?;
+        endpoint.set_default_client_config(ClientConfig::new(Arc::new(
+            quinn::crypto::rustls::QuicClientConfig::try_from(rustls_client)?,
+        )));
+
+        // Establishing the connection is a precondition, not the property under test, so
+        // it retries. No assertion below retries.
+        let mut last_err = None;
+        for attempt in 0..5 {
+            match tokio::time::timeout(
+                Duration::from_secs(10),
+                endpoint.connect(target, "localhost")?,
+            )
+            .await
+            {
+                Ok(Ok(connection)) => {
+                    return Ok(Self {
+                        _endpoint: endpoint,
+                        connection,
+                    })
+                }
+                Ok(Err(e)) => last_err = Some(e.to_string()),
+                Err(_) => last_err = Some("connect timed out".to_string()),
+            }
+            tokio::time::sleep(Duration::from_millis(150 * (attempt + 1))).await;
+        }
+        anyhow::bail!(
+            "could not establish the test connection after 5 attempts: {}",
+            last_err.unwrap_or_default()
+        )
+    }
+
+    /// Ask the peer for its known peers and return the DIDs it advertises.
+    ///
+    /// The responder answers on a *new* bidirectional stream it opens itself, so this
+    /// accepts an inbound stream rather than reading the reply half of the request.
+    async fn request_peer_exchange(
+        &self,
+        from: &Did,
+        to: &Did,
+        timeout: Duration,
+    ) -> Result<Vec<String>> {
+        let request = NetworkMessage::peer_exchange_request(from.clone(), to.clone(), 64, None);
+        let (mut send, _recv) = self.connection.open_bi().await?;
+        icn_net::protocol::write_message(&mut send, &request).await?;
+        send.finish().context("finish peer exchange request")?;
+
+        let (_send, mut recv) = tokio::time::timeout(timeout, self.connection.accept_bi())
+            .await
+            .context("timed out waiting for the peer exchange response stream")?
+            .context("peer exchange response stream failed")?;
+        let (message, _len) =
+            tokio::time::timeout(timeout, icn_net::protocol::read_message(&mut recv))
+                .await
+                .context("timed out reading the peer exchange response")?
+                .context("failed to read the peer exchange response")?;
+
+        match message.payload {
+            MessagePayload::PeerExchange(PeerExchangeMessage::Response { peers, .. }) => {
+                Ok(peers.into_iter().map(|peer| peer.did).collect())
+            }
+            other => anyhow::bail!("expected a PeerExchange::Response, got {other:?}"),
+        }
+    }
+}
+
+/// A successful address-only dial that authenticates must leave exactly one connection
+/// identity behind — the authenticated DID.
+///
+/// `connections_active` is the count of session-map entries and feeds the
+/// `icn_network_connections_active` gauge, so a surviving placeholder is not merely
+/// untidy: it reports one physical QUIC connection as two peers.
+#[tokio::test]
+async fn addr_only_dial_that_authenticates_leaves_one_connection_identity() -> Result<()> {
+    init();
+    let dialer = IdentityBundle::generate()?;
+    let listener = IdentityBundle::generate()?;
+    let listener_did = listener.did().clone();
+
+    let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+    let (_listener_handle, listener_addr, _listener_guard) = spawn_node(listener).await?;
+
+    // Address-only bootstrap: no DID is known in advance.
+    let placeholder = dialer_handle.dial_addr(listener_addr).await?;
+    assert_ne!(
+        placeholder, listener_did,
+        "precondition: the placeholder must not coincide with the peer's real DID"
+    );
+
+    assert!(
+        wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+        "precondition: the dialer never authenticated the peer, so nothing about the \
+         provisional key's fate has been exercised"
+    );
+
+    let stats = dialer_handle.get_stats().await?;
+    assert_eq!(
+        stats.connections_active, 1,
+        "one physical QUIC connection must have exactly one identity in the session map \
+         once the peer has authenticated; found {} entries, which means the provisional \
+         placeholder {placeholder} survived alongside the authenticated DID {listener_did} \
+         (#2530)",
+        stats.connections_active
+    );
+
+    Ok(())
+}
+
+/// Peer exchange must advertise only authenticated peers.
+///
+/// The placeholder is derivable offline from the address by anyone, and no peer can ever
+/// authenticate as it. Advertising it hands other nodes a phantom identity that they will
+/// treat as real topology.
+#[tokio::test]
+async fn peer_exchange_must_not_advertise_address_derived_placeholders() -> Result<()> {
+    init();
+    let dialer = IdentityBundle::generate()?;
+    let dialer_did = dialer.did().clone();
+    let listener = IdentityBundle::generate()?;
+    let listener_did = listener.did().clone();
+    let interrogator = IdentityBundle::generate()?;
+    let interrogator_did = interrogator.did().clone();
+
+    let (dialer_handle, dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+    let (_listener_handle, listener_addr, _listener_guard) = spawn_node(listener).await?;
+
+    let placeholder = dialer_handle.dial_addr(listener_addr).await?;
+    assert!(
+        wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+        "precondition: the dialer never authenticated the peer"
+    );
+
+    let client = WireClient::connect(&interrogator, dialer_addr).await?;
+    let advertised = client
+        .request_peer_exchange(&interrogator_did, &dialer_did, Duration::from_secs(20))
+        .await?;
+
+    // Positive control: without this, the negative assertion below would also pass on an
+    // empty response — i.e. if peer exchange were broken outright.
+    assert!(
+        advertised.contains(&listener_did.to_string()),
+        "precondition: the authenticated peer {listener_did} should be advertised, got {advertised:?}"
+    );
+    assert!(
+        !advertised.contains(&placeholder.to_string()),
+        "peer exchange advertised the address-derived placeholder {placeholder} as a peer \
+         identity; no node can ever authenticate as it, so every recipient now carries a \
+         phantom topology entry (#2530). Advertised: {advertised:?}"
+    );
+
+    Ok(())
+}
+
+/// A dial keyed on a DID that turns out not to be who answered must not leave that DID
+/// behind as a peer.
+///
+/// `SessionManager::dial` registers the caller's *claimed* key before any handshake has
+/// happened, so a bootstrap entry carrying a stale or wrong DID for an address registers a
+/// peer that does not exist. Hello then authenticates whoever actually answered and
+/// registers them too, leaving one connection under two identities — the same aliasing the
+/// address-only path produces, reached by a different route. This is what the eviction in
+/// `install_incoming_connection` covers, independently of where the stale key came from.
+#[tokio::test]
+async fn dial_keyed_on_the_wrong_did_does_not_leave_a_phantom_peer() -> Result<()> {
+    init();
+    let dialer = IdentityBundle::generate()?;
+    let dialer_did = dialer.did().clone();
+    let listener = IdentityBundle::generate()?;
+    let listener_did = listener.did().clone();
+    let interrogator = IdentityBundle::generate()?;
+    let interrogator_did = interrogator.did().clone();
+
+    // A DID that belongs to nobody on this connection.
+    let wrong_did = IdentityBundle::generate()?.did().clone();
+
+    let (dialer_handle, dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+    let (_listener_handle, listener_addr, _listener_guard) = spawn_node(listener).await?;
+
+    dialer_handle.dial(listener_addr, wrong_did.clone()).await?;
+    assert!(
+        wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+        "precondition: the dialer never authenticated the peer that actually answered"
+    );
+
+    let stats = dialer_handle.get_stats().await?;
+    assert_eq!(
+        stats.connections_active, 1,
+        "the connection must be held under the DID that authenticated, not also under the \
+         DID we guessed; found {} entries, so {wrong_did} survived as a phantom peer (#2530)",
+        stats.connections_active
+    );
+
+    let client = WireClient::connect(&interrogator, dialer_addr).await?;
+    let advertised = client
+        .request_peer_exchange(&interrogator_did, &dialer_did, Duration::from_secs(20))
+        .await?;
+    assert!(
+        advertised.contains(&listener_did.to_string()),
+        "precondition: the authenticated peer should be advertised, got {advertised:?}"
+    );
+    assert!(
+        !advertised.contains(&wrong_did.to_string()),
+        "peer exchange advertised {wrong_did}, a DID that never authenticated on this \
+         connection, as reachable topology (#2530). Advertised: {advertised:?}"
+    );
+
+    Ok(())
+}
+
+/// A broadcast must write once per physical connection, not once per map key.
+///
+/// `broadcast_message` iterates the session map and opens a stream per entry, so two keys
+/// aliasing one connection meant the peer received every broadcast twice — duplicate
+/// delivery and double the stream budget on a connection limited to 10 concurrent
+/// bidirectional streams.
+#[tokio::test]
+async fn broadcast_writes_once_per_physical_connection() -> Result<()> {
+    init();
+    let dialer = IdentityBundle::generate()?;
+    let dialer_did = dialer.did().clone();
+    let listener = IdentityBundle::generate()?;
+    let listener_did = listener.did().clone();
+
+    let received = Arc::new(AtomicUsize::new(0));
+    let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+    let (_listener_handle, listener_addr, _listener_guard) =
+        spawn_node_counting(listener, received.clone(), "Subscribe").await?;
+
+    let placeholder = dialer_handle.dial_addr(listener_addr).await?;
+    assert!(
+        wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+        "precondition: the dialer never authenticated the peer"
+    );
+
+    // Let the handshake settle before broadcasting.
+    //
+    // Two nodes currently reflect Hellos at each other until the receiver's per-DID rate
+    // limiter starts dropping them — `handle_hello` answers every Hello with a Hello, and a
+    // Hello response is indistinguishable on the wire from an initial one. That burst
+    // exhausts the sender's rate-limit budget, so a broadcast issued immediately after
+    // authentication is dropped before dispatch and this test would read 0 for a reason
+    // that has nothing to do with connection aliasing. The reflection is pre-existing on
+    // `main` and out of scope here; waiting for the limiter's window to refill sidesteps it
+    // without hiding it.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    received.store(0, Ordering::SeqCst);
+
+    dialer_handle
+        .broadcast(NetworkMessage::subscribe(
+            dialer_did.clone(),
+            listener_did.clone(),
+            vec!["test:topic".to_string()],
+        ))
+        .await?;
+
+    // Poll up to the deadline for the first delivery, then keep waiting out the remainder
+    // so a second, duplicate delivery has time to land and be counted. Asserting as soon
+    // as the count reaches 1 would pass even while a duplicate was still in flight.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while received.load(Ordering::SeqCst) == 0 && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    tokio::time::sleep(Duration::from_millis(750)).await;
+
+    assert_eq!(
+        received.load(Ordering::SeqCst),
+        1,
+        "one broadcast over one physical QUIC connection must be delivered once; the \
+         provisional placeholder {placeholder} aliasing the authenticated DID {listener_did} \
+         makes broadcast open a second stream and send the message twice (#2530)"
+    );
+
+    Ok(())
+}
+
+/// A connection that completes QUIC but never authenticates must leave nothing behind.
+///
+/// This is the failure mode a re-key-at-Hello fix does not cover: if the fix only evicts
+/// the placeholder when Hello arrives, a peer that accepts the connection and stays silent
+/// strands the placeholder permanently. There is no reaper — `disconnect_peer` and `stop`
+/// are the only removals — so "permanently" means until the process exits.
+#[tokio::test]
+async fn addr_only_dial_that_never_authenticates_leaves_no_peer_identity() -> Result<()> {
+    init();
+    let dialer = IdentityBundle::generate()?;
+    let silent = IdentityBundle::generate()?;
+
+    let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+
+    // A bare QUIC listener: completes the handshake, accepts the connection, and then
+    // says nothing. No Hello, so the dialer never learns an authenticated identity.
+    let silent_addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+    let server_config =
+        icn_net::tls::create_server_config(vec![silent.tls_cert().clone()], silent.tls_key())?;
+    let mut quic_server = quinn::ServerConfig::with_crypto(Arc::new(
+        quinn::crypto::rustls::QuicServerConfig::try_from(server_config)?,
+    ));
+    quic_server.transport_config(Arc::new({
+        let mut t = quinn::TransportConfig::default();
+        t.max_idle_timeout(Some(Duration::from_secs(60).try_into()?));
+        t
+    }));
+    let silent_endpoint = Endpoint::server(quic_server, silent_addr)?;
+    let accepted = tokio::spawn({
+        let endpoint = silent_endpoint.clone();
+        async move {
+            // Hold the accepted connection open; dropping it would close the connection
+            // and let the dialer clean up for the wrong reason.
+            let mut held = Vec::new();
+            while let Some(incoming) = endpoint.accept().await {
+                if let Ok(conn) = incoming.await {
+                    held.push(conn);
+                }
+            }
+            held
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let placeholder = dialer_handle.dial_addr(silent_addr).await?;
+
+    // Give the dialer ample opportunity to have registered something. There is no
+    // observable "authentication finished" event here — that is the point — so this
+    // waits out the window in which a Hello would plausibly have arrived.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let stats = dialer_handle.get_stats().await?;
+    assert_eq!(
+        stats.connections_active, 0,
+        "a connection whose peer never authenticated must not appear as an active peer; \
+         found {} entries, so the provisional placeholder {placeholder} was promoted into \
+         authenticated peer state on QUIC success alone (#2530)",
+        stats.connections_active
+    );
+
+    accepted.abort();
+    Ok(())
+}

--- a/icn/crates/icn-net/tests/relay_fallback.rs
+++ b/icn/crates/icn-net/tests/relay_fallback.rs
@@ -469,6 +469,32 @@ async fn test_relay_fallback_establishes_connection() {
                     nat_status.active_relay_count >= 1,
                     "Should have at least one active relay proxy"
                 );
+
+                // Reaching a peer through a relay is still only transport (#2530).
+                //
+                // `did_b` here is the identity Node A *expected* to find; Node B never
+                // completed a Hello over this relayed connection, so nothing has proven who
+                // is on the other end. The relay branch used to call the authenticated
+                // installer with that expected DID the moment TURN framing came up, which
+                // both violated that installer's stated precondition and made
+                // `connections_active` count an unauthenticated peer.
+                let stats = handle_a
+                    .get_stats()
+                    .await
+                    .expect("failed to get stats from Node A");
+                assert_eq!(
+                    stats.connections_active, 0,
+                    "a relayed connection must not become an authenticated peer before Hello; \
+                     found {} active connections, so the expected DID {} was registered on \
+                     relay transport success alone (#2530)",
+                    stats.connections_active, did_b
+                );
+                assert!(
+                    handle_a.connected_peers().await.is_empty(),
+                    "connected_peers() reports authenticated peers, so a relayed connection \
+                     with no completed Hello must not appear in it (#2530)"
+                );
+
                 info!("PASS: Relay fallback established QUIC connection successfully");
             }
             Ok(Err(ref e)) => {


### PR DESCRIPTION
## Symptom

An address-only bootstrap dial (`icn://HOST:PORT`) left a phantom peer behind forever. On
the production stack, before this change:

- `connections_active` reported **2** for a single physical QUIC connection;
- a broadcast was **delivered twice** over that one connection;
- a peer-exchange response advertised the synthetic placeholder to a third node as a
  dialable peer, complete with a reachable endpoint.

## How the scope grew

#2529 established that the mysterious bootstrap DID was an address-derived **placeholder** —
SHA-256 of the socket address reinterpreted as an Ed25519 public key — and not an
authenticated identity. This issue started as "that placeholder is never evicted."

Auditing every writer showed the placeholder was one instance of a broader state-model
violation, not the whole of it. `SessionManager::dial` inserted **whatever DID the caller
supplied** into the connection map the moment QUIC came up. Classifying those callers by
what the DID actually proves:

| Caller | DID source | Evidence it carries |
|---|---|---|
| `init_bootstrap.rs` `KnownDid` | operator config | configuration |
| `background_tasks.rs` reconnect | bootstrap status | configuration |
| **`init_network.rs:343`** | **another node's `KnownPeer.did`** | **peer assertion** |
| **`init_network.rs:410`** | **another node's `Announce`** | **peer assertion** |
| `nat_dial.rs` (×6) | candidate passed in | inherits caller's |
| relay branch of `handle_dial` | caller-supplied | configuration |

The two `init_network` callers are the propagation mechanism #2530's own text describes: a
receiver auto-dials an advertised peer, adopts that DID as a peer on transport success, and
re-advertises it. A placeholder-only fix would have left that running. The placeholder is in
one sense the *safest* of these inputs — no private key for it exists, so nobody can ever
authenticate as it — while a peer-advertised DID is attacker-chosen.

## The invariant

> QUIC transport establishment does not create peer identity. Addresses, configured DIDs,
> peer-advertised DIDs, discovery DIDs, placeholder DIDs, and relay candidates are all
> pre-authentication inputs. A connection enters the authenticated session map only after
> Hello cryptographically proves the DID against the current QUIC/TLS connection.

`install_incoming_connection` already documented that precondition — *"Callers must have
authenticated `peer_did` first"* — and every reader relies on it: peer exchange republishes
its keys to other nodes as topology, broadcast opens one stream per entry, and
`connections_active` counts entries as peers. The dial paths simply did not honour it.

## What changed

Every outbound path is now provisional:

```
address + optional supplied DID hint
        ↓  QUIC connection established
        ↓  (nothing written to the session map)
        ↓  Hello sent directly on the held connection
        ↓  #2520 DID ↔ current-cert verification
        ↓  install_incoming_connection()
   canonical authenticated entry
```

Covered: addr-only bootstrap, configured `KnownDid`, arbitrary caller-supplied DIDs,
DIDs learned from peer exchange, discovery-supplied DIDs, direct dialing, and relay/TURN
fallback.

- **`SessionManager::dial`** establishes the connection and returns it. It still *reads* the
  map to suppress a duplicate dial to a peer we already hold a live session with, and the
  DID still addresses the outgoing Hello. It no longer writes.
- **The relay branch** no longer calls the authenticated installer on TURN success.
- **`wire_new_connection`** writes the Hello straight to the connection it already holds.
  This had to come first: addressing the Hello *by DID through the map* is precisely why an
  unauthenticated key had to be registered before the handshake could run.
- **`dial_addr`** now just calls `dial`. The separate provisional path it briefly had is
  redundant once every outbound dial is provisional, and two paths could drift.

### Session-map writer census

```
disconnect_peer  → remove
stop()           → clear
authenticated Hello → install_incoming_connection → canonical entry
```

No pre-authentication insertion path remains, so `NetworkHandle::connected_peers` is true by
construction rather than by convention.

### Connection canonicalization

`install_incoming_connection` collapses any other key mapping to the same physical
connection, matched on `quinn::Connection::stable_id()` — connection *identity*, not address
or key — so it can only ever drop an alias of the connection in hand, never a different,
newer connection. Retained as defence in depth: nothing in production can create such an
alias now, which is exactly why the guarantee is asserted directly at the installer boundary
rather than through a path that happens to produce one.

### Bootstrap peer-exchange targeting

Separating configuration from authentication surfaced a second bug. Targets were seeded from
configured DIDs — DIDs that may never have authenticated. `dial_bootstrap_peers` now returns
the **addresses** transport reached, and targets are the intersection of those endpoints with
live authenticated sessions:

```
dialed:          A, B
authenticated:   DID_A @ A,  DID_C @ C
targets:         [DID_A]        (B never authenticated; C was never dialed)
```

Bootstrap dialing is direct-only (`peer_relay_addr: None`), so a connection's remote address
is the address dialed; under Kubernetes DNAT the client still observes the service address it
sent to, because conntrack rewrites the reply source back.

## `KnownDid` is a hint, not a pin

Unchanged and deliberate. `parse_bootstrap_peer` states it: *"parsing yields configuration,
and the peer's identity is proven only by DID-TLS binding verification in the Hello
handler."* Nothing compares a configured DID against the authenticated one. So dialing with
supplied DID X and having the peer authenticate as B means X never enters authenticated
state and B becomes canonical. Whether it *should* be an enforced pin is #2533 — it would
turn a stale bootstrap entry into a hard connectivity failure, which is an operational
trade-off worth deciding on its own.

## Tests

`icn-net/tests/provisional_connection_lifecycle.rs` (8) runs on the production composition
path — two real `NetworkActor`s, real QUIC/TLS, real dispatch loop, real `handle_hello` —
and asserts on observable surfaces (`get_stats`, the peer-exchange wire response) rather
than private state. All 8 fail on `main`.

1. addr-only dial that authenticates leaves exactly one identity
2. peer exchange never advertises the placeholder
3. addr-only dial that never authenticates leaves nothing
4. **DID-supplied** dial that never authenticates leaves nothing
5. only the authenticated DID becomes canonical when the supplied DID differs
6. one broadcast over one physical connection is delivered once
7. a Hello failing #2520 binding makes nobody a peer
8. **positive control** — the same scripted-peer harness *does* authenticate with a valid
   binding, without which (4) and (7) would pass for free

Plus: 2 installer-boundary unit tests (alias collapsed; unrelated live connection survives),
3 bootstrap target-selection tests (exclusion both ways, dedup, empty), and an assertion on
the existing relay test that a relayed connection is not a peer before Hello.

## Mutation evidence

**5/5 killed, 0 survivors, 0 no-ops**, each by a *distinct* test:

| | Mutation | Killed by |
|---|---|---|
| M5 | pre-auth DID insertion restored | 3 lifecycle tests |
| M2 | alias collapse removed | `test_install_evicts_other_keys_for_the_same_connection` |
| M6 | collapse ignores connection identity | `test_install_does_not_evict_keys_for_other_connections` |
| M4 | Hello re-depends on map registration | 4 lifecycle tests |
| M7 | relay pre-auth registration restored | `test_relay_fallback_establishes_connection` |

M7 is killed by a real relay-path behavioural test against the existing TURN stub, not by
source inspection. The harness asserts each mutation applies exactly once (a no-op means the
harness is lying) and restores byte-identical sources.

## Security classification

**Availability / topology integrity / trust-state correctness. Not an authentication
bypass.** #2520's binding checks were never weakened and still fail closed: an unauthenticated
DID could pollute topology and cause duplicate sends, inflated connection counts, and wasted
dials, but nothing could authenticate *as* it. No impersonation path was found.

## Validation

`icn-net` 411/0/23 · `icn-core` 737/0/43 · #2520 7/7 · #2521 7/7 (35/35 over 5 runs) ·
#2529 4/4 · #2530 lifecycle 8/8 (40/40 over 5 runs) · fmt, workspace Clippy `-D warnings`,
Meaning Firewall, compliance, overclaim, doc controls all pass. The six changed files were
hash-bracketed around the gate and were byte-identical afterwards.

## Follow-ups (not in this PR)

- **#2532** — Hello responses are indistinguishable from initial Hellos, so peers reflect
  them (~40 messages in ~17 ms) until the rate limiter stops them. Reproduced on pristine
  `main`; **not caused by this work**. The broadcast test here carries a bounded settling
  delay solely to route around it, with a comment pointing at #2532.
- **#2533** — should a `KnownDid` bootstrap entry enforce an expected DID?

Fixes #2530
