### PR TITLE
feat(governance): add the authenticated replication envelope primitive (#2469)

### DIFF
--- a/docs/design/authenticated-governance-replication.md
+++ b/docs/design/authenticated-governance-replication.md
@@ -1,17 +1,26 @@
 # Authenticated governance replication (#2469)
 
 **Status:** design + slice 1 (unwired primitive).
-**Derived against:** `origin/main` = `c378232132139235e2a8cc305792eaee2571267a`.
+**Derived against:** `origin/main` = `3d401dce0c65d70eea117335b48719baa2231e2e`.
 **Owns:** the durable replacement for the #2470 containment.
-**Refs:** #2469, #2441, #2470 (`bc291305`), #2471, #2480, #2510, #2520, #2535, #2544.
+**Refs:** #2469, #2441, #2470 (`bc291305`), #2471, #2480, #2510, #2520, #2535, #2544, #2583.
 
-Everything in §1 was re-derived from source at `c3782321`. Where an older campaign note
-disagrees, the source wins and the disagreement is called out.
+Everything in §1 was re-derived from source — originally at `c3782321`, re-verified at
+`3d401dce`. Where an older campaign note disagrees, the source wins and the disagreement is
+called out.
 
 **Revision 2** corrects three mechanisms from revision 1 that were unsafe under
 eventually-consistent delivery: the sequence gate, first-writer-wins collision
 arbitration, and whole-config authority binding. Revision 1's `prev` hash-chain field is
 also removed. See §10, §5.2, §5.3.
+
+**Revision 3** re-derives §1 against `3d401dce`, where **slice 2 has landed** as #2583:
+gossip now re-derives `entry.hash` from the payload before an unseen entry may claim a
+content-addressed slot. T3 is closed, and §5.6 step 6 became an upstream guarantee rather
+than work this design still has to schedule. **No architectural premise changed** — #2583
+authenticates payload↔digest only, and leaves authorship, authority and the #2470
+containment exactly as they were. Revision 3 also corrects a §7.0 mis-citation: the vote
+suspension gate was cited at the *proposer* gate's line.
 
 ---
 
@@ -24,8 +33,8 @@ also removed. See §10, §5.2, §5.3.
 | 1 | Operator issues a `GovernanceCommand` (RPC/HTTP) | `icn-rpc/src/handler/governance.rs`, `apps/governance/src/http/handlers.rs` |
 | 2 | `GovernanceActor` **persists to `GovernanceStateStore` first** | `apps/governance/src/actor.rs` command arms |
 | 3 | Actor builds a `GovernanceMessage`, serializes with `to_bytes()` = **`serde_json::to_vec`** | `icn-governance/src/message.rs:417` |
-| 4 | `gossip.publish(topic, data, author = own_did)`; ACL checked **for the local DID only**; `hash = Self::hash_data(&data)` | `icn-gossip/src/gossip.rs:911`, `:919` |
-| 5 | `store_entry(entry)` → fires notification callbacks (including governance's own loopback copy) | `icn-gossip/src/gossip.rs:968` |
+| 4 | `gossip.publish(topic, data, author = own_did)`; ACL checked **for the local DID only**; `hash = Self::hash_data(&data)` | `icn-gossip/src/gossip.rs:858`, `:925` |
+| 5 | `store_entry(entry)` → fires notification callbacks (including governance's own loopback copy) | `icn-gossip/src/gossip.rs:974` |
 | 6 | Outbound send wraps the `GossipMessage` in a **`SignedEnvelope`** — `PayloadType::Gossip`, Ed25519 by the node keypair, **durable monotonic sequence**, fail-closed if the sequence cannot be persisted (#2510) | `icn-core/src/supervisor/init_send_callback.rs:163` |
 | 7 | Sent as `MessagePayload::Signed` | `icn-net/src/protocol.rs:628` |
 
@@ -41,15 +50,20 @@ also removed. See §10, §5.2, §5.3.
 | 9b | Unsigned path → `gossip.handle_message(&net_msg.from, msg)` — `from` is **self-declared** | `icn-core/src/supervisor/init_network.rs:59–71` |
 | 10 | `handle_message_inner`: policy-oracle check on `sender` (`Domain::trust()`, `ActionKind::Read`). A coarse trust gate, **not** an authorship check | `icn-gossip/src/protocol.rs:46–68` |
 | 11 | `handle_response` — **ignores `sender` entirely**, stores the entry verbatim | `icn-gossip/src/handlers/push.rs:109–121` |
-| 12 | `store_entry`: dedups on the **sender-supplied `entry.hash`**; hash is **never recomputed**; no topic ACL; no signature — `GossipEntry` has no signature field | `icn-gossip/src/gossip.rs:968`, `types.rs:116–144` |
+| 12 | `store_entry`: **re-derives `entry.hash` from the payload before an unseen entry may claim a content-addressed slot (#2583)**; still no topic ACL; still no signature — `GossipEntry` has no signature field | `icn-gossip/src/gossip.rs:974`, `types.rs:116–144` |
 | 13 | Fires `EntryNotificationCallback = Fn(String, GossipEntry, Did)`. **No sender. No origin discriminator.** | `icn-gossip/src/gossip.rs:38` |
-| 14 | Governance callback: topic filter → `from_bytes` → `observe_replicated_governance_message` → **`debug!` only. No state mutation.** | `apps/governance/src/actor.rs:1277–1303`, `:3841` |
+| 14 | Governance callback: topic filter → `from_bytes` → `observe_replicated_governance_message` → **`debug!` only. No state mutation.** | `apps/governance/src/actor.rs:1277–1303`, `:3843` |
 
 ### 1.3 The verified facts that constrain the design
 
 1. **`GossipEntry` carries no signature.** `author: Did` is attacker-chosen.
-2. **The entry hash is never recomputed on receipt.** `hash_data` has exactly one caller,
-   the publish path (`gossip.rs:919`). Dedup keys on attacker-supplied `entry.hash`.
+2. **The entry hash *is* re-derived on receipt, as of #2583** (`3d401dce`). `store_entry`
+   (`gossip.rs:974`) refuses an unseen entry whose payload does not hash to its claimed
+   `entry.hash`, via `GossipEntry::validate_content_integrity` (`types.rs`). A slot already
+   owned by a validated entry short-circuits to a read-only duplicate lookup, so replayed
+   compressed bytes are never re-decompressed. This closes T3 and satisfies §5.6 step 6.
+   **It authenticates payload↔digest only** — `entry.author` remains an unsigned,
+   self-declared field that any peer may set to any DID, which is why fact 1 still stands.
 3. **The transport peer *is* authenticated** — Hello binds DID → live TLS cert
    (`handlers/hello.rs:44–108`), fails closed with no peer certificate.
 4. **That identity is discarded at the gossip seam.**
@@ -115,11 +129,11 @@ Attacker: can open a QUIC connection, complete Hello (so holds *some* valid DID 
 free to mint), and send arbitrary frames. Does not hold any victim's private key. May be a
 legitimate federation member acting outside its authority.
 
-| # | Attack | Status on `c3782321` |
+| # | Attack | Status on `3d401dce` |
 |---|---|---|
 | T1 | Forge `entry.author` as a victim DID and publish governance state | **Blocked** by containment; would otherwise fully succeed |
 | T2 | Publish raw unsigned `MessagePayload::Gossip` | **Open** (`connection.rs:822`) |
-| T3 | Supply `entry.hash` unrelated to content → poison dedup, pre-claim a hash to suppress a legitimate entry | **Open** — hash never recomputed |
+| T3 | Supply `entry.hash` unrelated to content → poison dedup, pre-claim a hash to suppress a legitimate entry | **Closed** by #2583 (`3d401dce`) — re-derived in `store_entry` |
 | T4 | Replay a legitimately signed op into a *different* domain | Open under a signature that omits domain binding |
 | T5 | Replay a superseded op | Open without a replay identity |
 | T6 | `ProposalOpened` force-reset on a terminal proposal, then `ProposalClosed` — **two-message finalization bypass** | **Blocked**; must stay blocked *regardless of authentication* |
@@ -319,7 +333,10 @@ witness protocol.
    lookup, no network.** → I1, I2
 4. Decode `op_bytes`; reject if the decoded variant disagrees with `op_kind`.
 5. Reject if the op's internal principal disagrees with `author` (`vote.voter`).
-6. Recompute `entry.hash` from `entry.data`; reject mismatch. → T3
+6. **Satisfied upstream since #2583** — `store_entry` re-derives `entry.hash` from the
+   payload before any notification callback fires, so an entry reaching this ingress has
+   already been shown to match its digest. Kept as a numbered step because the ingress
+   contract depends on the property holding, not because this design must still build it. → T3
 7. Resolve `domain_id` in **local durable state**. Absent → **quarantine; never fetch**. → I9
 8. **Resolve the op's state anchor locally and confirm it belongs to `domain_id`.** For
    `VoteCast`: load `vote.proposal_id`; absent → quarantine; reject unless
@@ -346,8 +363,8 @@ the gate stays reachable and its counters mean something under attack.
   instead of a bare `GovernanceMessage`.
 - Frames are distinguished by a leading **magic + version**, never by trial decoding (a bare
   `GovernanceMessage` is JSON; trial decoding is fragile and attacker-steerable).
-- The `entry.hash` recomputation (step 6) is a **generic gossip** change, separable, and
-  fixes T3 for all topics independently of this envelope.
+- The `entry.hash` recomputation (step 6) was a **generic gossip** change, separable, and
+  fixes T3 for all topics independently of this envelope. **Landed as #2583 (`3d401dce`).**
 
 ## 7. First safe replication variant set
 
@@ -368,14 +385,23 @@ Applying facts 12–15 to the 8 pre-containment mutation variants:
 
 ### 7.0 Membership is not the complete authority predicate for a vote
 
-Re-derived at `c3782321`. StaticList membership is **never** the complete authority
-predicate for `VoteCast` in the production composition:
+Re-derived at `c3782321` and re-verified at `3d401dce`. StaticList membership is **never**
+the complete authority predicate for `VoteCast` in the production composition:
 
-- `cast_vote` consults a `SuspensionChecker` before recording a vote —
-  `403 Forbidden` if the voter is suspended (`apps/governance/src/http/configure.rs:374–388`,
-  enforced at `handlers.rs:875`). Production wires it to
+- `cast_vote` (`handlers.rs:1812`) consults **two** external predicates before recording a
+  vote, either of which yields `403 Forbidden`: a `MemberStandingChecker` — the voter must
+  hold active commons Member standing (`handlers.rs:1850`) — and a `SuspensionChecker` — the
+  voter must not be suspended (`handlers.rs:1864`; type and contract at
+  `apps/governance/src/http/configure.rs:374–388`). Production wires the latter to
   `CoopManager::is_member_suspended` (`icn-gateway/src/server.rs:1904–1908`, installed at
   `:1947`).
+
+  > *Revision 3 correction.* Revision 2 cited this gate at `handlers.rs:875`. That line is
+  > the **proposer** suspension gate on proposal *submission*, not the vote gate; the file
+  > is untouched by #2583, so this was a mis-citation in revision 2 rather than drift. The
+  > substance is unchanged and in fact **stronger** than revision 2 claimed: vote casting
+  > carries two external predicates, not one, and neither is reproducible on a receiving
+  > node.
 - `close_proposal` **revalidates** active commons Member standing for every voter and
   excludes those who lost it (`actor.rs:2149–2189`, driven by handler-computed
   `eligible_voters`).
@@ -592,7 +618,9 @@ unit tests are listed separately in §13.
 3. Valid envelope re-wrapped under a different `entry.author` → still applied on its own
    merits (proves `entry.author` is *not* an authority) **and** rejected if the inner
    signature fails.
-4. `entry.hash` not matching `entry.data` → rejected.
+4. `entry.hash` not matching `entry.data` → rejected. **Already covered on main** by
+   #2583's `icn-gossip/tests/entry_hash_integrity.rs`; retained here as the ingress-level
+   assertion that the envelope path inherits that guarantee rather than re-implementing it.
 5. Envelope validly signed for domain A, replayed naming domain B → rejected.
 
 **Authority**
@@ -647,7 +675,7 @@ unit tests are listed separately in §13.
 | Slice | Content | Restores state application? |
 |---|---|---|
 | **1** | `SignedGovernanceOp` type, magic + version, canonical encoding, `membership_hash`, sign/verify (refusing an author/key mismatch), derived `op_id`. **Library only, unwired.** | No |
-| 2 | Recompute `entry.hash` on receipt in gossip. Generic, separable. | No |
+| 2 | ✅ **DONE — #2583 (`3d401dce`).** Re-derive `entry.hash` on receipt in gossip. Generic, separable. | No |
 | 3 | Emit signed envelopes from the governance publish path (durable per-`(author,domain)` seq, #2510 pattern); accept both shapes; apply nothing. | No |
 | 4 | Bounded quarantine store + steward release valve. | No |
 | 5 | Durable `op_id` applied-set + the §10.3 comparator in the state store. | No (local semantics only) |

--- a/docs/design/authenticated-governance-replication.md
+++ b/docs/design/authenticated-governance-replication.md
@@ -1,0 +1,605 @@
+# Authenticated governance replication (#2469)
+
+**Status:** design + slice 1 (unwired primitive).
+**Derived against:** `origin/main` = `c378232132139235e2a8cc305792eaee2571267a`.
+**Owns:** the durable replacement for the #2470 containment.
+**Refs:** #2469, #2441, #2470 (`bc291305`), #2471, #2480, #2510, #2520, #2535, #2544.
+
+Everything in §1 was re-derived from source at `c3782321`. Where an older campaign note
+disagrees, the source wins and the disagreement is called out.
+
+**Revision 2** corrects three mechanisms from revision 1 that were unsafe under
+eventually-consistent delivery: the sequence gate, first-writer-wins collision
+arbitration, and whole-config authority binding. Revision 1's `prev` hash-chain field is
+also removed. See §10, §5.2, §5.3.
+
+---
+
+## 1. Verified current behavior — source-to-sink trace
+
+### 1.1 Outbound: operator action → wire
+
+| # | Step | Location |
+|---|---|---|
+| 1 | Operator issues a `GovernanceCommand` (RPC/HTTP) | `icn-rpc/src/handler/governance.rs`, `apps/governance/src/http/handlers.rs` |
+| 2 | `GovernanceActor` **persists to `GovernanceStateStore` first** | `apps/governance/src/actor.rs` command arms |
+| 3 | Actor builds a `GovernanceMessage`, serializes with `to_bytes()` = **`serde_json::to_vec`** | `icn-governance/src/message.rs:417` |
+| 4 | `gossip.publish(topic, data, author = own_did)`; ACL checked **for the local DID only**; `hash = Self::hash_data(&data)` | `icn-gossip/src/gossip.rs:911`, `:919` |
+| 5 | `store_entry(entry)` → fires notification callbacks (including governance's own loopback copy) | `icn-gossip/src/gossip.rs:968` |
+| 6 | Outbound send wraps the `GossipMessage` in a **`SignedEnvelope`** — `PayloadType::Gossip`, Ed25519 by the node keypair, **durable monotonic sequence**, fail-closed if the sequence cannot be persisted (#2510) | `icn-core/src/supervisor/init_send_callback.rs:163` |
+| 7 | Sent as `MessagePayload::Signed` | `icn-net/src/protocol.rs:628` |
+
+**Honest nodes already sign every outbound gossip message.**
+
+### 1.2 Inbound: wire → state
+
+| # | Step | Location |
+|---|---|---|
+| 8a | `MessagePayload::Signed` → `ctx.handle_signed()` → `envelope.verify(max_age_secs)`: Ed25519 over `canonical_encoding()` (`sequence ‖ timestamp ‖ payload_type ‖ payload`), age check, replay guard | `icn-net/src/actor/connection.rs:857`, `handlers/signed.rs:360`, `replay_guard.rs` |
+| 8b | **`MessagePayload::Gossip` (raw, unsigned) is also accepted** and forwarded to the same external handler | `icn-net/src/actor/connection.rs:822` |
+| 9a | Signed path → `gossip.handle_message(&envelope.from, msg)` — `from` **is** authenticated | `icn-core/src/supervisor/init_network.rs:225–255` |
+| 9b | Unsigned path → `gossip.handle_message(&net_msg.from, msg)` — `from` is **self-declared** | `icn-core/src/supervisor/init_network.rs:59–71` |
+| 10 | `handle_message_inner`: policy-oracle check on `sender` (`Domain::trust()`, `ActionKind::Read`). A coarse trust gate, **not** an authorship check | `icn-gossip/src/protocol.rs:46–68` |
+| 11 | `handle_response` — **ignores `sender` entirely**, stores the entry verbatim | `icn-gossip/src/handlers/push.rs:109–121` |
+| 12 | `store_entry`: dedups on the **sender-supplied `entry.hash`**; hash is **never recomputed**; no topic ACL; no signature — `GossipEntry` has no signature field | `icn-gossip/src/gossip.rs:968`, `types.rs:116–144` |
+| 13 | Fires `EntryNotificationCallback = Fn(String, GossipEntry, Did)`. **No sender. No origin discriminator.** | `icn-gossip/src/gossip.rs:38` |
+| 14 | Governance callback: topic filter → `from_bytes` → `observe_replicated_governance_message` → **`debug!` only. No state mutation.** | `apps/governance/src/actor.rs:1277–1303`, `:3841` |
+
+### 1.3 The verified facts that constrain the design
+
+1. **`GossipEntry` carries no signature.** `author: Did` is attacker-chosen.
+2. **The entry hash is never recomputed on receipt.** `hash_data` has exactly one caller,
+   the publish path (`gossip.rs:919`). Dedup keys on attacker-supplied `entry.hash`.
+3. **The transport peer *is* authenticated** — Hello binds DID → live TLS cert
+   (`handlers/hello.rs:44–108`), fails closed with no peer certificate.
+4. **That identity is discarded at the gossip seam.**
+5. **The unsigned gossip door is open** (`connection.rs:822`).
+6. **`SignedEnvelope` authenticates the *hop*, not the *author*.** `handle_response`
+   (`push.rs:109`) stores a received entry verbatim; `handle_request_missing`
+   (`pull.rs:461`) re-serves `entry.clone()` onward under the *relay's own* envelope
+   signature. `entry.author` crosses every hop unauthenticated. **Any design requiring
+   `envelope.from == entry.author` accepts only single-hop delivery and destroys relay
+   and anti-entropy convergence.**
+7. **The DID *is* the public key.** `Did::to_verifying_key()` (`icn-identity/src/lib.rs:255`).
+   Verification needs no resolution, no DID document, no network round-trip.
+8. **`GovernanceDomain` has no owner, creator, or admin field** (`domain.rs:33–50`).
+   `GovernanceDomainId::generate()` is a random UUID; the domain declares its own
+   membership.
+9. **`MembershipSource::TrustThreshold` is node-subjective** (`resolver.rs:71–75`).
+10. **`save_domain` / `save_proposal` / `save_vote` are LWW upserts** (`state_store.rs:32,43,54`).
+11. **`VoteCast.signature` is dead** (only producer `actor.rs:2090` passes `None`);
+    `GovernanceDomainSeedManifest` (`bootstrap.rs:114`) has zero production consumers.
+
+### 1.4 New in revision 2 — identity and key structure
+
+12. **All governance identifiers are caller-chosen strings.**
+    `ProposalId::generate()` / `GovernanceDomainId::generate()` / `DelegationId::generate()`
+    are random UUIDv4, and each type also exposes `new(impl Into<String>)` accepting an
+    arbitrary string (`proposal.rs:243–255`, `domain.rs:9–21`, `delegation.rs:69–81`).
+    **No identifier is bound to its creator.**
+13. **Exactly one storage key is author-bound.** From `state_store.rs:192–247`:
+
+    | Key helper | Shape | Binds principal? |
+    |---|---|---|
+    | `vote_key(proposal_id, voter)` | `gov:vote:{pid}:{voter}` | **Yes — the voter DID** |
+    | `proposal_key(id)` | `gov:proposal:{id}` | No |
+    | `domain_key(id)` | `gov:domain:{id}` | No |
+    | `delegation_key(id)` | `gov:delegation:{id}` | No |
+    | `proof_key(id)` / `close_intent_key(id)` | `…:{pid}` | No |
+
+14. **The pre-containment mutation set was exactly 8 variants** (from the `bc291305`
+    diff): `DomainCreated`, `DomainUpdated`, `ProposalCreated`, `ProposalOpened`,
+    `VoteCast`, `ProposalClosed`, `DelegationCreated`, `DelegationRevoked`.
+    **`Comment*`, `Deliberation*` and `Reaction*` were never persisted by the replication
+    ingress** — `GovernanceStateStore` has no comment key space at all. Revision 1 listed
+    them as restoration candidates; that was wrong, and replicating them would be a no-op.
+15. **`CastVote` overwrites unconditionally** (`actor.rs:2072–2087`) — no "already voted"
+    check. A voter can change their vote, so the vote key is **not** write-once.
+16. **`GovernanceConfig` = `{ profile, membership, params, emergency }`** (`config.rs:25–37`).
+    `params` (quorum, approval thresholds) and `emergency` govern how state is *evaluated*,
+    not who may *author*. **`cooperative_default()` uses `MembershipConfig::trust_threshold(0.3)`**
+    (`config.rs:81`) — i.e. the default profile is **not** supported by v1 (§5.5).
+
+### 1.5 The authority-root finding
+
+- **Domain-anchored variants** reference a domain directly or via `proposal_id`.
+  Authority *could* be membership in that domain — if the receiver already holds it.
+- **Domain-defining variants** (`DomainCreated`, `DomainUpdated`): per fact 8, **no
+  authority root exists in the data model.** A signature proves only "some keypair said so."
+
+---
+
+## 2. Threat model
+
+Attacker: can open a QUIC connection, complete Hello (so holds *some* valid DID — DIDs are
+free to mint), and send arbitrary frames. Does not hold any victim's private key. May be a
+legitimate federation member acting outside its authority.
+
+| # | Attack | Status on `c3782321` |
+|---|---|---|
+| T1 | Forge `entry.author` as a victim DID and publish governance state | **Blocked** by containment; would otherwise fully succeed |
+| T2 | Publish raw unsigned `MessagePayload::Gossip` | **Open** (`connection.rs:822`) |
+| T3 | Supply `entry.hash` unrelated to content → poison dedup, pre-claim a hash to suppress a legitimate entry | **Open** — hash never recomputed |
+| T4 | Replay a legitimately signed op into a *different* domain | Open under a signature that omits domain binding |
+| T5 | Replay a superseded op | Open without a replay identity |
+| T6 | `ProposalOpened` force-reset on a terminal proposal, then `ProposalClosed` — **two-message finalization bypass** | **Blocked**; must stay blocked *regardless of authentication* |
+| T7 | Collide a `GovernanceDomainId` / `ProposalId` / `DelegationId` and overwrite via LWW | **Open** in the data model (facts 12–13); masked by containment |
+| T8 | Member of domain A authors an op affecting domain B | Open without explicit per-domain authority |
+| T9 | Relay tampers with a relayed entry's contents | **Open** — no content binding survives a hop |
+| T10 | Two honest nodes disagree on `TrustThreshold` membership → divergent verdicts | **Latent**; resolved by the O1 decision (§5.5) |
+| T11 | **Delivery-order divergence** — two honest nodes apply the same op set in different orders and reach different final state | **Latent**; the subject of §10 |
+| T12 | **Sequence-gap denial** — an attacker (or ordinary loss) causes an op to be discarded permanently because a higher sequence arrived first | Would be **introduced** by revision 1's design; corrected in §10 |
+
+Out of scope per #2469: TLS redesign, governance consensus, the `GovernanceProofV2`
+attestation-signer authority model, generic gossip ACL redesign.
+
+---
+
+## 3. Required invariants
+
+- **I1 Content binding.** Signature over the exact op bytes, verified before any state read
+  the op could influence.
+- **I2 Author binding.** Verifies under `author.to_verifying_key()`; `author` is the acting
+  principal — not `entry.author`, not `envelope.from`.
+- **I3 Domain binding.** The signed bytes include the affected `GovernanceDomainId`.
+- **I4 Authority.** `author` held a specific authority over that specific domain.
+- **I5 Origin vs relay.** Relay is untrusted; only the origin signature counts.
+- **I6 Replay identity.** Applying the same op twice is a no-op.
+- **I7 Lifecycle monotonicity.** Terminal proposals never regress, *independently of
+  authentication*.
+- **I8 Conflict safety.** Colliding IDs must not permit silent overwrite.
+- **I9 No circular bootstrap.** Verification never fetches authority material over the
+  channel carrying the op.
+- **I10 Deterministic verdict.** Two honest nodes with the same durable state reach the same
+  accept/reject decision.
+- **I11 Positive convergence.** A legitimate op from another node **is applied**.
+- **I12 Order-independent convergence (new).** Two honest nodes that receive the same set of
+  ops in *any* order reach the same final state. No op is permanently discarded because of
+  arrival order.
+
+---
+
+## 4. Design alternatives
+
+### A. Signed `GossipEntry` (generic content envelope)
+*Against:* changes the shared gossip wire format for every subsystem at once; requires every
+entry producer to hold a signing key; delivers **no** authority (I4). The "generic gossip
+security" broadening #2469 warns against.
+
+### B. Transport rebinding + sender-authored-entry requirement
+**Disqualified.** Per fact 6, requiring `envelope.from == entry.author` accepts only
+single-hop delivery, breaking relay and anti-entropy (violates I5, I11). Closing the
+unsigned door (T2) remains worth doing separately under #2471/#2480.
+
+### C. Governance-specific signed replication envelope — **recommended**
+Carried inside `entry.data`, which gossip already treats as opaque. Minimal blast radius;
+carries domain binding (I3) and authority context (I4), which A and B structurally cannot;
+survives relay because the signature is *inside* the replicated content (I5).
+
+### D. Typed `ReplicationPolicy` at the shared topic-registration seam (#2441)
+The name **already exists** at `icn-kernel-api/src/state.rs:29` as a durability/placement
+policy — #2441's proposal collides head-on. Substantively, the three #2441 classes have
+different authority roots; a shared seam would be a framework built before any instance is
+proven. **Prove the governance instance first.**
+
+### E. Reuse `SignedEnvelope`
+Hop authenticator (fact 6), no domain binding, no authority model. **Reuse the pattern, not
+the type** — specifically its length-prefixed `canonical_encoding()` and its
+sign-the-transmitted-bytes discipline (§5.4).
+
+---
+
+## 5. Recommended minimal architecture
+
+### 5.1 The v1 envelope
+
+```rust
+pub struct SignedGovernanceOp {
+    pub version: u16,                     // GOV_OP_V1; unknown → reject
+    pub author: Did,                      // acting principal; key via to_verifying_key()
+    pub domain_id: GovernanceDomainId,    // explicit, never inferred from the payload
+    pub authority: ReplicationAuthority,  // StaticMembership { membership_hash }
+    pub seq: u64,                         // per-(author, domain); COMPARATOR, never a gate
+    pub op_kind: GovernanceOpKind,        // signed routing discriminator
+    pub op_bytes: Vec<u8>,                // transmitted verbatim; signature covers these bytes
+    pub signature: Vec<u8>,               // Ed25519 over canonical_body()
+}
+
+pub enum ReplicationAuthority {
+    StaticMembership { membership_hash: [u8; 32] },
+}
+```
+
+`op_id = SHA-256(canonical_body())` — **derived, never carried**, so it cannot disagree with
+content.
+
+Removed from revision 1: `prev` (hash chaining — see §10) and `domain_config_hash`
+(over-binding — see §5.3). No timestamp field: wall-clock orders nothing here, so carrying
+one would only invite it to be used.
+
+### 5.2 Canonical encoding
+
+`canonical_body()` is an explicit, hand-rolled, length-prefixed concatenation in the style of
+`SignedEnvelope::canonical_encoding` (`icn-net/src/envelope.rs:403`):
+
+```
+"ICN-GOV-OP-v1\0"                     domain separator (fixed, unambiguous)
+u16_be(version)
+lp(author.as_str())                   lp(x) = u32_be(len) ‖ bytes
+lp(domain_id.0)
+u8(authority discriminant) ‖ authority payload
+u64_be(seq)
+u8(op_kind discriminant)
+lp(op_bytes)
+```
+
+Every variable-length field is length-prefixed, so no field boundary is ambiguous and no
+concatenation collision is reachable.
+
+### 5.3 Why `op_bytes` is opaque, and why that is *not* "signing serde_json"
+
+`op_bytes` are signed and transmitted **verbatim**: the receiver verifies the signature over
+exactly the bytes it received, and decodes those same bytes. There is no re-serialization
+step anywhere in the pipeline, so serde_json's determinism is **never relied upon**. This is
+strictly stronger than canonicalizing `GovernanceMessage`, and it is the discipline
+`SignedEnvelope` already uses (`payload: Vec<u8>` + `payload_type`).
+
+Verbatim transport is guaranteed by verified fact 6: `entry.data` is opaque to gossip and
+relays re-serve `entry.clone()` byte-for-byte.
+
+The alternative — hand-rolling a canonical encoder for ~20 `GovernanceMessage` variants over
+deeply nested types (`Proposal`, `GovernanceDomain`, `TallySnapshot`, `GovernanceProofV2`) —
+would be a large, permanently-maintained surface where **a newly added field is silently
+excluded from the signature**. That is a worse vulnerability class than the one it avoids.
+
+*Accepted consequence:* JSON is malleable, so two byte strings can decode to the same
+message and yield different `op_id`s. Not exploitable — an attacker cannot re-sign a
+re-encoding — and the §10 comparator resolves any resulting duplicate deterministically.
+
+### 5.4 The authority snapshot — membership only, not whole config
+
+Revision 1 bound `domain_config_hash`. That conflates two different questions:
+
+- **who may author an operation** → depends only on the member set;
+- **the rules under which the resulting state is evaluated** → `params`, `emergency`,
+  `profile`.
+
+Binding the whole config means an unrelated quorum-threshold edit invalidates every
+in-flight signed vote — a liveness failure with **no** security benefit, because a quorum
+change never grants anyone authorship.
+
+v1 therefore binds exactly the authority-relevant snapshot:
+
+```
+membership_hash = SHA-256(
+    "ICN-GOV-STATIC-MEMBERSHIP-v1\0"
+  ‖ lp(domain_id.0)
+  ‖ u32_be(member_count)
+  ‖ lp(member[0]) ‖ lp(member[1]) ‖ …      // sorted bytewise, deduplicated
+)
+```
+
+Sorted and deduplicated so the hash is a function of the *set*, not of list order.
+`domain_id` is inside the hash so a membership snapshot cannot be lifted between domains
+even if two domains happen to share a member set.
+
+The `ReplicationAuthority` enum exists so a v2 basis (witness set, `AuthorityGrant` from
+`icn-governance/src/authority.rs`, charter binding) can be added as a new variant that a v1
+verifier rejects explicitly rather than misreads. One variant today; no abstract framework.
+
+### 5.5 O1 resolved — StaticList only, and what that excludes
+
+**Decision: v1 supports only domains whose `MembershipSource` is `StaticList`.**
+
+`TrustThreshold` resolves against each node's local trust graph (fact 9), so two honest
+nodes can legitimately compute different membership and reach different verdicts on the
+same op — permanent divergence (T10, violating I10). It **remains fail-closed for remote
+state application** until ICN has a separately designed deterministic membership-snapshot /
+witness protocol.
+
+**Compatibility limitation, stated plainly:**
+
+- `GovernanceConfig::cooperative_default()` uses `trust_threshold(0.3)` (`config.rs:81`).
+  **Domains built from the default cooperative profile are NOT eligible for authenticated
+  replication in v1**, and no part of #2469 attempts to make that configuration safe.
+- A `TrustThreshold` domain behaves exactly as it does under the #2470 containment today:
+  replicated governance ops targeting it are **not applied**. This is a no-op change for
+  those domains, not a regression.
+- Eligibility is decided by the **receiver's local** copy of the domain. A node that holds a
+  `StaticList` domain applies eligible ops; a node whose copy is `TrustThreshold` does not.
+  Operators must therefore not mix membership sources for the same logical institution
+  across nodes — a mixed deployment converges only on the `StaticList` side.
+
+### 5.6 Verification order at ingress (fail-closed, in this order)
+
+1. Decode the envelope framing; reject unknown magic or `version`.
+2. Reject `op_kind` outside the v1 restorable set (§7) — **before** decoding `op_bytes`, so
+   an unsupported or oversized payload is never parsed.
+3. Recover `author.to_verifying_key()`; verify `signature` over `canonical_body()`. **No
+   lookup, no network.** → I1, I2
+4. Decode `op_bytes`; reject if the decoded variant disagrees with `op_kind`.
+5. Reject if the op's internal principal disagrees with `author` (`vote.voter`).
+6. Recompute `entry.hash` from `entry.data`; reject mismatch. → T3
+7. Resolve `domain_id` in **local durable state**. Absent → **quarantine; never fetch**. → I9
+8. **Resolve the op's state anchor locally and confirm it belongs to `domain_id`.** For
+   `VoteCast`: load `vote.proposal_id`; absent → quarantine; reject unless
+   `proposal.domain_id == envelope.domain_id`. Without this a member of domain D could
+   vote into domain E's tally by declaring `domain_id = D` — the signature, the membership
+   check and the domain binding would all pass, because none of them looks at what the
+   *proposal* belongs to. → I3, T8
+9. Reject unless the local domain's `MembershipSource` is `StaticList`. → §5.5
+10. Recompute `membership_hash` from the local member set; reject mismatch. → I10
+11. Reject unless `author` ∈ the local member set. → I4
+12. Reject if `op_id` is already in the durable applied-set. → I6
+13. Lifecycle: reject terminal-state regressions **unconditionally**. → I7, T6
+14. Apply under the §10 comparator, not LWW.
+
+Note the ordering discipline: the allow-list gate (2) precedes the fallible decode (4), so
+the gate stays reachable and its counters mean something under attack.
+
+---
+
+## 6. Wire-format implications
+
+- **Gossip wire format: unchanged.** `entry.data` is already opaque bytes.
+- **Governance topic payload: changed.** `entry.data` becomes a `SignedGovernanceOp` frame
+  instead of a bare `GovernanceMessage`.
+- Frames are distinguished by a leading **magic + version**, never by trial decoding (a bare
+  `GovernanceMessage` is JSON; trial decoding is fragile and attacker-steerable).
+- The `entry.hash` recomputation (step 6) is a **generic gossip** change, separable, and
+  fixes T3 for all topics independently of this envelope.
+
+## 7. First safe replication variant set
+
+Applying facts 12–15 to the 8 pre-containment mutation variants:
+
+| Variant | Storage key | Cross-author collision | Authority root | v1 |
+|---|---|---|---|---|
+| **`VoteCast`** | `gov:vote:{pid}:{voter}` — **author-bound** | **Impossible** (§8) | membership + `vote.voter == author` | **RESTORE** |
+| `ProposalCreated` | `gov:proposal:{id}` | **Yes** — any member may pick another's `ProposalId` | membership | contain (§8) |
+| `DelegationCreated` | `gov:delegation:{id}` | **Yes** — same | membership | contain (§8) |
+| `DelegationRevoked` | mutates existing `gov:delegation:{id}` | n/a | `revoked_by == delegator` in local state | contain — safe but inert (§7.1) |
+| `ProposalOpened` | mutates `gov:proposal:{id}` | n/a | **undecided** (§7.2) | contain |
+| `ProposalClosed` | mutates `gov:proposal:{id}` + proof | n/a | **undecided** (§7.2) | contain |
+| `DomainCreated` / `DomainUpdated` | `gov:domain:{id}` | Yes | **none exists** (fact 8) | contain |
+
+**v1 restores exactly one variant: `VoteCast`.**
+
+### 7.1 Why `DelegationRevoked` is excluded despite being safe
+
+Revocation is monotonic, idempotent, order-independent, and authorized by a principal named
+in state the receiver already holds — it is genuinely safe. But it can only act on a
+delegation that exists locally, and `DelegationCreated` is contained, so on a remote node it
+is a guaranteed no-op. Shipping a capability with no reachable effect adds verification
+surface for nothing. It becomes useful the moment `DelegationCreated` is restorable.
+
+### 7.2 Why `ProposalOpened` / `ProposalClosed` / `ProposalCancelled` are excluded
+
+Membership is not the right authority for choosing an outcome. `ProposalClosed` carries
+`outcome` and `tally` as **attacker-supplied fields**; accepting it on membership alone lets
+any single member declare any result, which is strictly worse than the current containment.
+The correct authority is the tally/state transition itself — which entangles with the
+`GovernanceProofV2` signer-authority model that #2469 lists as a non-goal. `ProposalOpened`
+is the force-reset half of the T6 finalization bypass and must not return before the
+lifecycle guard exists.
+
+### 7.3 Honest scope of what v1 delivers
+
+A replicated `VoteCast` requires the referenced proposal to be present locally, so that step
+5's domain check can confirm the vote belongs to `domain_id`. Since `ProposalCreated` stays
+contained, **v1 restores vote convergence only for proposals a node already holds** (created
+locally or provisioned out of band). That is a narrow capability. It is nonetheless the
+right first slice: it is the smallest change that exercises the entire chain — sign → gossip
+→ relay → verify → authority → apply → converge — which is exactly the positive-convergence
+evidence #2469 demands, and it establishes the pattern without inventing unsafe semantics
+for the harder variants.
+
+## 8. Collision semantics — corrected
+
+Revision 1 proposed first-writer-wins. **That is arrival-order dependent and non-convergent**
+(T11): node A sees Alice's object first, node B sees Bob's colliding object first, and the
+two permanently disagree on the owner. It is withdrawn.
+
+Since no identifier is bound to its creator (fact 12), the options for a colliding
+`ProposalId` / `DelegationId` are:
+
+| Rule | Deterministic? | Safe? |
+|---|---|---|
+| First-writer-wins | **No** — arrival-order | — |
+| Deterministic tiebreak (e.g. highest `op_id` wins) | Yes | **No** — lets any member displace another's proposal content by grinding `op_id`; votes keyed by `(pid, voter)` survive and silently re-attach to the substituted proposal |
+| Reject on existing-with-different-author | No — arrival-order | — |
+| **Derived identifiers** — `ProposalId = H(proposer ‖ domain ‖ nonce ‖ content)` | Yes | Yes — collision becomes impossible by construction |
+
+Derived identifiers are the correct fix, and they are **out of scope for #2469**: identifier
+construction reaches HTTP routes, RPC, storage keys, receipts, proofs and the test suite.
+
+**Per the standing instruction, the affected mutation class stays contained rather than
+receiving invented conflict semantics.** `ProposalCreated`, `DelegationCreated`,
+`DomainCreated` and `DomainUpdated` remain refused. A follow-up issue should give governance
+objects creator-derived identifiers; that unlocks them.
+
+**`VoteCast` needs none of this.** `vote_key(proposal_id, voter)` already embeds the voter
+DID, and step 5 requires `vote.voter == author`, which step 3 authenticated. Alice can write
+only `gov:vote:{pid}:{alice}`. **Cross-author collision on a vote key is impossible by
+construction** — the one place the existing data model already does the right thing.
+
+## 9. Key rotation / revocation
+
+Because the DID *is* the key (fact 7), an op signed by DID *D* verifies forever — so rotation
+and revocation are invisible at the signature layer.
+
+`DidDocument` exists (`icn-identity/src/multi_device.rs:19`) with a `DidDocumentCache`
+(`sync.rs:68`), and `revocation.rs` / `revocation_store.rs` exist, but the supervisor wires
+revocation only for **RPC tokens** (`init_rpc.rs:57–63`), not identities.
+
+**v1 treats rotation and revocation as *membership* changes, not signature-layer changes.**
+A removed or rotated-out member fails the step 10 membership check even though the signature
+still verifies. This keeps the signature layer lookup-free (I9) and puts revocation where
+authority already lives. Because `membership_hash` is bound into the signature, an op
+authored against a stale member set is rejected at step 9 — membership edits invalidate
+in-flight ops by construction, which is the desired fail-closed direction.
+
+Accepting an op signed by a key valid *at authoring time* but rotated since requires a
+trusted time source and resolvable key history. **Deferred to its own issue.**
+
+## 10. Replay / order / conflict semantics — corrected
+
+Revision 1 proposed rejecting `seq <= last_seen`. **That is unsafe** and is withdrawn.
+
+### 10.1 The failure it would have caused
+
+Alice authors seq=10 (vote on proposal P) and seq=11 (vote on proposal Q). Node B receives 11
+then 10. A watermark gate rejects 10 as stale, so **B permanently loses Alice's vote on P**
+while A has it — T12, violating I12. Gossip guarantees no delivery order, and anti-entropy
+can deliver an op arbitrarily late.
+
+### 10.2 The five candidate mechanisms
+
+| Mechanism | Verdict |
+|---|---|
+| **`op_id`-only durable dedup** | **Necessary and sufficient for replay.** Order-independent; never discards an unseen op. Does not by itself resolve same-key conflict. |
+| `seq` + sliding replay window | ❌ A window is a bounded watermark. Gossip delivery delay is unbounded — anti-entropy may deliver hours later — so any window drops legitimate ops. |
+| `seq` + gap quarantine + contiguous-prefix watermark | ❌ The most plausible-looking option and the trap: it requires contiguity, so a **permanently dropped op wedges that author's entire stream forever**, and the quarantine grows unboundedly under a trivial attack (author high sequence numbers, never send the gaps). |
+| Hash chaining (`prev`) | ❌ Same wedge as above — a missing link blocks every descendant — and it forces an author's ops to be strictly serial, which they are not. This is why `prev` is removed from the envelope. |
+| Drop `seq` from acceptance entirely; rely on state/lifecycle/CAS | ✅ Correct for *acceptance*. Insufficient alone for same-key conflict where state is non-monotonic — and vote state **is** non-monotonic (For ↔ Against, fact 15). |
+
+### 10.3 The chosen design
+
+**`seq` has zero role in acceptance. It is only a comparator, scoped to a key.**
+
+- **Replay gate — the only acceptance gate.** A durable set of applied `op_id`s. Reject iff
+  `op_id` was already applied. Order-independent; an op arriving late is applied normally.
+  No watermark, no contiguity requirement, no gap quarantine. Gaps are normal and permanent.
+- **Same-key conflict — deterministic comparator.** When a key already holds a value, apply
+  the incoming op iff `(incoming.seq, incoming.op_id) > (stored.seq, stored.op_id)`
+  lexicographically. `seq` carries the author's intent order (a later vote beats an earlier
+  one); `op_id` breaks ties deterministically.
+
+This converges under any delivery order. Worked through the §10.1 scenario, and through
+Alice changing her vote (seq=10 For, seq=11 Against):
+
+| | Node A (10 then 11) | Node B (11 then 10) |
+|---|---|---|
+| first op | apply 10 → For | apply 11 → Against |
+| second op | 11 > 10 → apply → **Against** | 10 < 11 → no-op → **Against** |
+
+Both converge to Against, and **op 10 is never *rejected* — it is accepted and then loses
+the comparator**, which is the distinction that makes §10.1 safe.
+
+`seq` must be per-`(author, domain)` monotonic at the origin. The durable monotonic counter
+pattern from #2510 (`init_send_callback.rs`, fail-closed on persistence failure) is the
+precedent to reuse when slice 3 wires emission.
+
+- **Cross-author ordering is deliberately not provided.** That is consensus, which #2469
+  excludes. Safety without it comes from I7 (lifecycle monotonicity) and §8 (no cross-author
+  key collisions in the restorable set).
+- **Wall-clock fields order nothing.** `entry.timestamp`, `vote.timestamp` and
+  `updated_at`-style LWW are attacker-supplied and are not authorities.
+
+## 11. Relationship to #2441
+
+Same defect *class*, different authority roots.
+
+- #2441's proposed `ReplicationPolicy` **name-collides** with `icn-kernel-api/src/state.rs:29`.
+  Whichever issue moves first should rename.
+- Governance can close without #2441, and vice versa.
+- **Do not build the shared seam yet.** The pieces most likely to generalize are the
+  quarantine store, the canonical-encoding helper and the `op_id` dedup set — **not** the
+  authority model, which is genuinely per-class.
+
+## 12. RED tests required before implementation
+
+Exercised through production wiring (`init_governance_actor` + `GossipActor::handle_message`),
+extending `apps/governance/tests/fp02_governance_replication_containment.rs`. Slice 1's own
+unit tests are listed separately in §13.
+
+**Content / author / domain binding**
+1. Forged `author`, no valid signature → rejected before any state write.
+2. Valid signature, one byte of `op_bytes` mutated → rejected.
+3. Valid envelope re-wrapped under a different `entry.author` → still applied on its own
+   merits (proves `entry.author` is *not* an authority) **and** rejected if the inner
+   signature fails.
+4. `entry.hash` not matching `entry.data` → rejected.
+5. Envelope validly signed for domain A, replayed naming domain B → rejected.
+
+**Authority**
+6. Valid signature by a non-member of the target domain → rejected.
+7. `vote.voter` ≠ envelope `author` → rejected.
+7b. **Cross-domain tally injection:** a member of domain D signs a `VoteCast` for a
+    proposal belonging to domain E, declaring `domain_id = D` → rejected at step 8. Every
+    other check passes, so this fails only if the proposal anchor is checked.
+8. Unknown `domain_id` → quarantined, not applied, **no network fetch**.
+8b. Known `domain_id` but unknown `vote.proposal_id` → quarantined, not applied.
+9. Local domain is `TrustThreshold` → **not applied** (§5.5), and this is asserted as
+   deliberate, not incidental.
+10. `membership_hash` computed against a stale member set → rejected.
+
+**Replay / order — the corrected semantics**
+11. Byte-identical replay of an applied op → no second application.
+12. **Out-of-order delivery: ops seq=10 (proposal P) and seq=11 (proposal Q) delivered 11
+    then 10 → BOTH applied.** The direct regression test for T12; must fail against a
+    watermark implementation.
+13. Same-key conflict delivered in both orders (10 For / 11 Against, and 11 then 10) → both
+    nodes converge to Against.
+14. An op with `seq` far below the author's highest seen, on an untouched key → applied.
+
+**Lifecycle**
+15. `ProposalOpened` on a terminal proposal → rejected **even when fully authorized** (T6).
+16. Reopen→close finalization bypass → outcome unchanged.
+
+**Containment retained**
+17. A validly signed, authority-bearing `ProposalCreated` / `DelegationCreated` /
+    `DomainCreated` → **still not applied** (§7, §8), asserted as deliberate.
+
+**Positive convergence — the test that makes this a fix rather than another block**
+18. A legitimately signed, authority-bearing `VoteCast` from a *second* node, relayed through
+    a *third*, **is applied**, and the nodes converge. Must exercise a real relay hop so
+    fact 6 is actually covered.
+
+**Migration**
+19. An unsigned legacy payload is refused while a signed one is applied.
+
+## 13. Implementation slices, in order
+
+| Slice | Content | Restores state application? |
+|---|---|---|
+| **1** | `SignedGovernanceOp` type, magic + version, canonical encoding, `membership_hash`, sign/verify, derived `op_id`. **Library only, unwired.** | No |
+| 2 | Recompute `entry.hash` on receipt in gossip. Generic, separable. | No |
+| 3 | Emit signed envelopes from the governance publish path (durable per-`(author,domain)` seq, #2510 pattern); accept both shapes; apply nothing. | No |
+| 4 | Bounded quarantine store + steward release valve. | No |
+| 5 | Durable `op_id` applied-set + the §10.3 comparator in the state store. | No (local semantics only) |
+| 6 | Lifecycle monotonicity guard, enforced unconditionally. | No |
+| 7 | **Verify + authority + apply, lifting containment for `VoteCast` only.** Containment tests updated, not deleted. | **Yes** |
+
+Slices 1–6 restore nothing. Slice 7 is the only one that lifts containment, and does so in
+the same change that proves positive convergence (test 18).
+
+**Slice 1 unit tests (this change):**
+sign→verify round-trip; tampered `op_bytes`; tampered `domain_id`; tampered `author`;
+tampered `seq`; tampered `authority`; tampered `op_kind`; wrong-signer rejection; unknown
+version rejected; bad magic rejected; truncated frame rejected; `op_id` determinism and
+sensitivity to every signed field; `membership_hash` set-order and duplicate invariance,
+domain separation, and sensitivity to member changes; encode→decode round-trip;
+`op_kind`/payload disagreement rejected.
+
+## 14. Is the field set stable enough to freeze?
+
+**Yes.** Each previously open question either has a decision or has been shown not to touch
+the envelope:
+
+| Question | Resolution | Touches field set? |
+|---|---|---|
+| O1 membership determinism | StaticList-only (§5.5) | Yes → `ReplicationAuthority::StaticMembership { membership_hash }` |
+| Replay under out-of-order delivery | `op_id` gate + `seq` comparator (§10.3) | Yes → keeps `seq`, **removes `prev`** |
+| Collision arbitration | Contain the affected classes (§8) | No — no field needed |
+| Authority snapshot scope | Membership only, not whole config (§5.4) | Yes → **removes `domain_config_hash`** |
+| First restorable variant set | `VoteCast` only (§7) | No — `op_kind` already carries it |
+| `ProposalClosed` authority (old O2) | Contained; deferred with the proof-signer model | No |
+| Key rotation / revocation | Membership-mediated in v1 (§9) | No |
+| Quarantine bounds (old O3) | Slice 4 detail | No |
+
+The remaining unknowns — derived identifiers, tally-rooted lifecycle authority, deterministic
+membership witnesses — all resolve into either a **new `ReplicationAuthority` variant** or a
+**version bump**, which is precisely what `version` and the one-variant enum exist to absorb.
+
+**Slice 1 is cleared to implement.**

--- a/docs/design/authenticated-governance-replication.md
+++ b/docs/design/authenticated-governance-replication.md
@@ -363,7 +363,80 @@ Applying facts 12–15 to the 8 pre-containment mutation variants:
 | `ProposalClosed` | mutates `gov:proposal:{id}` + proof | n/a | **undecided** (§7.2) | contain |
 | `DomainCreated` / `DomainUpdated` | `gov:domain:{id}` | Yes | **none exists** (fact 8) | contain |
 
-**v1 restores exactly one variant: `VoteCast`.**
+**Structurally, `VoteCast` is the only candidate. It is not sufficient on its own — see
+§7.0, which narrows this further.**
+
+### 7.0 Membership is not the complete authority predicate for a vote
+
+Re-derived at `c3782321`. StaticList membership is **never** the complete authority
+predicate for `VoteCast` in the production composition:
+
+- `cast_vote` consults a `SuspensionChecker` before recording a vote —
+  `403 Forbidden` if the voter is suspended (`apps/governance/src/http/configure.rs:374–388`,
+  enforced at `handlers.rs:875`). Production wires it to
+  `CoopManager::is_member_suspended` (`icn-gateway/src/server.rs:1904–1908`, installed at
+  `:1947`).
+- `close_proposal` **revalidates** active commons Member standing for every voter and
+  excludes those who lost it (`actor.rs:2149–2189`, driven by handler-computed
+  `eligible_voters`).
+- `GovernanceContextValidationError` (`configure.rs:183`) states outright that production
+  deployments must wire `MemberStandingChecker`, `SuspensionChecker`, a
+  `MembershipResolver` and a `MandateGate`, because *"unresolved standing must not be
+  treated as standing."*
+
+Critically, **a suspended member remains in the domain's `StaticList`.** That is precisely
+the configuration `icn-gateway/tests/e2e_close_time_revalidation.rs` constructs: a
+three-member StaticList domain where Bob's *commons* standing flips to Suspended while his
+StaticList entry is untouched, and his vote is then excluded at resolution. The file states
+the principle directly — *"standing is a continuous predicate across the full decision arc,
+not a one-time entry gate."*
+
+**Consequence for this design.** A suspended-but-listed DID would pass every check in
+§5.6: the signature verifies, the domain resolves, the source is `StaticList`, the
+`membership_hash` matches (they are still listed), and `author ∈ members`. The replication
+path would therefore **apply a vote that the HTTP path refuses with 403** — a bypass of a
+live production gate, reachable by any suspended member who publishes over gossip instead
+of over HTTP.
+
+**Why close-time revalidation does not rescue it.** It filters the *effective tally*, so
+the final outcome is protected on the closing node — but (a) the vote is stored and
+observable before close; (b) revalidation is handler-driven and fails open when the checker
+is unwired (`configure.rs:552–570` says so explicitly for the resolver case); (c) it does
+not make *stored state* converge, so nodes hold different vote sets; and (d) relying on
+downstream filtering to neutralize a write the ingress already believed illegitimate is the
+snapshot-only posture that revalidation was introduced to replace. An ingress must not
+knowingly write state it cannot justify.
+
+**Why the predicate cannot be checked on the receiver.** It lives in commons/coop state,
+which is not governance state, is not reachable from `GovernanceActor` at all (the checkers
+are HTTP-layer closures the actor never sees), and whose own replication is the
+unauthenticated class tracked by #2441. Verifying it on a receiving node would mean
+resolving authority against untrusted, non-deterministic state — manufacturing false
+determinism, and reintroducing the circularity I9 forbids.
+
+Binding a `standing_hash` into the envelope would be **actively wrong** for the same
+reason: the receiver would compare it against commons state that is itself unauthenticated.
+
+### 7.0.1 The resulting v1 authority boundary
+
+> **v1 boundary = `StaticList` membership **AND** no external authority predicate applies
+> on the receiving node.**
+>
+> Not "StaticList-only". A composition that wires a `SuspensionChecker` (or any standing,
+> capability, charter or mandate gate) over vote casting **stays contained**, because the
+> receiver cannot deterministically evaluate that predicate.
+
+Since the production gateway composition always wires `SuspensionChecker`, the honest
+statement is: **authenticated `VoteCast` application is not restorable in the production
+composition in v1.** It is restorable only where no external predicate is wired, and the
+ingress slice must *detect* which composition it is in and fail closed by default — an
+unwired checker must read as "predicate unresolved," never as "predicate satisfied," per
+`configure.rs:183`.
+
+Unblocking production needs a deterministic, authenticated standing source. That is
+squarely #2441's territory (authenticated institutional-state replication) and is **not**
+in scope here. This is the second place where #2469 and #2441 turn out to be genuinely
+coupled — the first being the shared quarantine machinery (§11).
 
 ### 7.1 Why `DelegationRevoked` is excluded despite being safe
 
@@ -547,6 +620,16 @@ unit tests are listed separately in §13.
 15. `ProposalOpened` on a terminal proposal → rejected **even when fully authorized** (T6).
 16. Reopen→close finalization bypass → outcome unchanged.
 
+**Standing predicate — §7.0**
+16b. **A suspended-but-listed member's validly signed `VoteCast` → not applied.** Build the
+     `e2e_close_time_revalidation.rs` shape: DID stays in the `StaticList`, commons standing
+     flips to Suspended. Signature, domain, `membership_hash` and membership all pass, so
+     this fails unless the standing predicate is consulted.
+16c. **A composition with a `SuspensionChecker` wired → `VoteCast` not applied at all**, and
+     asserted as deliberate rather than incidental.
+16d. **An unwired checker reads as "unresolved", not "satisfied"** — the ingress must fail
+     closed, matching `configure.rs:183`.
+
 **Containment retained**
 17. A validly signed, authority-bearing `ProposalCreated` / `DelegationCreated` /
     `DomainCreated` → **still not applied** (§7, §8), asserted as deliberate.
@@ -563,13 +646,13 @@ unit tests are listed separately in §13.
 
 | Slice | Content | Restores state application? |
 |---|---|---|
-| **1** | `SignedGovernanceOp` type, magic + version, canonical encoding, `membership_hash`, sign/verify, derived `op_id`. **Library only, unwired.** | No |
+| **1** | `SignedGovernanceOp` type, magic + version, canonical encoding, `membership_hash`, sign/verify (refusing an author/key mismatch), derived `op_id`. **Library only, unwired.** | No |
 | 2 | Recompute `entry.hash` on receipt in gossip. Generic, separable. | No |
 | 3 | Emit signed envelopes from the governance publish path (durable per-`(author,domain)` seq, #2510 pattern); accept both shapes; apply nothing. | No |
 | 4 | Bounded quarantine store + steward release valve. | No |
 | 5 | Durable `op_id` applied-set + the §10.3 comparator in the state store. | No (local semantics only) |
 | 6 | Lifecycle monotonicity guard, enforced unconditionally. | No |
-| 7 | **Verify + authority + apply, lifting containment for `VoteCast` only.** Containment tests updated, not deleted. | **Yes** |
+| 7 | **Verify + authority + apply, lifting containment for `VoteCast` only, and only in a composition with no external standing predicate (§7.0.1).** Must fail closed when a `SuspensionChecker` or equivalent is wired. Containment tests updated, not deleted. | **Yes, narrowly** |
 
 Slices 1–6 restore nothing. Slice 7 is the only one that lifts containment, and does so in
 the same change that proves positive convergence (test 18).
@@ -594,6 +677,7 @@ the envelope:
 | Collision arbitration | Contain the affected classes (§8) | No — no field needed |
 | Authority snapshot scope | Membership only, not whole config (§5.4) | Yes → **removes `domain_config_hash`** |
 | First restorable variant set | `VoteCast` only (§7) | No — `op_kind` already carries it |
+| **Standing / suspension predicate** (§7.0) | Ingress policy; fail closed where it applies | **No** — see below |
 | `ProposalClosed` authority (old O2) | Contained; deferred with the proof-signer model | No |
 | Key rotation / revocation | Membership-mediated in v1 (§9) | No |
 | Quarantine bounds (old O3) | Slice 4 detail | No |
@@ -602,4 +686,17 @@ The remaining unknowns — derived identifiers, tally-rooted lifecycle authority
 membership witnesses — all resolve into either a **new `ReplicationAuthority` variant** or a
 **version bump**, which is precisely what `version` and the one-variant enum exist to absorb.
 
-**Slice 1 is cleared to implement.**
+### 14.1 Why the standing finding does not move the field set
+
+The §7.0 discovery narrows *what v1 may apply*, not *what v1 must sign*. The envelope
+already binds author, domain, membership snapshot and content; the suspension predicate is
+evaluated against **receiver-local** state at ingress, exactly like the domain lookup and
+the membership check, none of which are carried on the wire either.
+
+Adding a `standing_hash` was considered and rejected: the receiver would have to compare it
+against commons state that is itself unauthenticated (#2441), so the field would create the
+appearance of a deterministic check over non-deterministic data — worse than having no
+field, because it would look like the hole was closed.
+
+**Field set frozen as in §5.1. Slice 1 stands; the correction lands in §7.0/§7.0.1 and in
+slice 7's policy.**

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -69,6 +69,7 @@ pub mod protocol_store;
 #[allow(missing_docs)]
 pub mod protocol_validation;
 #[allow(missing_docs)]
+pub mod replication;
 pub mod resolver;
 #[allow(missing_docs)]
 pub mod sdis;

--- a/icn/crates/icn-governance/src/lib.rs
+++ b/icn/crates/icn-governance/src/lib.rs
@@ -68,8 +68,8 @@ pub mod protocol_defaults;
 pub mod protocol_store;
 #[allow(missing_docs)]
 pub mod protocol_validation;
-#[allow(missing_docs)]
 pub mod replication;
+#[allow(missing_docs)]
 pub mod resolver;
 #[allow(missing_docs)]
 pub mod sdis;

--- a/icn/crates/icn-governance/src/replication.rs
+++ b/icn/crates/icn-governance/src/replication.rs
@@ -97,6 +97,18 @@ pub enum ReplicationEnvelopeError {
     /// The message variant cannot be carried in a replication envelope.
     #[error("governance message variant {0} is not a replicable state mutation")]
     NotReplicable(&'static str),
+
+    /// The signing key does not belong to the DID named as author.
+    ///
+    /// Constructing such an envelope would produce an object that can never verify, so
+    /// the signing constructor refuses rather than emitting one.
+    #[error("signing key belongs to {derived}, not the declared author {declared}")]
+    AuthorKeyMismatch {
+        /// The DID the supplied signing key actually corresponds to.
+        derived: Box<Did>,
+        /// The DID the caller asked to name as author.
+        declared: Box<Did>,
+    },
 }
 
 /// The basis on which an author claims authority over a domain.
@@ -149,17 +161,35 @@ pub enum GovernanceOpKind {
     DelegationRevoked,
 }
 
-/// Operation kinds authenticated replication v1 is permitted to apply.
+/// Operation kinds authenticated replication v1 may apply — **necessary, not sufficient**.
 ///
-/// Only `VoteCast`: its storage key `gov:vote:{proposal}:{voter}` already embeds the voter
-/// DID, so once the voter is authenticated a cross-author key collision is impossible by
-/// construction. Every other kind either has no authority root (`DomainCreated`,
-/// `DomainUpdated`), has a caller-chosen identifier that permits cross-author collision
-/// (`ProposalCreated`, `DelegationCreated`), or has an undecided state-transition authority
-/// (`ProposalOpened`, `ProposalClosed`).
+/// Only `VoteCast` clears the *structural* bar: its storage key
+/// `gov:vote:{proposal}:{voter}` already embeds the voter DID, so once the voter is
+/// authenticated a cross-author key collision is impossible by construction. Every other
+/// kind either has no authority root (`DomainCreated`, `DomainUpdated`), has a
+/// caller-chosen identifier permitting cross-author collision (`ProposalCreated`,
+/// `DelegationCreated`), or has an undecided state-transition authority (`ProposalOpened`,
+/// `ProposalClosed`).
+///
+/// # Membership is not the whole authority predicate
+///
+/// Passing this list does **not** mean an operation may be applied. In the production
+/// composition, casting a vote additionally requires that the voter is *not suspended*:
+/// `cast_vote` consults a `SuspensionChecker` wired to `CoopManager::is_member_suspended`
+/// (`icn-gateway/src/server.rs:1904`), and `close_proposal` revalidates active commons
+/// Member standing for every voter. A suspended member **remains in the domain's
+/// `StaticList`** — that is exactly the shape
+/// `icn-gateway/tests/e2e_close_time_revalidation.rs` exercises.
+///
+/// That predicate lives in commons/coop state, which is not governance state, is not
+/// visible to `GovernanceActor` at all (the checkers are HTTP-layer closures), and whose
+/// own replication is the unauthenticated class tracked by #2441. It therefore **cannot be
+/// deterministically evaluated on a receiving node**, so the ingress slice must fail closed
+/// wherever such a predicate applies rather than apply on membership alone.
 ///
 /// This is a **declaration**, not an enforcement point — enforcement lands with the ingress
 /// slice. It lives here so the decision is version-controlled next to the wire format.
+/// See `docs/design/authenticated-governance-replication.md` §7.0 and §7.0.1.
 pub const V1_RESTORABLE_OP_KINDS: &[GovernanceOpKind] = &[GovernanceOpKind::VoteCast];
 
 impl GovernanceOpKind {
@@ -262,6 +292,11 @@ impl SignedGovernanceOp {
     /// for same-key conflicts, never an acceptance gate**: a receiver must not reject an
     /// operation for having a lower `seq` than one already seen, because gossip delivers
     /// out of order and doing so would permanently discard legitimate operations.
+    ///
+    /// Refuses with [`ReplicationEnvelopeError::AuthorKeyMismatch`] if `signing_key` does
+    /// not belong to `author`. A public constructor must not hand back an object that is
+    /// unverifiable by construction — the caller would have no way to notice until a
+    /// remote node rejected it.
     pub fn sign(
         signing_key: &SigningKey,
         author: Did,
@@ -270,6 +305,14 @@ impl SignedGovernanceOp {
         seq: u64,
         op: &GovernanceMessage,
     ) -> Result<Self, ReplicationEnvelopeError> {
+        let derived = Did::from_public_key(&signing_key.verifying_key());
+        if derived != author {
+            return Err(ReplicationEnvelopeError::AuthorKeyMismatch {
+                derived: Box::new(derived),
+                declared: Box::new(author),
+            });
+        }
+
         let op_kind = GovernanceOpKind::from_message(op)
             .ok_or(ReplicationEnvelopeError::NotReplicable(op.message_type()))?;
 
@@ -584,23 +627,59 @@ mod tests {
     }
 
     #[test]
-    fn a_signature_from_a_different_key_does_not_verify() {
+    fn signing_refuses_to_name_an_author_the_key_does_not_belong_to() {
         let alice = keypair();
         let mallory = keypair();
 
-        // Mallory signs, but the envelope names Alice as author.
-        let env = SignedGovernanceOp::sign(
+        // Mallory's key, Alice's name. The constructor must refuse rather than hand back
+        // an object that can never verify.
+        let result = SignedGovernanceOp::sign(
             &signing_key(&mallory),
             alice.did().clone(),
             domain(),
             authority(),
             1,
             &vote_msg(alice.did()),
+        );
+
+        match result {
+            Err(ReplicationEnvelopeError::AuthorKeyMismatch { derived, declared }) => {
+                assert_eq!(*derived, *mallory.did());
+                assert_eq!(*declared, *alice.did());
+            }
+            other => panic!("expected AuthorKeyMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_signature_from_a_different_key_does_not_verify() {
+        // The constructor refuses this shape now, so build the adversarial object the way
+        // a hostile peer would have to: sign as Mallory, then rewrite the author on the
+        // wire. The verifier must still be what catches it — a constructor-side check
+        // protects honest callers, not against an attacker who never calls it.
+        let alice = keypair();
+        let mallory = keypair();
+
+        let mut env = SignedGovernanceOp::sign(
+            &signing_key(&mallory),
+            mallory.did().clone(),
+            domain(),
+            authority(),
+            1,
+            &vote_msg(alice.did()),
         )
         .unwrap();
+        env.author = alice.did().clone();
 
         assert_eq!(
             env.verify(),
+            Err(ReplicationEnvelopeError::SignatureInvalid)
+        );
+
+        // The tampered frame must not survive a decode→verify round trip either.
+        let round = SignedGovernanceOp::decode(&env.encode()).unwrap();
+        assert_eq!(
+            round.verify(),
             Err(ReplicationEnvelopeError::SignatureInvalid)
         );
     }
@@ -985,6 +1064,9 @@ mod tests {
 
     #[test]
     fn only_vote_cast_is_restorable_in_v1() {
+        // Structural eligibility only. Clearing this list is necessary, not sufficient —
+        // the production suspension predicate is an additional ingress gate that this
+        // module deliberately does not model. See the constant's docs.
         assert!(GovernanceOpKind::VoteCast.is_restorable_in_v1());
         for kind in [
             GovernanceOpKind::DomainCreated,

--- a/icn/crates/icn-governance/src/replication.rs
+++ b/icn/crates/icn-governance/src/replication.rs
@@ -1,0 +1,1023 @@
+//! Authenticated governance replication envelope (#2469, slice 1).
+//!
+//! # What this module is
+//!
+//! A [`SignedGovernanceOp`] binds a governance operation to the DID that authored it, to
+//! the governance domain it affects, and to the membership snapshot under which that DID
+//! held authority. It is the content-layer primitive for authenticated governance
+//! replication.
+//!
+//! **This module is deliberately unwired.** Nothing here reads or writes governance state,
+//! subscribes to gossip, or lifts the #2470 containment. It provides the type, its
+//! canonical encoding, signing and verification; ingress wiring is a later slice.
+//!
+//! # Why the signature lives here and not at the transport layer
+//!
+//! `SignedEnvelope` (`icn-net`) authenticates a *hop*: a relaying node re-serves a stored
+//! entry verbatim under its own envelope signature, so the original author's identity does
+//! not survive the relay. Authenticating the author of replicated content therefore
+//! requires a signature *inside* the replicated bytes, which is what this type is.
+//!
+//! # Why `op_bytes` is opaque
+//!
+//! The signature covers the operation's bytes exactly as transmitted, and the receiver
+//! verifies over the bytes it received rather than re-serializing. Serialization
+//! determinism is therefore never relied upon — a strictly stronger position than
+//! canonicalizing [`GovernanceMessage`], and the same discipline `SignedEnvelope` uses for
+//! its payload. The envelope's *own* fields, by contrast, are canonically encoded here
+//! (§[`SignedGovernanceOp::canonical_body`]).
+//!
+//! See `docs/design/authenticated-governance-replication.md`.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{GovernanceDomainId, GovernanceMessage};
+use icn_identity::Did;
+
+/// Frame magic and version tag. Also the domain separator for the signed body, so a
+/// signature over an envelope can never be reinterpreted under another protocol.
+pub const GOV_OP_MAGIC: &[u8] = b"ICN-GOV-OP-v1\0";
+
+/// Envelope version understood by this implementation.
+pub const GOV_OP_V1: u16 = 1;
+
+/// Domain separator for the static-membership authority snapshot.
+const MEMBERSHIP_HASH_DOMAIN: &[u8] = b"ICN-GOV-STATIC-MEMBERSHIP-v1\0";
+
+/// Errors from encoding, decoding or verifying a [`SignedGovernanceOp`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ReplicationEnvelopeError {
+    /// The frame did not begin with [`GOV_OP_MAGIC`].
+    #[error("not a governance replication frame: bad magic")]
+    BadMagic,
+
+    /// The frame declared a version this implementation does not understand.
+    #[error("unsupported governance replication envelope version: {0}")]
+    UnsupportedVersion(u16),
+
+    /// The frame ended in the middle of a field.
+    #[error("truncated governance replication frame")]
+    Truncated,
+
+    /// A length prefix exceeded the remaining frame, or a field was malformed.
+    #[error("malformed governance replication frame: {0}")]
+    Malformed(String),
+
+    /// The authority discriminant is not one this version defines.
+    #[error("unknown replication authority discriminant: {0}")]
+    UnknownAuthority(u8),
+
+    /// The operation-kind discriminant is not one this version defines.
+    #[error("unknown governance operation kind discriminant: {0}")]
+    UnknownOpKind(u8),
+
+    /// The author DID does not yield a usable Ed25519 verifying key.
+    #[error("author DID is not a usable verifying key: {0}")]
+    UnusableAuthorKey(String),
+
+    /// The signature is not 64 bytes, or does not verify under the author's key.
+    #[error("signature does not verify for the declared author")]
+    SignatureInvalid,
+
+    /// `op_bytes` did not decode as a [`GovernanceMessage`].
+    #[error("operation payload did not decode: {0}")]
+    PayloadUndecodable(String),
+
+    /// The decoded payload is a different variant than `op_kind` declares.
+    #[error("operation kind {declared:?} disagrees with payload variant {actual}")]
+    OpKindMismatch {
+        /// The kind named in the signed envelope.
+        declared: GovernanceOpKind,
+        /// The variant the payload actually decoded to.
+        actual: &'static str,
+    },
+
+    /// The message variant cannot be carried in a replication envelope.
+    #[error("governance message variant {0} is not a replicable state mutation")]
+    NotReplicable(&'static str),
+}
+
+/// The basis on which an author claims authority over a domain.
+///
+/// One variant today. It exists as an enum so that a future basis (a membership witness
+/// set, an `AuthorityGrant`, a charter binding) is a *new discriminant* that this
+/// version's verifier rejects explicitly, rather than a reinterpretation of these bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReplicationAuthority {
+    /// Authority derives from membership in a `MembershipSource::StaticList` domain,
+    /// pinned to the exact member set via [`static_membership_hash`].
+    StaticMembership {
+        /// Canonical hash of the domain's member set at authoring time.
+        membership_hash: [u8; 32],
+    },
+}
+
+impl ReplicationAuthority {
+    /// Wire discriminant. Stable across versions; never reuse a retired value.
+    const fn discriminant(&self) -> u8 {
+        match self {
+            Self::StaticMembership { .. } => 1,
+        }
+    }
+}
+
+/// The state-mutating governance operations a replication envelope may carry.
+///
+/// Deliberately not a mirror of every [`GovernanceMessage`] variant: only operations that
+/// mutate durable governance state can ever be replicated, and the pre-containment ingress
+/// persisted exactly these eight. Comment, deliberation and reaction messages were never
+/// persisted by the replication path and are therefore not replicable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GovernanceOpKind {
+    /// [`GovernanceMessage::DomainCreated`]
+    DomainCreated,
+    /// [`GovernanceMessage::DomainUpdated`]
+    DomainUpdated,
+    /// [`GovernanceMessage::ProposalCreated`]
+    ProposalCreated,
+    /// [`GovernanceMessage::ProposalOpened`]
+    ProposalOpened,
+    /// [`GovernanceMessage::VoteCast`]
+    VoteCast,
+    /// [`GovernanceMessage::ProposalClosed`]
+    ProposalClosed,
+    /// [`GovernanceMessage::DelegationCreated`]
+    DelegationCreated,
+    /// [`GovernanceMessage::DelegationRevoked`]
+    DelegationRevoked,
+}
+
+/// Operation kinds authenticated replication v1 is permitted to apply.
+///
+/// Only `VoteCast`: its storage key `gov:vote:{proposal}:{voter}` already embeds the voter
+/// DID, so once the voter is authenticated a cross-author key collision is impossible by
+/// construction. Every other kind either has no authority root (`DomainCreated`,
+/// `DomainUpdated`), has a caller-chosen identifier that permits cross-author collision
+/// (`ProposalCreated`, `DelegationCreated`), or has an undecided state-transition authority
+/// (`ProposalOpened`, `ProposalClosed`).
+///
+/// This is a **declaration**, not an enforcement point — enforcement lands with the ingress
+/// slice. It lives here so the decision is version-controlled next to the wire format.
+pub const V1_RESTORABLE_OP_KINDS: &[GovernanceOpKind] = &[GovernanceOpKind::VoteCast];
+
+impl GovernanceOpKind {
+    /// Wire discriminant. Stable across versions; never reuse a retired value.
+    const fn discriminant(&self) -> u8 {
+        match self {
+            Self::DomainCreated => 1,
+            Self::DomainUpdated => 2,
+            Self::ProposalCreated => 3,
+            Self::ProposalOpened => 4,
+            Self::VoteCast => 5,
+            Self::ProposalClosed => 6,
+            Self::DelegationCreated => 7,
+            Self::DelegationRevoked => 8,
+        }
+    }
+
+    const fn from_discriminant(d: u8) -> Option<Self> {
+        match d {
+            1 => Some(Self::DomainCreated),
+            2 => Some(Self::DomainUpdated),
+            3 => Some(Self::ProposalCreated),
+            4 => Some(Self::ProposalOpened),
+            5 => Some(Self::VoteCast),
+            6 => Some(Self::ProposalClosed),
+            7 => Some(Self::DelegationCreated),
+            8 => Some(Self::DelegationRevoked),
+            _ => None,
+        }
+    }
+
+    /// Classify a message, or `None` if it is not a replicable state mutation.
+    pub fn from_message(msg: &GovernanceMessage) -> Option<Self> {
+        match msg {
+            GovernanceMessage::DomainCreated { .. } => Some(Self::DomainCreated),
+            GovernanceMessage::DomainUpdated { .. } => Some(Self::DomainUpdated),
+            GovernanceMessage::ProposalCreated { .. } => Some(Self::ProposalCreated),
+            GovernanceMessage::ProposalOpened { .. } => Some(Self::ProposalOpened),
+            GovernanceMessage::VoteCast { .. } => Some(Self::VoteCast),
+            GovernanceMessage::ProposalClosed { .. } => Some(Self::ProposalClosed),
+            GovernanceMessage::DelegationCreated { .. } => Some(Self::DelegationCreated),
+            GovernanceMessage::DelegationRevoked { .. } => Some(Self::DelegationRevoked),
+            _ => None,
+        }
+    }
+
+    /// Whether authenticated replication v1 may apply this kind.
+    pub fn is_restorable_in_v1(&self) -> bool {
+        V1_RESTORABLE_OP_KINDS.contains(self)
+    }
+}
+
+/// Canonical hash of a `StaticList` domain's member set.
+///
+/// The member DIDs are sorted bytewise and deduplicated, so the hash is a function of the
+/// *set* and not of the order the caller happened to supply. `domain_id` is bound inside
+/// the hash so a snapshot cannot be lifted between two domains that share a member set.
+///
+/// Length-prefixed throughout: no member DID can be split or joined across a boundary to
+/// forge a different set with the same hash.
+pub fn static_membership_hash(domain_id: &GovernanceDomainId, members: &[Did]) -> [u8; 32] {
+    let mut canonical: Vec<&str> = members.iter().map(Did::as_str).collect();
+    canonical.sort_unstable();
+    canonical.dedup();
+
+    let mut hasher = Sha256::new();
+    hasher.update(MEMBERSHIP_HASH_DOMAIN);
+    push_lp(&mut hasher, domain_id.0.as_bytes());
+    hasher.update((canonical.len() as u32).to_be_bytes());
+    for did in canonical {
+        push_lp(&mut hasher, did.as_bytes());
+    }
+    hasher.finalize().into()
+}
+
+/// A governance operation bound to its author, its domain, and the membership snapshot
+/// under which that author held authority.
+///
+/// Construct with [`SignedGovernanceOp::sign`]; validate with
+/// [`SignedGovernanceOp::verify`]. Verifying establishes **content and author binding
+/// only** — that these exact bytes were authored by this DID. It does *not* establish that
+/// the DID held authority; that requires resolving the domain against local state and is
+/// the ingress slice's job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignedGovernanceOp {
+    version: u16,
+    author: Did,
+    domain_id: GovernanceDomainId,
+    authority: ReplicationAuthority,
+    seq: u64,
+    op_kind: GovernanceOpKind,
+    op_bytes: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+impl SignedGovernanceOp {
+    /// Sign a governance operation.
+    ///
+    /// `seq` orders the author's own operations within `domain_id`. It is a **comparator
+    /// for same-key conflicts, never an acceptance gate**: a receiver must not reject an
+    /// operation for having a lower `seq` than one already seen, because gossip delivers
+    /// out of order and doing so would permanently discard legitimate operations.
+    pub fn sign(
+        signing_key: &SigningKey,
+        author: Did,
+        domain_id: GovernanceDomainId,
+        authority: ReplicationAuthority,
+        seq: u64,
+        op: &GovernanceMessage,
+    ) -> Result<Self, ReplicationEnvelopeError> {
+        let op_kind = GovernanceOpKind::from_message(op)
+            .ok_or(ReplicationEnvelopeError::NotReplicable(op.message_type()))?;
+
+        let op_bytes = op
+            .to_bytes()
+            .map_err(|e| ReplicationEnvelopeError::Malformed(e.to_string()))?;
+
+        let mut envelope = Self {
+            version: GOV_OP_V1,
+            author,
+            domain_id,
+            authority,
+            seq,
+            op_kind,
+            op_bytes,
+            signature: Vec::new(),
+        };
+
+        let signature: Signature = signing_key.sign(&envelope.canonical_body());
+        envelope.signature = signature.to_bytes().to_vec();
+        Ok(envelope)
+    }
+
+    /// The exact byte range the signature covers.
+    ///
+    /// Every variable-length field is length-prefixed, so no field boundary is ambiguous
+    /// and no two distinct field assignments can produce the same body. This is also the
+    /// frame's literal prefix: an encoded envelope is `canonical_body() ‖ lp(signature)`.
+    fn canonical_body(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(GOV_OP_MAGIC);
+        out.extend_from_slice(&self.version.to_be_bytes());
+        push_lp_vec(&mut out, self.author.as_str().as_bytes());
+        push_lp_vec(&mut out, self.domain_id.0.as_bytes());
+        out.push(self.authority.discriminant());
+        match self.authority {
+            ReplicationAuthority::StaticMembership { membership_hash } => {
+                out.extend_from_slice(&membership_hash);
+            }
+        }
+        out.extend_from_slice(&self.seq.to_be_bytes());
+        out.push(self.op_kind.discriminant());
+        push_lp_vec(&mut out, &self.op_bytes);
+        out
+    }
+
+    /// Verify content and author binding.
+    ///
+    /// Establishes that these exact bytes were signed by `author`'s key. Establishes
+    /// **nothing** about authority over the domain.
+    pub fn verify(&self) -> Result<(), ReplicationEnvelopeError> {
+        if self.version != GOV_OP_V1 {
+            return Err(ReplicationEnvelopeError::UnsupportedVersion(self.version));
+        }
+
+        let verifying_key = self
+            .author
+            .to_verifying_key()
+            .map_err(|e| ReplicationEnvelopeError::UnusableAuthorKey(e.to_string()))?;
+
+        let sig_bytes: [u8; 64] = self
+            .signature
+            .as_slice()
+            .try_into()
+            .map_err(|_| ReplicationEnvelopeError::SignatureInvalid)?;
+
+        verifying_key
+            .verify(&self.canonical_body(), &Signature::from_bytes(&sig_bytes))
+            .map_err(|_| ReplicationEnvelopeError::SignatureInvalid)
+    }
+
+    /// Replay identity: the SHA-256 of the signed body.
+    ///
+    /// Derived rather than carried, so it cannot disagree with the content. A receiver
+    /// deduplicates on this value; because it is order-independent it never causes a
+    /// legitimate unseen operation to be discarded.
+    pub fn op_id(&self) -> [u8; 32] {
+        Sha256::digest(self.canonical_body()).into()
+    }
+
+    /// Decode the carried operation, checking it against the signed `op_kind`.
+    ///
+    /// Call only after [`verify`](Self::verify) — decoding unverified attacker bytes is
+    /// exactly the ordering mistake this envelope exists to prevent.
+    pub fn decode_op(&self) -> Result<GovernanceMessage, ReplicationEnvelopeError> {
+        let msg = GovernanceMessage::from_bytes(&self.op_bytes)
+            .map_err(|e| ReplicationEnvelopeError::PayloadUndecodable(e.to_string()))?;
+
+        match GovernanceOpKind::from_message(&msg) {
+            Some(actual) if actual == self.op_kind => Ok(msg),
+            _ => Err(ReplicationEnvelopeError::OpKindMismatch {
+                declared: self.op_kind,
+                actual: msg.message_type(),
+            }),
+        }
+    }
+
+    /// Serialize to the wire frame: `canonical_body() ‖ lp(signature)`.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = self.canonical_body();
+        push_lp_vec(&mut out, &self.signature);
+        out
+    }
+
+    /// Parse a wire frame. Does **not** verify the signature; call
+    /// [`verify`](Self::verify) next.
+    pub fn decode(frame: &[u8]) -> Result<Self, ReplicationEnvelopeError> {
+        let mut cur = Cursor::new(frame);
+
+        if cur.take(GOV_OP_MAGIC.len())? != GOV_OP_MAGIC {
+            return Err(ReplicationEnvelopeError::BadMagic);
+        }
+
+        let version = u16::from_be_bytes(
+            cur.take(2)?
+                .try_into()
+                .map_err(|_| ReplicationEnvelopeError::Truncated)?,
+        );
+        if version != GOV_OP_V1 {
+            return Err(ReplicationEnvelopeError::UnsupportedVersion(version));
+        }
+
+        let author_bytes = cur.take_lp()?;
+        let author_str = std::str::from_utf8(author_bytes)
+            .map_err(|e| ReplicationEnvelopeError::Malformed(e.to_string()))?;
+        let author = Did::from_str(author_str)
+            .map_err(|e| ReplicationEnvelopeError::Malformed(e.to_string()))?;
+
+        let domain_bytes = cur.take_lp()?;
+        let domain_id = GovernanceDomainId::new(
+            std::str::from_utf8(domain_bytes)
+                .map_err(|e| ReplicationEnvelopeError::Malformed(e.to_string()))?,
+        );
+
+        let authority_disc = cur.take_u8()?;
+        let authority = match authority_disc {
+            1 => {
+                let hash: [u8; 32] = cur
+                    .take(32)?
+                    .try_into()
+                    .map_err(|_| ReplicationEnvelopeError::Truncated)?;
+                ReplicationAuthority::StaticMembership {
+                    membership_hash: hash,
+                }
+            }
+            other => return Err(ReplicationEnvelopeError::UnknownAuthority(other)),
+        };
+
+        let seq = u64::from_be_bytes(
+            cur.take(8)?
+                .try_into()
+                .map_err(|_| ReplicationEnvelopeError::Truncated)?,
+        );
+
+        let kind_disc = cur.take_u8()?;
+        let op_kind = GovernanceOpKind::from_discriminant(kind_disc)
+            .ok_or(ReplicationEnvelopeError::UnknownOpKind(kind_disc))?;
+
+        let op_bytes = cur.take_lp()?.to_vec();
+        let signature = cur.take_lp()?.to_vec();
+
+        if !cur.is_empty() {
+            return Err(ReplicationEnvelopeError::Malformed(
+                "trailing bytes after frame".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            version,
+            author,
+            domain_id,
+            authority,
+            seq,
+            op_kind,
+            op_bytes,
+            signature,
+        })
+    }
+
+    /// Envelope version.
+    pub fn version(&self) -> u16 {
+        self.version
+    }
+    /// The DID whose key signed this envelope.
+    pub fn author(&self) -> &Did {
+        &self.author
+    }
+    /// The governance domain this operation affects.
+    pub fn domain_id(&self) -> &GovernanceDomainId {
+        &self.domain_id
+    }
+    /// The authority basis claimed by the author.
+    pub fn authority(&self) -> &ReplicationAuthority {
+        &self.authority
+    }
+    /// The author's per-domain ordering comparator. Not an acceptance gate.
+    pub fn seq(&self) -> u64 {
+        self.seq
+    }
+    /// The declared operation kind.
+    pub fn op_kind(&self) -> GovernanceOpKind {
+        self.op_kind
+    }
+    /// The carried operation bytes, exactly as signed.
+    pub fn op_bytes(&self) -> &[u8] {
+        &self.op_bytes
+    }
+}
+
+// ---- Encoding helpers ----
+
+fn push_lp_vec(out: &mut Vec<u8>, bytes: &[u8]) {
+    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(bytes);
+}
+
+fn push_lp(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u32).to_be_bytes());
+    hasher.update(bytes);
+}
+
+/// Bounds-checked forward reader. Every read is length-checked against the remaining
+/// frame, so a truncated or over-declared frame is an error rather than a panic.
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], ReplicationEnvelopeError> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or(ReplicationEnvelopeError::Truncated)?;
+        if end > self.buf.len() {
+            return Err(ReplicationEnvelopeError::Truncated);
+        }
+        let out = &self.buf[self.pos..end];
+        self.pos = end;
+        Ok(out)
+    }
+
+    fn take_u8(&mut self) -> Result<u8, ReplicationEnvelopeError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn take_lp(&mut self) -> Result<&'a [u8], ReplicationEnvelopeError> {
+        let len = u32::from_be_bytes(
+            self.take(4)?
+                .try_into()
+                .map_err(|_| ReplicationEnvelopeError::Truncated)?,
+        ) as usize;
+        self.take(len)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pos == self.buf.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ProposalId, Vote, VoteChoice};
+    use icn_identity::KeyPair;
+
+    fn keypair() -> KeyPair {
+        KeyPair::generate().unwrap()
+    }
+
+    fn signing_key(kp: &KeyPair) -> SigningKey {
+        SigningKey::from_bytes(&kp.to_signing_key_bytes())
+    }
+
+    fn domain() -> GovernanceDomainId {
+        GovernanceDomainId::new("domain-alpha")
+    }
+
+    fn authority() -> ReplicationAuthority {
+        ReplicationAuthority::StaticMembership {
+            membership_hash: [7u8; 32],
+        }
+    }
+
+    fn vote_msg(voter: &Did) -> GovernanceMessage {
+        let vote = Vote::new(ProposalId::new("prop-1"), voter.clone(), VoteChoice::For);
+        GovernanceMessage::vote_cast(vote, None)
+    }
+
+    fn signed(kp: &KeyPair) -> SignedGovernanceOp {
+        SignedGovernanceOp::sign(
+            &signing_key(kp),
+            kp.did().clone(),
+            domain(),
+            authority(),
+            1,
+            &vote_msg(kp.did()),
+        )
+        .unwrap()
+    }
+
+    // ---- Content and author binding ----
+
+    #[test]
+    fn a_signed_envelope_verifies_under_its_author() {
+        let kp = keypair();
+        assert!(signed(&kp).verify().is_ok());
+    }
+
+    #[test]
+    fn a_signature_from_a_different_key_does_not_verify() {
+        let alice = keypair();
+        let mallory = keypair();
+
+        // Mallory signs, but the envelope names Alice as author.
+        let env = SignedGovernanceOp::sign(
+            &signing_key(&mallory),
+            alice.did().clone(),
+            domain(),
+            authority(),
+            1,
+            &vote_msg(alice.did()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            env.verify(),
+            Err(ReplicationEnvelopeError::SignatureInvalid)
+        );
+    }
+
+    #[test]
+    fn mutating_a_single_payload_byte_breaks_verification() {
+        let kp = keypair();
+        let mut env = signed(&kp);
+        env.op_bytes[0] ^= 0x01;
+        assert_eq!(
+            env.verify(),
+            Err(ReplicationEnvelopeError::SignatureInvalid)
+        );
+    }
+
+    #[test]
+    fn retargeting_the_domain_breaks_verification() {
+        let kp = keypair();
+        let mut env = signed(&kp);
+        env.domain_id = GovernanceDomainId::new("domain-beta");
+        assert_eq!(
+            env.verify(),
+            Err(ReplicationEnvelopeError::SignatureInvalid)
+        );
+    }
+
+    #[test]
+    fn reassigning_the_author_breaks_verification() {
+        let kp = keypair();
+        let other = keypair();
+        let mut env = signed(&kp);
+        env.author = other.did().clone();
+        assert_eq!(
+            env.verify(),
+            Err(ReplicationEnvelopeError::SignatureInvalid)
+        );
+    }
+
+    #[test]
+    fn altering_the_sequence_breaks_verification() {
+        let kp = keypair();
+        let mut env = signed(&kp);
+        env.seq += 1;
+        assert_eq!(
+            env.verify(),
+            Err(ReplicationEnvelopeError::SignatureInvalid)
+        );
+    }
+
+    #[test]
+    fn altering_the_authority_snapshot_breaks_verification() {
+        let kp = keypair();
+        let mut env = signed(&kp);
+        env.authority = ReplicationAuthority::StaticMembership {
+            membership_hash: [9u8; 32],
+        };
+        assert_eq!(
+            env.verify(),
+            Err(ReplicationEnvelopeError::SignatureInvalid)
+        );
+    }
+
+    #[test]
+    fn altering_the_op_kind_breaks_verification() {
+        let kp = keypair();
+        let mut env = signed(&kp);
+        env.op_kind = GovernanceOpKind::ProposalCreated;
+        assert_eq!(
+            env.verify(),
+            Err(ReplicationEnvelopeError::SignatureInvalid)
+        );
+    }
+
+    #[test]
+    fn a_truncated_signature_is_rejected_rather_than_panicking() {
+        let kp = keypair();
+        let mut env = signed(&kp);
+        env.signature.truncate(63);
+        assert_eq!(
+            env.verify(),
+            Err(ReplicationEnvelopeError::SignatureInvalid)
+        );
+    }
+
+    // ---- op_id ----
+
+    #[test]
+    fn op_id_is_stable_across_encode_decode() {
+        let kp = keypair();
+        let env = signed(&kp);
+        let round = SignedGovernanceOp::decode(&env.encode()).unwrap();
+        assert_eq!(env.op_id(), round.op_id());
+    }
+
+    #[test]
+    fn op_id_changes_with_every_signed_field() {
+        let kp = keypair();
+        let base = signed(&kp);
+        let baseline = base.op_id();
+
+        let mut d = base.clone();
+        d.domain_id = GovernanceDomainId::new("domain-beta");
+        assert_ne!(baseline, d.op_id(), "domain_id must affect op_id");
+
+        let mut s = base.clone();
+        s.seq += 1;
+        assert_ne!(baseline, s.op_id(), "seq must affect op_id");
+
+        let mut a = base.clone();
+        a.authority = ReplicationAuthority::StaticMembership {
+            membership_hash: [9u8; 32],
+        };
+        assert_ne!(baseline, a.op_id(), "authority must affect op_id");
+
+        let mut k = base.clone();
+        k.op_kind = GovernanceOpKind::ProposalCreated;
+        assert_ne!(baseline, k.op_id(), "op_kind must affect op_id");
+
+        let mut p = base.clone();
+        p.op_bytes[0] ^= 0x01;
+        assert_ne!(baseline, p.op_id(), "op_bytes must affect op_id");
+
+        let other = keypair();
+        let mut au = base.clone();
+        au.author = other.did().clone();
+        assert_ne!(baseline, au.op_id(), "author must affect op_id");
+    }
+
+    #[test]
+    fn op_id_ignores_the_signature_itself() {
+        // The signature is not part of the signed body, so a re-signature of identical
+        // content yields the same replay identity. Ed25519 is deterministic, so this also
+        // documents that assumption explicitly rather than relying on it silently.
+        let kp = keypair();
+        let a = signed(&kp);
+        let mut b = a.clone();
+        b.signature = vec![0u8; 64];
+        assert_eq!(a.op_id(), b.op_id());
+    }
+
+    // ---- Membership hash ----
+
+    #[test]
+    fn membership_hash_ignores_member_order() {
+        let a = keypair().did().clone();
+        let b = keypair().did().clone();
+        let d = domain();
+        assert_eq!(
+            static_membership_hash(&d, &[a.clone(), b.clone()]),
+            static_membership_hash(&d, &[b, a])
+        );
+    }
+
+    #[test]
+    fn membership_hash_ignores_duplicates() {
+        let a = keypair().did().clone();
+        let b = keypair().did().clone();
+        let d = domain();
+        assert_eq!(
+            static_membership_hash(&d, &[a.clone(), b.clone()]),
+            static_membership_hash(&d, &[a.clone(), b, a])
+        );
+    }
+
+    #[test]
+    fn membership_hash_changes_when_the_member_set_changes() {
+        let a = keypair().did().clone();
+        let b = keypair().did().clone();
+        let d = domain();
+        assert_ne!(
+            static_membership_hash(&d, std::slice::from_ref(&a)),
+            static_membership_hash(&d, &[a, b])
+        );
+    }
+
+    #[test]
+    fn membership_hash_is_domain_separated() {
+        let a = keypair().did().clone();
+        let members = [a];
+        assert_ne!(
+            static_membership_hash(&GovernanceDomainId::new("domain-alpha"), &members),
+            static_membership_hash(&GovernanceDomainId::new("domain-beta"), &members)
+        );
+    }
+
+    #[test]
+    fn an_empty_member_set_is_still_bound_to_its_domain() {
+        // The degenerate case must not collapse to a constant: two domains with no
+        // members must still hash differently, or an empty snapshot would be portable
+        // between domains.
+        assert_ne!(
+            static_membership_hash(&GovernanceDomainId::new("domain-alpha"), &[]),
+            static_membership_hash(&GovernanceDomainId::new("domain-beta"), &[])
+        );
+    }
+
+    #[test]
+    fn the_domain_member_boundary_cannot_be_shifted() {
+        // Without a length prefix on domain_id, domain "ab" + member set M would hash
+        // identically to domain "a" + a set whose encoding began with "b". The prefix is
+        // what forbids that; assert the boundary is real rather than trusting it.
+        let m = keypair().did().clone();
+        assert_ne!(
+            static_membership_hash(&GovernanceDomainId::new("ab"), std::slice::from_ref(&m)),
+            static_membership_hash(&GovernanceDomainId::new("a"), std::slice::from_ref(&m))
+        );
+    }
+
+    // ---- Frame encoding ----
+
+    #[test]
+    fn encode_decode_round_trips_every_field() {
+        let kp = keypair();
+        let env = signed(&kp);
+        let round = SignedGovernanceOp::decode(&env.encode()).unwrap();
+        assert_eq!(env, round);
+        assert!(round.verify().is_ok());
+    }
+
+    #[test]
+    fn the_signed_body_is_a_prefix_of_the_frame() {
+        let kp = keypair();
+        let env = signed(&kp);
+        assert!(env.encode().starts_with(&env.canonical_body()));
+    }
+
+    #[test]
+    fn a_frame_without_the_magic_is_rejected() {
+        let kp = keypair();
+        let mut frame = signed(&kp).encode();
+        frame[0] ^= 0xff;
+        assert_eq!(
+            SignedGovernanceOp::decode(&frame),
+            Err(ReplicationEnvelopeError::BadMagic)
+        );
+    }
+
+    #[test]
+    fn a_bare_governance_message_is_not_mistaken_for_a_frame() {
+        // Migration depends on this: legacy payloads are bare JSON and must be
+        // distinguishable by magic, never by trial decoding.
+        let kp = keypair();
+        let legacy = vote_msg(kp.did()).to_bytes().unwrap();
+        assert_eq!(
+            SignedGovernanceOp::decode(&legacy),
+            Err(ReplicationEnvelopeError::BadMagic)
+        );
+    }
+
+    #[test]
+    fn an_unknown_version_is_rejected() {
+        let kp = keypair();
+        let mut frame = signed(&kp).encode();
+        let v = GOV_OP_MAGIC.len();
+        frame[v..v + 2].copy_from_slice(&99u16.to_be_bytes());
+        assert_eq!(
+            SignedGovernanceOp::decode(&frame),
+            Err(ReplicationEnvelopeError::UnsupportedVersion(99))
+        );
+    }
+
+    #[test]
+    fn a_truncated_frame_is_rejected_at_every_length() {
+        let kp = keypair();
+        let frame = signed(&kp).encode();
+        for cut in 0..frame.len() {
+            assert!(
+                SignedGovernanceOp::decode(&frame[..cut]).is_err(),
+                "prefix of length {cut} must not decode"
+            );
+        }
+    }
+
+    #[test]
+    fn trailing_bytes_are_rejected() {
+        let kp = keypair();
+        let mut frame = signed(&kp).encode();
+        frame.push(0x00);
+        assert!(matches!(
+            SignedGovernanceOp::decode(&frame),
+            Err(ReplicationEnvelopeError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn an_over_declared_length_prefix_is_rejected() {
+        let kp = keypair();
+        let mut frame = signed(&kp).encode();
+        // Author length prefix sits immediately after magic + version.
+        let at = GOV_OP_MAGIC.len() + 2;
+        frame[at..at + 4].copy_from_slice(&u32::MAX.to_be_bytes());
+        assert_eq!(
+            SignedGovernanceOp::decode(&frame),
+            Err(ReplicationEnvelopeError::Truncated)
+        );
+    }
+
+    #[test]
+    fn an_unknown_authority_discriminant_is_rejected() {
+        let kp = keypair();
+        let env = signed(&kp);
+        let mut frame = env.encode();
+        let at = GOV_OP_MAGIC.len() + 2 + 4 + env.author.as_str().len() + 4 + env.domain_id.0.len();
+        frame[at] = 0xfe;
+        assert_eq!(
+            SignedGovernanceOp::decode(&frame),
+            Err(ReplicationEnvelopeError::UnknownAuthority(0xfe))
+        );
+    }
+
+    #[test]
+    fn an_unknown_op_kind_discriminant_is_rejected() {
+        let kp = keypair();
+        let env = signed(&kp);
+        let mut frame = env.encode();
+        let at = GOV_OP_MAGIC.len()
+            + 2
+            + 4
+            + env.author.as_str().len()
+            + 4
+            + env.domain_id.0.len()
+            + 1
+            + 32
+            + 8;
+        frame[at] = 0xfd;
+        assert_eq!(
+            SignedGovernanceOp::decode(&frame),
+            Err(ReplicationEnvelopeError::UnknownOpKind(0xfd))
+        );
+    }
+
+    // ---- Payload / kind agreement ----
+
+    #[test]
+    fn decode_op_returns_the_carried_operation() {
+        let kp = keypair();
+        let env = signed(&kp);
+        let msg = env.decode_op().unwrap();
+        assert_eq!(msg.message_type(), "VoteCast");
+    }
+
+    #[test]
+    fn a_payload_disagreeing_with_the_declared_kind_is_rejected() {
+        let kp = keypair();
+        let mut env = signed(&kp);
+        // Re-sign so the signature is valid but the kind lies about the payload.
+        env.op_kind = GovernanceOpKind::DelegationRevoked;
+        let sig: Signature = signing_key(&kp).sign(&env.canonical_body());
+        env.signature = sig.to_bytes().to_vec();
+
+        assert!(env.verify().is_ok(), "signature must still be valid");
+        assert!(matches!(
+            env.decode_op(),
+            Err(ReplicationEnvelopeError::OpKindMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn a_non_mutating_message_cannot_be_wrapped() {
+        let kp = keypair();
+        let msg = GovernanceMessage::CommentCreated {
+            proposal_id: ProposalId::new("prop-1"),
+            comment_id: crate::CommentId::from_string("c-1"),
+            author: kp.did().clone(),
+            parent_id: None,
+            created_at: 0,
+        };
+        assert!(matches!(
+            SignedGovernanceOp::sign(
+                &signing_key(&kp),
+                kp.did().clone(),
+                domain(),
+                authority(),
+                1,
+                &msg,
+            ),
+            Err(ReplicationEnvelopeError::NotReplicable(_))
+        ));
+    }
+
+    // ---- v1 policy declaration ----
+
+    #[test]
+    fn only_vote_cast_is_restorable_in_v1() {
+        assert!(GovernanceOpKind::VoteCast.is_restorable_in_v1());
+        for kind in [
+            GovernanceOpKind::DomainCreated,
+            GovernanceOpKind::DomainUpdated,
+            GovernanceOpKind::ProposalCreated,
+            GovernanceOpKind::ProposalOpened,
+            GovernanceOpKind::ProposalClosed,
+            GovernanceOpKind::DelegationCreated,
+            GovernanceOpKind::DelegationRevoked,
+        ] {
+            assert!(
+                !kind.is_restorable_in_v1(),
+                "{kind:?} must stay contained in v1"
+            );
+        }
+    }
+
+    #[test]
+    fn op_kind_discriminants_are_stable() {
+        // Wire discriminants are permanent. Changing one silently reinterprets every
+        // previously signed envelope, so pin them.
+        for (kind, disc) in [
+            (GovernanceOpKind::DomainCreated, 1u8),
+            (GovernanceOpKind::DomainUpdated, 2),
+            (GovernanceOpKind::ProposalCreated, 3),
+            (GovernanceOpKind::ProposalOpened, 4),
+            (GovernanceOpKind::VoteCast, 5),
+            (GovernanceOpKind::ProposalClosed, 6),
+            (GovernanceOpKind::DelegationCreated, 7),
+            (GovernanceOpKind::DelegationRevoked, 8),
+        ] {
+            assert_eq!(kind.discriminant(), disc);
+            assert_eq!(GovernanceOpKind::from_discriminant(disc), Some(kind));
+        }
+    }
+}


### PR DESCRIPTION
**Slice 1 of authenticated governance replication. The primitive only — deliberately unwired.**

Nothing here reads or writes governance state, touches gossip, changes migration behavior, or lifts the #2470 containment. `SignedGovernanceOp` is a library type with unit tests and zero callers.

Design artifact: `docs/design/authenticated-governance-replication.md` (added here).

## What this adds

`SignedGovernanceOp` binds a governance operation to the DID that authored it, the domain it affects, and the membership snapshot under which that DID held authority — plus canonical encoding, signing, verification, a derived `op_id`, and a deterministic `static_membership_hash`.

## Why the signature is in the content, not the transport

`SignedEnvelope` authenticates a **hop**, not an author. Verified on current main: `handle_response` (`icn-gossip/src/handlers/push.rs:109`) stores a received entry verbatim, and `handle_request_missing` (`pull.rs:461`) re-serves `entry.clone()` onward under the **relay's own** envelope signature. `entry.author` therefore crosses every hop unauthenticated.

Requiring `envelope.from == entry.author` would accept only single-hop delivery, breaking relay and anti-entropy — destroying the convergence #2469 exists to restore. Authenticating the author requires a signature *inside* the replicated bytes.

## Decisions frozen into the wire format

| Decision | Rationale |
|---|---|
| `op_bytes` signed and transmitted **verbatim** | Serialization determinism is never relied upon — stronger than canonicalizing `GovernanceMessage`, and avoids a hand-rolled encoder over ~20 nested variants where a newly added field would be silently unsigned. |
| Envelope fields canonically encoded | Fixed domain separator, length-prefixed throughout, stable wire discriminants (pinned by test). |
| `op_id` **derived**, not carried | Cannot disagree with content. Order-independent, so it never discards a legitimately unseen op. |
| `seq` is a **comparator, never a gate** | A watermark (`reject seq <= last_seen`) would permanently drop op 10 when op 11 arrived first — which gossip permits and anti-entropy makes routine. |
| Authority binds **membership only** | Quorum/threshold/emergency settings govern how state is *evaluated*, not who may *author*. Binding the whole `GovernanceConfig` would invalidate in-flight votes on an unrelated quorum edit. |
| `sign()` refuses an author/key mismatch | A public constructor must not emit an object that is unverifiable by construction. |

## The v1 authority boundary (corrected in `3b7bab5a` — please read this part)

An initial draft of this work claimed `VoteCast` was restorable on StaticList membership alone. **That was wrong**, and the correction is the most important thing in this PR.

In the production composition, casting a vote *also* requires that the voter is not suspended: `cast_vote` consults a `SuspensionChecker` wired to `CoopManager::is_member_suspended` (`icn-gateway/src/server.rs:1904`), and `close_proposal` revalidates commons Member standing for every voter (`actor.rs:2149-2189`).

**A suspended member remains in the domain's `StaticList`** — precisely the shape `icn-gateway/tests/e2e_close_time_revalidation.rs` constructs. So a suspended-but-listed DID would have passed every proposed ingress check and had a vote applied that the HTTP path refuses with 403: a gossip bypass of a live production gate.

Close-time revalidation does not rescue this. It filters the effective tally, but the vote is stored and observable before close, revalidation is handler-driven and fails open when unwired, and stored state still diverges across nodes.

The predicate **cannot be evaluated on a receiving node**: it lives in commons/coop state, is invisible to `GovernanceActor` (the checkers are HTTP-layer closures), and its own replication is the unauthenticated class tracked by #2441.

> **v1 boundary = `StaticList` membership AND no external authority predicate applies on the receiver.**
> Production compositions **stay contained**. Authenticated `VoteCast` application is not restorable in production in v1.

A `standing_hash` field was considered and **rejected**: the receiver would compare it against unauthenticated commons state, manufacturing false determinism over untrusted data — worse than no field, because it would look like the hole was closed.

**This did not change the field set.** It narrows what slice 7 may apply, not what slice 1 must sign.

## Other compatibility limitation

`TrustThreshold` membership resolves against each node's **local** trust graph, so two honest nodes can reach different verdicts — permanent divergence. It stays fail-closed. `GovernanceConfig::cooperative_default()` uses `trust_threshold(0.3)`, so the default cooperative profile is not eligible for v1 either.

## Risk

Minimal. No production code path reaches this module — zero callers. The only non-additive change is one `pub mod` line in `icn-governance/src/lib.rs`.

## Test plan

34 unit tests: sign/verify round-trip; author/key mismatch refused at construction; adversarial wrong-author envelope still rejected by the verifier (before and after a decode round trip); tamper detection on every signed field; truncated signature; `op_id` determinism and per-field sensitivity; `membership_hash` set-order/duplicate invariance, domain separation, boundary-shift resistance; frame round-trip; bad magic; unknown version; truncation at every prefix length; trailing bytes; over-declared length prefix; unknown discriminants; payload/kind disagreement; legacy bare-JSON payload not mistaken for a frame.

```
cargo fmt --all --check                                        → 0
cargo clippy -p icn-governance --all-targets -- -D warnings    → 0
cargo test -p icn-governance      → 733 + 42 + 4 + 7 passed, 0 failed
doc_control_check.py                                           → 0
```

## Rebased onto `3d401dce` — slice 2 has landed

This branch is rebased onto current main, which now contains **#2583 (slice 2)**: gossip re-derives `entry.hash` from the payload before an unseen entry may claim a content-addressed slot. The two PRs were file-disjoint (3 files here, 8 there, zero overlap), so the rebase was a conflict-free replay — all three blobs are byte-identical to the pre-rebase commits.

`5e0ec94f` re-derives the design doc against `3d401dce`: §1.2/§1.3 no longer claim the hash is never recomputed, T3 moves Open → Closed, §5.6 step 6 becomes an upstream guarantee, and the slice table marks slice 2 done. **No architectural premise moved** — #2583 authenticates payload↔digest only, never authorship, so the containment and the authority boundary below are untouched.

It also corrects a mis-citation in §7.0: revision 2 cited the vote suspension gate at `handlers.rs:875`, which is the **proposer** gate on proposal submission. `handlers.rs` is untouched by #2583, so this was wrong when written rather than drift. The substance is unchanged and **stronger** — `cast_vote` carries *two* external predicates, not one: a `MemberStandingChecker` (`handlers.rs:1850`) and a `SuspensionChecker` (`handlers.rs:1864`).

## Not in this PR

Slices 3–7: signed emission, quarantine, the `op_id` applied-set and comparator, the lifecycle guard, and finally verification + apply. (Slice 2, entry-hash recomputation, landed separately as #2583.) **Only slice 7 lifts containment**, must prove positive convergence through a real relay hop, and must fail closed wherever a standing predicate is wired.

Refs #2469 #2441

