### PR TITLE
fix(net): bind rate-limit tiers to authenticated connection identity

### DIFF
--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -303,11 +303,14 @@ fn register_core_oracles(
         // It is not registered raw. `NetworkRateLimitOracle` replaces the trust
         // oracle's hard-coded 5/20/100/unlimited ladder with the operator's
         // configured per-tier limits (#2496), and clamps the result to the
-        // highest configured tier as an absolute ceiling. The ceiling matters
-        // because the rate limiter keys on the *unauthenticated*
-        // `NetworkMessage.from`: the tier is chosen from a DID the sender merely
-        // claims, so no tier may be an unbounded pre-authentication budget
-        // (defence in depth for #2491, which is a separate protocol change).
+        // highest configured tier as an absolute ceiling.
+        //
+        // The actor this oracle is asked about is a DID bound to the connection
+        // carrying the message (#2491): before that binding exists, `icn-net`
+        // charges an anonymous per-connection budget and never reaches here. The
+        // ceiling is retained regardless — it bounds any trust-derived value that
+        // is not an operator-configured tier, so nothing can exceed what the
+        // operator allowed.
         let network_domain = icn_kernel_api::authz::Domain::new(icn_net::NETWORK_DOMAIN);
         let tiers = super::network_policy::NetworkRateLimitTiers::from_config(rate_limiting);
         // Maximum across all four tiers, not the federated tier: an operator may

--- a/icn/crates/icn-core/src/supervisor/network_policy.rs
+++ b/icn/crates/icn-core/src/supervisor/network_policy.rs
@@ -2,17 +2,23 @@
 //!
 //! # Why this exists
 //!
-//! `icn-net`'s rate limiter is keyed on `NetworkMessage.from`, which is
+//! `icn-net`'s rate limiter used to be keyed on `NetworkMessage.from`, which is
 //! **self-asserted and not yet authenticated** when the check runs — the Hello
 //! binding proof and `SignedEnvelope` verification both happen after dispatch
-//! (`icn-net/src/actor/connection.rs`). DIDs are public, so a sender can name any
-//! DID it likes and receive whatever tier that DID's trust score maps to.
+//! (`icn-net/src/actor/connection.rs`). DIDs are public, so a sender could name
+//! any DID it liked and receive whatever tier that DID's trust score mapped to.
 //!
-//! On its own that is a pre-existing weakness bounded by whatever the tier
-//! allows. It stops being bounded when the tier is `RateLimit::unlimited()`,
-//! which is `u32::MAX` for both rate and burst: a sender that claims a
-//! well-trusted DID gets no effective limit at all, and can force repeated
-//! deserialization, binding checks, and signature verification for free.
+//! On its own that was a weakness bounded by whatever the tier allows. It stopped
+//! being bounded when the tier was `RateLimit::unlimited()`, which is `u32::MAX`
+//! for both rate and burst: a sender that claimed a well-trusted DID got no
+//! effective limit at all, and could force repeated deserialization, binding
+//! checks, and signature verification for free.
+//!
+//! #2491 since fixed the ordering: a connection spends an anonymous per-connection
+//! budget until an authenticated Hello binds a DID to its certificate, and only
+//! then does a tier apply — selected from that bound DID. So the actor this oracle
+//! is asked about is now an *authenticated* one. The ceiling below is retained
+//! anyway; see "The absolute ceiling".
 //!
 //! # What this does
 //!
@@ -44,12 +50,18 @@
 //!
 //! ## The absolute ceiling
 //!
-//! Tier selection does not replace the ceiling — both apply. The ceiling is
-//! defence in depth for #2491: since the tier is chosen from an unauthenticated
-//! DID, a misconfigured or overly generous tier must not become an unbounded
-//! pre-authentication budget. #2491 itself (binding the tier to a *verified*
-//! identity) is a protocol change tracked separately and deliberately not solved
-//! here.
+//! Tier selection does not replace the ceiling — both apply. The ceiling began as
+//! defence in depth for #2491, when the tier was chosen from an unauthenticated
+//! DID and a misconfigured tier could become an unbounded pre-authentication
+//! budget. #2491 has since bound tier selection to an authenticated identity, so
+//! that specific exposure is closed.
+//!
+//! The ceiling stays because it was never only about that. It bounds anything
+//! reaching this oracle that is *not* an operator-configured tier — an inner
+//! oracle returning `RateLimit::unlimited()`, a future oracle with its own ladder
+//! — so no trust-derived value can exceed what the operator allowed. Removing it
+//! would restore an unbounded path for an *authenticated* peer, which is a
+//! smaller blast radius than before but not zero.
 //!
 //! ## Cost
 //!

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -4,7 +4,8 @@
 //!
 //! - **Connection acceptance**: Listens for new connections via the session manager
 //! - **Stream processing**: Handles bidirectional streams for message exchange
-//! - **Rate limiting**: Enforces per-DID and per-personhood-anchor limits for Sybil resistance
+//! - **Rate limiting**: Two-phase — an anonymous per-connection budget until the peer
+//!   authenticates, then per-DID and per-personhood-anchor limits for Sybil resistance
 //! - **Byzantine detection**: Reports misbehavior to the misbehavior detector
 //! - **Blob announcements**: Extracts and registers blob availability from incoming messages
 //!
@@ -26,6 +27,30 @@
 //!
 //! So a shutdown deadline may cancel the wait for new work, but must never become a
 //! maximum lifetime for a handshake that has already arrived.
+//!
+//! # Rate limiting is two phases, not one
+//!
+//! The limit check runs immediately after `read_message`, before any dispatch — which means
+//! before anything has verified who sent the message. So the check cannot ask the message
+//! who to charge (#2491):
+//!
+//! ```text
+//! before authentication:
+//!     charge the connection's own anonymous budget.
+//!     No DID input: no trust tier, no personhood anchor.
+//!
+//! after an authenticated Hello:
+//!     charge the DID cryptographically bound to THIS connection's certificate (#2520),
+//!     which selects the operator-configured tier (#2490).
+//! ```
+//!
+//! `NetworkMessage.from` selects rate-limit authority in neither phase. It remains a claim
+//! about origin, useful for diagnostics and nothing else here. Content authorship and relay
+//! semantics are a separate question, tracked by #2480; a transport limiter only needs to
+//! know whose traffic this connection is carrying.
+//!
+//! Scope: this bounds what one connection can spend. Bounding how many connections one
+//! source may open is connection admission, and is not addressed here.
 
 use anyhow::Result;
 use icn_identity::{Did, IdentityBundle};
@@ -249,20 +274,53 @@ impl NetworkActor {
                                 bytes_read as u64,
                             );
 
-                            // Check rate limit BEFORE processing message
-                            // Uses dual-path rate limiting: per-DID and per-anchor (if Sybil resistance enabled)
-                            let (did_allowed, anchor_allowed) = rate_limiter
-                                .check_rate_limit_with_personhood(&message.from)
-                                .await;
+                            // Check rate limit BEFORE processing message.
+                            //
+                            // Which identity may select this message's limit is decided by
+                            // what *this connection* has proven, never by what the message
+                            // claims (#2491):
+                            //
+                            //   PRE-AUTH   the transport source is known, the peer's DID is
+                            //              not. Trust cannot select a tier, and there is no
+                            //              DID to derive a personhood anchor from either.
+                            //   POST-AUTH  this connection has a DID bound to the
+                            //              certificate it is actually using (#2520). That
+                            //              DID selects the tier.
+                            //
+                            // `message.from` describes a claimed origin and is kept for
+                            // diagnostics below. It never selects transport rate-limit
+                            // authority in either phase — that is the whole defect: DIDs are
+                            // public, so keying on `from` let any sender name a well-trusted
+                            // peer and be charged as one.
+                            //
+                            // Read per message rather than cached: a later valid Hello can
+                            // re-authenticate this connection (#2537), and the limit must
+                            // follow the identity in force *now*.
+                            let authenticated = ctx.authenticated_peer().await;
+                            let (did_allowed, anchor_allowed) = match &authenticated {
+                                Some(authenticated) => {
+                                    rate_limiter
+                                        .check_rate_limit_with_personhood(authenticated)
+                                        .await
+                                }
+                                // No DID, so nothing DID-keyed runs: not the trust tier and
+                                // not the anchor lookup. Inventing an anchor from the claim
+                                // would let a sender spend somebody else's per-person budget.
+                                None => (ctx.check_pre_auth_rate_limit().await, true),
+                            };
 
                             if !did_allowed {
                                 warn!(
-                                    "Rate limited message from {} (per-DID limit exceeded)",
-                                    message.from
+                                    claimed_from = %message.from,
+                                    authenticated = ?authenticated,
+                                    "Rate limited message (per-DID limit exceeded)"
                                 );
 
                                 // Track rate limiting metric
                                 icn_obs::metrics::network::messages_rate_limited_inc();
+                                if authenticated.is_none() {
+                                    icn_obs::metrics::network::messages_rate_limited_pre_auth_inc();
+                                }
 
                                 // Close stream before continuing to avoid resource leak
                                 if let Err(e) = send.finish() {
@@ -275,8 +333,8 @@ impl NetworkActor {
 
                             if !anchor_allowed {
                                 warn!(
-                                    "Rate limited message from {} (per-person limit exceeded - Sybil mitigation)",
-                                    message.from
+                                    claimed_from = %message.from,
+                                    "Rate limited message (per-person limit exceeded - Sybil mitigation)"
                                 );
 
                                 // Track Sybil-specific rate limiting metric

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -310,11 +310,24 @@ impl NetworkActor {
                             };
 
                             if !did_allowed {
-                                warn!(
-                                    claimed_from = %message.from,
-                                    authenticated = ?authenticated,
-                                    "Rate limited message (per-DID limit exceeded)"
-                                );
+                                // Two different limits reach this branch, and the message says
+                                // which. "Per-DID limit" is not true of a phase that has no
+                                // DID, and the distinction is the operational one: a throttled
+                                // authenticated peer is a tier that may want raising, while an
+                                // exhausted anonymous budget is load from a connection that
+                                // never got as far as saying who it was.
+                                match &authenticated {
+                                    Some(authenticated) => warn!(
+                                        claimed_from = %message.from,
+                                        authenticated = %authenticated,
+                                        "Rate limited message (per-DID limit exceeded)"
+                                    ),
+                                    None => warn!(
+                                        claimed_from = %message.from,
+                                        "Rate limited message (pre-authentication connection \
+                                         budget exhausted)"
+                                    ),
+                                }
 
                                 // Track rate limiting metric
                                 icn_obs::metrics::network::messages_rate_limited_inc();

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -293,9 +293,15 @@ impl NetworkActor {
                             // public, so keying on `from` let any sender name a well-trusted
                             // peer and be charged as one.
                             //
-                            // Read per message rather than cached: a later valid Hello can
-                            // re-authenticate this connection (#2537), and the limit must
-                            // follow the identity in force *now*.
+                            // Read per message rather than cached, because the connection's
+                            // identity is genuinely mutable. `handlers::hello` records an
+                            // authenticated peer on *every* valid Hello — the `hello_responded`
+                            // guard bounds the reply (#2537), not the binding — and #2520's
+                            // checks tie a DID to this connection's certificate without tying
+                            // that certificate to the DID's key. A second Hello can therefore
+                            // move this connection from A to B, and the limit must follow the
+                            // identity in force *now*. Caching the first one would keep
+                            // charging a peer that is no longer the one on this session.
                             let authenticated = ctx.authenticated_peer().await;
                             let (did_allowed, anchor_allowed) = match &authenticated {
                                 Some(authenticated) => {
@@ -306,6 +312,16 @@ impl NetworkActor {
                                 // No DID, so nothing DID-keyed runs: not the trust tier and
                                 // not the anchor lookup. Inventing an anchor from the claim
                                 // would let a sender spend somebody else's per-person budget.
+                                //
+                                // The `true` is the anchor verdict, and it does change what
+                                // `EnforcementMode::RequirePersonhood` covers: that mode no
+                                // longer denies pre-authentication traffic. It never usefully
+                                // did. The anchor was looked up for `message.from`, so naming
+                                // any anchored DID satisfied it, while the peers it actually
+                                // turned away were honest un-anchored ones — whose Hello it
+                                // dropped before they could ever authenticate. Personhood is
+                                // now enforced where it can mean something: on the branch
+                                // above, against the DID this connection has proven.
                                 None => (ctx.check_pre_auth_rate_limit().await, true),
                             };
 

--- a/icn/crates/icn-net/src/handlers/encrypted.rs
+++ b/icn/crates/icn-net/src/handlers/encrypted.rs
@@ -232,6 +232,7 @@ mod tests {
             // Inbound: we did not choose this peer, so we expected nobody (#2533).
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
+            pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -385,6 +386,7 @@ mod tests {
             // Inbound: we did not choose this peer, so we expected nobody (#2533).
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
+            pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/icn/crates/icn-net/src/handlers/handshake.rs
+++ b/icn/crates/icn-net/src/handlers/handshake.rs
@@ -243,6 +243,7 @@ mod tests {
             // Inbound: we did not choose this peer, so we expected nobody (#2533).
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
+            pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -279,6 +280,7 @@ mod tests {
             // Inbound: we did not choose this peer, so we expected nobody (#2533).
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
+            pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/icn/crates/icn-net/src/handlers/mod.rs
+++ b/icn/crates/icn-net/src/handlers/mod.rs
@@ -63,14 +63,28 @@ pub struct ConnectionContext {
     /// certificate *this* connection is actually using (#2520).
     ///
     /// This exists because a `NetworkMessage`'s `from` field cannot answer "who is asking".
-    /// It is chosen by the sender and verified by nobody — the same confusion that makes
-    /// the pre-authentication rate-limit tier forgeable (#2491). Handlers that disclose
-    /// something about this node must consult *this* field, which is bound to the
-    /// connection's certificate, and never `message.from`.
+    /// It is chosen by the sender and verified by nobody — the same confusion that once made
+    /// the rate-limit tier forgeable, until #2491 made the limiter ask this field too.
+    /// Handlers that disclose something about this node, or that spend a resource on its
+    /// behalf, must consult *this* field, which is bound to the connection's certificate,
+    /// and never `message.from`.
+    ///
+    /// `None` is a statement about what this node can prove, not about the peer, and its
+    /// only safe reading is "we do not know who this is" — which is why the rate limiter
+    /// treats it as a phase, not as a peer with a default tier.
     ///
     /// Per connection, not per peer: a peer that opens two connections authenticates on
     /// each one separately, and one connection's Hello says nothing about the other.
     authenticated_peer: RwLock<Option<Did>>,
+    /// What this connection may spend while [`Self::authenticated_peer`] is still `None`.
+    ///
+    /// The other half of the same idea. `authenticated_peer` answers "may this connection
+    /// have a trust-derived limit at all"; this is what it gets while the answer is no.
+    ///
+    /// It lives here rather than in the shared [`RateLimiter`] because its key *is* this
+    /// struct: one connection, one budget, no map, no eviction, and nothing the sender can
+    /// say to be issued a different one (#2491).
+    pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter,
     /// Whether this node answers peer-exchange requests at all.
     ///
     /// Shared with the actor, so an operator posture set once at startup applies to every
@@ -156,6 +170,7 @@ impl ConnectionContext {
             direction,
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: RwLock::new(None),
+            pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
             peer_exchange_enabled,
             expected_peer,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
@@ -185,6 +200,15 @@ impl ConnectionContext {
     /// prove, and the only safe reading of it is "we do not know who this is".
     pub(crate) async fn authenticated_peer(&self) -> Option<Did> {
         self.authenticated_peer.read().await.clone()
+    }
+
+    /// Spend one message against this connection's anonymous budget.
+    ///
+    /// Call this only on the branch where [`Self::authenticated_peer`] is `None`. It takes
+    /// no identity because at that point there is none — see
+    /// [`crate::rate_limit::PreAuthRateLimiter`].
+    pub(crate) async fn check_pre_auth_rate_limit(&self) -> bool {
+        self.pre_auth_limiter.check().await
     }
 
     /// Weigh the operator's expectation for this connection against the identity that just

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -430,6 +430,7 @@ mod tests {
             // Inbound: we did not choose this peer, so we expected nobody (#2533).
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
+            pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -277,6 +277,17 @@ impl TokenBucket {
 ///   `isolated`'s rate. It is not zero: a handshake that is retrying must still make
 ///   progress.
 ///
+/// The burst is worth one more note, because at 20 it is *larger* than the default
+/// `isolated` (2) and `known` (10) bursts and equal to `partner`'s. That is not a better
+/// deal for staying anonymous, because nothing ever obliged an attacker to authenticate:
+/// the comparison that matters is against what an unauthenticated connection could spend
+/// *before* this change, which was the tier of whatever DID it cared to name — up to
+/// `federated`'s 200/s and burst 50, and before #2490's ceiling, `unlimited`. What the
+/// extra burst buys is at most twenty deserializations on a connection that still cannot
+/// reach peer exchange (#2535), a personhood budget, or anything else DID-gated. Sizing it
+/// down to `isolated`'s 2 would buy nothing against that and would risk a silent bootstrap
+/// failure, which is the one outcome this must not have.
+///
 /// # What this does not do
 ///
 /// It bounds one connection. An attacker who opens *N* connections gets *N* of these

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -265,8 +265,18 @@ impl TokenBucket {
 /// # Where the numbers come from
 ///
 /// This budget exists to fund *one thing*: reaching authentication. That is a property of
-/// the Hello protocol, not of an operator's trust posture, which is why it is derived here
-/// rather than configured.
+/// the Hello protocol, not of an operator's trust posture, which is why it lives here
+/// rather than in configuration.
+///
+/// What the protocol fixes, though, is a *range* rather than a pair of values. It says the
+/// budget must be nonzero, because a node that cannot afford a Hello cannot join; that it
+/// can be small, because an unauthenticated connection has nothing legitimate to do besides
+/// authenticate; and that it needs deterministic headroom above the one-Hello floor, because
+/// the cost of being wrong in that direction is a silent bootstrap failure. The two
+/// constants below are a conservative default chosen inside that range, deliberately
+/// generous against the floor. They are **not** uniquely derived, and no invariant here
+/// depends on their exact values — only on their being small, positive, and unrelated to
+/// anything the sender said.
 ///
 /// - **burst 20** — a handshake costs one Hello. Twenty leaves room for a peer that
 ///   interleaves other traffic before its Hello lands, for version renegotiation, and for

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -245,11 +245,116 @@ impl TokenBucket {
     }
 }
 
+/// What a connection may spend before it has authenticated anybody (#2491).
+///
+/// # Why this is a constant and not a trust tier
+///
+/// Every other limit in this module is selected by trust class, from operator
+/// configuration. This one cannot be, and the reason is the whole of #2491: selecting a
+/// tier requires knowing *who* the peer is, and before the Hello binding runs
+/// (`handlers::hello`) nobody knows. The only DID available is `NetworkMessage.from`,
+/// which the sender chose. Consulting trust for it is exactly the defect.
+///
+/// Nor is it any of the four configured tiers. `isolated` is the tempting one — it is the
+/// smallest — but it means "a peer we have classified and found unconnected", which is a
+/// statement about a known identity. "We do not know who this is" is a different claim, and
+/// giving it a trust class would assert something the node cannot support. The tiers are
+/// also not required to be ordered (see [`NetworkRateLimitTiers::ceiling`] in
+/// `icn-core`), so `min` over them is not a policy either.
+///
+/// # Where the numbers come from
+///
+/// This budget exists to fund *one thing*: reaching authentication. That is a property of
+/// the Hello protocol, not of an operator's trust posture, which is why it is derived here
+/// rather than configured.
+///
+/// - **burst 20** — a handshake costs one Hello. Twenty leaves room for a peer that
+///   interleaves other traffic before its Hello lands, for version renegotiation, and for
+///   retries. Sizing this near the true cost would fail closed on the one path a node needs
+///   in order to join at all, and would do it silently.
+/// - **10 messages/second** — a connection that has not authenticated has no legitimate
+///   sustained traffic, so this is deliberately far below every default tier except
+///   `isolated`'s rate. It is not zero: a handshake that is retrying must still make
+///   progress.
+///
+/// # What this does not do
+///
+/// It bounds one connection. An attacker who opens *N* connections gets *N* of these
+/// budgets, because each is scoped to a `ConnectionContext`. That is connection admission /
+/// source aggregation, a separate problem this deliberately does not claim to solve — see
+/// the module note on [`PreAuthRateLimiter`].
+pub const PRE_AUTH_RATE_LIMIT: RateLimitConfig = RateLimitConfig {
+    max_messages_per_second: 10,
+    burst_capacity: 20,
+    refill_interval: Duration::from_millis(100),
+};
+
+/// The budget an unauthenticated connection spends, scoped to that connection.
+///
+/// # Why the connection is the key
+///
+/// The key has to be something the remote end cannot choose, and on an inbound stream
+/// almost nothing qualifies. `NetworkMessage.from` is chosen by the sender outright. The
+/// remote address is transport-derived but is *not* stable per attacker: a new source port
+/// is a new key, so reconnecting mints a fresh budget, and QUIC connection migration can
+/// change it mid-connection. The remote IP is stable but shared — one bucket per IP charges
+/// every peer behind a NAT for its noisiest neighbour, and needs a global map with its own
+/// eviction policy.
+///
+/// The connection itself has none of those problems. It is created by *this* node when a
+/// handshake completes; nothing in any message influences which one a byte lands on. It
+/// lives and dies with the peer's session, so there is no map to grow and nothing to evict.
+/// And it is the resource actually being consumed: the question a transport limiter answers
+/// is "whose traffic is this connection carrying", not "who wrote this payload".
+///
+/// Rotating the claimed DID therefore buys nothing — every message on one connection meets
+/// the same bucket, whatever name it carries.
+///
+/// # Scope
+///
+/// One connection, one budget. *N* connections is *N* budgets; bounding that is connection
+/// admission, which this does not address and does not claim to.
+#[derive(Debug)]
+pub struct PreAuthRateLimiter {
+    bucket: RwLock<TokenBucket>,
+}
+
+impl PreAuthRateLimiter {
+    /// A fresh budget for a newly established connection.
+    pub fn new() -> Self {
+        Self {
+            bucket: RwLock::new(TokenBucket::new(
+                PRE_AUTH_RATE_LIMIT.burst_capacity as f64,
+                refill_rate_per_interval(&PRE_AUTH_RATE_LIMIT),
+                PRE_AUTH_RATE_LIMIT.refill_interval,
+            )),
+        }
+    }
+
+    /// Spend one message's worth of the connection's anonymous budget.
+    ///
+    /// Takes no DID, and that is the point: there is nothing to pass. A signature here
+    /// would be an invitation to key this on a claim.
+    pub async fn check(&self) -> bool {
+        self.bucket.write().await.try_consume()
+    }
+}
+
+impl Default for PreAuthRateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Per-peer rate limiter using token bucket algorithm
 ///
 /// Supports two layers of rate limiting:
 /// 1. Per-DID: Policy-based rate limiting via PolicyOracle
 /// 2. Per-anchor (Sybil resistance): Aggregate limits across DIDs sharing same PersonhoodAnchor
+///
+/// Both layers key on a DID, so both are usable **only after** that DID has been
+/// authenticated against the connection carrying the message (#2491). Before that, see
+/// [`PreAuthRateLimiter`].
 pub struct RateLimiter {
     /// Policy oracle for determining rate limits (optional)
     oracle: Option<Arc<dyn PolicyOracle>>,

--- a/icn/crates/icn-net/tests/authenticated_rate_limit_identity.rs
+++ b/icn/crates/icn-net/tests/authenticated_rate_limit_identity.rs
@@ -1,0 +1,921 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Which identity may select an inbound message's rate limit.
+//!
+//! #2491. The rate-limit check runs immediately after `read_message`, before any dispatch,
+//! and it used to be keyed on `NetworkMessage.from` — a field the sender chooses and nobody
+//! has verified at that point. DIDs are public, so naming a well-trusted one bought that
+//! peer's tier without holding its key.
+//!
+//! The fix is an ordering, not a new identity mechanism. A connection has two phases, and
+//! the phase decides what may key the limiter:
+//!
+//! ```text
+//! before an authenticated Hello:  the connection's own budget. No DID input at all.
+//! after  an authenticated Hello:  the DID bound to THIS connection's certificate (#2520).
+//! ```
+//!
+//! `NetworkMessage.from` selects nothing in either phase.
+//!
+//! # How these tests know
+//!
+//! Two observables, both structural — neither depends on wall-clock refill timing.
+//!
+//! 1. **Who the oracle was asked about.** [`TierOracle`] records every actor DID passed to
+//!    `PolicyOracle::evaluate`. That is precisely "whose trust class was consulted", which
+//!    is the question #2491 asks. An assertion that a DID never appears cannot pass
+//!    vacuously the way a timing assertion can.
+//!
+//! 2. **How many messages reached the external handler.** A rate-limited message never
+//!    reaches it, so counting arrivals measures the budget that was actually applied. The
+//!    tiers below are deliberately far apart — a spoofable tier admits *everything*, a
+//!    starved tier admits *two* — so no arrival count is reachable from two different
+//!    tiers by accident.
+//!
+//! Every negative assertion is paired with a positive control in the same file:
+//! [`authentication_moves_the_connection_onto_its_configured_tier`] proves traffic still
+//! flows, so "nothing arrived" cannot be mistaken for a dead harness, and
+//! [`the_pre_authentication_budget_admits_a_handshake`] proves the anonymous budget is not
+//! so tight that bootstrap cannot happen.
+
+use anyhow::{Context, Result};
+use icn_identity::{Did, IdentityBundle, PersonhoodAnchor, PersonhoodStoreTrait};
+use icn_kernel_api::authz::{
+    ConstraintSet, Domain, PolicyDecision, PolicyOracle, PolicyRequest, RateLimit,
+};
+use icn_net::{
+    envelope::{PayloadType, SignedEnvelope},
+    IncomingMessageHandler, NetworkActor, NetworkHandle, NetworkMessage, VersionInfo,
+};
+use quinn::{ClientConfig, Endpoint};
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+/// Ports already handed out in this process.
+///
+/// `pick_unused_port` binds, closes, and returns the port, so two tests running
+/// concurrently can be handed the same one. Remembering what we issued removes that race
+/// within the process; callers still retry, because nothing rules out another process
+/// taking it in between.
+static ISSUED_PORTS: Mutex<Option<HashSet<u16>>> = Mutex::new(None);
+
+fn pick_port() -> u16 {
+    let mut guard = ISSUED_PORTS.lock().expect("port registry poisoned");
+    let issued = guard.get_or_insert_with(HashSet::new);
+    for _ in 0..64 {
+        if let Some(port) = portpicker::pick_unused_port() {
+            if issued.insert(port) {
+                return port;
+            }
+        }
+    }
+    panic!("could not find an unused port");
+}
+
+fn init() {
+    // Without a process-level provider every TLS handshake panics, which would fail every
+    // assertion in this file for a reason that has nothing to do with rate limiting.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("icn_net=debug")
+        .try_init();
+}
+
+/// Keeps a node's shutdown sender alive for the duration of a test.
+struct Guard(broadcast::Sender<()>);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Observables
+// ---------------------------------------------------------------------------
+
+/// A `PolicyOracle` that records *who it was asked about* and answers with a fixed tier.
+///
+/// The recording is the point. #2491 is not a question about numbers, it is a question
+/// about which identity reached the trust lookup, and this answers it directly: a DID that
+/// never appears in [`TierOracle::consulted`] never selected a rate limit.
+///
+/// It serves [`icn_net::NETWORK_DOMAIN`], the domain the limiter queries, so registering it
+/// exercises the same path #2490 wired at the composition root.
+#[derive(Debug)]
+struct TierOracle {
+    consulted: Arc<Mutex<Vec<String>>>,
+    tiers: HashMap<String, RateLimit>,
+    default_tier: RateLimit,
+}
+
+impl TierOracle {
+    fn new(default_tier: RateLimit) -> Self {
+        Self {
+            consulted: Arc::new(Mutex::new(Vec::new())),
+            tiers: HashMap::new(),
+            default_tier,
+        }
+    }
+
+    fn with_tier(mut self, did: &Did, tier: RateLimit) -> Self {
+        self.tiers.insert(did.to_string(), tier);
+        self
+    }
+
+    fn consulted_handle(&self) -> Arc<Mutex<Vec<String>>> {
+        self.consulted.clone()
+    }
+}
+
+impl PolicyOracle for TierOracle {
+    fn evaluate(&self, request: &PolicyRequest) -> PolicyDecision {
+        let actor = request.core.actor.to_string();
+        self.consulted
+            .lock()
+            .expect("consulted log poisoned")
+            .push(actor.clone());
+        let tier = self
+            .tiers
+            .get(&actor)
+            .cloned()
+            .unwrap_or_else(|| self.default_tier.clone());
+        PolicyDecision::allow_with(ConstraintSet::new().with_rate_limit(tier))
+    }
+
+    fn domain(&self) -> Domain {
+        Domain::new(icn_net::NETWORK_DOMAIN)
+    }
+}
+
+/// A personhood store that records every DID whose anchor was looked up.
+///
+/// It holds no anchors: the question here is not what the answer was, but whether the
+/// question was asked about a DID nobody had authenticated (#2491 phase 10). Returning
+/// `None` is also the graceful-degradation path, so its presence cannot change any
+/// admission decision and cannot mask the tier assertions.
+#[derive(Debug, Default)]
+struct RecordingPersonhoodStore {
+    looked_up: Arc<Mutex<Vec<String>>>,
+}
+
+impl RecordingPersonhoodStore {
+    fn looked_up_handle(&self) -> Arc<Mutex<Vec<String>>> {
+        self.looked_up.clone()
+    }
+}
+
+impl PersonhoodStoreTrait for RecordingPersonhoodStore {
+    fn get_anchor(&self, _anchor_id: &[u8; 32]) -> anyhow::Result<Option<PersonhoodAnchor>> {
+        Ok(None)
+    }
+
+    fn get_anchor_by_did(&self, did: &Did) -> anyhow::Result<Option<PersonhoodAnchor>> {
+        self.looked_up
+            .lock()
+            .expect("lookup log poisoned")
+            .push(did.to_string());
+        Ok(None)
+    }
+
+    fn get_anchor_id_for_did(&self, did: &Did) -> anyhow::Result<Option<[u8; 32]>> {
+        self.looked_up
+            .lock()
+            .expect("lookup log poisoned")
+            .push(did.to_string());
+        Ok(None)
+    }
+}
+
+/// Every message that survived the rate limiter and reached the external handler.
+///
+/// A denied message is dropped before dispatch, so this count *is* the budget that was
+/// applied. Recording `from` as well makes it possible to assert that the messages which
+/// arrived are the ones the test sent, not incidental protocol traffic.
+#[derive(Clone, Default)]
+struct Delivered(Arc<Mutex<Vec<String>>>);
+
+impl Delivered {
+    fn count_from(&self, claimed: &Did) -> usize {
+        let claimed = claimed.to_string();
+        self.0
+            .lock()
+            .expect("delivery log poisoned")
+            .iter()
+            .filter(|from| **from == claimed)
+            .count()
+    }
+
+    fn total(&self) -> usize {
+        self.0.lock().expect("delivery log poisoned").len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/// Spawn a real node on the production stack.
+///
+/// The handler is required, not optional: `NetworkActor::spawn` only starts the inbound
+/// accept loop when `incoming_handler` is `Some`. Without it nothing here would receive a
+/// message at all, and every "denied" assertion would pass for the wrong reason.
+async fn spawn_node(
+    bundle: IdentityBundle,
+    oracle: Option<Arc<dyn PolicyOracle>>,
+    personhood: Option<Arc<dyn PersonhoodStoreTrait>>,
+) -> Result<(NetworkHandle, SocketAddr, Guard, Delivered)> {
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let delivered = Delivered::default();
+    let sink = delivered.0.clone();
+    let handler: IncomingMessageHandler = Arc::new(move |msg: NetworkMessage| {
+        sink.lock()
+            .expect("delivery log poisoned")
+            .push(msg.from.to_string());
+    });
+
+    // Binding is setup, not the property under test, so it retries: a port reported free
+    // can still be taken by another process before we bind it.
+    let mut last_err = None;
+    for _ in 0..8 {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        match NetworkActor::spawn(
+            bundle.clone(),
+            addr,
+            shutdown_tx.clone(),
+            Some(handler.clone()),
+            oracle.clone(),
+            None, // fallback_config
+            None, // topology_config
+            None, // stun_servers
+            None, // turn_config
+            None, // misbehavior_detector
+            None, // store
+            personhood.clone(),
+            None, // anchor_rate_config
+            None, // advertised_addr
+        )
+        .await
+        {
+            Ok(handle) => {
+                // Let the endpoint bind before anyone dials it.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                return Ok((handle, addr, Guard(shutdown_tx), delivered));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
+}
+
+/// A raw QUIC client that speaks the wire protocol, authenticating only when asked to.
+///
+/// The gap between "has a connection" and "has authenticated" is the whole subject of this
+/// file, so the two are separate methods and no test does the second by accident.
+struct WireClient {
+    _endpoint: Endpoint,
+    connection: quinn::Connection,
+    identity: IdentityBundle,
+}
+
+impl WireClient {
+    async fn connect(identity: &IdentityBundle, target: SocketAddr) -> Result<Self> {
+        let rustls_client = icn_net::tls::create_tofu_client_config(
+            vec![identity.tls_cert().clone()],
+            identity.tls_key(),
+        )?;
+        let mut endpoint = Endpoint::client("127.0.0.1:0".parse()?)?;
+        endpoint.set_default_client_config(ClientConfig::new(Arc::new(
+            quinn::crypto::rustls::QuicClientConfig::try_from(rustls_client)?,
+        )));
+
+        // Establishing the connection is a precondition, not the property under test, so
+        // it retries. No assertion below retries.
+        let mut last_err = None;
+        for attempt in 0..5 {
+            match tokio::time::timeout(
+                Duration::from_secs(10),
+                endpoint.connect(target, "localhost")?,
+            )
+            .await
+            {
+                Ok(Ok(connection)) => {
+                    return Ok(Self {
+                        _endpoint: endpoint,
+                        connection,
+                        identity: identity.clone(),
+                    })
+                }
+                Ok(Err(e)) => last_err = Some(e.to_string()),
+                Err(_) => last_err = Some("connect timed out".to_string()),
+            }
+            tokio::time::sleep(Duration::from_millis(150 * (attempt + 1))).await;
+        }
+        anyhow::bail!(
+            "could not establish the test connection after 5 attempts: {}",
+            last_err.unwrap_or_default()
+        )
+    }
+
+    /// Complete an authenticated Hello with `to`, using this client's own certificate.
+    ///
+    /// The binding is this identity's own and the certificate on the wire is this
+    /// identity's own, so the #2520 check passes and the responder learns who is on the
+    /// other end of *this* connection.
+    async fn authenticate(&self, to: &Did) -> Result<()> {
+        let hello = NetworkMessage::hello(
+            self.identity.did().clone(),
+            to.clone(),
+            self.identity.binding_info(),
+            VersionInfo::new("icnd-test-client".to_string()),
+            None,
+            *self.identity.x25519_public_bytes(),
+            None,
+            None,
+        );
+        self.send(&hello).await
+    }
+
+    /// Authenticate a *different* identity on this already-established connection.
+    ///
+    /// This is a real rebinding, not a trick. #2520 asks two questions of a Hello: does the
+    /// binding's certificate hash match the certificate on this connection, and did the
+    /// named DID's key sign that hash. Neither requires the certificate to belong to the
+    /// DID — signing this connection's certificate hash is how a key holder says "I am the
+    /// party on this session". So `other` genuinely authenticates here, and the connection's
+    /// identity genuinely changes.
+    async fn authenticate_as(&self, other: &IdentityBundle, to: &Did) -> Result<()> {
+        use sha2::{Digest, Sha256};
+
+        let cert_hash: [u8; 32] = {
+            let mut hasher = Sha256::new();
+            hasher.update(self.identity.tls_cert().as_ref());
+            hasher.finalize().into()
+        };
+        let binding = icn_identity::BindingInfo {
+            did: other.did().clone(),
+            tls_cert_hash: cert_hash,
+            tls_binding_sig: other.sign(&cert_hash)?.to_bytes().to_vec(),
+            created_at: 0,
+        };
+
+        let hello = NetworkMessage::hello(
+            other.did().clone(),
+            to.clone(),
+            binding,
+            VersionInfo::new("icnd-test-client".to_string()),
+            None,
+            *other.x25519_public_bytes(),
+            None,
+            None,
+        );
+        self.send(&hello).await
+    }
+
+    /// Send one message claiming to be `claimed_from`.
+    ///
+    /// `Subscribe` is used as the carrier because the inbound dispatch forwards it to the
+    /// external handler untouched — no verification, no state change — so an arrival
+    /// records exactly one thing: the rate limiter admitted it.
+    async fn send_claiming(&self, claimed_from: &Did, to: &Did) -> Result<()> {
+        let message = NetworkMessage::subscribe(
+            claimed_from.clone(),
+            to.clone(),
+            vec!["icn.test.2491".to_string()],
+        );
+        self.send(&message).await
+    }
+
+    async fn send(&self, message: &NetworkMessage) -> Result<()> {
+        let (mut send, _recv) = self.connection.open_bi().await?;
+        icn_net::protocol::write_message(&mut send, message).await?;
+        send.finish().context("finish stream")?;
+        Ok(())
+    }
+}
+
+/// Poll until `observer` has authenticated `did`, or the deadline passes.
+///
+/// `peer_connections` is written only by `handle_hello`, after the #2520 DID-TLS binding
+/// checks pass, so this returning `true` is proof the handshake completed. Synchronising on
+/// that observable rather than sleeping is what keeps the post-authentication assertions
+/// honest: "charged to the pre-auth bucket" and "the Hello has not landed yet" would
+/// otherwise be indistinguishable.
+async fn wait_until_authenticated(observer: &NetworkHandle, did: &Did, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if observer.get_peer_connection_info(did).await.is_some() {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// Give the node time to drain what was written before reading the observables.
+///
+/// Writes are streams the node accepts asynchronously, so a test that asserts immediately
+/// after its last `send` can observe a partial count. This waits for quiescence — the
+/// delivered total holding still — rather than a fixed sleep, and it can only ever let
+/// *more* messages through, so it cannot manufacture a passing denial assertion.
+async fn settle(delivered: &Delivered) {
+    let mut last = usize::MAX;
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let now = delivered.total();
+        if now == last {
+            return;
+        }
+        last = now;
+    }
+}
+
+/// A tier so large that no test sends enough to exhaust it.
+///
+/// Standing in for "a well-trusted peer": if a spoofed claim selects this, every message
+/// the test sends arrives.
+fn spoofable_tier() -> RateLimit {
+    RateLimit {
+        messages_per_second: 5_000,
+        burst_size: 500,
+    }
+}
+
+/// A tier that admits two messages and never refills.
+///
+/// `messages_per_second: 0` genuinely means no replenishment (#2503), so an arrival count
+/// above two proves this tier was *not* the one applied — with no timing tolerance needed.
+fn starved_tier() -> RateLimit {
+    RateLimit {
+        messages_per_second: 0,
+        burst_size: 2,
+    }
+}
+
+/// How many messages each test fires.
+///
+/// Comfortably above the pre-authentication burst and comfortably below the spoofable
+/// tier's burst, so the three possible outcomes — spoofable tier, pre-auth budget, starved
+/// tier — land in three non-overlapping ranges.
+const VOLLEY: usize = 60;
+
+/// The largest arrival count still explainable by the pre-authentication budget.
+///
+/// The budget is a burst plus whatever refills while the volley is in flight. Sending
+/// [`VOLLEY`] small messages over loopback takes well under a second, so this leaves
+/// generous headroom above burst-plus-refill while staying far below [`VOLLEY`] itself.
+/// The primary assertion in every test is the oracle log, which has no timing component at
+/// all; this bound is the corroborating one.
+const PRE_AUTH_CEILING: usize = 45;
+
+// ---------------------------------------------------------------------------
+// Pre-authentication: no DID claim may select a tier
+// ---------------------------------------------------------------------------
+
+/// RED A — naming a well-trusted DID must not buy its tier.
+///
+/// The attacker holds its own key and its own certificate. It never proves anything about
+/// `trusted`; it merely writes that DID into `from`.
+#[tokio::test]
+async fn an_unauthenticated_claim_cannot_buy_a_trusted_peers_tier() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let trusted = IdentityBundle::generate()?;
+    let attacker = IdentityBundle::generate()?;
+
+    let oracle = TierOracle::new(starved_tier()).with_tier(trusted.did(), spoofable_tier());
+    let consulted = oracle.consulted_handle();
+
+    let (_handle, addr, _guard, delivered) =
+        spawn_node(node.clone(), Some(Arc::new(oracle)), None).await?;
+
+    let client = WireClient::connect(&attacker, addr).await?;
+    for _ in 0..VOLLEY {
+        client.send_claiming(trusted.did(), node.did()).await?;
+    }
+    settle(&delivered).await;
+
+    let consulted = consulted.lock().expect("consulted log poisoned").clone();
+    assert!(
+        !consulted.contains(&trusted.did().to_string()),
+        "the trusted DID's tier was looked up for a connection that never authenticated it; \
+         consulted = {consulted:?}"
+    );
+
+    let arrived = delivered.count_from(trusted.did());
+    assert!(
+        arrived <= PRE_AUTH_CEILING,
+        "{arrived} of {VOLLEY} spoofed messages were admitted, which is more than the \
+         pre-authentication budget can explain — the claimed DID's tier was applied"
+    );
+
+    Ok(())
+}
+
+/// RED B — rotating the claimed DID must not multiply the budget.
+///
+/// Keying the limiter on `from` gives every new name its own bucket, so an attacker with a
+/// list of DIDs gets one starved tier's worth of budget *per name*. Thirty names times two
+/// tokens is the entire volley. A connection-scoped budget is indifferent to the name.
+#[tokio::test]
+async fn rotating_the_claimed_did_does_not_multiply_the_budget() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let attacker = IdentityBundle::generate()?;
+
+    // Thirty distinct names, two messages each. Under `from`-keying every one of them
+    // opens a fresh starved bucket holding exactly the two tokens it is about to spend.
+    let names: Vec<Did> = (0..30)
+        .map(|_| IdentityBundle::generate().map(|b| b.did().clone()))
+        .collect::<Result<_, _>>()?;
+
+    let oracle = TierOracle::new(starved_tier());
+    let consulted = oracle.consulted_handle();
+
+    let (_handle, addr, _guard, delivered) =
+        spawn_node(node.clone(), Some(Arc::new(oracle)), None).await?;
+
+    let client = WireClient::connect(&attacker, addr).await?;
+    for _ in 0..2 {
+        for name in &names {
+            client.send_claiming(name, node.did()).await?;
+        }
+    }
+    settle(&delivered).await;
+
+    let consulted = consulted.lock().expect("consulted log poisoned").clone();
+    for name in &names {
+        assert!(
+            !consulted.contains(&name.to_string()),
+            "a claimed DID reached the trust lookup on an unauthenticated connection: {name}"
+        );
+    }
+
+    let arrived = delivered.total();
+    assert!(
+        arrived <= PRE_AUTH_CEILING,
+        "{arrived} of {} messages were admitted across {} rotating claims — changing the \
+         claimed DID bought additional budget",
+        names.len() * 2,
+        names.len()
+    );
+
+    Ok(())
+}
+
+/// RED F — a connection that never authenticates never leaves the anonymous phase.
+///
+/// Traffic alone is not evidence of identity, however much of it there is and however long
+/// it goes on. This sends in two separated waves so that "the first wave exhausted the
+/// bucket" cannot be confused with "the connection was promoted".
+#[tokio::test]
+async fn an_unauthenticated_connection_never_earns_a_trust_tier() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let trusted = IdentityBundle::generate()?;
+    let attacker = IdentityBundle::generate()?;
+
+    let oracle = TierOracle::new(starved_tier()).with_tier(trusted.did(), spoofable_tier());
+    let consulted = oracle.consulted_handle();
+
+    let (_handle, addr, _guard, delivered) =
+        spawn_node(node.clone(), Some(Arc::new(oracle)), None).await?;
+
+    let client = WireClient::connect(&attacker, addr).await?;
+    for _ in 0..VOLLEY {
+        client.send_claiming(trusted.did(), node.did()).await?;
+    }
+    settle(&delivered).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    for _ in 0..VOLLEY {
+        client.send_claiming(trusted.did(), node.did()).await?;
+    }
+    settle(&delivered).await;
+
+    let consulted = consulted.lock().expect("consulted log poisoned").clone();
+    assert!(
+        consulted.is_empty(),
+        "an unauthenticated connection reached the trust lookup: {consulted:?}"
+    );
+
+    Ok(())
+}
+
+/// Phase 7 — a valid signature on a payload does not authenticate the *connection*.
+///
+/// A `SignedEnvelope` proves who signed that envelope. It says nothing about who holds the
+/// QUIC session it arrived on: the envelope is a self-contained artefact, and anyone who
+/// has seen one can put it on their own connection. Only the #2520 Hello binds a DID to
+/// *this* connection's certificate, so only the Hello may move the connection into the
+/// trust-derived phase.
+#[tokio::test]
+async fn a_signed_envelope_does_not_authenticate_the_connection() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let signer = IdentityBundle::generate()?;
+    let attacker = IdentityBundle::generate()?;
+
+    let oracle = TierOracle::new(starved_tier()).with_tier(signer.did(), spoofable_tier());
+    let consulted = oracle.consulted_handle();
+
+    let (_handle, addr, _guard, delivered) =
+        spawn_node(node.clone(), Some(Arc::new(oracle)), None).await?;
+
+    // A genuinely valid envelope, signed by `signer`'s real key — but relayed by the
+    // attacker on the attacker's own connection, which is exactly the confusion under test.
+    let keypair = signer.keypair()?;
+    let envelope = SignedEnvelope::new(
+        signer.did(),
+        &keypair,
+        1,
+        PayloadType::Trust,
+        b"2491-signed-before-hello".to_vec(),
+    )?;
+
+    let client = WireClient::connect(&attacker, addr).await?;
+    client
+        .send(&NetworkMessage::signed(Some(node.did().clone()), envelope))
+        .await?;
+    for _ in 0..VOLLEY {
+        client.send_claiming(signer.did(), node.did()).await?;
+    }
+    settle(&delivered).await;
+
+    let consulted = consulted.lock().expect("consulted log poisoned").clone();
+    assert!(
+        !consulted.contains(&signer.did().to_string()),
+        "a signed payload promoted the connection to the signer's tier; consulted = \
+         {consulted:?}"
+    );
+
+    let arrived = delivered.count_from(signer.did());
+    assert!(
+        arrived <= PRE_AUTH_CEILING,
+        "{arrived} of {VOLLEY} messages were admitted after a signed envelope — the \
+         connection left the anonymous phase without a Hello"
+    );
+
+    Ok(())
+}
+
+/// RED G — an unauthenticated claim must not reach the personhood store either.
+///
+/// Fixing the trust tier while leaving the anchor lookup keyed on `from` would still let a
+/// sender spend somebody else's per-person budget. Before authentication there is no DID,
+/// so there is no anchor to look up — not a default one, and certainly not one derived from
+/// the claim.
+#[tokio::test]
+async fn an_unauthenticated_claim_never_reaches_the_personhood_store() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let victim = IdentityBundle::generate()?;
+    let attacker = IdentityBundle::generate()?;
+
+    let personhood = RecordingPersonhoodStore::default();
+    let looked_up = personhood.looked_up_handle();
+
+    let (_handle, addr, _guard, delivered) = spawn_node(
+        node.clone(),
+        Some(Arc::new(TierOracle::new(starved_tier()))),
+        Some(Arc::new(personhood)),
+    )
+    .await?;
+
+    let client = WireClient::connect(&attacker, addr).await?;
+    for _ in 0..VOLLEY {
+        client.send_claiming(victim.did(), node.did()).await?;
+    }
+    settle(&delivered).await;
+
+    let looked_up = looked_up.lock().expect("lookup log poisoned").clone();
+    assert!(
+        !looked_up.contains(&victim.did().to_string()),
+        "a personhood anchor was looked up for an unauthenticated claim: {looked_up:?}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Post-authentication: the connection's proven identity, and only it
+// ---------------------------------------------------------------------------
+
+/// RED C and RED E — authentication really does switch the phase, onto the real tier.
+///
+/// This is the positive control the negative tests lean on. A fix that simply refused
+/// trust-derived tiering forever would satisfy every assertion above and fail here.
+#[tokio::test]
+async fn authentication_moves_the_connection_onto_its_configured_tier() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let peer = IdentityBundle::generate()?;
+
+    let oracle = TierOracle::new(starved_tier()).with_tier(peer.did(), spoofable_tier());
+    let consulted = oracle.consulted_handle();
+
+    let (handle, addr, _guard, delivered) =
+        spawn_node(node.clone(), Some(Arc::new(oracle)), None).await?;
+
+    let client = WireClient::connect(&peer, addr).await?;
+    client.authenticate(node.did()).await?;
+    assert!(
+        wait_until_authenticated(&handle, peer.did(), Duration::from_secs(10)).await,
+        "the Hello never authenticated; nothing below would be measuring the right phase"
+    );
+
+    for _ in 0..VOLLEY {
+        client.send_claiming(peer.did(), node.did()).await?;
+    }
+    settle(&delivered).await;
+
+    let consulted = consulted.lock().expect("consulted log poisoned").clone();
+    assert!(
+        consulted.contains(&peer.did().to_string()),
+        "the authenticated peer's tier was never consulted, so the connection never left \
+         the anonymous phase; consulted = {consulted:?}"
+    );
+
+    let arrived = delivered.count_from(peer.did());
+    assert!(
+        arrived > PRE_AUTH_CEILING,
+        "only {arrived} of {VOLLEY} messages from an authenticated, well-trusted peer were \
+         admitted — its configured tier is not being applied"
+    );
+
+    Ok(())
+}
+
+/// RED D — after authentication, a forged `from` cannot upgrade the connection.
+///
+/// The connection belongs to `peer`, whose tier admits two messages and never refills. The
+/// messages name a well-trusted DID. They are `peer`'s traffic on `peer`'s connection, and
+/// they must be charged as such.
+#[tokio::test]
+async fn an_authenticated_connection_is_charged_to_its_own_tier() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let peer = IdentityBundle::generate()?;
+    let trusted = IdentityBundle::generate()?;
+
+    let oracle = TierOracle::new(starved_tier()).with_tier(trusted.did(), spoofable_tier());
+    let consulted = oracle.consulted_handle();
+
+    let (handle, addr, _guard, delivered) =
+        spawn_node(node.clone(), Some(Arc::new(oracle)), None).await?;
+
+    let client = WireClient::connect(&peer, addr).await?;
+    client.authenticate(node.did()).await?;
+    assert!(
+        wait_until_authenticated(&handle, peer.did(), Duration::from_secs(10)).await,
+        "the Hello never authenticated; the assertion below would pass for the wrong reason"
+    );
+
+    for _ in 0..VOLLEY {
+        client.send_claiming(trusted.did(), node.did()).await?;
+    }
+    settle(&delivered).await;
+
+    let consulted = consulted.lock().expect("consulted log poisoned").clone();
+    assert!(
+        !consulted.contains(&trusted.did().to_string()),
+        "a claimed DID reached the trust lookup on a connection authenticated as somebody \
+         else; consulted = {consulted:?}"
+    );
+    assert!(
+        consulted.contains(&peer.did().to_string()),
+        "the authenticated peer's own tier was never consulted; consulted = {consulted:?}"
+    );
+
+    let arrived = delivered.count_from(trusted.did());
+    assert!(
+        arrived <= 2,
+        "{arrived} messages were admitted, but the authenticated peer's tier allows two — \
+         the claimed DID's tier was applied instead"
+    );
+
+    Ok(())
+}
+
+/// Phase 6 — the anonymous budget is not so tight that a peer cannot authenticate.
+///
+/// The positive control for bootstrap. A pre-authentication limiter sized below the cost of
+/// a handshake would fail closed in the most damaging way possible: silently, and only on
+/// the path that lets a node join at all.
+#[tokio::test]
+async fn the_pre_authentication_budget_admits_a_handshake() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let peer = IdentityBundle::generate()?;
+
+    // The starved tier applies to everyone here, including `peer` once it authenticates.
+    // If the Hello itself were charged to a trust tier this would be the tightest possible
+    // configuration; charged to the anonymous budget it is irrelevant, which is the point.
+    let (handle, addr, _guard, _delivered) = spawn_node(
+        node.clone(),
+        Some(Arc::new(TierOracle::new(starved_tier()))),
+        None,
+    )
+    .await?;
+
+    let client = WireClient::connect(&peer, addr).await?;
+    client.authenticate(node.did()).await?;
+
+    assert!(
+        wait_until_authenticated(&handle, peer.did(), Duration::from_secs(10)).await,
+        "a first-contact Hello was not admitted by the pre-authentication budget — \
+         bootstrap is broken"
+    );
+
+    Ok(())
+}
+
+/// Phase 9 — the rate-limit identity follows a rebinding, and never anticipates one.
+///
+/// A repeated Hello is verified like any other (#2537), and a valid one can move the
+/// connection's authenticated identity. Two things must hold across that move:
+///
+/// - the rebinding Hello is charged to the identity in force *before* it, because the new
+///   DID is not authenticated until the Hello succeeds;
+/// - traffic after it is charged to the new identity, which requires reading the
+///   connection's current identity per message rather than caching the first one.
+///
+/// The two identities are given opposite tiers, so "which one is charged" is answered by an
+/// arrival count that cannot be produced by the other. `first` is starved; `second` is not.
+/// A node that cached the identity it saw first would keep charging `first` and admit two
+/// messages, which is the mutation this pins.
+#[tokio::test]
+async fn the_rate_limit_identity_is_the_connections_current_one() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let first = IdentityBundle::generate()?;
+    let second = IdentityBundle::generate()?;
+
+    let oracle = TierOracle::new(starved_tier()).with_tier(second.did(), spoofable_tier());
+    let consulted = oracle.consulted_handle();
+
+    let (handle, addr, _guard, delivered) =
+        spawn_node(node.clone(), Some(Arc::new(oracle)), None).await?;
+
+    // Phase one: the connection belongs to `first`, whose tier is starved.
+    let client = WireClient::connect(&first, addr).await?;
+    client.authenticate(node.did()).await?;
+    assert!(
+        wait_until_authenticated(&handle, first.did(), Duration::from_secs(10)).await,
+        "the first Hello never authenticated"
+    );
+
+    // Phase two: `second` authenticates on the same connection, over the same certificate.
+    client.authenticate_as(&second, node.did()).await?;
+    assert!(
+        wait_until_authenticated(&handle, second.did(), Duration::from_secs(10)).await,
+        "the rebinding Hello never authenticated, so the assertion below would be measuring \
+         the wrong phase"
+    );
+
+    for _ in 0..VOLLEY {
+        client.send_claiming(second.did(), node.did()).await?;
+    }
+    settle(&delivered).await;
+
+    let consulted = consulted.lock().expect("consulted log poisoned").clone();
+    let first_hits = consulted
+        .iter()
+        .filter(|d| **d == first.did().to_string())
+        .count();
+    let second_hits = consulted
+        .iter()
+        .filter(|d| **d == second.did().to_string())
+        .count();
+    assert!(
+        consulted.contains(&second.did().to_string()),
+        "the rebound identity's tier was never consulted; first={} hits={first_hits} \
+         second={} hits={second_hits} total={} delivered_second={} delivered_total={}",
+        first.did(),
+        second.did(),
+        consulted.len(),
+        delivered.count_from(second.did()),
+        delivered.total()
+    );
+
+    let arrived = delivered.count_from(second.did());
+    assert!(
+        arrived > PRE_AUTH_CEILING,
+        "only {arrived} of {VOLLEY} messages were admitted after the rebinding — the \
+         connection is still being charged to the identity it authenticated first"
+    );
+
+    Ok(())
+}

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -38,6 +38,11 @@ pub fn init_descriptions() {
         "icn_network_messages_rate_limited_total",
         "Total number of messages dropped due to rate limiting"
     );
+    // Two-phase inbound rate limiting (Issue #2491)
+    describe_counter!(
+        "icn_network_messages_rate_limited_pre_auth_total",
+        "Total number of messages denied by a connection's anonymous pre-authentication budget, before any peer identity was bound to it"
+    );
     describe_counter!(
         "icn_network_messages_rate_limited_by_rate_total",
         "Total number of messages rate limited, bucketed by rate limit (0-10, 11-50, 51-100, 100+)"

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -210,6 +210,21 @@ pub fn messages_rate_limited_inc() {
     counter!("icn_network_messages_rate_limited_total").increment(1);
 }
 
+/// A message denied against a connection's pre-authentication budget (#2491).
+///
+/// A subset of `messages_rate_limited_total`, separated because the two mean opposite
+/// things operationally. A throttled *authenticated* peer is a tier that may need raising;
+/// this counter is anonymous traffic that never got as far as saying who it was, and a
+/// sustained rise in it is a load signal rather than a configuration one.
+///
+/// Deliberately unlabelled. The tempting labels here — the claimed DID, the remote address
+/// — are unbounded and attacker-chosen, which is the same mistake at the metrics layer that
+/// #2491 fixes at the policy layer. (Distinguishing denial *causes* more finely is #2499's
+/// subject, not this one's.)
+pub fn messages_rate_limited_pre_auth_inc() {
+    counter!("icn_network_messages_rate_limited_pre_auth_total").increment(1);
+}
+
 /// Increment rate limit configuration change counter
 ///
 /// Called when rate limit parameters change for a peer (e.g., due to policy updates).


### PR DESCRIPTION
Fixes #2491

## What

Inbound rate limiting becomes two phases. Before a connection has authenticated anybody it spends an anonymous per-connection budget; after an authenticated Hello it is charged to the DID cryptographically bound to that connection's certificate.

`NetworkMessage.from` selects rate-limit authority in **neither** phase.

## Why

The limit check runs immediately after `read_message`, before dispatch — so before anything has verified who sent the message. It was keyed on `message.from`:

```text
read message
   ↓
message.from = a name the sender chose
   ↓
trust lookup on that name
   ↓
rate tier
   ↓
… authenticate later, if at all
```

DIDs are public. Naming a well-trusted peer bought that peer's tier without holding its key, and the elevated tier then applied to exactly the expensive pre-authentication work it was supposed to bound: deserialization, binding checks, signature verification.

#2490's absolute ceiling bounded the damage. It did not fix the ordering — an unauthenticated sender still picked its own tier, just from a bounded range.

## How

`ConnectionContext` already carried `authenticated_peer`, written only by the #2520 Hello path and only once all three DID-TLS facts hold (the binding names the DID, that DID's key signed it, and the signed hash is of the certificate *this* connection is presenting). The limiter becomes its second reader rather than a new identity mechanism:

```text
PRE-AUTH   authenticated_peer == None
           → the connection's own anonymous budget
           → no PolicyOracle lookup, no personhood lookup

POST-AUTH  authenticated_peer == Some(A)
           → the existing #2490 configured tier for A
           → the existing personhood path for A
```

Read per message rather than cached at first authentication, so a later valid Hello that re-authenticates the connection moves subsequent traffic onto the new identity.

### Signed content does not authenticate transport

A `SignedEnvelope` proves who signed that envelope. It says nothing about who holds the QUIC session it arrived on — the envelope is a self-contained artefact, and anyone who has seen one can put it on their own connection. Only the #2520 Hello binds a DID to *this* connection's certificate, so only the Hello may move a connection into the trust-derived phase. Pinned by `a_signed_envelope_does_not_authenticate_the_connection`.

### Rebinding

`verify_did_matches_binding` and `verify_binding_info` do not require the certificate to belong to the DID — signing this connection's certificate hash is how a key holder says "I am the party on this session". A physical QUIC connection is therefore not an immutable identity: a later valid Hello can move it from A to B, and B must genuinely name itself, sign with its own key, and hash *this* connection's certificate to do so.

That is why the current identity is read dynamically. `the_rate_limit_identity_is_the_connections_current_one` performs a real A→B rebind through the production Hello path and asserts that later traffic is charged to B. Nothing resets `authenticated_peer` back to `None`, so an authenticated connection cannot fall back to the anonymous budget.

### Pre-authentication budget

`PRE_AUTH_RATE_LIMIT` = **10 msg/s, burst 20**, refill interval 100 ms. A protocol constant, not a fifth tier.

- **Not configurable, on purpose.** It funds one thing — reaching authentication — which is a property of the Hello exchange, not of an operator's trust posture.
- **Not one of the four tiers.** `isolated` is the tempting one, but it means "a peer we have classified and found unconnected", a statement about a known identity. "We do not know who this is" is a different claim. The tiers are also not required to be ordered, so `min` over them is not a policy either.
- **burst 20** — a normal lifecycle costs exactly one inbound Hello: the initiator owes one, the responder answers once (guarded by `hello_responded`), and receiving that answer completes the initiator's handshake rather than obliging it to speak again (#2537). Twenty leaves room for traffic that interleaves ahead of the Hello, for version renegotiation, and for retries. Sizing near the true cost would fail closed on the one path a node needs in order to join at all, and would do it silently.
- **10 msg/s** — an unauthenticated connection has no legitimate sustained traffic. Far below every default tier's rate except `isolated`'s, which it equals. Not zero: a retrying handshake must still make progress.
- **On burst 20 exceeding `isolated` (2) and `known` (10):** nothing ever obliged an attacker to authenticate, so the comparison that matters is against what an unauthenticated connection could spend *before* this change — the tier of any DID it cared to name, up to `federated`'s 200/s and burst 50, and before #2490's ceiling, `unlimited`. The extra burst buys at most twenty deserializations on a connection that still cannot reach peer exchange (#2535), a personhood budget, or anything else DID-gated.

Repeated Hellos do not change this: after the first valid one the connection is authenticated, so further Hellos are charged to its tier, not to the anonymous budget.

### Independent phase budgets

Authentication grants a fresh post-authentication burst rather than carrying pre-auth consumption forward. This is intentional. The pre-auth budget exists only to reach authentication; post-auth capacity is governed by operator-configured trust policy and has now paid the cryptographic cost of proving an identity. Transferring consumption between them would couple unrelated concerns for a bounded gain — the amplification is at most one pre-auth budget per connection, which is subsumed by the per-connection scope already tracked in #2547.

## Scope

**This does not solve connection flooding.** The budget bounds one connection; *N* connections is *N* budgets, because each is scoped to a `ConnectionContext`. Connection admission and source aggregation are tracked separately in #2547, which also covers whether to wire, replace, or delete the unreferenced `GlobalRateLimiter`.

No source-IP limiting is smuggled in here. Tier values, the #2488/#2490 oracle registration, and the personhood system are untouched. No config change and no `NetworkActor::spawn` signature change.

## Test plan

New `authenticated_rate_limit_identity` suite — **9 tests**. The oracle records which actor DID reached the trust lookup and the personhood store records which DID had its anchor queried, so the primary assertions are structural ("whose identity selected the tier?") rather than timing-based. Arrival counts corroborate via deliberately non-overlapping tiers. The handler is required, not optional, because `NetworkActor::spawn` starts no accept loop without one — otherwise every "denied" assertion would pass for the wrong reason.

Against pristine `main` production code with this suite applied: **6 failed, 3 passed**. All six fail on the structural oracle assertion, not on a count. The three that pass are the positive controls (`the_pre_authentication_budget_admits_a_handshake`, `authentication_moves_the_connection_onto_its_configured_tier`, `the_rate_limit_identity_is_the_connections_current_one`), which stay green.

### Mutations — 6/6 killed

| | Mutation | Killed by |
|---|---|---|
| M1 | restore claimed-DID authority everywhere | 6 tests |
| M2 | trust `message.from` only pre-auth | 5 tests |
| M3 | never transition out of the anonymous phase | 3 tests |
| M4 | use `message.from` post-auth | `an_authenticated_connection_is_charged_to_its_own_tier` |
| M5 | derive the pre-auth anchor from `message.from` | `an_unauthenticated_claim_never_reaches_the_personhood_store` |
| M6 | cache the first authenticated DID for the connection's life | `the_rate_limit_identity_is_the_connections_current_one` |

M6 is why the identity is read per message rather than hoisted out of the stream loop to avoid a lock. Under it the oracle logs `first` 61 times and `second` 0 times.

**Harness freshness.** Restoring mutated sources by moving a backup can hand cargo bytes with an mtime older than the compiled artifacts, which then links the *mutated* binary and reports a false result. Every mutation and restore here rewrites through the tool (fresh mtime), the tree is asserted clean after each restore, and each run is rejected unless cargo actually emitted `Compiling icn-net`. All six results carry a verified recompile.

### Regression

Full `icn-net` **443 passed / 0 failed / 23 ignored** across 19 targets, including `bootstrap_did_expectation` (#2533) 7, `peer_exchange_policy` (#2535) 6, `provisional_connection_lifecycle` (#2534) 8, `hello_current_cert_binding` (#2520) 7, `hello_handshake_termination` (#2537) 5, `redundant_dial_idempotence` (#2536) 5, `nat_traversal_integration` 4, `relay_fallback` 2, `accept_handshake_cancellation` 7.

`icn-core --lib` 441. `#2490` oracle suite (`network_domain_oracle_registration`) 9/9. `cargo fmt --all --check` clean. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean. Meaning Firewall, firewall taxonomy + denylist, regulatory compliance, readiness overclaim, and doc control all pass.

### Independent review (second pass)

Re-verified from fresh truth against `origin/main` @ `d1ea4aaf`, not from the first pass's conclusions.

- **Authority boundary re-traced from scratch.** `check_rate_limit_with_personhood` has exactly one production caller in `icn-net` (`actor/connection.rs`), and it passes the authenticated identity. The personhood store is reachable only from inside that method, and the `PolicyOracle` only from inside `check_rate_limit`. `accept_bi` is the only inbound stream path in the crate — no uni-stream or datagram ingress bypasses the check. The other production `check_rate_limit` caller (`icn-rpc`) keys on JWT claims or a synthetic anonymous DID, not on anything a network sender chose.
- **Connection lifetime confirmed.** One `ConnectionContext` per `handle_connection`, and `wire_new_connection` runs only on `DialOutcome::Established` — `AlreadyConnected` does not re-wire (#2536). One physical connection cannot mint two anonymous budgets.
- **Phase transition is not a race.** The stream loop is sequential: `accept_bi().await` then inline dispatch, with `record_authenticated_peer` (the sole writer) called from that same task. A message seeing unverified identity as authenticated is structurally unreachable, not merely lock-protected.
- **RED re-derived independently.** Reverting only the production sources to `main` while keeping this suite reproduces **6 failed / 3 passed** in 1.56 s, and all six panic on their primary assertion line, not on harness setup. Restoring gave a byte-identical tree and 9/9 green.
- **M6 re-run independently**, since it is the one invariant *not* pinned by "revert to main" (its test passes on `main` for an unrelated reason). Caching the first authenticated identity kills exactly `the_rate_limit_identity_is_the_connections_current_one` and nothing else, with a verified `Compiling icn-net` and a byte-identical restore.
- **Tier comparisons checked against the real defaults** (`isolated` 10/s burst 2, `known` 50/10, `partner` 100/20, `federated` 200/50) rather than the test fixture in `network_policy.rs`, which is deliberately different. Every numeric claim in the rationale holds.
- **Two prose overclaims corrected** in `d420032c` (comments only, no non-comment line changed): the pre-auth constants were framed as derived from the Hello protocol when the protocol fixes only a range, and the `RequirePersonhood` narrowing above was undocumented. The `#2537` citation for re-authentication was also made precise — that issue bounds the Hello *reply*, not the binding.

Because that commit changes no executable line, the mutation campaign was not re-run; the M6 re-run above was performed against the same production code the branch ships.

## Metrics

Adds `icn_network_messages_rate_limited_pre_auth_total`, a subset of `icn_network_messages_rate_limited_total`. Deliberately unlabelled — the tempting labels (claimed DID, remote address) are unbounded and attacker-chosen, which would be the same mistake at the metrics layer that this fixes at the policy layer.

Logs distinguish `claimed_from` from the authenticated identity, and the two phases now emit distinct denial messages: "per-DID limit exceeded" is not true of a phase that has no DID.

## Risk

Behaviour changes for unauthenticated inbound traffic, which is now bounded by the anonymous budget instead of a claimed DID's tier. Bootstrap is the path that would notice: it is covered by `the_pre_authentication_budget_admits_a_handshake` under the tightest possible tier configuration, and by the unchanged #2533/#2536/#2520/#2537 suites.

**`EnforcementMode::RequirePersonhood` no longer denies pre-authentication traffic.** The pre-auth branch returns an `anchor_allowed` of `true`, because there is no DID to derive an anchor from. This is a deliberate narrowing of when that mode applies, and it is an improvement in both directions: the anchor used to be looked up for `message.from`, so naming any anchored DID satisfied it, while the peers it actually turned away were honest un-anchored ones — whose Hello it dropped before they could ever authenticate. Personhood is now enforced against the DID the connection has proven. Operators running `RequirePersonhood` will see un-anchored peers complete a handshake and then be denied post-authentication, rather than being unable to handshake at all.

## Non-goals

Message-origin and relay semantics (#2480), connection admission and source aggregation (#2547), #2539, #2542–#2545, rate-tier redesign, personhood redesign.

Refs #2491, #2490, #2520, #2535, #2537, #2547

