### PR TITLE
fix(net): surface bootstrap DID expectation mismatches

### DIFF
--- a/docs/architecture/network-session-identity-binding.md
+++ b/docs/architecture/network-session-identity-binding.md
@@ -104,6 +104,45 @@ equality, not by freshness. Signing or validating `created_at` would only be nee
 support binding *expiry* independent of certificate lifetime, which is a separate design
 question.
 
+## What the authenticated identity is checked against
+
+The invariant above says who a connection may be attributed to. It does not say whether that
+party is who the operator *meant* to reach. Those are separate questions, and a bootstrap
+entry of the form `icn://did:icn:X@HOST:PORT` raises the second one.
+
+**A configured DID is an operator expectation, not a cryptographic pin.** When X is
+configured and B authenticates, B is the peer — for the session map, for peer exchange, for
+trust, for addressing. The connection is kept. What changed in #2533 is only that the
+divergence is no longer silent: it is logged once per connection at `warn!`, with both DIDs
+and the remote address, and counted by `icn_network_bootstrap_did_expectation_mismatch_total`.
+
+Three properties make that comparison safe, and each is load-bearing:
+
+| Property | Why |
+|---|---|
+| Compared only *after* the three checks above | Before them `from` is a name the sender picked. Comparing against a claim would let whoever answers the address decide what this node reports about its own configuration — and would report a divergence at the one moment the node cannot say who it is talking to. A connection that never authenticates produces no observation. |
+| Held per physical connection, keyed by nothing | The expectation belongs to one dial. Concurrent dials to one address can carry different expectations, an address can be reused by a different node, and the expected DID is precisely the value that is wrong in the case being detected — so neither address nor DID is a sound key. It lives in `ConnectionContext` and dies with the connection. |
+| Stated by the caller, never inferred from the dial argument | `dial_addr` synthesises a placeholder DID from the socket address and dials with it, so an address-only bootstrap is type-identical to a `KnownDid` one by the time the actor sees it. Inferring an expectation from "the DID we dialled with" would report every `icn://HOST:PORT` entry as misconfigured. `NetworkHandle::dial_expecting` is the only entry point that states one, and `dial_bootstrap_peers`' `KnownDid` arm is its only production caller. |
+
+**A divergence is not misbehaviour.** Nothing is scored, nobody is banned, and neither DID is
+penalised — for the same reason a failed binding does not penalise the claimed DID, and one
+more besides: the peer did nothing wrong by being itself. A mismatch means configuration and
+reality disagree, which is the operator's to resolve.
+
+**Why not enforce the pin.** Refusing the connection would turn a bootstrap entry left stale
+by a key rotation, a redeploy, or a copy-paste into a hard connectivity failure with no
+in-band way to recover. It would also buy less than it appears to: under the invariant above,
+an authenticated B *cannot* be impersonating X, so a mismatch is never impersonation — it is
+"you reached a different real node than you named". Refusing is a federation-membership
+policy, not an authentication fix, and no in-repo document has ever promised it. #2533 records
+the full option analysis; the metric exists so that a future decision to enforce can be made
+against evidence rather than intuition.
+
+Regression coverage: `crates/icn-net/tests/bootstrap_did_expectation.rs` (the policy itself,
+including a test that a strict-pin implementation would fail) and
+`crates/icn-core/tests/bootstrap_did_expectation_wiring.rs` (that the bootstrap path actually
+states the expectation).
+
 ## Enforcement point
 
 One check, in `ConnectionContext::handle_hello`. Both connection directions —

--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -3644,6 +3644,8 @@ dependencies = [
  "icn-store",
  "icn-time",
  "mdns-sd",
+ "metrics",
+ "metrics-util 0.19.1",
  "portpicker",
  "quinn",
  "rand 0.9.4",

--- a/icn/crates/icn-core/src/supervisor/init_bootstrap.rs
+++ b/icn/crates/icn-core/src/supervisor/init_bootstrap.rs
@@ -59,6 +59,14 @@ impl BootstrapConfig {
 /// configured `KnownDid` is therefore an expectation, and the `AddrOnly` placeholder is not
 /// even that — see [`icn_net::NetworkHandle::dial_addr`] and #2530.
 ///
+/// The two forms therefore reach the network by different entry points, and the difference
+/// is load-bearing. A `KnownDid` entry goes through [`icn_net::NetworkHandle::dial_expecting`],
+/// which carries the operator's expectation to the connection so a divergence from the
+/// authenticated identity can be reported. An `AddrOnly` entry names nobody, so it must not
+/// acquire an expectation on the way down: `dial_addr` synthesises a placeholder DID that
+/// *looks* like one, and treating it as such would report every address-only entry as
+/// misconfigured (#2533).
+///
 /// The addresses are what lets [`request_peer_exchange`] find *these* peers once they
 /// authenticate, without widening to every peer the node happens to be connected to.
 pub async fn dial_bootstrap_peers(
@@ -82,7 +90,16 @@ pub async fn dial_bootstrap_peers(
                     "Connecting to bootstrap peer: {} at {}",
                     peer_did, peer_addr
                 );
-                match network_handle.dial(peer_addr, peer_did.clone()).await {
+                // `dial_expecting`, not `dial`: this is the one dial in the daemon whose DID
+                // came from operator configuration rather than from an address or another
+                // node's claim, so it is the one dial where a divergence from the
+                // authenticated identity says something about *this* node's configuration.
+                // The expectation still does not gate the connection — it is carried so the
+                // divergence can be seen rather than enforced (#2533).
+                match network_handle
+                    .dial_expecting(peer_addr, peer_did.clone())
+                    .await
+                {
                     Ok(_) => {
                         // The configured DID is an expectation, not a result: this records
                         // that transport came up, and the peer is named only once Hello

--- a/icn/crates/icn-core/tests/bootstrap_did_expectation_wiring.rs
+++ b/icn/crates/icn-core/tests/bootstrap_did_expectation_wiring.rs
@@ -1,0 +1,259 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! The bootstrap composition path must actually *state* the operator's expectation.
+//!
+//! `icn-net` can weigh a configured DID against the authenticated one, but only for a dial
+//! that declared an expectation. Whether the bootstrap path declares one is a property of
+//! `dial_bootstrap_peers`, not of `icn-net` — and it is exactly the kind of property that
+//! looks fine in review and is absent at runtime, because the two dial entry points differ
+//! by one word at the call site (#2533).
+//!
+//! So this drives the real `dial_bootstrap_peers` against a real `NetworkActor`, from a
+//! bootstrap **URL string**, and asserts on what the node observed. A version of this
+//! function that called `dial` instead of `dial_expecting` would still connect, still log
+//! "✓ Reached bootstrap peer", and record nothing — which is the regression to catch.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use icn_core::supervisor::init_bootstrap::{dial_bootstrap_peers, BootstrapConfig};
+use icn_identity::{Did, IdentityBundle};
+use icn_net::{IncomingMessageHandler, NetworkActor, NetworkHandle, NetworkMessage};
+use metrics::with_local_recorder;
+use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+use tokio::sync::broadcast;
+
+const MISMATCH_METRIC: &str = "icn_network_bootstrap_did_expectation_mismatch_total";
+
+fn init() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+}
+
+fn mismatch_total(snapshotter: &Snapshotter) -> u64 {
+    snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter_map(|(key, _, _, value)| {
+            if key.key().name() != MISMATCH_METRIC {
+                return None;
+            }
+            match value {
+                DebugValue::Counter(v) => Some(v),
+                _ => None,
+            }
+        })
+        .sum()
+}
+
+/// A current-thread runtime plus a recorder only this thread can see.
+///
+/// Both are required together: `with_local_recorder` is thread-local, and the mismatch is
+/// decided inside a spawned connection-handler task, which only a current-thread runtime
+/// polls on the thread that holds the recorder.
+fn run_with_local_metrics<F>(body: F) -> anyhow::Result<Snapshotter>
+where
+    F: std::future::Future<Output = anyhow::Result<()>>,
+{
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    with_local_recorder(&recorder, || runtime.block_on(body))?;
+    Ok(snapshotter)
+}
+
+async fn spawn_node(bundle: IdentityBundle) -> anyhow::Result<(NetworkHandle, SocketAddr, Guard)> {
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let handler: IncomingMessageHandler = Arc::new(|_msg: NetworkMessage| {});
+
+    let mut last_err = None;
+    for _ in 0..8 {
+        let port = portpicker::pick_unused_port().expect("no free port");
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
+        match NetworkActor::spawn(
+            bundle.clone(),
+            addr,
+            shutdown_tx.clone(),
+            Some(handler.clone()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        {
+            Ok(handle) => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                return Ok((handle, addr, Guard(shutdown_tx)));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
+}
+
+struct Guard(broadcast::Sender<()>);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+async fn wait_until_authenticated(observer: &NetworkHandle, did: &Did, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if observer.get_peer_connection_info(did).await.is_some() {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+fn bootstrap_config(urls: Vec<String>) -> BootstrapConfig {
+    BootstrapConfig {
+        bootstrap_peers: urls,
+        federation_enabled: false,
+        network_name: "test".to_string(),
+        peer_exchange_delay_ms: 0,
+        peer_exchange_max_peers: 0,
+    }
+}
+
+/// A `icn://did:icn:X@HOST:PORT` entry whose named DID is not who answers is recorded.
+///
+/// The whole point of routing this through a URL string is that the URL is the operator's
+/// interface. `parse_bootstrap_peer` turns it into `KnownDid`, and the `KnownDid` arm is the
+/// only production caller that may claim an expectation.
+#[test]
+fn a_known_did_bootstrap_entry_records_a_divergent_peer() -> anyhow::Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let listener = IdentityBundle::generate()?;
+        let listener_did = listener.did().clone();
+        let expected_did = IdentityBundle::generate()?.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let (_listener_handle, listener_addr, _listener_guard) = spawn_node(listener).await?;
+
+        let config = bootstrap_config(vec![format!("icn://{expected_did}@{listener_addr}")]);
+        let dialed = dial_bootstrap_peers(&config, &dialer_handle).await;
+        assert_eq!(
+            dialed,
+            vec![listener_addr],
+            "precondition: bootstrap must have reached the endpoint at all"
+        );
+
+        assert!(
+            wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+            "precondition: the node that actually answered never authenticated"
+        );
+        assert_eq!(
+            dialer_handle.connected_peers().await,
+            vec![listener_did.clone()],
+            "the authenticated peer stays canonical — a bootstrap entry names an endpoint \
+             and an expectation, never a peer"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        1,
+        "the bootstrap URL named one DID and another authenticated; `dial_bootstrap_peers` \
+         must state that expectation so it can be weighed (#2533)"
+    );
+    Ok(())
+}
+
+/// Control: the same path, with the entry naming the node that really is there.
+///
+/// Without this, the test above would still pass if `dial_bootstrap_peers` reported a
+/// mismatch unconditionally — which would make the signal worthless in exactly the
+/// deployment where the configuration is right.
+#[test]
+fn a_correct_known_did_bootstrap_entry_records_nothing() -> anyhow::Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let listener = IdentityBundle::generate()?;
+        let listener_did = listener.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let (_listener_handle, listener_addr, _listener_guard) = spawn_node(listener).await?;
+
+        let config = bootstrap_config(vec![format!("icn://{listener_did}@{listener_addr}")]);
+        let dialed = dial_bootstrap_peers(&config, &dialer_handle).await;
+        assert_eq!(
+            dialed,
+            vec![listener_addr],
+            "precondition: bootstrap must have reached the endpoint at all"
+        );
+        assert!(
+            wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+            "precondition: the configured peer never authenticated, so nothing was weighed"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        0,
+        "the entry named the node that answered; a correct configuration must stay silent"
+    );
+    Ok(())
+}
+
+/// Control: an `icn://HOST:PORT` entry states no expectation, so it cannot fail one.
+///
+/// This is the addr-only arm of the same production function. It reaches `icn-net` through
+/// `dial_addr`, which synthesises a placeholder DID — so a bootstrap path that derived an
+/// expectation from "the DID we dialled with" would report every address-only entry as a
+/// misconfiguration.
+#[test]
+fn an_addr_only_bootstrap_entry_records_nothing() -> anyhow::Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let listener = IdentityBundle::generate()?;
+        let listener_did = listener.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let (_listener_handle, listener_addr, _listener_guard) = spawn_node(listener).await?;
+
+        let config = bootstrap_config(vec![format!("icn://{listener_addr}")]);
+        let dialed = dial_bootstrap_peers(&config, &dialer_handle).await;
+        assert_eq!(
+            dialed,
+            vec![listener_addr],
+            "precondition: bootstrap must have reached the endpoint at all"
+        );
+        assert!(
+            wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+            "precondition: the peer never authenticated, so no comparison was reachable"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        0,
+        "an address-only entry names nobody, so the peer that answers cannot be the wrong one"
+    );
+    Ok(())
+}

--- a/icn/crates/icn-net/Cargo.toml
+++ b/icn/crates/icn-net/Cargo.toml
@@ -52,6 +52,8 @@ rand_core.workspace = true
 criterion = "0.5"
 tempfile = "3.24"
 portpicker.workspace = true
+metrics.workspace = true
+metrics-util = { version = "0.19", features = ["debugging"] }
 
 [[bench]]
 name = "net_bench"

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -180,6 +180,8 @@ impl NetworkActor {
                     own_did_clone,
                     crate::handlers::ConnectionDirection::Inbound,
                     peer_exchange_enabled,
+                    // We did not choose this peer, so there is nobody we expected (#2533).
+                    None,
                 )
                 .await
                 {
@@ -213,6 +215,7 @@ impl NetworkActor {
         own_did: Did,
         direction: crate::handlers::ConnectionDirection,
         peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
+        expected_peer: Option<Did>,
     ) -> Result<()> {
         info!("Handling connection from {}", connection.remote_address());
 
@@ -231,6 +234,7 @@ impl NetworkActor {
             own_did.clone(),
             direction,
             peer_exchange_enabled,
+            expected_peer,
         );
 
         loop {

--- a/icn/crates/icn-net/src/actor/messages.rs
+++ b/icn/crates/icn-net/src/actor/messages.rs
@@ -41,9 +41,12 @@ impl NetworkActor {
                 addr,
                 did,
                 peer_relay_addr,
+                expected_peer,
                 response,
             } => {
-                let result = self.handle_dial(addr, did, peer_relay_addr).await;
+                let result = self
+                    .handle_dial(addr, did, peer_relay_addr, expected_peer)
+                    .await;
                 let _ = response.send(result);
             }
 
@@ -103,6 +106,7 @@ impl NetworkActor {
         addr: std::net::SocketAddr,
         did: Did,
         peer_relay_addr: Option<std::net::SocketAddr>,
+        expected_peer: Option<Did>,
     ) -> Result<()> {
         // Read configurable dial timeout (default 30s, overridable via NetworkHandle::set_dial_timeout)
         let dial_timeout_ms = self
@@ -129,7 +133,7 @@ impl NetworkActor {
                 // succeeds without creating anything, and that session is already wired.
                 match outcome {
                     crate::session::DialOutcome::Established(connection) => {
-                        self.wire_new_connection(connection, &did);
+                        self.wire_new_connection(connection, &did, expected_peer);
                     }
                     crate::session::DialOutcome::AlreadyConnected(_) => {
                         debug!(
@@ -235,7 +239,7 @@ impl NetworkActor {
                         self.relay_proxies.write().await.insert(did.clone(), proxy);
 
                         // Wire up connection handler + Hello
-                        self.wire_new_connection(connection, &did);
+                        self.wire_new_connection(connection, &did, expected_peer);
 
                         let mut ns = self.nat_status.write().await;
                         ns.last_traversal_mode = TraversalMode::Relayed;
@@ -281,7 +285,12 @@ impl NetworkActor {
     /// of the session manager's authenticated connection map entirely (#2530) — the map
     /// lookup this used to perform was the only thing that forced an unauthenticated key
     /// to be registered before the handshake could run.
-    fn wire_new_connection(&self, connection: quinn::Connection, did: &Did) {
+    fn wire_new_connection(
+        &self,
+        connection: quinn::Connection,
+        did: &Did,
+        expected_peer: Option<Did>,
+    ) {
         // Increment connection counter
         let stats = self.stats.clone();
         tokio::spawn(async move {
@@ -322,6 +331,7 @@ impl NetworkActor {
                     own_did,
                     crate::handlers::ConnectionDirection::Outbound,
                     peer_exchange_enabled,
+                    expected_peer,
                 )
                 .await
                 {

--- a/icn/crates/icn-net/src/actor/mod.rs
+++ b/icn/crates/icn-net/src/actor/mod.rs
@@ -91,6 +91,14 @@ pub enum NetworkMsg {
         did: Did,
         /// Peer's TURN relay address for fallback (None = direct only)
         peer_relay_addr: Option<SocketAddr>,
+        /// The DID an operator configured for this endpoint, if any.
+        ///
+        /// Distinct from `did`, which is only how the dial is addressed and keyed. `did`
+        /// may be an address-derived placeholder, or a DID some *peer* advertised; neither
+        /// is anybody's expectation. `Some` here means an operator wrote this DID into a
+        /// bootstrap entry, which is the one case where a divergence says something about
+        /// configuration rather than about the network (#2533).
+        expected_peer: Option<Did>,
         response: oneshot::Sender<Result<()>>,
     },
 
@@ -189,8 +197,30 @@ impl NetworkHandle {
     }
 
     /// Dial a peer (direct only, no relay fallback)
+    ///
+    /// `did` addresses the dial; it is not asserted to be who will answer, and no
+    /// expectation is attached. Callers that dial a DID an operator *configured* — as
+    /// opposed to one a peer advertised or one derived from an address — want
+    /// [`Self::dial_expecting`] instead.
     pub async fn dial(&self, addr: SocketAddr, did: Did) -> Result<()> {
         self.dial_with_relay(addr, did, None).await
+    }
+
+    /// Dial an endpoint an operator configured, naming the DID they expect to find there.
+    ///
+    /// The expectation travels with the connection and is weighed against the identity that
+    /// authenticates on it (#2533). It changes nothing about the dial itself: the connection
+    /// is established, and whoever passes the Hello binding checks is the peer, exactly as
+    /// with [`Self::dial`]. A divergence is recorded, not enforced — see
+    /// `ConnectionContext::resolve_peer_expectation` for why, and for what it deliberately
+    /// does *not* do.
+    ///
+    /// Only operator configuration may call this. A DID learned over peer exchange is a
+    /// claim by some other node, and passing it here would report that node's inaccuracy as
+    /// this operator's misconfiguration.
+    pub async fn dial_expecting(&self, addr: SocketAddr, expected: Did) -> Result<()> {
+        self.dial_inner(addr, expected.clone(), None, Some(expected))
+            .await
     }
 
     /// Dial a peer with optional TURN relay fallback
@@ -203,12 +233,23 @@ impl NetworkHandle {
         did: Did,
         peer_relay_addr: Option<SocketAddr>,
     ) -> Result<()> {
+        self.dial_inner(addr, did, peer_relay_addr, None).await
+    }
+
+    async fn dial_inner(
+        &self,
+        addr: SocketAddr,
+        did: Did,
+        peer_relay_addr: Option<SocketAddr>,
+        expected_peer: Option<Did>,
+    ) -> Result<()> {
         let (tx, rx) = oneshot::channel();
         self.tx
             .send(NetworkMsg::Dial {
                 addr,
                 did,
                 peer_relay_addr,
+                expected_peer,
                 response: tx,
             })
             .await
@@ -2127,6 +2168,7 @@ mod tests {
             addr,
             did,
             peer_relay_addr: Some(relay),
+            expected_peer: None,
             response: tx,
         };
         match msg {
@@ -2148,6 +2190,7 @@ mod tests {
             addr,
             did,
             peer_relay_addr: None,
+            expected_peer: None,
             response: tx,
         };
         match msg {

--- a/icn/crates/icn-net/src/handlers/encrypted.rs
+++ b/icn/crates/icn-net/src/handlers/encrypted.rs
@@ -229,6 +229,9 @@ mod tests {
             identity_bundle,
             own_did,
             direction: crate::handlers::ConnectionDirection::Inbound,
+            // Inbound: we did not choose this peer, so we expected nobody (#2533).
+            expected_peer: None,
+            expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -379,6 +382,9 @@ mod tests {
             identity_bundle,
             own_did: own_did.clone(),
             direction: crate::handlers::ConnectionDirection::Inbound,
+            // Inbound: we did not choose this peer, so we expected nobody (#2533).
+            expected_peer: None,
+            expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/icn/crates/icn-net/src/handlers/handshake.rs
+++ b/icn/crates/icn-net/src/handlers/handshake.rs
@@ -240,6 +240,9 @@ mod tests {
             identity_bundle,
             own_did,
             direction: crate::handlers::ConnectionDirection::Inbound,
+            // Inbound: we did not choose this peer, so we expected nobody (#2533).
+            expected_peer: None,
+            expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -273,6 +276,9 @@ mod tests {
             identity_bundle,
             own_did,
             direction: crate::handlers::ConnectionDirection::Inbound,
+            // Inbound: we did not choose this peer, so we expected nobody (#2533).
+            expected_peer: None,
+            expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/icn/crates/icn-net/src/handlers/hello.rs
+++ b/icn/crates/icn-net/src/handlers/hello.rs
@@ -107,6 +107,12 @@ impl ConnectionContext {
         // who they are talking to without trusting a sender-chosen field (#2535, #2491).
         self.record_authenticated_peer(from).await;
 
+        // Now — and only now — is there an identity to weigh the operator's expectation
+        // against. Before the three checks above, `from` is a name the sender chose; after
+        // them it is a DID proven against this connection's certificate. A configured DID is
+        // still not a pin, so this records a divergence and changes nothing else (#2533).
+        self.resolve_peer_expectation(from, connection.remote_address());
+
         // Verify DID-PQ binding if proof is present
         // Returns: Ok(true) = verified, Ok(false) = no PQ key or legacy (no proof), Err = invalid proof
         let pq_binding_result =

--- a/icn/crates/icn-net/src/handlers/mod.rs
+++ b/icn/crates/icn-net/src/handlers/mod.rs
@@ -17,8 +17,10 @@ use crate::topology::{NeighborSets, TopologyConfig};
 use crate::{BlobLocationRegistry, RateLimiter, SessionManager};
 use icn_identity::{Did, IdentityBundle};
 use icn_security::MisbehaviorDetector;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tracing::warn;
 
 /// Context for handling incoming connections
 ///
@@ -75,6 +77,36 @@ pub struct ConnectionContext {
     /// connection without re-plumbing. Distinct from authentication: this says whether
     /// *this node* is participating, not who is asking (#2535).
     peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
+    /// The DID an operator configured for the endpoint this connection was dialled to.
+    ///
+    /// `Some` only for a bootstrap entry that named a DID — `icn://did:icn:X@HOST:PORT`.
+    /// `None` everywhere else, and the everywhere-else cases are the point:
+    ///
+    /// - **inbound** — we did not choose this peer, so we expected nobody;
+    /// - **address-only bootstrap** — `dial_addr` derives a placeholder `Did` from the
+    ///   socket address and dials with it, so the dial argument *looks* like an expectation
+    ///   while naming nobody. Reading one off it would report a divergence on every
+    ///   `icn://HOST:PORT` entry;
+    /// - **a DID learned over peer exchange or discovery** — a claim by another node, whose
+    ///   inaccuracy is not this operator's misconfiguration.
+    ///
+    /// Per connection, and owned by it: an expectation belongs to one dial. Two concurrent
+    /// dials to one address can carry different ones, an address can be reused by a
+    /// different node, and the expected DID is precisely the value that is wrong in the case
+    /// this exists to detect — so neither the address nor the DID is a sound key for holding
+    /// this anywhere global (#2533).
+    expected_peer: Option<Did>,
+    /// Whether a divergence has already been reported for this connection.
+    ///
+    /// Named for what it records, because the distinction is load-bearing: it is set *only*
+    /// when a mismatch is reported, never when an expectation is met. A Hello that matches
+    /// returns before touching it, so a connection that first authenticates the configured
+    /// DID and later authenticates a different one can still report that — a successful match
+    /// must not permanently spend the ability to notice a later rebinding.
+    ///
+    /// It exists because a Hello is verified every time one arrives, so without it a peer
+    /// that repeats its Hello would set the rate of a signal about *local* configuration.
+    expectation_mismatch_reported: std::sync::atomic::AtomicBool,
 }
 
 /// Which end of a QUIC connection this node is.
@@ -107,6 +139,7 @@ impl ConnectionContext {
         own_did: Did,
         direction: ConnectionDirection,
         peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
+        expected_peer: Option<Did>,
     ) -> Self {
         Self {
             handler,
@@ -124,6 +157,8 @@ impl ConnectionContext {
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: RwLock::new(None),
             peer_exchange_enabled,
+            expected_peer,
+            expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -150,6 +185,66 @@ impl ConnectionContext {
     /// prove, and the only safe reading of it is "we do not know who this is".
     pub(crate) async fn authenticated_peer(&self) -> Option<Did> {
         self.authenticated_peer.read().await.clone()
+    }
+
+    /// Weigh the operator's expectation for this connection against the identity that just
+    /// authenticated on it.
+    ///
+    /// **Call this only from the Hello path, and only after the DID-TLS binding checks have
+    /// passed.** `authenticated` has to be a DID proven against *this* connection's
+    /// certificate, never `message.from`, never the address, never a session-map key.
+    /// Comparing against a claim would hand the far end control of what this node reports
+    /// about its own configuration, and would report a divergence at the one moment the node
+    /// cannot say who it is talking to at all. A connection that never authenticates
+    /// produces no observation: "we do not know who this is" is not evidence that the
+    /// operator was wrong.
+    ///
+    /// ## What a divergence is, and what it is not
+    ///
+    /// `icn://did:icn:X@HOST:PORT` states an expectation. It is not a cryptographic pin, and
+    /// this does not make it one: the connection is kept and `authenticated` remains the
+    /// canonical peer — for peer exchange, for trust, for addressing, for everything. Only
+    /// the *silence* changes.
+    ///
+    /// That is a deliberate policy choice, not an oversight. Refusing the connection would
+    /// turn a bootstrap entry left stale by a key rotation, a redeploy, or a copy-paste into
+    /// a hard connectivity failure with no in-band way to recover — and it would buy less
+    /// than it appears to, because an authenticated peer cannot be impersonating the
+    /// configured DID (#2520). A divergence means configuration and reality disagree, which
+    /// is the operator's to resolve. So nothing is scored, nobody is banned, and neither DID
+    /// is penalised: the peer did nothing wrong by being itself. #2533 records the reasoning;
+    /// `crates/icn-net/tests/bootstrap_did_expectation.rs` pins the policy so that changing
+    /// it has to be deliberate.
+    ///
+    /// At most once per connection — see [`Self::expectation_mismatch_reported`].
+    pub(crate) fn resolve_peer_expectation(&self, authenticated: &Did, remote_addr: SocketAddr) {
+        let Some(expected) = self.expected_peer.as_ref() else {
+            return;
+        };
+        if expected == authenticated {
+            return;
+        }
+        // Only a divergence consumes the guard: a connection whose first Hello matched must
+        // still be able to report a later one that does not.
+        if self
+            .expectation_mismatch_reported
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            return;
+        }
+
+        // `warn!`, not `info!`: this is unusual and the operator is the only one who can act
+        // on it. Bounded to once per connection, so a reconnect loop against a misconfigured
+        // entry produces one line per connection rather than one per Hello.
+        warn!(
+            expected_did = %expected,
+            authenticated_did = %authenticated,
+            remote_addr = %remote_addr,
+            "Bootstrap entry named a different DID than the peer that authenticated; keeping \
+             the authenticated peer. Update the bootstrap entry if this endpoint's identity \
+             changed (#2533)"
+        );
+        icn_obs::metrics::network::bootstrap_did_expectation_mismatch_inc();
     }
 
     /// Forward message to external handler

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -427,6 +427,9 @@ mod tests {
             identity_bundle,
             own_did,
             direction: crate::handlers::ConnectionDirection::Inbound,
+            // Inbound: we did not choose this peer, so we expected nobody (#2533).
+            expected_peer: None,
+            expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/icn/crates/icn-net/tests/bootstrap_did_expectation.rs
+++ b/icn/crates/icn-net/tests/bootstrap_did_expectation.rs
@@ -1,0 +1,629 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! A bootstrap entry that names a DID states an *expectation*, and an expectation that goes
+//! unmet must not go unrecorded.
+//!
+//! `icn://did:icn:X@HOST:PORT` says "I expect X at this address". Nothing about reaching that
+//! address proves X is there: identity is proven only by the DID-TLS binding checks in
+//! `handle_hello` (#2520), and whoever passes them becomes the canonical peer (#2530). So
+//! when the operator configured X and B answers, the node has learned something the operator
+//! has not — and until #2533 it kept it to itself.
+//!
+//! ## What these tests pin, and what they deliberately do not
+//!
+//! The policy pinned here is **warn-and-accept**: a divergence is recorded, and the
+//! authenticated peer stays canonical. That is a decision, not a law of nature — the
+//! alternative is a strict pin that refuses the connection, which would turn a stale
+//! bootstrap entry into a hard connectivity failure after any key rotation or redeploy.
+//! `an_unmet_expectation_is_recorded_and_the_authenticated_peer_stays_canonical` asserts
+//! *both* halves, so a future change to strict rejection has to come and edit it. The
+//! policy is therefore executable, not folklore.
+//!
+//! ## Why the counter is the oracle
+//!
+//! The property is "this stopped being silent", and silence is only measurable against
+//! something that speaks. A log line would need a global subscriber; the counter can be read
+//! from a recorder that is local to this thread, so each test observes exactly the events it
+//! caused and nothing another test caused. `metrics::with_local_recorder` installs a
+//! *thread-local* recorder, which is why each test drives a current-thread runtime by hand:
+//! on a multi-thread runtime the connection handler task would run on a worker thread that
+//! cannot see the recorder, and every assertion would read zero for the wrong reason.
+//!
+//! The label set is asserted to be empty. That is not tidiness: the two values a mismatch is
+//! *about* — the expected DID and the authenticated one — are exactly the values that must
+//! never become label dimensions, because they are unbounded. They belong in the log line,
+//! which is a diagnostic record, not in a time series.
+
+use anyhow::{Context, Result};
+use icn_identity::{Did, IdentityBundle};
+use icn_net::{IncomingMessageHandler, NetworkActor, NetworkHandle, NetworkMessage};
+use metrics::with_local_recorder;
+use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+use quinn::Endpoint;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+const MISMATCH_METRIC: &str = "icn_network_bootstrap_did_expectation_mismatch_total";
+
+/// Ports already handed out in this process.
+///
+/// `pick_unused_port` binds, closes, and returns the port, so two tests running concurrently
+/// can be handed the same one — the port is genuinely free at each moment it is checked.
+static ISSUED_PORTS: std::sync::Mutex<Option<std::collections::HashSet<u16>>> =
+    std::sync::Mutex::new(None);
+
+fn pick_port() -> u16 {
+    let mut guard = ISSUED_PORTS.lock().expect("issued-port lock poisoned");
+    let issued = guard.get_or_insert_with(std::collections::HashSet::new);
+    for _ in 0..200 {
+        let port = portpicker::pick_unused_port().expect("no free port");
+        if issued.insert(port) {
+            return port;
+        }
+    }
+    panic!("could not find an unissued free port");
+}
+
+fn init() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+}
+
+/// Run `body` on a current-thread runtime with a recorder only this thread can see.
+///
+/// Both halves matter. The recorder must be local, or concurrent tests in this binary would
+/// read each other's increments. The runtime must be current-thread, or the connection
+/// handler — which is where the mismatch is decided — would be polled on a worker thread
+/// outside the recorder's scope.
+fn run_with_local_metrics<F>(body: F) -> Result<Snapshotter>
+where
+    F: std::future::Future<Output = Result<()>>,
+{
+    let recorder = DebuggingRecorder::new();
+    // Taken before the recorder is consumed: the snapshotter shares the registry, so it
+    // still reads what the body recorded once the run is over.
+    let snapshotter = recorder.snapshotter();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    with_local_recorder(&recorder, || runtime.block_on(body))?;
+    Ok(snapshotter)
+}
+
+/// Every emitted mismatch series, as `(sorted labels, value)`.
+fn mismatch_series(snapshotter: &Snapshotter) -> Vec<(Vec<(String, String)>, u64)> {
+    let mut out: Vec<(Vec<(String, String)>, u64)> = snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter_map(|(key, _, _, value)| {
+            let k = key.key();
+            if k.name() != MISMATCH_METRIC {
+                return None;
+            }
+            let mut labels: Vec<(String, String)> = k
+                .labels()
+                .map(|l| (l.key().to_string(), l.value().to_string()))
+                .collect();
+            labels.sort();
+            match value {
+                DebugValue::Counter(v) => Some((labels, v)),
+                _ => None,
+            }
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// Total mismatches recorded, across every label set.
+fn mismatch_total(snapshotter: &Snapshotter) -> u64 {
+    mismatch_series(snapshotter).iter().map(|(_, v)| v).sum()
+}
+
+/// Spawn a real node on the production stack.
+///
+/// The handler is required, not optional: it is what makes `wire_new_connection` spawn a
+/// dispatch loop for an *outbound* connection. Without it the dialer would never process the
+/// peer's Hello, so nothing here would authenticate and every assertion would read zero for
+/// a reason that has nothing to do with expectations.
+async fn spawn_node(bundle: IdentityBundle) -> Result<(NetworkHandle, SocketAddr, Guard)> {
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let handler: IncomingMessageHandler = Arc::new(|_msg: NetworkMessage| {});
+
+    let mut last_err = None;
+    for _ in 0..8 {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        match NetworkActor::spawn(
+            bundle.clone(),
+            addr,
+            shutdown_tx.clone(),
+            Some(handler.clone()),
+            None, // oracle
+            None, // fallback_config
+            None, // topology_config
+            None, // stun_servers
+            None, // turn_config
+            None, // misbehavior_detector
+            None, // store
+            None, // personhood_store
+            None, // anchor_rate_config
+            None, // advertised_addr
+        )
+        .await
+        {
+            Ok(handle) => {
+                // Let the endpoint bind before anyone dials it.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                return Ok((handle, addr, Guard(shutdown_tx)));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
+}
+
+/// Keeps a node's shutdown sender alive for the duration of a test.
+struct Guard(broadcast::Sender<()>);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+/// Poll until `observer` has authenticated `did`, or the deadline passes.
+///
+/// `peer_connections` is written only by `handle_hello`, after the #2520 binding checks pass,
+/// so this returning `true` is proof that an identity was proven on the connection — the
+/// exact moment the expectation becomes answerable. Synchronising on that observable, rather
+/// than sleeping, is what keeps "no mismatch recorded" distinguishable from "nothing has
+/// happened yet".
+async fn wait_until_authenticated(observer: &NetworkHandle, did: &Did, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if observer.get_peer_connection_info(did).await.is_some() {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// A bare QUIC listener that answers each accepted connection with a scripted Hello sequence.
+///
+/// Two things a real node cannot do are needed here: send a Hello that fails verification,
+/// and send the same Hello twice on one connection.
+struct ScriptedPeer {
+    addr: SocketAddr,
+    accept_task: tokio::task::JoinHandle<Vec<quinn::Connection>>,
+}
+
+impl ScriptedPeer {
+    /// Async because the settle below must not block: on the current-thread runtime these
+    /// tests use, a `std::thread::sleep` here would also stop the accept task from being
+    /// polled, so the listener would not actually be warm when it returned.
+    async fn spawn(identity: &IdentityBundle, hellos: Vec<NetworkMessage>) -> Result<Self> {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        let server_config = icn_net::tls::create_server_config(
+            vec![identity.tls_cert().clone()],
+            identity.tls_key(),
+        )?;
+        let mut quic_server = quinn::ServerConfig::with_crypto(Arc::new(
+            quinn::crypto::rustls::QuicServerConfig::try_from(server_config)?,
+        ));
+        quic_server.transport_config(Arc::new({
+            let mut t = quinn::TransportConfig::default();
+            t.max_idle_timeout(Some(Duration::from_secs(60).try_into()?));
+            t
+        }));
+        let mut endpoint = None;
+        let mut addr = addr;
+        for _ in 0..8 {
+            match Endpoint::server(quic_server.clone(), addr) {
+                Ok(ep) => {
+                    endpoint = Some(ep);
+                    break;
+                }
+                Err(_) => addr = format!("127.0.0.1:{}", pick_port()).parse()?,
+            }
+        }
+        let endpoint = endpoint.context("could not bind the scripted peer")?;
+        let accept_task = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Some(incoming) = endpoint.accept().await {
+                if let Ok(conn) = incoming.await {
+                    for hello in &hellos {
+                        if let Ok((mut send, _recv)) = conn.open_bi().await {
+                            let _ = icn_net::protocol::write_message(&mut send, hello).await;
+                            let _ = send.finish();
+                        }
+                        // Each Hello on its own stream, delivered in order: the dispatch loop
+                        // accepts one stream at a time, so without a gap the second can be
+                        // opened before the first is read and the ordering is not the one the
+                        // test names.
+                        tokio::time::sleep(Duration::from_millis(150)).await;
+                    }
+                    held.push(conn);
+                }
+            }
+            held
+        });
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        Ok(Self { addr, accept_task })
+    }
+}
+
+impl Drop for ScriptedPeer {
+    fn drop(&mut self) {
+        self.accept_task.abort();
+    }
+}
+
+/// Build a Hello from `speaker`, addressed to `to`, carrying `binding`'s binding info.
+///
+/// Passing a `binding` other than `speaker`'s own is how a Hello is made to fail the #2520
+/// checks while still being a well-formed message.
+fn hello_from(speaker: &IdentityBundle, to: &Did, binding: &IdentityBundle) -> NetworkMessage {
+    NetworkMessage::hello(
+        speaker.did().clone(),
+        to.clone(),
+        binding.binding_info(),
+        icn_net::VersionInfo::new("icnd-scripted".to_string()),
+        None,
+        *speaker.x25519_public_bytes(),
+        None,
+        None,
+    )
+}
+
+/// Positive control: when the peer that answers is the peer the operator named, nothing is
+/// recorded.
+///
+/// This is the case that must stay quiet, and it is the reason the mismatch signal is worth
+/// having at all. A counter that also fires on correct configuration would be noise, and an
+/// operator would learn to ignore it.
+#[test]
+fn a_met_expectation_records_no_mismatch() -> Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let listener = IdentityBundle::generate()?;
+        let listener_did = listener.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let (_listener_handle, listener_addr, _listener_guard) = spawn_node(listener).await?;
+
+        dialer_handle
+            .dial_expecting(listener_addr, listener_did.clone())
+            .await?;
+        assert!(
+            wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+            "precondition: the peer we expected never authenticated, so nothing was \
+                 compared and this test would pass vacuously"
+        );
+
+        assert_eq!(
+            dialer_handle.connected_peers().await,
+            vec![listener_did.clone()],
+            "the expected peer authenticated, so it must be the canonical peer"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        0,
+        "the configured DID is who answered, so there is no divergence to report; recorded \
+         series: {:?}",
+        mismatch_series(&snapshotter)
+    );
+    Ok(())
+}
+
+/// The policy test: a divergence is recorded, **and** the peer that authenticated stays
+/// canonical.
+///
+/// Both halves are the decision. Recording without accepting would be a strict pin — a
+/// materially different availability posture, in which a bootstrap entry left stale by a key
+/// rotation or a redeploy stops being degraded connectivity and becomes none at all, with no
+/// in-band way to recover. Accepting without recording is the status quo #2533 exists to end.
+///
+/// A future change to strict rejection is legitimate, but it must come here and rewrite this
+/// test, which is the point: it makes the policy something the repository states rather than
+/// something it happens to do.
+#[test]
+fn an_unmet_expectation_is_recorded_and_the_authenticated_peer_stays_canonical() -> Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let listener = IdentityBundle::generate()?;
+        let listener_did = listener.did().clone();
+        // Nobody on this connection holds this DID's key — the stale-config case.
+        let expected_did = IdentityBundle::generate()?.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let (_listener_handle, listener_addr, _listener_guard) = spawn_node(listener).await?;
+
+        dialer_handle
+            .dial_expecting(listener_addr, expected_did.clone())
+            .await?;
+        assert!(
+            wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+            "precondition: the peer that actually answered never authenticated"
+        );
+
+        assert_eq!(
+            dialer_handle.connected_peers().await,
+            vec![listener_did.clone()],
+            "the authenticated DID stays canonical: an expectation is metadata, and \
+                 {expected_did} proved nothing"
+        );
+        let stats = dialer_handle.get_stats().await?;
+        assert_eq!(
+            stats.connections_active, 1,
+            "the connection is accepted, not refused — this is warn-and-accept, not a \
+                 strict pin"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        1,
+        "the operator configured one DID and a different one authenticated; that divergence \
+         must be recorded exactly once (#2533). Recorded series: {:?}",
+        mismatch_series(&snapshotter)
+    );
+    assert_eq!(
+        mismatch_series(&snapshotter),
+        vec![(Vec::new(), 1)],
+        "the mismatch counter must carry no labels: the DIDs it is about are unbounded, and \
+         labelling by them would let bootstrap configuration drive metric cardinality"
+    );
+    Ok(())
+}
+
+/// An address-only bootstrap entry states no expectation, so it can never fail one.
+///
+/// This is the control that keeps the feature honest. `dial_addr` synthesises a placeholder
+/// DID from the socket address and hands it to the same dial path a configured DID uses, so
+/// by the time the actor sees it the two are the same type carrying the same kind of value.
+/// An implementation that compared "the DID we dialled with" against the authenticated one
+/// would therefore report a mismatch on *every* `icn://HOST:PORT` bootstrap — manufacturing
+/// an expectation the operator never wrote.
+#[test]
+fn an_addr_only_dial_states_no_expectation_and_never_mismatches() -> Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let listener = IdentityBundle::generate()?;
+        let listener_did = listener.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let (_listener_handle, listener_addr, _listener_guard) = spawn_node(listener).await?;
+
+        let placeholder = dialer_handle.dial_addr(listener_addr).await?;
+        assert_ne!(
+            placeholder, listener_did,
+            "precondition: the placeholder must differ from the authenticated DID, or \
+                 this test could not distinguish the two implementations"
+        );
+        assert!(
+            wait_until_authenticated(&dialer_handle, &listener_did, Duration::from_secs(20)).await,
+            "precondition: the peer never authenticated, so no comparison was reachable"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        0,
+        "an addr-only bootstrap entry names nobody, so the peer that answers cannot be the \
+         wrong one; recorded series: {:?}",
+        mismatch_series(&snapshotter)
+    );
+    Ok(())
+}
+
+/// A peer that fails the #2520 checks must not produce an expectation mismatch, however
+/// different the DID it claimed.
+///
+/// The comparison has exactly one legitimate right-hand side: the DID *proven* against this
+/// connection's certificate. `message.from` is chosen by the sender and verified by nobody,
+/// so comparing against it would let whoever is at that address decide what this node reports
+/// about its own configuration — and, worse, would report a divergence at a moment when the
+/// node cannot say who it is talking to at all. "Not authenticated" is a statement about our
+/// knowledge, not about the peer, and it is not evidence that the operator's expectation was
+/// wrong.
+#[test]
+fn a_peer_that_never_authenticates_records_no_expectation_mismatch() -> Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let dialer_did = dialer.did().clone();
+        // Presents this identity's certificate on the wire...
+        let wire_identity = IdentityBundle::generate()?;
+        // ...but claims to be this one, with that one's own valid — but wrong-certificate
+        // — binding. Fails check (3): the binding is not of this connection's cert.
+        let impersonated = IdentityBundle::generate()?;
+        let impersonated_did = impersonated.did().clone();
+        // What the operator configured. Different from every DID above.
+        let expected_did = IdentityBundle::generate()?.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let liar = ScriptedPeer::spawn(
+            &wire_identity,
+            vec![hello_from(&impersonated, &dialer_did, &impersonated)],
+        )
+        .await?;
+
+        dialer_handle
+            .dial_expecting(liar.addr, expected_did.clone())
+            .await?;
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let stats = dialer_handle.get_stats().await?;
+        assert_eq!(
+            stats.connections_active, 0,
+            "precondition: the scripted Hello must be rejected, or this test is not \
+                 about an unauthenticated peer at all (#2520)"
+        );
+        assert!(
+            dialer_handle
+                .get_peer_connection_info(&impersonated_did)
+                .await
+                .is_none(),
+            "precondition: a rejected Hello must not populate authenticated peer info"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        0,
+        "nobody authenticated on that connection, so there is no identity to weigh the \
+         operator's expectation against; a claimed DID is not one. Recorded series: {:?}",
+        mismatch_series(&snapshotter)
+    );
+    Ok(())
+}
+
+/// A later message *claiming* to be the expected DID does not retire the mismatch.
+///
+/// `message.from` is chosen by the sender and verified by nobody. A single Hello cannot both
+/// claim X and authenticate as B — that is precisely what the #2520 binding checks forbid, and
+/// such a Hello is refused before it reaches any of this. But nothing stops a peer that has
+/// legitimately authenticated as B from putting X in the `from` field of its *next* message,
+/// and an implementation that consulted that field would read it as the expectation having
+/// been satisfied after all.
+///
+/// So: B authenticates, the divergence from X is recorded, and then the peer says "actually,
+/// I'm X". The recorded divergence must stand, B must remain the only canonical peer, and X
+/// must never become one. Expectation is answered by proof, once, and a claim is not proof —
+/// not before authentication, and not after it either.
+#[test]
+fn a_later_message_claiming_the_expected_did_does_not_retire_the_mismatch() -> Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let dialer_did = dialer.did().clone();
+        let peer_identity = IdentityBundle::generate()?;
+        let authenticated_did = peer_identity.did().clone();
+        // Configured by the operator; nobody on this connection holds its key.
+        let expected_did = IdentityBundle::generate()?.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let peer = ScriptedPeer::spawn(
+            &peer_identity,
+            vec![
+                // Legitimate: authenticates as B.
+                hello_from(&peer_identity, &dialer_did, &peer_identity),
+                // Then claims to be the DID the operator configured. Unverified, and on a
+                // payload that carries no binding at all.
+                NetworkMessage::ping(expected_did.clone(), dialer_did.clone()),
+            ],
+        )
+        .await?;
+
+        dialer_handle
+            .dial_expecting(peer.addr, expected_did.clone())
+            .await?;
+        assert!(
+            wait_until_authenticated(&dialer_handle, &authenticated_did, Duration::from_secs(20))
+                .await,
+            "precondition: the peer never authenticated, so no expectation was ever weighed"
+        );
+        // Let the forged claim land after the Hello has been processed.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        assert_eq!(
+            dialer_handle.connected_peers().await,
+            vec![authenticated_did.clone()],
+            "claiming to be {expected_did} must not make the claimant that peer, nor add it \
+             alongside the DID that actually authenticated"
+        );
+        assert!(
+            dialer_handle
+                .get_peer_connection_info(&expected_did)
+                .await
+                .is_none(),
+            "the configured DID never authenticated on this connection, so it must hold no \
+             authenticated peer state however often it is named"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        1,
+        "the divergence was established by proof and cannot be talked away by a later \
+         sender-chosen `from` (#2533, #2491)"
+    );
+    Ok(())
+}
+
+/// One connection, one mismatch — however many Hellos arrive on it.
+///
+/// A Hello is verified every time it arrives, so a peer that repeats one drives the
+/// comparison repeatedly. The thing being counted is a *connection whose expectation was not
+/// met*, which happens once per connection no matter how talkative the peer is; counting
+/// Hellos instead would let the remote end set the rate of a metric about local
+/// configuration.
+///
+/// Reconnection is the other repeat vector and is deliberately *not* deduplicated: a fresh
+/// connection to a still-misconfigured entry is a fresh observation, and a bootstrap entry
+/// that keeps reconnecting to the wrong node is exactly the condition worth seeing a rate on.
+#[test]
+fn repeated_hellos_on_one_connection_record_the_mismatch_once() -> Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let dialer_did = dialer.did().clone();
+        let talkative = IdentityBundle::generate()?;
+        let talkative_did = talkative.did().clone();
+        let expected_did = IdentityBundle::generate()?.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let peer = ScriptedPeer::spawn(
+            &talkative,
+            vec![
+                hello_from(&talkative, &dialer_did, &talkative),
+                hello_from(&talkative, &dialer_did, &talkative),
+                hello_from(&talkative, &dialer_did, &talkative),
+            ],
+        )
+        .await?;
+
+        dialer_handle
+            .dial_expecting(peer.addr, expected_did.clone())
+            .await?;
+        assert!(
+            wait_until_authenticated(&dialer_handle, &talkative_did, Duration::from_secs(20)).await,
+            "precondition: the scripted peer never authenticated"
+        );
+        // Let the remaining Hellos land after the first has been processed.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        assert_eq!(
+            dialer_handle.connected_peers().await,
+            vec![talkative_did.clone()],
+            "precondition: repeated Hellos must not change who is canonical"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        1,
+        "three Hellos arrived on one connection whose expectation was unmet; the connection \
+         diverged once. Recorded series: {:?}",
+        mismatch_series(&snapshotter)
+    );
+    Ok(())
+}

--- a/icn/crates/icn-net/tests/bootstrap_did_expectation.rs
+++ b/icn/crates/icn-net/tests/bootstrap_did_expectation.rs
@@ -270,16 +270,59 @@ impl Drop for ScriptedPeer {
 /// Passing a `binding` other than `speaker`'s own is how a Hello is made to fail the #2520
 /// checks while still being a well-formed message.
 fn hello_from(speaker: &IdentityBundle, to: &Did, binding: &IdentityBundle) -> NetworkMessage {
+    hello_with_binding(speaker, to, binding.binding_info())
+}
+
+/// Build a Hello from `speaker` carrying an arbitrary `binding`.
+///
+/// Split out from [`hello_from`] because one test needs a binding that no `IdentityBundle`
+/// produces on its own — see [`binding_over_foreign_cert`].
+fn hello_with_binding(
+    speaker: &IdentityBundle,
+    to: &Did,
+    binding: icn_identity::BindingInfo,
+) -> NetworkMessage {
     NetworkMessage::hello(
         speaker.did().clone(),
         to.clone(),
-        binding.binding_info(),
+        binding,
         icn_net::VersionInfo::new("icnd-scripted".to_string()),
         None,
         *speaker.x25519_public_bytes(),
         None,
         None,
     )
+}
+
+/// A binding by which `speaker` authenticates over a certificate belonging to `cert_owner`.
+///
+/// This is not a forgery and it is not an attack — it passes all three #2520 checks honestly.
+/// The binding names `speaker`, `speaker`'s own key signs it, and the hash is of the
+/// certificate the connection really presents. What it needs that `IdentityBundle` cannot
+/// give is a binding over *someone else's* certificate, because `binding_info()` only ever
+/// hashes the bundle's own.
+///
+/// The situation it models is a single endpoint that holds two identities: the TLS material
+/// for `cert_owner` and the DID key for `speaker`. A node that rotates its DID without
+/// reissuing its certificate is exactly this, and it is the only way one physical connection
+/// can authenticate two different DIDs — check (3) pins every Hello on a connection to the
+/// one certificate that connection is using.
+fn binding_over_foreign_cert(
+    speaker: &IdentityBundle,
+    cert_owner: &IdentityBundle,
+) -> Result<icn_identity::BindingInfo> {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(cert_owner.tls_cert().as_ref());
+    let cert_hash: [u8; 32] = hasher.finalize().into();
+
+    // Keep `did` and `created_at` from the speaker's real binding; only the certificate this
+    // binding is *about* changes.
+    let mut binding = speaker.binding_info();
+    binding.tls_binding_sig = speaker.sign(&cert_hash)?.to_bytes().to_vec();
+    binding.tls_cert_hash = cert_hash;
+    Ok(binding)
 }
 
 /// Positive control: when the peer that answers is the peer the operator named, nothing is
@@ -623,6 +666,95 @@ fn repeated_hellos_on_one_connection_record_the_mismatch_once() -> Result<()> {
         1,
         "three Hellos arrived on one connection whose expectation was unmet; the connection \
          diverged once. Recorded series: {:?}",
+        mismatch_series(&snapshotter)
+    );
+    Ok(())
+}
+
+/// A met expectation must not spend the ability to notice a later unmet one.
+///
+/// The once-per-connection guard is the only thing standing between this signal and a remote
+/// peer setting its rate, so it is worth being exact about *when* it is spent: only a reported
+/// divergence consumes it, never a satisfied expectation. Written the other way — `swap`ping
+/// the flag before comparing, which is the tidier-looking order — a connection whose first
+/// Hello matched would go permanently deaf, and every other test in this file would still
+/// pass, because none of them has a connection that matches first.
+///
+/// The sequence is one physical connection that authenticates the configured DID and then
+/// authenticates a different one. Check (3) of #2520 ties every Hello on a connection to the
+/// certificate that connection presents, so this is only reachable for an endpoint holding
+/// both the certificate for X and the DID key for B — a node that rotated its DID without
+/// reissuing its certificate. Rare, real, and precisely the case where the operator's
+/// bootstrap entry has just gone stale and they most need to hear about it.
+#[test]
+fn a_first_hello_that_matches_does_not_suppress_a_later_rebinding() -> Result<()> {
+    init();
+    let snapshotter = run_with_local_metrics(async {
+        let dialer = IdentityBundle::generate()?;
+        let dialer_did = dialer.did().clone();
+        // Owns the certificate this connection presents, and is what the operator configured.
+        let expected = IdentityBundle::generate()?;
+        let expected_did = expected.did().clone();
+        // Rebinds the same connection to a different identity.
+        let rebound = IdentityBundle::generate()?;
+        let rebound_did = rebound.did().clone();
+
+        let (dialer_handle, _dialer_addr, _dialer_guard) = spawn_node(dialer).await?;
+        let peer = ScriptedPeer::spawn(
+            &expected,
+            vec![
+                // 1. The expectation is met. Nothing is recorded, and — the property under
+                //    test — nothing is spent.
+                hello_from(&expected, &dialer_did, &expected),
+                // 2. A different DID authenticates on the same connection, honestly: its own
+                //    key, over the certificate this connection is really using.
+                hello_with_binding(
+                    &rebound,
+                    &dialer_did,
+                    binding_over_foreign_cert(&rebound, &expected)?,
+                ),
+            ],
+        )
+        .await?;
+
+        dialer_handle
+            .dial_expecting(peer.addr, expected_did.clone())
+            .await?;
+        assert!(
+            wait_until_authenticated(&dialer_handle, &expected_did, Duration::from_secs(20)).await,
+            "precondition: the configured DID never authenticated, so the expectation was \
+             never met and this test is not about a rebinding at all"
+        );
+        // Let the second Hello land after the first has been processed.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // Both halves matter, and neither is racy once the connection has settled: the peer
+        // info for the configured DID survives, so Hello 1 demonstrably authenticated it,
+        // while the session map has moved to the DID that authenticated last. Together they
+        // are the positive control that *two* Hellos were processed on one connection — the
+        // premise the mismatch count below is only meaningful against.
+        assert!(
+            dialer_handle
+                .get_peer_connection_info(&expected_did)
+                .await
+                .is_some(),
+            "precondition: the configured DID must have authenticated first"
+        );
+        assert_eq!(
+            dialer_handle.connected_peers().await,
+            vec![rebound_did.clone()],
+            "the DID that authenticated last is canonical, and the earlier one is not left \
+             alongside it as a phantom peer (#2530)"
+        );
+        Ok(())
+    })?;
+
+    assert_eq!(
+        mismatch_total(&snapshotter),
+        1,
+        "the connection first authenticated the configured DID and then a different one; a \
+         satisfied expectation must not retire the guard that reports the divergence. \
+         Recorded series: {:?}",
         mismatch_series(&snapshotter)
     );
     Ok(())

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -187,6 +187,10 @@ pub fn init_descriptions() {
         "icn_personhood_store_failures_total",
         "Total number of personhood store lookup failures (Sybil protection degraded)"
     );
+    describe_counter!(
+        "icn_network_bootstrap_did_expectation_mismatch_total",
+        "Total number of connections where a bootstrap entry's configured DID differed from the DID that authenticated"
+    );
 }
 
 // Simple counters
@@ -582,4 +586,21 @@ pub fn personhood_anchors_active_set(count: usize) {
 /// Operators should alert on this metric to detect storage issues.
 pub fn personhood_store_failures_inc() {
     counter!("icn_personhood_store_failures_total").increment(1);
+}
+
+/// A bootstrap entry named a DID, and a different DID authenticated on that connection.
+///
+/// Counts *connections*, not Hellos: a peer may repeat its Hello, and the rate of a signal
+/// about local configuration must not be settable by the remote end.
+///
+/// Deliberately unlabelled. The two values this is about — the configured DID and the
+/// authenticated one — are unbounded, so as labels they would let bootstrap configuration
+/// and whoever answers the address drive metric cardinality between them. They are recorded
+/// in the accompanying `warn!`, which is a diagnostic record rather than a time series.
+///
+/// This is not a misbehaviour signal. A divergence means the operator's configuration and
+/// the network disagree — a rotated key, a redeployed node, a copy-pasted address — and
+/// says nothing bad about either DID.
+pub fn bootstrap_did_expectation_mismatch_inc() {
+    counter!("icn_network_bootstrap_did_expectation_mismatch_total").increment(1);
 }


### PR DESCRIPTION
## Problem

A bootstrap entry can name a DID:

```
icn://did:icn:X@host:port
```

The operator is saying "I expect X at this address". Nothing about reaching that address
proves X is there. Identity is proven only by the DID-TLS binding checks in `handle_hello`
(#2520), and whoever passes them becomes the canonical peer (#2530). So:

```
operator names          X
peer authenticates      B
X != B

old behaviour:          accept B, silently
```

The node had learned something the operator had not — that their configuration and the
network disagree — and kept it to itself. A stale bootstrap entry after a key rotation, a
redeploy, or a copy-pasted address was indistinguishable at runtime from a correct one.

## Policy

**`KnownDid` is an expectation, not a pin.**

```
authenticated DID remains canonical

mismatch is:
    accepted   — the connection is kept, nothing is refused
    warned     — one warn! line naming both DIDs and the address
    metered    — one increment of an unlabelled counter
```

Nothing is scored, nobody is banned, and neither DID is penalised. The peer did nothing wrong
by being itself; a divergence is a statement about *this node's configuration*.

## Security boundary

The comparison happens **only after** all three #2520 facts hold, against the certificate
*this* connection is presenting:

1. the binding names the DID that sent the Hello (`did == from`)
2. that DID's key signed the binding
3. the signed hash is of the certificate this connection is actually using

`resolve_peer_expectation` is called immediately after `record_authenticated_peer`, and every
one of those three checks returns `Err` before reaching it. There is exactly one call site.

**`NetworkMessage.from` is not used as identity evidence.** Before the checks it is a name the
sender chose; comparing against it would hand the far end control of what this node reports
about its own configuration, and would report a divergence at the one moment the node cannot
say who it is talking to at all. A connection that never authenticates produces no
observation — "we do not know who this is" is not evidence that the operator was wrong.

## Only the operator-configured dial carries an expectation

`dial_expecting` is a distinct entry point, and `dial_bootstrap_peers`' `KnownDid` arm is its
only production caller. Every other dial passes `None`:

| dial site | expectation |
|---|---|
| `init_bootstrap` — `KnownDid` bootstrap | **`Some(expected)`** |
| `init_bootstrap` — addr-only bootstrap (`dial_addr`) | `None` |
| `init_network` — peer-exchange discovered peer | `None` |
| `init_network` — announced/mDNS peer | `None` |
| `nat_dial` — relay, local, public, happy-eyeballs | `None` |
| `background_tasks` — bootstrap health task (dormant, #2542) | `None` |
| `icn-rpc` `network.dial` (reached by `icnctl network dial`) | `None` |
| inbound accepted connections | `None` |

The address-only case is the one that makes this load-bearing rather than cosmetic:
`dial_addr` **synthesises a real `Did`** from the socket address and dials with it, so the
dial argument *looks* like an expectation while naming nobody. Reading one off it would report
every `icn://HOST:PORT` entry as misconfigured. Likewise a DID learned over peer exchange is a
claim by another node, whose inaccuracy is not this operator's misconfiguration.

## Why not a strict pin

This is a policy choice, not an oversight. Refusing the connection would turn a bootstrap
entry left stale by a key rotation, a redeploy, or a copy-paste into a hard connectivity
failure with no in-band way to recover — and it would buy less than it appears to, because an
authenticated peer cannot be impersonating the configured DID (#2520). The realistic causes of
a divergence are operational drift, not attack.

**This does not permanently reject strict pinning.** There are deployments where an operator
would reasonably want it, and the current evidence is simply not enough to make it the default
policy. Making it configurable is a separate decision with its own failure modes (an operator
who pins and then rotates has locked themselves out), and is deliberately not in this PR.

`an_unmet_expectation_is_recorded_and_the_authenticated_peer_stays_canonical` asserts *both*
halves, so a future change to strict rejection has to come and edit it. The policy is
executable, not folklore.

## Expectation state lifetime

Per **physical connection**, owned by its `ConnectionContext`. Not keyed globally by address,
by configured DID, or by peer-map identity — two concurrent dials to one address can carry
different expectations, an address can be reused by a different node, and the expected DID is
precisely the value that is wrong in the case this exists to detect.

`DialOutcome::AlreadyConnected` discards the expectation, which is correct rather than merely
harmless: `SessionManager::dial` looks the existing session up **by the dial argument**, which
for `dial_expecting(addr, X)` *is* X, and the session map is only ever keyed by an
authenticated DID (#2530). So `AlreadyConnected` means a live authenticated session with X
already exists — the expectation is already satisfied and there is nothing to weigh.
`AlreadyConnected(B)` for `B != X` is structurally unreachable. No existing `ConnectionContext`
is mutated, no duplicate handler is spawned (#2536 preserved), and X never becomes canonical.

## Once-per-connection semantics

The guard is set **only when a mismatch is reported**, never when an expectation is met:

```
mismatch, then more Hellos      → one observation      (guard consumed)
match, then a later rebinding   → still observed       (guard untouched by the match)
new physical reconnect          → a new observation    (new connection, new guard)
```

Reconnection is deliberately *not* deduplicated: a fresh connection to a still-misconfigured
entry is a fresh observation, and a bootstrap entry that keeps reconnecting to the wrong node
is exactly the condition worth seeing a rate on. Bounded to one line per connection, a
reconnect loop produces one warning per connection rather than one per Hello — the remote end
cannot set the rate of a signal about local configuration.

`warn!` rather than `info!` is justified because the event is unusual, occurs only after
authentication, and the operator is the only one who can act on it. No generic rate limiting
was added; the per-connection bound is the mechanism.

## Metric cardinality

`icn_network_bootstrap_did_expectation_mismatch_total` — **no labels at all**. The two values a
mismatch is *about* are the configured DID and the authenticated one, and both are unbounded;
as labels they would let bootstrap configuration and whoever answers the address drive metric
cardinality between them. They go in the `warn!` line, which is a diagnostic record rather than
a time series. Counts connections, not Hellos. The tests assert the label set is empty.

## Composition proof

`crates/icn-core/tests/bootstrap_did_expectation_wiring.rs` drives the real
`dial_bootstrap_peers` against a real `NetworkActor`, starting from a bootstrap **URL string**
— the operator's actual interface — and asserts on what the node observed. A version of
`dial_bootstrap_peers` that called `dial` instead of `dial_expecting` would still connect,
still log "✓ Reached bootstrap peer", and record nothing; that is the regression it catches.
It does not reproduce the implementation. All three controls are present: matching `KnownDid`,
mismatching `KnownDid`, and addr-only. The mismatch case asserts both the observable mismatch
*and* that the authenticated peer remains canonical.

## Evidence

```
icn-net   bootstrap_did_expectation           7 passed  0 failed  0 ignored
icn-core  bootstrap_did_expectation_wiring    3 passed  0 failed  0 ignored

#2534  provisional_connection_lifecycle       8 passed
#2520  hello_current_cert_binding             7 passed
#2537  hello_handshake_termination            5 passed
#2536  redundant_dial_idempotence             5 passed
#2535  peer_exchange_policy                   6 passed

full icn-net                                434 passed  0 failed
icn-core --lib                              441 passed  0 failed

cargo fmt --all -- --check                  clean
cargo clippy -p icn-net -p icn-core --all-targets   clean
```

## Mutations

Six applied, six killed.

| | mutation | killed by |
|---|---|---|
| M1 | remove the mismatch comparison | `an_unmet_expectation_...`, `a_known_did_bootstrap_entry_...` |
| M2 | compare before authentication | `a_peer_that_never_authenticates_...` |
| M3 | manufacture an expectation on the addr-only path | `an_addr_only_dial_...`, `an_addr_only_bootstrap_entry_...` |
| M4 | make the expectation canonical | `an_unmet_expectation_..._stays_canonical` |
| M5 | reject the mismatch (strict pin) | `an_unmet_expectation_..._stays_canonical` |
| M6 | consume the guard *before* the comparison | `a_first_hello_that_matches_does_not_suppress_a_later_rebinding` |

M6 was added during independent review. It killed **only** the new test — 6 of 7 still passed
— which is what makes that test worth its place: the hole it closes was genuinely open, and no
existing test had a connection that matches before it diverges.

## Non-goals

Explicitly excluded from this PR:

* **#2491** — not started.
* **#2539** — reviving the ignored legacy DID-TLS suites. Its coverage claim about #2520 has
  been corrected (`hello_current_cert_binding` is 7/7 executing); the remaining debt stands.
* **#2542** — the dormant bootstrap health task. It is not composed at all, so its
  configured-DID liveness assumption is latent, not a live bug. Not activated or altered here.
* **#2544** — a general config→runtime composition-contract harness.
* **Strict-pin configuration.** No new config surface; see "Why not a strict pin".

Refs #2533
