### PR TITLE
feat(governance): emit signed replication envelopes from the publish path (#2469 slice 3)

### DIFF
--- a/docs/design/authenticated-governance-replication.md
+++ b/docs/design/authenticated-governance-replication.md
@@ -1,7 +1,7 @@
 # Authenticated governance replication (#2469)
 
-**Status:** design + slice 1 (unwired primitive).
-**Derived against:** `origin/main` = `3d401dce0c65d70eea117335b48719baa2231e2e`.
+**Status:** design + slice 1 (primitive) + slice 2 (#2583) + slice 3 (signed emission).
+**Derived against:** `origin/main` = `6754d30c83cc944e5ad22e4687e5bb63ac8dc51e`.
 **Owns:** the durable replacement for the #2470 containment.
 **Refs:** #2469, #2441, #2470 (`bc291305`), #2471, #2480, #2510, #2520, #2535, #2544, #2583.
 
@@ -21,6 +21,13 @@ than work this design still has to schedule. **No architectural premise changed*
 authenticates payload↔digest only, and leaves authorship, authority and the #2470
 containment exactly as they were. Revision 3 also corrects a §7.0 mis-citation: the vote
 suspension gate was cited at the *proposer* gate's line.
+
+**Revision 4** lands **slice 3** (signed emission) at `6754d30c` and records what wiring the
+emission path revealed. Two findings are load-bearing for slice 7 and are written up in
+§7.0.2 and §7.0.3: **a node can only sign for itself**, which removes gateway-hosted votes
+from the signable set for a reason independent of §7.0.1; and **per-federation governance
+topics are never created**, so that route carries nothing today. Neither moves the field set.
+§13 records the slice as done.
 
 ---
 
@@ -464,6 +471,62 @@ squarely #2441's territory (authenticated institutional-state replication) and i
 in scope here. This is the second place where #2469 and #2441 turn out to be genuinely
 coupled — the first being the shared quarantine machinery (§11).
 
+### 7.0.2 A node can only sign for itself — the custody boundary
+
+Derived while wiring slice 3, at `6754d30c`.
+
+The envelope's `author` is the **acting principal**, and `SignedGovernanceOp::sign` refuses
+any key that does not derive it (`replication.rs:308`). A `GovernanceActor` holds exactly one
+key: the node's own identity key, extracted from `identity_bundle.keypair()`
+(`icn-core/src/supervisor/lifecycle.rs:782`).
+
+But `GovernanceCommand::CastVote { proposal_id, voter, choice, comment }`
+(`apps/governance/src/actor.rs:2073`) takes `voter` as a **parameter**, and the actor never
+constrains it to `self.did`. In the gateway composition many members vote through one node,
+which holds none of their key material.
+
+> **A node can emit a signed operation only when it *is* the acting principal.**
+> Gateway-hosted votes are unsignable in v1 — not a gap to patch, a custody fact. Signing a
+> member's vote with the node's key would assert an authorship that does not exist, which is
+> precisely the forgery this envelope exists to prevent.
+
+This is **additive to §7.0.1, not a restatement**, and it bites at the opposite end of the
+pipe. §7.0.1 says a *receiver* cannot evaluate the standing predicate, so it must not apply.
+This says a *sender* cannot produce the envelope at all. Either one alone is enough to keep
+production contained; together they mean the gateway path is contained twice over.
+
+**Consequence for slice 7.** Restoring `VoteCast` application does not, by itself, make
+gateway deployments converge, because those nodes emit nothing to converge on. A deployment
+only produces signed votes where the voter's own daemon holds the voter's key. Any plan that
+assumes slice 7 restores replication for the gateway composition is wrong on both counts.
+
+Slice 3 therefore falls back to the legacy payload whenever the key does not belong to the
+acting principal, and pins that in `signed_governance_emission.rs`
+(`a_vote_cast_for_another_member_is_never_signed`).
+
+### 7.0.3 Per-federation governance topics are never created
+
+Also derived at `6754d30c`, and **pre-existing** — unchanged by slice 3.
+
+`publish_federation_if_scoped` (`actor.rs:3269`) publishes to
+`federation:governance:<fed_id>`. The only federation governance topic anything creates or
+subscribes is the **root** `federation:governance`
+(`icn-core/src/supervisor/init_gossip.rs:325`). `TopicAutoCreationPolicy` defaults to
+`Reject` (`icn-gossip/src/types.rs:617`) and nothing in production calls
+`set_topic_auto_creation_policy`, so the per-federation publish is refused — and
+`publish_federation_if_scoped` swallows the error with a `warn!`.
+
+Federation-scoped governance therefore **never reaches the wire** in the default
+configuration, signed or legacy, before slice 3 or after it. Verified empirically: a
+federation-scoped vote produces three entries on `governance:proposal` and zero on
+`federation:governance:<fed_id>`.
+
+The emission policy still covers the route **by construction** — `publish` and
+`publish_to_topic` share one encoder — which the suite proves by declaring the topic first.
+Wiring the topic itself is a topic-lifecycle change outside #2469; the current behaviour is
+pinned by `a_per_federation_topic_is_never_created_in_the_default_configuration` so a later
+fix cannot land silently.
+
 ### 7.1 Why `DelegationRevoked` is excluded despite being safe
 
 Revocation is monotonic, idempotent, order-independent, and authorized by a principal named
@@ -676,7 +739,7 @@ unit tests are listed separately in §13.
 |---|---|---|
 | **1** | `SignedGovernanceOp` type, magic + version, canonical encoding, `membership_hash`, sign/verify (refusing an author/key mismatch), derived `op_id`. **Library only, unwired.** | No |
 | 2 | ✅ **DONE — #2583 (`3d401dce`).** Re-derive `entry.hash` on receipt in gossip. Generic, separable. | No |
-| 3 | Emit signed envelopes from the governance publish path (durable per-`(author,domain)` seq, #2510 pattern); accept both shapes; apply nothing. | No |
+| 3 | ✅ **DONE.** Emit signed envelopes from the governance publish path (durable per-`(author,domain)` seq, #2510 pattern); recognise both shapes; apply nothing. | No |
 | 4 | Bounded quarantine store + steward release valve. | No |
 | 5 | Durable `op_id` applied-set + the §10.3 comparator in the state store. | No (local semantics only) |
 | 6 | Lifecycle monotonicity guard, enforced unconditionally. | No |
@@ -684,6 +747,25 @@ unit tests are listed separately in §13.
 
 Slices 1–6 restore nothing. Slice 7 is the only one that lifts containment, and does so in
 the same change that proves positive convergence (test 18).
+
+**Slice 3, as built.** `publish` (`actor.rs:3128`) and `publish_to_topic` (`:3136`) are the
+only two functions that hand governance bytes to gossip, and both route through one
+`encode_for_emission` seam, so federation cannot drift onto a different policy. Corrected
+counts: **12** `publish` call sites (not ~10), and **1** `publish_to_topic` call site (not
+~9) — `publish_federation_if_scoped`, which itself has 7 callers.
+
+Eligibility falls back to the legacy payload at every step (kind not replicable, no acting
+principal, domain unresolvable, membership not `StaticList`, no key, key not the
+principal's); **commitment** fails closed, because a signed operation carrying a sequence
+that was never persisted is an ambiguity no receiver can detect. Signing is not restricted
+to `V1_RESTORABLE_OP_KINDS` — `ProposalCreated`, `DelegationCreated` and `DelegationRevoked`
+are signed where their principal is the node — but **eligible is not restorable**, and
+ingress still applies nothing.
+
+Recognition reads `entry.get_data()`, not `entry.data`: `publish` compresses entries above a
+size threshold *after* hashing, so the raw field is not the payload and a prefix check over
+it would misclassify every large entry. This matches `computed_content_hash`, which resolves
+the logical payload for the same reason.
 
 **Slice 1 unit tests (this change):**
 sign→verify round-trip; tampered `op_bytes`; tampered `domain_id`; tampered `author`;

--- a/icn/apps/governance/src/actor.rs
+++ b/icn/apps/governance/src/actor.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, error, info, warn};
 
+use crate::replication_emission::{self, Eligibility};
+use crate::replication_sequence::GovernanceSequenceCounter;
 use crate::state_store::{GovernanceStateStore, SledGovernanceStateStore};
 use icn_gossip::GossipActor;
 use icn_identity::Did;
@@ -1244,6 +1246,19 @@ pub struct GovernanceActor {
     /// (proposal_id, effect_kind) keeps this safe when the HTTP handler
     /// also invokes emission after the actor-backed close returns.
     receipt_store: Option<Arc<dyn crate::receipt_backend::GovernanceReceiptBackend>>,
+    /// Durable per-`(author, domain)` sequence source for signed governance emission (#2469).
+    ///
+    /// Consumed only on the emission path, and only after an operation has been found
+    /// eligible to sign. `seq` is a comparator for same-key conflicts, never an acceptance
+    /// gate — there is deliberately no receive-side counterpart.
+    replication_sequences: Arc<GovernanceSequenceCounter>,
+    /// The DID derived from [`Self::signing_key`], or `None` when no key is available.
+    ///
+    /// Cached at construction because deriving it is a scalar multiplication and the
+    /// emission path consults it on every publish. Holding it separately from `did` is what
+    /// lets `classify` check the key against the acting principal *and* against this node's
+    /// identity rather than assuming the two agree.
+    signing_key_did: Option<Did>,
 }
 
 impl GovernanceActor {
@@ -1257,6 +1272,33 @@ impl GovernanceActor {
         signing_key: Option<Arc<ed25519_dalek::SigningKey>>,
     ) -> Result<GovernanceHandle> {
         info!("Spawning GovernanceActor for DID: {}", did);
+
+        // Durable emission sequences share the governance store, so a restart resumes them
+        // together with the state they order. Opening fails only on a corrupt or
+        // future-versioned store, which must stop the actor rather than silently restart
+        // sequences this node has already published under its signature (#2510).
+        let replication_sequences = Arc::new(GovernanceSequenceCounter::new(store.clone())?);
+
+        // Derived once: the identity the available key actually proves. This is checked
+        // against the acting principal on every signed emission.
+        let signing_key_did = signing_key
+            .as_ref()
+            .map(|k| Did::from_public_key(&k.verifying_key()));
+
+        if let Some(ref key_did) = signing_key_did {
+            if key_did != &did {
+                // Not fatal: signing simply never engages, because `classify` requires the
+                // key to belong to both the acting principal and this node. Worth saying
+                // loudly, since it means every governance emission stays on the legacy path.
+                warn!(
+                    actor_did = %did,
+                    key_did = %key_did,
+                    "Governance signing key does not match the actor DID; \
+                     signed replication emission is disabled for this node"
+                );
+            }
+        }
+
         // Wrap raw store in typed state store abstraction
         let store: Arc<dyn GovernanceStateStore> = Arc::new(SledGovernanceStateStore::new(store));
 
@@ -1294,7 +1336,41 @@ impl GovernanceActor {
                     return;
                 }
 
-                match GovernanceMessage::from_bytes(&entry.data) {
+                // Resolve the *logical* payload before looking at it. `GossipActor::publish`
+                // compresses entries above a size threshold *after* hashing them, so
+                // `entry.data` is not necessarily the payload — reading it raw would
+                // misclassify every entry large enough to have been compressed, in both
+                // directions.
+                //
+                // `get_data` is the accessor `computed_content_hash` already uses for
+                // exactly this reason, and its decompression is bounded. It has also
+                // already succeeded once for this entry: `store_entry` runs
+                // `validate_content_integrity` (#2583) before firing any callback, so
+                // nothing here is the first code to touch hostile bytes.
+                let payload = match entry.get_data() {
+                    Ok(payload) => payload,
+                    Err(e) => {
+                        debug!("Governance entry payload could not be read: {}", e);
+                        return;
+                    }
+                };
+
+                // Discriminate the two wire shapes on the frame magic, never by trying to
+                // decode one and falling through on failure. Trial decoding would make the
+                // format decision a function of a parser's error behaviour on hostile bytes,
+                // and would silently reclassify anything a future decoder became more
+                // permissive about.
+                //
+                // Recognition only. A signed frame is *not* decoded, *not* verified and
+                // *not* applied here: slice 3 restores no remote state application, and
+                // parsing an unverified attacker-supplied envelope to enrich a log line
+                // would be work done on behalf of an unauthenticated peer for no benefit.
+                if payload.starts_with(icn_governance::replication::GOV_OP_MAGIC) {
+                    observe_replicated_signed_frame(payload.len(), &did_notify);
+                    return;
+                }
+
+                match GovernanceMessage::from_bytes(&payload) {
                     Ok(msg) => observe_replicated_governance_message(&msg, &did_notify),
                     Err(e) => {
                         debug!("Failed to deserialize governance message: {}", e);
@@ -1322,6 +1398,8 @@ impl GovernanceActor {
             executor: None,
             action_item_store: None,
             receipt_store: None,
+            replication_sequences,
+            signing_key_did,
         };
 
         // Slot for the scheduler task JoinHandle; filled in after spawn.
@@ -3124,9 +3202,63 @@ impl GovernanceActor {
         Ok(())
     }
 
+    /// Encode an outbound governance message, signing it when this node can (#2469 slice 3).
+    ///
+    /// The **single** encoding seam. `publish` and `publish_to_topic` are the only two
+    /// functions that hand governance bytes to gossip, and both route through here, so the
+    /// federation topics cannot drift onto a different emission policy than
+    /// `governance:proposal` — there is no second place to forget to update.
+    ///
+    /// Returns either a `SignedGovernanceOp` frame or the legacy payload, byte-identical to
+    /// what this node published before slice 3. See [`crate::replication_emission`] for why
+    /// eligibility degrades to legacy while commitment fails closed.
+    ///
+    /// The returned bytes become the gossip entry's `data` verbatim, and `store_entry`
+    /// re-derives `entry.hash` from them (#2583) — the frame is bound to its digest by that
+    /// mechanism, not by a second one here.
+    async fn encode_for_emission(&self, msg: &GovernanceMessage) -> Result<Vec<u8>> {
+        let decision = replication_emission::classify(
+            self.store.as_ref(),
+            msg,
+            &self.did,
+            self.signing_key_did.as_ref(),
+        );
+
+        let Eligibility::Signed {
+            author,
+            domain_id,
+            authority,
+        } = decision
+        else {
+            if let Eligibility::Legacy(reason) = decision {
+                debug!(
+                    message_type = msg.message_type(),
+                    reason = reason.as_str(),
+                    "Emitting governance message unsigned"
+                );
+            }
+            return msg.to_bytes().map_err(Into::into);
+        };
+
+        // Eligibility already established that a key exists and derives `author`; this is the
+        // structural proof of it rather than an `expect`.
+        let Some(ref signing_key) = self.signing_key else {
+            return msg.to_bytes().map_err(Into::into);
+        };
+
+        replication_emission::build_signed_frame(
+            signing_key,
+            author,
+            domain_id,
+            authority,
+            &self.replication_sequences,
+            msg,
+        )
+    }
+
     /// Publish a governance message to the network
     async fn publish(&self, msg: GovernanceMessage) -> Result<[u8; 32]> {
-        let bytes = msg.to_bytes()?;
+        let bytes = self.encode_for_emission(&msg).await?;
         let mut g = self.gossip.write().await;
         let hash = g.publish(GOVERNANCE_TOPIC, bytes).await?;
         Ok(hash)
@@ -3134,7 +3266,7 @@ impl GovernanceActor {
 
     /// Publish a governance message to a specific topic
     async fn publish_to_topic(&self, topic: &str, msg: GovernanceMessage) -> Result<[u8; 32]> {
-        let bytes = msg.to_bytes()?;
+        let bytes = self.encode_for_emission(&msg).await?;
         let mut g = self.gossip.write().await;
         let hash = g.publish(topic, bytes).await?;
         Ok(hash)
@@ -3840,6 +3972,24 @@ impl GovernanceActor {
 /// outright — "failure doesn't roll back the local write"). The loopback copy this ingress
 /// also receives is a redundant re-application of state the node already wrote, so refusing
 /// it costs local governance nothing.
+/// Note a `SignedGovernanceOp` frame arriving on a governance topic (#2469 slice 3).
+///
+/// The signed shape is **recognised, not honoured**. Everything the containment above says
+/// applies unchanged: this runs in the same callback, which captures no
+/// `GovernanceStateStore`, so a signed entry has no more path to governance state than an
+/// unsigned one. A valid signature proves content and authorship; it proves nothing about
+/// authority over a domain, and authority is what applying state would require.
+///
+/// Only the frame length is recorded — deliberately not the author, op kind or domain, all
+/// of which would require parsing an unverified envelope supplied by an unauthenticated peer.
+fn observe_replicated_signed_frame(frame_len: usize, local_did: &Did) {
+    debug!(
+        local_did = %local_did,
+        frame_len,
+        "Signed governance replication frame observed; recognised but not verified or applied"
+    );
+}
+
 fn observe_replicated_governance_message(msg: &GovernanceMessage, local_did: &Did) {
     // Bounded and deliberately low-severity: `message_type()` is a `&'static str` over a
     // fixed variant set, and this path fires for ordinary local governance too (each local

--- a/icn/apps/governance/src/lib.rs
+++ b/icn/apps/governance/src/lib.rs
@@ -43,6 +43,8 @@ pub mod mandate_gate;
 pub mod receipt_backend;
 pub mod registry;
 pub mod rehearsal_workspace;
+pub mod replication_emission;
+pub mod replication_sequence;
 pub mod state_store;
 
 pub use actor::{GovernanceActor, GovernanceCommand, GovernanceConfigLite, GovernanceHandle};

--- a/icn/apps/governance/src/replication_emission.rs
+++ b/icn/apps/governance/src/replication_emission.rs
@@ -1,0 +1,709 @@
+//! Signed governance emission — the sending half of #2469 (slice 3).
+//!
+//! Decides whether an outbound [`GovernanceMessage`] can be wrapped in a
+//! [`SignedGovernanceOp`] and, if so, builds the frame. Everything here is **emission only**.
+//! No function in this module is reachable from the receive path, and slice 3 restores no
+//! remote state application whatsoever: the #2470 containment is untouched.
+//!
+//! # The two-phase rule
+//!
+//! Eligibility and commitment fail in opposite directions, deliberately:
+//!
+//! - **Eligibility is best-effort.** Any reason we cannot establish a signed envelope —
+//!   unresolvable domain, non-`StaticList` membership, absent key, an author we do not hold
+//!   the key for — degrades to the legacy payload, which is byte-identical to what this node
+//!   published before slice 3. Nothing regresses, and the common `cooperative_default()`
+//!   profile (`trust_threshold(0.3)`) keeps working exactly as it does today.
+//! - **Commitment is fail-closed.** Once we have decided to sign, the sequence must be
+//!   durably recorded before the frame goes out. A failure there aborts the publish rather
+//!   than quietly downgrading, because a signed operation carrying an unrecorded sequence is
+//!   an ambiguity no receiver can detect (see [`crate::replication_sequence`]).
+//!
+//! # Who may be named as author
+//!
+//! The envelope's `author` is the **acting principal** — the member whose authority the
+//! operation claims — not the node that relays it. `SignedGovernanceOp::sign` enforces this
+//! by refusing any key that does not derive `author`, and the ingress design
+//! (`docs/design/authenticated-governance-replication.md` §5.6 step 5) re-checks the op's
+//! internal principal against it.
+//!
+//! A `GovernanceActor` holds exactly one key: the node's own identity key
+//! (`icn-core/src/supervisor/lifecycle.rs:782`). It therefore cannot sign for anyone else.
+//! `GovernanceCommand::CastVote` accepts a `voter` parameter and never constrains it to
+//! `self.did`, so in the gateway composition — many members voting through one node — the
+//! node holds none of their keys and every vote takes the legacy path. That is a custody
+//! fact, not a gap to be patched: signing a member's vote with the node's key would assert an
+//! authorship that does not exist, which is exactly the forgery this envelope prevents.
+//!
+//! # Eligible is not restorable
+//!
+//! Several op kinds can be signed here that no v1 receiver may ever apply
+//! (`V1_RESTORABLE_OP_KINDS` is `[VoteCast]` alone). Signing them costs nothing and keeps one
+//! emission rule instead of two, but it confers no application rights: restorability is
+//! decided at ingress, in a later slice.
+
+use anyhow::{Context, Result};
+
+use icn_governance::replication::{
+    static_membership_hash, GovernanceOpKind, ReplicationAuthority, SignedGovernanceOp,
+};
+use icn_governance::{
+    DelegationScope, GovernanceDomainId, GovernanceMessage, MembershipSource, ProposalId,
+};
+use icn_identity::Did;
+
+use crate::replication_sequence::GovernanceSequenceCounter;
+use crate::state_store::GovernanceStateStore;
+
+/// Why an outbound message was not signed.
+///
+/// Carried rather than merely logged so tests can assert *which* guard fired. A test that
+/// only asserted "the payload is legacy" would pass just as happily if signing were broken
+/// outright, or if the wrong guard rejected it for the wrong reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacyReason {
+    /// The message is not a replicable state mutation (deliberation, comments, reactions).
+    NotReplicable,
+    /// The operation has no acting principal in the message, or none that v1 recognises as
+    /// an authority root — `DomainCreated`/`DomainUpdated` (no root exists) and
+    /// `ProposalOpened`/`ProposalClosed` (root undecided; see design §7.2).
+    NoActingPrincipal,
+    /// The governance domain could not be resolved from authoritative local state, or the
+    /// operation spans domains (a `Blanket` delegation).
+    DomainUnresolved,
+    /// The domain's membership is not a `StaticList`, so no deterministic snapshot exists.
+    /// `TrustThreshold` resolves against each node's local trust graph, so two honest nodes
+    /// can compute different membership (design §5.5).
+    MembershipNotStatic,
+    /// No signing key is available — a locked or hardware-backed keystore.
+    NoSigningKey,
+    /// The available key does not belong to the acting principal. Includes every
+    /// gateway-hosted operation.
+    KeyNotPrincipals,
+}
+
+impl LegacyReason {
+    /// Stable label for logs and metrics.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::NotReplicable => "not_replicable",
+            Self::NoActingPrincipal => "no_acting_principal",
+            Self::DomainUnresolved => "domain_unresolved",
+            Self::MembershipNotStatic => "membership_not_static",
+            Self::NoSigningKey => "no_signing_key",
+            Self::KeyNotPrincipals => "key_not_principals",
+        }
+    }
+}
+
+/// What a message is eligible for, before any sequence is consumed.
+///
+/// Split from frame construction so the decision can be tested without a durable counter,
+/// and so no sequence is burned deciding that an operation is ineligible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Eligibility {
+    /// Sign as `author` over `domain_id`, under this membership snapshot.
+    Signed {
+        author: Did,
+        domain_id: GovernanceDomainId,
+        authority: ReplicationAuthority,
+    },
+    /// Emit the legacy payload unchanged.
+    Legacy(LegacyReason),
+}
+
+/// The acting principal an operation claims authority from, if the message names one.
+///
+/// `DomainCreated`/`DomainUpdated` name none because no authority root for domain mutation
+/// exists at all (design fact 8). `ProposalOpened`/`ProposalClosed` name none because their
+/// authority root is a tally, not a member, and is undecided (design §7.2). Returning `None`
+/// for those is the fail-closed answer: the alternative is to name the relaying node as
+/// author, which would be a claim about authority that nothing in the system supports.
+fn acting_principal(msg: &GovernanceMessage) -> Option<Did> {
+    match msg {
+        GovernanceMessage::VoteCast { vote, .. } => Some(vote.voter.clone()),
+        GovernanceMessage::ProposalCreated { proposal } => Some(proposal.proposer.clone()),
+        GovernanceMessage::DelegationCreated { delegation } => Some(delegation.delegator.clone()),
+        GovernanceMessage::DelegationRevoked { revoked_by, .. } => Some(revoked_by.clone()),
+        _ => None,
+    }
+}
+
+/// Resolve the governance domain an operation belongs to, from **authoritative local state**.
+///
+/// Never inferred from the topic string. A topic is attacker-influenced on receipt and
+/// merely conventional on emission; the proposal and delegation records are the authority on
+/// which domain an operation belongs to, and every local command persists them before it
+/// publishes.
+///
+/// A store read failure is reported as `None` (ineligible) rather than propagated. The local
+/// write has already succeeded by this point, so degrading to the legacy payload preserves
+/// today's exact behaviour, whereas failing the publish would turn a transient read error
+/// into a new liveness regression.
+fn resolve_domain(
+    store: &dyn GovernanceStateStore,
+    msg: &GovernanceMessage,
+) -> Option<GovernanceDomainId> {
+    match msg {
+        GovernanceMessage::VoteCast { vote, .. } => domain_of_proposal(store, &vote.proposal_id),
+        GovernanceMessage::ProposalCreated { proposal } => domain_of_proposal(store, &proposal.id),
+        GovernanceMessage::DelegationCreated { delegation } => {
+            domain_of_scope(store, &delegation.scope)
+        }
+        GovernanceMessage::DelegationRevoked { id, .. } => {
+            // The revocation message carries no scope, so the stored delegation is the only
+            // authority on which domain it touches.
+            let delegation = store.get_delegation(id).ok().flatten()?;
+            domain_of_scope(store, &delegation.scope)
+        }
+        _ => None,
+    }
+}
+
+fn domain_of_proposal(
+    store: &dyn GovernanceStateStore,
+    id: &ProposalId,
+) -> Option<GovernanceDomainId> {
+    store.get_proposal(id).ok().flatten().map(|p| p.domain_id)
+}
+
+/// A `Blanket` delegation spans every domain, so it has no single domain to bind. Signing it
+/// under any one of them would understate its reach; this is the ambiguous case the design
+/// requires to fail closed.
+fn domain_of_scope(
+    store: &dyn GovernanceStateStore,
+    scope: &DelegationScope,
+) -> Option<GovernanceDomainId> {
+    match scope {
+        DelegationScope::Domain(id) => Some(id.clone()),
+        DelegationScope::Proposal(pid) => domain_of_proposal(store, pid),
+        DelegationScope::Blanket => None,
+    }
+}
+
+/// Decide whether `msg` can be emitted as a signed operation.
+///
+/// `local_did` is the node's own DID and `key_did` the DID derived from the available signing
+/// key, or `None` when no key is available. Both are checked: the key must belong to the
+/// acting principal *and* the node must be that principal. The second check is redundant with
+/// the first whenever the key really is the node's own, and it is kept because that is an
+/// assumption about wiring rather than a property of this module — if a future composition
+/// ever hands the actor a key that is not its own, this fails closed instead of silently
+/// emitting under a borrowed identity.
+pub fn classify(
+    store: &dyn GovernanceStateStore,
+    msg: &GovernanceMessage,
+    local_did: &Did,
+    key_did: Option<&Did>,
+) -> Eligibility {
+    if GovernanceOpKind::from_message(msg).is_none() {
+        return Eligibility::Legacy(LegacyReason::NotReplicable);
+    }
+
+    let Some(principal) = acting_principal(msg) else {
+        return Eligibility::Legacy(LegacyReason::NoActingPrincipal);
+    };
+
+    let Some(domain_id) = resolve_domain(store, msg) else {
+        return Eligibility::Legacy(LegacyReason::DomainUnresolved);
+    };
+
+    let Some(domain) = store.get_domain(&domain_id).ok().flatten() else {
+        return Eligibility::Legacy(LegacyReason::DomainUnresolved);
+    };
+
+    let MembershipSource::StaticList(ref members) = domain.config.membership.source else {
+        return Eligibility::Legacy(LegacyReason::MembershipNotStatic);
+    };
+
+    let Some(key_did) = key_did else {
+        return Eligibility::Legacy(LegacyReason::NoSigningKey);
+    };
+
+    if key_did != &principal || local_did != &principal {
+        return Eligibility::Legacy(LegacyReason::KeyNotPrincipals);
+    }
+
+    Eligibility::Signed {
+        author: principal,
+        domain_id: domain_id.clone(),
+        authority: ReplicationAuthority::StaticMembership {
+            membership_hash: static_membership_hash(&domain_id, members),
+        },
+    }
+}
+
+/// Build the signed wire frame, consuming one durable sequence.
+///
+/// The returned bytes become the gossip entry's `data` verbatim. `GossipActor::store_entry`
+/// re-derives `entry.hash` from exactly these bytes (#2583), so the frame is bound to its
+/// digest with no additional mechanism here — duplicating that binding would create a second
+/// thing to keep in sync with it.
+///
+/// # Errors
+///
+/// Propagates a sequence-persistence failure. See the module docs: at this point the decision
+/// to sign has been made, and emitting an operation whose sequence was never recorded is the
+/// one outcome that must not happen silently.
+pub fn build_signed_frame(
+    signing_key: &ed25519_dalek::SigningKey,
+    author: Did,
+    domain_id: GovernanceDomainId,
+    authority: ReplicationAuthority,
+    sequences: &GovernanceSequenceCounter,
+    msg: &GovernanceMessage,
+) -> Result<Vec<u8>> {
+    let seq = sequences
+        .next_sequence(&author, &domain_id)
+        .context("Failed to allocate a durable governance replication sequence")?;
+
+    let signed = SignedGovernanceOp::sign(signing_key, author, domain_id, authority, seq, msg)
+        .context("Failed to sign governance operation")?;
+
+    Ok(signed.encode())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use icn_governance::replication::GOV_OP_MAGIC;
+    use icn_governance::{
+        Delegation, GovernanceConfig, GovernanceDomain, GovernanceMessage, MembershipConfig,
+        Proposal, ProposalId, ProposalPayload, Vote, VoteChoice,
+    };
+    use icn_identity::KeyPair;
+    use icn_store::SledStore;
+    use std::sync::Arc;
+
+    use crate::state_store::SledGovernanceStateStore;
+
+    /// A store plus the tempdir that backs it — the dir must outlive the store.
+    struct Fixture {
+        _tmp: tempfile::TempDir,
+        store: SledGovernanceStateStore,
+    }
+
+    fn fixture() -> Fixture {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let raw: Arc<dyn icn_store::Store> = Arc::new(SledStore::open(tmp.path()).expect("sled"));
+        Fixture {
+            _tmp: tmp,
+            store: SledGovernanceStateStore::new(raw),
+        }
+    }
+
+    fn keypair() -> KeyPair {
+        KeyPair::generate().unwrap()
+    }
+
+    fn signing_key(kp: &KeyPair) -> ed25519_dalek::SigningKey {
+        ed25519_dalek::SigningKey::from_bytes(&kp.to_signing_key_bytes())
+    }
+
+    /// A `StaticList` domain — the only membership source eligible for a v1 signed envelope.
+    fn static_domain(id: &str, members: Vec<Did>) -> GovernanceDomain {
+        let mut config = GovernanceConfig::cooperative_default();
+        config.membership = MembershipConfig::static_list(members);
+        GovernanceDomain {
+            id: GovernanceDomainId::new(id),
+            name: id.to_string(),
+            description: None,
+            config,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    /// The stock cooperative profile. Asserting it is `TrustThreshold` here keeps the
+    /// "default profile is ineligible" claim pinned to the profile rather than to a literal
+    /// this test happened to write.
+    fn default_profile_domain(id: &str) -> GovernanceDomain {
+        let domain = GovernanceDomain {
+            id: GovernanceDomainId::new(id),
+            name: id.to_string(),
+            description: None,
+            config: GovernanceConfig::cooperative_default(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        assert!(
+            matches!(
+                domain.config.membership.source,
+                MembershipSource::TrustThreshold(_)
+            ),
+            "cooperative_default() is expected to be TrustThreshold; if this changed, the \
+             eligibility story in the design doc needs revisiting"
+        );
+        domain
+    }
+
+    fn seeded_proposal(f: &Fixture, domain: &GovernanceDomain, proposer: &Did) -> Proposal {
+        let proposal = Proposal::new(
+            domain.id.clone(),
+            proposer.clone(),
+            "t".to_string(),
+            "d".to_string(),
+            ProposalPayload::Text {
+                body: "c".to_string(),
+            },
+        );
+        f.store.save_domain(domain).unwrap();
+        f.store.save_proposal(&proposal).unwrap();
+        proposal
+    }
+
+    fn vote_msg(proposal: &Proposal, voter: &Did) -> GovernanceMessage {
+        GovernanceMessage::vote_cast(
+            Vote::new(proposal.id.clone(), voter.clone(), VoteChoice::For),
+            None,
+        )
+    }
+
+    #[test]
+    fn eligible_static_list_vote_is_signed_with_the_proposals_domain() {
+        let f = fixture();
+        let kp = keypair();
+        let alice = kp.did().clone();
+        let domain = static_domain("coop-a", vec![alice.clone()]);
+        let proposal = seeded_proposal(&f, &domain, &alice);
+
+        match classify(&f.store, &vote_msg(&proposal, &alice), &alice, Some(&alice)) {
+            Eligibility::Signed {
+                author,
+                domain_id,
+                authority,
+            } => {
+                assert_eq!(author, alice);
+                assert_eq!(domain_id, domain.id, "domain must come from the proposal");
+                assert_eq!(
+                    authority,
+                    ReplicationAuthority::StaticMembership {
+                        membership_hash: static_membership_hash(&domain.id, &[alice]),
+                    }
+                );
+            }
+            other => panic!("expected Signed, got {other:?}"),
+        }
+    }
+
+    /// The domain must come from the proposal record, not from anything the caller supplies.
+    /// A proposal stored under a different domain must produce a different binding.
+    #[test]
+    fn the_bound_domain_tracks_the_stored_proposal() {
+        let f = fixture();
+        let alice = keypair().did().clone();
+
+        let domain_a = static_domain("coop-a", vec![alice.clone()]);
+        let domain_b = static_domain("coop-b", vec![alice.clone()]);
+        f.store.save_domain(&domain_b).unwrap();
+        let proposal = seeded_proposal(&f, &domain_a, &alice);
+
+        let Eligibility::Signed { domain_id, .. } =
+            classify(&f.store, &vote_msg(&proposal, &alice), &alice, Some(&alice))
+        else {
+            panic!("expected Signed");
+        };
+        assert_eq!(domain_id, domain_a.id);
+        assert_ne!(domain_id, domain_b.id);
+    }
+
+    /// The gateway composition: the node relays a vote for a member whose key it does not
+    /// hold. It must name neither itself nor the voter as author.
+    #[test]
+    fn a_vote_cast_by_someone_else_falls_back_to_legacy() {
+        let f = fixture();
+        let node = keypair().did().clone();
+        let bob = keypair().did().clone();
+        let domain = static_domain("coop-a", vec![node.clone(), bob.clone()]);
+        let proposal = seeded_proposal(&f, &domain, &node);
+
+        assert_eq!(
+            classify(&f.store, &vote_msg(&proposal, &bob), &node, Some(&node)),
+            Eligibility::Legacy(LegacyReason::KeyNotPrincipals),
+        );
+    }
+
+    /// A key that is not this node's own must not sign either, even when it *does* match the
+    /// acting principal — that would be emitting under a borrowed identity.
+    #[test]
+    fn a_key_that_is_not_this_nodes_own_does_not_sign() {
+        let f = fixture();
+        let node = keypair().did().clone();
+        let alice = keypair().did().clone();
+        let domain = static_domain("coop-a", vec![alice.clone()]);
+        let proposal = seeded_proposal(&f, &domain, &alice);
+
+        assert_eq!(
+            classify(&f.store, &vote_msg(&proposal, &alice), &node, Some(&alice)),
+            Eligibility::Legacy(LegacyReason::KeyNotPrincipals),
+        );
+    }
+
+    #[test]
+    fn trust_threshold_domain_falls_back_to_legacy() {
+        let f = fixture();
+        let alice = keypair().did().clone();
+        let domain = default_profile_domain("coop-trust");
+        let proposal = seeded_proposal(&f, &domain, &alice);
+
+        assert_eq!(
+            classify(&f.store, &vote_msg(&proposal, &alice), &alice, Some(&alice)),
+            Eligibility::Legacy(LegacyReason::MembershipNotStatic),
+        );
+    }
+
+    #[test]
+    fn absent_signing_key_falls_back_to_legacy_without_panicking() {
+        let f = fixture();
+        let alice = keypair().did().clone();
+        let domain = static_domain("coop-a", vec![alice.clone()]);
+        let proposal = seeded_proposal(&f, &domain, &alice);
+
+        assert_eq!(
+            classify(&f.store, &vote_msg(&proposal, &alice), &alice, None),
+            Eligibility::Legacy(LegacyReason::NoSigningKey),
+        );
+    }
+
+    #[test]
+    fn an_unknown_proposal_leaves_the_domain_unresolved() {
+        let f = fixture();
+        let alice = keypair().did().clone();
+        let orphan = Vote::new(
+            ProposalId::new("never-stored"),
+            alice.clone(),
+            VoteChoice::For,
+        );
+
+        assert_eq!(
+            classify(
+                &f.store,
+                &GovernanceMessage::vote_cast(orphan, None),
+                &alice,
+                Some(&alice)
+            ),
+            Eligibility::Legacy(LegacyReason::DomainUnresolved),
+        );
+    }
+
+    #[test]
+    fn deliberation_messages_are_not_replicable() {
+        let f = fixture();
+        let alice = keypair().did().clone();
+
+        assert_eq!(
+            classify(
+                &f.store,
+                &GovernanceMessage::deliberation_started(ProposalId::new("p"), 0, 1),
+                &alice,
+                Some(&alice)
+            ),
+            Eligibility::Legacy(LegacyReason::NotReplicable),
+        );
+    }
+
+    /// `ProposalOpened` / `ProposalClosed` / `Domain*` are replicable kinds with no
+    /// member-level authority root, so they must not be signed under the relaying node's
+    /// identity even though everything else about them is eligible.
+    #[test]
+    fn lifecycle_and_domain_messages_have_no_acting_principal() {
+        let f = fixture();
+        let alice = keypair().did().clone();
+        let domain = static_domain("coop-a", vec![alice.clone()]);
+        let proposal = seeded_proposal(&f, &domain, &alice);
+
+        let messages = [
+            GovernanceMessage::proposal_opened(proposal.id.clone(), 0, 1),
+            GovernanceMessage::domain_created(domain.clone()),
+            GovernanceMessage::domain_updated(domain.clone()),
+        ];
+
+        for msg in messages {
+            assert_eq!(
+                classify(&f.store, &msg, &alice, Some(&alice)),
+                Eligibility::Legacy(LegacyReason::NoActingPrincipal),
+                "{} must not be signed under the relaying node's identity",
+                msg.message_type()
+            );
+        }
+    }
+
+    #[test]
+    fn a_blanket_delegation_spans_domains_and_is_not_signed() {
+        let f = fixture();
+        let alice = keypair().did().clone();
+        let domain = static_domain("coop-a", vec![alice.clone()]);
+        f.store.save_domain(&domain).unwrap();
+
+        let delegation = Delegation::new(
+            alice.clone(),
+            keypair().did().clone(),
+            DelegationScope::Blanket,
+        );
+
+        assert_eq!(
+            classify(
+                &f.store,
+                &GovernanceMessage::delegation_created(delegation),
+                &alice,
+                Some(&alice)
+            ),
+            Eligibility::Legacy(LegacyReason::DomainUnresolved),
+        );
+    }
+
+    #[test]
+    fn a_domain_scoped_delegation_is_signed_under_that_domain() {
+        let f = fixture();
+        let alice = keypair().did().clone();
+        let domain = static_domain("coop-a", vec![alice.clone()]);
+        f.store.save_domain(&domain).unwrap();
+
+        let delegation = Delegation::new(
+            alice.clone(),
+            keypair().did().clone(),
+            DelegationScope::Domain(domain.id.clone()),
+        );
+
+        match classify(
+            &f.store,
+            &GovernanceMessage::delegation_created(delegation),
+            &alice,
+            Some(&alice),
+        ) {
+            Eligibility::Signed { domain_id, .. } => assert_eq!(domain_id, domain.id),
+            other => panic!("expected Signed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_signed_frame_carries_the_exact_message_and_is_magic_prefixed() {
+        let f = fixture();
+        let kp = keypair();
+        let alice = kp.did().clone();
+        let domain = static_domain("coop-a", vec![alice.clone()]);
+        let proposal = seeded_proposal(&f, &domain, &alice);
+        let msg = vote_msg(&proposal, &alice);
+
+        let Eligibility::Signed {
+            author,
+            domain_id,
+            authority,
+        } = classify(&f.store, &msg, &alice, Some(&alice))
+        else {
+            panic!("expected Signed");
+        };
+
+        let sequences = GovernanceSequenceCounter::in_memory();
+        let frame = build_signed_frame(
+            &signing_key(&kp),
+            author,
+            domain_id,
+            authority,
+            &sequences,
+            &msg,
+        )
+        .unwrap();
+
+        assert!(
+            frame.starts_with(GOV_OP_MAGIC),
+            "frame must be recognisable by magic"
+        );
+
+        let decoded = SignedGovernanceOp::decode(&frame).unwrap();
+        decoded.verify().expect("signature must verify");
+        assert_eq!(
+            decoded.op_bytes(),
+            msg.to_bytes().unwrap(),
+            "the signed bytes must be the exact transmitted operation"
+        );
+        assert_eq!(*decoded.author(), alice);
+        assert_eq!(*decoded.domain_id(), domain.id);
+        assert_eq!(decoded.seq(), 1);
+        // Decodes back to an equivalent message (GovernanceMessage has no PartialEq, so
+        // compare on the wire bytes, which is the representation that actually travels).
+        assert_eq!(
+            decoded.decode_op().unwrap().to_bytes().unwrap(),
+            msg.to_bytes().unwrap()
+        );
+    }
+
+    /// The signature must cover exactly these bytes: mutating the transmitted payload must
+    /// break verification rather than silently changing what was authorised.
+    #[test]
+    fn a_mutated_payload_no_longer_verifies() {
+        let f = fixture();
+        let kp = keypair();
+        let alice = kp.did().clone();
+        let domain = static_domain("coop-a", vec![alice.clone()]);
+        let proposal = seeded_proposal(&f, &domain, &alice);
+        let msg = vote_msg(&proposal, &alice);
+
+        let Eligibility::Signed {
+            author,
+            domain_id,
+            authority,
+        } = classify(&f.store, &msg, &alice, Some(&alice))
+        else {
+            panic!("expected Signed");
+        };
+
+        let sequences = GovernanceSequenceCounter::in_memory();
+        let frame = build_signed_frame(
+            &signing_key(&kp),
+            author,
+            domain_id,
+            authority,
+            &sequences,
+            &msg,
+        )
+        .unwrap();
+
+        // The op payload sits between the header and the trailing length-prefixed signature
+        // (64 bytes + 4 length bytes), so this lands inside the signed body.
+        let mut tampered = frame.clone();
+        let target = tampered.len() - 68 - 1;
+        tampered[target] ^= 0x01;
+
+        match SignedGovernanceOp::decode(&tampered) {
+            Ok(op) => assert!(op.verify().is_err(), "tampered frame must not verify"),
+            Err(_) => { /* framing rejected it even earlier, which is also fail-closed */ }
+        }
+    }
+
+    #[test]
+    fn each_emission_consumes_a_fresh_sequence() {
+        let f = fixture();
+        let kp = keypair();
+        let alice = kp.did().clone();
+        let domain = static_domain("coop-a", vec![alice.clone()]);
+        let proposal = seeded_proposal(&f, &domain, &alice);
+        let msg = vote_msg(&proposal, &alice);
+        let sequences = GovernanceSequenceCounter::in_memory();
+
+        let mut seqs = Vec::new();
+        for _ in 0..3 {
+            let Eligibility::Signed {
+                author,
+                domain_id,
+                authority,
+            } = classify(&f.store, &msg, &alice, Some(&alice))
+            else {
+                panic!("expected Signed");
+            };
+            let frame = build_signed_frame(
+                &signing_key(&kp),
+                author,
+                domain_id,
+                authority,
+                &sequences,
+                &msg,
+            )
+            .unwrap();
+            seqs.push(SignedGovernanceOp::decode(&frame).unwrap().seq());
+        }
+
+        assert_eq!(seqs, vec![1, 2, 3]);
+    }
+}

--- a/icn/apps/governance/src/replication_sequence.rs
+++ b/icn/apps/governance/src/replication_sequence.rs
@@ -1,0 +1,464 @@
+//! Durable per-`(author, domain)` sequence source for signed governance emission (#2469).
+//!
+//! # What `seq` is, and what it is emphatically not
+//!
+//! `SignedGovernanceOp.seq` orders one author's operations **within one governance domain**.
+//! It is a *comparator* for same-key conflicts and never an acceptance gate: a receiver that
+//! rejected an operation for carrying a lower `seq` than one already seen would permanently
+//! discard legitimate operations, because gossip delivers out of order and anti-entropy can
+//! deliver hours late. See `docs/design/authenticated-governance-replication.md` §10.
+//!
+//! Nothing in this module has a receive-side counterpart, and slice 3 deliberately adds none.
+//!
+//! # Why this is not `icn_net::SigningSequenceCounter`
+//!
+//! That counter (#2510) is the pattern this one follows, and it is reused where it fits — but
+//! it cannot be used directly here. It is hard-keyed to a single global watermark
+//! (`outgoing_signing_seq_reserved_end`) because its sequence space is genuinely per-sender:
+//! one node, one stream, consumed by a peer's `ReplayGuard`. Governance needs one independent
+//! space per `(author, domain)` pair, so that a vote in one institution never orders against a
+//! vote in another. Generalising the `icn-net` type in place would put a keying parameter on
+//! the gossip hot path in a kernel crate for the benefit of one domain caller; the invariants
+//! are cheap to restate and the coupling is not.
+//!
+//! Inherited verbatim from #2510:
+//!
+//! - **Block reservation.** The store holds `reserved_end`, an exclusive upper bound. The
+//!   durable invariant is *every sequence ever issued is strictly less than the persisted
+//!   `reserved_end`*, and the watermark is written **and flushed** before any sequence in the
+//!   new block is handed out. A crash resumes at or above anything that could have reached the
+//!   network; the unused remainder of a block is skipped, and gaps are harmless because `seq`
+//!   is a comparator.
+//! - **Fail closed on persistence failure.** `next_sequence` returns an error rather than a
+//!   number it could not record. Issuing an unrecorded sequence is what lets a later
+//!   incarnation reuse it.
+//! - **Semantic versioning.** An unknown version refuses to open rather than guessing.
+//! - **First sequence is 1.** Zero is reserved as "no sequence", so a value of 0 in a signed
+//!   envelope is always a construction bug rather than a legitimate first operation.
+//!
+//! # Key encoding
+//!
+//! ```text
+//! b"gov:repl:seq:v1:" ‖ u32_be(len(author)) ‖ author ‖ u32_be(len(domain)) ‖ domain
+//! ```
+//!
+//! Length-prefixed rather than separator-joined, so that distinct pairs are distinct keys by
+//! construction. Under a separator scheme, `(a, "x:y")` and `(a ‖ ":x", "y")` encode
+//! identically, which would silently merge two sequence spaces into one.
+//!
+//! Today `Did::from_str` validates DIDs into `did:icn:<base58>`, which contains no `:` after
+//! the prefix, so that particular collision is not currently *reachable* — a `GovernanceDomainId`
+//! is an unvalidated `String`, but the author half is not. The encoding does not lean on that.
+//! Key separation here would otherwise be a property of a validation rule in another crate,
+//! enforced nowhere near this file and free to be relaxed without anyone noticing that a
+//! sequence counter depended on it.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{anyhow, Context, Result};
+
+use icn_governance::GovernanceDomainId;
+use icn_identity::Did;
+use icn_store::Store;
+
+/// Number of sequences claimed per durable reservation.
+///
+/// One store write per 1,000 emitted operations, and at most 1,000 sequences skipped per
+/// restart. Governance emission is far colder than the gossip signing path this is borrowed
+/// from, so the block could be smaller; it is kept identical to #2510 so the two counters
+/// cannot drift into subtly different durability arguments.
+const RESERVATION_BLOCK: u64 = 1_000;
+
+/// Prefix for every per-`(author, domain)` watermark.
+const SEQUENCE_KEY_PREFIX: &[u8] = b"gov:repl:seq:v1:";
+
+/// Storage key recording which semantic regime produced the watermarks under
+/// [`SEQUENCE_KEY_PREFIX`].
+const SEQUENCE_VERSION_KEY: &[u8] = b"gov:repl:seq:semantic_version";
+
+/// Semantic regime this binary writes and can interpret.
+///
+/// Bump only when the meaning of a persisted watermark changes such that a previous version
+/// would misread it. There is no legacy value to migrate from: slice 3 is the first code to
+/// write these keys, so an absent version key on a store holding watermarks is impossible in
+/// practice and is treated as "fresh" rather than guessed at.
+const SEQUENCE_SEMANTIC_VERSION: u32 = 1;
+
+/// First sequence a fresh counter issues.
+///
+/// Zero is reserved to mean "no sequence assigned", so that a zero reaching a signed envelope
+/// is unambiguously a bug rather than a legitimate first operation.
+const FIRST_SEQUENCE: u64 = 1;
+
+/// Mutable per-pair state. Sequences in `[next, reserved_end)` are safe to issue without
+/// touching disk.
+#[derive(Clone, Copy)]
+struct PairState {
+    next: u64,
+    reserved_end: u64,
+}
+
+/// Durable monotonic sequence source keyed by `(author DID, governance domain)`.
+///
+/// Each pair advances independently: a counter for `(alice, coop-a)` is untouched by
+/// operations from `(alice, coop-b)` or `(bob, coop-a)`.
+pub struct GovernanceSequenceCounter {
+    /// `None` for the in-memory test/ephemeral counter.
+    store: Option<Arc<dyn Store>>,
+    /// Cached reservations, keyed by the same encoding used on disk.
+    state: Mutex<HashMap<Vec<u8>, PairState>>,
+}
+
+impl GovernanceSequenceCounter {
+    /// Open a durable counter over `store`.
+    ///
+    /// Watermarks are read lazily, per pair, on first use — a node may hold many domains and
+    /// there is no reason to scan them all at startup.
+    pub fn new(store: Arc<dyn Store>) -> Result<Self> {
+        let version = Self::reconcile_semantic_version(&store)?;
+        tracing::debug!(
+            semantic_version = version,
+            block = RESERVATION_BLOCK,
+            "Opened durable governance replication sequence counter"
+        );
+        Ok(Self {
+            store: Some(store),
+            state: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Create a non-durable counter for tests and genuinely ephemeral nodes.
+    ///
+    /// **Warning**: restarts reset every pair to [`FIRST_SEQUENCE`], reissuing sequences that
+    /// have already been signed and published under this author's key. Never use on a node
+    /// with persistent storage.
+    pub fn in_memory() -> Self {
+        Self {
+            store: None,
+            state: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Establish which semantic regime this store's watermarks belong to, stamping it if
+    /// absent.
+    ///
+    /// An unknown version means the store was written by a binary that knows something this
+    /// one does not. Refuse to open: a sender that guesses wrong reissues sequences under a
+    /// signature that already carried them.
+    fn reconcile_semantic_version(store: &Arc<dyn Store>) -> Result<u32> {
+        let found = match store
+            .get(SEQUENCE_VERSION_KEY)
+            .context("Failed to read governance replication sequence semantic version")?
+        {
+            Some(bytes) => {
+                let raw: [u8; 4] = bytes.as_slice().try_into().map_err(|_| {
+                    anyhow!(
+                        "Corrupt governance replication sequence semantic version: \
+                         expected 4 bytes, found {}",
+                        bytes.len()
+                    )
+                })?;
+                Some(u32::from_be_bytes(raw))
+            }
+            None => None,
+        };
+
+        match found {
+            Some(v) if v == SEQUENCE_SEMANTIC_VERSION => Ok(v),
+            Some(v) => Err(anyhow!(
+                "Governance replication sequence store has semantic version {v}, but this \
+                 binary understands only {SEQUENCE_SEMANTIC_VERSION}; refusing to reinterpret \
+                 it, because guessing here reissues sequences that peers have already seen \
+                 signed"
+            )),
+            None => {
+                store
+                    .put(
+                        SEQUENCE_VERSION_KEY,
+                        &SEQUENCE_SEMANTIC_VERSION.to_be_bytes(),
+                    )
+                    .context("Failed to persist governance replication sequence version")?;
+                store
+                    .flush()
+                    .context("Failed to flush governance replication sequence version")?;
+                Ok(SEQUENCE_SEMANTIC_VERSION)
+            }
+        }
+    }
+
+    /// Issue the next sequence for `(author, domain)`, extending the durable reservation if
+    /// the cached block is exhausted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the reservation cannot be persisted. The caller **must** treat that
+    /// as fatal for the operation: emitting a signed envelope carrying a sequence that was
+    /// never recorded is precisely the ambiguity this counter exists to prevent, and unlike a
+    /// dropped message it cannot be detected after the fact.
+    ///
+    /// # Why the store write happens under the lock
+    ///
+    /// Correctness depends on "persist, then issue from the new block" being atomic per pair.
+    /// Releasing the lock around a blocking write would let two callers each observe an
+    /// exhausted reservation and both extend it from the same base, reissuing the overlap.
+    /// The cost is amortised to one write per [`RESERVATION_BLOCK`] operations.
+    pub fn next_sequence(&self, author: &Did, domain: &GovernanceDomainId) -> Result<u64> {
+        let key = sequence_key(author, domain);
+
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow!("Governance replication sequence counter mutex poisoned"))?;
+
+        let entry = match state.get(&key).copied() {
+            Some(cached) => cached,
+            None => {
+                // First use of this pair in this process: resume from the persisted watermark.
+                let reserved_end = self.load_watermark(&key)?;
+                PairState {
+                    next: reserved_end.max(FIRST_SEQUENCE),
+                    reserved_end,
+                }
+            }
+        };
+        let mut entry = entry;
+
+        if entry.next >= entry.reserved_end {
+            let new_end = entry.next.checked_add(RESERVATION_BLOCK).context(
+                "Governance replication sequence space exhausted for this (author, domain) \
+                 pair (requires 2^64 operations)",
+            )?;
+
+            // Persist BEFORE issuing anything from the new block, so a crash between here and
+            // the publish resumes above every sequence that could have escaped. The flush is
+            // what makes that claim true rather than aspirational.
+            if let Some(ref store) = self.store {
+                store
+                    .put(&key, &new_end.to_be_bytes())
+                    .context("Failed to persist governance replication sequence reservation")?;
+                store
+                    .flush()
+                    .context("Failed to flush governance replication sequence reservation")?;
+            }
+
+            entry.reserved_end = new_end;
+        }
+
+        let sequence = entry.next;
+        entry.next += 1;
+        state.insert(key, entry);
+        Ok(sequence)
+    }
+
+    /// Read the persisted exclusive upper bound for one pair, or 0 if it has never been used.
+    fn load_watermark(&self, key: &[u8]) -> Result<u64> {
+        let Some(ref store) = self.store else {
+            return Ok(0);
+        };
+        match store
+            .get(key)
+            .context("Failed to read governance replication sequence watermark")?
+        {
+            Some(bytes) => {
+                let raw: [u8; 8] = bytes.as_slice().try_into().map_err(|_| {
+                    anyhow!(
+                        "Corrupt governance replication sequence watermark: \
+                         expected 8 bytes, found {}",
+                        bytes.len()
+                    )
+                })?;
+                Ok(u64::from_be_bytes(raw))
+            }
+            None => Ok(0),
+        }
+    }
+}
+
+/// Length-prefixed storage key for one `(author, domain)` pair.
+///
+/// See the module docs: length prefixing makes distinct pairs distinct keys without relying
+/// on any character being absent from a DID or a domain id.
+fn sequence_key(author: &Did, domain: &GovernanceDomainId) -> Vec<u8> {
+    let author = author.as_str().as_bytes();
+    let domain = domain.0.as_bytes();
+
+    let mut key = Vec::with_capacity(SEQUENCE_KEY_PREFIX.len() + 8 + author.len() + domain.len());
+    key.extend_from_slice(SEQUENCE_KEY_PREFIX);
+    key.extend_from_slice(&(author.len() as u32).to_be_bytes());
+    key.extend_from_slice(author);
+    key.extend_from_slice(&(domain.len() as u32).to_be_bytes());
+    key.extend_from_slice(domain);
+    key
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use icn_identity::KeyPair;
+    use icn_store::SledStore;
+
+    fn author() -> Did {
+        KeyPair::generate().unwrap().did().clone()
+    }
+
+    fn domain(s: &str) -> GovernanceDomainId {
+        GovernanceDomainId::new(s)
+    }
+
+    fn temp_store() -> (tempfile::TempDir, Arc<dyn Store>) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store: Arc<dyn Store> = Arc::new(SledStore::open(tmp.path()).expect("sled"));
+        (tmp, store)
+    }
+
+    #[test]
+    fn sequences_start_at_one_and_advance() {
+        let counter = GovernanceSequenceCounter::in_memory();
+        let (a, d) = (author(), domain("coop-a"));
+
+        assert_eq!(counter.next_sequence(&a, &d).unwrap(), 1);
+        assert_eq!(counter.next_sequence(&a, &d).unwrap(), 2);
+        assert_eq!(counter.next_sequence(&a, &d).unwrap(), 3);
+    }
+
+    #[test]
+    fn domains_advance_independently() {
+        let counter = GovernanceSequenceCounter::in_memory();
+        let alice = author();
+
+        assert_eq!(counter.next_sequence(&alice, &domain("coop-a")).unwrap(), 1);
+        assert_eq!(counter.next_sequence(&alice, &domain("coop-a")).unwrap(), 2);
+
+        // A different domain is a different space, not a continuation of the first.
+        assert_eq!(counter.next_sequence(&alice, &domain("coop-b")).unwrap(), 1);
+        assert_eq!(counter.next_sequence(&alice, &domain("coop-a")).unwrap(), 3);
+    }
+
+    #[test]
+    fn authors_never_share_sequence_state() {
+        let counter = GovernanceSequenceCounter::in_memory();
+        let d = domain("coop-a");
+
+        let alice = author();
+        let bob = author();
+        assert_eq!(counter.next_sequence(&alice, &d).unwrap(), 1);
+        assert_eq!(counter.next_sequence(&alice, &d).unwrap(), 2);
+        assert_eq!(counter.next_sequence(&bob, &d).unwrap(), 1);
+    }
+
+    /// The property the length-prefixed key exists for: the encoding is injective over
+    /// `(author, domain)` without depending on any byte being absent from either half.
+    ///
+    /// A `GovernanceDomainId` is an unvalidated `String`, so the domain half genuinely may
+    /// contain the separator a naive key would have used.
+    #[test]
+    fn adversarial_domain_ids_produce_distinct_keys() {
+        let alice = author();
+        let bob = author();
+
+        let keys = [
+            sequence_key(&alice, &domain("a:b")),
+            sequence_key(&alice, &domain("a")),
+            sequence_key(&alice, &domain("b")),
+            sequence_key(&alice, &domain("")),
+            sequence_key(&bob, &domain("a:b")),
+            sequence_key(&bob, &domain("a")),
+        ];
+
+        let mut unique = keys.to_vec();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(unique.len(), keys.len(), "sequence keys must be injective");
+    }
+
+    /// A domain id may itself look like a key suffix. Length prefixing means the parse is
+    /// unambiguous regardless.
+    #[test]
+    fn a_domain_id_cannot_impersonate_another_pair() {
+        let alice = author();
+        let bob = author();
+
+        // Domain id that literally spells out another author's key tail.
+        let impersonating = domain(&format!("{}{}", bob.as_str(), "coop-a"));
+
+        assert_ne!(
+            sequence_key(&alice, &impersonating),
+            sequence_key(&bob, &domain("coop-a")),
+        );
+    }
+
+    #[test]
+    fn sequences_survive_restart() {
+        let (_tmp, store) = temp_store();
+        let (a, d) = (author(), domain("coop-a"));
+
+        let issued = {
+            let counter = GovernanceSequenceCounter::new(store.clone()).unwrap();
+            let first = counter.next_sequence(&a, &d).unwrap();
+            let second = counter.next_sequence(&a, &d).unwrap();
+            assert_eq!((first, second), (1, 2));
+            second
+        };
+
+        // Reopen: a fresh process over the same store.
+        let reopened = GovernanceSequenceCounter::new(store).unwrap();
+        let after_restart = reopened.next_sequence(&a, &d).unwrap();
+
+        assert!(
+            after_restart > issued,
+            "restart reissued sequence {after_restart} at or below the already-issued {issued}"
+        );
+    }
+
+    #[test]
+    fn restart_isolation_is_per_pair() {
+        let (_tmp, store) = temp_store();
+        let alice = author();
+
+        {
+            let counter = GovernanceSequenceCounter::new(store.clone()).unwrap();
+            counter.next_sequence(&alice, &domain("coop-a")).unwrap();
+        }
+
+        let reopened = GovernanceSequenceCounter::new(store).unwrap();
+        // coop-a advanced past its block; coop-b was never used and must still start fresh.
+        assert!(reopened.next_sequence(&alice, &domain("coop-a")).unwrap() > 1);
+        assert_eq!(
+            reopened.next_sequence(&alice, &domain("coop-b")).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn unknown_semantic_version_refuses_to_open() {
+        let (_tmp, store) = temp_store();
+        store
+            .put(
+                SEQUENCE_VERSION_KEY,
+                &(SEQUENCE_SEMANTIC_VERSION + 1).to_be_bytes(),
+            )
+            .unwrap();
+
+        assert!(
+            GovernanceSequenceCounter::new(store).is_err(),
+            "a store from a newer binary must not be reinterpreted"
+        );
+    }
+
+    #[test]
+    fn corrupt_watermark_is_an_error_not_a_reset() {
+        let (_tmp, store) = temp_store();
+        let (a, d) = (author(), domain("coop-a"));
+
+        GovernanceSequenceCounter::new(store.clone()).unwrap();
+        store.put(&sequence_key(&a, &d), b"short").unwrap();
+
+        let counter = GovernanceSequenceCounter::new(store).unwrap();
+        assert!(
+            counter.next_sequence(&a, &d).is_err(),
+            "a corrupt watermark must fail closed, not silently restart the sequence"
+        );
+    }
+}

--- a/icn/apps/governance/tests/signed_governance_emission.rs
+++ b/icn/apps/governance/tests/signed_governance_emission.rs
@@ -12,6 +12,24 @@
 //! applying state would require. The containment assertions at the bottom of this file are
 //! part of the slice, not a formality — and the full #2470 suite in
 //! `fp02_governance_replication_containment.rs` must stay green alongside it.
+//!
+//! # A deliberately unkillable mutant
+//!
+//! Deleting the signed-frame recognition branch from the ingress callback entirely — so a
+//! signed frame falls through to the legacy decode and merely logs a different line — fails
+//! **no** test here or in the #2470 suite. That was checked, and it is the correct outcome
+//! rather than a coverage hole.
+//!
+//! Recognition is a *diagnostic*, and the containment it sits inside is *structural*: the
+//! callback captures no `GovernanceStateStore`, so neither branch can reach governance state
+//! and neither branch is an authorization decision. The mutant is equivalent with respect to
+//! every property this slice guarantees, which is exactly the claim
+//! `observe_replicated_governance_message` already makes about itself — "there is
+//! deliberately no telemetry to evade, because there is deliberately nothing to gate."
+//!
+//! Emission is where the observable behaviour lives, and that is where the mutation proof
+//! bites: collapsing the sequence key, unbinding the domain, dropping the author/key check,
+//! or letting `publish_to_topic` bypass the shared encoder each kill tests below.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 

--- a/icn/apps/governance/tests/signed_governance_emission.rs
+++ b/icn/apps/governance/tests/signed_governance_emission.rs
@@ -1,0 +1,958 @@
+//! Signed governance emission through the production composition (#2469 slice 3).
+//!
+//! Every test here drives `init_governance_actor` — the same entry point
+//! `icn-core/src/supervisor/init_governance.rs` calls — and then reads the bytes that
+//! actually reached the gossip topic. Nothing asserts on a helper in isolation: the claim
+//! under test is "what this node puts on the wire", and only the wire can answer it.
+//!
+//! # What this suite does NOT claim
+//!
+//! Slice 3 restores **no** remote state application. A signed envelope proves content and
+//! authorship; it proves nothing about authority over a domain, and authority is what
+//! applying state would require. The containment assertions at the bottom of this file are
+//! part of the slice, not a formality — and the full #2470 suite in
+//! `fp02_governance_replication_containment.rs` must stay green alongside it.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+
+use icn_gossip::{GossipActor, GossipEntry};
+use icn_governance::replication::{GovernanceOpKind, SignedGovernanceOp, GOV_OP_MAGIC};
+use icn_governance::{
+    GovernanceDomainId, GovernanceMessage, GovernanceOps, GovernanceParams, MembershipConfig,
+    ProposalId, ProposalPayload, ProposalScope, Vote, VoteChoice,
+};
+use icn_governance_actor::init::{init_governance_actor, GovernanceActorDeps};
+use icn_governance_actor::manager::GovernanceManager;
+use icn_governance_actor::state_store::{GovernanceStateStore, SledGovernanceStateStore};
+use icn_identity::{Did, IdentityBundle};
+use icn_kernel_api::events::{EventEmitter, SystemEvent};
+
+const GOVERNANCE_TOPIC: &str = "governance:proposal";
+
+struct NoopKernelEvents;
+
+#[async_trait::async_trait]
+impl EventEmitter for NoopKernelEvents {
+    async fn emit(&self, _event: SystemEvent) {}
+}
+
+/// A node wired exactly as production wires one, optionally holding its own signing key.
+///
+/// `with_key` mirrors `lifecycle.rs:782`: the key is derived from the node's *own* identity
+/// bundle, so `Did::from_public_key(key)` equals the actor DID. A node built without one
+/// stands in for a locked or hardware-backed keystore, which is a supported production state.
+struct Node {
+    _tmp: tempfile::TempDir,
+    did: Did,
+    gossip: Arc<tokio::sync::RwLock<GossipActor>>,
+    ops: GovernanceManager,
+    state: SledGovernanceStateStore,
+    /// Positive control on *delivery*, counting every entry dispatched to this node's own
+    /// subscription on a governance topic — signed or legacy.
+    ///
+    /// Deliberately shape-agnostic, unlike the production callback, which returns early on
+    /// the signed shape. A control that could only see legacy payloads would report zero for
+    /// exactly the injections the containment tests care about most.
+    delivered: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl Node {
+    fn delivered(&self) -> usize {
+        self.delivered.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    async fn spawn(with_key: bool) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bundle = IdentityBundle::generate().expect("IdentityBundle::generate");
+        let did = bundle.did().clone();
+
+        let signing_key = with_key.then(|| {
+            let kp = bundle.keypair().expect("keypair");
+            Arc::new(ed25519_dalek::SigningKey::from_bytes(
+                &kp.to_signing_key_bytes(),
+            ))
+        });
+
+        let gossip = Arc::new(tokio::sync::RwLock::new(GossipActor::new(
+            did.clone(),
+            None,
+        )));
+
+        let services = init_governance_actor(
+            tmp.path(),
+            did.clone(),
+            GovernanceActorDeps {
+                gossip_handle: gossip.clone(),
+                event_bus: Arc::new(NoopKernelEvents),
+                signing_key,
+                trust_service: None,
+            },
+        )
+        .await
+        .expect("init_governance_actor");
+
+        let delivered = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        {
+            let counter = delivered.clone();
+            let own = did.clone();
+            gossip.write().await.add_notification_callback(Arc::new(
+                move |topic: String, _entry: GossipEntry, subscriber_did: Did| {
+                    let federation_root = icn_federation::TOPIC_FEDERATION_GOVERNANCE;
+                    let is_gov = topic == GOVERNANCE_TOPIC || topic.starts_with(federation_root);
+                    if is_gov && subscriber_did == own {
+                        counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                },
+            ));
+        }
+
+        let state = SledGovernanceStateStore::new(services.governance_store.clone());
+        let ops = GovernanceManager::with_handle(
+            Arc::new(services.governance_handle) as Arc<dyn GovernanceOps + Send + Sync>
+        );
+
+        Self {
+            _tmp: tmp,
+            did,
+            gossip,
+            ops,
+            state,
+            delivered,
+        }
+    }
+
+    async fn entries(&self, topic: &str) -> Vec<GossipEntry> {
+        self.gossip.read().await.get_entries(topic)
+    }
+
+    /// Create and subscribe a topic that production leaves undeclared.
+    ///
+    /// Needed only for per-federation governance topics — see
+    /// `a_per_federation_topic_is_never_created_in_the_default_configuration`.
+    async fn declare_topic(&self, topic: &str) {
+        let mut g = self.gossip.write().await;
+        g.create_topic(icn_gossip::Topic::new(
+            topic.to_string(),
+            icn_gossip::AccessControl::Public,
+        ));
+        g.subscribe(topic, self.did.clone())
+            .await
+            .expect("subscribe");
+    }
+
+    /// The logical payloads on `topic`, decompressed.
+    ///
+    /// `publish` compresses entries above a size threshold, so `entry.data` is not the
+    /// payload for large entries. Every reader here goes through `get_data`, matching the
+    /// production ingress and `computed_content_hash`.
+    async fn payloads(&self, topic: &str) -> Vec<Vec<u8>> {
+        self.entries(topic)
+            .await
+            .iter()
+            .map(|e| e.get_data().expect("entry payload must be readable"))
+            .collect()
+    }
+
+    /// Every signed frame on `topic`, decoded.
+    ///
+    /// Note that a seeded domain emits more than one: the node is also the *proposer*, so its
+    /// own `ProposalCreated` is eligible and signed too. Assertions below therefore filter by
+    /// op kind rather than counting frames — a bare count would silently conflate the two and
+    /// would keep passing if the wrong operation were the one being signed.
+    async fn signed_ops(&self, topic: &str) -> Vec<SignedGovernanceOp> {
+        self.payloads(topic)
+            .await
+            .iter()
+            .filter(|p| p.starts_with(GOV_OP_MAGIC))
+            .map(|p| SignedGovernanceOp::decode(p).expect("frame must decode"))
+            .collect()
+    }
+
+    async fn signed_ops_of_kind(
+        &self,
+        topic: &str,
+        kind: GovernanceOpKind,
+    ) -> Vec<SignedGovernanceOp> {
+        self.signed_ops(topic)
+            .await
+            .into_iter()
+            .filter(|op| op.op_kind() == kind)
+            .collect()
+    }
+
+    /// The single signed operation of `kind` on `topic`.
+    async fn only_signed_op(&self, topic: &str, kind: GovernanceOpKind) -> SignedGovernanceOp {
+        let mut ops = self.signed_ops_of_kind(topic, kind).await;
+        assert_eq!(
+            ops.len(),
+            1,
+            "expected exactly one signed {kind:?} on {topic}, found {}",
+            ops.len()
+        );
+        ops.remove(0)
+    }
+
+    async fn signed_vote_count(&self, topic: &str) -> usize {
+        self.signed_ops_of_kind(topic, GovernanceOpKind::VoteCast)
+            .await
+            .len()
+    }
+
+    /// Establish a `StaticList` domain containing this node, plus an open proposal.
+    async fn seed_static_domain(&self, domain: &str, scope: ProposalScope) -> ProposalId {
+        let domain_id = GovernanceDomainId(domain.to_string());
+        self.ops
+            .create_domain(
+                domain_id.clone(),
+                format!("Domain {domain}"),
+                "cooperative_default".to_string(),
+                GovernanceParams::new(50, 50, 3600),
+                MembershipConfig::static_list(vec![self.did.clone()]),
+            )
+            .await
+            .expect("create_domain");
+
+        let proposal_id = self
+            .ops
+            .create_proposal(
+                ProposalId("_ignored".to_string()),
+                domain_id,
+                self.did.clone(),
+                "Seed".to_string(),
+                "Seed".to_string(),
+                ProposalPayload::Text {
+                    body: "seed".to_string(),
+                },
+                scope,
+            )
+            .await
+            .expect("create_proposal");
+
+        self.ops
+            .open_proposal(proposal_id.clone(), 3600)
+            .await
+            .expect("open_proposal");
+
+        proposal_id
+    }
+
+    /// A domain whose membership is `TrustThreshold` — the stock cooperative default, and
+    /// deliberately not eligible for a v1 signed envelope (design §5.5).
+    async fn seed_trust_threshold_domain(&self, domain: &str) -> ProposalId {
+        let domain_id = GovernanceDomainId(domain.to_string());
+        self.ops
+            .create_domain(
+                domain_id.clone(),
+                format!("Domain {domain}"),
+                "cooperative_default".to_string(),
+                GovernanceParams::new(50, 50, 3600),
+                MembershipConfig::trust_threshold(0.3),
+            )
+            .await
+            .expect("create_domain");
+
+        let proposal_id = self
+            .ops
+            .create_proposal(
+                ProposalId("_ignored".to_string()),
+                domain_id,
+                self.did.clone(),
+                "Seed".to_string(),
+                "Seed".to_string(),
+                ProposalPayload::Text {
+                    body: "seed".to_string(),
+                },
+                ProposalScope::Local,
+            )
+            .await
+            .expect("create_proposal");
+
+        self.ops
+            .open_proposal(proposal_id.clone(), 3600)
+            .await
+            .expect("open_proposal");
+
+        proposal_id
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Emission — the signed shape
+// ---------------------------------------------------------------------------
+
+/// Proofs 1, 2, 4, 5: an eligible `StaticList` vote the node itself authors is emitted as a
+/// valid envelope, whose author is the signing-key-derived DID, whose domain came from the
+/// proposal, and whose signed bytes are the exact operation.
+#[tokio::test(flavor = "current_thread")]
+async fn a_vote_the_node_authors_is_emitted_as_a_verifiable_signed_frame() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("signed-domain", ProposalScope::Local)
+        .await;
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+
+    let op = node
+        .only_signed_op(GOVERNANCE_TOPIC, GovernanceOpKind::VoteCast)
+        .await;
+
+    op.verify().expect("emitted envelope must verify");
+    assert_eq!(
+        *op.author(),
+        node.did,
+        "author must be the signing identity"
+    );
+
+    let proposal = node
+        .state
+        .get_proposal(&proposal_id)
+        .unwrap()
+        .expect("proposal");
+    assert_eq!(
+        *op.domain_id(),
+        proposal.domain_id,
+        "domain must be bound from the proposal, not from the topic"
+    );
+
+    // Proof 5: the signed bytes are the exact operation, verbatim — not a re-serialization.
+    match op.decode_op().expect("op_bytes must decode") {
+        GovernanceMessage::VoteCast { vote, .. } => {
+            assert_eq!(vote.voter, node.did);
+            assert_eq!(vote.proposal_id, proposal_id);
+            assert_eq!(vote.choice, VoteChoice::For);
+        }
+        other => panic!("expected VoteCast, got {}", other.message_type()),
+    }
+
+    // The seeded proposal took seq 1 in this domain (the node is its proposer, so it is
+    // signed too); the vote is the second operation this author made here.
+    assert_eq!(op.seq(), 2);
+}
+
+/// Signing is not restricted to the restorable set: the node's own `ProposalCreated` is
+/// signed too, because it has an unambiguous acting principal (`proposal.proposer`).
+///
+/// Pinned deliberately. `V1_RESTORABLE_OP_KINDS` is `[VoteCast]` alone, so this operation is
+/// **eligible but not restorable** — a receiver may never apply it. Emitting it costs
+/// nothing and keeps one emission rule instead of two, but the distinction is easy to lose,
+/// and losing it in the other direction (reading "signed" as "may be applied") is exactly
+/// the mistake slice 7 must not make.
+#[tokio::test(flavor = "current_thread")]
+async fn a_signed_kind_is_not_thereby_a_restorable_kind() {
+    let node = Node::spawn(true).await;
+    node.seed_static_domain("eligible-domain", ProposalScope::Local)
+        .await;
+
+    let created = node
+        .only_signed_op(GOVERNANCE_TOPIC, GovernanceOpKind::ProposalCreated)
+        .await;
+    created.verify().expect("it is a valid envelope");
+    assert_eq!(*created.author(), node.did);
+
+    assert!(
+        !created.op_kind().is_restorable_in_v1(),
+        "ProposalCreated must remain outside the v1 restorable set despite being signed"
+    );
+    assert!(
+        GovernanceOpKind::VoteCast.is_restorable_in_v1(),
+        "sanity: VoteCast is the one restorable kind"
+    );
+
+    // ProposalOpened has no acting principal, so it stays legacy even here.
+    assert!(
+        node.signed_ops_of_kind(GOVERNANCE_TOPIC, GovernanceOpKind::ProposalOpened)
+            .await
+            .is_empty(),
+        "a lifecycle transition has no member-level author to sign as"
+    );
+}
+
+/// Proof 6: the gossip entry's content hash binds the signed frame, through #2583's
+/// mechanism rather than a second one added here.
+#[tokio::test(flavor = "current_thread")]
+async fn the_gossip_content_hash_binds_the_signed_frame() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("hash-domain", ProposalScope::Local)
+        .await;
+
+    node.ops
+        .cast_vote(proposal_id, node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+
+    let entry = node
+        .entries(GOVERNANCE_TOPIC)
+        .await
+        .into_iter()
+        .find(|e| {
+            e.get_data()
+                .map(|p| p.starts_with(GOV_OP_MAGIC))
+                .unwrap_or(false)
+        })
+        .expect("a signed entry");
+
+    entry
+        .validate_content_integrity()
+        .expect("#2583: entry.hash must re-derive from the signed frame");
+
+    // And the binding is to the frame specifically: mutating it breaks the check.
+    let mut tampered = entry.clone();
+    tampered.data[GOV_OP_MAGIC.len() + 1] ^= 0x01;
+    assert!(
+        tampered.validate_content_integrity().is_err(),
+        "a mutated frame must no longer match the claimed content hash"
+    );
+}
+
+/// Proof 12: the federation route signs on the same policy as `governance:proposal`.
+///
+/// `publish_to_topic` has exactly one caller (`publish_federation_if_scoped`) and shares the
+/// encoder with `publish`, so this is the seam that would catch the two drifting apart.
+///
+/// The per-federation topic must be created explicitly here — see
+/// `a_per_federation_topic_is_never_created_in_the_default_configuration` for why, and for
+/// the pre-existing defect that makes it necessary.
+#[tokio::test(flavor = "current_thread")]
+async fn the_federation_topic_carries_the_same_signed_shape() {
+    let node = Node::spawn(true).await;
+
+    let federation_topic = format!(
+        "{}:{}",
+        icn_federation::TOPIC_FEDERATION_GOVERNANCE,
+        "fed-alpha"
+    );
+    node.declare_topic(&federation_topic).await;
+
+    let proposal_id = node
+        .seed_static_domain(
+            "fed-domain",
+            ProposalScope::Federation("fed-alpha".to_string()),
+        )
+        .await;
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+
+    let on_governance = node
+        .only_signed_op(GOVERNANCE_TOPIC, GovernanceOpKind::VoteCast)
+        .await;
+    let on_federation = node
+        .only_signed_op(&federation_topic, GovernanceOpKind::VoteCast)
+        .await;
+
+    on_federation
+        .verify()
+        .expect("the federation copy must verify too");
+    assert_eq!(*on_federation.author(), node.did);
+    assert_eq!(on_federation.domain_id(), on_governance.domain_id());
+    assert_eq!(
+        on_federation.op_bytes(),
+        on_governance.op_bytes(),
+        "both topics must carry the identical signed operation"
+    );
+}
+
+/// A pre-existing defect on `main`, pinned so slice 3 does not get blamed for it and so a
+/// later fix is noticed.
+///
+/// `publish_federation_if_scoped` publishes to `federation:governance:<fed_id>`, but the only
+/// federation governance topic anything creates or subscribes is the **root**
+/// `federation:governance` (`icn-core/src/supervisor/init_gossip.rs:325`). With the default
+/// `TopicAutoCreationPolicy::Reject`, the per-federation publish is refused, and
+/// `publish_federation_if_scoped` swallows the error with a `warn!`.
+///
+/// So federation-scoped governance never reaches the wire in the default configuration —
+/// signed or legacy, before this change or after it. The encoder covers the route by
+/// construction (proved by the test above, which declares the topic first); the route itself
+/// is simply not wired. Fixing that is a topic-lifecycle change well outside #2469.
+#[tokio::test(flavor = "current_thread")]
+async fn a_per_federation_topic_is_never_created_in_the_default_configuration() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain(
+            "fed-unwired",
+            ProposalScope::Federation("fed-unwired".to_string()),
+        )
+        .await;
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote must succeed even though the federation publish is dropped");
+
+    let topic = format!(
+        "{}:{}",
+        icn_federation::TOPIC_FEDERATION_GOVERNANCE,
+        "fed-unwired"
+    );
+    assert!(
+        node.entries(&topic).await.is_empty(),
+        "if this topic now receives entries, the per-federation route was wired up and the \
+         federation emission path needs re-examining"
+    );
+
+    // The local vote and the `governance:proposal` copy are unaffected.
+    assert_eq!(node.signed_vote_count(GOVERNANCE_TOPIC).await, 1);
+    assert!(node
+        .state
+        .get_vote(&proposal_id, &node.did)
+        .unwrap()
+        .is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Emission — the fallbacks, each for its own reason
+// ---------------------------------------------------------------------------
+
+/// Proof 9: a `TrustThreshold` domain is ineligible and must degrade, not fail.
+///
+/// `GovernanceConfig::cooperative_default()` is `trust_threshold(0.3)`, so this is the common
+/// configuration. Turning it into an error would break ordinary governance for most domains.
+#[tokio::test(flavor = "current_thread")]
+async fn a_trust_threshold_domain_emits_the_legacy_payload() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node.seed_trust_threshold_domain("trust-domain").await;
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote must still succeed on a TrustThreshold domain");
+
+    assert_eq!(
+        node.signed_vote_count(GOVERNANCE_TOPIC).await,
+        0,
+        "a TrustThreshold domain has no deterministic membership snapshot to bind"
+    );
+
+    // The legacy payload is still there and still decodes — nothing was lost.
+    let decoded_votes = node
+        .entries(GOVERNANCE_TOPIC)
+        .await
+        .iter()
+        .filter_map(|e| GovernanceMessage::from_bytes(&e.data).ok())
+        .filter(|m| matches!(m, GovernanceMessage::VoteCast { .. }))
+        .count();
+    assert_eq!(decoded_votes, 1, "the vote must still be published legacy");
+
+    // And the vote was recorded locally regardless.
+    assert!(node
+        .state
+        .get_vote(&proposal_id, &node.did)
+        .unwrap()
+        .is_some());
+}
+
+/// Proof 10: a locked or hardware-backed keystore is a supported production state. Governance
+/// must keep working, unsigned, without a panic.
+#[tokio::test(flavor = "current_thread")]
+async fn a_node_without_a_signing_key_emits_the_legacy_payload() {
+    let node = Node::spawn(false).await;
+    let proposal_id = node
+        .seed_static_domain("nokey-domain", ProposalScope::Local)
+        .await;
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote must succeed without a signing key");
+
+    assert_eq!(
+        node.signed_ops(GOVERNANCE_TOPIC).await.len(),
+        0,
+        "no key means nothing at all is signed, not merely no votes"
+    );
+    assert!(node
+        .state
+        .get_vote(&proposal_id, &node.did)
+        .unwrap()
+        .is_some());
+}
+
+/// Proof 3: the gateway composition. A node relaying another member's vote holds none of
+/// their key material, so it must not sign — naming itself author would assert an authorship
+/// that does not exist, and naming the voter is refused by `SignedGovernanceOp::sign`.
+#[tokio::test(flavor = "current_thread")]
+async fn a_vote_cast_for_another_member_is_never_signed() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("relay-domain", ProposalScope::Local)
+        .await;
+
+    let bob = IdentityBundle::generate().unwrap().did().clone();
+
+    node.ops
+        .cast_vote(proposal_id.clone(), bob.clone(), VoteChoice::For, None)
+        .await
+        .expect("cast_vote");
+
+    assert_eq!(
+        node.signed_vote_count(GOVERNANCE_TOPIC).await,
+        0,
+        "a node must not sign a vote for a principal whose key it does not hold"
+    );
+    assert!(node.state.get_vote(&proposal_id, &bob).unwrap().is_some());
+}
+
+/// Proofs 7-8 at the composition seam: sequences are per-`(author, domain)` and independent.
+///
+/// The unit tests cover restart and key separation directly; this pins that the actor is
+/// actually keying by domain rather than sharing one counter across the node.
+#[tokio::test(flavor = "current_thread")]
+async fn sequences_are_independent_per_domain_through_the_real_path() {
+    let node = Node::spawn(true).await;
+
+    let first = node.seed_static_domain("seq-a", ProposalScope::Local).await;
+    let second = node.seed_static_domain("seq-b", ProposalScope::Local).await;
+
+    node.ops
+        .cast_vote(first.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .unwrap();
+    node.ops
+        .cast_vote(second.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .unwrap();
+
+    let votes = node
+        .signed_ops_of_kind(GOVERNANCE_TOPIC, GovernanceOpKind::VoteCast)
+        .await;
+
+    assert_eq!(votes.len(), 2, "both votes should be signed");
+    assert_ne!(
+        votes[0].domain_id(),
+        votes[1].domain_id(),
+        "the two votes are in distinct domains"
+    );
+
+    // Both votes share one author, one node and one topic, and differ only in domain. A
+    // node-wide counter or a per-topic counter would therefore have given the second vote a
+    // higher number than the first. Only per-(author, domain) keying makes them equal.
+    for op in &votes {
+        assert_eq!(
+            op.seq(),
+            2,
+            "domain {:?} must run its own sequence (1 = its own ProposalCreated, 2 = its \
+             vote) rather than continuing another domain's",
+            op.domain_id()
+        );
+    }
+}
+
+/// A second vote in the *same* domain advances that domain's sequence.
+#[tokio::test(flavor = "current_thread")]
+async fn a_second_operation_in_one_domain_advances_its_sequence() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("seq-same", ProposalScope::Local)
+        .await;
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .unwrap();
+    node.ops
+        .cast_vote(
+            proposal_id.clone(),
+            node.did.clone(),
+            VoteChoice::Against,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let mut vote_seqs: Vec<u64> = node
+        .signed_ops_of_kind(GOVERNANCE_TOPIC, GovernanceOpKind::VoteCast)
+        .await
+        .iter()
+        .map(|op| op.seq())
+        .collect();
+    vote_seqs.sort_unstable();
+
+    assert_eq!(vote_seqs.len(), 2, "both votes should be signed");
+    assert!(
+        vote_seqs[1] > vote_seqs[0],
+        "the author's intent order must advance within one domain: got {vote_seqs:?}"
+    );
+
+    // Nothing in this domain reused a sequence — the property that makes `seq` usable as a
+    // same-key comparator at all.
+    let all: Vec<u64> = node
+        .signed_ops(GOVERNANCE_TOPIC)
+        .await
+        .iter()
+        .map(|op| op.seq())
+        .collect();
+    let mut unique = all.clone();
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        all.len(),
+        "no sequence may be issued twice within one (author, domain): got {all:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Recognition and containment
+// ---------------------------------------------------------------------------
+
+/// Proofs 13-14: both shapes are recognised during rollout, and recognition is by magic.
+#[tokio::test(flavor = "current_thread")]
+async fn both_wire_shapes_are_distinguishable_by_magic() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("mixed-domain", ProposalScope::Local)
+        .await;
+
+    node.ops
+        .cast_vote(proposal_id.clone(), node.did.clone(), VoteChoice::For, None)
+        .await
+        .unwrap();
+
+    let payloads = node.payloads(GOVERNANCE_TOPIC).await;
+
+    let signed: Vec<_> = payloads
+        .iter()
+        .filter(|p| p.starts_with(GOV_OP_MAGIC))
+        .collect();
+    let legacy: Vec<_> = payloads
+        .iter()
+        .filter(|p| !p.starts_with(GOV_OP_MAGIC))
+        .collect();
+
+    // Both shapes coexist on one topic during rollout: the vote and the node's own proposal
+    // are signed; the domain and lifecycle messages have no acting principal and stay legacy.
+    assert_eq!(
+        node.signed_vote_count(GOVERNANCE_TOPIC).await,
+        1,
+        "the vote is signed"
+    );
+    assert!(
+        !legacy.is_empty(),
+        "domain and lifecycle messages remain legacy during rollout"
+    );
+
+    // The discriminator is sound in both directions: a legacy payload never carries the
+    // magic, and a signed frame never decodes as a bare GovernanceMessage. Neither shape can
+    // be mistaken for the other, which is what lets recognition be a prefix check rather
+    // than a trial decode.
+    for payload in &legacy {
+        assert!(
+            GovernanceMessage::from_bytes(payload).is_ok(),
+            "a non-magic payload must still be a decodable legacy message"
+        );
+    }
+    for payload in &signed {
+        assert!(
+            GovernanceMessage::from_bytes(payload).is_err(),
+            "a signed frame must not be mistaken for a legacy payload"
+        );
+    }
+}
+
+/// Proof 15, the load-bearing one: a **validly signed** envelope from a real member,
+/// delivered over the remote ingress, still applies nothing.
+///
+/// This is the test that separates slice 3 from slice 7. Everything about this envelope is
+/// legitimate — real key, real member, real domain, real proposal, signature verifies — and
+/// it must *still* be inert, because authenticity is not authority.
+#[tokio::test(flavor = "current_thread")]
+async fn a_validly_signed_remote_vote_still_applies_nothing() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("contained", ProposalScope::Local)
+        .await;
+
+    // A second member, with their own real key, authoring a genuinely valid envelope.
+    let bundle = IdentityBundle::generate().unwrap();
+    let member = bundle.did().clone();
+    let key =
+        ed25519_dalek::SigningKey::from_bytes(&bundle.keypair().unwrap().to_signing_key_bytes());
+
+    let proposal = node.state.get_proposal(&proposal_id).unwrap().unwrap();
+    let domain = node.state.get_domain(&proposal.domain_id).unwrap().unwrap();
+    let members = match &domain.config.membership.source {
+        icn_governance::MembershipSource::StaticList(m) => m.clone(),
+        other => panic!("expected StaticList, got {other:?}"),
+    };
+
+    let msg = GovernanceMessage::vote_cast(
+        Vote::new(proposal_id.clone(), member.clone(), VoteChoice::For),
+        None,
+    );
+    let op = SignedGovernanceOp::sign(
+        &key,
+        member.clone(),
+        proposal.domain_id.clone(),
+        icn_governance::replication::ReplicationAuthority::StaticMembership {
+            membership_hash: icn_governance::replication::static_membership_hash(
+                &proposal.domain_id,
+                &members,
+            ),
+        },
+        1,
+        &msg,
+    )
+    .expect("sign");
+    op.verify().expect("this envelope is genuinely valid");
+
+    inject_remote(&node, GOVERNANCE_TOPIC, &member, op.encode()).await;
+
+    assert!(
+        node.state
+            .get_vote(&proposal_id, &member)
+            .unwrap()
+            .is_none(),
+        "#2470 containment: a signed remote vote must not be applied in slice 3"
+    );
+}
+
+/// The same, on a federation topic — the route added alongside the signed emission.
+#[tokio::test(flavor = "current_thread")]
+async fn a_signed_frame_on_a_federation_topic_applies_nothing() {
+    let node = Node::spawn(true).await;
+    let topic = format!(
+        "{}:{}",
+        icn_federation::TOPIC_FEDERATION_GOVERNANCE,
+        "fed-beta"
+    );
+    node.declare_topic(&topic).await;
+
+    let proposal_id = node
+        .seed_static_domain(
+            "contained-fed",
+            ProposalScope::Federation("fed-beta".to_string()),
+        )
+        .await;
+
+    let bundle = IdentityBundle::generate().unwrap();
+    let member = bundle.did().clone();
+    let key =
+        ed25519_dalek::SigningKey::from_bytes(&bundle.keypair().unwrap().to_signing_key_bytes());
+
+    let proposal = node.state.get_proposal(&proposal_id).unwrap().unwrap();
+    let msg = GovernanceMessage::vote_cast(
+        Vote::new(proposal_id.clone(), member.clone(), VoteChoice::For),
+        None,
+    );
+    let op = SignedGovernanceOp::sign(
+        &key,
+        member.clone(),
+        proposal.domain_id.clone(),
+        icn_governance::replication::ReplicationAuthority::StaticMembership {
+            membership_hash: [0u8; 32],
+        },
+        1,
+        &msg,
+    )
+    .expect("sign");
+
+    inject_remote(&node, &topic, &member, op.encode()).await;
+
+    assert!(node
+        .state
+        .get_vote(&proposal_id, &member)
+        .unwrap()
+        .is_none());
+}
+
+/// Deliver bytes over the remote gossip ingress, exactly as a peer would.
+///
+/// Hashes the payload honestly so #2583 admits the entry: the claim under test is that a
+/// *well-formed* signed entry is still inert, not that a malformed one is rejected — which
+/// `icn-gossip/tests/entry_hash_integrity.rs` already covers.
+///
+/// Returns after asserting the entry was actually delivered on this node's subscription. A
+/// containment assertion is only meaningful if the message got there to be refused; without
+/// this control, a dropped subscription or a topic-filter regression would leave every
+/// "applies nothing" test below green while testing nothing at all.
+async fn inject_remote(node: &Node, topic: &str, author: &Did, data: Vec<u8>) {
+    use icn_gossip::{GossipMessage, VectorClock};
+
+    let before = node.delivered();
+
+    let entry = GossipEntry {
+        hash: icn_gossip::content_hash(&data),
+        author: author.clone(),
+        clock: VectorClock::new(),
+        topic: topic.to_string(),
+        data,
+        compressed: false,
+        timestamp: 1_700_000_000,
+        replica_offered: None,
+    };
+
+    node.gossip
+        .write()
+        .await
+        .handle_message(author, GossipMessage::Response { entry })
+        .await
+        .expect("gossip transport must keep accepting the entry");
+
+    assert_eq!(
+        node.delivered(),
+        before + 1,
+        "injected entry was not delivered exactly once on the local subscription"
+    );
+}
+
+/// A signed frame large enough to be compressed must still be recognised.
+///
+/// `GossipActor::publish` compresses entries above a size threshold *after* hashing them, so
+/// `entry.data` stops being the payload. Recognition that read the raw field would silently
+/// misclassify every large entry — legacy ones as undecodable, signed ones as legacy — while
+/// every small-payload test above stayed green.
+#[tokio::test(flavor = "current_thread")]
+async fn a_compressed_signed_frame_is_still_recognised_by_magic() {
+    let node = Node::spawn(true).await;
+    let proposal_id = node
+        .seed_static_domain("compress-domain", ProposalScope::Local)
+        .await;
+
+    // A comment long enough to push the entry over the compression threshold. Highly
+    // repetitive so zstd definitely shrinks it.
+    let bulky = "ratify the amended bylaws. ".repeat(400);
+
+    node.ops
+        .cast_vote(
+            proposal_id.clone(),
+            node.did.clone(),
+            VoteChoice::For,
+            Some(bulky.clone()),
+        )
+        .await
+        .expect("cast_vote");
+
+    let compressed_entries = node
+        .entries(GOVERNANCE_TOPIC)
+        .await
+        .into_iter()
+        .filter(|e| e.compressed)
+        .count();
+    assert!(
+        compressed_entries > 0,
+        "this test is only meaningful if something actually got compressed; \
+         raise the payload size if the threshold moved"
+    );
+
+    // Recognition still works, because it reads the logical payload.
+    let op = node
+        .only_signed_op(GOVERNANCE_TOPIC, GovernanceOpKind::VoteCast)
+        .await;
+    op.verify().expect("a compressed frame must still verify");
+
+    match op.decode_op().expect("op_bytes must decode") {
+        GovernanceMessage::VoteCast { vote, .. } => {
+            assert_eq!(vote.comment.as_deref(), Some(bulky.as_str()));
+        }
+        other => panic!("expected VoteCast, got {}", other.message_type()),
+    }
+}


### PR DESCRIPTION
## What

Slice 3 of #2469: **signed governance emission**. Wires the `SignedGovernanceOp` primitive
(slice 1, #2582) into the governance publish path, with a durable per-`(author, domain)`
sequence and signed/legacy coexistence.

**This restores no remote state application.** The #2470 containment is untouched and its 12
tests are unchanged and green. A signed envelope proves content and authorship; it proves
nothing about authority over a domain, and authority is what applying state would require.

## Why

Slice 3 is the emission half of the design in
`docs/design/authenticated-governance-replication.md` §13. Without it there is nothing signed
on the wire for the later ingress slices to verify.

## How

**One encoder, two publishers.** `publish` (`actor.rs:3128`) and `publish_to_topic` (`:3136`)
are the only two functions that hand governance bytes to gossip, and both now route through
`encode_for_emission`. The federation route cannot drift onto a different policy because
there is no second place to forget.

*Correction to the prior emission-graph analysis:* on `6754d30c` there are **12** `publish`
call sites (not ~10 — two are `self\n.publish(` delegation arms) and **1** `publish_to_topic`
call site (not ~9) — `publish_federation_if_scoped`, which itself has 7 callers.

**Eligibility degrades; commitment fails closed.** Any reason a signed envelope cannot be
established — kind not replicable, no acting principal, unresolvable domain, non-`StaticList`
membership, no key, key not the principal's — falls back to the legacy payload, byte-identical
to today. But once the decision to sign is made, a sequence that cannot be persisted aborts
the publish rather than emitting an operation whose sequence was never recorded — an
ambiguity no receiver can detect.

The domain is always resolved from **authoritative local state** (`get_proposal` /
`get_delegation`), never inferred from the topic string. A `Blanket` delegation spans domains
and is therefore ineligible.

**Durable sequence.** `GovernanceSequenceCounter` follows #2510's discipline — block
reservation, flush *before* issuing from the new block, semantic-version stamp, error rather
than a number it could not record — but keys per `(author, domain)` with a length-prefixed
key so two pairs can never share a sequence space. It is a new type rather than a
generalisation of `icn_net::SigningSequenceCounter`, which is hard-keyed to one global
watermark on the gossip hot path in a kernel crate.

**Recognition, not verification.** Receivers discriminate the two shapes on the frame magic —
never by trial decoding. Signed frames are recognised and then ignored: not decoded, not
verified, not applied. The ingress callback still captures no `GovernanceStateStore`, so the
containment stays structural.

Recognition reads `entry.get_data()`, not `entry.data`: `publish` compresses entries above a
size threshold *after* hashing them, so a prefix check over the raw field would misclassify
every large entry. This matches `computed_content_hash`, which resolves the logical payload
for the same reason.

## Two findings, written up in the design doc

**§7.0.2 — a node can only sign for itself.** `GovernanceCommand::CastVote` takes `voter` as a
parameter and never constrains it to `self.did`, while the actor holds only the node's own
key (`lifecycle.rs:782`). So a gateway relaying many members' votes holds none of their key
material and can sign none of them. This is *additive to §7.0.1*, not a restatement, and it
bites at the opposite end of the pipe: §7.0.1 says a receiver cannot evaluate the standing
predicate; this says a sender cannot produce the envelope at all.

*Consequence for slice 7:* restoring `VoteCast` application will not make gateway deployments
converge, because those nodes emit nothing to converge on.

**§7.0.3 — per-federation governance topics are never created (pre-existing).**
`publish_federation_if_scoped` publishes to `federation:governance:<fed_id>`, but only the
**root** `federation:governance` is ever declared (`init_gossip.rs:325`). With the default
`TopicAutoCreationPolicy::Reject`, that publish is refused and the error is swallowed by a
`warn!`. Verified empirically: a federation-scoped vote yields 3 entries on
`governance:proposal` and **0** on the per-federation topic — before this change and after.

The emission policy still covers the route by construction (proved by a test that declares
the topic first). Wiring the topic is a topic-lifecycle change outside #2469, so the current
behaviour is pinned by a test rather than fixed here.

## Risk

Emission-side only. A node without a signing key, and every `TrustThreshold` domain, produces
byte-identical output to before. `GovernanceConfig::cooperative_default()` is
`trust_threshold(0.3)`, so the common profile is explicitly on the unchanged path.

`GovernanceActor::spawn` now returns `Err` if the sequence store is corrupt or written by a
newer binary — deliberate, per #2510: guessing there reissues sequences peers have already
seen signed.

## Test plan

- **23 new unit tests** — eligibility per guard (each asserting *which* guard fired, not just
  "legacy"), sequence restart/independence/key-injectivity, corrupt-watermark and
  unknown-version fail-closed.
- **14 new integration tests** through the real `init_governance_actor` composition —
  author/domain/payload binding, `entry.hash` binding via #2583, federation parity,
  TrustThreshold and no-key fallbacks, both-shapes recognition, compressed-frame recognition,
  and a **validly signed remote vote that still applies nothing**.
- **12 #2470 containment tests unchanged and green.**
- Mutation proof: collapsing the sequence key, unbinding the domain, dropping the author/key
  check, removing the durable flush, and letting `publish_to_topic` bypass the shared encoder
  are each killed. Deleting the recognition branch survives — documented in the test file as
  an equivalent mutant, since recognition is a diagnostic inside a structural containment.

Gates: `cargo fmt --all --check`, `cargo clippy -p icn-governance-actor -p icn-governance
--all-targets -- -D warnings`, `cargo check --workspace --all-targets`, `cargo test -p
icn-governance-actor -p icn-governance` (53 suites, 0 failures), meaning-firewall check,
doc-control, compliance + overclaim linters, drift-check PASS.

Local `icn-prereview` was unavailable (Zentith model tunnel down); self-reviewed against
`review-lessons.md` instead — no new `unwrap`/`expect` in non-test code, fail-closed
throughout, no regulated vocabulary.

Part of #2469. Slice 4 (quarantine) and slice 7 (verify + apply) remain.
