### PR TITLE
feat(agent): give a pull request a convergent delivery lifecycle

### DIFF
--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -7,6 +7,7 @@ allowed-tools: "Bash, Read, Grep, Glob"
 truth_contract:
   canonical_sources:
     - ops/state/truth/policy.json       # required checks, branch naming conventions
+    - ops/state/truth/delivery.json     # delivery lanes and the lifecycle block the PR must carry
     - ops/state/config/repo-map.json    # workspace root
   live_load_required:
     - "git branch --show-current"
@@ -44,6 +45,27 @@ Determine the scope from ICN scopes: `core`, `identity`, `trust`, `net`, `gossip
 Use `gh pr create` with this body structure:
 
 ```markdown
+## Delivery
+
+- **Delivery lane**: FAST | STANDARD | DEEP  (default from `lanes.default`; DEEP is the
+  maintainer's call, not yours)
+- **Acceptance contract**: what this PR claims to deliver, in one or two lines. A FULL review is
+  scoped against this, and the blocker predicate is measured against it, so an unstated contract
+  makes review unbounded.
+- **Explicit non-goals**: what this PR deliberately does not do.
+
+<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
+```
+ICN DELIVERY LIFECYCLE
+State:                IMPLEMENTING
+Lane:                 <lane>
+Review generation:    not yet requested
+Freeze head:          -
+Known blockers:       -
+Follow-up ledger:     -
+```
+<!-- ICN-DELIVERY-LIFECYCLE:END -->
+
 ## Summary
 
 <1-2 sentence description>
@@ -88,6 +110,9 @@ Title: `<type>(<scope>): <description>` (under 70 chars)
 
 ### Important
 
+- The lifecycle block is the PR's control surface for delivery state, and `ops/state/truth/delivery.json`
+  owns what the states mean. Keep the state there, never in a repository file. The `ship-pr` skill
+  reads and advances it from here on.
 - Base branch defaults to `main` unless `$ARGUMENTS` specifies otherwise
 - Push the branch with `-u` flag before creating PR
 - Include a `Co-Authored-By:` trailer naming the assisting model actually used for the change.

--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -59,6 +59,7 @@ Use `gh pr create` with this body structure:
 ICN DELIVERY LIFECYCLE
 State:                IMPLEMENTING
 Lane:                 <lane>
+Acceptance contract:  <one line, or a pointer into the Delivery section above>
 Review generation:    not yet requested
 Freeze head:          -
 Known blockers:       -

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -78,9 +78,14 @@ is a blocker only when **every** condition in `blocker_predicate.all_must_hold` 
 A reviewer's own severity label is advisory evidence about that reviewer's confidence. It is not
 authority, and it never satisfies the predicate by itself.
 
-Reply to every thread with its disposition and the evidence, then resolve it. Server-side
-conversation resolution still applies to a frozen PR; dispositioning a thread is not reopening
-review.
+Reply to every thread with its disposition and the evidence. Resolve it when
+`finding_dispositions[].resolve_thread` says you may — which is not always now. A **QUESTION stays
+unresolved** until it is answered and reclassified: merge readiness counts unresolved threads, so
+resolving an unanswered question would manufacture readiness out of a question nobody answered. A
+BLOCKER's thread resolves once its fix is verified, not when it is written.
+
+Server-side conversation resolution still applies to a frozen PR; dispositioning a thread is not
+reopening review.
 
 ## 6. Handle blockers as one batch
 

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -128,9 +128,16 @@ maintainer decision, not a widening of the frozen scope.
 
 ## 10. Wait only on live merge gates
 
-Use the repository's bounded wait primitive, `ops/scripts/icn-wait`. Never an ad-hoc polling loop.
-Read which gates actually matter from the merge owner and live branch protection — this skill does
-not know them and must not learn them.
+Do not work out which gates matter. `icn-merge-pr check` already reads the merge owner and live
+protection and returns the answer as structured reasons; deciding it here would make this skill a
+second owner of readiness, which its Boundaries forbid — and a policy or protection change would
+then leave it waiting on the wrong set, or on checks that never block.
+
+So: run `check`, and if it refuses only because a required gate is still pending, wait for the
+gate it named using the repository's bounded wait primitive, `ops/scripts/icn-wait`, then run
+`check` again. Never an ad-hoc polling loop, and never wait on a check the evaluator did not name.
+`check` mutates nothing, so re-running it after a wait is not retrying a refusal — the one
+mutation is never retried.
 
 ## 11. Check the freeze head, then hand over
 

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: ship-pr
+description: Finish a pull request. Read its lifecycle state, run one bounded review generation, batch blocker fixes, freeze an exact head, then hand over to the merge primitive.
+argument-hint: "[PR number]"
+user-invocable: true
+allowed-tools: "Bash, Read, Grep, Glob"
+truth_contract:
+  canonical_sources:
+    - ops/state/truth/delivery.json     # lifecycle, dispositions, blocker predicate, freeze
+    - ops/state/truth/skills.json       # which skill owns the merge primitive
+  live_load_required:
+    - "gh pr view <N> --json state,isDraft,mergeable,baseRefName,headRefOid,body"
+    - "gh api graphql  # review threads and their resolved state"
+  examples_only: []
+  never_hardcode:
+    - lifecycle states, dispositions, or the blocker predicate — load delivery.json
+    - required checks, merge strategy, or readiness rules — this skill owns none of them
+    - PR number, branch name, or head SHA
+---
+
+# ship-pr
+
+Take one pull request from where it is to merged, without letting review run forever.
+
+The governing rule, owned by `ops/state/truth/delivery.json`:
+**automated review is evidence, not unbounded veto authority.**
+
+This skill decides *when* a PR is ready to hand over. It never decides *whether* the merge is
+permitted. That belongs to the merge primitive and its executable, and a second implementation
+here would be a second owner of merge semantics — with the copy being the one that rots.
+
+## Input
+- `$1` = PR number. If omitted: `gh pr view --json number --jq .number`.
+
+## Load first, every time
+
+```bash
+python3 -c "import json;print(json.dumps(json.load(open('ops/state/truth/delivery.json')),indent=2))"
+```
+
+Do not work from memory of this file. The lifecycle states, the finding dispositions, the blocker
+predicate, the freeze rules and the lane definitions are all owned there and may have changed.
+
+## 1. Read the live state
+
+Query the PR. Read the lifecycle block from the PR body — the delimiters are named by
+`lifecycle.state_surface` in the policy. The PR body is where lifecycle state lives; a repository
+file claiming to know a PR's current state is stale by construction.
+
+If there is no block, the PR is in the first state of `lifecycle.states`. Write the block.
+
+## 2. Confirm the lane
+
+`lanes.default` unless the block already names one. The DEEP lane requires the maintainer to
+select it — do not choose it yourself.
+
+## 3. Establish the acceptance contract
+
+The contract is what the PR claims to deliver, plus its explicit non-goals. It comes from the PR
+body; `pr-create` puts it there. If it is missing, write it from the diff and the linked issue and
+say so. Everything downstream — what a FULL review may inspect, and what makes a finding a
+blocker — is measured against this contract, so an unstated contract makes the lane unbounded.
+
+## 4. Run the review generation
+
+One comprehensive generation per lane. Request it once, when the implementation is complete and
+verification is green — not after every push.
+
+Record the generation in the block. **A push does not reset it.** If fixing findings reopened
+discovery, then fixing would be the act that triggers the next unbounded search, and no PR that
+fixes anything could ever converge.
+
+## 5. Classify every finding
+
+Use the dispositions in `finding_dispositions` and the predicate in `blocker_predicate`. A finding
+is a blocker only when **every** condition in `blocker_predicate.all_must_hold` is satisfied.
+
+A reviewer's own severity label is advisory evidence about that reviewer's confidence. It is not
+authority, and it never satisfies the predicate by itself.
+
+Reply to every thread with its disposition and the evidence, then resolve it. Server-side
+conversation resolution still applies to a frozen PR; dispositioning a thread is not reopening
+review.
+
+## 6. Handle blockers as one batch
+
+Fix the known blockers together. For each: the smallest local correction plus only the regression
+coverage that directly proves it closed. Do not inspect sibling areas for more things to fix —
+`blocker_predicate.no_sibling_sweep` says why.
+
+## 7. Defer everything else
+
+Valid observations that are not blockers go to one follow-up ledger issue for this PR — reuse it,
+do not open one per comment. Each entry states the observation, why it was deferred, and the fix,
+with a link back to its thread. Reply to the thread saying it is valid but outside the frozen
+delivery contract, link the ledger, and resolve.
+
+## 8. Verify
+
+Run the verification appropriate to the changed paths. After a blocker batch this is DELTA
+verification: the changed delta and whether it addresses the known findings. Not a restart.
+
+## 9. Freeze
+
+When `freeze.entry_conditions` are all met, name the exact head and write the block:
+
+```
+ICN DELIVERY LIFECYCLE
+State:                FROZEN
+Lane:                 <lane>
+Acceptance contract:  <one line, or a pointer into the body>
+Review generation:    CLOSED
+Freeze head:          <exact 40-hex head>
+Known blockers:       0
+Follow-up ledger:     <issue>
+```
+
+After this, a new automated review comment does not reopen the PR. A late finding breaks the
+freeze only if it satisfies every blocker condition; then make one targeted correction, run delta
+verification, update the freeze head, and return to FROZEN. Do not run another comprehensive
+review. If a late observation would need a substantial design change, it is a follow-up and a
+maintainer decision, not a widening of the frozen scope.
+
+## 10. Wait only on live merge gates
+
+Use the repository's bounded wait primitive, `ops/scripts/icn-wait`. Never an ad-hoc polling loop.
+Read which gates actually matter from the merge owner and live branch protection — this skill does
+not know them and must not learn them.
+
+## 11. Hand over
+
+```bash
+icn-merge-pr check "$PR"
+```
+
+Report the structured outcome verbatim. If it is not ready, stop: the reasons say what has to
+change. If it is ready, the mutation is the `merge-pr` skill's, under explicit per-PR maintainer
+authorization. Move the block to the merging state, then to the final state with the merge commit.
+
+Do not re-derive, second-guess, or work around anything the executable decided, and do not
+substitute another path when it refuses.
+
+## 12. Report
+
+The final head, the merge commit, the disposition counts, and the follow-up ledger.
+
+## Boundaries
+
+- Do not evaluate merge requirements here. Do not read branch protection to decide readiness.
+- Do not request another comprehensive review generation. Only the maintainer may.
+- Do not escalate a follow-up into a blocker, or reopen discovery, on your own.
+- Do not drop a valid observation instead of recording it.
+- Do not put lifecycle state in a repository file.

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -132,7 +132,15 @@ Use the repository's bounded wait primitive, `ops/scripts/icn-wait`. Never an ad
 Read which gates actually matter from the merge owner and live branch protection — this skill does
 not know them and must not learn them.
 
-## 11. Hand over
+## 11. Check the freeze head, then hand over
+
+**Compare the live head with the recorded freeze head before anything else.** A freeze names an
+exact head because that is the head that was reviewed and verified. Anything pushed since has been
+through neither, and nothing downstream will catch it: the merge executable pins the head it
+mutates, but it has no idea which head was reviewed.
+
+On a mismatch, the new content is unverified. Run DELTA verification on it, update the freeze head,
+return to FROZEN, and only then continue. `freeze.head_must_match_before_handoff` is the rule.
 
 ```bash
 icn-merge-pr check "$PR"

--- a/.claude/agents/icn-code-reviewer.md
+++ b/.claude/agents/icn-code-reviewer.md
@@ -1,96 +1,122 @@
 ---
 name: icn-code-reviewer
-description: PR review agent with ICN invariants lens. High signal-to-noise ratio - only surfaces issues that genuinely matter (bugs, security, invariant violations, logic errors). Use for reviewing PRs, diffs, or staged changes.
+description: PR review agent with an ICN invariants lens, bound to the canonical delivery lifecycle. High signal-to-noise: classifies every finding as BLOCKER, FOLLOW_UP, QUESTION or NOT_A_FINDING and declares FULL or DELTA.
 model: inherit
 ---
 
 You are the **ICN Code Reviewer**.
 
-Your job is to review code changes with extremely high signal-to-noise ratio. You only surface issues that genuinely matter.
+Review with a high signal-to-noise ratio, and against a bounded contract. Your findings are
+evidence for a decision the maintainer owns. They are not a veto.
 
-## Expert Knowledge
+## Load before reviewing
 
-You have deep expertise in:
-- **Rust**: Ownership, lifetimes, async/await, error handling, unsafe code
-- **Distributed Systems**: Race conditions, ordering bugs, partition handling, CAP theorem
-- **Security**: Input validation, auth/authz, injection, timing attacks
-- **ICN Invariants**: The five core invariants and how code can violate them
-- **Test Coverage**: Missing edge cases, flaky patterns, insufficient assertions
+1. `AGENTS.md` — the five ICN invariants and the operating contract. It owns them; this file does
+   not restate them.
+2. `ops/state/truth/delivery.json` — the delivery lifecycle. It owns the finding dispositions, the
+   blocker predicate, the FULL/DELTA distinction, and the freeze rules. Load it; do not work from
+   memory of it, and never define your own version of any of it here.
+3. The pull request's **acceptance contract** and explicit non-goals, from its body. Everything
+   below is measured against that contract.
+4. The pull request's lifecycle block, for its current state and review generation.
 
-## ICN Invariants (non-negotiable)
+## Where to look
 
-| Invariant | What to check |
-|-----------|---------------|
-| **Adversarial-by-default** | Peer claims verified, signatures checked, no implicit trust |
-| **Determinism** | No HashMap iteration order reliance, no time-dependent logic, no unseeded random |
-| **Canonical encodings** | Serialization unchanged, field order preserved, optional fields versioned |
-| **No panics in protocol** | No `unwrap()`/`expect()` on network input, actor handlers, deserialization |
-| **Kernel/app boundaries** | No domain imports in kernel crates, no reverse meaning firewall |
+Lenses, not verdicts. What blocks is decided by the predicate below; this is only where the
+defects that satisfy it tend to be.
 
-## Review Process
+- **Rust** — ownership and lifetimes, async cancellation and cancel-safety, error propagation,
+  `unsafe`.
+- **Distributed systems** — ordering, races, partition and retry behaviour, idempotence.
+- **Security** — input validation, authorization boundaries, injection, timing, and anything that
+  widens a trusted surface.
+- **The invariants `AGENTS.md` owns** — adversarial-by-default, determinism, canonical encodings,
+  no panics in protocol paths, and the kernel/app boundary. Read them there; a violation of one is
+  usually the clearest way a finding satisfies the predicate.
+- **Tests** — missing edge cases, assertions that cannot fail, and coverage that does not actually
+  exercise the change.
 
-1. Read the diff (use `git diff origin/main...HEAD` or the specified PR)
-2. Identify all changed files and their crate locations
-3. For each file, check against the invariants
-4. Classify issues by severity
+## Declare what kind of review this is
 
-## What You ALWAYS Flag (blocking)
+Every review states **FULL** or **DELTA** at the top.
 
-- Panics in protocol paths (`unwrap()`, `expect()`, `panic!()` on untrusted input)
-- Weakened validation to make tests pass
-- Trust escalation without explicit authorization
-- Non-deterministic state transitions
-- Breaking canonical encoding changes without versioning
-- Dependency cycle introduction (especially domain→kernel)
-- Security vulnerabilities (injection, auth bypass, timing)
-- Meaning firewall violations (domain imports in kernel crates)
+- **FULL** — the scheduled comprehensive generation. May inspect the bounded pull request against
+  its acceptance contract and the invariants owned by `AGENTS.md`.
+- **DELTA** — may inspect only the changes since the reviewed head, plus the consequences needed to
+  decide whether the known findings were actually fixed. A patch is not permission to rediscover
+  the whole pull request.
 
-## What You Sometimes Flag (judgment call)
+Any review of a pull request in the frozen state is DELTA.
 
-- Performance regressions in hot paths
-- Missing error context (`.context()` on errors)
-- Insufficient test coverage for new code
-- Documentation drift from implementation
+## Classify every finding
 
-## What You NEVER Comment On
+Use the dispositions defined in `finding_dispositions`: **BLOCKER**, **FOLLOW_UP**,
+**NOT_A_FINDING**, **QUESTION**. Every finding carries exactly one.
 
-- Style/formatting (cargo fmt handles this)
-- Import ordering
-- Trivial naming preferences
-- "I would have done it differently" opinions
+A finding is a BLOCKER only when **every** condition in `blocker_predicate.all_must_hold` is
+satisfied. Load the conditions; do not paraphrase them here, and do not substitute your own list.
+Two of them do most of the work and are the ones most often skipped:
 
-## Output Format
+- the finding must occur on a **supported and realistic execution path**, not only as generalised
+  hardening speculation;
+- leaving it unfixed must **materially** make the deliverable incorrect or unusable.
+
+A fail-closed abort on an input the upstream API cannot produce is not the deliverable being
+unusable. Neither is a hazard that requires an actor who already holds the capability being
+defended.
+
+Anything valid that misses even one condition is **FOLLOW_UP**. Say so plainly — "valid, not a
+blocker, here is why" is a complete and useful review outcome.
+
+## Severity is advisory
+
+You may attach a severity to help the maintainer triage. It carries no authority: it never
+satisfies the predicate, and it never breaks a freeze. `automated_severity_is_advisory` in the
+policy is the governing statement.
+
+## Reviewing a frozen pull request
+
+The freeze means the comprehensive generation is closed. Apply the late-blocker threshold in
+`freeze.late_finding_rule`. If a finding would need a substantial design change to address, it is
+follow-up work and a maintainer decision — not a reason to widen the frozen scope. Do not sweep
+for siblings of a finding you just reported.
+
+## What never to comment on
+
+- Style and formatting — the formatter owns it.
+- Import ordering, trivial naming, "I would have done it differently".
+- Anything the pull request declared as an explicit non-goal.
+- Anything already dispositioned in an earlier generation, unless it demonstrably regressed.
+
+## Output format
 
 ```
-## Review Summary
+## Review
 
-**Verdict**: APPROVE / REQUEST_CHANGES / NEEDS_DISCUSSION
+Kind:        FULL | DELTA
+Contract:    <the acceptance contract this was measured against>
+Reviewed:    <head sha>
+Findings:    <n> BLOCKER · <n> FOLLOW_UP · <n> QUESTION · <n> NOT_A_FINDING
 
-**Scope**: <crates touched, lines changed>
+### BLOCKER — `file:line`
+<what is wrong, and the reproduction>
+Predicate: <which conditions hold, and how you know>
+Fix: <specific>
 
-### Blocking Issues
-1. **[INVARIANT]** `file:line` - <issue description>
-   ```rust
-   // problematic code
-   ```
-   **Fix**: <specific fix with code>
+### FOLLOW_UP — `file:line`
+<the observation>
+Why not a blocker: <the condition it misses>
 
-### Warnings
-1. **[PERF|SECURITY|COVERAGE]** `file:line` - <concern>
-   **Suggestion**: <specific suggestion>
-
-### Questions
-1. `file:line` - <clarifying question about intent>
-
-### Looks Good
-- <positive callout if warranted>
+### QUESTION — `file:line`
+<what you could not determine from the registered owners and the implementation>
 ```
+
+Nothing else. No verdict vocabulary of your own: the dispositions above are the whole set, and the
+decision to merge belongs to the maintainer and the merge primitive.
 
 ## Guidelines
 
-- Be direct, not diplomatic
-- Provide specific fixes, not vague suggestions
-- Prioritize by impact (security > correctness > performance > style)
-- Trust the author's judgment on style
-- If unsure about intent, ask rather than block
-- Reference the specific invariant being violated
+- Be direct. Give the reproduction, not an impression.
+- Prefer one well-evidenced finding to five speculative ones.
+- If you cannot determine intent from the registered owners and the code, ask — do not block.
+- Name the specific invariant or acceptance condition a BLOCKER violates.

--- a/.claude/agents/icn-code-reviewer.md
+++ b/.claude/agents/icn-code-reviewer.md
@@ -85,7 +85,10 @@ for siblings of a finding you just reported.
 
 - Style and formatting — the formatter owns it.
 - Import ordering, trivial naming, "I would have done it differently".
-- Anything the pull request declared as an explicit non-goal.
+- Anything the pull request declared as an explicit non-goal — **unless** it is one of the
+  invariants `AGENTS.md` owns, or a regression in behaviour this diff actually changes. A
+  non-goal bounds what the pull request set out to build. It cannot waive a repository
+  invariant, and it cannot put a regression the diff introduced out of scope.
 - Anything already dispositioned in an earlier generation, unless it demonstrably regressed.
 
 ## Output format

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -7,6 +7,7 @@ allowed-tools: "Bash, Read, Grep, Glob"
 truth_contract:
   canonical_sources:
     - ops/state/truth/policy.json       # required checks, branch naming conventions
+    - ops/state/truth/delivery.json     # delivery lanes and the lifecycle block the PR must carry
     - ops/state/config/repo-map.json    # workspace root
   live_load_required:
     - "git branch --show-current"
@@ -44,6 +45,27 @@ Determine the scope from ICN scopes: `core`, `identity`, `trust`, `net`, `gossip
 Use `gh pr create` with this body structure:
 
 ```markdown
+## Delivery
+
+- **Delivery lane**: FAST | STANDARD | DEEP  (default from `lanes.default`; DEEP is the
+  maintainer's call, not yours)
+- **Acceptance contract**: what this PR claims to deliver, in one or two lines. A FULL review is
+  scoped against this, and the blocker predicate is measured against it, so an unstated contract
+  makes review unbounded.
+- **Explicit non-goals**: what this PR deliberately does not do.
+
+<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
+```
+ICN DELIVERY LIFECYCLE
+State:                IMPLEMENTING
+Lane:                 <lane>
+Review generation:    not yet requested
+Freeze head:          -
+Known blockers:       -
+Follow-up ledger:     -
+```
+<!-- ICN-DELIVERY-LIFECYCLE:END -->
+
 ## Summary
 
 <1-2 sentence description>
@@ -88,6 +110,9 @@ Title: `<type>(<scope>): <description>` (under 70 chars)
 
 ### Important
 
+- The lifecycle block is the PR's control surface for delivery state, and `ops/state/truth/delivery.json`
+  owns what the states mean. Keep the state there, never in a repository file. The `ship-pr` skill
+  reads and advances it from here on.
 - Base branch defaults to `main` unless `$ARGUMENTS` specifies otherwise
 - Push the branch with `-u` flag before creating PR
 - Include a `Co-Authored-By:` trailer naming the assisting model actually used for the change.

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -59,6 +59,7 @@ Use `gh pr create` with this body structure:
 ICN DELIVERY LIFECYCLE
 State:                IMPLEMENTING
 Lane:                 <lane>
+Acceptance contract:  <one line, or a pointer into the Delivery section above>
 Review generation:    not yet requested
 Freeze head:          -
 Known blockers:       -

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -78,9 +78,14 @@ is a blocker only when **every** condition in `blocker_predicate.all_must_hold` 
 A reviewer's own severity label is advisory evidence about that reviewer's confidence. It is not
 authority, and it never satisfies the predicate by itself.
 
-Reply to every thread with its disposition and the evidence, then resolve it. Server-side
-conversation resolution still applies to a frozen PR; dispositioning a thread is not reopening
-review.
+Reply to every thread with its disposition and the evidence. Resolve it when
+`finding_dispositions[].resolve_thread` says you may — which is not always now. A **QUESTION stays
+unresolved** until it is answered and reclassified: merge readiness counts unresolved threads, so
+resolving an unanswered question would manufacture readiness out of a question nobody answered. A
+BLOCKER's thread resolves once its fix is verified, not when it is written.
+
+Server-side conversation resolution still applies to a frozen PR; dispositioning a thread is not
+reopening review.
 
 ## 6. Handle blockers as one batch
 

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -128,9 +128,16 @@ maintainer decision, not a widening of the frozen scope.
 
 ## 10. Wait only on live merge gates
 
-Use the repository's bounded wait primitive, `ops/scripts/icn-wait`. Never an ad-hoc polling loop.
-Read which gates actually matter from the merge owner and live branch protection — this skill does
-not know them and must not learn them.
+Do not work out which gates matter. `icn-merge-pr check` already reads the merge owner and live
+protection and returns the answer as structured reasons; deciding it here would make this skill a
+second owner of readiness, which its Boundaries forbid — and a policy or protection change would
+then leave it waiting on the wrong set, or on checks that never block.
+
+So: run `check`, and if it refuses only because a required gate is still pending, wait for the
+gate it named using the repository's bounded wait primitive, `ops/scripts/icn-wait`, then run
+`check` again. Never an ad-hoc polling loop, and never wait on a check the evaluator did not name.
+`check` mutates nothing, so re-running it after a wait is not retrying a refusal — the one
+mutation is never retried.
 
 ## 11. Check the freeze head, then hand over
 

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: ship-pr
+description: Finish a pull request. Read its lifecycle state, run one bounded review generation, batch blocker fixes, freeze an exact head, then hand over to the merge primitive.
+argument-hint: "[PR number]"
+user-invocable: true
+allowed-tools: "Bash, Read, Grep, Glob"
+truth_contract:
+  canonical_sources:
+    - ops/state/truth/delivery.json     # lifecycle, dispositions, blocker predicate, freeze
+    - ops/state/truth/skills.json       # which skill owns the merge primitive
+  live_load_required:
+    - "gh pr view <N> --json state,isDraft,mergeable,baseRefName,headRefOid,body"
+    - "gh api graphql  # review threads and their resolved state"
+  examples_only: []
+  never_hardcode:
+    - lifecycle states, dispositions, or the blocker predicate — load delivery.json
+    - required checks, merge strategy, or readiness rules — this skill owns none of them
+    - PR number, branch name, or head SHA
+---
+
+# ship-pr
+
+Take one pull request from where it is to merged, without letting review run forever.
+
+The governing rule, owned by `ops/state/truth/delivery.json`:
+**automated review is evidence, not unbounded veto authority.**
+
+This skill decides *when* a PR is ready to hand over. It never decides *whether* the merge is
+permitted. That belongs to the merge primitive and its executable, and a second implementation
+here would be a second owner of merge semantics — with the copy being the one that rots.
+
+## Input
+- `$1` = PR number. If omitted: `gh pr view --json number --jq .number`.
+
+## Load first, every time
+
+```bash
+python3 -c "import json;print(json.dumps(json.load(open('ops/state/truth/delivery.json')),indent=2))"
+```
+
+Do not work from memory of this file. The lifecycle states, the finding dispositions, the blocker
+predicate, the freeze rules and the lane definitions are all owned there and may have changed.
+
+## 1. Read the live state
+
+Query the PR. Read the lifecycle block from the PR body — the delimiters are named by
+`lifecycle.state_surface` in the policy. The PR body is where lifecycle state lives; a repository
+file claiming to know a PR's current state is stale by construction.
+
+If there is no block, the PR is in the first state of `lifecycle.states`. Write the block.
+
+## 2. Confirm the lane
+
+`lanes.default` unless the block already names one. The DEEP lane requires the maintainer to
+select it — do not choose it yourself.
+
+## 3. Establish the acceptance contract
+
+The contract is what the PR claims to deliver, plus its explicit non-goals. It comes from the PR
+body; `pr-create` puts it there. If it is missing, write it from the diff and the linked issue and
+say so. Everything downstream — what a FULL review may inspect, and what makes a finding a
+blocker — is measured against this contract, so an unstated contract makes the lane unbounded.
+
+## 4. Run the review generation
+
+One comprehensive generation per lane. Request it once, when the implementation is complete and
+verification is green — not after every push.
+
+Record the generation in the block. **A push does not reset it.** If fixing findings reopened
+discovery, then fixing would be the act that triggers the next unbounded search, and no PR that
+fixes anything could ever converge.
+
+## 5. Classify every finding
+
+Use the dispositions in `finding_dispositions` and the predicate in `blocker_predicate`. A finding
+is a blocker only when **every** condition in `blocker_predicate.all_must_hold` is satisfied.
+
+A reviewer's own severity label is advisory evidence about that reviewer's confidence. It is not
+authority, and it never satisfies the predicate by itself.
+
+Reply to every thread with its disposition and the evidence, then resolve it. Server-side
+conversation resolution still applies to a frozen PR; dispositioning a thread is not reopening
+review.
+
+## 6. Handle blockers as one batch
+
+Fix the known blockers together. For each: the smallest local correction plus only the regression
+coverage that directly proves it closed. Do not inspect sibling areas for more things to fix —
+`blocker_predicate.no_sibling_sweep` says why.
+
+## 7. Defer everything else
+
+Valid observations that are not blockers go to one follow-up ledger issue for this PR — reuse it,
+do not open one per comment. Each entry states the observation, why it was deferred, and the fix,
+with a link back to its thread. Reply to the thread saying it is valid but outside the frozen
+delivery contract, link the ledger, and resolve.
+
+## 8. Verify
+
+Run the verification appropriate to the changed paths. After a blocker batch this is DELTA
+verification: the changed delta and whether it addresses the known findings. Not a restart.
+
+## 9. Freeze
+
+When `freeze.entry_conditions` are all met, name the exact head and write the block:
+
+```
+ICN DELIVERY LIFECYCLE
+State:                FROZEN
+Lane:                 <lane>
+Acceptance contract:  <one line, or a pointer into the body>
+Review generation:    CLOSED
+Freeze head:          <exact 40-hex head>
+Known blockers:       0
+Follow-up ledger:     <issue>
+```
+
+After this, a new automated review comment does not reopen the PR. A late finding breaks the
+freeze only if it satisfies every blocker condition; then make one targeted correction, run delta
+verification, update the freeze head, and return to FROZEN. Do not run another comprehensive
+review. If a late observation would need a substantial design change, it is a follow-up and a
+maintainer decision, not a widening of the frozen scope.
+
+## 10. Wait only on live merge gates
+
+Use the repository's bounded wait primitive, `ops/scripts/icn-wait`. Never an ad-hoc polling loop.
+Read which gates actually matter from the merge owner and live branch protection — this skill does
+not know them and must not learn them.
+
+## 11. Hand over
+
+```bash
+icn-merge-pr check "$PR"
+```
+
+Report the structured outcome verbatim. If it is not ready, stop: the reasons say what has to
+change. If it is ready, the mutation is the `merge-pr` skill's, under explicit per-PR maintainer
+authorization. Move the block to the merging state, then to the final state with the merge commit.
+
+Do not re-derive, second-guess, or work around anything the executable decided, and do not
+substitute another path when it refuses.
+
+## 12. Report
+
+The final head, the merge commit, the disposition counts, and the follow-up ledger.
+
+## Boundaries
+
+- Do not evaluate merge requirements here. Do not read branch protection to decide readiness.
+- Do not request another comprehensive review generation. Only the maintainer may.
+- Do not escalate a follow-up into a blocker, or reopen discovery, on your own.
+- Do not drop a valid observation instead of recording it.
+- Do not put lifecycle state in a repository file.

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -132,7 +132,15 @@ Use the repository's bounded wait primitive, `ops/scripts/icn-wait`. Never an ad
 Read which gates actually matter from the merge owner and live branch protection — this skill does
 not know them and must not learn them.
 
-## 11. Hand over
+## 11. Check the freeze head, then hand over
+
+**Compare the live head with the recorded freeze head before anything else.** A freeze names an
+exact head because that is the head that was reviewed and verified. Anything pushed since has been
+through neither, and nothing downstream will catch it: the merge executable pins the head it
+mutates, but it has no idea which head was reviewed.
+
+On a mismatch, the new content is unverified. Run DELTA verification on it, update the freeze head,
+return to FROZEN, and only then continue. `freeze.head_must_match_before_handoff` is the rule.
 
 ```bash
 icn-merge-pr check "$PR"

--- a/.github/agents/icn-code-reviewer.md
+++ b/.github/agents/icn-code-reviewer.md
@@ -1,76 +1,125 @@
 ---
 name: icn-code-reviewer
 description: >
-  PR review agent with ICN invariants lens. High signal-to-noise ratio—only surfaces
-  issues that genuinely matter: bugs, security, invariant violations, logic errors.
+  PR review agent with an ICN invariants lens, bound to the canonical delivery lifecycle.
+  High signal-to-noise: classifies every finding as BLOCKER, FOLLOW_UP, QUESTION or
+  NOT_A_FINDING and declares FULL or DELTA.
 infer: false
 ---
 
 You are the **ICN Code Reviewer**.
 
-Your job is to review PRs with extremely high signal-to-noise ratio.
+Review with a high signal-to-noise ratio, and against a bounded contract. Your findings are
+evidence for a decision the maintainer owns. They are not a veto.
 
-## Expert Knowledge
+## Load before reviewing
 
-You have deep expertise in:
-- **Code Smell Detection**: Anti-patterns, performance issues, maintainability
-- **Security Review**: Input validation, auth/authz, injection, timing attacks
-- **ICN Invariants**: All five core invariants and how code can violate them
-- **Test Coverage**: Gaps in testing, missing edge cases, flaky patterns
-- **Rust Idioms**: Ownership, lifetimes, async patterns, error handling
-- **Distributed Systems**: Race conditions, ordering bugs, partition handling
+1. `AGENTS.md` — the five ICN invariants and the operating contract. It owns them; this file does
+   not restate them.
+2. `ops/state/truth/delivery.json` — the delivery lifecycle. It owns the finding dispositions, the
+   blocker predicate, the FULL/DELTA distinction, and the freeze rules. Load it; do not work from
+   memory of it, and never define your own version of any of it here.
+3. The pull request's **acceptance contract** and explicit non-goals, from its body. Everything
+   below is measured against that contract.
+4. The pull request's lifecycle block, for its current state and review generation.
 
-## What You Review For
+## Where to look
 
-### ALWAYS flag (blocking)
-- Panics in protocol paths (`unwrap()`, `expect()`, `panic!()`)
-- Weakened validation to make tests pass
-- Trust escalation without explicit authorization
-- Non-deterministic state transitions
-- Breaking canonical encoding changes
-- Dependency cycle introduction
-- Security vulnerabilities
+Lenses, not verdicts. What blocks is decided by the predicate below; this is only where the
+defects that satisfy it tend to be.
 
-### Sometimes flag (judgment call)
-- Performance regressions in hot paths
-- Missing error context
-- Insufficient test coverage for new code
-- Documentation drift
+- **Rust** — ownership and lifetimes, async cancellation and cancel-safety, error propagation,
+  `unsafe`.
+- **Distributed systems** — ordering, races, partition and retry behaviour, idempotence.
+- **Security** — input validation, authorization boundaries, injection, timing, and anything that
+  widens a trusted surface.
+- **The invariants `AGENTS.md` owns** — adversarial-by-default, determinism, canonical encodings,
+  no panics in protocol paths, and the kernel/app boundary. Read them there; a violation of one is
+  usually the clearest way a finding satisfies the predicate.
+- **Tests** — missing edge cases, assertions that cannot fail, and coverage that does not actually
+  exercise the change.
 
-### NEVER comment on
-- Style/formatting (cargo fmt handles this)
-- Import ordering
-- Trivial naming preferences
-- "I would have done it differently" opinions
+## Declare what kind of review this is
 
-## Output Format
+Every review states **FULL** or **DELTA** at the top.
+
+- **FULL** — the scheduled comprehensive generation. May inspect the bounded pull request against
+  its acceptance contract and the invariants owned by `AGENTS.md`.
+- **DELTA** — may inspect only the changes since the reviewed head, plus the consequences needed to
+  decide whether the known findings were actually fixed. A patch is not permission to rediscover
+  the whole pull request.
+
+Any review of a pull request in the frozen state is DELTA.
+
+## Classify every finding
+
+Use the dispositions defined in `finding_dispositions`: **BLOCKER**, **FOLLOW_UP**,
+**NOT_A_FINDING**, **QUESTION**. Every finding carries exactly one.
+
+A finding is a BLOCKER only when **every** condition in `blocker_predicate.all_must_hold` is
+satisfied. Load the conditions; do not paraphrase them here, and do not substitute your own list.
+Two of them do most of the work and are the ones most often skipped:
+
+- the finding must occur on a **supported and realistic execution path**, not only as generalised
+  hardening speculation;
+- leaving it unfixed must **materially** make the deliverable incorrect or unusable.
+
+A fail-closed abort on an input the upstream API cannot produce is not the deliverable being
+unusable. Neither is a hazard that requires an actor who already holds the capability being
+defended.
+
+Anything valid that misses even one condition is **FOLLOW_UP**. Say so plainly — "valid, not a
+blocker, here is why" is a complete and useful review outcome.
+
+## Severity is advisory
+
+You may attach a severity to help the maintainer triage. It carries no authority: it never
+satisfies the predicate, and it never breaks a freeze. `automated_severity_is_advisory` in the
+policy is the governing statement.
+
+## Reviewing a frozen pull request
+
+The freeze means the comprehensive generation is closed. Apply the late-blocker threshold in
+`freeze.late_finding_rule`. If a finding would need a substantial design change to address, it is
+follow-up work and a maintainer decision — not a reason to widen the frozen scope. Do not sweep
+for siblings of a finding you just reported.
+
+## What never to comment on
+
+- Style and formatting — the formatter owns it.
+- Import ordering, trivial naming, "I would have done it differently".
+- Anything the pull request declared as an explicit non-goal.
+- Anything already dispositioned in an earlier generation, unless it demonstrably regressed.
+
+## Output format
 
 ```
-## Review Summary
+## Review
 
-**Verdict**: APPROVE / REQUEST_CHANGES / NEEDS_DISCUSSION
+Kind:        FULL | DELTA
+Contract:    <the acceptance contract this was measured against>
+Reviewed:    <head sha>
+Findings:    <n> BLOCKER · <n> FOLLOW_UP · <n> QUESTION · <n> NOT_A_FINDING
 
-### Blocking Issues
-1. **[INVARIANT]** <file>:<line> - <issue>
-   ```rust
-   // problematic code
-   ```
-   **Fix**: <specific fix>
+### BLOCKER — `file:line`
+<what is wrong, and the reproduction>
+Predicate: <which conditions hold, and how you know>
+Fix: <specific>
 
-### Warnings
-1. **[PERF]** <file>:<line> - <concern>
+### FOLLOW_UP — `file:line`
+<the observation>
+Why not a blocker: <the condition it misses>
 
-### Questions
-1. <file>:<line> - <clarifying question>
-
-### Looks Good
-- <positive callout if warranted>
+### QUESTION — `file:line`
+<what you could not determine from the registered owners and the implementation>
 ```
+
+Nothing else. No verdict vocabulary of your own: the dispositions above are the whole set, and the
+decision to merge belongs to the maintainer and the merge primitive.
 
 ## Guidelines
 
-- Be direct, not diplomatic
-- Provide specific fixes, not vague suggestions
-- Prioritize by impact
-- Trust the author's judgment on style
-- If unsure, ask rather than block
+- Be direct. Give the reproduction, not an impression.
+- Prefer one well-evidenced finding to five speculative ones.
+- If you cannot determine intent from the registered owners and the code, ask — do not block.
+- Name the specific invariant or acceptance condition a BLOCKER violates.

--- a/.github/agents/icn-code-reviewer.md
+++ b/.github/agents/icn-code-reviewer.md
@@ -88,7 +88,10 @@ for siblings of a finding you just reported.
 
 - Style and formatting — the formatter owns it.
 - Import ordering, trivial naming, "I would have done it differently".
-- Anything the pull request declared as an explicit non-goal.
+- Anything the pull request declared as an explicit non-goal — **unless** it is one of the
+  invariants `AGENTS.md` owns, or a regression in behaviour this diff actually changes. A
+  non-goal bounds what the pull request set out to build. It cannot waive a repository
+  invariant, and it cannot put a regression the diff introduced out of scope.
 - Anything already dispositioned in an earlier generation, unless it demonstrably regressed.
 
 ## Output format

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,471 +1,72 @@
 # GitHub Copilot Instructions for ICN
 
-This file provides guidance to GitHub Copilot when working with the ICN (Intercooperative Network) codebase.
-
-## Absolute Rules (must follow)
-
-1. **Read `AGENTS.md` first** for operating mode, invariants, and change routing.
-2. **Never weaken safety to fix tests**: Do not relax validation, trust gates, signature checks, encoding rules, or determinism requirements.
-3. **Verify before claiming**: Do not claim tests passed without showing output. Run the actual commands.
-4. **Follow change routing**: Run the right checks for what you touched (see `AGENTS.md`).
-5. **Docs must match code**: If you change semantics, update the relevant doc/spec in the same PR.
-
-> Custom agents are available in `.github/agents/` - use `@icn-orchestrator` to route multi-subsystem requests.
-
-> For path-specific instructions (Rust, web, SDK, docs), see `.github/instructions/` directory.
-
-## Project Overview
-
-ICN is a substrate daemon for the cooperative internet. It is **not** a blockchain or federation server - it's a P2P coordination layer providing:
-
-- **Identity Layer**: Decentralized identifiers (DIDs) with Ed25519 cryptography
-- **Trust Graph**: Web-of-participation based trust computation
-- **Networking**: QUIC/TLS secure sessions with mDNS discovery
-- **Cooperative Contracts**: CCL (Cooperative Contract Language) execution
-- **Mutual Credit Ledger**: Double-entry accounting with Merkle-DAG
-- **P2P Coordination**: Gossip protocol with trust-gated topics
-- **Distributed Compute**: Trust-gated CCL execution with intelligent scheduling
-- **Governance**: Democratic proposals and voting primitives
-- **Gateway API**: REST + WebSocket API for cooperative applications
-- **Cooperative Management**: Lifecycle, membership, and multi-stakeholder governance
-- **Federation**: Inter-cooperative coordination and cross-coop settlements
-- **Privacy**: Encrypted metadata, onion routing, traffic obfuscation
-- **Post-Quantum Security**: Hybrid cryptography for long-term protection
-- **SDIS Integration**: Sovereign Digital Identity with VUI and zero-knowledge proofs
-- **Byzantine Tolerance**: Misbehavior detection and reputation-based security
-
-## Repository Structure
-
-```
-icn/
-├── icn/                    # Main Rust workspace
-│   ├── crates/            # Core library crates
-│   │   ├── icn-core/      # Actor runtime & supervisor
-│   │   ├── icn-identity/  # DID generation & keystore
-│   │   ├── icn-trust/     # Trust graph computation
-│   │   ├── icn-net/       # QUIC/TLS networking
-│   │   ├── icn-gossip/    # Topic-based gossip protocol
-│   │   ├── icn-ledger/    # Mutual credit accounting
-│   │   ├── icn-ccl/       # Contract language interpreter
-│   │   ├── icn-store/     # Persistent storage (Sled)
-│   │   ├── icn-rpc/       # JSON-RPC API server
-│   │   ├── icn-gateway/   # REST + WebSocket API
-│   │   ├── icn-governance/# Governance primitives
-│   │   ├── icn-compute/   # Distributed compute layer
-│   │   ├── icn-obs/       # Metrics & observability
-│   │   ├── icn-coop/      # Cooperative management & lifecycle
-│   │   ├── icn-community/ # Community structures & civic engine
-│   │   ├── icn-entity/    # Unified entity model (individuals/coops/federations)
-│   │   ├── icn-federation/# Inter-cooperative coordination
-│   │   ├── icn-privacy/   # Privacy primitives & metadata protection
-│   │   ├── icn-security/  # Byzantine fault detection & reputation
-│   │   ├── icn-crypto-pq/ # Post-quantum hybrid cryptography
-│   │   ├── icn-steward/   # SDIS steward network & VUI computation
-│   │   ├── icn-zkp/       # Zero-knowledge proofs for SDIS
-│   │   ├── icn-time/      # Clock synchronization (Rough Time Protocol)
-│   │   ├── icn-snapshot/  # State snapshots for restarts
-│   │   ├── icn-api/       # API types and definitions
-│   │   ├── icn-encoding/  # Serialization utilities
-│   │   └── icn-testkit/   # Testing utilities
-│   └── bins/              # Binaries
-│       ├── icnd/          # ICN daemon
-│       ├── icnctl/        # CLI management tool
-│       └── icn-console/   # Interactive TUI for cooperative management
-├── docs/                  # Comprehensive documentation
-├── deploy/                # Kubernetes & deployment configs
-├── web/                   # Web UIs (pilot-ui, etc.)
-├── sdk/                   # Client SDKs (TypeScript, etc.)
-└── examples/              # Usage examples
-```
-
-## Current Working Context
-
-- See docs/STATE.md and docs/TODO.md for current status, known issues, and priorities.
-- Rust toolchain note: the toolchain is pinned in `icn/rust-toolchain.toml` — do NOT upgrade it. If a dependency demands a newer rustc, pin a compatible dependency version instead (see CLAUDE.md non-negotiables).
-
-## Development Workflow
-
-### Build & Test Commands
-
-All commands must be run from the `icn/` directory:
-
-```bash
-# Build everything
-cargo build
-
-# Build release binaries
-cargo build --release
-
-# Run all tests
-cargo test
-
-# Run tests for a specific package
-cargo test -p icn-gossip
-
-# Run a specific test by name
-cargo test test_two_node_convergence
-
-# Linting
-cargo clippy -- -D warnings
-
-# Formatting
-cargo fmt
-
-# Run the daemon
-./target/debug/icnd
-
-# Use the CLI
-./target/debug/icnctl status
-```
-
-### Code Quality Standards
-
-- **Follow existing patterns**: The codebase has established patterns for actors, handles, and message passing
-- **Error handling**: Use `Result<T, E>` types, never panic in protocol code
-- **Async operations**: Use Tokio runtime, no blocking operations in async contexts
-- **Testing**: Write tests for all new functionality, follow existing test patterns
-- **Documentation**: Add rustdoc comments for public APIs
-- **Linting**: Code must pass `cargo clippy` and `cargo fmt`
-
-### Commit Message Format
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-<type>(<scope>): <description>
-
-[optional body]
-```
-
-Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
-
-Examples:
-- `feat(gateway): add WebSocket authentication`
-- `fix(ledger): correct double-entry balance calculation`
-- `test(compute): add task cancellation tests`
-
-## Architecture Patterns
-
-### Actor-Based Runtime
-
-ICNd uses Tokio with an actor pattern:
-
-1. **Supervisor** (`icn-core/src/supervisor.rs`): Spawns and manages all actors
-2. **Actors**: GossipActor, NetworkActor, Ledger, GovernanceActor, ComputeActor
-3. **Handles**: Each actor provides a handle for async API access
-4. **Message Passing**: Use `mpsc::channel` for actor communication
-5. **Shared State**: Use `Arc<RwLock<T>>` for shared access
-
-Example actor handle pattern:
-```rust
-pub struct ActorHandle {
-    tx: mpsc::Sender<ActorMsg>,
-}
-
-impl ActorHandle {
-    pub async fn do_something(&self, arg: T) -> Result<R> {
-        let (tx, rx) = oneshot::channel();
-        self.tx.send(ActorMsg::DoSomething { arg, reply: tx }).await?;
-        rx.await?
-    }
-}
-```
-
-### Gossip Protocol
-
-- **Push announcements**: Broadcast new content hashes
-- **Pull requests**: Request missing content by hash
-- **Anti-entropy**: Periodic Bloom filter exchange
-- **Vector clocks**: Track causal dependencies per peer
-- **Subscription notifications**: Reactive callbacks for new entries
-- **Access control**: Public, Private, or TrustGated topics
-
-### Security Architecture
-
-Three-layer security model:
-
-1. **Transport Layer**: QUIC/TLS with DID-TLS binding
-2. **Message Layer**: SignedEnvelope with Ed25519 signatures + replay protection
-3. **Application Layer**: EncryptedEnvelope with end-to-end encryption
-
-### Trust Graph
-
-- Trust scores between 0.0 and 1.0
-- Transitive trust computation using weighted edges
-- Used for access control, rate limiting, and resource allocation
-- Trust thresholds vary by operation (e.g., MIN_TRUST_EXECUTE = 0.3)
-
-### Cooperative & Federation Architecture
-
-**Cooperatives** (`icn-coop`):
-- Management and lifecycle (formation, dissolution, membership)
-- CoopActor handles coop operations via gossip topic `coop:updates`
-- Member roles, tiers, and status tracking
-- Asset distribution and capital return methods
-
-**Communities** (`icn-community`):
-- Civic structures grouping cooperatives and individuals
-- Community types: Geographic, Interest-based, Project-based
-- Shared governance, resources, and mutual support
-- CommunityActor syncs via `community:updates` topic
-
-**Entities** (`icn-entity`):
-- Unified recursive model for individuals, cooperatives, and federations
-- EntityId format: `entity:icn:<type>:<identifier>`
-- DID interoperability for individuals
-- Enables arbitrary organizational hierarchies
-
-**Federation** (`icn-federation`):
-- Inter-cooperative coordination and discovery
-- Federated trust attestations and DID resolution
-- Cross-cooperative credit settlement
-- Cooperative-scoped gossip routing
-- DID format with cooperative prefix: `did:icn:coop-name:pubkey`
-
-### Security & Privacy
-
-**Byzantine Detection** (`icn-security`):
-- MisbehaviorDetector tracks violations and reputation
-- Automatic quarantine and banning based on thresholds
-- Trust penalty callbacks for network protection
-- Violation records with severity scoring
-
-**Privacy Primitives** (`icn-privacy`):
-- ChaCha20-Poly1305 encryption for topic metadata
-- Bloom filter-based topic discovery (privacy-preserving)
-- Onion routing for sender/receiver anonymity (planned)
-- Traffic obfuscation and cover traffic (planned)
-
-**Post-Quantum Cryptography** (`icn-crypto-pq`):
-- Hybrid classical/PQ constructions for long-term security
-- Ed25519 + ML-DSA (Dilithium) for signatures
-- X25519 + ML-KEM (Kyber) for key exchange
-- Defense-in-depth: attacker must break both algorithms
-
-### SDIS (Sovereign Digital Identity System)
-
-**Steward Network** (`icn-steward`):
-- Threshold PRF for Verifiable Unique Identifiers (VUI)
-- Proof-of-Personhood enrollment ceremonies
-- Blind signatures for privacy-preserving tokens
-- Social recovery through steward attestations
-- Distributed VUI registry for uniqueness checking
-
-**Zero-Knowledge Proofs** (`icn-zkp`):
-- Attribute proofs (age, citizenship, membership) without revealing data
-- Non-revocation proofs with RSA or Merkle accumulators
-- Compound proofs combining multiple attributes
-- PQ-safe Merkle accumulators for future-proof revocation
-
-### Infrastructure
-
-**Clock Synchronization** (`icn-time`):
-- Rough Time Protocol (RFC 8915) for cooperative-wide time sync
-- Distributed timestamp validation
-- Replay attack protection
-- Clock skew detection and correction
-
-**State Snapshots** (`icn-snapshot`):
-- Local state serialization for graceful restarts
-- Distributed snapshots (Chandy-Lamport) for network consistency
-- Actor state export/restore for gossip, network, ledger
-- Checkpoint-based recovery
-
-## Common Development Tasks
-
-### Adding a New Actor
-
-1. Create actor struct with state
-2. Implement message enum for actor operations
-3. Create handle struct with `mpsc::Sender<Msg>`
-4. Implement `spawn()` method that returns handle
-5. Register with supervisor in `supervisor.rs`
-6. Wire up communication with other actors via callbacks/channels
-
-### Adding a New Gossip Topic
-
-1. Define topic string (convention: `namespace:purpose`)
-2. Configure `AccessControl` enum (Public, Private, TrustGated)
-3. Subscribe in relevant actor: `gossip.subscribe(topic, access_control)`
-4. Implement message serialization (use `bincode` or `serde_json`)
-5. Set up notification callback to receive new entries
-6. Handle incoming messages in gossip actor's message handler. Handlers for a *received*
-   `Subscribe`/`Unsubscribe` must call `subscribe_from_network`/`unsubscribe_from_network`,
-   never the local `subscribe`/`unsubscribe` — `NetworkMessage.from` is self-declared
-   (see `docs/reference/api/topic-subscriptions-api.md`, issue #2471)
-
-### Adding Metrics
-
-1. Define metric in `icn-obs/src/metrics.rs`
-2. Register in `init_descriptions()` function
-3. Increment/observe at instrumentation points
-4. Follow naming convention: `{actor}_{metric}_{unit}`
-
-### Working with the Ledger
-
-- Double-entry bookkeeping with Merkle-DAG
-- Entries are immutable once recorded
-- Gossip syncs via `ledger:sync` topic
-- Quarantine mechanism for conflicting entries
-- All transactions require valid signatures
-
-### Working with Contracts (CCL)
-
-- AST-based language with deterministic execution
-- Capability system: `ReadLedger`, `WriteLedger`, `ReadTrust`
-- Fuel metering prevents infinite loops
-- Not Turing-complete: No recursion, fixed iteration bounds
-- Invoked via `ContractRuntime::invoke_rule()`
-
-## Testing Patterns
-
-### Integration Tests
-
-- Use `TestNode` helper pattern to spawn isolated nodes
-- Each node gets unique port and keypair
-- Nodes dial each other via `network_handle.dial(addr, did)`
-- Verify convergence with retries and timeouts
-- Located in `icn/crates/icn-core/tests/` and package-specific `tests/` dirs
-
-### Test Utilities
-
-- `icn-testkit`: Helpers for multi-node test scenarios
-- Temporary directory management
-- Test keypair generation
-- Use `#[tokio::test]` for async tests
-
-## Key Files to Reference
-
-When working on specific features, reference these files:
-
-**Core Infrastructure:**
-- **Actor Runtime**: `icn-core/src/supervisor.rs`, `icn-core/src/runtime.rs`
-- **Network Protocol**: `icn-net/src/protocol.rs`, `icn-net/src/actor.rs`
-- **Gossip Implementation**: `icn-gossip/src/gossip.rs`
-- **Storage**: `icn-store/src/lib.rs`
-- **Metrics**: `icn-obs/src/metrics.rs`
-
-**Identity & Cryptography:**
-- **Identity**: `icn-identity/src/keystore.rs`, `icn-identity/src/did.rs`
-- **Post-Quantum Crypto**: `icn-crypto-pq/src/keypair.rs`, `icn-crypto-pq/src/signature.rs`
-- **Trust Graph**: `icn-trust/src/graph.rs`, `icn-trust/src/computation.rs`
-
-**Economic & Governance:**
-- **Ledger Logic**: `icn-ledger/src/ledger.rs`, `icn-ledger/src/sync.rs`
-- **Contract Execution**: `icn-ccl/src/interpreter.rs`, `icn-ccl/src/ast.rs`
-- **Governance**: `icn-governance/src/proposal.rs`, `icn-governance/src/domain.rs`, `icn-governance/src/vote.rs`
-
-**Cooperative Structures:**
-- **Cooperatives**: `icn-coop/src/actor.rs`, `icn-coop/src/lifecycle.rs`, `icn-coop/src/membership.rs`
-- **Communities**: `icn-community/src/actor.rs`, `icn-community/src/types.rs`
-- **Entities**: `icn-entity/src/lib.rs`
-- **Federation**: `icn-federation/src/registry.rs`, `icn-federation/src/bridge.rs`
-
-**Security & Privacy:**
-- **Security**: `icn-security/src/misbehavior.rs`
-- **Privacy**: `icn-privacy/src/topic_encryption.rs`, `icn-privacy/src/bloom.rs`
-
-**SDIS (Sovereign Digital Identity):**
-- **Steward Network**: `icn-steward/src/vui.rs`, `icn-steward/src/enrollment.rs`
-- **Zero-Knowledge Proofs**: `icn-zkp/src/prover.rs`, `icn-zkp/src/verifier.rs`
-
-**Services:**
-- **Gateway API**: `icn-gateway/src/server.rs`, `icn-gateway/src/api/`
-- **Compute Layer**: `icn-compute/src/actor.rs`, `icn-compute/src/executor.rs`
-- **RPC Server**: `icn-rpc/src/server.rs`
-- **Clock Sync**: `icn-time/src/sync.rs`
-- **Snapshots**: `icn-snapshot/src/local.rs`, `icn-snapshot/src/distributed.rs`
-
-## Documentation
-
-Comprehensive documentation is available in the `docs/` directory:
-
-- **ARCHITECTURE.md**: System architecture and design decisions
-- **GETTING_STARTED.md**: Quick start guide for new contributors
-- **STATE.md** / **PHASE_PROGRESS.md**: Current project state and phase tracking (canonical)
-- **strategy/ICN-Roadmap-Live.md**: Long-arc roadmap
-- **security/production-hardening.md**: Security hardening measures
-- **design/governance/governance-primitives.md**: Governance system design
-- **design/scheduler-evolution-plan.md**: Distributed compute scheduler design
-- **development/sessions/**: Development session notes (organized by month)
-- **dev/**: Developer handoffs and working notes
-
-## Design Principles
-
-ICN is built on five foundational principles:
-
-1. **Local-first**: Nodes operate independently and reconcile via gossip
-2. **Trust-native**: Security derives from social trust edges, not global consensus
-3. **Deterministic compute**: Same inputs → same outputs → same ledger state
-4. **Capability-based security**: Contracts have explicit permissions
-5. **Human-governed**: Democratic and auditable policy changes
-
-## Important Notes
-
-- The daemon requires an unlocked keystore (passphrase prompt on startup)
-- All actor handles use interior mutability (`Arc<RwLock<T>>` or message passing)
-- Shutdown propagates via `tokio::sync::broadcast` channel
-- Integration tests should use unique ports per node (avoid bind conflicts)
-- Vector clocks prevent duplicate processing of gossip messages
-- Never use blocking operations in Tokio runtime contexts
-- DID format: `did:icn:<base58-pubkey>`
-
-## Production Hardening
-
-The codebase includes extensive production hardening:
-
-- **Network protections**: Trust-gated rate limiting, QUIC stream limits, message validation
-- **Protocol protections**: Certificate verification, Bloom filter validation, timestamp overflow protection
-- **Runtime protections**: Async-safe operations, error handling, graceful degradation
-- **Byzantine detection**: MisbehaviorDetector with automatic quarantine and banning
-- **Metrics**: Comprehensive Prometheus metrics for monitoring
-- **Backup/Restore**: `icnctl backup/restore` commands for disaster recovery
-
-## Current Status
-
-**Status: Phase 2 — Pilot Launch, in progress (partner-bound).** Do NOT describe ICN as pilot-ready, production-ready, or complete. Canonical current state lives in `docs/STATE.md` + `docs/PHASE_PROGRESS.md`; the retired "Phase 1–20" numbering is pre-reset history (`docs/PHASE_HISTORY.md`) and must not be cited as current. Never quote test/crate counts from this file — derive them (`cargo test`, `cargo metadata`) or cite `docs/status.toml`.
-
-The codebase includes substantial infrastructure across the following areas (existence, not completeness or readiness):
-
-**Core Infrastructure:**
-- Complete actor runtime with supervisor
-- DID-TLS binding with persistent certificates
-- Message integrity with Ed25519 signatures
-- End-to-end encryption with X25519-ChaCha20-Poly1305
-- Multi-device identity support
-- Byzantine fault detection with reputation system
-- Storage replication with trust-weighted selection
-- State snapshots for graceful restarts
-
-**Economic & Governance:**
-- Economic safety rails (credit limits, dispute resolution)
-- Governance primitives (domains, proposals, voting)
-- Mutual credit ledger with Merkle-DAG
-- Cooperative lifecycle management (formation, dissolution)
-- Multi-stakeholder membership models
-
-**Federation & Coordination:**
-- Federation protocol for inter-cooperative coordination
-- Cross-cooperative credit settlement
-- Federated trust attestations
-- Community structures for civic organization
-- Unified entity model (individuals/coops/federations)
-
-**Security & Privacy:**
-- Post-quantum hybrid cryptography (Ed25519+ML-DSA, X25519+ML-KEM)
-- Privacy-preserving topic encryption
-- Clock synchronization for replay protection
-- Byzantine misbehavior detection
-
-**SDIS Integration:**
-- Steward network for VUI computation
-- Zero-knowledge attribute proofs
-- Enrollment ceremonies and token issuance
-- Social recovery mechanisms
-
-**Services:**
-- Gateway REST + WebSocket API
-- Distributed compute layer with intelligent scheduling
-- Comprehensive Prometheus metrics
-
-See `docs/STATE.md` and `docs/PHASE_PROGRESS.md` for current state, `docs/strategy/ICN-Roadmap-Live.md` for upcoming direction, and `CHANGELOG.md` for recent changes.
+A **provider adapter**. It says how Copilot reaches this repository's contract and where its
+provider-specific surfaces live. It does not restate the contract, and it owns no project facts.
+
+Everything this file used to carry — project overview, repository structure, architecture
+patterns, build commands, testing patterns, current status — had registered owners elsewhere, and
+the copies here rotted. A provider surface that answers "what is this project" is a second
+handbook, and the second handbook is the one that goes stale silently.
+
+## Start here, every session
+
+1. **[`AGENTS.md`](../AGENTS.md)** — the provider-neutral operating contract: the five ICN
+   invariants, scope and mutation discipline, and how verification is chosen from the changed
+   paths. Read it before non-trivial work. It outranks this file.
+2. **[`ops/state/truth/sources.json`](../ops/state/truth/sources.json)** — the truth-ownership map.
+   Resolve the question to its owner before loading any broad document. Load only the owners the
+   task needs.
+3. **Live state is queried live.** Branch, head, PR, reviews, checks, issues, branch protection.
+   Never from this file, a handoff, a cached prompt, or model memory.
+
+If this file ever disagrees with `AGENTS.md` or a registered owner, this file is the stale layer.
+
+## Reviewing and finishing a pull request
+
+The pull-request delivery lifecycle is owned by
+**[`ops/state/truth/delivery.json`](../ops/state/truth/delivery.json)**. Load it. It defines the
+lifecycle states, the finding dispositions (BLOCKER, FOLLOW_UP, QUESTION, NOT_A_FINDING), the
+blocker predicate, the FULL/DELTA review distinction, freeze and refreeze, and which decisions
+belong to the maintainer alone.
+
+Three consequences that matter to an automated reviewer:
+
+- **Comprehensive review is bounded.** A normal pull request gets one comprehensive generation.
+  A push does not reset it.
+- **Severity is advisory.** A P1/P2/critical label is evidence about your confidence. It is not
+  authority, and it never breaks a freeze on its own.
+- **A frozen pull request stays frozen** unless a finding satisfies every blocker condition.
+  Valid observations below that threshold become follow-up work, not a reopened pull request.
+
+Do not define blocker, severity, or freeze semantics here or in any reviewer prompt. That is
+enforced by `scripts/check-delivery-lifecycle.py`.
+
+## Provider surfaces
+
+- **Agents**: [`.github/agents/`](agents/) — `@icn-orchestrator` routes multi-subsystem requests.
+  `icn-code-reviewer` is bound to the delivery lifecycle above and mirrors its Claude counterpart.
+- **Path-specific instructions**: [`.github/instructions/`](instructions/) — Rust, web, SDK, docs.
+- **Skills**: canonical paths come from
+  [`ops/state/truth/skills.json`](../ops/state/truth/skills.json), not from whichever directory a
+  provider happens to load. `ship-pr` finishes a pull request; `merge-pr` is the narrow merge
+  primitive.
+
+## Rules that are not negotiable here
+
+1. **Never weaken safety to make something pass.** Not validation, trust gates, signature checks,
+   encoding rules, determinism requirements, tests, or invariant checks.
+2. **Verify before claiming.** Show the command and its output. "Implemented" is not "integrated",
+   "deployed", or "adopted" — `AGENTS.md` §9 owns that distinction.
+3. **Scope is a hard boundary.** A failing check is not permission for unrelated cleanup.
+4. **Do not silently upgrade toolchains or dependencies.**
+5. **Docs must match code.** If you change semantics, update the owner in the same pull request.
+
+## Verification
+
+Choose it from the changed paths, the domain owner, and the repository's merge policy — the
+procedure is in `AGENTS.md` §5, which also records the documentation-control entrypoints once, so
+they are not duplicated into provider adapters like this one.
+
+Merge requirements come from [`ops/state/truth/policy.json`](../ops/state/truth/policy.json) plus
+live branch protection. A fixed list of required checks written into a prompt is stale by
+construction.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,27 @@
 # Pull Request
 
+## Delivery
+
+Two lines a human writes; the rest an agent keeps current. Semantics are owned by
+[`ops/state/truth/delivery.json`](../ops/state/truth/delivery.json) — lane definitions, what the
+states mean, and when comprehensive review ends.
+
+- **Delivery lane**: FAST | STANDARD | DEEP <!-- DEEP is the maintainer's call -->
+- **Acceptance contract**: what this PR claims to deliver.
+- **Explicit non-goals**: what it deliberately does not do.
+
+<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
+```
+ICN DELIVERY LIFECYCLE
+State:                IMPLEMENTING
+Lane:                 <lane>
+Review generation:    not yet requested
+Freeze head:          -
+Known blockers:       -
+Follow-up ledger:     -
+```
+<!-- ICN-DELIVERY-LIFECYCLE:END -->
+
 ## Summary
 What changed and why?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@ states mean, and when comprehensive review ends.
 ICN DELIVERY LIFECYCLE
 State:                IMPLEMENTING
 Lane:                 <lane>
+Acceptance contract:  <one line, or a pointer into the Delivery section above>
 Review generation:    not yet requested
 Freeze head:          -
 Known blockers:       -

--- a/.github/workflows/agent-drift-check.yml
+++ b/.github/workflows/agent-drift-check.yml
@@ -23,6 +23,11 @@ on:
       - 'tools/icn-merge-pr/**'
       - 'scripts/tests/test_icn_merge_pr.py'
       - 'scripts/tests/test_icn_merge_pr_install.py'
+      # icn#2661: the delivery lifecycle owner, its gate, and the provider surfaces it binds.
+      - 'scripts/check-delivery-lifecycle.py'
+      - 'scripts/tests/test_delivery_lifecycle.py'
+      - '.github/copilot-instructions.md'
+      - '.github/pull_request_template.md'
       - 'ops/scripts/setup-skill-symlinks.sh'
       - 'ops/state/truth/**'
       - 'ops/scripts/drift-check.sh'
@@ -117,6 +122,15 @@ jobs:
       # default-branch tip, and the installed runtime must not import candidate-worktree code.
       - name: Ordinary-merge evaluator provenance gate (Refs icn#2651)
         run: python3 scripts/tests/test_icn_merge_pr_install.py
+
+      # icn#2661: one owner for the delivery lifecycle. This proves the provider reviewer
+      # surfaces still bind to it — a prompt that regains its own blocker or freeze semantics is
+      # a second owner of them, and the copy is the one that rots.
+      - name: Delivery lifecycle owner and provider bindings (Refs icn#2661)
+        run: python3 scripts/check-delivery-lifecycle.py --verbose
+
+      - name: Delivery lifecycle gate rejects its own violations (Refs icn#2661)
+        run: python3 scripts/tests/test_delivery_lifecycle.py
 
       - name: SessionStart hook runs and degrades honestly (Refs icn#2634)
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Use this rule:
 | What is being worked on right now? | The live issue/PR control surface via `gh`. Never a sprint file, a handoff, or a cached prompt |
 | Is a sprint cadence running, and what is the sprint board lineage? | `ops/state/sprint/current.json` |
 | What are the merge requirements? | `ops/state/truth/policy.json` plus live branch protection |
+| When does comprehensive review end, and may this PR ship? | `ops/state/truth/delivery.json` plus the pull request's live lifecycle block |
 | Which agent or skill owns a workflow? | `ops/state/truth/agents.json` and `ops/state/truth/skills.json` |
 | What is the current branch, PR, review, or CI state? | Live `git` and GitHub data. Never a handoff or cached prompt |
 | What happened previously? | Git history, issues/PRs, and handoffs as historical evidence |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ Use this rule:
 | What is being worked on right now? | The live issue/PR control surface via `gh`. Never a sprint file, a handoff, or a cached prompt |
 | Is a sprint cadence running, and what is the sprint board lineage? | `ops/state/sprint/current.json` |
 | What are the merge requirements? | `ops/state/truth/policy.json` plus live branch protection |
-| When does comprehensive review end, and may this PR ship? | `ops/state/truth/delivery.json` plus the pull request's live lifecycle block |
+| Is comprehensive review complete, and may this PR be frozen? | `ops/state/truth/delivery.json` plus the pull request's live lifecycle block. It owns review completion only, and disclaims merge requirements |
+| May this PR actually merge? | The merge-requirements row above — `ops/state/truth/policy.json` plus live branch protection and live PR state. A frozen PR can still be draft, conflicting, or missing a required check |
 | Which agent or skill owns a workflow? | `ops/state/truth/agents.json` and `ops/state/truth/skills.json` |
 | What is the current branch, PR, review, or CI state? | Live `git` and GitHub data. Never a handoff or cached prompt |
 | What happened previously? | Git history, issues/PRs, and handoffs as historical evidence |

--- a/docs/ai/WORKFLOW_ARCHITECTURE.md
+++ b/docs/ai/WORKFLOW_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 Status: normative
 Authority: agent workflow architecture
 Canonical: yes
-Last verified: 2026-08-19
+Last verified: 2026-08-28
 ---
 
 # ICN Agent Workflow Architecture
@@ -41,6 +41,7 @@ Answers **where a fact of this kind is owned**. The agent resolves the question 
 Supporting registries:
 
 - `ops/state/truth/policy.json` owns merge-policy data.
+- `ops/state/truth/delivery.json` owns the pull-request delivery lifecycle: when comprehensive review ends, what freezes, and how a late finding is classified.
 - `ops/state/truth/agents.json` owns agent routing.
 - `ops/state/truth/skills.json` owns skill routing/canonical paths.
 - `ops/state/config/repo-map.json` owns repository/worktree topology.

--- a/docs/reference/project-index/generated/agent-capabilities.json
+++ b/docs/reference/project-index/generated/agent-capabilities.json
@@ -323,6 +323,12 @@
       "summary": ""
     },
     {
+      "name": "ship-pr",
+      "group": "icn_level",
+      "canonical_path": ".agents/skills/ship-pr/SKILL.md",
+      "summary": ""
+    },
+    {
       "name": "sync-docs",
       "group": "icn_level",
       "canonical_path": ".agents/skills/sync-docs/SKILL.md",
@@ -551,6 +557,10 @@
     {
       "domain": "merge_policy",
       "owner": "ops/state/truth/policy.json"
+    },
+    {
+      "domain": "pr_delivery_lifecycle",
+      "owner": "ops/state/truth/delivery.json"
     },
     {
       "domain": "repo_topology",

--- a/ops/state/truth/delivery.json
+++ b/ops/state/truth/delivery.json
@@ -107,6 +107,14 @@
         "Known blockers",
         "Follow-up ledger"
       ],
+      "rendered_by": [
+        ".github/pull_request_template.md",
+        ".agents/skills/pr-create/SKILL.md",
+        ".claude/skills/pr-create/SKILL.md",
+        ".agents/skills/ship-pr/SKILL.md",
+        ".claude/skills/ship-pr/SKILL.md"
+      ],
+      "rendered_by_why": "The owner names the fields; these surfaces render the block. Two of them rendered a different set and nothing noticed, so the list is data and the gate checks it.",
       "not_owned_by": [
         "repository files",
         "handoffs",

--- a/ops/state/truth/delivery.json
+++ b/ops/state/truth/delivery.json
@@ -150,22 +150,26 @@
     {
       "name": "BLOCKER",
       "means": "Satisfies every condition in blocker_predicate.all_must_hold.",
-      "action": "Make the smallest local correction, add only directly necessary regression coverage, do not inspect sibling areas for more things to fix."
+      "action": "Make the smallest local correction, add only directly necessary regression coverage, do not inspect sibling areas for more things to fix. Resolve the thread once the fix is verified, not when it is written.",
+      "resolve_thread": "after_the_fix_is_verified"
     },
     {
       "name": "FOLLOW_UP",
       "means": "Valid or potentially useful, but does not satisfy every blocker condition.",
-      "action": "Do not change the pull request for it. Append it to the follow-up ledger with a link back to the thread, reply saying it is valid but outside the delivery contract, link the ledger, and resolve the thread."
+      "action": "Do not change the pull request for it. Append it to the follow-up ledger with a link back to the thread, reply saying it is valid but outside the delivery contract, link the ledger, and resolve the thread.",
+      "resolve_thread": "after_the_ledger_entry_exists"
     },
     {
       "name": "NOT_A_FINDING",
       "means": "Incorrect, duplicate, already fixed, obsolete, or outside the pull request's contract.",
-      "action": "Reply briefly with the evidence and resolve the thread."
+      "action": "Reply briefly with the evidence and resolve the thread.",
+      "resolve_thread": "after_the_reply"
     },
     {
       "name": "QUESTION",
       "means": "Intent genuinely cannot be determined from the registered owners and implementation evidence.",
-      "action": "Ask. Do not guess, and do not treat the ambiguity as a blocker."
+      "action": "Ask. Do not guess, and do not treat the ambiguity as a blocker. Leave the thread UNRESOLVED until it is answered and reclassified: merge readiness counts unresolved threads, so resolving an unanswered question manufactures readiness out of a question nobody answered.",
+      "resolve_thread": "after_it_is_answered_and_reclassified"
     }
   ],
   "blocker_predicate": {
@@ -383,6 +387,7 @@
           }
         ]
       }
-    ]
+    ],
+    "inventory_note": "The surfaces, the mirror pairs, and each surface's required references and forbidden patterns are a FLOOR pinned in scripts/check-delivery-lifecycle.py. This list may add to them; it may not shrink below them. Without that, an edit could keep three entries, point them all at one prompt, cut must_reference to a single string and replace every pattern with one that cannot match \u2014 detaching the Copilot adapters while the required check stayed green."
   }
 }

--- a/ops/state/truth/delivery.json
+++ b/ops/state/truth/delivery.json
@@ -1,0 +1,380 @@
+{
+  "schema": "icn.delivery-lifecycle.v1",
+  "description": "Canonical semantics for the pull-request delivery lifecycle: when comprehensive review ends, what freezes, and how a late finding is classified. This file is the single owner of those semantics. Provider reviewer prompts and skills load it; they do not restate it.",
+  "principle": "Automated review is evidence, not unbounded veto authority.",
+  "why_this_exists": "A pull request that is correct, complete and green could still fail to converge: each push drew a fresh full review, each full review produced valid-but-non-blocking observations, and each observation reopened the whole PR. Nothing said when review ENDS, so every reviewer surface invented its own blocking rules. Recorded because the failure mode is invisible while it is happening \u2014 each individual round looks reasonable.",
+  "owner_boundary": {
+    "owns": [
+      "the delivery lifecycle states and their transitions",
+      "review generations, and what a FULL and a DELTA review may inspect",
+      "the disposition vocabulary for a review finding",
+      "the blocker predicate, including the higher threshold after freeze",
+      "freeze entry, freeze effect, and refreeze",
+      "the follow-up ledger convention",
+      "the delivery lanes",
+      "which lifecycle decisions are maintainer-only"
+    ],
+    "does_not_own": [
+      {
+        "fact": "merge requirements and merge-mutation semantics",
+        "owner": "ops/state/truth/policy.json#merge, executed by tools/icn-merge-pr"
+      },
+      {
+        "fact": "the five ICN invariants a review applies",
+        "owner": "AGENTS.md"
+      },
+      {
+        "fact": "how an agent resolves truth and loads context",
+        "owner": "docs/ai/WORKFLOW_ARCHITECTURE.md"
+      },
+      {
+        "fact": "current state of any specific pull request",
+        "owner": "github-api, queried live"
+      },
+      {
+        "fact": "skill and agent routing",
+        "owner": "ops/state/truth/skills.json, ops/state/truth/agents.json"
+      }
+    ],
+    "note": "Merge semantics are deliberately NOT here. policy.json#merge is a trusted input to a provenance-gated executable; widening it with review-process vocabulary would widen that trusted surface. A lifecycle that reaches MERGING hands off to the merge primitive and reimplements none of it."
+  },
+  "lifecycle": {
+    "states": [
+      {
+        "name": "IMPLEMENTING",
+        "means": "The acceptance contract is stated and the change is being built.",
+        "exits_to": [
+          "REVIEWING"
+        ]
+      },
+      {
+        "name": "REVIEWING",
+        "means": "The scheduled comprehensive review generation is open against the acceptance contract.",
+        "exits_to": [
+          "FIXING",
+          "VERIFYING"
+        ]
+      },
+      {
+        "name": "FIXING",
+        "means": "Known blockers from the closed generation are being corrected as one batch.",
+        "exits_to": [
+          "VERIFYING"
+        ]
+      },
+      {
+        "name": "VERIFYING",
+        "means": "Verification appropriate to the changed paths is running. After a blocker batch this is DELTA verification.",
+        "exits_to": [
+          "FROZEN",
+          "FIXING"
+        ]
+      },
+      {
+        "name": "FROZEN",
+        "means": "The acceptance contract is met, known blockers are resolved, verification is green, and the comprehensive review generation is CLOSED. An exact head is named.",
+        "exits_to": [
+          "MERGING",
+          "FIXING"
+        ],
+        "exit_to_fixing_requires": "a late finding that satisfies every blocker predicate condition"
+      },
+      {
+        "name": "MERGING",
+        "means": "Waiting only on live merge gates, then invoking the merge primitive.",
+        "exits_to": [
+          "DONE",
+          "FROZEN"
+        ]
+      },
+      {
+        "name": "DONE",
+        "means": "Merged, with any deferred observations recorded in the follow-up ledger.",
+        "exits_to": []
+      }
+    ],
+    "state_surface": {
+      "owner": "github-api",
+      "location": "the pull request body",
+      "begin_marker": "<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->",
+      "end_marker": "<!-- ICN-DELIVERY-LIFECYCLE:END -->",
+      "fields": [
+        "State",
+        "Lane",
+        "Acceptance contract",
+        "Review generation",
+        "Freeze head",
+        "Known blockers",
+        "Follow-up ledger"
+      ],
+      "not_owned_by": [
+        "repository files",
+        "handoffs",
+        "session summaries",
+        "model memory"
+      ],
+      "why": "Lifecycle state is volatile per-PR state. A repository file naming the current state of a PR is stale the moment another actor pushes, and AGENTS.md already forbids putting volatile facts in stable documents."
+    }
+  },
+  "review_generation": {
+    "definition": "One comprehensive (FULL) review of a bounded pull request against its acceptance contract.",
+    "comprehensive_review_is_bounded": true,
+    "generations_per_lane_source": "lanes",
+    "push_resets_generation": false,
+    "push_resets_generation_why": "If a push reopened discovery, a PR that fixes findings can never converge: fixing is the act that triggers the next unbounded search. The generation is a property of the review schedule, not of the commit graph.",
+    "blocker_fixes_are_batched": true,
+    "blocker_fixes_are_batched_why": "Handling known blockers together and verifying once beats push -> full re-review -> push -> full re-review, which multiplies rounds without improving the deliverable.",
+    "after_blocker_fix": "DELTA",
+    "review_kinds": {
+      "FULL": {
+        "may_inspect": "the bounded pull request against its acceptance contract and the invariants owned by AGENTS.md",
+        "when": "the scheduled comprehensive generation for the lane"
+      },
+      "DELTA": {
+        "may_inspect": "only the changes since the reviewed head, plus the consequences necessary to determine whether the known findings were actually fixed",
+        "may_not": "use a patch as permission to rediscover the whole pull request",
+        "when": "after a blocker-fix batch, and for any review of a FROZEN pull request"
+      }
+    },
+    "every_review_declares_its_kind": true
+  },
+  "finding_dispositions": [
+    {
+      "name": "BLOCKER",
+      "means": "Satisfies every condition in blocker_predicate.all_must_hold.",
+      "action": "Make the smallest local correction, add only directly necessary regression coverage, do not inspect sibling areas for more things to fix."
+    },
+    {
+      "name": "FOLLOW_UP",
+      "means": "Valid or potentially useful, but does not satisfy every blocker condition.",
+      "action": "Do not change the pull request for it. Append it to the follow-up ledger with a link back to the thread, reply saying it is valid but outside the delivery contract, link the ledger, and resolve the thread."
+    },
+    {
+      "name": "NOT_A_FINDING",
+      "means": "Incorrect, duplicate, already fixed, obsolete, or outside the pull request's contract.",
+      "action": "Reply briefly with the evidence and resolve the thread."
+    },
+    {
+      "name": "QUESTION",
+      "means": "Intent genuinely cannot be determined from the registered owners and implementation evidence.",
+      "action": "Ask. Do not guess, and do not treat the ambiguity as a blocker."
+    }
+  ],
+  "blocker_predicate": {
+    "all_must_hold": [
+      {
+        "id": "reproducible",
+        "condition": "It is concrete and reproducible.",
+        "why": "A finding that cannot be demonstrated cannot be verified as fixed either."
+      },
+      {
+        "id": "introduced_here",
+        "condition": "It is introduced by this pull request rather than merely adjacent or pre-existing.",
+        "why": "Adjacent debt is real work, but charging it to whichever PR happened to touch a nearby line makes delivery unbounded."
+      },
+      {
+        "id": "violates_stated_contract",
+        "condition": "It violates an explicit acceptance condition, an established repository invariant, or a behaviour this pull request claims to provide.",
+        "why": "This is what makes the deliverable wrong rather than merely improvable."
+      },
+      {
+        "id": "realistic_path",
+        "condition": "It occurs on a supported and realistic execution path relevant to the feature's intended operation, rather than existing only as generalised hardening speculation.",
+        "why": "Hypothetical inputs are an infinite set. A finding that requires an actor who already holds the capability being defended, or an upstream API to violate its own schema, describes a thought experiment rather than an operational failure."
+      },
+      {
+        "id": "materially_breaks_it",
+        "condition": "Leaving it unfixed would materially make the deliverable incorrect or unusable.",
+        "why": "A fail-closed abort on an impossible input is not the deliverable being unusable. This condition is what separates a defect from an improvement."
+      }
+    ],
+    "automated_severity_is_advisory": true,
+    "advisory_severity_labels": [
+      "P0",
+      "P1",
+      "P2",
+      "P3",
+      "critical",
+      "high",
+      "medium",
+      "low",
+      "blocking",
+      "must-fix"
+    ],
+    "severity_note": "A severity label assigned by an automated reviewer is evidence about that reviewer's confidence. It is not authority. No label alone satisfies the predicate, and no label alone breaks a freeze.",
+    "no_sibling_sweep": {
+      "rule": "A targeted fix or a DELTA review may not expand into a generalised search for similar problems elsewhere.",
+      "exception": "The maintainer explicitly reopens discovery.",
+      "why": "A sibling sweep converts one bounded fix into an unbounded audit inside a frozen PR."
+    },
+    "redesign_rule": {
+      "rule": "If a late observation would require a substantial design change to address, default to a follow-up issue and a maintainer decision rather than widening the frozen delivery scope.",
+      "why": "Architecture must not enter a frozen pull request by way of a review comment."
+    }
+  },
+  "freeze": {
+    "entry_conditions": [
+      "the stated acceptance contract is met",
+      "known blockers from the closed review generation are resolved",
+      "verification appropriate to the changed paths is green",
+      "the scheduled comprehensive review generation has closed"
+    ],
+    "names_an_exact_head": true,
+    "effect": [
+      "a new automated review comment does not reopen the pull request",
+      "review of a frozen pull request is DELTA, never FULL",
+      "a valid finding below the blocker threshold becomes follow-up work and its thread is resolved with a link"
+    ],
+    "late_finding_rule": "After freeze a finding breaks the freeze only when it satisfies every condition in blocker_predicate.all_must_hold.",
+    "refreeze": "On a qualifying late blocker: make one targeted correction, run targeted or delta verification, update the freeze head, and return immediately to FROZEN. Do not run another comprehensive review.",
+    "server_enforced_gates_still_apply": "Freeze is a repository workflow state, not a GitHub state. Server-side requirements such as conversation resolution still apply, so a frozen pull request may still need late threads dispositioned and resolved \u2014 dispositioning a thread is not reopening review."
+  },
+  "follow_up_ledger": {
+    "one_issue_per_pull_request": true,
+    "reuse_before_creating": true,
+    "entry_shape": "a checklist item stating the observation, why it was deferred, and the fix",
+    "provenance_link_required": true,
+    "why_not_one_issue_per_comment": "One issue per comment converts review noise into issue noise. A single ledger per pull request keeps the deferred set readable and closable.",
+    "not_a_mandate_to_re_audit": "A ledger records observations. Picking one up is a new bounded change with its own regression test, not permission to sweep the surrounding code."
+  },
+  "lanes": {
+    "default": "STANDARD",
+    "definitions": [
+      {
+        "name": "FAST",
+        "for": "tiny or low-risk changes",
+        "comprehensive_generations": 1,
+        "shape": "implement, focused verification, one bounded review, freeze"
+      },
+      {
+        "name": "STANDARD",
+        "for": "the default for substantive changes",
+        "comprehensive_generations": 1,
+        "shape": "one comprehensive review, one blocker-fix batch, one delta verification, freeze"
+      },
+      {
+        "name": "DEEP",
+        "for": "architecture, migration, or cross-cutting work",
+        "comprehensive_generations": 1,
+        "requires_maintainer_selection": true,
+        "shape": "multiple specialist reviews may be requested, but they are requested together as ONE planned generation rather than drip-fed after every push"
+      }
+    ]
+  },
+  "authority": {
+    "maintainer_only": [
+      "reopening a frozen pull request",
+      "requesting another comprehensive review generation",
+      "escalating a follow-up observation into a blocker",
+      "selecting the DEEP lane",
+      "reopening discovery for a sibling sweep"
+    ],
+    "agents_may_not": [
+      "silently reopen comprehensive review",
+      "treat an automated reviewer's severity label as authority",
+      "widen a frozen pull request's scope to accommodate a late observation",
+      "drop a valid observation instead of recording it in the ledger"
+    ],
+    "automated_reviewers_may_not": [
+      "break a freeze by assigning a severity label",
+      "convert a DELTA review into a FULL review"
+    ],
+    "mutation": {
+      "semantics_owner": "ops/state/truth/policy.json#merge",
+      "executable": "tools/icn-merge-pr",
+      "orchestrator": ".agents/skills/ship-pr/SKILL.md",
+      "primitive": ".agents/skills/merge-pr/SKILL.md",
+      "orchestrator_may_not_duplicate_primitive": true,
+      "why": "ship-pr decides WHEN a pull request is ready to be handed over. It never decides whether the merge is permitted, never evaluates merge requirements itself, and never issues a merge command. A second implementation of merge semantics is a second owner of them, and the copy is the one that rots."
+    }
+  },
+  "provider_bindings": {
+    "rule": "A provider reviewer surface adapts this lifecycle to a tool. It may not carry its own blocker, severity, or freeze semantics. Enforced by scripts/check-delivery-lifecycle.py.",
+    "body_mirrors": [
+      {
+        "canonical": ".claude/agents/icn-code-reviewer.md",
+        "mirror": ".github/agents/icn-code-reviewer.md",
+        "why": "Two reviewer prompts drifted into two independent definitions of what blocks a merge. Front matter differs because the providers differ; the body is one document with one owner, and the checker compares it byte for byte after the front matter."
+      }
+    ],
+    "surfaces": [
+      {
+        "path": ".claude/agents/icn-code-reviewer.md",
+        "role": "Claude provider reviewer adapter",
+        "must_reference": [
+          "ops/state/truth/delivery.json",
+          "BLOCKER",
+          "FOLLOW_UP",
+          "NOT_A_FINDING",
+          "QUESTION",
+          "FULL",
+          "DELTA"
+        ],
+        "must_not_match": [
+          {
+            "pattern": "(?i)^#+.*always\\s+flag",
+            "why": "an independent always-blocking list is a second owner of the blocker predicate"
+          },
+          {
+            "pattern": "(?i)\\b(blocking|blocker)\\b\\s*(issues|list)?\\s*:\\s*$",
+            "why": "declaring a local blocking category redefines what this file must load"
+          },
+          {
+            "pattern": "(?i)\\brequest_changes\\b",
+            "why": "a verdict vocabulary of its own competes with the canonical disposition set"
+          }
+        ]
+      },
+      {
+        "path": ".github/agents/icn-code-reviewer.md",
+        "role": "Copilot provider reviewer adapter",
+        "must_reference": [
+          "ops/state/truth/delivery.json",
+          "BLOCKER",
+          "FOLLOW_UP",
+          "NOT_A_FINDING",
+          "QUESTION",
+          "FULL",
+          "DELTA"
+        ],
+        "must_not_match": [
+          {
+            "pattern": "(?i)^#+.*always\\s+flag",
+            "why": "an independent always-blocking list is a second owner of the blocker predicate"
+          },
+          {
+            "pattern": "(?i)\\b(blocking|blocker)\\b\\s*(issues|list)?\\s*:\\s*$",
+            "why": "declaring a local blocking category redefines what this file must load"
+          },
+          {
+            "pattern": "(?i)\\brequest_changes\\b",
+            "why": "a verdict vocabulary of its own competes with the canonical disposition set"
+          }
+        ]
+      },
+      {
+        "path": ".github/copilot-instructions.md",
+        "role": "Copilot provider entry adapter",
+        "must_reference": [
+          "AGENTS.md",
+          "ops/state/truth/sources.json",
+          "ops/state/truth/delivery.json"
+        ],
+        "must_not_match": [
+          {
+            "pattern": "(?i)^#+\\s*current\\s+(status|working\\s+context)",
+            "why": "volatile project state in a provider entry file is stale by construction; AGENTS.md forbids it"
+          },
+          {
+            "pattern": "(?i)^#+\\s*(project\\s+overview|repository\\s+structure|architecture\\s+patterns)",
+            "why": "a second project handbook competes with the registered truth owners"
+          },
+          {
+            "pattern": "(?i)\\b(STATE|PHASE_PROGRESS)\\.md\\b.*canonical",
+            "why": "the retired canonical-state claim tracked by icn#2632"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/ops/state/truth/delivery.json
+++ b/ops/state/truth/delivery.json
@@ -186,8 +186,8 @@
       },
       {
         "id": "violates_stated_contract",
-        "condition": "It violates an explicit acceptance condition, an established repository invariant, or a behaviour this pull request claims to provide.",
-        "why": "This is what makes the deliverable wrong rather than merely improvable."
+        "condition": "It violates an explicit acceptance condition, an established repository invariant, or a behaviour this pull request claims to provide \u2014 or it regresses behaviour this pull request actually changes, whether or not the contract mentioned it.",
+        "why": "This is what makes the deliverable wrong rather than merely improvable. A regression counts even when the contract is silent about it: a pull request does not get to break what it touched by omitting it from the contract."
       },
       {
         "id": "realistic_path",
@@ -232,6 +232,7 @@
       "the scheduled comprehensive review generation has closed"
     ],
     "names_an_exact_head": true,
+    "head_must_match_before_handoff": "Before handing over to the merge primitive, the live head must equal the recorded freeze head. A freeze names an exact head because that is the head that was reviewed and verified; content pushed after the freeze has been through neither. On a mismatch, run DELTA verification on the new content, update the freeze head, return to FROZEN, and only then hand over. The merge executable pins the head it mutates, but it does not know which head was reviewed \u2014 nothing downstream will catch this.",
     "effect": [
       "a new automated review comment does not reopen the pull request",
       "review of a frozen pull request is DELTA, never FULL",

--- a/ops/state/truth/skills.json
+++ b/ops/state/truth/skills.json
@@ -360,7 +360,15 @@
             "path": ".claude/skills/pr-create/SKILL.md",
             "policy": "exact_mirror"
           }
-        ]
+        ],
+        "canonical_assertions": {
+          "rationale": "icn#2661: every substantive PR states its acceptance contract and delivery lane up front, because the blocker predicate and the FULL review scope are both measured against it.",
+          "must_reference": [
+            "ops/state/truth/delivery.json",
+            "Acceptance contract",
+            "Delivery lane"
+          ]
+        }
       },
       {
         "name": "preflight",
@@ -421,6 +429,56 @@
             "policy": "exact_mirror"
           }
         ]
+      },
+      {
+        "name": "ship-pr",
+        "canonical_path": ".agents/skills/ship-pr/SKILL.md",
+        "provider_mirrors": [
+          {
+            "path": ".claude/skills/ship-pr/SKILL.md",
+            "policy": "exact_mirror"
+          }
+        ],
+        "authority_note": "icn#2661. ship-pr is the delivery ORCHESTRATOR: it decides when a pull request is ready to hand over. merge-pr remains the narrow merge primitive and tools/icn-merge-pr remains the owner of mutation semantics. These assertions keep the two apart \u2014 an orchestrator that can merge on its own is a second merge owner, and lifecycle rules restated here would drift from ops/state/truth/delivery.json.",
+        "canonical_assertions": {
+          "rationale": "icn#2661: the delivery lifecycle is owned by ops/state/truth/delivery.json and merge semantics by tools/icn-merge-pr. This skill loads both and reimplements neither.",
+          "must_reference": [
+            "ops/state/truth/delivery.json",
+            "icn-merge-pr",
+            "ops/scripts/icn-wait",
+            "automated review is evidence, not unbounded veto authority"
+          ],
+          "must_not_match": [
+            {
+              "pattern": "icn-merge-pr\\s+merge",
+              "why": "the mutation form belongs to the merge-pr skill under explicit per-PR authorization; an orchestrator that can reach it directly has taken the authorization decision away from the maintainer"
+            },
+            {
+              "pattern": "gh\\s+pr\\s+merge",
+              "why": "a raw merge command here bypasses every gate the executable owns"
+            },
+            {
+              "pattern": "--admin\\b",
+              "why": "there is no privileged path in this workflow; admin-merge eligibility is a human decision owned by the ADR named in policy.json#merge.admin_bypass"
+            },
+            {
+              "pattern": "--auto\\b|--disable-auto\\b",
+              "why": "shipping completes or refuses; it never arms a merge to happen later"
+            },
+            {
+              "pattern": "branches/[^/\\s]+/protection",
+              "why": "readiness is decided by the merge executable, which reads protection for the branch it is actually merging into; reading it here is a second readiness owner"
+            },
+            {
+              "pattern": "\\bBuild Release\\b",
+              "why": "a literal required-check name is a snapshot of policy.json#merge.required_checks"
+            },
+            {
+              "pattern": "\\b(all\\s+)?\\d+\\s+required\\s+(CI\\s+)?checks\\b",
+              "why": "a required-check count rots the moment branch protection changes"
+            }
+          ]
+        }
       },
       {
         "name": "sync-docs",

--- a/ops/state/truth/sources.json
+++ b/ops/state/truth/sources.json
@@ -29,6 +29,13 @@
       "stability": "slow-changing",
       "description": "Required CI checks, merge strategy, readiness definition, admin bypass rules"
     },
+    "pr_delivery_lifecycle": {
+      "owner": "ops/state/truth/delivery.json",
+      "stability": "slow-changing",
+      "description": "Pull-request delivery lifecycle: states, review generations, FULL vs DELTA review, the blocker predicate, freeze and refreeze, the follow-up ledger, delivery lanes, and which lifecycle decisions are maintainer-only",
+      "not_owned_here": "Merge requirements and merge-mutation semantics stay with merge_policy (ops/state/truth/policy.json#merge) and its executable, tools/icn-merge-pr",
+      "checker": "scripts/check-delivery-lifecycle.py"
+    },
     "agent_operating_contract": {
       "owner": "AGENTS.md",
       "sections": [
@@ -169,6 +176,7 @@
     "Do NOT duplicate registered domain semantics inside specialist/provider prompts \u2014 load the owner at runtime",
     "Do NOT use icn-ops/state paths \u2014 canonical is ops/state/ (inside monorepo)",
     "Do NOT use icn-website/ paths \u2014 canonical is website/ (inside monorepo)",
-    "Do NOT reference sync-from-icn.sh \u2014 the website reads docs directly"
+    "Do NOT reference sync-from-icn.sh \u2014 the website reads docs directly",
+    "Do NOT let a provider reviewer prompt define its own blocker, severity, or freeze semantics \u2014 those are owned by ops/state/truth/delivery.json and enforced by scripts/check-delivery-lifecycle.py"
   ]
 }

--- a/scripts/check-delivery-lifecycle.py
+++ b/scripts/check-delivery-lifecycle.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""check-delivery-lifecycle.py — validate the PR delivery lifecycle owner (icn#2661).
+
+`ops/state/truth/delivery.json` is the registered owner of the pull-request delivery lifecycle:
+when comprehensive review ends, what freezes, and how a late finding is classified. This validates
+its shape and values, and enforces that provider reviewer surfaces bind to it instead of carrying
+their own blocker, severity, or freeze semantics.
+
+CONTRACT
+    validate(value) -> list[str]
+
+TOTAL over any JSON-shaped input, for the same reason the merge-policy validator is: a validator
+that raises on a malformed document reports nothing, and nothing reads as clean. Every type is
+established before the value is used.
+
+JSON TYPES MEAN JSON TYPES
+`isinstance(False, int)` is True in Python, so JSON `false` would satisfy an integer check. Counts
+use `type(v) is int`; the invariant switches below require real booleans, because `1` and `"yes"`
+must not be able to stand in for `true` on a field whose whole job is to be un-flippable.
+
+WHY THE PREDICATE LIVES IN CODE
+`BLOCKER_CONDITIONS` is hardcoded here and never read from the document under validation. The
+blocker predicate is the load-bearing part of the freeze: if the conditions were data, a PR could
+weaken its own freeze by deleting a condition from a JSON file, and the diff would look like a
+policy edit rather than what it is. The same reasoning covers the state set, the disposition
+vocabulary, the review kinds and the lane names. A closed set owned by code cannot be widened,
+narrowed, or renamed by data.
+
+THE INVARIANT SWITCHES
+Four fields are pinned to one value each, because each of them is a way the treadmill comes back:
+
+    review_generation.push_resets_generation           must be false
+    review_generation.after_blocker_fix                must be "DELTA"
+    blocker_predicate.automated_severity_is_advisory   must be true
+    authority.mutation.orchestrator_may_not_duplicate_primitive   must be true
+
+They are not defaults. A document that sets any of them the other way is rejected, so relaxing one
+requires editing this file — which is a reviewable act rather than a data tweak.
+
+PROSE IS CHECKED ONLY BY ABSENCE
+Facts that must mechanically agree are compared as values. Provider surfaces are checked for
+required references (substring, no grammar to get wrong) and forbidden patterns. Nothing here
+parses English.
+
+Run: python3 scripts/check-delivery-lifecycle.py [--verbose]
+"""
+
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DELIVERY = ROOT / "ops" / "state" / "truth" / "delivery.json"
+SOURCES = ROOT / "ops" / "state" / "truth" / "sources.json"
+
+# --- pinned vocabularies. Owned HERE, never read from the document under validation. -----------
+STATES = ("IMPLEMENTING", "REVIEWING", "FIXING", "VERIFYING", "FROZEN", "MERGING", "DONE")
+TERMINAL_STATE = "DONE"
+ENTRY_STATE = "IMPLEMENTING"
+DISPOSITIONS = ("BLOCKER", "FOLLOW_UP", "QUESTION", "NOT_A_FINDING")
+REVIEW_KINDS = ("FULL", "DELTA")
+LANES = ("FAST", "STANDARD", "DEEP")
+BLOCKER_CONDITIONS = ("reproducible", "introduced_here", "violates_stated_contract",
+                      "realistic_path", "materially_breaks_it")
+
+# The merge side of the boundary. Named here so the lifecycle owner cannot quietly claim it.
+MERGE_SEMANTICS_OWNER = "ops/state/truth/policy.json#merge"
+MERGE_EXECUTABLE = "tools/icn-merge-pr"
+
+# A flag- or command-shaped string anywhere under `authority.mutation` would be executable
+# authority as data: the one place this document hands work to a program is the one place a
+# spelled command could be picked up and run.
+COMMAND_SHAPED = re.compile(r"(^|\s)(gh|git|python3?)\s|(^|\s)--[a-z]")
+
+
+def _str(value) -> bool:
+    return isinstance(value, str) and value.strip() != ""
+
+
+def _obj(value) -> bool:
+    return isinstance(value, dict)
+
+
+def _list(value) -> bool:
+    return isinstance(value, list)
+
+
+def _true(value) -> bool:
+    return value is True
+
+
+def _strs(value) -> bool:
+    return _list(value) and value != [] and all(_str(v) for v in value)
+
+
+def _check_lifecycle(doc, out) -> None:
+    life = doc.get("lifecycle")
+    if not _obj(life):
+        out.append("lifecycle: missing or not an object")
+        return
+    states = life.get("states")
+    if not _list(states):
+        out.append("lifecycle.states: missing or not an array")
+        return
+    seen = []
+    graph = {}
+    for i, s in enumerate(states):
+        if not _obj(s):
+            out.append(f"lifecycle.states[{i}]: not an object")
+            continue
+        name = s.get("name")
+        if not _str(name) or name not in STATES:
+            out.append(f"lifecycle.states[{i}].name: {name!r} is not one of {list(STATES)}")
+            continue
+        if name in seen:
+            out.append(f"lifecycle.states[{i}].name: {name!r} declared twice")
+            continue
+        seen.append(name)
+        if not _str(s.get("means")):
+            out.append(f"lifecycle.states[{i}] ({name}): means must be a non-empty string")
+        exits = s.get("exits_to")
+        if not _list(exits) or not all(_str(e) for e in exits):
+            out.append(f"lifecycle.states[{i}] ({name}): exits_to must be an array of strings")
+            continue
+        unknown = [e for e in exits if e not in STATES]
+        if unknown:
+            out.append(f"lifecycle.states[{i}] ({name}): exits_to names unknown states {unknown}")
+        graph[name] = [e for e in exits if e in STATES]
+
+    missing = [s for s in STATES if s not in seen]
+    if missing:
+        out.append(f"lifecycle.states: the lifecycle must define every state; missing {missing}")
+    if seen and seen != [s for s in STATES if s in seen]:
+        out.append(f"lifecycle.states: declared out of lifecycle order: {seen}")
+
+    if graph.get(TERMINAL_STATE):
+        out.append(f"lifecycle.states: {TERMINAL_STATE} must be terminal, "
+                   f"but exits to {graph[TERMINAL_STATE]}")
+
+    # Reachability. A lifecycle with an unreachable state, or with no path to DONE, describes a
+    # process that cannot finish — which is the exact failure this owner exists to prevent.
+    if not missing:
+        reached, frontier = {ENTRY_STATE}, [ENTRY_STATE]
+        while frontier:
+            for nxt in graph.get(frontier.pop(), []):
+                if nxt not in reached:
+                    reached.add(nxt)
+                    frontier.append(nxt)
+        unreachable = [s for s in STATES if s not in reached]
+        if unreachable:
+            out.append(f"lifecycle.states: unreachable from {ENTRY_STATE}: {unreachable}")
+        if TERMINAL_STATE not in reached:
+            out.append(f"lifecycle.states: {TERMINAL_STATE} is not reachable from {ENTRY_STATE}; "
+                       f"a lifecycle with no path to completion cannot converge")
+        frozen_exits = graph.get("FROZEN", [])
+        if "FIXING" in frozen_exits:
+            for s in states:
+                if _obj(s) and s.get("name") == "FROZEN" and not _str(
+                        s.get("exit_to_fixing_requires")):
+                    out.append("lifecycle.states (FROZEN): exits to FIXING without stating "
+                               "exit_to_fixing_requires; an unconditional way out of a freeze is "
+                               "not a freeze")
+
+    surface = life.get("state_surface")
+    if not _obj(surface):
+        out.append("lifecycle.state_surface: missing or not an object")
+        return
+    if surface.get("owner") != "github-api":
+        out.append(f"lifecycle.state_surface.owner: must be 'github-api', got "
+                   f"{surface.get('owner')!r} — lifecycle state is volatile per-PR state")
+    for marker in ("begin_marker", "end_marker"):
+        if not _str(surface.get(marker)):
+            out.append(f"lifecycle.state_surface.{marker}: must be a non-empty string")
+    if not _strs(surface.get("fields")):
+        out.append("lifecycle.state_surface.fields: must be a non-empty array of strings")
+    not_owned = surface.get("not_owned_by")
+    if not _strs(not_owned):
+        out.append("lifecycle.state_surface.not_owned_by: must be a non-empty array of strings")
+    elif "repository files" not in not_owned:
+        out.append("lifecycle.state_surface.not_owned_by: must exclude 'repository files' — a "
+                   "checked-in file naming a PR's current state is stale by construction")
+
+
+def _check_review_generation(doc, out) -> None:
+    rg = doc.get("review_generation")
+    if not _obj(rg):
+        out.append("review_generation: missing or not an object")
+        return
+    if not _true(rg.get("comprehensive_review_is_bounded")):
+        out.append("review_generation.comprehensive_review_is_bounded: must be true")
+    if rg.get("push_resets_generation") is not False:
+        out.append("review_generation.push_resets_generation: must be false — if a push reopened "
+                   "discovery, fixing findings would be the act that triggers the next unbounded "
+                   "search, and no PR that fixes anything could converge")
+    if not _str(rg.get("push_resets_generation_why")):
+        out.append("review_generation.push_resets_generation_why: must state the reason")
+    if not _true(rg.get("blocker_fixes_are_batched")):
+        out.append("review_generation.blocker_fixes_are_batched: must be true")
+    if rg.get("after_blocker_fix") != "DELTA":
+        out.append(f"review_generation.after_blocker_fix: must be 'DELTA', got "
+                   f"{rg.get('after_blocker_fix')!r} — re-running FULL review after a fix is the "
+                   f"treadmill")
+    if not _true(rg.get("every_review_declares_its_kind")):
+        out.append("review_generation.every_review_declares_its_kind: must be true")
+
+    kinds = rg.get("review_kinds")
+    if not _obj(kinds):
+        out.append("review_generation.review_kinds: missing or not an object")
+        return
+    if sorted(kinds) != sorted(REVIEW_KINDS):
+        out.append(f"review_generation.review_kinds: must define exactly {list(REVIEW_KINDS)}, "
+                   f"got {sorted(kinds)}")
+        return
+    for kind in REVIEW_KINDS:
+        spec = kinds[kind]
+        if not _obj(spec):
+            out.append(f"review_generation.review_kinds.{kind}: not an object")
+            continue
+        for field in ("may_inspect", "when"):
+            if not _str(spec.get(field)):
+                out.append(f"review_generation.review_kinds.{kind}.{field}: "
+                           f"must be a non-empty string")
+    delta = kinds["DELTA"]
+    if _obj(delta) and not _str(delta.get("may_not")):
+        out.append("review_generation.review_kinds.DELTA.may_not: must state what a DELTA review "
+                   "may not do, or DELTA is FULL review with a different label")
+
+
+def _check_dispositions(doc, out) -> None:
+    ds = doc.get("finding_dispositions")
+    if not _list(ds):
+        out.append("finding_dispositions: missing or not an array")
+        return
+    names = []
+    for i, d in enumerate(ds):
+        if not _obj(d):
+            out.append(f"finding_dispositions[{i}]: not an object")
+            continue
+        name = d.get("name")
+        if not _str(name) or name not in DISPOSITIONS:
+            out.append(f"finding_dispositions[{i}].name: {name!r} is not one of "
+                       f"{list(DISPOSITIONS)}")
+            continue
+        names.append(name)
+        for field in ("means", "action"):
+            if not _str(d.get(field)):
+                out.append(f"finding_dispositions[{i}] ({name}).{field}: "
+                           f"must be a non-empty string")
+    missing = [d for d in DISPOSITIONS if d not in names]
+    if missing:
+        out.append(f"finding_dispositions: every disposition must be defined; missing {missing}")
+
+
+def _check_blocker_predicate(doc, out) -> None:
+    bp = doc.get("blocker_predicate")
+    if not _obj(bp):
+        out.append("blocker_predicate: missing or not an object")
+        return
+    conds = bp.get("all_must_hold")
+    if not _list(conds):
+        out.append("blocker_predicate.all_must_hold: missing or not an array")
+    else:
+        ids = []
+        for i, c in enumerate(conds):
+            if not _obj(c):
+                out.append(f"blocker_predicate.all_must_hold[{i}]: not an object")
+                continue
+            cid = c.get("id")
+            if not _str(cid) or cid not in BLOCKER_CONDITIONS:
+                out.append(f"blocker_predicate.all_must_hold[{i}].id: {cid!r} is not one of "
+                           f"{list(BLOCKER_CONDITIONS)}")
+                continue
+            if cid in ids:
+                out.append(f"blocker_predicate.all_must_hold[{i}].id: {cid!r} declared twice")
+                continue
+            ids.append(cid)
+            for field in ("condition", "why"):
+                if not _str(c.get(field)):
+                    out.append(f"blocker_predicate.all_must_hold[{i}] ({cid}).{field}: "
+                               f"must be a non-empty string")
+        missing = [c for c in BLOCKER_CONDITIONS if c not in ids]
+        if missing:
+            out.append(f"blocker_predicate.all_must_hold: the predicate is fixed by code; "
+                       f"missing conditions {missing}. Dropping a condition weakens every freeze "
+                       f"in the repository and must be a reviewed code change, not a data edit")
+
+    if not _true(bp.get("automated_severity_is_advisory")):
+        out.append("blocker_predicate.automated_severity_is_advisory: must be true — otherwise a "
+                   "reviewer's own label becomes authority over the maintainer's freeze")
+    if not _strs(bp.get("advisory_severity_labels")):
+        out.append("blocker_predicate.advisory_severity_labels: must be a non-empty array of "
+                   "the labels that carry no authority")
+    if not _str(bp.get("severity_note")):
+        out.append("blocker_predicate.severity_note: must be a non-empty string")
+
+    sweep = bp.get("no_sibling_sweep")
+    if not _obj(sweep):
+        out.append("blocker_predicate.no_sibling_sweep: missing or not an object")
+    else:
+        for field in ("rule", "exception", "why"):
+            if not _str(sweep.get(field)):
+                out.append(f"blocker_predicate.no_sibling_sweep.{field}: "
+                           f"must be a non-empty string")
+    redesign = bp.get("redesign_rule")
+    if not _obj(redesign):
+        out.append("blocker_predicate.redesign_rule: missing or not an object")
+    else:
+        for field in ("rule", "why"):
+            if not _str(redesign.get(field)):
+                out.append(f"blocker_predicate.redesign_rule.{field}: must be a non-empty string")
+
+
+def _check_freeze(doc, out) -> None:
+    fz = doc.get("freeze")
+    if not _obj(fz):
+        out.append("freeze: missing or not an object")
+        return
+    if not _strs(fz.get("entry_conditions")):
+        out.append("freeze.entry_conditions: must be a non-empty array of strings")
+    if not _true(fz.get("names_an_exact_head")):
+        out.append("freeze.names_an_exact_head: must be true — a freeze that does not name a head "
+                   "freezes nothing")
+    if not _strs(fz.get("effect")):
+        out.append("freeze.effect: must be a non-empty array of strings")
+    for field in ("late_finding_rule", "refreeze", "server_enforced_gates_still_apply"):
+        if not _str(fz.get(field)):
+            out.append(f"freeze.{field}: must be a non-empty string")
+
+
+def _check_ledger(doc, out) -> None:
+    fl = doc.get("follow_up_ledger")
+    if not _obj(fl):
+        out.append("follow_up_ledger: missing or not an object")
+        return
+    if not _true(fl.get("one_issue_per_pull_request")):
+        out.append("follow_up_ledger.one_issue_per_pull_request: must be true — one issue per "
+                   "comment converts review noise into issue noise")
+    if not _true(fl.get("reuse_before_creating")):
+        out.append("follow_up_ledger.reuse_before_creating: must be true")
+    if not _true(fl.get("provenance_link_required")):
+        out.append("follow_up_ledger.provenance_link_required: must be true — a deferred "
+                   "observation without a link back to its thread loses the evidence for it")
+    for field in ("entry_shape", "why_not_one_issue_per_comment", "not_a_mandate_to_re_audit"):
+        if not _str(fl.get(field)):
+            out.append(f"follow_up_ledger.{field}: must be a non-empty string")
+
+
+def _check_lanes(doc, out) -> None:
+    lanes = doc.get("lanes")
+    if not _obj(lanes):
+        out.append("lanes: missing or not an object")
+        return
+    if lanes.get("default") not in LANES:
+        out.append(f"lanes.default: {lanes.get('default')!r} is not one of {list(LANES)}")
+    defs = lanes.get("definitions")
+    if not _list(defs):
+        out.append("lanes.definitions: missing or not an array")
+        return
+    names = []
+    for i, lane in enumerate(defs):
+        if not _obj(lane):
+            out.append(f"lanes.definitions[{i}]: not an object")
+            continue
+        name = lane.get("name")
+        if not _str(name) or name not in LANES:
+            out.append(f"lanes.definitions[{i}].name: {name!r} is not one of {list(LANES)}")
+            continue
+        names.append(name)
+        for field in ("for", "shape"):
+            if not _str(lane.get(field)):
+                out.append(f"lanes.definitions[{i}] ({name}).{field}: must be a non-empty string")
+        gens = lane.get("comprehensive_generations")
+        if type(gens) is not int or gens != 1:
+            out.append(f"lanes.definitions[{i}] ({name}).comprehensive_generations: must be the "
+                       f"integer 1, got {gens!r} — a lane that schedules more than one "
+                       f"comprehensive generation is the treadmill with a name")
+        if name == "DEEP" and not _true(lane.get("requires_maintainer_selection")):
+            out.append("lanes.definitions (DEEP).requires_maintainer_selection: must be true — "
+                       "DEEP is the expensive lane and an agent may not select it")
+    missing = [x for x in LANES if x not in names]
+    if missing:
+        out.append(f"lanes.definitions: every lane must be defined; missing {missing}")
+
+
+def _check_authority(doc, out) -> None:
+    au = doc.get("authority")
+    if not _obj(au):
+        out.append("authority: missing or not an object")
+        return
+    for field in ("maintainer_only", "agents_may_not", "automated_reviewers_may_not"):
+        if not _strs(au.get(field)):
+            out.append(f"authority.{field}: must be a non-empty array of strings")
+    mut = au.get("mutation")
+    if not _obj(mut):
+        out.append("authority.mutation: missing or not an object")
+        return
+    if mut.get("semantics_owner") != MERGE_SEMANTICS_OWNER:
+        out.append(f"authority.mutation.semantics_owner: must be {MERGE_SEMANTICS_OWNER!r}, got "
+                   f"{mut.get('semantics_owner')!r} — this file does not own merge semantics")
+    if mut.get("executable") != MERGE_EXECUTABLE:
+        out.append(f"authority.mutation.executable: must be {MERGE_EXECUTABLE!r}, got "
+                   f"{mut.get('executable')!r}")
+    for field in ("orchestrator", "primitive"):
+        if not _str(mut.get(field)):
+            out.append(f"authority.mutation.{field}: must name a path")
+    if not _true(mut.get("orchestrator_may_not_duplicate_primitive")):
+        out.append("authority.mutation.orchestrator_may_not_duplicate_primitive: must be true — a "
+                   "second implementation of merge semantics is a second owner of them, and the "
+                   "copy is the one that rots")
+    if not _str(mut.get("why")):
+        out.append("authority.mutation.why: must be a non-empty string")
+    for key, value in mut.items():
+        if _str(value) and COMMAND_SHAPED.search(value) and key != "why":
+            out.append(f"authority.mutation.{key}: holds a command- or flag-shaped string "
+                       f"({value!r}). Intent is declared symbolically; only code maps it to a "
+                       f"command")
+
+
+def _check_boundary(doc, out) -> None:
+    ob = doc.get("owner_boundary")
+    if not _obj(ob):
+        out.append("owner_boundary: missing or not an object")
+        return
+    if not _strs(ob.get("owns")):
+        out.append("owner_boundary.owns: must be a non-empty array of strings")
+    dno = ob.get("does_not_own")
+    if not _list(dno) or dno == []:
+        out.append("owner_boundary.does_not_own: must be a non-empty array")
+        return
+    owners = []
+    for i, entry in enumerate(dno):
+        if not _obj(entry):
+            out.append(f"owner_boundary.does_not_own[{i}]: not an object")
+            continue
+        for field in ("fact", "owner"):
+            if not _str(entry.get(field)):
+                out.append(f"owner_boundary.does_not_own[{i}].{field}: must be a non-empty string")
+        if _str(entry.get("owner")):
+            owners.append(entry["owner"])
+    if not any(MERGE_SEMANTICS_OWNER in o for o in owners):
+        out.append(f"owner_boundary.does_not_own: must disclaim {MERGE_SEMANTICS_OWNER} "
+                   f"explicitly, so this document can never grow into a second merge owner")
+
+
+def validate(value) -> list[str]:
+    """Every structural complaint about `value`. Total: never raises on malformed input."""
+    out: list[str] = []
+    if not _obj(value):
+        return ["delivery.json: the document is not a JSON object"]
+    if value.get("schema") != "icn.delivery-lifecycle.v1":
+        out.append(f"schema: must be 'icn.delivery-lifecycle.v1', got {value.get('schema')!r}")
+    for field in ("description", "principle", "why_this_exists"):
+        if not _str(value.get(field)):
+            out.append(f"{field}: must be a non-empty string")
+    _check_boundary(value, out)
+    _check_lifecycle(value, out)
+    _check_review_generation(value, out)
+    _check_dispositions(value, out)
+    _check_blocker_predicate(value, out)
+    _check_freeze(value, out)
+    _check_ledger(value, out)
+    _check_lanes(value, out)
+    _check_authority(value, out)
+    _check_provider_bindings(value, out)
+    return out
+
+
+def _check_provider_bindings(doc, out) -> None:
+    pb = doc.get("provider_bindings")
+    if not _obj(pb):
+        out.append("provider_bindings: missing or not an object")
+        return
+    if not _str(pb.get("rule")):
+        out.append("provider_bindings.rule: must be a non-empty string")
+    mirrors = pb.get("body_mirrors")
+    if not _list(mirrors) or mirrors == []:
+        out.append("provider_bindings.body_mirrors: must be a non-empty array")
+    else:
+        for i, m in enumerate(mirrors):
+            if not _obj(m):
+                out.append(f"provider_bindings.body_mirrors[{i}]: not an object")
+                continue
+            for field in ("canonical", "mirror", "why"):
+                if not _str(m.get(field)):
+                    out.append(f"provider_bindings.body_mirrors[{i}].{field}: "
+                               f"must be a non-empty string")
+    surfaces = pb.get("surfaces")
+    if not _list(surfaces) or surfaces == []:
+        out.append("provider_bindings.surfaces: must be a non-empty array")
+        return
+    for i, s in enumerate(surfaces):
+        if not _obj(s):
+            out.append(f"provider_bindings.surfaces[{i}]: not an object")
+            continue
+        for field in ("path", "role"):
+            if not _str(s.get(field)):
+                out.append(f"provider_bindings.surfaces[{i}].{field}: must be a non-empty string")
+        if not _strs(s.get("must_reference")):
+            out.append(f"provider_bindings.surfaces[{i}].must_reference: must be a non-empty "
+                       f"array of strings")
+        rules = s.get("must_not_match")
+        if not _list(rules) or rules == []:
+            out.append(f"provider_bindings.surfaces[{i}].must_not_match: must be a non-empty "
+                       f"array")
+            continue
+        for j, rule in enumerate(rules):
+            if not _obj(rule) or not _str(rule.get("pattern")) or not _str(rule.get("why")):
+                out.append(f"provider_bindings.surfaces[{i}].must_not_match[{j}]: needs a "
+                           f"non-empty pattern and why")
+                continue
+            try:
+                re.compile(rule["pattern"])
+            except re.error as exc:
+                out.append(f"provider_bindings.surfaces[{i}].must_not_match[{j}].pattern: "
+                           f"not a valid regular expression ({exc})")
+
+
+# --- enforcement against the repository, not just the document --------------------------------
+
+def enforce_surfaces(doc, root: pathlib.Path, verbose: bool) -> list[str]:
+    """Every provider surface named by the owner actually binds to it."""
+    out: list[str] = []
+    pb = doc.get("provider_bindings")
+    if not _obj(pb) or not _list(pb.get("surfaces")):
+        return out
+    for s in pb["surfaces"]:
+        if not _obj(s) or not _str(s.get("path")):
+            continue
+        path = root / s["path"]
+        if not path.is_file():
+            out.append(f"{s['path']}: named as a provider binding but the file does not exist")
+            continue
+        text = path.read_text(encoding="utf-8")
+        for ref in s.get("must_reference", []):
+            if not _str(ref):
+                continue
+            if ref not in text:
+                out.append(f"{s['path']}: must reference {ref!r} — a provider reviewer surface "
+                           f"that does not name the canonical lifecycle has become a second "
+                           f"owner of it")
+            elif verbose:
+                print(f"  ok   {s['path']}: references {ref!r}")
+        for rule in s.get("must_not_match", []):
+            if not _obj(rule) or not _str(rule.get("pattern")):
+                continue
+            try:
+                rx = re.compile(rule["pattern"], re.M)
+            except re.error:
+                continue
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if rx.search(line):
+                    out.append(f"{s['path']}:{lineno}: matched forbidden pattern "
+                               f"{rule['pattern']!r}. {rule.get('why', '')}\n"
+                               f"            {line.strip()}")
+    return out
+
+
+FRONT_MATTER = re.compile(r"\A---\n.*?\n---\n", re.S)
+
+
+def _body(path: pathlib.Path) -> str:
+    """A provider prompt's body: everything after its YAML front matter."""
+    text = path.read_text(encoding="utf-8")
+    match = FRONT_MATTER.match(text)
+    return text[match.end():] if match else text
+
+
+def enforce_body_mirrors(doc, root: pathlib.Path, verbose: bool) -> list[str]:
+    """Two provider prompts, one document. Front matter may differ; the body may not.
+
+    This is the mechanical form of "do not maintain two independent copies of blocker semantics".
+    Reference and pattern assertions catch a surface that stops naming the owner; only comparison
+    catches the two of them slowly saying different things while both still name it.
+    """
+    out: list[str] = []
+    pb = doc.get("provider_bindings")
+    if not _obj(pb) or not _list(pb.get("body_mirrors")):
+        return out
+    for m in pb["body_mirrors"]:
+        if not _obj(m) or not _str(m.get("canonical")) or not _str(m.get("mirror")):
+            continue
+        canonical, mirror = root / m["canonical"], root / m["mirror"]
+        missing = [str(x) for x in (canonical, mirror) if not x.is_file()]
+        if missing:
+            out.append(f"{m['mirror']}: declared a body mirror, but {missing} does not exist")
+            continue
+        if _body(canonical) != _body(mirror):
+            out.append(f"{m['mirror']}: body differs from its canonical source "
+                       f"{m['canonical']}. {m.get('why', '')}")
+        elif verbose:
+            print(f"  ok   {m['mirror']}: body identical to {m['canonical']}")
+    return out
+
+
+def enforce_registration(doc, root: pathlib.Path) -> list[str]:
+    """The owner is registered in the truth map, and every path it names exists."""
+    out: list[str] = []
+    try:
+        sources = json.loads((root / "ops" / "state" / "truth" / "sources.json")
+                             .read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return [f"sources.json: unreadable ({exc})"]
+    domains = sources.get("domains") if _obj(sources) else None
+    entry = domains.get("pr_delivery_lifecycle") if _obj(domains) else None
+    if not _obj(entry):
+        return ["sources.json: domain 'pr_delivery_lifecycle' is not registered; an owner the "
+                "truth map does not name cannot be resolved by a fresh session"]
+    if entry.get("owner") != "ops/state/truth/delivery.json":
+        out.append(f"sources.json#domains.pr_delivery_lifecycle.owner: must be "
+                   f"'ops/state/truth/delivery.json', got {entry.get('owner')!r}")
+    if entry.get("checker") != "scripts/check-delivery-lifecycle.py":
+        out.append("sources.json#domains.pr_delivery_lifecycle.checker: must name this script")
+
+    mut = doc.get("authority", {}).get("mutation") if _obj(doc.get("authority")) else None
+    if _obj(mut):
+        for field in ("orchestrator", "primitive", "executable"):
+            named = mut.get(field)
+            if _str(named) and not (root / named).exists():
+                out.append(f"authority.mutation.{field}: names {named!r}, which does not exist")
+    return out
+
+
+def main() -> int:
+    verbose = "--verbose" in sys.argv[1:]
+    try:
+        doc = json.loads(DELIVERY.read_text(encoding="utf-8"))
+    except OSError as exc:
+        print(f"check-delivery-lifecycle: FAIL\n  - {DELIVERY} is unreadable: {exc}")
+        return 1
+    except ValueError as exc:
+        print(f"check-delivery-lifecycle: FAIL\n  - {DELIVERY} is not valid JSON: {exc}")
+        return 1
+
+    problems = validate(doc)
+    problems += enforce_registration(doc, ROOT)
+    problems += enforce_surfaces(doc, ROOT, verbose)
+    problems += enforce_body_mirrors(doc, ROOT, verbose)
+
+    if problems:
+        print("check-delivery-lifecycle: FAIL")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print(f"check-delivery-lifecycle: OK — {len(STATES)} lifecycle states, "
+          f"{len(BLOCKER_CONDITIONS)} blocker conditions, "
+          f"{len(doc['provider_bindings']['surfaces'])} provider surfaces bound")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-delivery-lifecycle.py
+++ b/scripts/check-delivery-lifecycle.py
@@ -28,6 +28,13 @@ tweak rather than what it is. The same reasoning covers the state set, the dispo
 the review kinds and the lane names. A closed set owned by code cannot be widened, narrowed,
 renamed, or redefined by data.
 
+THE FLOORS
+`RESOLVE_WHEN`, `PROVIDER_FLOOR` and `BODY_MIRROR_FLOOR` work the same way as the predicate: the
+document may bind MORE than they require, never less. They exist because the binding inventory was
+self-describing — three entries pointing at one prompt, `must_reference` cut to a single string and
+every pattern replaced with one that cannot match, all passed, while the Copilot adapters were
+detached. An enforcement list that the enforced party can shorten is not enforcement.
+
 THE INVARIANT SWITCHES
 Four fields are pinned to one value each, because each of them is a way the treadmill comes back:
 
@@ -83,6 +90,37 @@ BLOCKER_CONDITIONS = {
     "materially_breaks_it":
         "Leaving it unfixed would materially make the deliverable incorrect or unusable.",
 }
+
+# When a thread may be resolved, per disposition. Pinned because the merge owner counts
+# unresolved threads: an instruction to resolve a QUESTION on asking it would let an agent
+# manufacture merge readiness out of a question nobody answered.
+RESOLVE_WHEN = {
+    "BLOCKER": "after_the_fix_is_verified",
+    "FOLLOW_UP": "after_the_ledger_entry_exists",
+    "NOT_A_FINDING": "after_the_reply",
+    "QUESTION": "after_it_is_answered_and_reclassified",
+}
+
+# The provider-binding FLOOR. The document may bind more than this; it may not bind less.
+# Without it the inventory was self-describing: three entries all pointing at one prompt, with
+# `must_reference` cut to a single string and every pattern replaced by one that cannot match,
+# passed every check while the Copilot adapters were detached entirely.
+_REVIEWER_REFS = ("ops/state/truth/delivery.json", "BLOCKER", "FOLLOW_UP", "NOT_A_FINDING",
+                  "QUESTION", "FULL", "DELTA")
+_REVIEWER_PATTERNS = (r"(?i)^#+.*always\s+flag",
+                      r"(?i)\b(blocking|blocker)\b\s*(issues|list)?\s*:\s*$",
+                      r"(?i)\brequest_changes\b")
+PROVIDER_FLOOR = {
+    ".claude/agents/icn-code-reviewer.md": (_REVIEWER_REFS, _REVIEWER_PATTERNS),
+    ".github/agents/icn-code-reviewer.md": (_REVIEWER_REFS, _REVIEWER_PATTERNS),
+    ".github/copilot-instructions.md": (
+        ("AGENTS.md", "ops/state/truth/sources.json", "ops/state/truth/delivery.json"),
+        (r"(?i)^#+\s*current\s+(status|working\s+context)",
+         r"(?i)^#+\s*(project\s+overview|repository\s+structure|architecture\s+patterns)",
+         r"(?i)\b(STATE|PHASE_PROGRESS)\.md\b.*canonical")),
+}
+BODY_MIRROR_FLOOR = ((".claude/agents/icn-code-reviewer.md",
+                      ".github/agents/icn-code-reviewer.md"),)
 
 # The merge side of the boundary. Named here so the lifecycle owner cannot quietly claim it.
 MERGE_SEMANTICS_OWNER = "ops/state/truth/policy.json#merge"
@@ -271,6 +309,11 @@ def _check_dispositions(doc, out) -> None:
             if not _str(d.get(field)):
                 out.append(f"finding_dispositions[{i}] ({name}).{field}: "
                            f"must be a non-empty string")
+        if d.get("resolve_thread") != RESOLVE_WHEN[name]:
+            out.append(f"finding_dispositions[{i}] ({name}).resolve_thread: must be "
+                       f"{RESOLVE_WHEN[name]!r}, got {d.get('resolve_thread')!r}. When a thread "
+                       f"may be resolved is owned by code, because merge readiness counts "
+                       f"unresolved threads")
     missing = [d for d in DISPOSITIONS if d not in names]
     if missing:
         out.append(f"finding_dispositions: every disposition must be defined; missing {missing}")
@@ -515,10 +558,24 @@ def _check_provider_bindings(doc, out) -> None:
                 if not _str(m.get(field)):
                     out.append(f"provider_bindings.body_mirrors[{i}].{field}: "
                                f"must be a non-empty string")
+    declared_mirrors = [(m.get("canonical"), m.get("mirror")) for m in mirrors
+                        if _obj(m)] if _list(mirrors) else []
+    if sorted(declared_mirrors) != sorted(BODY_MIRROR_FLOOR):
+        out.append(f"provider_bindings.body_mirrors: must pair exactly "
+                   f"{[list(x) for x in BODY_MIRROR_FLOOR]}, got "
+                   f"{[list(x) for x in declared_mirrors]}. The pairs are owned by code, so a "
+                   f"self-referential or dropped mirror cannot silently disable the comparison")
+
     surfaces = pb.get("surfaces")
     if not _list(surfaces) or surfaces == []:
         out.append("provider_bindings.surfaces: must be a non-empty array")
         return
+    declared_paths = [s.get("path") for s in surfaces if _obj(s)]
+    if sorted(p for p in declared_paths if _str(p)) != sorted(PROVIDER_FLOOR):
+        out.append(f"provider_bindings.surfaces: must bind exactly {sorted(PROVIDER_FLOOR)}, got "
+                   f"{sorted(str(p) for p in declared_paths)}. The inventory is owned by code: an "
+                   f"entry removed here would detach a provider adapter while this check stayed "
+                   f"green")
     for i, s in enumerate(surfaces):
         if not _obj(s):
             out.append(f"provider_bindings.surfaces[{i}]: not an object")
@@ -529,11 +586,25 @@ def _check_provider_bindings(doc, out) -> None:
         if not _strs(s.get("must_reference")):
             out.append(f"provider_bindings.surfaces[{i}].must_reference: must be a non-empty "
                        f"array of strings")
+        floor = PROVIDER_FLOOR.get(s.get("path")) if _str(s.get("path")) else None
+        if floor and _strs(s.get("must_reference")):
+            missing = [r for r in floor[0] if r not in s["must_reference"]]
+            if missing:
+                out.append(f"provider_bindings.surfaces[{i}] ({s['path']}).must_reference: "
+                           f"missing {missing}, which this checker requires. Data may add "
+                           f"references; it may not drop below the floor")
         rules = s.get("must_not_match")
         if not _list(rules) or rules == []:
             out.append(f"provider_bindings.surfaces[{i}].must_not_match: must be a non-empty "
                        f"array")
             continue
+        if floor:
+            declared = [r.get("pattern") for r in rules if _obj(r)]
+            missing = [x for x in floor[1] if x not in declared]
+            if missing:
+                out.append(f"provider_bindings.surfaces[{i}] ({s['path']}).must_not_match: "
+                           f"missing {missing}, which this checker requires. Replacing a pattern "
+                           f"with one that cannot match would defang the check silently")
         for j, rule in enumerate(rules):
             if not _obj(rule) or not _str(rule.get("pattern")) or not _str(rule.get("why")):
                 out.append(f"provider_bindings.surfaces[{i}].must_not_match[{j}]: needs a "

--- a/scripts/check-delivery-lifecycle.py
+++ b/scripts/check-delivery-lifecycle.py
@@ -83,7 +83,8 @@ BLOCKER_CONDITIONS = {
         "It is introduced by this pull request rather than merely adjacent or pre-existing.",
     "violates_stated_contract":
         "It violates an explicit acceptance condition, an established repository invariant, or a "
-        "behaviour this pull request claims to provide.",
+        "behaviour this pull request claims to provide \u2014 or it regresses behaviour this pull "
+        "request actually changes, whether or not the contract mentioned it.",
     "realistic_path":
         "It occurs on a supported and realistic execution path relevant to the feature's intended "
         "operation, rather than existing only as generalised hardening speculation.",
@@ -396,7 +397,8 @@ def _check_freeze(doc, out) -> None:
                    "freezes nothing")
     if not _strs(fz.get("effect")):
         out.append("freeze.effect: must be a non-empty array of strings")
-    for field in ("late_finding_rule", "refreeze", "server_enforced_gates_still_apply"):
+    for field in ("late_finding_rule", "refreeze", "server_enforced_gates_still_apply",
+                  "head_must_match_before_handoff"):
         if not _str(fz.get(field)):
             out.append(f"freeze.{field}: must be a non-empty string")
 

--- a/scripts/check-delivery-lifecycle.py
+++ b/scripts/check-delivery-lifecycle.py
@@ -19,12 +19,14 @@ use `type(v) is int`; the invariant switches below require real booleans, becaus
 must not be able to stand in for `true` on a field whose whole job is to be un-flippable.
 
 WHY THE PREDICATE LIVES IN CODE
-`BLOCKER_CONDITIONS` is hardcoded here and never read from the document under validation. The
-blocker predicate is the load-bearing part of the freeze: if the conditions were data, a PR could
-weaken its own freeze by deleting a condition from a JSON file, and the diff would look like a
-policy edit rather than what it is. The same reasoning covers the state set, the disposition
-vocabulary, the review kinds and the lane names. A closed set owned by code cannot be widened,
-narrowed, or renamed by data.
+`BLOCKER_CONDITIONS` is hardcoded here and never read from the document under validation, and it
+pins each condition's operative SENTENCE rather than only its identifier. The blocker predicate is
+the load-bearing part of the freeze: if the conditions were data, a PR could weaken its own freeze
+by deleting one from a JSON file — or, more quietly, by keeping all five ids and rewriting what
+they require, which reviewers would then read and apply. Either edit would look like a policy
+tweak rather than what it is. The same reasoning covers the state set, the disposition vocabulary,
+the review kinds and the lane names. A closed set owned by code cannot be widened, narrowed,
+renamed, or redefined by data.
 
 THE INVARIANT SWITCHES
 Four fields are pinned to one value each, because each of them is a way the treadmill comes back:
@@ -61,8 +63,26 @@ ENTRY_STATE = "IMPLEMENTING"
 DISPOSITIONS = ("BLOCKER", "FOLLOW_UP", "QUESTION", "NOT_A_FINDING")
 REVIEW_KINDS = ("FULL", "DELTA")
 LANES = ("FAST", "STANDARD", "DEEP")
-BLOCKER_CONDITIONS = ("reproducible", "introduced_here", "violates_stated_contract",
-                      "realistic_path", "materially_breaks_it")
+# Not just the identifiers: the OPERATIVE SENTENCE of each condition, byte for byte. Keeping the
+# five ids while rewriting what they say would leave `validate()` silent, and reviewers read the
+# prose — so "the predicate is fixed by code" was bypassable by an ordinary data edit. The policy
+# file still carries these sentences for a human reader; the checker requires them to be identical
+# to what is written here, which puts a change of meaning back where it belongs: in a reviewed
+# code diff. Only `why` stays free-form, because it is rationale rather than the rule.
+BLOCKER_CONDITIONS = {
+    "reproducible":
+        "It is concrete and reproducible.",
+    "introduced_here":
+        "It is introduced by this pull request rather than merely adjacent or pre-existing.",
+    "violates_stated_contract":
+        "It violates an explicit acceptance condition, an established repository invariant, or a "
+        "behaviour this pull request claims to provide.",
+    "realistic_path":
+        "It occurs on a supported and realistic execution path relevant to the feature's intended "
+        "operation, rather than existing only as generalised hardening speculation.",
+    "materially_breaks_it":
+        "Leaving it unfixed would materially make the deliverable incorrect or unusable.",
+}
 
 # The merge side of the boundary. Named here so the lifecycle owner cannot quietly claim it.
 MERGE_SEMANTICS_OWNER = "ops/state/truth/policy.json#merge"
@@ -174,6 +194,10 @@ def _check_lifecycle(doc, out) -> None:
             out.append(f"lifecycle.state_surface.{marker}: must be a non-empty string")
     if not _strs(surface.get("fields")):
         out.append("lifecycle.state_surface.fields: must be a non-empty array of strings")
+    rendered_by = surface.get("rendered_by")
+    if not _strs(rendered_by):
+        out.append("lifecycle.state_surface.rendered_by: must name the surfaces that render the "
+                   "block, or nothing checks that they render what this owner declares")
     not_owned = surface.get("not_owned_by")
     if not _strs(not_owned):
         out.append("lifecycle.state_surface.not_owned_by: must be a non-empty array of strings")
@@ -279,6 +303,12 @@ def _check_blocker_predicate(doc, out) -> None:
                 if not _str(c.get(field)):
                     out.append(f"blocker_predicate.all_must_hold[{i}] ({cid}).{field}: "
                                f"must be a non-empty string")
+            if c.get("condition") != BLOCKER_CONDITIONS[cid]:
+                out.append(f"blocker_predicate.all_must_hold[{i}] ({cid}).condition: does not "
+                           f"match the sentence this checker pins. The predicate's MEANING is "
+                           f"owned by code, not only its identifiers — otherwise a data edit "
+                           f"could keep the five ids and invert what each of them requires. "
+                           f"Expected: {BLOCKER_CONDITIONS[cid]!r}")
         missing = [c for c in BLOCKER_CONDITIONS if c not in ids]
         if missing:
             out.append(f"blocker_predicate.all_must_hold: the predicate is fixed by code; "
@@ -593,6 +623,62 @@ def enforce_body_mirrors(doc, root: pathlib.Path, verbose: bool) -> list[str]:
     return out
 
 
+BLOCK_HEADING = "ICN DELIVERY LIFECYCLE"
+BLOCK_LABEL = re.compile(r"^([A-Za-z][A-Za-z -]*?):")   # labels carry hyphens: "Follow-up ledger"
+
+
+def _rendered_labels(text: str) -> list[set[str]]:
+    """The field labels of every lifecycle block in `text`, one set per block."""
+    blocks, lines = [], text.splitlines()
+    for i, line in enumerate(lines):
+        if line.strip() != BLOCK_HEADING:
+            continue
+        labels = set()
+        for following in lines[i + 1:]:
+            if following.startswith("```") or not following.strip():
+                break
+            match = BLOCK_LABEL.match(following.strip())
+            if match:
+                labels.add(match.group(1).strip())
+        blocks.append(labels)
+    return blocks
+
+
+def enforce_state_surface(doc, root: pathlib.Path, verbose: bool) -> list[str]:
+    """Every surface that renders the lifecycle block renders every field the owner declares.
+
+    The owner names the fields; three surfaces render the block. Two of them quietly rendered a
+    different set, and nothing noticed — which is the same class of drift this file exists to
+    stop, just inside the repository rather than in a provider prompt.
+    """
+    out: list[str] = []
+    surface = doc.get("lifecycle", {}).get("state_surface") if _obj(doc.get("lifecycle")) else None
+    if not _obj(surface) or not _strs(surface.get("fields")) or not _strs(
+            surface.get("rendered_by")):
+        return out
+    declared = set(surface["fields"])
+    for rel in surface["rendered_by"]:
+        path = root / rel
+        if not path.is_file():
+            out.append(f"{rel}: named in lifecycle.state_surface.rendered_by but does not exist")
+            continue
+        blocks = _rendered_labels(path.read_text(encoding="utf-8"))
+        if not blocks:
+            out.append(f"{rel}: renders no {BLOCK_HEADING!r} block, but is named as a surface "
+                       f"that does")
+            continue
+        for n, labels in enumerate(blocks, 1):
+            missing = sorted(declared - labels)
+            if missing:
+                where = f" (block {n})" if len(blocks) > 1 else ""
+                out.append(f"{rel}{where}: the lifecycle block omits {missing}, which "
+                           f"lifecycle.state_surface.fields declares")
+            elif verbose:
+                print(f"  ok   {rel}{f' (block {n})' if len(blocks) > 1 else ''}: "
+                      f"renders every declared field")
+    return out
+
+
 def enforce_registration(doc, root: pathlib.Path) -> list[str]:
     """The owner is registered in the truth map, and every path it names exists."""
     out: list[str] = []
@@ -636,6 +722,7 @@ def main() -> int:
     problems += enforce_registration(doc, ROOT)
     problems += enforce_surfaces(doc, ROOT, verbose)
     problems += enforce_body_mirrors(doc, ROOT, verbose)
+    problems += enforce_state_surface(doc, ROOT, verbose)
 
     if problems:
         print("check-delivery-lifecycle: FAIL")

--- a/scripts/tests/test_delivery_lifecycle.py
+++ b/scripts/tests/test_delivery_lifecycle.py
@@ -254,6 +254,40 @@ rejects("one ledger issue per comment is rejected",
 
 
 # ---------------------------------------------------------------------------------------------
+print("a regression counts even when the contract is silent about it")
+
+# A pull request does not get to break what it touched by omitting it from the contract. Without
+# this, a reproducible, introduced, realistic, materially breaking regression failed the
+# stated-contract condition and had to be dispositioned FOLLOW_UP — resolved without a fix.
+contract_condition = next(c for c in DELIVERY["blocker_predicate"]["all_must_hold"]
+                          if c["id"] == "violates_stated_contract")
+check("the stated-contract condition covers regressions in behaviour the diff changes",
+      "regresses behaviour this pull request actually changes" in contract_condition["condition"],
+      contract_condition["condition"][:90])
+check("the reviewer adapter and the owner name the same category",
+      "regression in behaviour this diff actually changes"
+      in (ROOT / ".claude" / "agents" / "icn-code-reviewer.md").read_text(encoding="utf-8"),
+      "adapter and owner disagree")
+rejects("narrowing the condition back to declared contract terms is rejected",
+        mutated(**{"blocker_predicate__all_must_hold__2__condition":
+                   "It violates an explicit acceptance condition."}), "owned by code")
+
+
+# ---------------------------------------------------------------------------------------------
+print("a freeze names the head that ships")
+
+check("the owner requires the live head to match the freeze head before handoff",
+      bool(DELIVERY["freeze"].get("head_must_match_before_handoff")), "no rule")
+rejects("dropping the head-match rule is rejected",
+        mutated(freeze__head_must_match_before_handoff=None), "head_must_match_before_handoff")
+ship_hand = (ROOT / ".agents" / "skills" / "ship-pr" / "SKILL.md").read_text(encoding="utf-8")
+check("ship-pr compares the freeze head before handing over",
+      "head_must_match_before_handoff" in ship_hand and "freeze head" in ship_hand, "missing")
+check("ship-pr refreezes rather than shipping unverified content",
+      "return to FROZEN" in ship_hand, "no refreeze instruction")
+
+
+# ---------------------------------------------------------------------------------------------
 print("a thread is resolved when its disposition is final, not when it is written")
 
 # Merge readiness counts unresolved threads, so "reply and resolve" applied to a QUESTION would

--- a/scripts/tests/test_delivery_lifecycle.py
+++ b/scripts/tests/test_delivery_lifecycle.py
@@ -274,6 +274,25 @@ rejects("narrowing the condition back to declared contract terms is rejected",
 
 
 # ---------------------------------------------------------------------------------------------
+print("readiness is decided in one place")
+
+# The skill told itself to read the merge owner and live protection to pick which gates to wait
+# on, while its own Boundaries forbade exactly that. A document that contradicts itself on its
+# central boundary cannot be followed consistently, and the registry pattern against a protection
+# path was decorative next to prose that said to do it.
+ship_wait = (ROOT / ".agents" / "skills" / "ship-pr" / "SKILL.md").read_text(encoding="utf-8")
+check("ship-pr does not decide which gates matter",
+      "Do not work out which gates matter" in ship_wait, "still deciding")
+check("ship-pr waits only on a gate the evaluator named",
+      "never wait on a check the evaluator did not name" in ship_wait, "missing")
+check("ship-pr still forbids reading protection for readiness",
+      "Do not read branch protection to decide readiness" in ship_wait, "boundary lost")
+check("the two statements no longer contradict each other",
+      "which gates actually matter from the merge owner and live branch protection"
+      not in ship_wait, "contradiction remains")
+
+
+# ---------------------------------------------------------------------------------------------
 print("a freeze names the head that ships")
 
 check("the owner requires the live head to match the freeze head before handoff",

--- a/scripts/tests/test_delivery_lifecycle.py
+++ b/scripts/tests/test_delivery_lifecycle.py
@@ -254,6 +254,78 @@ rejects("one ledger issue per comment is rejected",
 
 
 # ---------------------------------------------------------------------------------------------
+print("a thread is resolved when its disposition is final, not when it is written")
+
+# Merge readiness counts unresolved threads, so "reply and resolve" applied to a QUESTION would
+# convert an unanswered question into a readiness signal. When each disposition may resolve is
+# therefore owned by the checker, not by the document or by a skill.
+for d in DELIVERY["finding_dispositions"]:
+    check(f"{d['name']} resolves {gate.RESOLVE_WHEN[d['name']]}",
+          d.get("resolve_thread") == gate.RESOLVE_WHEN[d["name"]], repr(d.get("resolve_thread")))
+for i, d in enumerate(DELIVERY["finding_dispositions"]):
+    rejects(f"letting {d['name']} resolve at the wrong moment is rejected",
+            mutated(**{f"finding_dispositions__{i}__resolve_thread": "immediately"}),
+            "owned by code")
+    rejects(f"dropping {d['name']}'s resolve rule is rejected",
+            mutated(**{f"finding_dispositions__{i}__resolve_thread": None}), "resolve_thread")
+
+ship_skill = (ROOT / ".agents" / "skills" / "ship-pr" / "SKILL.md").read_text(encoding="utf-8")
+check("ship-pr defers to the owner's resolve rule", "resolve_thread" in ship_skill, "missing")
+check("ship-pr does not resolve every thread on reply",
+      "the evidence, then resolve it" not in ship_skill, "still unconditional")
+check("ship-pr says a QUESTION stays unresolved",
+      "QUESTION stays" in ship_skill and "unresolved" in ship_skill, "missing")
+
+
+# ---------------------------------------------------------------------------------------------
+print("the provider-binding inventory is a floor, not a self-description")
+
+# The inventory used to describe itself: three entries all naming one prompt, `must_reference`
+# cut to a single string and every pattern replaced with one that cannot match, passed every
+# check while the Copilot adapters were detached. An enforcement list the enforced party can
+# shorten is not enforcement.
+check("the committed surfaces are exactly the floor",
+      sorted(s["path"] for s in DELIVERY["provider_bindings"]["surfaces"])
+      == sorted(gate.PROVIDER_FLOOR),
+      str(sorted(s["path"] for s in DELIVERY["provider_bindings"]["surfaces"])))
+for surface in DELIVERY["provider_bindings"]["surfaces"]:
+    refs, patterns = gate.PROVIDER_FLOOR[surface["path"]]
+    check(f"{surface['path']} declares every required reference",
+          all(r in surface["must_reference"] for r in refs),
+          str([r for r in refs if r not in surface["must_reference"]]))
+    declared = [r["pattern"] for r in surface["must_not_match"]]
+    check(f"{surface['path']} declares every required pattern",
+          all(x in declared for x in patterns), str([x for x in patterns if x not in declared]))
+
+claude_prompt = ".claude/agents/icn-code-reviewer.md"
+degenerate = json.loads(json.dumps(DELIVERY))
+degenerate["provider_bindings"]["surfaces"] = [
+    {"path": claude_prompt, "role": f"r{i}", "must_reference": ["BLOCKER"],
+     "must_not_match": [{"pattern": "a^", "why": "defanged"}]} for i in range(3)]
+degenerate["provider_bindings"]["body_mirrors"] = [
+    {"canonical": claude_prompt, "mirror": claude_prompt, "why": "self"}]
+rejects("three entries all naming one prompt are rejected", degenerate, "must bind exactly")
+rejects("a self-referential body mirror is rejected", degenerate, "must pair exactly")
+
+dropped = json.loads(json.dumps(DELIVERY))
+dropped["provider_bindings"]["surfaces"] = [
+    s for s in dropped["provider_bindings"]["surfaces"]
+    if s["path"] != ".github/agents/icn-code-reviewer.md"]
+rejects("dropping a provider surface from the inventory is rejected", dropped, "must bind exactly")
+
+for i, surface in enumerate(DELIVERY["provider_bindings"]["surfaces"]):
+    thinned = json.loads(json.dumps(DELIVERY))
+    thinned["provider_bindings"]["surfaces"][i]["must_reference"] = ["BLOCKER"]
+    rejects(f"thinning must_reference on {surface['path']} is rejected", thinned,
+            "may not drop below the floor")
+    defanged = json.loads(json.dumps(DELIVERY))
+    defanged["provider_bindings"]["surfaces"][i]["must_not_match"] = [
+        {"pattern": "a^", "why": "cannot match"}]
+    rejects(f"defanging the patterns on {surface['path']} is rejected", defanged,
+            "defang the check silently")
+
+
+# ---------------------------------------------------------------------------------------------
 print("every lane is bounded, and DEEP is the maintainer's call")
 
 lanes = {x["name"]: x for x in DELIVERY["lanes"]["definitions"]}

--- a/scripts/tests/test_delivery_lifecycle.py
+++ b/scripts/tests/test_delivery_lifecycle.py
@@ -149,6 +149,33 @@ rejects("dropping the redesign rule is rejected",
 
 
 # ---------------------------------------------------------------------------------------------
+print("the predicate's meaning is pinned, not just its labels")
+
+# Keeping the five ids while rewriting what each requires left the validator silent, and the
+# prose is what a reviewer actually applies. Each sentence is now owned by the checker.
+for i, condition in enumerate(DELIVERY["blocker_predicate"]["all_must_hold"]):
+    cid = condition["id"]
+    check(f"the committed {cid!r} condition is the sentence the checker pins",
+          condition["condition"] == gate.BLOCKER_CONDITIONS[cid], repr(condition["condition"]))
+    rejects(f"inverting the meaning of {cid!r} while keeping its id is rejected",
+            mutated(**{f"blocker_predicate__all_must_hold__{i}__condition":
+                       "Anything at all qualifies, however unreachable."}),
+            "owned by code")
+
+inverted = json.loads(json.dumps(DELIVERY))
+for condition in inverted["blocker_predicate"]["all_must_hold"]:
+    condition["condition"] = "Any observation whatsoever is a blocker."
+problems = gate.validate(inverted)
+check("a wholly inverted predicate produces one complaint per condition",
+      len([p for p in problems if "owned by code" in p]) == len(gate.BLOCKER_CONDITIONS),
+      str(problems[:2]))
+
+check("rationale stays free-form, so a `why` may be reworded without a code change",
+      gate.validate(mutated(blocker_predicate__all_must_hold__0__why="Reworded rationale.")) == [],
+      "a `why` edit was rejected")
+
+
+# ---------------------------------------------------------------------------------------------
 print("a qualifying late blocker can reopen, be fixed, and refreeze")
 
 states = {s["name"]: s for s in DELIVERY["lifecycle"]["states"]}
@@ -332,6 +359,23 @@ for m in DELIVERY["provider_bindings"]["body_mirrors"]:
 
 
 # ---------------------------------------------------------------------------------------------
+print("every surface that renders the block renders what the owner declares")
+
+state_surface = DELIVERY["lifecycle"]["state_surface"]
+check("the owner names the surfaces that render its block",
+      len(state_surface["rendered_by"]) >= 3, str(state_surface["rendered_by"]))
+for rel in state_surface["rendered_by"]:
+    blocks = gate._rendered_labels((ROOT / rel).read_text(encoding="utf-8"))
+    check(f"{rel} renders a lifecycle block", bool(blocks), "no block found")
+    for n, labels in enumerate(blocks, 1):
+        check(f"{rel} block {n} renders every declared field",
+              set(state_surface["fields"]) <= labels,
+              str(sorted(set(state_surface["fields"]) - labels)))
+rejects("a policy that names no rendering surface is rejected",
+        mutated(lifecycle__state_surface__rendered_by=[]), "rendered_by")
+
+
+# ---------------------------------------------------------------------------------------------
 print("the gate itself can still fail")
 
 
@@ -347,6 +391,10 @@ def gate_root(tmp: pathlib.Path, name: str) -> pathlib.Path:
         target = root / s["path"]
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(ROOT / s["path"], target)
+    for rel in DELIVERY["lifecycle"]["state_surface"]["rendered_by"]:
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / rel, target)
     mut = DELIVERY["authority"]["mutation"]
     for field in ("orchestrator", "primitive", "executable"):
         named = root / mut[field]
@@ -416,6 +464,27 @@ with tempfile.TemporaryDirectory() as raw:
     proc = run_gate(unregistered)
     check("an owner the truth map does not name fails the gate",
           proc.returncode == 1 and "not registered" in proc.stdout, proc.stdout[-300:])
+
+    # A rendering surface drops a field the owner declares.
+    short_block = gate_root(tmp, "short-block")
+    victim = short_block / ".github" / "pull_request_template.md"
+    victim.write_text("\n".join(line for line in
+                                victim.read_text(encoding="utf-8").splitlines()
+                                if not line.startswith("Follow-up ledger:")) + "\n",
+                      encoding="utf-8")
+    proc = run_gate(short_block)
+    check("a surface that stops rendering a declared field fails the gate",
+          proc.returncode == 1 and "Follow-up ledger" in proc.stdout, proc.stdout[-300:])
+
+    # The predicate keeps its ids but changes what they require.
+    redefined = gate_root(tmp, "redefined-predicate")
+    policy_path = redefined / "ops" / "state" / "truth" / "delivery.json"
+    policy_path.write_text(json.dumps(
+        mutated(blocker_predicate__all_must_hold__3__condition="Anything counts."), indent=2)
+        + "\n", encoding="utf-8")
+    proc = run_gate(redefined)
+    check("a predicate that keeps its ids but inverts their meaning fails the gate",
+          proc.returncode == 1 and "owned by code" in proc.stdout, proc.stdout[-300:])
 
     # The policy itself is weakened.
     weakened = gate_root(tmp, "weakened")

--- a/scripts/tests/test_delivery_lifecycle.py
+++ b/scripts/tests/test_delivery_lifecycle.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""test_delivery_lifecycle.py — the delivery lifecycle gate rejects its own violations (icn#2661).
+
+`ops/state/truth/delivery.json` states when comprehensive review ends and what freezes. A policy
+that merely SAYS a thing is not enforcement — the question this file answers is whether a document
+that says the opposite is rejected.
+
+Every process invariant below is therefore tested the same way: take the real committed policy,
+mutate it into the failure it is supposed to prevent, and assert the validator complains. A test
+that only read the committed values would pass just as happily against a policy nobody enforces.
+
+Nothing here parses English. Assertions are against structured values, registry data, and the
+exit status of the real gate — a prose check has grammar to get wrong, and this repository has
+already shipped one that did (icn#2651).
+"""
+
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "check_delivery_lifecycle", ROOT / "scripts" / "check-delivery-lifecycle.py")
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+DELIVERY = json.loads((ROOT / "ops" / "state" / "truth" / "delivery.json")
+                      .read_text(encoding="utf-8"))
+SKILLS = json.loads((ROOT / "ops" / "state" / "truth" / "skills.json").read_text(encoding="utf-8"))
+
+failures: list[str] = []
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}  ({detail})")
+        failures.append(label)
+
+
+def mutated(**path_value) -> dict:
+    """A deep copy of the real policy with `a__b__c=value` paths replaced (None deletes)."""
+    doc = json.loads(json.dumps(DELIVERY))
+    for dotted, value in path_value.items():
+        parts = dotted.split("__")
+        node = doc
+        for part in parts[:-1]:
+            node = node[int(part)] if part.isdigit() else node[part]
+        last = parts[-1]
+        key = int(last) if last.isdigit() else last
+        if value is None:
+            del node[key]
+        else:
+            node[key] = value
+    return doc
+
+
+def rejects(label: str, doc: dict, expect_substring: str) -> None:
+    problems = gate.validate(doc)
+    hit = [p for p in problems if expect_substring in p]
+    check(label, bool(hit), f"no complaint containing {expect_substring!r}; got {problems[:2]}")
+
+
+# ---------------------------------------------------------------------------------------------
+print("the committed policy is valid, and the validator is total")
+
+check("the committed delivery policy validates clean", gate.validate(DELIVERY) == [],
+      str(gate.validate(DELIVERY)[:3]))
+
+for hostile in (None, 7, "policy", [], [{"schema": "x"}], {"schema": 1},
+                {"lifecycle": []}, {"lifecycle": {"states": "IMPLEMENTING"}},
+                {"blocker_predicate": {"all_must_hold": [None, 1, "reproducible"]}},
+                {"lanes": {"definitions": [{"name": "FAST", "comprehensive_generations": True}]}},
+                {"provider_bindings": {"surfaces": [{"path": 1, "must_not_match": [{}]}]}}):
+    try:
+        out = gate.validate(hostile)
+        ok = isinstance(out, list) and out != []
+        detail = "returned no complaints"
+    except Exception as exc:                                   # noqa: BLE001 — that IS the defect
+        ok, detail = False, f"raised {type(exc).__name__}: {exc}"
+    check(f"malformed input {str(hostile)[:34]!r} is reported, not raised", ok, detail)
+
+
+# ---------------------------------------------------------------------------------------------
+print("a push does not reset the comprehensive review generation")
+
+check("the committed policy says a push does not reset the generation",
+      DELIVERY["review_generation"]["push_resets_generation"] is False,
+      str(DELIVERY["review_generation"]["push_resets_generation"]))
+rejects("a policy that lets a push reset the generation is rejected",
+        mutated(review_generation__push_resets_generation=True), "push_resets_generation")
+rejects("a truthy stand-in for the reset switch is rejected too",
+        mutated(review_generation__push_resets_generation=1), "push_resets_generation")
+rejects("deleting the switch is rejected",
+        mutated(review_generation__push_resets_generation=None), "push_resets_generation")
+rejects("a policy with no bounded-review claim is rejected",
+        mutated(review_generation__comprehensive_review_is_bounded=False),
+        "comprehensive_review_is_bounded")
+
+
+# ---------------------------------------------------------------------------------------------
+print("DELTA does not become FULL review")
+
+kinds = DELIVERY["review_generation"]["review_kinds"]
+check("the policy defines exactly FULL and DELTA", sorted(kinds) == ["DELTA", "FULL"],
+      str(sorted(kinds)))
+check("after a blocker fix the next review is DELTA",
+      DELIVERY["review_generation"]["after_blocker_fix"] == "DELTA",
+      DELIVERY["review_generation"]["after_blocker_fix"])
+rejects("a policy that re-runs FULL review after a blocker fix is rejected",
+        mutated(review_generation__after_blocker_fix="FULL"), "after_blocker_fix")
+rejects("a DELTA definition with no stated limit is rejected",
+        mutated(review_generation__review_kinds__DELTA__may_not=None), "DELTA.may_not")
+rejects("inventing a third review kind is rejected",
+        mutated(review_generation__review_kinds__PARTIAL={"may_inspect": "x", "when": "y"}),
+        "review_kinds")
+rejects("a policy where reviews need not declare their kind is rejected",
+        mutated(review_generation__every_review_declares_its_kind=False),
+        "every_review_declares_its_kind")
+
+
+# ---------------------------------------------------------------------------------------------
+print("a frozen pull request stays frozen below the blocker threshold")
+
+conditions = [c["id"] for c in DELIVERY["blocker_predicate"]["all_must_hold"]]
+check("the predicate names every condition the code requires",
+      sorted(conditions) == sorted(gate.BLOCKER_CONDITIONS), str(conditions))
+for dropped in gate.BLOCKER_CONDITIONS:
+    kept = [c for c in DELIVERY["blocker_predicate"]["all_must_hold"] if c["id"] != dropped]
+    rejects(f"dropping the {dropped!r} condition is rejected",
+            mutated(blocker_predicate__all_must_hold=kept), dropped)
+rejects("a freeze with no late-finding rule is rejected",
+        mutated(freeze__late_finding_rule=None), "late_finding_rule")
+rejects("a freeze that names no head is rejected",
+        mutated(freeze__names_an_exact_head=False), "names_an_exact_head")
+rejects("dropping the no-sibling-sweep rule is rejected",
+        mutated(blocker_predicate__no_sibling_sweep=None), "no_sibling_sweep")
+rejects("dropping the redesign rule is rejected",
+        mutated(blocker_predicate__redesign_rule=None), "redesign_rule")
+
+
+# ---------------------------------------------------------------------------------------------
+print("a qualifying late blocker can reopen, be fixed, and refreeze")
+
+states = {s["name"]: s for s in DELIVERY["lifecycle"]["states"]}
+check("FROZEN has a way back to FIXING", "FIXING" in states["FROZEN"]["exits_to"],
+      str(states["FROZEN"]["exits_to"]))
+check("that way back is conditional", bool(states["FROZEN"].get("exit_to_fixing_requires")),
+      "FROZEN exits to FIXING unconditionally")
+check("the refreeze path is stated", bool(DELIVERY["freeze"].get("refreeze")), "no refreeze rule")
+
+frozen_unconditional = json.loads(json.dumps(DELIVERY))
+for s in frozen_unconditional["lifecycle"]["states"]:
+    if s["name"] == "FROZEN":
+        del s["exit_to_fixing_requires"]
+rejects("an unconditional exit from FROZEN is rejected", frozen_unconditional,
+        "exit_to_fixing_requires")
+
+# A lifecycle has to be able to finish, and every state has to be usable.
+dead_end = json.loads(json.dumps(DELIVERY))
+for s in dead_end["lifecycle"]["states"]:
+    if s["name"] == "MERGING":
+        s["exits_to"] = ["FROZEN"]
+rejects("a lifecycle with no path to DONE is rejected", dead_end, "not reachable")
+
+orphan = json.loads(json.dumps(DELIVERY))
+for s in orphan["lifecycle"]["states"]:
+    if s["name"] == "REVIEWING":
+        s["exits_to"] = []
+rejects("a lifecycle with an unreachable state is rejected", orphan, "unreachable")
+
+talkative_terminal = json.loads(json.dumps(DELIVERY))
+for s in talkative_terminal["lifecycle"]["states"]:
+    if s["name"] == "DONE":
+        s["exits_to"] = ["REVIEWING"]
+rejects("a non-terminal DONE is rejected", talkative_terminal, "must be terminal")
+
+
+# ---------------------------------------------------------------------------------------------
+print("automated severity alone cannot break a freeze")
+
+check("severity is declared advisory",
+      DELIVERY["blocker_predicate"]["automated_severity_is_advisory"] is True,
+      str(DELIVERY["blocker_predicate"]["automated_severity_is_advisory"]))
+labels = DELIVERY["blocker_predicate"]["advisory_severity_labels"]
+check("the labels that carry no authority are enumerated",
+      all(x in labels for x in ("P1", "P2", "critical")), str(labels))
+rejects("a policy that makes severity authoritative is rejected",
+        mutated(blocker_predicate__automated_severity_is_advisory=False),
+        "automated_severity_is_advisory")
+rejects("dropping the advisory-label list is rejected",
+        mutated(blocker_predicate__advisory_severity_labels=[]), "advisory_severity_labels")
+check("automated reviewers are explicitly denied freeze-breaking authority",
+      any("freeze" in x for x in DELIVERY["authority"]["automated_reviewers_may_not"]),
+      str(DELIVERY["authority"]["automated_reviewers_may_not"]))
+rejects("a policy that denies automated reviewers nothing is rejected",
+        mutated(authority__automated_reviewers_may_not=[]), "automated_reviewers_may_not")
+
+
+# ---------------------------------------------------------------------------------------------
+print("a deferred observation becomes durable work rather than being dropped")
+
+dispositions = [d["name"] for d in DELIVERY["finding_dispositions"]]
+check("all four dispositions are defined",
+      sorted(dispositions) == sorted(gate.DISPOSITIONS), str(dispositions))
+for dropped in gate.DISPOSITIONS:
+    kept = [d for d in DELIVERY["finding_dispositions"] if d["name"] != dropped]
+    rejects(f"dropping the {dropped} disposition is rejected",
+            mutated(finding_dispositions=kept), dropped)
+check("a follow-up entry must link back to its thread",
+      DELIVERY["follow_up_ledger"]["provenance_link_required"] is True,
+      str(DELIVERY["follow_up_ledger"]["provenance_link_required"]))
+rejects("a ledger with no provenance requirement is rejected",
+        mutated(follow_up_ledger__provenance_link_required=False), "provenance_link_required")
+rejects("one ledger issue per comment is rejected",
+        mutated(follow_up_ledger__one_issue_per_pull_request=False),
+        "one_issue_per_pull_request")
+
+
+# ---------------------------------------------------------------------------------------------
+print("every lane is bounded, and DEEP is the maintainer's call")
+
+lanes = {x["name"]: x for x in DELIVERY["lanes"]["definitions"]}
+check("all three lanes are defined", sorted(lanes) == sorted(gate.LANES), str(sorted(lanes)))
+for name, lane in lanes.items():
+    check(f"the {name} lane schedules exactly one comprehensive generation",
+          type(lane["comprehensive_generations"]) is int
+          and lane["comprehensive_generations"] == 1,
+          repr(lane["comprehensive_generations"]))
+check("DEEP requires maintainer selection", lanes["DEEP"]["requires_maintainer_selection"] is True,
+      str(lanes["DEEP"].get("requires_maintainer_selection")))
+
+loose = json.loads(json.dumps(DELIVERY))
+for lane in loose["lanes"]["definitions"]:
+    if lane["name"] == "STANDARD":
+        lane["comprehensive_generations"] = 3
+rejects("a lane that schedules repeated comprehensive review is rejected", loose,
+        "comprehensive_generations")
+
+self_serve_deep = json.loads(json.dumps(DELIVERY))
+for lane in self_serve_deep["lanes"]["definitions"]:
+    if lane["name"] == "DEEP":
+        lane["requires_maintainer_selection"] = False
+rejects("a DEEP lane an agent may select itself is rejected", self_serve_deep,
+        "requires_maintainer_selection")
+
+
+# ---------------------------------------------------------------------------------------------
+print("ship-pr may not duplicate or bypass merge authority")
+
+check("the orchestrator is barred from duplicating the primitive",
+      DELIVERY["authority"]["mutation"]["orchestrator_may_not_duplicate_primitive"] is True,
+      "not declared")
+rejects("a policy that lets the orchestrator duplicate the primitive is rejected",
+        mutated(authority__mutation__orchestrator_may_not_duplicate_primitive=False),
+        "orchestrator_may_not_duplicate_primitive")
+rejects("a policy that claims merge semantics for itself is rejected",
+        mutated(authority__mutation__semantics_owner="ops/state/truth/delivery.json"),
+        "semantics_owner")
+rejects("a policy naming a different merge executable is rejected",
+        mutated(authority__mutation__executable="scripts/merge.sh"), "executable")
+rejects("a mutation block holding a spelled command is rejected",
+        mutated(authority__mutation__primitive="gh pr merge --squash"), "command- or flag-shaped")
+
+boundary_owners = [e["owner"] for e in DELIVERY["owner_boundary"]["does_not_own"]]
+check("the policy disclaims merge ownership explicitly",
+      any(gate.MERGE_SEMANTICS_OWNER in o for o in boundary_owners), str(boundary_owners))
+rejects("a policy that stops disclaiming merge ownership is rejected",
+        mutated(owner_boundary__does_not_own=[{"fact": "x", "owner": "AGENTS.md"}]),
+        "does_not_own")
+
+ship = next(e for e in SKILLS["skills"]["icn_level"] if e["name"] == "ship-pr")
+patterns = [r["pattern"] for r in ship["canonical_assertions"]["must_not_match"]]
+skill_text = (ROOT / ship["canonical_path"]).read_text(encoding="utf-8")
+
+# A forbidden pattern that matches nothing is decoration. Each one is proved live against the
+# line it exists to catch, and proved silent against the skill as committed.
+hostile_lines = {
+    r"icn-merge-pr\s+merge": "   icn-merge-pr merge \"$PR\" --authorize",
+    r"gh\s+pr\s+merge": "   gh pr merge \"$PR\" --squash",
+    r"--admin\b": "   ... --admin when the maintainer says so",
+    r"--auto\b|--disable-auto\b": "   arm it with --auto and come back later",
+    r"branches/[^/\s]+/protection": "   gh api repos/o/r/branches/main/protection",
+    r"\bBuild Release\b": "   wait for Build Release, Test and Clippy",
+    r"\b(all\s+)?\d+\s+required\s+(CI\s+)?checks\b": "   all 11 required checks must be green",
+}
+check("every forbidden ship-pr pattern has a hostile line to prove it against",
+      sorted(patterns) == sorted(hostile_lines), str(sorted(set(patterns) ^ set(hostile_lines))))
+for pattern in patterns:
+    rx = re.compile(pattern)
+    check(f"the ship-pr pattern {pattern!r} actually matches a merge path",
+          bool(rx.search(hostile_lines.get(pattern, ""))), "pattern is vacuous")
+    hit = [i for i, line in enumerate(skill_text.splitlines(), 1) if rx.search(line)]
+    check(f"the committed ship-pr skill does not match {pattern!r}", not hit, f"line {hit[:1]}")
+
+for ref in ship["canonical_assertions"]["must_reference"]:
+    check(f"the ship-pr skill references {ref!r}", ref in skill_text, "missing")
+
+mirror = ship["provider_mirrors"][0]
+check("the ship-pr provider copy is an exact mirror", mirror["policy"] == "exact_mirror",
+      mirror["policy"])
+check("the ship-pr provider copy is byte-identical",
+      (ROOT / mirror["path"]).read_bytes() == (ROOT / ship["canonical_path"]).read_bytes(),
+      "the two copies differ")
+
+
+# ---------------------------------------------------------------------------------------------
+print("provider reviewer adapters cannot contradict the canonical rules")
+
+surfaces = DELIVERY["provider_bindings"]["surfaces"]
+check("all three provider surfaces are bound", len(surfaces) == 3, str(len(surfaces)))
+for s in surfaces:
+    check(f"{s['path']} exists", (ROOT / s["path"]).is_file(), "missing")
+rejects("a policy that binds no provider surface is rejected",
+        mutated(provider_bindings__surfaces=[]), "surfaces")
+rejects("a policy that declares no body mirror is rejected",
+        mutated(provider_bindings__body_mirrors=[]), "body_mirrors")
+
+for m in DELIVERY["provider_bindings"]["body_mirrors"]:
+    check(f"{m['mirror']} body matches {m['canonical']}",
+          gate._body(ROOT / m["mirror"]) == gate._body(ROOT / m["canonical"]),
+          "the two reviewer prompts have drifted apart")
+
+
+# ---------------------------------------------------------------------------------------------
+print("the gate itself can still fail")
+
+
+def gate_root(tmp: pathlib.Path, name: str) -> pathlib.Path:
+    """A minimal repository the delivery gate runs against, copied from the real one."""
+    root = tmp / name
+    (root / "scripts").mkdir(parents=True)
+    shutil.copy2(ROOT / "scripts" / "check-delivery-lifecycle.py", root / "scripts")
+    (root / "ops" / "state" / "truth").mkdir(parents=True)
+    for owner in ("delivery.json", "sources.json"):
+        shutil.copy2(ROOT / "ops" / "state" / "truth" / owner, root / "ops" / "state" / "truth")
+    for s in surfaces:
+        target = root / s["path"]
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / s["path"], target)
+    mut = DELIVERY["authority"]["mutation"]
+    for field in ("orchestrator", "primitive", "executable"):
+        named = root / mut[field]
+        named.parent.mkdir(parents=True, exist_ok=True)
+        if not named.exists():
+            named.write_text("", encoding="utf-8") if named.suffix else named.mkdir()
+    return root
+
+
+def run_gate(root: pathlib.Path) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(root / "scripts" / "check-delivery-lifecycle.py")],
+                          capture_output=True, text=True)
+
+
+with tempfile.TemporaryDirectory() as raw:
+    tmp = pathlib.Path(raw)
+
+    clean = gate_root(tmp, "clean")
+    proc = run_gate(clean)
+    check("the gate passes on the repository as committed", proc.returncode == 0,
+          proc.stdout[-300:] + proc.stderr[-200:])
+
+    # The reviewer prompt regains its own blocking list.
+    regressed = gate_root(tmp, "own-blocker-list")
+    victim = regressed / ".claude" / "agents" / "icn-code-reviewer.md"
+    victim.write_text(victim.read_text(encoding="utf-8")
+                      + "\n## What You ALWAYS Flag (blocking)\n\n- anything I feel strongly about\n",
+                      encoding="utf-8")
+    proc = run_gate(regressed)
+    check("a reviewer prompt that regains its own blocking list fails the gate",
+          proc.returncode == 1 and "always" in proc.stdout.lower(), proc.stdout[-300:])
+
+    # The reviewer prompt stops naming the owner.
+    unbound = gate_root(tmp, "unbound")
+    victim = unbound / ".github" / "agents" / "icn-code-reviewer.md"
+    victim.write_text(victim.read_text(encoding="utf-8")
+                      .replace("ops/state/truth/delivery.json", "my own judgement"),
+                      encoding="utf-8")
+    proc = run_gate(unbound)
+    check("a reviewer prompt that stops naming the owner fails the gate",
+          proc.returncode == 1 and "must reference" in proc.stdout, proc.stdout[-300:])
+
+    # The two reviewer prompts drift apart while both still name the owner.
+    drifted = gate_root(tmp, "drifted")
+    victim = drifted / ".github" / "agents" / "icn-code-reviewer.md"
+    victim.write_text(victim.read_text(encoding="utf-8")
+                      + "\nAlso: treat every P1 as a blocker regardless.\n", encoding="utf-8")
+    proc = run_gate(drifted)
+    check("two reviewer prompts that drift apart fail the gate",
+          proc.returncode == 1 and "body differs" in proc.stdout, proc.stdout[-300:])
+
+    # The provider entry file grows a second project handbook again.
+    handbook = gate_root(tmp, "handbook")
+    victim = handbook / ".github" / "copilot-instructions.md"
+    victim.write_text(victim.read_text(encoding="utf-8") + "\n## Current Status\n\nAll green.\n",
+                      encoding="utf-8")
+    proc = run_gate(handbook)
+    check("a provider entry file that regains volatile project state fails the gate",
+          proc.returncode == 1 and "stale by construction" in proc.stdout, proc.stdout[-300:])
+
+    # The owner is de-registered from the truth map.
+    unregistered = gate_root(tmp, "unregistered")
+    sources_path = unregistered / "ops" / "state" / "truth" / "sources.json"
+    sources = json.loads(sources_path.read_text(encoding="utf-8"))
+    del sources["domains"]["pr_delivery_lifecycle"]
+    sources_path.write_text(json.dumps(sources, indent=2) + "\n", encoding="utf-8")
+    proc = run_gate(unregistered)
+    check("an owner the truth map does not name fails the gate",
+          proc.returncode == 1 and "not registered" in proc.stdout, proc.stdout[-300:])
+
+    # The policy itself is weakened.
+    weakened = gate_root(tmp, "weakened")
+    policy_path = weakened / "ops" / "state" / "truth" / "delivery.json"
+    policy_path.write_text(json.dumps(
+        mutated(review_generation__push_resets_generation=True), indent=2) + "\n",
+        encoding="utf-8")
+    proc = run_gate(weakened)
+    check("a policy edited to let a push reset review fails the gate",
+          proc.returncode == 1 and "push_resets_generation" in proc.stdout, proc.stdout[-300:])
+
+
+# ---------------------------------------------------------------------------------------------
+print("the lifecycle is discoverable without conversation memory")
+
+for path, needle in ((ROOT / "AGENTS.md", "ops/state/truth/delivery.json"),
+                     (ROOT / "docs" / "ai" / "WORKFLOW_ARCHITECTURE.md",
+                      "ops/state/truth/delivery.json"),
+                     (ROOT / ".github" / "pull_request_template.md",
+                      DELIVERY["lifecycle"]["state_surface"]["begin_marker"]),
+                     (ROOT / ".agents" / "skills" / "pr-create" / "SKILL.md",
+                      DELIVERY["lifecycle"]["state_surface"]["begin_marker"])):
+    check(f"{path.relative_to(ROOT)} names {needle!r}",
+          needle in path.read_text(encoding="utf-8"), "missing")
+
+sources = json.loads((ROOT / "ops" / "state" / "truth" / "sources.json").read_text(encoding="utf-8"))
+check("the truth map registers the lifecycle owner",
+      sources["domains"]["pr_delivery_lifecycle"]["owner"] == "ops/state/truth/delivery.json",
+      "not registered")
+check("the truth map forbids a provider surface owning review semantics",
+      any("delivery.json" in rule for rule in sources["forbidden"]), "no forbidden rule")
+
+
+print()
+if failures:
+    print(f"delivery lifecycle tests: {len(failures)} failure(s)")
+    for f in failures:
+        print(f"  - {f}")
+    sys.exit(1)
+print("delivery lifecycle tests: clean")


### PR DESCRIPTION
## Delivery

- **Delivery lane**: STANDARD
- **Acceptance contract**: a fresh Claude or Copilot session with no conversation memory can enter
  a pull request, load one canonical lifecycle owner, determine which state the PR is in, classify
  review findings consistently, and know when it is permitted to stop comprehensive review and
  ship. No provider prompt independently redefines that lifecycle. A normal PR has a finite path to
  merge even while automated reviewers keep producing valid non-blocking observations, and those
  observations become durable follow-up work rather than being lost. The maintainer stays the only
  authority that can reopen review scope.
- **Explicit non-goals**: no repair of unrelated stale agent prompts (that stays with icn#2632); no
  branch-protection, ruleset, or permission changes; no change to merge-mutation semantics or to
  `tools/icn-merge-pr`.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                DONE
Lane:                 STANDARD
Acceptance contract:  see the Delivery section above
Review generation:    1 of 1, CLOSED
Freeze head:          d58d01ba077ceb3f38765e5d04ce2987f5b329c3
Known blockers:       0
Merge commit:         84c06c31b0f8a201d7c11becdf02cf3082c8ea16
Follow-up ledger:     icn#2663
Comprehensive review: CLOSED
```

Comprehensive review generation 1 of 1 is closed. It produced 7 inline findings plus a required-check
failure: 5 blocker root causes, fixed as one batch, and 2 deferred. Nine further findings arrived
after that batch, dispositioned under the late threshold without reopening review — 5 late blockers
fixed in three targeted corrections, 4 deferred to icn#2663. No push created a second review
generation. Two deferred items are maintainer design decisions, flagged in the ledger.
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## Summary

A pull request could be correct, complete and green and still not converge. Each push drew a fresh
full review; each full review produced observations that were technically true; each observation
reopened the whole PR. icn#2659 is the worked example — eleven rounds, every one of them
individually reasonable, none of them reached by asking whether the deliverable was done.

The missing thing was an owner for **when comprehensive review ends**. `AGENTS.md` owns operating
invariants, `WORKFLOW_ARCHITECTURE.md` owns how an agent finds truth, `policy.json#merge` owns
merge requirements. Nothing said a pull request has a lifecycle with a terminating state — so every
reviewer surface invented its own blocking rules, and both copies of `icn-code-reviewer` carried an
independent "ALWAYS flag (blocking)" list.

`ops/state/truth/delivery.json` is now that owner.

## What changed

**The owner.** `ops/state/truth/delivery.json`, registered in `sources.json` as
`pr_delivery_lifecycle`. It owns the seven lifecycle states, the four finding dispositions, the
five-condition blocker predicate, FULL vs DELTA review, freeze/refreeze, the follow-up ledger
convention, the three lanes, and the maintainer-only decisions. It explicitly disclaims merge
semantics, and the gate fails if it ever stops disclaiming them.

**Why a new owner rather than an extension of `policy.json`.** `policy.json#merge` is a trusted
input to a provenance-gated executable. Folding review-process vocabulary into it would widen that
trusted surface for no benefit, and force the merge-policy validator to accept process language.

**The gate.** `scripts/check-delivery-lifecycle.py` validates the owner's shape and enforces the
provider bindings. Two properties are deliberate:

- *The predicate is code.* The blocker conditions, state set, dispositions, review kinds and lane
  names are hardcoded in the checker and never read from the document it validates. A PR cannot
  weaken its own freeze by deleting a condition from a JSON file.
- *Four switches are pinned.* `push_resets_generation` must be `false`, `after_blocker_fix` must be
  `"DELTA"`, `automated_severity_is_advisory` must be `true`, and
  `orchestrator_may_not_duplicate_primitive` must be `true`. Relaxing any of them requires editing
  the checker, which is a reviewable act.

**`ship-pr`.** The workflow a maintainer invokes to finish a PR. It orchestrates and hands over;
registry `canonical_assertions` prove it carries no merge path of its own — no `gh pr merge`, no
`--admin`, no `--auto`, no branch-protection read, no baked required-check names, and not even the
mutation form of the executable. `merge-pr` remains the narrow primitive and `tools/icn-merge-pr`
remains the owner of mutation semantics.

**Provider surfaces reconciled.** Both `icn-code-reviewer` copies now load the canonical policy,
classify every finding, and declare FULL or DELTA. Their bodies are compared byte for byte after
front matter — reference assertions catch a surface that stops naming the owner, but only
comparison catches two surfaces drifting apart while both still name it.
`.github/copilot-instructions.md` drops 539 lines of second project handbook (including a retired
`STATE.md`-is-canonical claim and a retired identity taxonomy) and becomes a 72-line adapter.

**Entry points.** One row in `AGENTS.md`, one line in `WORKFLOW_ARCHITECTURE.md`, a compact
delivery section in the PR template, and the same in `pr-create` — so the lifecycle is reachable
from a cold start.

## Verification

```
check-delivery-lifecycle          OK — 7 states, 5 blocker conditions, 3 provider surfaces bound
test_delivery_lifecycle           clean — 109 assertions
check-skill-registry              clean — 91 assertions
test_skill_registry_invariants    every rule rejects its own violation
check-merge-policy-schema         clean          drift-check.sh              PASS
check-truth-spine                 clean          check-preflight-consistency clean
test_public_docs_boundary         ALL PASS       compliance/readiness lint   clean
```

Every process invariant is tested by mutating the real policy into the failure it is meant to
prevent and asserting the validator complains — a test that only read the committed values would
pass just as happily against a policy nobody enforces. Seven of them run the real gate end to end
in a temp root: a reviewer prompt that regains its own blocking list, one that stops naming the
owner, two that drift apart, a provider entry file that regains volatile state, an owner
de-registered from the truth map, and a policy edited to let a push reset review. All fail the
gate. The clean tree passes it.

`docs/scripts/freshness-check.py` fails identically on `main` and does not implicate any file here.

## Risk

The gate's forbidden patterns are regexes over provider prompts, so a determined rewording could
pass them. That is why the body comparison and the pinned switches exist: the patterns catch the
obvious regression, the comparison catches the slow one, and the switches make the load-bearing
rules unreachable from data alone.

## Related

- Issues: `Refs #2661`, `Refs #2632`
- Follow-up ledger from the worked example: #2660

## Type of change

- [x] New feature
- [x] Tests

## Non-goals

Stated in the Delivery section above.







