### PR TITLE
fix(ops-mcp): refuse sprint-board mutation while no sprint is active

### DIFF
--- a/docs/reference/project-index/generated/agent-capabilities.json
+++ b/docs/reference/project-index/generated/agent-capabilities.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "close_sprint",
-      "summary": "Archive current sprint to history/ and start a new sprint, carrying over unfinished tasks."
+      "summary": "REFUSES on any v2 record: archiving would round-trip it through a v1 write model that drops schema/cadence/lineage, and the successor number is never inferred."
     },
     {
       "name": "cluster_health",

--- a/ops/mcp/src/tests/sprint-mutation-guard.test.ts
+++ b/ops/mcp/src/tests/sprint-mutation-guard.test.ts
@@ -22,7 +22,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, readdirSync } from "fs";
+import {
+  mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, readdirSync, copyFileSync,
+} from "fs";
+import { execFileSync } from "child_process";
 import { tmpdir } from "os";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -135,6 +138,68 @@ describe("cadence vocabulary tracks scripts/check-truth-spine.py", () => {
     expect(keys).not.toBeNull();
     const pyKeys = [...keys![1]!.matchAll(/"([^"]+)"/g)].map((x) => x[1]!);
     expect([...tasks.DORMANCY_KEYS]).toEqual(pyKeys);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Differential: the TS resolver must agree with the shell resolver it mirrors.
+// ---------------------------------------------------------------------------
+//
+// The vocabulary test above catches drift in the WORD LISTS. This catches drift in the
+// ALGORITHM, which is the other half of "one canonical source": `resolveSprintCadence` is a
+// hand-mirror of `.claude/hooks/session-orient.sh`, and nothing but this stops the two
+// diverging. Both are driven over the same records and their verdicts compared.
+
+describe("resolveSprintCadence agrees with .claude/hooks/session-orient.sh", () => {
+  const CASES: Array<[string, unknown]> = [
+    ["dormant declared", { cadence: "dormant", active_sprint: null, status: "closed" }],
+    ["active with an in-progress label", { cadence: "active", active_sprint: 31, status: "in-progress" }],
+    ["running with an open label", { cadence: "running", active_sprint: 7, status: "open" }],
+    ["absent active_sprint is silence", { sprint: 26, status: "closed", tasks: [] }],
+    ["active + null active_sprint", { cadence: "active", active_sprint: null }],
+    ["dormant + a sprint number", { cadence: "dormant", active_sprint: 31 }],
+    ["unrecognised cadence", { cadence: "weekly", active_sprint: 31 }],
+    ["active_sprint null, no cadence", { active_sprint: null, status: "closed" }],
+    ["a status label alone decides nothing", { status: "active" }],
+    ["case and whitespace tolerant", { cadence: "  Dormant " }],
+  ];
+
+  /** Run the real hook against `record` in a throwaway repo skeleton. */
+  function hookVerdict(record: unknown): "active" | "dormant" | "unresolved" {
+    const box = mkdtempSync(join(tmpdir(), "icn-hook-"));
+    mkdirSync(join(box, "ops", "state", "sprint"), { recursive: true });
+    mkdirSync(join(box, "ops", "state", "truth"), { recursive: true });
+    mkdirSync(join(box, ".claude", "hooks"), { recursive: true });
+    copyFileSync(
+      join(REPO_ROOT, ".claude", "hooks", "session-orient.sh"),
+      join(box, ".claude", "hooks", "session-orient.sh")
+    );
+    copyFileSync(
+      join(REPO_ROOT, "ops", "state", "truth", "sources.json"),
+      join(box, "ops", "state", "truth", "sources.json")
+    );
+    writeFileSync(join(box, "ops", "state", "sprint", "current.json"), JSON.stringify(record));
+    const out = execFileSync("bash", [join(box, ".claude", "hooks", "session-orient.sh")], {
+      env: { ...process.env, CLAUDE_PROJECT_DIR: box, ICN_ROOT: box },
+      encoding: "utf-8",
+    });
+    rmSync(box, { recursive: true, force: true });
+    const line = out.split("\n").find((l) => l.includes("sprint: ")) ?? "";
+    const verdict = line.split("sprint: ")[1] ?? "";
+    if (verdict.startsWith("none active")) return "dormant";
+    if (verdict.startsWith("unresolved")) return "unresolved";
+    return "active";
+  }
+
+  it.each(CASES)("%s", async (_name, record) => {
+    await boot(DORMANT_V2);
+    expect(tasks.resolveSprintCadence(record).kind).toBe(hookVerdict(record));
+  });
+
+  // CONTROL: the comparison would be vacuous if the hook answered the same thing every time.
+  it("the hook itself produces all three verdicts across these cases", () => {
+    const seen = new Set(CASES.map(([, r]) => hookVerdict(r)));
+    expect([...seen].sort()).toEqual(["active", "dormant", "unresolved"]);
   });
 });
 

--- a/ops/mcp/src/tests/sprint-mutation-guard.test.ts
+++ b/ops/mcp/src/tests/sprint-mutation-guard.test.ts
@@ -1,0 +1,186 @@
+// The sprint board must refuse mutation while no sprint is active (icn#2419).
+//
+// WHY THIS FILE EXISTS, AND WHY IT CALLS THE TOOLS
+//   `ops/state/sprint/current.json` is the registered `sprint_state` truth owner and an
+//   honestly CLOSED record. Every mutating task tool loaded it, edited it and saved it with no
+//   status check, so any agent calling `create_task` would resurrect "current work" inside a
+//   closed sprint.
+//
+//   `tasks.test.ts` already covers this file's shape — but it does it by reading and writing a
+//   fixture with `fs`, and by unit-testing the pure `computeNextSprint`. Neither touches a tool
+//   handler, which is precisely the layer the guard lives in. That is the same gap that shipped
+//   `claim_files`/`session_info` broken with 163 tests green (see `session-tools.test.ts`). So
+//   the refusals below are driven THROUGH THE PROTOCOL, against a redirected state file, and
+//   the file is re-read afterwards to prove nothing was written.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { assertSprintMutable } from "../tools/tasks.js";
+
+// ---------------------------------------------------------------------------
+// The pure guard. No files, no protocol — just the decision.
+// ---------------------------------------------------------------------------
+
+describe("assertSprintMutable", () => {
+  it("permits an active sprint", () => {
+    expect(assertSprintMutable({ sprint: 27, status: "active" }).ok).toBe(true);
+  });
+
+  it("refuses a closed sprint", () => {
+    const r = assertSprintMutable({ sprint: 26, status: "closed" });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.message).toContain("sprint 26");
+    expect(r.message).toContain('status "closed"');
+  });
+
+  // The important half: absent must not mean mutable. Pre-v2 records on disk carry no
+  // `status`, and defaulting those to writable would restore the exact behaviour this
+  // guard removes.
+  it("refuses a record with no status field at all", () => {
+    const r = assertSprintMutable({ sprint: 26 });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.message).toContain("no status field");
+  });
+
+  it("refuses any status that is not exactly active", () => {
+    for (const status of ["Active", "ACTIVE", "dormant", "done", "closed", "", "paused"]) {
+      expect(assertSprintMutable({ sprint: 26, status }).ok).toBe(false);
+    }
+  });
+
+  // Opening the next sprint is blocked on a human decision (#2637). The refusal must say so
+  // rather than inviting the caller to pick a number.
+  it("routes the caller to the numbering decision, not to a guess", () => {
+    const r = assertSprintMutable({ sprint: 26, status: "closed" });
+    if (r.ok) throw new Error("expected a refusal");
+    expect(r.message).toContain("icn#2637");
+    expect(r.message).toMatch(/undetermined/i);
+    expect(r.message).toContain("gh issue list");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The tools, over the protocol, against a real (redirected) state file.
+// ---------------------------------------------------------------------------
+
+const MUTATORS: Array<[string, Record<string, unknown>]> = [
+  ["create_task", { id: "resurrected", title: "should never be written" }],
+  ["claim_task", { task_id: "t1", session_id: "s1", agent_name: "tester" }],
+  ["update_task", { task_id: "t1", status: "done" }],
+  ["delete_task", { task_id: "t1" }],
+  ["close_sprint", { next_name: "should never be opened" }],
+];
+
+/** A closed v2-shaped record, minus the prose. Deliberately has no `started`/`epics`. */
+const CLOSED_V2 = {
+  schema: "icn-sprint-state/v2",
+  cadence: "dormant",
+  sprint: 26,
+  status: "closed",
+  tasks: [{ id: "t1", title: "archived", status: "pending", pr: null, assignee: null, epic: null }],
+  next_sprint_number: null,
+};
+
+let root: string;
+let sprintFile: string;
+let client: Client;
+let priorIcnRoot: string | undefined;
+
+beforeEach(async () => {
+  root = mkdtempSync(join(tmpdir(), "icn-sprint-guard-"));
+  mkdirSync(join(root, "ops", "state", "sprint"), { recursive: true });
+  sprintFile = join(root, "ops", "state", "sprint", "current.json");
+  writeFileSync(sprintFile, JSON.stringify(CLOSED_V2, null, 2) + "\n");
+
+  // `tasks.ts` resolves SPRINT_FILE once at module load, so the env has to be set before the
+  // module is imported and the module cache has to be dropped between suites.
+  priorIcnRoot = process.env["ICN_ROOT"];
+  process.env["ICN_ROOT"] = root;
+  vi.resetModules();
+  const tasks = await import("../tools/tasks.js");
+
+  const server = new McpServer({ name: "icn-ops-test", version: "0.0.0" });
+  (tasks as { registerTaskTools: (s: McpServer, d: unknown) => void }).registerTaskTools(
+    server,
+    null
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+});
+
+afterEach(() => {
+  if (priorIcnRoot === undefined) delete process.env["ICN_ROOT"];
+  else process.env["ICN_ROOT"] = priorIcnRoot;
+  rmSync(root, { recursive: true, force: true });
+});
+
+async function callRaw(name: string, args: Record<string, unknown>) {
+  return (await client.callTool({ name, arguments: args })) as {
+    isError?: boolean;
+    content: Array<{ type: string; text: string }>;
+  };
+}
+
+describe("mutating task tools against a closed sprint", () => {
+  it.each(MUTATORS)("%s is refused", async (name, args) => {
+    const res = await callRaw(name, args);
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toContain("Refusing to mutate the sprint board");
+  });
+
+  it("leaves the state file byte-identical after every refused call", async () => {
+    const before = readFileSync(sprintFile, "utf-8");
+    for (const [name, args] of MUTATORS) await callRaw(name, args);
+    expect(readFileSync(sprintFile, "utf-8")).toBe(before);
+  });
+
+  // close_sprint is the sharpest case. Unguarded it would archive to
+  // `sprint-26-undefined.json` (v2 has no `started`), then write `computeNextSprint`'s
+  // `sprint: 26 + 1` over the whole record — silently answering #2637 by arithmetic and
+  // destroying `next_sprint_number`, `board_lineage` and the notes with it.
+  it("close_sprint neither writes an archive nor invents sprint 27", async () => {
+    await callRaw("close_sprint", { next_name: "fabricated" });
+    const historyDir = join(root, "ops", "state", "sprint", "history");
+    let archived: string[] = [];
+    try {
+      archived = readdirSync(historyDir);
+    } catch {
+      archived = [];
+    }
+    expect(archived).toEqual([]);
+    const after = JSON.parse(readFileSync(sprintFile, "utf-8"));
+    expect(after.sprint).toBe(26);
+    expect(after.status).toBe("closed");
+    expect(after.next_sprint_number).toBeNull();
+    expect(after.schema).toBe("icn-sprint-state/v2");
+  });
+});
+
+describe("read tools are unaffected", () => {
+  it("get_tasks still works on a closed sprint", async () => {
+    const res = await callRaw("get_tasks", {});
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0]?.text).toContain("t1");
+  });
+});
+
+describe("an active sprint is still mutable", () => {
+  it("create_task succeeds once the record says active", async () => {
+    writeFileSync(
+      sprintFile,
+      JSON.stringify({ ...CLOSED_V2, sprint: 27, status: "active" }, null, 2) + "\n"
+    );
+    const res = await callRaw("create_task", { id: "real", title: "a real task" });
+    expect(res.isError).toBeFalsy();
+    const after = JSON.parse(readFileSync(sprintFile, "utf-8"));
+    expect(after.tasks.map((t: { id: string }) => t.id)).toContain("real");
+  });
+});

--- a/ops/mcp/src/tests/sprint-mutation-guard.test.ts
+++ b/ops/mcp/src/tests/sprint-mutation-guard.test.ts
@@ -292,6 +292,55 @@ describe("assertSprintMutable", () => {
     expect(tasks.assertSprintMutable({ lifecycle: "inactive", active_sprint: 31 }).ok).toBe(false);
   });
 
+  // Review round 2, reproduced before fixing: `declares_dormancy` returns on the FIRST key it
+  // recognises, so mirroring it let `cadence: "active"` short-circuit past `lifecycle:
+  // "inactive"`. Every dormancy key is scanned now.
+  it("refuses when one cadence key says active and another declares dormancy", () => {
+    expect(
+      tasks.assertSprintMutable({ cadence: "active", lifecycle: "inactive", active_sprint: 31 }).ok
+    ).toBe(false);
+    expect(
+      tasks.assertSprintMutable({ lifecycle: "dormant", cadence: "running", active_sprint: 7 }).ok
+    ).toBe(false);
+    // Control: agreeing keys are still mutable, so the check is not refusing on key count.
+    expect(
+      tasks.assertSprintMutable({ cadence: "active", lifecycle: "running", active_sprint: 31 }).ok
+    ).toBe(true);
+  });
+
+  // Review round 2: the state file is parsed with an unchecked assertion, so a non-null but
+  // unusable `active_sprint` read as an active board.
+  it("refuses an active_sprint that cannot name a sprint", () => {
+    for (const bad of [false, true, {}, [], "", "   ", NaN, Infinity]) {
+      expect(
+        tasks.assertSprintMutable({ cadence: "active", active_sprint: bad }).ok,
+        `active_sprint: ${JSON.stringify(bad)}`
+      ).toBe(false);
+    }
+    // Controls: real identifiers stay mutable, including 0 and a string id.
+    for (const good of [31, 0, "31", "2026-Q3"]) {
+      expect(
+        tasks.assertSprintMutable({ cadence: "active", active_sprint: good }).ok,
+        `active_sprint: ${JSON.stringify(good)}`
+      ).toBe(true);
+    }
+  });
+
+  // Review round 2: the refusal used to hardcode today's lineage dispute, so it would keep
+  // citing icn#2637 long after the number was settled.
+  it("mentions the numbering decision only while the successor is undetermined", () => {
+    const undetermined = tasks.assertSprintMutable(DORMANT_V2);
+    if (undetermined.ok) throw new Error("expected a refusal");
+    expect(undetermined.message).toContain("icn#2637");
+
+    const settled = tasks.assertSprintMutable({ ...DORMANT_V2, next_sprint_number: 44 });
+    if (settled.ok) throw new Error("expected a refusal");
+    expect(settled.message).not.toContain("icn#2637");
+    expect(settled.message).not.toMatch(/numbering planes/);
+    // Still refuses, and still says why — only the stale recovery advice is gone.
+    expect(settled.message).toContain("no sprint is active");
+  });
+
   it("routes the caller to the numbering decision, not to a guess", () => {
     const r = tasks.assertSprintMutable(DORMANT_V2);
     if (r.ok) throw new Error("expected a refusal");

--- a/ops/mcp/src/tests/sprint-mutation-guard.test.ts
+++ b/ops/mcp/src/tests/sprint-mutation-guard.test.ts
@@ -1,17 +1,22 @@
 // The sprint board must refuse mutation while no sprint is active (icn#2419).
 //
 // WHY THIS FILE EXISTS, AND WHY IT CALLS THE TOOLS
-//   `ops/state/sprint/current.json` is the registered `sprint_state` truth owner and an
-//   honestly CLOSED record. Every mutating task tool loaded it, edited it and saved it with no
-//   status check, so any agent calling `create_task` would resurrect "current work" inside a
-//   closed sprint.
+//   `ops/state/sprint/current.json` is the registered `sprint_state` truth owner. Every
+//   mutating task tool loaded it, edited it and saved it with no cadence check, so any agent
+//   calling `create_task` would resurrect "current work" inside a dormant board.
 //
-//   `tasks.test.ts` already covers this file's shape — but it does it by reading and writing a
-//   fixture with `fs`, and by unit-testing the pure `computeNextSprint`. Neither touches a tool
-//   handler, which is precisely the layer the guard lives in. That is the same gap that shipped
-//   `claim_files`/`session_info` broken with 163 tests green (see `session-tools.test.ts`). So
-//   the refusals below are driven THROUGH THE PROTOCOL, against a redirected state file, and
-//   the file is re-read afterwards to prove nothing was written.
+//   `tasks.test.ts` covers this file's shape — but via `fs` on a fixture and the pure
+//   `computeNextSprint`. Neither touches a tool handler, which is the layer the guards live
+//   in. That is the same gap that shipped `claim_files`/`session_info` broken with 163 tests
+//   green (see `session-tools.test.ts`). So every refusal below is driven THROUGH THE
+//   PROTOCOL against a redirected state file, and the file is re-read afterwards.
+//
+// NOTE ON IMPORTS (review finding, PR #2657)
+//   Nothing is imported from `../tools/tasks.js` at module scope. `tasks.ts` resolves
+//   SPRINT_FILE once at load, so a module-scope import would bind it to the real repo path
+//   before `ICN_ROOT` is set. Every symbol — pure predicates included — is pulled off the
+//   same dynamically imported instance the tools are registered from, so there is exactly one
+//   module instance per test and no split-brain between the two.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -19,56 +24,40 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, readdirSync } from "fs";
 import { tmpdir } from "os";
-import { join } from "path";
-import { assertSprintMutable } from "../tools/tasks.js";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 
-// ---------------------------------------------------------------------------
-// The pure guard. No files, no protocol — just the decision.
-// ---------------------------------------------------------------------------
+type TasksModule = typeof import("../tools/tasks.js");
 
-describe("assertSprintMutable", () => {
-  it("permits an active sprint", () => {
-    expect(assertSprintMutable({ sprint: 27, status: "active" }).ok).toBe(true);
-  });
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 
-  it("refuses a closed sprint", () => {
-    const r = assertSprintMutable({ sprint: 26, status: "closed" });
-    expect(r.ok).toBe(false);
-    if (r.ok) return;
-    expect(r.message).toContain("sprint 26");
-    expect(r.message).toContain('status "closed"');
-  });
+/** A dormant v2-shaped record, minus the prose. Deliberately has no `started`/`epics`. */
+const DORMANT_V2 = {
+  schema: "icn-sprint-state/v2",
+  cadence: "dormant",
+  active_sprint: null,
+  sprint: 26,
+  status: "closed",
+  tasks: [{ id: "t1", title: "archived", status: "pending", pr: null, assignee: null, epic: null }],
+  next_sprint_number: null,
+};
 
-  // The important half: absent must not mean mutable. Pre-v2 records on disk carry no
-  // `status`, and defaulting those to writable would restore the exact behaviour this
-  // guard removes.
-  it("refuses a record with no status field at all", () => {
-    const r = assertSprintMutable({ sprint: 26 });
-    expect(r.ok).toBe(false);
-    if (r.ok) return;
-    expect(r.message).toContain("no status field");
-  });
-
-  it("refuses any status that is not exactly active", () => {
-    for (const status of ["Active", "ACTIVE", "dormant", "done", "closed", "", "paused"]) {
-      expect(assertSprintMutable({ sprint: 26, status }).ok).toBe(false);
-    }
-  });
-
-  // Opening the next sprint is blocked on a human decision (#2637). The refusal must say so
-  // rather than inviting the caller to pick a number.
-  it("routes the caller to the numbering decision, not to a guess", () => {
-    const r = assertSprintMutable({ sprint: 26, status: "closed" });
-    if (r.ok) throw new Error("expected a refusal");
-    expect(r.message).toContain("icn#2637");
-    expect(r.message).toMatch(/undetermined/i);
-    expect(r.message).toContain("gh issue list");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// The tools, over the protocol, against a real (redirected) state file.
-// ---------------------------------------------------------------------------
+/**
+ * A genuinely running board. This is the reviewer's exact counter-example, and it is the
+ * positive control the whole suite rests on: the previous `status === "active"` predicate
+ * REFUSED this record, and the registered resolver reports it as active.
+ */
+const ACTIVE_V1 = {
+  cadence: "active",
+  active_sprint: 31,
+  sprint: 31,
+  status: "in-progress",
+  name: "Sprint 31",
+  started: "2026-08-01",
+  goals: [],
+  epics: {},
+  tasks: [{ id: "t1", title: "live", status: "pending", pr: null, assignee: null, epic: null }],
+};
 
 const MUTATORS: Array<[string, Record<string, unknown>]> = [
   ["create_task", { id: "resurrected", title: "should never be written" }],
@@ -78,42 +67,29 @@ const MUTATORS: Array<[string, Record<string, unknown>]> = [
   ["close_sprint", { next_name: "should never be opened" }],
 ];
 
-/** A closed v2-shaped record, minus the prose. Deliberately has no `started`/`epics`. */
-const CLOSED_V2 = {
-  schema: "icn-sprint-state/v2",
-  cadence: "dormant",
-  sprint: 26,
-  status: "closed",
-  tasks: [{ id: "t1", title: "archived", status: "pending", pr: null, assignee: null, epic: null }],
-  next_sprint_number: null,
-};
-
 let root: string;
 let sprintFile: string;
 let client: Client;
+let tasks: TasksModule;
 let priorIcnRoot: string | undefined;
 
-beforeEach(async () => {
+async function boot(record: unknown) {
+  writeFileSync(sprintFile, JSON.stringify(record, null, 2) + "\n");
+  vi.resetModules();
+  tasks = await import("../tools/tasks.js");
+  const server = new McpServer({ name: "icn-ops-test", version: "0.0.0" });
+  tasks.registerTaskTools(server, null as never);
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([server.connect(st), client.connect(ct)]);
+}
+
+beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "icn-sprint-guard-"));
   mkdirSync(join(root, "ops", "state", "sprint"), { recursive: true });
   sprintFile = join(root, "ops", "state", "sprint", "current.json");
-  writeFileSync(sprintFile, JSON.stringify(CLOSED_V2, null, 2) + "\n");
-
-  // `tasks.ts` resolves SPRINT_FILE once at module load, so the env has to be set before the
-  // module is imported and the module cache has to be dropped between suites.
   priorIcnRoot = process.env["ICN_ROOT"];
   process.env["ICN_ROOT"] = root;
-  vi.resetModules();
-  const tasks = await import("../tools/tasks.js");
-
-  const server = new McpServer({ name: "icn-ops-test", version: "0.0.0" });
-  (tasks as { registerTaskTools: (s: McpServer, d: unknown) => void }).registerTaskTools(
-    server,
-    null
-  );
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  client = new Client({ name: "test-client", version: "0.0.0" });
-  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
 });
 
 afterEach(() => {
@@ -129,11 +105,149 @@ async function callRaw(name: string, args: Record<string, unknown>) {
   };
 }
 
-describe("mutating task tools against a closed sprint", () => {
+// ---------------------------------------------------------------------------
+// The vocabulary is not ours. Prove it still matches the owner.
+// ---------------------------------------------------------------------------
+
+describe("cadence vocabulary tracks scripts/check-truth-spine.py", () => {
+  /** Parse a `NAME = {"a", "b"}` set literal out of the Python owner. */
+  function pySet(src: string, name: string): Set<string> {
+    const m = new RegExp(`^${name}\\s*=\\s*\\{([^}]*)\\}`, "m").exec(src);
+    if (!m) throw new Error(`${name} not found in check-truth-spine.py`);
+    return new Set([...m[1]!.matchAll(/"([^"]+)"/g)].map((x) => x[1]!));
+  }
+
+  it("has identical DORMANT and ACTIVE value sets", async () => {
+    await boot(DORMANT_V2);
+    const py = readFileSync(join(REPO_ROOT, "scripts", "check-truth-spine.py"), "utf-8");
+
+    // Control first: if the parser silently returned nothing, every comparison below would
+    // be vacuously true against an empty TS set.
+    const pyDormant = pySet(py, "DORMANT_VALUES");
+    const pyActive = pySet(py, "ACTIVE_VALUES");
+    expect(pyDormant.size).toBeGreaterThan(0);
+    expect(pyActive.size).toBeGreaterThan(0);
+
+    expect([...tasks.DORMANT_CADENCES].sort()).toEqual([...pyDormant].sort());
+    expect([...tasks.ACTIVE_CADENCES].sort()).toEqual([...pyActive].sort());
+
+    const keys = /^DORMANCY_KEYS\s*=\s*\(([^)]*)\)/m.exec(py);
+    expect(keys).not.toBeNull();
+    const pyKeys = [...keys![1]!.matchAll(/"([^"]+)"/g)].map((x) => x[1]!);
+    expect([...tasks.DORMANCY_KEYS]).toEqual(pyKeys);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cadence resolution — three-valued, mirroring .claude/hooks/session-orient.sh
+// ---------------------------------------------------------------------------
+
+describe("resolveSprintCadence", () => {
+  beforeEach(async () => {
+    await boot(DORMANT_V2);
+  });
+
+  it("resolves a declared active board", () => {
+    expect(tasks.resolveSprintCadence({ cadence: "active", active_sprint: 31 })).toMatchObject({
+      kind: "active",
+      sprint: 31,
+    });
+    expect(tasks.resolveSprintCadence({ cadence: "running", active_sprint: 7 }).kind).toBe("active");
+  });
+
+  it("resolves a declared dormant board", () => {
+    for (const c of ["dormant", "inactive", "none", "paused"]) {
+      expect(tasks.resolveSprintCadence({ cadence: c }).kind).toBe("dormant");
+    }
+    expect(tasks.resolveSprintCadence({ active_sprint: null }).kind).toBe("dormant");
+  });
+
+  it("is case- and whitespace-tolerant, like the owner", () => {
+    expect(tasks.resolveSprintCadence({ cadence: "  Dormant " }).kind).toBe("dormant");
+    expect(tasks.resolveSprintCadence({ cadence: " ACTIVE ", active_sprint: 3 }).kind).toBe("active");
+  });
+
+  // The four cases the registered resolver reports as `unresolved`. None may be mutable, and
+  // none may be reported as dormant — silence is not a declaration.
+  it("refuses to resolve silence or self-contradiction", () => {
+    const cases: Array<[string, unknown]> = [
+      ["absent active_sprint key is silence, not null", { sprint: 26, status: "closed" }],
+      ["active cadence + null active_sprint", { cadence: "active", active_sprint: null }],
+      ["dormant cadence + a sprint number", { cadence: "dormant", active_sprint: 31 }],
+      ["unrecognised cadence", { cadence: "weekly", active_sprint: 31 }],
+      ["not an object", ["not", "an", "object"]],
+    ];
+    for (const [why, rec] of cases) {
+      expect(tasks.resolveSprintCadence(rec).kind, why).toBe("unresolved");
+    }
+  });
+});
+
+describe("assertSprintMutable", () => {
+  beforeEach(async () => {
+    await boot(DORMANT_V2);
+  });
+
+  // POSITIVE CONTROLS. Without these the suite could be green because everything is refused.
+  it("permits a genuinely active board", () => {
+    expect(tasks.assertSprintMutable(ACTIVE_V1).ok).toBe(true);
+    expect(tasks.assertSprintMutable({ cadence: "running", active_sprint: 7 }).ok).toBe(true);
+    expect(tasks.assertSprintMutable({ active_sprint: 12 }).ok).toBe(true);
+  });
+
+  // The old predicate's two failures, pinned in both directions.
+  it("no longer refuses an active board whose status label is not the word active", () => {
+    expect(ACTIVE_V1.status).not.toBe("active");
+    expect(tasks.assertSprintMutable(ACTIVE_V1).ok).toBe(true);
+  });
+
+  it("no longer permits a dormant board whose status label happens to be active", () => {
+    const r = tasks.assertSprintMutable({ cadence: "dormant", active_sprint: null, status: "active" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("fails closed on dormant, unresolved, silent and malformed records", () => {
+    for (const rec of [
+      DORMANT_V2,
+      {},
+      { sprint: 26 },
+      { cadence: "weekly", active_sprint: 31 },
+      { cadence: "active", active_sprint: null },
+      { status: "active" },
+      null,
+      ["x"],
+    ]) {
+      expect(tasks.assertSprintMutable(rec).ok, JSON.stringify(rec)).toBe(false);
+    }
+  });
+
+  // `declares_dormancy` is fail-OPEN by design (silence is not dormancy), so a guard written
+  // as `!declaresDormancy(x)` would make silence mutable. Pin the polarity.
+  it("treats a lifecycle dormancy declaration as refusal even with a live active_sprint", () => {
+    expect(tasks.assertSprintMutable({ lifecycle: "inactive", active_sprint: 31 }).ok).toBe(false);
+  });
+
+  it("routes the caller to the numbering decision, not to a guess", () => {
+    const r = tasks.assertSprintMutable(DORMANT_V2);
+    if (r.ok) throw new Error("expected a refusal");
+    expect(r.message).toContain("icn#2637");
+    expect(r.message).toContain("gh issue list");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The tools, over the protocol
+// ---------------------------------------------------------------------------
+
+describe("mutating task tools against a dormant board", () => {
+  beforeEach(async () => {
+    await boot(DORMANT_V2);
+  });
+
   it.each(MUTATORS)("%s is refused", async (name, args) => {
     const res = await callRaw(name, args);
     expect(res.isError).toBe(true);
-    expect(res.content[0]?.text).toContain("Refusing to mutate the sprint board");
+    expect(res.content[0]?.text).toMatch(/Refusing to (mutate the sprint board|close the sprint)/);
   });
 
   it("leaves the state file byte-identical after every refused call", async () => {
@@ -142,45 +256,191 @@ describe("mutating task tools against a closed sprint", () => {
     expect(readFileSync(sprintFile, "utf-8")).toBe(before);
   });
 
-  // close_sprint is the sharpest case. Unguarded it would archive to
-  // `sprint-26-undefined.json` (v2 has no `started`), then write `computeNextSprint`'s
-  // `sprint: 26 + 1` over the whole record — silently answering #2637 by arithmetic and
-  // destroying `next_sprint_number`, `board_lineage` and the notes with it.
-  it("close_sprint neither writes an archive nor invents sprint 27", async () => {
-    await callRaw("close_sprint", { next_name: "fabricated" });
-    const historyDir = join(root, "ops", "state", "sprint", "history");
-    let archived: string[] = [];
-    try {
-      archived = readdirSync(historyDir);
-    } catch {
-      archived = [];
-    }
-    expect(archived).toEqual([]);
-    const after = JSON.parse(readFileSync(sprintFile, "utf-8"));
-    expect(after.sprint).toBe(26);
-    expect(after.status).toBe("closed");
-    expect(after.next_sprint_number).toBeNull();
-    expect(after.schema).toBe("icn-sprint-state/v2");
-  });
-});
-
-describe("read tools are unaffected", () => {
-  it("get_tasks still works on a closed sprint", async () => {
+  it("get_tasks still works — reads are unaffected", async () => {
     const res = await callRaw("get_tasks", {});
     expect(res.isError).toBeFalsy();
     expect(res.content[0]?.text).toContain("t1");
   });
 });
 
-describe("an active sprint is still mutable", () => {
-  it("create_task succeeds once the record says active", async () => {
-    writeFileSync(
-      sprintFile,
-      JSON.stringify({ ...CLOSED_V2, sprint: 27, status: "active" }, null, 2) + "\n"
-    );
+describe("mutating task tools against an active board", () => {
+  beforeEach(async () => {
+    await boot(ACTIVE_V1);
+  });
+
+  it("create_task succeeds", async () => {
     const res = await callRaw("create_task", { id: "real", title: "a real task" });
     expect(res.isError).toBeFalsy();
     const after = JSON.parse(readFileSync(sprintFile, "utf-8"));
     expect(after.tasks.map((t: { id: string }) => t.id)).toContain("real");
+  });
+
+  it("update_task and claim_task succeed", async () => {
+    expect((await callRaw("claim_task", { task_id: "t1", session_id: "s", agent_name: "a" })).isError).toBeFalsy();
+    expect((await callRaw("update_task", { task_id: "t1", status: "done" })).isError).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// close_sprint — the two structural gates
+// ---------------------------------------------------------------------------
+
+describe("close_sprint cannot fabricate a successor", () => {
+  // ACTIVE so the cadence guard is out of the way: this proves the successor gate stands on
+  // its own rather than being masked by dormancy.
+  it("refuses when next_sprint_number is absent, even on an active board", async () => {
+    await boot(ACTIVE_V1);
+    const res = await callRaw("close_sprint", { next_name: "fabricated" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toContain("UNDETERMINED");
+    expect(res.content[0]?.text).toContain("icn#2637");
+    // 26+1 and 31+1 must appear nowhere: the tool must not even suggest a number.
+    expect(res.content[0]?.text).not.toMatch(/\b32\b/);
+  });
+
+  it("refuses when next_sprint_number is explicitly null", async () => {
+    await boot({ ...ACTIVE_V1, next_sprint_number: null });
+    const res = await callRaw("close_sprint", { next_name: "fabricated" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toContain("UNDETERMINED");
+  });
+
+  it("writes nothing and archives nothing when it refuses", async () => {
+    await boot(ACTIVE_V1);
+    const before = readFileSync(sprintFile, "utf-8");
+    await callRaw("close_sprint", { next_name: "fabricated" });
+    expect(readFileSync(sprintFile, "utf-8")).toBe(before);
+    let archived: string[] = [];
+    try {
+      archived = readdirSync(join(root, "ops", "state", "sprint", "history"));
+    } catch {
+      archived = [];
+    }
+    expect(archived).toEqual([]);
+  });
+
+  // DISCRIMINATOR, and the reason the identity gate runs first. With an explicit successor
+  // the close still refuses — but on SHAPE, not identity. The refusal reason changing is what
+  // proves the successor gate actually passed rather than the tool blanket-refusing.
+  //
+  // It also records the honest consequence of this PR: `close_sprint` cannot currently succeed
+  // on ANY record the cadence guard admits, because being active requires `active_sprint` and
+  // the v1 write model cannot emit that key. That is the bounded outcome — v2 closure refuses
+  // until a v2 transition contract exists — not an accident.
+  it("with an explicit successor it refuses on SHAPE, not on identity", async () => {
+    await boot({ ...ACTIVE_V1, next_sprint_number: 44 });
+    const res = await callRaw("close_sprint", { next_name: "Sprint 44" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toContain("would DELETE");
+    expect(res.content[0]?.text).not.toContain("UNDETERMINED");
+  });
+
+  it("resolveSuccessorSprint never derives a number", async () => {
+    await boot(DORMANT_V2);
+    expect(tasks.resolveSuccessorSprint({ sprint: 26 }).kind).toBe("undetermined");
+    expect(tasks.resolveSuccessorSprint({ sprint: 26, next_sprint_number: null }).kind).toBe("undetermined");
+    expect(tasks.resolveSuccessorSprint({ sprint: 26, next_sprint_number: "" }).kind).toBe("undetermined");
+    expect(tasks.resolveSuccessorSprint({ sprint: 26, next_sprint_number: 29 })).toMatchObject({
+      kind: "explicit",
+      sprint: 29,
+    });
+  });
+});
+
+describe("close_sprint cannot downgrade a v2 record through the v1 write model", () => {
+  /** An ACTIVE v2 record with an explicit successor: both other gates are satisfied. */
+  const ACTIVE_V2 = {
+    schema: "icn-sprint-state/v2",
+    domain: "sprint_state",
+    cadence: "active",
+    active_sprint: 31,
+    sprint: 31,
+    status: "in-progress",
+    name: "Sprint 31",
+    started: "2026-08-01",
+    goals: [],
+    epics: {},
+    tasks: [],
+    next_sprint_number: 44,
+    board_lineage: { last_recorded_sprint: 30 },
+    current_work_pointer: { note: "live query" },
+    notes: "must survive",
+  };
+
+  it("refuses, naming every field the v1 write would delete", async () => {
+    await boot(ACTIVE_V2);
+    const res = await callRaw("close_sprint", { next_name: "Sprint 44" });
+    expect(res.isError).toBe(true);
+    const text = res.content[0]!.text;
+    for (const f of [
+      "schema",
+      "domain",
+      "cadence",
+      "active_sprint",
+      "status",
+      "next_sprint_number",
+      "board_lineage",
+      "current_work_pointer",
+      "notes",
+    ]) {
+      expect(text, `expected the refusal to name ${f}`).toContain(f);
+    }
+  });
+
+  // THE STRUCTURAL REGRESSION. Not "is the board dormant today" — "can a v2 record ever be
+  // rewritten as v1". Every gate before this one is satisfied, so only the shape check stands.
+  it("no v2 field is lost: the record is byte-identical after the refused close", async () => {
+    await boot(ACTIVE_V2);
+    const before = readFileSync(sprintFile, "utf-8");
+    await callRaw("close_sprint", { next_name: "Sprint 44" });
+    const after = readFileSync(sprintFile, "utf-8");
+    expect(after).toBe(before);
+    const parsed = JSON.parse(after);
+    expect(parsed.schema).toBe("icn-sprint-state/v2");
+    expect(parsed.board_lineage).toEqual({ last_recorded_sprint: 30 });
+    expect(parsed.notes).toBe("must survive");
+  });
+
+  it("fieldsLostByV1Write reports exactly the non-v1 keys, and nothing for a v1 record", async () => {
+    await boot(DORMANT_V2);
+    expect(tasks.fieldsLostByV1Write(ACTIVE_V2)).toEqual([
+      "active_sprint",
+      "board_lineage",
+      "cadence",
+      "current_work_pointer",
+      "domain",
+      "next_sprint_number",
+      "notes",
+      "schema",
+      "status",
+    ]);
+    // Control: a pure v1 record loses nothing, so the gate is not simply always-on.
+    expect(
+      tasks.fieldsLostByV1Write({
+        sprint: 1,
+        name: "n",
+        started: "d",
+        goals: [],
+        tasks: [],
+        epics: {},
+      })
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The live repository record must be refused by the shipped guard.
+// ---------------------------------------------------------------------------
+
+describe("the real ops/state/sprint/current.json", () => {
+  it("is dormant, and every mutator refuses it", async () => {
+    const live = JSON.parse(
+      readFileSync(join(REPO_ROOT, "ops", "state", "sprint", "current.json"), "utf-8")
+    );
+    await boot(live);
+    expect(tasks.resolveSprintCadence(live).kind).toBe("dormant");
+    for (const [name, args] of MUTATORS) {
+      expect((await callRaw(name, args)).isError, name).toBe(true);
+    }
   });
 });

--- a/ops/mcp/src/tests/sprint-mutation-guard.test.ts
+++ b/ops/mcp/src/tests/sprint-mutation-guard.test.ts
@@ -341,6 +341,21 @@ describe("assertSprintMutable", () => {
     expect(settled.message).toContain("no sprint is active");
   });
 
+  // Review round 3: the refusal asserted "no sprint is active" for records whose cadence the
+  // resolver expressly refused to resolve — a cadence fact this surface must not emit.
+  it("reports unresolved cadence as unresolved, not as dormancy", () => {
+    const dormant = tasks.assertSprintMutable({ cadence: "dormant", active_sprint: null });
+    if (dormant.ok) throw new Error("expected a refusal");
+    expect(dormant.message).toContain("no sprint is active");
+
+    for (const rec of [{ sprint: 26 }, { cadence: "weekly", active_sprint: 3 }, { cadence: "active", active_sprint: null }]) {
+      const r = tasks.assertSprintMutable(rec);
+      if (r.ok) throw new Error(`expected a refusal for ${JSON.stringify(rec)}`);
+      expect(r.message, JSON.stringify(rec)).toContain("cadence cannot be resolved");
+      expect(r.message, JSON.stringify(rec)).not.toContain("no sprint is active");
+    }
+  });
+
   it("routes the caller to the numbering decision, not to a guess", () => {
     const r = tasks.assertSprintMutable(DORMANT_V2);
     if (r.ok) throw new Error("expected a refusal");
@@ -447,6 +462,37 @@ describe("close_sprint cannot fabricate a successor", () => {
     expect(res.isError).toBe(true);
     expect(res.content[0]?.text).toContain("would DELETE");
     expect(res.content[0]?.text).not.toContain("UNDETERMINED");
+  });
+
+  // Review round 3: the generic refusal was de-hardcoded but close_sprint's own kept citing
+  // this board's 26/27/28 lineage, which would be false guidance on any other board.
+  it("its refusal states no particular board's lineage", async () => {
+    await boot({ ...ACTIVE_V1, sprint: 77, active_sprint: 77 });
+    const res = await callRaw("close_sprint", { next_name: "x" });
+    const text = res.content[0]!.text;
+    expect(res.isError).toBe(true);
+    // Word-bounded: `icn#2637` legitimately contains "26", and the point is that no bare
+    // sprint NUMBER from this board's history is stated.
+    for (const stale of ["26", "27", "28"]) {
+      expect(text, `must not hardcode sprint ${stale}`).not.toMatch(new RegExp(`\\b${stale}\\b`));
+    }
+    for (const stale of ["numbering planes", "narrated cadence"]) {
+      expect(text, `must not hardcode "${stale}"`).not.toContain(stale);
+    }
+    // Still actionable: names the field to set and where the decision lives.
+    expect(text).toContain("next_sprint_number");
+    expect(text).toContain("icn#2637");
+  });
+
+  // Review round 3: the MCP description advertised archive-and-start, which cannot occur —
+  // passing the identity gate requires `next_sprint_number`, itself a non-v1 key the shape
+  // gate then rejects.
+  it("does not advertise an operation it can never perform", async () => {
+    await boot(DORMANT_V2);
+    const { tools } = await client.listTools();
+    const desc = tools.find((t) => t.name === "close_sprint")!.description!;
+    expect(desc).toMatch(/REFUSES/);
+    expect(desc).not.toMatch(/start a new sprint/i);
   });
 
   it("resolveSuccessorSprint never derives a number", async () => {

--- a/ops/mcp/src/tests/tasks.test.ts
+++ b/ops/mcp/src/tests/tasks.test.ts
@@ -73,18 +73,23 @@ describe("computeNextSprint", () => {
     ],
   };
 
-  it("increments the sprint number", () => {
-    expect(computeNextSprint(base, "Sprint 27", [], "2026-07-01").sprint).toBe(27);
+  // Renamed from "increments the sprint number": it no longer does, and must not. The
+  // successor is supplied by the caller from `resolveSuccessorSprint` (#2419 / #2637).
+  it("uses the successor number it is given, never current.sprint + 1", () => {
+    expect(computeNextSprint(base, 31, "Sprint 31", [], "2026-07-01").sprint).toBe(31);
+    // Discriminating: 27 IS base.sprint + 1, so a test that only asserted 27 would pass
+    // against restored arithmetic. 31 cannot be produced by incrementing 26.
+    expect(computeNextSprint(base, 27, "Sprint 27", [], "2026-07-01").sprint).toBe(27);
   });
 
   it("carries over only non-done tasks and clears their assignee", () => {
-    const next = computeNextSprint(base, "Sprint 27", [], "2026-07-01");
+    const next = computeNextSprint(base, 27, "Sprint 27", [], "2026-07-01");
     expect(next.tasks.map((t) => t.id)).toEqual(["t2", "t3"]);
     expect(next.tasks.every((t) => t.assignee === null)).toBe(true);
   });
 
   it("applies the new name, goals, and start date; preserves epics", () => {
-    const next = computeNextSprint(base, "Sprint 27", ["land pilot"], "2026-07-01");
+    const next = computeNextSprint(base, 27, "Sprint 27", ["land pilot"], "2026-07-01");
     expect(next.name).toBe("Sprint 27");
     expect(next.goals).toEqual(["land pilot"]);
     expect(next.started).toBe("2026-07-01");
@@ -93,13 +98,13 @@ describe("computeNextSprint", () => {
 
   it("does not mutate the input sprint", () => {
     const snapshot = JSON.parse(JSON.stringify(base));
-    computeNextSprint(base, "Sprint 27", [], "2026-07-01");
+    computeNextSprint(base, 27, "Sprint 27", [], "2026-07-01");
     expect(base).toEqual(snapshot);
   });
 
   it("returns state that shares no mutable references with the input", () => {
     const goals = ["ship"];
-    const next = computeNextSprint(base, "Sprint 27", goals, "2026-07-01");
+    const next = computeNextSprint(base, 27, "Sprint 27", goals, "2026-07-01");
     expect(next.epics).not.toBe(base.epics);
     expect(next.goals).not.toBe(goals);
     // Mutating the result must not leak back into the inputs via aliasing.

--- a/ops/mcp/src/tools/tasks.ts
+++ b/ops/mcp/src/tools/tasks.ts
@@ -23,6 +23,71 @@ export interface SprintState {
   goals: string[];
   tasks: Task[];
   epics: Record<string, string>;
+  /**
+   * Cadence status. Optional because this interface predates `icn-sprint-state/v2`
+   * (#2636) and pre-v2 archives on disk do not carry it. Absent is NOT "active":
+   * see `assertSprintMutable`.
+   */
+  status?: string;
+  /**
+   * v2 only, and deliberately `null` today: two numbering planes disagree and a human
+   * must reconcile them (#2637). Nothing here may infer it.
+   */
+  next_sprint_number?: number | null;
+}
+
+/**
+ * The only cadence status under which the sprint board may be mutated.
+ *
+ * `ops/state/sprint/current.json` is the registered `sprint_state` truth owner and is an
+ * honestly CLOSED record — Sprint 26 was closed retroactively by the 2026-07-13 truth refresh
+ * (#2413) and re-declared dormant by #2636. Every mutating tool below used to load it, edit it
+ * and save it with no status check at all, so any agent calling `create_task` would silently
+ * resurrect "current work" inside a closed sprint: exactly the stale-as-current failure the
+ * refresh removed.
+ */
+const MUTABLE_STATUS = "active";
+
+export interface SprintMutationRefusal {
+  ok: false;
+  message: string;
+}
+
+/**
+ * Fail CLOSED on anything that is not explicitly `active`.
+ *
+ * A MISSING status is refused too, and that is the important half. Treating absent as
+ * mutable would restore the exact pre-#2413 behaviour for any record that predates v2, which
+ * is the failure mode this guard exists to remove — and "the field I use to decide is not
+ * there" is never evidence that mutation is safe.
+ *
+ * Pure, and exported, so the refusal can be tested without redirecting the real state file.
+ */
+export function assertSprintMutable(
+  sprint: Pick<SprintState, "sprint" | "status">
+): { ok: true } | SprintMutationRefusal {
+  if (sprint.status === MUTABLE_STATUS) return { ok: true };
+  const observed = sprint.status === undefined ? "no status field" : `status "${sprint.status}"`;
+  return {
+    ok: false,
+    message:
+      `Refusing to mutate the sprint board: sprint ${sprint.sprint} has ${observed}, ` +
+      `not "${MUTABLE_STATUS}". ops/state/sprint/current.json is the sprint_state truth owner ` +
+      "and is dormant by design, not stale — see its `notes` field.\n\n" +
+      "Opening the next sprint is NOT available here: the next sprint number is undetermined " +
+      "because two numbering planes disagree, and picking one would fabricate board lineage. " +
+      "That decision is tracked at icn#2637 and must be made by a human first.\n\n" +
+      "Current work is a live query, not a board row: " +
+      "gh issue list --repo InterCooperative-Network/icn --state open",
+  };
+}
+
+/** Uniform MCP error result for a refused mutation. */
+function refuse(refusal: SprintMutationRefusal) {
+  return {
+    content: [{ type: "text" as const, text: refusal.message }],
+    isError: true as const,
+  };
 }
 
 function loadSprint(): SprintState {
@@ -103,6 +168,8 @@ export function registerTaskTools(
     },
     async ({ task_id, agent_name }) => {
       const sprint = loadSprint();
+      const mutable = assertSprintMutable(sprint);
+      if (!mutable.ok) return refuse(mutable);
       const task = sprint.tasks.find((t) => t.id === task_id);
       if (!task) {
         return {
@@ -143,6 +210,8 @@ export function registerTaskTools(
     },
     async ({ task_id, status, pr, assignee }) => {
       const sprint = loadSprint();
+      const mutable = assertSprintMutable(sprint);
+      if (!mutable.ok) return refuse(mutable);
       const task = sprint.tasks.find((t) => t.id === task_id);
       if (!task) {
         return {
@@ -168,6 +237,8 @@ export function registerTaskTools(
     },
     async ({ task_id }) => {
       const sprint = loadSprint();
+      const mutable = assertSprintMutable(sprint);
+      if (!mutable.ok) return refuse(mutable);
       const idx = sprint.tasks.findIndex((t) => t.id === task_id);
       if (idx === -1) {
         return {
@@ -195,6 +266,8 @@ export function registerTaskTools(
     },
     async ({ next_name, next_goals }) => {
       const sprint = loadSprint();
+      const mutable = assertSprintMutable(sprint);
+      if (!mutable.ok) return refuse(mutable);
       const historyDir = join(dirname(SPRINT_FILE), "history");
       if (!existsSync(historyDir)) mkdirSync(historyDir, { recursive: true });
 
@@ -232,6 +305,8 @@ export function registerTaskTools(
     },
     async ({ id, title, epic }) => {
       const sprint = loadSprint();
+      const mutable = assertSprintMutable(sprint);
+      if (!mutable.ok) return refuse(mutable);
       if (sprint.tasks.find((t) => t.id === id)) {
         return {
           content: [{ type: "text", text: `Error: task ${id} already exists` }],

--- a/ops/mcp/src/tools/tasks.ts
+++ b/ops/mcp/src/tools/tasks.ts
@@ -213,7 +213,14 @@ export function assertSprintMutable(state: unknown): { ok: true } | SprintMutati
   return {
     ok: false,
     message:
-      `Refusing to mutate the sprint board: no sprint is active (${resolved.kind} — ${because}). ` +
+      // `unresolved` is not `dormant`. Saying "no sprint is active" for a silent or
+      // self-contradictory record asserts a cadence fact the resolver expressly refused to
+      // assert (review, #2657) — the write refusal is identical either way, but the reason is
+      // not, and this surface must not emit a claim its own resolver rejected.
+      (resolved.kind === "dormant"
+        ? `Refusing to mutate the sprint board: no sprint is active (${because}). `
+        : "Refusing to mutate the sprint board: the board's cadence cannot be resolved " +
+          `(${because}), so whether a sprint is running is unknown. `) +
       "ops/state/sprint/current.json is the sprint_state truth owner; activity is decided by " +
       "cadence/active_sprint, not by the status label." +
       numbering +
@@ -453,7 +460,10 @@ export function registerTaskTools(
 
   server.tool(
     "close_sprint",
-    "Archive current sprint to history/ and start a new sprint, carrying over unfinished tasks.",
+    "REFUSES on any v2 record: archiving would round-trip it through a v1 write model that " +
+      "drops schema/cadence/lineage, and the successor number is never inferred. Archive-and-" +
+      "start is unavailable until a v2 transition contract exists (icn#2419). Reads are " +
+      "unaffected; use get_tasks.",
     {
       next_name: z.string().describe("Name for the next sprint"),
       next_goals: z
@@ -478,10 +488,11 @@ export function registerTaskTools(
           message:
             "Refusing to close the sprint: the successor sprint number is UNDETERMINED " +
             `(${successor.reason}).\n\n` +
-            "This tool will not infer one. Two numbering planes disagree \u2014 the board never " +
-            "advanced past 26, while the narrated cadence already spent 27 and 28 \u2014 so both " +
-            "27 and 29 are lineage claims the repository cannot support. The decision is " +
-            "tracked at icn#2637; set next_sprint_number in the record once it is made.",
+            "This tool will not infer one, and deliberately does not restate any particular " +
+            "board's lineage here: a successor number derived from arithmetic is a lineage " +
+            "claim the record has not made. Set next_sprint_number in the record once the " +
+            "owner has decided it. For the current board that decision is tracked at " +
+            "icn#2637; read ops/state/sprint/current.json for what this record itself says.",
         });
       }
 

--- a/ops/mcp/src/tools/tasks.ts
+++ b/ops/mcp/src/tools/tasks.ts
@@ -130,22 +130,43 @@ export function resolveSprintCadence(state: unknown): SprintCadence {
 }
 
 /**
- * The `declares_dormancy()` predicate from `scripts/check-truth-spine.py`, over BOTH
- * dormancy keys.
+ * Does ANY supported cadence key declare dormancy?
  *
- * Used only to make the guard stricter. `resolveSprintCadence` mirrors the session hook,
- * which reads `cadence` alone; this catches a record whose `lifecycle` declares dormancy that
- * the hook would not look at. It can only ever turn "mutable" into "refused", never the
- * reverse, so honouring the wider owner here cannot open a hole.
+ * Deliberately **not** a faithful port of `declares_dormancy()` in
+ * `scripts/check-truth-spine.py`. That function returns on the first key it recognises, so
+ * `{cadence: "active", lifecycle: "inactive"}` short-circuits on `cadence` and never inspects
+ * `lifecycle` — which let a record explicitly declaring dormancy on its second key be treated
+ * as mutable (review, #2657). Every key is scanned here, and any dormancy declaration wins.
+ *
+ * The divergence is only ever in the refusing direction, and the polarity matters: this is a
+ * write gate, not the dormancy oracle. `declares_dormancy` answers "has the owner declared
+ * nothing is running", where an early return is harmless; this answers "is it safe to write",
+ * where it is not.
  */
-function declaresDormancy(rec: Record<string, unknown>): boolean {
+function anyKeyDeclaresDormancy(rec: Record<string, unknown>): boolean {
   for (const key of DORMANCY_KEYS) {
     if (!Object.prototype.hasOwnProperty.call(rec, key)) continue;
-    const raw = String(rec[key]).trim().toLowerCase();
-    if (DORMANT_CADENCES.has(raw)) return true;
-    if (ACTIVE_CADENCES.has(raw)) return false;
+    if (DORMANT_CADENCES.has(String(rec[key]).trim().toLowerCase())) return true;
   }
   return Object.keys(rec).some((k) => k.startsWith("active_") && rec[k] === null);
+}
+
+/**
+ * Is `active_sprint` a value that can actually name a sprint?
+ *
+ * `resolveSprintCadence` only asks whether the value is non-null, because that is what
+ * `session-orient.sh` asks. But the state file is parsed with an unchecked type assertion, so
+ * `active_sprint: false`, `{}`, `[]` or `""` all reached the resolver as "not null" and were
+ * read as an active board (review, #2657). A malformed record must fail closed, not open.
+ *
+ * Checked here rather than in the resolver so the resolver stays a faithful mirror of the
+ * hook. The hook shares this leniency; that is an upstream observation, not something this
+ * guard can fix on its behalf.
+ */
+function isUsableSprintIdentifier(value: unknown): boolean {
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value === "string") return value.trim() !== "";
+  return false;
 }
 
 export interface SprintMutationRefusal {
@@ -169,23 +190,34 @@ export function assertSprintMutable(state: unknown): { ok: true } | SprintMutati
       ? (state as Record<string, unknown>)
       : {};
 
-  if (resolved.kind === "active" && !declaresDormancy(rec)) return { ok: true };
+  let because: string | null = null;
+  if (resolved.kind !== "active") {
+    because = resolved.reason;
+  } else if (anyKeyDeclaresDormancy(rec)) {
+    because = "another cadence key declares dormancy, contradicting the active one";
+  } else if (!isUsableSprintIdentifier(resolved.sprint)) {
+    because = `active_sprint is ${JSON.stringify(resolved.sprint)}, which cannot name a sprint`;
+  }
+  if (because === null) return { ok: true };
 
-  const because =
-    resolved.kind === "active"
-      ? "a dormancy declaration on another cadence key contradicts it"
-      : resolved.reason;
+  // Recovery guidance is generated from the record in hand, never copied from today's owner
+  // state (review, #2657). Once the lineage dispute is settled and `next_sprint_number` is
+  // set, repeating the icn#2637 paragraph would be false guidance.
+  const successor = resolveSuccessorSprint(state);
+  const numbering =
+    successor.kind === "explicit"
+      ? ""
+      : "\n\nNote that the successor sprint number is also undetermined " +
+        `(${successor.reason}); that decision is tracked at icn#2637 and belongs to a human.`;
 
   return {
     ok: false,
     message:
       `Refusing to mutate the sprint board: no sprint is active (${resolved.kind} — ${because}). ` +
       "ops/state/sprint/current.json is the sprint_state truth owner; activity is decided by " +
-      "cadence/active_sprint, not by the status label. See its `notes` field.\n\n" +
-      "Opening the next sprint is NOT available here: the next sprint number is undetermined " +
-      "because two numbering planes disagree, and picking one would fabricate board lineage. " +
-      "That decision is tracked at icn#2637 and must be made by a human first.\n\n" +
-      "Current work is a live query, not a board row: " +
+      "cadence/active_sprint, not by the status label." +
+      numbering +
+      "\n\nCurrent work is a live query, not a board row: " +
       "gh issue list --repo InterCooperative-Network/icn --state open",
   };
 }

--- a/ops/mcp/src/tools/tasks.ts
+++ b/ops/mcp/src/tools/tasks.ts
@@ -24,29 +24,129 @@ export interface SprintState {
   tasks: Task[];
   epics: Record<string, string>;
   /**
-   * Cadence status. Optional because this interface predates `icn-sprint-state/v2`
-   * (#2636) and pre-v2 archives on disk do not carry it. Absent is NOT "active":
-   * see `assertSprintMutable`.
+   * Cadence — the field the registered resolver actually decides activity on.
+   * Optional because this interface predates `icn-sprint-state/v2` (#2636).
    */
+  cadence?: string;
+  /** Second dormancy-bearing key recognised by `declares_dormancy()`. */
+  lifecycle?: string;
+  /** v2. `null` is an explicit dormancy declaration; ABSENT is silence, not null. */
+  active_sprint?: number | string | null;
+  /** Display label only — NOT the activity determinant. See `resolveSprintCadence`. */
   status?: string;
-  /**
-   * v2 only, and deliberately `null` today: two numbering planes disagree and a human
-   * must reconcile them (#2637). Nothing here may infer it.
-   */
-  next_sprint_number?: number | null;
+  /** v2, and deliberately `null` today: two numbering planes disagree (#2637). */
+  next_sprint_number?: number | string | null;
+}
+
+function loadSprint(): SprintState {
+  return JSON.parse(readFileSync(SPRINT_FILE, "utf-8")) as SprintState;
+}
+
+function saveSprint(state: SprintState): void {
+  writeFileSync(SPRINT_FILE, JSON.stringify(state, null, 2) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Sprint cadence — mirrored from the registered owners, not invented here.
+// ---------------------------------------------------------------------------
+//
+// The activity of the sprint board is NOT `status`. `status` is a display label:
+// `.claude/hooks/session-orient.sh` prints it as `"{active_sprint} ({status})"` and
+// `scripts/tests/test_sprint_state_invariants.py` drives that resolver with
+// `status: "in-progress"` and `status: "open"` on records it expects to read as ACTIVE.
+// Activity is decided by `cadence`/`lifecycle` plus `active_sprint`.
+//
+// An earlier revision of this guard used `status === "active"` as the sole authority. That
+// was wrong in BOTH directions, which is why it is replaced rather than widened: it refused
+// `{cadence: "active", active_sprint: 31, status: "in-progress"}` — a genuinely running
+// sprint — and it permitted `{cadence: "dormant", status: "active"}`, a self-contradictory
+// record the registered resolver reports as `unresolved`.
+//
+// These three constants are the vocabulary of `declares_dormancy()` in
+// `scripts/check-truth-spine.py`, duplicated here only because that owner is Python and this
+// is TypeScript. `sprint-mutation-guard.test.ts` parses the Python source and asserts the two
+// sets are identical, so drift is a test failure rather than a comment nobody re-reads.
+export const DORMANT_CADENCES: ReadonlySet<string> = new Set([
+  "dormant",
+  "inactive",
+  "none",
+  "paused",
+]);
+export const ACTIVE_CADENCES: ReadonlySet<string> = new Set(["active", "running"]);
+export const DORMANCY_KEYS = ["cadence", "lifecycle"] as const;
+
+export type SprintCadence =
+  | { kind: "active"; sprint: number | string }
+  | { kind: "dormant"; reason: string }
+  | { kind: "unresolved"; reason: string };
+
+/**
+ * Resolve the board's cadence exactly as `.claude/hooks/session-orient.sh` does.
+ *
+ * Three-valued on purpose. `unresolved` is not a synonym for `dormant`: silence and
+ * self-contradiction are states in which the owner has declared nothing, and collapsing them
+ * into either answer states a fact the record does not carry. Both are un-mutable here, but
+ * they are un-mutable for different reasons and the refusal says which.
+ */
+export function resolveSprintCadence(state: unknown): SprintCadence {
+  if (typeof state !== "object" || state === null || Array.isArray(state)) {
+    return { kind: "unresolved", reason: "the sprint record is not a JSON object" };
+  }
+  const rec = state as Record<string, unknown>;
+  const hasActiveKey = Object.prototype.hasOwnProperty.call(rec, "active_sprint");
+  const active = rec["active_sprint"];
+
+  if (Object.prototype.hasOwnProperty.call(rec, "cadence")) {
+    const cadence = String(rec["cadence"]).trim().toLowerCase();
+    if (DORMANT_CADENCES.has(cadence)) {
+      if (hasActiveKey && active !== null && active !== undefined) {
+        return {
+          kind: "unresolved",
+          reason: `the record contradicts itself: cadence="${cadence}" but active_sprint=${JSON.stringify(active)}`,
+        };
+      }
+      return { kind: "dormant", reason: `cadence is "${cadence}"` };
+    }
+    if (ACTIVE_CADENCES.has(cadence)) {
+      if (!hasActiveKey || active === null || active === undefined) {
+        return {
+          kind: "unresolved",
+          reason: `the record contradicts itself: cadence="${cadence}" but no active_sprint`,
+        };
+      }
+      return { kind: "active", sprint: active as number | string };
+    }
+    return { kind: "unresolved", reason: `unrecognised cadence "${cadence}"` };
+  }
+
+  // No cadence key. `active_sprint: null` is the other accepted spelling of dormancy, but the
+  // key must be PRESENT — an absent key is silence, and reading silence as dormancy is the
+  // fail-open the registered resolver exists to avoid.
+  if (!hasActiveKey) {
+    return { kind: "unresolved", reason: "the record declares neither cadence nor active_sprint" };
+  }
+  if (active === null) return { kind: "dormant", reason: "active_sprint is null" };
+  return { kind: "active", sprint: active as number | string };
 }
 
 /**
- * The only cadence status under which the sprint board may be mutated.
+ * The `declares_dormancy()` predicate from `scripts/check-truth-spine.py`, over BOTH
+ * dormancy keys.
  *
- * `ops/state/sprint/current.json` is the registered `sprint_state` truth owner and is an
- * honestly CLOSED record — Sprint 26 was closed retroactively by the 2026-07-13 truth refresh
- * (#2413) and re-declared dormant by #2636. Every mutating tool below used to load it, edit it
- * and save it with no status check at all, so any agent calling `create_task` would silently
- * resurrect "current work" inside a closed sprint: exactly the stale-as-current failure the
- * refresh removed.
+ * Used only to make the guard stricter. `resolveSprintCadence` mirrors the session hook,
+ * which reads `cadence` alone; this catches a record whose `lifecycle` declares dormancy that
+ * the hook would not look at. It can only ever turn "mutable" into "refused", never the
+ * reverse, so honouring the wider owner here cannot open a hole.
  */
-const MUTABLE_STATUS = "active";
+function declaresDormancy(rec: Record<string, unknown>): boolean {
+  for (const key of DORMANCY_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(rec, key)) continue;
+    const raw = String(rec[key]).trim().toLowerCase();
+    if (DORMANT_CADENCES.has(raw)) return true;
+    if (ACTIVE_CADENCES.has(raw)) return false;
+  }
+  return Object.keys(rec).some((k) => k.startsWith("active_") && rec[k] === null);
+}
 
 export interface SprintMutationRefusal {
   ok: false;
@@ -54,26 +154,34 @@ export interface SprintMutationRefusal {
 }
 
 /**
- * Fail CLOSED on anything that is not explicitly `active`.
+ * May the sprint board be mutated right now?
  *
- * A MISSING status is refused too, and that is the important half. Treating absent as
- * mutable would restore the exact pre-#2413 behaviour for any record that predates v2, which
- * is the failure mode this guard exists to remove — and "the field I use to decide is not
- * there" is never evidence that mutation is safe.
- *
- * Pure, and exported, so the refusal can be tested without redirecting the real state file.
+ * Fails CLOSED on everything that is not a positively resolved ACTIVE cadence — dormant,
+ * unresolved, silent, contradictory, malformed. Note the polarity: this is a positive
+ * activity test, NOT `!declaresDormancy(...)`. `declares_dormancy` is deliberately fail-open
+ * (silence is not dormancy), so negating it would make silence *mutable*, which is precisely
+ * the pre-#2413 behaviour this guard removes.
  */
-export function assertSprintMutable(
-  sprint: Pick<SprintState, "sprint" | "status">
-): { ok: true } | SprintMutationRefusal {
-  if (sprint.status === MUTABLE_STATUS) return { ok: true };
-  const observed = sprint.status === undefined ? "no status field" : `status "${sprint.status}"`;
+export function assertSprintMutable(state: unknown): { ok: true } | SprintMutationRefusal {
+  const resolved = resolveSprintCadence(state);
+  const rec =
+    typeof state === "object" && state !== null && !Array.isArray(state)
+      ? (state as Record<string, unknown>)
+      : {};
+
+  if (resolved.kind === "active" && !declaresDormancy(rec)) return { ok: true };
+
+  const because =
+    resolved.kind === "active"
+      ? "a dormancy declaration on another cadence key contradicts it"
+      : resolved.reason;
+
   return {
     ok: false,
     message:
-      `Refusing to mutate the sprint board: sprint ${sprint.sprint} has ${observed}, ` +
-      `not "${MUTABLE_STATUS}". ops/state/sprint/current.json is the sprint_state truth owner ` +
-      "and is dormant by design, not stale — see its `notes` field.\n\n" +
+      `Refusing to mutate the sprint board: no sprint is active (${resolved.kind} — ${because}). ` +
+      "ops/state/sprint/current.json is the sprint_state truth owner; activity is decided by " +
+      "cadence/active_sprint, not by the status label. See its `notes` field.\n\n" +
       "Opening the next sprint is NOT available here: the next sprint number is undetermined " +
       "because two numbering planes disagree, and picking one would fabricate board lineage. " +
       "That decision is tracked at icn#2637 and must be made by a human first.\n\n" +
@@ -90,22 +198,79 @@ function refuse(refusal: SprintMutationRefusal) {
   };
 }
 
-function loadSprint(): SprintState {
-  return JSON.parse(readFileSync(SPRINT_FILE, "utf-8")) as SprintState;
+// ---------------------------------------------------------------------------
+// Successor identity, and the v1 write model
+// ---------------------------------------------------------------------------
+
+/**
+ * The exact set of top-level keys `saveSprint` can write, because `computeNextSprint` builds
+ * a `SprintState` literal with these and no others.
+ *
+ * Any key present in a loaded record and absent from this set is a field the v1 write model
+ * would silently DROP. That is checked structurally rather than by listing v2's fields, so a
+ * future schema is protected by the same guard without anyone remembering to update it.
+ */
+const V1_WRITABLE_KEYS: ReadonlySet<string> = new Set([
+  "sprint",
+  "name",
+  "started",
+  "goals",
+  "tasks",
+  "epics",
+]);
+
+/** Top-level keys a `saveSprint(computeNextSprint(...))` round-trip would destroy. */
+export function fieldsLostByV1Write(state: unknown): string[] {
+  if (typeof state !== "object" || state === null || Array.isArray(state)) return [];
+  return Object.keys(state as Record<string, unknown>)
+    .filter((k) => !V1_WRITABLE_KEYS.has(k))
+    .sort();
 }
 
-function saveSprint(state: SprintState): void {
-  writeFileSync(SPRINT_FILE, JSON.stringify(state, null, 2) + "\n");
+export type SuccessorResolution =
+  | { kind: "explicit"; sprint: number | string }
+  | { kind: "undetermined"; reason: string };
+
+/**
+ * The successor sprint number, read — never derived.
+ *
+ * `current.sprint + 1` used to supply this. On the live record that is `26 + 1 = 27`, and 27
+ * is exactly the number `next_sprint_number_note` exists to forbid: the board never advanced
+ * past 26 while the narrated cadence already spent 27 and 28, so either choice fabricates
+ * lineage the repository cannot support (#2637). Arithmetic is not a source of identity.
+ */
+export function resolveSuccessorSprint(state: unknown): SuccessorResolution {
+  const rec =
+    typeof state === "object" && state !== null && !Array.isArray(state)
+      ? (state as Record<string, unknown>)
+      : {};
+  const next = rec["next_sprint_number"];
+  if (typeof next === "number" || (typeof next === "string" && next.trim() !== "")) {
+    return { kind: "explicit", sprint: next };
+  }
+  return {
+    kind: "undetermined",
+    reason:
+      next === null
+        ? "the record sets next_sprint_number: null, which is a deliberate declaration that the successor is UNDETERMINED"
+        : "the record carries no next_sprint_number",
+  };
 }
 
 /**
- * Compute the next sprint from the current one: carry over every task that
- * isn't done (clearing its assignee), increment the sprint number, and apply
- * the new name/goals. Pure — the caller supplies the start date and handles
- * archiving/persistence — so the carry-over invariant is unit-testable.
+ * Compute the next sprint from the current one: carry over every task that isn't done
+ * (clearing its assignee), apply the RESOLVED successor number, and apply the new
+ * name/goals. Pure — the caller supplies the start date and handles archiving/persistence —
+ * so the carry-over invariant is unit-testable.
+ *
+ * `nextSprint` is a PARAMETER, not `current.sprint + 1`. It used to be the latter, which made
+ * this function a source of sprint identity by arithmetic; on the live record that yields 27,
+ * the one number `next_sprint_number_note` exists to forbid (#2637). Taking it as an argument
+ * means a fabricated successor cannot originate here — the caller must have read one.
  */
 export function computeNextSprint(
   current: SprintState,
+  nextSprint: number | string,
   nextName: string,
   nextGoals: string[],
   startedDate: string
@@ -114,7 +279,7 @@ export function computeNextSprint(
   // Copy goals/epics so the returned state shares no mutable references with
   // the input — mutating the result must never leak back into `current`.
   return {
-    sprint: current.sprint + 1,
+    sprint: nextSprint as number,
     name: nextName,
     started: startedDate,
     goals: [...nextGoals],
@@ -268,6 +433,45 @@ export function registerTaskTools(
       const sprint = loadSprint();
       const mutable = assertSprintMutable(sprint);
       if (!mutable.ok) return refuse(mutable);
+
+      // GATE 1 — identity. Ordered FIRST so each gate is independently observable through the
+      // tool: a record with no successor refuses here, and one WITH a successor gets past this
+      // point and refuses on shape below. If shape came first it would mask this gate entirely,
+      // because any record active enough to reach close_sprint necessarily carries active_sprint,
+      // which the v1 write model cannot emit. The successor number is READ, never derived.
+      const successor = resolveSuccessorSprint(sprint);
+      if (successor.kind !== "explicit") {
+        return refuse({
+          ok: false,
+          message:
+            "Refusing to close the sprint: the successor sprint number is UNDETERMINED " +
+            `(${successor.reason}).\n\n` +
+            "This tool will not infer one. Two numbering planes disagree \u2014 the board never " +
+            "advanced past 26, while the narrated cadence already spent 27 and 28 \u2014 so both " +
+            "27 and 29 are lineage claims the repository cannot support. The decision is " +
+            "tracked at icn#2637; set next_sprint_number in the record once it is made.",
+        });
+      }
+
+      // GATE 2 — structural. `saveSprint` writes only the v1 key set, so closing a record
+      // that carries anything else destroys those fields. Checked by comparing the loaded
+      // record's keys against what the write model can emit, so a v3 record is protected by
+      // the same code, and it does NOT depend on the board being dormant today: a future v2
+      // record marked active reaches here and must still be refused.
+      const lost = fieldsLostByV1Write(sprint);
+      if (lost.length > 0) {
+        return refuse({
+          ok: false,
+          message:
+            "Refusing to close the sprint: this MCP write path is v1-shaped and would DELETE " +
+            `${lost.length} field(s) from the record \u2014 ${lost.join(", ")}.\n\n` +
+            "Closing an `icn-sprint-state/v2` record needs v2 transition semantics that do not " +
+            "exist yet: what the successor's cadence, active_sprint and board_lineage should be " +
+            "is a governance decision, not a serialization detail. Until that contract exists " +
+            "this tool refuses rather than round-tripping v2 state through the v1 model.",
+        });
+      }
+
       const historyDir = join(dirname(SPRINT_FILE), "history");
       if (!existsSync(historyDir)) mkdirSync(historyDir, { recursive: true });
 
@@ -277,6 +481,7 @@ export function registerTaskTools(
       const startedDate = new Date().toISOString().split("T")[0]!;
       const next = computeNextSprint(
         sprint,
+        successor.sprint,
         next_name,
         next_goals ?? [],
         startedDate


### PR DESCRIPTION
## Delivery

- **Delivery lane**: STANDARD
- **Acceptance contract**: five MCP task tools refuse to mutate `ops/state/sprint/current.json`
  unless the registered `sprint_state` owner positively resolves an ACTIVE cadence; mutability
  derives from cadence, not from the `status` display label; `close_sprint` reads
  `next_sprint_number` and never derives a successor; v2 records cannot round-trip through the
  v1 write model.
- **Explicit non-goals**: does not choose `next_sprint_number` (that is #2637, a human decision),
  does not open or reopen a sprint, does not restore the sprint board as a current-work owner,
  and does not constrain the relationship between `active_sprint` and `sprint` (see #2670).

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN
Lane:                 STANDARD
Acceptance contract:  see the Delivery section above — unchanged; still only the dormant/
                      unresolved sprint-board mutation guard
Review generation:    CLOSED — 13 threads across the generation; 2 late findings on e091b078
                      classified FOLLOW_UP and ledgered; 0 unresolved. NOT reopened: the
                      refreeze below is a base update, not new content.
Freeze head:          929a829f7d5ad60affe0e12728ea0375c558fe7a
Known blockers:       0
Follow-up ledger:     #2670
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

**Rebased onto current `main`.** Was `BEHIND` at `10a3b7cf` (base `8e5f8943`); rebased cleanly with
no conflicts onto `8e41458e` as `e091b078`. The contract above is unchanged by the rebase.

**DELTA verification on `e091b078`:**

| check | result |
|---|---|
| `ops/mcp` build + `npm test` | **313 passed / 18 files** |
| `check-agent-capabilities` | ok — manifest true (43 MCP tools verified against the live server) |
| `check-skill-registry` | clean (94 assertions) |
| `check-truth-spine` | clean |
| `check-agent-runtime-adoption` | 25 checks, 0 failures |
| `check-merge-policy-schema` / `check-delivery-lifecycle` | clean / OK |
| `test_sprint_state_invariants.py` | all checks passed |
| required CI contexts | **11/11 SUCCESS** |

**Freeze evidence** (trusted evaluator, read-only `icn-merge-pr check 2657`, exit 0):

```
READY  InterCooperative-Network/icn#2657
head e091b078  base 8e41458e  merge_state UNSTABLE  mergeable MERGEABLE
required checks: 11/11 SUCCESS   unresolved review threads: 0/13
auto_merge_armed: false   is_draft: false
```

**No merge was performed and no merge authorization is implied** — this PR awaits maintainer
merge authorization. Per `delivery.json#freeze`, the live head must still equal
`e091b078...` at hand-off; if anything is pushed after this freeze, run DELTA verification on the
new content and re-freeze before handing over.

---

Closes #2419.

`ops/state/sprint/current.json` is the registered `sprint_state` truth owner. Five MCP task
tools loaded it, edited it and saved it with no cadence check, so any agent calling
`create_task` would resurrect "current work" inside a dormant board.

**Head `10a3b7cf` · base `8e5f8943` (current `main`, no conflict).**

## What two review rounds changed

Round 1 established that the original guard used the wrong authority. Round 2 found three
fail-open paths still left in the repaired guard. Every finding below was reproduced against
the built module before being fixed.

### Round 1

**1 · Mutability derives from cadence, not from `status`.** `status` is a **display label** —
`.claude/hooks/session-orient.sh` prints `"{active_sprint} ({status})"`, and
`scripts/tests/test_sprint_state_invariants.py` drives that resolver with `status: "in-progress"`
and `status: "open"` on records it expects to read ACTIVE. Activity is decided by
`cadence`/`lifecycle` plus `active_sprint`. The old predicate was wrong in **both** directions:

| record | before | now |
|---|---|---|
| `{cadence: "active", active_sprint: 31, status: "in-progress"}` | refused a **running sprint** | permitted |
| `{cadence: "dormant", status: "active"}` | **permitted** a dormant board | refused |

`resolveSprintCadence` mirrors the hook and is **three-valued**: `unresolved` is not a synonym
for `dormant`. No second taxonomy is introduced — the constants are `check-truth-spine.py`'s,
and a test parses the Python source to assert the sets match. Polarity is deliberate: this is a
positive activity test, **not** `!declaresDormancy(...)`, which would make silence mutable.

**2 · The successor number is read, never derived.** `computeNextSprint` took
`current.sprint + 1`; it now takes the successor as a parameter. `close_sprint` reads
`next_sprint_number` and refuses when it is null or absent, naming #2637 rather than proposing
a number.

**3 · v2 state cannot round-trip through the v1 write model.** `fieldsLostByV1Write` compares
the loaded record's keys against what `saveSprint` can emit — structural, so a v3 record is
protected by the same code, and independent of whether the board is dormant today.

> **Consequence, stated plainly:** `close_sprint` cannot currently succeed on any record the
> cadence guard admits, because being active requires `active_sprint` and the v1 model cannot
> emit that key. That is the intended bounded outcome — **v2 closure refuses until a v2
> transition contract exists** — not an accident. This PR does not make that governance call.

The identity gate runs first so both gates stay independently observable.

**4 · Tests at the protocol boundary.** Nothing is imported from `tasks.ts` at module scope;
every symbol comes off the same dynamically imported instance the tools are registered from,
after `ICN_ROOT` is set.

### Round 2 — three fail-open paths

| # | input | before | now |
|---|---|---|---|
| 1 | `{cadence: "active", lifecycle: "inactive", active_sprint: 31}` | **mutable** | refused |
| 2 | `active_sprint` = `false` / `true` / `{}` / `[]` / `""` / `"   "` / `NaN` / `Infinity` | **mutable** | refused |
| 3 | any refusal, once `next_sprint_number` is settled | cited #2637 forever | derived per record |

**1.** The dormancy helper mirrored `declares_dormancy()`, which returns on the *first* key it
recognises — so `cadence: "active"` short-circuited and `lifecycle` was never read. The comment
claiming the helper "can only ever turn mutable into refused" was **wrong for exactly this
input**, and the existing test passed only because its record carried no `cadence` key. All keys
are scanned now. A deliberate divergence from the Python predicate, in the refusing direction
only: `declares_dormancy` answers *has the owner declared nothing is running* (early return
harmless); this answers *is it safe to write* (it is not).

**2.** The resolver only asks whether `active_sprint` is non-null — which is what the hook asks
— and `loadSprint` parses with an unchecked `as SprintState`. Now validated as a finite number
or non-empty string, **in the guard rather than the resolver**, so the resolver stays a faithful
mirror and the differential test keeps its meaning. `0` is deliberately still accepted.
*Upstream observation: the hook shares this leniency — reported, not silently patched here.*

**3.** The refusal copied a volatile fact into a generic code path. That paragraph is now
generated from `resolveSuccessorSprint` on the record in hand.

### Also added: a differential test

`resolveSprintCadence` and the real `.claude/hooks/session-orient.sh` are driven over the same
ten records and their verdicts compared, with a control asserting the hook itself produces all
three outcomes. The vocabulary test catches word-list drift; this catches **algorithm** drift —
the other half of "one canonical source".

### Round 3 — three more, all reproduced

| # | defect | fix |
|---|---|---|
| 1 | every refusal said "no sprint is active", including for records the resolver **declined to resolve** | dormant says that; `unresolved` says the cadence cannot be resolved and whether a sprint runs is unknown |
| 2 | `close_sprint`'s own refusal still hardcoded 26/27/28 — I de-hardcoded the generic one and missed this | states the rule, not the instance; names `next_sprint_number` and the record to read |
| 3 | the MCP description advertised "archive and start a new sprint", which **can never happen** | description states the refusal and why |

On (3): passing the identity gate requires `next_sprint_number`, itself absent from
`V1_WRITABLE_KEYS`, so the shape gate rejects the same record — and any cadence-mutable record
carries `active_sprint` too. `close_sprint` is unconditionally unreachable. The tool is not
unregistered, because that would change the advertised surface and the capability manifest; the
description now tells the truth instead.

## Mutation matrix — every guard proved load-bearing

Baseline **54/54** across `sprint-mutation-guard.test.ts` (46) and `tasks.test.ts` (8). Each
mutation applied to production source and reverted.

| mutation | result |
|---|---|
| restore arithmetic successor selection | **killed** |
| restore the v1 destructive write path | **killed** |
| bypass mutability classification | **killed** |
| revert to the `status === "active"` taxonomy | **killed** |
| treat `unresolved` as mutable (fail open) | **killed** |
| drop `running` from the active vocabulary | **killed** |
| algorithm drift: read silence as dormant | **killed** |
| restore the first-key short-circuit | **killed** |
| drop the `active_sprint` identifier validation | **killed** |
| hardcode the #2637 paragraph unconditionally | **killed** |
| conflate `unresolved` with `dormant` in the refusal | **killed** |
| re-hardcode this board's lineage in the close refusal | **killed** |
| re-advertise archive-and-start in the description | **killed** |

Thirteen mutations, all killed.

## The red `Test` check on the round-1 head — ambient, and now green

The failure on `757ef8be` was **`crates/icn-core/tests/resource_enforcer_gossip.rs:267`** —
`assert_eq!(stats.total_revocations, 1)` got `2`, a spawn-versus-`force_check` race in
`ResourceAccessEnforcerActor`. There was exactly one CI run on that head, and its log contains
**zero** occurrences of `icnb`, `settlement_conservation` or
`persisted_totals_match_accepted_settlements`.

1. **Causally impossible from this branch.** `git diff origin/main..HEAD --name-only` is
   confined to `ops/mcp/**` — zero Rust files, zero CI files.
2. **22 local runs, 0 failures**, same worktree and cargo cache for both SHAs: `757ef8be` 8/8;
   `8e5f8943` (main) 8/8 clean and **6/6 under 16-way CPU contention**.
3. `Test` went **green** on the next push without any change to Rust or CI.

I could not reproduce the failure locally and do not claim to have; the claim is that it cannot
originate here. No ledger, CI or build machinery was touched.

## Verification (local, at `10a3b7cf`)

`tsc --noEmit` **0** · `npm run build` **0** · **313/313 vitest across 18 files** ·
`check-truth-spine.py` **0** · `check-agent-capabilities.py` **0** ·
`check-agent-runtime-adoption.py` **0** · `check-skill-registry.py` **0** ·
`test_sprint_state_invariants.py` **0**.

> There is **no lint gate for this package.** `ops/mcp` has no `lint` script; an earlier
> revision of this body claimed `npm run lint` passed because the check piped npm through
> `tail` and captured *tail's* exit status. `tsc --noEmit` is the type gate. The absence of an
> ESLint config for `ops/mcp` is pre-existing and out of scope.

## A required check I broke, and fixed

`Agent Tooling Drift Check` went **red** on `e1b03683`. Rewriting `close_sprint`'s MCP
description left the committed capability manifest claiming the old text, and that manifest is
generated from the live runtime surface:

```
present in the runtime but NOT in the manifest: "REFUSES on any v2 record: ..."
claimed by the manifest but NOT in the runtime: "Archive current sprint to history/ ..."
```

The gate did its job. The failure was mine: the same checker exited 1 in the pre-push batch and
I pushed anyway, because its two previous runs had failed for an unrelated reason (an unbuilt
`ops/mcp/dist` in a fresh worktree) and I carried that explanation over instead of re-running it
with the build present. Regenerated in `10a3b7cf`; every gate re-verified with the build.

## Note on `mergeStateStatus: BLOCKED`

All 11 required checks green. `BLOCKED` reflects **non-required** checks only — `Security Audit`
(red on every open PR: ambient RUSTSEC dependency advisories) plus others in progress. Per
`policy.json` (`unstable_is_mergeable: true`, `non_blocking_checks`), those do not block.

## Out of scope

No sprint-numbering policy chosen. No cadence reopened. No v2 close/open transition contract —
that needs #2637 decided first, which is a human call. No change to the closed record itself.




