### PR TITLE
fix(gossip): reject received entries whose payload does not match their hash

### DIFF
--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -3804,8 +3804,9 @@ impl GovernanceActor {
 ///
 /// A [`icn_gossip::GossipEntry`] carries a claimed `author` DID and **no signature binding
 /// that DID to the entry contents**. The receive path (`GossipActor::store_entry`) does
-/// re-derive the entry hash from the payload and reject a mismatch (#2469 slice 2), but that
-/// binds *content to digest* and nothing else: it does not enforce the topic ACL, and the
+/// re-derive the entry hash from the payload before that entry may claim a content-addressed
+/// slot, and rejects a mismatch (#2469 slice 2), but that binds *content to digest* and
+/// nothing else: it does not enforce the topic ACL, and the
 /// transport-level policy gate above it evaluates a self-declared sender DID with no
 /// threshold attached. Every value that reaches this function is still attacker-chosen
 /// *input*, not authenticated authority. Comparing anything against `entry.author` is not an

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -3803,13 +3803,14 @@ impl GovernanceActor {
 /// governance state.
 ///
 /// A [`icn_gossip::GossipEntry`] carries a claimed `author` DID and **no signature binding
-/// that DID to the entry contents**. The receive path (`GossipActor::store_entry`) neither
-/// recomputes the entry hash — it dedups on the sender-supplied `entry.hash` — nor enforces
-/// the topic ACL, and the transport-level policy gate above it evaluates a self-declared
-/// sender DID with no threshold attached. Every value that reaches this function is
-/// attacker-chosen *input*, not authenticated authority. Comparing anything against
-/// `entry.author` is not an authorization check: a peer that wants to be treated as some DID
-/// simply writes that DID into the field.
+/// that DID to the entry contents**. The receive path (`GossipActor::store_entry`) does
+/// re-derive the entry hash from the payload and reject a mismatch (#2469 slice 2), but that
+/// binds *content to digest* and nothing else: it does not enforce the topic ACL, and the
+/// transport-level policy gate above it evaluates a self-declared sender DID with no
+/// threshold attached. Every value that reaches this function is still attacker-chosen
+/// *input*, not authenticated authority. Comparing anything against `entry.author` is not an
+/// authorization check: a peer that wants to be treated as some DID simply writes that DID
+/// into the field — and hashes its own chosen payload perfectly correctly while doing so.
 ///
 /// So this ingress applies nothing. Until authenticated governance replication exists
 /// (issue #2469), a message that arrives here is *observed*, not *obeyed*. Entries are still

--- a/icn/apps/governance/tests/fp02_governance_replication_containment.rs
+++ b/icn/apps/governance/tests/fp02_governance_replication_containment.rs
@@ -12,12 +12,13 @@
 //!
 //! `GossipEntry` (`icn-gossip/src/types.rs`) carries a claimed `author` DID but
 //! **no signature binding that DID to the entry contents**. The receive path
-//! (`GossipActor::store_entry`) re-derives the entry hash and rejects a payload that
-//! does not match it (#2469 slice 2), but it does not enforce the topic ACL and that
-//! hash says nothing about who wrote the entry. So any peer that can reach the node
-//! may still publish a correctly-hashed entry claiming *any* author. The governance
-//! replication ingress therefore receives an attacker-chosen DID, not an
-//! authenticated one — comparing anything against it is not an authorization check.
+//! (`GossipActor::store_entry`) re-derives the entry hash before an entry may claim a
+//! content-addressed slot, and rejects a payload that does not match it (#2469 slice 2),
+//! but it does not enforce the topic ACL and that hash says nothing about who wrote the
+//! entry. So any peer that can reach the node may still publish a correctly-hashed entry
+//! claiming *any* author. The governance replication ingress therefore receives an
+//! attacker-chosen DID, not an authenticated one — comparing anything against it is not
+//! an authorization check.
 //!
 //! Every negative test below uses a genuinely attacker-controlled `entry.author`.
 //! A test that merely passes `None` would not exercise the real vulnerability.

--- a/icn/apps/governance/tests/fp02_governance_replication_containment.rs
+++ b/icn/apps/governance/tests/fp02_governance_replication_containment.rs
@@ -11,12 +11,13 @@
 //! ## The mechanism these tests exercise
 //!
 //! `GossipEntry` (`icn-gossip/src/types.rs`) carries a claimed `author` DID but
-//! **no signature binding that DID to the entry contents**, and the receive path
-//! (`GossipActor::store_entry`) neither recomputes the entry hash nor enforces the
-//! topic ACL. So any peer that can reach the node may publish an entry claiming
-//! *any* author. The governance replication ingress therefore receives an
-//! attacker-chosen DID, not an authenticated one — comparing anything against it
-//! is not an authorization check.
+//! **no signature binding that DID to the entry contents**. The receive path
+//! (`GossipActor::store_entry`) re-derives the entry hash and rejects a payload that
+//! does not match it (#2469 slice 2), but it does not enforce the topic ACL and that
+//! hash says nothing about who wrote the entry. So any peer that can reach the node
+//! may still publish a correctly-hashed entry claiming *any* author. The governance
+//! replication ingress therefore receives an attacker-chosen DID, not an
+//! authenticated one — comparing anything against it is not an authorization check.
 //!
 //! Every negative test below uses a genuinely attacker-controlled `entry.author`.
 //! A test that merely passes `None` would not exercise the real vulnerability.
@@ -85,10 +86,6 @@ struct Node {
     /// only a bounded `debug!` — which is precisely why the containment holds. The negative
     /// assertions below inspect durable governance state directly.
     observed: Arc<std::sync::Mutex<Vec<(String, Did)>>>,
-    /// Distinguishes otherwise-identical injections. `store_entry` dedups on the
-    /// sender-supplied `entry.hash`, so replays must carry distinct claimed hashes to
-    /// reach the ingress independently — which is exactly the attacker's capability.
-    seq: std::sync::atomic::AtomicU64,
 }
 
 impl Node {
@@ -148,7 +145,6 @@ impl Node {
             ops,
             state,
             observed,
-            seq: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -201,16 +197,16 @@ impl Node {
         wire_sender: &Did,
         data: Vec<u8>,
     ) {
-        // The attacker picks the hash freely: `store_entry` dedups on this field and
-        // never recomputes it from `data`. Mixing in a per-injection counter models that
-        // freedom and keeps repeated injections of identical bytes from being silently
-        // deduped away before they reach the ingress.
-        let nonce = self.seq.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        let mut hash = [0u8; 32];
-        for (i, b) in data.iter().take(24).enumerate() {
-            hash[i] = *b ^ 0xA5;
-        }
-        hash[24..32].copy_from_slice(&nonce.to_le_bytes());
+        // Hash the attacker's own chosen bytes honestly. Since #2469 slice 2 the receive
+        // path re-derives this digest and refuses a mismatch, so a forged hash would be
+        // dropped by the transport and never reach the ingress these tests exist to probe.
+        //
+        // That costs the attacker nothing this suite depends on: a correct content hash
+        // says only that `data` matches the digest, and `claimed_author` below is still
+        // whatever DID the attacker cares to write. The one capability it does remove is
+        // dedup evasion — identical bytes now collapse to a single entry — so a test that
+        // needs N independent deliveries has to vary the payload rather than the hash.
+        let hash = icn_gossip::content_hash(&data);
 
         let entry = GossipEntry {
             hash,
@@ -688,12 +684,16 @@ async fn quarantine_does_not_stop_generic_gossip_transport() {
 
     let domain = make_domain("transport-check", vec![mallory.clone()]);
     let domain_id = domain.id.clone();
-    let msg = GovernanceMessage::domain_created(domain);
 
     // `inject_forged` already asserts `handle_message` returns Ok — transport accepted
     // the entry. Confirm the entry was retained by the gossip layer for observability.
-    node.inject_forged(GOVERNANCE_TOPIC, &mallory, &mallory, &msg)
-        .await;
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::domain_created(domain),
+    )
+    .await;
 
     let entries = node.gossip.read().await.get_entries(GOVERNANCE_TOPIC);
     assert!(
@@ -701,9 +701,15 @@ async fn quarantine_does_not_stop_generic_gossip_transport() {
         "the quarantined entry must still be stored by the gossip layer"
     );
 
-    // And the actor keeps serving further traffic.
-    node.inject_forged(GOVERNANCE_TOPIC, &mallory, &mallory, &msg)
-        .await;
+    // And the actor keeps serving further traffic — a second, distinct domain, since
+    // identical bytes would now be absorbed by content-addressed dedup.
+    node.inject_forged(
+        GOVERNANCE_TOPIC,
+        &mallory,
+        &mallory,
+        &GovernanceMessage::domain_created(make_domain("transport-check-2", vec![mallory.clone()])),
+    )
+    .await;
     assert!(
         node.state.get_domain(&domain_id).unwrap().is_none(),
         "transport retention must not become state application"
@@ -721,16 +727,22 @@ async fn replayed_unauthenticated_messages_remain_non_mutating() {
     let (_, proposal_id) = seed_open_proposal(&node).await;
 
     let victim = node.did.clone();
-    let vote = Vote::new(proposal_id.clone(), victim.clone(), VoteChoice::Against);
-    let msg = GovernanceMessage::vote_cast(vote, None);
 
-    // Same payload, replayed three times, each carrying a *different* claimed hash —
-    // which is what an attacker does to defeat `store_entry`'s dedup. Each injection
-    // therefore reaches the ingress independently (asserted by the positive control in
-    // `inject_forged`), and each must still be refused.
-    for _ in 0..3 {
-        node.inject_forged(GOVERNANCE_TOPIC, &victim, &mallory, &msg)
-            .await;
+    // Three attempts to record the same vote, by the same victim, on the same proposal,
+    // differing only in the vote's own timestamp. Varying the payload is what an attacker
+    // has to do to get each attempt past content-addressed dedup and in front of the
+    // ingress independently — the positive control in `inject_forged` asserts each one
+    // actually arrived. All three must still be refused.
+    for i in 0..3u64 {
+        let mut vote = Vote::new(proposal_id.clone(), victim.clone(), VoteChoice::Against);
+        vote.timestamp += i;
+        node.inject_forged(
+            GOVERNANCE_TOPIC,
+            &victim,
+            &mallory,
+            &GovernanceMessage::vote_cast(vote, None),
+        )
+        .await;
     }
 
     assert!(

--- a/icn/crates/icn-core/tests/gossip_subscription_control.rs
+++ b/icn/crates/icn-core/tests/gossip_subscription_control.rs
@@ -80,15 +80,20 @@ fn counting_callback() -> (EntryNotificationCallback, Arc<Mutex<u32>>) {
     (cb, count)
 }
 
-/// A well-formed entry that did not come from us. `author` and `hash` are attacker-chosen;
-/// `hash` is never recomputed by the receiver, so it is not an identity of anything.
+/// A well-formed entry that did not come from us. `author` is attacker-chosen and stays
+/// unauthenticated: since #2469 slice 2 the receiver re-derives `hash` from the payload, but
+/// a correct content hash identifies the *bytes*, never the peer that sent them.
+///
+/// `marker` varies the payload rather than the hash, so repeated injections remain distinct
+/// entries now that the digest is a function of the content.
 fn remote_entry(author: &Did, marker: u8) -> GossipEntry {
+    let data = format!("remote entry {marker}").into_bytes();
     GossipEntry {
-        hash: [marker; 32],
+        hash: icn_gossip::content_hash(&data),
         author: author.clone(),
         clock: VectorClock::new(),
         topic: TOPIC.to_string(),
-        data: b"remote entry".to_vec(),
+        data,
         compressed: false,
         timestamp: 1_700_000_000_000,
         replica_offered: None,

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -626,7 +626,13 @@ impl GossipActor {
                     Some(requester),
                     GossipMessage::Response {
                         entry: GossipEntry {
-                            hash: blake3::hash(&response_data).into(),
+                            // Canonical entry hash (SHA-256 over the logical payload). This
+                            // built a blake3 digest instead, which no receiver ever checked;
+                            // now that the receive path re-derives the hash, a blake3 one
+                            // would be rejected on arrival. `handle_rotation_message` has no
+                            // caller today, so this corrects a latent divergence rather than
+                            // a live path — see the PR for #2469 slice 2.
+                            hash: Self::hash_data(&response_data),
                             author: self.own_did.clone(),
                             clock: self.clock.clone(),
                             topic: crate::key_rotation::TOPIC_KEY_ROTATION.to_string(),
@@ -966,6 +972,37 @@ impl GossipActor {
     ///
     /// This method is async to allow non-blocking access to the storage quota manager.
     pub(crate) async fn store_entry(&mut self, entry: GossipEntry) -> Result<()> {
+        // Content integrity, ahead of everything that trusts `entry.hash` (#2469).
+        //
+        // On every receive path `entry.hash` is a value the sending peer chose, and the rest
+        // of this function keys off it: the dedup lookup below, the bloom filter, and the
+        // storage map itself. Re-deriving it from the payload first is what stops a peer
+        // filing arbitrary bytes under a digest they do not hash to, and stops it squatting
+        // the dedup slot of an entry it has never seen so the genuine one is later dropped
+        // as a duplicate.
+        //
+        // Enforced here rather than in the individual receive handlers because this is the
+        // only function that inserts into `self.entries` — a check in the handlers would be
+        // one forgotten ingress path away from being bypassed. It is correct for the local
+        // `publish` path too: that path hashes the caller's bytes and only then compresses,
+        // so it already satisfies the invariant by construction.
+        //
+        // This binds content to digest and nothing else. `entry.author` is still unsigned
+        // and self-declared, so this is not authorship authentication — see
+        // `GossipEntry::validate_content_integrity`.
+        if let Err(e) = entry.validate_content_integrity() {
+            warn!(
+                author = %entry.author,
+                topic = %entry.topic,
+                claimed_hash = %hex::encode(entry.hash),
+                entry_size = entry.data.len(),
+                error = %e,
+                "Rejecting entry - payload does not match claimed content hash"
+            );
+            icn_obs::metrics::gossip::entries_rejected_hash_mismatch_inc();
+            bail!("Entry rejected: {e}");
+        }
+
         let topic = &entry.topic;
         let hash = entry.hash;
         let entry_size = entry.data.len() as u64;
@@ -1217,14 +1254,11 @@ impl GossipActor {
     }
 
     /// Hash data to create content hash
+    ///
+    /// Delegates to [`crate::types::content_hash`] so the digest a publisher stamps on an
+    /// entry and the digest the receive path re-derives cannot drift apart.
     fn hash_data(data: &[u8]) -> ContentHash {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(data);
-        let result = hasher.finalize();
-        let mut hash = [0u8; 32];
-        hash.copy_from_slice(&result);
-        hash
+        crate::types::content_hash(data)
     }
 
     /// Export gossip actor state for persistence
@@ -2469,7 +2503,7 @@ mod tests {
         // ACL does not gate (`store_entry` accepts entries regardless of publish rights).
         let sender = KeyPair::generate().unwrap().did().clone();
         let entry = GossipEntry {
-            hash: [11u8; 32],
+            hash: crate::types::content_hash(b"after recreate"),
             author: sender.clone(),
             clock: VectorClock::new(),
             topic: "reconfig:me".to_string(),
@@ -2533,7 +2567,7 @@ mod tests {
             *c.lock().unwrap() += 1;
         }));
         let entry = GossipEntry {
-            hash: [9u8; 32],
+            hash: crate::types::content_hash(b"after restart"),
             author: sender.clone(),
             clock: VectorClock::new(),
             topic: "runtime:created".to_string(),

--- a/icn/crates/icn-gossip/src/gossip.rs
+++ b/icn/crates/icn-gossip/src/gossip.rs
@@ -972,14 +972,42 @@ impl GossipActor {
     ///
     /// This method is async to allow non-blocking access to the storage quota manager.
     pub(crate) async fn store_entry(&mut self, entry: GossipEntry) -> Result<()> {
-        // Content integrity, ahead of everything that trusts `entry.hash` (#2469).
+        // Content integrity for anything that can CLAIM a content-addressed slot (#2469).
         //
-        // On every receive path `entry.hash` is a value the sending peer chose, and the rest
-        // of this function keys off it: the dedup lookup below, the bloom filter, and the
-        // storage map itself. Re-deriving it from the payload first is what stops a peer
-        // filing arbitrary bytes under a digest they do not hash to, and stops it squatting
-        // the dedup slot of an entry it has never seen so the genuine one is later dropped
-        // as a duplicate.
+        // The invariant maintained here is:
+        //
+        //     no unvalidated entry may claim or mutate a content-addressed slot.
+        //
+        // `entry.hash` is chosen by the sending peer, so on arrival it is a *claim*. It is
+        // used below as the storage key, the dedup key and the bloom-filter key.
+        //
+        // Read-only duplicate lookup first. Consulting an untrusted hash is safe for a
+        // *read* because every entry resident in `self.entries` got there through this
+        // function and so already satisfied the invariant — `create_topic` only ever
+        // inserts an empty map, `restore_state` restores clock/topics/subscriptions but no
+        // entries, and there is no other writer. A hit therefore proves the slot is already
+        // owned by a validated entry, which the incoming bytes can neither claim nor mutate:
+        // they are discarded unread. Deliberately the canonical map and not the bloom
+        // filter, which is probabilistic — a false positive there would suppress a real
+        // entry.
+        //
+        // Skipping re-derivation for that case is what stops a peer replaying one ~350-byte
+        // zstd frame to force a 10 MiB decompress plus SHA-256 on every delivery while
+        // holding the actor write lock (ingress rate limiting charges per message, not per
+        // decompressed byte).
+        if self
+            .entries
+            .get(&entry.topic)
+            .is_some_and(|topic_entries| topic_entries.contains_key(&entry.hash))
+        {
+            return Ok(()); // Already have it, and it was validated when it was stored
+        }
+
+        // The slot is unclaimed, so the hash is still only a claim. Re-derive it from the
+        // payload before this entry may create storage, bloom/dedup state, or callbacks —
+        // this is what stops a peer filing arbitrary bytes under a digest they do not hash
+        // to, and stops it squatting the slot of an entry it has never seen so the genuine
+        // one is later dropped as a duplicate.
         //
         // Enforced here rather than in the individual receive handlers because this is the
         // only function that inserts into `self.entries` — a check in the handlers would be
@@ -1000,7 +1028,7 @@ impl GossipActor {
                 "Rejecting entry - payload does not match claimed content hash"
             );
             icn_obs::metrics::gossip::entries_rejected_hash_mismatch_inc();
-            bail!("Entry rejected: {e}");
+            return Err(e.context("rejecting gossip entry claiming an unoccupied content hash"));
         }
 
         let topic = &entry.topic;
@@ -1008,13 +1036,8 @@ impl GossipActor {
         let entry_size = entry.data.len() as u64;
         let author = entry.author.clone();
 
-        // Get or create topic entries
+        // Get or create topic entries. The duplicate case already returned above.
         let topic_entries = self.entries.entry(topic.clone()).or_default();
-
-        // Check if already have this entry
-        if topic_entries.contains_key(&hash) {
-            return Ok(()); // Already have it
-        }
 
         // Phase 18 Week 6: Check storage quota for author
         if let Some(quota_manager) = &self.storage_quota_manager {

--- a/icn/crates/icn-gossip/src/lib.rs
+++ b/icn/crates/icn-gossip/src/lib.rs
@@ -75,8 +75,8 @@ pub use partition::{
 pub use scalability::{CompressedVectorClock, ShardStats, ShardedTopic, TopicShard, VarInt};
 pub use sync::{Backoff, PeerSyncManager, PeerSyncState};
 pub use types::{
-    AccessControl, AdaptiveFanoutConfig, ContentHash, GossipEntry, GossipMessage, ResourceLimits,
-    Scope, Subscription, SyncCursor, Topic, TopicAutoCreationPolicy,
+    content_hash, AccessControl, AdaptiveFanoutConfig, ContentHash, GossipEntry, GossipMessage,
+    ResourceLimits, Scope, Subscription, SyncCursor, Topic, TopicAutoCreationPolicy,
 };
 pub use vector_clock::VectorClock;
 

--- a/icn/crates/icn-gossip/src/types.rs
+++ b/icn/crates/icn-gossip/src/types.rs
@@ -197,6 +197,58 @@ impl GossipEntry {
             Ok(self.data.clone())
         }
     }
+
+    /// Re-derive the content hash this entry's own payload implies.
+    ///
+    /// Hashes the *logical* payload via [`GossipEntry::get_data`], so compression is
+    /// transparent here exactly as it is for every other reader. Decompression stays
+    /// bounded, so a hostile payload yields an error rather than exhausting memory.
+    pub fn computed_content_hash(&self) -> anyhow::Result<ContentHash> {
+        Ok(content_hash(&self.get_data()?))
+    }
+
+    /// Check, fail-closed, that `hash` really is the digest of this entry's payload.
+    ///
+    /// A payload that cannot be decoded at all is a failure, not a pass: an entry whose
+    /// hash cannot be re-derived has not been shown to satisfy the invariant.
+    ///
+    /// # What a pass does and does not mean
+    ///
+    /// Passing proves exactly one thing: `data` corresponds to the digest in `hash`. It
+    /// authenticates **neither `author`, nor the peer that relayed the entry, nor any
+    /// institutional authority** — `author` remains an unsigned, self-declared field that
+    /// any peer may set to any DID. Authenticated authorship is issue #2469's remaining
+    /// work, not a property of this check.
+    pub fn validate_content_integrity(&self) -> anyhow::Result<()> {
+        use anyhow::Context;
+
+        let computed = self
+            .computed_content_hash()
+            .context("entry payload could not be decoded to re-derive its hash")?;
+
+        if computed != self.hash {
+            anyhow::bail!(
+                "content hash mismatch: entry claims {} but its payload hashes to {}",
+                hex::encode(self.hash),
+                hex::encode(computed)
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Canonical content hash for a gossip entry payload.
+///
+/// [`GossipEntry::hash`] commits to the entry's *logical* payload — the bytes the publisher
+/// supplied, before any transport compression is applied. Publication and receive-side
+/// validation both derive it here so the two can never drift apart.
+pub fn content_hash(data: &[u8]) -> ContentHash {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().into()
 }
 
 /// Decompress zstd data with a bounded output size to prevent memory exhaustion.

--- a/icn/crates/icn-gossip/tests/entry_hash_integrity.rs
+++ b/icn/crates/icn-gossip/tests/entry_hash_integrity.rs
@@ -137,6 +137,11 @@ async fn pull_response_entry_with_mismatched_hash_cannot_bypass_the_check() {
     let claimed_hash = sha256(honest_payload);
     let forged = entry_with(&sender, claimed_hash, b"attacker-substituted payload");
 
+    // Echoes the nonce of the PullRequest this answers. Despite the field name it is a
+    // request/response correlation id from `PeerSyncState::next_nonce`, not a cryptographic
+    // nonce — nothing about the check under test depends on its value.
+    let correlation_nonce = u64::from_le_bytes(claimed_hash[..8].try_into().unwrap());
+
     let result = gossip
         .handle_message(
             &sender,
@@ -144,7 +149,7 @@ async fn pull_response_entry_with_mismatched_hash_cannot_bypass_the_check() {
                 topic: TOPIC.to_string(),
                 entries: vec![forged],
                 truncated: false,
-                nonce: 1,
+                nonce: correlation_nonce,
                 next_cursor: None,
             },
         )

--- a/icn/crates/icn-gossip/tests/entry_hash_integrity.rs
+++ b/icn/crates/icn-gossip/tests/entry_hash_integrity.rs
@@ -7,11 +7,18 @@
 //! Every entry a peer supplies arrives with that hash already filled in, and the receive
 //! path used it as a storage key without ever recomputing it. These tests drive the real
 //! ingress paths (`GossipMessage::Response` and `GossipMessage::PullResponse`) through
-//! `GossipActor::handle_message` and pin that a claimed hash is re-derived before it is
-//! trusted.
+//! `GossipActor::handle_message` and pin the invariant:
+//!
+//!     no unvalidated entry may claim or mutate a content-addressed slot.
+//!
+//! An untrusted claimed hash may be read to establish that a slot is *already* owned by a
+//! previously validated entry, in which case the incoming duplicate is discarded and its
+//! bytes are never trusted or even decoded. Anything reaching new storage, new bloom/dedup
+//! state, or callbacks must first have its logical payload re-derived to its hash.
 //!
 //! Scope note: matching hashes prove only that the payload corresponds to the claimed
-//! digest. They authenticate neither `entry.author` nor any institutional authority.
+//! digest — `content <-> digest`. They authenticate neither `entry.author`, nor the relaying
+//! peer, nor any institutional authority or governance authorization.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -242,6 +249,85 @@ async fn compressed_entry_with_mismatched_hash_is_rejected() {
     assert!(
         gossip.get_entries(TOPIC).is_empty(),
         "a rejected compressed entry must never be stored"
+    );
+}
+
+/// Once a slot is occupied by a validated entry, the incoming bytes for that same hash are
+/// irrelevant — they cannot claim or mutate the slot, so they must not be decompressed or
+/// re-hashed at all.
+///
+/// The duplicate here is deliberately one that would FAIL `validate_content_integrity()` if
+/// it were ever invoked (`compressed = true` over bytes that are not a zstd frame). It must
+/// still be absorbed as a plain duplicate: no error escapes, the stored entry is untouched,
+/// and no second callback fires.
+///
+/// This is the property that makes the duplicate fast path safe rather than merely faster:
+/// an already-validated slot makes the incoming payload unable to affect any state.
+#[tokio::test]
+async fn duplicate_of_a_validated_hash_is_absorbed_without_touching_its_payload() {
+    let (mut gossip, delivered) = subscribed_actor().await;
+    let sender = KeyPair::generate().unwrap().did().clone();
+
+    // 1. A legitimate entry establishes the slot.
+    let payload = b"the genuine payload that owns this slot";
+    let hash = sha256(payload);
+    gossip
+        .handle_message(
+            &sender,
+            GossipMessage::Response {
+                entry: entry_with(&sender, hash, payload),
+            },
+        )
+        .await
+        .expect("the genuine entry must be accepted");
+
+    assert_eq!(
+        gossip.get_entries(TOPIC).len(),
+        1,
+        "precondition: the slot is occupied exactly once"
+    );
+    assert_eq!(
+        *delivered.lock().unwrap(),
+        vec![hash],
+        "precondition: the genuine entry fired exactly one callback"
+    );
+
+    // 2. A duplicate claiming the same hash, whose payload could not be re-derived at all.
+    let mut poisoned = entry_with(&sender, hash, b"not a zstd frame, and not the payload");
+    poisoned.compressed = true;
+    assert!(
+        poisoned.validate_content_integrity().is_err(),
+        "precondition: this payload must be one that validation would reject, so the test \
+         proves validation was skipped rather than passed"
+    );
+
+    let result = gossip
+        .handle_message(&sender, GossipMessage::Response { entry: poisoned })
+        .await;
+
+    // 3. It is absorbed as an ordinary duplicate — the decompression failure never happens.
+    assert!(
+        result.is_ok(),
+        "a duplicate of an already-validated hash must be discarded quietly, not decoded"
+    );
+    assert_eq!(
+        gossip.get_entries(TOPIC).len(),
+        1,
+        "the duplicate must not add a second entry"
+    );
+    assert_eq!(
+        gossip.get_entry(TOPIC, &hash).map(|e| e.data),
+        Some(payload.to_vec()),
+        "the stored entry must be untouched by the duplicate's payload"
+    );
+    assert!(
+        !gossip.get_entry(TOPIC, &hash).unwrap().compressed,
+        "the duplicate must not have mutated the stored entry's framing"
+    );
+    assert_eq!(
+        *delivered.lock().unwrap(),
+        vec![hash],
+        "a duplicate must not fire a second notification callback"
     );
 }
 

--- a/icn/crates/icn-gossip/tests/entry_hash_integrity.rs
+++ b/icn/crates/icn-gossip/tests/entry_hash_integrity.rs
@@ -1,0 +1,265 @@
+//! Content-integrity of remotely received gossip entries (#2469, slice 2).
+//!
+//! `GossipEntry.hash` is the SHA-256 of the entry's *logical* (uncompressed) payload:
+//! `GossipActor::publish` hashes the caller's bytes and only then compresses, so the
+//! contract a receiver must re-derive is `hash == sha256(entry.get_data()?)`.
+//!
+//! Every entry a peer supplies arrives with that hash already filled in, and the receive
+//! path used it as a storage key without ever recomputing it. These tests drive the real
+//! ingress paths (`GossipMessage::Response` and `GossipMessage::PullResponse`) through
+//! `GossipActor::handle_message` and pin that a claimed hash is re-derived before it is
+//! trusted.
+//!
+//! Scope note: matching hashes prove only that the payload corresponds to the claimed
+//! digest. They authenticate neither `entry.author` nor any institutional authority.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::{Arc, Mutex};
+
+use icn_gossip::{AccessControl, GossipActor, GossipEntry, GossipMessage, Topic, VectorClock};
+use icn_identity::{Did, KeyPair};
+use sha2::{Digest, Sha256};
+
+const TOPIC: &str = "integrity:test";
+
+fn sha256(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
+/// An actor subscribed to `TOPIC` by its own DID, so notification callbacks actually fire
+/// (`store_entry` gates local delivery on `local_topic_subscriptions`).
+///
+/// Returns the actor plus the hashes of every entry delivered to a callback.
+async fn subscribed_actor() -> (GossipActor, Arc<Mutex<Vec<[u8; 32]>>>) {
+    let own = KeyPair::generate().unwrap().did().clone();
+    let mut gossip = GossipActor::new(own.clone(), None);
+    gossip.create_topic(Topic::new(TOPIC.to_string(), AccessControl::Public));
+    gossip.subscribe(TOPIC, own.clone()).await.unwrap();
+    assert!(
+        gossip.is_locally_subscribed(TOPIC),
+        "precondition: the actor must be locally subscribed or callbacks never fire"
+    );
+
+    let delivered = Arc::new(Mutex::new(Vec::new()));
+    let sink = delivered.clone();
+    gossip.add_notification_callback(Arc::new(move |_topic, entry: GossipEntry, _from| {
+        sink.lock().unwrap().push(entry.hash);
+    }));
+
+    (gossip, delivered)
+}
+
+fn entry_with(author: &Did, hash: [u8; 32], data: &[u8]) -> GossipEntry {
+    GossipEntry {
+        hash,
+        author: author.clone(),
+        clock: VectorClock::new(),
+        topic: TOPIC.to_string(),
+        data: data.to_vec(),
+        compressed: false,
+        timestamp: 1_700_000_000_000,
+        replica_offered: None,
+    }
+}
+
+/// RED-1: a `Response` entry whose claimed hash is the digest of *different* bytes must not
+/// be stored, must not claim a dedup slot, and must not reach a notification callback.
+#[tokio::test]
+async fn response_entry_with_mismatched_hash_is_rejected_before_storage() {
+    let (mut gossip, delivered) = subscribed_actor().await;
+    let sender = KeyPair::generate().unwrap().did().clone();
+
+    let honest_payload = b"the payload this digest actually commits to";
+    let claimed_hash = sha256(honest_payload);
+    let forged = entry_with(&sender, claimed_hash, b"attacker-substituted payload");
+
+    let result = gossip
+        .handle_message(&sender, GossipMessage::Response { entry: forged })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an entry whose hash does not match its content must be rejected at ingress"
+    );
+    assert!(
+        gossip.get_entries(TOPIC).is_empty(),
+        "a rejected entry must never be stored"
+    );
+    assert!(
+        gossip.get_entry(TOPIC, &claimed_hash).is_none(),
+        "a rejected entry must never occupy the dedup slot for the hash it claimed"
+    );
+    assert!(
+        delivered.lock().unwrap().is_empty(),
+        "a rejected entry must never reach a notification callback"
+    );
+}
+
+/// RED-2: the same path must still accept a legitimate entry — the check rejects forgeries,
+/// not reception.
+#[tokio::test]
+async fn response_entry_with_matching_hash_is_still_accepted() {
+    let (mut gossip, delivered) = subscribed_actor().await;
+    let sender = KeyPair::generate().unwrap().did().clone();
+
+    let payload = b"a legitimately hashed payload";
+    let hash = sha256(payload);
+    let honest = entry_with(&sender, hash, payload);
+
+    gossip
+        .handle_message(&sender, GossipMessage::Response { entry: honest })
+        .await
+        .expect("a correctly hashed entry must still be accepted");
+
+    assert_eq!(
+        gossip.get_entries(TOPIC).len(),
+        1,
+        "a correctly hashed entry must still be stored"
+    );
+    assert_eq!(
+        *delivered.lock().unwrap(),
+        vec![hash],
+        "a correctly hashed entry must still reach notification callbacks exactly once"
+    );
+}
+
+/// RED-3: anti-entropy is a second insertion path into the same store. It must not be a way
+/// around the check, and a forged entry must not take the dedup slot away from the real one.
+#[tokio::test]
+async fn pull_response_entry_with_mismatched_hash_cannot_bypass_the_check() {
+    let (mut gossip, delivered) = subscribed_actor().await;
+    let sender = KeyPair::generate().unwrap().did().clone();
+
+    let honest_payload = b"the payload this digest actually commits to";
+    let claimed_hash = sha256(honest_payload);
+    let forged = entry_with(&sender, claimed_hash, b"attacker-substituted payload");
+
+    let result = gossip
+        .handle_message(
+            &sender,
+            GossipMessage::PullResponse {
+                topic: TOPIC.to_string(),
+                entries: vec![forged],
+                truncated: false,
+                nonce: 1,
+                next_cursor: None,
+            },
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "anti-entropy must re-derive the hash exactly as the push path does"
+    );
+    assert!(
+        gossip.get_entries(TOPIC).is_empty(),
+        "a rejected anti-entropy entry must never be stored"
+    );
+    assert!(
+        delivered.lock().unwrap().is_empty(),
+        "a rejected anti-entropy entry must never reach a notification callback"
+    );
+
+    // The forged entry must not have poisoned the slot: the genuine entry that really does
+    // hash to `claimed_hash` still has to be accepted afterwards.
+    let honest = entry_with(&sender, claimed_hash, honest_payload);
+    gossip
+        .handle_message(&sender, GossipMessage::Response { entry: honest })
+        .await
+        .expect("the genuine entry for that hash must still be accepted");
+
+    assert_eq!(
+        gossip.get_entry(TOPIC, &claimed_hash).map(|e| e.data),
+        Some(honest_payload.to_vec()),
+        "the genuine payload must be what ends up stored under that hash"
+    );
+}
+
+/// A compressed entry is the case a naive `sha256(entry.data)` check gets wrong: `publish`
+/// hashes the payload *before* compressing, so the digest commits to the uncompressed bytes
+/// while `data` carries the zstd frame. Reception of compressed entries must keep working.
+#[tokio::test]
+async fn compressed_entry_hashed_over_uncompressed_payload_is_accepted() {
+    let (mut gossip, delivered) = subscribed_actor().await;
+    let sender = KeyPair::generate().unwrap().did().clone();
+
+    // Well over the 1 KiB compression threshold and highly compressible, so `compress()`
+    // actually engages.
+    let payload = vec![b'z'; 8192];
+    let hash = sha256(&payload);
+    let mut entry = entry_with(&sender, hash, &payload);
+    entry.compress().unwrap();
+    assert!(
+        entry.compressed && entry.data != payload,
+        "precondition: the entry must actually be compressed for this test to mean anything"
+    );
+
+    gossip
+        .handle_message(&sender, GossipMessage::Response { entry })
+        .await
+        .expect("a compressed entry hashed over its uncompressed payload must be accepted");
+
+    assert_eq!(
+        gossip.get_entries(TOPIC).len(),
+        1,
+        "compressed entries must still be storable"
+    );
+    assert_eq!(
+        *delivered.lock().unwrap(),
+        vec![hash],
+        "compressed entries must still reach notification callbacks"
+    );
+}
+
+/// A compressed entry whose digest does not match its decompressed payload is still a
+/// forgery, and compression must not be a way to smuggle one past the check.
+#[tokio::test]
+async fn compressed_entry_with_mismatched_hash_is_rejected() {
+    let (mut gossip, _delivered) = subscribed_actor().await;
+    let sender = KeyPair::generate().unwrap().did().clone();
+
+    let payload = vec![b'z'; 8192];
+    let mut entry = entry_with(&sender, sha256(b"something else entirely"), &payload);
+    entry.compress().unwrap();
+    assert!(entry.compressed, "precondition: entry must be compressed");
+
+    let result = gossip
+        .handle_message(&sender, GossipMessage::Response { entry })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "compression must not let a mismatched hash through"
+    );
+    assert!(
+        gossip.get_entries(TOPIC).is_empty(),
+        "a rejected compressed entry must never be stored"
+    );
+}
+
+/// Hostile input must fail closed, not panic: `compressed = true` over bytes that are not a
+/// valid zstd frame cannot be re-derived, so it must be refused.
+#[tokio::test]
+async fn entry_claiming_compression_over_undecodable_bytes_is_rejected() {
+    let (mut gossip, _delivered) = subscribed_actor().await;
+    let sender = KeyPair::generate().unwrap().did().clone();
+
+    let mut entry = entry_with(&sender, sha256(b"anything"), b"not a zstd frame at all");
+    entry.compressed = true;
+
+    let result = gossip
+        .handle_message(&sender, GossipMessage::Response { entry })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an entry whose payload cannot be decoded must be refused, not accepted or panicked on"
+    );
+    assert!(
+        gossip.get_entries(TOPIC).is_empty(),
+        "an undecodable entry must never be stored"
+    );
+}

--- a/icn/crates/icn-obs/src/metrics_legacy.rs
+++ b/icn/crates/icn-obs/src/metrics_legacy.rs
@@ -2382,6 +2382,12 @@ pub mod gossip {
         counter!("icn_gossip_messages_rejected_low_trust_total").increment(1);
     }
 
+    /// #2469: Entries rejected because the payload does not hash to the claimed
+    /// `entry.hash` (content-integrity failure, not an authorship check)
+    pub fn entries_rejected_hash_mismatch_inc() {
+        counter!("icn_gossip_entries_rejected_hash_mismatch_total").increment(1);
+    }
+
     // Issue #123: Message compression metrics
     /// Track bytes before compression
     pub fn bytes_before_compression_add(bytes: u64) {


### PR DESCRIPTION
Slice 2 of #2469, and an **independent prerequisite** — it branches from `main`, not from the slice-1 envelope work in #2582, and does not depend on `SignedGovernanceOp`.

## What

`GossipEntry.hash` is the SHA-256 of the entry's *logical* payload. The receive path never re-derived it: `handle_response` and `handle_pull_response` hand a peer-supplied entry straight to `store_entry`, which then uses the **claimed** hash as the storage key, the dedup key and the bloom-filter key.

Two consequences, both reachable by any peer that can deliver a gossip message:

1. Arbitrary bytes could be filed under any digest — content addressing was not actually enforced anywhere.
2. A peer could **squat the slot** of an entry it had never seen, so the genuine entry carrying that hash was later dropped as a duplicate.

## The invariant

> **No unvalidated entry may claim or mutate a content-addressed slot.**

An untrusted claimed hash may be used for a **read-only lookup** solely to establish that a slot is *already* owned by a previously validated entry — in which case the incoming duplicate is discarded and its bytes are never trusted or even decoded.

Anything that reaches **new storage, new bloom/dedup state, or callbacks** must first have its logical payload re-derived to its hash.

## How

Enforced in `store_entry`, which is the only function that inserts into `self.entries`. That seam was chosen over the individual receive handlers because a check in the handlers would be one future ingress path away from a silent bypass. It is also correct for local publish, which already satisfies the invariant by construction: `publish` hashes the caller's bytes and only then compresses.

Hashing goes through `GossipEntry::get_data()`, so:

- **compressed entries are covered correctly** — the digest commits to the uncompressed payload, so a naive `sha256(entry.data)` would have rejected every compressed entry;
- **hostile input fails closed** — a payload claiming `compressed = true` over a non-zstd frame errors out through the existing bounded decoder rather than panicking or allocating without limit.

Rejection is fail-closed, preserving the `anyhow` cause chain, with a structured `warn!` and an `icn_gossip_entries_rejected_hash_mismatch_total` counter.

### Why consulting a stored hash before validating is safe

Every entry resident in `self.entries` got there through `store_entry` and therefore already satisfied the invariant. Verified exhaustively on this branch:

- `create_topic` inserts only an **empty** map;
- `restore_state` restores clock/topics/subscriptions but **no entries** (gossip entries are not persisted — they are re-gossiped via anti-entropy);
- `ShardedTopic` in `scalability.rs` holds a second `entries` map but has **no in-workspace consumer**;
- `store_entry` has exactly three callers — `publish`, `handle_response`, `handle_pull_response`.

So a lookup hit *proves* the slot is owned by a validated entry, which the incoming bytes can neither claim nor mutate. The **canonical map** is used deliberately and **not the bloom filter** — a probabilistic false positive there could suppress a real entry.

## Review findings addressed

**Copilot — error chain.** `bail!("Entry rejected: {e}")` flattened the `anyhow` cause chain into a string. Now returns the original error via `.context(...)`.

**Codex P1 — decompression before dedup.** Confirmed from source, not taken on faith:

- `GossipHandle = Arc<RwLock<GossipActor>>` and the incoming handler holds `.write().await` across `handle_message`, so this work serialises **all** gossip processing;
- `MAX_DECOMPRESSED_SIZE` is 10 MiB, and a measured worst case is **~350 bytes of zstd expanding to 10 MiB (~30,000×)**;
- ingress rate limiting charges **per message**, not per decompressed byte.

So a peer could replay one small frame and force a 10 MiB decompress + SHA-256 on every delivery, under the actor write lock, even though the slot was already occupied. The duplicate fast path removes exactly that: a duplicate of an already-validated hash is discarded without decompressing or hashing the incoming payload. An **unseen** hash is still fully re-derived before it may claim anything.

**CodeQL — hard-coded nonce.** Addressed in `a43f6714`; the thread is resolved and outdated. The gossip pull nonce is a request/response correlation id from `PeerSyncState::next_nonce`, not a cryptographic nonce. No suppression or CodeQL config was added.

## Security property

**What this provides:** anything stored, dedup-visible, bloom-visible, or callback-visible has had its payload re-derived to the digest it claims. Content is bound to digest.

**What this does NOT provide:**

- It does **not** authenticate `entry.author`. That field remains unsigned and self-declared; any peer may set it to any DID and hash its own chosen payload perfectly correctly.
- It does **not** authenticate the relaying peer, any institutional authority, or any governance authorization.
- It does **not** restore governance replication, and **#2470 containment is unchanged** — replicated governance state is still applied nowhere.

Authenticated authorship remains the open part of #2469.

## Also in this diff

- `GossipActor::hash_data` now delegates to the canonical `types::content_hash`, so the digest a publisher stamps and the digest a receiver re-derives cannot drift apart.
- The key-rotation query responder stamped a **blake3** digest on an entry it emitted as a `Response`, diverging from the SHA-256 contract. `handle_rotation_message` has no caller anywhere in the workspace, so this corrects a latent divergence rather than a live path.

## Test-fixture updates (not behaviour changes)

Some existing fixtures forged hashes, which is no longer a capability an attacker has. They now vary the **payload** instead of the digest, preserving each test's property:

- `fp02_governance_replication_containment` (#2470) — the injector hashes the attacker's own bytes honestly; `entry.author` stays fully attacker-controlled, which is what those tests actually exercise.
- `gossip_subscription_control` (#2471) — `remote_entry`'s `marker` varies the data rather than the hash.

## Risk

Rejection propagates as an `Err`, so a `PullResponse` batch containing a forged entry aborts mid-batch. **Not a new failure class** — `store_entry` could already abort a pull batch via the storage-quota `bail!`. The peer sending the forged entry is the one whose own sync stalls; no third-party amplification.

Rejections are not cached, so a peer can re-offer the same *unseen* bad hash and drive repeated Request/Response round-trips. This is 1:1 and bounded by the peer's own bandwidth. No peer-penalty framework is introduced here.

## Test plan

`icn-gossip/tests/entry_hash_integrity.rs` — 7 tests driving the **real** ingress (`handle_message` → `Response` / `PullResponse`):

- forged hash rejected before storage, before the dedup slot is claimed, before callbacks;
- anti-entropy cannot bypass the check, and a forged entry cannot poison the slot of the genuine entry that really does hash to that digest;
- compressed-valid accepted; compressed-forged rejected; undecodable-zstd refused;
- **duplicate of a validated hash is absorbed without touching its payload** — the duplicate is deliberately one that *would fail* validation (`compressed = true` over non-zstd bytes), proving validation was skipped rather than passed, and that the stored entry, its framing, and the callback count are all unchanged.

Mutation proof (two orthogonal mutations):

- bypass unseen-hash validation → the 4 forgery tests go RED, duplicate test unaffected;
- force duplicates back through validation → only the duplicate test goes RED, the 6 others stay green.

Gates: `cargo test -p icn-gossip -p icn-governance-actor -p icn-obs -p icn-core` → 126 suites, 1870 tests, 0 failures (`fp02` 12, `gossip_subscription_control` 9, `entry_hash_integrity` 7). `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `check-meaning-firewall.sh` (icn-gossip clean), `drift-check.sh`, `git diff --check` — all pass.

Base-health note: `Security Audit` fails on `main` at the base commit `c3782321` with an **identical 11-RUSTSEC advisory set** (pre-existing, #2579). It is not a branch-protection–required check. `Compare Against Base` is likewise non-required.

Refs #2469
