### PR TITLE
feat(net): name which pre-authentication budget refused a frame

### DIFF
--- a/icn/crates/icn-net/src/actor/connection.rs
+++ b/icn/crates/icn-net/src/actor/connection.rs
@@ -615,42 +615,43 @@ impl NetworkActor {
                     // attributable to a proven identity, and #2558 is about work performed for a
                     // peer that has not proven one.
                     //
-                    // The operand order is load-bearing, not stylistic. `check_pre_auth_rate_limit`
-                    // *consumes* a token, so it must stay last: `&&` short-circuits, and the two
-                    // guards ahead of it are what keep an incomplete frame and an authenticated
-                    // peer from being charged. Reordering this spends tokens on both.
-                    if frame.is_ok()
-                        && authenticated.is_none()
-                        && !ctx.check_pre_auth_rate_limit().await
-                    {
-                        // No `claimed_from` here, unlike the authenticated arm below: the frame
-                        // has deliberately not been decoded, so there is no claim to log — and
-                        // the claim was never authority for anything in this phase anyway.
-                        //
-                        // The message does not name which of its own two buckets refused. An
-                        // inbound connection spends a per-connection burst (#2491) and a shared
-                        // per-source budget (#2549), the first is consulted first and
-                        // short-circuits, and an outbound connection has no source budget at all.
-                        // Naming the source here points operators at NAT contention for what is
-                        // just as likely one connection spending its own burst. Attributing it
-                        // exactly means returning the refusing bucket from `PreAuthBudget::check`,
-                        // which is a change to the gate itself rather than to this log line.
-                        warn!(
-                            "Refused pre-authentication work (a pre-authentication budget is \
-                             exhausted: this connection's own burst, or the shared budget for its \
-                             source if it has one)"
-                        );
+                    // The guard order is load-bearing, not stylistic. `check_pre_auth_rate_limit`
+                    // *consumes* a token, so it must stay innermost: the two conditions ahead of
+                    // it are what keep an incomplete frame and an authenticated peer from being
+                    // charged. Reordering this spends tokens on both.
+                    if frame.is_ok() && authenticated.is_none() {
+                        if let Err(refusal) = ctx.check_pre_auth_rate_limit().await {
+                            // No `claimed_from` here, unlike the authenticated arm below: the
+                            // frame has deliberately not been decoded, so there is no claim to
+                            // log — and the claim was never authority for anything in this phase
+                            // anyway.
+                            //
+                            // `refusal` names which of the two budgets refused (#2558): this
+                            // connection's own burst (#2491), or the budget shared by everything
+                            // from its source (#2549). Those want different responses — one
+                            // connection misbehaving against one peer's worth of allowance, or
+                            // an address whose whole allowance is gone — and the counter could
+                            // not tell them apart, which is the operability gap #2558 names.
+                            // It is a closed two-value set, so it is safe to carry as a label.
+                            warn!(
+                                bound = refusal.as_str(),
+                                "Refused pre-authentication work (the named pre-authentication \
+                                 budget is exhausted)"
+                            );
 
-                        icn_obs::metrics::network::messages_rate_limited_inc();
-                        icn_obs::metrics::network::messages_rate_limited_pre_auth_inc();
+                            icn_obs::metrics::network::messages_rate_limited_inc();
+                            icn_obs::metrics::network::messages_rate_limited_pre_auth_inc(
+                                refusal.as_str(),
+                            );
 
-                        // Close stream before continuing to avoid resource leak
-                        if let Err(e) = send.finish() {
-                            tracing::debug!("Stream finish error during rate limit: {}", e);
+                            // Close stream before continuing to avoid resource leak
+                            if let Err(e) = send.finish() {
+                                tracing::debug!("Stream finish error during rate limit: {}", e);
+                            }
+
+                            // Drop the frame — undecoded (don't call handler)
+                            continue;
                         }
-
-                        // Drop the frame — undecoded (don't call handler)
-                        continue;
                     }
 
                     // Second half: interpret the authorized frame.

--- a/icn/crates/icn-net/src/handlers/mod.rs
+++ b/icn/crates/icn-net/src/handlers/mod.rs
@@ -271,7 +271,12 @@ impl ConnectionContext {
     /// authenticate it is decoded, let alone dispatched. Authentication cannot refund it, which
     /// is the point: self-issuing a DID and a binding is cheap, so anything an attacker could buy
     /// by authenticating would be no bound at all.
-    pub(crate) async fn check_pre_auth_rate_limit(&self) -> bool {
+    /// `Err` names which budget refused, for the log line and the refusal counter (#2558). It
+    /// says nothing about a token having been spent in that budget — see
+    /// [`crate::rate_limit::PreAuthBudget::check`].
+    pub(crate) async fn check_pre_auth_rate_limit(
+        &self,
+    ) -> Result<(), crate::rate_limit::PreAuthRefusal> {
         self.pre_auth_limiter.check().await
     }
 

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -793,9 +793,21 @@ pub enum PreAuthRefusal {
     /// Reported without the source budget having been consulted at all — see
     /// [`PreAuthBudget::check`].
     Connection,
-    /// This connection's source has spent its shared anonymous allowance (#2549).
+    /// The source-scoped budget refused (#2549).
     ///
     /// The connection's own token was already taken to reach this — see [`PreAuthBudget::check`].
+    ///
+    /// "Source-scoped" is not always "this source's own". When the budget table is saturated and a
+    /// sweep frees nothing, untracked sources spend from a single shared fallback bucket
+    /// ([`SourcePreAuthBudget::spend`]), and its exhaustion is reported here too — so in that
+    /// overload mode this does **not** mean one address has spent its allowance. The two are
+    /// deliberately one label: #2558 asked to separate the per-connection bound from the
+    /// per-source one, and both of these are the per-source one. They do want different responses,
+    /// which is why the overload mode has its own signal — read this alongside
+    /// `icn_network_preauth_source_budget_degraded_total`, which is non-zero exactly when spends
+    /// are going through that fallback, and the `icn_network_preauth_source_budget_tracked` gauge
+    /// sitting at `MAX_PREAUTH_BUDGET_SOURCES`. Promoting the fallback to its own attribution is a
+    /// separate change to `spend`'s signature and is tracked separately.
     Source,
 }
 

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -759,6 +759,45 @@ pub enum PreAuthBudget {
     Connection(PreAuthRateLimiter),
 }
 
+/// Which of a connection's anonymous budgets refused a frame (#2558).
+///
+/// The refusal counter used to name no bucket, so an operator watching
+/// `icn_network_messages_rate_limited_pre_auth_total` climb could not tell one connection
+/// spending its own burst (#2491) from a source whose shared allowance is dry (#2549). Those are
+/// different conditions with different responses — the first is one peer, the second is every peer
+/// behind an address — and #2558 lists not being able to separate them as what would make any new
+/// bound hard to operate.
+///
+/// Two variants and no payload, deliberately. It is admissible as a metric label for exactly the
+/// reason [`crate::preauth_admission::AdmissionRefusal`] is: the value set is closed in this file,
+/// so nothing a remote peer sends can add a series.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreAuthRefusal {
+    /// This connection's own anonymous burst is spent (#2491).
+    ///
+    /// Reported without the source budget having been consulted at all — see
+    /// [`PreAuthBudget::check`].
+    Connection,
+    /// This connection's source has spent its shared anonymous allowance (#2549).
+    ///
+    /// The connection's own token was already taken to reach this — see [`PreAuthBudget::check`].
+    Source,
+}
+
+impl PreAuthRefusal {
+    /// A short, bounded label for logs and metrics.
+    ///
+    /// Deliberately a fixed set of two strings, for the same reason
+    /// [`crate::preauth_admission::AdmissionRefusal::as_str`] is: it is safe as a metric label
+    /// precisely because nothing an attacker sends can add a new value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PreAuthRefusal::Connection => "connection",
+            PreAuthRefusal::Source => "source",
+        }
+    }
+}
+
 impl PreAuthBudget {
     /// Spend one message's worth of every allowance this connection draws on.
     ///
@@ -768,14 +807,39 @@ impl PreAuthBudget {
     /// only ever make the bound *tighter* than stated, never looser, and the alternative — a
     /// peek across two locks followed by a commit — buys nothing for a message that is being
     /// dropped either way.
-    pub async fn check(&self) -> bool {
+    ///
+    /// `Err` names the bucket that refused (#2558). Naming it changes nothing about what is
+    /// authorized: the early returns below *are* the short-circuiting `&&` this used to be, so a
+    /// refusing connection still never consults the source, and no bucket is consulted in an
+    /// order it was not consulted in before. Discovering the answer by asking both would be a
+    /// policy change wearing an observability change's clothes — it is the reversal
+    /// `a_spent_connection_does_not_charge_its_source` exists to forbid.
+    ///
+    /// What a refusal does **not** say is that a token was spent in the bucket that refused: a
+    /// refused `TokenBucket::try_consume` takes nothing. `Source` in particular means the
+    /// *connection* was charged and the source was not.
+    pub async fn check(&self) -> Result<(), PreAuthRefusal> {
         match self {
             Self::Source {
                 connection,
                 budget,
                 key,
-            } => connection.check().await && budget.spend(*key),
-            Self::Connection(limiter) => limiter.check().await,
+            } => {
+                if !connection.check().await {
+                    return Err(PreAuthRefusal::Connection);
+                }
+                if !budget.spend(*key) {
+                    return Err(PreAuthRefusal::Source);
+                }
+                Ok(())
+            }
+            Self::Connection(limiter) => {
+                if limiter.check().await {
+                    Ok(())
+                } else {
+                    Err(PreAuthRefusal::Connection)
+                }
+            }
         }
     }
 }
@@ -2385,7 +2449,7 @@ mod source_budget_tests {
 
         let mut granted = 0usize;
         for _ in 0..(PRE_AUTH_RATE_LIMIT.burst_capacity as usize + HAMMER) {
-            if inbound.check().await {
+            if inbound.check().await.is_ok() {
                 granted += 1;
             }
         }
@@ -2412,6 +2476,173 @@ mod source_budget_tests {
              {} went to messages that were never dispatched, so a spent connection is draining \
              its source's allowance",
             SOURCE_BURST as i64 - (granted + left) as i64
+        );
+    }
+
+    // -- #2558: which of the two buckets refused ------------------------------------------------
+
+    /// A source table that refuses the first spend, so a refusal needs no elapsed time to set up.
+    fn dry_table() -> Arc<SourcePreAuthBudget> {
+        Arc::new(SourcePreAuthBudget::with_policy(
+            0.0,
+            0.0,
+            PRE_AUTH_RATE_LIMIT.refill_interval,
+            16,
+        ))
+    }
+
+    /// A dry source is named as the source — until the connection itself runs out.
+    ///
+    /// This is the whole attribution property in one run, and it is deliberately one test rather
+    /// than two: the *switch* is what proves the two refusals are distinguishable. An
+    /// implementation that reported one label for both — the obvious way to get this wrong — is
+    /// green on either half alone and fails here.
+    ///
+    /// The switch point is also the token-consumption asymmetry made observable. A source refusal
+    /// is reached *through* a connection token that has already been spent, so a connection
+    /// sitting over a dry source runs its own bucket down one refusal at a time and eventually
+    /// starts refusing on its own account. That is documented as deliberate on
+    /// [`PreAuthBudget::check`]; it is pinned here so a later change that made refusals free
+    /// cannot pass unnoticed.
+    #[tokio::test]
+    async fn a_dry_source_is_named_until_the_connection_itself_runs_out() {
+        let inbound = PreAuthBudget::Source {
+            connection: PreAuthRateLimiter::new(),
+            budget: dry_table(),
+            key: key("203.0.113.42:1000"),
+        };
+
+        // Every one of these is refused by the *source*: the connection still has tokens, and
+        // spends one to reach the source each time.
+        for spent in 1..=PRE_AUTH_RATE_LIMIT.burst_capacity {
+            assert_eq!(
+                inbound.check().await,
+                Err(PreAuthRefusal::Source),
+                "refusal {spent} was attributed to the wrong bucket: the connection had {} of its \
+                 {} tokens left, so the source is what refused",
+                PRE_AUTH_RATE_LIMIT.burst_capacity - spent + 1,
+                PRE_AUTH_RATE_LIMIT.burst_capacity
+            );
+        }
+
+        assert_eq!(
+            inbound.check().await,
+            Err(PreAuthRefusal::Connection),
+            "the connection spent one of its {} tokens on each source refusal above, so it is now \
+             empty and must be the bucket refusing — reporting the source here would mean either \
+             the connection is not charged for a source refusal, or both refusals carry one label",
+            PRE_AUTH_RATE_LIMIT.burst_capacity
+        );
+    }
+
+    /// A connection that has spent its own burst is named, and its source is never asked.
+    ///
+    /// Both halves matter. The label is what #2558 asks for; the untouched source budget is the
+    /// short-circuit that asking for it must not have cost. An implementation that evaluated both
+    /// buckets to discover which one was empty would satisfy the first assertion and fail the
+    /// second — and would have converted a free denial into one that drains the shared allowance,
+    /// which is exactly the reversal `a_spent_connection_does_not_charge_its_source` forbids.
+    #[tokio::test]
+    async fn a_refusing_connection_is_named_and_leaves_its_source_untouched() {
+        const SOURCE_BURST: usize = 64;
+
+        let budget = Arc::new(SourcePreAuthBudget::with_policy(
+            SOURCE_BURST as f64,
+            0.0,
+            PRE_AUTH_RATE_LIMIT.refill_interval,
+            16,
+        ));
+        let k = key("203.0.113.43:1000");
+        let inbound = PreAuthBudget::Source {
+            connection: PreAuthRateLimiter::new(),
+            budget: budget.clone(),
+            key: k,
+        };
+
+        // Spend the connection's burst. Each grant costs one source token too.
+        let mut granted = 0usize;
+        loop {
+            match inbound.check().await {
+                Ok(()) => {
+                    granted += 1;
+                    assert!(granted < 10_000, "the connection bucket never refused");
+                }
+                Err(refusal) => {
+                    assert_eq!(
+                        refusal,
+                        PreAuthRefusal::Connection,
+                        "a connection that has spent its own burst over a source with \
+                         {} of {SOURCE_BURST} tokens left was attributed to the source",
+                        SOURCE_BURST - granted
+                    );
+                    break;
+                }
+            }
+        }
+        // Non-vacuity: the connection has to have been able to spend something, or the run never
+        // exercised a *spent* connection at all.
+        assert_eq!(
+            granted, PRE_AUTH_RATE_LIMIT.burst_capacity as usize,
+            "the connection was granted {granted} of its burst of {}; this run did not reach the \
+             edge it means to test",
+            PRE_AUTH_RATE_LIMIT.burst_capacity
+        );
+
+        // Several more refusals, so an implementation that consulted the source on the refusal
+        // path is off by more than one token and cannot be mistaken for rounding.
+        for _ in 0..8 {
+            assert_eq!(inbound.check().await, Err(PreAuthRefusal::Connection));
+        }
+
+        assert_eq!(
+            drain(&budget, k),
+            SOURCE_BURST - granted,
+            "the source has fewer tokens left than the {granted} grants account for, so the \
+             refusals above reached it: naming the refusing bucket cost the short-circuit"
+        );
+    }
+
+    /// Both buckets permitting names no bucket at all.
+    #[tokio::test]
+    async fn a_permitted_frame_names_no_bucket() {
+        let inbound = PreAuthBudget::Source {
+            connection: PreAuthRateLimiter::new(),
+            budget: Arc::new(SourcePreAuthBudget::with_policy(
+                8.0,
+                0.0,
+                PRE_AUTH_RATE_LIMIT.refill_interval,
+                16,
+            )),
+            key: key("203.0.113.44:1000"),
+        };
+
+        assert_eq!(
+            inbound.check().await,
+            Ok(()),
+            "a frame both buckets permitted was reported as refused, so a permitted frame would \
+             increment a refusal counter"
+        );
+    }
+
+    /// An outbound connection has no source budget, so its only possible refusal is its own.
+    #[tokio::test]
+    async fn an_outbound_connection_can_only_refuse_as_itself() {
+        let outbound = PreAuthBudget::Connection(PreAuthRateLimiter::new());
+
+        for spent in 1..=PRE_AUTH_RATE_LIMIT.burst_capacity {
+            assert_eq!(
+                outbound.check().await,
+                Ok(()),
+                "grant {spent} of a fresh burst of {} was refused",
+                PRE_AUTH_RATE_LIMIT.burst_capacity
+            );
+        }
+
+        assert_eq!(
+            outbound.check().await,
+            Err(PreAuthRefusal::Connection),
+            "an outbound connection has no source budget, so naming one here would be reporting a \
+             bucket that does not exist"
         );
     }
 }

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -372,6 +372,21 @@ impl PreAuthRateLimiter {
         }
     }
 
+    /// A budget with an explicit policy, so a test can state a bound instead of racing the clock.
+    ///
+    /// Test-only, and private on purpose. Every production connection gets exactly
+    /// [`PRE_AUTH_RATE_LIMIT`]; a policy seam on the public surface would be an invitation to
+    /// hand some caller a larger anonymous allowance, which is the one thing this budget must not
+    /// have. Tests need it because [`TokenBucket::refill`] reads `Instant::now()`, so a limiter
+    /// built by [`Self::new`] hands back a token every `refill_interval` — which is fine for a
+    /// test asserting a *range*, and fatal to one asserting *which bucket* refused.
+    #[cfg(test)]
+    fn with_policy(capacity: f64, refill_rate: f64, refill_interval: Duration) -> Self {
+        Self {
+            bucket: RwLock::new(TokenBucket::new(capacity, refill_rate, refill_interval)),
+        }
+    }
+
     /// Spend one message's worth of the connection's anonymous budget.
     ///
     /// Takes no DID, and that is the point: there is nothing to pass. A signature here
@@ -2491,6 +2506,29 @@ mod source_budget_tests {
         ))
     }
 
+    /// What a frozen connection budget may spend before it starts refusing.
+    ///
+    /// Stated here rather than taken from `PRE_AUTH_RATE_LIMIT` for the reason `table()` states
+    /// its own numbers: these tests are about *which* bucket refused, and a test that has to
+    /// spend the shipped burst to reach the edge hides which edge it reached.
+    const CONNECTION_BURST: u32 = 4;
+
+    /// A connection budget that never refills.
+    ///
+    /// Zero refill is load-bearing, not tidiness. `TokenBucket::refill` reads `Instant::now()`, so
+    /// a production limiter hands back a token every 100 ms — and a test process descheduled for
+    /// one interval mid-loop would see a connection refusal turn back into a source refusal, or
+    /// be granted more than its burst. The pre-existing
+    /// `a_spent_connection_does_not_charge_its_source` copes by asserting a *range*; these tests
+    /// assert an exact identity and a variant, so they have to freeze the clock out instead.
+    fn frozen_connection() -> PreAuthRateLimiter {
+        PreAuthRateLimiter::with_policy(
+            CONNECTION_BURST as f64,
+            0.0,
+            PRE_AUTH_RATE_LIMIT.refill_interval,
+        )
+    }
+
     /// A dry source is named as the source — until the connection itself runs out.
     ///
     /// This is the whole attribution property in one run, and it is deliberately one test rather
@@ -2507,31 +2545,30 @@ mod source_budget_tests {
     #[tokio::test]
     async fn a_dry_source_is_named_until_the_connection_itself_runs_out() {
         let inbound = PreAuthBudget::Source {
-            connection: PreAuthRateLimiter::new(),
+            connection: frozen_connection(),
             budget: dry_table(),
             key: key("203.0.113.42:1000"),
         };
 
         // Every one of these is refused by the *source*: the connection still has tokens, and
         // spends one to reach the source each time.
-        for spent in 1..=PRE_AUTH_RATE_LIMIT.burst_capacity {
+        for spent in 1..=CONNECTION_BURST {
             assert_eq!(
                 inbound.check().await,
                 Err(PreAuthRefusal::Source),
                 "refusal {spent} was attributed to the wrong bucket: the connection had {} of its \
-                 {} tokens left, so the source is what refused",
-                PRE_AUTH_RATE_LIMIT.burst_capacity - spent + 1,
-                PRE_AUTH_RATE_LIMIT.burst_capacity
+                 {CONNECTION_BURST} tokens left, so the source is what refused",
+                CONNECTION_BURST - spent + 1
             );
         }
 
         assert_eq!(
             inbound.check().await,
             Err(PreAuthRefusal::Connection),
-            "the connection spent one of its {} tokens on each source refusal above, so it is now \
-             empty and must be the bucket refusing — reporting the source here would mean either \
-             the connection is not charged for a source refusal, or both refusals carry one label",
-            PRE_AUTH_RATE_LIMIT.burst_capacity
+            "the connection spent one of its {CONNECTION_BURST} tokens on each source refusal \
+             above, so it is now empty and must be the bucket refusing — reporting the source \
+             here would mean either the connection is not charged for a source refusal, or both \
+             refusals carry one label"
         );
     }
 
@@ -2554,7 +2591,7 @@ mod source_budget_tests {
         ));
         let k = key("203.0.113.43:1000");
         let inbound = PreAuthBudget::Source {
-            connection: PreAuthRateLimiter::new(),
+            connection: frozen_connection(),
             budget: budget.clone(),
             key: k,
         };
@@ -2582,10 +2619,9 @@ mod source_budget_tests {
         // Non-vacuity: the connection has to have been able to spend something, or the run never
         // exercised a *spent* connection at all.
         assert_eq!(
-            granted, PRE_AUTH_RATE_LIMIT.burst_capacity as usize,
-            "the connection was granted {granted} of its burst of {}; this run did not reach the \
-             edge it means to test",
-            PRE_AUTH_RATE_LIMIT.burst_capacity
+            granted, CONNECTION_BURST as usize,
+            "the connection was granted {granted} of its burst of {CONNECTION_BURST}; this run \
+             did not reach the edge it means to test"
         );
 
         // Several more refusals, so an implementation that consulted the source on the refusal
@@ -2606,7 +2642,7 @@ mod source_budget_tests {
     #[tokio::test]
     async fn a_permitted_frame_names_no_bucket() {
         let inbound = PreAuthBudget::Source {
-            connection: PreAuthRateLimiter::new(),
+            connection: frozen_connection(),
             budget: Arc::new(SourcePreAuthBudget::with_policy(
                 8.0,
                 0.0,
@@ -2627,14 +2663,13 @@ mod source_budget_tests {
     /// An outbound connection has no source budget, so its only possible refusal is its own.
     #[tokio::test]
     async fn an_outbound_connection_can_only_refuse_as_itself() {
-        let outbound = PreAuthBudget::Connection(PreAuthRateLimiter::new());
+        let outbound = PreAuthBudget::Connection(frozen_connection());
 
-        for spent in 1..=PRE_AUTH_RATE_LIMIT.burst_capacity {
+        for spent in 1..=CONNECTION_BURST {
             assert_eq!(
                 outbound.check().await,
                 Ok(()),
-                "grant {spent} of a fresh burst of {} was refused",
-                PRE_AUTH_RATE_LIMIT.burst_capacity
+                "grant {spent} of a fresh burst of {CONNECTION_BURST} was refused"
             );
         }
 

--- a/icn/crates/icn-net/tests/preauth_work_before_the_gate.rs
+++ b/icn/crates/icn-net/tests/preauth_work_before_the_gate.rs
@@ -130,6 +130,9 @@ fn install_metrics() -> Snapshotter {
 }
 
 /// Total value of `name` across every label set, or 0 if it was never recorded.
+///
+/// Summing across label sets is what keeps the aggregate readings below meaning the same thing
+/// they meant when the refusal counter carried no labels at all (#2558 added `bound`).
 fn counter(snapshotter: &Snapshotter, name: &str) -> u64 {
     snapshotter
         .snapshot()
@@ -141,6 +144,24 @@ fn counter(snapshotter: &Snapshotter, name: &str) -> u64 {
                 _ => None,
             },
         )
+        .sum()
+}
+
+/// Total value of `name` for label sets carrying `label=value`, or 0 if there are none.
+fn counter_labelled(snapshotter: &Snapshotter, name: &str, label: &str, value: &str) -> u64 {
+    snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter_map(|(key, _, _, recorded)| {
+            let key = key.key();
+            let matches =
+                key.name() == name && key.labels().any(|l| l.key() == label && l.value() == value);
+            match (matches, recorded) {
+                (true, DebugValue::Counter(v)) => Some(v),
+                _ => None,
+            }
+        })
         .sum()
 }
 
@@ -363,6 +384,33 @@ async fn frames_are_authorized_before_they_are_decoded() -> Result<()> {
         "the two outcomes do not add up to the {FRAMES} frames sent: {decoded} decoded plus \
          {refused} refused. Under-count means frames were consumed unaccounted; over-count means \
          the node decoded frames it had already refused"
+    );
+
+    // Every refusal names exactly one budget (#2558).
+    //
+    // Conservation rather than an expected split, because the split is a property of the machine
+    // this ran on and the identity is a property of the code. It fails in both directions that
+    // matter: short means a refusal was counted without a `bound` label at all, long means one
+    // refused frame incremented more than one of them.
+    //
+    // This says nothing about *which* label is right — one connection sending far past its own
+    // burst over a source budget it cannot drain produces connection refusals, but an
+    // implementation reporting one label for everything would satisfy this too. That the two are
+    // distinguishable at all is proven deterministically in `rate_limit.rs`, by
+    // `a_dry_source_is_named_until_the_connection_itself_runs_out`; this only proves the gate's
+    // counter carries the attribution end to end.
+    let by_connection = counter_labelled(&metrics, REFUSED_METRIC, "bound", "connection");
+    let by_source = counter_labelled(&metrics, REFUSED_METRIC, "bound", "source");
+    assert_eq!(
+        by_connection + by_source,
+        refused,
+        "{refused} frames were refused but {by_connection} + {by_source} carry a bound label: \
+         a refusal reached the counter without naming a budget, or named two"
+    );
+    assert!(
+        by_connection >= 1,
+        "no refusal was attributed to this connection's own burst, though one connection sent \
+         {FRAMES} frames against a burst of far fewer: the label is not being set from the gate"
     );
 
     assert!(

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -267,8 +267,12 @@ pub fn messages_rate_limited_inc() {
 /// this refusal happens before the frame is decoded (#2558), so at this point the message has
 /// not said who it claims to be.
 ///
-/// A refusal counted under `bound="source"` does **not** mean a source token was spent: the
-/// connection's token was, and the source's was not. See `PreAuthBudget::check`.
+/// Two readings `bound="source"` does **not** support. It does not mean a source token was spent —
+/// the connection's token was, and the source's was not (see `PreAuthBudget::check`). And it does
+/// not always mean *one address* has spent its allowance: when the budget table is saturated,
+/// untracked sources share a single fallback bucket whose exhaustion is counted here too. Pair it
+/// with `icn_network_preauth_source_budget_degraded_total`, which is non-zero exactly in that
+/// overload mode, before reading a rise here as one noisy address or NAT.
 ///
 /// (Distinguishing the *other* rate-limit counter's causes — policy denial versus throttling on
 /// `messages_rate_limited_total` — is #2499's subject, not this one's.)

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -41,7 +41,7 @@ pub fn init_descriptions() {
     // Two-phase inbound rate limiting (Issue #2491)
     describe_counter!(
         "icn_network_messages_rate_limited_pre_auth_total",
-        "Total number of messages denied by a connection's anonymous pre-authentication budget, before any peer identity was bound to it"
+        "Total number of messages denied by an anonymous pre-authentication budget before any peer identity was bound to the connection, by which budget refused (connection or source)"
     );
     describe_counter!(
         "icn_network_messages_rate_limited_by_rate_total",
@@ -253,12 +253,24 @@ pub fn messages_rate_limited_inc() {
 /// this counter is anonymous traffic that never got as far as saying who it was, and a
 /// sustained rise in it is a load signal rather than a configuration one.
 ///
-/// Deliberately unlabelled. The tempting labels here — the claimed DID, the remote address
-/// — are unbounded and attacker-chosen, which is the same mistake at the metrics layer that
-/// #2491 fixes at the policy layer. (Distinguishing denial *causes* more finely is #2499's
-/// subject, not this one's.)
-pub fn messages_rate_limited_pre_auth_inc() {
-    counter!("icn_network_messages_rate_limited_pre_auth_total").increment(1);
+/// `bound` says which budget refused, and is the **only** label here on purpose (#2558). An
+/// inbound connection spends two: its own burst (#2491) and the one shared by everything from
+/// its source (#2549). Unlabelled, this counter could not separate a single connection
+/// exhausting its own allowance from an address whose whole allowance is gone — conditions that
+/// look identical here and want different responses. The value comes from the closed two-value
+/// set `PreAuthRefusal::as_str`, so nothing a remote peer sends can add a series.
+///
+/// The labels this still deliberately does not carry — the claimed DID, the remote address, the
+/// source key — are unbounded and attacker-chosen, which is the same mistake at the metrics
+/// layer that #2491 fixes at the policy layer. They belong in the log line, and are there.
+///
+/// A refusal counted under `bound="source"` does **not** mean a source token was spent: the
+/// connection's token was, and the source's was not. See `PreAuthBudget::check`.
+///
+/// (Distinguishing the *other* rate-limit counter's causes — policy denial versus throttling on
+/// `messages_rate_limited_total` — is #2499's subject, not this one's.)
+pub fn messages_rate_limited_pre_auth_inc(bound: &'static str) {
+    counter!("icn_network_messages_rate_limited_pre_auth_total", "bound" => bound).increment(1);
 }
 
 /// An inbound connection was refused a pre-authentication slot (#2547).

--- a/icn/crates/icn-obs/src/metrics/network.rs
+++ b/icn/crates/icn-obs/src/metrics/network.rs
@@ -260,9 +260,12 @@ pub fn messages_rate_limited_inc() {
 /// look identical here and want different responses. The value comes from the closed two-value
 /// set `PreAuthRefusal::as_str`, so nothing a remote peer sends can add a series.
 ///
-/// The labels this still deliberately does not carry — the claimed DID, the remote address, the
-/// source key — are unbounded and attacker-chosen, which is the same mistake at the metrics
-/// layer that #2491 fixes at the policy layer. They belong in the log line, and are there.
+/// The labels this still deliberately does not carry — the remote address and the source key —
+/// are unbounded and attacker-chosen, which is the same mistake at the metrics layer that #2491
+/// fixes at the policy layer. Identifying detail belongs in tracing instead, and the remote
+/// address is already on the connection's span. A claimed DID is not among the options at all:
+/// this refusal happens before the frame is decoded (#2558), so at this point the message has
+/// not said who it claims to be.
 ///
 /// A refusal counted under `bound="source"` does **not** mean a source token was spent: the
 /// connection's token was, and the source's was not. See `PreAuthBudget::check`.


### PR DESCRIPTION
## Summary

The last item on #2558's own "To investigate" list — the one it says would make any new bound hard to operate:

> What is the right observable? `icn_network_messages_rate_limited_pre_auth_total` currently cannot distinguish a #2491 per-connection refusal from a #2549 per-source one.

A pre-authentication refusal now names the budget that refused. This is an observability change: no admission or rate policy moves.

## Changes

- `PreAuthBudget::check` returns `Result<(), PreAuthRefusal>` instead of a bare `bool`.
- New `PreAuthRefusal { Connection, Source }` — two variants, no payload, `as_str() -> &'static str`.
- `icn_network_messages_rate_limited_pre_auth_total` gains one bounded label:

```
{bound="connection"}   this connection's own burst is spent (#2491)
{bound="source"}       this source's shared allowance is dry (#2549)
```

- The refusal log line carries the same `bound` field.
- `describe_counter!` help text updated; the doc comment claiming the counter is "deliberately unlabelled" rewritten.

Those two conditions want different responses. `connection` is one peer against one connection's worth of allowance; `source` is an address whose whole allowance is gone, which on a NAT is everyone behind it. Unlabelled they were the same number.

## Motivation

Closes the final open item of #2558. The allocation half landed in #2573, the decode-ordering half in #2574; #2574 shipped `Refs` rather than `Closes` precisely because this observable was still missing.

## Why this is not a policy change

Deliberately behaviour-preserving: nothing changes about which frames are authorized, which are refused, when tokens are spent, or how the two buckets interact.

`check` was `connection.check().await && budget.spend(*key)`; it is now two sequential early returns, which is the same `&&` performed:

- a refusing connection still **never consults the source** — it does not take the shared lock and spends no source token;
- a refusal still spends nothing in the bucket that refused (`TokenBucket::try_consume` decrements only on success);
- a `source` refusal is still reached **through** an already-spent connection token.

That last asymmetry is the one that most invites a "cleanup". It is deliberate, documented on `PreAuthBudget::check`, and only ever makes the bound tighter than stated — so it is left exactly as it was and is now pinned by a test instead of only by prose. Discovering the refusing bucket by asking *both* would be a policy change wearing an observability change's clothes: it converts a free denial into one that drains the shared allowance, the reversal `a_spent_connection_does_not_charge_its_source` exists to forbid.

## Cardinality

`PreAuthRefusal` is a two-variant, payload-free enum; the label is `&'static str` from `as_str`. Nothing a remote peer sends can add a series. This mirrors `AdmissionRefusal` / `icn_network_preauth_admission_refused_total{bound=...}` from #2547 — same question, same answer, one issue earlier.

The labels still excluded — the remote address and the source key — remain unbounded and attacker-chosen; identifying detail belongs in tracing, and the remote address is already on the connection's span. A claimed DID is not among the options at all: this refusal happens before the frame is decoded, so the message has not said who it claims to be.

## Metric compatibility

Same metric name, one bounded label added. Audited repo-wide before choosing: **no dashboard, alert rule, runbook, doc, or generated inventory consumes this counter.** `monitoring/alert_rules.yml` and `deploy/config/grafana/.../icn-dashboard.json` query `icn_network_messages_rate_limited_total`, a different counter, untouched here.

Anything summing across label sets reads what it read before — including the #2574 regression's `counter()` helper, which already summed across label sets and needed no change to stay green. Keeping a separate unlabelled aggregate was considered and rejected: it would add a redundant series to protect a consumer that does not exist.

## Testing

- [x] Unit tests added
- [x] Integration tests pass
- [x] Manual testing: N/A — the property is a counter identity, asserted in tests rather than observed by hand

Deterministic; no wall-clock thresholds, no sleeps. The connection budget in every new test is built through a private `#[cfg(test)] PreAuthRateLimiter::with_policy` with **zero refill**, so no amount of descheduling can change a result (see the review round below).

- **`a_dry_source_is_named_until_the_connection_itself_runs_out`** — the attribution property and the asymmetry in one run. A fresh connection over a dry source is refused as `Source` exactly `CONNECTION_BURST` times, then as `Connection`. The switch happens only because each source refusal spends a connection token. **This is the test that fails if both refusals share one label** — verified by implementing it wrong first: with both arms returning `Connection` it failed `left: Err(Connection), right: Err(Source)` while the other three attribution tests still passed.
- **`a_refusing_connection_is_named_and_leaves_its_source_untouched`** — a spent connection is named `Connection`, and after nine further refusals the source's remaining tokens still equal `burst - granted` exactly. An implementation that evaluated both buckets to find the empty one passes the label assertion and fails this one.
- **`a_permitted_frame_names_no_bucket`** — `Ok(())`, so a permitted frame cannot increment a refusal counter.
- **`an_outbound_connection_can_only_refuse_as_itself`** — `PreAuthBudget::Connection` has no source budget; naming one would report a bucket that does not exist.
- **`preauth_work_before_the_gate`** gains an end-to-end conservation assertion: `bound="connection"` + `bound="source"` equals total refused, so a refusal cannot reach the counter unlabelled or increment two labels. It asserts the identity rather than an expected split — the split is a property of the machine, the identity is a property of the code.

## Review round 1 — both findings valid, both fixed in `a501bd4b`

**Codex P2 (the load-bearing one).** The first revision built its connection budgets with
`PreAuthRateLimiter::new()`, whose bucket refills from `Instant::now()` — one token per 100 ms. A
test process descheduled for a single interval mid-loop would have seen the final `Err(Connection)`
turn back into `Err(Source)`, and `granted == burst` become `granted > burst`. The pre-existing
`a_spent_connection_does_not_charge_its_source` tolerates this by asserting a *range*; these tests
assert a variant and an exact identity and had no such tolerance, so they were partly measuring the
scheduler. Fixed by construction rather than by widening assertions: a private `#[cfg(test)]`
`with_policy` with `refill_rate = 0.0` and a module-local `CONNECTION_BURST = 4`. Private on
purpose — every production connection must get exactly `PRE_AUTH_RATE_LIMIT`, and a public policy
seam would invite handing a caller a larger anonymous allowance. Re-proved the tests still
distinguish the two refusals afterwards; 5 consecutive runs green, now at 0.00s.

**Copilot.** The counter's doc said the labels it omits "belong in the log line, and are there".
False for the claimed DID on this path: the refusal happens before the frame is decoded, so there is
nothing to log rather than a choice not to. The remote address is on the connection span
(`actor/connection.rs:393`), not on this counter. Reworded.

## Review round 2 — Codex P2 on the saturated-table fallback, docs fixed in `e86243d9`, split to #2576

Correct on the facts: `SourcePreAuthBudget::spend` refuses from two buckets — this source's own,
and the single `state.shared` fallback used once the table is saturated and a sweep frees nothing —
and both reach `check` as a bare `false`, so both report `Source`. In that mode the label does not
mean one address spent its allowance.

Not fixed here, deliberately: #2558's item is separating the per-connection bound from the
per-source one, and *both* of those buckets are the per-source one. Promoting the fallback changes
the signature of `SourcePreAuthBudget::spend`, which is `pub`, and interacts with #2562 (the
promotion transition runs through the same shared bucket). Filed as **#2576** with the
behaviour-preservation and cardinality constraints carried over.

What is fixed is the misdirection, which bites without a signature change. The condition is already
independently observable — `preauth_source_budget_degraded_total` increments on *every* spend
through the fallback, and `preauth_source_budget_tracked` sits at `MAX_PREAUTH_BUDGET_SOURCES` — but
nothing said so where an operator reads the label. Both `PreAuthRefusal::Source` and the metric doc
now state that the fallback is counted under `bound="source"`, that this is one label on purpose,
and name those two signals as the check to run before reading a rise as one noisy address or NAT.

## Invariants

- [x] No panics introduced in protocol paths — no `unwrap`/`expect` added outside tests
- [x] Determinism preserved
- [x] Canonical encodings unchanged — `protocol.rs` untouched on this branch
- [x] Trust gates not weakened — evaluation order, short-circuit, and token consumption all identical
- [x] Kernel/app boundaries respected — `check-meaning-firewall.sh` PASS, no new domain imports

Security regressions from the earlier halves, both still green:

- **#2574 (decode after the gate)** — 400 frames, **20 decoded, 380 refused before decode**, 20 + 380 = 400. Signature unchanged. Gate still precedes `from_bytes_negotiated`.
- **#2573 (declared length is not a memory commitment)** — 2 passed; `protocol.rs` untouched.

## Verification

```
cargo fmt --all --check                                          EXIT=0
cargo clippy -p icn-net --all-targets -- -D warnings             EXIT=0
cargo clippy -p icn-obs --all-targets -- -D warnings             EXIT=0
cargo clippy --workspace --all-targets -- -D warnings            EXIT=0
cargo test -p icn-net --test preauth_work_before_the_gate              1 passed
cargo test -p icn-net --test preauth_source_work_budget                6 passed
cargo test -p icn-net --test preauth_declared_length_allocation        2 passed
cargo test -p icn-net --test authenticated_rate_limit_identity         9 passed
cargo test -p icn-net --no-fail-fast    504 passed, 0 failed, 23 ignored (24 binaries)

scripts/check-meaning-firewall.sh                                EXIT=0
.github/scripts/compliance_linter.py                             EXIT=0
.github/scripts/readiness_overclaim_linter.py                    EXIT=0
ops/scripts/drift-check.sh                                       PASS (0 errors, 0 warnings)
```

`icn-prereview` was not run: the Zentith Ollama tunnel on `127.0.0.1:11435` is down this session. It is an optional local reviewer, not a canonical gate.

## Risk

Low. `PreAuthBudget::check` is public via `pub mod rate_limit` and its signature changed, but it is not re-exported at the crate root and has no consumer outside `icn-net`. `check_pre_auth_rate_limit` is `pub(crate)`. `messages_rate_limited_pre_auth_inc` has exactly one caller. Workspace-wide clippy confirms nothing else binds either surface.

## Documentation

- [x] Docs updated — metric help text and the affected doc comments; no separate doc page describes this counter
- [x] API changes reflected in OpenAPI — N/A, no HTTP surface

## Issue closure

Every item on #2558's list now has a landed answer: the gate runs before deserialization and needs no protocol or framing change (#2574); malformed input is charged for the decode attempt it used to get free (#2574); exhaustion throttles a message rather than closing the connection, so a peer behind a busy NAT keeps its session (#2557/#2574); work-per-window is composed with windows-per-source through the authentication deadline (#2549/#2552); declared length does not become memory commitment (#2573); and the refusal metric now names the responsible budget (this PR). The #2549 constraints hold — no unbounded source map, no new rate limiter, and no claim to bound attacks distributed across many sources.

Closes #2558
Refs #2573, #2574, #2549, #2557, #2491, #2547, #2552
