### PR TITLE
fix(net): inherit the fallback's level when a source is promoted to tracked

### DIFF
--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -499,6 +499,19 @@ pub const MAX_PREAUTH_BUDGET_SOURCES: usize = 4096;
 /// sweep is safe: the caller falls through to the shared budget, which is bounded.
 const BUDGET_SWEEP_MIN_INTERVAL: Duration = Duration::from_secs(1);
 
+/// What a source is guaranteed on promotion even when the pool it inherits is empty (#2562).
+///
+/// One token, and the reason is liveness rather than allowance: a peer needs exactly one anonymous
+/// message to send the Hello that authenticates it out of this phase altogether. Seeding a
+/// promotion from a dry fallback without this floor would refuse that first message, and a
+/// legitimate peer that does not retry then sits until `PREAUTH_AUTHENTICATION_DEADLINE` closes it.
+/// The burst docs already promise exactly this much — "a peer needs one token to authenticate".
+///
+/// It is also the exact size of what remains of the promotion exception: at most one token more
+/// than the source had earned, once per promotion, and a repeat requires its own bucket to refill
+/// to full first — see [`SourcePreAuthBudget::spend`].
+const PROMOTION_LIVENESS_FLOOR: usize = 1;
+
 /// Tokens added per refill interval to renew `PREAUTH_SOURCE_BURST` over the renewal window.
 fn source_refill_rate_per_interval() -> f64 {
     PREAUTH_SOURCE_BURST as f64 * PRE_AUTH_RATE_LIMIT.refill_interval.as_secs_f64()
@@ -572,6 +585,41 @@ impl BudgetState {
         TokenBucket::new(self.capacity, self.refill_rate, self.refill_interval)
     }
 
+    /// The bucket a source is inserted with.
+    ///
+    /// A source arriving here is one of two things this table cannot tell apart: a newcomer it had
+    /// room for, or a source being promoted out of the shared fallback it has been spending from.
+    /// Handing both a *full* bucket is what let the second mint a second burst (#2562) — whatever
+    /// it had just spent on the fallback was simply forgotten.
+    ///
+    /// Both therefore inherit the fallback's current level, floored at
+    /// [`PROMOTION_LIVENESS_FLOOR`]. For the promoted source that is exact: the tokens it took from
+    /// the fallback are precisely the ones missing from the level it inherits, so the fallback and
+    /// the promotion together grant one burst rather than two.
+    ///
+    /// For the newcomer it is conservative — it can be seeded low because *other* untracked sources
+    /// drained the pool. Telling those two apart needs per-source accounting for sources the table
+    /// has no room to track, which is the exact state the fallback exists to avoid, so the cost is
+    /// paid rather than removed. It is bounded: at most one burst of initial deficit, refilling at
+    /// the ordinary rate, and never the first message — that is what the floor guarantees.
+    ///
+    /// Below saturation this changes nothing. The shared bucket is only ever spent from on the
+    /// degraded path, so a table that has never run out of room has it at capacity, and every
+    /// insert still gets a full bucket exactly as before.
+    fn promotion_bucket(&mut self) -> TokenBucket {
+        // Read the level *now*: a stale level would credit or charge a promotion for time that
+        // has since passed.
+        self.shared.refill();
+        let inherited = self
+            .shared
+            .tokens
+            .max(PROMOTION_LIVENESS_FLOOR as f64)
+            .min(self.capacity);
+        let mut bucket = self.fresh_bucket();
+        bucket.tokens = inherited;
+        bucket
+    }
+
     /// Drop every entry whose allowance has come all the way back.
     ///
     /// Returns the number removed. Rate-limited by [`BUDGET_SWEEP_MIN_INTERVAL`]; a refused sweep
@@ -632,8 +680,7 @@ impl SourcePreAuthBudget {
     /// permits a full burst at the start of a window and another once it has refilled, so the
     /// sliding-window reading of it is wrong by up to a factor of two.
     ///
-    /// One exception, in the saturated table's promotion path only — see *The promotion transition
-    /// is the one place the per-source burst is not exact* below, and #2562.
+    /// One exception, worth a single token — see *What promotion costs* below (#2562).
     ///
     /// It does **not** bound the QUIC/TLS handshake, which is complete before the source key
     /// exists at all (#2559), nor the `ConnectionContext` and task a connection allocates, nor
@@ -666,26 +713,33 @@ impl SourcePreAuthBudget {
     /// source is bounded" to "every untracked source is bounded *together*, by one source's
     /// worth" — never to "unbounded".
     ///
-    /// # The promotion transition is the one place the per-source burst is not exact
+    /// # What promotion costs
     ///
-    /// Stated because it is a real exception to the headline bound (#2562 tracks it). A source
-    /// that spends from the shared bucket while untracked and is *then* promoted — a later sweep
-    /// frees a slot — is inserted with [`BudgetState::fresh_bucket`], a full one. Its shared
-    /// spending is not carried across, so across that transition its burst term can reach `2B`
-    /// rather than `B`, once, before settling back to `B + rate × T`.
+    /// A source that spent from the shared bucket while untracked and is *then* promoted — a later
+    /// sweep frees a slot — used to be inserted with a **full** bucket, so its shared spending was
+    /// forgotten and its burst term could reach `2B` (#2562). Insertion now goes through
+    /// [`BudgetState::promotion_bucket`], which seeds the new bucket from the shared bucket's
+    /// current level: the tokens the source took from the fallback are exactly the ones missing
+    /// from what it inherits, so the two together grant one burst.
     ///
-    /// It is not fixed here because carrying the debt means per-source accounting for sources the
-    /// table has *no room to track* — the exact state the fallback exists to avoid. Bounding it by
-    /// seeding the promoted bucket from the shared level would instead charge a newly-arrived
-    /// honest source for its neighbours' spending.
+    /// What remains is [`PROMOTION_LIVENESS_FLOOR`] — one token, so that a promoted source can
+    /// always send the Hello that authenticates it out of this phase. The bound is therefore
+    /// `B + rate × T + 1` rather than `B + rate × T`, and the extra token is not repeatable at
+    /// will: a second promotion requires the source to be swept first, and a sweep only drops a
+    /// bucket that is back to **full** — by which point the allowance was earned rather than
+    /// minted.
     ///
-    /// What survives unchanged is the anti-gaming argument, which is an aggregate one: the extra
-    /// is drawn from the shared bucket, and there is only one of those, so *all* promoted sources
-    /// together can gain at most its throughput. Filling the table costs `max_sources` distinct
-    /// keys and leaves every one of the attacker's sources with less than being tracked would have
-    /// given it. So there is still nothing to gain by filling the table — but "being untracked is
-    /// never better than being tracked", which this doc used to claim outright, is false at the
-    /// moment of promotion.
+    /// The price is paid by a *newcomer* promoted while other untracked sources have drained the
+    /// pool: it inherits their spending. Telling it apart from a source promoted out of its own
+    /// debt needs per-source accounting for sources the table has no room to track, which is the
+    /// state the fallback exists to avoid, so the cost is bounded and stated instead of removed —
+    /// at most one burst of deficit, refilling at the ordinary rate, never the first message.
+    ///
+    /// The anti-gaming argument is unchanged and remains an aggregate one: there is one shared
+    /// bucket, so *all* promoted sources together can gain at most its throughput. Filling the
+    /// table costs `max_sources` distinct keys and leaves every one of the attacker's sources with
+    /// less than being tracked would have given it.
+    ///
     /// `Err` names *which* of the two buckets refused (#2576), because they mean different things
     /// to an operator: `PerSource` is one address that has spent its own allowance, `SharedFallback`
     /// is the table having no room to track it at all. Reported as one value they read alike, and
@@ -723,7 +777,7 @@ impl SourcePreAuthBudget {
                 .ok_or(SourceRefusal::SharedFallback);
         }
 
-        let mut bucket = state.fresh_bucket();
+        let mut bucket = state.promotion_bucket();
         let allowed = bucket.try_consume();
         state.per_source.insert(key, bucket);
         // Published from the two places the table can change size — here and the sweep above —
@@ -2913,6 +2967,245 @@ mod source_budget_tests {
             labels.len(),
             "two refusal kinds share a metric label ({labels:?}), so the counter cannot separate \
              them"
+        );
+    }
+
+    // -- #2562: the untracked -> tracked promotion must not mint a second burst -----------------
+
+    /// A burst small enough that "one burst" and "two bursts" are unmistakable in a message.
+    const PROMO_BURST: usize = 8;
+    /// Small on purpose: filling the table is setup, not the property under test.
+    const PROMO_CAP: usize = 4;
+
+    /// A frozen table whose entries are all *below* full, so a sweep can reclaim nothing.
+    ///
+    /// That is what forces the next unknown source onto the shared fallback rather than straight
+    /// into a free slot — the precondition for a promotion to exist at all.
+    fn fill_unreclaimable(budget: &SourcePreAuthBudget, cap: usize) {
+        let mut state = budget.state.lock().expect("test lock");
+        for i in 0..cap {
+            let mut bucket =
+                TokenBucket::new(PROMO_BURST as f64, 0.0, PRE_AUTH_RATE_LIMIT.refill_interval);
+            // One token short of full: not replenished, so `sweep_replenished` retains it.
+            bucket.tokens = PROMO_BURST as f64 - 1.0;
+            state
+                .per_source
+                .insert(key(&format!("203.0.113.{}:1000", 200 + i)), bucket);
+        }
+        assert_eq!(state.per_source.len(), cap);
+    }
+
+    /// Make exactly one tracked entry reclaimable, so the next sweep frees exactly one slot.
+    ///
+    /// `except` is never chosen, and that restriction is the point rather than tidiness: a real
+    /// entry only reaches full by *refilling*, so handing the source under test a full bucket
+    /// would be granting it the very allowance these tests are measuring. Without the exclusion
+    /// this helper silently modelled an attacker who can refill on demand.
+    fn free_one_slot(budget: &SourcePreAuthBudget, except: SourceKey) {
+        let mut state = budget.state.lock().expect("test lock");
+        let victim = *state
+            .per_source
+            .keys()
+            .find(|k| **k != except)
+            .expect("table has an entry other than the source under test");
+        let capacity = state.capacity;
+        state
+            .per_source
+            .get_mut(&victim)
+            .expect("victim present")
+            .tokens = capacity;
+    }
+
+    /// Clear the sweep throttle without moving any allowance.
+    ///
+    /// `advance` rewinds every `last_refill` as well as `last_sweep`, which would normally hand
+    /// out tokens — but every bucket in these tests has `refill_rate = 0`, so the only thing it
+    /// can change is whether [`BUDGET_SWEEP_MIN_INTERVAL`] has elapsed. That is what keeps the
+    /// assertions below about *promotion* rather than about refill.
+    fn allow_next_sweep(budget: &SourcePreAuthBudget) {
+        budget.advance(BUDGET_SWEEP_MIN_INTERVAL);
+    }
+
+    /// Promotion out of the fallback must not hand the source a second burst (#2562).
+    ///
+    /// The transition: a source spends from the shared bucket while the table has no room for it,
+    /// a later sweep frees a slot, and the source is inserted. Inserting a *full* bucket there
+    /// forgets everything it just spent, so across the transition one source could take `2B`
+    /// where its documented burst is `B`.
+    ///
+    /// Every bucket here refills at zero, so the `rate × T` term of the bound is exactly zero and
+    /// any token above the burst was minted by the transition itself rather than earned by
+    /// waiting. That is what makes this a statement about the invariant and not about timing.
+    #[test]
+    fn promotion_out_of_the_fallback_does_not_mint_a_second_burst() {
+        let budget = frozen_table(PROMO_BURST as f64, PROMO_CAP);
+        fill_unreclaimable(&budget, PROMO_CAP);
+
+        let source = key("192.0.2.10:1000");
+
+        // Phase 1 — untracked: everything this source spends comes from the shared bucket.
+        let from_fallback = drain(&budget, source);
+        assert_eq!(
+            from_fallback, PROMO_BURST,
+            "the fallback granted {from_fallback}, not the shared burst of {PROMO_BURST}; this \
+             run never put the source in debt, so it cannot demonstrate the transition"
+        );
+        assert_eq!(
+            budget.tracked_sources(),
+            PROMO_CAP,
+            "the source was tracked while it should have been on the fallback"
+        );
+
+        // Phase 2 — a slot frees and the same source is promoted into it.
+        free_one_slot(&budget, source);
+        allow_next_sweep(&budget);
+        let after_promotion = drain(&budget, source);
+
+        let total = from_fallback + after_promotion;
+        assert!(
+            total <= PROMO_BURST + PROMOTION_LIVENESS_FLOOR,
+            "one source spent {total} across an untracked -> tracked promotion: {from_fallback} \
+             from the shared fallback, then {after_promotion} more from the bucket promotion \
+             handed it. Its burst is {PROMO_BURST} and the refill rate here is zero, so \
+             {} of those tokens were minted by the transition. A promoted source must inherit \
+             the pool it was drawing from, not a fresh allowance.",
+            total.saturating_sub(PROMO_BURST)
+        );
+    }
+
+    /// The control: a promotion the fallback never funded still grants the whole burst.
+    ///
+    /// Without this, "seed every promoted source at the floor" would satisfy the test above while
+    /// quietly making a newly-arrived honest source pay for a saturation it had no part in. The
+    /// table here fills with *replenished* entries, so the sweep frees the slots and the source
+    /// reaches the insert path having spent nothing from the shared bucket.
+    #[test]
+    fn a_promotion_over_an_unspent_fallback_still_grants_the_whole_burst() {
+        let budget = frozen_table(PROMO_BURST as f64, PROMO_CAP);
+        {
+            let mut state = budget.state.lock().expect("test lock");
+            for i in 0..PROMO_CAP {
+                state.per_source.insert(
+                    key(&format!("203.0.113.{}:1000", 210 + i)),
+                    TokenBucket::new(PROMO_BURST as f64, 0.0, PRE_AUTH_RATE_LIMIT.refill_interval),
+                );
+            }
+        }
+
+        let newcomer = key("198.51.100.7:1000");
+        let granted = drain(&budget, newcomer);
+
+        assert_eq!(
+            granted, PROMO_BURST,
+            "a source promoted while the shared bucket was untouched got {granted} of its burst \
+             of {PROMO_BURST}; nothing had drawn on the fallback, so there was no debt to inherit"
+        );
+    }
+
+    /// What the fallback gave and what promotion grants add up to one burst.
+    ///
+    /// Walks the whole range rather than one point: no spending, partial, and a fully drained
+    /// fallback. The identity is exact until the fallback is empty, where the liveness floor is
+    /// the single deliberate exception — a promoted source is always able to send the one message
+    /// that authenticates it out of the anonymous phase.
+    #[test]
+    fn the_fallback_and_the_promotion_together_grant_one_burst() {
+        for taken in [0usize, 1, PROMO_BURST / 2, PROMO_BURST] {
+            let budget = frozen_table(PROMO_BURST as f64, PROMO_CAP);
+            fill_unreclaimable(&budget, PROMO_CAP);
+            let source = key("192.0.2.11:1000");
+
+            for i in 0..taken {
+                assert!(
+                    budget.spend(source).is_ok(),
+                    "fallback refused spend {i} of {taken}"
+                );
+            }
+
+            free_one_slot(&budget, source);
+            allow_next_sweep(&budget);
+            let after_promotion = drain(&budget, source);
+            let total = taken + after_promotion;
+
+            let expected = if taken == PROMO_BURST {
+                PROMO_BURST + PROMOTION_LIVENESS_FLOOR
+            } else {
+                PROMO_BURST
+            };
+            assert_eq!(
+                total, expected,
+                "after taking {taken} from the fallback the source was promoted with \
+                 {after_promotion} more, totalling {total}; expected {expected}"
+            );
+        }
+    }
+
+    /// A second promotion does not compound the exception.
+    ///
+    /// To be promoted again a source must first be swept, and a sweep only drops a bucket that is
+    /// back to full — by which point the allowance was earned rather than minted. Pinned because
+    /// "once per promotion" is only a bound if promotions cannot be cycled.
+    #[test]
+    fn repeated_promotions_do_not_compound() {
+        let budget = frozen_table(PROMO_BURST as f64, PROMO_CAP);
+        fill_unreclaimable(&budget, PROMO_CAP);
+        let source = key("192.0.2.12:1000");
+
+        let from_fallback = drain(&budget, source);
+        free_one_slot(&budget, source);
+        allow_next_sweep(&budget);
+        let first_promotion = drain(&budget, source);
+
+        // Try to go around again: the source's own entry is spent, so it is not sweep-eligible
+        // and nothing can put it back on the fallback.
+        free_one_slot(&budget, source);
+        allow_next_sweep(&budget);
+        let second_round = drain(&budget, source);
+
+        let total = from_fallback + first_promotion + second_round;
+        assert!(
+            total <= PROMO_BURST + PROMOTION_LIVENESS_FLOOR,
+            "cycling sweeps produced {total} for one source against a burst of {PROMO_BURST}: \
+             {from_fallback} on the fallback, {first_promotion} on promotion, {second_round} on a \
+             second attempt. The exception must not be repeatable."
+        );
+    }
+
+    /// One source draining the fallback does not hand its neighbour a fresh burst either.
+    ///
+    /// The NAT-shaped case, stated rather than buried: while the table is saturated the fallback
+    /// is shared, so a second source promoted after the first has drained it inherits the empty
+    /// pool and receives only the liveness floor. That is the cost of not keeping per-source
+    /// accounting for sources the table has no room to track — it is bounded at one burst, it
+    /// refills at the ordinary rate, and it never denies the source its first message.
+    #[test]
+    fn a_neighbour_promoted_after_the_fallback_is_drained_inherits_the_empty_pool() {
+        let budget = frozen_table(PROMO_BURST as f64, PROMO_CAP);
+        fill_unreclaimable(&budget, PROMO_CAP);
+
+        let noisy = key("192.0.2.20:1000");
+        let neighbour = key("192.0.2.21:1000");
+
+        assert_eq!(
+            drain(&budget, noisy),
+            PROMO_BURST,
+            "the noisy source did not drain the shared fallback"
+        );
+        assert_eq!(
+            budget.spend(neighbour),
+            Err(SourceRefusal::SharedFallback),
+            "the neighbour should be meeting the drained *fallback*, not a bucket of its own"
+        );
+
+        free_one_slot(&budget, neighbour);
+        allow_next_sweep(&budget);
+        let granted = drain(&budget, neighbour);
+
+        assert_eq!(
+            granted, PROMOTION_LIVENESS_FLOOR,
+            "a neighbour promoted over a drained fallback got {granted}; it must get the liveness \
+             floor — enough to authenticate at once — and no more, or the drained pool would be a \
+             way to mint bursts"
         );
     }
 }

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -726,14 +726,19 @@ impl SourcePreAuthBudget {
     /// always send the Hello that authenticates it out of this phase. The bound is therefore
     /// `B + rate × T + 1` rather than `B + rate × T`.
     ///
-    /// That `+1` is bounded *per window*, not merely per promotion, and the mechanism is worth
-    /// stating because it is not obvious. The floor only binds when the fallback is dry, which
-    /// leaves the promoted source at zero tokens. The only way back onto the fallback is to be
-    /// swept, and [`BudgetState::sweep_replenished`] drops an entry only once it is back at
-    /// **full** — a whole burst of refill away. So consecutive floor grants to one source are
-    /// separated by a full renewal window, over which the `rate × T` term already grants it `B`.
-    /// The exception cannot be cycled faster than the allowance it is an exception to.
-    /// Pinned by `a_floor_grant_leaves_the_source_unsweepable_until_it_refills`.
+    /// That `+1` does not accumulate over repeated promotions, and the mechanism is worth stating
+    /// because elapsed time alone is not the whole of it. The floor only binds when the fallback is
+    /// dry, which leaves the promoted source at zero. The only way back onto the fallback is to be
+    /// swept, [`BudgetState::sweep_replenished`] drops an entry only once it is back at **full**,
+    /// and the sweep *drops* it — so the source forfeits the entire burst it just spent a refill
+    /// period accumulating, and returns holding the floor.
+    ///
+    /// A lap therefore trades `B` earned tokens for `1`. Repetition destroys allowance rather than
+    /// accruing it, which is why the exception stays a single token however many times a source
+    /// goes around. Pinned from both ends:
+    /// `a_floor_grant_leaves_the_source_unsweepable_until_it_refills` for a source that cannot
+    /// refill at all, and `cycling_promotions_over_a_dry_fallback_only_ever_gains_the_floor` for
+    /// one that can.
     ///
     /// The price is paid by a *newcomer* promoted while other untracked sources have drained the
     /// pool: it inherits their spending. Telling it apart from a source promoted out of its own
@@ -3221,6 +3226,123 @@ mod source_budget_tests {
                  fallback again; the floor would then be repeatable without refilling"
             );
         }
+    }
+
+    /// Keep the shared fallback empty, as busy neighbours would.
+    ///
+    /// The floor only binds against a dry fallback, so holding it dry is how a test reaches the
+    /// one path where cycling could pay.
+    fn hold_fallback_dry(budget: &SourcePreAuthBudget) {
+        let mut state = budget.state.lock().expect("test lock");
+        state.shared.tokens = 0.0;
+        // Consume the elapsed time as well. Zeroing the balance alone leaves the refill credit
+        // that `advance` just created still owed, and `promotion_bucket` calls `refill()` before
+        // reading the level — so the pool would be full again by the time it is inherited.
+        state.shared.last_refill = Instant::now();
+    }
+
+    /// Is this source currently holding a tracked entry?
+    fn tracked(budget: &SourcePreAuthBudget, k: SourceKey) -> bool {
+        budget
+            .state
+            .lock()
+            .expect("test lock")
+            .per_source
+            .contains_key(&k)
+    }
+
+    /// Put the table in the one state from which a promotion can repeat: the source tracked with a
+    /// **full** bucket, and every other slot held by an entry that can never be reclaimed.
+    ///
+    /// Full is the precondition for being swept, and being swept is the only route back onto the
+    /// fallback — so this is the top of the cycle an attacker would have to ride.
+    fn source_tracked_and_full(budget: &SourcePreAuthBudget, source: SourceKey, refill: f64) {
+        let mut state = budget.state.lock().expect("test lock");
+        state.per_source.clear();
+        state.per_source.insert(
+            source,
+            TokenBucket::new(PROMO_BURST as f64, refill, Duration::from_millis(100)),
+        );
+        for i in 0..(PROMO_CAP - 1) {
+            let mut filler = TokenBucket::new(PROMO_BURST as f64, 0.0, Duration::from_millis(100));
+            filler.tokens = PROMO_BURST as f64 - 1.0;
+            state
+                .per_source
+                .insert(key(&format!("203.0.113.{}:1000", 220 + i)), filler);
+        }
+        assert_eq!(
+            state.per_source.len(),
+            PROMO_CAP,
+            "table should be saturated"
+        );
+    }
+
+    /// Cycling promotions over a dry fallback gains the floor and forfeits a whole burst each lap.
+    ///
+    /// The refill-and-repromotion path, with a **real** refill rate — the test above pins the
+    /// degenerate case where a source can never refill at all, which is not the case worth arguing
+    /// about.
+    ///
+    /// What bounds it is not elapsed time alone. To be swept an entry must be at **full**, and the
+    /// sweep *drops* it, so the source forfeits the entire burst it spent a refill period
+    /// accumulating and comes back holding the floor. Each lap trades `B` earned tokens for `1`.
+    /// Cycling is not a way to accumulate an advantage; it destroys allowance the source already
+    /// had.
+    #[test]
+    fn cycling_promotions_over_a_dry_fallback_only_ever_gains_the_floor() {
+        const LAPS: usize = 3;
+        const REFILL: f64 = 1.0;
+        let budget = SourcePreAuthBudget::with_policy(
+            PROMO_BURST as f64,
+            REFILL,
+            Duration::from_millis(100),
+            PROMO_CAP,
+        );
+        let source = key("192.0.2.32:1000");
+
+        let mut gained = 0usize;
+        for lap in 1..=LAPS {
+            // Top of the cycle: the source holds a full bucket — B tokens it could spend now.
+            source_tracked_and_full(&budget, source, REFILL);
+
+            // An unrelated source misses against the saturated table. That is what runs the sweep,
+            // and the sweep drops the source's full entry: the forfeiture. The throttle has to be
+            // cleared first or the miss reclaims nothing and the lap measures nothing.
+            allow_next_sweep(&budget);
+            hold_fallback_dry(&budget);
+            let probe = key(&format!("198.51.100.{}:1000", 60 + lap));
+            let _ = budget.spend(probe);
+            assert!(
+                !tracked(&budget, source),
+                "lap {lap}: the sweep did not drop the source's full entry, so this lap never \
+                 forfeited anything and cannot measure the trade"
+            );
+
+            // Give it a slot back and let it be promoted over a fallback its neighbours keep dry.
+            free_one_slot(&budget, probe);
+            allow_next_sweep(&budget);
+            hold_fallback_dry(&budget);
+
+            let granted = drain(&budget, source);
+            assert_eq!(
+                granted, PROMOTION_LIVENESS_FLOOR,
+                "lap {lap}: promotion over a dry fallback granted {granted}, not the floor — a \
+                 source riding this cycle would accumulate more than one token per lap"
+            );
+            gained += granted;
+        }
+
+        let forfeited = LAPS * PROMO_BURST;
+        assert_eq!(
+            gained,
+            LAPS * PROMOTION_LIVENESS_FLOOR,
+            "riding {LAPS} promotion cycles gained {gained} tokens"
+        );
+        assert!(
+            gained < forfeited,
+            "cycling gained {gained} against {forfeited} forfeited — a lap must be a net loss, or \
+             repetition becomes an attack rather than a waste"
+        );
     }
 
     /// One source draining the fallback does not hand its neighbour a fresh burst either.

--- a/icn/crates/icn-net/src/rate_limit.rs
+++ b/icn/crates/icn-net/src/rate_limit.rs
@@ -724,10 +724,16 @@ impl SourcePreAuthBudget {
     ///
     /// What remains is [`PROMOTION_LIVENESS_FLOOR`] — one token, so that a promoted source can
     /// always send the Hello that authenticates it out of this phase. The bound is therefore
-    /// `B + rate × T + 1` rather than `B + rate × T`, and the extra token is not repeatable at
-    /// will: a second promotion requires the source to be swept first, and a sweep only drops a
-    /// bucket that is back to **full** — by which point the allowance was earned rather than
-    /// minted.
+    /// `B + rate × T + 1` rather than `B + rate × T`.
+    ///
+    /// That `+1` is bounded *per window*, not merely per promotion, and the mechanism is worth
+    /// stating because it is not obvious. The floor only binds when the fallback is dry, which
+    /// leaves the promoted source at zero tokens. The only way back onto the fallback is to be
+    /// swept, and [`BudgetState::sweep_replenished`] drops an entry only once it is back at
+    /// **full** — a whole burst of refill away. So consecutive floor grants to one source are
+    /// separated by a full renewal window, over which the `rate × T` term already grants it `B`.
+    /// The exception cannot be cycled faster than the allowance it is an exception to.
+    /// Pinned by `a_floor_grant_leaves_the_source_unsweepable_until_it_refills`.
     ///
     /// The price is paid by a *newcomer* promoted while other untracked sources have drained the
     /// pool: it inherits their spending. Telling it apart from a source promoted out of its own
@@ -3140,13 +3146,14 @@ mod source_budget_tests {
         }
     }
 
-    /// A second promotion does not compound the exception.
+    /// Retrying while the promoted bucket is still spent grants nothing further.
     ///
-    /// To be promoted again a source must first be swept, and a sweep only drops a bucket that is
-    /// back to full — by which point the allowance was earned rather than minted. Pinned because
-    /// "once per promotion" is only a bound if promotions cannot be cycled.
+    /// Deliberately named for what it exercises. It does **not** cover the source refilling and
+    /// being re-promoted — that path is
+    /// [`a_floor_grant_leaves_the_source_unsweepable_until_it_refills`], which is what actually
+    /// bounds the exception in time.
     #[test]
-    fn repeated_promotions_do_not_compound() {
+    fn a_retry_while_spent_grants_nothing_further() {
         let budget = frozen_table(PROMO_BURST as f64, PROMO_CAP);
         fill_unreclaimable(&budget, PROMO_CAP);
         let source = key("192.0.2.12:1000");
@@ -3169,6 +3176,51 @@ mod source_budget_tests {
              {from_fallback} on the fallback, {first_promotion} on promotion, {second_round} on a \
              second attempt. The exception must not be repeatable."
         );
+    }
+
+    /// A floor grant leaves the source empty, and an empty source cannot be promoted again.
+    ///
+    /// This is what bounds the exception *in time*, and it is the question "is the floor really
+    /// one-time?" answered directly. The only route back onto the fallback is a sweep, and
+    /// [`BudgetState::sweep_replenished`] drops an entry only when it is back at **full**. A source
+    /// that has just taken the floor sits at zero, so the next floor grant is a whole refill of the
+    /// burst away — during which the `rate × T` term of the bound grants it `B`, dwarfing the one
+    /// token by the size of the burst.
+    ///
+    /// The table here never refills, which makes the pinning absolute and the assertion exact: no
+    /// number of sweeps can return this source to the fallback.
+    #[test]
+    fn a_floor_grant_leaves_the_source_unsweepable_until_it_refills() {
+        let budget = frozen_table(PROMO_BURST as f64, PROMO_CAP);
+        fill_unreclaimable(&budget, PROMO_CAP);
+        let source = key("192.0.2.31:1000");
+
+        assert_eq!(
+            drain(&budget, source),
+            PROMO_BURST,
+            "the fallback did not fund the source, so no floor grant follows"
+        );
+        free_one_slot(&budget, source);
+        allow_next_sweep(&budget);
+        assert_eq!(
+            drain(&budget, source),
+            PROMOTION_LIVENESS_FLOOR,
+            "the promotion did not go through the floor, so this run does not test repeating it"
+        );
+
+        // The source is now tracked and empty. Free a slot and sweep repeatedly: none of it can
+        // reclaim *this* entry, so the source can never draw on the fallback again — and so can
+        // never be handed the floor again — until it has refilled to full.
+        for round in 1..=4 {
+            free_one_slot(&budget, source);
+            allow_next_sweep(&budget);
+            assert_eq!(
+                budget.spend(source),
+                Err(SourceRefusal::PerSource),
+                "on sweep round {round} an empty promoted source left its entry and reached the \
+                 fallback again; the floor would then be repeatable without refilling"
+            );
+        }
     }
 
     /// One source draining the fallback does not hand its neighbour a fresh burst either.


### PR DESCRIPTION
## Summary

`SourcePreAuthBudget` promotes an untracked source into the table by inserting a **full** bucket. A source that had been spending from the shared fallback therefore had that spending forgotten, and across the untracked → tracked transition its burst term could reach `2B` where the documented bound is `B`.

Promotion now inherits the fallback's current level instead of minting a fresh burst.

## The security property, and exactly which transition broke it

**Guaranteed today (and still):** over any window *T*, one source's anonymous decodes are at most `PREAUTH_SOURCE_BURST + rate × T`. Aggregate across the node: `(max_sources × (B + rate×T)) + (B + rate×T)` — the trailing term is the single shared fallback.

`spend` has three exits: the source's own tracked bucket; the shared fallback when the table is saturated; and the insert path when the table has room. **Only the second is shared**, and the defect is the second → third transition.

The violated term is the **burst** (instantaneous), not the windowed total. Draining the fallback and *waiting* for it to refill before promoting never broke the bound — the wait is paid for by `rate × T`. The break is drain-then-immediately-promote: `B` from the fallback plus a fresh `B`, at once.

- **Maximum extra:** `+B` (160 at shipped constants; 2B = 320).
- **Compounding:** no. A second promotion requires the source to be swept first, and `sweep_replenished` only drops buckets that are back to **full** — by which point the allowance was earned, not minted.
- **Deliberate churn:** not usefully. The bonus needs the table saturated (4096 distinct keys with allowances in flight) *and* the attacker's key untracked. Every promoted source draws the extra from **one** shared bucket, so all of them together gain at most its throughput — not `B` each. Filling the table costs 4096 keys and leaves each of the attacker's own sources with less than being tracked would give it.
- **NAT:** unaffected by the defect; the fallback was already shared.
- **Classification:** correctness of a claimed bound (`tier:1-correctness`), **not** an unbounded-resource vulnerability. The aggregate anti-gaming argument survives untouched. This PR does not claim otherwise.

## RED evidence

`promotion_out_of_the_fallback_does_not_mint_a_second_burst` builds the transition deterministically — a frozen table (`refill_rate = 0`), filled with entries one token short of full so nothing is reclaimable, forcing the source onto the fallback; then exactly one slot is freed and the sweep throttle cleared.

Because the refill rate is zero, the `rate × T` term is exactly zero and **every token above the burst was minted by the transition itself**. Before the fix:

```
one source spent 16 across an untracked -> tracked promotion: 8 from the shared fallback,
then 8 more from the bucket promotion handed it. Its burst is 8 and the refill rate here is
zero, so 8 of those tokens were minted by the transition.
```

## Chosen design

`BudgetState::promotion_bucket()` seeds an inserted bucket from the shared bucket's current level, floored at `PROMOTION_LIVENESS_FLOOR` (one token).

For a promoted source this is **exact**: the tokens it took from the fallback are precisely the ones missing from the level it inherits, so fallback + promotion grant one burst rather than two.

**The floor is not decorative.** A promotion seeded at zero has its *first* anonymous message refused — and that message is the Hello that authenticates the peer out of the anonymous phase entirely. Dropping it risks the connection sitting until `PREAUTH_AUTHENTICATION_DEADLINE` for a retry that may never come. One token preserves exactly what the burst docs already promise: "a peer needs one token to authenticate."

**New bound:** `B + rate × T + 1`, with the `+1` granted at most once per promotion and a repeat requiring a full refill first. That is a 160× reduction of the exception at shipped constants.

**Below saturation nothing changes.** The shared bucket is only ever spent from on the degraded path, so a table that has never run out of room has it at capacity and every insert still gets a full bucket — byte-identical behaviour.

### The honest cost

A newcomer promoted while *others* have drained the pool inherits their spending. It is bounded (≤ one burst of deficit), self-healing at the ordinary refill rate, and never costs the first message. Distinguishing that newcomer from a source promoted out of its own debt needs per-source accounting for sources the table has no room to track — the exact state the fallback exists to avoid — so the cost is stated and pinned by a test rather than removed.

## Rejected alternatives

| Design | Why not |
|---|---|
| Carry per-source debt for untracked sources | Unbounded map — the state the fallback exists to avoid. Explicitly out of bounds. |
| Seed from the fallback with **no** floor | Exact, but drops a legitimate peer's first Hello; the connection can then sit until the 30 s deadline. |
| Refuse promotion until the fallback refills | An attacker holding the fallback dry pins every honest newcomer in the degraded pool **indefinitely** — worse than the defect. |
| Bounded set of recent fallback users | Exact *and* fair, but evadable by cycling keys through the set, and reintroduces the cardinality problem in miniature. |
| Debit the fallback by `B` on promotion | Does not fix the per-source burst at all, and makes neighbours pay for the promotion. |

## Bounded-memory argument

Zero new state. No side table, no debt map, no new field on `BudgetState`, no allocation on the miss path. `promotion_bucket` reads one `f64` off a bucket that already exists. Memory remains `max_sources` entries plus one shared bucket, exactly as before.

## Observability

None added, deliberately. The saturated-table condition is already visible via `icn_network_preauth_source_budget_degraded_total` and the `icn_network_preauth_source_budget_tracked` gauge, and `bound="shared_fallback"` from #2576 still attributes fallback refusals. A "promotion was seeded low" counter would not tell an operator anything those three do not, and the label set stays closed and static.

## Tests

All deterministic — frozen buckets, zero wall-clock dependence.

- **`promotion_out_of_the_fallback_does_not_mint_a_second_burst`** — the invariant.
- **`a_promotion_over_an_unspent_fallback_still_grants_the_whole_burst`** — the control that forbids "seed everything at the floor".
- **`the_fallback_and_the_promotion_together_grant_one_burst`** — walks `taken ∈ {0, 1, B/2, B}`; the sum is exactly one burst until the fallback is empty, where the floor is the single exception.
- **`repeated_promotions_do_not_compound`** — cycling sweeps cannot repeat the bonus.
- **`a_neighbour_promoted_after_the_fallback_is_drained_inherits_the_empty_pool`** — the NAT-shaped cost, asserted rather than buried, and it also pins that the neighbour meets `SourceRefusal::SharedFallback` (no #2576/#2577 regression).

One test-design note worth recording: `free_one_slot` originally picked any tracked entry, including the source under test, which handed that source a full bucket and modelled an attacker who can refill on demand. `repeated_promotions_do_not_compound` failed on exactly that and the helper now excludes the source under test.

## Review round 1 — Codex P2 on repeating the floor grant, fixed in `7573b0e9`

The **test** criticism was right: `repeated_promotions_do_not_compound` retried while the promoted
bucket was still spent, so it never exercised refill-and-re-promotion. Renamed
`a_retry_while_spent_grants_nothing_further`, which is what it covers.

The **bound** holds, and the mechanism is now stated instead of assumed. The floor only binds when
the fallback is dry, so a promotion that takes it ends at **zero** tokens. The only route back onto
the fallback is a sweep, and `sweep_replenished` retains on `!is_replenished()` — it drops an entry
only once it is back at **full**. Consecutive floor grants to one source are therefore separated by
a whole burst of refill, over which `rate × T` has already granted it `B` (160 against the floor's
1). The exception cannot be cycled faster than the allowance it is an exception to.

`a_floor_grant_leaves_the_source_unsweepable_until_it_refills` pins it on a zero-refill table, so
the pinning is absolute: after the floor grant, four rounds of freeing a slot and sweeping leave
the source tracked and empty, refused as `SourceRefusal::PerSource`.

Per-source accounting of floor grants was considered and rejected for the same reason as carrying
debt: it needs memory for sources the table has no room to track.

## Review round 2 — Codex again on repetition, fixed in `f2984c3b`

Right about the evidence: round 1's test used a zero refill rate, so it proved the pinning only for
a source that can never refill — not the refill-and-repromotion path. Building the test asked for
produced a better argument than the one given.

**The bound holds by forfeiture, not by elapsed time.** To be swept an entry must be at FULL, and
`sweep_replenished` *drops* it (`retain(|_, b| !b.is_replenished())`). Riding the cycle therefore
means refilling an entire burst and having it thrown away, to return holding one token. **Each lap
trades `B` earned tokens for `1`** — repetition destroys allowance rather than accumulating it.

`cycling_promotions_over_a_dry_fallback_only_ever_gains_the_floor` drives three laps at a real
refill rate and asserts both halves: every promotion grants exactly the floor, and total gained
stays far below total forfeited.

Getting a source around that cycle once required four preconditions — the slot-freeing helper must
not gift the source a full bucket; holding the fallback dry must consume its pending refill credit
(`promotion_bucket` refills before reading the level); a tracked source with tokens never reaches
the sweep, so a third party must miss; and the sweep throttle must be cleared each lap. Those are
the preconditions an attacker would have to arrange per lap, to be paid one token for a forfeited
burst.

## Adjudicated contract — this PR relaxes one stated #2562 constraint

#2562's body requires: *"Must not make an honest, newly-arrived source pay for another source's
spending."* **This design does not satisfy that**, and closes the issue anyway. The disagreement is
recorded in durable history at
https://github.com/InterCooperative-Network/icn/issues/2562#issuecomment-5275646824 rather than
erased by the merge.

Short form: at the insert path a promoted spender and a genuine newcomer are the *same
observation* (`key ∉ per_source`), because nothing recorded that the first had been spending.
Charging the spender (D) and sparing the newcomer (F) therefore require distinguishing two
indistinguishable states — which needs per-key memory for keys the table has no room to track, the
exact state the fallback exists to avoid. **D and F are irreducibly in tension under bounded
state.**

A sharded fallback (`N` buckets of capacity `B/N`, inheriting the source's own shard deficit) was
the strongest candidate for restoring F and was rejected: it only *attenuates* F — `SourceKey`
derives from the remote address, so an attacker holding a range can grind into a victim's shard —
while cutting what a lone untracked source may draw from `B` to `B/N` and forcing #2549's aggregate
argument to be re-derived.

**Guarantee that results:** properties A (bounded memory), B (no untracked-source history), C (Hello
liveness), D (per-source burst across promotion), E (no indefinite pinning) hold. **F is relaxed**,
with the residual bounded as: a newly promoted source inherits at most the fallback's *current
deficit*; that deficit is bounded by one burst (160); it self-heals at the ordinary rate (5.33
tok/s, full within the 30 s window); the first Hello is preserved unconditionally by the floor; and
no new attacker-controlled state is introduced. Below saturation, behaviour is byte-identical.

## Invariants

- [x] No panics introduced in protocol paths — no `unwrap`/`expect` added outside tests
- [x] Determinism preserved
- [x] Canonical encodings unchanged — `protocol.rs` untouched
- [x] Trust gates not weakened — burst, refill rate, `SourceKey` normalization, the absence of an authentication refund, and the order the two buckets are consulted in are all unchanged; this only changes the level an inserted bucket starts at
- [x] Kernel/app boundaries respected — `check-meaning-firewall.sh` PASS

## Verification

```
cargo fmt --all --check                                          EXIT=0
cargo clippy -p icn-net --all-targets -- -D warnings             EXIT=0
cargo clippy --workspace --all-targets -- -D warnings            EXIT=0
cargo test -p icn-net --test preauth_source_work_budget                6 passed
cargo test -p icn-net --test preauth_work_before_the_gate              1 passed
cargo test -p icn-net --test preauth_declared_length_allocation        2 passed
cargo test -p icn-net --test authenticated_rate_limit_identity         9 passed
cargo test -p icn-net --no-fail-fast    513 passed, 0 failed, 23 ignored (24 binaries)

scripts/check-meaning-firewall.sh                                EXIT=0
.github/scripts/compliance_linter.py                             EXIT=0
.github/scripts/readiness_overclaim_linter.py                    EXIT=0
ops/scripts/drift-check.sh                                       PASS
```

The non-required `Security Audit` job fails on `main` itself (`57879743`) on RUSTSEC-2026-0253,
unrelated to this change and untouched here.

Closes #2562
Refs #2549, #2557, #2547, #2558, #2576
