### PR TITLE
test(core): pin the RPC auth composition contract (#2544)

### DIFF
--- a/icn/crates/icn-core/tests/rpc_auth_composition_wiring.rs
+++ b/icn/crates/icn-core/tests/rpc_auth_composition_wiring.rs
@@ -23,9 +23,27 @@
 //! because no test observes what the *canonical config path* actually installs.
 //!
 //! So this drives the real `RpcConfig::from_daemon_config` — the function the
-//! daemon itself calls — from an operator-facing `Config`, builds the server on the
-//! same branch `init_rpc` takes, and asserts on the capability the server ended up
-//! holding. It does not reimplement the decision; it reads the one production makes.
+//! daemon itself calls, at `lifecycle.rs:1150` — from an operator-facing `Config`,
+//! builds the server on the same branch `spawn_rpc_server` takes, and asserts on the
+//! capability the server ended up holding.
+//!
+//! **What is and is not pinned here.** Be precise about this, because the difference
+//! is the whole point of #2500:
+//!
+//!   * **Pinned for real:** `RpcConfig::from_daemon_config`. It is invoked directly,
+//!     not imitated, so a change that drops the operator's `jwt_secret` or moves the
+//!     bind off loopback fails these tests.
+//!   * **Mirrored, NOT pinned:** the server-construction branch. `server_for` below
+//!     restates the `match` from `spawn_rpc_server` rather than calling it, because
+//!     `spawn_rpc_server` needs a full `RpcDeps` and a `JoinSet`. Changing the
+//!     authenticated arm of `spawn_rpc_server` to `RpcServer::new` would leave
+//!     production RPC unauthenticated and **these tests would still pass**.
+//!   * **Not covered at all:** the `set_auth_manager_with_store` upgrade that
+//!     `spawn_rpc_server` applies after construction to add token revocation (#2437).
+//!
+//! Closing the second and third bullets means driving `spawn_rpc_server` itself, which
+//! is a larger harness than this contract; it is deliberately left as follow-up rather
+//! than claimed here.
 //!
 //! The load-bearing assertion is the last one. Today the unauthenticated branch is
 //! reachable — `gateway.enabled` defaults to `false`, which yields
@@ -41,9 +59,14 @@ use icn_core::supervisor::init_rpc::RpcConfig;
 use icn_identity::IdentityBundle;
 use icn_rpc::RpcServer;
 
-/// Build a server exactly the way `init_rpc::init_rpc_services` does: branch on
-/// whether the composition path produced a JWT secret. Kept in one place so the
-/// tests below observe the real decision rather than restating it.
+/// Build a server the way `init_rpc::spawn_rpc_server` does at its construction site:
+/// branch on whether the composition path produced a JWT secret.
+///
+/// This branch is a **mirror** of `spawn_rpc_server`, not a call into it — that
+/// function requires a full `RpcDeps` and a `JoinSet`. So this helper does not guard
+/// `spawn_rpc_server`'s own arm; see the module header for exactly what that leaves
+/// uncovered. What it does do is keep the branch in one place, so every test below
+/// observes the same `RpcConfig` the production decision produced.
 fn server_for(config: &Config) -> (RpcConfig, RpcServer) {
     let rpc_config = RpcConfig::from_daemon_config(config);
     let signer = IdentityBundle::generate()
@@ -81,8 +104,12 @@ fn operator_enabling_the_gateway_installs_rpc_auth() {
 
 #[test]
 fn an_empty_secret_does_not_count_as_configured_auth() {
-    // An operator who enables the gateway but leaves the secret blank must not get a
-    // server that silently authenticates with an empty key.
+    // Defensive, not an operator scenario: `Config::validate()` (config/mod.rs:219)
+    // already rejects `gateway.enabled = true` with an empty `jwt_secret` as a fatal
+    // error, so a validated config cannot reach this state. This pins the behaviour
+    // for the paths that skip validation — programmatic `Config` construction and
+    // tests — so that if validation is ever relaxed or bypassed, the fallback is a
+    // server with no auth manager rather than one keyed on an empty secret.
     let mut config = Config::default();
     config.gateway.enabled = true;
     config.gateway.jwt_secret = String::new();

--- a/icn/crates/icn-core/tests/rpc_auth_composition_wiring.rs
+++ b/icn/crates/icn-core/tests/rpc_auth_composition_wiring.rs
@@ -1,0 +1,152 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! Whether the assembled daemon *has* RPC authentication is a property of the
+//! composition path, not of `icn-rpc`.
+//!
+//! `RpcAuthManager` works. It is implemented and tested. But `RpcServer` holds it
+//! as `Option<Arc<RpcAuthManager>>`, and `handle_rpc` opens with
+//! `if let Some(auth_manager) = &state.auth_manager` — so a server that was never
+//! given one does not reject requests, it simply **never checks any**. The absent
+//! case is silent by construction: no error, no warning at the call site, just a
+//! server that authenticates nothing.
+//!
+//! This is the recurring shape #2500 names, and `init_rpc.rs` already records two
+//! instances of it in its own comments:
+//!
+//!   * #2497 — `RpcServer::set_own_keypair` had no caller anywhere in the workspace,
+//!     so it stayed `None` for the daemon's whole lifetime and `handler/federation.rs`
+//!     emitted vouches with no signature *while still reporting success*.
+//!   * #2437 — `new_with_auth` alone left `revocation_list: None`, so `auth.revoke`
+//!     answered "Token revocation not available" even though the full
+//!     `TokenRevocationList` machinery existed and passed its own tests.
+//!
+//! Both were fixed at the composition root. Nothing stops either from regressing,
+//! because no test observes what the *canonical config path* actually installs.
+//!
+//! So this drives the real `RpcConfig::from_daemon_config` — the function the
+//! daemon itself calls — from an operator-facing `Config`, builds the server on the
+//! same branch `init_rpc` takes, and asserts on the capability the server ended up
+//! holding. It does not reimplement the decision; it reads the one production makes.
+//!
+//! The load-bearing assertion is the last one. Today the unauthenticated branch is
+//! reachable — `gateway.enabled` defaults to `false`, which yields
+//! `jwt_secret: None` and therefore no auth manager. That is safe *only* because
+//! `from_daemon_config` hardcodes the bind to IPv6 loopback. Those two facts live
+//! in different concerns and nothing currently ties them together: making the RPC
+//! address configurable would turn a documented-safe default into a remote
+//! unauthenticated control channel, and every existing test would still pass.
+//! This file is where that change is supposed to fail.
+
+use icn_core::config::Config;
+use icn_core::supervisor::init_rpc::RpcConfig;
+use icn_identity::IdentityBundle;
+use icn_rpc::RpcServer;
+
+/// Build a server exactly the way `init_rpc::init_rpc_services` does: branch on
+/// whether the composition path produced a JWT secret. Kept in one place so the
+/// tests below observe the real decision rather than restating it.
+fn server_for(config: &Config) -> (RpcConfig, RpcServer) {
+    let rpc_config = RpcConfig::from_daemon_config(config);
+    let signer = IdentityBundle::generate()
+        .expect("generate identity")
+        .signing_capability()
+        .expect("signing capability");
+    let server = match rpc_config.jwt_secret.as_ref() {
+        Some(secret) => RpcServer::new_with_auth(rpc_config.addr, secret.clone(), signer),
+        None => RpcServer::new(rpc_config.addr, signer),
+    };
+    (rpc_config, server)
+}
+
+fn enabled_gateway_config() -> Config {
+    let mut config = Config::default();
+    config.gateway.enabled = true;
+    config.gateway.jwt_secret = "composition-contract-secret-at-least-32-bytes".to_string();
+    config
+}
+
+#[test]
+fn operator_enabling_the_gateway_installs_rpc_auth() {
+    let (rpc_config, server) = server_for(&enabled_gateway_config());
+
+    assert!(
+        rpc_config.jwt_secret.is_some(),
+        "composition path dropped the operator's jwt_secret before the server was built"
+    );
+    assert!(
+        server.auth_manager().is_some(),
+        "gateway is enabled with a secret, but the assembled RPC server holds no auth \
+         manager — every request would skip the auth check entirely"
+    );
+}
+
+#[test]
+fn an_empty_secret_does_not_count_as_configured_auth() {
+    // An operator who enables the gateway but leaves the secret blank must not get a
+    // server that silently authenticates with an empty key.
+    let mut config = Config::default();
+    config.gateway.enabled = true;
+    config.gateway.jwt_secret = String::new();
+
+    let (rpc_config, server) = server_for(&config);
+
+    assert!(rpc_config.jwt_secret.is_none());
+    assert!(
+        server.auth_manager().is_none(),
+        "an empty jwt_secret produced an auth manager keyed on nothing"
+    );
+}
+
+#[test]
+fn the_default_config_yields_an_rpc_server_that_checks_no_credentials() {
+    // Not an aspiration — the current, intended behaviour, pinned so that a change
+    // to it is deliberate. `gateway.enabled` defaults to false, so the default
+    // daemon serves RPC with no auth manager at all.
+    let (rpc_config, server) = server_for(&Config::default());
+
+    assert!(
+        rpc_config.jwt_secret.is_none(),
+        "default config unexpectedly produced a jwt_secret"
+    );
+    assert!(
+        server.auth_manager().is_none(),
+        "default config unexpectedly installed an auth manager"
+    );
+}
+
+#[test]
+fn rpc_never_binds_off_loopback_whether_or_not_auth_is_installed() {
+    // THE CONTRACT. An RPC server with no auth manager checks no credentials, so
+    // the only thing standing between the default daemon and an unauthenticated
+    // control channel is the bind address. Assert it for both branches — the
+    // unauthenticated one is where it actually matters.
+    for (label, config) in [
+        ("default (no auth installed)", Config::default()),
+        ("gateway enabled (auth installed)", enabled_gateway_config()),
+    ] {
+        let (rpc_config, server) = server_for(&config);
+        let authed = server.auth_manager().is_some();
+
+        assert!(
+            rpc_config.addr.ip().is_loopback(),
+            "RPC bound to {} in the {label} case (auth installed: {authed}). An RPC server \
+             reachable off-loopback without an auth manager is an unauthenticated control \
+             channel: handle_rpc skips its auth block entirely when auth_manager is None.",
+            rpc_config.addr.ip()
+        );
+    }
+}
+
+#[test]
+fn the_unauthenticated_branch_is_reachable_from_operator_config() {
+    // Control for the assertion above: prove the no-auth branch is not dead code
+    // that the loopback check trivially passes over. If a future change makes auth
+    // mandatory, this test fails and the loopback contract can be revisited
+    // deliberately rather than quietly relied upon.
+    let (_, server) = server_for(&Config::default());
+    assert!(
+        server.auth_manager().is_none(),
+        "the unauthenticated branch is no longer reachable — if RPC auth is now \
+         mandatory, rpc_never_binds_off_loopback_whether_or_not_auth_is_installed is \
+         no longer load-bearing and this pair should be revisited together"
+    );
+}


### PR DESCRIPTION
## What

One executable composition contract, following the existing `*_wiring.rs` pattern (`bootstrap_did_expectation_wiring.rs`, `bootstrap_handles_wiring.rs`, `coop_entity_map_wiring.rs`). No new framework, no harness, no cluster — 5 tests, ~0.00s.

## Why

Whether the assembled daemon **has** RPC authentication is a property of the composition path, not of `icn-rpc`. `RpcServer` holds it as `Option<Arc<RpcAuthManager>>` and `handle_rpc` opens with `if let Some(auth_manager) = &state.auth_manager` — a server that was never given one does not reject requests, it **never checks any**. The absent case is silent by construction: no error, no warning at the call site.

`init_rpc.rs` already documents two instances of exactly this shape, in its own comments:

- **#2497** — `RpcServer::set_own_keypair` "had no caller anywhere in the workspace — so it stayed `None` for the daemon's whole lifetime", and `handler/federation.rs` "emitted vouches with no signature **while still reporting success**."
- **#2437** — `new_with_auth` alone left `revocation_list: None`, so `auth.revoke` answered "Token revocation not available" at runtime "even though the full `TokenRevocationList` machinery was implemented and tested — **the library had the capability, the daemon did not install it**."

Both were fixed at the composition root using two of the three strategies #2500 proposes (constructor-required dependency; composition-root installation, fail-closed). **Nothing stops either from regressing**, because no test observes what the canonical config path actually installs. That gap is what this fills.

## How

```
operator Config (gateway.enabled, gateway.jwt_secret)
      ↓
RpcConfig::from_daemon_config          ← the real function the daemon calls
      ↓                                     (invoked directly — lifecycle.rs:1150)
RpcServer built on the same branch spawn_rpc_server takes
      ↓                                     (MIRRORED, not called — see scope below)
observable: server.auth_manager().is_some()
```

### Scope — what this pins, and what it does not

Review (thanks @chatgpt-codex-connector, @copilot-pull-request-reviewer) correctly caught that
an earlier version of this description overclaimed. It said *"It does not reimplement the
decision — it reads the one production makes."* That is true of the config decision and
false of the server construction. The honest split:

| Layer | Status |
|---|---|
| `RpcConfig::from_daemon_config` | **Pinned for real.** Invoked directly, not imitated. Dropping the operator's `jwt_secret`, or moving the bind off loopback, fails these tests. |
| `spawn_rpc_server`'s construction branch | **Mirrored, NOT pinned.** `server_for` restates the `match` because `spawn_rpc_server` needs a full `RpcDeps` + `JoinSet`. Changing its authenticated arm to `RpcServer::new` would leave production RPC unauthenticated and **these tests would still pass**. |
| `set_auth_manager_with_store` revocation upgrade (#2437) | **Not covered.** |

Closing rows 2 and 3 means driving `spawn_rpc_server` itself — a larger harness than this
contract. Left as explicit follow-up rather than claimed here. The module header now records
the same split in-tree, so the limitation travels with the code.

## The load-bearing assertion

`rpc_never_binds_off_loopback_whether_or_not_auth_is_installed`.

The unauthenticated branch is **reachable today**: `gateway.enabled` defaults to `false` → `jwt_secret: None` → no auth manager. That is safe **only** because `from_daemon_config` hardcodes the bind to IPv6 loopback (`[::1]:{rpc_port}`, not configurable).

Those two facts live in different concerns and nothing tied them together. Making the RPC address configurable would turn a documented-safe default into a **remote unauthenticated control channel**, and every existing test would still pass. This file is where that change is supposed to fail.

`the_unauthenticated_branch_is_reachable_from_operator_config` is its paired control: if RPC auth ever becomes mandatory, it fails, signalling that the loopback contract is no longer load-bearing and the pair should be revisited together — rather than the loopback assertion quietly passing over dead code.

## Mutation-verified (not vacuous green)

| mutation to `init_rpc.rs` | result |
|---|---|
| bind `[::1]` → `0.0.0.0` | **`rpc_never_binds_off_loopback…` FAILS** — *"RPC bound to 0.0.0.0 in the default (no auth installed) case (auth installed: false)"* |
| `if config.gateway.enabled && !…is_empty()` → `if false` | **`operator_enabling_the_gateway_installs_rpc_auth` FAILS** |
| unmutated | 5 passed |

## Risk

Test-only. No production code touched. `cargo fmt --all --check` ✅ · `cargo clippy -p icn-core --tests -D warnings` ✅.

## Note (not acted on)

`RpcServer::set_auth_manager` (`icn-rpc/src/server.rs:186`) has **zero callers** anywhere — production or test. It is vestigial surface from before #2437, and calling it instead of `set_auth_manager_with_store` silently loses token revocation. Flagging for the #2500 audit; deliberately out of scope here.

Refs #2544, #2500.

