### PR TITLE
test(runtime): pin the network PolicyOracle composition contract to the real limiter (#2544)

### DIFF
--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -2134,36 +2134,70 @@ mod core_oracle_registration_tests {
             .expect("test DID must parse")
     }
 
+    /// A `[rate_limiting]` section whose `isolated` tier refills at **zero** — burst 2,
+    /// rate 0 — so the admit count below cannot drift with wall-clock time.
+    ///
+    /// `refill_rate_per_interval` is `rate * interval` with no floor: #2503 deleted the
+    /// `.max(1.0)` that used to turn a configured 0 into 10 msg/s. So rate 0 means the
+    /// bucket never refills, and "five immediate calls" becomes "five calls, whenever
+    /// they happen" — a descheduled test process on a loaded runner can no longer earn
+    /// an extra token and flake the assertion.
+    ///
+    /// Separate from `tiered_rate_limiting()` on purpose: that fixture is shared with
+    /// the constraint-value tests above and changing it would alter what they assert.
+    /// The other three tiers are kept, so `ceiling()` is unchanged and nothing clamps.
+    fn burst_only_rate_limiting() -> crate::config::RateLimitingConfig {
+        let tier = |rate, burst| crate::config::TrustClassRateLimitConfig {
+            max_messages_per_second: rate,
+            burst_capacity: burst,
+        };
+        crate::config::RateLimitingConfig {
+            isolated: tier(0, 2),
+            known: tier(30, 9),
+            partner: tier(70, 13),
+            federated: tier(200, 50),
+            ..Default::default()
+        }
+    }
+
     /// Positive control: the operator's configured burst reaches the real limiter.
     ///
-    /// `tiered_rate_limiting()` sets `isolated` to a burst of 2, and `FakeTrust` scores
-    /// the peer 0.0 — the isolated class. The whole chain runs for real: config ->
-    /// `register_core_oracles` -> `OracleRegistry` -> `RateLimiter::check_rate_limit`.
+    /// `burst_only_rate_limiting()` sets `isolated` to burst 2 / rate 0, and `FakeTrust`
+    /// scores the peer 0.0 — the isolated class. The whole chain runs for real: config
+    /// -> `register_core_oracles` -> `OracleRegistry` -> `RateLimiter::check_rate_limit`.
     ///
     /// The registry assertion is a precondition guard, not the property. The property
     /// is the admit count: if the limiter ever stops honouring `burst_size`, the
     /// constraint-value tests above still pass and only this one fails.
     #[tokio::test]
     async fn the_configured_burst_survives_into_the_real_limiter() {
+        let peer = limiter_peer();
         let registry = std::sync::Arc::new(OracleRegistry::new());
         register_core_oracles(
             &registry,
             Some(FakeTrust::arc(std::sync::Arc::new(UnlimitedOracle), 0.0)),
             None,
-            &tiered_rate_limiting(),
+            &burst_only_rate_limiting(),
         );
         registry.set_phase(BootstrapPhase::Running);
 
         // Precondition: the composition root really did put the isolated tier on `net`.
-        let limit = rate_limit_of(registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN)));
+        // Asked about the *same* principal the limiter will ask about, so the guard and
+        // the property cannot drift apart if tier selection ever becomes actor-dependent.
+        let probe = PolicyRequest::new(
+            peer.to_string(),
+            ActionKind::Custom("network_message".to_string()),
+            Domain::new(icn_net::NETWORK_DOMAIN),
+        );
+        let limit = rate_limit_of(registry.evaluate(&probe));
         assert_eq!(
-            limit.burst_size, 2,
+            (limit.burst_size, limit.messages_per_second),
+            (2, 0),
             "precondition: register_core_oracles must place the configured isolated \
-             burst on the network domain; got {limit:?}"
+             tier on the network domain; got {limit:?}"
         );
 
         let limiter = icn_net::RateLimiter::new_with_oracle(registry, limiter_fallback());
-        let peer = limiter_peer();
 
         let mut admitted = 0usize;
         for _ in 0..5 {
@@ -2174,9 +2208,10 @@ mod core_oracle_registration_tests {
 
         assert_eq!(
             admitted, 2,
-            "the operator configured an isolated burst of 2, so five immediate \
-             messages must admit exactly 2. A different count means the number the \
-             composition root registered is not the number the limiter enforces."
+            "the operator configured an isolated burst of 2 with no refill, so five \
+             calls must admit exactly 2 however long they take. A different count means \
+             the number the composition root registered is not the number the limiter \
+             enforces."
         );
     }
 
@@ -2189,7 +2224,9 @@ mod core_oracle_registration_tests {
     #[tokio::test]
     async fn without_the_network_registration_the_real_limiter_drops_everything() {
         let registry = std::sync::Arc::new(OracleRegistry::new());
-        register_core_oracles(&registry, None, None, &tiered_rate_limiting());
+        // Same config, same fallback, same peer as the positive control — the only
+        // difference is that no trust service means no `net` registration.
+        register_core_oracles(&registry, None, None, &burst_only_rate_limiting());
         registry.set_phase(BootstrapPhase::Running);
 
         let limiter = icn_net::RateLimiter::new_with_oracle(registry, limiter_fallback());

--- a/icn/crates/icn-core/src/supervisor/lifecycle.rs
+++ b/icn/crates/icn-core/src/supervisor/lifecycle.rs
@@ -2103,4 +2103,110 @@ mod core_oracle_registration_tests {
              fail closed; got {decision:?}"
         );
     }
+
+    // ---- Composition contract: config -> register_core_oracles -> real limiter ----
+    //
+    // Everything above stops at the `ConstraintSet` the registry hands back, and the
+    // integration suite in `tests/network_domain_oracle_registration.rs` starts from a
+    // hand-built registry — its helper says as much ("Mirrors what
+    // `register_core_oracles` produces"). Each half is real; the seam between them is
+    // not covered by either. A constraint the composition root emits correctly and the
+    // limiter then ignores would satisfy both suites and still be wrong on a live node.
+    //
+    // These two tests span that seam: one operator config, through the real
+    // `register_core_oracles`, into a real `icn_net::RateLimiter`, asserted on the only
+    // thing an operator can actually observe — how many messages get admitted.
+
+    fn limiter_fallback() -> icn_net::RateLimitConfig {
+        // Deliberately far above any configured tier, so anything observed being
+        // blocked was blocked by the oracle decision and not by the fallback bucket.
+        icn_net::RateLimitConfig {
+            max_messages_per_second: 1000,
+            burst_capacity: 1000,
+            ..icn_net::RateLimitConfig::default()
+        }
+    }
+
+    fn limiter_peer() -> icn_identity::Did {
+        // Fixed, valid DID: the trust path parses the actor, and an unparseable one
+        // would take a different branch than the one under test.
+        icn_identity::Did::from_str("did:icn:zAKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9")
+            .expect("test DID must parse")
+    }
+
+    /// Positive control: the operator's configured burst reaches the real limiter.
+    ///
+    /// `tiered_rate_limiting()` sets `isolated` to a burst of 2, and `FakeTrust` scores
+    /// the peer 0.0 — the isolated class. The whole chain runs for real: config ->
+    /// `register_core_oracles` -> `OracleRegistry` -> `RateLimiter::check_rate_limit`.
+    ///
+    /// The registry assertion is a precondition guard, not the property. The property
+    /// is the admit count: if the limiter ever stops honouring `burst_size`, the
+    /// constraint-value tests above still pass and only this one fails.
+    #[tokio::test]
+    async fn the_configured_burst_survives_into_the_real_limiter() {
+        let registry = std::sync::Arc::new(OracleRegistry::new());
+        register_core_oracles(
+            &registry,
+            Some(FakeTrust::arc(std::sync::Arc::new(UnlimitedOracle), 0.0)),
+            None,
+            &tiered_rate_limiting(),
+        );
+        registry.set_phase(BootstrapPhase::Running);
+
+        // Precondition: the composition root really did put the isolated tier on `net`.
+        let limit = rate_limit_of(registry.evaluate(&request_for(icn_net::NETWORK_DOMAIN)));
+        assert_eq!(
+            limit.burst_size, 2,
+            "precondition: register_core_oracles must place the configured isolated \
+             burst on the network domain; got {limit:?}"
+        );
+
+        let limiter = icn_net::RateLimiter::new_with_oracle(registry, limiter_fallback());
+        let peer = limiter_peer();
+
+        let mut admitted = 0usize;
+        for _ in 0..5 {
+            if limiter.check_rate_limit(&peer).await {
+                admitted += 1;
+            }
+        }
+
+        assert_eq!(
+            admitted, 2,
+            "the operator configured an isolated burst of 2, so five immediate \
+             messages must admit exactly 2. A different count means the number the \
+             composition root registered is not the number the limiter enforces."
+        );
+    }
+
+    /// Negative control: with no network oracle registered, the limiter admits nothing.
+    ///
+    /// This is #2488 as an operator would have experienced it — the daemon starts, the
+    /// registry is live, and every inbound message is dropped. It also proves the
+    /// positive control above is not passing on the generous fallback bucket: same
+    /// limiter, same fallback, same peer, only the registration differs.
+    #[tokio::test]
+    async fn without_the_network_registration_the_real_limiter_drops_everything() {
+        let registry = std::sync::Arc::new(OracleRegistry::new());
+        register_core_oracles(&registry, None, None, &tiered_rate_limiting());
+        registry.set_phase(BootstrapPhase::Running);
+
+        let limiter = icn_net::RateLimiter::new_with_oracle(registry, limiter_fallback());
+        let peer = limiter_peer();
+
+        let mut admitted = 0usize;
+        for _ in 0..5 {
+            if limiter.check_rate_limit(&peer).await {
+                admitted += 1;
+            }
+        }
+
+        assert_eq!(
+            admitted, 0,
+            "an unregistered network domain denies in the Running phase, so the \
+             limiter must admit nothing. A non-zero count means the fallback bucket \
+             is answering and the oracle decision is not reaching the limiter."
+        );
+    }
 }


### PR DESCRIPTION
## What

Two tests added to the existing `core_oracle_registration_tests` module in `icn-core/src/supervisor/lifecycle.rs`. No production code changed. No API widened.

They pin one chain end to end:

```
operator [rate_limiting] config
  → register_core_oracles(..)        ← the REAL canonical composition function
  → OracleRegistry                   ← the real registry, Running phase
  → icn_net::RateLimiter             ← the real subsystem
  → observed admit/drop count        ← the only thing an operator can see
```

- `the_configured_burst_survives_into_the_real_limiter` — positive control.
- `without_the_network_registration_the_real_limiter_drops_everything` — negative control.

## Why — the seam neither existing suite covers

Two suites already exist, and each covers exactly half of this chain:

| Suite | Runs the real `register_core_oracles`? | Drives a real `RateLimiter`? |
|---|---|---|
| `lifecycle.rs :: core_oracle_registration_tests` | **yes** | no — stops at reading `ConstraintSet` values |
| `tests/network_domain_oracle_registration.rs` | **no** — hand-builds the registry | **yes** |

The integration suite says so itself. Its helper is documented as:

> *"Mirrors what `register_core_oracles` produces after #2496"*

**Mirrors** — it constructs a `ConfiguredTierOracle` that imitates the composition root's output. Nothing joins the two halves, so the number the composition root registers and the number the limiter enforces are asserted in *different tests against different objects*. A change that makes the limiter ignore a constraint the registry emits correctly satisfies both suites and is still wrong on a live node.

This is the same shape as #2489 (staleness computed, discarded before the health decision) and #2470 (transport identity established, discarded before the authority decision): the correct value is produced and then dropped before the thing that consumes it. Here the risk is narrower — the value is produced and asserted, just never followed to its consumer.

## How

A dedicated `burst_only_rate_limiting()` sets `isolated` to **rate 0, burst 2** — deliberately unlike the trust oracle's hard-coded 5/20/100/unlimited ladder, so a leak of the wrong source is visible. `FakeTrust` scores the peer `0.0`, which `TrustClass::from_score` maps to `Isolated`.

Rate 0 makes the assertion **wall-clock independent**: `refill_rate_per_interval` is `rate * interval` with no floor since #2503 removed the `.max(1.0)` that used to turn a configured 0 into 10 msg/s, so the bucket never refills and a descheduled test process cannot earn an extra token. It is kept separate from the shared `tiered_rate_limiting()` fixture so the constraint-value tests above keep asserting what they always did.

The positive test asserts the registry carries the whole tier `(burst_size, messages_per_second) == (2, 0)` as a **precondition guard** — probed with the *same* peer DID the limiter is asked about, so guard and property cannot drift — then asserts the property: five calls through a real `RateLimiter` admit exactly 2, however long they take.

The negative control runs the same limiter, same config, same generous fallback, same peer, with only the registration removed (`trust_service = None` ⇒ no `net` oracle) and asserts 0 admitted. That is #2488 as an operator experienced it — daemon up, registry live, every inbound message dropped — and it also proves the positive control is not quietly passing on the fallback bucket.

## Mutation proof

Two mutations were applied and reverted, one at each end of the seam, and **both existing suites were run under each**:

**Mutation A** — the composition root stops registering the domain:
```rust
// icn-core/src/supervisor/lifecycle.rs:328
- oracle_registry.register(network_domain.clone(), network_oracle);
```

**Mutation B** — the limiter ignores the constraint the registry emitted:
```rust
// icn-net/src/rate_limit.rs:1117  (in rate_limit_from_constraints)
- burst_capacity: rate_limit.burst_size,
+ burst_capacity: fallback_config.burst_capacity,
```

| Mutation | Existing `core_oracle_registration_tests` | Existing `network_domain_oracle_registration.rs` | **New joined test** |
|---|---|---|---|
| **A** (root stops registering) | FAIL (4 tests) | **PASS — blind, 9/9 ok** | **FAIL** |
| **B** (limiter ignores the value) | **PASS — blind, 8/8 ok** | FAIL (3 tests) | **FAIL** |

Under **A** the integration suite is green because it hand-builds its registry and never consults the composition root. Under **B** the lifecycle tests are green because they read the `ConstraintSet` and never reach the limiter.

**Neither existing suite fails under both. The new test fails under both** — it is the only test that spans the seam. Under B its failure is exactly the defect in question:

```
assertion `left == right` failed: the operator configured an isolated burst of 2,
so five immediate messages must admit exactly 2. A different count means the
number the composition root registered is not the number the limiter enforces.
  left: 5
 right: 2
```

Both mutations were reverted; the tree is clean at the committed head and 10/10 pass.

## Risk

- **None to production.** Test-only change; `register_core_oracles` and every other production path are untouched.
- The tests live in the existing `#[cfg(test)]` module, so `register_core_oracles` stays private — no public API surface added to a kernel crate.
- Both new tests are `#[tokio::test]` because `RateLimiter::check_rate_limit` is async. They perform no sleeps and add ~0s to the suite.

## Test plan

- `cargo fmt --all --check` — clean.
- `cargo clippy -p icn-core --all-targets -- -D warnings` — clean.
- `cargo test -p icn-core --lib core_oracle_registration_tests` — 10/10 pass (8 pre-existing + 2 new).
- Mutation above verified to fail the new tests and pass without them.

## NOTE — adjacent, not acted on

`AppBuilder::with_oracle` (`icn-core/src/apps/runtime.rs:209`) has **zero call sites** on current main. The mechanism is complete — `builder.oracle` is consumed at `runtime.rs:344` with manifest-domain validation and registered into the `OracleRegistry` — but no production code ever calls it. It is a separate surface from `register_core_oracles`, which is the path `icnd` actually uses. Flagged, not changed.

Refs #2544 #2488 #2496


## Review round

Both findings were verified against source before acting, and both were real:

- **Two principals in one contract** (@copilot-pull-request-reviewer) — the guard probed the registry with a hardcoded DID while the limiter was asked about `limiter_peer()`. Now one `peer` throughout.
- **Wall-clock dependence** (@chatgpt-codex-connector) — at 10 msg/s a token refills every 100 ms, so a loaded runner could admit 3+ and flake `admitted == 2`. Fixed via the rate-0 tier above. Worth noting the fixture comment claiming `(rate * interval).max(1.0)` is **stale** — that floor was deleted by #2503, which is what makes the zero-refill route valid.

Re-verified after the rewrite that mutation B still kills only this test (`9 passed; 1 failed`).
