### PR TITLE
fix(net): gate peer-exchange disclosure on participation and authenticated identity

### DIFF
--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -1408,6 +1408,18 @@ async fn spawn_network_actor(
     )
     .await?;
 
+    // Translate the operator's federation posture into the network layer's participation
+    // policy (#2535). `icn-net` cannot read `FederationConfig` — `icn-core` depends on it,
+    // not the other way round — so this call is the only thing that turns peer exchange
+    // on. It defaults to off, which is why a node with no `[federation]` section (every
+    // current coop config) does not answer peer-exchange requests at all.
+    //
+    // `federation.enabled` already governs the rest of peer exchange in both directions:
+    // requesting (`init_bootstrap::request_peer_exchange`), federation topic subscriptions
+    // (`init_gossip`), and acting on an inbound Response or Announce (`init_network`).
+    // Answering a Request is now governed by the same switch.
+    network_handle.set_peer_exchange_enabled(federation_enabled);
+
     // Initialize network handle for incoming message handler
     *network_handle_for_handler.write().await = Some(network_handle.clone());
 

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -73,6 +73,7 @@ impl NetworkActor {
         misbehavior_detector: Option<Arc<RwLock<icn_security::MisbehaviorDetector>>>,
         identity_bundle: IdentityBundle,
         own_did: Did,
+        peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
         mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
     ) -> Result<()> {
         info!("Starting incoming connection handler");
@@ -149,6 +150,7 @@ impl NetworkActor {
             let misbehavior_detector_clone = misbehavior_detector.clone();
             let identity_bundle_clone = identity_bundle.clone();
             let own_did_clone = own_did.clone();
+            let peer_exchange_enabled = peer_exchange_enabled.clone();
             tokio::spawn(async move {
                 let connection = match incoming.await {
                     Ok(connection) => connection,
@@ -177,6 +179,7 @@ impl NetworkActor {
                     identity_bundle_clone,
                     own_did_clone,
                     crate::handlers::ConnectionDirection::Inbound,
+                    peer_exchange_enabled,
                 )
                 .await
                 {
@@ -209,6 +212,7 @@ impl NetworkActor {
         identity_bundle: IdentityBundle,
         own_did: Did,
         direction: crate::handlers::ConnectionDirection,
+        peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
     ) -> Result<()> {
         info!("Handling connection from {}", connection.remote_address());
 
@@ -226,6 +230,7 @@ impl NetworkActor {
             identity_bundle.clone(),
             own_did.clone(),
             direction,
+            peer_exchange_enabled,
         );
 
         loop {

--- a/icn/crates/icn-net/src/actor/messages.rs
+++ b/icn/crates/icn-net/src/actor/messages.rs
@@ -304,6 +304,7 @@ impl NetworkActor {
             let identity_bundle = self.identity_bundle.clone();
             let own_did = self.own_did.clone();
             let handler_connection = connection.clone();
+            let peer_exchange_enabled = self.peer_exchange_enabled.clone();
 
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_connection(
@@ -320,6 +321,7 @@ impl NetworkActor {
                     identity_bundle,
                     own_did,
                     crate::handlers::ConnectionDirection::Outbound,
+                    peer_exchange_enabled,
                 )
                 .await
                 {

--- a/icn/crates/icn-net/src/actor/mod.rs
+++ b/icn/crates/icn-net/src/actor/mod.rs
@@ -173,6 +173,8 @@ pub struct NetworkHandle {
     blob_registry: Option<Arc<RwLock<crate::BlobLocationRegistry>>>,
     /// Direct dial timeout in milliseconds (shared with actor via atomic)
     dial_timeout_ms: Arc<std::sync::atomic::AtomicU64>,
+    /// Whether this node answers peer-exchange requests (shared with actor via atomic)
+    peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl NetworkHandle {
@@ -223,6 +225,32 @@ impl NetworkHandle {
             timeout.as_millis() as u64,
             std::sync::atomic::Ordering::Relaxed,
         );
+    }
+
+    /// Declare whether this node participates in peer exchange.
+    ///
+    /// When disabled — the default — the node does not answer `PeerExchangeMessage::Request`
+    /// from anyone, however well authenticated. Enumerating the neighbourhood is
+    /// participation in federation, and whether to participate is the operator's decision,
+    /// expressed as `federation.enabled` (#2535).
+    ///
+    /// This crate deliberately does not read that configuration itself. `FederationConfig`
+    /// lives in `icn-core`, which depends on this crate, so the dependency only runs one
+    /// way; the composition root translates the operator's posture into this call, the
+    /// same way it turns `TopologyConfig` into a spawn argument.
+    ///
+    /// Defaulting to off means the window between `spawn` and this call is closed, not
+    /// open, and a composition root that forgets to call it breaks peer discovery rather
+    /// than leaking topology.
+    pub fn set_peer_exchange_enabled(&self, enabled: bool) {
+        self.peer_exchange_enabled
+            .store(enabled, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Whether this node currently answers peer-exchange requests.
+    pub fn peer_exchange_enabled(&self) -> bool {
+        self.peer_exchange_enabled
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Dial a peer by address only, returning a **placeholder connection key**.
@@ -1037,6 +1065,8 @@ pub struct NetworkActor {
     relay_proxies: Arc<RwLock<std::collections::HashMap<Did, crate::relay_proxy::ProxyHandle>>>,
     /// Direct dial timeout in milliseconds (shared with handle via atomic)
     dial_timeout_ms: Arc<std::sync::atomic::AtomicU64>,
+    /// Whether this node answers peer-exchange requests (shared with handle via atomic)
+    peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl NetworkActor {
@@ -1202,6 +1232,12 @@ impl NetworkActor {
         });
         info!("Byzantine fault detection enabled");
 
+        // Peer exchange is off until a composition root turns it on (#2535). Defaulting to
+        // off is deliberate: this crate cannot see `federation.enabled`, and the failure
+        // mode of a forgotten wiring should be "federation does not discover peers", which
+        // is loud, rather than "the node hands its neighbourhood to anyone", which is not.
+        let peer_exchange_enabled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
         // Spawn incoming connection handler if handler is provided
         if let Some(handler) = incoming_handler.clone() {
             let session_manager_clone = session_manager.clone();
@@ -1214,6 +1250,7 @@ impl NetworkActor {
             let misbehavior_detector_clone = misbehavior_detector.clone();
             let identity_bundle_clone = identity_bundle.clone();
             let own_did_clone = did.clone();
+            let peer_exchange_enabled_clone = peer_exchange_enabled.clone();
             let shutdown_rx = shutdown_tx.subscribe();
             tokio::spawn(async move {
                 if let Err(e) = Self::handle_incoming_connections(
@@ -1228,6 +1265,7 @@ impl NetworkActor {
                     misbehavior_detector_clone,
                     identity_bundle_clone,
                     own_did_clone,
+                    peer_exchange_enabled_clone,
                     shutdown_rx,
                 )
                 .await
@@ -1329,6 +1367,7 @@ impl NetworkActor {
             })),
             relay_proxies: Arc::new(RwLock::new(std::collections::HashMap::new())),
             dial_timeout_ms: dial_timeout_ms.clone(),
+            peer_exchange_enabled: peer_exchange_enabled.clone(),
         };
 
         // Spawn actor task
@@ -1347,6 +1386,7 @@ impl NetworkActor {
             own_did: did,
             blob_registry: blob_registry.clone(),
             dial_timeout_ms,
+            peer_exchange_enabled,
         })
     }
 
@@ -1613,6 +1653,7 @@ mod tests {
             own_did: own_did.clone(),
             blob_registry: None,
             dial_timeout_ms: Arc::new(std::sync::atomic::AtomicU64::new(30_000)),
+            peer_exchange_enabled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         // Alice supports E2E encryption
@@ -1718,6 +1759,7 @@ mod tests {
             own_did: test_did,
             blob_registry: None,
             dial_timeout_ms: Arc::new(std::sync::atomic::AtomicU64::new(30_000)),
+            peer_exchange_enabled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         // Get peers with E2E encryption (should be Alice and Charlie)
@@ -1796,6 +1838,7 @@ mod tests {
             own_did: test_did,
             blob_registry: None,
             dial_timeout_ms: Arc::new(std::sync::atomic::AtomicU64::new(30_000)),
+            peer_exchange_enabled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         // Get versions
@@ -1841,6 +1884,7 @@ mod tests {
             own_did: test_did,
             blob_registry: None,
             dial_timeout_ms: Arc::new(std::sync::atomic::AtomicU64::new(30_000)),
+            peer_exchange_enabled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         // Get full connection info
@@ -1880,6 +1924,7 @@ mod tests {
             own_did: own_did.clone(),
             blob_registry: Some(blob_registry.clone()),
             dial_timeout_ms: Arc::new(std::sync::atomic::AtomicU64::new(30_000)),
+            peer_exchange_enabled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         // Spawn task to handle response channel (prevents hanging)

--- a/icn/crates/icn-net/src/handlers/encrypted.rs
+++ b/icn/crates/icn-net/src/handlers/encrypted.rs
@@ -230,6 +230,8 @@ mod tests {
             own_did,
             direction: crate::handlers::ConnectionDirection::Inbound,
             hello_responded: std::sync::atomic::AtomicBool::new(false),
+            authenticated_peer: tokio::sync::RwLock::new(None),
+            peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         (ctx, forward_count)
@@ -378,6 +380,8 @@ mod tests {
             own_did: own_did.clone(),
             direction: crate::handlers::ConnectionDirection::Inbound,
             hello_responded: std::sync::atomic::AtomicBool::new(false),
+            authenticated_peer: tokio::sync::RwLock::new(None),
+            peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         // Create encrypted message

--- a/icn/crates/icn-net/src/handlers/handshake.rs
+++ b/icn/crates/icn-net/src/handlers/handshake.rs
@@ -241,6 +241,8 @@ mod tests {
             own_did,
             direction: crate::handlers::ConnectionDirection::Inbound,
             hello_responded: std::sync::atomic::AtomicBool::new(false),
+            authenticated_peer: tokio::sync::RwLock::new(None),
+            peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         (ctx, neighbor_sets)
@@ -272,6 +274,8 @@ mod tests {
             own_did,
             direction: crate::handlers::ConnectionDirection::Inbound,
             hello_responded: std::sync::atomic::AtomicBool::new(false),
+            authenticated_peer: tokio::sync::RwLock::new(None),
+            peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 

--- a/icn/crates/icn-net/src/handlers/hello.rs
+++ b/icn/crates/icn-net/src/handlers/hello.rs
@@ -101,6 +101,12 @@ impl ConnectionContext {
             "DID-TLS binding verified against current connection certificate"
         );
 
+        // This is the moment `from` stops being a claim and becomes an identity: all three
+        // DID-TLS facts hold, against the certificate *this* connection is presenting. Bind
+        // it to the connection so handlers that disclose something about this node can ask
+        // who they are talking to without trusting a sender-chosen field (#2535, #2491).
+        self.record_authenticated_peer(from).await;
+
         // Verify DID-PQ binding if proof is present
         // Returns: Ok(true) = verified, Ok(false) = no PQ key or legacy (no proof), Err = invalid proof
         let pq_binding_result =

--- a/icn/crates/icn-net/src/handlers/mod.rs
+++ b/icn/crates/icn-net/src/handlers/mod.rs
@@ -53,6 +53,28 @@ pub struct ConnectionContext {
     /// additionally makes the responder's obligation exactly once, so a repeated Hello
     /// cannot restart a response chain.
     pub hello_responded: std::sync::atomic::AtomicBool,
+    /// The peer identity proven for *this* connection, once Hello has authenticated one.
+    ///
+    /// `None` until [`ConnectionContext::record_authenticated_peer`] is called, which
+    /// happens only after the three DID-TLS facts in `handle_hello` all hold: the binding
+    /// names the claimed DID, that DID's key signed it, and it is a binding of the
+    /// certificate *this* connection is actually using (#2520).
+    ///
+    /// This exists because a `NetworkMessage`'s `from` field cannot answer "who is asking".
+    /// It is chosen by the sender and verified by nobody — the same confusion that makes
+    /// the pre-authentication rate-limit tier forgeable (#2491). Handlers that disclose
+    /// something about this node must consult *this* field, which is bound to the
+    /// connection's certificate, and never `message.from`.
+    ///
+    /// Per connection, not per peer: a peer that opens two connections authenticates on
+    /// each one separately, and one connection's Hello says nothing about the other.
+    authenticated_peer: RwLock<Option<Did>>,
+    /// Whether this node answers peer-exchange requests at all.
+    ///
+    /// Shared with the actor, so an operator posture set once at startup applies to every
+    /// connection without re-plumbing. Distinct from authentication: this says whether
+    /// *this node* is participating, not who is asking (#2535).
+    peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Which end of a QUIC connection this node is.
@@ -84,6 +106,7 @@ impl ConnectionContext {
         identity_bundle: IdentityBundle,
         own_did: Did,
         direction: ConnectionDirection,
+        peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
     ) -> Self {
         Self {
             handler,
@@ -99,7 +122,34 @@ impl ConnectionContext {
             own_did,
             direction,
             hello_responded: std::sync::atomic::AtomicBool::new(false),
+            authenticated_peer: RwLock::new(None),
+            peer_exchange_enabled,
         }
+    }
+
+    /// Whether this node participates in peer exchange.
+    pub(crate) fn peer_exchange_enabled(&self) -> bool {
+        self.peer_exchange_enabled
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Record that `peer` has authenticated on this connection.
+    ///
+    /// Call this only from the Hello path, and only after the DID-TLS binding has been
+    /// verified against this connection's current certificate. Calling it anywhere else
+    /// would make an unproven DID indistinguishable from a proven one, which is the whole
+    /// property this state exists to carry.
+    pub(crate) async fn record_authenticated_peer(&self, peer: &Did) {
+        *self.authenticated_peer.write().await = Some(peer.clone());
+    }
+
+    /// The peer identity proven for this connection, if any.
+    ///
+    /// `None` means no Hello has authenticated on this connection *yet*. It is not a
+    /// statement about the peer — it is a statement about what this node can currently
+    /// prove, and the only safe reading of it is "we do not know who this is".
+    pub(crate) async fn authenticated_peer(&self) -> Option<Did> {
+        self.authenticated_peer.read().await.clone()
     }
 
     /// Forward message to external handler

--- a/icn/crates/icn-net/src/handlers/peer_exchange.rs
+++ b/icn/crates/icn-net/src/handlers/peer_exchange.rs
@@ -11,7 +11,7 @@ use crate::candidate::{EndpointCandidate, EndpointKind};
 use crate::protocol::{KnownPeer, NetworkMessage, PeerExchangeMessage};
 use icn_identity::Did;
 use std::net::{IpAddr, SocketAddr};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 impl ConnectionContext {
     /// Handle a PeerExchange message
@@ -27,6 +27,8 @@ impl ConnectionContext {
                 max_peers,
                 network_filter,
             } => {
+                // `from` is passed on only so a refusal can name what the sender *claimed*
+                // to be; it is not used to authorise anything. See the handler.
                 self.handle_peer_exchange_request(connection, from, *max_peers, network_filter)
                     .await;
             }
@@ -43,18 +45,61 @@ impl ConnectionContext {
     }
 
     /// Handle peer exchange request - respond with known peers
+    ///
+    /// Answering enumerates this node's authenticated neighbourhood — peer DIDs and
+    /// reachable endpoints — so *who is asking* is part of the decision, not a detail
+    /// (#2535). The claimed `from` on the request cannot answer that: the sender chose it
+    /// and nobody verified it. The requester's identity is instead taken from the
+    /// connection, where Hello bound it to the certificate in use (#2520).
+    ///
+    /// A refusal here is not an accusation. An unauthenticated request may simply have
+    /// raced ahead of its own Hello, and a disabled local policy is this node's own
+    /// posture, not the peer's fault — so nothing is scored against anyone. Compare the
+    /// same reasoning in `handle_hello`: attributing a violation to an unproven DID would
+    /// let an attacker degrade the reputation of any peer it cared to name.
     async fn handle_peer_exchange_request(
         &self,
         connection: &quinn::Connection,
-        from: &Did,
+        claimed_from: &Did,
         max_peers: usize,
         network_filter: &Option<String>,
     ) {
+        icn_obs::metrics::peer_exchange::requests_received_inc();
+
+        // Participation before identity. Whether this node hands out its neighbourhood at
+        // all is its own posture, decided by the operator and independent of who is
+        // asking, so a node that is not participating need not evaluate the requester at
+        // all. `federation.enabled` already governs the rest of peer exchange in both
+        // directions; answering a request was the one behaviour it did not reach (#2535).
+        if !self.peer_exchange_enabled() {
+            debug!(
+                claimed_did = %claimed_from,
+                remote_addr = %connection.remote_address(),
+                "Declining peer exchange: this node does not participate in peer exchange"
+            );
+            icn_obs::metrics::peer_exchange::requests_denied_inc("peer_exchange_disabled");
+            return;
+        }
+
+        // Identity next: until Hello has authenticated this connection there is no
+        // requester, only a socket that sent bytes. Disclosing topology to it would hand a
+        // node's neighbourhood to anyone able to complete a QUIC handshake.
+        let Some(from) = self.authenticated_peer().await else {
+            warn!(
+                claimed_did = %claimed_from,
+                remote_addr = %connection.remote_address(),
+                "Refusing peer exchange: this connection has not authenticated a peer, so \
+                 the requester's identity is unproven"
+            );
+            icn_obs::metrics::peer_exchange::requests_denied_inc("unauthenticated_requester");
+            return;
+        };
+        let from = &from;
+
         info!(
             "Received peer exchange request from {} (max={}, filter={:?})",
             from, max_peers, network_filter
         );
-        icn_obs::metrics::peer_exchange::requests_received_inc();
 
         // Gather known peers from session manager
         let sm = self.session_manager.read().await;

--- a/icn/crates/icn-net/src/handlers/peer_exchange.rs
+++ b/icn/crates/icn-net/src/handlers/peer_exchange.rs
@@ -10,6 +10,7 @@ use super::ConnectionContext;
 use crate::candidate::{EndpointCandidate, EndpointKind};
 use crate::protocol::{KnownPeer, NetworkMessage, PeerExchangeMessage};
 use icn_identity::Did;
+use icn_obs::metrics::peer_exchange::PeerExchangeDenialReason as DenialReason;
 use std::net::{IpAddr, SocketAddr};
 use tracing::{debug, info, warn};
 
@@ -77,28 +78,40 @@ impl ConnectionContext {
                 remote_addr = %connection.remote_address(),
                 "Declining peer exchange: this node does not participate in peer exchange"
             );
-            icn_obs::metrics::peer_exchange::requests_denied_inc("peer_exchange_disabled");
+            icn_obs::metrics::peer_exchange::requests_denied_inc(DenialReason::Disabled);
             return;
         }
 
         // Identity next: until Hello has authenticated this connection there is no
         // requester, only a socket that sent bytes. Disclosing topology to it would hand a
         // node's neighbourhood to anyone able to complete a QUIC handshake.
-        let Some(from) = self.authenticated_peer().await else {
-            warn!(
+        //
+        // Logged at `debug!`, not `warn!`: reaching here needs nothing but a completed QUIC
+        // handshake, so a remote can emit this line as fast as it can open streams. A
+        // warning per attempt would let an unauthenticated caller drive this node's log
+        // volume — and the event may be entirely benign, since a request can arrive before
+        // its own Hello on a separate stream. The denial counter is the durable record;
+        // `icn_peer_exchange_requests_denied_total{reason="unauthenticated_requester"}` is
+        // what an operator alerts on, and it costs one increment rather than a log line.
+        let Some(authenticated_from) = self.authenticated_peer().await else {
+            debug!(
                 claimed_did = %claimed_from,
                 remote_addr = %connection.remote_address(),
                 "Refusing peer exchange: this connection has not authenticated a peer, so \
                  the requester's identity is unproven"
             );
-            icn_obs::metrics::peer_exchange::requests_denied_inc("unauthenticated_requester");
+            icn_obs::metrics::peer_exchange::requests_denied_inc(
+                DenialReason::UnauthenticatedRequester,
+            );
             return;
         };
-        let from = &from;
 
+        // From here on `authenticated_from` is the requester. `claimed_from` is not consulted
+        // again: it named nothing that was checked, and the two are deliberately distinct
+        // identifiers so that reaching for the wrong one has to be deliberate.
         info!(
             "Received peer exchange request from {} (max={}, filter={:?})",
-            from, max_peers, network_filter
+            authenticated_from, max_peers, network_filter
         );
 
         // Gather known peers from session manager
@@ -114,8 +127,9 @@ impl ConnectionContext {
         let mut known_peers: Vec<KnownPeer> = Vec::new();
 
         for (did_str, conn) in connections {
-            // Skip the requesting peer
-            if did_str == from.as_str() {
+            // Skip the requesting peer — identified by the DID this connection *proved*, so
+            // a requester cannot steer what it is excluded from by choosing a `from`.
+            if did_str == authenticated_from.as_str() {
                 continue;
             }
 
@@ -141,13 +155,13 @@ impl ConnectionContext {
         // Send response
         let response = NetworkMessage::peer_exchange_response(
             self.own_did.clone(),
-            from.clone(),
+            authenticated_from.clone(),
             known_peers,
             total_known,
         );
 
         let connection_clone = connection.clone();
-        let from_did = from.clone();
+        let from_did = authenticated_from;
         tokio::spawn(async move {
             match connection_clone.open_bi().await {
                 Ok((mut send_stream, _recv)) => {

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -428,6 +428,8 @@ mod tests {
             own_did,
             direction: crate::handlers::ConnectionDirection::Inbound,
             hello_responded: std::sync::atomic::AtomicBool::new(false),
+            authenticated_peer: tokio::sync::RwLock::new(None),
+            peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         (ctx, keypair, forward_count)

--- a/icn/crates/icn-net/tests/peer_exchange_policy.rs
+++ b/icn/crates/icn-net/tests/peer_exchange_policy.rs
@@ -334,6 +334,37 @@ async fn responder_holding_a_sentinel_peer(peer_exchange_enabled: bool) -> Resul
     })
 }
 
+/// Prove that a refusal was a decision, not a collapse.
+///
+/// Every negative test here asserts that something did *not* cross the connection. That is
+/// only worth asserting if the responder was in a position to disclose it and simply chose
+/// not to — a node that fell over mid-request produces the identical observation. Two facts
+/// establish that, and they fail in different ways, so both are checked:
+///
+/// 1. **The actor is still servicing requests.** `get_peers` is a round trip through the
+///    network actor's mailbox — it sends on the channel and awaits a `oneshot` — so it
+///    returns `Err` if that task has died. A shared-map read like
+///    `get_peer_connection_info` cannot detect this: the map outlives the actor that
+///    maintains it, so it would keep answering happily from a corpse.
+/// 2. **The sentinel is still in peer state**, so there really was something to withhold.
+async fn assert_responder_still_serving(fx: &Fixture) {
+    assert!(
+        fx.responder.get_peers().await.is_ok(),
+        "post-condition: the responder's network actor stopped servicing requests, so the \
+         absent peer-exchange response says nothing about policy — it is what a dead node \
+         looks like too"
+    );
+    assert!(
+        fx.responder
+            .get_peer_connection_info(&fx.sentinel_did)
+            .await
+            .is_some(),
+        "post-condition: the responder no longer holds the sentinel peer {}, so it had \
+         nothing left to disclose and the negative assertion above is vacuous",
+        fx.sentinel_did
+    );
+}
+
 /// A requester that has not authenticated must not learn the neighbourhood.
 ///
 /// The interrogator completes QUIC/TLS and nothing else — no Hello, so the responder has
@@ -369,16 +400,7 @@ async fn unauthenticated_requester_learns_no_peer_topology() -> Result<()> {
          `from` field is the caller's own claim (#2535). Disclosed: {disclosure:?}"
     );
 
-    // The responder must still be alive and holding the sentinel — otherwise the assertion
-    // above could have passed because the node fell over, not because policy held.
-    assert!(
-        fx.responder
-            .get_peer_connection_info(sentinel_did)
-            .await
-            .is_some(),
-        "post-condition: the responder must still hold the sentinel peer, otherwise the \
-         non-disclosure above proves nothing about policy"
-    );
+    assert_responder_still_serving(&fx).await;
 
     Ok(())
 }
@@ -486,6 +508,10 @@ async fn authenticated_requester_learns_nothing_when_peer_exchange_is_disabled()
          requester. The operator's configuration says this node is not participating \
          (#2535). Disclosed: {disclosure:?}"
     );
+
+    // The requester authenticated, so the only remaining explanations for silence are local
+    // policy or a responder that stopped working. Rule out the second.
+    assert_responder_still_serving(&fx).await;
 
     Ok(())
 }

--- a/icn/crates/icn-net/tests/peer_exchange_policy.rs
+++ b/icn/crates/icn-net/tests/peer_exchange_policy.rs
@@ -1,0 +1,639 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Who is allowed to learn a node's neighbourhood.
+//!
+//! #2534 settled *what* the peer-exchange responder enumerates: authenticated peers only.
+//! This file is about the separate question #2535 asks — *whether a given requester may
+//! receive that set at all*.
+//!
+//! Two properties, deliberately tested apart so neither can carry the other:
+//!
+//! 1. **Authentication.** A connection that has not completed an authenticated Hello must
+//!    not receive peer topology. Transport existing is not the same as knowing who is
+//!    asking: the request's `from` field is a claim the sender chose, and until the #2520
+//!    DID-TLS binding check has run against *this* connection's certificate, it is data,
+//!    not authority (the same confusion #2491 tracks on the rate-limit path).
+//!
+//! 2. **Participation.** A node whose operator has not enabled federation must not answer
+//!    peer-exchange requests, even from a peer that authenticated correctly. Enumerating
+//!    the neighbourhood is participation, and `federation.enabled` already gates every
+//!    other peer-exchange behaviour in both directions.
+//!
+//! Every assertion here is on decoded wire content, not on whether a handler ran. The
+//! property is disclosure — did a DID and a reachable endpoint cross the connection
+//! boundary — so the responder is stocked with a *sentinel* peer whose DID and address are
+//! known to the test, and the assertions name that sentinel. A test that only checked
+//! "response absent" would pass just as well against a node that had no peers to leak, or
+//! against a broken harness that never delivered the request.
+
+use anyhow::{Context, Result};
+use icn_identity::{Did, IdentityBundle};
+use icn_net::{
+    IncomingMessageHandler, MessagePayload, NetworkActor, NetworkHandle, NetworkMessage,
+    PeerExchangeMessage, VersionInfo,
+};
+use quinn::{ClientConfig, Endpoint};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+/// Ports already handed out in this process.
+///
+/// `pick_unused_port` binds, closes, and returns the port, so two tests running
+/// concurrently can be handed the same one. Remembering what we issued removes that race
+/// within the process; callers still retry, because nothing rules out another process
+/// taking it in between.
+static ISSUED_PORTS: std::sync::Mutex<Option<std::collections::HashSet<u16>>> =
+    std::sync::Mutex::new(None);
+
+fn pick_port() -> u16 {
+    let mut guard = ISSUED_PORTS.lock().expect("issued-port lock poisoned");
+    let issued = guard.get_or_insert_with(std::collections::HashSet::new);
+    for _ in 0..200 {
+        let port = portpicker::pick_unused_port().expect("no free port");
+        if issued.insert(port) {
+            return port;
+        }
+    }
+    panic!("could not find an unissued free port");
+}
+
+fn init() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+}
+
+/// Keeps a node's shutdown sender alive for the duration of a test.
+struct Guard(broadcast::Sender<()>);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+/// Spawn a real node on the production stack.
+///
+/// The handler is required, not optional: `NetworkActor::spawn` only starts the inbound
+/// accept loop when `incoming_handler` is `Some`, and it is also what makes
+/// `wire_new_connection` spawn a dispatch loop for an *outbound* connection. Without it
+/// nothing here would authenticate.
+///
+/// `peer_exchange_enabled` mirrors what the supervisor does with `federation.enabled` at
+/// startup. It is passed explicitly at every call site rather than defaulted, because
+/// which posture a node is in is the subject of half the tests in this file.
+async fn spawn_node(
+    bundle: IdentityBundle,
+    peer_exchange_enabled: bool,
+) -> Result<(NetworkHandle, SocketAddr, Guard)> {
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let handler: IncomingMessageHandler = Arc::new(move |_msg: NetworkMessage| {});
+
+    // Binding is setup, not the property under test, so it retries: a port reported free
+    // can still be taken by another process before we bind it.
+    let mut last_err = None;
+    for _ in 0..8 {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        match NetworkActor::spawn(
+            bundle.clone(),
+            addr,
+            shutdown_tx.clone(),
+            Some(handler.clone()),
+            None, // oracle
+            None, // fallback_config
+            None, // topology_config
+            None, // stun_servers
+            None, // turn_config
+            None, // misbehavior_detector
+            None, // store
+            None, // personhood_store
+            None, // anchor_rate_config
+            None, // advertised_addr
+        )
+        .await
+        {
+            Ok(handle) => {
+                handle.set_peer_exchange_enabled(peer_exchange_enabled);
+                // Let the endpoint bind before anyone dials it.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                return Ok((handle, addr, Guard(shutdown_tx)));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
+}
+
+/// Poll until `observer` has authenticated `did`, or the deadline passes.
+///
+/// `peer_connections` is written only by `handle_hello`, after the #2520 DID-TLS binding
+/// checks pass, so this returning `true` is proof the handshake completed. Synchronising
+/// on that observable rather than sleeping is what keeps the negative assertions
+/// non-vacuous: "denied by policy" and "Hello not processed yet" would otherwise look
+/// identical.
+async fn wait_until_authenticated(observer: &NetworkHandle, did: &Did, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if observer.get_peer_connection_info(did).await.is_some() {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// What a requester learned from a peer-exchange request.
+#[derive(Debug)]
+struct Disclosure {
+    dids: Vec<String>,
+    endpoints: Vec<SocketAddr>,
+}
+
+impl Disclosure {
+    fn leaks(&self, did: &Did, addr: SocketAddr) -> bool {
+        self.dids.contains(&did.to_string()) || self.endpoints.contains(&addr)
+    }
+}
+
+/// A raw QUIC client that speaks the wire protocol without necessarily being a peer.
+///
+/// It can interrogate a node's peer-exchange surface either anonymously — a connection
+/// that completed QUIC/TLS and nothing else — or as a properly authenticated peer, which
+/// is the difference the tests below turn on.
+struct WireClient {
+    _endpoint: Endpoint,
+    connection: quinn::Connection,
+    identity: IdentityBundle,
+}
+
+impl WireClient {
+    async fn connect(identity: &IdentityBundle, target: SocketAddr) -> Result<Self> {
+        let rustls_client = icn_net::tls::create_tofu_client_config(
+            vec![identity.tls_cert().clone()],
+            identity.tls_key(),
+        )?;
+        let mut endpoint = Endpoint::client("127.0.0.1:0".parse()?)?;
+        endpoint.set_default_client_config(ClientConfig::new(Arc::new(
+            quinn::crypto::rustls::QuicClientConfig::try_from(rustls_client)?,
+        )));
+
+        // Establishing the connection is a precondition, not the property under test, so
+        // it retries. No assertion below retries.
+        let mut last_err = None;
+        for attempt in 0..5 {
+            match tokio::time::timeout(
+                Duration::from_secs(10),
+                endpoint.connect(target, "localhost")?,
+            )
+            .await
+            {
+                Ok(Ok(connection)) => {
+                    return Ok(Self {
+                        _endpoint: endpoint,
+                        connection,
+                        identity: identity.clone(),
+                    })
+                }
+                Ok(Err(e)) => last_err = Some(e.to_string()),
+                Err(_) => last_err = Some("connect timed out".to_string()),
+            }
+            tokio::time::sleep(Duration::from_millis(150 * (attempt + 1))).await;
+        }
+        anyhow::bail!(
+            "could not establish the test connection after 5 attempts: {}",
+            last_err.unwrap_or_default()
+        )
+    }
+
+    /// Complete an authenticated Hello with `to`, using this client's own certificate.
+    ///
+    /// The binding is this identity's own and the certificate on the wire is this
+    /// identity's own, so the #2520 check passes and the responder learns who is on the
+    /// other end of *this* connection.
+    async fn authenticate(&self, to: &Did) -> Result<()> {
+        let hello = NetworkMessage::hello(
+            self.identity.did().clone(),
+            to.clone(),
+            self.identity.binding_info(),
+            VersionInfo::new("icnd-test-requester".to_string()),
+            None,
+            *self.identity.x25519_public_bytes(),
+            None,
+            None,
+        );
+        let (mut send, _recv) = self.connection.open_bi().await?;
+        icn_net::protocol::write_message(&mut send, &hello).await?;
+        send.finish().context("finish hello")?;
+        Ok(())
+    }
+
+    /// Ask the peer for its known peers.
+    ///
+    /// Returns `None` when the responder never answers, which is what a policy denial
+    /// looks like on the wire. The responder replies on a *new* bidirectional stream it
+    /// opens itself, so this accepts an inbound stream rather than reading the reply half
+    /// of the request.
+    async fn request_peer_exchange(
+        &self,
+        claimed_from: &Did,
+        to: &Did,
+        timeout: Duration,
+    ) -> Result<Option<Disclosure>> {
+        let request =
+            NetworkMessage::peer_exchange_request(claimed_from.clone(), to.clone(), 64, None);
+        let (mut send, _recv) = self.connection.open_bi().await?;
+        icn_net::protocol::write_message(&mut send, &request).await?;
+        send.finish().context("finish peer exchange request")?;
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(None);
+            }
+            let accepted = match tokio::time::timeout(remaining, self.connection.accept_bi()).await
+            {
+                Ok(inner) => inner.context("inbound stream failed")?,
+                Err(_) => return Ok(None),
+            };
+            let (_send, mut recv) = accepted;
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let read =
+                match tokio::time::timeout(remaining, icn_net::protocol::read_message(&mut recv))
+                    .await
+                {
+                    Ok(inner) => inner.context("failed to read an inbound message")?,
+                    Err(_) => return Ok(None),
+                };
+
+            // Skip anything that is not the answer we asked for. An authenticated requester
+            // also receives the responder's own Hello, on its own stream and first (#2537);
+            // treating the first inbound stream as the answer would report "no response"
+            // for a node that answered perfectly well.
+            if let MessagePayload::PeerExchange(PeerExchangeMessage::Response { peers, .. }) =
+                read.0.payload
+            {
+                return Ok(Some(Disclosure {
+                    dids: peers.iter().map(|p| p.did.clone()).collect(),
+                    endpoints: peers
+                        .iter()
+                        .flat_map(|p| p.endpoints.iter().map(|e| e.addr))
+                        .collect(),
+                }));
+            }
+        }
+    }
+}
+
+/// A responder that genuinely has something to leak.
+///
+/// Without a populated peer set, every "learned nothing" assertion below would pass
+/// trivially — against a node with no peers, or against a harness that never delivered the
+/// request. The sentinel is what gives those assertions something to be about.
+struct Fixture {
+    responder: NetworkHandle,
+    responder_did: Did,
+    responder_addr: SocketAddr,
+    /// The peer the responder has authenticated, and whose disclosure the tests assert on.
+    sentinel_did: Did,
+    sentinel_addr: SocketAddr,
+    _guards: (Guard, Guard),
+}
+
+async fn responder_holding_a_sentinel_peer(peer_exchange_enabled: bool) -> Result<Fixture> {
+    let responder = IdentityBundle::generate()?;
+    let responder_did = responder.did().clone();
+    let sentinel = IdentityBundle::generate()?;
+    let sentinel_did = sentinel.did().clone();
+
+    let (responder_handle, responder_addr, responder_guard) =
+        spawn_node(responder, peer_exchange_enabled).await?;
+    // The sentinel's own posture is irrelevant: it is dialled, and never asked anything.
+    let (_sentinel_handle, sentinel_addr, sentinel_guard) = spawn_node(sentinel, false).await?;
+
+    responder_handle
+        .dial(sentinel_addr, sentinel_did.clone())
+        .await?;
+    anyhow::ensure!(
+        wait_until_authenticated(&responder_handle, &sentinel_did, Duration::from_secs(20)).await,
+        "precondition: the responder never authenticated the sentinel peer, so there would \
+         be nothing to disclose and every negative assertion would pass for free"
+    );
+
+    Ok(Fixture {
+        responder: responder_handle,
+        responder_did,
+        responder_addr,
+        sentinel_did,
+        sentinel_addr,
+        _guards: (responder_guard, sentinel_guard),
+    })
+}
+
+/// A requester that has not authenticated must not learn the neighbourhood.
+///
+/// The interrogator completes QUIC/TLS and nothing else — no Hello, so the responder has
+/// no verified identity for this connection. It then asks, naming itself in the request's
+/// `from` field. That field is the requester's own unverified claim, and answering it
+/// hands an anonymous caller a real peer's DID and a reachable address for it.
+#[tokio::test]
+async fn unauthenticated_requester_learns_no_peer_topology() -> Result<()> {
+    init();
+    let fx = responder_holding_a_sentinel_peer(true).await?;
+
+    let interrogator = IdentityBundle::generate()?;
+    let interrogator_did = interrogator.did().clone();
+
+    let client = WireClient::connect(&interrogator, fx.responder_addr).await?;
+    // Deliberately no `authenticate()` call: this is the whole point of the test.
+    let disclosure = client
+        .request_peer_exchange(
+            &interrogator_did,
+            &fx.responder_did,
+            Duration::from_secs(10),
+        )
+        .await?;
+
+    let (sentinel_did, sentinel_addr) = (&fx.sentinel_did, fx.sentinel_addr);
+    assert!(
+        !disclosure
+            .as_ref()
+            .is_some_and(|d| d.leaks(sentinel_did, sentinel_addr)),
+        "a connection that never completed an authenticated Hello received peer topology: \
+         the sentinel peer {sentinel_did} at {sentinel_addr} crossed the connection \
+         boundary to an anonymous caller. Transport is not identity, and the request's \
+         `from` field is the caller's own claim (#2535). Disclosed: {disclosure:?}"
+    );
+
+    // The responder must still be alive and holding the sentinel — otherwise the assertion
+    // above could have passed because the node fell over, not because policy held.
+    assert!(
+        fx.responder
+            .get_peer_connection_info(sentinel_did)
+            .await
+            .is_some(),
+        "post-condition: the responder must still hold the sentinel peer, otherwise the \
+         non-disclosure above proves nothing about policy"
+    );
+
+    Ok(())
+}
+
+/// Positive control: an authenticated requester does receive the neighbourhood.
+///
+/// Without this, `unauthenticated_requester_learns_no_peer_topology` would pass against a
+/// node whose peer exchange was broken outright, or against a harness that never delivered
+/// the request at all. It also pins the #2534 invariant from the other side: what an
+/// authorised requester gets back is the authenticated peer set.
+#[tokio::test]
+async fn authenticated_requester_receives_peer_topology() -> Result<()> {
+    init();
+    let fx = responder_holding_a_sentinel_peer(true).await?;
+
+    let interrogator = IdentityBundle::generate()?;
+    let interrogator_did = interrogator.did().clone();
+
+    let client = WireClient::connect(&interrogator, fx.responder_addr).await?;
+    client.authenticate(&fx.responder_did).await?;
+    assert!(
+        wait_until_authenticated(&fx.responder, &interrogator_did, Duration::from_secs(20)).await,
+        "precondition: the requester's Hello was not accepted, so this control cannot \
+         distinguish an authorised requester from an anonymous one"
+    );
+
+    let disclosure = client
+        .request_peer_exchange(
+            &interrogator_did,
+            &fx.responder_did,
+            Duration::from_secs(20),
+        )
+        .await?
+        .context("an authenticated requester received no peer-exchange response at all")?;
+
+    let (sentinel_did, sentinel_addr) = (&fx.sentinel_did, fx.sentinel_addr);
+    assert!(
+        disclosure.dids.contains(&sentinel_did.to_string()),
+        "an authenticated requester must receive the authenticated peer set; the sentinel \
+         {sentinel_did} was missing. Disclosed: {disclosure:?}"
+    );
+    assert!(
+        disclosure.endpoints.contains(&sentinel_addr),
+        "the response must carry a reachable endpoint for the sentinel {sentinel_addr}; \
+         without it this control would not prove that endpoints are disclosable at all. \
+         Disclosed: {disclosure:?}"
+    );
+    assert!(
+        !disclosure.dids.contains(&interrogator_did.to_string()),
+        "the responder listed the requester back to itself. A peer is not something it \
+         discovered about its own neighbourhood, and echoing it is how a node ends up \
+         treating itself as a peer (#2506). Disclosed: {disclosure:?}"
+    );
+
+    Ok(())
+}
+
+/// A node that is not participating in peer exchange must not answer, even for a peer that
+/// authenticated correctly.
+///
+/// Authentication answers "who is asking". It does not answer "should this node be handing
+/// out its neighbourhood at all", which is the operator's call. `federation.enabled`
+/// already governs that in both directions — it gates sending the request
+/// (`init_bootstrap`), subscribing to federation topics (`init_gossip`), and acting on an
+/// inbound `Response` or `Announce` (`init_network`). Answering a `Request` was the one
+/// peer-exchange behaviour left ungated, which is the asymmetry #2535 reports.
+///
+/// The requester here is fully authenticated, so a denial can only come from local policy.
+/// That is what keeps this test independent of the authentication gate: if someone deleted
+/// the authentication check tomorrow, this test would still pass, and if someone deleted
+/// this policy check, the authentication test would still pass. Neither can carry the
+/// other.
+#[tokio::test]
+async fn authenticated_requester_learns_nothing_when_peer_exchange_is_disabled() -> Result<()> {
+    init();
+    let fx = responder_holding_a_sentinel_peer(false).await?;
+
+    let interrogator = IdentityBundle::generate()?;
+    let interrogator_did = interrogator.did().clone();
+
+    let client = WireClient::connect(&interrogator, fx.responder_addr).await?;
+    client.authenticate(&fx.responder_did).await?;
+    assert!(
+        wait_until_authenticated(&fx.responder, &interrogator_did, Duration::from_secs(20)).await,
+        "precondition: the requester must actually authenticate, otherwise this would be \
+         the authentication test wearing a different name and would pass without the \
+         participation gate existing at all"
+    );
+
+    let disclosure = client
+        .request_peer_exchange(
+            &interrogator_did,
+            &fx.responder_did,
+            Duration::from_secs(10),
+        )
+        .await?;
+
+    let (sentinel_did, sentinel_addr) = (&fx.sentinel_did, fx.sentinel_addr);
+    assert!(
+        !disclosure
+            .as_ref()
+            .is_some_and(|d| d.leaks(sentinel_did, sentinel_addr)),
+        "a node with peer exchange disabled enumerated its neighbourhood anyway: the \
+         sentinel {sentinel_did} at {sentinel_addr} was disclosed to an authenticated \
+         requester. The operator's configuration says this node is not participating \
+         (#2535). Disclosed: {disclosure:?}"
+    );
+
+    Ok(())
+}
+
+/// A freshly spawned node does not answer peer-exchange requests until told to.
+///
+/// This is the property that makes the wiring safe to forget. `icn-net` cannot read
+/// `federation.enabled`, so participation has to be pushed in from the composition root
+/// (`supervisor::lifecycle::spawn_network_actor`). If that call is ever dropped in a
+/// refactor, the consequence must be that federation stops discovering peers — noticeable,
+/// and not a security failure — rather than that every node silently reverts to answering
+/// anyone. Defaults decide which of those two you get.
+///
+/// It also pins the deployment reality behind #2535: `FederationConfig::enabled` is
+/// `#[serde(default)]` → `false` and no shipped config has a `[federation]` section, so
+/// "off" is the posture essentially every node is actually in.
+#[tokio::test]
+async fn peer_exchange_is_disabled_until_a_composition_root_enables_it() -> Result<()> {
+    init();
+    let node = IdentityBundle::generate()?;
+    let (handle, _addr, _guard) = spawn_node(node, false).await?;
+
+    assert!(
+        !handle.peer_exchange_enabled(),
+        "a node must not participate in peer exchange until something explicitly enables \
+         it; a fail-open default would turn a forgotten composition-root call into silent \
+         topology disclosure (#2535)"
+    );
+
+    // And the switch must actually move, or the assertion above would hold for a constant.
+    handle.set_peer_exchange_enabled(true);
+    assert!(
+        handle.peer_exchange_enabled(),
+        "enabling participation must take effect, otherwise the default above is not a \
+         default but a hard-coded refusal"
+    );
+
+    Ok(())
+}
+
+/// The `from` field on the request must not be treated as the requester's identity.
+///
+/// Here an authenticated requester lies about who it is, naming the sentinel — a real,
+/// currently-connected peer — in the request's `from` field. The responder excludes "the
+/// requesting peer" from its answer, so if it took that field as identity it would exclude
+/// the sentinel, and the lie would have steered the response.
+///
+/// The expected behaviour is that the lie changes nothing: identity comes from the
+/// connection, which Hello bound to a certificate (#2520), and the claimed field is inert.
+/// Asserting that the sentinel *is still returned* is what makes this test specific to
+/// identity confusion rather than to disclosure in general — it fails exactly when
+/// `message.from` starts being believed (#2491).
+#[tokio::test]
+async fn a_claimed_from_field_does_not_stand_in_for_authenticated_identity() -> Result<()> {
+    init();
+    let fx = responder_holding_a_sentinel_peer(true).await?;
+
+    let interrogator = IdentityBundle::generate()?;
+    let interrogator_did = interrogator.did().clone();
+
+    let client = WireClient::connect(&interrogator, fx.responder_addr).await?;
+    client.authenticate(&fx.responder_did).await?;
+    assert!(
+        wait_until_authenticated(&fx.responder, &interrogator_did, Duration::from_secs(20)).await,
+        "precondition: the requester must be authenticated, so that the only thing under \
+         test is which identity the responder believes"
+    );
+
+    // The lie: claim to be the sentinel, a peer this node really is connected to.
+    let disclosure = client
+        .request_peer_exchange(&fx.sentinel_did, &fx.responder_did, Duration::from_secs(20))
+        .await?
+        .context("an authenticated requester received no peer-exchange response at all")?;
+
+    let sentinel_did = &fx.sentinel_did;
+    assert!(
+        disclosure.dids.contains(&sentinel_did.to_string()),
+        "the responder shaped its answer around the requester's *claimed* DID: it omitted \
+         {sentinel_did}, which is only explicable if the unverified `from` field was taken \
+         as the requester's identity. Identity must come from the connection, not the \
+         message (#2535, #2491). Disclosed: {disclosure:?}"
+    );
+
+    Ok(())
+}
+
+/// Asking before authenticating must not bank permission for later.
+///
+/// Hello and a peer-exchange request arrive on separate QUIC streams, so a peer can send
+/// the request first and authenticate afterwards. The property that has to hold is
+/// monotonicity: before authentication, nothing; after authentication, normal policy. What
+/// must *not* happen is the in-between — a request that arrives unauthenticated, is held,
+/// and is then answered once Hello completes, which would let any caller obtain topology
+/// simply by asking early.
+///
+/// The reason this holds is structural rather than lucky: a connection's dispatch loop
+/// awaits each handler inline, so messages on one connection are processed strictly in
+/// order and the gate is evaluated once, at the time the request is handled. This test
+/// pins that as behaviour rather than as an implementation detail someone could reorder.
+#[tokio::test]
+async fn a_request_that_precedes_hello_is_not_answered_once_hello_lands() -> Result<()> {
+    init();
+    let fx = responder_holding_a_sentinel_peer(true).await?;
+
+    let interrogator = IdentityBundle::generate()?;
+    let interrogator_did = interrogator.did().clone();
+    let client = WireClient::connect(&interrogator, fx.responder_addr).await?;
+
+    // Ask first, while this connection is still anonymous.
+    let early = client
+        .request_peer_exchange(&interrogator_did, &fx.responder_did, Duration::from_secs(5))
+        .await?;
+
+    let (sentinel_did, sentinel_addr) = (&fx.sentinel_did, fx.sentinel_addr);
+    assert!(
+        !early
+            .as_ref()
+            .is_some_and(|d| d.leaks(sentinel_did, sentinel_addr)),
+        "the early, unauthenticated request was answered. Disclosed: {early:?}"
+    );
+
+    // Now authenticate, and confirm the earlier request stays unanswered rather than being
+    // completed retroactively.
+    client.authenticate(&fx.responder_did).await?;
+    assert!(
+        wait_until_authenticated(&fx.responder, &interrogator_did, Duration::from_secs(20)).await,
+        "precondition: the requester must authenticate, or the second half of this test \
+         proves nothing"
+    );
+
+    // A *fresh* request after authentication must succeed — otherwise "no late answer"
+    // could just mean the connection was broken by the denial.
+    let late = client
+        .request_peer_exchange(
+            &interrogator_did,
+            &fx.responder_did,
+            Duration::from_secs(20),
+        )
+        .await?
+        .context(
+            "after authenticating, a new request must be answered on the same connection; \
+             a denial must not poison the connection for later legitimate requests",
+        )?;
+    assert!(
+        late.dids.contains(&sentinel_did.to_string()),
+        "an authenticated request on a connection that was previously denied must be \
+         answered normally. Disclosed: {late:?}"
+    );
+
+    Ok(())
+}

--- a/icn/crates/icn-net/tests/provisional_connection_lifecycle.rs
+++ b/icn/crates/icn-net/tests/provisional_connection_lifecycle.rs
@@ -114,6 +114,10 @@ async fn spawn_node_counting(
         .await
         {
             Ok(handle) => {
+                // These tests are about *what* a node advertises, so it has to be a node
+                // that advertises at all. Peer exchange is off by default (#2535), which is
+                // a separate policy question from the one under test here.
+                handle.set_peer_exchange_enabled(true);
                 // Let the endpoint bind before anyone dials it.
                 tokio::time::sleep(Duration::from_millis(300)).await;
                 return Ok((handle, addr, Guard(shutdown_tx)));
@@ -162,6 +166,7 @@ async fn wait_until_authenticated(observer: &NetworkHandle, did: &Did, timeout: 
 struct WireClient {
     _endpoint: Endpoint,
     connection: quinn::Connection,
+    identity: IdentityBundle,
 }
 
 impl WireClient {
@@ -189,6 +194,7 @@ impl WireClient {
                     return Ok(Self {
                         _endpoint: endpoint,
                         connection,
+                        identity: identity.clone(),
                     })
                 }
                 Ok(Err(e)) => last_err = Some(e.to_string()),
@@ -200,6 +206,29 @@ impl WireClient {
             "could not establish the test connection after 5 attempts: {}",
             last_err.unwrap_or_default()
         )
+    }
+
+    /// Complete an authenticated Hello, so the responder knows who is asking.
+    ///
+    /// Peer exchange does not answer an unauthenticated connection (#2535), so an
+    /// interrogator that wants to read the advertised peer set has to be a peer first.
+    /// This uses the client's own binding and its own certificate, which is exactly what
+    /// the #2520 check requires.
+    async fn authenticate(&self, to: &Did) -> Result<()> {
+        let hello = NetworkMessage::hello(
+            self.identity.did().clone(),
+            to.clone(),
+            self.identity.binding_info(),
+            icn_net::VersionInfo::new("icnd-interrogator".to_string()),
+            None,
+            *self.identity.x25519_public_bytes(),
+            None,
+            None,
+        );
+        let (mut send, _recv) = self.connection.open_bi().await?;
+        icn_net::protocol::write_message(&mut send, &hello).await?;
+        send.finish().context("finish hello")?;
+        Ok(())
     }
 
     /// Ask the peer for its known peers and return the DIDs it advertises.
@@ -217,21 +246,31 @@ impl WireClient {
         icn_net::protocol::write_message(&mut send, &request).await?;
         send.finish().context("finish peer exchange request")?;
 
-        let (_send, mut recv) = tokio::time::timeout(timeout, self.connection.accept_bi())
-            .await
-            .context("timed out waiting for the peer exchange response stream")?
-            .context("peer exchange response stream failed")?;
-        let (message, _len) =
-            tokio::time::timeout(timeout, icn_net::protocol::read_message(&mut recv))
+        // An authenticated interrogator is answered with the responder's own Hello too, on
+        // its own stream and first (#2537), so skip anything that is not the answer.
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            anyhow::ensure!(
+                !remaining.is_zero(),
+                "timed out waiting for the peer exchange response"
+            );
+            let (_send, mut recv) = tokio::time::timeout(remaining, self.connection.accept_bi())
                 .await
-                .context("timed out reading the peer exchange response")?
-                .context("failed to read the peer exchange response")?;
+                .context("timed out waiting for the peer exchange response stream")?
+                .context("peer exchange response stream failed")?;
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let (message, _len) =
+                tokio::time::timeout(remaining, icn_net::protocol::read_message(&mut recv))
+                    .await
+                    .context("timed out reading the peer exchange response")?
+                    .context("failed to read the peer exchange response")?;
 
-        match message.payload {
-            MessagePayload::PeerExchange(PeerExchangeMessage::Response { peers, .. }) => {
-                Ok(peers.into_iter().map(|peer| peer.did).collect())
+            if let MessagePayload::PeerExchange(PeerExchangeMessage::Response { peers, .. }) =
+                message.payload
+            {
+                return Ok(peers.into_iter().map(|peer| peer.did).collect());
             }
-            other => anyhow::bail!("expected a PeerExchange::Response, got {other:?}"),
         }
     }
 }
@@ -303,6 +342,13 @@ async fn peer_exchange_must_not_advertise_address_derived_placeholders() -> Resu
     );
 
     let client = WireClient::connect(&interrogator, dialer_addr).await?;
+    // Reading the advertised set requires being a peer, not merely a socket (#2535).
+    client.authenticate(&dialer_did).await?;
+    assert!(
+        wait_until_authenticated(&dialer_handle, &interrogator_did, Duration::from_secs(20))
+            .await,
+        "precondition: the interrogator must authenticate before it can read the          advertised peer set"
+    );
     let advertised = client
         .request_peer_exchange(&interrogator_did, &dialer_did, Duration::from_secs(20))
         .await?;
@@ -377,6 +423,13 @@ async fn only_the_authenticated_did_becomes_canonical_when_the_supplied_did_diff
     );
 
     let client = WireClient::connect(&interrogator, dialer_addr).await?;
+    // Reading the advertised set requires being a peer, not merely a socket (#2535).
+    client.authenticate(&dialer_did).await?;
+    assert!(
+        wait_until_authenticated(&dialer_handle, &interrogator_did, Duration::from_secs(20))
+            .await,
+        "precondition: the interrogator must authenticate before it can read the          advertised peer set"
+    );
     let advertised = client
         .request_peer_exchange(&interrogator_did, &dialer_did, Duration::from_secs(20))
         .await?;

--- a/icn/crates/icn-net/tests/provisional_connection_lifecycle.rs
+++ b/icn/crates/icn-net/tests/provisional_connection_lifecycle.rs
@@ -345,9 +345,9 @@ async fn peer_exchange_must_not_advertise_address_derived_placeholders() -> Resu
     // Reading the advertised set requires being a peer, not merely a socket (#2535).
     client.authenticate(&dialer_did).await?;
     assert!(
-        wait_until_authenticated(&dialer_handle, &interrogator_did, Duration::from_secs(20))
-            .await,
-        "precondition: the interrogator must authenticate before it can read the          advertised peer set"
+        wait_until_authenticated(&dialer_handle, &interrogator_did, Duration::from_secs(20)).await,
+        "precondition: the interrogator must authenticate before it can read the \
+         advertised peer set"
     );
     let advertised = client
         .request_peer_exchange(&interrogator_did, &dialer_did, Duration::from_secs(20))
@@ -426,9 +426,9 @@ async fn only_the_authenticated_did_becomes_canonical_when_the_supplied_did_diff
     // Reading the advertised set requires being a peer, not merely a socket (#2535).
     client.authenticate(&dialer_did).await?;
     assert!(
-        wait_until_authenticated(&dialer_handle, &interrogator_did, Duration::from_secs(20))
-            .await,
-        "precondition: the interrogator must authenticate before it can read the          advertised peer set"
+        wait_until_authenticated(&dialer_handle, &interrogator_did, Duration::from_secs(20)).await,
+        "precondition: the interrogator must authenticate before it can read the \
+         advertised peer set"
     );
     let advertised = client
         .request_peer_exchange(&interrogator_did, &dialer_did, Duration::from_secs(20))

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2019,17 +2019,50 @@ pub mod peer_exchange {
         counter!("icn_peer_exchange_responses_sent_total").increment(1);
     }
 
+    /// Why this node refused to answer a peer-exchange request (#2535).
+    ///
+    /// A closed vocabulary, not a string: the label is chosen by the compiler from these
+    /// variants, so no caller — and in particular nothing derived from a request — can
+    /// widen it.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum PeerExchangeDenialReason {
+        /// This node does not participate in peer exchange (`federation.enabled = false`).
+        ///
+        /// The requester did nothing wrong; this is the operator's posture.
+        Disabled,
+        /// The connection has not authenticated a peer, so the requester is unproven.
+        ///
+        /// May be benign — a request can simply race ahead of its own Hello.
+        UnauthenticatedRequester,
+    }
+
+    impl PeerExchangeDenialReason {
+        /// Fixed label value for this reason.
+        pub fn as_label(self) -> &'static str {
+            match self {
+                Self::Disabled => "peer_exchange_disabled",
+                Self::UnauthenticatedRequester => "unauthenticated_requester",
+            }
+        }
+    }
+
     /// A peer-exchange request this node refused to answer.
     ///
-    /// `reason` distinguishes *why* the node declined, because the two cases are
-    /// operationally unalike: `unauthenticated_requester` means someone asked before
-    /// proving who they were, while `peer_exchange_disabled` means this node is not
-    /// participating and the requester did nothing wrong. Neither is peer misbehaviour, so
-    /// neither is scored against a DID — a denial counter is the whole record.
-    pub fn requests_denied_inc(reason: &str) {
+    /// The two reasons are operationally unalike and worth separating:
+    /// `unauthenticated_requester` means someone asked before proving who they were, while
+    /// `peer_exchange_disabled` means this node is not participating. Neither is peer
+    /// misbehaviour, so neither is scored against a DID — this counter is the whole record.
+    ///
+    /// # Privacy budget
+    ///
+    /// The label is a `&'static str` drawn from a closed enum. No DID, peer address,
+    /// certificate, or message field is ever recorded — in particular not the request's
+    /// claimed `from`, which is chosen by the sender and would hand a remote caller control
+    /// of this series' cardinality. Maximum cardinality is 2 series.
+    pub fn requests_denied_inc(reason: PeerExchangeDenialReason) {
         counter!(
             "icn_peer_exchange_requests_denied_total",
-            "reason" => reason.to_string()
+            "reason" => reason.as_label()
         )
         .increment(1);
     }

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2019,6 +2019,21 @@ pub mod peer_exchange {
         counter!("icn_peer_exchange_responses_sent_total").increment(1);
     }
 
+    /// A peer-exchange request this node refused to answer.
+    ///
+    /// `reason` distinguishes *why* the node declined, because the two cases are
+    /// operationally unalike: `unauthenticated_requester` means someone asked before
+    /// proving who they were, while `peer_exchange_disabled` means this node is not
+    /// participating and the requester did nothing wrong. Neither is peer misbehaviour, so
+    /// neither is scored against a DID — a denial counter is the whole record.
+    pub fn requests_denied_inc(reason: &str) {
+        counter!(
+            "icn_peer_exchange_requests_denied_total",
+            "reason" => reason.to_string()
+        )
+        .increment(1);
+    }
+
     pub fn responses_received_inc() {
         counter!("icn_peer_exchange_responses_received_total").increment(1);
     }


### PR DESCRIPTION
## Problem

A node answered `PeerExchangeMessage::Request` from anyone who could complete a QUIC/TLS
handshake, and answered it whether or not its operator had enabled federation.

What it handed over is not metadata. `handle_peer_exchange_request` enumerates the
responder's **authenticated peer set** — for each peer, its DID and a reachable
`EndpointCandidate` derived from the live connection's remote address. So a caller that had
proven nothing about itself received a list of real cooperative identities paired with
addresses it could dial.

Two independent things were missing, and neither substitutes for the other:

- **Identity.** The handler took the requester's identity from `NetworkMessage.from`. That
  field is chosen by the sender and verified by nobody.
- **Participation.** `federation.enabled` already gated every other peer-exchange
  behaviour. Answering a `Request` was the one side it did not reach.

Refs #2535.

## Baseline — the leak was asserted as a requirement on `main`

The strongest fail-before evidence is not a new test. It is a test that passes on `main`
today.

`provisional_connection_lifecycle.rs` (the #2534 preservation suite) builds a `WireClient`
that does QUIC/TLS `connect()` and nothing else — on `main` that struct has no
`authenticate()` method and never sends a Hello. It then asks for the peer list and asserts,
as its **positive control**:

```rust
// Positive control: without this, the negative assertion below would also pass on an
// empty response — i.e. if peer exchange were broken outright.
assert!(
    advertised.contains(&listener_did.to_string()),
    "precondition: the authenticated peer {listener_did} should be advertised, got {advertised:?}"
);
```

That is `main` asserting that a never-authenticated socket **must** receive a non-empty
authenticated-peer list. The disclosure was not an untested corner; it was load-bearing for
a green suite.

The new suite pins the same surface with a *sentinel*: the responder is stocked with a peer
whose DID and socket address the test knows, and every assertion names that sentinel. A test
that only checked "no response arrived" would pass equally against a node with no peers, or
against a harness that never delivered the request.

## Identity fix — where `from` stops being a claim

```
NetworkMessage.from            = a claim the sender chose
connection-bound authenticated  = authority
```

`ConnectionContext` gains `authenticated_peer: RwLock<Option<Did>>`, written only by
`record_authenticated_peer`, called from exactly one place: `handle_hello`, immediately after
all three DID-TLS facts hold —

1. the binding names the DID that sent this Hello,
2. that DID's key signed the binding,
3. the signed hash is of the certificate **this** connection is presenting (#2520).

(1)+(2) alone are replayable by anyone who has ever exchanged a Hello with the peer; (3) is
what ties the claim to the live TLS session.

`handle_peer_exchange_request` now takes its requester identity from that field. The claimed
`from` is renamed `claimed_from` and survives only inside two log lines, as `claimed_did` —
it authorises nothing, selects nothing, and addresses nothing.

**What this state means, precisely:** *"the DID-TLS identity of this physical connection is
proven"* — not *"this connection completed an accepted ICN Hello"*. Those are different
properties, and the field deliberately carries the first. See "Authenticated-peer lifetime"
below for why the write point is safe.

It is per connection, not per peer: a peer that opens two connections authenticates on each
separately.

## Participation fix — `federation.enabled` is symmetric

`federation.enabled` already governs peer exchange in both directions, at four existing
sites:

| Behaviour | Gated at |
|---|---|
| Sending a `Request` | `init_bootstrap::request_peer_exchange` |
| Federation topic subscriptions | `init_gossip` |
| Acting on an inbound `Response` | `init_network` |
| Acting on an inbound `Announce` | `init_network` |

Answering a `Request` was the missing side. `NetworkHandle::set_peer_exchange_enabled` is
called from `supervisor::lifecycle::spawn_network_actor` with the same
`federation_enabled` local that already feeds the three subsystems above.

`icn-net` deliberately does not read `FederationConfig` itself — `icn-core` depends on
`icn-net`, not the reverse — so the composition root translates the operator's posture, as
it already does for `TopologyConfig`.

**The default is `false`.** A composition root that forgets the call breaks peer discovery,
which is loud, rather than disclosing topology, which is not. That matters in practice:
`FederationConfig::enabled` is `#[serde(default)]` → `false` and no shipped config carries a
`[federation]` section, so "off" is the posture nearly every node is actually in.

Resulting truth table:

```
disabled + unauthenticated  → no topology
disabled + authenticated    → no topology     (authentication does not override local policy)
enabled  + unauthenticated  → no topology     (local policy does not manufacture identity)
enabled  + authenticated    → normal response
```

## Failure semantics — a denial is not an accusation

Neither refusal scores misbehaviour, creates a ban, touches trust, or quarantines anything.
There is no call into `MisbehaviorDetector` anywhere in the peer-exchange path.

- *Unauthenticated requester* — may simply have raced ahead of its own Hello. Attributing a
  violation here would let an attacker degrade the reputation of any peer it cared to name,
  since the only identity available is the one it chose. This mirrors the reasoning already
  written into `handle_hello`'s binding-failure paths.
- *Peer exchange disabled* — this node's own posture. The requester did nothing wrong.

The record is a counter: `icn_peer_exchange_requests_denied_total{reason}`, with `reason` one
of two fixed literals (`unauthenticated_requester`, `peer_exchange_disabled`). No
sender-controlled value becomes a metrics label. `requests_received_total` now increments
before the gates, so denials are a visible subset rather than an invisible drop.

## Design questions resolved before opening this PR

**Authenticated-peer lifetime.** `handle_hello` does more fallible work after
`record_authenticated_peer`: PQ-binding validation, version negotiation, and (under
`post-quantum`) keypair load in `send_hello_response`. None of those can leave a live
dispatcher holding a proven identity, and the reason is structural:

- `ConnectionContext::new` has **exactly one** call site in the crate —
  `handle_connection` — and `ctx` is an owned local, never cloned, never moved into a task.
- The stream loop awaits every handler inline, so one connection's messages are processed
  strictly in order.
- The `Hello` arm is the **only** arm in the dispatch match that propagates with `?`. Every
  other arm swallows its error.

So any post-record Hello failure returns `Err` from `handle_connection`, exits the loop, and
drops the only `ConnectionContext` — taking `authenticated_peer` with it. No further stream
is accepted on that connection's dispatcher, so no `PeerExchange` request can execute behind
a failed Hello. (For the PQ and version paths the connection is not even session-installed
yet; installation happens later in the function.)

Stated plainly, because it is worth a reviewer's attention: that argument is *structural, not
asserted*. No executing test covers "Hello passes DID-TLS, then fails, and the connection
must not answer" — the ordering test covers the pre-Hello case only. If a future change made
the `Hello` arm swallow its error the way every sibling arm does, the gap would open
silently. Naming it here rather than leaving it implicit in the control flow.

**Repeated Hello / rebinding.** `authenticated_peer` is last-writer-wins, which mirrors
existing behaviour rather than introducing it: on `main`, a repeated Hello is already fully
verified and already refreshes peer state and the canonical session installation (#2537
kept the *response* to once-only, not the verification). Re-keying to a different DID
requires that DID's key to have signed a binding over *this connection's* certificate — it
is authenticated, not forgeable. Making the field write-once would desynchronise
peer-exchange authority from canonical session identity, which is worse.

**Runtime mutability of the policy.** Retained as `Arc<AtomicBool>` + setter, deliberately:

- It mirrors the one existing sibling on the same struct, `set_dial_timeout`
  (`Arc<AtomicU64>`, same shared-with-actor mechanism). It is the established
  `NetworkHandle` pattern, not a new one.
- The immutable alternative means a 15th positional argument on `NetworkActor::spawn`, which
  already takes 14 and has 35 call sites. A bare positional `bool` in that list is *less*
  safe than a named setter, and the churn would bury the security change.
- The authority concern is bounded by the fail-closed default: the worst a forgotten or
  mis-ordered call does is disable discovery.

There is one production caller and no configuration-reload path; `federation.enabled` is
startup-static. If `spawn` ever grows a config struct, this flag belongs in it.

## Non-goals

- **#2491** — the pre-authentication rate limiter still keys on claimed `message.from`
  (`connection.rs`, before dispatch). Untouched here by design.
- **#2533** — `KnownDid` expectation-mismatch semantics.
- **#2539** — reviving the `#[ignore]`d DID-TLS suites.
- Trust-tier / `PolicyOracle` authorisation for topology disclosure. This PR asks *whether
  the requester is authenticated*, not *whether it is trusted enough*.
- General federation redesign.

## Evidence

### New: `icn-net/tests/peer_exchange_policy.rs` — 6 passed, 0 failed, 0 ignored

| Test | Property |
|---|---|
| `unauthenticated_requester_learns_no_peer_topology` | QUIC/TLS only, no Hello → sentinel DID and address must not cross the boundary. Post-condition re-asserts the responder still holds the sentinel, so the negative cannot pass by the node falling over. |
| `authenticated_requester_receives_peer_topology` | Positive control. Sentinel DID **and** endpoint returned — plus the requester is **not** echoed back to itself. |
| `authenticated_requester_learns_nothing_when_peer_exchange_is_disabled` | Requester fully authenticated, so only local policy can deny. Independent of the identity gate in both directions. |
| `peer_exchange_is_disabled_until_a_composition_root_enables_it` | Fail-closed default, and the switch actually moves (so the default is a default, not a hard-coded refusal). |
| `a_claimed_from_field_does_not_stand_in_for_authenticated_identity` | Authenticated requester lies, naming the sentinel in `from`. Asserts the sentinel is **still returned** — fails exactly when `message.from` starts being believed. |
| `a_request_that_precedes_hello_is_not_answered_once_hello_lands` | Ordering. The early unauthenticated request is never answered retroactively; a fresh request after Hello succeeds, so "no late answer" cannot mean "connection poisoned". |

Every assertion is on decoded wire content naming a known sentinel peer, not on
whether a handler ran.

### Mutation campaign — 5/5 killed

| Mutation | Result |
|---|---|
| M1 remove the authentication gate | killed |
| M2 use claimed `message.from` as identity | killed |
| M3 force peer exchange enabled | killed |
| M4 deny all requests | killed |
| M5 remove requester self-exclusion | **survived first** → assertion added to the positive control → killed |

M5 surviving was the campaign working: the suite could not yet see self-exclusion, so
an assertion was added rather than the mutation excused. That assertion is non-vacuous —
by the time it runs the interrogator really is one of the responder's authenticated
connections, so removing self-exclusion genuinely puts it in the response.

Not re-run this session: the only change since was a test **message string**, so production
semantics are byte-identical.

### Regressions — preserved

| Suite | Result |
|---|---|
| `provisional_connection_lifecycle` (#2534) | 8 passed, 0 failed |
| `hello_handshake_termination` (#2537) | 5 passed, 0 failed |
| `redundant_dial_idempotence` (#2536) | 5 passed, 0 failed |
| `hello_current_cert_binding` (#2520) | 7 passed, 0 failed, **0 ignored** |

The two adapted #2534 tests now authenticate their inspection client instead of relying on
anonymous disclosure, and still assert the original property: an address-derived placeholder
DID never appears in peer-exchange results.

On **#2539** specifically, to avoid an easy misreading: the two *dedicated* DID-TLS suites do
carry ignored coverage (`client_cert_verification` 0/4 executing, `did_tls_binding` 2 pass /
4 ignored). That is not the same as #2520 being untested — `hello_current_cert_binding` gives
it 7 executing tests through the production path. Reviving those suites is #2539's job.

### Gates

`cargo fmt --all --check` · `cargo clippy --all-targets -D warnings` · Meaning Firewall ·
Regulatory Compliance Linter · readiness/overclaim linter · doc-control — all green.

## Caveat — no executing composition-root test

There is **no** test that boots the canonical `icn-core` supervisor and proves
`config.federation.enabled` reaches the network actor. `spawn_network_actor` is private and
requires seven constructed dependencies plus a bound QUIC socket, and building a
supervisor-boot harness is out of scope here.

What exists instead:

- `peer_exchange_is_disabled_until_a_composition_root_enables_it` proves the network-layer
  contract: fail-closed default, and the switch actually moves.
- The wiring line is verified **structurally** — it consumes `federation_enabled`, the same
  local read at the top of `spawn_network_actor` and already passed to
  `create_incoming_handler` three lines later.

Structural inspection is not an executing composition test and is not presented as one. This
is a pre-existing repo-wide gap, not one this PR introduces: the closest precedent —
`gossip_subscription_control.rs` (#2471, same flag, same composition root) — hand-constructs
`MessageHandlerDeps { federation_enabled: false }` rather than proving the wiring either.

## Risk

Behaviour change for any deployment that relied on unauthenticated peer exchange, and for
any node running with `federation.enabled = false` that was previously answering requests.
Both are the intended effect. Because the default is off and no shipped config sets
`[federation]`, the practical change for current deployments is that peer-exchange responses
stop entirely unless federation is explicitly enabled.
