### PR TITLE
fix(gateway): trust forwarded client IP only from trusted proxies

### DIFF
--- a/deploy/appliance/lan/nginx-icn-rehearsal-http.conf.in
+++ b/deploy/appliance/lan/nginx-icn-rehearsal-http.conf.in
@@ -35,6 +35,12 @@ server {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
+        # The gateway trusts loopback to assert forwarding metadata, so this proxy MUST
+        # assert it. $proxy_add_x_forwarded_for appends the address nginx actually saw;
+        # the gateway reads the rightmost untrusted hop, discarding anything the caller
+        # prepended. Omitting this line forwards a caller-supplied header verbatim and
+        # launders it through the trust gate (#2567).
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
     # Static: rehearsal landing + member shell + fixture pack.

--- a/deploy/appliance/lan/nginx-icn-rehearsal-https.conf.in
+++ b/deploy/appliance/lan/nginx-icn-rehearsal-https.conf.in
@@ -44,6 +44,12 @@ server {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
+        # The gateway trusts loopback to assert forwarding metadata, so this proxy MUST
+        # assert it. $proxy_add_x_forwarded_for appends the address nginx actually saw;
+        # the gateway reads the rightmost untrusted hop, discarding anything the caller
+        # prepended. Omitting this line forwards a caller-supplied header verbatim and
+        # launders it through the trust gate (#2567).
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
     # Static: rehearsal landing + member shell + fixture pack.

--- a/deploy/config/nginx.conf
+++ b/deploy/config/nginx.conf
@@ -10,6 +10,15 @@ server {
     }
 
     # Proxy API requests to icnd
+    #
+    # This asserts X-Forwarded-For correctly ($proxy_add_x_forwarded_for appends the address
+    # nginx actually saw), but the gateway only reads it from a trusted peer. Here the peer is
+    # this container's address on the compose network, not loopback, so it is untrusted by
+    # default: since #2567 X-Forwarded-For is ignored and every client behind this proxy shares
+    # one rate-limit bucket keyed on the container address. That is fail-closed, not fail-open.
+    # To restore per-client attribution, set TRUSTED_PROXY_IPS on the icnd service to this
+    # container's address (exact IPs, no CIDR). Note a non-empty value replaces the loopback
+    # default rather than extending it.
     location /v1 {
         proxy_pass http://icnd:8080;
         proxy_http_version 1.1;

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -11,10 +11,20 @@ data:
   # Examples: "https://icn.example.com", "http://10.8.30.40:30080"
   gateway_base_url: "http://10.8.30.40:30080"
 
-  # Trusted proxy IPs that can set X-Forwarded-* headers (comma-separated)
-  # Only needed if GATEWAY_BASE_URL is not set and you're behind a reverse proxy
-  # Example: "10.42.0.1,10.43.0.1" (K8s cluster IPs)
-  # If not set, only localhost (127.0.0.1, ::1) is trusted
+  # Trusted proxy IPs that may assert forwarding metadata (comma-separated, exact
+  # addresses, no CIDR). Example: "10.42.0.1,10.43.0.1" (K8s cluster IPs).
+  # If not set, only localhost (127.0.0.1, ::1) is trusted.
+  #
+  # This gates BOTH the QR-login URL derivation and — since #2567 — the client IP used
+  # for rate limiting and audit attribution on unauthenticated endpoints. If you run an
+  # ingress in front of the gateway and leave this unset, that ingress is untrusted:
+  # X-Forwarded-For is ignored and every client behind it shares one rate-limit bucket
+  # keyed on the ingress address. That is fail-closed, not fail-open, but it will limit
+  # real users. Set this to the ingress address before serving traffic through a proxy.
+  #
+  # The proxy must also set X-Forwarded-For itself (nginx:
+  # `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;`). A trusted proxy that
+  # forwards the client's header verbatim launders a caller-supplied claim through the gate.
   # trusted_proxy_ips: "10.42.0.1"
   icn.toml: |
     data_dir = "/data"

--- a/icn/crates/icn-gateway/src/api/auth.rs
+++ b/icn/crates/icn-gateway/src/api/auth.rs
@@ -11,27 +11,13 @@ use crate::session_authority::SessionAuthority;
 use crate::validation;
 use icn_obs::metrics::gateway;
 
-/// Extract client IP address from request
-/// Returns IP as string, using X-Forwarded-For header if present (proxy support)
+/// Extract client IP address from request.
+///
+/// SECURITY: `X-Forwarded-For` is honoured only when the immediate transport peer is a
+/// trusted proxy; otherwise the socket peer is the client (#2567). See
+/// [`crate::client_ip`] for the trust model.
 fn get_client_ip(req: &HttpRequest) -> String {
-    // Check for X-Forwarded-For header first (reverse proxy support)
-    if let Some(forwarded) = req.headers().get("x-forwarded-for") {
-        if let Ok(forwarded_str) = forwarded.to_str() {
-            // X-Forwarded-For can contain multiple IPs (client, proxy1, proxy2...)
-            // Use the first one (actual client)
-            if let Some(client_ip) = forwarded_str.split(',').next() {
-                return client_ip.trim().to_string();
-            }
-        }
-    }
-
-    // Fall back to connection info
-    if let Some(peer_addr) = req.peer_addr() {
-        return peer_addr.ip().to_string();
-    }
-
-    // Last resort: return placeholder (should never happen)
-    "unknown".to_string()
+    crate::client_ip::client_ip_key(req)
 }
 
 /// POST /auth/challenge - Request authentication challenge

--- a/icn/crates/icn-gateway/src/api/listings.rs
+++ b/icn/crates/icn-gateway/src/api/listings.rs
@@ -27,24 +27,13 @@ use icn_identity::Did;
 // Helper Functions
 // ============================================================================
 
-/// Extract client IP address from request
-/// Returns IP as string, using X-Forwarded-For header if present (proxy support)
+/// Extract client IP address from request.
+///
+/// SECURITY: `X-Forwarded-For` is honoured only when the immediate transport peer is a
+/// trusted proxy; otherwise the socket peer is the client (#2567). See
+/// [`crate::client_ip`] for the trust model.
 fn get_client_ip(req: &HttpRequest) -> String {
-    // Check for X-Forwarded-For header first (reverse proxy support)
-    if let Some(forwarded) = req.headers().get("x-forwarded-for") {
-        if let Ok(forwarded_str) = forwarded.to_str() {
-            // X-Forwarded-For can contain multiple IPs (client, proxy1, proxy2...)
-            // Use the first one (actual client)
-            if let Some(client_ip) = forwarded_str.split(',').next() {
-                return client_ip.trim().to_string();
-            }
-        }
-    }
-
-    // Fall back to peer address
-    req.peer_addr()
-        .map(|addr| addr.ip().to_string())
-        .unwrap_or_else(|| "unknown".to_string())
+    crate::client_ip::client_ip_key(req)
 }
 
 /// Extract caller DID from JWT claims (required auth)

--- a/icn/crates/icn-gateway/src/api/sessions.rs
+++ b/icn/crates/icn-gateway/src/api/sessions.rs
@@ -44,19 +44,14 @@ const WEB_SESSION_SCOPE_CEILING: &[&str] = &[
     "governance:write",
 ];
 
-/// Extract client IP address from request (for rate limiting)
+/// Extract client IP address from request (for rate limiting).
+///
+/// SECURITY: `X-Forwarded-For` is honoured only when the immediate transport peer is a
+/// trusted proxy; otherwise the socket peer is the client (#2567). This is the same
+/// allowlist [`get_gateway_url`] gates `X-Forwarded-*` on, via
+/// [`crate::client_ip::is_trusted_proxy`].
 fn get_client_ip(req: &HttpRequest) -> String {
-    if let Some(forwarded) = req.headers().get("x-forwarded-for") {
-        if let Ok(forwarded_str) = forwarded.to_str() {
-            if let Some(client_ip) = forwarded_str.split(',').next() {
-                return client_ip.trim().to_string();
-            }
-        }
-    }
-    if let Some(peer_addr) = req.peer_addr() {
-        return peer_addr.ip().to_string();
-    }
-    "unknown".to_string()
+    crate::client_ip::client_ip_key(req)
 }
 
 /// Get gateway base URL from environment or request headers
@@ -72,21 +67,12 @@ pub(crate) fn get_gateway_url(req: &HttpRequest) -> String {
         return url;
     }
 
-    // Check if the request came from a trusted proxy
-    let is_trusted_proxy = if let Some(peer_addr) = req.peer_addr() {
-        let peer_ip = peer_addr.ip().to_string();
-
-        // Get trusted proxy list from environment (comma-separated IPs)
-        // Example: TRUSTED_PROXY_IPS="127.0.0.1,::1,10.0.0.1"
-        if let Ok(trusted_ips) = std::env::var("TRUSTED_PROXY_IPS") {
-            trusted_ips.split(',').any(|ip| ip.trim() == peer_ip)
-        } else {
-            // If TRUSTED_PROXY_IPS not set, only trust localhost
-            peer_ip == "127.0.0.1" || peer_ip == "::1"
-        }
-    } else {
-        false
-    };
+    // Check if the request came from a trusted proxy.
+    // One trust model for the whole gateway — see `crate::client_ip` for the semantics of
+    // TRUSTED_PROXY_IPS (exact addresses, comma-separated, loopback by default).
+    let is_trusted_proxy = req
+        .peer_addr()
+        .is_some_and(|peer_addr| crate::client_ip::is_trusted_proxy(peer_addr.ip()));
 
     // Only trust X-Forwarded-* headers if from a trusted proxy
     if is_trusted_proxy {

--- a/icn/crates/icn-gateway/src/client_ip.rs
+++ b/icn/crates/icn-gateway/src/client_ip.rs
@@ -1,0 +1,238 @@
+//! Canonical client-IP derivation for the gateway (#2567).
+//!
+//! # Trust model
+//!
+//! Forwarded client identity is an **untrusted request claim** unless the immediate transport
+//! peer is explicitly trusted to assert forwarding metadata. If the immediate peer is not
+//! trusted, the socket peer IP is the client IP.
+//!
+//! This is the same allowlist `api::sessions::get_gateway_url` uses to gate `X-Forwarded-*`
+//! for QR-login URL derivation; both read it through [`is_trusted_proxy`] so the gateway has
+//! exactly one trusted-proxy model.
+//!
+//! # Configuration
+//!
+//! `TRUSTED_PROXY_IPS` is a comma-separated list of **exact** proxy addresses (no CIDR):
+//!
+//! ```text
+//! TRUSTED_PROXY_IPS="10.42.0.1,::1"
+//! ```
+//!
+//! - unset — loopback only (`127.0.0.1`, `::1`)
+//! - set and empty — trust nobody; every request is keyed on its socket peer
+//! - unparseable entries are ignored (they cannot match a kernel-supplied peer address)
+//!
+//! Addresses are compared as parsed [`IpAddr`]s with IPv4-mapped IPv6 unwrapped, so a peer
+//! arriving as `::ffff:10.42.0.1` on a dual-stack listener matches a `10.42.0.1` entry. Both
+//! sides of the comparison come from the same normalization, so this narrows nothing: the
+//! mapped form denotes the same host. It also keeps the rate-limit key from splitting across
+//! two spellings of one address, the class fixed in #2557 / #2563.
+//!
+//! # Deployment note
+//!
+//! A trusted proxy must *overwrite or append to* `X-Forwarded-For` itself. A proxy that
+//! forwards the client's header verbatim launders the claim through the trust gate: the
+//! gateway cannot tell a proxy-asserted hop from a caller-supplied one.
+
+use std::net::IpAddr;
+
+use actix_web::HttpRequest;
+
+/// Header carrying the forwarding chain. `X-Real-IP` and RFC 7239 `Forwarded` are
+/// deliberately not consulted — neither is set by any proxy config in this repository, and
+/// reading them would widen the attacker-controlled input surface for no deployment benefit.
+const FORWARDED_FOR: &str = "x-forwarded-for";
+
+/// Environment variable holding the trusted-proxy allowlist.
+const TRUSTED_PROXY_ENV: &str = "TRUSTED_PROXY_IPS";
+
+/// Key used when a request has no transport peer at all (synthetic/test requests).
+const UNKNOWN_CLIENT: &str = "unknown";
+
+/// Unwrap IPv4-mapped IPv6 (`::ffff:a.b.c.d`) to its IPv4 form.
+///
+/// Uses `to_ipv4_mapped`, not `to_ipv4`: the latter also converts IPv4-*compatible* addresses
+/// (`::a.b.c.d`), which are deprecated and would let two distinct notions of an address
+/// collapse together.
+fn canonicalize(ip: IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(IpAddr::V6(v6), IpAddr::V4),
+        v4 => v4,
+    }
+}
+
+/// Parse the configured trusted-proxy allowlist.
+fn trusted_proxies() -> Vec<IpAddr> {
+    let Ok(configured) = std::env::var(TRUSTED_PROXY_ENV) else {
+        // Default: only a proxy on this host may assert forwarding metadata.
+        return vec![
+            IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+        ];
+    };
+
+    configured
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .filter_map(|entry| match entry.parse::<IpAddr>() {
+            Ok(ip) => Some(canonicalize(ip)),
+            Err(_) => {
+                tracing::debug!(
+                    entry = %entry,
+                    "Ignoring unparseable {TRUSTED_PROXY_ENV} entry; it cannot match a peer address"
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+/// Whether `ip` is allowed to assert forwarding metadata.
+pub(crate) fn is_trusted_proxy(ip: IpAddr) -> bool {
+    let ip = canonicalize(ip);
+    trusted_proxies().contains(&ip)
+}
+
+/// Resolve the client IP for `req`, honouring forwarded metadata only from a trusted peer.
+///
+/// Returns `None` only when the request has no transport peer.
+pub(crate) fn client_ip(req: &HttpRequest) -> Option<IpAddr> {
+    let peer = canonicalize(req.peer_addr()?.ip());
+    let trusted = trusted_proxies();
+
+    if !trusted.contains(&peer) {
+        if req.headers().contains_key(FORWARDED_FOR) {
+            // Not a warning: behind an unconfigured proxy this is every request. The
+            // equivalent misconfiguration is surfaced loudly on the QR-login path by
+            // `api::sessions::get_gateway_url`.
+            tracing::debug!(
+                peer = %peer,
+                "Ignoring {FORWARDED_FOR} from an untrusted peer; keying on the socket address. \
+                 Set {TRUSTED_PROXY_ENV} if this peer is a reverse proxy."
+            );
+        }
+        return Some(peer);
+    }
+
+    let Some(chain) = req
+        .headers()
+        .get(FORWARDED_FOR)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return Some(peer);
+    };
+
+    let hops: Vec<IpAddr> = chain
+        .split(',')
+        .map(str::trim)
+        .filter_map(|hop| hop.parse::<IpAddr>().ok())
+        .map(canonicalize)
+        .collect();
+
+    // Walk right to left, skipping hops that are themselves trusted proxies: the first
+    // element a trusted proxy did not vouch for is the client. Anything the caller prepended
+    // sits to the left of what the proxy appended, so it can never be reached first.
+    hops.iter()
+        .rev()
+        .find(|hop| !trusted.contains(hop))
+        .copied()
+        // Every hop is a trusted proxy, so the furthest-upstream claim is as far as the
+        // trusted chain reaches. An empty/unparseable chain falls back to the socket peer.
+        .or_else(|| hops.first().copied())
+        .or(Some(peer))
+}
+
+/// Client IP rendered as a rate-limit / audit key.
+///
+/// The value is a canonicalized [`IpAddr`], so one host cannot occupy two buckets by
+/// arriving under two spellings.
+pub(crate) fn client_ip_key(req: &HttpRequest) -> String {
+    client_ip(req).map_or_else(|| UNKNOWN_CLIENT.to_string(), |ip| ip.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::test::TestRequest;
+
+    /// `TRUSTED_PROXY_IPS` is process-global; these tests read the default (unset) policy
+    /// only, so they never mutate it and cannot race the rest of the suite.
+    fn request(peer: &str, forwarded_for: Option<&str>) -> HttpRequest {
+        let mut req = TestRequest::default().peer_addr(peer.parse().expect("valid socket addr"));
+        if let Some(value) = forwarded_for {
+            req = req.insert_header((FORWARDED_FOR, value));
+        }
+        req.to_http_request()
+    }
+
+    #[test]
+    fn untrusted_peer_keeps_its_socket_address() {
+        let req = request("198.51.100.42:443", Some("203.0.113.7"));
+        assert_eq!(client_ip_key(&req), "198.51.100.42");
+    }
+
+    #[test]
+    fn untrusted_peer_cannot_hide_behind_an_appended_chain() {
+        let req = request("198.51.100.42:443", Some("203.0.113.7, 198.51.100.42"));
+        assert_eq!(client_ip_key(&req), "198.51.100.42");
+    }
+
+    #[test]
+    fn trusted_peer_asserts_the_client() {
+        let req = request("127.0.0.1:443", Some("203.0.113.7"));
+        assert_eq!(client_ip_key(&req), "203.0.113.7");
+    }
+
+    #[test]
+    fn trusted_peer_ignores_a_prepended_claim() {
+        // nginx `$proxy_add_x_forwarded_for` appends the address it saw; the caller supplied
+        // everything to its left.
+        let req = request("127.0.0.1:443", Some("203.0.113.7, 198.51.100.42"));
+        assert_eq!(client_ip_key(&req), "198.51.100.42");
+    }
+
+    #[test]
+    fn trusted_hops_are_skipped_during_the_walk() {
+        // Two loopback proxies in front; the client is upstream of both.
+        let req = request("127.0.0.1:443", Some("198.51.100.42, 127.0.0.1, ::1"));
+        assert_eq!(client_ip_key(&req), "198.51.100.42");
+    }
+
+    #[test]
+    fn chain_of_only_trusted_hops_yields_the_furthest_upstream() {
+        let req = request("127.0.0.1:443", Some("127.0.0.1, ::1"));
+        assert_eq!(client_ip_key(&req), "127.0.0.1");
+    }
+
+    #[test]
+    fn unparseable_chain_falls_back_to_the_peer() {
+        let req = request("127.0.0.1:443", Some("not-an-ip"));
+        assert_eq!(client_ip_key(&req), "127.0.0.1");
+    }
+
+    #[test]
+    fn absent_header_uses_the_peer() {
+        let req = request("198.51.100.42:443", None);
+        assert_eq!(client_ip_key(&req), "198.51.100.42");
+    }
+
+    #[test]
+    fn mapped_peer_matches_the_dotted_default_and_does_not_split_keys() {
+        // A dual-stack listener reports loopback as `::ffff:127.0.0.1`. It must still be
+        // recognised as the trusted default, and must key identically to `127.0.0.1`.
+        let mapped = request("[::ffff:127.0.0.1]:443", Some("203.0.113.7"));
+        assert_eq!(client_ip_key(&mapped), "203.0.113.7");
+
+        let mapped_client = request("127.0.0.1:443", Some("::ffff:203.0.113.7"));
+        assert_eq!(client_ip_key(&mapped_client), "203.0.113.7");
+    }
+
+    #[test]
+    fn no_transport_peer_yields_unknown() {
+        let req = TestRequest::default()
+            .insert_header((FORWARDED_FOR, "203.0.113.7"))
+            .to_http_request();
+        assert_eq!(client_ip_key(&req), UNKNOWN_CLIENT);
+    }
+}

--- a/icn/crates/icn-gateway/src/client_ip.rs
+++ b/icn/crates/icn-gateway/src/client_ip.rs
@@ -22,6 +22,12 @@
 //! - set and empty — trust nobody; every request is keyed on its socket peer
 //! - unparseable entries are ignored (they cannot match a kernel-supplied peer address)
 //!
+//! A non-empty value **replaces** the loopback default rather than extending it. An operator
+//! adding an upstream ingress must therefore list loopback explicitly if a proxy on this host
+//! also fronts the gateway — the appliance nginx reaches it over `127.0.0.1`. A value whose
+//! entries all fail to parse (a CIDR, say) leaves the list empty, which trusts nobody: that
+//! is fail-closed, but it silently collapses every client onto the proxy address.
+//!
 //! Addresses are compared as parsed [`IpAddr`]s with IPv4-mapped IPv6 unwrapped, so a peer
 //! arriving as `::ffff:10.42.0.1` on a dual-stack listener matches a `10.42.0.1` entry. Both
 //! sides of the comparison come from the same normalization, so this narrows nothing: the
@@ -115,16 +121,17 @@ pub(crate) fn client_ip(req: &HttpRequest) -> Option<IpAddr> {
         return Some(peer);
     }
 
-    let Some(chain) = req
+    // RFC 7230 §3.2.2: repeated field-lines are equivalent to one field-line whose value is
+    // the values joined by comma, in order received. Reading only the first header would let
+    // a caller-supplied `X-Forwarded-For` outrank one a trusted proxy *appended* as a
+    // separate header, putting the attacker's claim to the right of the proxy's assertion.
+    // An absent header, a non-UTF-8 value, and an unparseable chain all leave `hops` empty
+    // and fall through to the socket peer below.
+    let hops: Vec<IpAddr> = req
         .headers()
-        .get(FORWARDED_FOR)
-        .and_then(|value| value.to_str().ok())
-    else {
-        return Some(peer);
-    };
-
-    let hops: Vec<IpAddr> = chain
-        .split(',')
+        .get_all(FORWARDED_FOR)
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
         .map(str::trim)
         .filter_map(|hop| hop.parse::<IpAddr>().ok())
         .map(canonicalize)
@@ -203,6 +210,20 @@ mod tests {
     fn chain_of_only_trusted_hops_yields_the_furthest_upstream() {
         let req = request("127.0.0.1:443", Some("127.0.0.1, ::1"));
         assert_eq!(client_ip_key(&req), "127.0.0.1");
+    }
+
+    #[test]
+    fn repeated_headers_are_one_chain_in_order() {
+        // A proxy that appends its assertion as a *separate* header must still outrank the
+        // caller's, so the two field-lines are read as one comma-joined chain (RFC 7230
+        // §3.2.2). Reading only the first header would return the caller-supplied
+        // 203.0.113.7 here.
+        let req = TestRequest::default()
+            .peer_addr("127.0.0.1:443".parse().expect("valid socket addr"))
+            .append_header((FORWARDED_FOR, "203.0.113.7"))
+            .append_header((FORWARDED_FOR, "198.51.100.42"))
+            .to_http_request();
+        assert_eq!(client_ip_key(&req), "198.51.100.42");
     }
 
     #[test]

--- a/icn/crates/icn-gateway/src/lib.rs
+++ b/icn/crates/icn-gateway/src/lib.rs
@@ -25,6 +25,7 @@ pub mod api;
 pub mod audit;
 pub mod auth;
 pub(crate) mod authority;
+pub(crate) mod client_ip;
 pub mod commons_mgr;
 pub mod commons_store;
 pub mod community_mgr;

--- a/icn/crates/icn-gateway/tests/forwarded_client_ip_trust.rs
+++ b/icn/crates/icn-gateway/tests/forwarded_client_ip_trust.rs
@@ -1,0 +1,326 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Forwarded client identity must be gated on the immediate transport peer (#2567).
+//!
+//! The invariant under test:
+//!
+//! > Forwarded client identity is an untrusted request claim unless the immediate transport
+//! > peer is explicitly trusted to assert forwarding metadata. If the immediate peer is not
+//! > trusted, the socket peer IP is the client IP.
+//!
+//! These tests enter through the real route (`POST /auth/challenge`) rather than calling the
+//! extraction helper directly, because the property at stake is which value reaches
+//! `IpRateLimiter`, not what a comma parser returns.
+//!
+//! Rate-limit identity is observed behaviourally: drain one bucket, then check whether a
+//! caller-supplied header can mint a second one from the same socket.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use actix_http::Request;
+use actix_web::http::StatusCode;
+use actix_web::{test, web, App};
+use icn_gateway::api;
+use icn_gateway::auth::AuthManager;
+use icn_gateway::rate_limit::IpRateLimiter;
+use icn_gateway::session_authority::SessionAuthority;
+use icn_identity::IdentityBundle;
+
+/// A routable, non-loopback socket peer: NOT a trusted proxy under the default policy.
+const UNTRUSTED_PEER: &str = "198.51.100.42:54321";
+
+/// Loopback is trusted to assert forwarding metadata when `TRUSTED_PROXY_IPS` is unset,
+/// matching the existing `get_gateway_url` gate in `api/sessions.rs`.
+const TRUSTED_PEER: &str = "127.0.0.1:54321";
+
+/// `IpRateLimiter::new_for_auth` has capacity 20 and refills 2 tokens/second. An in-process
+/// drain completes in milliseconds, so this bound is generous but finite.
+const MAX_DRAIN: usize = 200;
+
+fn challenge_request(peer: &str, did: &str, forwarded_for: Option<&str>) -> Request {
+    let peer_addr: SocketAddr = peer.parse().expect("test setup: valid socket address");
+    let mut req = test::TestRequest::post()
+        .uri("/auth/challenge")
+        .peer_addr(peer_addr)
+        .set_json(serde_json::json!({ "did": did }));
+
+    if let Some(value) = forwarded_for {
+        req = req.insert_header(("x-forwarded-for", value));
+    }
+
+    req.to_request()
+}
+
+fn test_app_data() -> (Arc<SessionAuthority>, Arc<IpRateLimiter>) {
+    let auth = Arc::new(AuthManager::new(b"test_secret".to_vec()));
+    (
+        Arc::new(SessionAuthority::evaluator(auth)),
+        Arc::new(IpRateLimiter::new_for_auth()),
+    )
+}
+
+/// Build the app, returning it alongside a freshly generated DID string.
+macro_rules! challenge_app {
+    () => {{
+        let (authority, ip_limiter) = test_app_data();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(authority))
+                .app_data(web::Data::new(ip_limiter))
+                .service(api::auth::challenge),
+        )
+        .await;
+        let bundle = IdentityBundle::generate().expect("test setup: identity generation");
+        (app, bundle.did().to_string())
+    }};
+}
+
+/// Send requests until the limiter rejects one. Returns how many it took.
+///
+/// This is the control half of every test below: if the bucket never drains, a later
+/// "still limited" assertion would pass for the wrong reason.
+macro_rules! drain_bucket {
+    ($app:expr, $peer:expr, $did:expr, $xff:expr) => {{
+        let mut attempts = 0usize;
+        let mut drained = false;
+        for _ in 0..MAX_DRAIN {
+            attempts += 1;
+            let resp = test::call_service(&$app, challenge_request($peer, &$did, $xff)).await;
+            if resp.status() == StatusCode::TOO_MANY_REQUESTS {
+                drained = true;
+                break;
+            }
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "control: unexpected status while draining the bucket"
+            );
+        }
+        assert!(
+            drained,
+            "control failed: the limiter never rejected a request from {} after {} attempts, \
+             so a later 'still limited' assertion would be vacuous",
+            $peer, MAX_DRAIN
+        );
+        attempts
+    }};
+}
+
+/// An untrusted socket peer cannot relocate its own rate-limit identity with a header.
+#[actix_web::test]
+async fn untrusted_peer_cannot_mint_buckets_with_forwarded_for() {
+    let (app, did) = challenge_app!();
+
+    drain_bucket!(app, UNTRUSTED_PEER, did, None);
+
+    // Same socket, a novel forwarded claim per request.
+    for n in 1..=5u8 {
+        let spoofed = format!("203.0.113.{n}");
+        let resp = test::call_service(
+            &app,
+            challenge_request(UNTRUSTED_PEER, &did, Some(&spoofed)),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "peer {UNTRUSTED_PEER} is not a trusted proxy, so `X-Forwarded-For: {spoofed}` \
+             must not mint a fresh limiter bucket"
+        );
+    }
+}
+
+/// The chain shape produced by the repository's own nginx config must not move the key either.
+///
+/// `deploy/config/nginx.conf` sets `X-Forwarded-For $proxy_add_x_forwarded_for`, which
+/// *appends* the peer address to whatever the client sent. A client that sends
+/// `X-Forwarded-For: 203.0.113.7` causes the upstream to receive
+/// `203.0.113.7, <real-peer>` — so the leftmost element is caller-controlled end to end.
+#[actix_web::test]
+async fn untrusted_peer_cannot_mint_buckets_with_appended_chain() {
+    let (app, did) = challenge_app!();
+
+    drain_bucket!(app, UNTRUSTED_PEER, did, None);
+
+    for n in 1..=5u8 {
+        let chain = format!("203.0.113.{n}, 198.51.100.42");
+        let resp =
+            test::call_service(&app, challenge_request(UNTRUSTED_PEER, &did, Some(&chain))).await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "peer {UNTRUSTED_PEER} is not a trusted proxy, so the nginx-shaped chain \
+             `{chain}` must not mint a fresh limiter bucket"
+        );
+    }
+}
+
+/// From a *trusted* peer, the caller-prepended element must not displace the real client.
+///
+/// This is the nginx case with the proxy actually in front: the socket peer is the proxy, the
+/// chain is `<caller claim>, <address nginx saw>`. Only the latter is proxy-asserted, so it —
+/// not the prepended claim — is the client identity.
+#[actix_web::test]
+async fn trusted_peer_ignores_caller_prepended_chain_element() {
+    let (app, did) = challenge_app!();
+
+    // Establish the bucket belonging to the address the proxy actually observed.
+    drain_bucket!(app, TRUSTED_PEER, did, Some("198.51.100.42"));
+
+    for n in 1..=5u8 {
+        let chain = format!("203.0.113.{n}, 198.51.100.42");
+        let resp =
+            test::call_service(&app, challenge_request(TRUSTED_PEER, &did, Some(&chain))).await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "the proxy asserted 198.51.100.42; the caller-prepended `203.0.113.{n}` in \
+             `{chain}` must not mint a fresh limiter bucket"
+        );
+    }
+}
+
+/// Audit attribution must not be mintable either.
+///
+/// `api/auth.rs` derives one `client_ip` and feeds it to both `IpRateLimiter` and
+/// `AuditLogger`. This captures the `auth_attempt` audit event and asserts the recorded
+/// address is the one the transport establishes, not the one the caller asked for.
+mod audit_attribution {
+    use super::*;
+    use std::sync::Mutex;
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::Layer;
+
+    #[derive(Default)]
+    struct Fields {
+        event_type: Option<String>,
+        ip: Option<String>,
+    }
+
+    impl Visit for Fields {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            match field.name() {
+                "event_type" => self.event_type = Some(value.to_string()),
+                "ip" => self.ip = Some(value.to_string()),
+                _ => {}
+            }
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            let rendered = format!("{value:?}");
+            self.record_str(field, rendered.trim_matches('"'));
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedAuthIps(Arc<Mutex<Vec<String>>>);
+
+    impl<S: tracing::Subscriber> Layer<S> for CapturedAuthIps {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let mut fields = Fields::default();
+            event.record(&mut fields);
+            if fields.event_type.as_deref() == Some("auth_attempt") {
+                if let Some(ip) = fields.ip {
+                    self.0.lock().expect("capture mutex").push(ip);
+                }
+            }
+        }
+    }
+
+    /// Drive one failing `/auth/verify` and return the audited client IP.
+    async fn audited_ip_for(peer: &str, forwarded_for: Option<&str>) -> String {
+        let captured = CapturedAuthIps::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        // Thread-local: `#[actix_web::test]` drives the handler on this thread, and other
+        // tests in this binary are unaffected.
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let (authority, ip_limiter) = test_app_data();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(authority))
+                .app_data(web::Data::new(ip_limiter))
+                .service(api::auth::verify),
+        )
+        .await;
+
+        let bundle = IdentityBundle::generate().expect("test setup: identity generation");
+        let peer_addr: SocketAddr = peer.parse().expect("test setup: valid socket address");
+        let mut req = test::TestRequest::post()
+            .uri("/auth/verify")
+            .peer_addr(peer_addr)
+            .set_json(serde_json::json!({
+                "did": bundle.did().to_string(),
+                // Well-formed but wrong: reaches the failure path that audits the attempt.
+                "signature": hex::encode([0u8; 64]),
+                "coop_id": "test-coop",
+                "scopes": [],
+            }));
+        if let Some(value) = forwarded_for {
+            req = req.insert_header(("x-forwarded-for", value));
+        }
+
+        let resp = test::call_service(&app, req.to_request()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "control: the request must reach the audited failure path"
+        );
+
+        let ips = captured.0.lock().expect("capture mutex").clone();
+        assert_eq!(
+            ips.len(),
+            1,
+            "control: expected exactly one audited auth_attempt, got {ips:?}"
+        );
+        ips.into_iter().next().expect("one captured ip")
+    }
+
+    #[actix_web::test]
+    async fn untrusted_peer_is_audited_by_its_socket_address() {
+        let audited = audited_ip_for(UNTRUSTED_PEER, Some("203.0.113.7")).await;
+        assert_eq!(
+            audited, "198.51.100.42",
+            "peer {UNTRUSTED_PEER} is not a trusted proxy, so the audit record must name the \
+             socket address, not the caller-supplied 203.0.113.7"
+        );
+    }
+
+    #[actix_web::test]
+    async fn trusted_peer_audits_the_proxy_asserted_client() {
+        let audited = audited_ip_for(TRUSTED_PEER, Some("203.0.113.7, 198.51.100.42")).await;
+        assert_eq!(
+            audited, "198.51.100.42",
+            "the proxy asserted 198.51.100.42; the caller-prepended 203.0.113.7 must not \
+             become the audit identity"
+        );
+    }
+}
+
+/// Guard against over-correction: trusted forwarding must still distinguish real clients.
+///
+/// If the fix simply keyed everything on the socket peer, every client behind the proxy would
+/// share one bucket and this test would fail.
+#[actix_web::test]
+async fn trusted_peer_still_separates_distinct_forwarded_clients() {
+    let (app, did) = challenge_app!();
+
+    drain_bucket!(app, TRUSTED_PEER, did, Some("203.0.113.7"));
+
+    let resp = test::call_service(
+        &app,
+        challenge_request(TRUSTED_PEER, &did, Some("203.0.113.8")),
+    )
+    .await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "203.0.113.8 is a different client asserted by a trusted proxy and must have its own \
+         bucket; collapsing all proxied clients onto the proxy address would be a regression"
+    );
+}


### PR DESCRIPTION
## What

`X-Forwarded-For` was trusted unconditionally. Three separate copies of `get_client_ip` in
`icn-gateway` returned the **leftmost** element of the header with no check on who sent it, and
that value became the `IpRateLimiter` key and the audit client IP.

This replaces all three with one gated derivation.

## The authority invariant

> Forwarded client identity is an untrusted request claim unless the immediate transport peer is
> explicitly trusted to assert forwarding metadata. If the immediate peer is not trusted, the
> socket peer IP is the client IP.

## Why this is not "take the rightmost XFF value"

Picking the rightmost element is a different bug, not a fix — it still reads a caller-supplied
header without establishing that anyone trustworthy wrote it, and it breaks the moment there are
two proxies. The implemented algorithm is a **trust-gated traversal**:

1. Resolve the immediate transport peer (`req.peer_addr()`).
2. If that peer is **not** on the trusted-proxy allowlist: ignore `X-Forwarded-For` entirely, the
   socket peer is the client. Done.
3. If it **is** trusted: walk the chain **right to left** — from the transport-peer side inward —
   **skipping hops that are themselves trusted proxies**. The first hop no trusted proxy vouched
   for is the client.
4. If every hop is a trusted proxy, the furthest-upstream element is as far as the trusted chain
   reaches. An absent, empty, or unparseable chain falls back to the socket peer.

Step 3 is what makes a multi-proxy chain resolve correctly, and it is why anything a caller
prepends can never win: the caller's bytes sit to the *left* of whatever the trusted proxy
appended, so the right-to-left walk reaches the proxy-asserted hop first.

## Behaviour table

| immediate peer | `X-Forwarded-For` | effective client IP |
| --- | --- | --- |
| untrusted `198.51.100.42` | *(absent)* | `198.51.100.42` |
| untrusted `198.51.100.42` | `203.0.113.7` | `198.51.100.42` — header ignored |
| untrusted `198.51.100.42` | `203.0.113.7, 198.51.100.42` | `198.51.100.42` — header ignored |
| trusted `127.0.0.1` | `203.0.113.7` | `203.0.113.7` — proxy-asserted |
| trusted `127.0.0.1` | `203.0.113.7, 198.51.100.42` | `198.51.100.42` — prepended claim discarded |
| trusted `127.0.0.1` | `198.51.100.42, 127.0.0.1, ::1` | `198.51.100.42` — trusted hops skipped |
| trusted `127.0.0.1` | `not-an-ip` | `127.0.0.1` — falls back to peer |
| *(no transport peer)* | anything | `unknown` |

## Pre-fix reproduction — route level, not a parsing helper

The reproduction drives the real `POST /v1/auth/challenge` route with the real `IpRateLimiter`,
and observes limiter *identity* behaviourally: drain the bucket for one socket peer, then check
whether a caller-supplied header can mint a fresh one. A test that called the extraction helper
directly would prove what a comma parser returns, not what the limiter is keyed on.

Against the pre-fix code, 3 of the 4 route-level assertions went red:

| socket peer | `X-Forwarded-For` | expected after bucket exhaustion | observed |
| --- | --- | --- | --- |
| `198.51.100.42` | `203.0.113.1` | 429 | **200** |
| `198.51.100.42` | `203.0.113.1, 198.51.100.42` | 429 | **200** |
| `127.0.0.1` | `203.0.113.1, 198.51.100.42` | 429 | **200** |

Each drain step asserts it actually observed a 429 first, so a later "still limited" assertion
cannot pass vacuously.

The fourth test — distinct forwarded clients behind a trusted proxy must keep distinct buckets —
passes both before and after. It is deliberately included as a guard against over-correcting into
"always key on the socket peer", which would collapse every client behind a proxy into one bucket.

## Consequence 1: the IP rate limit bounded a header, not a source

`IpRateLimiter::check_rate_limit(&client_ip)` on:

**Public / unauthenticated by design (4):**

| call site | route |
| --- | --- |
| `api/auth.rs` | `POST /v1/auth/challenge` |
| `api/auth.rs` | `POST /v1/auth/verify` |
| `api/sessions.rs` | `POST /v1/sessions` |
| `api/sessions.rs` | `GET /v1/sessions/{session_id}` |

**Authenticated (1):**

| call site | route | protection |
| --- | --- | --- |
| `api/listings.rs` | `POST /v1/listings/{id}/interest` | `auth.clone()` on the `/listings` scope **plus** `require_scope("coop:write")` |

This corrects the issue report, which listed all five as "unauthenticated by design". Only the
first four are reachable without a credential; the listings route is defence-in-depth IP limiting
layered under JWT auth.

Varying the header per request minted a fresh bucket each time, so the ceiling constrained a
behaviour rather than a resource.

## Consequence 2: caller-controlled network-origin attribution in audit records

`api/auth.rs` derives one `client_ip` and passes it to both the limiter and the audit sink:
`AuditLogger::log_auth_attempt(...)` and `AuditLogger::log_invalid_scope_request(...)`. A caller
could therefore choose the **network-origin / client-IP field** recorded against an authentication
attempt.

Scope of that claim, stated narrowly: this is attribution of the origin address only. It is **not**
DID impersonation, **not** authenticated-user impersonation, and **not** an authorization bypass —
the DID and its signature verification are untouched by the header, and a forged `X-Forwarded-For`
grants no credential.

Proved rather than asserted: the tests install a thread-local `tracing` subscriber, capture the real
`auth_attempt` event, and assert on its `ip` field. Both were re-run with the old `get_client_ip`
temporarily restored and went red on their own assertions, so they are not vacuous green.

## Changes

**One canonical derivation** — new `icn/crates/icn-gateway/src/client_ip.rs` (`pub(crate)`),
exposing `client_ip`, `client_ip_key`, and `is_trusted_proxy`.

**Three former copies migrated** to call it:

- `icn/crates/icn-gateway/src/api/auth.rs`
- `icn/crates/icn-gateway/src/api/listings.rs`
- `icn/crates/icn-gateway/src/api/sessions.rs`

**Trust model unified.** `api/sessions.rs::get_gateway_url` already gated `X-Forwarded-*` on
`TRUSTED_PROXY_IPS`, about twenty lines below the ungated `get_client_ip` in the same file. It had
its own inline predicate doing an exact **string** comparison against `peer_addr.ip().to_string()`.
It now calls `client_ip::is_trusted_proxy`, so the gateway has one trusted-proxy model instead of
two that could drift.

**Dual-stack / IPv4-mapped handling.** Allowlist entries and peer addresses are compared as parsed
`IpAddr` after unwrapping IPv4-mapped IPv6 (`::ffff:a.b.c.d`) via `to_ipv4_mapped` — strictly
`to_ipv4_mapped`, not `to_ipv4`, so deprecated IPv4-*compatible* (`::a.b.c.d`) addresses are not
folded in.

The stated goal is narrow: prevent one logical address from occupying two different identities
purely because it appeared once as native IPv4 and once as strict IPv4-mapped IPv6 — the key-split
class of #2557 / #2563 — and stop a dual-stack peer from silently failing to match a dotted
allowlist entry. Reviewers should attack specifically whether mapped-form equivalence is correct for
**trusted-proxy authority** as well as for **client limiter identity**; those are two different
questions and this PR answers both the same way.

**Configuration semantics** (`TRUSTED_PROXY_IPS`, unchanged variable, now load-bearing for more):
exact addresses, comma-separated, no CIDR. Unset means loopback only (`127.0.0.1`, `::1`) —
preserving the prior default. Set-and-empty means trust nobody. Unparseable entries are skipped;
they could not match a kernel-supplied peer address anyway.

## Appliance nginx: a trusted proxy must *assert*, not relay

Found during implementation, not stated in the issue, and kept here because it is the same
authority boundary rather than a separate deployment concern.

`deploy/appliance/lan/nginx-icn-rehearsal-http.conf.in` and its `-https` sibling proxy `/v1/` to
`127.0.0.1:8080` while setting only `Host`. Two facts combine badly:

- the gateway sees a **loopback** transport peer, which is **trusted by default**;
- nginx forwarded the client's `X-Forwarded-For` **verbatim**, asserting nothing of its own.

So on that posture a correct application-side gate is still bypassed. The attacker's claim arrives
through a peer the application legitimately trusts and comes out the other side authoritative.

The general failure: **a trusted-proxy gate authenticates the sender of the header, not the
provenance of its contents.** Only the proxy can distinguish the two, by writing the address it
actually observed into the chain. A trusted-but-silent proxy is worse than an untrusted one,
because the untrusted one fails closed.

Both templates now set:

```nginx
proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
```

`$proxy_add_x_forwarded_for` appends the address nginx actually saw, so the right-to-left walk
reaches it first and discards anything prepended. `deploy/config/nginx.conf` already did this; the
review pass added an operator comment to it (see below) but left its behaviour untouched.

## Deployment requirement — reverse proxy / ingress

> **Deployments behind a reverse proxy or ingress must explicitly configure that proxy in
> `trusted_proxy_ips`.** Otherwise forwarded identity is intentionally ignored and every client
> behind the proxy shares the proxy's transport IP as its per-IP limiting identity.

That rule is general. **It does not describe the shipped Kubernetes topology**, and the review
settled that question rather than leaving it open:

- `deploy/k8s/` ships **no `Ingress` object**. The gateway is reached over **NodePort 30080**
  (`services.yaml`), i.e. directly.
- Both `configMapKeyRef`s (`gateway_base_url`, `trusted_proxy_ips`) are `optional: true`, so the
  commented-out key cannot break pod startup.
- With `externalTrafficPolicy` unset (default `Cluster`), kube-proxy SNATs the client address to
  the node **regardless of this PR**, so per-client attribution is already collapsed there and no
  proxy is setting `X-Forwarded-For` to recover it.

So leaving `trusted_proxy_ips` commented out is **correct for what is actually shipped**, and this
PR does not make the default Kubernetes deployment worse. Classification: **NOT A DEFECT**.

The general rule still binds any operator who *adds* a reverse proxy or ingress: without an explicit
entry the gateway sees the proxy's transport IP, does not trust it, ignores `X-Forwarded-For`, and
keys every client behind it on that one address — against an `IpRateLimiter` of capacity 20, refill
2/s. That is **fail-closed** behaviour, not a spoofing bypass, but it will limit real users. This PR
updates the configmap comment to make the requirement discoverable and **deliberately does not guess
a production ingress address**.

Explicitly not done: trusting all RFC1918, trusting a cluster CIDR, trusting `X-Forwarded-For` when
the allowlist is empty, or auto-detecting proxies.

## Confirmed not affected

`rate_limit.rs:549` builds the anonymous-DID limiter key from `connection_info().peer_addr()`, which
returns the socket peer only. The `X-Forwarded-For`-consulting accessor in actix-web is
`realip_remote_addr()`, and it has **zero callers** in this repository. That path is outside this
change and is not broadened into.

## Tests

New `icn/crates/icn-gateway/tests/forwarded_client_ip_trust.rs` — 6 tests, all through the real
route:

- `untrusted_peer_cannot_mint_buckets_with_forwarded_for`
- `untrusted_peer_cannot_mint_buckets_with_appended_chain` (the shipped nginx chain shape)
- `trusted_peer_ignores_caller_prepended_chain_element`
- `trusted_peer_still_separates_distinct_forwarded_clients` (over-correction guard)
- `audit_attribution::untrusted_peer_is_audited_by_its_socket_address`
- `audit_attribution::trusted_peer_audits_the_proxy_asserted_client`

Plus 10 unit tests in `client_ip.rs` covering the traversal, trusted-hop skipping, mapped-address
normalization, unparseable input, and the no-peer case. Those read the default (unset) policy only,
so they never mutate the process-global `TRUSTED_PROXY_IPS` and cannot race the rest of the suite.

**Red proofs.** Route-level: 3 of 4 red pre-fix, on the intended assertions (200 where 429 was
expected). Audit: both tests re-run against a temporarily restored vulnerable `get_client_ip`, both
red, then the revert was undone and re-verified.

## Local validation

```
cargo fmt --all --check                                              clean
cargo clippy -p icn-gateway --all-targets --all-features -D warnings exit 0
cargo test -p icn-gateway --all-features                             47 binaries, 0 failures
cargo test -p icn-gateway --test forwarded_client_ip_trust           6 passed, 0 failed
```

## Risk

Behaviour changes for any deployment that was relying on `X-Forwarded-For` from an untrusted peer —
by design, that is the bug. The failure direction is closed (identity collapses onto the transport
peer), not open. The over-correction guard test covers the legitimate proxied case. `get_gateway_url`
keeps its existing semantics; only its trust predicate moved.

## Non-goals

- Not a general reverse-proxy framework.
- No RFC 7239 `Forwarded` support, and no `X-Real-IP` support — neither is read today and neither is
  set by any proxy config in this repository; reading them would widen attacker-controlled input for
  no deployment benefit.
- No CIDR support in the allowlist; exact addresses only, as before.
- No DNS or IP-policy changes.
- No automatic Kubernetes ingress discovery, and no invented ingress address.
- No changes to the `connection_info().peer_addr()` anonymous-DID path.
- No work on #2549, and none on #2550 or #2556.

Closes #2567

Refs #2564, #2566, #2557, #2563



---

## Independent adversarial review pass (`f3339512`)

A fresh session re-derived the patch from `origin/main..HEAD` without inheriting the implementation
session's trust model, reproduced the pre-fix defect by isolated mutation, and ran an independent
43-case matrix through the real `POST /v1/auth/verify` audit path plus five targeted mutations.
Result: the authority invariant holds. One residual finding was fixed on this branch.

### Fixed: only the first `X-Forwarded-For` field-line was read

`client_ip` collected the chain with `HeaderMap::get`, which returns the **first** field-line only.
A trusted proxy that asserts its observation by **appending a separate header** rather than
rewriting the caller's leaves two field-lines on the wire — and the caller's is first. The
attacker's claim therefore ended up to the *right* of the proxy's assertion in the chain the
right-to-left walk actually saw, and won it.

Measured through the real audit path, trusted peer `127.0.0.1`, two headers
`X-Forwarded-For: 203.0.113.7` then `X-Forwarded-For: 198.51.100.42`:

| | effective client IP |
| --- | --- |
| before | `203.0.113.7` — caller's claim |
| after | `198.51.100.42` — proxy-asserted |

**Not reachable in any shipped topology**: both appliance templates and `deploy/config/nginx.conf`
use `proxy_set_header`, which emits a single merged field-line, and nginx already folds duplicate
client-sent `X-Forwarded-For` headers into one `$http_x_forwarded_for` value. It is fixed anyway
because it made the gate depend on a proxy's header-emission style rather than on the trust
decision. Per RFC 7230 3.2.2 repeated field-lines are equivalent to one comma-joined field-line, so
reading all of them reconstructs the true chain.

### Verified, not merely re-read

- **Untrusted peer**: header content is irrelevant across absent / single / multi / IPv4 / IPv6 /
  strict-mapped / malformed / empty / `unknown` / `host:port` / `[bracketed]` / 60k-comma inputs —
  all 11 produce the socket peer.
- **Strict mapped-v4 trust authority** is the correct narrow choice. `::ffff:127.0.0.1` inherits
  loopback authority; IPv4-*compatible* `::127.0.0.1`, NAT64 `64:ff9b::7f00:1`, and IPv4-translated
  `::ffff:0:7f00:1` all do **not**. That is exactly the `to_ipv4_mapped` / `to_ipv4` distinction.
- **Config parsing fails closed**: a CIDR typo, junk, or an empty value yields an empty allowlist —
  trust nobody, including loopback. `0.0.0.0` is a literal address, never a wildcard.
- **Multi-proxy** traversal stops at the first untrusted hop from the trusted edge; it does not walk
  past an untrusted intermediary to reach an earlier claim.
- **Chain work is bounded** by actix-http's 128 KiB request-head limit (`MAX_BUFFER_SIZE`), with
  `client_request_timeout(30s)` bounding the read. Unparseable entries allocate nothing.
- **Mutation controls**: reverting the peer gate, the walk direction, forwarded metadata entirely,
  strict-mapped normalization, and the header-merge each turn at least one test red; the pre-fix
  `get_client_ip` turns 5 of 6 integration tests red while every unit test stays green — which is
  precisely why the suite enters through the route.

### Also recorded (no behaviour change)

- A non-empty `TRUSTED_PROXY_IPS` **replaces** the loopback default rather than extending it, so an
  operator adding an ingress silently de-trusts an on-host proxy. The appliance nginx reaches the
  gateway over `127.0.0.1`, so this matters there. Documented in `client_ip.rs`.
- `deploy/config/nginx.conf` asserts the header correctly, but the gateway sees that container's
  compose-network address, not loopback — so it is untrusted by default and every client behind it
  now shares one bucket. Fail-closed, but it needed saying where the operator looks.

### Out of scope, filed as observations rather than acted on

- `api/sessions.rs` `get_gateway_url`'s **fallback** branch derives the scheme from
  `connection_info().scheme()`, which consults `X-Forwarded-Proto` / `Forwarded` regardless of peer
  trust. Pre-existing on `main`, unchanged by this PR, and self-targeting (it shapes the QR URL
  returned to the same caller). Not widened into here.
- `rate_limit.rs`'s anonymous-DID key uses `to_string()` on the socket peer without mapped-v4
  canonicalization, so it can still split across two spellings — the #2557 / #2563 / #2564 class.
  It reads the socket peer only, so it is not a forwarded-identity defect.
- The shipped K8s topology exposes the gateway via **NodePort 30080 with no Ingress object**, and
  `externalTrafficPolicy` is unset (defaults to `Cluster`), so kube-proxy SNATs the client address
  to the node regardless of this change. Leaving `trusted_proxy_ips` commented out is therefore
  correct for what is actually shipped; both `configMapKeyRef`s are `optional: true`, so the
  commented key cannot break pod startup.



---

## Final reviewed record

Bookkeeping pass after the independent review. No source changes; this section is the record the
merge gate should rely on instead of re-deriving it.

### Authority invariant, as finally reviewed

> Forwarded client identity is an **untrusted request claim** unless the immediate transport peer is
> explicitly trusted as a proxy. A trusted peer permits *interpretation* of the asserted forwarding
> chain, but traversal proceeds **from the transport-peer side inward and stops at the first
> untrusted hop**.

And the provenance distinction, which is the part that is easy to lose:

> Trusting the transport peer establishes **who may assert** forwarding metadata. It does not make
> the contents true. The proxy must still *construct* that metadata correctly — merely relaying an
> attacker-supplied `X-Forwarded-For` launders the claim through the gate. The appliance nginx
> change completes this contract for the bundled same-host deployment by appending the address
> nginx actually observed.

This is **not** "use the rightmost `X-Forwarded-For` value". Rightmost-wins is a different bug: it
still reads a caller-supplied header without establishing that anyone trustworthy wrote it, and it
breaks with two proxies.

### Mutation evidence (completed — do not rerun)

| | mutation | result |
| --- | --- | --- |
| REPRO | restore the original vulnerable `get_client_ip` | **killed** — 5/6 integration red, all unit green |
| M1 | trust `X-Forwarded-For` from untrusted peers | **killed** |
| M2 | caller-controlled / wrong chain direction | **killed** |
| M3 | ignore forwarding metadata entirely | **killed** |
| M4 | remove strict mapped-v4 normalization | **killed** |
| M5 | consume only the first `X-Forwarded-For` field-line | **killed** |

REPRO is the load-bearing one: every *unit* test stayed green while 5 of 6 *integration* tests went
red. That asymmetry is why the suite enters through the real route rather than the helper.

### Deployment classifications

| deployment | proxy → gateway | trusted by default? | classification |
| --- | --- | --- | --- |
| appliance LAN templates | nginx → `127.0.0.1:8080`, now appends observed client | **yes**, loopback | authority chain **complete** |
| `deploy/config/nginx.conf` (compose) | nginx → `icnd:8080`, appends observed client | **no** — container/network address | **fail-closed**; operator must configure the exact address |
| `deploy/k8s` | none — NodePort 30080, no `Ingress` shipped | n/a | **NOT A DEFECT** |

The application deliberately does **not** broadly trust RFC1918 or container/cluster CIDRs.

### `TRUSTED_PROXY_IPS` semantics

| value | effect |
| --- | --- |
| unset | loopback only (`127.0.0.1`, `::1`) |
| non-empty | the supplied list **replaces** the loopback default — it does not extend it |
| set-and-empty, or every entry unparseable | trusts **nobody** (fail-closed) |

Consequence worth stating plainly: an operator running **both** the same-host appliance nginx **and**
another reverse proxy must list loopback explicitly, or the on-host proxy is silently de-trusted.
Behaviour is unchanged by this PR; it is documented in `client_ip.rs` and in the two nginx configs.

### Same-class audit — settled, do not re-derive

**In scope, fixed:** `api/auth.rs`, `api/listings.rs`, `api/sessions.rs` migrated to one canonical
`client_ip` authority; appliance nginx now asserts `X-Forwarded-For`; duplicate field-line handling.

**Reviewed, not #2568 defects:** `rate_limit.rs:549` uses the raw socket peer and never consumes the
forwarded helper; `/v1/dev/demo/` proxies to a separate loopback-bound demo service that gates on
`Origin`, not client IP; Kubernetes ships NodePort with no ingress.

**Follow-ups filed (not implemented):**

- #2569 — `fix(gateway): authenticate forwarded scheme and host metadata before use`
- #2570 — `fix(gateway): canonicalize socket peer IP before anonymous rate-limit keying`
- #2571 — `refactor(gateway): cache and startup-validate the TRUSTED_PROXY_IPS allowlist`

#2571 came from the Copilot review on this PR and is classified non-blocking: caching changes cost,
not the trust outcome. None of the three are closed by this PR.
