### PR TITLE
docs(identity): fix post-merge architecture summary propagation

### DIFF
--- a/docs/architecture/HUMAN_IDENTITY_ARCHITECTURE.md
+++ b/docs/architecture/HUMAN_IDENTITY_ARCHITECTURE.md
@@ -1664,7 +1664,8 @@ bolted beside the chain rule — it **is** the chain rule.
 | Produced offline? | **yes** | **no** — needs an online M-of-N quorum |
 | UX cost | one phrase at onboarding | guardian setup + coordination |
 
-> **Path (b) is a kill switch unless it uses a single group key.** With `M`-of-`N`
+> **Path (b) is a kill switch, and a single group key is necessary but not
+> sufficient to close it.** With `M`-of-`N`
 > guardians signing **independently**, two different quorums produce two different
 > authorized establishment bodies at the same position, so `supersede` cannot
 > choose and the subject **halts permanently** (§9.2.1, constraint 3). That means

--- a/docs/architecture/HUMAN_IDENTITY_ARCHITECTURE.md
+++ b/docs/architecture/HUMAN_IDENTITY_ARCHITECTURE.md
@@ -1660,7 +1660,7 @@ bolted beside the chain rule — it **is** the chain rule.
 | Pre-rotation commits to | keys derived from the continuity root (recovery phrase) | a **threshold** key set held by M-of-N guardians |
 | Total-loss recovery | restore phrase → rotate | M distinct guardians co-sign → rotate |
 | Root/backup compromise | **takeover, and *unrecoverable*** — see below | insufficient alone |
-| Any M guardians can... | — | **halt the subject permanently**, unless (b) uses a single group key — see below |
+| Any M guardians can... | — | **halt the subject permanently.** Closing this needs a single group key (N7) **and** `authorized` enforcing canonical body derivation **and** exactly one next authority per position — **N7 alone is not sufficient**; see below |
 | Produced offline? | **yes** | **no** — needs an online M-of-N quorum |
 | UX cost | one phrase at onboarding | guardian setup + coordination |
 
@@ -1921,7 +1921,7 @@ a uniqueness or unlinkability property.** Migration is therefore:
 | device rosters | **MIGRATE** | fix #2588 (binding) and #2590 (attenuation) **as part of** the migration, never after |
 | memberships | **MIGRATE** (was "KEEP, extended") | the bidirectional index (`sled_registry.rs:9-12`) is the right shape, but rows keyed by the member's `Did` need a documented bridge to the new `SubjectId` (§15.1). Signing and replication remain #2441's (F17) |
 | governance state | **KEEP** | class 1 becomes cheap **once votes key on the subject**; today `vote_key(proposal_id, voter: &Did)` (`apps/governance/src/state_store.rs:222`) keys on a **`Did`**, so re-casting from a new device writes a second tallied row (§9.3) |
-| historical signatures / receipts | **KEEP — permanently verifiable** | "key K was authorized at position N" is an append-only fact (R2.3) |
+| historical signatures / receipts | **KEEP — the signature is permanently verifiable; the *authorization* is not** | Pre-fork positions: "key K was authorized at position N" is an append-only fact and R2.3 holds. After a superseding rotation at `p`, a key first authorized at `N > p` is no longer established by the derived view — the receipt still proves *"K signed these bytes"*, and with the orphaned bodies retained *"this body existed on a branch later superseded"*, but **not** that K remained authorized (§9.2.2). Migration must therefore keep the orphaned bodies and their chaining, **not the raw receipts alone**; full historical authorization needs the per-branch endorsement evidence **O-N9** leaves undefined |
 | gateway challenge auth | **MIGRATE** | add a domain separator and bind `coop_id`/`scopes` into the signed payload (§3.4) |
 | invite redemption | **REMOVE the unproven-subject mint** | #2589 |
 | React Native wallet | **MIGRATE** | today one key per install *is* the person (F19); needs subject/device separation and off-device pre-rotation backup |
@@ -2038,6 +2038,11 @@ untraced anchor↔member keying question in §15.2.
               signing (F7).  Without N7, independent M-of-N signatures give any
               M guardians a KILL SWITCH (two quorums => two authorized bodies at
               one position => permanent halt), so path (b) must not ship first.
+              NECESSARY BUT NOT SUFFICIENT: N7 alone leaves the halt attack
+              intact — a group key authenticates a quorum, it does not bind that
+              quorum to ONE message.  Path (b) is safe only with N7 PLUS
+              `authorized` ENFORCING canonical body derivation PLUS exactly ONE
+              next authority armed per position (§9.2.1 constraint 3).
               Without N7, R9.1 [HARD] is met only by the backup-phrase path.
 
   independent, and should not wait:
@@ -2218,7 +2223,7 @@ Everything else in §19.2 is testable once those four are fixed.
 | Rotation bodies must be deterministic; threshold recovery must emit one body (§9.2.1) | **RECOMMENDED, normative for N1** — without them a crash-retry or a second quorum halts the subject with no attacker |
 | Authority principals inside events must be raw `Did`s, never `SubjectId`s (§9.2.1) | **RECOMMENDED, normative for N1** — otherwise `derive` is not a pure function |
 | Superseding recovery orphans the suffix (§9.2.1) | **ESTABLISHED consequence** — a stated cost of recovery, growing with fork depth |
-| N7 (threshold signing) is a hard prerequisite of guardian recovery (§12.2) | **RECOMMENDED** — otherwise any `M` guardians hold a kill switch |
+| N7 (threshold signing) is a hard prerequisite of guardian recovery (§12.2) | **RECOMMENDED** — **necessary, not sufficient**. Without it any `M` guardians hold a kill switch; with it the switch closes only alongside enforced canonical body derivation and exactly one next-authority commitment per position (§9.2.1 constraint 3) |
 | Fork monitoring is a client obligation ("responsive controller") (§9.2.2) | **RECOMMENDED**, inherited from KERI |
 | `Did` narrowed to "cryptographic principal" (§10) | **RECOMMENDED** |
 | No global Person identifier (§10) | **RECOMMENDED** |


### PR DESCRIPTION
## What

Propagates two corrections that already exist in the load-bearing sections of
`docs/architecture/HUMAN_IDENTITY_ARCHITECTURE.md` into four summary rows that
failed to inherit them.

**Docs only. No Rust. No Cargo. One file. 8 insertions, 3 deletions.**

## Why

#2592 merged after every then-visible review gate passed at head `f5526889`
with zero unresolved threads. Two valid review comments landed roughly 30
seconds *after* the merge, so the defects they describe are now on `main`.

Both comments are correct, and both describe the same defect class: a
correction that reached the deep sections but not their summary projections.
Summaries are what implementers actually read, so a stale summary is not
cosmetic — in both cases it can steer a builder into shipping the wrong thing.

**No architecture choice is being reopened.** The deeper sections already
contain the correct rules; this PR only makes the summaries agree with them.

## How

### Defect A — guardian recovery kill switch (§12.2 row)

The row said the kill switch disappears if path (b) uses a single group key.
Per §9.2.1 constraint 3 (sharpened in review round 5), that is false: a FROST
group key authenticates *a quorum*, it does not bind that quorum to **one
message**, so the same `M` guardians can still sign two distinct bodies — as
can a phrase-holder racing a guardian quorum.

The row now carries all three required conditions and states non-sufficiency
outright, so a builder cannot read it as "implement FROST ⇒ guardian recovery
is safe":

1. a single threshold/group public key (N7);
2. `authorized` **enforcing** canonical recovery-body derivation;
3. exactly one next authority armed per position — path (a) **or** (b), never both.

N7 remains classified as a **HARD PREREQUISITE — necessary, not sufficient.**

### Defect B — historical receipts (§15.3 row)

The row described `"key K was authorized at position N"` as an unconditional
append-only fact and implied receipts stay permanently verifiable in that full
authorization sense. Per the R2.3 correction in §9.2.2, a superseding rotation
at `p` orphans the suffix, so a key first authorized at `N > p` is no longer
established by the effective derived view.

The row now separates the two properties:

- **pre-fork / undisputed history** — ordinary authorization proof remains available;
- **post-fork / superseded suffix** — the raw signature still verifies, and with
  the orphaned bodies retained it proves *"authored on a branch later
  superseded"*, but **not** that K remained an authorized principal.

It also states the migration consequence the reviewer flagged: preserving only
raw receipts discards the evidence needed to establish historical
authorization. Full historical authorization needs the per-branch endorsement
evidence **O-N9** leaves undefined. **O-N9 is not invented or solved here.**

### Two direct duplicates of Defect A

Sweeping the whole file for the two stale claims surfaced two more sites that
repeat A. Both are build-facing — precisely where the reviewer's stated harm
("a builder could ship N7 alone") lands — so both are corrected identically:

- **§19.1 slice graph, N7 node** — the artifact a builder plans N7 from.
- **§20 decision classification index, N7 row** — its only qualifier was the
  "otherwise" direction, which reads as implying sufficiency.

No decision *class* was changed in either.

## Risk

Very low. Documentation-only; no protocol, identity, or production code is
touched. The risk of *not* landing it is higher than landing it: the §12.2 row
can lead to shipping N7 alone while retaining the permanent-halt attack, and
the §15.3 row can lead migration work to discard evidence it cannot recreate.

## Test plan

- `doc_control_check.py` — **PASS** (965 files; the edited file raises no warning)
- `compliance_linter.py` — **PASS** (no violations)
- `readiness_overclaim_linter.py` — **PASS** (no un-disclaimed overclaims)
- `freshness-check.py` — pre-existing staleness only, in the foundational-manual
  set (147d/62d/31d age-based); untouched by this diff and not attributable to a
  today-dated edit
- `cargo fmt --all --check` — **clean**
- `cargo check --workspace` — **exit 0**
- Markdown table column integrity verified on all three edited tables
- Adversarial consistency pass — see below

## Adversarial consistency pass

| Question | Result |
|---|---|
| Can a reader still infer FROST alone closes the guardian kill switch? | **No** — all four summary sites now state non-sufficiency, matching §9.2.1 c3, §9.6 item 19, and the §1 corrections list |
| Can a reader still infer post-recovery receipts retain authorization proof? | **No** in §15.3 — it now splits signature from authorization. One residual noted below |
| Does any corrected summary contradict §9.2.1, §9.2.2, §9.6, or the OPEN index? | **No** — wording was taken from those sections |
| Did this patch accidentally make N7 sufficient? | **No** — explicitly "necessary, not sufficient" in all four |
| Did this patch accidentally claim O-N9 is solved? | **No** — cited as leaving the evidence undefined; still OPEN |

## Note — one site deliberately NOT changed

`§7 evaluation matrix` line 865 scores Model C **✔** on "Historical signature
validity (R2.3)". Given R2.3 is now qualified, that cell arguably overclaims.
It is left alone on purpose: it is a *model-selection scoring* cell, and
rescoring it chains into the "Selected: Model C / three shortfall cells"
rationale in §7 — which would be reopening the architecture selection, out of
scope here. Flagged for a maintainer decision rather than changed unilaterally.

Refs #2592