### PR TITLE
docs(net): correct dial outcome ownership semantics

### DIFF
--- a/icn/crates/icn-net/src/session.rs
+++ b/icn/crates/icn-net/src/session.rs
@@ -113,8 +113,8 @@ pub struct SessionManager {
 pub enum DialOutcome {
     /// A new QUIC connection was established, and nothing is reading from it yet.
     ///
-    /// The caller owns it and must install a connection handler; dropping it closes the
-    /// connection, because nothing else holds it.
+    /// The caller receives the sole handle and must install a connection handler; dropping it
+    /// closes the connection, because nothing else holds it.
     Established(quinn::Connection),
 
     /// A live authenticated session already existed for this peer, and this is that
@@ -125,6 +125,11 @@ pub enum DialOutcome {
     /// again would spawn a second `handle_connection` loop over it — two loops then race for
     /// each inbound stream, so per-connection handler state becomes ambiguous — and would
     /// write a redundant Hello onto an already-handshaken session.
+    ///
+    /// This hands the caller a *borrowed* view of that session rather than custody of it. The
+    /// connection map entry it was cloned from — and the session's own handler task — still
+    /// hold handles, so dropping this one decrements the reference count without closing
+    /// anything. There is nothing here for the caller to install, own, or release.
     AlreadyConnected(quinn::Connection),
 }
 
@@ -357,12 +362,27 @@ impl SessionManager {
     /// we already hold a live session with, and it is what the outgoing Hello is addressed
     /// to. It just never becomes an entry in the connection map (#2530).
     ///
-    /// **The caller owns the returned connection.** Dropping it closes the QUIC connection,
-    /// because nothing else holds it: registering the dial in the connection map used to
-    /// keep it alive as a side effect, and that is exactly the pre-authentication entry this
-    /// no longer creates. In production `NetworkActor::handle_dial` hands it to
-    /// `wire_new_connection`, which moves it into the spawned connection handler — the task
-    /// that reads from it — and that task is its owner until Hello registers it or it closes.
+    /// **Ownership of the reported connection differs per variant**, and a caller that treats
+    /// the two alike is wrong in one of them. `quinn::Connection` is a handle onto a
+    /// reference-counted connection, so dropping one closes the QUIC connection only when it
+    /// was the *last* handle. Which case applies is precisely what [`DialOutcome`] encodes.
+    ///
+    /// [`DialOutcome::Established`] transfers sole ownership. Nothing else holds that
+    /// connection — registering the dial in the connection map used to keep it alive as a side
+    /// effect, and that is exactly the pre-authentication entry this no longer creates — so
+    /// dropping it does close the connection. In production `NetworkActor::handle_dial` hands
+    /// it to `wire_new_connection`, which passes it to the spawned connection handler — the
+    /// task that reads from it — and that task is its owner until Hello registers it or it
+    /// closes.
+    ///
+    /// [`DialOutcome::AlreadyConnected`] transfers no ownership at all. It is a handle cloned
+    /// out of the connection map, and the live session owns itself: the map entry it was
+    /// cloned from still holds the connection, as does that session's running
+    /// `handle_connection` task. Dropping this handle therefore only decrements the reference
+    /// count — the existing session is unaffected and stays live. The caller has nothing to
+    /// install and nothing to release, so discarding the value is the correct response, which
+    /// is what `handle_dial` does. Note that the connection this call actually opened is *not*
+    /// the one reported: it was closed as a duplicate before returning.
     pub async fn dial(&self, addr: SocketAddr, peer_did: String) -> Result<DialOutcome> {
         // Never dial ourselves into our own remote-peer map (#2506). Discovery sources echo our
         // own advertisement back to us — over `network:candidates`, peer exchange, or mDNS — and
@@ -1064,10 +1084,11 @@ mod tests {
     /// Have `dialer` connect to `listener`, returning the connection `listener` accepted.
     /// Dialer-side connections, kept alive for the lifetime of the test binary.
     ///
-    /// `SessionManager::dial` transfers ownership of the connection to its caller, so
-    /// dropping it closes the QUIC connection and tears down the listener side these tests
-    /// are about to assert on. Production keeps it alive by moving it into the spawned
-    /// connection handler; there is no such handler here, so the test binary holds it.
+    /// `SessionManager::dial` transfers sole ownership on [`DialOutcome::Established`] — the
+    /// only outcome this helper accepts — so dropping it closes the QUIC connection and tears
+    /// down the listener side these tests are about to assert on. Production keeps it alive by
+    /// moving it into the spawned connection handler; there is no such handler here, so the
+    /// test binary holds it.
     static DIALER_SIDE: std::sync::Mutex<Vec<quinn::Connection>> =
         std::sync::Mutex::new(Vec::new());
 


### PR DESCRIPTION
## What

Corrects the `SessionManager::dial` rustdoc, which still documented a single ownership rule over the two-variant `DialOutcome` return introduced by #2538.

## Why

Current main says, unconditionally:

> **The caller owns the returned connection.** Dropping it closes the QUIC connection, because nothing else holds it...

That is accurate for `DialOutcome::Established`, and false for `DialOutcome::AlreadyConnected`.

`AlreadyConnected` carries a handle cloned out of the connection map for a session that is already live, authenticated, and wired. `quinn::Connection` is a newtype over a reference-counted `ConnectionRef` — `Clone` does `ref_count += 1`, and `Drop` decrements and calls `implicit_close` **only** when the count reaches zero (quinn 0.11.9, `src/connection.rs:920-941`). For that variant the connection map entry still holds the connection, and so does the session's running `handle_connection` task, so dropping the returned handle closes nothing.

This is not theoretical. The sole production consumer already depends on the correct semantics:

```rust
crate::session::DialOutcome::AlreadyConnected(_) => {
    debug!(peer = %did, "Dial found a live session; leaving its existing connection handler in place");
}
```

It binds `_` and drops the handle immediately. If the documented rule were true, every redundant dial would tear down the live authenticated session it just found — which is precisely the class of defect #2536 existed to prevent.

This was raised by the final automated review on #2538 and merged unresolved.

## How

Documentation only, one file:

- `SessionManager::dial` — the single ownership paragraph is replaced by a per-variant statement, leading with the refcount rule that makes the two cases differ.
- `DialOutcome::Established` — "the caller receives the sole handle" (unchanged meaning, made explicit).
- `DialOutcome::AlreadyConnected` — adds the drop semantics: borrowed view, not custody; nothing for the caller to install, own, or release.
- The `connect` test helper carried the same unconditional claim; scoped to `Established`, which is the only outcome it accepts (it panics on the other).

The ownership discussion is kept rather than deleted — the differing lifecycle semantics of the two success cases are the entire reason `DialOutcome` exists.

## Risk

None to runtime. No code changed. The runtime was audited first and found correct: it was the documentation that contradicted the implementation, not the reverse. Had the audit gone the other way this would have been reported rather than turned into a second implementation change.

## Test plan

Proportionate to a comment-only correction:

- `cargo fmt --all --check` — exit 0, no output
- `cargo clippy -p icn-net --all-targets --all-features` — exit 0, zero warnings
- `cargo doc -p icn-net --no-deps` — exit 0; new intra-doc links (`DialOutcome::Established`, `DialOutcome::AlreadyConnected`) resolve, no new warnings. The one pre-existing `session.rs` warning (`dial` links to private item `install_incoming_connection`) is untouched by this change.

Refs #2536

🤖 Generated with [Claude Code](https://claude.com/claude-code)