### PR TITLE
fix(net): require an admitted connection to authenticate within a deadline

### DIFF
--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -80,7 +80,7 @@
 use anyhow::Result;
 use icn_identity::{Did, IdentityBundle};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{RwLock, Semaphore};
 use tracing::{debug, info, instrument, warn};
 
@@ -114,6 +114,29 @@ const MAX_CONCURRENT_INBOUND_HANDSHAKES: usize = 64;
 const PREAUTH_ADMISSION_REFUSED_CODE: u32 = 0x1c4b;
 
 use crate::preauth_admission::PREAUTH_AUTHENTICATION_TIMEOUT_CODE;
+
+/// End a connection that held a pre-authentication slot without ever authenticating (#2552).
+///
+/// Closes the transport and leaves the slot to the guard's destructor, which the caller reaches
+/// by breaking out of the handler loop. Releasing the reservation while letting the anonymous
+/// connection live on would satisfy the admission table and let the thing it bounds escape the
+/// bound, so the transport is always what ends first.
+///
+/// Shared by the three places the deadline can be observed — expired before a wait, expired
+/// during one, expired mid-read — because they are one event and an operator watching
+/// `icn_network_preauth_authentication_timeout_total` should not have to know which of them
+/// noticed.
+fn close_for_missed_authentication(connection: &quinn::Connection) {
+    warn!(
+        remote_addr = %connection.remote_address(),
+        "Closing inbound connection: it held a pre-authentication slot without ever authenticating"
+    );
+    icn_obs::metrics::network::preauth_authentication_timeout_inc();
+    connection.close(
+        PREAUTH_AUTHENTICATION_TIMEOUT_CODE.into(),
+        b"pre-authentication deadline",
+    );
+}
 
 /// Backoff before re-checking for an endpoint that has not been started yet.
 const ENDPOINT_RETRY_INTERVAL: Duration = Duration::from_millis(100);
@@ -365,24 +388,43 @@ impl NetworkActor {
                 authenticate_by = None;
             }
 
+            // The expiry is *checked*, not raced.
+            //
+            // Deciding it inside the `select!` below alone would make enforcement depend on the
+            // scheduler choosing to poll a timer, and `biased` deliberately does not: it polls
+            // its arms in order and returns on the first that is ready, without touching the
+            // rest. A tokio `Sleep` is not an interrupt — it completes only when polled — so a
+            // peer that keeps `accept_bi` ready on every iteration keeps the timer arm from ever
+            // being polled, and an absolute instant that nothing observes has no effect however
+            // far into the past it goes. What currently prevents that is `max_concurrent_bidi_
+            // streams`, since returning stream credit costs a round trip and so drains the
+            // accept queue to empty constantly; that is a transport tuning constant doing a
+            // security property's job. Asking `Instant::now()` here costs one comparison and
+            // owes nothing to either the scheduler or the stream limit.
+            if let Some(deadline) = authenticate_by {
+                if Instant::now() >= deadline {
+                    close_for_missed_authentication(&connection);
+                    break;
+                }
+            }
+
             // Accept incoming bidirectional stream.
             //
             // While the connection is still anonymous, the deadline races the *wait* — never
-            // the handling. That is the same rule the accept loop above follows for shutdown,
-            // and it is what makes the expiry safe:
+            // the verification. That is the same rule the accept loop above follows for
+            // shutdown, and it is what makes the expiry safe:
             //
             // - `accept_bi` is cancel-safe. quinn removes a stream from the connection's queue
             //   only on the poll that returns it (`poll_accept`), so a losing arm here cannot
             //   swallow a peer's Hello — it stays queued for the next call.
-            // - the deadline can only fire while nothing is being processed. If a Hello has
+            // - the deadline can only fire while nothing is being verified. If a Hello has
             //   arrived, `accept_bi` has already returned and this future is dropped; if the
             //   deadline fires, no Hello has been read, so none can have authenticated. There
             //   is no interleaving in which a verified Hello is discarded by a timeout.
             // - `biased` gives a simultaneous readiness to the peer. A stream that arrives in
-            //   the same instant the timer expires is served, and the deadline — an absolute
-            //   instant, already past — fires on the very next wait. So the tie buys exactly
-            //   one more message, which the anonymous budget already bounds, and never a
-            //   renewed lease.
+            //   the same instant the timer expires is served, and the check above ends the
+            //   connection on the next iteration. So the tie buys exactly one more message,
+            //   which the anonymous budget already bounds, and never a renewed lease.
             //
             // Absolute, not per-iteration: a `timeout` around each wait would restart on every
             // message, and "send something every T-1 seconds" would hold the slot forever
@@ -393,21 +435,7 @@ impl NetworkActor {
                     biased;
                     accepted = connection.accept_bi() => accepted,
                     _ = tokio::time::sleep_until(deadline.into()) => {
-                        warn!(
-                            remote_addr = %connection.remote_address(),
-                            "Closing inbound connection: it held a pre-authentication slot \
-                             without ever authenticating"
-                        );
-                        icn_obs::metrics::network::preauth_authentication_timeout_inc();
-                        // Close the transport, then leave the loop. Releasing the slot while
-                        // letting the anonymous connection live on would satisfy the admission
-                        // table and let the thing it bounds escape the bound. The release
-                        // itself is the guard's destructor, reached by dropping `ctx` when
-                        // this function returns.
-                        connection.close(
-                            PREAUTH_AUTHENTICATION_TIMEOUT_CODE.into(),
-                            b"pre-authentication deadline",
-                        );
+                        close_for_missed_authentication(&connection);
                         break;
                     }
                 },
@@ -415,8 +443,37 @@ impl NetworkActor {
 
             match accepted {
                 Ok((mut send, mut recv)) => {
-                    // Read network message
-                    match read_message(&mut recv).await {
+                    // Read network message.
+                    //
+                    // Bounded by the same absolute instant while the connection is anonymous.
+                    // `read_message` is an unbounded await the *peer* controls: `read_exact`
+                    // on a length prefix whose remaining bytes never arrive never returns, so
+                    // three bytes of a four-byte header parks this task inside the loop body
+                    // forever — past the wait, where no deadline could reach it. That is the
+                    // same squat #2552 is about, reached for the price of one stream.
+                    //
+                    // Bounding the read and not the dispatch is the whole distinction. Reading
+                    // bytes is not verifying them: a cancelled read discards a message nobody
+                    // has looked at yet, on a connection that is being closed regardless.
+                    // Cancelling `handle_hello` could instead abandon a peer *mid-verification*
+                    // — or, worse, after `record_authenticated_peer` had already released the
+                    // slot — so dispatch stays outside the deadline exactly as before.
+                    let read = match authenticate_by {
+                        None => read_message(&mut recv).await,
+                        Some(deadline) => {
+                            match tokio::time::timeout_at(deadline.into(), read_message(&mut recv))
+                                .await
+                            {
+                                Ok(read) => read,
+                                Err(_elapsed) => {
+                                    close_for_missed_authentication(&connection);
+                                    break;
+                                }
+                            }
+                        }
+                    };
+
+                    match read {
                         Ok((message, bytes_read)) => {
                             // Track bandwidth contribution (aggregate, no per-DID tracking)
                             icn_obs::metrics::contribution::total_bandwidth_bytes_add(

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -61,21 +61,37 @@
 //! node's own keepalives hold the transport open, and nothing maps or evicts an unauthenticated
 //! peer. So the reservation had a ceiling but no expiry (#2552).
 //!
-//! The deadline that fixes it is enforced in [`NetworkActor::handle_connection`], and it races
-//! only the *wait* for the next stream — never the handling of one:
+//! The deadline that fixes it is enforced in [`NetworkActor::handle_connection`]. It bounds
+//! everything the peer can make this task wait on, and stops at the point where the node starts
+//! deciding things:
 //!
 //! ```text
-//! anonymous:      select { accept_bi , deadline -> close + release }
-//! authenticated:  accept_bi
+//! anonymous:      check expiry -> select { accept_bi , deadline } -> read within deadline -> dispatch
+//! authenticated:  accept_bi -> read -> dispatch
 //! ```
 //!
-//! This is the same rule the accept loop follows for shutdown, for the same reason. Cancelling
-//! a wait is free; cancelling work in progress destroys it. `accept_bi` is cancel-safe, so a
-//! losing arm cannot swallow a Hello, and because the loop is a single sequential task, "has
-//! this connection authenticated" is answered by program order rather than by synchronisation:
-//! the Hello is verified inside the loop body, the deadline is consulted at the top of the next
-//! iteration, and the two never run concurrently. There is no timer task to outlive the phase
-//! it belongs to.
+//! The boundary between the last two columns is the whole design. Cancelling a wait is free and
+//! cancelling an unread message costs nothing anybody has looked at, so both are bounded;
+//! cancelling *dispatch* could abandon a peer mid-verification, or after
+//! `record_authenticated_peer` had already released its slot, so dispatch is not. `accept_bi` is
+//! cancel-safe, so a losing arm cannot swallow a Hello.
+//!
+//! Bounding the read is not belt-and-braces. `read_message` has no timeout of its own, and
+//! `read_exact` on a length prefix whose remaining bytes never arrive never returns — so a peer
+//! that sends three bytes of a four-byte header parks this task inside the loop body, past every
+//! deadline, holding the slot exactly as if it had sent nothing at all. A deadline that guards
+//! only the wait is defeated by anything that keeps the task out of the wait.
+//!
+//! The expiry is also *checked* at the loop boundary rather than left to the `select!`, because
+//! `biased` returns on the first ready arm without polling the rest and a tokio `Sleep` completes
+//! only when polled. Empirically a maximal stream flood does not starve it — stream credit costs
+//! a round trip to return, so the accept queue drains to empty constantly — but that is
+//! `max_concurrent_bidi_streams` underwriting the property, not this loop.
+//!
+//! Because the loop is a single sequential task, "has this connection authenticated" is answered
+//! by program order rather than by synchronisation: the Hello is verified inside the loop body,
+//! the deadline is consulted at the top of the next iteration, and the two never run
+//! concurrently. There is no timer task to outlive the phase it belongs to.
 
 use anyhow::Result;
 use icn_identity::{Did, IdentityBundle};

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -50,7 +50,32 @@
 //! know whose traffic this connection is carrying.
 //!
 //! Scope: this bounds what one connection can spend. Bounding how many connections one
-//! source may open is connection admission, and is not addressed here.
+//! source may open is connection admission, below.
+//!
+//! # The anonymous phase is bounded in size and in time
+//!
+//! Admission (#2547) reserves a slot per established-but-unauthenticated inbound connection and
+//! releases it at the authenticated Hello. That bounds how many anonymous connections exist at
+//! an instant. It does not, on its own, make any of them ever *stop* being anonymous — and a
+//! silent connection is durable here, because the handshake permit is already released, this
+//! node's own keepalives hold the transport open, and nothing maps or evicts an unauthenticated
+//! peer. So the reservation had a ceiling but no expiry (#2552).
+//!
+//! The deadline that fixes it is enforced in [`NetworkActor::handle_connection`], and it races
+//! only the *wait* for the next stream — never the handling of one:
+//!
+//! ```text
+//! anonymous:      select { accept_bi , deadline -> close + release }
+//! authenticated:  accept_bi
+//! ```
+//!
+//! This is the same rule the accept loop follows for shutdown, for the same reason. Cancelling
+//! a wait is free; cancelling work in progress destroys it. `accept_bi` is cancel-safe, so a
+//! losing arm cannot swallow a Hello, and because the loop is a single sequential task, "has
+//! this connection authenticated" is answered by program order rather than by synchronisation:
+//! the Hello is verified inside the loop body, the deadline is consulted at the top of the next
+//! iteration, and the two never run concurrently. There is no timer task to outlive the phase
+//! it belongs to.
 
 use anyhow::Result;
 use icn_identity::{Did, IdentityBundle};
@@ -87,6 +112,8 @@ const MAX_CONCURRENT_INBOUND_HANDSHAKES: usize = 64;
 /// perfectly well-behaved peer that arrived while its source's allowance was spent, and
 /// retrying later is the correct response.
 const PREAUTH_ADMISSION_REFUSED_CODE: u32 = 0x1c4b;
+
+use crate::preauth_admission::PREAUTH_AUTHENTICATION_TIMEOUT_CODE;
 
 /// Backoff before re-checking for an endpoint that has not been started yet.
 const ENDPOINT_RETRY_INTERVAL: Duration = Duration::from_millis(100);
@@ -296,6 +323,19 @@ impl NetworkActor {
     ) -> Result<()> {
         info!("Handling connection from {}", connection.remote_address());
 
+        // When this connection must have authenticated by, while it still holds a
+        // pre-authentication slot (#2552).
+        //
+        // `None` for a connection that took no slot — an outbound dial, which this node chose.
+        // The deadline exists to bound a reservation somebody else's connection is spending, so
+        // a connection that spends none is not its subject.
+        //
+        // Read off the guard rather than computed here, so the clock starts when the *slot* was
+        // taken. Set below to `None` the moment this connection authenticates: the slot is gone
+        // by then, and an expiry that outlived the resource it bounds is exactly the state that
+        // would let this close a peer that had already identified itself.
+        let mut authenticate_by = admission.as_ref().map(|guard| guard.authenticate_by());
+
         // Create connection context for handlers (clone shared state)
         let ctx = ConnectionContext::new(
             handler.clone(),
@@ -316,8 +356,64 @@ impl NetworkActor {
         );
 
         loop {
-            // Accept incoming bidirectional stream
-            match connection.accept_bi().await {
+            // A connection stops being anonymous exactly once and never goes back, so this only
+            // ever clears the deadline — and it is read here, in the same sequential task that
+            // writes it, so "has it authenticated yet" needs no synchronisation beyond program
+            // order. `handle_hello` runs inside this loop's body; this runs at the top of the
+            // next iteration, strictly after it.
+            if authenticate_by.is_some() && ctx.authenticated_peer().await.is_some() {
+                authenticate_by = None;
+            }
+
+            // Accept incoming bidirectional stream.
+            //
+            // While the connection is still anonymous, the deadline races the *wait* — never
+            // the handling. That is the same rule the accept loop above follows for shutdown,
+            // and it is what makes the expiry safe:
+            //
+            // - `accept_bi` is cancel-safe. quinn removes a stream from the connection's queue
+            //   only on the poll that returns it (`poll_accept`), so a losing arm here cannot
+            //   swallow a peer's Hello — it stays queued for the next call.
+            // - the deadline can only fire while nothing is being processed. If a Hello has
+            //   arrived, `accept_bi` has already returned and this future is dropped; if the
+            //   deadline fires, no Hello has been read, so none can have authenticated. There
+            //   is no interleaving in which a verified Hello is discarded by a timeout.
+            // - `biased` gives a simultaneous readiness to the peer. A stream that arrives in
+            //   the same instant the timer expires is served, and the deadline — an absolute
+            //   instant, already past — fires on the very next wait. So the tie buys exactly
+            //   one more message, which the anonymous budget already bounds, and never a
+            //   renewed lease.
+            //
+            // Absolute, not per-iteration: a `timeout` around each wait would restart on every
+            // message, and "send something every T-1 seconds" would hold the slot forever
+            // again. The property is *authenticate* within T, not *speak* within T.
+            let accepted = match authenticate_by {
+                None => connection.accept_bi().await,
+                Some(deadline) => tokio::select! {
+                    biased;
+                    accepted = connection.accept_bi() => accepted,
+                    _ = tokio::time::sleep_until(deadline.into()) => {
+                        warn!(
+                            remote_addr = %connection.remote_address(),
+                            "Closing inbound connection: it held a pre-authentication slot \
+                             without ever authenticating"
+                        );
+                        icn_obs::metrics::network::preauth_authentication_timeout_inc();
+                        // Close the transport, then leave the loop. Releasing the slot while
+                        // letting the anonymous connection live on would satisfy the admission
+                        // table and let the thing it bounds escape the bound. The release
+                        // itself is the guard's destructor, reached by dropping `ctx` when
+                        // this function returns.
+                        connection.close(
+                            PREAUTH_AUTHENTICATION_TIMEOUT_CODE.into(),
+                            b"pre-authentication deadline",
+                        );
+                        break;
+                    }
+                },
+            };
+
+            match accepted {
                 Ok((mut send, mut recv)) => {
                     // Read network message
                     match read_message(&mut recv).await {

--- a/icn/crates/icn-net/src/lib.rs
+++ b/icn/crates/icn-net/src/lib.rs
@@ -49,7 +49,8 @@ pub use global_rate_limit::GlobalRateLimiter;
 pub use nat::{NatConfig, NatTraversal, NatType, PublicAddress, TurnServerConfig};
 pub use preauth_admission::{
     AdmissionGuard, AdmissionRefusal, PreAuthAdmission, MAX_PREAUTH_CONNECTIONS_PER_SOURCE,
-    MAX_PREAUTH_CONNECTIONS_TOTAL,
+    MAX_PREAUTH_CONNECTIONS_TOTAL, PREAUTH_AUTHENTICATION_DEADLINE,
+    PREAUTH_AUTHENTICATION_TIMEOUT_CODE,
 };
 pub use protocol::{
     read_message, read_message_compressed, read_message_negotiated, write_message,

--- a/icn/crates/icn-net/src/preauth_admission.rs
+++ b/icn/crates/icn-net/src/preauth_admission.rs
@@ -20,20 +20,41 @@
 //! nothing tracks or evicts it.
 //!
 //! Established-but-unauthenticated connections were therefore unbounded in count and
-//! effectively immortal. This module bounds them.
+//! effectively immortal. This module bounds them on both axes.
 //!
-//! # The invariant
+//! # The invariants
+//!
+//! **Count** (#2547):
 //!
 //! > At any instant, the number of established-but-unauthenticated inbound connections is
 //! > bounded, both server-wide and per source.
 //!
-//! **Concurrency, not rate.** This says nothing about how fast connections may be opened and
-//! closed; see the module's "what this does not bound" note below.
+//! **Duration** (#2552):
+//!
+//! > A connection holding a pre-authentication slot must authenticate within
+//! > [`PREAUTH_AUTHENTICATION_DEADLINE`] of taking it, or its transport is closed and the slot
+//! > released.
+//!
+//! Neither is sufficient alone, and the second is why the first is worth having. A count bound
+//! on its own describes an instant: an adversary that reaches the ceiling and never moves holds
+//! it indefinitely, and since every new peer starts anonymous, a full table refuses *all* new
+//! inbound connections rather than only anonymous ones. Silence is the cheapest way to do it —
+//! cheaper than traffic, because this node's own keepalives maintain the connection and the
+//! peer's QUIC stack answers at the transport layer. The duration bound converts "hold forever"
+//! into "hold for `T`", which is what makes the count bound mean something over time.
+//!
+//! A duration bound alone would be equally useless: it bounds one connection and aggregates
+//! nothing.
+//!
+//! **Neither is a rate bound.** Together they say how much anonymous concurrency may exist and
+//! for how long, and nothing about how fast a source may open and close connections underneath
+//! them; see "what this does not bound" below.
 //!
 //! **Pre-authentication only.** The reservation is released the moment a connection
 //! authenticates, so this never constrains established authenticated peers — a peer that
 //! says who it is stops consuming source admission immediately, and is thereafter governed
-//! by the per-DID and per-anchor limits (#2490, #2491).
+//! by the per-DID and per-anchor limits (#2490, #2491). The deadline ends at the same instant
+//! and for the same reason: it is the slot's expiry, not the connection's maximum lifetime.
 //!
 //! # Why the post-handshake remote IP can be trusted as a key
 //!
@@ -75,8 +96,19 @@
 //!   indirectly, by handshake concurrency divided by handshake latency. Tracked by #2549,
 //!   which is separate because a rate bound needs entries that *outlive* their connections —
 //!   the opposite of what makes this table's cardinality provable.
+//!
+//!   The deadline does not change this, and it is worth being exact about why, because
+//!   "connections now expire" sounds like it should. Expiry bounds how long one connection may
+//!   squat; it places no floor on how quickly the next may arrive. A source that connects,
+//!   waits, is closed, and immediately reconnects stays inside every bound here forever — it
+//!   simply pays a handshake each time instead of nothing. So the deadline converts a *free*
+//!   permanent hold into a *recurring* cost, which is a real change in the attacker's economics
+//!   and not a rate limit. #2549 remains exactly as necessary as it was.
 //! - How many connections one source may hold once they are *authenticated*: the slot is
-//!   released at the Hello, and DIDs are free to mint. Tracked by #2550.
+//!   released at the Hello, and DIDs are free to mint. Tracked by #2550. The deadline stops at
+//!   the same boundary deliberately — extending it past authentication would make it a maximum
+//!   connection lifetime, which is a different bound with different victims, and belongs to
+//!   #2550 if it is wanted at all.
 //! - Authenticated application traffic, which is #2490's and #2491's subject.
 //!
 //! None of this is general DoS prevention.
@@ -84,6 +116,54 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// How long an admitted connection may stay unauthenticated before it is closed (#2552).
+///
+/// # Why a duration bound exists at all
+///
+/// The two count bounds below are instantaneous: they say how many anonymous connections may
+/// exist *now*. On their own that is a ceiling an adversary can reach and simply stay at, because
+/// nothing here made a connection ever finish becoming a peer. Silence was free — cheaper than
+/// traffic, since the node's own `keep_alive_interval` maintains the connection and the peer's
+/// QUIC stack answers at the transport layer. Converting "forever" into a finite `T` is what
+/// makes a count bound mean anything over time rather than only at an instant.
+///
+/// # Why thirty seconds
+///
+/// The value is policy, and deliberately generous, because no security property here depends on
+/// it — every value converts an unbounded hold into a bounded one, and the choice only trades
+/// how long an adversary may squat against how much slack an honest peer gets.
+///
+/// A healthy exchange needs about one round trip. An ICN dialer sends its Hello immediately and
+/// unconditionally on connecting (`actor::messages::wire_new_connection`); there is no lazy or
+/// deferred path in which an honest peer legitimately holds an inbound connection anonymous and
+/// waits. So the accepting side expects a Hello roughly one RTT after the handshake, plus this
+/// node's own Ed25519 binding checks, which are sub-millisecond.
+///
+/// Thirty seconds is therefore some thirty times the *pathological* healthy case — a WAN RTT of
+/// a second, retransmits, a badly overloaded node's scheduling delay, a peer whose path changed
+/// mid-connection. Two further properties pin it rather than leaving it a round number:
+///
+/// - it equals `keep_alive_interval`, so the node spends at most one keepalive cycle on a peer
+///   that will not identify itself — a direct answer to the mechanism that caused the defect;
+/// - it is strictly below `max_idle_timeout` (60 s), so for a silent connection *this* is the
+///   binding constraint rather than a race with the idle timer, which keeps the behaviour
+///   attributable to one cause.
+///
+/// Like the two counts, this is a protocol constant rather than operator configuration. That is
+/// consistency with the bound it completes, and a conservative starting point — not a claim that
+/// no deployment will want to tune it.
+pub const PREAUTH_AUTHENTICATION_DEADLINE: Duration = Duration::from_secs(30);
+
+/// QUIC application close code for a connection that never authenticated in time (#2552).
+///
+/// Distinct from a silent drop so the peer learns *why*, and distinct from the admission refusal
+/// code next to it (`0x1c4b`) because the two are different events an operator needs to tell
+/// apart: refused means "the table was full when you arrived", timed out means "you were given a
+/// slot and never used it". Neither is a protocol error — a peer that is slow, or that connected
+/// speculatively, is not misbehaving, and retrying later is the correct response.
+pub const PREAUTH_AUTHENTICATION_TIMEOUT_CODE: u32 = 0x1c4c;
 
 /// Maximum established-but-unauthenticated inbound connections, server-wide.
 ///
@@ -230,6 +310,7 @@ pub struct PreAuthAdmission {
     state: Mutex<AdmissionState>,
     max_total: usize,
     max_per_source: usize,
+    authentication_deadline: Duration,
 }
 
 impl PreAuthAdmission {
@@ -241,14 +322,29 @@ impl PreAuthAdmission {
         )
     }
 
-    /// An admission table with explicit bounds.
+    /// An admission table with explicit count bounds and the default deadline.
     ///
     /// Exists so tests can drive the boundary without opening hundreds of real connections.
     pub fn with_limits(max_total: usize, max_per_source: usize) -> Self {
+        Self::with_policy(max_total, max_per_source, PREAUTH_AUTHENTICATION_DEADLINE)
+    }
+
+    /// An admission table with every bound stated explicitly.
+    ///
+    /// The whole pre-authentication policy — how many anonymous connections, and for how long —
+    /// lives on one object because the two halves are the same bound. A count without a duration
+    /// is a ceiling an adversary can park at; a duration without a count bounds one connection
+    /// and no aggregate.
+    pub fn with_policy(
+        max_total: usize,
+        max_per_source: usize,
+        authentication_deadline: Duration,
+    ) -> Self {
         Self {
             state: Mutex::new(AdmissionState::default()),
             max_total,
             max_per_source,
+            authentication_deadline,
         }
     }
 
@@ -261,6 +357,10 @@ impl PreAuthAdmission {
         addr: SocketAddr,
     ) -> Result<AdmissionGuard, AdmissionRefusal> {
         let key = SourceKey::from_addr(addr);
+        // Read before the slot is taken, so the deadline can only ever be *shorter* than the
+        // slot's real life, never longer. The two are created by one operation, which is what
+        // lets the guard state its own expiry rather than the caller guessing when it started.
+        let authenticate_by = Instant::now() + self.authentication_deadline;
         let cardinality = {
             let mut state = self.lock_state();
 
@@ -286,6 +386,7 @@ impl PreAuthAdmission {
         Ok(AdmissionGuard {
             admission: Arc::clone(self),
             key,
+            authenticate_by,
         })
     }
 
@@ -363,6 +464,24 @@ impl Default for PreAuthAdmission {
 pub struct AdmissionGuard {
     admission: Arc<PreAuthAdmission>,
     key: SourceKey,
+    /// When this reservation stops being justified — see [`Self::authenticate_by`].
+    authenticate_by: Instant,
+}
+
+impl AdmissionGuard {
+    /// The instant by which the connection holding this slot must have authenticated.
+    ///
+    /// Stamped by [`PreAuthAdmission::try_admit`], so the answer to "when did the clock start"
+    /// is "when the resource was taken" — not "when some handler got around to noticing". The
+    /// guard carries it for its whole life, so nothing downstream has to reconstruct a start
+    /// time, and a connection cannot be given a fresh deadline by being passed around.
+    ///
+    /// Enforcing it is the connection handler's job (`actor::connection`), because expiry has to
+    /// close a transport and this type deliberately knows nothing about transports. What lives
+    /// here is the *when*; what lives there is the *what happens*.
+    pub fn authenticate_by(&self) -> Instant {
+        self.authenticate_by
+    }
 }
 
 impl Drop for AdmissionGuard {
@@ -493,6 +612,69 @@ mod tests {
             0,
             "releasing every slot must leave no residue in the table"
         );
+    }
+
+    /// The expiry is born with the slot, not with whoever later looks at it.
+    ///
+    /// This is the "when does the clock start" answer made checkable: a guard handed around,
+    /// stored, or read late still reports the instant its *reservation* was taken.
+    #[test]
+    fn a_slot_carries_the_deadline_it_was_admitted_with() {
+        let deadline = Duration::from_millis(250);
+        let admission = Arc::new(PreAuthAdmission::with_policy(10, 10, deadline));
+
+        let before = Instant::now();
+        let guard = admission.try_admit(v4("203.0.113.7")).expect("admitted");
+        let after = Instant::now();
+
+        assert!(
+            guard.authenticate_by() >= before + deadline
+                && guard.authenticate_by() <= after + deadline,
+            "the deadline was not stamped from the moment the slot was taken"
+        );
+    }
+
+    /// Slots admitted at different moments expire at different moments.
+    ///
+    /// Guards against a deadline shared by the table rather than owned by the reservation — a
+    /// shape in which one long-lived squatter's expiry would silently become everybody's.
+    #[test]
+    fn each_slot_expires_on_its_own_clock() {
+        let admission = Arc::new(PreAuthAdmission::with_policy(
+            10,
+            10,
+            Duration::from_millis(250),
+        ));
+
+        let first = admission.try_admit(v4("203.0.113.1")).expect("admitted");
+        std::thread::sleep(Duration::from_millis(20));
+        let second = admission.try_admit(v4("203.0.113.2")).expect("admitted");
+
+        assert!(
+            second.authenticate_by() > first.authenticate_by(),
+            "two slots taken at different times were given the same expiry"
+        );
+    }
+
+    /// The production constructors carry the production deadline.
+    ///
+    /// Without this, `with_policy` could drift into being the only path that sets a deadline at
+    /// all and every real connection would quietly get whatever `Default` produced — the failure
+    /// mode where the tests exercise a policy the node never uses.
+    #[test]
+    fn the_default_table_uses_the_protocol_deadline() {
+        for admission in [
+            Arc::new(PreAuthAdmission::new()),
+            Arc::new(PreAuthAdmission::with_limits(10, 10)),
+        ] {
+            let before = Instant::now();
+            let guard = admission.try_admit(v4("203.0.113.7")).expect("admitted");
+
+            assert!(
+                guard.authenticate_by() >= before + PREAUTH_AUTHENTICATION_DEADLINE,
+                "a table built for production did not use PREAUTH_AUTHENTICATION_DEADLINE"
+            );
+        }
     }
 
     /// A refusal must not itself grow the map — otherwise attacking the limiter would be

--- a/icn/crates/icn-net/tests/preauth_authentication_deadline.rs
+++ b/icn/crates/icn-net/tests/preauth_authentication_deadline.rs
@@ -429,15 +429,42 @@ async fn expiring_deadlines_return_slots_to_the_source() -> Result<()> {
         "the source's allowance was not full, so this test cannot show a slot being returned"
     );
 
-    // Wait the squatters out. Their deadlines were stamped at admission, so they expire
-    // together, and each release is the guard's destructor.
-    tokio::time::sleep(PREAUTH_AUTHENTICATION_DEADLINE + SLACK).await;
+    // Wait the squatters out structurally, not on a clock.
+    //
+    // A fixed `DEADLINE + SLACK` sleep costs its full length every run and proves less than it
+    // looks: it establishes that time passed, not that the node expired anything, so it would
+    // read identically if the connections had ended for some other reason entirely. Observing
+    // each close — and its code — is the stronger statement and returns as soon as it is true.
+    for squatter in &squatters {
+        let code = squatter
+            .closed_within(PREAUTH_AUTHENTICATION_DEADLINE + SLACK)
+            .await
+            .context("a squatting connection was still open past its deadline")?;
+        assert_eq!(
+            code,
+            u64::from(PREAUTH_AUTHENTICATION_TIMEOUT_CODE),
+            "a squatting connection ended, but not because of the pre-authentication deadline"
+        );
+    }
 
-    let after = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
-    after.tag(node.did()).await?;
-    settle(&delivered).await;
+    // Closed is not yet released, and the difference is the point of this test. The frame the
+    // client just saw is sent by `connection.close()`, which runs *before* the handler returns
+    // and drops the guard, so at this instant every release is imminent rather than done.
+    // Retrying converges as fast as the node actually releases, and still fails outright if the
+    // release never happens — which a sleep long enough to hide the window would not.
+    let mut admitted = false;
+    for _ in 0..20 {
+        let after = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
+        after.tag(node.did()).await?;
+        settle(&delivered).await;
+        if delivered.saw(after.did()) {
+            admitted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
     assert!(
-        delivered.saw(after.did()),
+        admitted,
         "the source was still at its ceiling after every squatting connection timed out: the \
          deadline closed connections without returning their reservations"
     );
@@ -565,6 +592,115 @@ async fn an_invalid_hello_does_not_authenticate_the_connection() -> Result<()> {
     assert!(
         ended.is_ok(),
         "a connection whose Hello failed DID-TLS binding verification was still open"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// RED — the deadline must not be starvable by keeping the handler busy
+// ---------------------------------------------------------------------------
+
+/// A peer that always has another stream waiting must not outlive its deadline.
+///
+/// [`unauthenticated_traffic_does_not_extend_the_deadline`] sends a burst every few seconds, so
+/// the node spends nearly all of the window *waiting* — and a wait is where the deadline was
+/// being enforced. That leaves the adversarial case untested: a peer that never lets the wait
+/// happen at all.
+///
+/// The enforcement point was a `select!` marked `biased`, which polls its arms in order and
+/// returns on the first that is ready, without polling the rest. A tokio timer is not an
+/// interrupt — a `Sleep` only completes when something polls it. So if `accept_bi` is ready on
+/// every iteration, the timer arm is never polled, never registered, and the absolute deadline
+/// passes unobserved however far into the past it goes.
+///
+/// `max_concurrent_bidi_streams` is 10, which makes the attack self-clocking rather than
+/// bandwidth-bound: each opener parks until the node retires a stream and opens the replacement
+/// immediately, so several openers keep a waiter queued for every credit the node frees. The
+/// anonymous budget (#2491) does not help — an exhausted budget `continue`s the loop, which is
+/// the *fastest* path back to `accept_bi` and so makes the queue easier to keep full, not harder.
+#[tokio::test]
+async fn a_continuous_stream_backlog_does_not_starve_the_deadline() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, _delivered) = spawn_node(node.clone()).await?;
+
+    let client = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
+
+    let mut flood = Vec::new();
+    for _ in 0..4 {
+        flood.push(tokio::spawn({
+            let connection = client.connection.clone();
+            let from = client.did().clone();
+            let to = node.did().clone();
+            async move {
+                while let Ok((mut send, _recv)) = connection.open_bi().await {
+                    let message = NetworkMessage::subscribe(
+                        from.clone(),
+                        to.clone(),
+                        vec!["icn.test.2552".to_string()],
+                    );
+                    let _ = icn_net::write_message(&mut send, &message).await;
+                    let _ = send.finish();
+                }
+            }
+        }));
+    }
+
+    let code = client
+        .closed_within(PREAUTH_AUTHENTICATION_DEADLINE + SLACK)
+        .await;
+    for opener in flood {
+        opener.abort();
+    }
+
+    assert_eq!(
+        code.context(
+            "a connection that kept a stream always ready outlived its pre-authentication \
+             deadline"
+        )?,
+        u64::from(PREAUTH_AUTHENTICATION_TIMEOUT_CODE),
+        "the connection was closed, but not by the pre-authentication deadline"
+    );
+    Ok(())
+}
+
+/// One stream the peer opens and never completes must not postpone the deadline either.
+///
+/// The same starvation reached without any flood, and without racing the scheduler for it.
+/// `read_message` is called *inside* the loop body, after the deadline has been left behind,
+/// and it has no timeout of its own: `read_exact` on a stream whose remaining bytes never
+/// arrive is an await that never returns. The node is then parked in the body of an iteration
+/// forever, so the deadline is not merely lost to a biased poll — it is never reached again.
+///
+/// Three bytes of a four-byte length prefix is the whole attack. It costs one stream and one
+/// packet, and unlike the flood it is deterministic: there is no instant at which the node
+/// could have noticed.
+#[tokio::test]
+async fn a_stalled_stream_does_not_postpone_the_deadline() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, _delivered) = spawn_node(node.clone()).await?;
+
+    let client = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
+
+    // Held for the rest of the test: dropping the stream would reset it and hand the node the
+    // error that ends its wait, which is the node escaping rather than the node coping.
+    let (mut send, _recv) = client.connection.open_bi().await?;
+    send.write_all(&[0u8, 0, 0]).await?;
+
+    let code = client
+        .closed_within(PREAUTH_AUTHENTICATION_DEADLINE + SLACK)
+        .await
+        .context(
+            "a connection holding one incomplete stream outlived its pre-authentication deadline",
+        )?;
+
+    assert_eq!(
+        code,
+        u64::from(PREAUTH_AUTHENTICATION_TIMEOUT_CODE),
+        "the connection was closed, but not by the pre-authentication deadline"
     );
     Ok(())
 }

--- a/icn/crates/icn-net/tests/preauth_authentication_deadline.rs
+++ b/icn/crates/icn-net/tests/preauth_authentication_deadline.rs
@@ -1,0 +1,570 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! How long an admitted connection may stay unauthenticated (#2552).
+//!
+//! #2551 bounded the *number* of established-but-unauthenticated inbound connections, per
+//! source and server-wide. It deliberately released the reservation at authentication rather
+//! than at close, which is what keeps the bound off legitimate peers. Nothing, however,
+//! required a connection to ever reach that point:
+//!
+//! ```text
+//! handshake completes -> slot acquired -> peer says nothing -> slot held until the peer
+//!                                                              closes, or the node restarts
+//! ```
+//!
+//! Four mechanisms could have terminated such a connection and none does. The
+//! concurrent-handshake permit is dropped before admission is taken. `max_idle_timeout` (60 s)
+//! never fires, because this node installs `keep_alive_interval` (30 s) on its **server**
+//! transport config and so PINGs its own inbound connections — the peer's QUIC stack answers
+//! at the transport layer, for free, and the idle timer never advances. The session map holds
+//! only authenticated peers (#2530), so nothing evicts it. And the admission table has, by
+//! design, no expiry.
+//!
+//! So a spatial bound without a temporal one is a bound an attacker can pin at its ceiling
+//! and keep there. `MAX_PREAUTH_CONNECTIONS_PER_SOURCE` silent connections from enough sources
+//! refuse *all* new inbound connections, because every new peer starts anonymous.
+//!
+//! # The property under test
+//!
+//! > A connection that has taken a pre-authentication slot must authenticate within
+//! > [`PREAUTH_AUTHENTICATION_DEADLINE`], or its transport is closed and its slot released.
+//!
+//! Duration, not rate and not count. These tests say nothing about how fast a source may churn
+//! connections (#2549) or how many it may hold once authenticated (#2550).
+//!
+//! # How these tests know
+//!
+//! Two structural observables, never a bare sleep:
+//!
+//! - **the QUIC application close code.** A timed-out connection is closed with
+//!   [`PREAUTH_AUTHENTICATION_TIMEOUT_CODE`], which no other path uses, so the client can
+//!   distinguish "the node timed me out" from "the node went away".
+//! - **slot reuse.** A connection that could not be admitted while the table was full, and can
+//!   be admitted afterwards, proves the slot actually returned to the table — which closing the
+//!   transport alone would not.
+//!
+//! Every negative is paired with a positive control:
+//! [`authenticating_before_the_deadline_survives_it`] proves the deadline does not touch peers
+//! that identify themselves, and is the assertion that fails if a timer were left running past
+//! authentication.
+
+use anyhow::{Context, Result};
+use icn_identity::{Did, IdentityBundle};
+use icn_net::{
+    IncomingMessageHandler, NetworkActor, NetworkHandle, NetworkMessage, VersionInfo,
+    MAX_PREAUTH_CONNECTIONS_PER_SOURCE, PREAUTH_AUTHENTICATION_DEADLINE,
+    PREAUTH_AUTHENTICATION_TIMEOUT_CODE,
+};
+use quinn::{ClientConfig, Endpoint};
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+/// How long past the deadline a test waits before calling the node's behaviour final.
+///
+/// Slack for scheduling, not a timing assumption: every assertion below is about *what*
+/// happened (a close code, an admission), never about when. Widening this can only make a
+/// failing test take longer to fail — it cannot turn a failure into a pass.
+const SLACK: Duration = Duration::from_secs(10);
+
+static ISSUED_PORTS: Mutex<Option<HashSet<u16>>> = Mutex::new(None);
+
+fn pick_port() -> u16 {
+    let mut issued = ISSUED_PORTS.lock().expect("port registry poisoned");
+    let issued = issued.get_or_insert_with(HashSet::new);
+    for _ in 0..64 {
+        if let Some(port) = portpicker::pick_unused_port() {
+            if issued.insert(port) {
+                return port;
+            }
+        }
+    }
+    panic!("could not find an unused port");
+}
+
+fn init() {
+    // Must be the provider the workspace actually builds against: installing a different one
+    // makes every TLS handshake fail, which presents as a connect timeout and would look
+    // exactly like the deadline closing connections.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("icn_net=debug")
+        .try_init();
+}
+
+/// Shuts the node down when the test ends.
+struct Guard(broadcast::Sender<()>);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+/// Every message that reached the external handler, by claimed `from`.
+///
+/// A connection with no handler loop — refused, or closed by the deadline — contributes
+/// nothing here, so counting distinct tags counts connections that were live at the time.
+#[derive(Clone, Default)]
+struct Delivered(Arc<Mutex<Vec<String>>>);
+
+impl Delivered {
+    fn saw(&self, did: &Did) -> bool {
+        self.0
+            .lock()
+            .expect("delivery log poisoned")
+            .iter()
+            .any(|seen| seen == did.as_str())
+    }
+}
+
+/// Spawn a real node on the production stack.
+///
+/// The handler is required, not optional: `NetworkActor::spawn` starts no inbound accept loop
+/// without one, and every assertion below would then hold for the wrong reason.
+async fn spawn_node(
+    bundle: IdentityBundle,
+) -> Result<(NetworkHandle, SocketAddr, Guard, Delivered)> {
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let delivered = Delivered::default();
+    let sink = delivered.0.clone();
+    let handler: IncomingMessageHandler = Arc::new(move |msg: NetworkMessage| {
+        sink.lock()
+            .expect("delivery log poisoned")
+            .push(msg.from.to_string());
+    });
+
+    let mut last_err = None;
+    for _ in 0..8 {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        match NetworkActor::spawn(
+            bundle.clone(),
+            addr,
+            shutdown_tx.clone(),
+            Some(handler.clone()),
+            None, // oracle
+            None, // fallback_config
+            None, // topology_config
+            None, // stun_servers
+            None, // turn_config
+            None, // misbehavior_detector
+            None, // store
+            None, // personhood
+            None, // anchor_rate_config
+            None, // advertised_addr
+        )
+        .await
+        {
+            Ok(handle) => {
+                // Returned rather than dropped: the handle owns the actor's mailbox sender.
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                return Ok((handle, addr, Guard(shutdown_tx), delivered));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
+}
+
+/// How long to wait for the node's answer to a Hello before calling it a failure.
+///
+/// A liveness backstop so a broken node fails the test instead of hanging it, not a timing
+/// assumption. The property is carried by the response arriving at all.
+const HELLO_RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Transport settings for a client that intends to *keep* what it was given.
+///
+/// This is the difference between measuring the node and measuring the test harness, and it is
+/// load-bearing enough to be worth stating plainly.
+///
+/// A quinn client left on its defaults gives up on an idle connection after about thirty
+/// seconds. Every test below then ends with the connection closed and the node's slot returned —
+/// on unfixed code, with no deadline anywhere — because the *client* got bored. A slot-reuse
+/// assertion passes, a close is observed, and the whole file certifies a fix that does nothing.
+/// (The close-code assertions are what exposed this: the observed close was a transport idle
+/// timeout, not an application close.)
+///
+/// A real adversary is not polite. Holding a connection open costs it nothing, so it sets a long
+/// idle timeout and keeps its own side alive — which is exactly what makes the defect durable
+/// rather than self-healing. Modelling that is the whole point: with these settings the *only*
+/// thing that can end a connection here is the node deciding to end it.
+fn squatter_transport() -> quinn::TransportConfig {
+    let mut transport = quinn::TransportConfig::default();
+    // Comfortably longer than any deadline these tests wait out, so the client's own timer can
+    // never be the cause of a close.
+    transport.max_idle_timeout(Some(
+        Duration::from_secs(600)
+            .try_into()
+            .expect("600s is a valid QUIC idle timeout"),
+    ));
+    transport.keep_alive_interval(Some(Duration::from_secs(2)));
+    transport
+}
+
+/// A raw QUIC client that authenticates only when asked to.
+struct WireClient {
+    _endpoint: Endpoint,
+    connection: quinn::Connection,
+    identity: IdentityBundle,
+}
+
+impl WireClient {
+    async fn connect(identity: &IdentityBundle, target: SocketAddr) -> Result<Self> {
+        let rustls_client = icn_net::tls::create_tofu_client_config(
+            vec![identity.tls_cert().clone()],
+            identity.tls_key(),
+        )?;
+        let mut endpoint = Endpoint::client("127.0.0.1:0".parse()?)?;
+        let mut client_config = ClientConfig::new(Arc::new(
+            quinn::crypto::rustls::QuicClientConfig::try_from(rustls_client)?,
+        ));
+        client_config.transport_config(Arc::new(squatter_transport()));
+        endpoint.set_default_client_config(client_config);
+
+        // Establishing the connection is a precondition, not the property under test.
+        let mut last_err = None;
+        for attempt in 0..5 {
+            match tokio::time::timeout(
+                Duration::from_secs(10),
+                endpoint.connect(target, "localhost")?,
+            )
+            .await
+            {
+                Ok(Ok(connection)) => {
+                    return Ok(Self {
+                        _endpoint: endpoint,
+                        connection,
+                        identity: identity.clone(),
+                    })
+                }
+                Ok(Err(e)) => last_err = Some(e.to_string()),
+                Err(_) => last_err = Some("connect timed out".to_string()),
+            }
+            tokio::time::sleep(Duration::from_millis(150 * (attempt + 1))).await;
+        }
+        anyhow::bail!(
+            "could not establish the test connection after 5 attempts: {}",
+            last_err.unwrap_or_default()
+        )
+    }
+
+    fn did(&self) -> &Did {
+        self.identity.did()
+    }
+
+    /// Send one `Subscribe` tagged with this client's own DID.
+    ///
+    /// `Subscribe` specifically, because it reaches the external handler untouched — no
+    /// verification and no state change — so an arrival records exactly one thing: this
+    /// connection had a live handler loop. Payloads the node answers itself (`Ping`, `Hello`)
+    /// never reach the handler.
+    async fn tag(&self, to: &Did) -> Result<()> {
+        let message = NetworkMessage::subscribe(
+            self.identity.did().clone(),
+            to.clone(),
+            vec!["icn.test.2552".to_string()],
+        );
+        self.send(&message).await
+    }
+
+    /// Authenticate, and do not return until the node has processed the Hello.
+    ///
+    /// The node answers a valid Hello on a stream *it* opens, and it opens that stream strictly
+    /// after binding the identity to the connection. So the answer arriving is the
+    /// synchronisation: authentication had already been recorded when it was written.
+    async fn authenticate(&self, to: &Did) -> Result<()> {
+        let message = NetworkMessage::new(
+            self.identity.did().clone(),
+            Some(to.clone()),
+            icn_net::MessagePayload::Hello {
+                binding_info: self.identity.binding_info(),
+                version_info: Some(VersionInfo::new("2552-test".to_string())),
+                topology_info: None,
+                x25519_public: *self.identity.x25519_public_bytes(),
+                ml_dsa_public: None,
+                ml_kem_public: None,
+                pq_binding_proof: None,
+            },
+        );
+
+        self.send(&message).await?;
+
+        let (_send, mut recv) =
+            tokio::time::timeout(HELLO_RESPONSE_TIMEOUT, self.connection.accept_bi())
+                .await
+                .context("timed out waiting for the node to answer the Hello")?
+                .context("accepting the node's Hello response stream")?;
+        tokio::time::timeout(HELLO_RESPONSE_TIMEOUT, icn_net::read_message(&mut recv))
+            .await
+            .context("timed out reading the node's Hello response")?
+            .context("reading the node's Hello response")?;
+        Ok(())
+    }
+
+    /// Send a Hello carrying somebody else's binding.
+    ///
+    /// The binding names `impostor` while `from` names this client, so
+    /// `verify_did_matches_binding` rejects it — the first of the three DID-TLS facts
+    /// `handle_hello` requires (#2520).
+    async fn send_invalid_hello(&self, to: &Did, impostor: &IdentityBundle) -> Result<()> {
+        let message = NetworkMessage::new(
+            self.identity.did().clone(),
+            Some(to.clone()),
+            icn_net::MessagePayload::Hello {
+                binding_info: impostor.binding_info(),
+                version_info: Some(VersionInfo::new("2552-test".to_string())),
+                topology_info: None,
+                x25519_public: *self.identity.x25519_public_bytes(),
+                ml_dsa_public: None,
+                ml_kem_public: None,
+                pq_binding_proof: None,
+            },
+        );
+        self.send(&message).await
+    }
+
+    async fn send(&self, message: &NetworkMessage) -> Result<()> {
+        let (mut send, _recv) = self
+            .connection
+            .open_bi()
+            .await
+            .context("open_bi on the test connection")?;
+        icn_net::write_message(&mut send, message).await?;
+        send.finish()?;
+        Ok(())
+    }
+
+    /// Wait for the node to close this connection, and report why.
+    ///
+    /// Returns the QUIC application close code, which is the structural observable: a
+    /// deadline close is distinguishable from every other reason the connection could end.
+    async fn closed_within(&self, patience: Duration) -> Result<u64> {
+        let reason = tokio::time::timeout(patience, self.connection.closed())
+            .await
+            .context("the connection was still open")?;
+        match reason {
+            quinn::ConnectionError::ApplicationClosed(closed) => Ok(closed.error_code.into_inner()),
+            other => anyhow::bail!("connection ended for a non-application reason: {other}"),
+        }
+    }
+}
+
+/// Let the node finish dispatching before anything is counted.
+///
+/// Waits for the delivery total to stop moving rather than sleeping a fixed amount.
+async fn settle(delivered: &Delivered) {
+    let mut last = usize::MAX;
+    for _ in 0..40 {
+        let now = delivered.0.lock().expect("delivery log poisoned").len();
+        if now == last {
+            return;
+        }
+        last = now;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RED — an admitted connection must not hold its slot forever
+// ---------------------------------------------------------------------------
+
+/// RED A — the transport of a silent connection is closed, with a reason that names why.
+///
+/// The close code matters as much as the close. Releasing the slot while leaving the anonymous
+/// connection alive would satisfy the admission table and leave the resource the table exists
+/// to bound running free, so this asserts the transport itself ended — and ended *because of
+/// the deadline*, not because the node went away.
+#[tokio::test]
+async fn a_silent_connection_is_closed_when_its_deadline_expires() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, _delivered) = spawn_node(node.clone()).await?;
+
+    let client = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
+
+    let code = client
+        .closed_within(PREAUTH_AUTHENTICATION_DEADLINE + SLACK)
+        .await
+        .context(
+            "an admitted connection that never authenticated was still open past its deadline",
+        )?;
+
+    assert_eq!(
+        code,
+        u64::from(PREAUTH_AUTHENTICATION_TIMEOUT_CODE),
+        "the connection was closed, but not by the pre-authentication deadline"
+    );
+    Ok(())
+}
+
+/// RED B — the slot a silent connection held becomes reusable.
+///
+/// Closing the transport is not enough on its own: the bound is on the *reservation*, and a
+/// close that failed to release it would leave the table permanently full. This drives the
+/// per-source allowance to its ceiling, confirms it is genuinely full, and then confirms that
+/// waiting out the deadline makes the source admissible again.
+#[tokio::test]
+async fn expiring_deadlines_return_slots_to_the_source() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, delivered) = spawn_node(node.clone()).await?;
+
+    // Fill this source's whole anonymous allowance, and keep every one of them silent.
+    let mut squatters = Vec::new();
+    for _ in 0..MAX_PREAUTH_CONNECTIONS_PER_SOURCE {
+        squatters.push(WireClient::connect(&IdentityBundle::generate()?, addr).await?);
+    }
+
+    // Positive control on the precondition: with the table full, a further connection is
+    // refused, so it never gets a handler loop and cannot deliver. Without this the final
+    // assertion could pass on a node that was never full in the first place.
+    let refused = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
+    let _ = refused.tag(node.did()).await;
+    settle(&delivered).await;
+    assert!(
+        !delivered.saw(refused.did()),
+        "the source's allowance was not full, so this test cannot show a slot being returned"
+    );
+
+    // Wait the squatters out. Their deadlines were stamped at admission, so they expire
+    // together, and each release is the guard's destructor.
+    tokio::time::sleep(PREAUTH_AUTHENTICATION_DEADLINE + SLACK).await;
+
+    let after = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
+    after.tag(node.did()).await?;
+    settle(&delivered).await;
+    assert!(
+        delivered.saw(after.did()),
+        "the source was still at its ceiling after every squatting connection timed out: the \
+         deadline closed connections without returning their reservations"
+    );
+
+    drop(squatters);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls
+// ---------------------------------------------------------------------------
+
+/// A peer that authenticates in time is untouched by the deadline.
+///
+/// This is the assertion that fails if authentication did not cancel the deadline, or if a
+/// timer were left running that could close the connection afterwards. It waits well past the
+/// deadline and then requires the connection to still carry traffic — liveness proven by use,
+/// not by the absence of a close event.
+#[tokio::test]
+async fn authenticating_before_the_deadline_survives_it() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, delivered) = spawn_node(node.clone()).await?;
+
+    let client = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
+    client.authenticate(node.did()).await?;
+
+    // Well past the point at which an unauthenticated connection would have been closed.
+    tokio::time::sleep(PREAUTH_AUTHENTICATION_DEADLINE + SLACK).await;
+
+    client
+        .tag(node.did())
+        .await
+        .context("an authenticated connection was closed by the pre-authentication deadline")?;
+    settle(&delivered).await;
+
+    assert!(
+        delivered.saw(client.did()),
+        "an authenticated connection stopped being served after the pre-authentication \
+         deadline elapsed — the deadline outlived the phase it belongs to"
+    );
+    Ok(())
+}
+
+/// Traffic is not authentication: sending messages does not buy more time.
+///
+/// A peer that keeps a connection busy without ever saying who it is holds exactly the
+/// resource this bounds. The deadline is therefore absolute from admission, not a
+/// last-activity idle timer — the distinction between "authenticate within T" and "send
+/// packets", which is the property #2552 is about.
+#[tokio::test]
+async fn unauthenticated_traffic_does_not_extend_the_deadline() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, _delivered) = spawn_node(node.clone()).await?;
+
+    let client = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
+
+    // The chatter must run on *the connection under assertion*, not a sibling. A mutation that
+    // let any inbound message clear the deadline would leave a silent observer timing out
+    // exactly on schedule, so asserting on a second connection would pass straight through it.
+    let chatter = tokio::spawn({
+        let connection = client.connection.clone();
+        let from = client.did().clone();
+        let to = node.did().clone();
+        async move {
+            // Every ~3 s across the whole window: far inside the anonymous budget (burst 20,
+            // refilling every 100 ms), so these are genuinely read and dispatched rather than
+            // dropped by the rate limiter — which would make the traffic decorative.
+            loop {
+                for message in [
+                    NetworkMessage::ping(from.clone(), to.clone()),
+                    NetworkMessage::subscribe(
+                        from.clone(),
+                        to.clone(),
+                        vec!["icn.test.2552".to_string()],
+                    ),
+                ] {
+                    if let Ok((mut send, _recv)) = connection.open_bi().await {
+                        let _ = icn_net::write_message(&mut send, &message).await;
+                        let _ = send.finish();
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(3)).await;
+            }
+        }
+    });
+
+    let code = client
+        .closed_within(PREAUTH_AUTHENTICATION_DEADLINE + SLACK)
+        .await
+        .context("a connection sending pre-authentication traffic outlived its deadline");
+    chatter.abort();
+
+    assert_eq!(
+        code?,
+        u64::from(PREAUTH_AUTHENTICATION_TIMEOUT_CODE),
+        "the connection was closed, but not by the pre-authentication deadline"
+    );
+    Ok(())
+}
+
+/// An invalid Hello authenticates nothing, and costs the connection immediately.
+///
+/// Pins why "a failed Hello cancels the deadline" is not a state this design can reach: a
+/// Hello whose binding does not verify makes `handle_hello` return an error, which ends the
+/// handler loop there and then. The connection is gone strictly *before* its deadline, so
+/// there is no window in which a rejected Hello could have cancelled anything.
+#[tokio::test]
+async fn an_invalid_hello_does_not_authenticate_the_connection() -> Result<()> {
+    init();
+
+    let node = IdentityBundle::generate()?;
+    let (_handle, addr, _guard, _delivered) = spawn_node(node.clone()).await?;
+
+    let client = WireClient::connect(&IdentityBundle::generate()?, addr).await?;
+    let impostor = IdentityBundle::generate()?;
+    client.send_invalid_hello(node.did(), &impostor).await?;
+
+    // Strictly sooner than the deadline: this connection is not being timed out, it is being
+    // rejected. Asserting the tighter bound is what keeps the two causes distinguishable.
+    let ended = tokio::time::timeout(HELLO_RESPONSE_TIMEOUT, client.connection.closed()).await;
+    assert!(
+        ended.is_ok(),
+        "a connection whose Hello failed DID-TLS binding verification was still open"
+    );
+    Ok(())
+}

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -64,6 +64,11 @@ pub fn init_descriptions() {
         "icn_network_preauth_sources_tracked",
         "Distinct sources currently holding at least one pre-authentication slot (bounded by the global admission limit)"
     );
+    // Pre-authentication deadline (Issue #2552)
+    describe_counter!(
+        "icn_network_preauth_authentication_timeout_total",
+        "Total inbound connections closed for holding a pre-authentication slot without ever authenticating"
+    );
     describe_counter!(
         "icn_network_rate_limit_config_changes_total",
         "Total number of peer rate limit configuration changes"
@@ -282,6 +287,21 @@ pub fn preauth_connections_live_set(count: usize) {
 /// not a leak.
 pub fn preauth_sources_tracked_set(count: usize) {
     gauge!("icn_network_preauth_sources_tracked").set(count as f64);
+}
+
+/// A connection was closed for never authenticating within its deadline (#2552).
+///
+/// Unlabelled on purpose. There is exactly one reason to reach here, so a `reason` dimension
+/// would carry no information, and every dimension worth attributing this to — source address,
+/// /64, claimed DID — is chosen by the party being counted. Attaching any of them would let an
+/// unauthenticated peer mint metric series, which is the same unbounded-cardinality mistake
+/// `preauth_admission_refused_inc` avoids for the same reason. The address is in the log line.
+///
+/// Read together with `preauth_connections_live`: this rising while that gauge stays flat means
+/// the deadline is turning squatters over as fast as they arrive, which is the bound working.
+/// This flat while the gauge sits at its ceiling would mean the deadline is not firing at all.
+pub fn preauth_authentication_timeout_inc() {
+    counter!("icn_network_preauth_authentication_timeout_total").increment(1);
 }
 
 /// Increment rate limit configuration change counter


### PR DESCRIPTION
## What

**BEFORE** — an established inbound connection that never authenticates may hold its pre-authentication slot indefinitely.

**AFTER** — a connection holding a pre-authentication slot must authenticate within `PREAUTH_AUTHENTICATION_DEADLINE` (30s) of taking it, or its transport is closed and the reservation released.

#2551 bounded the *count* of established-but-unauthenticated inbound connections. This adds the *duration* half. Neither is sufficient alone: a count bound describes an instant, and an adversary that reaches the ceiling and never moves holds it forever; a duration bound alone bounds one connection and aggregates nothing.

## Why — the defect, re-derived on merged main (`5528acd0`)

I traced the inbound lifecycle from scratch rather than taking the issue's word for it, and enumerated everything that could terminate a silent peer:

| Mechanism | Why it does not fire |
|---|---|
| `MAX_CONCURRENT_INBOUND_HANDSHAKES` (64) | permit is dropped at `connection.rs` *before* `try_admit` — bounds concurrent handshakes, never established connections |
| `max_idle_timeout` (60s) | never reached, see next row |
| `keep_alive_interval` (30s) | installed on the **server** config (`session.rs:221`), so the node PINGs its own inbound connections; the peer's QUIC stack auto-ACKs at the transport layer and the idle timer never advances — **at zero cost to the peer** |
| session-map eviction | an unauthenticated connection is in no map (#2530) |
| `hello_responded` (#2532/#2537) | bounds the Hello *storm* after one arrives; says nothing about a first Hello never arriving |
| `PreAuthRateLimiter` (#2491) | bounds messages *sent*; a peer sending zero spends zero. It throttles, it does not evict |
| `PreAuthAdmission` (#2551) | documents "no expiry timer, no eviction policy and no cleanup task" — correct for its invariant, and exactly this gap |

**Nothing terminates it.** The slot is held until the peer closes or the node restarts. Confirmed independently; matches the issue.

## The invariant

> A connection that has taken a pre-authentication slot must authenticate within `T` of taking it, or its transport is closed and its slot released.

- **Start** — `PreAuthAdmission::try_admit`. The deadline is stamped where the slot is created, so the resource and its expiry are born of one operation and nothing downstream reconstructs a start time. (Handshake completion and handler start are within microseconds either side, with no await between; anchoring on admission is what makes the answer exact rather than approximate.)
- **Cancelled by** — `ConnectionContext::record_authenticated_peer`, and nothing else. That has exactly one production call site (`handlers/hello.rs:108`), gated behind all three DID-TLS facts (#2520): the binding names `from`, `from`'s key signed it, and it binds the certificate *this* connection is presenting. Not arbitrary traffic, not `NetworkMessage.from`, not `SignedEnvelope`, not Ping/Subscribe/Handshake, not a failed Hello.
- **On expiry** — close the transport with a distinct application code, *then* release. Releasing the slot while leaving the anonymous connection alive would satisfy the admission table and let the thing it bounds escape the bound.

## Design — alternatives considered

**A. `select!` around the whole handler until authentication.** Rejected: it can cancel work in progress, including a `handle_hello` midway between verifying the binding and recording authentication.

**B. Deadline owned by `ConnectionContext` with a separate timer task.** Rejected: a task that outlives the phase it belongs to is precisely the "timer closes an authenticated peer later" hazard, and it would need real synchronisation to avoid it.

**C. Transport config / disable server keepalive for inbound.** Rejected on semantics, not mechanics. Transport-idle and authentication are different properties: a peer may exchange pre-auth traffic indefinitely and still never authenticate, so an idle timer would never fire on the case that matters. (Also, quinn applies one transport config per endpoint, shared with outbound.)

**D — selected. The deadline races only the wait, never the work.**

```text
anonymous:      select! { biased; accept_bi , sleep_until(deadline) -> close + release }
authenticated:  accept_bi
```

This is the same rule the accept loop already follows for shutdown (#2521): *a deadline may cancel the wait for new work, but must never become a maximum lifetime for work that has already arrived.*

## Race and cancellation audit

I verified in quinn 0.11.9 (`connection.rs::poll_accept`) that **`AcceptBi` is cancel-safe**: a stream is removed from the connection's queue only on the poll that returns `Poll::Ready`. Dropping the future while `Pending` discards nothing but a wakeup registration. A losing `select!` arm therefore cannot swallow a peer's Hello. This is load-bearing — had it buffered, the design would be wrong.

The happens-before is **program order in a single sequential task**, which is the strongest available form and needs no primitive: `handle_hello` runs in the loop body; the deadline is consulted at the top of the next iteration; they never run concurrently.

| Forbidden state | Why unreachable |
|---|---|
| slot released twice | `Option::take()` under a mutex, RAII destructor — taking is idempotent (#2551) |
| authenticated connection closed afterwards | `authenticate_by` is cleared before the next wait; the deadline arm no longer exists |
| timeout sees stale `authenticated_peer` | same task, read strictly after the write, in program order |
| Hello succeeds after logical rejection | the close is only reachable while `accept_bi` has *not* yielded, so no Hello has been read |
| timer task outlives authentication | **there is no task** — the deadline is a future dropped with the `select!` |

Simultaneous readiness: `biased` gives the tie to the peer. A stream arriving in the same instant the timer expires is served; the deadline is absolute and already past, so it fires on the very next wait. The tie buys exactly one more message — which the anonymous budget already bounds — never a renewed lease.

## Timeout value

Policy, not truth: no security property depends on it, since every value converts an unbounded hold into a bounded one.

Evidence, not vibes: an ICN dialer sends its Hello **immediately and unconditionally** on connecting (`actor::messages::wire_new_connection`). There is no lazy or deferred path in which an honest peer legitimately holds an inbound connection anonymous. So the accepting side expects a Hello ~1 RTT after the handshake, plus sub-millisecond binding checks. **Had this come out the other way, a deadline would have been the wrong fix**, so it is stated as the load-bearing fact it is.

30s is ~30× the *pathological* healthy case (1s WAN RTT, retransmits, an overloaded node's scheduling delay, a mid-connection path change). Two properties pin it rather than leaving it a round number:
- it equals `keep_alive_interval`, so the node spends at most **one keepalive cycle** on a peer that will not identify itself — a direct answer to the mechanism that caused the defect;
- it is strictly below `max_idle_timeout` (60s), so for a silent connection *this* is the binding constraint rather than a race with the idle timer.

**Protocol constant, not operator configuration** — consistency with `MAX_PREAUTH_CONNECTIONS_PER_SOURCE`, which #2551 made a constant on the same reasoning. The trade-off, stated: operators cannot tune it without a rebuild. `NetworkActor::spawn` has 46 call sites across the workspace, so plumbing a 15th parameter through would be disproportionate API churn for this slice. `PreAuthAdmission::with_policy` makes the value injectable for tests today and is the seam a future config would use.

## Evidence

**RED, on the production stack, before implementation** — 3 tests failed on merged main, 2 controls already held:

| Test | Before | After |
|---|---|---|
| `a_silent_connection_is_closed_when_its_deadline_expires` | **FAIL** — still open past deadline | pass |
| `expiring_deadlines_return_slots_to_the_source` | **FAIL** — slot never returned | pass |
| `unauthenticated_traffic_does_not_extend_the_deadline` | **FAIL** — still open | pass |
| `authenticating_before_the_deadline_survives_it` | pass (control) | pass |
| `an_invalid_hello_does_not_authenticate_the_connection` | pass (control) | pass |

Observables are structural — the QUIC application close code, and slot reuse — never a bare sleep.

### One finding worth calling out

The first RED run **passed** `expiring_deadlines_return_slots_to_the_source` on unfixed code, and failed `a_silent_connection_...` with *"connection ended for a non-application reason: timed out"*. Cause: the test client was a stock quinn client, so **its own** idle timer reaped the connection at ~30s and freed the node's slot. The node did nothing. A real squatter is not that polite — holding a connection open is free.

The harness now models a faithful adversary (`squatter_transport()`: 600s idle timeout, 2s keepalive), so the only thing that can end a connection in these tests is the node deciding to end it. **The close-code assertion is what caught this**; asserting merely "closed" would have certified a fix that does nothing.

### Mutations — 5/5 killed

Anchor-verified (abort unless the anchor matches exactly once), recompiled, `touch`ed on restore, and each restore checked byte-identical by sha256. Verdicts parsed from `test result:` lines, not per-test `ok` lines.

| Mutation | Verdict | Killed by |
|---|---|---|
| M1 deadline never armed | KILLED | all 3 REDs |
| M2 releases slot but does not close | KILLED | `a_silent_connection_...`, `unauthenticated_traffic_...` |
| M3 any accepted stream cancels the deadline | KILLED | `unauthenticated_traffic_...` |
| M5 verified Hello does not cancel | KILLED | `authenticating_before_the_deadline_survives_it` |
| M7 deadline relative per-wait instead of absolute | KILLED | `unauthenticated_traffic_...` |

Each killed by a *different* named test, which is also evidence the tests are not redundant. M2 is the discriminating case: the slot is still released, so `expiring_deadlines_...` passes and only the close-code assertions fail — which is why those are two tests rather than one.

**M4 ("a failed Hello cancels the deadline") and M6 ("timer task outlives authentication") are unreachable in this design, and are reported rather than faked.** M6: there is no task. M4: see follow-up below — I probed it rather than asserting it.

### Regression

| Gate | Result |
|---|---|
| `cargo test -p icn-net` | **460 passed / 0 failed** / 23 ignored, 21 targets (baseline 452/20 → +8: 5 integration, 3 unit) |
| `cargo test -p icn-core --lib` | 441 passed / 0 failed |
| `cargo test -p icn-obs --lib` | 64 passed / 0 failed |
| `cargo fmt --all --check` | clean |
| `cargo clippy --workspace --all-targets --features "hsm,post-quantum" -- -D warnings` | clean, 0 warnings |
| Meaning Firewall · Regulatory Compliance · Readiness Overclaim · Doc Control · Agent Tooling Drift | PASS |
| Doc Freshness | fails identically on merged main (unrelated stale sections) — pre-existing, not a required check |

Suites specifically preserved: #2551 admission, #2491 authenticated rate-limit identity, #2520 Hello current-cert binding, #2525 handshake cancellation, #2530 provisional connection semantics, #2532/#2537 Hello termination, #2533 bootstrap DID expectation, #2535 peer-exchange authorization, #2536 redundant-dial idempotence.

## Metrics

`icn_network_preauth_authentication_timeout_total` — **unlabelled**. One reason to reach it, so a `reason` dimension carries no information; every dimension worth attributing it to (source address, /64, claimed DID) is chosen by the party being counted. The address is in the log line. Existing pre-auth gauges fall on release automatically, since #2551 publishes them from the mutation inside `PreAuthAdmission`.

## Interaction with the neighbours

**#2549 (churn) — unchanged, and deliberately not touched.** Expiry bounds how long *one* connection may squat; it places no floor on how fast the next may arrive. A source that connects, waits, is closed, and reconnects stays inside every bound here forever. What changes is the attacker's economics — a *free permanent* hold becomes a *recurring* cost of one handshake per interval. **That is not a rate limit and this PR does not claim to be one.** #2549 remains exactly as necessary as it was.

**#2550 (authenticated multiplicity) — unchanged.** The deadline stops at authentication on purpose. Extending it past that point would make it a maximum connection lifetime — a different bound with different victims — and belongs to #2550 if it is wanted at all.

## What remains unbounded

- attacks distributed across many sources or /64s — a single node cannot solve this locally;
- connection *rate* / churn (#2549);
- authenticated connection multiplicity (#2550);
- QUIC/TLS handshake work below the admission hook.

**This is not general DoS prevention**, and no claim here should be read as one.

## Follow-up found (not fixed here — out of scope)

Probing M4 turned up a genuine pre-existing coverage gap, reported rather than absorbed. Moving `record_authenticated_peer` *above* the DID-TLS checks in `handle_hello` **survives all three relevant suites** — the deadline suite, #2520's `hello_current_cert_binding`, and #2491's `authenticated_rate_limit_identity`.

It is not exploitable today: the failed check returns `Err` on the same path, so the connection is destroyed before the unproven identity is ever consulted. But it would miscount `preauth_admission_released_total` as an authentication, and the ordering guarantee it depends on is asserted nowhere. That is #2520's property, not #2552's — I will file it separately. My deadline's correctness does lean on that ordering, so it is flagged prominently rather than buried.

## Post-review changes (independent adversarial pre-merge review)

The review re-derived the invariant from merged main rather than from this description, and found one **BLOCKER**, fixed in `1fa59d42`.

**The deadline guarded the wait, not the loop body.** `read_message` is called inside the loop body, has no timeout of its own, and `read_exact` on a length prefix whose remaining bytes never arrive never returns. **Three bytes of a four-byte header** parked the handler task past the deadline permanently and held the slot — the same squat this PR exists to prevent, for one stream and one packet, deterministic and with no race to win.

Fixed by bounding the anonymous read with the same absolute instant, and by *checking* that instant at the loop boundary instead of leaving it to `select!` arm ordering. Dispatch stays outside the deadline deliberately: a cancelled read discards bytes nobody has inspected on a connection being closed regardless, whereas a cancelled `handle_hello` could abandon a peer mid-verification, or after `record_authenticated_peer` had already released its slot.

**The `biased`-starvation hypothesis did not reproduce.** A maximal flood — 462,331 stream drains in 30s (~15k/sec) — still closed on time. `max_concurrent_bidi_streams(10)` is why: returning stream credit costs a round trip, so the accept queue drains to empty constantly and the timer arm gets its poll. That is a transport tuning constant underwriting a security property, which is why the boundary check is there to remove the dependency.

Mutations re-run for the changed code only: M1 KILLED, M2 KILLED (both re-run because the close path was refactored into a shared helper — a text-substitution mutation can silently become a no-op after restructuring), **M8 unbounded-read KILLED by exactly the one new test**, **M9 boundary-check SURVIVED**. Restore sha256-verified byte-identical; clean control 7/7.

M9 surviving is stated rather than hidden: the boundary check is not test-pinned, because the failure it prevents is currently masked by flow control. It is structural hardening, not a proven-by-test property.

Also corrected: the fixed-sleep review finding (thread resolved), and the module header, which still described the deadline as racing "only the wait".

## Risk

Behaviour changes only for inbound connections holding a pre-authentication slot that do not authenticate within 30s. Outbound dials take no slot and are untouched. Authenticated connections are untouched — `authenticating_before_the_deadline_survives_it` waits 40s past the deadline and then requires the connection to still carry traffic.

## Test plan

```
cargo test -p icn-net --test preauth_authentication_deadline   # 7/7, ~61s (real 30s deadline)
cargo test -p icn-net --test preauth_connection_admission      # 3/3, #2551 preserved
cargo test -p icn-net --lib preauth_admission                  # 9/9
cargo test -p icn-net                                          # all suites green
cargo test -p icn-core --lib                                   # 441/0
cargo test -p icn-obs --lib                                    # 64/0
cargo fmt --all --check
cargo clippy --workspace --all-targets --features "hsm,post-quantum" -- -D warnings
```

Plus the sanctioned non-Rust gates: Meaning Firewall, regulatory compliance, readiness overclaim, doc control — all exit 0.

Fixes #2552

Refs #2547, #2551, #2549, #2550, #2554

