### PR TITLE
fix(gateway): make QR gateway authority operator-controlled

### DIFF
--- a/deploy/appliance/lan/icnd-30-lan-origin.conf.in
+++ b/deploy/appliance/lan/icnd-30-lan-origin.conf.in
@@ -3,7 +3,7 @@
 # ICN_APPLIANCE_LAN_PROFILE=1. Sorts AFTER 20-demo-profile.conf, so its
 # last-assignment-wins directives override the demo profile's.
 #
-# Two overrides, both load-bearing for the single-origin security posture:
+# Three overrides, all load-bearing for the single-origin security posture:
 #
 # 1. Gateway bind 127.0.0.1:8080 (the demo drop-in binds 0.0.0.0:8080).
 #    On a bridged LAN VM, 0.0.0.0 makes the dev gateway — which runs with
@@ -23,7 +23,21 @@
 #    loopback set PLUS the single LAN origin the reverse proxy serves. Exact
 #    scheme://host[:port] matches only — the gateway's CORS matcher does no
 #    wildcarding (crates/icn-gateway/src/security.rs).
+#
+# 3. GATEWAY_BASE_URL is the operator's assertion of the origin a *second
+#    device* can reach this appliance at. QR login and enrollment embed it in
+#    the QR payload, and the scanning phone posts its bearer credential to it
+#    (examples/mobile-app/.../QRScannerScreen.tsx), so it is a credential
+#    destination and must be operator-owned (#2569). Two reasons it cannot be
+#    inferred at request time:
+#      - the gateway is bound to 127.0.0.1 by override 1, so nothing about the
+#        connection describes a LAN-reachable origin; and
+#      - nginx below is `default_server`, so a caller-chosen Host reaches the
+#        gateway over loopback wearing this host's proxy trust.
+#    @LAN_ORIGIN@ is the same already-validated, already-canonicalized origin
+#    used for CORS above, so this adds no new configuration surface.
 [Service]
 ExecStart=
 ExecStart=/usr/local/bin/icnd --data-dir /var/lib/icn --gateway-enable --gateway-bind 127.0.0.1:8080
 Environment=ICN_CORS_ORIGINS=http://localhost:8090,http://127.0.0.1:8090,http://localhost:18090,http://127.0.0.1:18090,@LAN_ORIGIN@
+Environment=GATEWAY_BASE_URL=@LAN_ORIGIN@

--- a/deploy/appliance/lan/nginx-icn-rehearsal-http.conf.in
+++ b/deploy/appliance/lan/nginx-icn-rehearsal-http.conf.in
@@ -39,7 +39,8 @@ server {
         # caller-chosen value to a gateway that trusts loopback, laundering attacker
         # authority through this proxy's trust (#2569 — the same class as #2567, one
         # header over). The gateway no longer derives QR authority from any header
-        # (GATEWAY_BASE_URL above is the sole source), so this is defence in depth.
+        # (GATEWAY_BASE_URL, set in the icnd drop-in, is the sole source), so this is
+        # defence in depth.
         proxy_set_header Host @LAN_HOST@;
         # Assert the scheme from nginx's own connection state. Without it the gateway
         # sees only the plaintext loopback hop, so anything reading forwarded proto

--- a/deploy/appliance/lan/nginx-icn-rehearsal-http.conf.in
+++ b/deploy/appliance/lan/nginx-icn-rehearsal-http.conf.in
@@ -34,7 +34,17 @@ server {
     location /v1/ {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        # ASSERT the operator's authority, do not RELAY the caller's. This server is
+        # `default_server`, so it answers for any Host; `$host` would forward a
+        # caller-chosen value to a gateway that trusts loopback, laundering attacker
+        # authority through this proxy's trust (#2569 — the same class as #2567, one
+        # header over). The gateway no longer derives QR authority from any header
+        # (GATEWAY_BASE_URL above is the sole source), so this is defence in depth.
+        proxy_set_header Host @LAN_HOST@;
+        # Assert the scheme from nginx's own connection state. Without it the gateway
+        # sees only the plaintext loopback hop, so anything reading forwarded proto
+        # concludes "http" even on the TLS variant of this template.
+        proxy_set_header X-Forwarded-Proto $scheme;
         # The gateway trusts loopback to assert forwarding metadata, so this proxy MUST
         # assert it. $proxy_add_x_forwarded_for appends the address nginx actually saw;
         # the gateway reads the rightmost untrusted hop, discarding anything the caller

--- a/deploy/appliance/lan/nginx-icn-rehearsal-https.conf.in
+++ b/deploy/appliance/lan/nginx-icn-rehearsal-https.conf.in
@@ -43,7 +43,17 @@ server {
     location /v1/ {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        # ASSERT the operator's authority, do not RELAY the caller's. This server is
+        # `default_server`, so it answers for any Host; `$host` would forward a
+        # caller-chosen value to a gateway that trusts loopback, laundering attacker
+        # authority through this proxy's trust (#2569 — the same class as #2567, one
+        # header over). The gateway no longer derives QR authority from any header
+        # (GATEWAY_BASE_URL is the sole source), so this is defence in depth.
+        proxy_set_header Host @LAN_HOST@;
+        # Assert the scheme from nginx's own connection state: TLS terminates here and
+        # the upstream hop is plaintext loopback, so without this anything reading
+        # forwarded proto would conclude "http" on a TLS deployment.
+        proxy_set_header X-Forwarded-Proto $scheme;
         # The gateway trusts loopback to assert forwarding metadata, so this proxy MUST
         # assert it. $proxy_add_x_forwarded_for appends the address nginx actually saw;
         # the gateway reads the rightmost untrusted hop, discarding anything the caller

--- a/deploy/appliance/systemd/icnd.service.d/20-demo-profile.conf
+++ b/deploy/appliance/systemd/icnd.service.d/20-demo-profile.conf
@@ -29,6 +29,25 @@
 #    forces a CORS preflight. The origins listed here are the hostfwd'd
 #    shell URLs. Setting this also switches the gateway to its dev CORS
 #    config (see crates/icn-gateway/src/security.rs).
+#
+# Deliberately absent: GATEWAY_BASE_URL.
+#
+# QR login and SDIS enrollment embed an origin that a SECOND device — a phone —
+# posts its bearer credential to (#2569). This profile has no such origin to
+# assert. The 0.0.0.0 bind in override 1 is host-only exposure behind QEMU
+# user-mode hostfwd: nothing on the LAN can route to this guest, so there is no
+# address a phone could be handed. The bind address is not an answer either —
+# 0.0.0.0 names no reachable host.
+#
+# So QR issuance fails closed here: POST /v1/sessions and the SDIS enrollment
+# start route return 503 and log the reason. That is the correct outcome for a
+# host-only demo, not a regression. Everything the demo actually drives — the
+# member shell, standing bootstrap, the proposal/vote path — is unaffected.
+#
+# The LAN rehearsal profile is the one that CAN issue QR material: it is reached
+# over a bridged NIC through nginx, and its drop-in
+# (deploy/appliance/lan/icnd-30-lan-origin.conf.in) sets GATEWAY_BASE_URL to the
+# same operator-validated @LAN_ORIGIN@ its CORS allowlist uses.
 
 [Service]
 ExecStart=

--- a/deploy/devnet/docker-compose.yml
+++ b/deploy/devnet/docker-compose.yml
@@ -1,8 +1,14 @@
 version: '3.8'
 
-# QR login / SDIS enrollment on this devnet (#2569)
+# QR login on this devnet (#2569)
 #
-# Those flows embed a `gateway_url` in QR material that a *second device* — a phone —
+# Scope: `POST /v1/sessions` only. SDIS enrollment is NOT reachable on this profile and
+# these variables do not change that — `/v1/sdis/enrollment/*` is mounted only when
+# ICN_ENABLE_SELF_SERVE_ENROLLMENT=true (crates/icn-gateway/src/server.rs), which no
+# shipped composition sets, including this one. Those paths return 404 (or 401 on
+# scope fallthrough) because the routes do not exist here, not 503 for a missing origin.
+#
+# QR login embeds a `gateway_url` in QR material that a *second device* — a phone —
 # posts its bearer credential to. So the origin has to be one that phone can actually
 # reach, and it is an operator assertion, never inferred from a request header or the
 # bind address. There is no honest static default here: each node is published on a

--- a/deploy/devnet/docker-compose.yml
+++ b/deploy/devnet/docker-compose.yml
@@ -21,6 +21,14 @@ version: '3.8'
 #
 # Use this host's LAN address, not localhost. The value is validated at use time
 # (absolute http/https origin, no userinfo, path, query, or fragment).
+#
+# Invite links are deliberately NOT configured here. `POST /v1/invites` returns an
+# `invite_url` of the form `{ICN_INVITE_BASE_URL}/join?code=...`, which is a human-facing
+# UI destination, not a gateway API origin. This profile serves no member UI at all — the
+# only web surface below is Grafana, which happens to occupy port 3000 — so there is no
+# honest origin to name, and inventing one would advertise a route nothing here serves.
+# Setting GATEWAY_BASE_URL above cannot affect invite links: the two authorities are
+# separate variables (see crates/icn-gateway/src/api/invites.rs).
 
 services:
   node-a:

--- a/deploy/devnet/docker-compose.yml
+++ b/deploy/devnet/docker-compose.yml
@@ -1,5 +1,27 @@
 version: '3.8'
 
+# QR login / SDIS enrollment on this devnet (#2569)
+#
+# Those flows embed a `gateway_url` in QR material that a *second device* — a phone —
+# posts its bearer credential to. So the origin has to be one that phone can actually
+# reach, and it is an operator assertion, never inferred from a request header or the
+# bind address. There is no honest static default here: each node is published on a
+# different host port (8080/8081/8082) and the host itself is unknown, while
+# `localhost` names the phone, not this machine.
+#
+# So each node takes its own origin variable, and each defaults to empty. Empty is
+# treated exactly like unset: QR issuance fails closed with 503 and logs why, and the
+# rest of the devnet (gossip, ledger, governance, the protocol tests this profile
+# exists for) is unaffected. Set them only if you are driving a QR flow:
+#
+#   ICN_DEVNET_NODE_A_ORIGIN=http://192.0.2.10:8080 \
+#   ICN_DEVNET_NODE_B_ORIGIN=http://192.0.2.10:8081 \
+#   ICN_DEVNET_NODE_C_ORIGIN=http://192.0.2.10:8082 \
+#     docker compose up -d
+#
+# Use this host's LAN address, not localhost. The value is validated at use time
+# (absolute http/https origin, no userinfo, path, query, or fragment).
+
 services:
   node-a:
     image: icn:latest
@@ -12,6 +34,8 @@ services:
       - ICN_NODE_NAME=node-a
       - ICN_DATA_DIR=/data/node-a
       - ICN_GATEWAY_PORT=8080
+      # Advertised origin for QR material — see the header note. Empty = QR off (503).
+      - GATEWAY_BASE_URL=${ICN_DEVNET_NODE_A_ORIGIN:-}
       - ICN_P2P_PORT=9000
       - ICN_METRICS_PORT=9100
       - ICN_BOOTSTRAP_PEERS=
@@ -51,6 +75,8 @@ services:
       - ICN_NODE_NAME=node-b
       - ICN_DATA_DIR=/data/node-b
       - ICN_GATEWAY_PORT=8080
+      # Advertised origin for QR material — see the header note. Empty = QR off (503).
+      - GATEWAY_BASE_URL=${ICN_DEVNET_NODE_B_ORIGIN:-}
       - ICN_P2P_PORT=9000
       - ICN_METRICS_PORT=9100
       - ICN_BOOTSTRAP_PEERS=icn://node-a:9000
@@ -93,6 +119,8 @@ services:
       - ICN_NODE_NAME=node-c
       - ICN_DATA_DIR=/data/node-c
       - ICN_GATEWAY_PORT=8080
+      # Advertised origin for QR material — see the header note. Empty = QR off (503).
+      - GATEWAY_BASE_URL=${ICN_DEVNET_NODE_C_ORIGIN:-}
       - ICN_P2P_PORT=9000
       - ICN_METRICS_PORT=9100
       - ICN_BOOTSTRAP_PEERS=icn://node-a:9000,icn://node-b:9000

--- a/deploy/icnd.env.example
+++ b/deploy/icnd.env.example
@@ -17,3 +17,21 @@ ICN_GATEWAY_JWT_SECRET=your-strong-secret-here
 
 # Optional: Static files directory for web UI
 # ICN_STATIC_DIR=/usr/share/icn/static
+
+# Required ONLY to issue QR login / SDIS enrollment material (#2569)
+#
+# The externally reachable origin (scheme://host[:port]) that a *second device* — the
+# phone scanning the QR code — can reach this gateway at. It is embedded in the QR
+# payload and is where that device sends its bearer credential, so it is a credential
+# destination: an operator assertion, never inferred from a request header or from the
+# bind address.
+#
+# icnd.service binds 127.0.0.1:8080, so this is normally your reverse proxy's public
+# origin, not the bind address. Set it to the exact origin operators hand out.
+#
+# Leave it unset if this node issues no QR material. Unset is not an error at startup:
+# the node runs normally and only QR issuance fails closed with 503.
+#
+# Must be an absolute http/https origin with no userinfo, path, query, or fragment;
+# it is validated at use time and rejected loudly in the log if malformed.
+# GATEWAY_BASE_URL=https://icn.example.coop

--- a/deploy/icnd.env.example
+++ b/deploy/icnd.env.example
@@ -35,3 +35,20 @@ ICN_GATEWAY_JWT_SECRET=your-strong-secret-here
 # Must be an absolute http/https origin with no userinfo, path, query, or fragment;
 # it is validated at use time and rejected loudly in the log if malformed.
 # GATEWAY_BASE_URL=https://icn.example.coop
+
+# Optional: member-facing UI origin used for invite links
+#
+# `POST /v1/invites` returns an `invite_url` of the form `{this}/join?code=...`, meant for a
+# person to open in a browser. That is a different authority from GATEWAY_BASE_URL above,
+# which is where a *device* sends authenticated API traffic — do not set them to the same
+# value expecting either to work.
+#
+# Honest status: no composition shipped in this repository serves `GET /join?code=...`. The
+# only invite redemption path is `POST /v1/invites/join`, which carries the code in the request
+# body, and the pilot UI collects that code from a typed form. Set this only if you run a
+# member UI that implements such a route; otherwise the returned link addresses nothing.
+#
+# Unset defaults to http://localhost:3000 for local development, which is where
+# deploy/docker-compose.yml serves the pilot UI. That default is not reachable from another
+# device and is not claimed to be correct for any deployment profile.
+# ICN_INVITE_BASE_URL=https://members.example.coop

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -15,9 +15,15 @@ data:
   # addresses, no CIDR). Example: "10.42.0.1,10.43.0.1" (K8s cluster IPs).
   # If not set, only localhost (127.0.0.1, ::1) is trusted.
   #
-  # This gates BOTH the QR-login URL derivation and — since #2567 — the client IP used
-  # for rate limiting and audit attribution on unauthenticated endpoints. If you run an
-  # ingress in front of the gateway and leave this unset, that ingress is untrusted:
+  # Scope is the client IP only — since #2567, the address used for rate limiting and
+  # audit attribution on unauthenticated endpoints. It does NOT gate QR-login URL
+  # derivation: since #2569 the advertised origin comes solely from `gateway_base_url`
+  # above, and X-Forwarded-Host / X-Forwarded-Proto are not read at all. Trusting a
+  # proxy to report who the client is does not authorize it to say where a scanning
+  # device should send credentials, so configuring only this leaves QR issuance failing
+  # closed with 503 until `gateway_base_url` is set.
+  #
+  # If you run an ingress in front of the gateway and leave this unset, that ingress is untrusted:
   # X-Forwarded-For is ignored and every client behind it shares one rate-limit bucket
   # keyed on the ingress address. That is fail-closed, not fail-open, but it will limit
   # real users. Set this to the ingress address before serving traffic through a proxy.

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -100,16 +100,23 @@ spec:
         # CORS: allow Pilot UI origin for cross-origin API access
         - name: ICN_CORS_ORIGINS
           value: "http://10.8.30.40:30030"
-        # Gateway base URL for QR login - set this to the external URL where the gateway is accessible
-        # This is used in QR codes for mobile wallet login
+        # Gateway base URL for QR login - the external origin (scheme://host[:port]) a
+        # *scanning device* can reach this gateway at. It is embedded in QR material and is
+        # where that device sends its bearer credential, so it is an operator assertion and
+        # is never inferred from request headers or the bind address (#2569).
+        # `optional: true` is retained deliberately: a gateway that issues no QR material
+        # needs no origin. Omitting the key does not fall back to a request-derived origin —
+        # QR issuance fails closed (503) until an origin is configured.
         - name: GATEWAY_BASE_URL
           valueFrom:
             configMapKeyRef:
               name: icn-config
               key: gateway_base_url
               optional: true
-        # Trusted proxy IPs for X-Forwarded-* header validation (comma-separated)
-        # Only these IPs can set X-Forwarded-Host/Proto headers
+        # Trusted proxy IPs allowed to assert the forwarded *client IP* (comma-separated).
+        # Scope is X-Forwarded-For only, for rate-limit and audit identity (#2567/#2568).
+        # It does NOT authorize a proxy to assert the advertised origin: X-Forwarded-Host
+        # and X-Forwarded-Proto are not read at all — set GATEWAY_BASE_URL for that.
         # If not set, only localhost (127.0.0.1, ::1) is trusted
         - name: TRUSTED_PROXY_IPS
           valueFrom:

--- a/docs/guides/onboarding-runbook.md
+++ b/docs/guides/onboarding-runbook.md
@@ -63,6 +63,19 @@ curl -X POST http://localhost:8080/v1/invites \
 # Returns: { "invite_code": "abc123...", "invite_url": "https://..." }
 ```
 
+> **`invite_url` needs a member UI you run yourself.** It is built as
+> `{ICN_INVITE_BASE_URL}/join?code=…`, a human-facing browser destination — a different
+> authority from `GATEWAY_BASE_URL`, which is the gateway API origin devices post to. Setting
+> the gateway origin does not and must not change this link (#2569).
+>
+> No composition shipped in this repository serves `GET /join?code=…`. The redemption path that
+> does exist is `POST /v1/invites/join`, which carries the code in the request body, and the
+> pilot UI collects that code from a typed form. So unless you run a member UI implementing a
+> `/join` route and point `ICN_INVITE_BASE_URL` at it, hand the recipient the `invite_code` and
+> have them enter it in the UI rather than sending them `invite_url`. Unset, the link falls back
+> to `http://localhost:3000`, which is local-development only and not reachable from another
+> device.
+
 ### Post-join admin steps
 
 After the person joins, assign them to committees:

--- a/docs/sdis/SDIS_QUICK_START.md
+++ b/docs/sdis/SDIS_QUICK_START.md
@@ -283,6 +283,13 @@ The daemon still starts and every other route works — a gateway that issues no
 needs no origin. `TRUSTED_PROXY_IPS` does not substitute for it: trusting a proxy to report
 the client IP (#2567) does not authorize it to assert the advertised origin.
 
+Configuring an origin does **not** by itself make these enrollment routes reachable: as the
+banner at the top of this guide says, `/v1/sdis/enrollment/*` is mounted only under
+`ICN_ENABLE_SELF_SERVE_ENROLLMENT=true`, which no shipped profile sets. Where the routes are
+absent you get 404 (or 401 on scope fallthrough), not the 503 described above. The origin below
+is what the *other* QR flow — `POST /v1/sessions` — needs on every profile, and what enrollment
+would additionally need on an isolated rehearsal deployment that opts in.
+
 Where each shipped profile gets it: `deploy/k8s/configmap.yaml` (`gateway_base_url`); the LAN
 appliance drop-in `deploy/appliance/lan/icnd-30-lan-origin.conf.in` (from
 `ICN_APPLIANCE_LAN_ORIGIN`); `ICN_DEVNET_NODE_{A,B,C}_ORIGIN` for `deploy/devnet`, which

--- a/docs/sdis/SDIS_QUICK_START.md
+++ b/docs/sdis/SDIS_QUICK_START.md
@@ -136,6 +136,10 @@ View your steward metrics:
 
 #### Enroll a Device
 
+> Step 1 returns `503` unless `GATEWAY_BASE_URL` is set — the QR it issues names an origin a
+> scanning device sends credentials to, and that cannot be guessed from the request
+> (#2569). See [Configuration](#configuration) under *For Operators*.
+
 ```bash
 # Step 1: Request enrollment
 curl -X POST http://localhost:8080/v1/sdis/enrollment/start \
@@ -262,6 +266,35 @@ make build deploy
 ```
 
 ### Configuration
+
+#### `GATEWAY_BASE_URL` — required to issue enrollment QR material
+
+`POST /v1/sdis/enrollment/start` returns a QR payload containing a `gateway_url`. A **second
+device** scans it and posts its bearer credential there, so that origin is a credential
+destination and must be an operator assertion. It is not derived from the request's `Host`,
+`Forwarded`, or `X-Forwarded-*` headers, and not from the bind address (#2569).
+
+Set `GATEWAY_BASE_URL` to the externally reachable `scheme://host[:port]` a scanning phone can
+reach this gateway at — normally your reverse proxy's public origin, not the bind address. It
+must have no userinfo, path, query, or fragment; it is validated at use time.
+
+With no origin configured, enrollment start **fails closed with `503`** and logs the reason.
+The daemon still starts and every other route works — a gateway that issues no QR material
+needs no origin. `TRUSTED_PROXY_IPS` does not substitute for it: trusting a proxy to report
+the client IP (#2567) does not authorize it to assert the advertised origin.
+
+Where each shipped profile gets it: `deploy/k8s/configmap.yaml` (`gateway_base_url`); the LAN
+appliance drop-in `deploy/appliance/lan/icnd-30-lan-origin.conf.in` (from
+`ICN_APPLIANCE_LAN_ORIGIN`); `ICN_DEVNET_NODE_{A,B,C}_ORIGIN` for `deploy/devnet`, which
+ADR-0086 names the canonical Compose entry point; and a commented example in
+`deploy/icnd.env.example` for native installs. The QEMU demo appliance profile deliberately
+does not set one — it is host-only, so no phone can reach it, and QR issuance is correctly off.
+
+The remaining Compose and Kubernetes trees (`deploy/docker-compose.yml`, `deploy/compose/`,
+`deploy/kubernetes/`, `deploy/helm/icn/`) are compatibility material under ADR-0086 and are not
+wired for QR. Do not add an origin to one expecting enrollment to work: the latter two cannot
+bring a gateway to Ready at all, since they probe `/health/liveness` — a route that does not
+exist — and set env names the daemon never reads.
 
 Edit `config/icn.toml`:
 

--- a/icn/crates/icn-gateway/src/advertised_origin.rs
+++ b/icn/crates/icn-gateway/src/advertised_origin.rs
@@ -114,39 +114,57 @@ fn unusable(reason: &str) -> GatewayError {
     )
 }
 
+/// The crate's **only** serialization point for test-time `GATEWAY_BASE_URL` mutation.
+///
+/// Every `#[cfg(test)]` module in this crate compiles into the *same* lib test binary, and
+/// libtest runs those tests as threads in one process. A per-module mutex therefore serializes
+/// nothing across modules: two tests holding two different locks still race on the one
+/// process-global variable. That is not merely flaky — it lets a fail-closed assertion observe
+/// another module's configured origin and pass for the wrong reason.
+///
+/// So this lock is process-wide by being the only one. Its `#[cfg(test)]` gate keeps it out of
+/// every non-test build, and `pub(crate)` keeps it off the public API.
 #[cfg(test)]
-mod tests {
-    use super::*;
+pub(crate) mod test_env {
+    use super::GATEWAY_BASE_URL_ENV;
     use std::sync::{Mutex, MutexGuard};
 
-    /// Serializes mutation of the process-global env this module reads.
     static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
 
-    struct EnvGuard {
+    /// Pins `GATEWAY_BASE_URL` for the guard's lifetime, restoring the prior value on drop.
+    /// Hold it for as long as the value must stay pinned — dropping it releases the lock.
+    pub(crate) struct EnvGuard {
         _lock: MutexGuard<'static, ()>,
         prior: Option<String>,
     }
 
     impl EnvGuard {
-        fn acquire(value: Option<&str>) -> Self {
+        pub(crate) fn acquire(value: Option<&str>) -> Self {
             let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             let prior = std::env::var(GATEWAY_BASE_URL_ENV).ok();
-            match value {
-                Some(v) => std::env::set_var(GATEWAY_BASE_URL_ENV, v),
-                None => std::env::remove_var(GATEWAY_BASE_URL_ENV),
-            }
+            set_or_clear(value);
             Self { _lock: lock, prior }
         }
     }
 
     impl Drop for EnvGuard {
         fn drop(&mut self) {
-            match self.prior.as_deref() {
-                Some(v) => std::env::set_var(GATEWAY_BASE_URL_ENV, v),
-                None => std::env::remove_var(GATEWAY_BASE_URL_ENV),
-            }
+            set_or_clear(self.prior.as_deref());
         }
     }
+
+    fn set_or_clear(value: Option<&str>) {
+        match value {
+            Some(v) => std::env::set_var(GATEWAY_BASE_URL_ENV, v),
+            None => std::env::remove_var(GATEWAY_BASE_URL_ENV),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_env::EnvGuard;
+    use super::*;
 
     fn resolve(value: Option<&str>) -> Result<String> {
         let _guard = EnvGuard::acquire(value);
@@ -219,6 +237,57 @@ mod tests {
                 "{why}: expected fail-closed ServiceUnavailable, got {err:?}"
             );
         }
+    }
+
+    /// `test_env::EnvGuard` only serializes the modules that actually use it. A new test module
+    /// that reaches for `std::env` directly would silently reintroduce the cross-module race
+    /// (which reproduced at ~47% and could make a fail-closed assertion pass for the wrong
+    /// reason), so the single-mutator property is asserted rather than documented.
+    ///
+    /// This test lives in the one file allowed to mutate, and skips that file — so it cannot
+    /// match its own literals, and stays honest as modules are added.
+    #[test]
+    fn this_module_is_the_only_test_time_mutator_of_the_env() {
+        fn rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            for entry in std::fs::read_dir(dir).expect("crate src/ must be readable") {
+                let path = entry.expect("readable dir entry").path();
+                if path.is_dir() {
+                    rs_files(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut files = Vec::new();
+        rs_files(&src, &mut files);
+        assert!(
+            files.len() > 1,
+            "source scan found nothing; the walk is wrong"
+        );
+
+        let this_file = src.join("advertised_origin.rs");
+        let mutators = ["set_var(", "remove_var("];
+
+        let offenders: Vec<String> = files
+            .iter()
+            .filter(|p| **p != this_file)
+            .filter(|p| {
+                let body = std::fs::read_to_string(p).expect("source file must be readable");
+                body.lines().any(|line| {
+                    line.contains(GATEWAY_BASE_URL_ENV) && mutators.iter().any(|m| line.contains(m))
+                })
+            })
+            .map(|p| p.strip_prefix(&src).unwrap_or(p).display().to_string())
+            .collect();
+
+        assert!(
+            offenders.is_empty(),
+            "these modules mutate {GATEWAY_BASE_URL_ENV} directly instead of taking \
+             `advertised_origin::test_env::EnvGuard`; a second lock does not serialize \
+             against the first in a shared lib test process: {offenders:?}"
+        );
     }
 
     /// The refusal must not echo the configured value back to an unauthenticated caller.

--- a/icn/crates/icn-gateway/src/advertised_origin.rs
+++ b/icn/crates/icn-gateway/src/advertised_origin.rs
@@ -1,0 +1,233 @@
+//! The origin this gateway advertises to other devices (#2569).
+//!
+//! # Why this is not derived from the request
+//!
+//! QR login and SDIS enrollment embed a `gateway_url` in QR material that a **second device**
+//! consumes. The reference scanner posts to `{gateway_url}/v1/sessions/{id}/approve` carrying
+//! `Authorization: Bearer <token>` (`examples/mobile-app/src/screens/QRScannerScreen.tsx`), so
+//! whoever controls that origin receives a member's bearer credential. The advertised origin is
+//! therefore a **credential destination**, and its authority must be an operator assertion.
+//!
+//! Request metadata cannot carry that authority, for two independent reasons:
+//!
+//! - **A direct caller chooses its own `Host`.** The requester need not be the scanner: it can
+//!   obtain QR material with an attacker-chosen authority and present that QR to someone else.
+//!   "The requester sees its own QR" does not make request-derived `Host` self-targeting.
+//! - **A trusted proxy authenticates the sender, not the provenance of what it relays.** #2567
+//!   established that a trusted immediate peer may assert the *client IP*; it does not follow
+//!   that every value such a peer forwards is an operator assertion. The appliance's nginx is
+//!   `default_server` and historically relayed `proxy_set_header Host $host`, so a caller-chosen
+//!   `Host` arrived over loopback wearing the proxy's trust.
+//!
+//! Actix's [`actix_web::HttpRequest::connection_info`] is not an escape hatch either: it parses
+//! RFC 7239 `Forwarded` and then `X-Forwarded-Proto`/`-Host` with **no** trusted-peer gate, so
+//! reading it would reintroduce exactly the header control this module exists to remove. Nothing
+//! here takes an `HttpRequest`, which makes that regression a compile error rather than a review
+//! question.
+//!
+//! # Configuration
+//!
+//! `GATEWAY_BASE_URL` is the single source of authority: one canonical externally reachable
+//! origin per gateway process.
+//!
+//! - k8s supplies it from `deploy/k8s/configmap.yaml` (`gateway_base_url`).
+//! - The LAN appliance supplies it from `ICN_APPLIANCE_LAN_ORIGIN` via `@LAN_ORIGIN@`, the same
+//!   already-validated origin its CORS allowlist uses.
+//!
+//! There is deliberately **no inference fallback**. A bind address is not an advertised origin:
+//! the appliance gateway is bound to `127.0.0.1`, and `0.0.0.0` names no reachable host at all,
+//! so neither could be handed to a scanning phone. With no configured origin there is no safe
+//! value to advertise, so QR issuance fails closed (503) rather than guessing one.
+//!
+//! Validation happens at use time rather than startup: a gateway that never issues QR material
+//! should not fail to boot over configuration it does not need.
+
+use url::Url;
+
+use crate::error::{GatewayError, Result};
+
+/// Operator-set absolute base URL for this gateway's externally reachable origin.
+pub(crate) const GATEWAY_BASE_URL_ENV: &str = "GATEWAY_BASE_URL";
+
+/// The operator-authoritative `scheme://host[:port]` to embed in device-facing QR material.
+///
+/// Returns [`GatewayError::ServiceUnavailable`] when no usable operator origin is configured.
+/// The rejection reason is logged for the operator and deliberately **not** returned to the
+/// caller: an unauthenticated client learning why the gateway's own configuration was refused
+/// gains nothing it should have.
+pub(crate) fn advertised_origin() -> Result<String> {
+    let configured = std::env::var(GATEWAY_BASE_URL_ENV).unwrap_or_default();
+    let configured = configured.trim();
+
+    if configured.is_empty() {
+        return Err(unusable("unset or empty"));
+    }
+
+    let url =
+        Url::parse(configured).map_err(|e| unusable(&format!("not an absolute URL ({e})")))?;
+
+    match url.scheme() {
+        "http" | "https" => {}
+        other => return Err(unusable(&format!("unsupported scheme `{other}`"))),
+    }
+
+    // Credentials in an advertised origin would be handed to every scanning device.
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(unusable("must not contain userinfo"));
+    }
+
+    // The scanner appends its own `/v1/...` path. Anything already occupying the path, query, or
+    // fragment silently reroutes or truncates the approval request it builds.
+    if !matches!(url.path(), "" | "/") {
+        return Err(unusable("must not contain a path"));
+    }
+    if url.query().is_some() {
+        return Err(unusable("must not contain a query string"));
+    }
+    if url.fragment().is_some() {
+        return Err(unusable("must not contain a fragment"));
+    }
+
+    let origin = url.origin();
+    if !origin.is_tuple() {
+        return Err(unusable("does not denote a host-bearing origin"));
+    }
+
+    // Serialize through `Origin` rather than reassembling from parts: it keeps IPv6 literals
+    // bracketed (`host_str()` strips the brackets, which would yield an unparseable URL at the
+    // scanner), drops a redundant default port, and emits no trailing slash — so the scanner's
+    // `{origin}/v1/...` concatenation cannot produce `//v1/...`.
+    Ok(origin.ascii_serialization())
+}
+
+/// Log the operator-facing reason and return the client-facing refusal.
+fn unusable(reason: &str) -> GatewayError {
+    tracing::error!(
+        env = GATEWAY_BASE_URL_ENV,
+        reason,
+        "Refusing to issue QR material: no operator-authoritative gateway origin. A QR \
+         `gateway_url` is where a scanning device sends its bearer credential, so it cannot be \
+         inferred from the request or the bind address."
+    );
+    GatewayError::ServiceUnavailable(
+        "QR login is not configured on this gateway: no advertised gateway origin".to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    /// Serializes mutation of the process-global env this module reads.
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        prior: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn acquire(value: Option<&str>) -> Self {
+            let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prior = std::env::var(GATEWAY_BASE_URL_ENV).ok();
+            match value {
+                Some(v) => std::env::set_var(GATEWAY_BASE_URL_ENV, v),
+                None => std::env::remove_var(GATEWAY_BASE_URL_ENV),
+            }
+            Self { _lock: lock, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prior.as_deref() {
+                Some(v) => std::env::set_var(GATEWAY_BASE_URL_ENV, v),
+                None => std::env::remove_var(GATEWAY_BASE_URL_ENV),
+            }
+        }
+    }
+
+    fn resolve(value: Option<&str>) -> Result<String> {
+        let _guard = EnvGuard::acquire(value);
+        advertised_origin()
+    }
+
+    #[test]
+    fn canonicalizes_accepted_origins() {
+        // (configured, advertised)
+        let cases = [
+            (
+                "https://gateway.example.coop",
+                "https://gateway.example.coop",
+            ),
+            // trailing slash dropped: the scanner concatenates `{origin}/v1/...`
+            (
+                "https://gateway.example.coop/",
+                "https://gateway.example.coop",
+            ),
+            // explicit non-default port preserved (the k8s NodePort posture)
+            ("http://192.0.2.10:30080", "http://192.0.2.10:30080"),
+            // redundant default port dropped
+            (
+                "https://gateway.example.coop:443",
+                "https://gateway.example.coop",
+            ),
+            // IPv6 literal stays bracketed
+            ("http://[2001:db8::1]:30080", "http://[2001:db8::1]:30080"),
+            // host case is normalized, not attacker-relevant but must not error
+            (
+                "HTTPS://Gateway.Example.COOP",
+                "https://gateway.example.coop",
+            ),
+            // surrounding whitespace from a config file is not a malformed value
+            ("  https://rehearsal.lan  ", "https://rehearsal.lan"),
+        ];
+
+        for (configured, expected) in cases {
+            assert_eq!(
+                resolve(Some(configured)).expect("should be accepted"),
+                expected,
+                "GATEWAY_BASE_URL={configured:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unusable_origins() {
+        let cases = [
+            (None, "absent"),
+            (Some(""), "empty"),
+            (Some("   "), "whitespace only"),
+            (Some("gateway.example.coop"), "no scheme"),
+            (Some("//gateway.example.coop"), "scheme-relative"),
+            (Some("ftp://gateway.example.coop"), "unsupported scheme"),
+            (Some("javascript:alert(1)"), "non-hierarchical scheme"),
+            (Some("https://"), "no host"),
+            (Some("http://[::1"), "malformed IPv6 literal"),
+            (Some("https://user:pass@gateway.example.coop"), "userinfo"),
+            (Some("https://user@gateway.example.coop"), "username only"),
+            (Some("https://gateway.example.coop/api"), "path"),
+            (Some("https://gateway.example.coop?x=1"), "query"),
+            (Some("https://gateway.example.coop#frag"), "fragment"),
+        ];
+
+        for (configured, why) in cases {
+            let err = resolve(configured).expect_err(&format!("{why} must be rejected"));
+            assert!(
+                matches!(err, GatewayError::ServiceUnavailable(_)),
+                "{why}: expected fail-closed ServiceUnavailable, got {err:?}"
+            );
+        }
+    }
+
+    /// The refusal must not echo the configured value back to an unauthenticated caller.
+    #[test]
+    fn refusal_does_not_leak_the_configured_value() {
+        let err = resolve(Some("https://internal-admin.example.coop/secret-path"))
+            .expect_err("path must be rejected");
+        let rendered = err.to_string();
+        assert!(!rendered.contains("internal-admin"));
+        assert!(!rendered.contains("secret-path"));
+    }
+}

--- a/icn/crates/icn-gateway/src/advertised_origin.rs
+++ b/icn/crates/icn-gateway/src/advertised_origin.rs
@@ -55,6 +55,11 @@
 //! so neither could be handed to a scanning phone. With no configured origin there is no safe
 //! value to advertise, so QR issuance fails closed (503) rather than guessing one.
 //!
+//! That sentence is enforced, not merely asserted: an operator who pastes a wildcard bind into
+//! the variable is refused. `0.0.0.0`, `[::]` and their IPv4-mapped form parse as perfectly
+//! ordinary tuple origins, so validation rejects unspecified hosts explicitly — a phone that
+//! resolved one would address itself rather than this gateway.
+//!
 //! Validation happens at use time rather than startup: a gateway that never issues QR material
 //! should not fail to boot over configuration it does not need.
 
@@ -112,6 +117,29 @@ pub(crate) fn advertised_origin() -> Result<String> {
     // that fails silently in someone's hand.
     if url.port() == Some(0) {
         return Err(unusable("port 0 is not a reachable destination"));
+    }
+
+    // The wildcard *bind* addresses, pasted into an *advertised* origin. `0.0.0.0` and `[::]`
+    // parse as ordinary tuple origins, so nothing above rejects them — but they name no host.
+    // A phone that resolved one would target itself, not this gateway. This is the same rule as
+    // port 0, and the module contract above already says a bind address is not an origin; this
+    // is where that sentence becomes enforceable rather than advisory.
+    if let Some(url::Host::Ipv4(v4)) = url.host() {
+        if v4.is_unspecified() {
+            return Err(unusable(
+                "unspecified address is not a reachable destination",
+            ));
+        }
+    }
+    if let Some(url::Host::Ipv6(v6)) = url.host() {
+        // `to_ipv4_mapped`, not `to_ipv4`: the latter also unwraps IPv4-*compatible* addresses,
+        // which is the deprecated form this codebase deliberately avoids (#2564).
+        let mapped_unspecified = v6.to_ipv4_mapped().is_some_and(|v4| v4.is_unspecified());
+        if v6.is_unspecified() || mapped_unspecified {
+            return Err(unusable(
+                "unspecified address is not a reachable destination",
+            ));
+        }
     }
 
     let origin = url.origin();
@@ -298,6 +326,16 @@ mod tests {
             // Parses fine; nothing can connect to it.
             (Some("https://gateway.example.coop:0"), "port zero"),
             (Some("http://192.0.2.10:0"), "port zero on a literal IPv4"),
+            // A wildcard *bind* pasted into an *advertised* origin. Parses as a tuple origin,
+            // but names no host: a phone resolving it would target itself.
+            (Some("http://0.0.0.0:8080"), "unspecified IPv4 bind"),
+            (Some("http://0.0.0.0"), "unspecified IPv4, default port"),
+            (Some("http://[::]:8080"), "unspecified IPv6 bind"),
+            (Some("https://[::]"), "unspecified IPv6, default port"),
+            (
+                Some("http://[::ffff:0.0.0.0]:8080"),
+                "IPv4-mapped unspecified",
+            ),
         ];
 
         for (configured, why) in cases {

--- a/icn/crates/icn-gateway/src/advertised_origin.rs
+++ b/icn/crates/icn-gateway/src/advertised_origin.rs
@@ -30,9 +30,25 @@
 //! `GATEWAY_BASE_URL` is the single source of authority: one canonical externally reachable
 //! origin per gateway process.
 //!
+//! Where each shipped profile that can issue QR material gets it:
+//!
 //! - k8s supplies it from `deploy/k8s/configmap.yaml` (`gateway_base_url`).
 //! - The LAN appliance supplies it from `ICN_APPLIANCE_LAN_ORIGIN` via `@LAN_ORIGIN@`, the same
 //!   already-validated origin its CORS allowlist uses.
+//! - `deploy/devnet` — ADR-0086's canonical Compose entry point — takes
+//!   `ICN_DEVNET_NODE_{A,B,C}_ORIGIN`, defaulting to empty rather than to a fabricated URL:
+//!   each node is published on a different host port and the host is unknown, so no static
+//!   default could name an origin a scanning phone can reach. Empty is treated as unset.
+//! - Native installs get a documented, commented example in `deploy/icnd.env.example`.
+//!
+//! The other Compose trees (`deploy/docker-compose.yml`, `deploy/compose/`) are compatibility
+//! material under ADR-0086 and are deliberately not wired here; so are `deploy/kubernetes/` and
+//! `deploy/helm/icn/`, which cannot bring a gateway to Ready at all (they probe
+//! `/health/liveness`, a route that does not exist, and set env names nothing reads).
+//!
+//! Profiles that deliberately supply nothing, where failing closed is the correct outcome:
+//! the appliance base unit (bound to `127.0.0.1`) and the QEMU demo profile (`0.0.0.0` behind
+//! user-mode hostfwd is host-only, so no second device can route to it at all).
 //!
 //! There is deliberately **no inference fallback**. A bind address is not an advertised origin:
 //! the appliance gateway is bound to `127.0.0.1`, and `0.0.0.0` names no reachable host at all,
@@ -56,7 +72,7 @@ pub(crate) const GATEWAY_BASE_URL_ENV: &str = "GATEWAY_BASE_URL";
 /// caller: an unauthenticated client learning why the gateway's own configuration was refused
 /// gains nothing it should have.
 pub(crate) fn advertised_origin() -> Result<String> {
-    let configured = std::env::var(GATEWAY_BASE_URL_ENV).unwrap_or_default();
+    let configured = configured_origin().unwrap_or_default();
     let configured = configured.trim();
 
     if configured.is_empty() {
@@ -88,6 +104,16 @@ pub(crate) fn advertised_origin() -> Result<String> {
         return Err(unusable("must not contain a fragment"));
     }
 
+    // Port 0 parses (WHATWG allows it, and `url`'s `parse_port` only rejects >u16::MAX), and
+    // would be advertised verbatim as `https://host:0`. No device can connect there — port 0
+    // names "any free port" to a listener and is not a destination to a client. Rejecting it
+    // is the same rule as the path/query/fragment cases above: refuse a value the scanner
+    // cannot use, here at the gateway with a logged reason, rather than shipping a QR code
+    // that fails silently in someone's hand.
+    if url.port() == Some(0) {
+        return Err(unusable("port 0 is not a reachable destination"));
+    }
+
     let origin = url.origin();
     if !origin.is_tuple() {
         return Err(unusable("does not denote a host-bearing origin"));
@@ -98,6 +124,21 @@ pub(crate) fn advertised_origin() -> Result<String> {
     // scanner), drops a redundant default port, and emits no trailing slash — so the scanner's
     // `{origin}/v1/...` concatenation cannot produce `//v1/...`.
     Ok(origin.ascii_serialization())
+}
+
+/// Where the raw configured origin comes from.
+///
+/// In a normal build this is the process environment — the operator's deployment authority.
+/// Under `cfg(test)` it is a thread-local slot owned by [`test_env`] instead; see that module
+/// for why the lib test process must not resolve this through a shared global.
+#[cfg(not(test))]
+fn configured_origin() -> Option<String> {
+    std::env::var(GATEWAY_BASE_URL_ENV).ok()
+}
+
+#[cfg(test)]
+fn configured_origin() -> Option<String> {
+    test_env::configured_origin()
 }
 
 /// Log the operator-facing reason and return the client-facing refusal.
@@ -114,49 +155,75 @@ fn unusable(reason: &str) -> GatewayError {
     )
 }
 
-/// The crate's **only** serialization point for test-time `GATEWAY_BASE_URL` mutation.
+/// Per-test origin configuration for the lib test binary.
 ///
 /// Every `#[cfg(test)]` module in this crate compiles into the *same* lib test binary, and
-/// libtest runs those tests as threads in one process. A per-module mutex therefore serializes
-/// nothing across modules: two tests holding two different locks still race on the one
-/// process-global variable. That is not merely flaky — it lets a fail-closed assertion observe
-/// another module's configured origin and pass for the wrong reason.
+/// libtest runs those tests concurrently in one process. A process-global therefore has no
+/// owner: two modules that each mutate `GATEWAY_BASE_URL` under their own mutex still race on
+/// the one variable, and a per-module lock serializes nothing against the other module's. That
+/// is not merely flaky — it lets a fail-closed assertion observe a *different* test's
+/// configured origin and pass for the wrong reason.
 ///
-/// So this lock is process-wide by being the only one. Its `#[cfg(test)]` gate keeps it out of
-/// every non-test build, and `pub(crate)` keeps it off the public API.
+/// A previous revision tried to hold that line by asserting, via a source scan, that this
+/// module was the crate's only mutator. That is the wrong enforcement boundary: source
+/// spelling is not a structural property, and review found the scan blind to a rustfmt-wrapped
+/// `set_var(\n  "GATEWAY_BASE_URL",\n  ..)` — a form the formatter itself produces.
+///
+/// So the shared mutable state is removed instead of policed. Under `cfg(test)` the origin
+/// resolves from a thread-local, and libtest gives each test its own thread. Tests are
+/// order-independent by construction and need no lock, and a stray `std::env::set_var` cannot
+/// steer [`advertised_origin`] — there is no spelling left to detect, because this resolver
+/// reads no shared cell. `tests::process_env_mutation_is_inert_against_the_code_under_test`
+/// proves exactly that, using the counterexamples the scan missed.
+///
+/// **Scope of that claim, precisely.** It covers this module's resolver, not the whole crate.
+/// [`crate::api::invites`] still calls `std::env::var("GATEWAY_BASE_URL")` directly for its own
+/// (different, and currently incompatible) purpose, so it continues to read the real process
+/// environment in lib tests as in production. Any future test that mutates the variable can
+/// still perturb that consumer; what is guaranteed here is only that it cannot perturb the
+/// advertised origin. Unifying the two is deliberately a separate change — see the note at the
+/// `invites.rs` call site.
+///
+/// The production path is unchanged and still reads the process environment; integration
+/// tests in `tests/` link the lib without `cfg(test)`, so they exercise that real read
+/// end-to-end through the HTTP call sites.
 #[cfg(test)]
 pub(crate) mod test_env {
-    use super::GATEWAY_BASE_URL_ENV;
-    use std::sync::{Mutex, MutexGuard};
+    use std::cell::RefCell;
 
-    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+    thread_local! {
+        /// `None` models an unconfigured gateway. Private to this module: the only way to
+        /// change it is [`EnvGuard`], which restores on drop.
+        static CONFIGURED_ORIGIN: RefCell<Option<String>> = const { RefCell::new(None) };
+    }
 
-    /// Pins `GATEWAY_BASE_URL` for the guard's lifetime, restoring the prior value on drop.
-    /// Hold it for as long as the value must stay pinned — dropping it releases the lock.
+    /// Read by `super::configured_origin()` under `cfg(test)`.
+    pub(super) fn configured_origin() -> Option<String> {
+        CONFIGURED_ORIGIN.with(|slot| slot.borrow().clone())
+    }
+
+    /// Pins the advertised origin for this test's thread for the guard's lifetime, restoring
+    /// the prior value on drop. Hold it for as long as the value must stay pinned.
+    ///
+    /// Restoring matters even though each test normally owns its thread: `--test-threads=1`
+    /// runs tests on a shared thread, and restore-on-drop keeps that mode order-independent
+    /// too. `EnvGuard::acquire(None)` is the fail-closed precondition, and it is a real
+    /// assertion of absence rather than the hope that nothing else configured one.
     pub(crate) struct EnvGuard {
-        _lock: MutexGuard<'static, ()>,
         prior: Option<String>,
     }
 
     impl EnvGuard {
         pub(crate) fn acquire(value: Option<&str>) -> Self {
-            let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            let prior = std::env::var(GATEWAY_BASE_URL_ENV).ok();
-            set_or_clear(value);
-            Self { _lock: lock, prior }
+            let prior = CONFIGURED_ORIGIN.with(|slot| slot.replace(value.map(str::to_owned)));
+            Self { prior }
         }
     }
 
     impl Drop for EnvGuard {
         fn drop(&mut self) {
-            set_or_clear(self.prior.as_deref());
-        }
-    }
-
-    fn set_or_clear(value: Option<&str>) {
-        match value {
-            Some(v) => std::env::set_var(GATEWAY_BASE_URL_ENV, v),
-            None => std::env::remove_var(GATEWAY_BASE_URL_ENV),
+            let prior = self.prior.take();
+            CONFIGURED_ORIGIN.with(|slot| *slot.borrow_mut() = prior);
         }
     }
 }
@@ -228,6 +295,9 @@ mod tests {
             (Some("https://gateway.example.coop/api"), "path"),
             (Some("https://gateway.example.coop?x=1"), "query"),
             (Some("https://gateway.example.coop#frag"), "fragment"),
+            // Parses fine; nothing can connect to it.
+            (Some("https://gateway.example.coop:0"), "port zero"),
+            (Some("http://192.0.2.10:0"), "port zero on a literal IPv4"),
         ];
 
         for (configured, why) in cases {
@@ -239,55 +309,92 @@ mod tests {
         }
     }
 
-    /// `test_env::EnvGuard` only serializes the modules that actually use it. A new test module
-    /// that reaches for `std::env` directly would silently reintroduce the cross-module race
-    /// (which reproduced at ~47% and could make a fail-closed assertion pass for the wrong
-    /// reason), so the single-mutator property is asserted rather than documented.
+    /// The property the deleted source scanner was reaching for, asserted behaviourally.
     ///
-    /// This test lives in the one file allowed to mutate, and skips that file — so it cannot
-    /// match its own literals, and stays honest as modules are added.
+    /// That scanner tried to prove "no other module mutates `GATEWAY_BASE_URL`" by matching
+    /// `set_var(`/`remove_var(` and the variable name **on the same source line**. Review
+    /// supplied two counterexamples; measuring them showed one real hole:
+    ///
+    /// - `set_var(GATEWAY_BASE_URL_ENV, ..)` was in fact caught — the constant's identifier
+    ///   contains the variable name as a substring — so that half of the report was wrong;
+    /// - the rustfmt-wrapped multi-line call below was **not** caught, and rustfmt produces
+    ///   exactly that shape whenever the arguments cross the width limit. A guard the
+    ///   formatter can silently disarm is not a guard.
+    ///
+    /// The fix is not a third spelling. Under `cfg(test)` the origin no longer resolves
+    /// through any process-global, so both spellings — and any spelling not yet imagined —
+    /// are inert against the code under test. This test runs them to show that, and would
+    /// fail loudly if `configured_origin()` were ever repointed at the environment.
+    ///
+    /// Scope: `advertised_origin` only. `api::invites` still reads the variable straight from
+    /// the environment, so these mutations remain visible *there* — see the `test_env` module
+    /// doc. This asserts what the resolver ignores, not that the crate has no env readers.
     #[test]
-    fn this_module_is_the_only_test_time_mutator_of_the_env() {
-        fn rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
-            for entry in std::fs::read_dir(dir).expect("crate src/ must be readable") {
-                let path = entry.expect("readable dir entry").path();
-                if path.is_dir() {
-                    rs_files(&path, out);
-                } else if path.extension().is_some_and(|e| e == "rs") {
-                    out.push(path);
-                }
-            }
+    fn process_env_mutation_is_inert_against_the_code_under_test() {
+        let _guard = EnvGuard::acquire(Some("https://gateway.example.coop"));
+
+        // Counterexample 1: single-line literal — the form the scanner did catch.
+        std::env::set_var(GATEWAY_BASE_URL_ENV, "https://attacker.example");
+        assert_eq!(
+            advertised_origin().expect("guard value must survive"),
+            "https://gateway.example.coop",
+            "a single-line set_var reached the code under test"
+        );
+
+        // Counterexample 2: the rustfmt-wrapped form the scanner could not see.
+        #[rustfmt::skip]
+        std::env::set_var(
+            GATEWAY_BASE_URL_ENV,
+            "https://attacker.example/hijacked",
+        );
+        assert_eq!(
+            advertised_origin().expect("guard value must survive"),
+            "https://gateway.example.coop",
+            "a multi-line set_var reached the code under test"
+        );
+
+        // And removal cannot forge a fail-closed result either: a fail-closed assertion must
+        // observe *its own* absence, never another test's `remove_var`.
+        std::env::remove_var(GATEWAY_BASE_URL_ENV);
+        assert_eq!(
+            advertised_origin().expect("guard value must survive"),
+            "https://gateway.example.coop",
+            "a remove_var reached the code under test"
+        );
+    }
+
+    /// Order-independence, asserted rather than assumed.
+    ///
+    /// The failure this rules out is directional and silent: a test asserting the fail-closed
+    /// 503 can only be *fooled* by inheriting a configured origin, so absence must be
+    /// established by the test itself. Taking the guard after a sibling has pinned a value
+    /// must yield absence, and dropping it must restore what the sibling had — which is what
+    /// keeps `--test-threads=1`, where tests share a thread, honest too.
+    #[test]
+    fn absence_is_established_not_inherited() {
+        let outer = EnvGuard::acquire(Some("https://sibling.example.coop"));
+        assert_eq!(
+            advertised_origin().expect("sibling value applies"),
+            "https://sibling.example.coop"
+        );
+
+        {
+            let _inner = EnvGuard::acquire(None);
+            assert!(
+                matches!(
+                    advertised_origin(),
+                    Err(GatewayError::ServiceUnavailable(_))
+                ),
+                "acquiring None must mean absence, not the sibling's origin"
+            );
         }
 
-        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-        let mut files = Vec::new();
-        rs_files(&src, &mut files);
-        assert!(
-            files.len() > 1,
-            "source scan found nothing; the walk is wrong"
+        assert_eq!(
+            advertised_origin().expect("prior value must be restored on drop"),
+            "https://sibling.example.coop",
+            "dropping a nested guard must restore, or a shared thread leaks between tests"
         );
-
-        let this_file = src.join("advertised_origin.rs");
-        let mutators = ["set_var(", "remove_var("];
-
-        let offenders: Vec<String> = files
-            .iter()
-            .filter(|p| **p != this_file)
-            .filter(|p| {
-                let body = std::fs::read_to_string(p).expect("source file must be readable");
-                body.lines().any(|line| {
-                    line.contains(GATEWAY_BASE_URL_ENV) && mutators.iter().any(|m| line.contains(m))
-                })
-            })
-            .map(|p| p.strip_prefix(&src).unwrap_or(p).display().to_string())
-            .collect();
-
-        assert!(
-            offenders.is_empty(),
-            "these modules mutate {GATEWAY_BASE_URL_ENV} directly instead of taking \
-             `advertised_origin::test_env::EnvGuard`; a second lock does not serialize \
-             against the first in a shared lib test process: {offenders:?}"
-        );
+        drop(outer);
     }
 
     /// The refusal must not echo the configured value back to an unauthenticated caller.

--- a/icn/crates/icn-gateway/src/advertised_origin.rs
+++ b/icn/crates/icn-gateway/src/advertised_origin.rs
@@ -176,13 +176,13 @@ fn unusable(reason: &str) -> GatewayError {
 /// reads no shared cell. `tests::process_env_mutation_is_inert_against_the_code_under_test`
 /// proves exactly that, using the counterexamples the scan missed.
 ///
-/// **Scope of that claim, precisely.** It covers this module's resolver, not the whole crate.
-/// [`crate::api::invites`] still calls `std::env::var("GATEWAY_BASE_URL")` directly for its own
-/// (different, and currently incompatible) purpose, so it continues to read the real process
-/// environment in lib tests as in production. Any future test that mutates the variable can
-/// still perturb that consumer; what is guaranteed here is only that it cannot perturb the
-/// advertised origin. Unifying the two is deliberately a separate change — see the note at the
-/// `invites.rs` call site.
+/// **Scope of that claim, precisely.** It covers this module's resolver, not every environment
+/// reader in the crate. `GATEWAY_BASE_URL` now has exactly one consumer — this module — because
+/// [`crate::api::invites`] was moved onto its own `ICN_INVITE_BASE_URL` (the same variable was
+/// previously carrying both a device-facing API origin and a human-facing UI origin). That
+/// module still reads *its* variable from the real process environment, so a test mutating
+/// `ICN_INVITE_BASE_URL` can perturb it. What is guaranteed here is narrower and exact: nothing
+/// a test does to the process environment can change the advertised origin.
 ///
 /// The production path is unchanged and still reads the process environment; integration
 /// tests in `tests/` link the lib without `cfg(test)`, so they exercise that real read

--- a/icn/crates/icn-gateway/src/api/invites.rs
+++ b/icn/crates/icn-gateway/src/api/invites.rs
@@ -79,7 +79,25 @@ pub async fn create_invite(
         _ => format!("Coop {}", req.coop_id), // Fallback if charter not found
     };
 
-    // Construct invite URL
+    // Construct invite URL.
+    //
+    // NOTE (#2569): this reads `GATEWAY_BASE_URL` for a *different* purpose than
+    // `crate::advertised_origin`, and the two meanings do not agree. That module treats the
+    // variable as the gateway's own externally reachable API origin — the `{origin}/v1/...`
+    // a scanning device posts a bearer credential to — and fails closed without it. Here the
+    // same value is used as a *member-facing UI* base, and `/join` is not a gateway route;
+    // it exists nowhere in this repository. So under the k8s configmap
+    // (`gateway_base_url: http://…:30080`, the gateway NodePort, while the pilot UI is on
+    // 30030) this already yields a link to a route the gateway does not serve, and the
+    // `localhost:3000` fallback names the compose web-UI port rather than any gateway.
+    //
+    // That is a pre-existing wrong-destination bug, not the #2569 header-authority class:
+    // nothing here is request-derived, so no caller can influence where this points. It is
+    // deliberately left alone rather than half-fixed — giving invites their own operator
+    // variable is a new config surface across every deployment profile, which belongs in its
+    // own change. Do not "unify" these by pointing this at `advertised_origin()`: that would
+    // silently repoint invite links at the API origin and hard-fail invite creation on
+    // gateways that legitimately issue no QR material.
     let base_url =
         std::env::var("GATEWAY_BASE_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
     let invite_url = format!("{}/join?code={}", base_url, invite.code);

--- a/icn/crates/icn-gateway/src/api/invites.rs
+++ b/icn/crates/icn-gateway/src/api/invites.rs
@@ -79,28 +79,11 @@ pub async fn create_invite(
         _ => format!("Coop {}", req.coop_id), // Fallback if charter not found
     };
 
-    // Construct invite URL.
+    // Construct invite URL — base resolved by `invite_base_url()` below.
     //
-    // NOTE (#2569): this reads `GATEWAY_BASE_URL` for a *different* purpose than
-    // `crate::advertised_origin`, and the two meanings do not agree. That module treats the
-    // variable as the gateway's own externally reachable API origin — the `{origin}/v1/...`
-    // a scanning device posts a bearer credential to — and fails closed without it. Here the
-    // same value is used as a *member-facing UI* base, and `/join` is not a gateway route;
-    // it exists nowhere in this repository. So under the k8s configmap
-    // (`gateway_base_url: http://…:30080`, the gateway NodePort, while the pilot UI is on
-    // 30030) this already yields a link to a route the gateway does not serve, and the
-    // `localhost:3000` fallback names the compose web-UI port rather than any gateway.
-    //
-    // That is a pre-existing wrong-destination bug, not the #2569 header-authority class:
-    // nothing here is request-derived, so no caller can influence where this points. It is
-    // deliberately left alone rather than half-fixed — giving invites their own operator
-    // variable is a new config surface across every deployment profile, which belongs in its
-    // own change. Do not "unify" these by pointing this at `advertised_origin()`: that would
-    // silently repoint invite links at the API origin and hard-fail invite creation on
-    // gateways that legitimately issue no QR material.
-    let base_url =
-        std::env::var("GATEWAY_BASE_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
-    let invite_url = format!("{}/join?code={}", base_url, invite.code);
+    // This link is a *member-facing UI* destination, not a gateway API origin — see
+    // `invite_base_url` for why the two configurations are deliberately separate (#2569).
+    let invite_url = format!("{}/join?code={}", invite_base_url(), invite.code);
 
     // Record metrics
     gateway::invites_created(&req.coop_id);
@@ -113,6 +96,103 @@ pub async fn create_invite(
         expires_at: invite.expires_at,
         invite_url,
     }))
+}
+
+/// Operator-set base for the human-facing `{base}/join?code=…` invite link.
+pub(crate) const INVITE_BASE_URL_ENV: &str = "ICN_INVITE_BASE_URL";
+
+/// Local-development default: `deploy/docker-compose.yml` serves the pilot UI on port 3000.
+/// It is honest only where a member UI actually runs there, which is why the doc below is
+/// explicit that no shipped profile serves this route.
+const INVITE_BASE_URL_DEFAULT: &str = "http://localhost:3000";
+
+/// Base URL for the human-facing `{base}/join?code=…` invite link.
+///
+/// # Why this is not `GATEWAY_BASE_URL`
+///
+/// One variable was carrying two incompatible authorities (#2569):
+///
+/// - **A — gateway API origin.** Where a *device* sends authenticated traffic. Owned by
+///   [`crate::advertised_origin`], fails closed when absent, and must stay operator-controlled.
+/// - **B — member UI origin.** Where a *person* opens a join link. That is this value.
+///
+/// Reading A for B coupled them, and wiring A into a deployment then corrupted invite links two
+/// different ways. Both were reproduced: with `GATEWAY_BASE_URL=` present-but-empty (what
+/// Compose exports for an unconfigured `${VAR:-}`) `std::env::var` returns `Ok("")`, so an
+/// `unwrap_or_else` that only fires on `Err` yielded a hostless `/join?code=…`; and with it
+/// set to a real API origin the link became `{gateway API}/join?code=…`, a route the gateway
+/// does not serve. Setting the QR origin must not be able to move a UI link, so this reads its
+/// own variable and never consults `GATEWAY_BASE_URL`.
+///
+/// # Honest status of this link
+///
+/// **No composition in this repository serves `GET /join?code=…`.** The only invite redemption
+/// path is `POST /v1/invites/join`, which carries the code in the request body; `web/pilot-ui`
+/// collects it from a typed form and posts there. Nothing reads `code` from a URL query.
+/// So this string is advisory: an operator who runs a member UI implementing such a route
+/// points `ICN_INVITE_BASE_URL` at it, and otherwise the link addresses nothing.
+///
+/// The default is retained for local development only, and is **not** claimed to be reachable
+/// in any deployment profile — on the devnet profile port 3000 is Grafana, and no member UI is
+/// served at all. Empty and whitespace-only are treated as absent so a misconfigured value
+/// degrades to that default rather than to a hostless path.
+fn invite_base_url() -> String {
+    resolve_invite_base(configured_invite_base())
+}
+
+/// Pure resolution, so the policy is testable without touching any ambient state.
+fn resolve_invite_base(configured: Option<String>) -> String {
+    configured
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| INVITE_BASE_URL_DEFAULT.to_string())
+}
+
+#[cfg(not(test))]
+fn configured_invite_base() -> Option<String> {
+    std::env::var(INVITE_BASE_URL_ENV).ok()
+}
+
+#[cfg(test)]
+fn configured_invite_base() -> Option<String> {
+    test_env::configured()
+}
+
+/// Per-test UI-origin configuration, for the same reason [`crate::advertised_origin::test_env`]
+/// exists: every `#[cfg(test)]` module lands in one lib test binary, so a process-global read
+/// here would let two tests configuring different origins race. libtest gives each test its own
+/// thread, so a thread-local makes them order-independent by construction rather than by a lock
+/// every future author must remember.
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::cell::RefCell;
+
+    thread_local! {
+        static CONFIGURED: RefCell<Option<String>> = const { RefCell::new(None) };
+    }
+
+    pub(super) fn configured() -> Option<String> {
+        CONFIGURED.with(|slot| slot.borrow().clone())
+    }
+
+    /// Pins the member-UI origin for this thread, restoring the prior value on drop.
+    pub(crate) struct UiOriginGuard {
+        prior: Option<String>,
+    }
+
+    impl UiOriginGuard {
+        pub(crate) fn acquire(value: Option<&str>) -> Self {
+            let prior = CONFIGURED.with(|slot| slot.replace(value.map(str::to_owned)));
+            Self { prior }
+        }
+    }
+
+    impl Drop for UiOriginGuard {
+        fn drop(&mut self) {
+            let prior = self.prior.take();
+            CONFIGURED.with(|slot| *slot.borrow_mut() = prior);
+        }
+    }
 }
 
 /// GET /invites - List all invites for a cooperative
@@ -223,6 +303,120 @@ mod tests {
     use crate::invite::InviteManager;
     use actix_web::http::StatusCode;
     use actix_web::{test as actix_test, App, HttpMessage};
+
+    /// Absent, empty and whitespace-only all mean "unconfigured", and never a hostless link.
+    ///
+    /// The empty case is the one that bit: Compose exports an unconfigured `${VAR:-}` as a
+    /// present-but-empty variable, so `std::env::var` returns `Ok("")` and an `unwrap_or_else`
+    /// that only fires on `Err` produced a relative `/join?code=…` with no host at all.
+    #[test]
+    fn unconfigured_invite_base_degrades_to_the_default_not_to_a_hostless_link() {
+        for configured in [None, Some(""), Some("   "), Some("\t\n")] {
+            let base = resolve_invite_base(configured.map(str::to_string));
+            assert_eq!(
+                base, INVITE_BASE_URL_DEFAULT,
+                "{configured:?} must resolve to the default, got {base:?}"
+            );
+            assert!(
+                base.starts_with("http"),
+                "invite link must carry a host, got {base:?}"
+            );
+        }
+    }
+
+    /// The operator-facing variable name is a documented contract (`deploy/icnd.env.example`,
+    /// `docs/guides/onboarding-runbook.md`), so renaming it should break a test, not just docs.
+    #[test]
+    fn invite_base_url_env_name_is_the_documented_one() {
+        assert_eq!(INVITE_BASE_URL_ENV, "ICN_INVITE_BASE_URL");
+    }
+
+    /// A configured member-UI origin is used verbatim, with surrounding whitespace trimmed.
+    #[test]
+    fn configured_invite_base_is_used_and_trimmed() {
+        assert_eq!(
+            resolve_invite_base(Some("https://members.example.coop".to_string())),
+            "https://members.example.coop"
+        );
+        assert_eq!(
+            resolve_invite_base(Some("  https://members.example.coop  ".to_string())),
+            "https://members.example.coop"
+        );
+    }
+
+    /// **The independence proof.** Setting the gateway API origin alone must not move the
+    /// invite link — driven through the real handler, not the helper.
+    ///
+    /// This is the half of the review finding that treating empty-as-absent did not fix: an
+    /// operator following the QR-origin instructions set `GATEWAY_BASE_URL` to a real API
+    /// origin, and invite links silently became `{gateway API}/join?code=…`, a route the
+    /// gateway does not serve. The two authorities are now separate variables, so the QR
+    /// origin has no reachable path to this value.
+    ///
+    /// The gateway API origin is pinned through the authority that actually owns it, and the
+    /// member-UI origin is left unconfigured. Neither test touches the process environment, so
+    /// the two independence cases below cannot race each other.
+    #[actix_web::test]
+    async fn setting_the_gateway_api_origin_cannot_move_the_invite_link() {
+        let _api = crate::advertised_origin::test_env::EnvGuard::acquire(Some(
+            "http://gateway.example:8080",
+        ));
+        let _ui = test_env::UiOriginGuard::acquire(None);
+
+        let invite_url = created_invite_url().await;
+
+        assert!(
+            !invite_url.contains("gateway.example"),
+            "the gateway API origin leaked into the invite link: {invite_url}"
+        );
+        assert!(
+            invite_url.starts_with(INVITE_BASE_URL_DEFAULT),
+            "expected the member-UI default, got {invite_url}"
+        );
+    }
+
+    /// With both configured to different values, each authority stays in its own lane.
+    #[actix_web::test]
+    async fn api_origin_and_invite_origin_are_independent_when_both_are_set() {
+        let _api = crate::advertised_origin::test_env::EnvGuard::acquire(Some(
+            "http://gateway.example:8080",
+        ));
+        let _ui = test_env::UiOriginGuard::acquire(Some("https://members.example.coop"));
+
+        let invite_url = created_invite_url().await;
+
+        assert!(
+            invite_url.starts_with("https://members.example.coop/join?code="),
+            "invite link must use the member-UI origin only, got {invite_url}"
+        );
+        assert!(
+            !invite_url.contains("gateway.example"),
+            "the gateway API origin leaked into the invite link: {invite_url}"
+        );
+    }
+
+    /// Drives the real `create_invite` handler and returns the `invite_url` it produced.
+    async fn created_invite_url() -> String {
+        let invite_mgr = Arc::new(InviteManager::new());
+        let commons_mgr = Arc::new(CommonsManager::new());
+        let app = actix_test::init_service(
+            App::new()
+                .app_data(web::Data::new(invite_mgr))
+                .app_data(web::Data::new(commons_mgr))
+                .service(web::scope("/invites").service(create_invite)),
+        )
+        .await;
+
+        let sub = icn_identity::KeyPair::generate().unwrap().did().to_string();
+        let req = actix_test::TestRequest::post()
+            .uri("/invites")
+            .set_json(serde_json::json!({ "coop_id": "coopA", "role": "member" }))
+            .to_request();
+        req.extensions_mut().insert(admin_claims("coopA", &sub));
+
+        let body: InviteResponse = actix_test::call_and_read_body_json(&app, req).await;
+        body.invite_url
+    }
 
     fn admin_claims(coop: &str, sub: &str) -> TokenClaims {
         TokenClaims {

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -1337,9 +1337,9 @@ pub(crate) fn authorize_steward_act(
 mod tests {
     use super::*;
 
-    // The crate-wide lock, not a local one: these tests share the process-global
-    // `GATEWAY_BASE_URL` with every other test module in this lib test binary, and a
-    // second mutex would serialize nothing against them (#2569).
+    // The crate's single test-time origin authority. Under `cfg(test)` the advertised origin
+    // resolves from a module-private thread-local rather than the process environment, so this
+    // guard pins a per-test value and no env locking is needed here (#2569).
     use crate::advertised_origin::test_env::EnvGuard;
     use actix_web::App;
 

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -1336,6 +1336,11 @@ pub(crate) fn authorize_steward_act(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The crate-wide lock, not a local one: these tests share the process-global
+    // `GATEWAY_BASE_URL` with every other test module in this lib test binary, and a
+    // second mutex would serialize nothing against them (#2569).
+    use crate::advertised_origin::test_env::EnvGuard;
     use actix_web::App;
 
     #[test]
@@ -1398,36 +1403,6 @@ mod tests {
             !qr.contains("192.0.2.10"),
             "the request Host must not reach a device-facing QR payload"
         );
-    }
-
-    /// Serializes mutation of `GATEWAY_BASE_URL` for the tests in this module and restores the
-    /// prior value on drop.
-    struct EnvGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        prior: Option<String>,
-    }
-
-    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    impl EnvGuard {
-        fn acquire(value: Option<&str>) -> Self {
-            let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            let prior = std::env::var("GATEWAY_BASE_URL").ok();
-            match value {
-                Some(v) => std::env::set_var("GATEWAY_BASE_URL", v),
-                None => std::env::remove_var("GATEWAY_BASE_URL"),
-            }
-            Self { _lock: lock, prior }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.prior.as_deref() {
-                Some(v) => std::env::set_var("GATEWAY_BASE_URL", v),
-                None => std::env::remove_var("GATEWAY_BASE_URL"),
-            }
-        }
     }
 
     #[test]

--- a/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
+++ b/icn/crates/icn-gateway/src/api/sdis/simple_enrollment.rs
@@ -54,7 +54,7 @@ use tokio::sync::RwLock;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::api::sessions::get_gateway_url;
+use crate::advertised_origin::advertised_origin;
 use crate::error::{GatewayError, Result};
 use crate::session_authority::SessionAuthority;
 use crate::steward_mgr::StewardManager;
@@ -280,10 +280,14 @@ pub struct CompleteEnrollmentResponse {
 /// POST /enrollment/start
 #[post("/enrollment/start")]
 pub async fn start_enrollment(
-    http_req: HttpRequest,
     store: web::Data<Arc<EnrollmentStore>>,
     req: web::Json<StartEnrollmentRequest>,
 ) -> Result<HttpResponse> {
+    // The enrollment QR is scanned by a second device, so its origin carries the same
+    // credential-destination authority as the QR-login one and comes from the same
+    // operator-owned source (#2569). Resolved before any enrollment state is allocated.
+    let gateway_url = advertised_origin()?;
+
     let enrollment_id = Uuid::new_v4().to_string();
     let verification_code = generate_verification_code();
     let now = icn_time::current_timestamp_secs();
@@ -294,7 +298,7 @@ pub async fn start_enrollment(
         "type": "icn-enrollment",
         "enrollment_id": enrollment_id,
         "challenge": base64::Engine::encode(&base64::engine::general_purpose::STANDARD, enrollment_id.as_bytes()),
-        "gateway_url": get_gateway_url(&http_req)
+        "gateway_url": gateway_url
     });
 
     // Create enrollment session
@@ -1355,11 +1359,18 @@ mod tests {
         });
     }
 
+    /// Replaces `test_start_enrollment_uses_request_gateway_url`, which asserted that a
+    /// request-supplied `Host` became the enrollment QR's `gateway_url`. That behaviour is the
+    /// #2569 vulnerability, not a feature: the enrollment QR is scanned by a second device, so
+    /// a caller-chosen `Host` chose where that device would send authenticated traffic. The
+    /// authority now comes only from `GATEWAY_BASE_URL`.
+    ///
+    /// Endpoint-level authority coverage (hostile headers across trusted and untrusted peers,
+    /// malformed configuration, fail-closed) lives in
+    /// `tests/qr_gateway_url_authority.rs`; this keeps the in-module happy path honest.
     #[actix_web::test]
-    async fn test_start_enrollment_uses_request_gateway_url() {
-        // Ensure env-based overrides do not short-circuit the request-derived path.
-        std::env::remove_var("GATEWAY_BASE_URL");
-        std::env::remove_var("TRUSTED_PROXY_IPS");
+    async fn test_start_enrollment_advertises_configured_origin_not_request_host() {
+        let _guard = EnvGuard::acquire(Some("https://gateway.example.coop"));
 
         let app = actix_web::test::init_service(
             App::new()
@@ -1377,13 +1388,46 @@ mod tests {
 
         let body = actix_web::test::call_and_read_body(&app, req).await;
         let resp: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let qr = resp["qr_code"].as_str().unwrap();
+
         assert!(
-            resp["qr_code"]
-                .as_str()
-                .unwrap()
-                .contains("\"gateway_url\":\"http://192.0.2.10:30080\""),
-            "qr payload should advertise the current request gateway"
+            qr.contains("\"gateway_url\":\"https://gateway.example.coop\""),
+            "qr payload must advertise the operator origin, got {qr}"
         );
+        assert!(
+            !qr.contains("192.0.2.10"),
+            "the request Host must not reach a device-facing QR payload"
+        );
+    }
+
+    /// Serializes mutation of `GATEWAY_BASE_URL` for the tests in this module and restores the
+    /// prior value on drop.
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        prior: Option<String>,
+    }
+
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    impl EnvGuard {
+        fn acquire(value: Option<&str>) -> Self {
+            let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prior = std::env::var("GATEWAY_BASE_URL").ok();
+            match value {
+                Some(v) => std::env::set_var("GATEWAY_BASE_URL", v),
+                None => std::env::remove_var("GATEWAY_BASE_URL"),
+            }
+            Self { _lock: lock, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prior.as_deref() {
+                Some(v) => std::env::set_var("GATEWAY_BASE_URL", v),
+                None => std::env::remove_var("GATEWAY_BASE_URL"),
+            }
+        }
     }
 
     #[test]

--- a/icn/crates/icn-gateway/src/api/sessions.rs
+++ b/icn/crates/icn-gateway/src/api/sessions.rs
@@ -263,9 +263,9 @@ mod tests {
     use super::*;
     use actix_web::{test, App};
 
-    // The crate-wide lock, not a local one: these tests share the process-global
-    // `GATEWAY_BASE_URL` with every other test module in this lib test binary, and a
-    // second mutex would serialize nothing against them (#2569).
+    // The crate's single test-time origin authority. Under `cfg(test)` the advertised origin
+    // resolves from a module-private thread-local rather than the process environment, so this
+    // guard pins a per-test value and no env locking is needed here (#2569).
     use crate::advertised_origin::test_env::EnvGuard;
 
     /// Builds the `/sessions` app under test.

--- a/icn/crates/icn-gateway/src/api/sessions.rs
+++ b/icn/crates/icn-gateway/src/api/sessions.rs
@@ -47,90 +47,13 @@ const WEB_SESSION_SCOPE_CEILING: &[&str] = &[
 /// Extract client IP address from request (for rate limiting).
 ///
 /// SECURITY: `X-Forwarded-For` is honoured only when the immediate transport peer is a
-/// trusted proxy; otherwise the socket peer is the client (#2567). This is the same
-/// allowlist [`get_gateway_url`] gates `X-Forwarded-*` on, via
-/// [`crate::client_ip::is_trusted_proxy`].
+/// trusted proxy; otherwise the socket peer is the client (#2567). See [`crate::client_ip`].
+///
+/// That trust is scoped to *rate-limit identity* and nothing else. It does not extend to the
+/// origin advertised in QR material — see [`crate::advertised_origin`], which takes no request
+/// at all (#2569).
 fn get_client_ip(req: &HttpRequest) -> String {
     crate::client_ip::client_ip_key(req)
-}
-
-/// Get gateway base URL from environment or request headers
-/// Handles reverse proxy scenarios (K8s ingress, Cloudflare, nginx, etc.)
-///
-/// **Security**: Pinned GATEWAY_BASE_URL prevents X-Forwarded-* header spoofing.
-/// If GATEWAY_BASE_URL is not set, X-Forwarded-* headers are only trusted if the
-/// request comes from a trusted proxy IP (configured via TRUSTED_PROXY_IPS).
-pub(crate) fn get_gateway_url(req: &HttpRequest) -> String {
-    // First try environment variable (recommended for production)
-    // This takes precedence over all headers to prevent spoofing
-    if let Ok(url) = std::env::var("GATEWAY_BASE_URL") {
-        return url;
-    }
-
-    // Check if the request came from a trusted proxy.
-    // One trust model for the whole gateway — see `crate::client_ip` for the semantics of
-    // TRUSTED_PROXY_IPS (exact addresses, comma-separated, loopback by default).
-    let is_trusted_proxy = req
-        .peer_addr()
-        .is_some_and(|peer_addr| crate::client_ip::is_trusted_proxy(peer_addr.ip()));
-
-    // Only trust X-Forwarded-* headers if from a trusted proxy
-    if is_trusted_proxy {
-        // Determine scheme from X-Forwarded-Proto (set by reverse proxies)
-        let scheme = req
-            .headers()
-            .get("x-forwarded-proto")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or_else(|| {
-                // Check if connection is secure
-                if req.connection_info().scheme() == "https" {
-                    "https"
-                } else {
-                    "http"
-                }
-            });
-
-        // Get host from X-Forwarded-Host (reverse proxy) or Host header
-        let host = req
-            .headers()
-            .get("x-forwarded-host")
-            .and_then(|v| v.to_str().ok())
-            .or_else(|| req.headers().get("host").and_then(|v| v.to_str().ok()));
-
-        if let Some(h) = host {
-            // Strip port for standard ports
-            let clean_host = if (scheme == "https" && h.ends_with(":443"))
-                || (scheme == "http" && h.ends_with(":80"))
-            {
-                h.split(':').next().unwrap_or(h)
-            } else {
-                h
-            };
-            return format!("{scheme}://{clean_host}");
-        }
-    } else if req.headers().contains_key("x-forwarded-for")
-        || req.headers().contains_key("x-forwarded-host")
-    {
-        // Untrusted proxy detected - log warning
-        tracing::warn!(
-            peer_addr = ?req.peer_addr(),
-            "Rejecting X-Forwarded-* headers from untrusted source. \
-             Set GATEWAY_BASE_URL or TRUSTED_PROXY_IPS to enable proxied QR login."
-        );
-    }
-
-    // Fallback: derive from connection info (direct connection only)
-    let scheme = if req.connection_info().scheme() == "https" {
-        "https"
-    } else {
-        "http"
-    };
-
-    if let Some(host) = req.headers().get("host").and_then(|v| v.to_str().ok()) {
-        format!("{scheme}://{host}")
-    } else {
-        "http://localhost:8080".to_string()
-    }
 }
 
 // ============================================================================
@@ -155,14 +78,16 @@ pub async fn create_session(
     // Validate coop_id
     validation::validate_coop_id(&req.coop_id)?;
 
+    // The origin a scanning device will send its bearer credential to. Resolved BEFORE the
+    // session is allocated: an unadvertisable session is useless, and minting one per refused
+    // request would let an unauthenticated caller accumulate session state (#2569).
+    let gateway_url = crate::advertised_origin::advertised_origin()?;
+
     // Create session
     let session = session_mgr
         .create_session(req.coop_id.clone())
         .await
         .map_err(|e| GatewayError::InternalError(format!("Failed to create session: {e}")))?;
-
-    // Get gateway URL for QR data
-    let gateway_url = get_gateway_url(&http_req);
 
     let qr_data = SessionQrData {
         session_id: session.session_id.clone(),
@@ -337,34 +262,87 @@ pub async fn approve_session_handler(
 mod tests {
     use super::*;
     use actix_web::{test, App};
+    use std::sync::{Mutex, MutexGuard};
+
+    /// Serializes mutation of `GATEWAY_BASE_URL` across the tests in this module.
+    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
+        prior: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn acquire(value: Option<&str>) -> Self {
+            let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prior = std::env::var("GATEWAY_BASE_URL").ok();
+            match value {
+                Some(v) => std::env::set_var("GATEWAY_BASE_URL", v),
+                None => std::env::remove_var("GATEWAY_BASE_URL"),
+            }
+            Self { _lock: lock, prior }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.prior.as_deref() {
+                Some(v) => std::env::set_var("GATEWAY_BASE_URL", v),
+                None => std::env::remove_var("GATEWAY_BASE_URL"),
+            }
+        }
+    }
+
+    /// Builds the `/sessions` app under test.
+    macro_rules! session_app {
+        () => {
+            test::init_service(
+                App::new()
+                    .app_data(web::Data::new(Arc::new(SessionManager::new())))
+                    .app_data(web::Data::new(Arc::new(IpRateLimiter::new_for_auth())))
+                    .service(web::scope("/sessions").service(create_session)),
+            )
+            .await
+        };
+    }
+
+    fn create_request() -> actix_http::Request {
+        test::TestRequest::post()
+            .uri("/sessions")
+            .set_json(&CreateSessionRequest {
+                coop_id: "test-coop".to_string(),
+            })
+            .to_request()
+    }
 
     #[actix_web::test]
     async fn test_create_session() {
-        let session_mgr = Arc::new(SessionManager::new());
-        let ip_limiter = Arc::new(IpRateLimiter::new_for_auth());
+        // QR issuance requires an operator-authoritative origin (#2569); this test previously
+        // relied on one being inferred from the request.
+        let _env = EnvGuard::acquire(Some("https://gateway.example.coop"));
+        let app = session_app!();
 
-        let app = test::init_service(
-            App::new()
-                .app_data(web::Data::new(session_mgr))
-                .app_data(web::Data::new(ip_limiter))
-                .service(web::scope("/sessions").service(create_session)),
-        )
-        .await;
-
-        let req_body = CreateSessionRequest {
-            coop_id: "test-coop".to_string(),
-        };
-
-        let req = test::TestRequest::post()
-            .uri("/sessions")
-            .set_json(&req_body)
-            .to_request();
-
-        let resp: CreateSessionResponse = test::call_and_read_body_json(&app, req).await;
+        let resp: CreateSessionResponse =
+            test::call_and_read_body_json(&app, create_request()).await;
 
         assert_eq!(resp.session_id.len(), 64); // 32 bytes hex
         assert_eq!(resp.qr_data.coop_id, "test-coop");
-        assert!(!resp.qr_data.gateway_url.is_empty());
+        assert_eq!(resp.qr_data.gateway_url, "https://gateway.example.coop");
+    }
+
+    /// Without a configured origin there is nothing safe to advertise to a scanning device, so
+    /// the session is refused rather than issued with an inferred authority (#2569).
+    /// Header-level authority coverage lives in `tests/qr_gateway_url_authority.rs`.
+    #[actix_web::test]
+    async fn test_create_session_fails_closed_without_configured_origin() {
+        let _env = EnvGuard::acquire(None);
+        let app = session_app!();
+
+        let resp = test::call_service(&app, create_request()).await;
+        assert_eq!(
+            resp.status(),
+            actix_web::http::StatusCode::SERVICE_UNAVAILABLE
+        );
     }
 
     #[actix_web::test]

--- a/icn/crates/icn-gateway/src/api/sessions.rs
+++ b/icn/crates/icn-gateway/src/api/sessions.rs
@@ -262,36 +262,11 @@ pub async fn approve_session_handler(
 mod tests {
     use super::*;
     use actix_web::{test, App};
-    use std::sync::{Mutex, MutexGuard};
 
-    /// Serializes mutation of `GATEWAY_BASE_URL` across the tests in this module.
-    static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvGuard {
-        _lock: MutexGuard<'static, ()>,
-        prior: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn acquire(value: Option<&str>) -> Self {
-            let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            let prior = std::env::var("GATEWAY_BASE_URL").ok();
-            match value {
-                Some(v) => std::env::set_var("GATEWAY_BASE_URL", v),
-                None => std::env::remove_var("GATEWAY_BASE_URL"),
-            }
-            Self { _lock: lock, prior }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.prior.as_deref() {
-                Some(v) => std::env::set_var("GATEWAY_BASE_URL", v),
-                None => std::env::remove_var("GATEWAY_BASE_URL"),
-            }
-        }
-    }
+    // The crate-wide lock, not a local one: these tests share the process-global
+    // `GATEWAY_BASE_URL` with every other test module in this lib test binary, and a
+    // second mutex would serialize nothing against them (#2569).
+    use crate::advertised_origin::test_env::EnvGuard;
 
     /// Builds the `/sessions` app under test.
     macro_rules! session_app {

--- a/icn/crates/icn-gateway/src/client_ip.rs
+++ b/icn/crates/icn-gateway/src/client_ip.rs
@@ -6,9 +6,18 @@
 //! peer is explicitly trusted to assert forwarding metadata. If the immediate peer is not
 //! trusted, the socket peer IP is the client IP.
 //!
-//! This is the same allowlist `api::sessions::get_gateway_url` uses to gate `X-Forwarded-*`
-//! for QR-login URL derivation; both read it through [`is_trusted_proxy`] so the gateway has
-//! exactly one trusted-proxy model.
+//! # Scope of this trust
+//!
+//! This allowlist authorizes a peer to assert **one** thing: the client IP used for rate-limit
+//! identity. It is not a general "this peer's headers are operator assertions" switch.
+//!
+//! Concretely, it does **not** cover the origin advertised in QR material. That origin is where
+//! a scanning device sends its bearer credential, so it is operator-configured only and reads no
+//! request metadata at all — see [`crate::advertised_origin`] (#2569). QR-login URL derivation
+//! previously did gate `X-Forwarded-Host`/`-Proto` on this same allowlist; that was insufficient,
+//! because a trusted proxy that *relays* a caller's `Host` launders the caller's claim through
+//! its own trust. Authenticating the sender is not authenticating the provenance of what the
+//! sender forwards.
 //!
 //! # Configuration
 //!
@@ -94,12 +103,6 @@ fn trusted_proxies() -> Vec<IpAddr> {
         .collect()
 }
 
-/// Whether `ip` is allowed to assert forwarding metadata.
-pub(crate) fn is_trusted_proxy(ip: IpAddr) -> bool {
-    let ip = canonicalize(ip);
-    trusted_proxies().contains(&ip)
-}
-
 /// Resolve the client IP for `req`, honouring forwarded metadata only from a trusted peer.
 ///
 /// Returns `None` only when the request has no transport peer.
@@ -109,9 +112,8 @@ pub(crate) fn client_ip(req: &HttpRequest) -> Option<IpAddr> {
 
     if !trusted.contains(&peer) {
         if req.headers().contains_key(FORWARDED_FOR) {
-            // Not a warning: behind an unconfigured proxy this is every request. The
-            // equivalent misconfiguration is surfaced loudly on the QR-login path by
-            // `api::sessions::get_gateway_url`.
+            // Not a warning: behind an unconfigured proxy this is every request, and the
+            // fallback is the safe one (key on the socket peer).
             tracing::debug!(
                 peer = %peer,
                 "Ignoring {FORWARDED_FOR} from an untrusted peer; keying on the socket address. \

--- a/icn/crates/icn-gateway/src/lib.rs
+++ b/icn/crates/icn-gateway/src/lib.rs
@@ -21,6 +21,7 @@
 // Translation keys are used in error.rs for user-facing API error messages.
 rust_i18n::i18n!("locales", fallback = "en");
 
+pub(crate) mod advertised_origin;
 pub mod api;
 pub mod audit;
 pub mod auth;

--- a/icn/crates/icn-gateway/tests/forwarded_client_ip_trust.rs
+++ b/icn/crates/icn-gateway/tests/forwarded_client_ip_trust.rs
@@ -30,7 +30,8 @@ use icn_identity::IdentityBundle;
 const UNTRUSTED_PEER: &str = "198.51.100.42:54321";
 
 /// Loopback is trusted to assert forwarding metadata when `TRUSTED_PROXY_IPS` is unset,
-/// matching the existing `get_gateway_url` gate in `api/sessions.rs`.
+/// per `crate::client_ip`. That trust covers rate-limit identity only — it does not extend to
+/// the origin advertised in QR material, which is operator-configured (#2569).
 const TRUSTED_PEER: &str = "127.0.0.1:54321";
 
 /// `IpRateLimiter::new_for_auth` has capacity 20 and refills 2 tokens/second. An in-process

--- a/icn/crates/icn-gateway/tests/fp01_credential_holder_escalation.rs
+++ b/icn/crates/icn-gateway/tests/fp01_credential_holder_escalation.rs
@@ -98,6 +98,10 @@ fn mint(authority: &SessionAuthority, did: &Did, coop: &str, scope_list: &[&str]
 /// mount flags and the app data the enrollment handlers resolve.
 macro_rules! sdis_app {
     ($authority:expr, $trust:expr, $flags:expr) => {{
+        // Mounting the enrollment tree is the last point before a request can reach
+        // `/v1/sdis/enrollment/start`, so the advertised origin is established here rather
+        // than in each test body — see `ensure_advertised_origin`.
+        ensure_advertised_origin();
         test::init_service(
             App::new()
                 .app_data(web::Data::new($authority.clone()))
@@ -296,7 +300,6 @@ async fn refused_self_edge_leaves_the_vouch_threshold_unmet() {
 /// cannot enroll into an arbitrary cooperative because there is no route to.
 #[actix_web::test]
 async fn enrollment_tree_absent_without_explicit_declaration() {
-    ensure_advertised_origin();
     let authority = authority();
     let trust = Arc::new(TrustManager::new());
     let app = sdis_app!(authority, trust, SdisMountFlags::default());
@@ -353,7 +356,6 @@ async fn steward_surface_survives_the_containment() {
 /// is a mount decision, not a removal of the feature.
 #[actix_web::test]
 async fn enrollment_tree_present_under_explicit_declaration() {
-    ensure_advertised_origin();
     let authority = authority();
     let trust = Arc::new(TrustManager::new());
     let app = sdis_app!(
@@ -393,7 +395,6 @@ async fn enrollment_tree_present_under_explicit_declaration() {
 /// institution the voucher belongs to.
 #[actix_web::test]
 async fn vouch_denied_for_a_foreign_cooperative() {
-    ensure_advertised_origin();
     let authority = authority();
     let trust = Arc::new(TrustManager::new());
     let app = sdis_app!(
@@ -481,7 +482,6 @@ async fn vouch_denied_for_a_foreign_cooperative() {
 /// credential is minted for the foreign cooperative.
 #[actix_web::test]
 async fn completion_denied_while_vouch_is_unbound() {
-    ensure_advertised_origin();
     let authority = authority();
     let trust = Arc::new(TrustManager::new());
     let app = sdis_app!(
@@ -700,6 +700,10 @@ async fn no_credential_is_minted_when_a_required_write_fails() {
     let trust = Arc::new(TrustManager::new());
     let store = Arc::new(EnrollmentStore::new());
 
+    // Same rule as `sdis_app!`: this assembles the enrollment tree, so it owns the
+    // precondition too. This case only drives `/enrollment/complete`, but the mounted
+    // tree includes `/enrollment/start` and the next edit here should not have to notice.
+    ensure_advertised_origin();
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(authority.clone()))
@@ -780,9 +784,22 @@ async fn no_credential_is_minted_when_a_required_write_fails() {
 }
 
 /// Enrollment initiation issues a device-facing QR, whose `gateway_url` requires an
-/// operator-authoritative origin (#2569). These tests are about route authority, not QR
-/// authority, so they only need a valid one present. Set idempotently to the same value: no
-/// test in this binary wants it unset, so there is nothing to race.
+/// operator-authoritative origin (#2569). These tests are about containment and route
+/// authority, not QR authority, so they only need a valid origin to exist.
+///
+/// **Called from app assembly, never from a test body.** An earlier revision left this to
+/// each test to remember, and `legitimate_enrollment_still_completes` did not: it drives
+/// `/v1/sdis/enrollment/start` through `run_enrollment` and passed only when some sibling
+/// test had already set the variable. Run alone it returned 503 against an expected 200 — a
+/// suite that was green while that case proved nothing. Assembling the app is the one step
+/// no test can skip and still issue a request, so the precondition lives there.
+///
+/// `Once` rather than an idempotent `set_var`: libtest runs these tests on many threads, and
+/// re-writing on every call means a write can overlap a handler thread's read of the same
+/// variable. One write, and `call_once` gives every later caller a happens-before edge to it.
 fn ensure_advertised_origin() {
-    std::env::set_var("GATEWAY_BASE_URL", "https://gateway.example.coop");
+    static CONFIGURED: std::sync::Once = std::sync::Once::new();
+    CONFIGURED.call_once(|| {
+        std::env::set_var("GATEWAY_BASE_URL", "https://gateway.example.coop");
+    });
 }

--- a/icn/crates/icn-gateway/tests/fp01_credential_holder_escalation.rs
+++ b/icn/crates/icn-gateway/tests/fp01_credential_holder_escalation.rs
@@ -296,6 +296,7 @@ async fn refused_self_edge_leaves_the_vouch_threshold_unmet() {
 /// cannot enroll into an arbitrary cooperative because there is no route to.
 #[actix_web::test]
 async fn enrollment_tree_absent_without_explicit_declaration() {
+    ensure_advertised_origin();
     let authority = authority();
     let trust = Arc::new(TrustManager::new());
     let app = sdis_app!(authority, trust, SdisMountFlags::default());
@@ -352,6 +353,7 @@ async fn steward_surface_survives_the_containment() {
 /// is a mount decision, not a removal of the feature.
 #[actix_web::test]
 async fn enrollment_tree_present_under_explicit_declaration() {
+    ensure_advertised_origin();
     let authority = authority();
     let trust = Arc::new(TrustManager::new());
     let app = sdis_app!(
@@ -391,6 +393,7 @@ async fn enrollment_tree_present_under_explicit_declaration() {
 /// institution the voucher belongs to.
 #[actix_web::test]
 async fn vouch_denied_for_a_foreign_cooperative() {
+    ensure_advertised_origin();
     let authority = authority();
     let trust = Arc::new(TrustManager::new());
     let app = sdis_app!(
@@ -478,6 +481,7 @@ async fn vouch_denied_for_a_foreign_cooperative() {
 /// credential is minted for the foreign cooperative.
 #[actix_web::test]
 async fn completion_denied_while_vouch_is_unbound() {
+    ensure_advertised_origin();
     let authority = authority();
     let trust = Arc::new(TrustManager::new());
     let app = sdis_app!(
@@ -773,4 +777,12 @@ async fn no_credential_is_minted_when_a_required_write_fails() {
             .is_none(),
         "no membership may be reported: {body}"
     );
+}
+
+/// Enrollment initiation issues a device-facing QR, whose `gateway_url` requires an
+/// operator-authoritative origin (#2569). These tests are about route authority, not QR
+/// authority, so they only need a valid one present. Set idempotently to the same value: no
+/// test in this binary wants it unset, so there is nothing to race.
+fn ensure_advertised_origin() {
+    std::env::set_var("GATEWAY_BASE_URL", "https://gateway.example.coop");
 }

--- a/icn/crates/icn-gateway/tests/qr_gateway_url_authority.rs
+++ b/icn/crates/icn-gateway/tests/qr_gateway_url_authority.rs
@@ -1,0 +1,515 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! QR gateway authority must be operator-owned, not request-derived (#2569).
+//!
+//! The invariant under test:
+//!
+//! > A URL embedded in QR material that causes another device to transmit an ICN bearer
+//! > credential MUST have operator-authoritative scheme/host/port. Its authority MUST NOT be
+//! > derived from request-controlled `Host`, `Forwarded`, `X-Forwarded-Host`,
+//! > `X-Forwarded-Proto`, or request target authority — not even when the immediate peer is a
+//! > trusted proxy.
+//!
+//! Why this is a credential-destination property and not a cosmetic one: the QR payload's
+//! `gateway_url` is consumed by a *second device*. The reference scanner
+//! (`examples/mobile-app/src/screens/QRScannerScreen.tsx`) POSTs to
+//! `${qrData.gateway_url}/v1/sessions/{id}/approve` with `Authorization: Bearer <token>`.
+//! Whoever controls that origin receives a member's bearer credential.
+//!
+//! #2567/#2568 established that a trusted immediate peer may assert the *client IP*. That does
+//! not make every value such a peer relays an operator assertion: the appliance nginx is
+//! `default_server` and relays `proxy_set_header Host $host`, so a caller-chosen `Host` reaches
+//! the gateway over loopback wearing the proxy's trust. Authenticating the proxy does not
+//! authenticate the provenance of what the proxy relays.
+//!
+//! These tests enter through the real QR-producing routes rather than the derivation helper,
+//! because the property at stake is what lands in QR material, not what a formatter returns.
+
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use actix_http::Request;
+use actix_web::http::StatusCode;
+use actix_web::{test, web, App};
+use icn_gateway::api;
+use icn_gateway::api::sdis::simple_enrollment::EnrollmentStore;
+use icn_gateway::rate_limit::IpRateLimiter;
+use icn_gateway::session::SessionManager;
+
+/// Loopback is a trusted proxy under the default policy — this is exactly the appliance's
+/// on-host nginx position, and the trust #2568 relies on.
+const TRUSTED_PEER: &str = "127.0.0.1:54321";
+
+/// A routable, non-loopback socket peer: NOT a trusted proxy under the default policy.
+const UNTRUSTED_PEER: &str = "198.51.100.42:54321";
+
+/// The origin an attacker wants a scanning phone to send its bearer token to.
+const HOSTILE_HOST: &str = "attacker.example.net";
+
+/// A canonical operator-owned origin, in the shape `deploy/k8s/configmap.yaml` and the
+/// appliance's `ICN_APPLIANCE_LAN_ORIGIN` both produce.
+const OPERATOR_ORIGIN: &str = "https://gateway.example.coop";
+
+/// Serializes mutation of the process-global env the QR authority reads.
+static ENV_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Pins `GATEWAY_BASE_URL` (and clears `TRUSTED_PROXY_IPS` to the documented default) for the
+/// test's lifetime, restoring prior values on drop under a shared lock.
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    prior_base: Option<String>,
+    prior_proxies: Option<String>,
+}
+
+impl EnvGuard {
+    fn acquire(base_url: Option<&str>) -> Self {
+        let lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prior_base = std::env::var("GATEWAY_BASE_URL").ok();
+        let prior_proxies = std::env::var("TRUSTED_PROXY_IPS").ok();
+        set_or_clear("GATEWAY_BASE_URL", base_url);
+        // Unset => loopback-only default, which is what the appliance actually runs.
+        set_or_clear("TRUSTED_PROXY_IPS", None);
+        Self {
+            _lock: lock,
+            prior_base,
+            prior_proxies,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        set_or_clear("GATEWAY_BASE_URL", self.prior_base.as_deref());
+        set_or_clear("TRUSTED_PROXY_IPS", self.prior_proxies.as_deref());
+    }
+}
+
+fn set_or_clear(key: &str, value: Option<&str>) {
+    match value {
+        Some(v) => std::env::set_var(key, v),
+        None => std::env::remove_var(key),
+    }
+}
+
+/// Every request-controlled lever that has ever fed the advertised origin.
+#[derive(Clone, Copy)]
+struct HostileHeaders {
+    host: Option<&'static str>,
+    forwarded_host: Option<&'static str>,
+    forwarded_proto: Option<&'static str>,
+    forwarded: Option<&'static str>,
+}
+
+impl HostileHeaders {
+    const fn none() -> Self {
+        Self {
+            host: None,
+            forwarded_host: None,
+            forwarded_proto: None,
+            forwarded: None,
+        }
+    }
+}
+
+fn session_request(peer: &str, headers: HostileHeaders) -> Request {
+    let peer_addr: SocketAddr = peer.parse().expect("test setup: valid socket address");
+    let mut req = test::TestRequest::post()
+        .uri("/v1/sessions")
+        .peer_addr(peer_addr)
+        .set_json(serde_json::json!({ "coop_id": "test-coop" }));
+
+    if let Some(v) = headers.host {
+        req = req.insert_header(("host", v));
+    }
+    if let Some(v) = headers.forwarded_host {
+        req = req.insert_header(("x-forwarded-host", v));
+    }
+    if let Some(v) = headers.forwarded_proto {
+        req = req.insert_header(("x-forwarded-proto", v));
+    }
+    if let Some(v) = headers.forwarded {
+        req = req.insert_header(("forwarded", v));
+    }
+    req.to_request()
+}
+
+fn enrollment_request(peer: &str, headers: HostileHeaders) -> Request {
+    let peer_addr: SocketAddr = peer.parse().expect("test setup: valid socket address");
+    let mut req = test::TestRequest::post()
+        .uri("/v1/sdis/enrollment/start")
+        .peer_addr(peer_addr)
+        .set_json(serde_json::json!({
+            "identity_name": "Test User",
+            "coop_id": "test-coop"
+        }));
+
+    if let Some(v) = headers.host {
+        req = req.insert_header(("host", v));
+    }
+    if let Some(v) = headers.forwarded_host {
+        req = req.insert_header(("x-forwarded-host", v));
+    }
+    if let Some(v) = headers.forwarded_proto {
+        req = req.insert_header(("x-forwarded-proto", v));
+    }
+    if let Some(v) = headers.forwarded {
+        req = req.insert_header(("forwarded", v));
+    }
+    req.to_request()
+}
+
+macro_rules! session_app {
+    () => {{
+        test::init_service(
+            App::new()
+                .app_data(web::Data::new(Arc::new(SessionManager::new())))
+                .app_data(web::Data::new(Arc::new(IpRateLimiter::new_for_auth())))
+                .service(web::scope("/v1/sessions").service(api::sessions::create_session)),
+        )
+        .await
+    }};
+}
+
+macro_rules! enrollment_app {
+    () => {{
+        test::init_service(
+            App::new()
+                .app_data(web::Data::new(Arc::new(EnrollmentStore::new())))
+                .service(
+                    web::scope("/v1/sdis").service(api::sdis::simple_enrollment::start_enrollment),
+                ),
+        )
+        .await
+    }};
+}
+
+/// The full matrix of request-controlled authority claims, each paired with the peer position
+/// that makes it maximally dangerous.
+fn hostile_matrix() -> Vec<(&'static str, &'static str, HostileHeaders)> {
+    vec![
+        (
+            "trusted proxy relays a caller-chosen Host (appliance nginx `Host $host`)",
+            TRUSTED_PEER,
+            HostileHeaders {
+                host: Some(HOSTILE_HOST),
+                ..HostileHeaders::none()
+            },
+        ),
+        (
+            "trusted proxy relays a caller-chosen X-Forwarded-Host",
+            TRUSTED_PEER,
+            HostileHeaders {
+                host: Some("gateway.example.coop"),
+                forwarded_host: Some(HOSTILE_HOST),
+                ..HostileHeaders::none()
+            },
+        ),
+        (
+            "trusted proxy relays a caller-chosen X-Forwarded-Proto",
+            TRUSTED_PEER,
+            HostileHeaders {
+                host: Some("gateway.example.coop"),
+                forwarded_proto: Some("http"),
+                ..HostileHeaders::none()
+            },
+        ),
+        (
+            "direct caller chooses Host (no proxy anywhere)",
+            UNTRUSTED_PEER,
+            HostileHeaders {
+                host: Some(HOSTILE_HOST),
+                ..HostileHeaders::none()
+            },
+        ),
+        (
+            "direct caller chooses RFC 7239 Forwarded",
+            UNTRUSTED_PEER,
+            HostileHeaders {
+                host: Some("gateway.example.coop"),
+                forwarded: Some("proto=http;host=attacker.example.net"),
+                ..HostileHeaders::none()
+            },
+        ),
+        (
+            "direct caller chooses X-Forwarded-Host and X-Forwarded-Proto",
+            UNTRUSTED_PEER,
+            HostileHeaders {
+                host: Some("gateway.example.coop"),
+                forwarded_host: Some(HOSTILE_HOST),
+                forwarded_proto: Some("http"),
+                ..HostileHeaders::none()
+            },
+        ),
+    ]
+}
+
+// ============================================================================
+// Operator origin configured: it wins over every request-controlled claim.
+// ============================================================================
+
+/// Covers requirements 1, 2, 3, 4 and 5: no request-controlled lever — through a trusted proxy
+/// or direct — can move the origin a scanning device will send its bearer token to.
+#[actix_web::test]
+async fn configured_origin_defeats_every_request_controlled_authority_claim() {
+    let _env = EnvGuard::acquire(Some(OPERATOR_ORIGIN));
+    let app = session_app!();
+
+    for (label, peer, headers) in hostile_matrix() {
+        let resp = test::call_service(&app, session_request(peer, headers)).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "{label}: a configured operator origin must still serve QR sessions"
+        );
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let advertised = body["qr_data"]["gateway_url"]
+            .as_str()
+            .expect("qr_data.gateway_url must be a string");
+
+        assert_eq!(
+            advertised, OPERATOR_ORIGIN,
+            "{label}: QR authority must be the operator origin verbatim"
+        );
+        assert!(
+            !advertised.contains(HOSTILE_HOST),
+            "{label}: a scanning device would send its bearer token to {HOSTILE_HOST}"
+        );
+    }
+}
+
+/// Requirement 9: the shipped k8s posture (`gateway_base_url` in configmap.yaml) is unchanged —
+/// an explicit host:port origin round-trips exactly, port included.
+#[actix_web::test]
+async fn configured_origin_with_explicit_port_is_preserved() {
+    let _env = EnvGuard::acquire(Some("http://192.0.2.10:30080"));
+    let app = session_app!();
+
+    let resp = test::call_service(
+        &app,
+        session_request(
+            TRUSTED_PEER,
+            HostileHeaders {
+                host: Some(HOSTILE_HOST),
+                ..HostileHeaders::none()
+            },
+        ),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["qr_data"]["gateway_url"], "http://192.0.2.10:30080");
+}
+
+/// Requirement 8: the supported appliance path still advertises a reachable external origin.
+/// The appliance gateway is bound to 127.0.0.1 and fronted by nginx, so the advertised origin
+/// can only come from configuration — never from the request or the bind.
+#[actix_web::test]
+async fn appliance_lan_origin_is_advertised_verbatim() {
+    let _env = EnvGuard::acquire(Some("https://rehearsal.lan"));
+    let app = session_app!();
+
+    let resp = test::call_service(
+        &app,
+        session_request(
+            TRUSTED_PEER,
+            HostileHeaders {
+                host: Some(HOSTILE_HOST),
+                forwarded_proto: Some("http"),
+                ..HostileHeaders::none()
+            },
+        ),
+    )
+    .await;
+
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let advertised = body["qr_data"]["gateway_url"].as_str().unwrap();
+    assert_eq!(advertised, "https://rehearsal.lan");
+    assert!(
+        advertised.starts_with("https://"),
+        "a TLS appliance must not advertise a downgraded scheme to a scanning device"
+    );
+}
+
+/// A configured origin's trailing slash must not produce `//v1/...` at the scanner, which some
+/// routers treat as a different path and some proxies collapse to a different origin.
+#[actix_web::test]
+async fn configured_origin_trailing_slash_is_normalized() {
+    let _env = EnvGuard::acquire(Some("https://gateway.example.coop/"));
+    let app = session_app!();
+
+    let resp =
+        test::call_service(&app, session_request(TRUSTED_PEER, HostileHeaders::none())).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    let advertised = body["qr_data"]["gateway_url"].as_str().unwrap();
+    assert_eq!(advertised, OPERATOR_ORIGIN);
+    assert!(
+        !advertised.ends_with('/'),
+        "scanner concatenates `{{gateway_url}}/v1/...`; a trailing slash yields `//v1/...`"
+    );
+}
+
+// ============================================================================
+// Missing configuration: fail closed.
+// ============================================================================
+
+/// Requirement 6: with no operator-authoritative origin there is no safe value to advertise,
+/// so QR creation fails rather than inferring one from the request.
+#[actix_web::test]
+async fn missing_configured_origin_fails_closed_for_every_peer_position() {
+    let _env = EnvGuard::acquire(None);
+    let app = session_app!();
+
+    for (label, peer, headers) in hostile_matrix() {
+        let resp = test::call_service(&app, session_request(peer, headers)).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "{label}: unconfigured QR authority must fail closed, not infer an origin"
+        );
+
+        let body = test::read_body(resp).await;
+        let text = String::from_utf8_lossy(&body);
+        assert!(
+            !text.contains(HOSTILE_HOST),
+            "{label}: the hostile authority must not reach the client even in an error body"
+        );
+    }
+}
+
+/// Fail-closed must not depend on the request being hostile: a perfectly benign request with no
+/// forwarding headers at all is equally unable to establish an advertised origin.
+#[actix_web::test]
+async fn missing_configured_origin_fails_closed_for_benign_requests() {
+    let _env = EnvGuard::acquire(None);
+    let app = session_app!();
+
+    let resp =
+        test::call_service(&app, session_request(TRUSTED_PEER, HostileHeaders::none())).await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// An empty value is a present-but-unusable setting; treating it as "configured" would advertise
+/// an empty authority, so it must fail closed exactly like an absent one.
+#[actix_web::test]
+async fn empty_configured_origin_fails_closed() {
+    let _env = EnvGuard::acquire(Some("   "));
+    let app = session_app!();
+
+    let resp =
+        test::call_service(&app, session_request(TRUSTED_PEER, HostileHeaders::none())).await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+// ============================================================================
+// Malformed configuration: explicit, fail-closed behaviour.
+// ============================================================================
+
+/// Requirement 7. Each of these is a way a configured value could still hand a scanning device
+/// somewhere the operator did not mean, so none may be silently accepted.
+#[actix_web::test]
+async fn malformed_configured_origin_fails_closed() {
+    let cases: &[(&str, &str)] = &[
+        (
+            "gateway.example.coop",
+            "no scheme: scanner would build a relative request",
+        ),
+        ("ftp://gateway.example.coop", "unsupported scheme"),
+        ("javascript:alert(1)", "non-hierarchical scheme"),
+        ("https://", "no host"),
+        (
+            "https://user:pass@gateway.example.coop",
+            "userinfo: credentials in an advertised origin",
+        ),
+        (
+            "https://gateway.example.coop/api",
+            "path: silently reroutes /v1/sessions/{id}/approve",
+        ),
+        (
+            "https://gateway.example.coop?x=1",
+            "query: appended before the scanner's own path",
+        ),
+        (
+            "https://gateway.example.coop#frag",
+            "fragment: truncates the scanner's constructed URL",
+        ),
+        ("http://[::1", "malformed IPv6 literal"),
+    ];
+
+    for (value, why) in cases {
+        let _env = EnvGuard::acquire(Some(value));
+        let app = session_app!();
+
+        let resp =
+            test::call_service(&app, session_request(TRUSTED_PEER, HostileHeaders::none())).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "GATEWAY_BASE_URL={value:?} must fail closed ({why})"
+        );
+    }
+}
+
+/// A bracketed IPv6 literal is a legitimate operator origin and must survive intact — dropping
+/// the brackets would produce an unparseable URL at the scanner.
+#[actix_web::test]
+async fn configured_ipv6_origin_is_preserved() {
+    let _env = EnvGuard::acquire(Some("http://[2001:db8::1]:30080"));
+    let app = session_app!();
+
+    let resp =
+        test::call_service(&app, session_request(TRUSTED_PEER, HostileHeaders::none())).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert_eq!(body["qr_data"]["gateway_url"], "http://[2001:db8::1]:30080");
+}
+
+// ============================================================================
+// Enrollment path parity.
+// ============================================================================
+
+/// Requirement 10: the enrollment QR is a second device-facing payload built from the same
+/// authority, so it must not be able to reintroduce request-derived origins.
+#[actix_web::test]
+async fn enrollment_qr_authority_is_operator_owned() {
+    let _env = EnvGuard::acquire(Some(OPERATOR_ORIGIN));
+    let app = enrollment_app!();
+
+    for (label, peer, headers) in hostile_matrix() {
+        let resp = test::call_service(&app, enrollment_request(peer, headers)).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "{label}: configured origin must still serve enrollment QR"
+        );
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        let qr = body["qr_code"].as_str().expect("qr_code must be a string");
+        assert!(
+            qr.contains(&format!("\"gateway_url\":\"{OPERATOR_ORIGIN}\"")),
+            "{label}: enrollment QR authority must be the operator origin, got {qr}"
+        );
+        assert!(
+            !qr.contains(HOSTILE_HOST),
+            "{label}: enrollment QR would point a device at {HOSTILE_HOST}"
+        );
+    }
+}
+
+/// Enrollment fails closed on missing configuration for the same reason sessions do.
+#[actix_web::test]
+async fn enrollment_qr_fails_closed_without_configured_origin() {
+    let _env = EnvGuard::acquire(None);
+    let app = enrollment_app!();
+
+    let resp = test::call_service(
+        &app,
+        enrollment_request(TRUSTED_PEER, HostileHeaders::none()),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}

--- a/icn/crates/icn-gateway/tests/sdis_route_authority.rs
+++ b/icn/crates/icn-gateway/tests/sdis_route_authority.rs
@@ -355,6 +355,7 @@ async fn body_supplied_steward_did_must_match_the_verified_subject() {
 /// `require_coop_access`.
 #[actix_web::test]
 async fn steward_cannot_act_on_another_cooperatives_enrollment() {
+    ensure_advertised_origin();
     let authority = authority(1);
     let app = sdis_app!(authority.clone());
 
@@ -408,6 +409,7 @@ async fn steward_cannot_act_on_another_cooperatives_enrollment() {
 /// lock out every legitimate steward with no test noticing.
 #[actix_web::test]
 async fn same_coop_steward_vouch_succeeds_and_records_the_verified_subject() {
+    ensure_advertised_origin();
     let authority = authority(1);
     let app = sdis_app!(authority.clone());
 
@@ -558,6 +560,7 @@ async fn restricted_reads_require_steward_capability() {
 /// other profile, which is a mount decision, not a route-authority one.
 #[actix_web::test]
 async fn public_enrollment_initiation_remains_anonymous() {
+    ensure_advertised_origin();
     let authority = authority(1);
     let app = sdis_app!(authority.clone());
 
@@ -704,4 +707,12 @@ async fn misassembly_without_session_authority_refuses_even_with_a_usable_auth_m
         500,
         "a misassembled runtime must refuse rather than fall back to signature-only auth"
     );
+}
+
+/// Enrollment initiation issues a device-facing QR, whose `gateway_url` requires an
+/// operator-authoritative origin (#2569). These tests are about route authority, not QR
+/// authority, so they only need a valid one present. Set idempotently to the same value: no
+/// test in this binary wants it unset, so there is nothing to race.
+fn ensure_advertised_origin() {
+    std::env::set_var("GATEWAY_BASE_URL", "https://gateway.example.coop");
 }

--- a/icn/crates/icn-gateway/tests/sdis_route_authority.rs
+++ b/icn/crates/icn-gateway/tests/sdis_route_authority.rs
@@ -79,6 +79,10 @@ fn authority(ttl_hours: u64) -> Arc<SessionAuthority> {
 /// `fp01_credential_holder_escalation.rs`, not here.
 macro_rules! sdis_app {
     ($authority:expr) => {{
+        // Mounting the enrollment tree is the last point before a request can reach
+        // `/v1/sdis/enrollment/start`, so the advertised origin is established here rather
+        // than in each test body — see `ensure_advertised_origin`.
+        ensure_advertised_origin();
         test::init_service(
             App::new()
                 .app_data(web::Data::new($authority))
@@ -355,7 +359,6 @@ async fn body_supplied_steward_did_must_match_the_verified_subject() {
 /// `require_coop_access`.
 #[actix_web::test]
 async fn steward_cannot_act_on_another_cooperatives_enrollment() {
-    ensure_advertised_origin();
     let authority = authority(1);
     let app = sdis_app!(authority.clone());
 
@@ -409,7 +412,6 @@ async fn steward_cannot_act_on_another_cooperatives_enrollment() {
 /// lock out every legitimate steward with no test noticing.
 #[actix_web::test]
 async fn same_coop_steward_vouch_succeeds_and_records_the_verified_subject() {
-    ensure_advertised_origin();
     let authority = authority(1);
     let app = sdis_app!(authority.clone());
 
@@ -560,7 +562,6 @@ async fn restricted_reads_require_steward_capability() {
 /// other profile, which is a mount decision, not a route-authority one.
 #[actix_web::test]
 async fn public_enrollment_initiation_remains_anonymous() {
-    ensure_advertised_origin();
     let authority = authority(1);
     let app = sdis_app!(authority.clone());
 
@@ -620,6 +621,9 @@ async fn public_scope_does_not_expose_the_steward_surface() {
 async fn nested_protected_scope_does_not_shadow_sibling_routes() {
     let authority = authority(1);
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
+    // Same rule as `sdis_app!`: this assembles the enrollment tree, so it owns the
+    // precondition too, whether or not this particular case drives `/enrollment/start`.
+    ensure_advertised_origin();
     let app = test::init_service(
         App::new()
             .app_data(web::Data::new(authority))
@@ -671,6 +675,9 @@ async fn misassembly_without_session_authority_refuses_even_with_a_usable_auth_m
         .expect("mint");
 
     let auth_mw = HttpAuthentication::bearer(jwt_auth);
+    // Same rule as `sdis_app!`: this assembles the enrollment tree, so it owns the
+    // precondition too, whether or not this particular case drives `/enrollment/start`.
+    ensure_advertised_origin();
     let app = test::init_service(
         App::new()
             // Deliberately NO SessionAuthority. Both plausible shapes of a bare
@@ -711,8 +718,20 @@ async fn misassembly_without_session_authority_refuses_even_with_a_usable_auth_m
 
 /// Enrollment initiation issues a device-facing QR, whose `gateway_url` requires an
 /// operator-authoritative origin (#2569). These tests are about route authority, not QR
-/// authority, so they only need a valid one present. Set idempotently to the same value: no
-/// test in this binary wants it unset, so there is nothing to race.
+/// authority, so they only need a valid origin to exist.
+///
+/// **Called from app assembly, never from a test body.** Leaving it to each test to remember
+/// is what made the sibling binary `fp01_credential_holder_escalation.rs` order-dependent:
+/// a test that reached `/v1/sdis/enrollment/start` without calling this passed only when
+/// another test had run first, and returned 503 in isolation. Assembling the app is the one
+/// step no test can skip and still issue a request, so the precondition lives there.
+///
+/// `Once` rather than an idempotent `set_var`: libtest runs these tests on many threads, and
+/// re-writing on every call means a write can overlap a handler thread's read of the same
+/// variable. One write, and `call_once` gives every later caller a happens-before edge to it.
 fn ensure_advertised_origin() {
-    std::env::set_var("GATEWAY_BASE_URL", "https://gateway.example.coop");
+    static CONFIGURED: std::sync::Once = std::sync::Once::new();
+    CONFIGURED.call_once(|| {
+        std::env::set_var("GATEWAY_BASE_URL", "https://gateway.example.coop");
+    });
 }


### PR DESCRIPTION
A gateway URL embedded in session and enrollment QR material is consumed
by another device, which may send authenticated ICN traffic to that
authority.

Request-derived Host and forwarded scheme/host metadata are therefore not
authoritative enough for this destination.

## Authority

- makes `GATEWAY_BASE_URL` the operator-authoritative advertised origin
- removes request metadata from QR authority construction: `advertised_origin()`
  takes no `HttpRequest`, so reintroducing Host / Forwarded / X-Forwarded-Host /
  X-Forwarded-Proto input is a compile error rather than a review question
- resolves the origin before any QR session or enrollment durable state is
  allocated, so a refusal leaves no partial record behind
- fails QR issuance closed (503) when the configured origin is absent or
  invalid, logging the operator-facing reason without echoing the value
- validates the configured value as an HTTP(S) origin: absolute, no userinfo,
  no path, query or fragment, and rejects two values that parse but cannot be
  reached — **port 0**, and **unspecified/wildcard hosts** (`0.0.0.0`, `[::]`,
  and the IPv4-mapped `[::ffff:0.0.0.0]` form, unmapped via `to_ipv4_mapped`
  rather than `to_ipv4` per #2564). A wildcard *bind* is the value an operator
  is most likely to paste, since the demo profile binds `0.0.0.0:8080`; a phone
  resolving it would address itself rather than this gateway
- updates LAN appliance configuration to provide the canonical origin
- makes nginx assert its own Host/scheme metadata as defense in depth
- preserves existing trusted-client-IP behavior from #2568 — that mechanism
  authenticates *who* reported a client address and remains entirely separate
  from advertised-origin authority; a trusted proxy does not thereby gain the
  right to assert this origin. `deploy/k8s/configmap.yaml` was corrected, as it
  still told operators `TRUSTED_PROXY_IPS` gated QR-login URL derivation

## Two authorities, two variables

Review surfaced that one variable was carrying two incompatible meanings, and
that wiring the QR origin into a deployment therefore corrupted invite links.
They are now separate:

| variable | authority | consumer | served route |
|---|---|---|---|
| `GATEWAY_BASE_URL` | device-facing gateway **API** origin | `advertised_origin()` → QR/session/enrollment payloads | real: `POST /v1/sessions/{id}/approve`, `/v1/sdis/enrollment/*` |
| `ICN_INVITE_BASE_URL` | human-facing **UI** origin | `create_invite()` → `invite_url` | none shipped — see below |

`invite_base_url()` never consults `GATEWAY_BASE_URL`, so **configuring the QR
origin cannot move an invite link**. Both failure modes it caused were
reproduced before fixing — a present-but-empty value yielding a hostless
`/join?code=…`, and a configured API origin yielding `{gateway API}/join?code=…`
— and the independence tests were confirmed non-vacuous by re-coupling the
resolver and observing them go red.

**Bounded product debt, not fixed here:** ICN does not serve a
`GET /join?code=…` route, and this PR does not add one. Invite codes are
redeemed through the existing flow — `POST /v1/invites/join`, with the code in
the request body, which `web/pilot-ui` collects from a typed form. So
`invite_url` is advisory: it is meaningful only if an operator runs a member UI
implementing such a route and points `ICN_INVITE_BASE_URL` at it. The
`http://localhost:3000` fallback is local-development only and is not claimed
reachable from another device. `docs/guides/onboarding-runbook.md` now tells
operators to hand over the `invite_code` rather than the link.

## Test authority

- unit-test advertised-origin authority is isolated **structurally**: under
  `cfg(test)` the origin resolves from a module-private thread-local, so
  libtest's per-test threads make order-independence a property of the design
  rather than of a lock everyone must remember to take. Process-environment
  mutation cannot steer `advertised_origin()` in that configuration; the
  accompanying test runs the mutation forms explicitly to show it, and was
  confirmed non-vacuous by repointing the resolver at the environment
- this replaces the earlier process-global mutex plus source-scanning
  "single-mutator" guard. Source spelling was the wrong enforcement boundary —
  a rustfmt-wrapped `set_var(...)` evades a line-oriented scan — so the shared
  state was removed rather than the scan extended
- `GATEWAY_BASE_URL` now has exactly one consumer, so nothing a test does to the
  process environment can change the advertised origin. `ICN_INVITE_BASE_URL`
  gets the same thread-local treatment, so two tests configuring different
  invite origins cannot race either
- integration tests establish their required origin deterministically at app
  assembly, the one step no test can skip and still issue a request. This
  fixes a real order-dependent false green: `legitimate_enrollment_still_completes`
  returned 503 against an expected 200 when run in isolation, and passed only
  when a sibling test had already set the variable

## Deployment profiles

Every shipped gateway launch path was classified against ADR-0086 rather than
assumed equivalent. Each supported profile either supplies operator authority
or explicitly lacks QR capability:

- **operator origin supplied** — k8s (`gateway_base_url`), the LAN appliance
  drop-in (`ICN_APPLIANCE_LAN_ORIGIN`), devnet (ADR-0086's canonical Compose
  entry point, via `ICN_DEVNET_NODE_{A,B,C}_ORIGIN`), and native installs via a
  documented example in `deploy/icnd.env.example`. The devnet and native values
  default to **empty**, not to a fabricated URL: nodes publish on different host
  ports and the host is unknown, so no static default could name an origin a
  scanning phone can reach, and `localhost` would name the phone. Empty is
  treated as unset, so absence stays fail-closed.
- **intentionally not QR-capable** — the QEMU demo appliance profile is
  host-only behind user-mode hostfwd, so no second device can route to it. It
  supplies no origin and fails closed, which is the correct outcome; that is now
  documented in the drop-in so it is not later read as an oversight.
- **legacy / reference / non-authoritative** — `deploy/kubernetes/`,
  `deploy/helm/icn/`, `deploy/compose/`, `deploy/docker-compose.yml` and
  `deploy/k8s/reference/*` are **not** repaired by this PR and are not claimed
  to work. The first three probe `/health/liveness`, a route that exists nowhere
  in `icn/crates`, and set env names the daemon never reads, against port 8000
  where the gateway binds 8080 — so their QR flows were already unavailable
  before this branch. `deploy/k8s/reference/*` are captured cluster state, not
  deployable manifests.

Note on scope of the enrollment flow: `/v1/sdis/enrollment/*` mounts only under
`ICN_ENABLE_SELF_SERVE_ENROLLMENT=true`, which **no shipped composition sets**.
Where those routes are absent the result is 404 (or 401 on scope fallthrough),
not the 503 described above. Configuring an origin does not by itself make them
reachable; `POST /v1/sessions` is the QR flow every profile actually exposes.

## Test plan

`cargo fmt --all --check`, `cargo clippy -p icn-gateway --all-targets -D warnings`,
and `cargo test -p icn-gateway --no-fail-fast` all green — **1085 passed, 0 failed,
5 ignored across 48 gateway test binaries**. Every test in the three affected
gateway test binaries was additionally run **individually** (38/38) to prove no
test depends on another having run first.

`Compare Against Base` is red and is non-blocking per `ops/state/truth/policy.json`.
Its 16 reported movements are dominated by crates this PR does not touch
(`icn-compute`, `icn-gossip`, `icn-net`, `icn-trust`) — none of which depends on
`icn-gateway`, and whose sources, benches, `Cargo.toml` and `Cargo.lock` are all
unchanged, so the code they execute is identical. The two `icn-gateway` entries
exercise `CommonsManager` (`src/commons_mgr.rs`), which this PR does not modify.

Closes #2569.
Refs #2568.
