### PR TITLE
fix(net): authorize pre-authentication decode work before performing it

### DIFF
--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -594,10 +594,20 @@ impl NetworkActor {
                     // rate limit into an availability primitive; charging after the decode is
                     // what this fixes.
                     //
-                    // A refusal here now costs the sender its token *without* buying the decode,
-                    // which is the property. It also means a malformed body is charged: that is
-                    // deliberate, because unparseable input is exactly the input an attacker gets
-                    // to produce for free otherwise. The token is the same single token the
+                    // The invariant is one-directional, and only that direction is claimed: a
+                    // frame is decoded **only if** this gate permitted it. The converse does not
+                    // hold and does not need to. `PreAuthBudget::check` is
+                    // `connection.check() && budget.spend()`, so an exhausted connection bucket
+                    // short-circuits and costs nothing at all, while a connection bucket that
+                    // permits over a dry source budget spends its token on a frame that is never
+                    // decoded. That asymmetry predates this change and is documented as
+                    // deliberate on `PreAuthBudget::check`; it can only make the bound tighter
+                    // than stated, never looser.
+                    //
+                    // What did change is that a malformed body is now charged for the decode
+                    // *attempt* where it used to be free — the decode error short-circuited past
+                    // this gate entirely, so unparseable input, exactly what an attacker
+                    // manufactures cheaply, was never metered. It is the same single token the
                     // message would have spent one step later, so nothing is charged twice.
                     //
                     // Only the anonymous phase moves. An authenticated peer's DID- and

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -604,6 +604,11 @@ impl NetworkActor {
                     // anchor-keyed limits stay where they were, below the decode: that traffic is
                     // attributable to a proven identity, and #2558 is about work performed for a
                     // peer that has not proven one.
+                    //
+                    // The operand order is load-bearing, not stylistic. `check_pre_auth_rate_limit`
+                    // *consumes* a token, so it must stay last: `&&` short-circuits, and the two
+                    // guards ahead of it are what keep an incomplete frame and an authenticated
+                    // peer from being charged. Reordering this spends tokens on both.
                     if frame.is_ok()
                         && authenticated.is_none()
                         && !ctx.check_pre_auth_rate_limit().await

--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -32,9 +32,8 @@
 //!
 //! # Rate limiting is two phases, not one
 //!
-//! The limit check runs immediately after `read_message`, before any dispatch — which means
-//! before anything has verified who sent the message. So the check cannot ask the message
-//! who to charge (#2491):
+//! Both limit checks run before any dispatch — which means before anything has verified who sent
+//! the message. So neither check can ask the message who to charge (#2491):
 //!
 //! ```text
 //! before authentication:
@@ -59,11 +58,40 @@
 //! spend from it, and authentication does not refund what was already spent — self-minting a
 //! DID and a binding is cheap, so any exemption it could buy would be no bound at all.
 //!
-//! Scope: this bounds the anonymous *dispatch* one source can fund. It does not bound that
-//! source's QUIC/TLS handshake rate, which is complete before the source key exists, nor the
-//! deserialization of a message that is then denied — that read happens before the gate, and
-//! one held connection can drive it without reconnecting. Bounding how many connections one
-//! source holds *at once* is connection admission, below.
+//! Scope: this bounds the anonymous *work* one source can fund — the decode as well as the
+//! dispatch it feeds. It does not bound that source's QUIC/TLS handshake rate, which is complete
+//! before the source key exists (#2559). Bounding how many connections one source holds *at once*
+//! is connection admission, below.
+//!
+//! # The gate sits between framing and decoding, not after both
+//!
+//! It used to sit after both, and that was the defect #2558 filed. `read_message` is two steps
+//! welded together — acquire the frame, then interpret it — and only the first is work the peer
+//! has already paid for in bytes it actually sent. Interpreting a frame means a wire-format parse,
+//! zstd decompression bounded only by `MAX_MESSAGE_SIZE`, and a full postcard deserialization of
+//! the envelope. All of that ran before either budget was consulted, so a refusal cost the sender
+//! nothing and the budget bounded what this node would *act on* rather than what it would *do*:
+//!
+//! ```text
+//! was:  accept_bi -> read frame -> DECODE -> budget -> dispatch
+//! now:  accept_bi -> read frame -> budget -> DECODE -> dispatch
+//! ```
+//!
+//! The new position is the earliest point where both halves of the charge are true: enough of the
+//! peer's input has arrived to justify charging a unit, and the work the budget meters has not
+//! happened yet. Charging on stream accept instead would bill an idle or stalled connection for
+//! work nobody has asked for, which would turn a rate limit into an availability primitive.
+//!
+//! Only the anonymous phase moved. The post-authentication per-DID and per-anchor limits stay
+//! below the decode, because that traffic is attributable to an identity this connection has
+//! proven and because those log lines quote `message.from`. A malformed body is now charged where
+//! it used to be free — deliberately, since unparseable input is exactly what an attacker gets to
+//! manufacture cheaply. It is the same single token the message would have spent one step later,
+//! so nothing is charged twice.
+//!
+//! What this does **not** change is how many frames the node *reads*. A refused peer still gets
+//! its frame read; that is bounded by the authentication deadline and by admission, not by this
+//! budget. Reading bytes is not the resource #2558 is about.
 //!
 //! # The anonymous phase is bounded in size and in time
 //!
@@ -89,11 +117,13 @@
 //! `record_authenticated_peer` had already released its slot, so dispatch is not. `accept_bi` is
 //! cancel-safe, so a losing arm cannot swallow a Hello.
 //!
-//! Bounding the read is not belt-and-braces. `read_message` has no timeout of its own, and
+//! Bounding the read is not belt-and-braces. `read_frame` has no timeout of its own, and
 //! `read_exact` on a length prefix whose remaining bytes never arrive never returns — so a peer
 //! that sends three bytes of a four-byte header parks this task inside the loop body, past every
 //! deadline, holding the slot exactly as if it had sent nothing at all. A deadline that guards
-//! only the wait is defeated by anything that keeps the task out of the wait.
+//! only the wait is defeated by anything that keeps the task out of the wait. The deadline wraps
+//! exactly that peer-controlled await; the decode below it is CPU-bound and has no await to
+//! cancel at, so the split changed nothing about what the deadline covers.
 //!
 //! The expiry is also *checked* at the loop boundary rather than left to the `select!`, because
 //! `biased` returns on the first ready arm without polling the rest and a tokio `Sleep` completes
@@ -115,7 +145,7 @@ use tracing::{debug, info, instrument, warn};
 
 use crate::{
     handlers::ConnectionContext,
-    protocol::{read_message, MessagePayload},
+    protocol::{read_frame, MessagePayload, NetworkMessage},
     replay_guard::ReplayGuard,
     topology::{NeighborSets, TopologyConfig},
     IncomingMessageHandler, SessionManager,
@@ -493,14 +523,25 @@ impl NetworkActor {
 
             match accepted {
                 Ok((mut send, mut recv)) => {
-                    // Read network message.
+                    // Acquire the frame — bytes only, nothing interpreted yet.
+                    //
+                    // This is the first half of what `read_message` used to do in one step. The
+                    // split is the subject of #2558: `read_frame` is bounded work the peer has
+                    // already paid for in bytes it actually sent (#2573), while turning those
+                    // bytes into a `NetworkMessage` is unbounded-by-comparison work this node
+                    // performs on the peer's behalf — a wire-format parse, zstd decompression
+                    // bounded only by `MAX_MESSAGE_SIZE`, and a full postcard deserialization.
+                    // The budget that decides whether an anonymous peer may spend that work now
+                    // sits between the two, below.
                     //
                     // Bounded by the same absolute instant while the connection is anonymous.
-                    // `read_message` is an unbounded await the *peer* controls: `read_exact`
+                    // Frame acquisition is an unbounded await the *peer* controls: `read_exact`
                     // on a length prefix whose remaining bytes never arrive never returns, so
                     // three bytes of a four-byte header parks this task inside the loop body
                     // forever — past the wait, where no deadline could reach it. That is the
-                    // same squat #2552 is about, reached for the price of one stream.
+                    // same squat #2552 is about, reached for the price of one stream. The
+                    // deadline wraps exactly the peer-controlled await and nothing else; decode
+                    // is CPU-bound and has no await to cancel at.
                     //
                     // Bounding the read and not the dispatch is the whole distinction. Reading
                     // bytes is not verifying them: a cancelled read discards a message nobody
@@ -508,13 +549,13 @@ impl NetworkActor {
                     // Cancelling `handle_hello` could instead abandon a peer *mid-verification*
                     // — or, worse, after `record_authenticated_peer` had already released the
                     // slot — so dispatch stays outside the deadline exactly as before.
-                    let read = match authenticate_by {
-                        None => read_message(&mut recv).await,
+                    let frame = match authenticate_by {
+                        None => read_frame(&mut recv).await,
                         Some(deadline) => {
-                            match tokio::time::timeout_at(deadline.into(), read_message(&mut recv))
+                            match tokio::time::timeout_at(deadline.into(), read_frame(&mut recv))
                                 .await
                             {
-                                Ok(read) => read,
+                                Ok(frame) => frame,
                                 Err(_elapsed) => {
                                     close_for_missed_authentication(&connection);
                                     break;
@@ -523,14 +564,87 @@ impl NetworkActor {
                         }
                     };
 
-                    match read {
-                        Ok((message, bytes_read)) => {
-                            // Track bandwidth contribution (aggregate, no per-DID tracking)
-                            icn_obs::metrics::contribution::total_bandwidth_bytes_add(
-                                bytes_read as u64,
-                            );
+                    // Track bandwidth contribution (aggregate, no per-DID tracking).
+                    //
+                    // Counted against the frame, before the gate, rather than against a successful
+                    // decode. Refused traffic was already counted here before this change — a
+                    // refused message had necessarily been decoded by the time it reached the gate
+                    // — and moving the gate earlier without moving this would blind the counter in
+                    // exactly the case #2558 is about. Total bytes: 4 (length prefix) + frame
+                    // body, as `read_message` reported. A frame that never completed is not
+                    // counted, as before.
+                    if let Ok(frame) = &frame {
+                        icn_obs::metrics::contribution::total_bandwidth_bytes_add(
+                            (4 + frame.len()) as u64,
+                        );
+                    }
 
-                            // Check rate limit BEFORE processing message.
+                    // Which identity this connection has proven, read once. Nothing between here
+                    // and the dispatch below can change it — decode is pure — so the pre- and
+                    // post-authentication gates are answering the same question about the same
+                    // instant, as they did when both sat after the decode.
+                    let authenticated = ctx.authenticated_peer().await;
+
+                    // PRE-AUTHENTICATION WORK AUTHORIZATION (#2558).
+                    //
+                    // The earliest point at which both halves of the charge are true: enough of
+                    // the peer's input has arrived to justify charging one unit, and the work the
+                    // budget meters has not happened yet. Charging on stream accept instead would
+                    // bill an idle or stalled connection for work nobody has asked for, turning a
+                    // rate limit into an availability primitive; charging after the decode is
+                    // what this fixes.
+                    //
+                    // A refusal here now costs the sender its token *without* buying the decode,
+                    // which is the property. It also means a malformed body is charged: that is
+                    // deliberate, because unparseable input is exactly the input an attacker gets
+                    // to produce for free otherwise. The token is the same single token the
+                    // message would have spent one step later, so nothing is charged twice.
+                    //
+                    // Only the anonymous phase moves. An authenticated peer's DID- and
+                    // anchor-keyed limits stay where they were, below the decode: that traffic is
+                    // attributable to a proven identity, and #2558 is about work performed for a
+                    // peer that has not proven one.
+                    if frame.is_ok()
+                        && authenticated.is_none()
+                        && !ctx.check_pre_auth_rate_limit().await
+                    {
+                        // No `claimed_from` here, unlike the authenticated arm below: the frame
+                        // has deliberately not been decoded, so there is no claim to log — and
+                        // the claim was never authority for anything in this phase anyway.
+                        //
+                        // The message does not name which of its own two buckets refused. An
+                        // inbound connection spends a per-connection burst (#2491) and a shared
+                        // per-source budget (#2549), the first is consulted first and
+                        // short-circuits, and an outbound connection has no source budget at all.
+                        // Naming the source here points operators at NAT contention for what is
+                        // just as likely one connection spending its own burst. Attributing it
+                        // exactly means returning the refusing bucket from `PreAuthBudget::check`,
+                        // which is a change to the gate itself rather than to this log line.
+                        warn!(
+                            "Refused pre-authentication work (a pre-authentication budget is \
+                             exhausted: this connection's own burst, or the shared budget for its \
+                             source if it has one)"
+                        );
+
+                        icn_obs::metrics::network::messages_rate_limited_inc();
+                        icn_obs::metrics::network::messages_rate_limited_pre_auth_inc();
+
+                        // Close stream before continuing to avoid resource leak
+                        if let Err(e) = send.finish() {
+                            tracing::debug!("Stream finish error during rate limit: {}", e);
+                        }
+
+                        // Drop the frame — undecoded (don't call handler)
+                        continue;
+                    }
+
+                    // Second half: interpret the authorized frame.
+                    let read =
+                        frame.and_then(|frame| NetworkMessage::from_bytes_negotiated(&frame));
+
+                    match read {
+                        Ok(message) => {
+                            // Check the authenticated peer's rate limit BEFORE processing.
                             //
                             // Which identity may select this message's limit is decided by
                             // what *this connection* has proven, never by what the message
@@ -538,10 +652,15 @@ impl NetworkActor {
                             //
                             //   PRE-AUTH   the transport source is known, the peer's DID is
                             //              not. Trust cannot select a tier, and there is no
-                            //              DID to derive a personhood anchor from either.
+                            //              DID to derive a personhood anchor from either. That
+                            //              phase is gated above, before the decode (#2558) —
+                            //              nothing about it needed the message, which is why it
+                            //              could move.
                             //   POST-AUTH  this connection has a DID bound to the
                             //              certificate it is actually using (#2520). That
-                            //              DID selects the tier.
+                            //              DID selects the tier. It stays here: the work is
+                            //              attributable to a proven identity, and `message.from`
+                            //              is available for the diagnostics below.
                             //
                             // `message.from` describes a claimed origin and is kept for
                             // diagnostics below. It never selects transport rate-limit
@@ -549,101 +668,73 @@ impl NetworkActor {
                             // public, so keying on `from` let any sender name a well-trusted
                             // peer and be charged as one.
                             //
-                            // Read per message rather than cached, because the connection's
-                            // identity is genuinely mutable. `handlers::hello` records an
-                            // authenticated peer on *every* valid Hello — the `hello_responded`
-                            // guard bounds the reply (#2537), not the binding — and #2520's
-                            // checks tie a DID to this connection's certificate without tying
-                            // that certificate to the DID's key. A second Hello can therefore
-                            // move this connection from A to B, and the limit must follow the
-                            // identity in force *now*. Caching the first one would keep
-                            // charging a peer that is no longer the one on this session.
-                            let authenticated = ctx.authenticated_peer().await;
-                            let (did_allowed, anchor_allowed) = match &authenticated {
-                                Some(authenticated) => {
-                                    rate_limiter
-                                        .check_rate_limit_with_personhood(authenticated)
-                                        .await
-                                }
-                                // No DID, so nothing DID-keyed runs: not the trust tier and
-                                // not the anchor lookup. Inventing an anchor from the claim
-                                // would let a sender spend somebody else's per-person budget.
-                                //
-                                // The `true` is the anchor verdict, and it does change what
-                                // `EnforcementMode::RequirePersonhood` covers: that mode no
-                                // longer denies pre-authentication traffic. It never usefully
-                                // did. The anchor was looked up for `message.from`, so naming
-                                // any anchored DID satisfied it, while the peers it actually
-                                // turned away were honest un-anchored ones — whose Hello it
-                                // dropped before they could ever authenticate. Personhood is
-                                // now enforced where it can mean something: on the branch
-                                // above, against the DID this connection has proven.
-                                None => (ctx.check_pre_auth_rate_limit().await, true),
-                            };
+                            // `authenticated` is read once per message above rather than cached
+                            // across messages, because the connection's identity is genuinely
+                            // mutable. `handlers::hello` records an authenticated peer on *every*
+                            // valid Hello — the `hello_responded` guard bounds the reply (#2537),
+                            // not the binding — and #2520's checks tie a DID to this connection's
+                            // certificate without tying that certificate to the DID's key. A
+                            // second Hello can therefore move this connection from A to B, and the
+                            // limit must follow the identity in force *now*. Caching the first one
+                            // would keep charging a peer that is no longer the one on this
+                            // session.
+                            //
+                            // With no DID, nothing DID-keyed runs: not the trust tier and not the
+                            // anchor lookup. Inventing an anchor from the claim would let a sender
+                            // spend somebody else's per-person budget. That also means
+                            // `EnforcementMode::RequirePersonhood` does not cover
+                            // pre-authentication traffic. It never usefully did: the anchor was
+                            // looked up for `message.from`, so naming any anchored DID satisfied
+                            // it, while the peers it actually turned away were honest un-anchored
+                            // ones — whose Hello it dropped before they could ever authenticate.
+                            if let Some(peer) = authenticated.as_ref() {
+                                let (did_allowed, anchor_allowed) =
+                                    rate_limiter.check_rate_limit_with_personhood(peer).await;
 
-                            if !did_allowed {
-                                // Two limits reach this branch and the message says which of the
-                                // two: "per-DID limit" is not true of a phase that has no DID,
-                                // and the distinction is the operational one — a throttled
-                                // authenticated peer is a tier that may want raising, while an
-                                // exhausted anonymous budget is load from a connection that never
-                                // got as far as saying who it was.
-                                //
-                                // The anonymous arm deliberately does *not* name which of its own
-                                // two buckets refused. An inbound connection spends a
-                                // per-connection burst (#2491) and a shared per-source budget
-                                // (#2549), the first is consulted first and short-circuits, and an
-                                // outbound connection has no source budget at all. Naming the
-                                // source here — as this message briefly did — points operators at
-                                // NAT contention for what is just as likely one connection
-                                // spending its own burst. Attributing it exactly means returning
-                                // the refusing bucket from `PreAuthBudget::check`, which is a
-                                // change to the gate itself rather than to this log line.
-                                match &authenticated {
-                                    Some(authenticated) => warn!(
+                                if !did_allowed {
+                                    warn!(
                                         claimed_from = %message.from,
-                                        authenticated = %authenticated,
+                                        authenticated = %peer,
                                         "Rate limited message (per-DID limit exceeded)"
-                                    ),
-                                    None => warn!(
+                                    );
+
+                                    // Track rate limiting metric
+                                    icn_obs::metrics::network::messages_rate_limited_inc();
+
+                                    // Close stream before continuing to avoid resource leak
+                                    if let Err(e) = send.finish() {
+                                        tracing::debug!(
+                                            "Stream finish error during rate limit: {}",
+                                            e
+                                        );
+                                    }
+
+                                    // Drop the message (don't call handler)
+                                    continue;
+                                }
+
+                                if !anchor_allowed {
+                                    warn!(
                                         claimed_from = %message.from,
-                                        "Rate limited message (a pre-authentication budget is \
-                                         exhausted: this connection's own burst, or the shared \
-                                         budget for its source if it has one)"
-                                    ),
+                                        authenticated = %peer,
+                                        "Rate limited message (per-person limit exceeded - Sybil mitigation)"
+                                    );
+
+                                    // Track Sybil-specific rate limiting metric
+                                    icn_obs::metrics::network::messages_rate_limited_by_anchor_inc(
+                                    );
+
+                                    // Close stream before continuing to avoid resource leak
+                                    if let Err(e) = send.finish() {
+                                        tracing::debug!(
+                                            "Stream finish error during rate limit: {}",
+                                            e
+                                        );
+                                    }
+
+                                    // Drop the message (don't call handler)
+                                    continue;
                                 }
-
-                                // Track rate limiting metric
-                                icn_obs::metrics::network::messages_rate_limited_inc();
-                                if authenticated.is_none() {
-                                    icn_obs::metrics::network::messages_rate_limited_pre_auth_inc();
-                                }
-
-                                // Close stream before continuing to avoid resource leak
-                                if let Err(e) = send.finish() {
-                                    tracing::debug!("Stream finish error during rate limit: {}", e);
-                                }
-
-                                // Drop the message (don't call handler)
-                                continue;
-                            }
-
-                            if !anchor_allowed {
-                                warn!(
-                                    claimed_from = %message.from,
-                                    "Rate limited message (per-person limit exceeded - Sybil mitigation)"
-                                );
-
-                                // Track Sybil-specific rate limiting metric
-                                icn_obs::metrics::network::messages_rate_limited_by_anchor_inc();
-
-                                // Close stream before continuing to avoid resource leak
-                                if let Err(e) = send.finish() {
-                                    tracing::debug!("Stream finish error during rate limit: {}", e);
-                                }
-
-                                // Drop the message (don't call handler)
-                                continue;
                             }
 
                             info!(

--- a/icn/crates/icn-net/src/handlers/mod.rs
+++ b/icn/crates/icn-net/src/handlers/mod.rs
@@ -254,17 +254,23 @@ impl ConnectionContext {
         self.authenticated_peer.read().await.clone()
     }
 
-    /// Spend one message against the anonymous budget this connection draws on.
+    /// Spend one frame's worth of the anonymous budget this connection draws on.
     ///
     /// Call this only on the branch where [`Self::authenticated_peer`] is `None`. It takes
     /// no identity because at that point there is none — see
     /// [`crate::rate_limit::PreAuthBudget`].
     ///
+    /// Charged against a **frame that has arrived in full but has not yet been decoded** (#2558).
+    /// That position is load-bearing in both directions: later and the node performs the decode
+    /// the token is meant to pay for before deciding whether it was authorized; earlier — at
+    /// stream accept, say — and an idle or stalled connection is billed for work nobody asked
+    /// for, which turns this limiter into an availability primitive.
+    ///
     /// For an inbound connection the budget is its *source's* and is shared with every other
     /// connection from that source (#2549), so this is charged before the Hello that would
-    /// authenticate it is dispatched. Authentication cannot refund it, which is the point:
-    /// self-issuing a DID and a binding is cheap, so anything an attacker could buy by
-    /// authenticating would be no bound at all.
+    /// authenticate it is decoded, let alone dispatched. Authentication cannot refund it, which
+    /// is the point: self-issuing a DID and a binding is cheap, so anything an attacker could buy
+    /// by authenticating would be no bound at all.
     pub(crate) async fn check_pre_auth_rate_limit(&self) -> bool {
         self.pre_auth_limiter.check().await
     }

--- a/icn/crates/icn-net/src/protocol.rs
+++ b/icn/crates/icn-net/src/protocol.rs
@@ -1057,7 +1057,16 @@ fn frame_capacity_target(current_capacity: usize, held: usize, len: usize) -> us
 ///
 /// Cancellation is unaffected: the caller's timeout still wraps this future, and dropping it
 /// discards a partial buffer whose size is bounded by what the peer really sent.
-async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
+///
+/// # Why this is reachable from the connection loop
+///
+/// `pub(crate)`, not private, because the inbound loop needs the two halves of `read_message`
+/// separately (#2558). Acquiring the frame is bounded work the peer has already paid for in
+/// bytes; turning it into a `NetworkMessage` is not, and the pre-authentication budget has to sit
+/// between them. Splitting here rather than adding a second framing parser keeps the size policy
+/// in one place — which was the whole point of consolidating it (#2573). Deliberately not `pub`:
+/// no caller outside this crate has a reason to hold a raw frame.
+pub(crate) async fn read_frame(recv: &mut quinn::RecvStream) -> Result<Vec<u8>> {
     // Read 4-byte length prefix (big-endian)
     let mut len_buf = [0u8; 4];
     recv.read_exact(&mut len_buf)

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -429,9 +429,11 @@ impl Default for PreAuthRateLimiter {
 ///
 /// # What this does not bound
 ///
-/// The QUIC/TLS handshake, the `ConnectionContext` and task a connection allocates, and the
-/// deserialization of messages that are then denied here — all of that happens before or outside
-/// this gate. See the module note on [`SourcePreAuthBudget::spend`].
+/// The QUIC/TLS handshake (#2559), the `ConnectionContext` and task a connection allocates, and
+/// the *reading* of a frame that is then denied here — all of that happens before or outside this
+/// gate. **Deserializing** that frame does not: #2558 moved this gate to sit between frame
+/// acquisition and decode, so one token buys the decode as well as the dispatch it feeds. See the
+/// module note on [`SourcePreAuthBudget::spend`].
 ///
 /// # The NAT price, stated rather than buried
 ///

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -585,7 +585,8 @@ impl SourcePreAuthBudget {
     ///
     /// # What this bounds
     ///
-    /// Over any window of length *T*, one source's anonymous **dispatches** are at most
+    /// Over any window of length *T*, one source's anonymous **decodes, and so the dispatches
+    /// they feed**, are at most
     /// `PREAUTH_SOURCE_BURST + rate * T`. Not `PREAUTH_SOURCE_BURST` per window: a token bucket
     /// permits a full burst at the start of a window and another once it has refilled, so the
     /// sliding-window reading of it is wrong by up to a factor of two.
@@ -594,9 +595,15 @@ impl SourcePreAuthBudget {
     /// is the one place the per-source burst is not exact* below, and #2562.
     ///
     /// It does **not** bound the QUIC/TLS handshake, which is complete before the source key
-    /// exists at all, nor the `ConnectionContext` and task a connection allocates, nor reading and
-    /// deserializing a message that is then denied here — that read happens before this gate, and
-    /// one held connection can force it without reconnecting even once.
+    /// exists at all (#2559), nor the `ConnectionContext` and task a connection allocates, nor
+    /// *reading* the frame of a message that is then denied here — frame acquisition precedes
+    /// this gate, and one held connection can force it without reconnecting even once. Frame
+    /// acquisition is bounded in size by `MAX_MESSAGE_SIZE` and in memory by what actually
+    /// arrived (#2573), and in time by `PREAUTH_AUTHENTICATION_DEADLINE` (#2552).
+    ///
+    /// **Deserializing** that message it does bound, since #2558 — decode is on the far side of
+    /// this gate, so a denied message is denied undecoded. Stated one-directionally on purpose:
+    /// see the note on [`PreAuthBudget::check`] for why a spent token does not imply a decode.
     ///
     /// # Bounded state, and what happens when it runs out
     ///

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -432,8 +432,12 @@ impl Default for PreAuthRateLimiter {
 /// The QUIC/TLS handshake (#2559), the `ConnectionContext` and task a connection allocates, and
 /// the *reading* of a frame that is then denied here — all of that happens before or outside this
 /// gate. **Deserializing** that frame does not: #2558 moved this gate to sit between frame
-/// acquisition and decode, so one token buys the decode as well as the dispatch it feeds. See the
-/// module note on [`SourcePreAuthBudget::spend`].
+/// acquisition and decode, so a frame is deserialized only if this gate permitted it.
+///
+/// Stated in that direction on purpose. The converse is not an invariant: [`PreAuthBudget::check`]
+/// asks the connection's bucket before the source's, so a connection bucket that permits over a
+/// dry source budget spends a token on a frame nothing goes on to decode. That only ever makes the
+/// bound tighter than stated. See the module note on [`SourcePreAuthBudget::spend`].
 ///
 /// # The NAT price, stated rather than buried
 ///

--- a/icn/crates/icn-net/tests/authenticated_rate_limit_identity.rs
+++ b/icn/crates/icn-net/tests/authenticated_rate_limit_identity.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 //! Which identity may select an inbound message's rate limit.
 //!
-//! #2491. The rate-limit check runs immediately after `read_message`, before any dispatch,
-//! and it used to be keyed on `NetworkMessage.from` — a field the sender chooses and nobody
-//! has verified at that point. DIDs are public, so naming a well-trusted one bought that
+//! #2491. The rate-limit check runs before any dispatch — for an anonymous connection, before
+//! the decode as well (#2558) — and it used to be keyed on `NetworkMessage.from`, a field the
+//! sender chooses and nobody has verified at that point. DIDs are public, so naming a well-trusted one bought that
 //! peer's tier without holding its key.
 //!
 //! The fix is an ordering, not a new identity mechanism. A connection has two phases, and

--- a/icn/crates/icn-net/tests/preauth_declared_length_allocation.rs
+++ b/icn/crates/icn-net/tests/preauth_declared_length_allocation.rs
@@ -32,13 +32,13 @@
 //!   allocation limit.
 //! - `PREAUTH_AUTHENTICATION_DEADLINE` bounds how *long* the commitment is held, not how large it
 //!   is.
-//! - The per-connection (#2491) and per-source (#2549/#2557) budgets sit *after* `read_message`
-//!   returns. `preauth_source_work_budget.rs` says so in its own words: reading and deserializing
-//!   a message that is then denied "happens before this gate".
+//! - The per-connection (#2491) and per-source (#2549/#2557) budgets sit *after* the frame has
+//!   been acquired — they gate the decode, not the read (#2558). A frame is read before either is
+//!   consulted, so an allocation made during the read is made on nobody's authority.
 //!
 //! # Scale
 //!
-//! The connection loop reads **sequentially** — `accept_bi().await` then `read_message().await` in
+//! The connection loop reads **sequentially** — `accept_bi().await` then `read_frame().await` in
 //! one task per connection, with no per-stream spawn — so one connection has at most one read in
 //! flight. The multiplier is therefore connections, not streams:
 //! `MAX_PREAUTH_CONNECTIONS_PER_SOURCE` (8) × `MAX_MESSAGE_SIZE` (10 MiB) = **80 MiB per source**,

--- a/icn/crates/icn-net/tests/preauth_source_work_budget.rs
+++ b/icn/crates/icn-net/tests/preauth_source_work_budget.rs
@@ -33,8 +33,10 @@
 //!
 //! The QUIC/TLS handshake is finished before the source key exists, so nothing here bounds its
 //! rate — see the PR body. Neither is the `ConnectionContext` and task a connection allocates,
-//! nor reading and deserializing a message that is then denied, which happens before this gate
-//! and which one held connection can drive without reconnecting even once.
+//! nor *reading* the frame of a message that is then denied, which one held connection can drive
+//! without reconnecting even once. **Deserializing** that message no longer happens before this
+//! gate: #2558 moved the gate between frame acquisition and decode, so a denied message is denied
+//! undecoded. The observable below is still dispatch, which is a subset of what the token buys.
 //!
 //! # How these tests know
 //!

--- a/icn/crates/icn-net/tests/preauth_work_before_the_gate.rs
+++ b/icn/crates/icn-net/tests/preauth_work_before_the_gate.rs
@@ -28,9 +28,8 @@
 //!
 //! #2549 is about what a source re-acquires by *reconnecting*. Nothing here reconnects: one
 //! connection is opened once and every frame rides a fresh bidirectional stream over it.
-//! `preauth_source_work_budget.rs` says as much in its own words — reading and deserializing a
-//! message that is then denied "happens before this gate", and one held connection "can drive it
-//! without reconnecting even once".
+//! `preauth_source_work_budget.rs` scopes itself out of this in its own words: one held connection
+//! "can drive it without reconnecting even once".
 //!
 //! Nor is the assertion a throughput threshold. Wall-clock rate is reported below as
 //! characterization only. The assertion is an **ordering** fact, read off two counters this node

--- a/icn/crates/icn-net/tests/preauth_work_before_the_gate.rs
+++ b/icn/crates/icn-net/tests/preauth_work_before_the_gate.rs
@@ -1,0 +1,391 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Decoding an unauthenticated peer's frame is work, and work must be authorized before it is
+//! performed (#2558, work/decode axis).
+//!
+//! The allocation axis of #2558 is closed: `read_frame` no longer sizes anything from the declared
+//! length (#2573). This is the other half, and that change did not touch it. The read loop was:
+//!
+//! ```text
+//! accept_bi
+//!   -> read_message           <- bounded frame read AND full decode happen together here
+//!   -> per-connection budget (#2491)
+//!   -> per-source budget     (#2549 / #2557)
+//!   -> dispatch
+//! ```
+//!
+//! `read_message` is `read_frame` followed by `NetworkMessage::from_bytes_negotiated`, and the
+//! second half is the expensive one: a wire-format byte, then **zstd decompression bounded only by
+//! `MAX_MESSAGE_SIZE`**, then a postcard deserialization of the whole envelope, then the version
+//! check. All of it ran before either budget was consulted.
+//!
+//! # The property under test
+//!
+//! > A frame from an unauthenticated peer is decoded only if that peer's pre-authentication
+//! > allowance authorized the decode. Frames the allowance refuses are never handed to the
+//! > decoder.
+//!
+//! # Why this is not #2549, and not a rate measurement
+//!
+//! #2549 is about what a source re-acquires by *reconnecting*. Nothing here reconnects: one
+//! connection is opened once and every frame rides a fresh bidirectional stream over it.
+//! `preauth_source_work_budget.rs` says as much in its own words — reading and deserializing a
+//! message that is then denied "happens before this gate", and one held connection "can drive it
+//! without reconnecting even once".
+//!
+//! Nor is the assertion a throughput threshold. Wall-clock rate is reported below as
+//! characterization only. The assertion is an **ordering** fact, read off two counters this node
+//! already emits in production, and it does not move with the speed of the machine.
+//!
+//! # How this knows whether the decoder ran
+//!
+//! Every frame sent here is *poison*: outer framing is valid, and the body is a well-formed
+//! postcard `NetworkMessage` whose `version` is one past `MAX_SUPPORTED_VERSION`. Version
+//! validation is the **last** step of `from_bytes_negotiated`, after decompression and after the
+//! envelope has been fully deserialized — so a recorded version mismatch is proof that the whole
+//! decode ran, not just that a header byte was glanced at.
+//!
+//! That gives two disjoint outcomes per frame, each with its own production counter:
+//!
+//! ```text
+//! icn_network_protocol_version_mismatch_total     <- the decoder ran on this frame
+//! icn_network_messages_rate_limited_pre_auth_total <- the budget refused this frame
+//! ```
+//!
+//! Their sum must account for every frame the node consumed, and the first must never exceed what
+//! the peer was allowed to spend. Before the fix the first counter reads the *whole burst* and the
+//! second reads **zero** — the budget never saw a single frame, because the decoder had already
+//! consumed them all.
+//!
+//! Consumption itself needs no counter. QUIC bounds concurrency: `session.rs` sets
+//! `max_concurrent_bidi_streams(10)`, so a client may hold only ten unfinished streams at a time
+//! and `open_bi` blocks once that credit is spent. Credit returns only when the node accepts a
+//! stream and finishes with it. Opening hundreds of streams sequentially therefore *cannot*
+//! complete unless the node read essentially all of them — the loop would stall on the eleventh
+//! otherwise. That argument is what makes this test honest on a multi-threaded runtime.
+
+use anyhow::{Context, Result};
+use icn_identity::IdentityBundle;
+use icn_net::{
+    IncomingMessageHandler, NetworkActor, NetworkHandle, NetworkMessage, PREAUTH_SOURCE_BURST,
+    PREAUTH_SOURCE_RENEWAL_WINDOW,
+};
+use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+use quinn::{ClientConfig, Endpoint};
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::sync::broadcast;
+
+/// Recorded once per decode that reached version validation — i.e. per frame fully deserialized.
+const DECODED_METRIC: &str = "icn_network_protocol_version_mismatch_total";
+/// Recorded once per frame an anonymous connection's budget refused.
+const REFUSED_METRIC: &str = "icn_network_messages_rate_limited_pre_auth_total";
+/// Recorded once per message that cleared every gate and reached dispatch.
+const DISPATCHED_METRIC: &str = "icn_network_messages_received_total";
+
+/// Streams one client may hold unfinished at once — `session.rs`'s `max_concurrent_bidi_streams`.
+///
+/// Duplicated deliberately and asserted against behaviour rather than imported: the point is that
+/// opening far more than this many streams *sequentially* proves consumption, and that argument
+/// holds for whatever the real limit is, so long as it is far below the frame count below.
+const CONCURRENT_STREAM_CREDIT: usize = 10;
+
+static ISSUED_PORTS: Mutex<Option<HashSet<u16>>> = Mutex::new(None);
+
+fn pick_port() -> u16 {
+    let mut issued = ISSUED_PORTS.lock().expect("port registry poisoned");
+    let issued = issued.get_or_insert_with(HashSet::new);
+    for _ in 0..64 {
+        if let Some(port) = portpicker::pick_unused_port() {
+            if issued.insert(port) {
+                return port;
+            }
+        }
+    }
+    panic!("could not find an unused port");
+}
+
+fn init() {
+    // Must be the provider the workspace builds against: a different one makes every TLS
+    // handshake fail, which presents as a connect timeout rather than as a TLS error.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
+/// Install a process-global recorder and hand back its snapshotter.
+///
+/// Global rather than thread-local, and that is the point. A `with_local_recorder` recorder is
+/// visible only to the installing thread, which forces the whole test onto a current-thread
+/// runtime — and this file's consumption argument, and its characterization figure, are only
+/// honest on a multi-threaded one. This binary runs exactly one test, so a global recorder has
+/// nobody to collide with and no other test's increments to read.
+fn install_metrics() -> Snapshotter {
+    let recorder = DebuggingRecorder::new();
+    // Taken before the recorder is consumed: the snapshotter shares the registry, so it still
+    // reads what the run recorded afterwards.
+    let snapshotter = recorder.snapshotter();
+    recorder
+        .install()
+        .expect("this binary installs the global recorder exactly once");
+    snapshotter
+}
+
+/// Total value of `name` across every label set, or 0 if it was never recorded.
+fn counter(snapshotter: &Snapshotter, name: &str) -> u64 {
+    snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter_map(
+            |(key, _, _, value)| match (key.key().name() == name, value) {
+                (true, DebugValue::Counter(v)) => Some(v),
+                _ => None,
+            },
+        )
+        .sum()
+}
+
+struct Guard(broadcast::Sender<()>);
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = self.0.send(());
+    }
+}
+
+/// Messages the node dispatched to its external handler.
+#[derive(Clone, Default)]
+struct Delivered(Arc<Mutex<usize>>);
+
+impl Delivered {
+    fn count(&self) -> usize {
+        *self.0.lock().expect("delivery log poisoned")
+    }
+}
+
+/// Spawn a real node on the production stack.
+///
+/// The handler is required, not optional: `NetworkActor::spawn` starts no inbound accept loop
+/// without one, and a node that accepts nothing would stall the stream loop below rather than
+/// measuring anything.
+async fn spawn_node(
+    bundle: IdentityBundle,
+) -> Result<(NetworkHandle, SocketAddr, Guard, Delivered)> {
+    let (shutdown_tx, _) = broadcast::channel(1);
+    let delivered = Delivered::default();
+    let sink = delivered.0.clone();
+    let handler: IncomingMessageHandler = Arc::new(move |_msg: NetworkMessage| {
+        *sink.lock().expect("delivery log poisoned") += 1;
+    });
+
+    let mut last_err = None;
+    for _ in 0..8 {
+        let addr: SocketAddr = format!("127.0.0.1:{}", pick_port()).parse()?;
+        match NetworkActor::spawn(
+            bundle.clone(),
+            addr,
+            shutdown_tx.clone(),
+            Some(handler.clone()),
+            None, // oracle
+            None, // fallback_config
+            None, // topology_config
+            None, // stun_servers
+            None, // turn_config
+            None, // misbehavior_detector
+            None, // store
+            None, // personhood
+            None, // anchor_rate_config
+            None, // advertised_addr
+        )
+        .await
+        {
+            Ok(handle) => {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                // The handle is returned, not dropped: dropping it tears the actor down, and the
+                // connection below would then time out as if TLS had failed.
+                return Ok((handle, addr, Guard(shutdown_tx), delivered));
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("could not bind a node")))
+}
+
+async fn connect(
+    identity: &IdentityBundle,
+    target: SocketAddr,
+) -> Result<(Endpoint, quinn::Connection)> {
+    let rustls_client = icn_net::tls::create_tofu_client_config(
+        vec![identity.tls_cert().clone()],
+        identity.tls_key(),
+    )?;
+    let mut endpoint = Endpoint::client("127.0.0.1:0".parse()?)?;
+    endpoint.set_default_client_config(ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(rustls_client)?,
+    )));
+
+    let mut last_err = None;
+    for attempt in 0..5 {
+        match tokio::time::timeout(
+            Duration::from_secs(10),
+            endpoint.connect(target, "localhost")?,
+        )
+        .await
+        {
+            Ok(Ok(connection)) => return Ok((endpoint, connection)),
+            Ok(Err(e)) => last_err = Some(e.to_string()),
+            Err(_) => last_err = Some("connect timed out".to_string()),
+        }
+        tokio::time::sleep(Duration::from_millis(150 * (attempt + 1))).await;
+    }
+    anyhow::bail!(
+        "could not establish the test connection after 5 attempts: {}",
+        last_err.unwrap_or_default()
+    )
+}
+
+/// The anonymous units one source may fund over `elapsed`.
+///
+/// `burst + rate * elapsed`, the honest reading of a token bucket — computed from measured time so
+/// nothing here depends on how long a handshake happened to take on this machine. Deliberately
+/// *not* "burst per window": a bucket hands out a full burst at the start and another once it has
+/// refilled, so the sliding-window reading is wrong by up to a factor of two.
+///
+/// This is the *source* allowance. The per-connection burst (#2491) is asked first and is far
+/// tighter, so the real ceiling on one connection is lower still; the looser of the two is used
+/// because it is the one built from constants this crate exports, and it is already an order of
+/// magnitude below the burst sent below.
+fn source_allowance(elapsed: Duration) -> f64 {
+    let rate = PREAUTH_SOURCE_BURST as f64 / PREAUTH_SOURCE_RENEWAL_WINDOW.as_secs_f64();
+    PREAUTH_SOURCE_BURST as f64 + rate * elapsed.as_secs_f64()
+}
+
+/// A frame that is valid to the framer and fatal to the decoder.
+///
+/// Outer framing is exactly what any peer sends, so `read_frame` accepts it without complaint.
+/// The body is a fully-formed postcard `NetworkMessage` carrying a version one past
+/// `MAX_SUPPORTED_VERSION` — which `from_bytes_negotiated` rejects only at its *final* step, after
+/// decompression and after the envelope has been deserialized in full. Nothing short of a complete
+/// decode can produce that rejection.
+fn poison(from: &IdentityBundle, to: &IdentityBundle) -> NetworkMessage {
+    let mut message = NetworkMessage::subscribe(
+        from.did().clone(),
+        to.did().clone(),
+        vec!["icn.test.2558.work".to_string()],
+    );
+    message.version = icn_net::protocol::MAX_SUPPORTED_VERSION + 1;
+    message
+}
+
+/// The decoder must run only on frames the pre-authentication allowance paid for.
+///
+/// One connection, opened once, never reconnected.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn frames_are_authorized_before_they_are_decoded() -> Result<()> {
+    init();
+    let metrics = install_metrics();
+
+    // Far above the concurrent-stream credit, so completing the loop is itself the proof that the
+    // node consumed them, and far above any plausible allowance for the window.
+    const FRAMES: usize = 400;
+    const {
+        assert!(
+            FRAMES > CONCURRENT_STREAM_CREDIT * 10,
+            "the frame count must dwarf the stream credit for the consumption argument to hold"
+        )
+    };
+
+    let server = IdentityBundle::generate().expect("server identity");
+    let (_handle, addr, _guard, delivered) = spawn_node(server.clone()).await?;
+
+    let client = IdentityBundle::generate().expect("client identity");
+    let (_endpoint, connection) = connect(&client, addr).await?;
+
+    // Baseline after the handshake, so nothing the node emitted while starting up is counted.
+    let decoded_before = counter(&metrics, DECODED_METRIC);
+    let refused_before = counter(&metrics, REFUSED_METRIC);
+    let dispatched_before = counter(&metrics, DISPATCHED_METRIC);
+
+    let started = Instant::now();
+    for i in 0..FRAMES {
+        let message = poison(&client, &server);
+        // `open_bi` is the consumption proof: it blocks once `CONCURRENT_STREAM_CREDIT` streams
+        // are outstanding, and credit returns only as the node accepts and finishes them.
+        let (mut send, _recv) = connection
+            .open_bi()
+            .await
+            .with_context(|| format!("open_bi for frame {i} — the node stopped consuming"))?;
+        icn_net::write_message(&mut send, &message).await?;
+        send.finish()?;
+    }
+    let send_window = started.elapsed();
+
+    // Let the node finish anything still in flight before reading the counters.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let elapsed = started.elapsed();
+
+    assert!(
+        connection.close_reason().is_none(),
+        "the connection was closed during the run, so this measured a closure rather than the \
+         budget refusing frames on a live connection"
+    );
+
+    let decoded = counter(&metrics, DECODED_METRIC) - decoded_before;
+    let refused = counter(&metrics, REFUSED_METRIC) - refused_before;
+    let dispatched = counter(&metrics, DISPATCHED_METRIC) - dispatched_before;
+    let allowance = source_allowance(elapsed);
+
+    // Characterization, reported and never asserted on: what this machine did, not a contract.
+    println!(
+        "#2558 characterization: {FRAMES} frames in {send_window:?} ({:.0} frame/s), \
+         {decoded} decoded, {refused} refused before decode, {dispatched} dispatched, \
+         source allowance over {elapsed:?} = {allowance:.1}",
+        FRAMES as f64 / send_window.as_secs_f64(),
+    );
+
+    // Non-vacuity, in both directions.
+    //
+    // The poison frame must really be poisonous: if the decoder never rejected one, either it was
+    // never reached at all (so the node consumed nothing and the run proves nothing) or the frame
+    // is not the probe this test believes it is. Either way the assertion below would pass for a
+    // reason that has nothing to do with ordering.
+    assert!(
+        decoded >= 1,
+        "no frame ever reached the decoder, so this run cannot distinguish anything: the probe is \
+         not poisonous, the metric is not wired, or the node consumed nothing"
+    );
+    // And every consumed frame must be accounted for by *exactly* one of the two outcomes. Both
+    // directions are real failures: short of {FRAMES} means frames were consumed without recording
+    // either, so neither figure below can be trusted; past {FRAMES} means the node did both to the
+    // same frame — decoded it *and* refused it — which is #2558 in its purest form.
+    assert_eq!(
+        decoded + refused,
+        FRAMES as u64,
+        "the two outcomes do not add up to the {FRAMES} frames sent: {decoded} decoded plus \
+         {refused} refused. Under-count means frames were consumed unaccounted; over-count means \
+         the node decoded frames it had already refused"
+    );
+
+    assert!(
+        (decoded as f64) <= allowance,
+        "one unauthenticated connection, never reconnected, made this node fully deserialize \
+         {decoded} frames in {elapsed:?} while its pre-authentication allowance over that window \
+         was {allowance:.1}.\n\
+         frames consumed by the node : {FRAMES} (proved by {FRAMES} sequential open_bi against a \
+         credit of {CONCURRENT_STREAM_CREDIT})\n\
+         fully decoded               : {decoded}\n\
+         refused before decoding     : {refused}\n\
+         dispatched                  : {dispatched} (handler saw {})\n\
+         send window                 : {send_window:?} ({:.0} frame/s, characterization only)\n\
+         decode per authorised unit  : {:.1}x\n\
+         Each of those decodes ran a wire-format parse, zstd decompression bounded only by \
+         MAX_MESSAGE_SIZE, and a full postcard deserialization — the version check that recorded \
+         them is the last step of the decode, so none of them stopped early. The budget refused \
+         {refused} of the {FRAMES}: it bounds what this node will *act on*, not what it will *do*.",
+        delivered.count(),
+        FRAMES as f64 / send_window.as_secs_f64(),
+        decoded as f64 / allowance,
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Moves the pre-authentication budget so it sits **between** bounded frame acquisition and the decode that frame pays for.

```text
was:  accept_bi -> read frame -> DECODE -> budget -> dispatch
now:  accept_bi -> read frame -> budget -> DECODE -> dispatch
```

#2558 has two axes. The allocation axis was closed by #2573 (`b498f9c9`): an untrusted declared length no longer determines pre-arrival memory commitment. This is the other axis, which that change deliberately did not touch.

## Why

`read_message` is two steps welded together — acquire a length-prefixed frame, then interpret it — and both budgets sat after the pair. Only the first step is work the peer has already paid for in bytes it actually sent. Interpreting a frame means:

- a wire-format byte parse,
- **zstd decompression bounded only by `MAX_MESSAGE_SIZE`** (10 MiB),
- a full postcard deserialization of the envelope,
- the version check.

All of that ran before either budget was consulted. So the budget bounded what the node would *act on*, not what it would *do*, and a refusal cost the sender nothing. Worse: an undecodable frame short-circuited into the decode-error branch and never reached the gate at all, so it was refused **by the decoder** and charged **nothing**. That is measured below — the budget saw zero of 400 frames.

This needs no reconnect (so it is not #2549) and no unusual frame size (so it is not #2573). One held connection opening sequential streams drives it.

## How

`read_frame` — the single framing implementation #2573 consolidated — becomes `pub(crate)`. **Its body is untouched**, so the allocation policy stays in exactly one place and no second framing parser exists. The connection loop calls it, then gates, then calls the already-public `NetworkMessage::from_bytes_negotiated`. No new public API.

The gate's new position is the earliest point where both halves of the charge are true: enough of the peer's input has arrived to justify charging a unit, **and** the metered work has not happened yet. It is guarded on a frame that arrived in full (`frame.is_ok()`), so a stalled or truncated frame spends nothing — charging at stream accept would bill an idle connection for work nobody asked for, which would turn the limiter into an availability primitive.

**Only the anonymous phase moved.** The post-authentication per-DID and per-anchor limits stay below the decode: that traffic is attributable to an identity this connection has proven, and those log lines quote `message.from`.

Deliberate consequences, stated:

- **A malformed body is now charged**, where it used to be free. That is the point — unparseable input is exactly what an attacker manufactures cheaply.
- It is the **same single token** the message would have spent one step later. Nothing is charged twice; `check_pre_auth_rate_limit` has exactly one call site.
- The deny path is still `continue`. A peer sharing a busy NAT keeps its session, preserving #2557's semantics.
- The pre-auth refusal log loses `claimed_from`. There is no decoded message to read it from, and the claim was never authority for anything in that phase.
- Bandwidth accounting moves with the gate (counted per acquired frame), so refused traffic is still counted. Leaving it below the decode would blind the counter in exactly the case this issue is about.
- `read_frame` is still what the authentication deadline wraps. Decode is CPU-bound with no await, so #2552's cancellation property is unchanged.

## Deterministic regression: `tests/preauth_work_before_the_gate.rs`

The assertion is an **ordering** fact, not a throughput threshold.

Every frame sent is **poison**: valid outer framing, body a well-formed postcard `NetworkMessage` carrying `MAX_SUPPORTED_VERSION + 1`. Version validation is the **last** step of `from_bytes_negotiated` — after decompression, after the envelope is fully deserialized — so a recorded mismatch proves the *whole* decode ran, not that a header byte was glanced at.

That yields two disjoint outcomes per frame, each with a counter this node already emits in production:

| counter | meaning |
|---|---|
| `icn_network_protocol_version_mismatch_total` | the decoder ran on this frame |
| `icn_network_messages_rate_limited_pre_auth_total` | the budget refused this frame |

400 frames, one connection, opened once, never reconnected:

| | before | after |
|---|---|---|
| frames consumed | 400 | 400 |
| **fully decoded** | **400** | **20** |
| **refused before decode** | **0** | **380** |
| dispatched | 0 | 0 |

20 is not approximate — it is exactly `PRE_AUTH_RATE_LIMIT.burst_capacity`, the per-connection bucket that is asked first and `&&`-short-circuits.

Consumption needs no counter: `max_concurrent_bidi_streams` is 10, so 400 *sequential* `open_bi` calls cannot complete unless the node accepted and finished essentially all of them. That argument holds on a multi-threaded runtime, which is why the recorder here is global rather than the thread-local `with_local_recorder` used elsewhere in this crate.

### Non-vacuity — three ways

1. **RED on unmodified main** with the mechanism visible, not just a verdict: 400 decoded / **0 refused**. The budget did not lose to the decoder; it never ran.
2. **Gate disabled** (`&& false` on the refusal condition, tokens still spent) → reproduces main exactly: 400 decoded, 0 refused.
3. **Decode moved above an enforcing gate** → 421 decoded + 379 refused = 800 accounted for 400 frames. Caught by the conservation identity `decoded + refused == frames`, which holds in both real compositions and so is an integrity check rather than the discriminator.

Wall-clock rate is `println!`-reported characterization only and is asserted on nowhere. It moved between 2.3k and 12.9k frame/s across runs on this machine; neither it nor the ~4,100 msg/s figure in the issue is a contract.

## #2573 preserved

`protocol.rs` diff is **doc comment + visibility only**; `read_frame`'s body is byte-identical.

- no `vec![0; declared_len]`-style allocation returns (`grep` over `icn-net/src`: none)
- no fixed scratch buffer in the connection future — the only `[0u8; N]` in the read path is the 4-byte length prefix
- first reservation is still `held.min(len)`; growth still geometric and clamped by `frame_capacity_target`
- `MAX_MESSAGE_SIZE` still rejects an oversized declaration before any body byte is read
- `read_chunk` framing intact; all framing variants still share this one implementation

`cargo test -p icn-net --test preauth_declared_length_allocation` → 2 passed.

## Test plan

| gate | result |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy -p icn-net --all-targets -- -D warnings` | exit 0 |
| `cargo check --workspace --all-targets` | exit 0 |
| `cargo test -p icn-net --no-fail-fast` | exit 0 — **500 passed, 0 failed, 23 ignored** across 24 binaries |
| `scripts/check-meaning-firewall.sh` | no new unpinned domain imports |
| `ops/scripts/drift-check.sh` | STATUS: PASS |

Siblings whose invariants this could have moved, all green: `preauth_source_work_budget` 6/6 · `preauth_declared_length_allocation` 2/2 · `preauth_authentication_deadline` 7/7 · `preauth_connection_admission` 3/3 · `accept_handshake_cancellation` 7/7 · `authenticated_rate_limit_identity` 9/9 · `trust_gated_rate_limiting_integration` 3/3 · `encoding_negotiation_integration` 10/10 · `hello_handshake_termination` 5/5 · `hello_current_cert_binding` 7/7 · `peer_exchange_policy` 6/6.

`icn-prereview` (local-model pre-review) was **not** run: the Zentith Ollama tunnel on `127.0.0.1:11435` is down in this session.

## Risk

Wire format, encoding negotiation, message-size enforcement, cancellation semantics, authentication-deadline semantics and source isolation are all unchanged. The behavioural deltas are the three named above: malformed bodies now cost a token, the pre-auth refusal log drops `claimed_from`, and bandwidth is counted per frame rather than per successful decode.

Adversarial checks performed against source, not assumed:

- exactly **one** inbound frame reader exists in production (`connection.rs`). `read_message`, `read_message_negotiated` and `read_message_compressed` have **zero** production call sites — tests only.
- exactly **one** decoder invocation in the loop, and it is below the gate. No alternate encoding path bypasses the seam; decompression is inside `from_bytes_negotiated`.
- opening more streams does not evade source accounting (same gate, shared source bucket); reconnecting does not reset it (#2549 unchanged).
- authenticated traffic is untouched — the gate is `authenticated.is_none()`-guarded, as before.

## Review — three findings, all valid, all documentation (no behaviour change)

### Copilot ×2 → `9b4d8d72`

Copilot flagged two comments of mine as overstating the charging semantics. Checked against source rather than argued with: `PreAuthBudget::check` is `connection.check().await && budget.spend(*key)`, and `TokenBucket::try_consume` returns `false` **without** decrementing. So:

- exhausted per-connection bucket → `&&` short-circuits → the refusal costs **nothing**;
- connection bucket permits over a dry source budget → **one** connection token spent on a frame nothing goes on to decode.

The invariant that actually holds, and the only one now claimed anywhere in the diff, is one-directional: **a frame is decoded only if the gate permitted it.** The converse asymmetry predates this change, is already documented as deliberate on `PreAuthBudget::check`, and can only make the bound tighter than stated. No behaviour change; the regression is unaffected and still green.

### Codex P2 → `88e6630f`

`SourcePreAuthBudget::spend` still stated that reading **and deserializing** a denied message happen before the gate. Since `SourcePreAuthBudget` is the source-scoped half of the very budget this PR moved, that rustdoc was asserting the opposite security guarantee to `PreAuthBudget`'s, two hundred lines above — a contradiction, not just a stale line.

Corrected to: frame acquisition precedes the gate (bounded in size by `MAX_MESSAGE_SIZE`, in memory by bytes actually received per #2573, in time by `PREAUTH_AUTHENTICATION_DEADLINE` per #2552); **decoding is bounded by the gate**. The headline bound now reads as decodes — and the dispatches they feed — rather than dispatches alone.

Swept the crate for the same class rather than fixing only the flagged line. One more turned up: the new test quoted sibling wording in `preauth_source_work_budget.rs` that this branch had itself rewritten, so the quotation no longer matched its source. Every other before/after-the-gate claim in `icn-net` re-read and confirmed accurate.

## Scope boundary

Out of scope, unchanged, and not claimed:

- **#2559 — QUIC/TLS handshake work.** The handshake completes before the source key exists. Nothing here bounds it.
- RustSec / dependency debt.
- `GlobalRateLimiter` — not touched; #2558 does not require it.
- A single node still cannot bound an attack distributed across many sources.

## What remains on #2558

`Refs`, not `Closes`. The issue's title contract — bound source-driven pre-authentication deserialization work — is met. One item from its own "To investigate" list is **not**:

> `icn_network_messages_rate_limited_pre_auth_total` currently cannot distinguish a #2491 per-connection refusal from a #2549 per-source one, which would make any new bound hard to operate.

Still true. The counter's *meaning* is now sharper (it counts refused **work**, not refused dispatch), but it still cannot say which bucket refused. Attributing it exactly means returning the refusing bucket from `PreAuthBudget::check` — a change to the gate's signature, not to a log line, and tier:2 rather than tier:1. Left for a maintainer to split out or fold in.

Refs #2558, #2573, #2549, #2557, #2491, #2552, #2559

🤖 Generated with [Claude Code](https://claude.com/claude-code)
