### PR TITLE
fix(merge-pr): bind the ordinary merge to the head its authorization named

### DIFF
--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -50,9 +50,20 @@ silently rots (icn#2651).
    ```bash
    icn-merge-pr merge "$PR" --authorize
    ```
+   If the caller supplied the exact head the authorization was given for, pass it through
+   unchanged:
+   ```bash
+   icn-merge-pr merge "$PR" --authorize --expected-head "$AUTHORIZED_HEAD"
+   ```
+   **Forward it verbatim or not at all.** Do not read the live head to fill it in: a value derived
+   here is a statement about now, and the whole point of the option is that it comes from whatever
+   established the head was fit to merge. Do not substitute, shorten, or re-derive it, and do not
+   drop it and merge anyway when it does not match — the program owns that decision.
+
    The program re-reads every signal immediately before acting, so a `READY` from step 1 is a
    report, not a promise. A refusal here means the state genuinely changed; it is not a glitch to
-   retry.
+   retry. `REFUSED_EXPECTED_HEAD` means the pull request moved off the head that was authorized:
+   whatever justified the merge covered a commit that is no longer the head.
 
 6. **Report** the final outcome, quoting the code. Each one describes **this invocation**, not
    the pull request's history.

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -143,18 +143,16 @@ mutation is never retried.
 
 **Compare the live head with the recorded freeze head before anything else.** A freeze names an
 exact head because that is the head that was reviewed and verified. Anything pushed since has been
-through neither, and nothing downstream will catch it: the merge executable pins the head it
-mutates, but it has no idea which head was reviewed.
+through neither.
 
 On a mismatch, the new content is unverified. Run DELTA verification on it, update the freeze head,
 return to FROZEN, and only then continue. `freeze.head_must_match_before_handoff` is the rule.
 
 Then **hand the freeze head down with the authorization**. Comparing here is not enough on its own:
-a push can land between this comparison and the mutation, and the executable would pin whatever is
-at the top of the branch by then. Give `merge-pr` the exact frozen head so the mutation is bound to
-the commit that was actually reviewed, and it refuses rather than merging a newer one. Pass the
+a push can land between this comparison and the mutation. Give `merge-pr` the exact frozen head, and
+the executable binds the mutation to it — refusing rather than merging a newer one. Pass the
 recorded value; do not re-read the live head to produce it, because that would authorize whatever
-just landed.
+just landed, which is the whole failure this is here to prevent.
 
 ```bash
 icn-merge-pr check "$PR"

--- a/.agents/skills/ship-pr/SKILL.md
+++ b/.agents/skills/ship-pr/SKILL.md
@@ -149,6 +149,13 @@ mutates, but it has no idea which head was reviewed.
 On a mismatch, the new content is unverified. Run DELTA verification on it, update the freeze head,
 return to FROZEN, and only then continue. `freeze.head_must_match_before_handoff` is the rule.
 
+Then **hand the freeze head down with the authorization**. Comparing here is not enough on its own:
+a push can land between this comparison and the mutation, and the executable would pin whatever is
+at the top of the branch by then. Give `merge-pr` the exact frozen head so the mutation is bound to
+the commit that was actually reviewed, and it refuses rather than merging a newer one. Pass the
+recorded value; do not re-read the live head to produce it, because that would authorize whatever
+just landed.
+
 ```bash
 icn-merge-pr check "$PR"
 ```

--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -50,9 +50,20 @@ silently rots (icn#2651).
    ```bash
    icn-merge-pr merge "$PR" --authorize
    ```
+   If the caller supplied the exact head the authorization was given for, pass it through
+   unchanged:
+   ```bash
+   icn-merge-pr merge "$PR" --authorize --expected-head "$AUTHORIZED_HEAD"
+   ```
+   **Forward it verbatim or not at all.** Do not read the live head to fill it in: a value derived
+   here is a statement about now, and the whole point of the option is that it comes from whatever
+   established the head was fit to merge. Do not substitute, shorten, or re-derive it, and do not
+   drop it and merge anyway when it does not match — the program owns that decision.
+
    The program re-reads every signal immediately before acting, so a `READY` from step 1 is a
    report, not a promise. A refusal here means the state genuinely changed; it is not a glitch to
-   retry.
+   retry. `REFUSED_EXPECTED_HEAD` means the pull request moved off the head that was authorized:
+   whatever justified the merge covered a commit that is no longer the head.
 
 6. **Report** the final outcome, quoting the code. Each one describes **this invocation**, not
    the pull request's history.

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -143,18 +143,16 @@ mutation is never retried.
 
 **Compare the live head with the recorded freeze head before anything else.** A freeze names an
 exact head because that is the head that was reviewed and verified. Anything pushed since has been
-through neither, and nothing downstream will catch it: the merge executable pins the head it
-mutates, but it has no idea which head was reviewed.
+through neither.
 
 On a mismatch, the new content is unverified. Run DELTA verification on it, update the freeze head,
 return to FROZEN, and only then continue. `freeze.head_must_match_before_handoff` is the rule.
 
 Then **hand the freeze head down with the authorization**. Comparing here is not enough on its own:
-a push can land between this comparison and the mutation, and the executable would pin whatever is
-at the top of the branch by then. Give `merge-pr` the exact frozen head so the mutation is bound to
-the commit that was actually reviewed, and it refuses rather than merging a newer one. Pass the
+a push can land between this comparison and the mutation. Give `merge-pr` the exact frozen head, and
+the executable binds the mutation to it — refusing rather than merging a newer one. Pass the
 recorded value; do not re-read the live head to produce it, because that would authorize whatever
-just landed.
+just landed, which is the whole failure this is here to prevent.
 
 ```bash
 icn-merge-pr check "$PR"

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -149,6 +149,13 @@ mutates, but it has no idea which head was reviewed.
 On a mismatch, the new content is unverified. Run DELTA verification on it, update the freeze head,
 return to FROZEN, and only then continue. `freeze.head_must_match_before_handoff` is the rule.
 
+Then **hand the freeze head down with the authorization**. Comparing here is not enough on its own:
+a push can land between this comparison and the mutation, and the executable would pin whatever is
+at the top of the branch by then. Give `merge-pr` the exact frozen head so the mutation is bound to
+the commit that was actually reviewed, and it refuses rather than merging a newer one. Pass the
+recorded value; do not re-read the live head to produce it, because that would authorize whatever
+just landed.
+
 ```bash
 icn-merge-pr check "$PR"
 ```

--- a/ops/state/truth/delivery.json
+++ b/ops/state/truth/delivery.json
@@ -232,7 +232,7 @@
       "the scheduled comprehensive review generation has closed"
     ],
     "names_an_exact_head": true,
-    "head_must_match_before_handoff": "Before handing over to the merge primitive, the live head must equal the recorded freeze head. A freeze names an exact head because that is the head that was reviewed and verified; content pushed after the freeze has been through neither. On a mismatch, run DELTA verification on the new content, update the freeze head, return to FROZEN, and only then hand over. The merge executable pins the head it mutates, but it does not know which head was reviewed \u2014 nothing downstream will catch this.",
+    "head_must_match_before_handoff": "Before handing over to the merge primitive, the live head must equal the recorded freeze head. A freeze names an exact head because that is the head that was reviewed and verified; content pushed after the freeze has been through neither. On a mismatch, run DELTA verification on the new content, update the freeze head, return to FROZEN, and only then hand over. Comparing is not sufficient on its own, because a push can land between the comparison and the mutation: the freeze head is therefore also passed down with the authorization, and the merge executable refuses rather than merging a head the authorization did not name (icn#2666).",
     "effect": [
       "a new automated review comment does not reopen the pull request",
       "review of a frozen pull request is DELTA, never FULL",

--- a/ops/state/truth/skills.json
+++ b/ops/state/truth/skills.json
@@ -289,7 +289,9 @@
           "must_reference": [
             "ops/state/truth/policy.json",
             "icn-merge-pr",
-            "explicit, per-PR maintainer authorization"
+            "explicit, per-PR maintainer authorization",
+            "--expected-head",
+            "Forward it verbatim or not at all"
           ],
           "must_not_match": [
             {
@@ -319,6 +321,10 @@
             {
               "pattern": "REFUSED.*\\bdid not merge\\b|\\bthe (PR|pull request) (did not merge|is not merged|was not merged)\\b",
               "why": "an outcome describes this invocation, not about the pull request: a target may already have been merged or closed by another actor, in which case the evaluator refuses with the observed state and this wording would state the opposite of the evidence it was told to quote"
+            },
+            {
+              "pattern": "headRefOid|--jq\\s+\\.head",
+              "why": "reading the live head here would fabricate the value the caller is supposed to supply; an authorized head derived at merge time authorizes whatever just landed"
             }
           ]
         }
@@ -446,7 +452,8 @@
             "ops/state/truth/delivery.json",
             "icn-merge-pr",
             "ops/scripts/icn-wait",
-            "automated review is evidence, not unbounded veto authority"
+            "automated review is evidence, not unbounded veto authority",
+            "hand the freeze head down"
           ],
           "must_not_match": [
             {

--- a/scripts/tests/test_delivery_lifecycle.py
+++ b/scripts/tests/test_delivery_lifecycle.py
@@ -274,6 +274,32 @@ rejects("narrowing the condition back to declared contract terms is rejected",
 
 
 # ---------------------------------------------------------------------------------------------
+print("the frozen head is the head the mutation is authorized for")
+
+# Comparing the head before handoff is not sufficient on its own: a push can land between that
+# comparison and the mutation, and the executable would pin whatever is on top by then. The freeze
+# head is therefore passed down with the authorization (icn#2666).
+ship_bind = (ROOT / ".agents" / "skills" / "ship-pr" / "SKILL.md").read_text(encoding="utf-8")
+merge_bind = (ROOT / ".agents" / "skills" / "merge-pr" / "SKILL.md").read_text(encoding="utf-8")
+check("the owner says the freeze head is passed down with the authorization",
+      "passed down with the authorization"
+      in DELIVERY["freeze"]["head_must_match_before_handoff"], "owner is silent")
+check("the owner no longer claims nothing downstream catches this",
+      "nothing downstream" not in DELIVERY["freeze"]["head_must_match_before_handoff"],
+      "the superseded claim is still there")
+check("ship-pr hands the freeze head down", "hand the freeze head down" in ship_bind, "missing")
+check("ship-pr does not re-read the live head to produce it",
+      "do not re-read the live head to produce it" in ship_bind, "missing")
+check("merge-pr accepts an authorized head", "--expected-head" in merge_bind, "missing")
+check("merge-pr forwards it verbatim",
+      "Forward it verbatim or not at all" in merge_bind, "missing")
+check("merge-pr does not derive the head itself",
+      "headRefOid" not in merge_bind, "the wrapper reads the live head")
+check("ship-pr still owns no mutation form",
+      not re.search(r"icn-merge-pr\s+merge", ship_bind), "a mutation path entered the orchestrator")
+
+
+# ---------------------------------------------------------------------------------------------
 print("readiness is decided in one place")
 
 # The skill told itself to read the merge owner and live protection to pick which gates to wait

--- a/scripts/tests/test_delivery_lifecycle.py
+++ b/scripts/tests/test_delivery_lifecycle.py
@@ -298,6 +298,12 @@ check("ship-pr hands the freeze head down", "hand the freeze head down" in ship_
 check("ship-pr does not re-read the live head to produce it",
       "do not re-read the live head to produce it" in ship_bind, "missing")
 check("merge-pr accepts an authorized head", "--expected-head" in merge_bind, "missing")
+# An optional contract nobody can discover is close to no contract, and this design rests on
+# callers choosing to pass it. The tool's README enumerates its invocations, so it must list this.
+_readme = (ROOT / "tools" / "icn-merge-pr" / "README.md").read_text(encoding="utf-8")
+check("the tool's README documents the authorized-head option",
+      "--expected-head" in _readme and "REFUSED_EXPECTED_HEAD" in _readme,
+      "the README enumerates the CLI without it")
 check("merge-pr forwards it verbatim",
       "Forward it verbatim or not at all" in merge_bind, "missing")
 check("merge-pr does not derive the head itself",

--- a/scripts/tests/test_delivery_lifecycle.py
+++ b/scripts/tests/test_delivery_lifecycle.py
@@ -287,6 +287,13 @@ check("the owner says the freeze head is passed down with the authorization",
 check("the owner no longer claims nothing downstream catches this",
       "nothing downstream" not in DELIVERY["freeze"]["head_must_match_before_handoff"],
       "the superseded claim is still there")
+# The same superseded claim was also written into the skill, and correcting only the owner left
+# the procedure telling an agent the opposite of what the executable now does.
+for _surface in (".agents/skills/ship-pr/SKILL.md", ".claude/skills/ship-pr/SKILL.md"):
+    _text = (ROOT / _surface).read_text(encoding="utf-8")
+    check(f"{_surface} does not carry the superseded claim either",
+          "nothing downstream" not in _text and "no idea which head was reviewed" not in _text,
+          "the skill still contradicts the executable")
 check("ship-pr hands the freeze head down", "hand the freeze head down" in ship_bind, "missing")
 check("ship-pr does not re-read the live head to produce it",
       "do not re-read the live head to produce it" in ship_bind, "missing")

--- a/scripts/tests/test_icn_merge_pr.py
+++ b/scripts/tests/test_icn_merge_pr.py
@@ -1070,6 +1070,63 @@ fake, _ = expect_merge("the default-branch commit moves",
 check("no merge was attempted after a default-branch race", fake.merge_calls == [])
 
 
+# --- the head authorization named -----------------------------------------------------------------------
+print("a merge is bound to the head its authorization named (icn#2666)")
+
+# The race check above covers seconds: this program's own two reads. This covers the wait for a
+# human to say yes, which is where a push actually lands. Nothing else knows which head was
+# reviewed, so if this does not refuse, nothing does.
+fake, result = expect_merge("the live head is still the head that was authorized", world(),
+                            codes.MERGED, expected_head=HEAD)
+check("the authorized head is the head pinned in the merge request",
+      [c["sha"] for c in fake.merge_calls] == [HEAD], str(fake.merge_calls))
+check("the authorized head is reported back in the evidence",
+      result.evidence.get("expected_head") == HEAD, str(result.evidence.get("expected_head")))
+
+fake, _ = expect_merge("the head is not the head that was authorized", world(),
+                       codes.REFUSED_EXPECTED_HEAD, expected_head="a" * 40)
+check("no merge is attempted when the head is not the authorized one", fake.merge_calls == [])
+
+# Case matters nowhere else in git, and must not matter here either.
+fake, _ = expect_merge("the authorized head differs only in case", world(), codes.MERGED,
+                       expected_head=HEAD.upper())
+check("a merge still happened for a case-different authorized head",
+      [c["sha"] for c in fake.merge_calls] == [HEAD], str(fake.merge_calls))
+
+# No fallback to the newer head, stated two ways: authorizing the OLD head refuses, and so does
+# authorizing the NEW one — because a head that moved mid-flight was never evaluated at all.
+fake, _ = expect_merge("the head moves after authorization named the old one", racing(set_head),
+                       codes.REFUSED_HEAD_CHANGED, expected_head=HEAD)
+check("no merge was attempted when the authorized head was overtaken", fake.merge_calls == [])
+fake, _ = expect_merge("the head moves and authorization named the NEW one", racing(set_head),
+                       codes.REFUSED_HEAD_CHANGED, expected_head="9" * 40)
+check("naming the newer head does not authorize it either", fake.merge_calls == [])
+
+fake, _ = expect_merge("no authorized head is named at all", world(), codes.MERGED)
+check("an unbound merge still pins the live head",
+      [c["sha"] for c in fake.merge_calls] == [HEAD], str(fake.merge_calls))
+
+
+def parse_refusal(argv) -> str:
+    buffer = io.StringIO()
+    with redirect_stdout(buffer), redirect_stderr(io.StringIO()):
+        cli.main(argv)
+    return json.loads(buffer.getvalue())["outcome"]
+
+
+check("--expected-head is refused on check, which never mutates",
+      parse_refusal(["check", "1", "--expected-head", HEAD]) == codes.REFUSED_USAGE)
+for bad in (HEAD[:12], HEAD + "0", "z" * 40, "", "HEAD", "refs/heads/main"):
+    check(f"--expected-head {bad!r} is refused as a shape",
+          parse_refusal(["merge", "1", "--authorize", "--expected-head", bad])
+          == codes.REFUSED_USAGE, bad)
+check("--expected-head given twice is refused",
+      parse_refusal(["merge", "1", "--authorize", "--expected-head", HEAD,
+                     "--expected-head", HEAD]) == codes.REFUSED_USAGE)
+check("--expected-head with no value is refused",
+      parse_refusal(["merge", "1", "--authorize", "--expected-head"]) == codes.REFUSED_USAGE)
+
+
 def change_policy(w):
     document = json.loads(POLICY_TEXT)
     document["merge"]["race_note"] = "the document changed underneath the evaluation"

--- a/tools/icn-merge-pr/README.md
+++ b/tools/icn-merge-pr/README.md
@@ -64,8 +64,29 @@ has merely gained an unexpected importable file no longer gets to run it.
 icn-merge-pr check <PR>              # evaluate; mutates nothing
 icn-merge-pr merge <PR> --authorize  # re-read everything, then merge once, or refuse
                                      # (only an INSTALLED copy may mutate)
+icn-merge-pr merge <PR> --authorize --expected-head <full 40-hex sha>
+                                     # ...and refuse unless the live head is still
+                                     # exactly that commit
 icn-merge-pr provenance              # which commit is installed
 ```
+
+### `--expected-head`
+
+Names the commit the authorization was given **for**. Checked immediately before the mutation,
+against the same read the merge request pins, so the head that is proved is the head that is
+merged. A mismatch is `REFUSED_EXPECTED_HEAD` and attempts nothing; there is no fallback to the
+newer head, and naming the newer head does not authorize it either.
+
+It exists because review and authorization are separated by a human decision. Without it the
+program merges whatever is at the top of the branch by the time consent arrives, which may be code
+nobody reviewed.
+
+It is optional, and deliberately so: a caller that derives the value from the live head at call
+time gains nothing, because it would only re-assert what it just read. The value is meaningful
+only when it comes from whatever established that the head was fit to merge — which is why
+`ship-pr` passes its recorded freeze head down through `merge-pr`, and `merge-pr` forwards it
+verbatim rather than re-deriving one. An invocation that omits it is exactly as bound as this
+program was before the option existed: no weaker, and no stronger.
 
 Results are JSON on stdout with a stable `outcome` code (`icn_merge_pr/codes.py`); a summary goes
 to stderr.

--- a/tools/icn-merge-pr/icn_merge_pr/cli.py
+++ b/tools/icn-merge-pr/icn_merge_pr/cli.py
@@ -2,7 +2,7 @@
 
 TWO FORMS, ONE OF WHICH MUTATES
     icn-merge-pr check <PR>
-    icn-merge-pr merge <PR> --authorize
+    icn-merge-pr merge <PR> --authorize [--expected-head <full sha>]
 
 Evaluation is always available without mutating anything. Mutation requires `--authorize` to be
 written out; there is no configuration, environment variable or implicit mode that supplies it.
@@ -17,6 +17,7 @@ too — the point of a closed grammar is that nothing arrives by accident.
 from __future__ import annotations
 
 import json
+import re
 import sys
 
 from . import codes, provenance
@@ -29,11 +30,20 @@ USAGE = """icn-merge-pr — the trusted ordinary-merge primitive for ICN (icn#26
 
   icn-merge-pr check <PR>  [--repo OWNER/NAME]
   icn-merge-pr merge <PR>  --authorize [--repo OWNER/NAME]
+                           [--expected-head <full 40-hex sha>]
                            [--strategy <policy exception> --reason "<why>"]
   icn-merge-pr provenance
 
 `check` evaluates and mutates nothing. `merge` re-reads every piece of evidence immediately
-before acting and performs at most one head-pinned ordinary merge. It has no privileged mode and
+before acting and performs at most one head-pinned ordinary merge.
+
+`--expected-head` names the commit the authorization was given FOR. The merge is refused unless
+the live head is still exactly that commit, and that same commit is the one pinned in the merge
+request. It exists because a caller reviews one head and authorizes minutes later: without it the
+program merges whatever is at the top of the branch by then, which may be code nobody reviewed.
+It is optional, because a caller who derives it from the live head at call time would gain
+nothing; the value is only meaningful when it comes from whatever established that the head was
+fit to merge. It has no privileged mode and
 cannot arm, enqueue or defer a merge. Results are JSON on stdout; a one-line summary goes to
 stderr.
 
@@ -62,7 +72,10 @@ FORBIDDEN_OPTIONS = {
 
 COMMANDS = ("check", "merge", "provenance")
 
-_VALUE_OPTIONS = {"--repo", "--strategy", "--reason"}
+# Full object ids only. Owned here, like every other shape this grammar accepts.
+_FULL_OID = re.compile(r"[0-9a-fA-F]{40}")
+
+_VALUE_OPTIONS = {"--repo", "--strategy", "--reason", "--expected-head"}
 _FLAG_OPTIONS = {"--authorize"}
 
 
@@ -75,6 +88,7 @@ class Invocation:
         self.authorize = False
         self.strategy: str | None = None
         self.reason: str | None = None
+        self.expected_head: str | None = None
 
 
 def parse(argv: list[str]) -> Invocation:
@@ -139,9 +153,20 @@ def parse(argv: list[str]) -> Invocation:
             inv.strategy = value
         elif option == "--reason":
             inv.reason = value
+        elif option == "--expected-head":
+            # A full object id, not a prefix. An abbreviation is ambiguous by construction, and
+            # this value decides whether a mutation happens — it is not a convenience argument.
+            if not _FULL_OID.fullmatch(value):
+                raise UsageError(
+                    f"--expected-head must be a full 40-character Git object id, got {value!r}")
+            inv.expected_head = value.lower()
 
     if inv.command == "check" and inv.authorize:
         raise UsageError("--authorize belongs to `merge`; `check` never mutates")
+    if inv.command == "check" and inv.expected_head is not None:
+        raise UsageError(
+            "--expected-head belongs to `merge`; `check` never mutates, so there is nothing for "
+            "it to bind")
     if inv.command == "merge" and not inv.authorize:
         raise UsageError(
             "`merge` mutates and requires --authorize to be stated explicitly. Run "
@@ -247,7 +272,7 @@ def main(argv: list[str]) -> int:
         installed_commit = record.get("source_commit")
     result = run(GhCli(), owner, name, inv.number, authorize=inv.authorize,
                  requested_strategy=inv.strategy, exception_reason=inv.reason,
-                 installed_commit=installed_commit)
+                 installed_commit=installed_commit, expected_head=inv.expected_head)
     print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
     print(_summary(result), file=sys.stderr)
     return codes.exit_code(result.outcome)

--- a/tools/icn-merge-pr/icn_merge_pr/codes.py
+++ b/tools/icn-merge-pr/icn_merge_pr/codes.py
@@ -53,6 +53,7 @@ REFUSED_STRATEGY_INVALID = "REFUSED_STRATEGY_INVALID"        # outside the close
 REFUSED_STRATEGY_UNAVAILABLE = "REFUSED_STRATEGY_UNAVAILABLE"  # repository does not allow it
 
 # --- races ------------------------------------------------------------------------------------
+REFUSED_EXPECTED_HEAD = "REFUSED_EXPECTED_HEAD"    # live head != the head authorization named
 REFUSED_HEAD_CHANGED = "REFUSED_HEAD_CHANGED"
 REFUSED_BASE_CHANGED = "REFUSED_BASE_CHANGED"
 REFUSED_DEFAULT_BRANCH_CHANGED = "REFUSED_DEFAULT_BRANCH_CHANGED"

--- a/tools/icn-merge-pr/icn_merge_pr/errors.py
+++ b/tools/icn-merge-pr/icn_merge_pr/errors.py
@@ -69,6 +69,18 @@ class GitHubRefused(MergeToolError):
     outcome = codes.REFUSED_GITHUB
 
 
+class ExpectedHeadMismatch(MergeToolError):
+    """Authorization named one head and the live pull request is on another.
+
+    Distinct from `REFUSED_HEAD_CHANGED`, which reports a head moving between this program's own
+    two reads. This one reports the head moving away from what the CALLER authorized, which is a
+    different fact: the review that justified the merge covered a commit that is no longer the
+    head, and nothing else in this program can notice that.
+    """
+
+    outcome = codes.REFUSED_EXPECTED_HEAD
+
+
 class UsageError(MergeToolError):
     outcome = codes.REFUSED_USAGE
 

--- a/tools/icn-merge-pr/icn_merge_pr/run.py
+++ b/tools/icn-merge-pr/icn_merge_pr/run.py
@@ -149,7 +149,7 @@ def stale_evaluator(client, owner: str, name: str, installed: str, live: str) ->
 
 def run(client, owner: str, name: str, number: int, *, authorize: bool,
         requested_strategy: str | None = None, exception_reason: str | None = None,
-        installed_commit: str | None = None) -> Result:
+        installed_commit: str | None = None, expected_head: str | None = None) -> Result:
     """`check` when `authorize` is false; the full evaluate-refresh-merge path when it is true."""
     command = "merge" if authorize else "check"
     result = Result(command=command, owner=owner, name=name, number=number,
@@ -185,10 +185,28 @@ def run(client, owner: str, name: str, number: int, *, authorize: bool,
         return result
 
     result.evidence = _evidence(fresh)
+    if expected_head is not None:
+        result.evidence["expected_head"] = expected_head
     race = detect_race(snap, fresh)
     if race is not None:
         result.outcome = race.code
         result.reasons = [race]
+        return result
+
+    # The head the caller AUTHORIZED, against the head that is live now. This is not the race
+    # check above: that one asks whether the head moved between this program's own two reads,
+    # which is a window of seconds. This asks whether the head is still the commit whose review
+    # justified the merge — a window that spans the wait for a human to say yes. Nothing else in
+    # this program knows which head was reviewed, so if this does not refuse, nothing will.
+    if expected_head is not None and fresh.head_oid.lower() != expected_head.lower():
+        result.outcome = codes.REFUSED_EXPECTED_HEAD
+        result.reasons = [Reason(
+            codes.REFUSED_EXPECTED_HEAD,
+            f"authorization named head {expected_head[:12]}, and #{number} is now at "
+            f"{fresh.head_oid[:12]}. The commit that was reviewed is not the commit that would "
+            f"be merged. This program does not fall back to the newer head: re-establish that "
+            f"the current head is fit to merge, then authorize that head.")]
+        result.merge = {"attempted": False, "confirmed_merged": False, "merge_commit_sha": None}
         return result
 
     if installed_commit:


### PR DESCRIPTION
## Delivery

- **Delivery lane**: STANDARD
- **Acceptance contract**: the head that was frozen and DELTA-verified is the head the ordinary
  merge primitive is authorized to merge. An expected-head contract owned by the executable
  refuses any other head, performs no merge action on mismatch, and never falls back to a newer
  head. `ship-pr` passes its recorded freeze head through `merge-pr` to the executable; `merge-pr`
  forwards it verbatim and derives no head of its own; the executable remains the sole mutation
  authority and no merge implementation enters `ship-pr`.
- **Explicit non-goals**: no redesign of Stage B; no general review of the merge executable; no
  branch-protection, ruleset or permission changes; the lifecycle-state-authority work is a
  separate track (#2663).

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                DONE
Lane:                 STANDARD
Acceptance contract:  see the Delivery section above
Review generation:    1 of 1, CLOSED
Freeze head:          824557ed71fbd8bf491bdb99547141f315f55a33
Known blockers:       0
Follow-up ledger:     icn#2668
Merge commit:         8e41458e59d7f571351f626f0fb8aa725f1c1036
Comprehensive review: CLOSED
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

**Generation 1 of 1 is CLOSED.** Scheduled automated reviewers:

| Reviewer | Outcome |
|---|---|
| `copilot-pull-request-reviewer` | responded `2026-08-28T08:47:20Z` on `65dd70ad` — 1 observation, classified FOLLOW_UP (icn#2668) |
| `chatgpt-codex-connector` | **`NO_SHOW`** — no response by the 15-minute cutoff (`08:59:12Z`) |

**Basis for the cutoff.** The intake clock runs from when the FULL generation
opened. For this pull request that is demonstrably the moment it was created
(`2026-08-28T08:44:12Z`): opening it is what scheduled the reviewers, and
Copilot returned three minutes later against the creation head. `createdAt` is
being used here because it is the same event, not because it is the canonical
source — a durable generation-open record is part of the Track D work in
icn#2663.

**Late findings after the cutoff.** The reviewer recorded `NO_SHOW` returned twice
after generation 1 closed, at `09:13:32Z` and `09:25:50Z`. Both were handled under
the late threshold without reopening review, in two targeted refreeze cycles:
a contradictory handoff claim this PR made false but left in the skill, and the
option being absent from the tool's README. A third part of the second finding —
making `--expected-head` mandatory — is a breaking Stage-B contract change and is
escalated to icn#2668 as a maintainer decision.

**Base synchronized.** Rebased onto `a0c8afdb` (#2665) after that landed. A base
update to an already-open generation is not a second FULL generation; its
consequences are covered by DELTA verification.

**Lane note.** STANDARD, not DEEP. This touches an authority boundary, but the canonical lifecycle
defines DEEP as `requires_maintainer_selection: true` and an agent may not select it. The
maintainer specified STANDARD unless the lifecycle itself demands otherwise, and it does not.

## Summary

`ship-pr` compared the live head with the recorded freeze head before handing over — but that
comparison and the mutation are not the same moment. `merge-pr` then waits for a human to authorize,
the executable re-reads live state, and `perform_merge` pins whatever is on top of the branch by
then. A push during that wait merged content that never received DELTA verification.

The merge was never unsafe in the racing sense: it has always pinned an exact head, so it cannot
race GitHub. The gap was narrower and worse — the head it pinned was not necessarily the head that
was *reviewed*, and nothing downstream could notice, because the executable had no idea which head
the review covered.

Reported against #2662 and deferred there as a maintainer decision:
https://github.com/InterCooperative-Network/icn/pull/2662#discussion_r3878436327

## The contract

```
icn-merge-pr merge <PR> --authorize --expected-head <full 40-hex sha>
```

- **Full object ids only.** An abbreviation is ambiguous by construction, and this value decides
  whether a mutation happens — it is not a convenience argument.
- **Mutating flow only.** Refused on `check`, which never mutates, so there is nothing to bind.
- **Checked immediately after the pre-mutation refresh**, against the same snapshot `perform_merge`
  pins. The head that is proved is therefore the head that is merged.
- **Mismatch is `REFUSED_EXPECTED_HEAD`** and attempts nothing.
- **No fallback, no retry.** A head that moved mid-flight refuses either way — including when the
  caller names the *new* head, because that head was never evaluated.

**Why a distinct code rather than reusing `REFUSED_HEAD_CHANGED`.** That one reports the head moving
between this program's own two reads: a window of seconds. This reports the head moving away from
what the caller authorized: a window that spans a human decision. They are different facts and an
operator needs to tell them apart.

**Why optional.** A caller who derives the value from the live head at call time gains nothing — it
would just re-assert what it had already read. The value is only meaningful when it comes from
whatever established the head was fit to merge. So the guarantee is wired at the callers:
`ship-pr` passes its recorded freeze head down, `merge-pr` forwards it verbatim, and a registry
assertion forbids the wrapper from reading the live head to fabricate one.

## Corrected claim

`freeze.head_must_match_before_handoff` said the executable "does not know which head was reviewed
— nothing downstream will catch this." That is no longer true, and the owner has been updated
rather than left carrying a superseded statement. A control asserts the old wording is gone.

## Verification

```
test_icn_merge_pr              clean — 510 assertions
test_icn_merge_pr_install      clean
test_delivery_lifecycle        clean — 186 assertions
check-skill-registry           clean — 94 assertions
test_skill_registry_invariants every rule rejects its own violation
check-delivery-lifecycle       OK      check-merge-policy-schema  clean
check-truth-spine              clean   drift-check.sh             PASS
```

New behaviour coverage: the authorized head is the head pinned in the merge request; a mismatch
attempts nothing; case-insensitive comparison; a mid-flight move refuses whether the old or the new
head was named; an unbound merge still works; and the CLI refuses `--expected-head` on `check`, as
a prefix, over-length, non-hex, empty, symbolic, duplicated, and valueless.

After this lands the tool is reinstalled through the documented default-branch bootstrap and
verified to carry the new contract.

## Related

- Issues: `Refs #2666`, `Refs #2663`, `Refs #2651`

## Type of change

- [x] Bug fix
- [x] Tests

## Non-goals

Stated in the Delivery section above.




