### PR TITLE
fix(net): normalize IPv4-mapped addresses before peer endpoint classification

### DIFF
--- a/icn/crates/icn-net/src/handlers/peer_exchange.rs
+++ b/icn/crates/icn-net/src/handlers/peer_exchange.rs
@@ -224,8 +224,33 @@ impl ConnectionContext {
 /// Private/loopback/link-local addresses (RFC1918, ULA, fe80::/10) are classified
 /// as `Local`; everything else is `Public`. This prevents misclassifying LAN peers
 /// as publicly reachable when the observed remote address is non-routable.
+///
+/// IPv4-mapped addresses are unmapped before classifying, and that is load bearing rather than
+/// tidiness. `listen_addr` defaults to `[::]:7777`, nothing in this crate sets `IPV6_V6ONLY`, and
+/// where the OS leaves it off the socket is dual-stack — so an IPv4 peer is reported as
+/// `::ffff:a.b.c.d`. Rust does not unmap that implicitly, so without this the v6 arm would see a
+/// LAN peer, match neither ULA nor link-local, and call it `Public`: precisely the
+/// misclassification described above. `Ipv6Addr::is_loopback` has the same gap — it is true only
+/// for `::1`, never for a mapped `127/8` address.
+///
+/// Only `::ffff:0:0/96` is unmapped, via [`std::net::Ipv6Addr::to_ipv4_mapped`]. Deprecated
+/// IPv4-*compatible* addresses (`::a.b.c.d`) stay on the v6 path: they are not what a dual-stack
+/// socket produces, and `to_ipv4` would additionally rewrite `::1` to `0.0.0.1` and classify v6
+/// loopback through the IPv4 rules. This matches `SourceKey::from_addr` (#2557), so the two
+/// subsystems agree on what a peer's address means.
+///
+/// Normalising once here keeps both classification arms exactly as they were: what counts as local
+/// or public is unchanged, only the representation it is read from.
 fn endpoint_kind_for_addr(addr: SocketAddr) -> EndpointKind {
-    match addr.ip() {
+    let normalized = match addr.ip() {
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => IpAddr::V4(v4),
+            None => IpAddr::V6(v6),
+        },
+        already_v4 => already_v4,
+    };
+
+    match normalized {
         IpAddr::V4(ip) => {
             if ip.is_private() || ip.is_loopback() || ip.is_link_local() {
                 EndpointKind::Local
@@ -247,5 +272,102 @@ fn endpoint_kind_for_addr(addr: SocketAddr) -> EndpointKind {
                 EndpointKind::Public
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod endpoint_kind_tests {
+    use super::*;
+
+    fn kind(addr: &str) -> EndpointKind {
+        endpoint_kind_for_addr(addr.parse::<SocketAddr>().expect("test address"))
+    }
+
+    /// The address a dual-stack listener actually reports for an IPv4 peer.
+    ///
+    /// `listen_addr` defaults to `[::]:7777` and nothing sets `IPV6_V6ONLY`, so an IPv4 peer
+    /// arrives as `::ffff:a.b.c.d`. Rust does not unmap that implicitly, so without normalization
+    /// these take the IPv6 arm, match none of loopback/ULA/link-local, and come out `Public` —
+    /// exactly the misclassification this function exists to prevent.
+    fn mapped(v4: &str) -> String {
+        format!("[::ffff:{v4}]:7777")
+    }
+
+    #[test]
+    fn mapped_rfc1918_is_local() {
+        for v4 in ["10.0.0.1", "172.16.0.1", "192.168.1.5"] {
+            assert_eq!(
+                kind(&mapped(v4)),
+                EndpointKind::Local,
+                "mapped private address ::ffff:{v4} was not classified Local"
+            );
+        }
+    }
+
+    #[test]
+    fn mapped_loopback_is_local() {
+        assert_eq!(
+            kind(&mapped("127.0.0.1")),
+            EndpointKind::Local,
+            "mapped loopback was not classified Local — Ipv6Addr::is_loopback() is true only for \
+             ::1, never for a mapped 127/8 address"
+        );
+    }
+
+    #[test]
+    fn mapped_link_local_is_local() {
+        assert_eq!(
+            kind(&mapped("169.254.1.1")),
+            EndpointKind::Local,
+            "mapped IPv4 link-local was not classified Local"
+        );
+    }
+
+    #[test]
+    fn mapped_public_v4_is_public() {
+        // TEST-NET-3, a documentation range the existing V4 logic treats as non-private.
+        assert_eq!(kind(&mapped("203.0.113.7")), EndpointKind::Public);
+    }
+
+    /// The strongest compact invariant: representation must not change classification.
+    #[test]
+    fn native_and_mapped_v4_classify_identically() {
+        for v4 in [
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.1.5",
+            "127.0.0.1",
+            "169.254.1.1",
+            "203.0.113.7",
+            "8.8.8.8",
+            // The existing V4 arm does not treat the unspecified address as local, and this
+            // change does not alter that — it only has to reach the same verdict either way.
+            "0.0.0.0",
+        ] {
+            assert_eq!(
+                kind(&format!("{v4}:7777")),
+                kind(&mapped(v4)),
+                "{v4} classified differently depending on whether it arrived native or mapped"
+            );
+        }
+    }
+
+    /// Unmapping must not disturb addresses that are genuinely IPv6.
+    #[test]
+    fn genuine_ipv6_classification_is_unchanged() {
+        assert_eq!(
+            kind("[::1]:7777"),
+            EndpointKind::Local,
+            "::1 is v6 loopback"
+        );
+        assert_eq!(kind("[fd00::1]:7777"), EndpointKind::Local, "ULA");
+        assert_eq!(kind("[fc00::1]:7777"), EndpointKind::Local, "ULA low half");
+        assert_eq!(kind("[fe80::1]:7777"), EndpointKind::Local, "link-local");
+        assert_eq!(
+            kind("[2001:db8::1]:7777"),
+            EndpointKind::Public,
+            "public v6"
+        );
+        assert_eq!(kind("[2606:4700::1111]:7777"), EndpointKind::Public);
     }
 }


### PR DESCRIPTION
Closes #2563.

On the default listener, every LAN peer was advertised to other peers as publicly reachable.

## Reproduction, before any production edit

The regression matrix was written first and run against unfixed `main` (`2ca06887`):

```
mapped_rfc1918_is_local ................. FAILED   ::ffff:10.0.0.1 was Public
mapped_loopback_is_local ................ FAILED   ::ffff:127.0.0.1 was Public
mapped_link_local_is_local .............. FAILED   ::ffff:169.254.1.1 was Public
native_and_mapped_v4_classify_identically FAILED   10.0.0.1 differed by representation
mapped_public_v4_is_public .............. ok       (control)
genuine_ipv6_classification_is_unchanged  ok       (control)
```

Two controls passing is the point: the suite is not failing indiscriminately, and genuine IPv6 was
never broken.

## Why mapped IPv4 reaches the IPv6 arm

`listen_addr` defaults to `[::]:7777` (`icn-core/src/config/mod.rs`), production binds it with a
plain `std::net::UdpSocket::bind` (`icn-net/src/session.rs`), and **nothing in the workspace sets
`IPV6_V6ONLY`** — verified by grep, only doc comments mention it. Where the OS leaves that option
off the socket is dual-stack, and an IPv4 peer is reported as `::ffff:a.b.c.d`. Rust does not unmap
implicitly, so `endpoint_kind_for_addr` took `IpAddr::V6`, matched neither ULA (`fc00::/7`) nor
link-local (`fe80::/10`), and returned `Public`.

`Ipv6Addr::is_loopback()` has the same gap — true only for `::1`, never for a mapped `127/8`
address, which is why mapped loopback also came out `Public`.

Stated platform-neutrally on purpose: this is not a claim that every supported OS defaults to
dual-stack. Receiving a mapped address is semantically valid regardless, so the code should handle
it either way.

## Broken classifications

| address | before | after |
|---|---|---|
| `::ffff:10.0.0.1` / `::ffff:172.16.0.1` / `::ffff:192.168.1.5` | Public | **Local** |
| `::ffff:127.0.0.1` | Public | **Local** |
| `::ffff:169.254.1.1` | Public | **Local** |
| `::ffff:203.0.113.7` | Public | Public (unchanged) |
| `::1`, ULA, link-local, public v6 | unchanged | unchanged |

## Normalization choice

`to_ipv4_mapped()`, **not** `to_ipv4()`. The latter also converts deprecated IPv4-*compatible*
addresses (`::a.b.c.d`) and would rewrite `::1` to `0.0.0.1`, classifying v6 loopback through the
IPv4 rules. Only `::ffff:0:0/96` is unmapped. This is the same normalization `SourceKey::from_addr`
landed in #2557, so the two subsystems now agree on what a peer's address means.

The change normalizes **once** at the top and leaves both classification arms byte-identical — no
policy change, only the representation they read from. Eight lines of production code.

## Actual consequence and severity

The one production call site is the peer-exchange **response** path, which labels each connected
peer's `remote_address()` before advertising it.

> **Corrected during independent review of this PR.** An earlier revision of this section (and of
> #2563's body, and of commit `00618c42`'s message) claimed the mislabel drove wrong dial tiering,
> a wrong dial timeout and a wrong metric label. Tracing every `EndpointKind` consumer shows that
> is not true of the current call graph. The corrected trace is below.

- **Not an information-exposure fix.** There is no kind-based filtering before advertisement — the
  address was sent whatever its label. Only the label was wrong.
- **No behavioural change in the current call graph.** `endpoint_kind_for_addr` reaches exactly one
  live consumer: the `PeerExchangeMessage::Response` arm of `supervisor::init_network`, which picks
  `find(Public).or_else(first)`. Every `KnownPeer` this node emits carries exactly one endpoint
  (`peer_exchange.rs`, `endpoints: vec![ep]`), so the same address is dialed either way.
- **The Announce tier ordering is not fed by this function.** That arm does order candidates
  `Local -> Public -> Relay` under `MAX_ENDPOINTS_PER_KIND = 3`, but nothing in the workspace ever
  sends `PeerExchangeMessage::Announce` — `NetworkHandle::announce_peer` has no callers repo-wide.
  It is a *latent* consumer: wrong only once the announce path is wired.
- **`nat_dial` never sees these labels.** Its per-kind Happy Eyeballs split
  (`local_dial_timeout_ms` vs `public_dial_timeout_ms`, `dial_attempt_inc("local"|"public")`)
  reads `ConnectionCandidate`, which production builds only in `session.rs:647` via
  `ConnectionCandidate::new`. That constructor labels by *provenance* — bind address `Local`,
  STUN `Public`, TURN `Relay` — and inspects no address. This classifier's output cannot reach it.

**Severity: a wrong label on the wire — a violated contract and a latent trap, not a live
behaviour change.** The function's own doc comment promises LAN peers are not advertised as
publicly reachable, and it was not keeping that promise; the already-written Announce tiering, and
any future consumer that gates on `EndpointKind`, would inherit the wrong answer. Not a privacy
leak and not a trust or authorization bypass — nothing gates on `EndpointKind` today.

**Merge gate:** commit `00618c42`'s message still carries the superseded consequence paragraph.
The squash message must be hand-supplied from this corrected section rather than taken from
`COMMIT_MESSAGES`.

## Same-class sweep

`icn-gossip`: no address classification at all — zero matches.

`icn-net`, besides the fix:

| site | verdict |
|---|---|
| `session.rs` `raw_local_addr.ip().is_unspecified()` | NOT A DEFECT — the node's *own* bind address, never a mapped peer address |
| `turn.rs` `IpAddr::V6(ip)` | NOT A DEFECT — faithfully decodes a wire format into a Relay candidate; no classifier branches on it |
| `stun.rs` `Ipv6Addr::from(xaddr)` | NOT A DEFECT — decodes the family-0x02 XOR-MAPPED-ADDRESS; the result becomes an `EndpointCandidate::public` by *provenance*, and no branch reads its representation |
| `nat.rs` `local_addr.ip() == public_addr.ip()` | NOT A DEFECT — an address-identity compare that a native/mapped mismatch *would* break, but its socket is bound `0.0.0.0:0` so both sides decode native v4, and `NatDetector` has no callers outside `nat.rs` |
| `preauth_admission.rs` `SourceKey::from_addr` | already correct (#2557) — cross-checked, see below |

Swept wider than required. One genuine same-class defect outside those crates, filed as **#2564**
rather than fixed here (different crate, different policy, security control — deserves its own
review): `icn-gateway`'s `is_private_ip` SSRF blocklist has the identical IPv6-arm gap, so
`https://[::ffff:169.254.169.254]/` and every mapped RFC1918 form pass it. No server-side fetch of
those URLs exists today, so it is a bypassable defense-in-depth control rather than a demonstrated
live SSRF — stated that way in the issue.

## SourceKey cross-check (#2557, not modified)

Verified rather than assumed, all green: mapped == native, distinct mapped addresses stay distinct,
source port irrelevant, genuine IPv6 still /64-keyed, `::1` still genuine IPv6. Left alone.

## Red proof

Bypassed the normalization so mapped addresses stay in the V6 arm. The same four tests failed and
the two controls still passed; restored exactly, no residue.

## Tests

`cargo fmt --all --check` 0 · `cargo test -p icn-net` **494 passed, 0 failed** ·
`cargo test -p icn-gossip` **275 passed, 0 failed** ·
`cargo clippy --workspace --all-targets --features "hsm,post-quantum" -- -D warnings` exit 0 ·
meaning-firewall, compliance linter, readiness-overclaim linter, drift-check all exit 0.
Adjacent suites re-run explicitly: `preauth_connection_admission` 3, `preauth_source_work_budget` 6.

## Scope

No shared normalization helper. Two one-line uses in one crate does not justify an address
abstraction; #2564 is in a different crate with different policy. Peer-exchange policy is untouched.

Discovery context, non-closing: #2557, squash `2ca06887`.

