### PR TITLE
fix(net): size frame buffers from bytes received, not the declared length

### DIFF
--- a/icn/crates/icn-net/src/lib.rs
+++ b/icn/crates/icn-net/src/lib.rs
@@ -56,6 +56,7 @@ pub use protocol::{
     read_message, read_message_compressed, read_message_negotiated, write_message,
     write_message_compressed, write_message_negotiated, CompressionFormat, EncodingFormat,
     KnownPeer, MessagePayload, NetworkMessage, PeerExchangeMessage, COMPRESSION_THRESHOLD,
+    MAX_MESSAGE_SIZE,
 };
 pub use rate_limit::{
     RateLimitConfig, RateLimiter, SourcePreAuthBudget, MAX_PREAUTH_BUDGET_SOURCES, NETWORK_DOMAIN,

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -1066,27 +1066,38 @@ async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
     // Safe to cast after validation
     let len = len_u32 as usize;
 
-    // Reserve nothing up front: capacity is only ever taken *after* a step has actually been
-    // read, so a peer that declares a frame and then goes silent holds no buffer at all.
-    // `read_exact` per step means a truncated frame still fails on the step that runs short,
-    // exactly as a single `read_exact` over the whole body did.
+    // Reserve nothing up front, and keep no scratch buffer: `read_chunk` hands back only the
+    // bytes that have actually arrived, so nothing here is sized by the declaration. A fixed
+    // scratch array would instead live inline in every suspended connection future, charging
+    // idle unauthenticated connections a constant cost before a single body byte exists —
+    // which is the same defect one level down.
+    //
+    // A stream that ends before the declared length yields `None`, so a truncated frame is
+    // still an error, exactly as a single `read_exact` over the whole body was.
     let mut buf: Vec<u8> = Vec::new();
-    let mut step = [0u8; FRAME_READ_STEP];
     while buf.len() < len {
         let want = (len - buf.len()).min(FRAME_READ_STEP);
-        recv.read_exact(&mut step[..want])
+        let chunk = recv
+            .read_chunk(want, true)
             .await
-            .context("Failed to read message body")?;
+            .context("Failed to read message body")?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Failed to read message body: stream ended after {} of {len} bytes",
+                    buf.len()
+                )
+            })?;
 
         // Grow geometrically — so a large frame still costs amortised O(n) copying rather than
-        // one realloc per step — but never past the declared length. Letting
+        // one realloc per chunk — but never past the declared length. Letting
         // `extend_from_slice` pick the growth would round a 10 MiB frame up to a 16 MiB
         // capacity, i.e. *more* than the eager allocation this replaces.
-        if buf.capacity() < buf.len() + want {
-            let target = frame_capacity_target(buf.capacity(), len);
+        let arrived = chunk.bytes.len();
+        if buf.capacity() < buf.len() + arrived {
+            let target = frame_capacity_target(buf.capacity(), len).max(buf.len() + arrived);
             buf.reserve_exact(target - buf.len());
         }
-        buf.extend_from_slice(&step[..want]);
+        buf.extend_from_slice(&chunk.bytes);
     }
 
     Ok(buf)

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -26,6 +26,20 @@ pub const MAX_SUPPORTED_VERSION: u32 = 2;
 /// Maximum message size (10MB)
 pub const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
 
+/// Largest buffer a frame body may reserve before the sender has delivered anything (#2558).
+///
+/// The declared length is a claim, not evidence. Committing `MAX_MESSAGE_SIZE` on the strength of
+/// a four-byte prefix lets a peer that goes silent immediately afterwards hold that memory for as
+/// long as the read is allowed to wait — and before authentication, "the peer" is anyone who
+/// completed a QUIC handshake. So the body is read in bounded steps and the buffer grows with the
+/// bytes that actually arrive, capped per step by this value.
+///
+/// This is a *reservation* bound, not a message-size bound: `MAX_MESSAGE_SIZE` remains the sole
+/// authority on how large a message may be, and a legitimate message still reaches its full size.
+/// The value is a plain I/O step, chosen well under the 1 MiB QUIC `stream_receive_window` so a
+/// step never reserves more than a stream could have buffered anyway.
+const FRAME_READ_STEP: usize = 64 * 1024;
+
 /// Compression threshold in bytes (1KB) - messages below this are not compressed
 pub const COMPRESSION_THRESHOLD: usize = 1024;
 
@@ -996,6 +1010,27 @@ impl NetworkMessage {
 ///
 /// Returns the message and the number of bytes read (including 4-byte length prefix)
 pub async fn read_message(recv: &mut quinn::RecvStream) -> Result<(NetworkMessage, usize)> {
+    let buf = read_frame(recv).await?;
+    let msg = NetworkMessage::from_bytes_negotiated(&buf)?;
+    // Return total bytes: 4 (length prefix) + message body
+    Ok((msg, 4 + buf.len()))
+}
+
+/// Read one length-prefixed frame body, committing memory in proportion to bytes received.
+///
+/// The single framing implementation behind every `read_message*` helper. It was three copies of
+/// the same preamble, which meant a bound added to one left the others open — so the size policy
+/// lives here once (#2558).
+///
+/// `MAX_MESSAGE_SIZE` is unchanged and still rejects an oversized declaration before any body byte
+/// is read, so the wire contract and the fail-closed behaviour are exactly as before. What changed
+/// is the allocation: instead of `vec![0u8; declared]` up front, the buffer starts at one
+/// [`FRAME_READ_STEP`] and grows only as bytes actually land. A peer that declares a large frame
+/// and then sends nothing now holds one step, not the whole declaration.
+///
+/// Cancellation is unaffected: the caller's timeout still wraps this future, and dropping it
+/// discards a partial buffer whose size is bounded by what the peer really sent.
+async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
     // Read 4-byte length prefix (big-endian)
     let mut len_buf = [0u8; 4];
     recv.read_exact(&mut len_buf)
@@ -1014,15 +1049,19 @@ pub async fn read_message(recv: &mut quinn::RecvStream) -> Result<(NetworkMessag
     // Safe to cast after validation
     let len = len_u32 as usize;
 
-    // Allocate buffer (size is now validated)
-    let mut buf = vec![0u8; len];
-    recv.read_exact(&mut buf)
-        .await
-        .context("Failed to read message body")?;
+    // Reserve a step, not the declaration. `read_exact` on each step means a truncated frame still
+    // fails on the step that runs short, exactly as a single `read_exact` over the whole body did.
+    let mut buf: Vec<u8> = Vec::with_capacity(len.min(FRAME_READ_STEP));
+    let mut step = [0u8; FRAME_READ_STEP];
+    while buf.len() < len {
+        let want = (len - buf.len()).min(FRAME_READ_STEP);
+        recv.read_exact(&mut step[..want])
+            .await
+            .context("Failed to read message body")?;
+        buf.extend_from_slice(&step[..want]);
+    }
 
-    let msg = NetworkMessage::from_bytes_negotiated(&buf)?;
-    // Return total bytes: 4 (length prefix) + message body
-    Ok((msg, 4 + len))
+    Ok(buf)
 }
 
 /// Helper for reading length-prefixed messages with compression support
@@ -1031,33 +1070,10 @@ pub async fn read_message(recv: &mut quinn::RecvStream) -> Result<(NetworkMessag
 pub async fn read_message_compressed(
     recv: &mut quinn::RecvStream,
 ) -> Result<(NetworkMessage, usize)> {
-    // Read 4-byte length prefix (big-endian)
-    let mut len_buf = [0u8; 4];
-    recv.read_exact(&mut len_buf)
-        .await
-        .context("Failed to read message length")?;
-    let len_u32 = u32::from_be_bytes(len_buf);
-
-    // Validate message size BEFORE casting to usize to prevent overflow on 32-bit systems
-    if len_u32 == 0 {
-        anyhow::bail!("Invalid message: zero length");
-    }
-    if len_u32 > MAX_MESSAGE_SIZE as u32 {
-        anyhow::bail!("Message too large: {len_u32} bytes (max {MAX_MESSAGE_SIZE})");
-    }
-
-    // Safe to cast after validation
-    let len = len_u32 as usize;
-
-    // Allocate buffer (size is now validated)
-    let mut buf = vec![0u8; len];
-    recv.read_exact(&mut buf)
-        .await
-        .context("Failed to read message body")?;
-
+    let buf = read_frame(recv).await?;
     let msg = NetworkMessage::from_bytes_compressed(&buf)?;
     // Return total bytes: 4 (length prefix) + message body
-    Ok((msg, 4 + len))
+    Ok((msg, 4 + buf.len()))
 }
 
 /// Helper for writing length-prefixed messages to QUIC streams
@@ -1108,33 +1124,10 @@ pub async fn write_message_compressed(
 pub async fn read_message_negotiated(
     recv: &mut quinn::RecvStream,
 ) -> Result<(NetworkMessage, usize)> {
-    // Read 4-byte length prefix (big-endian)
-    let mut len_buf = [0u8; 4];
-    recv.read_exact(&mut len_buf)
-        .await
-        .context("Failed to read message length")?;
-    let len_u32 = u32::from_be_bytes(len_buf);
-
-    // Validate message size BEFORE casting to usize to prevent overflow on 32-bit systems
-    if len_u32 == 0 {
-        anyhow::bail!("Invalid message: zero length");
-    }
-    if len_u32 > MAX_MESSAGE_SIZE as u32 {
-        anyhow::bail!("Message too large: {len_u32} bytes (max {MAX_MESSAGE_SIZE})");
-    }
-
-    // Safe to cast after validation
-    let len = len_u32 as usize;
-
-    // Allocate buffer (size is now validated)
-    let mut buf = vec![0u8; len];
-    recv.read_exact(&mut buf)
-        .await
-        .context("Failed to read message body")?;
-
+    let buf = read_frame(recv).await?;
     let msg = NetworkMessage::from_bytes_negotiated(&buf)?;
     // Return total bytes: 4 (length prefix) + message body
-    Ok((msg, 4 + len))
+    Ok((msg, 4 + buf.len()))
 }
 
 /// Helper for writing length-prefixed messages with negotiated encoding

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -1049,15 +1049,30 @@ async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
     // Safe to cast after validation
     let len = len_u32 as usize;
 
-    // Reserve a step, not the declaration. `read_exact` on each step means a truncated frame still
-    // fails on the step that runs short, exactly as a single `read_exact` over the whole body did.
-    let mut buf: Vec<u8> = Vec::with_capacity(len.min(FRAME_READ_STEP));
+    // Reserve nothing up front: capacity is only ever taken *after* a step has actually been
+    // read, so a peer that declares a frame and then goes silent holds no buffer at all.
+    // `read_exact` per step means a truncated frame still fails on the step that runs short,
+    // exactly as a single `read_exact` over the whole body did.
+    let mut buf: Vec<u8> = Vec::new();
     let mut step = [0u8; FRAME_READ_STEP];
     while buf.len() < len {
         let want = (len - buf.len()).min(FRAME_READ_STEP);
         recv.read_exact(&mut step[..want])
             .await
             .context("Failed to read message body")?;
+
+        // Grow geometrically — so a large frame still costs amortised O(n) copying rather than
+        // one realloc per step — but never past the declared length. Letting
+        // `extend_from_slice` pick the growth would round a 10 MiB frame up to a 16 MiB
+        // capacity, i.e. *more* than the eager allocation this replaces.
+        if buf.capacity() < buf.len() + want {
+            let target = buf
+                .capacity()
+                .max(FRAME_READ_STEP)
+                .saturating_mul(2)
+                .min(len);
+            buf.reserve_exact(target - buf.len());
+        }
         buf.extend_from_slice(&step[..want]);
     }
 

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -1040,11 +1040,16 @@ pub async fn read_message(recv: &mut quinn::RecvStream) -> Result<(NetworkMessag
 /// Split out as a pure function because that is the only way to test the bound honestly: measured
 /// end-to-end, the figure is dominated by whether the sender's copy is still live when the
 /// receiver allocates, which is scheduling, not policy.
-fn frame_capacity_target(current_capacity: usize, len: usize) -> usize {
-    current_capacity
-        .max(FRAME_READ_STEP)
-        .saturating_mul(2)
-        .min(len)
+fn frame_capacity_target(current_capacity: usize, held: usize, len: usize) -> usize {
+    if current_capacity == 0 {
+        // First reservation: exactly the bytes in hand. Seeding it at a step instead would
+        // charge a peer that sent one byte for a whole one — across the server-wide admission
+        // limit, a constant unrelated to what anyone actually sent.
+        held.min(len)
+    } else {
+        // Thereafter geometric, so a large frame costs amortised O(n) copying.
+        current_capacity.saturating_mul(2).max(held).min(len)
+    }
 }
 
 async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
@@ -1094,7 +1099,7 @@ async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
         // capacity, i.e. *more* than the eager allocation this replaces.
         let arrived = chunk.bytes.len();
         if buf.capacity() < buf.len() + arrived {
-            let target = frame_capacity_target(buf.capacity(), len).max(buf.len() + arrived);
+            let target = frame_capacity_target(buf.capacity(), buf.len() + arrived, len);
             buf.reserve_exact(target - buf.len());
         }
         buf.extend_from_slice(&chunk.bytes);
@@ -1225,10 +1230,13 @@ mod tests {
             MAX_MESSAGE_SIZE,
         ] {
             // Walk the whole sequence the read loop would produce.
+            // Simulate the loop: a chunk arrives, then capacity is taken for what is held.
             let mut capacity = 0usize;
+            let mut held = 0usize;
             let mut guard = 0;
             while capacity < len {
-                let next = frame_capacity_target(capacity, len);
+                held = (held + FRAME_READ_STEP).min(len);
+                let next = frame_capacity_target(capacity, held, len);
                 assert!(
                     next <= len,
                     "len={len}: capacity target {next} exceeds the declared length"
@@ -1248,8 +1256,10 @@ mod tests {
     /// A small frame takes exactly what it needs, not a whole step.
     #[test]
     fn a_small_frame_reserves_only_its_own_length() {
-        assert_eq!(frame_capacity_target(0, 100), 100);
-        assert_eq!(frame_capacity_target(0, 1), 1);
+        assert_eq!(frame_capacity_target(0, 100, 100), 100);
+        assert_eq!(frame_capacity_target(0, 1, 1), 1);
+        // And a peer that declares the maximum but delivers one byte reserves one byte.
+        assert_eq!(frame_capacity_target(0, 1, MAX_MESSAGE_SIZE), 1);
     }
 
     /// Growth is geometric, so a large frame costs amortised O(n) copying rather than one
@@ -1257,10 +1267,12 @@ mod tests {
     #[test]
     fn growth_is_geometric_not_one_step_at_a_time() {
         let len = MAX_MESSAGE_SIZE;
-        let mut capacity = frame_capacity_target(0, len);
+        let mut capacity = frame_capacity_target(0, FRAME_READ_STEP, len);
+        let mut held = FRAME_READ_STEP;
         let mut steps = 1;
         while capacity < len {
-            capacity = frame_capacity_target(capacity, len);
+            held = (held + FRAME_READ_STEP).min(len);
+            capacity = frame_capacity_target(capacity, held, len);
             steps += 1;
         }
         let one_step_at_a_time = len.div_ceil(FRAME_READ_STEP);

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -1016,20 +1016,6 @@ pub async fn read_message(recv: &mut quinn::RecvStream) -> Result<(NetworkMessag
     Ok((msg, 4 + buf.len()))
 }
 
-/// Read one length-prefixed frame body, committing memory in proportion to bytes received.
-///
-/// The single framing implementation behind every `read_message*` helper. It was three copies of
-/// the same preamble, which meant a bound added to one left the others open — so the size policy
-/// lives here once (#2558).
-///
-/// `MAX_MESSAGE_SIZE` is unchanged and still rejects an oversized declaration before any body byte
-/// is read, so the wire contract and the fail-closed behaviour are exactly as before. What changed
-/// is the allocation: instead of `vec![0u8; declared]` up front, the buffer starts at one
-/// [`FRAME_READ_STEP`] and grows only as bytes actually land. A peer that declares a large frame
-/// and then sends nothing now holds one step, not the whole declaration.
-///
-/// Cancellation is unaffected: the caller's timeout still wraps this future, and dropping it
-/// discards a partial buffer whose size is bounded by what the peer really sent.
 /// Capacity the frame buffer should grow to, given what it holds now and the declared length.
 ///
 /// Geometric so a large frame costs amortised O(n) copying rather than one realloc per step, and
@@ -1052,6 +1038,25 @@ fn frame_capacity_target(current_capacity: usize, held: usize, len: usize) -> us
     }
 }
 
+/// Read one length-prefixed frame body, committing memory in proportion to bytes received.
+///
+/// The single framing implementation behind every `read_message*` helper. It was three copies of
+/// the same preamble, which meant a bound added to one left the others open — so the size policy
+/// lives here once (#2558).
+///
+/// `MAX_MESSAGE_SIZE` is unchanged and still rejects an oversized declaration before any body byte
+/// is read, so the wire contract and the fail-closed behaviour are exactly as before. What changed
+/// is the allocation. `vec![0u8; declared]` committed the buffer on the strength of a number the
+/// peer chose; nothing here is sized by the declaration at all. The buffer starts empty, capacity
+/// is taken only in response to bytes [`RecvStream::read_chunk`] has actually delivered, and
+/// [`frame_capacity_target`] caps every subsequent reservation at the declared length. A peer that
+/// declares a large frame and then sends nothing holds no body buffer.
+///
+/// `FRAME_READ_STEP` appears only as the ceiling on a single `read_chunk` request — it bounds how
+/// much may arrive in one poll, never how much is reserved before it does.
+///
+/// Cancellation is unaffected: the caller's timeout still wraps this future, and dropping it
+/// discards a partial buffer whose size is bounded by what the peer really sent.
 async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
     // Read 4-byte length prefix (big-endian)
     let mut len_buf = [0u8; 4];

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -1030,6 +1030,23 @@ pub async fn read_message(recv: &mut quinn::RecvStream) -> Result<(NetworkMessag
 ///
 /// Cancellation is unaffected: the caller's timeout still wraps this future, and dropping it
 /// discards a partial buffer whose size is bounded by what the peer really sent.
+/// Capacity the frame buffer should grow to, given what it holds now and the declared length.
+///
+/// Geometric so a large frame costs amortised O(n) copying rather than one realloc per step, and
+/// clamped to `len` so it can never exceed what the peer declared. Letting `Vec` choose would
+/// round a frame just past a power of two up to the next one — for a maximum-size frame, 16 MiB
+/// against a declared 10 MiB, i.e. *more* than the eager allocation this replaces.
+///
+/// Split out as a pure function because that is the only way to test the bound honestly: measured
+/// end-to-end, the figure is dominated by whether the sender's copy is still live when the
+/// receiver allocates, which is scheduling, not policy.
+fn frame_capacity_target(current_capacity: usize, len: usize) -> usize {
+    current_capacity
+        .max(FRAME_READ_STEP)
+        .saturating_mul(2)
+        .min(len)
+}
+
 async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
     // Read 4-byte length prefix (big-endian)
     let mut len_buf = [0u8; 4];
@@ -1066,11 +1083,7 @@ async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
         // `extend_from_slice` pick the growth would round a 10 MiB frame up to a 16 MiB
         // capacity, i.e. *more* than the eager allocation this replaces.
         if buf.capacity() < buf.len() + want {
-            let target = buf
-                .capacity()
-                .max(FRAME_READ_STEP)
-                .saturating_mul(2)
-                .min(len);
+            let target = frame_capacity_target(buf.capacity(), len);
             buf.reserve_exact(target - buf.len());
         }
         buf.extend_from_slice(&step[..want]);
@@ -1184,6 +1197,68 @@ pub async fn write_message_negotiated(
 
 #[cfg(test)]
 mod tests {
+    /// Capacity may never exceed the declared length, at any point in the growth sequence.
+    ///
+    /// This is the bound the end-to-end allocator measurement could not establish: there the
+    /// figure depends on whether the sender's copy is still live when the receiver allocates, so
+    /// the same code measured 0.1 MiB on one machine and 4.7 MiB on another. The policy itself is
+    /// pure arithmetic and can be checked exactly.
+    #[test]
+    fn frame_capacity_never_exceeds_the_declared_length() {
+        for len in [
+            1,
+            FRAME_READ_STEP - 1,
+            FRAME_READ_STEP,
+            FRAME_READ_STEP + 1,
+            8 * 1024 * 1024 + 1, // just past a power of two: where doubling overshoots worst
+            MAX_MESSAGE_SIZE,
+        ] {
+            // Walk the whole sequence the read loop would produce.
+            let mut capacity = 0usize;
+            let mut guard = 0;
+            while capacity < len {
+                let next = frame_capacity_target(capacity, len);
+                assert!(
+                    next <= len,
+                    "len={len}: capacity target {next} exceeds the declared length"
+                );
+                assert!(next > capacity, "len={len}: growth stalled at {capacity}");
+                capacity = next;
+                guard += 1;
+                assert!(guard < 1024, "len={len}: growth did not converge");
+            }
+            assert_eq!(
+                capacity, len,
+                "len={len}: final capacity must be exactly len"
+            );
+        }
+    }
+
+    /// A small frame takes exactly what it needs, not a whole step.
+    #[test]
+    fn a_small_frame_reserves_only_its_own_length() {
+        assert_eq!(frame_capacity_target(0, 100), 100);
+        assert_eq!(frame_capacity_target(0, 1), 1);
+    }
+
+    /// Growth is geometric, so a large frame costs amortised O(n) copying rather than one
+    /// reallocation per step.
+    #[test]
+    fn growth_is_geometric_not_one_step_at_a_time() {
+        let len = MAX_MESSAGE_SIZE;
+        let mut capacity = frame_capacity_target(0, len);
+        let mut steps = 1;
+        while capacity < len {
+            capacity = frame_capacity_target(capacity, len);
+            steps += 1;
+        }
+        let one_step_at_a_time = len.div_ceil(FRAME_READ_STEP);
+        assert!(
+            steps < one_step_at_a_time / 4,
+            "growth took {steps} reallocations; per-step growth would take {one_step_at_a_time}"
+        );
+    }
+
     use super::*;
     use icn_gossip::{types::ContentHash, VectorClock};
     use icn_identity::KeyPair;

--- a/icn/crates/icn-net/tests/preauth_declared_length_allocation.rs
+++ b/icn/crates/icn-net/tests/preauth_declared_length_allocation.rs
@@ -389,7 +389,6 @@ async fn a_frame_spanning_several_read_steps_arrives_intact() -> Result<()> {
     );
 
     let (mut send, _recv) = connection.open_bi().await.context("open_bi")?;
-    let baseline = arm_peak();
     icn_net::write_message(&mut send, &message).await?;
     send.finish()?;
 
@@ -402,18 +401,12 @@ async fn a_frame_spanning_several_read_steps_arrives_intact() -> Result<()> {
         "a {encoded}-byte frame spanning several read steps must arrive once, intact"
     );
 
-    // A frame must not retain more than it declared. Growing the buffer by `Vec`'s own amortised
-    // doubling would round a frame just past a power of two up to the next one — for a
-    // maximum-size frame, 16 MiB against a declared 10 MiB, i.e. worse than the eager allocation
-    // this change replaces. The ceiling is generous because the test process is also holding the
-    // sent copy and quinn's buffers; the defect it excludes is a *multiple* of the frame.
-    let growth = peak_growth_since(baseline);
-    assert!(
-        growth < encoded * 3,
-        "a {encoded}-byte frame retained {:.1} MiB — capacity is overshooting the declared \
-         length, not tracking it",
-        mib(growth),
-    );
+    // NOTE: this test deliberately does *not* assert a capacity ceiling. Measured end to end,
+    // that figure is dominated by whether the sender's copy is still live when the receiver
+    // allocates — the same code measured 0.1 MiB locally and 4.7 MiB on CI, which overlaps the
+    // 6.2 MiB the uncapped defect produces. An assertion that cannot separate those is not
+    // evidence. The capacity bound is proven exactly instead, by
+    // `protocol::tests::frame_capacity_never_exceeds_the_declared_length`.
 
     Ok(())
 }

--- a/icn/crates/icn-net/tests/preauth_declared_length_allocation.rs
+++ b/icn/crates/icn-net/tests/preauth_declared_length_allocation.rs
@@ -1,0 +1,397 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! What an unauthenticated peer may make this node *allocate* by declaring a length (#2558).
+//!
+//! Every `read_message*` helper reads a four-byte big-endian length prefix and rejects it if it
+//! exceeds `MAX_MESSAGE_SIZE`. Each then used to do this:
+//!
+//! ```text
+//! let mut buf = vec![0u8; len];   // sized from the DECLARED length
+//! recv.read_exact(&mut buf).await // …before a single body byte has arrived
+//! ```
+//!
+//! So the buffer was committed on the strength of a number the peer chose, not on bytes the peer
+//! actually sent. A peer that wrote the prefix and then stopped held that allocation until the
+//! body arrived — which it never did — or until `PREAUTH_AUTHENTICATION_DEADLINE` (30 s) closed
+//! the connection.
+//!
+//! All three helpers now share one `read_frame`, which keeps the same prefix validation and the
+//! same `MAX_MESSAGE_SIZE` authority but grows the buffer a step at a time as bytes arrive. The
+//! wire format is untouched.
+//!
+//! # The property under test
+//!
+//! > Before this node has authenticated a peer, the memory it commits on that peer's behalf is a
+//! > function of the bytes the peer has actually sent, not of a length the peer merely claimed.
+//!
+//! # Why the existing bounds do not establish it
+//!
+//! - `MAX_MESSAGE_SIZE` (10 MiB) caps the *claim*. It does not make the claim cost anything.
+//! - QUIC's `receive_window` (10 MiB/connection) and `stream_receive_window` (1 MiB) cap the bytes
+//!   a peer may **send**. They cannot bound an allocation sized from a length the peer never
+//!   fulfils — this is exactly the case where a transport byte limit does not imply a decoder
+//!   allocation limit.
+//! - `PREAUTH_AUTHENTICATION_DEADLINE` bounds how *long* the commitment is held, not how large it
+//!   is.
+//! - The per-connection (#2491) and per-source (#2549/#2557) budgets sit *after* `read_message`
+//!   returns. `preauth_source_work_budget.rs` says so in its own words: reading and deserializing
+//!   a message that is then denied "happens before this gate".
+//!
+//! # Scale
+//!
+//! The connection loop reads **sequentially** — `accept_bi().await` then `read_message().await` in
+//! one task per connection, with no per-stream spawn — so one connection has at most one read in
+//! flight. The multiplier is therefore connections, not streams:
+//! `MAX_PREAUTH_CONNECTIONS_PER_SOURCE` (8) × `MAX_MESSAGE_SIZE` (10 MiB) = **80 MiB per source**,
+//! bought with 8 × 4 = **32 bytes**, held for up to 30 s, entirely before authentication. That
+//! figure was measured here before the fix; afterwards the same sequence commits 0.5 MiB, because
+//! the reservation now tracks the read step rather than the declaration.
+//!
+//! # How this test knows
+//!
+//! A counting global allocator, measuring **bytes requested from the allocator**, not resident set
+//! size. That distinction is deliberate: `vec![0u8; n]` may be served by a lazily-zeroed mapping
+//! whose pages are not resident until touched, so RSS would under-report a commitment the program
+//! genuinely made. The number this test asserts on is the size the program asked for.
+//!
+//! The node runs in this process, so the counter sees its allocations. Connection setup is
+//! excluded by snapshotting *after* every connection and stream exists and before any prefix is
+//! written, which leaves the declared-length allocation as the only thing of this magnitude that
+//! can happen in the measured window.
+
+use anyhow::{Context, Result};
+use icn_identity::IdentityBundle;
+use icn_net::{
+    IncomingMessageHandler, NetworkActor, NetworkHandle, NetworkMessage, MAX_MESSAGE_SIZE,
+    MAX_PREAUTH_CONNECTIONS_PER_SOURCE,
+};
+use quinn::{ClientConfig, Endpoint};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+// ---------------------------------------------------------------------------
+// Counting allocator
+// ---------------------------------------------------------------------------
+
+static IN_USE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+/// Tracks bytes requested from the allocator, and the high-water mark of that figure.
+///
+/// `alloc_zeroed` is overridden rather than left to the trait default because `vec![0u8; n]` takes
+/// that path; counting only `alloc` would miss the exact allocation this test exists to observe.
+struct Counting;
+
+fn record_growth(bytes: usize) {
+    let now = IN_USE.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    PEAK.fetch_max(now, Ordering::Relaxed);
+}
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            record_growth(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc_zeroed(layout);
+        if !ptr.is_null() {
+            record_growth(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        IN_USE.fetch_sub(layout.size(), Ordering::Relaxed);
+        System.dealloc(ptr, layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = System.realloc(ptr, layout, new_size);
+        if !new_ptr.is_null() {
+            IN_USE.fetch_sub(layout.size(), Ordering::Relaxed);
+            record_growth(new_size);
+        }
+        new_ptr
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+/// Re-arms the high-water mark at the current in-use figure and returns that baseline.
+fn arm_peak() -> usize {
+    let now = IN_USE.load(Ordering::Relaxed);
+    PEAK.store(now, Ordering::Relaxed);
+    now
+}
+
+fn peak_growth_since(baseline: usize) -> usize {
+    PEAK.load(Ordering::Relaxed).saturating_sub(baseline)
+}
+
+fn mib(bytes: usize) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+// ---------------------------------------------------------------------------
+// Node harness (same shape as preauth_source_work_budget.rs)
+// ---------------------------------------------------------------------------
+
+static ISSUED_PORTS: Mutex<Option<HashSet<u16>>> = Mutex::new(None);
+
+fn pick_port() -> u16 {
+    let mut issued = ISSUED_PORTS.lock().expect("port registry poisoned");
+    let issued = issued.get_or_insert_with(HashSet::new);
+    for _ in 0..64 {
+        if let Some(port) = portpicker::pick_unused_port() {
+            if issued.insert(port) {
+                return port;
+            }
+        }
+    }
+    panic!("could not find an unused port");
+}
+
+fn init() {
+    // Must be the provider the workspace builds against: a different one makes every TLS
+    // handshake fail, which presents as a connect timeout rather than as a TLS error.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
+struct Guard(broadcast::Sender<()>);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+/// Topic counts of every `Subscribe` the node dispatched to its external handler.
+///
+/// A `Subscribe` reaches that handler untouched, so an arrival records that the node read,
+/// reassembled and decoded the whole frame — which is the property the chunked reader must not
+/// break.
+#[derive(Clone, Default)]
+struct Delivered(Arc<Mutex<Vec<usize>>>);
+
+impl Delivered {
+    fn topic_counts(&self) -> Vec<usize> {
+        self.0.lock().expect("delivery log poisoned").clone()
+    }
+}
+
+/// Spawn a real node on the production stack.
+///
+/// The handler is required, not optional: `NetworkActor::spawn` starts no inbound accept loop
+/// without one, and a node that never accepts a stream never reaches `read_message` — which would
+/// make the upper-bound assertion below pass for the wrong reason.
+async fn spawn_node(
+    bundle: IdentityBundle,
+) -> Result<(NetworkHandle, SocketAddr, Guard, Delivered)> {
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let delivered = Delivered::default();
+    let sink = delivered.0.clone();
+    let handler: IncomingMessageHandler = Arc::new(move |msg: NetworkMessage| {
+        if let icn_net::MessagePayload::Subscribe { topics } = &msg.payload {
+            sink.lock()
+                .expect("delivery log poisoned")
+                .push(topics.len());
+        }
+    });
+
+    let mut last_err = None;
+    for _ in 0..8 {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        match NetworkActor::spawn(
+            bundle.clone(),
+            addr,
+            shutdown_tx.clone(),
+            Some(handler.clone()),
+            None, // oracle
+            None, // fallback_config
+            None, // topology_config
+            None, // stun_servers
+            None, // turn_config
+            None, // misbehavior_detector
+            None, // store
+            None, // personhood
+            None, // anchor_rate_config
+            None, // advertised_addr
+        )
+        .await
+        {
+            Ok(handle) => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                return Ok((handle, addr, Guard(shutdown_tx), delivered));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
+}
+
+async fn connect(
+    identity: &IdentityBundle,
+    target: SocketAddr,
+) -> Result<(Endpoint, quinn::Connection)> {
+    let rustls_client = icn_net::tls::create_tofu_client_config(
+        vec![identity.tls_cert().clone()],
+        identity.tls_key(),
+    )?;
+    let mut endpoint = Endpoint::client("127.0.0.1:0".parse()?)?;
+    endpoint.set_default_client_config(ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(rustls_client)?,
+    )));
+
+    let mut last_err = None;
+    for attempt in 0..5 {
+        match tokio::time::timeout(
+            Duration::from_secs(10),
+            endpoint.connect(target, "localhost")?,
+        )
+        .await
+        {
+            Ok(Ok(connection)) => return Ok((endpoint, connection)),
+            Ok(Err(e)) => last_err = Some(e.to_string()),
+            Err(_) => last_err = Some("connect timed out".to_string()),
+        }
+        tokio::time::sleep(Duration::from_millis(150 * (attempt + 1))).await;
+    }
+    anyhow::bail!(
+        "could not establish the test connection after 5 attempts: {}",
+        last_err.unwrap_or_default()
+    )
+}
+
+// ---------------------------------------------------------------------------
+// The test
+// ---------------------------------------------------------------------------
+
+/// A declared length must not, by itself, commit memory.
+///
+/// Every connection writes only the four-byte prefix and then goes quiet. No body byte is ever
+/// sent, so a node that sizes its buffer from bytes received allocates essentially nothing here,
+/// while a node that sizes it from the declared length commits `MAX_MESSAGE_SIZE` per connection.
+///
+/// The ceiling asserted is one `MAX_MESSAGE_SIZE` for the *whole* fleet of connections. That is
+/// far above anything an incremental reader would use and far below the
+/// `MAX_PREAUTH_CONNECTIONS_PER_SOURCE × MAX_MESSAGE_SIZE` this path currently commits, so the
+/// assertion does not depend on where between those two a fix happens to land.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn declared_length_alone_does_not_commit_memory() -> Result<()> {
+    init();
+
+    let server = IdentityBundle::generate().expect("server identity");
+    let (_handle, addr, _guard, _delivered) = spawn_node(server).await?;
+
+    // One source, the most connections admission will grant it (#2551).
+    let fleet = MAX_PREAUTH_CONNECTIONS_PER_SOURCE;
+    let mut held = Vec::with_capacity(fleet);
+    for _ in 0..fleet {
+        let client = IdentityBundle::generate().expect("client identity");
+        let (endpoint, connection) = connect(&client, addr).await?;
+        let (send, _recv) = connection
+            .open_bi()
+            .await
+            .context("open_bi on the test connection")?;
+        held.push((endpoint, connection, send));
+    }
+
+    // Let connection setup and stream acceptance settle, so the measured window contains the
+    // declared-length allocation and nothing else of consequence.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let baseline = arm_peak();
+
+    // The entire attack: a four-byte length prefix per connection, and then silence.
+    let declared = MAX_MESSAGE_SIZE as u32;
+    let mut attacker_bytes = 0usize;
+    for (_endpoint, _connection, send) in held.iter_mut() {
+        send.write_all(&declared.to_be_bytes())
+            .await
+            .context("write length prefix")?;
+        attacker_bytes += 4;
+        // Deliberately no body, and deliberately no finish(): the stream stays open so the node
+        // remains parked in `read_exact` on a body that will never arrive.
+    }
+
+    // Give the node time to accept each stream, read the prefix, and reach the allocation.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let growth = peak_growth_since(baseline);
+    let committed_if_declared_is_trusted = fleet * MAX_MESSAGE_SIZE;
+    let ceiling = MAX_MESSAGE_SIZE;
+
+    assert!(
+        growth < ceiling,
+        "a declared length committed memory before any body byte arrived.\n\
+         attacker sent      : {attacker_bytes} bytes ({fleet} connections x 4-byte prefix)\n\
+         node peak growth   : {:.1} MiB\n\
+         ceiling asserted   : {:.1} MiB (one MAX_MESSAGE_SIZE for the whole fleet)\n\
+         would-be commitment: {:.1} MiB (MAX_PREAUTH_CONNECTIONS_PER_SOURCE x MAX_MESSAGE_SIZE)\n\
+         amplification      : {:.0}x",
+        mib(growth),
+        mib(ceiling),
+        mib(committed_if_declared_is_trusted),
+        growth as f64 / attacker_bytes as f64,
+    );
+
+    Ok(())
+}
+
+/// A frame larger than one read step still arrives intact.
+///
+/// This is the risk the fix introduces: the body is no longer read by a single `read_exact` over
+/// the whole buffer, but in steps that are appended as they arrive. A reassembly that dropped,
+/// duplicated or reordered a step would corrupt exactly the messages too large to fit in one —
+/// and every other test in this crate sends messages far below that size, so nothing else would
+/// notice. The payload here is chosen to span several steps.
+///
+/// It also pins the other half of the contract: bounding the *reservation* must not bound the
+/// *message*. `MAX_MESSAGE_SIZE` remains the only authority on how large a message may be.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_frame_spanning_several_read_steps_arrives_intact() -> Result<()> {
+    init();
+
+    let server = IdentityBundle::generate().expect("server identity");
+    let server_did = server.did().clone();
+    let (_handle, addr, _guard, delivered) = spawn_node(server).await?;
+
+    let client = IdentityBundle::generate().expect("client identity");
+    let (_endpoint, connection) = connect(&client, addr).await?;
+
+    // Comfortably more than one read step once encoded, so reassembly is actually exercised.
+    const TOPICS: usize = 4096;
+    let topics: Vec<String> = (0..TOPICS)
+        .map(|i| format!("icn.test.2558.reassembly.{i:0>48}"))
+        .collect();
+    let message = NetworkMessage::subscribe(client.did().clone(), server_did, topics);
+    let encoded = message.to_bytes_negotiated(false, false)?.len();
+    assert!(
+        encoded > 64 * 1024,
+        "payload must span more than one read step to exercise reassembly, got {encoded} bytes"
+    );
+
+    let (mut send, _recv) = connection.open_bi().await.context("open_bi")?;
+    icn_net::write_message(&mut send, &message).await?;
+    send.finish()?;
+
+    // Give the node time to read every step and dispatch.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    assert_eq!(
+        delivered.topic_counts(),
+        vec![TOPICS],
+        "a {encoded}-byte frame spanning several read steps must arrive once, intact"
+    );
+
+    Ok(())
+}

--- a/icn/crates/icn-net/tests/preauth_declared_length_allocation.rs
+++ b/icn/crates/icn-net/tests/preauth_declared_length_allocation.rs
@@ -368,19 +368,28 @@ async fn a_frame_spanning_several_read_steps_arrives_intact() -> Result<()> {
     let client = IdentityBundle::generate().expect("client identity");
     let (_endpoint, connection) = connect(&client, addr).await?;
 
-    // Comfortably more than one read step once encoded, so reassembly is actually exercised.
-    const TOPICS: usize = 4096;
+    // Sized in absolute terms rather than against the current step, so tuning the step upward
+    // cannot quietly stop this exercising the multi-step path while still passing. It also lands
+    // just past a power of two, which is where an unbounded growth strategy overshoots worst.
+    const TOPICS: usize = 20_000;
+    const SPANNING_FLOOR: usize = 1024 * 1024;
     let topics: Vec<String> = (0..TOPICS)
         .map(|i| format!("icn.test.2558.reassembly.{i:0>48}"))
         .collect();
     let message = NetworkMessage::subscribe(client.did().clone(), server_did, topics);
     let encoded = message.to_bytes_negotiated(false, false)?.len();
     assert!(
-        encoded > 64 * 1024,
-        "payload must span more than one read step to exercise reassembly, got {encoded} bytes"
+        encoded > SPANNING_FLOOR,
+        "payload must be large enough to span several read steps for any plausible step size, \
+         got {encoded} bytes"
+    );
+    assert!(
+        encoded < MAX_MESSAGE_SIZE,
+        "payload must remain a legal message, got {encoded} bytes"
     );
 
     let (mut send, _recv) = connection.open_bi().await.context("open_bi")?;
+    let baseline = arm_peak();
     icn_net::write_message(&mut send, &message).await?;
     send.finish()?;
 
@@ -391,6 +400,19 @@ async fn a_frame_spanning_several_read_steps_arrives_intact() -> Result<()> {
         delivered.topic_counts(),
         vec![TOPICS],
         "a {encoded}-byte frame spanning several read steps must arrive once, intact"
+    );
+
+    // A frame must not retain more than it declared. Growing the buffer by `Vec`'s own amortised
+    // doubling would round a frame just past a power of two up to the next one — for a
+    // maximum-size frame, 16 MiB against a declared 10 MiB, i.e. worse than the eager allocation
+    // this change replaces. The ceiling is generous because the test process is also holding the
+    // sent copy and quinn's buffers; the defect it excludes is a *multiple* of the frame.
+    let growth = peak_growth_since(baseline);
+    assert!(
+        growth < encoded * 3,
+        "a {encoded}-byte frame retained {:.1} MiB — capacity is overshooting the declared \
+         length, not tracking it",
+        mib(growth),
     );
 
     Ok(())


### PR DESCRIPTION
## The invariant

> Before this node has authenticated a peer, the memory it commits on that peer's behalf must be a
> function of the bytes the peer has actually sent, not of a length the peer merely claimed.

## What was wrong

Every `read_message*` helper validated the four-byte length prefix against `MAX_MESSAGE_SIZE` and
then allocated `vec![0u8; declared]` **before reading a single body byte**. The buffer was
committed on the strength of a number the peer chose. A peer that wrote the prefix and then went
quiet held that memory until the body arrived or the read deadline expired — and before
authentication, "the peer" is anyone who completed a QUIC handshake.

None of the neighbouring bounds established the invariant:

- `MAX_MESSAGE_SIZE` caps the *claim*; it does not make the claim cost anything.
- QUIC's `receive_window` / `stream_receive_window` cap the bytes a peer may **send** — they cannot
  bound an allocation sized from a length the peer never fulfils. A transport byte limit does not
  imply a decoder allocation limit.
- `PREAUTH_AUTHENTICATION_DEADLINE` bounds how *long* the commitment is held, not how large it is.
- The per-connection (#2491) and per-source (#2549/#2557) budgets sit *after* the read returns;
  `preauth_source_work_budget.rs` says so in its own words.

## Mechanism

All three helpers each carried their own copy of the framing preamble, so a bound added to one
would have left the other two open. They now share a single `read_frame`, which keeps the same
prefix validation and the same `MAX_MESSAGE_SIZE` authority. Nothing in the read path is sized by
the declaration:

- the body is read with `RecvStream::read_chunk`, which hands back only the bytes that have
  actually arrived — there is no fixed scratch buffer living inline in the connection future;
- the buffer starts empty, and the **first** reservation is exactly the bytes in hand;
- subsequent growth is geometric, so a large frame still costs amortised O(n) copying, but is
  **capped at the declared length**;
- `FRAME_READ_STEP` (64 KiB) appears only as the ceiling on one `read_chunk` request. It bounds
  how much may arrive in a single poll, never how much is reserved before it does.

`MAX_MESSAGE_SIZE` is unchanged and remains the only authority on how large a message may be.

## Scope — this closes the allocation axis of #2558, not the whole issue

#2558 as filed also measures a **work/rate** defect on the same read path: anonymous messages are
read and deserialized before the per-source budget refuses them. That axis is untouched here and
#2558 stays open for it — the body deliberately says `Refs`, not `Closes`, so merging this does not
silently retire the remaining invariant.

## Review-driven corrections

Worth recording, because each intermediate revision moved the cost rather than removing it:

| round | non-proportional cost found | scale |
|---|---|---|
| original defect | declared frame length | ~80 MiB / 8 pre-auth connections |
| rev 1 | `Vec` amortised doubling overshoot | 16 MiB for a legal 10 MiB frame |
| rev 2 | 64 KiB scratch inline in every connection future | ~16 MiB / 256 connections |
| rev 3 | first reservation seeded at a step, then doubled | ~32 MiB / 256 connections |

Two test-design faults were corrected alongside: an allocator threshold whose local (0.1 MiB) and
CI (4.7 MiB) ranges overlapped the defect it was meant to exclude (6.2 MiB) — replaced by
deterministic unit tests over the pure capacity policy rather than loosened; and unit tests that
advanced capacity without modelling the read loop, which is how the seeded first reservation
escaped them. They now simulate arrival → hold → reserve.

## What is preserved

- **Wire format** — the bytes read and their order are identical. No protocol change, no peer
  version sensitivity.
- **Fail-closed** — zero-length and oversized declarations are still rejected before any body read.
- **Truncation** — a short frame still fails on the step that runs short, exactly as a single
  `read_exact` over the whole body did.
- **Cancellation** — the caller's timeout still wraps the whole read; dropping it now discards only
  a partial buffer proportional to what the peer really sent.
- **Authenticated traffic** — same decode calls, same validation, unchanged.

## Evidence

The regression test counts **bytes requested from the allocator**, not RSS — a zeroed mapping can
be lazily backed, which would under-report a commitment the program genuinely made. Against a real
node on the production stack, the same pre-authentication sequence:

| | before | after |
|---|---|---|
| peak allocator growth | 80.0 MiB | **0.5 MiB** |

The post-fix figure tracks the read step rather than the declaration.

Both tests were checked for vacuity rather than assumed:

- the allocation test **passes** when the declared length is reduced tenfold, so it measures the
  declared length rather than fixed noise;
- the reassembly test (a frame spanning several read steps must arrive intact — the half this
  change actually put at risk) turns **red** when one byte per step is dropped.

## Validation

`cargo fmt --all --check` 0 · `cargo clippy -p icn-net --all-targets -D warnings` 0 (zero warnings) ·
`cargo test -p icn-net --no-fail-fast` 0 — **496 passed, 0 failed, 23 ignored** across 23 binaries.

Sibling suites run individually and green: `preauth_source_work_budget` 6/6,
`preauth_connection_admission` 3/3, `preauth_authentication_deadline` 7/7 (cancellation semantics),
`hello_handshake_termination` 5/5, `encoding_negotiation_integration` 10/10 (exercises both sibling
read paths).

## Adjacent boundaries

Untouched and unmodified: `preauth_admission.rs`, `rate_limit.rs`, `session.rs` (QUIC stream/session
limits) and `actor/connection.rs`. This PR changes framing only.

Refs #2558.

