### PR TITLE
refactor(authz): rename SubjectId to CapabilitySubjectId (N2-0)

### DIFF
--- a/docs/planning/icn-crate-reference.md
+++ b/docs/planning/icn-crate-reference.md
@@ -243,7 +243,7 @@ Week 5-6 (planned): Traffic obfuscation (random delays, size padding, cover traf
 ### `icn-authz`
 **Role:** Capability graph model (app-layer — interprets domain semantics)
 
-Types: `SubjectId`, `Action`, `ResourceId/Kind`, `Constraint`, `CapabilityEdge`, `CapabilityGraph`, `Decision`
+Types: `CapabilitySubjectId`, `Action`, `ResourceId/Kind`, `Constraint`, `CapabilityEdge`, `CapabilityGraph`, `Decision`
 
 The kernel sees only hashes from this crate, never the capability model itself (Meaning Firewall compliant)
 

--- a/icn/crates/icn-authz/src/error.rs
+++ b/icn/crates/icn-authz/src/error.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, thiserror::Error)]
 pub enum AuthzError {
-    #[error("invalid subject ID (must start with 'did:'): {0}")]
-    InvalidSubjectId(String),
+    #[error("invalid capability subject ID (must start with 'did:'): {0}")]
+    InvalidCapabilitySubjectId(String),
 
     #[error("invalid action format (expected 'domain:verb[:subverb]'): {0}")]
     InvalidAction(String),

--- a/icn/crates/icn-authz/src/graph/builder.rs
+++ b/icn/crates/icn-authz/src/graph/builder.rs
@@ -5,7 +5,7 @@
 //! The trait is defined here so B0 can write tests with mock sources.
 
 use crate::model::edge::{CapabilityEdge, CapabilityGraph};
-use crate::model::ids::SubjectId;
+use crate::model::ids::CapabilitySubjectId;
 
 // ---------------------------------------------------------------------------
 // CapabilitySource trait
@@ -17,7 +17,7 @@ use crate::model::ids::SubjectId;
 /// The trait is defined here so B0 can write tests with mock sources.
 pub trait CapabilitySource: Send + Sync {
     /// Return all capability edges this source knows about for the given subject.
-    fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge>;
+    fn edges_for_subject(&self, subject: &CapabilitySubjectId) -> Vec<CapabilityEdge>;
 
     /// Return all capability edges this source can produce.
     fn all_edges(&self) -> Vec<CapabilityEdge>;
@@ -60,7 +60,7 @@ impl GraphBuilder {
     /// Poll all sources for edges matching `subject` and build a canonical graph.
     ///
     /// The resulting [`CapabilityGraph`] is sorted and deduplicated.
-    pub fn build_for_subject(&self, subject: &SubjectId) -> CapabilityGraph {
+    pub fn build_for_subject(&self, subject: &CapabilitySubjectId) -> CapabilityGraph {
         let edges: Vec<CapabilityEdge> = self
             .sources
             .iter()
@@ -93,7 +93,7 @@ mod tests {
     }
 
     impl CapabilitySource for MockSource {
-        fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge> {
+        fn edges_for_subject(&self, subject: &CapabilitySubjectId) -> Vec<CapabilityEdge> {
             self.edges
                 .iter()
                 .filter(|e| e.subject == *subject)
@@ -108,12 +108,12 @@ mod tests {
 
     // -- Test helpers -------------------------------------------------------
 
-    fn alice() -> SubjectId {
-        SubjectId::new("did:icn:alice").unwrap()
+    fn alice() -> CapabilitySubjectId {
+        CapabilitySubjectId::new("did:icn:alice").unwrap()
     }
 
-    fn bob() -> SubjectId {
-        SubjectId::new("did:icn:bob").unwrap()
+    fn bob() -> CapabilitySubjectId {
+        CapabilitySubjectId::new("did:icn:bob").unwrap()
     }
 
     fn propose() -> Action {
@@ -124,7 +124,7 @@ mod tests {
         ResourceId::new(ResourceKind::Entity, "coop-1")
     }
 
-    fn make_edge(subject: SubjectId, action: Action) -> CapabilityEdge {
+    fn make_edge(subject: CapabilitySubjectId, action: Action) -> CapabilityEdge {
         CapabilityEdge::new(
             subject,
             action,

--- a/icn/crates/icn-authz/src/lib.rs
+++ b/icn/crates/icn-authz/src/lib.rs
@@ -21,6 +21,6 @@ pub mod model;
 pub use error::AuthzError;
 pub use graph::{CapabilitySource, GraphBuilder};
 pub use model::{
-    Action, CapabilityEdge, CapabilityGraph, Constraint, Decision, EdgeSource, ResourceId,
-    ResourceKind, SubjectId,
+    Action, CapabilityEdge, CapabilityGraph, CapabilitySubjectId, Constraint, Decision, EdgeSource,
+    ResourceId, ResourceKind,
 };

--- a/icn/crates/icn-authz/src/model/edge.rs
+++ b/icn/crates/icn-authz/src/model/edge.rs
@@ -9,7 +9,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::hash::hash_edge_set;
-use super::ids::{Action, BlockHeight, Constraint, EdgeSource, ResourceId, SubjectId};
+use super::ids::{Action, BlockHeight, CapabilitySubjectId, Constraint, EdgeSource, ResourceId};
 
 // ---------------------------------------------------------------------------
 // CapabilityEdge
@@ -20,7 +20,7 @@ use super::ids::{Action, BlockHeight, Constraint, EdgeSource, ResourceId, Subjec
 /// Constraints are always sorted and deduplicated (canonicalized in constructor).
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct CapabilityEdge {
-    pub subject: SubjectId,
+    pub subject: CapabilitySubjectId,
     pub action: Action,
     pub resource: ResourceId,
     /// INVARIANT: always sorted and deduplicated.
@@ -32,7 +32,7 @@ pub struct CapabilityEdge {
 impl CapabilityEdge {
     /// Create a new edge, sorting and deduplicating constraints.
     pub fn new(
-        subject: SubjectId,
+        subject: CapabilitySubjectId,
         action: Action,
         resource: ResourceId,
         mut constraints: Vec<Constraint>,
@@ -100,7 +100,12 @@ impl CapabilityGraph {
     ///
     /// Returns a [`Decision`] with matching edge indices. In B0, a match
     /// requires exact equality on subject, action, and resource.
-    pub fn query(&self, subject: &SubjectId, action: &Action, resource: &ResourceId) -> Decision {
+    pub fn query(
+        &self,
+        subject: &CapabilitySubjectId,
+        action: &Action,
+        resource: &ResourceId,
+    ) -> Decision {
         let matching_edges: Vec<usize> = self
             .edges
             .iter()
@@ -128,8 +133,8 @@ mod tests {
     use super::*;
     use crate::model::ids::{EdgeSource, ResourceKind};
 
-    fn make_subject() -> SubjectId {
-        SubjectId::new("did:icn:alice").unwrap()
+    fn make_subject() -> CapabilitySubjectId {
+        CapabilitySubjectId::new("did:icn:alice").unwrap()
     }
 
     fn make_action() -> Action {
@@ -188,7 +193,7 @@ mod tests {
     #[test]
     fn query_denied_when_no_matching_edge() {
         let graph = CapabilityGraph::from_edges(vec![make_edge(vec![])]);
-        let other_subject = SubjectId::new("did:icn:bob").unwrap();
+        let other_subject = CapabilitySubjectId::new("did:icn:bob").unwrap();
         let decision = graph.query(&other_subject, &make_action(), &make_resource());
         assert!(!decision.allowed);
         assert!(decision.matching_edges.is_empty());

--- a/icn/crates/icn-authz/src/model/hash.rs
+++ b/icn/crates/icn-authz/src/model/hash.rs
@@ -6,7 +6,7 @@
 
 use super::edge::CapabilityEdge;
 use super::ids::{
-    Action, BlockHeight, Constraint, EdgeSource, ResourceId, ResourceKind, SubjectId,
+    Action, BlockHeight, CapabilitySubjectId, Constraint, EdgeSource, ResourceId, ResourceKind,
 };
 
 // ---------------------------------------------------------------------------
@@ -121,8 +121,8 @@ fn edge_source_inner(es: &EdgeSource) -> &str {
 // Per-type hash functions
 // ---------------------------------------------------------------------------
 
-/// Deterministic BLAKE3 hash of a [`SubjectId`].
-pub fn hash_subject(s: &SubjectId) -> [u8; 32] {
+/// Deterministic BLAKE3 hash of a [`CapabilitySubjectId`].
+pub fn hash_subject(s: &CapabilitySubjectId) -> [u8; 32] {
     let mut hasher = blake3::Hasher::new();
     hasher.update(&[TAG_SUBJECT]);
     hash_bytes(&mut hasher, s.as_str().as_bytes());
@@ -210,12 +210,12 @@ pub fn hash_edge_set(edges: &[CapabilityEdge]) -> [u8; 32] {
 mod tests {
     use super::*;
 
-    fn alice() -> SubjectId {
-        SubjectId::new("did:icn:alice").unwrap()
+    fn alice() -> CapabilitySubjectId {
+        CapabilitySubjectId::new("did:icn:alice").unwrap()
     }
 
-    fn bob() -> SubjectId {
-        SubjectId::new("did:icn:bob").unwrap()
+    fn bob() -> CapabilitySubjectId {
+        CapabilitySubjectId::new("did:icn:bob").unwrap()
     }
 
     fn transfer() -> Action {
@@ -243,7 +243,7 @@ mod tests {
     }
 
     fn make_edge(
-        subject: SubjectId,
+        subject: CapabilitySubjectId,
         action: Action,
         valid_at: Option<BlockHeight>,
     ) -> CapabilityEdge {
@@ -257,7 +257,7 @@ mod tests {
         )
     }
 
-    // -- SubjectId hashing --------------------------------------------------
+    // -- CapabilitySubjectId hashing --------------------------------------------------
 
     #[test]
     fn hash_subject_deterministic() {

--- a/icn/crates/icn-authz/src/model/ids.rs
+++ b/icn/crates/icn-authz/src/model/ids.rs
@@ -214,18 +214,18 @@ mod tests {
     // -- CapabilitySubjectId ----------------------------------------------------------
 
     #[test]
-    fn subject_id_valid_did() {
+    fn capability_subject_id_valid_did() {
         let sid = CapabilitySubjectId::new("did:icn:abc123").unwrap();
         assert_eq!(sid.as_str(), "did:icn:abc123");
     }
 
     #[test]
-    fn subject_id_rejects_non_did() {
+    fn capability_subject_id_rejects_non_did() {
         assert!(CapabilitySubjectId::new("not-a-did").is_err());
     }
 
     #[test]
-    fn subject_id_rejects_empty() {
+    fn capability_subject_id_rejects_empty() {
         assert!(CapabilitySubjectId::new("").is_err());
     }
 
@@ -320,7 +320,7 @@ mod tests {
     // -- Serde roundtrips ---------------------------------------------------
 
     #[test]
-    fn subject_id_serde_roundtrip() {
+    fn capability_subject_id_serde_roundtrip() {
         let sid = CapabilitySubjectId::new("did:icn:abc").unwrap();
         let json = serde_json::to_string(&sid).unwrap();
         let back: CapabilitySubjectId = serde_json::from_str(&json).unwrap();

--- a/icn/crates/icn-authz/src/model/ids.rs
+++ b/icn/crates/icn-authz/src/model/ids.rs
@@ -8,22 +8,28 @@ use serde::{Deserialize, Serialize};
 use crate::AuthzError;
 
 // ---------------------------------------------------------------------------
-// SubjectId
+// CapabilitySubjectId
 // ---------------------------------------------------------------------------
 
 /// A validated DID identifying a capability subject.
 ///
 /// Must start with `"did:"`. Empty strings are rejected.
+///
+/// **Not** `icn_identity::authority_log::SubjectId`, which is a 32-byte
+/// `event_id(inception body)` naming a context-scoped human subject. This type names whatever
+/// principal a capability edge is written about, and carries no personhood meaning. Exactly one
+/// type in the workspace may hold the bare `SubjectId` name, and it is that one --- see
+/// `docs/architecture/IDENTITY_SEMANTICS.md`.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct SubjectId(String);
+pub struct CapabilitySubjectId(String);
 
-impl SubjectId {
-    /// Create a new `SubjectId`, rejecting values that do not start with `"did:"`.
+impl CapabilitySubjectId {
+    /// Create a new `CapabilitySubjectId`, rejecting values that do not start with `"did:"`.
     pub fn new(did: impl Into<String>) -> Result<Self, AuthzError> {
         let s = did.into();
         if !s.starts_with("did:") {
-            return Err(AuthzError::InvalidSubjectId(s));
+            return Err(AuthzError::InvalidCapabilitySubjectId(s));
         }
         Ok(Self(s))
     }
@@ -205,22 +211,22 @@ pub type BlockHeight = u64;
 mod tests {
     use super::*;
 
-    // -- SubjectId ----------------------------------------------------------
+    // -- CapabilitySubjectId ----------------------------------------------------------
 
     #[test]
     fn subject_id_valid_did() {
-        let sid = SubjectId::new("did:icn:abc123").unwrap();
+        let sid = CapabilitySubjectId::new("did:icn:abc123").unwrap();
         assert_eq!(sid.as_str(), "did:icn:abc123");
     }
 
     #[test]
     fn subject_id_rejects_non_did() {
-        assert!(SubjectId::new("not-a-did").is_err());
+        assert!(CapabilitySubjectId::new("not-a-did").is_err());
     }
 
     #[test]
     fn subject_id_rejects_empty() {
-        assert!(SubjectId::new("").is_err());
+        assert!(CapabilitySubjectId::new("").is_err());
     }
 
     // -- Action -------------------------------------------------------------
@@ -315,9 +321,9 @@ mod tests {
 
     #[test]
     fn subject_id_serde_roundtrip() {
-        let sid = SubjectId::new("did:icn:abc").unwrap();
+        let sid = CapabilitySubjectId::new("did:icn:abc").unwrap();
         let json = serde_json::to_string(&sid).unwrap();
-        let back: SubjectId = serde_json::from_str(&json).unwrap();
+        let back: CapabilitySubjectId = serde_json::from_str(&json).unwrap();
         assert_eq!(sid, back);
     }
 

--- a/icn/crates/icn-authz/src/model/mod.rs
+++ b/icn/crates/icn-authz/src/model/mod.rs
@@ -3,4 +3,6 @@ pub mod hash;
 pub mod ids;
 
 pub use edge::{CapabilityEdge, CapabilityGraph, Decision};
-pub use ids::{Action, BlockHeight, Constraint, EdgeSource, ResourceId, ResourceKind, SubjectId};
+pub use ids::{
+    Action, BlockHeight, CapabilitySubjectId, Constraint, EdgeSource, ResourceId, ResourceKind,
+};

--- a/icn/crates/icn-authz/tests/capability_graph_integration.rs
+++ b/icn/crates/icn-authz/tests/capability_graph_integration.rs
@@ -15,7 +15,7 @@ use icn_authz::*;
 struct FixedSource(Vec<CapabilityEdge>);
 
 impl CapabilitySource for FixedSource {
-    fn edges_for_subject(&self, subject: &SubjectId) -> Vec<CapabilityEdge> {
+    fn edges_for_subject(&self, subject: &CapabilitySubjectId) -> Vec<CapabilityEdge> {
         self.0
             .iter()
             .filter(|e| e.subject == *subject)
@@ -32,14 +32,14 @@ impl CapabilitySource for FixedSource {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn alice() -> SubjectId {
-    SubjectId::new("did:icn:alice").unwrap()
+fn alice() -> CapabilitySubjectId {
+    CapabilitySubjectId::new("did:icn:alice").unwrap()
 }
-fn bob() -> SubjectId {
-    SubjectId::new("did:icn:bob").unwrap()
+fn bob() -> CapabilitySubjectId {
+    CapabilitySubjectId::new("did:icn:bob").unwrap()
 }
-fn carol() -> SubjectId {
-    SubjectId::new("did:icn:carol").unwrap()
+fn carol() -> CapabilitySubjectId {
+    CapabilitySubjectId::new("did:icn:carol").unwrap()
 }
 fn propose() -> Action {
     Action::new("governance:propose").unwrap()
@@ -55,7 +55,7 @@ fn coop() -> ResourceId {
 }
 
 fn make_edge(
-    subject: SubjectId,
+    subject: CapabilitySubjectId,
     action: Action,
     resource: ResourceId,
     source: EdgeSource,


### PR DESCRIPTION
First bounded N2 Rust implementation tranche, root **N2-0**. Base: `33dd813e900d96becf9fcf503d34ac4cecfa70c8`.

## Why

Two types named `SubjectId` with opposite semantic contracts coexisted:

| | `icn_authz::SubjectId` | `icn_identity::authority_log::SubjectId` |
|---|---|---|
| shape | `SubjectId(String)` | `SubjectId([u8; 32])` |
| holds | a validated `did:` string | `event_id(inception body)` |
| names | whatever principal a capability edge is written about | a **context-scoped human subject** |

`docs/architecture/IDENTITY_SEMANTICS.md` invariant **I11** permits exactly one type in the workspace to carry that name, and reserves it for the human subject. This renames the capability-subject type.

## What changed

```
icn_authz::SubjectId          -> icn_authz::CapabilitySubjectId
AuthzError::InvalidSubjectId  -> AuthzError::InvalidCapabilitySubjectId
```

**8 Rust files** — exactly the surface §14 predicted — plus one line of `docs/planning/icn-crate-reference.md`, which is registered `status = "living"` / "Authoritative inventory of workspace crates" and would otherwise state a type that no longer exists. The two 2026-02-23 authz plan docs are dated historical plans, are not in `docs/registry.toml`, and are deliberately left alone.

The `AuthzError` display text moves from `invalid subject ID` to `invalid capability subject ID`. No test asserts on that string.

## This is not a wire-format change

- `CapabilitySubjectId` is a `#[serde(transparent)]` newtype over `String`, so the encoded form is the bare DID string and never carries the Rust type name.
- The BLAKE3 domain separator is the numeric constant `TAG_SUBJECT = 0x10`. It is **FROZEN** and untouched — no constant line appears in the diff.

Verified rather than asserted. Serde output and every hash function's bytes were captured before and after the rename with a throwaway probe (removed before commit):

```
SUBJECT_JSON="did:icn:abc123"
HASH_SUBJECT=[81, 63, 186, 117, ...]
EDGE_JSON={"subject":"did:icn:abc123","action":"ledger:transfer",...}
HASH_EDGE=[29, 65, 6, 198, ...]
HASH_EDGE_SET=[224, 39, 185, 217, ...]
```

`diff before after` → **identical**. Note the JSON key `"subject"` is the struct *field* name, which did not change.

## Scope held

Zero external consumers: no crate lists `icn-authz` in `[dependencies]`, and no `icn_authz` reference exists outside the crate.

Deliberately **not** renamed: the `subject` field, `hash_subject`, `build_for_subject`, `TAG_SUBJECT`. None carries the old type name; renaming them would expand the public surface beyond what I11 requires.

## Evidence

- `cargo test -p icn-authz` — **54 passed, 0 failed** (48 unit + 6 integration), identical to the pre-change baseline.
- `cargo check --workspace --all-targets` — exit 0.
- `cargo fmt --all -- --check` clean; `cargo clippy -p icn-authz --all-targets` clean.
- I11 now holds: `grep -rn 'struct SubjectId'` over the workspace returns exactly one hit, `icn-identity/src/authority_log/body.rs:46`.

## Truth status

**Library/type-level only.** Not runtime-integrated, not migrated, not deployed. Opening this PR does not make N2 "implemented".

**N2-A remains BLOCKED on N2-A0** (stored-key inventory). Nothing here canonicalizes `Did`, changes `Did` equality/hash, re-keys a persisted store, or rewrites a stored identifier.

Refs #2607