### PR TITLE
fix(gateway): apply the private-IP blocklist to IPv6 and mapped IPv4 hosts

### DIFF
--- a/icn/crates/icn-gateway/src/api/listings.rs
+++ b/icn/crates/icn-gateway/src/api/listings.rs
@@ -7,7 +7,7 @@ use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse};
 use std::net::IpAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use url::Url;
+use url::{Host, Url};
 use uuid::Uuid;
 
 use crate::error::{GatewayError, Result};
@@ -188,8 +188,23 @@ fn validate_photo_url(url_str: &str, index: usize) -> Result<()> {
         )));
     }
 
-    // Try to parse as IP address and block private ranges
-    if let Ok(ip) = host.parse::<IpAddr>() {
+    // Block literal IP hosts in private/reserved ranges.
+    //
+    // Read the address off `Url::host()`, which hands back the already-parsed
+    // `Ipv4Addr`/`Ipv6Addr`, rather than re-parsing `host_str()`. `host_str()`
+    // returns IPv6 hosts *bracketed* — `https://[::1]/` yields `"[::1]"` — and
+    // brackets are not part of an `IpAddr`, so `host.parse::<IpAddr>()` failed for
+    // every IPv6 literal and skipped this check entirely (#2564). Taking the parsed
+    // value also means the check sees one canonical address per host, so the dotted
+    // and hex spellings of a mapped address need no separate handling.
+    let literal_ip = match url.host() {
+        Some(Host::Ipv4(v4)) => Some(IpAddr::V4(v4)),
+        Some(Host::Ipv6(v6)) => Some(IpAddr::V6(v6)),
+        // A domain still resolves to an address at fetch time; this control only
+        // covers literal-IP hosts. See the note on `is_private_ip`.
+        Some(Host::Domain(_)) | None => None,
+    };
+    if let Some(ip) = literal_ip {
         if is_private_ip(&ip) {
             return Err(GatewayError::BadRequest(format!(
                 "Photo URL {} cannot reference private IP addresses",
@@ -210,7 +225,32 @@ fn validate_photo_url(url_str: &str, index: usize) -> Result<()> {
 }
 
 /// Check if an IP address is in a private/reserved range
+///
+/// Covers *literal* addresses only. A hostname that resolves to a private address,
+/// a redirect into one, or DNS rebinding after this check are all outside what this
+/// function can see; it is one layer, not a complete SSRF defence.
+///
+/// A strict IPv4-mapped address (`::ffff:0:0/96`) is judged by the IPv4 rules below.
+/// `a.b.c.d` and `::ffff:a.b.c.d` name the same host, so the representation a caller
+/// happens to write must not change the verdict — without this, every IPv4 range
+/// listed here could be expressed in mapped form and pass, because the IPv6 arm
+/// matches none of them and `Ipv6Addr::is_loopback()` is true only for `::1`, never
+/// for a mapped `127/8` address (#2564).
+///
+/// `to_ipv4_mapped()` and deliberately not `to_ipv4()`: the latter also converts
+/// deprecated IPv4-*compatible* addresses (`::a.b.c.d`) and would rewrite `::1` to
+/// `0.0.0.1`, judging IPv6 loopback by the IPv4 rules. Same strict normalization
+/// `SourceKey::from_addr` (#2557) and `peer_exchange::endpoint_kind_for_addr` (#2563)
+/// use — applied here at the policy boundary, not as a shared global helper, because
+/// other address checks in this crate deliberately want the opposite (see the
+/// dev-mode loopback gate in `server.rs`, where a mapped address failing
+/// `is_loopback()` keeps the privileged path disabled).
 fn is_private_ip(ip: &IpAddr) -> bool {
+    let ip = match ip {
+        IpAddr::V6(ipv6) => ipv6.to_ipv4_mapped().map_or(*ip, IpAddr::V4),
+        already_v4 => *already_v4,
+    };
+
     match ip {
         IpAddr::V4(ipv4) => {
             ipv4.is_private()
@@ -1278,5 +1318,170 @@ mod tests {
         assert!(!is_private_ip(
             &"2607:f8b0:4004:800::200e".parse::<IpAddr>().unwrap()
         ));
+    }
+
+    // ========================================================================
+    // #2564 — IPv4-mapped representation equivalence
+    // ========================================================================
+
+    /// Every IPv4 address the current policy *blocks*, one per distinct class it
+    /// recognises. Kept as data so the equivalence test below cannot silently drift
+    /// away from the classifier it is pinning.
+    const BLOCKED_V4: &[(&str, &str)] = &[
+        ("10.0.0.1", "RFC1918 10/8"),
+        ("172.16.0.1", "RFC1918 172.16/12"),
+        ("192.168.1.1", "RFC1918 192.168/16"),
+        ("127.0.0.1", "loopback"),
+        ("169.254.169.254", "link-local (cloud instance metadata)"),
+        ("255.255.255.255", "broadcast"),
+        ("192.0.2.1", "documentation TEST-NET-1"),
+        ("198.51.100.1", "documentation TEST-NET-2"),
+        ("203.0.113.1", "documentation TEST-NET-3"),
+        ("0.0.0.0", "unspecified"),
+        // RFC 6598 range boundaries as test vectors for the CGNAT rule below, not
+        // anyone's Tailscale address: sanitize-ok
+        ("100.64.0.1", "CGNAT 100.64/10 low edge"), // sanitize-ok
+        ("100.127.255.255", "CGNAT 100.64/10 high edge"), // sanitize-ok
+        ("192.0.0.1", "IETF protocol assignments 192.0.0/24"),
+    ];
+
+    /// Every IPv4 address the current policy *allows*, including the boundaries just
+    /// outside each blocked range. These are the controls: a fix that over-blocks
+    /// fails here rather than passing quietly.
+    const ALLOWED_V4: &[(&str, &str)] = &[
+        ("8.8.8.8", "public"),
+        ("1.1.1.1", "public"),
+        ("172.15.255.255", "just below 172.16/12"),
+        ("172.32.0.0", "just above 172.31/12"),
+        ("100.63.255.255", "just below CGNAT"),
+        ("100.128.0.0", "just above CGNAT"),
+        ("192.0.1.1", "just outside 192.0.0/24"),
+    ];
+
+    /// The property #2564 is about: representation must not change the verdict.
+    ///
+    /// `a.b.c.d` and `::ffff:a.b.c.d` are the same host. Before the fix the mapped
+    /// form took the IPv6 arm, matched none of loopback/unspecified/ULA/link-local,
+    /// and came back `false` for every blocked IPv4 range.
+    #[test]
+    fn mapped_v4_classifies_identically_to_native_v4() {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        for (addr, class) in BLOCKED_V4.iter().chain(ALLOWED_V4.iter()) {
+            let v4: Ipv4Addr = addr.parse().expect("test address");
+            let native = is_private_ip(&IpAddr::V4(v4));
+            let mapped = is_private_ip(&IpAddr::V6(v4.to_ipv6_mapped()));
+            assert_eq!(
+                native, mapped,
+                "{addr} ({class}) classified differently as native v4 ({native}) vs \
+                 ::ffff:{addr} ({mapped})"
+            );
+        }
+    }
+
+    /// Pins the *direction* of each verdict, so the equivalence test above cannot be
+    /// satisfied by a classifier that returns a constant.
+    #[test]
+    fn mapped_v4_verdicts_match_the_documented_policy() {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        for (addr, class) in BLOCKED_V4 {
+            let v4: Ipv4Addr = addr.parse().expect("test address");
+            assert!(
+                is_private_ip(&IpAddr::V6(v4.to_ipv6_mapped())),
+                "::ffff:{addr} ({class}) must be blocked, as native {addr} is"
+            );
+        }
+        for (addr, class) in ALLOWED_V4 {
+            let v4: Ipv4Addr = addr.parse().expect("test address");
+            assert!(
+                !is_private_ip(&IpAddr::V6(v4.to_ipv6_mapped())),
+                "::ffff:{addr} ({class}) must stay allowed, as native {addr} is"
+            );
+        }
+    }
+
+    /// Unmapping must not disturb addresses that are genuinely IPv6. In particular
+    /// `::1` must keep being judged by the IPv6 loopback rule — `to_ipv4()` would
+    /// rewrite it to `0.0.0.1` and judge it as IPv4, which is why the fix uses the
+    /// strict `to_ipv4_mapped()`.
+    #[test]
+    fn genuine_ipv6_policy_is_unchanged() {
+        use std::net::IpAddr;
+
+        for (addr, class) in [
+            ("::1", "v6 loopback"),
+            ("::", "v6 unspecified"),
+            ("fc00::1", "ULA low half"),
+            ("fd00::1", "ULA high half"),
+            ("fe80::1", "link-local"),
+            ("febf::1", "link-local top of fe80::/10"),
+        ] {
+            assert!(
+                is_private_ip(&addr.parse::<IpAddr>().unwrap()),
+                "{addr} ({class}) must remain blocked by the IPv6 arm"
+            );
+        }
+
+        for (addr, class) in [
+            ("2607:f8b0:4004:800::200e", "public v6"),
+            ("2606:4700::1111", "public v6"),
+            // Current policy does not block the IPv6 documentation range. Pinned so
+            // this fix is not mistaken for a licence to widen the IPv6 arm.
+            ("2001:db8::1", "v6 documentation — not blocked today"),
+            ("fec0::1", "site-local — deprecated, not blocked today"),
+        ] {
+            assert!(
+                !is_private_ip(&addr.parse::<IpAddr>().unwrap()),
+                "{addr} ({class}) must remain allowed by the IPv6 arm"
+            );
+        }
+    }
+
+    /// The classifier is only a security control if `validate_photo_url` actually
+    /// reaches it. `Url::host_str()` returns IPv6 hosts *bracketed* (`[::1]`), which
+    /// never parses as an `IpAddr` — so before the fix every IPv6 literal host,
+    /// mapped or genuine, skipped the blocklist entirely.
+    #[test]
+    fn photo_url_applies_the_blocklist_to_bracketed_ipv6_hosts() {
+        for (url, why) in [
+            ("https://[::ffff:169.254.169.254]/p.jpg", "mapped metadata"),
+            ("https://[::ffff:127.0.0.1]/p.jpg", "mapped loopback"),
+            ("https://[::ffff:10.0.0.1]/p.jpg", "mapped RFC1918"),
+            ("https://[::ffff:192.168.1.1]/p.jpg", "mapped RFC1918"),
+            // RFC 6598 test vector, not a real host: sanitize-ok
+            ("https://[::ffff:100.64.0.1]/p.jpg", "mapped CGNAT"), // sanitize-ok
+            // The URL parser canonicalises the mapped form to hex, so the dotted and
+            // hex spellings are the same parsed address and need no separate branch.
+            (
+                "https://[::ffff:7f00:1]/p.jpg",
+                "mapped loopback, hex spelling",
+            ),
+            ("https://[::1]/p.jpg", "genuine v6 loopback"),
+            ("https://[fe80::1]/p.jpg", "genuine v6 link-local"),
+            ("https://[fc00::1]/p.jpg", "genuine v6 ULA"),
+        ] {
+            assert!(
+                validate_photo_url(url, 0).is_err(),
+                "{url} ({why}) must be rejected"
+            );
+        }
+    }
+
+    /// Public hosts stay reachable in either representation — the fix restores
+    /// equivalence, it does not tighten what may be linked.
+    #[test]
+    fn photo_url_still_allows_public_hosts_in_either_representation() {
+        for url in [
+            "https://8.8.8.8/p.jpg",
+            "https://[::ffff:8.8.8.8]/p.jpg",
+            "https://[2607:f8b0:4004:800::200e]/p.jpg",
+            "https://images.unsplash.com/photo.jpg",
+        ] {
+            assert!(
+                validate_photo_url(url, 0).is_ok(),
+                "{url} must remain allowed"
+            );
+        }
     }
 }

--- a/icn/crates/icn-gateway/src/api/listings.rs
+++ b/icn/crates/icn-gateway/src/api/listings.rs
@@ -239,12 +239,16 @@ fn validate_photo_url(url_str: &str, index: usize) -> Result<()> {
 ///
 /// `to_ipv4_mapped()` and deliberately not `to_ipv4()`: the latter also converts
 /// deprecated IPv4-*compatible* addresses (`::a.b.c.d`) and would rewrite `::1` to
-/// `0.0.0.1`, judging IPv6 loopback by the IPv4 rules. Same strict normalization
-/// `SourceKey::from_addr` (#2557) and `peer_exchange::endpoint_kind_for_addr` (#2563)
-/// use — applied here at the policy boundary, not as a shared global helper, because
-/// other address checks in this crate deliberately want the opposite (see the
-/// dev-mode loopback gate in `server.rs`, where a mapped address failing
-/// `is_loopback()` keeps the privileged path disabled).
+/// `0.0.0.1`, judging IPv6 loopback by the IPv4 rules. Strict therefore also means
+/// narrow: the other ways an IPv4 address can be embedded in an IPv6 one stay on the
+/// IPv6 arm and remain allowed, exactly as before this change.
+///
+/// Same strict normalization `SourceKey::from_addr` (#2557) and
+/// `peer_exchange::endpoint_kind_for_addr` (#2563) use — applied here at the policy
+/// boundary, not as a shared global helper, because other address checks in this
+/// crate deliberately want the opposite (see the dev-mode loopback gate in
+/// `server.rs`, where a mapped address failing `is_loopback()` keeps the privileged
+/// path disabled).
 fn is_private_ip(ip: &IpAddr) -> bool {
     let ip = match ip {
         IpAddr::V6(ipv6) => ipv6.to_ipv4_mapped().map_or(*ip, IpAddr::V4),
@@ -1436,6 +1440,40 @@ mod tests {
                 "{addr} ({class}) must remain allowed by the IPv6 arm"
             );
         }
+    }
+
+    /// The boundary of the equivalence property above: only `::ffff:0:0/96` is
+    /// unmapped. The other IPv4-in-IPv6 embeddings are left on the IPv6 arm and are
+    /// allowed both before and after this fix — pinned so that boundary is explicit
+    /// rather than inferred from the absence of a test, and so a later "simplification"
+    /// to `to_ipv4()` (which would fold the first of these into the IPv4 rules, and
+    /// `::1` along with it) fails here.
+    #[test]
+    fn non_strict_ipv4_embeddings_are_not_unmapped() {
+        use std::net::{IpAddr, Ipv6Addr};
+
+        for (addr, class) in [
+            (
+                "::7f00:1",
+                "IPv4-compatible ::127.0.0.1, deprecated by RFC 4291",
+            ),
+            ("::ffff:0:7f00:1", "IPv4-translated ::ffff:0:0:0/96"),
+            ("64:ff9b::7f00:1", "NAT64 well-known prefix, RFC 6052"),
+        ] {
+            let v6: Ipv6Addr = addr.parse().expect("test address");
+            assert!(
+                v6.to_ipv4_mapped().is_none(),
+                "{addr} ({class}) must not be treated as strictly IPv4-mapped"
+            );
+            assert!(
+                !is_private_ip(&IpAddr::V6(v6)),
+                "{addr} ({class}) is allowed today; this fix neither blocks nor unblocks it"
+            );
+        }
+
+        // And the same at the call site, so this is a statement about what the
+        // production validator does, not only about the classifier.
+        assert!(validate_photo_url("https://[::127.0.0.1]/p.jpg", 0).is_ok());
     }
 
     /// The classifier is only a security control if `validate_photo_url` actually


### PR DESCRIPTION
Closes #2564.

The reported bypass is real, but it does not work the way the issue describes — and the fix the issue proposes would not have closed it.

## Pre-fix reproduction, measured on `4be2ec1a`

The regression matrix was written first and run against unfixed main:

```
mapped_v4_classifies_identically_to_native_v4 ........... FAILED
    10.0.0.1 (RFC1918 10/8) classified differently as native v4 (true)
    vs ::ffff:10.0.0.1 (false)
mapped_v4_verdicts_match_the_documented_policy .......... FAILED
photo_url_applies_the_blocklist_to_bracketed_ipv6_hosts . FAILED
genuine_ipv6_policy_is_unchanged ........................ ok    (control)
photo_url_still_allows_public_hosts_in_either_repr ...... ok    (control)
```

Two controls passing is the point: the suite is not failing indiscriminately.

## The actual mechanism — two independent layers

**Layer 1, the call site: `is_private_ip` was never reached for *any* IPv6 host.**

`validate_photo_url` did `host.parse::<IpAddr>()` on `Url::host_str()`. `host_str()` returns IPv6 hosts *bracketed*, and brackets are not part of an `IpAddr`, so the parse always failed:

| URL | `host_str()` | `parse::<IpAddr>()` | before |
|---|---|---|---|
| `https://[::ffff:127.0.0.1]/` | `[::ffff:7f00:1]` | `Err` | allowed |
| `https://[::ffff:169.254.169.254]/` | `[::ffff:a9fe:a9fe]` | `Err` | allowed |
| `https://[::1]/` | `[::1]` | `Err` | allowed |
| `https://[fe80::1]/` | `[fe80::1]` | `Err` | allowed |
| `https://127.0.0.1/` | `127.0.0.1` | `Ok` | rejected |

So **genuine IPv6 was bypassable too**, not only mapped IPv4 — the `IpAddr::V6` arm of `is_private_ip` was effectively dead at this call site. `test_is_private_ip_ipv6` passed throughout because it calls the classifier directly.

**Layer 2, the classifier: no IPv4-mapped normalization.** Even once reached, `::ffff:a.b.c.d` took the IPv6 arm and matched none of loopback / unspecified / ULA / link-local. `Ipv6Addr::is_loopback()` is true only for `::1`, never for a mapped `127/8` address.

**Both were required.** Unmapping alone is unreachable; fixing the call site alone routes mapped IPv4 into an arm that still answers "not private".

## Exact current `is_private_ip` policy (unchanged by this PR)

IPv4 blocks: RFC1918, loopback, link-local, broadcast, documentation (TEST-NET-1/2/3), unspecified, CGNAT `100.64/10`, IETF protocol assignments `192.0.0/24`. It does **not** block multicast, `240/4`, or benchmarking `198.18/15`.

IPv6 blocks: loopback, unspecified, ULA `fc00::/7`, link-local `fe80::/10`. It does **not** block IPv6 documentation `2001:db8::/32`, multicast, or deprecated site-local.

Both lists are pinned by the new tests, including the not-blocked entries, so this fix cannot be mistaken for licence to widen either arm.

## Fix

```rust
// call site — take the parsed address, don't re-parse the bracketed string
let literal_ip = match url.host() {
    Some(Host::Ipv4(v4)) => Some(IpAddr::V4(v4)),
    Some(Host::Ipv6(v6)) => Some(IpAddr::V6(v6)),
    Some(Host::Domain(_)) | None => None,
};

// classifier — strict mapped normalization, then the existing IPv4 rules
let ip = match ip {
    IpAddr::V6(ipv6) => ipv6.to_ipv4_mapped().map_or(*ip, IpAddr::V4),
    already_v4 => *already_v4,
};
```

`to_ipv4_mapped()` and **not** `to_ipv4()`: the latter also converts deprecated IPv4-*compatible* addresses (`::a.b.c.d`) and would rewrite `::1` to `0.0.0.1`, judging v6 loopback by the IPv4 rules. Only `::ffff:0:0/96` is unmapped. Confirmed available on the pinned toolchain (1.95.0; stable since 1.63).

Strict therefore also means **narrow**, and that boundary is now pinned by `non_strict_ipv4_embeddings_are_not_unmapped`: IPv4-*compatible* `::a.b.c.d`, IPv4-*translated* `::ffff:0:0:0/96` and the NAT64 well-known prefix `64:ff9b::/96` stay on the IPv6 arm and remain **allowed** — measured identical before (`4be2ec1a`) and after. Not a regression and not in scope to change here; pinned so the limit of the equivalence property is read off a test rather than inferred from the absence of one, and so a later swap to `to_ipv4()` fails loudly.

## Representation-equivalence matrix

Invariant pinned as data, so the test cannot drift from the classifier: for every representative `x`, `is_private_ip(V4(x)) == is_private_ip(V6(x.to_ipv6_mapped()))`.

| class | address | native | mapped |
|---|---|---|---|
| RFC1918 | `10.0.0.1`, `172.16.0.1`, `192.168.1.1` | blocked | **blocked** |
| loopback | `127.0.0.1` | blocked | **blocked** |
| link-local (metadata) | `169.254.169.254` | blocked | **blocked** |
| broadcast | `255.255.255.255` | blocked | **blocked** |
| documentation | `192.0.2.1`, `198.51.100.1`, `203.0.113.1` | blocked | **blocked** |
| unspecified | `0.0.0.0` | blocked | **blocked** |
| CGNAT | `100.64.0.1`, `100.127.255.255` | blocked | **blocked** |
| IETF proto | `192.0.0.1` | blocked | **blocked** |
| public control | `8.8.8.8`, `1.1.1.1` | allowed | **allowed** |
| range boundaries | `172.15.255.255`, `172.32.0.0`, `100.63.255.255`, `100.128.0.0`, `192.0.1.1` | allowed | **allowed** |

Genuine IPv6 unchanged: `::1`, `::`, `fc00::1`, `fd00::1`, `fe80::1`, `febf::1` blocked; `2607:f8b0:...`, `2606:4700::1111`, `2001:db8::1`, `fec0::1` allowed.

## Production call graph and severity

`is_private_ip` has exactly one production caller, `validate_photo_url`, reached from listing create (`validate_listing_input`) and update (`validate_listing_update`). The value is a user-supplied photo URL string.

**No server-side fetch sink exists.** Independently re-verified: the only outbound HTTP client in `icn-gateway` is `fcm_client.rs` (Firebase push, `reqwest`), which does not consume photo URLs. `photos` is stored by `listings_mgr.rs` and returned in responses; nothing fetches it.

**Severity: a bypassable defense-in-depth address-validation control, with no demonstrated server-side SSRF sink.** Not a live SSRF. It still matters — the control is documented as SSRF prevention so future code may rely on it, the bypass trivially covers cloud instance-metadata addresses, and stored URLs are served to clients that resolve them on their own networks.

## Scope: literal IPs only, not DNS SSRF

This control sees only literal IP hosts. A hostname resolving to a private address, a redirect into one, DNS rebinding after validation, and alternate schemes are all outside it — before and after this PR. Nothing here should be read as addressing them. The `is_private_ip` doc comment now says so explicitly.

## Parser representation audit

`url` 2.5.8 canonicalises the host before it reaches the check: `[::ffff:127.0.0.1]` and `[::ffff:7f00:1]` both parse to the same `Ipv6Addr`. The fix therefore operates on the parsed value and needs no per-spelling branches; both spellings are pinned in the URL-level test.

## Same-class audit, `icn-gateway`

| site | verdict |
|---|---|
| `listings.rs::is_private_ip` | **SAME BUG** — fixed |
| `listings.rs::validate_photo_url` host parse | **SAME BUG** (call site) — fixed |
| `server.rs:198,:211` `dev_opt_in && bind_addr.ip().is_loopback()` | **FAIL-CLOSED — do NOT normalize.** A mapped loopback yields `is_loopback() == false`, so the privileged dev path stays *disabled*. Normalizing would make it more permissive. Untouched, verified byte-identical. |
| `sessions.rs:76-88` trusted-proxy check (`peer_ip == "127.0.0.1" \|\| "::1"`, `TRUSTED_PROXY_IPS`) | **FAIL-CLOSED** — a mapped peer fails the comparison and X-Forwarded-* is *not* trusted. Normalizing would widen header trust. Untouched. |
| `auth.rs`/`listings.rs::get_client_ip` → `IpRateLimiter` + audit log | **FOLLOW-UP, not this issue.** Native and mapped forms would key different buckets, but that is dominated by a larger pre-existing gap: both helpers honour `X-Forwarded-For` unconditionally with no trusted-proxy guard, so the limiter key and the audit-logged client IP are already caller-chosen. `sessions.rs` implements exactly such a guard for a different purpose, which suggests oversight rather than design. Reported, deliberately not touched here — it is a different control with a different fix. |

## No shared helper

Two one-line uses across two crates do not justify an address abstraction, and `server.rs` above is positive evidence *against* a global "normalize every IP" primitive: normalization is correct only where the policy is about the embedded IPv4 address, and wrong where a mapped address failing a native check is the fail-closed outcome. Each policy boundary keeps its own local `to_ipv4_mapped()`.

## Red proof

Bypassed the mapped normalization (`IpAddr::V6(_) => *ip`), keeping the call-site fix. The three equivalence tests failed — first failure `::ffff:169.254.169.254` returning to allowed — while both controls and all 17 pre-existing listings tests stayed green. Restored exactly; file SHA-256 matches the pre-mutation snapshot, no residue.

## Tests and gates

`cargo fmt --all --check` **0** · `cargo test -p icn-gateway` **0** (719 lib + all integration suites, 0 failed) · `cargo test -p icn-gateway --features sled-storage` **0** (724 lib, 0 failed) · `cargo clippy --workspace --all-targets --features "hsm,post-quantum" -- -D warnings` **0**, zero warnings.

Repository gates, all exit 0: `doc_control_check.py`, `compliance_linter.py`, `readiness_overclaim_linter.py`, `check-meaning-firewall.sh`. The pre-commit/pre-push sanitize gate initially blocked three RFC 6598 CGNAT test vectors under its Tailscale-IP rule; marked `sanitize-ok` with justification rather than dropping the CGNAT coverage.

## Diff

One file, +246/−3 — **48 production lines (11 executable, the rest doc comments)** and 198 test lines. No API surface change, no new metrics, no error-message change: mapped and native representations now produce the identical `BadRequest` for the identical reason.

Discovery context, non-closing: #2557, #2563, `4be2ec1a`.

