### PR TITLE
fix(net): bound unauthenticated inbound connections per source and server-wide

### DIFF
--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -228,10 +228,6 @@ impl NetworkActor {
                         return;
                     }
                 };
-                icn_obs::metrics::network::preauth_connections_live_set(admission_ctl.live_total());
-                icn_obs::metrics::network::preauth_sources_tracked_set(
-                    admission_ctl.tracked_sources(),
-                );
 
                 info!("Accepted connection from {}", connection.remote_address());
 
@@ -259,13 +255,11 @@ impl NetworkActor {
                     warn!("Connection handler error: {}", e);
                 }
 
-                // The guard travelled into the context, so it is released here whatever
-                // happened above: authenticated (released early), errored, or ran to
-                // completion. Refresh the gauge against the table rather than assuming.
-                icn_obs::metrics::network::preauth_connections_live_set(admission_ctl.live_total());
-                icn_obs::metrics::network::preauth_sources_tracked_set(
-                    admission_ctl.tracked_sources(),
-                );
+                // The guard travelled into the context, so whatever happened above —
+                // authenticated (released early), errored, or ran to completion — the slot
+                // is given back by its destructor, which republishes the gauges itself. No
+                // refresh here: doing it at the call site is what left them stale for every
+                // connection that authenticated and stayed open.
             });
         }
 

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -80,6 +80,14 @@ use super::NetworkActor;
 /// here.
 const MAX_CONCURRENT_INBOUND_HANDSHAKES: usize = 64;
 
+/// QUIC application close code for a connection refused a pre-authentication slot (#2547).
+///
+/// Distinct from a silent drop so the peer learns it was refused rather than timing out, and
+/// distinct from a protocol error because it is not one: a refused connection may be a
+/// perfectly well-behaved peer that arrived while its source's allowance was spent, and
+/// retrying later is the correct response.
+const PREAUTH_ADMISSION_REFUSED_CODE: u32 = 0x1c4b;
+
 /// Backoff before re-checking for an endpoint that has not been started yet.
 const ENDPOINT_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -104,6 +112,11 @@ impl NetworkActor {
         info!("Starting incoming connection handler");
 
         let handshake_slots = Arc::new(Semaphore::new(MAX_CONCURRENT_INBOUND_HANDSHAKES));
+
+        // One admission table for this endpoint's whole lifetime. It is the only state here
+        // that aggregates across connections, which is exactly the point: every other bound
+        // on this path is per-connection and so cannot see a source opening many (#2547).
+        let admission_ctl = Arc::new(crate::preauth_admission::PreAuthAdmission::new());
 
         loop {
             // Reserve a handshake slot before taking on new work. Acquiring is cancel-safe,
@@ -176,6 +189,7 @@ impl NetworkActor {
             let identity_bundle_clone = identity_bundle.clone();
             let own_did_clone = own_did.clone();
             let peer_exchange_enabled = peer_exchange_enabled.clone();
+            let admission_ctl = admission_ctl.clone();
             tokio::spawn(async move {
                 let connection = match incoming.await {
                     Ok(connection) => connection,
@@ -187,6 +201,37 @@ impl NetworkActor {
                 // The slot bounds concurrent handshakes, not connection lifetimes: release
                 // it as soon as the handshake is done, before the long-lived stream loop.
                 drop(permit);
+
+                // Take this connection's share of its source's pre-authentication allowance
+                // (#2547). This is the first moment it can be taken and the last moment it is
+                // useful: only now is the remote address meaningful, because completing a QUIC
+                // handshake proves the peer receives traffic there (RFC 9000 §8), and a
+                // spoofed address never gets this far. Any earlier and the key would be a
+                // claim; any later and the connection would already own a handler task, a
+                // context and a budget — the things being bounded.
+                let admission = match admission_ctl.try_admit(connection.remote_address()) {
+                    Ok(guard) => guard,
+                    Err(refusal) => {
+                        // Deliberately logged, not counted by address: the label set stays
+                        // closed while the diagnostic detail stays available.
+                        warn!(
+                            remote_addr = %connection.remote_address(),
+                            bound = refusal.as_str(),
+                            "Refusing inbound connection: pre-authentication admission limit \
+                             reached"
+                        );
+                        icn_obs::metrics::network::preauth_admission_refused_inc(refusal.as_str());
+                        connection.close(
+                            PREAUTH_ADMISSION_REFUSED_CODE.into(),
+                            b"pre-authentication admission limit",
+                        );
+                        return;
+                    }
+                };
+                icn_obs::metrics::network::preauth_connections_live_set(admission_ctl.live_total());
+                icn_obs::metrics::network::preauth_sources_tracked_set(
+                    admission_ctl.tracked_sources(),
+                );
 
                 info!("Accepted connection from {}", connection.remote_address());
 
@@ -207,11 +252,20 @@ impl NetworkActor {
                     peer_exchange_enabled,
                     // We did not choose this peer, so there is nobody we expected (#2533).
                     None,
+                    Some(admission),
                 )
                 .await
                 {
                     warn!("Connection handler error: {}", e);
                 }
+
+                // The guard travelled into the context, so it is released here whatever
+                // happened above: authenticated (released early), errored, or ran to
+                // completion. Refresh the gauge against the table rather than assuming.
+                icn_obs::metrics::network::preauth_connections_live_set(admission_ctl.live_total());
+                icn_obs::metrics::network::preauth_sources_tracked_set(
+                    admission_ctl.tracked_sources(),
+                );
             });
         }
 
@@ -241,6 +295,10 @@ impl NetworkActor {
         direction: crate::handlers::ConnectionDirection,
         peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
         expected_peer: Option<Did>,
+        // This connection's pre-authentication slot, for inbound connections (#2547).
+        // `None` for outbound: we chose to dial that peer, so it is not consuming an
+        // allowance meant to bound connections chosen by somebody else.
+        admission: Option<crate::preauth_admission::AdmissionGuard>,
     ) -> Result<()> {
         info!("Handling connection from {}", connection.remote_address());
 
@@ -260,6 +318,7 @@ impl NetworkActor {
             direction,
             peer_exchange_enabled,
             expected_peer,
+            admission,
         );
 
         loop {

--- a/icn/crates/icn-net/src/actor/messages.rs
+++ b/icn/crates/icn-net/src/actor/messages.rs
@@ -332,6 +332,10 @@ impl NetworkActor {
                     crate::handlers::ConnectionDirection::Outbound,
                     peer_exchange_enabled,
                     expected_peer,
+                    // We chose to dial this peer, so it does not spend the inbound
+                    // pre-authentication allowance, which exists to bound connections
+                    // somebody else chose to open at us (#2547).
+                    None,
                 )
                 .await
                 {

--- a/icn/crates/icn-net/src/handlers/encrypted.rs
+++ b/icn/crates/icn-net/src/handlers/encrypted.rs
@@ -233,6 +233,9 @@ mod tests {
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
+            // No inbound admission slot: these contexts are built directly, not by the
+            // accept loop (#2547).
+            admission_guard: std::sync::Mutex::new(None),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -387,6 +390,9 @@ mod tests {
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
+            // No inbound admission slot: these contexts are built directly, not by the
+            // accept loop (#2547).
+            admission_guard: std::sync::Mutex::new(None),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/icn/crates/icn-net/src/handlers/handshake.rs
+++ b/icn/crates/icn-net/src/handlers/handshake.rs
@@ -244,6 +244,9 @@ mod tests {
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
+            // No inbound admission slot: these contexts are built directly, not by the
+            // accept loop (#2547).
+            admission_guard: std::sync::Mutex::new(None),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -281,6 +284,9 @@ mod tests {
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
+            // No inbound admission slot: these contexts are built directly, not by the
+            // accept loop (#2547).
+            admission_guard: std::sync::Mutex::new(None),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/icn/crates/icn-net/src/handlers/mod.rs
+++ b/icn/crates/icn-net/src/handlers/mod.rs
@@ -85,6 +85,19 @@ pub struct ConnectionContext {
     /// struct: one connection, one budget, no map, no eviction, and nothing the sender can
     /// say to be issued a different one (#2491).
     pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter,
+    /// This connection's share of its source's pre-authentication allowance (#2547).
+    ///
+    /// The third member of the same idea. `authenticated_peer` says whether this connection
+    /// may have a trust-derived limit; `pre_auth_limiter` is what it spends while the answer
+    /// is no; this is what stops one source from holding an unbounded number of the other
+    /// two.
+    ///
+    /// `None` for connections that never took a slot — outbound dials, which this node
+    /// chose, and the handler unit tests. Taken (and so released) by
+    /// [`Self::record_authenticated_peer`], because a peer that has said who it is no longer
+    /// spends *anonymous* admission; otherwise released when the context is dropped with its
+    /// handler task. Both are the guard's destructor, so no exit path leaks a slot.
+    admission_guard: std::sync::Mutex<Option<crate::preauth_admission::AdmissionGuard>>,
     /// Whether this node answers peer-exchange requests at all.
     ///
     /// Shared with the actor, so an operator posture set once at startup applies to every
@@ -154,6 +167,7 @@ impl ConnectionContext {
         direction: ConnectionDirection,
         peer_exchange_enabled: Arc<std::sync::atomic::AtomicBool>,
         expected_peer: Option<Did>,
+        admission_guard: Option<crate::preauth_admission::AdmissionGuard>,
     ) -> Self {
         Self {
             handler,
@@ -171,6 +185,7 @@ impl ConnectionContext {
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: RwLock::new(None),
             pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
+            admission_guard: std::sync::Mutex::new(admission_guard),
             peer_exchange_enabled,
             expected_peer,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
@@ -191,6 +206,21 @@ impl ConnectionContext {
     /// property this state exists to carry.
     pub(crate) async fn record_authenticated_peer(&self, peer: &Did) {
         *self.authenticated_peer.write().await = Some(peer.clone());
+
+        // This connection has stopped being anonymous, so it stops charging its source's
+        // anonymous allowance (#2547). Releasing here rather than at close is what keeps the
+        // bound off legitimate peers: a source is limited in how many connections it may
+        // hold *while refusing to identify itself*, not in how many it may hold. Dropping
+        // the guard is the release; taking it is idempotent, so the eventual context drop
+        // has nothing left to do.
+        let released = self
+            .admission_guard
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if released.is_some() {
+            icn_obs::metrics::network::preauth_admission_released_inc();
+        }
     }
 
     /// The peer identity proven for this connection, if any.

--- a/icn/crates/icn-net/src/handlers/signed.rs
+++ b/icn/crates/icn-net/src/handlers/signed.rs
@@ -431,6 +431,9 @@ mod tests {
             expected_peer: None,
             expectation_mismatch_reported: std::sync::atomic::AtomicBool::new(false),
             pre_auth_limiter: crate::rate_limit::PreAuthRateLimiter::new(),
+            // No inbound admission slot: these contexts are built directly, not by the
+            // accept loop (#2547).
+            admission_guard: std::sync::Mutex::new(None),
             hello_responded: std::sync::atomic::AtomicBool::new(false),
             authenticated_peer: tokio::sync::RwLock::new(None),
             peer_exchange_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/icn/crates/icn-net/src/lib.rs
+++ b/icn/crates/icn-net/src/lib.rs
@@ -18,6 +18,7 @@ pub mod error;
 pub mod global_rate_limit;
 mod handlers;
 pub mod nat;
+pub mod preauth_admission;
 pub mod protocol;
 pub mod rate_limit;
 pub mod relay_proxy;
@@ -46,6 +47,10 @@ pub use envelope::{PayloadType, SignedEnvelope};
 pub use error::{NetError, Result};
 pub use global_rate_limit::GlobalRateLimiter;
 pub use nat::{NatConfig, NatTraversal, NatType, PublicAddress, TurnServerConfig};
+pub use preauth_admission::{
+    AdmissionGuard, AdmissionRefusal, PreAuthAdmission, MAX_PREAUTH_CONNECTIONS_PER_SOURCE,
+    MAX_PREAUTH_CONNECTIONS_TOTAL,
+};
 pub use protocol::{
     read_message, read_message_compressed, read_message_negotiated, write_message,
     write_message_compressed, write_message_negotiated, CompressionFormat, EncodingFormat,

--- a/icn/crates/icn-net/src/preauth_admission.rs
+++ b/icn/crates/icn-net/src/preauth_admission.rs
@@ -47,6 +47,15 @@
 //! `NetworkMessage.from` lacked in #2491, and it is why keying on it here is sound while
 //! keying on a claimed DID was not.
 //!
+//! **QUIC migration does not multiply reservations.** The key is read once, at admission, and
+//! the resulting [`AdmissionGuard`] carries it for the connection's whole life. A connection
+//! that later migrates to a new address therefore stays charged to the source that was
+//! return-routable when it was admitted; it cannot acquire a second slot, because a second
+//! slot is only ever issued by a second admission, and admission happens once per connection.
+//! Charging a migrated connection to its original source is the conservative direction: the
+//! alternative — re-keying on migration — would let a peer release a contended allowance by
+//! moving, which is the amplification this exists to prevent.
+//!
 //! The alternatives aggregate nothing or cost too much:
 //!
 //! - **remote `SocketAddr`** — a new source port is a new key, so reconnecting mints a fresh
@@ -62,9 +71,15 @@
 //! - QUIC/TLS handshake work *below* this hook — that is the existing concurrent-handshake
 //!   semaphore's job, and it bounds concurrency rather than rate.
 //! - Connection *rate*. A source that opens, spends its anonymous burst, and closes stays
-//!   within every bound here. Churn is throttled only indirectly, by handshake concurrency
-//!   divided by handshake latency.
+//!   within every bound here, because concurrency never rises. Churn is throttled only
+//!   indirectly, by handshake concurrency divided by handshake latency. Tracked by #2549,
+//!   which is separate because a rate bound needs entries that *outlive* their connections —
+//!   the opposite of what makes this table's cardinality provable.
+//! - How many connections one source may hold once they are *authenticated*: the slot is
+//!   released at the Hello, and DIDs are free to mint. Tracked by #2550.
 //! - Authenticated application traffic, which is #2490's and #2491's subject.
+//!
+//! None of this is general DoS prevention.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
@@ -94,11 +109,23 @@ pub const MAX_PREAUTH_CONNECTIONS_PER_SOURCE: usize = 8;
 
 /// The unit a pre-authentication allowance is charged to.
 ///
-/// IPv4 is keyed on the exact address. IPv6 is keyed on the **/64**, because a single host is
-/// routinely assigned an entire /64 and exact-address keying would be defeated by rotating
-/// inside it at no cost — the v6 equivalent of picking a new source port. Treating v6
-/// structurally rather than as an opaque address matches what this crate already does when
-/// it classifies addresses (`handlers::peer_exchange`).
+/// IPv4 is keyed on the exact address. IPv6 is keyed on the **/64**.
+///
+/// The v6 argument is narrower than "every host owns a /64", which is not true in general.
+/// It is only this: an IPv6 client can often change its source address *cheaply* — SLAAC and
+/// privacy extensions rotate within a prefix by design, and delegations of a /64 or shorter
+/// are common — so keying on the exact address would frequently aggregate nothing, the same
+/// way keying on a source port does. /64 is the smallest unit that is not routinely cheap to
+/// rotate within. It is a heuristic about cost, not a claim about allocation.
+///
+/// That heuristic has a real price, stated rather than buried: hosts sharing a /64 share an
+/// allowance, so a v6 network that puts many distinct peers in one /64 is charged as one
+/// source. The same is true of IPv4 behind a NAT. What keeps that cost small is *when* the
+/// allowance is released — at authentication, not at close — so peers only contend while
+/// they are still anonymous. See [`PreAuthAdmission`].
+///
+/// Treating v6 structurally rather than as an opaque address matches what this crate already
+/// does when it classifies addresses (`handlers::peer_exchange`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SourceKey {
     /// An exact IPv4 address.

--- a/icn/crates/icn-net/src/preauth_admission.rs
+++ b/icn/crates/icn-net/src/preauth_admission.rs
@@ -1,0 +1,448 @@
+//! How many unauthenticated connections one source may hold at once (#2547).
+//!
+//! # What #2491 left open
+//!
+//! #2491 gave every connection its own anonymous budget, keyed on the `ConnectionContext`
+//! so that nothing the sender says can be issued a different one. That closed the
+//! identity-ordering defect. It deliberately did not bound *how many* of those budgets one
+//! source may hold:
+//!
+//! ```text
+//! attacker opens N connections -> attacker holds N anonymous budgets
+//! ```
+//!
+//! Three facts on the inbound path make that worse than it looks. The handshake semaphore
+//! releases its permit as soon as the handshake completes, so it caps concurrent
+//! *handshakes* and never the number of established connections. This node installs
+//! `keep_alive_interval` on its **server** config, so it PINGs its own inbound connections
+//! and an idle one never reaches the idle timeout. And an unauthenticated connection is in
+//! no map at all — the session map is populated only by an authenticated Hello (#2530) — so
+//! nothing tracks or evicts it.
+//!
+//! Established-but-unauthenticated connections were therefore unbounded in count and
+//! effectively immortal. This module bounds them.
+//!
+//! # The invariant
+//!
+//! > At any instant, the number of established-but-unauthenticated inbound connections is
+//! > bounded, both server-wide and per source.
+//!
+//! **Concurrency, not rate.** This says nothing about how fast connections may be opened and
+//! closed; see the module's "what this does not bound" note below.
+//!
+//! **Pre-authentication only.** The reservation is released the moment a connection
+//! authenticates, so this never constrains established authenticated peers — a peer that
+//! says who it is stops consuming source admission immediately, and is thereafter governed
+//! by the per-DID and per-anchor limits (#2490, #2491).
+//!
+//! # Why the post-handshake remote IP can be trusted as a key
+//!
+//! Admission is taken **after** the QUIC handshake completes, and that is what makes the
+//! address meaningful. Completing a QUIC handshake proves return-routability (RFC 9000 §8):
+//! the server sends its handshake packets to the claimed address and the peer must answer
+//! from it. A spoofed source address cannot reach this hook at all.
+//!
+//! So the key is attacker-*chosen* but not attacker-*forgeable*: to present a different one,
+//! an attacker must actually receive traffic there. That is precisely the property
+//! `NetworkMessage.from` lacked in #2491, and it is why keying on it here is sound while
+//! keying on a claimed DID was not.
+//!
+//! The alternatives aggregate nothing or cost too much:
+//!
+//! - **remote `SocketAddr`** — a new source port is a new key, so reconnecting mints a fresh
+//!   allowance and the bound aggregates nothing. QUIC connection migration can also change
+//!   it mid-connection.
+//! - **a global cap alone** — bounds total work, but one attacker can consume the entire
+//!   allowance and lock every honest peer out. Kept here as a second bound, not the only one.
+//!
+//! # What this does not bound
+//!
+//! - Attacks distributed across many source addresses or many /64s. A single node cannot
+//!   solve that locally, and nothing here pretends to.
+//! - QUIC/TLS handshake work *below* this hook — that is the existing concurrent-handshake
+//!   semaphore's job, and it bounds concurrency rather than rate.
+//! - Connection *rate*. A source that opens, spends its anonymous burst, and closes stays
+//!   within every bound here. Churn is throttled only indirectly, by handshake concurrency
+//!   divided by handshake latency.
+//! - Authenticated application traffic, which is #2490's and #2491's subject.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Mutex};
+
+/// Maximum established-but-unauthenticated inbound connections, server-wide.
+///
+/// Sized above `MAX_CONCURRENT_INBOUND_HANDSHAKES` (64, in `actor::connection`)
+/// so that this bound never shadows it: every handshake the node is willing to run
+/// concurrently must have somewhere to land, or the two limits would fight and the symptom
+/// would be refused connections under ordinary load rather than under attack.
+pub const MAX_PREAUTH_CONNECTIONS_TOTAL: usize = 256;
+
+/// Maximum established-but-unauthenticated inbound connections from one source.
+///
+/// A peer needs exactly one: connect, Hello, authenticated. This is not a limit on how many
+/// connections a source may hold — an authenticated connection has already released its
+/// reservation — it is a limit on how many it may hold *while still refusing to say who it
+/// is*. Eight leaves room for genuine concurrency (several peers behind one NAT starting at
+/// once, a retry racing an original) while keeping the per-source share of
+/// [`MAX_PREAUTH_CONNECTIONS_TOTAL`] small enough that one source cannot crowd the table.
+///
+/// Like the concurrent-handshake cap this sits next to, it is a protocol constant rather
+/// than operator configuration. That is a deliberately conservative starting point, not a
+/// claim that no deployment will want to tune it.
+pub const MAX_PREAUTH_CONNECTIONS_PER_SOURCE: usize = 8;
+
+/// The unit a pre-authentication allowance is charged to.
+///
+/// IPv4 is keyed on the exact address. IPv6 is keyed on the **/64**, because a single host is
+/// routinely assigned an entire /64 and exact-address keying would be defeated by rotating
+/// inside it at no cost — the v6 equivalent of picking a new source port. Treating v6
+/// structurally rather than as an opaque address matches what this crate already does when
+/// it classifies addresses (`handlers::peer_exchange`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SourceKey {
+    /// An exact IPv4 address.
+    V4(std::net::Ipv4Addr),
+    /// The leading 64 bits of an IPv6 address.
+    V6Prefix([u8; 8]),
+}
+
+impl SourceKey {
+    /// The key a connection from `addr` is charged to.
+    pub fn from_addr(addr: SocketAddr) -> Self {
+        match addr.ip() {
+            IpAddr::V4(ip) => SourceKey::V4(ip),
+            IpAddr::V6(ip) => {
+                let octets = ip.octets();
+                let mut prefix = [0u8; 8];
+                prefix.copy_from_slice(&octets[..8]);
+                SourceKey::V6Prefix(prefix)
+            }
+        }
+    }
+}
+
+/// Why a connection was refused admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionRefusal {
+    /// The server-wide pre-authentication allowance is exhausted.
+    GlobalLimit,
+    /// This source already holds its maximum pre-authentication allowance.
+    SourceLimit,
+}
+
+impl AdmissionRefusal {
+    /// A short, bounded label for logs and metrics.
+    ///
+    /// Deliberately a fixed set of two strings: it is safe as a metric label precisely
+    /// because nothing an attacker sends can add a new value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AdmissionRefusal::GlobalLimit => "global_limit",
+            AdmissionRefusal::SourceLimit => "source_limit",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct AdmissionState {
+    /// Live pre-authentication connections per source.
+    ///
+    /// An entry exists only while its count is non-zero — see [`PreAuthAdmission`] on why
+    /// that is what keeps this map from becoming the leak it is meant to prevent.
+    per_source: HashMap<SourceKey, usize>,
+    /// Live pre-authentication connections, all sources.
+    total: usize,
+}
+
+/// The pre-authentication connection allowance, shared by the whole node.
+///
+/// # Why this map cannot be turned into a leak
+///
+/// A DoS defence that introduces an attacker-controlled unbounded map is not a defence. This
+/// one is bounded by construction rather than by policy:
+///
+/// - an entry is created only by a successful admission, and admission first checks `total`
+///   against [`MAX_PREAUTH_CONNECTIONS_TOTAL`];
+/// - an entry is removed the instant its count reaches zero;
+/// - therefore every entry has at least one live connection behind it, and
+///   `per_source.len() <= total <= MAX_PREAUTH_CONNECTIONS_TOTAL` holds at all times.
+///
+/// There is no expiry timer, no eviction policy and no cleanup task, because there is
+/// nothing to expire: the map's size is pinned to the number of connections currently being
+/// counted, and those are bounded. Releasing is not a background job that could fall behind —
+/// it is [`AdmissionGuard`]'s destructor, so it runs on every exit path including panics.
+#[derive(Debug)]
+pub struct PreAuthAdmission {
+    state: Mutex<AdmissionState>,
+    max_total: usize,
+    max_per_source: usize,
+}
+
+impl PreAuthAdmission {
+    /// The node-wide admission table with the default bounds.
+    pub fn new() -> Self {
+        Self::with_limits(
+            MAX_PREAUTH_CONNECTIONS_TOTAL,
+            MAX_PREAUTH_CONNECTIONS_PER_SOURCE,
+        )
+    }
+
+    /// An admission table with explicit bounds.
+    ///
+    /// Exists so tests can drive the boundary without opening hundreds of real connections.
+    pub fn with_limits(max_total: usize, max_per_source: usize) -> Self {
+        Self {
+            state: Mutex::new(AdmissionState::default()),
+            max_total,
+            max_per_source,
+        }
+    }
+
+    /// Reserve a pre-authentication slot for a connection from `addr`.
+    ///
+    /// Returns the reservation on success. Dropping it releases the slot, so the caller
+    /// cannot forget: there is deliberately no `release` free function to leave uncalled.
+    pub fn try_admit(
+        self: &Arc<Self>,
+        addr: SocketAddr,
+    ) -> Result<AdmissionGuard, AdmissionRefusal> {
+        let key = SourceKey::from_addr(addr);
+        let mut state = self.lock_state();
+
+        if state.total >= self.max_total {
+            return Err(AdmissionRefusal::GlobalLimit);
+        }
+        let source_count = state.per_source.entry(key).or_insert(0);
+        if *source_count >= self.max_per_source {
+            // Leave no zero-valued entry behind: a refused admission must not be able to
+            // grow the map, or refusing would itself become the amplification.
+            if *source_count == 0 {
+                state.per_source.remove(&key);
+            }
+            return Err(AdmissionRefusal::SourceLimit);
+        }
+        *source_count += 1;
+        state.total += 1;
+
+        Ok(AdmissionGuard {
+            admission: Arc::clone(self),
+            key,
+        })
+    }
+
+    /// Live pre-authentication connections, all sources.
+    pub fn live_total(&self) -> usize {
+        self.lock_state().total
+    }
+
+    /// Live pre-authentication connections charged to `addr`'s source.
+    pub fn live_for(&self, addr: SocketAddr) -> usize {
+        let key = SourceKey::from_addr(addr);
+        self.lock_state().per_source.get(&key).copied().unwrap_or(0)
+    }
+
+    /// Number of sources currently holding at least one pre-authentication slot.
+    ///
+    /// This is the map's cardinality, exposed so the bound above can be asserted rather than
+    /// asserted-about.
+    pub fn tracked_sources(&self) -> usize {
+        self.lock_state().per_source.len()
+    }
+
+    /// Take the state lock, recovering from a poisoned mutex rather than panicking.
+    ///
+    /// A panic elsewhere must not turn connection admission into a permanent outage: the
+    /// counters are plain integers, so the worst a poisoned lock can mean is that one
+    /// release was interrupted, and refusing every future connection would be a far worse
+    /// failure than proceeding with a slightly stale count.
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, AdmissionState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn release(&self, key: SourceKey) {
+        let mut state = self.lock_state();
+        state.total = state.total.saturating_sub(1);
+        if let Some(count) = state.per_source.get_mut(&key) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                // The entry's whole purpose was to carry a non-zero count. Removing it here
+                // is what bounds the map's cardinality by the global limit.
+                state.per_source.remove(&key);
+            }
+        }
+    }
+}
+
+impl Default for PreAuthAdmission {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A reserved pre-authentication slot, released when dropped.
+///
+/// Held by the connection's [`ConnectionContext`](crate::handlers::ConnectionContext) until
+/// either the connection authenticates — at which point the context drops it, because an
+/// identified peer no longer spends anonymous admission — or the handler task ends and the
+/// context is dropped with it. Both paths are the same destructor, so there is no ordering
+/// to get wrong and no failure path that leaks a slot.
+#[derive(Debug)]
+pub struct AdmissionGuard {
+    admission: Arc<PreAuthAdmission>,
+    key: SourceKey,
+}
+
+impl Drop for AdmissionGuard {
+    fn drop(&mut self) {
+        self.admission.release(self.key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v4(addr: &str) -> SocketAddr {
+        format!("{addr}:9000").parse().expect("test address")
+    }
+
+    fn v6(addr: &str) -> SocketAddr {
+        format!("[{addr}]:9000").parse().expect("test address")
+    }
+
+    #[test]
+    fn a_source_cannot_exceed_its_share() {
+        let admission = Arc::new(PreAuthAdmission::with_limits(100, 3));
+        let addr = v4("203.0.113.7");
+
+        let guards: Vec<_> = (0..3)
+            .map(|_| admission.try_admit(addr).expect("within the source limit"))
+            .collect();
+        assert_eq!(admission.live_for(addr), 3);
+
+        assert_eq!(
+            admission.try_admit(addr).unwrap_err(),
+            AdmissionRefusal::SourceLimit,
+            "a fourth slot was issued to a source limited to three"
+        );
+
+        drop(guards);
+        assert_eq!(admission.live_for(addr), 0);
+        assert!(
+            admission.try_admit(addr).is_ok(),
+            "releasing every slot must make the source admissible again"
+        );
+    }
+
+    #[test]
+    fn one_source_cannot_lock_out_another() {
+        let admission = Arc::new(PreAuthAdmission::with_limits(100, 2));
+        let noisy = v4("203.0.113.7");
+        let honest = v4("198.51.100.9");
+
+        let _held: Vec<_> = (0..2)
+            .map(|_| admission.try_admit(noisy).expect("within the source limit"))
+            .collect();
+        assert_eq!(
+            admission.try_admit(noisy).unwrap_err(),
+            AdmissionRefusal::SourceLimit
+        );
+
+        assert!(
+            admission.try_admit(honest).is_ok(),
+            "an exhausted source must not deny an unrelated one — that would make the \
+             defence itself the outage"
+        );
+    }
+
+    #[test]
+    fn the_global_limit_binds_across_sources() {
+        let admission = Arc::new(PreAuthAdmission::with_limits(3, 100));
+
+        let _a = admission.try_admit(v4("203.0.113.1")).expect("first");
+        let _b = admission.try_admit(v4("203.0.113.2")).expect("second");
+        let _c = admission.try_admit(v4("203.0.113.3")).expect("third");
+
+        assert_eq!(
+            admission.try_admit(v4("203.0.113.4")).unwrap_err(),
+            AdmissionRefusal::GlobalLimit,
+            "the server-wide bound must hold even though no single source exceeded its share"
+        );
+    }
+
+    #[test]
+    fn ipv6_is_aggregated_by_prefix_not_by_address() {
+        let admission = Arc::new(PreAuthAdmission::with_limits(100, 2));
+
+        // Three different addresses, one /64. Rotating inside a prefix is free, so it must
+        // not buy a fresh allowance.
+        let _a = admission.try_admit(v6("2001:db8:0:1::1")).expect("first");
+        let _b = admission.try_admit(v6("2001:db8:0:1::2")).expect("second");
+        assert_eq!(
+            admission.try_admit(v6("2001:db8:0:1::3")).unwrap_err(),
+            AdmissionRefusal::SourceLimit,
+            "rotating the low 64 bits bought a fresh allowance"
+        );
+
+        // A genuinely different /64 is a different source.
+        assert!(
+            admission.try_admit(v6("2001:db8:0:2::1")).is_ok(),
+            "a different /64 must be charged separately"
+        );
+    }
+
+    /// The map's cardinality is the thing that could turn this defence into the leak it
+    /// prevents, so it is asserted directly rather than reasoned about.
+    #[test]
+    fn the_table_never_outgrows_the_global_limit() {
+        let admission = Arc::new(PreAuthAdmission::with_limits(4, 4));
+
+        // Far more distinct sources than the global limit allows.
+        let mut guards = Vec::new();
+        for i in 0..200u32 {
+            let addr = v4(&format!("203.0.113.{}", i % 256));
+            if let Ok(guard) = admission.try_admit(addr) {
+                guards.push(guard);
+            }
+        }
+        assert_eq!(admission.live_total(), 4);
+        assert!(
+            admission.tracked_sources() <= 4,
+            "the admission table grew past the global limit: {} entries",
+            admission.tracked_sources()
+        );
+
+        // And a refused admission must not leave an entry behind either.
+        drop(guards);
+        assert_eq!(admission.live_total(), 0);
+        assert_eq!(
+            admission.tracked_sources(),
+            0,
+            "releasing every slot must leave no residue in the table"
+        );
+    }
+
+    /// A refusal must not itself grow the map — otherwise attacking the limiter would be
+    /// cheaper than attacking what it protects.
+    #[test]
+    fn refusals_leave_no_residue() {
+        let admission = Arc::new(PreAuthAdmission::with_limits(1, 1));
+        let _held = admission.try_admit(v4("203.0.113.1")).expect("first");
+
+        for i in 0..100u32 {
+            let addr = v4(&format!("198.51.100.{}", i % 256));
+            assert_eq!(
+                admission.try_admit(addr).unwrap_err(),
+                AdmissionRefusal::GlobalLimit
+            );
+        }
+        assert_eq!(
+            admission.tracked_sources(),
+            1,
+            "refused admissions accumulated entries in the table"
+        );
+    }
+}

--- a/icn/crates/icn-net/src/preauth_admission.rs
+++ b/icn/crates/icn-net/src/preauth_admission.rs
@@ -171,6 +171,32 @@ impl AdmissionRefusal {
     }
 }
 
+/// The table's live cardinality — exactly what the two gauges report.
+///
+/// Captured while the state lock is held and published *after* it is released. Both halves
+/// matter: reading under the lock is what makes the pair consistent rather than two
+/// independently-sampled numbers, and publishing outside it keeps foreign metrics code —
+/// which may allocate — out of a critical section that serialises every inbound admission.
+#[derive(Debug, Clone, Copy)]
+struct Cardinality {
+    total: usize,
+    sources: usize,
+}
+
+impl Cardinality {
+    fn of(state: &AdmissionState) -> Self {
+        Self {
+            total: state.total,
+            sources: state.per_source.len(),
+        }
+    }
+
+    fn publish(self) {
+        icn_obs::metrics::network::preauth_connections_live_set(self.total);
+        icn_obs::metrics::network::preauth_sources_tracked_set(self.sources);
+    }
+}
+
 #[derive(Debug, Default)]
 struct AdmissionState {
     /// Live pre-authentication connections per source.
@@ -235,22 +261,27 @@ impl PreAuthAdmission {
         addr: SocketAddr,
     ) -> Result<AdmissionGuard, AdmissionRefusal> {
         let key = SourceKey::from_addr(addr);
-        let mut state = self.lock_state();
+        let cardinality = {
+            let mut state = self.lock_state();
 
-        if state.total >= self.max_total {
-            return Err(AdmissionRefusal::GlobalLimit);
-        }
-        let source_count = state.per_source.entry(key).or_insert(0);
-        if *source_count >= self.max_per_source {
-            // Leave no zero-valued entry behind: a refused admission must not be able to
-            // grow the map, or refusing would itself become the amplification.
-            if *source_count == 0 {
-                state.per_source.remove(&key);
+            if state.total >= self.max_total {
+                return Err(AdmissionRefusal::GlobalLimit);
             }
-            return Err(AdmissionRefusal::SourceLimit);
-        }
-        *source_count += 1;
-        state.total += 1;
+            let source_count = state.per_source.entry(key).or_insert(0);
+            if *source_count >= self.max_per_source {
+                // Leave no zero-valued entry behind: a refused admission must not be able to
+                // grow the map, or refusing would itself become the amplification.
+                if *source_count == 0 {
+                    state.per_source.remove(&key);
+                }
+                return Err(AdmissionRefusal::SourceLimit);
+            }
+            *source_count += 1;
+            state.total += 1;
+
+            Cardinality::of(&state)
+        };
+        cardinality.publish();
 
         Ok(AdmissionGuard {
             admission: Arc::clone(self),
@@ -289,17 +320,29 @@ impl PreAuthAdmission {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
+    /// Give back one slot charged to `key`, and republish the gauges.
+    ///
+    /// The gauges are refreshed *here*, at the mutation, rather than by whoever happened to
+    /// cause it. There are two release paths — the connection authenticates, or its handler
+    /// task ends — and only the second passes through the accept loop. Refreshing at the
+    /// call sites therefore left the gauges stale for the whole life of every connection
+    /// that authenticated and stayed open, which is the ordinary case and precisely the one
+    /// an operator reads these gauges to understand.
     fn release(&self, key: SourceKey) {
-        let mut state = self.lock_state();
-        state.total = state.total.saturating_sub(1);
-        if let Some(count) = state.per_source.get_mut(&key) {
-            *count = count.saturating_sub(1);
-            if *count == 0 {
-                // The entry's whole purpose was to carry a non-zero count. Removing it here
-                // is what bounds the map's cardinality by the global limit.
-                state.per_source.remove(&key);
+        let cardinality = {
+            let mut state = self.lock_state();
+            state.total = state.total.saturating_sub(1);
+            if let Some(count) = state.per_source.get_mut(&key) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    // The entry's whole purpose was to carry a non-zero count. Removing it
+                    // here is what bounds the map's cardinality by the global limit.
+                    state.per_source.remove(&key);
+                }
             }
-        }
+            Cardinality::of(&state)
+        };
+        cardinality.publish();
     }
 }
 

--- a/icn/crates/icn-net/tests/preauth_connection_admission.rs
+++ b/icn/crates/icn-net/tests/preauth_connection_admission.rs
@@ -156,6 +156,13 @@ async fn spawn_node(
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
 }
 
+/// How long to wait for the node's answer to a Hello before calling it a failure.
+///
+/// Generous on purpose: this is a liveness backstop so a broken node fails the test instead
+/// of hanging it, not a timing assumption the property depends on. The property is carried by
+/// the response arriving at all.
+const HELLO_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// A raw QUIC client that authenticates only when asked to.
 struct WireClient {
     _endpoint: Endpoint,
@@ -220,6 +227,19 @@ impl WireClient {
         self.send(&message).await
     }
 
+    /// Authenticate, and do not return until the node has processed the Hello.
+    ///
+    /// The node answers a valid Hello on a stream it opens back, and it opens that stream
+    /// strictly after binding the identity to the connection — `record_authenticated_peer`
+    /// runs early in `handle_hello`, the response is sent at the end of it. So the answer
+    /// arriving *is* the synchronisation: the slot was released before it was written.
+    /// Waiting on the delivery log instead would synchronise on nothing at all — a Hello is
+    /// answered by the node itself and never reaches the external handler, so it never moves
+    /// that log.
+    ///
+    /// That distinction is the whole point of this helper: without it the next connection
+    /// could ask for a slot before this one had given its back, and the test would be
+    /// measuring a race rather than the release-at-authentication property.
     async fn authenticate(&self, to: &Did) -> Result<()> {
         let message = NetworkMessage::new(
             self.identity.did().clone(),
@@ -234,7 +254,21 @@ impl WireClient {
                 pq_binding_proof: None,
             },
         );
-        self.send(&message).await
+
+        self.send(&message).await?;
+
+        // The node answers on a stream *it* opens, not on the one the Hello arrived on, so
+        // accept one rather than reading the Hello's own `recv`.
+        let (_send, mut recv) =
+            tokio::time::timeout(HELLO_RESPONSE_TIMEOUT, self.connection.accept_bi())
+                .await
+                .context("timed out waiting for the node to answer the Hello")?
+                .context("accepting the node's Hello response stream")?;
+        tokio::time::timeout(HELLO_RESPONSE_TIMEOUT, icn_net::read_message(&mut recv))
+            .await
+            .context("timed out reading the node's Hello response")?
+            .context("reading the node's Hello response")?;
+        Ok(())
     }
 
     async fn send(&self, message: &NetworkMessage) -> Result<()> {
@@ -369,10 +403,10 @@ async fn authenticating_releases_the_sources_slot() -> Result<()> {
         let client = WireClient::connect(&identity, addr)
             .await
             .context("an authenticated peer was refused admission")?;
+        // Returns only once the node has answered the Hello, so this connection has
+        // provably released its slot before the next one asks for one. If the slot were
+        // held past authentication, the ninth connection here would be refused.
         client.authenticate(node.did()).await?;
-        // Let the Hello land, so this connection has released its slot before the next one
-        // asks for one.
-        settle(&delivered).await;
         client.tag(node.did()).await?;
         clients.push(client);
     }

--- a/icn/crates/icn-net/tests/preauth_connection_admission.rs
+++ b/icn/crates/icn-net/tests/preauth_connection_admission.rs
@@ -1,0 +1,390 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! How many unauthenticated connections one source may hold at once (#2547).
+//!
+//! #2491 gave every connection its own anonymous budget and deliberately stopped there. The
+//! budget is scoped to a `ConnectionContext`, one per accepted connection, so:
+//!
+//! ```text
+//! attacker opens N connections -> attacker holds N anonymous budgets
+//! ```
+//!
+//! Three things on the inbound path made that accumulate rather than drain. The handshake
+//! semaphore releases its permit the moment the handshake completes, so it caps concurrent
+//! *handshakes* and never established connections. This node installs `keep_alive_interval`
+//! on its **server** transport config, so it PINGs its own inbound connections and an idle
+//! one never reaches the 60 s idle timeout. And an unauthenticated connection is in no map —
+//! the session map is populated only by an authenticated Hello (#2530) — so nothing evicts
+//! it.
+//!
+//! # The property under test
+//!
+//! > At any instant, one source may hold at most `MAX_PREAUTH_CONNECTIONS_PER_SOURCE`
+//! > established-but-unauthenticated connections.
+//!
+//! Concurrency, not rate — these tests say nothing about churn, and neither does the fix.
+//!
+//! # How these tests know
+//!
+//! The observable is **how many separate connections can get a message to the handler while
+//! refusing to authenticate**. A connection that was refused admission is closed before it
+//! ever owns a handler loop, so it cannot deliver; one that was admitted can. Each client
+//! stamps a distinct DID into `from`, so the delivery log counts *connections*, not messages,
+//! and the count is structural rather than timing-derived.
+//!
+//! `from` is untrusted, which is the whole of #2491 — it is used here only as a test-local
+//! tag for counting, never as an identity, and the node still charges every one of these
+//! messages to the connection's anonymous budget.
+//!
+//! Every negative is paired with a positive control:
+//! [`a_source_below_the_limit_is_not_throttled`] proves the bound does not break ordinary
+//! peers, and [`authenticating_releases_the_sources_slot`] proves it is a bound on *anonymous*
+//! connections rather than a connection cap.
+
+use anyhow::{Context, Result};
+use icn_identity::{Did, IdentityBundle};
+use icn_net::{
+    IncomingMessageHandler, NetworkActor, NetworkHandle, NetworkMessage, VersionInfo,
+    MAX_PREAUTH_CONNECTIONS_PER_SOURCE,
+};
+use quinn::{ClientConfig, Endpoint};
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+static ISSUED_PORTS: Mutex<Option<HashSet<u16>>> = Mutex::new(None);
+
+fn pick_port() -> u16 {
+    let mut issued = ISSUED_PORTS.lock().expect("port registry poisoned");
+    let issued = issued.get_or_insert_with(HashSet::new);
+    for _ in 0..64 {
+        if let Some(port) = portpicker::pick_unused_port() {
+            if issued.insert(port) {
+                return port;
+            }
+        }
+    }
+    panic!("could not find an unused port");
+}
+
+fn init() {
+    // Must be the provider the workspace actually builds against: installing a different one
+    // makes every TLS handshake fail, which presents as a connect timeout and would look
+    // exactly like the admission bound refusing connections.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("icn_net=debug")
+        .try_init();
+}
+
+/// Shuts the node down when the test ends.
+struct Guard(broadcast::Sender<()>);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+/// Every message that reached the external handler, by claimed `from`.
+///
+/// A connection refused admission is closed before it owns a handler loop, so it contributes
+/// nothing here. Counting *distinct* tags therefore counts admitted connections.
+#[derive(Clone, Default)]
+struct Delivered(Arc<Mutex<Vec<String>>>);
+
+impl Delivered {
+    fn distinct_senders(&self) -> usize {
+        self.0
+            .lock()
+            .expect("delivery log poisoned")
+            .iter()
+            .collect::<HashSet<_>>()
+            .len()
+    }
+}
+
+/// Spawn a real node on the production stack.
+///
+/// The handler is required, not optional: `NetworkActor::spawn` starts no inbound accept loop
+/// without one, and every "was not admitted" assertion below would then pass for the wrong
+/// reason.
+async fn spawn_node(
+    bundle: IdentityBundle,
+) -> Result<(NetworkHandle, SocketAddr, Guard, Delivered)> {
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let delivered = Delivered::default();
+    let sink = delivered.0.clone();
+    let handler: IncomingMessageHandler = Arc::new(move |msg: NetworkMessage| {
+        sink.lock()
+            .expect("delivery log poisoned")
+            .push(msg.from.to_string());
+    });
+
+    let mut last_err = None;
+    for _ in 0..8 {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        match NetworkActor::spawn(
+            bundle.clone(),
+            addr,
+            shutdown_tx.clone(),
+            Some(handler.clone()),
+            None, // oracle
+            None, // fallback_config
+            None, // topology_config
+            None, // stun_servers
+            None, // turn_config
+            None, // misbehavior_detector
+            None, // store
+            None, // personhood
+            None, // anchor_rate_config
+            None, // advertised_addr
+        )
+        .await
+        {
+            Ok(handle) => {
+                // The handle is returned, not dropped: it owns the actor's mailbox sender,
+                // and letting it fall out of scope here would tear the node down before any
+                // test could connect to it.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                return Ok((handle, addr, Guard(shutdown_tx), delivered));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
+}
+
+/// A raw QUIC client that authenticates only when asked to.
+struct WireClient {
+    _endpoint: Endpoint,
+    connection: quinn::Connection,
+    identity: IdentityBundle,
+}
+
+impl WireClient {
+    async fn connect(identity: &IdentityBundle, target: SocketAddr) -> Result<Self> {
+        let rustls_client = icn_net::tls::create_tofu_client_config(
+            vec![identity.tls_cert().clone()],
+            identity.tls_key(),
+        )?;
+        let mut endpoint = Endpoint::client("127.0.0.1:0".parse()?)?;
+        endpoint.set_default_client_config(ClientConfig::new(Arc::new(
+            quinn::crypto::rustls::QuicClientConfig::try_from(rustls_client)?,
+        )));
+
+        // Establishing the connection is a precondition, not the property under test.
+        let mut last_err = None;
+        for attempt in 0..5 {
+            match tokio::time::timeout(
+                Duration::from_secs(10),
+                endpoint.connect(target, "localhost")?,
+            )
+            .await
+            {
+                Ok(Ok(connection)) => {
+                    return Ok(Self {
+                        _endpoint: endpoint,
+                        connection,
+                        identity: identity.clone(),
+                    })
+                }
+                Ok(Err(e)) => last_err = Some(e.to_string()),
+                Err(_) => last_err = Some("connect timed out".to_string()),
+            }
+            tokio::time::sleep(Duration::from_millis(150 * (attempt + 1))).await;
+        }
+        anyhow::bail!(
+            "could not establish the test connection after 5 attempts: {}",
+            last_err.unwrap_or_default()
+        )
+    }
+
+    /// Send one message tagged with this client's own DID.
+    ///
+    /// `Subscribe` specifically, because it reaches the external handler untouched — no
+    /// verification and no state change — so an arrival records exactly one thing: this
+    /// connection was admitted and got a handler loop. Payloads the node answers itself
+    /// (`Ping`, `Hello`) never reach the handler, which would make every count below zero and
+    /// every upper-bound assertion pass for the wrong reason.
+    ///
+    /// Errors are swallowed by the caller on purpose: a connection the node refused is
+    /// closed, so writing to it *should* fail, and that failure is the signal.
+    async fn tag(&self, to: &Did) -> Result<()> {
+        let message = NetworkMessage::subscribe(
+            self.identity.did().clone(),
+            to.clone(),
+            vec!["icn.test.2547".to_string()],
+        );
+        self.send(&message).await
+    }
+
+    async fn authenticate(&self, to: &Did) -> Result<()> {
+        let message = NetworkMessage::new(
+            self.identity.did().clone(),
+            Some(to.clone()),
+            icn_net::MessagePayload::Hello {
+                binding_info: self.identity.binding_info(),
+                version_info: Some(VersionInfo::new("2547-test".to_string())),
+                topology_info: None,
+                x25519_public: *self.identity.x25519_public_bytes(),
+                ml_dsa_public: None,
+                ml_kem_public: None,
+                pq_binding_proof: None,
+            },
+        );
+        self.send(&message).await
+    }
+
+    async fn send(&self, message: &NetworkMessage) -> Result<()> {
+        let (mut send, _recv) = self
+            .connection
+            .open_bi()
+            .await
+            .context("open_bi on the test connection")?;
+        icn_net::write_message(&mut send, message).await?;
+        send.finish()?;
+        Ok(())
+    }
+}
+
+/// Let the node finish admitting and dispatching before anything is counted.
+///
+/// Waits for the delivery total to stop moving rather than sleeping a fixed amount, so it can
+/// only ever admit *more* messages than a fixed wait would — never fewer. That direction
+/// matters: every assertion below is an upper bound, so a premature read could only make the
+/// test pass when it should fail, and this removes that.
+async fn settle(delivered: &Delivered) {
+    let mut last = usize::MAX;
+    for _ in 0..40 {
+        let now = delivered.0.lock().expect("delivery log poisoned").len();
+        if now == last {
+            return;
+        }
+        last = now;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// How far past the limit to push. Small: each one is a real QUIC handshake.
+const OVERSHOOT: usize = 4;
+
+// ---------------------------------------------------------------------------
+// RED — one source must not hold unbounded anonymous connections
+// ---------------------------------------------------------------------------
+
+/// RED A — a source that never authenticates cannot hold more than its share.
+///
+/// Every client here connects from loopback, so they are all one source, and none of them
+/// sends a Hello. Before this change all of them were admitted, each acquiring a handler
+/// task, a `ConnectionContext` and its own anonymous budget, and the node kept every one of
+/// them alive with its own keepalives.
+#[tokio::test]
+async fn one_source_cannot_hold_unbounded_unauthenticated_connections() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, delivered) = spawn_node(node.clone()).await?;
+
+    let attempts = MAX_PREAUTH_CONNECTIONS_PER_SOURCE + OVERSHOOT;
+    let mut clients = Vec::new();
+    for _ in 0..attempts {
+        let identity = IdentityBundle::generate()?;
+        // A refused connection may fail to connect or fail to write; both mean "not
+        // admitted", and neither is an error for this test.
+        if let Ok(client) = WireClient::connect(&identity, addr).await {
+            let _ = client.tag(node.did()).await;
+            clients.push(client);
+        }
+    }
+    settle(&delivered).await;
+
+    let admitted = delivered.distinct_senders();
+    assert!(
+        admitted <= MAX_PREAUTH_CONNECTIONS_PER_SOURCE,
+        "{admitted} of {attempts} unauthenticated connections from one source were admitted, \
+         but the per-source pre-authentication limit is {MAX_PREAUTH_CONNECTIONS_PER_SOURCE}"
+    );
+
+    // Hold the clients until after the assertion: the property is about *simultaneously*
+    // live connections, and dropping them early would release slots and measure nothing.
+    drop(clients);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls
+// ---------------------------------------------------------------------------
+
+/// A source below the limit must be completely unaffected.
+///
+/// Without this, "nothing was admitted" and "the bound works" look identical, and a node that
+/// refused every inbound connection would pass the test above.
+#[tokio::test]
+async fn a_source_below_the_limit_is_not_throttled() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, delivered) = spawn_node(node.clone()).await?;
+
+    let below = MAX_PREAUTH_CONNECTIONS_PER_SOURCE - 1;
+    let mut clients = Vec::new();
+    for _ in 0..below {
+        let identity = IdentityBundle::generate()?;
+        let client = WireClient::connect(&identity, addr).await?;
+        client.tag(node.did()).await?;
+        clients.push(client);
+    }
+    settle(&delivered).await;
+
+    assert_eq!(
+        delivered.distinct_senders(),
+        below,
+        "a source under the limit was refused: the bound is throttling ordinary peers"
+    );
+
+    drop(clients);
+    Ok(())
+}
+
+/// The bound is on *anonymous* connections, not on connections.
+///
+/// A peer that authenticates releases its slot immediately, so one source can hold far more
+/// than the limit once those connections have said who they are. This is what keeps the fix
+/// off legitimate traffic — and it is the assertion that fails if the slot were released at
+/// close instead of at authentication.
+#[tokio::test]
+async fn authenticating_releases_the_sources_slot() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, delivered) = spawn_node(node.clone()).await?;
+
+    // Comfortably more than the anonymous limit, each authenticating before the next opens.
+    let total = MAX_PREAUTH_CONNECTIONS_PER_SOURCE + OVERSHOOT;
+    let mut clients = Vec::new();
+    for _ in 0..total {
+        let identity = IdentityBundle::generate()?;
+        let client = WireClient::connect(&identity, addr)
+            .await
+            .context("an authenticated peer was refused admission")?;
+        client.authenticate(node.did()).await?;
+        // Let the Hello land, so this connection has released its slot before the next one
+        // asks for one.
+        settle(&delivered).await;
+        client.tag(node.did()).await?;
+        clients.push(client);
+    }
+    settle(&delivered).await;
+
+    assert_eq!(
+        delivered.distinct_senders(),
+        total,
+        "only some of {total} authenticated connections from one source got through — the \
+         pre-authentication bound is being applied to peers that already identified themselves"
+    );
+
+    drop(clients);
+    Ok(())
+}

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -47,6 +47,23 @@ pub fn init_descriptions() {
         "icn_network_messages_rate_limited_by_rate_total",
         "Total number of messages rate limited, bucketed by rate limit (0-10, 11-50, 51-100, 100+)"
     );
+    // Pre-authentication connection admission (Issue #2547)
+    describe_counter!(
+        "icn_network_preauth_admission_refused_total",
+        "Total inbound connections refused a pre-authentication slot, by which bound was hit (global_limit or source_limit)"
+    );
+    describe_counter!(
+        "icn_network_preauth_admission_released_total",
+        "Total pre-authentication slots released because the connection authenticated"
+    );
+    describe_gauge!(
+        "icn_network_preauth_connections_live",
+        "Established inbound connections that have not yet authenticated a peer identity"
+    );
+    describe_gauge!(
+        "icn_network_preauth_sources_tracked",
+        "Distinct sources currently holding at least one pre-authentication slot (bounded by the global admission limit)"
+    );
     describe_counter!(
         "icn_network_rate_limit_config_changes_total",
         "Total number of peer rate limit configuration changes"
@@ -228,6 +245,43 @@ pub fn messages_rate_limited_inc() {
 /// subject, not this one's.)
 pub fn messages_rate_limited_pre_auth_inc() {
     counter!("icn_network_messages_rate_limited_pre_auth_total").increment(1);
+}
+
+/// An inbound connection was refused a pre-authentication slot (#2547).
+///
+/// `bound` says which limit was hit, and is the **only** label here on purpose: it comes
+/// from a closed two-value set in the code (`AdmissionRefusal::as_str`), so nothing a remote
+/// peer sends can add a series. The labels this deliberately does not carry — remote
+/// address, source key, connection id — are attacker-chosen and unbounded, which is the same
+/// cardinality mistake at the metrics layer that #2491 fixed at the policy layer.
+///
+/// The refused address belongs in logs, where a bounded-cardinality store is not the
+/// constraint, and it is logged there.
+pub fn preauth_admission_refused_inc(bound: &'static str) {
+    counter!("icn_network_preauth_admission_refused_total", "bound" => bound).increment(1);
+}
+
+/// A pre-authentication slot was released because its connection authenticated (#2547).
+///
+/// Rising alongside `preauth_connections_live` staying flat is the healthy shape: peers are
+/// arriving and identifying themselves. Refusals rising while this stays flat is the attack
+/// shape — connections arriving that never say who they are.
+pub fn preauth_admission_released_inc() {
+    counter!("icn_network_preauth_admission_released_total").increment(1);
+}
+
+/// Established inbound connections that have not yet authenticated (#2547).
+pub fn preauth_connections_live_set(count: usize) {
+    gauge!("icn_network_preauth_connections_live").set(count as f64);
+}
+
+/// Distinct sources holding at least one pre-authentication slot (#2547).
+///
+/// This is the admission table's cardinality. It is bounded by the global admission limit by
+/// construction, so an operator seeing it climb toward that limit is seeing the bound work,
+/// not a leak.
+pub fn preauth_sources_tracked_set(count: usize) {
+    gauge!("icn_network_preauth_sources_tracked").set(count as f64);
 }
 
 /// Increment rate limit configuration change counter


### PR DESCRIPTION
Part of #2547 — **deliberately leaves it open**. See "Why #2547 stays open" below.

## What

One source can no longer hold an unbounded number of established-but-unauthenticated inbound connections. A slot is taken when a connection completes its handshake and released the moment it authenticates, bounded per source and server-wide.

## The causal defect

#2491 gave every connection its own anonymous budget, keyed on the `ConnectionContext` so nothing the sender says can be issued a different one, and deliberately stopped there:

```text
attacker opens N connections -> attacker holds N anonymous budgets
```

Tracing merged `main`, three facts make that accumulate rather than drain — and the third is why the issue understates it:

1. **The handshake semaphore does not bound connections.** `drop(permit)` runs immediately after `incoming.await` and *before* `handle_connection`. The code says so: "The slot bounds concurrent handshakes, not connection lifetimes." `MAX_CONCURRENT_INBOUND_HANDSHAKES = 64` correctly caps concurrent handshakes and nothing else.
2. **This node keeps its own attackers alive.** `create_transport_config()` sets `keep_alive_interval(30 s)` against `max_idle_timeout(60 s)`, and the *same* config is installed on the **server** (`session.rs`). So the node PINGs its own inbound connections: an established connection that never sends anything **never reaches the idle timeout**.
3. **Nothing tracks or evicts it.** The session map is populated only by an authenticated Hello (#2530), so a pre-auth connection is in no map at all. The periodic cleanup task touches only the replay guard and rate-limiter buckets.

Together: established-but-unauthenticated connections were unbounded in count **and effectively immortal**. Each retains a tokio task parked on `accept_bi()`, a `ConnectionContext`, a `PreAuthRateLimiter`, quinn connection state, and advertised flow-control credit.

## The resource invariant

> At any instant, the number of established-but-unauthenticated inbound connections is bounded, both per source and server-wide.

**Concurrency, not rate.** **Pre-authentication only** — the slot is released at authentication, not at close, so this never constrains established authenticated peers.

## Why the key is trustworthy

Admission is taken **after** the QUIC handshake, and that is the whole argument. Completing a QUIC handshake proves return-routability (RFC 9000 §8): the server's handshake packets go to the claimed address and the peer must answer from it. A spoofed source address never reaches the hook.

So the key is attacker-*chosen* but not attacker-*forgeable* — to present a different one an attacker must actually receive traffic there. That is exactly the property `NetworkMessage.from` lacked in #2491, and it is why keying on an address is sound here while keying on a claimed DID was not.

Rejected alternatives:

- **remote `SocketAddr`** — a new source port is a new key, so reconnecting mints a fresh allowance and it aggregates nothing. Pinned by the `M5` mutation below, which makes exactly this substitution and is killed.
- **a global cap alone** — one attacker consumes the entire allowance and locks every honest peer out. Kept as a *second* bound, not the only one; `one_source_cannot_lock_out_another` pins that an exhausted source cannot deny an unrelated one.

IPv6 aggregates by **/64**, on a narrower argument than "every host owns a /64" (which is not true in general): an IPv6 client can often change source address *cheaply* — SLAAC and privacy extensions rotate within a prefix by design — so exact-address keying would frequently aggregate nothing, the same way source-port keying does. /64 is the smallest unit not routinely cheap to rotate within. A heuristic about cost, not a claim about allocation.

Its price, stated rather than buried: hosts sharing a /64 share an allowance, as do IPv4 hosts behind one NAT. What keeps that cost small is *when* the allowance is released — at authentication, not at close — so peers contend only while still anonymous.

**QUIC migration does not multiply reservations.** The key is read once at admission and the guard carries it for the connection's life, so a migrating connection stays charged to the source that was return-routable when it was admitted. That is the conservative direction: re-keying on migration would let a peer shed a contended allowance by moving.

## Cleanup and cardinality

A DoS defence that adds an attacker-controlled unbounded map is not a defence. This one is bounded **by construction**, not by policy:

- an entry is created only by a successful admission, which first checks the global total;
- an entry is removed the instant its count reaches zero;
- therefore `per_source.len() <= total <= MAX_PREAUTH_CONNECTIONS_TOTAL` at all times.

No expiry timer, no eviction policy, no cleanup task — there is nothing to expire, because the map's size is pinned to the number of connections currently counted, and those are bounded. Release is `AdmissionGuard`'s destructor, so every exit path runs it, including panics and handler errors. A refused admission leaves no entry behind either, so attacking the limiter is not cheaper than attacking what it protects.

Asserted directly rather than reasoned about: `the_table_never_outgrows_the_global_limit` and `refusals_leave_no_residue`.

## Defaults

`MAX_PREAUTH_CONNECTIONS_TOTAL = 256`, `MAX_PREAUTH_CONNECTIONS_PER_SOURCE = 8`.

Protocol constants, like the `MAX_CONCURRENT_INBOUND_HANDSHAKES` they sit beside — no config subsystem is added. The global bound is deliberately sized *above* the 64 concurrent-handshake cap so the two never fight; if it were lower the symptom would be refused connections under ordinary load rather than under attack. Per-source 8 is a conservative starting point, not a claim that no deployment will want to tune it.

## NAT / shared-source trade-off

The per-source cap is not a limit on how many connections a source may hold — it is a limit on how many it may hold **while still refusing to say who it is**. A legitimate peer authenticates one round trip after connecting and releases its slot immediately, so a NAT would need more than 8 peers *simultaneously mid-handshake-to-Hello* to be affected. `authenticating_releases_the_sources_slot` pins this: one source drives 12 connections — well past the limit of 8 — and all 12 get through because each identified itself.

## Test plan

New `preauth_connection_admission` integration suite (3 tests, production composition path) plus 6 unit tests on the admission table.

The integration observable is **how many separate connections can get a message to the handler while refusing to authenticate**. A refused connection is closed before it owns a handler loop, so it cannot deliver. Each client tags a distinct DID, so the delivery log counts *connections*, not messages — structural, not timing-derived. `Subscribe` specifically, because it reaches the external handler untouched; payloads the node answers itself (`Ping`, `Hello`) never arrive, which would make every count zero and every upper-bound assertion pass for the wrong reason.

Positive controls: `a_source_below_the_limit_is_not_throttled` (a node refusing everything would fail it) and `authenticating_releases_the_sources_slot` (proves this is a bound on anonymous connections, not a connection cap).

### RED evidence

With the release-at-authentication removed, only **8 of 12** connections get through and a refusal is logged — the bound demonstrably binds on the production path. Verified by hand and reproduced as mutation `M6`.

### Mutations — 6/6 killed

| | Mutation | Killed by |
|---|---|---|
| M1 | remove the global bound | 3 tests |
| M2 | remove the per-source bound | 4 tests, incl. `one_source_cannot_hold_unbounded_unauthenticated_connections` |
| M3 | guard destructor never releases | 3 tests, incl. `authenticating_releases_the_sources_slot` |
| M4 | never evict the zero entry | `the_table_never_outgrows_the_global_limit` |
| M5 | key by `SocketAddr` instead of source IP | 2 tests, incl. the integration bound |
| M6 | hold the slot past authentication | `authenticating_releases_the_sources_slot` |

**Harness honesty.** The first campaign reported M6 as a survivor. It was not — the harness was blind. This suite initialises tracing, whose output is written *between* `test NAME ... ` and the verdict, so a per-test `... ok` regex matched **zero** integration tests and the only target that could kill M6 was invisible. The parser now strips ANSI and reads cargo's own `test result:` summary plus the trailing `failures:` block. That correction also raised M2's and M5's kill counts, so the whole campaign was re-run rather than just M6. Every mutation is asserted to have changed source, to have emitted `Compiling icn-net`, and to have restored byte-identically; baseline and post-campaign controls are both 9/9 green.

### Regression

Full `icn-net`, `icn-core --lib`, `icn-obs --lib`, `cargo fmt --all --check`, and `cargo clippy --workspace --all-targets --features "hsm,post-quantum" -- -D warnings`. Meaning Firewall, regulatory compliance, readiness overclaim, doc control, and the pre-push drift check all pass.

Specifically preserved: #2520 Hello current-cert binding, #2525 handshake cancellation, #2530 provisional outbound connections, #2532/#2537 Hello termination, #2535 peer-exchange authorisation, #2536 redundant dial idempotence, #2533 bootstrap DID expectation, #2491 authenticated rate-limit identity.

## Metrics

`icn_network_preauth_admission_refused_total` carries one label, `bound`, drawn from a closed two-value set in code (`global_limit` / `source_limit`) — nothing a remote peer sends can add a series. The tempting labels here (remote address, source key, connection id) are attacker-chosen and unbounded, which would be the same cardinality mistake at the metrics layer that #2491 fixed at the policy layer; the refused address goes to logs instead, where cardinality is not the constraint.

Also adds `icn_network_preauth_admission_released_total` and gauges `icn_network_preauth_connections_live` / `icn_network_preauth_sources_tracked` (the table's cardinality, so an operator can watch the bound hold).

## Scope

`GlobalRateLimiter` was re-verified on merged `main`: still **zero production call sites**, and it caps `max_global_mps` — *messages*, not connections or handshakes. It does not fit this defect and is deliberately **not** wired. Whether to delete it remains open.

Authenticated session multiplicity (one DID holding several physical connections) is by design and is a different question; it is not folded in here.

## Why #2547 stays open

#2547's body names two gaps, not one: `MAX_CONCURRENT_INBOUND_HANDSHAKES` bounds "not the number of established connections, **and not the rate at which they are opened**", and its scope line reads "connection admission / source aggregation". This PR addresses the first and not the second, so it deliberately carries no closing keyword.

Fast churn remains reachable: connect, spend the anonymous burst, close, reconnect, repeat. Concurrency stays inside the bound the whole time, so nothing here is violated — the aggregate work simply is not source-rate-bounded. Tracked as #2549.

That was not folded in because it cannot reuse this design's central property. The admission table is bounded *by construction*: an entry exists only while a live connection sits behind it and is removed at zero. A rate bound requires entries to **outlive** the last connection — otherwise the bucket is discarded and re-minted on every reconnect, which is the behaviour being fixed — and that reintroduces attacker-controlled cardinality, expiry policy, wall-clock handling, and a cleanup owner. Materially different design, filed rather than smuggled in.

`GlobalRateLimiter`'s disposition ("wire, replace, or delete" — also named in #2547) is likewise carried to #2549: it caps *messages*, so it does not fit this defect.

## BOUNDS

- simultaneous established-but-unauthenticated inbound connections **per source**
- simultaneous established-but-unauthenticated inbound connections **globally**
- **admission-table cardinality** (structurally, under the global limit)

## DOES NOT BOUND

- **Distributed sources** — many addresses or many /64s. A single node cannot solve that locally, and nothing here pretends to.
- **Fast reconnect churn** — follow-up #2549.
- **Authenticated connection multiplicity** — one source can mint ephemeral DIDs, authenticate each, release its pre-auth slot, and hold the connections. The session map has no cardinality cap. Follow-up #2550.
- **QUIC/TLS handshake work below this hook** — the existing concurrent-handshake semaphore's job.
- **Authenticated application traffic** (#2490, #2491).

This is not general DoS prevention and does not make the node DoS-proof.

## Risk

Inbound connections from a source already holding 8 unauthenticated connections are now closed with a distinct application close code rather than accepted. Bootstrap is the path that would notice, and it is covered by the positive controls plus the unchanged #2533/#2536/#2520/#2537 suites. Outbound dials take no slot at all — we chose those peers.

Refs #2547, #2549, #2550, #2491, #2490, #2520, #2530, #2536
