### PR TITLE
fix(agent-runtime): let a fresh worktree become a working agent lane on its own

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -162,7 +162,7 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-lifecycle.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Registering agent session..."
           }
         ]

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,11 @@ __pycache__/
 dist/
 build/
 
+# The agent runtime bootstrap (ops/scripts/icn-runtime-build) publishes its resolved build into
+# a fresh worktree as a SYMLINK at ops/mcp/dist. `dist/` above matches directories only, so
+# without this line every bootstrapped lane reported an untracked ops/mcp/dist.
+ops/mcp/dist
+
 # Jupyter
 .ipynb_checkpoints/
 *.ipynb_checkpoints

--- a/docs/architecture/AGENT_RUNTIME.md
+++ b/docs/architecture/AGENT_RUNTIME.md
@@ -239,6 +239,53 @@ exposes the same core through a CLI (`ops/mcp/dist/cli/session.js`). MCP tools a
 **one shared module** (`ops/mcp/src/runtime/session-runtime.ts`); there is no second
 implementation to drift.
 
+### 3.1 How a fresh worktree gets that CLI
+
+`dist/` is gitignored, and no worktree-creation path — not `wt-new`, not Claude Code's nested
+`.claude/worktrees/<name>` lane, not `git worktree add` by hand — builds it. Requiring an
+in-tree build therefore made a new lane **permanently** unregistered rather than briefly
+degraded. When this was found, 44 of 50 worktrees on the dev VM could not register, the
+registry reported zero sessions while four Claude activations were live, and the readiness
+audit that found it was itself running unregistered. `mcp-host` worked only because its build
+happened to exist.
+
+`ops/scripts/icn-runtime-build` closes that. It resolves a build of the session CLI from a
+shared cache under `${XDG_CACHE_HOME:-~/.cache}/icn/agent-runtime`, keyed by a SHA-256 over the
+exact bytes of the checkout's runtime sources (`ops/mcp/src/**` plus `package.json`,
+`package-lock.json`, `tsconfig.json`), hashed with repo-relative paths so lanes holding
+identical sources agree on one key.
+
+- **Anti-stale — strengthened, not traded away.** The old rule was *this checkout's location
+  wins*. The cache key is a content hash, so running `<cache>/build/<fingerprint>/dist` proves
+  the executing bytes were compiled from **these** sources. A location rule only ever proved
+  the build sat next to them; it never noticed an in-tree `dist` gone stale against its own
+  `src`. An in-tree build still wins when present, so a developer's `npm run build` is
+  unaffected.
+- **Cost.** Measured on the dev VM: a cache hit is free and is the normal case, because a lane
+  branched from `main` has not touched `ops/mcp`. A first-of-its-kind source state costs one
+  `tsc` (~10s). The dependency tree (~157M, `better-sqlite3` compiled from source) is
+  machine-level state keyed by the lockfile, installed once and shared by every lane.
+- **Which events pay it.** `register` fires once per session and re-resolves unconditionally,
+  so a session always starts on a runtime built from the sources currently in the lane.
+  `progress`/`interaction` fire after every tool call and take the resolved path as-is; they
+  record liveness into a shared registry rather than interpreting it, and re-fingerprinting 52
+  files per tool call would cost ~116ms to re-answer a question they do not ask.
+- **Never blocking on the expensive half.** A missing `dist` is worth ~10s of a human's time
+  and is built inline. A missing dependency tree is a multi-minute native compile: the session
+  hands it to a detached background bootstrap, says plainly that *this* session is unregistered
+  and the next one will not be, and never fabricates a registration to hide it.
+- **Concurrency.** Entries are staged in a private directory and published with `rename(2)`,
+  with the completion marker written before the move, so a half-built tree is never observable.
+  `flock` stops duplicate work; it is not the correctness argument, since two racing builds of
+  one fingerprint produce the same bytes.
+
+The bootstrap publishes its resolution into the lane as a symlink at `ops/mcp/dist` (ignored by
+`.gitignore`), which keeps later hooks on the zero-cost path and makes provenance readable —
+the link target names the fingerprint the runtime was compiled from.
+
+Proven by `scripts/test-agent-runtime-bootstrap.sh`, whose standing rule is that no case may
+start from a worktree that already has a `dist`.
+
 Idempotency: registration is keyed on the provider conversation id taken from the hook
 payload's `session_id` field (§2.3). Re-running `register` for the same live activation returns
 the existing row, so a hook that fires twice cannot double-register. Launchers with no provider

--- a/docs/reference/project-index/generated/agent-capabilities.json
+++ b/docs/reference/project-index/generated/agent-capabilities.json
@@ -466,6 +466,13 @@
       "safety": "modifies_local"
     },
     {
+      "name": "icn-runtime-build",
+      "path": "ops/scripts/icn-runtime-build",
+      "capability": "agent-runtime-bootstrap",
+      "summary": "Resolve a runtime build for THIS checkout's ops/mcp sources, building it once into a shared content-addressed cache.",
+      "safety": "modifies_local"
+    },
+    {
       "name": "icn-wait",
       "path": "ops/scripts/icn-wait",
       "capability": "safe-waiting",

--- a/ops/scripts/icn-agent-session
+++ b/ops/scripts/icn-agent-session
@@ -153,8 +153,16 @@ fi
 # serving, for the same reason it resolves ROOT from its own location. The value matches what
 # the TypeScript computes in-tree (git-common-dir, resolved, plus icn-ops.db), so in-tree and
 # cached runtimes address one identical file.
+# The Git call is SANITISED. Git honours GIT_DIR, GIT_COMMON_DIR and their relatives over
+# `-C`, so an inherited value would silently pin this session's lifecycle data to another
+# repository's registry. ops/mcp/src/runtime/worktree-identity.ts strips the same set for the
+# same reason; this is the shell-side counterpart, not a new rule.
+git_repo() { env -u GIT_DIR -u GIT_COMMON_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+  -u GIT_OBJECT_DIRECTORY -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_CEILING_DIRECTORIES \
+  git -C "$1" "${@:2}" 2>/dev/null; }
+
 if [ -z "${ICN_OPS_DB:-}" ]; then
-  COMMON="$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null)"
+  COMMON="$(git_repo "$ROOT" rev-parse --git-common-dir)"
   if [ -n "$COMMON" ]; then
     case "$COMMON" in /*) ;; *) COMMON="$ROOT/$COMMON" ;; esac
     if COMMON="$(cd "$COMMON" 2>/dev/null && pwd -P)"; then

--- a/ops/scripts/icn-agent-session
+++ b/ops/scripts/icn-agent-session
@@ -113,9 +113,15 @@ resolve_cli() {
     CLI="$dist/cli/session.js"
     # Publish the resolution into the worktree as a symlink. It is ignored by .gitignore, it
     # keeps every later hook on the zero-cost path, and it makes provenance readable: the
-    # target path names the source fingerprint the runtime was compiled from. Never clobber a
-    # real in-tree build — a developer running `npm run build` still wins in their own lane.
-    if [ ! -e "$ROOT/ops/mcp/dist" ] || [ -L "$ROOT/ops/mcp/dist" ]; then
+    # target path names the fingerprint the runtime was compiled from. Never clobber a real
+    # in-tree build — a developer running `npm run build` still wins in their own lane.
+    #
+    # ONLY when the cache entry is actually read-only. The symlink is the sole path by which a
+    # lane can write into shared cache storage (`npm run build` would compile straight through
+    # it), so if the bootstrap could not protect the entry — a filesystem that ignores chmod —
+    # the link is exactly the hazard and is not worth the saved milliseconds. Later hooks then
+    # re-resolve, which is slower and correct.
+    if [ ! -w "$dist" ] && { [ ! -e "$ROOT/ops/mcp/dist" ] || [ -L "$ROOT/ops/mcp/dist" ]; }; then
       ln -sfn "$dist" "$ROOT/ops/mcp/dist" 2>/dev/null || true
     fi
     return 0

--- a/ops/scripts/icn-agent-session
+++ b/ops/scripts/icn-agent-session
@@ -73,11 +73,69 @@ degrade() {
 
 [ -n "$ROOT" ] && [ -d "$ROOT/ops/mcp" ] || degrade "could not resolve an ICN repo root"
 
-CLI="$ROOT/ops/mcp/dist/cli/session.js"
-if [ ! -f "$CLI" ]; then
-  degrade "session CLI not built ($CLI missing) — run: npm --prefix '$ROOT/ops/mcp' run build"
-fi
-
 command -v node >/dev/null 2>&1 || degrade "node not found on PATH"
+
+CLI="$ROOT/ops/mcp/dist/cli/session.js"
+BOOTSTRAP="$ROOT/ops/scripts/icn-runtime-build"
+
+# WHY THIS IS NOT JUST `[ -f "$CLI" ] || degrade`
+#   `dist/` is gitignored and nothing on any worktree-creation path builds it, so demanding an
+#   in-tree build meant every fresh worktree was permanently unregistered — 44 of 50 on the dev
+#   VM, including the lane of the audit that found it. icn-runtime-build resolves a build made
+#   from THIS checkout's runtime sources out of a shared content-addressed cache, so a new lane
+#   costs a ~10s compile at worst and nothing at all once some lane has presented these sources.
+#
+# WHEN WE RE-RESOLVE, AND WHY NOT ALWAYS
+#   `register` fires once per session from SessionStart: it re-resolves unconditionally, so a
+#   session always starts on a runtime built from the sources currently in the worktree.
+#   `progress`/`interaction` fire after every tool call; making them re-fingerprint 52 files
+#   would add ~116ms to each one to re-answer a question that cannot have changed in a way they
+#   care about — they record liveness into a shared registry, they do not interpret it. They
+#   therefore take the resolved path as-is and bootstrap only if it is missing entirely.
+#   A FAILED RE-RESOLUTION MUST NOT TAKE AWAY A RUNTIME THAT ALREADY WORKS. Before the
+#   bootstrap existed an in-tree dist was the only path, and it is still perfectly valid. An
+#   environment where the bootstrap cannot run — no npm, a partial checkout with no
+#   ops/mcp/package.json, a read-only cache — must therefore fall back to it rather than
+#   degrade. Without this, adding the bootstrap REGRESSED such environments from working to
+#   unregistered, which the adoption gate caught: its fixture carries a dist but no
+#   ops/mcp/package.json, so re-resolution failed and the session stopped registering.
+resolve_cli() {
+  local err dist reason
+  if [ ! -x "$BOOTSTRAP" ]; then
+    [ -f "$CLI" ] && return 0
+    degrade "session CLI not built and $BOOTSTRAP is missing or not executable"
+  fi
+  err="$(mktemp "${TMPDIR:-/tmp}/icn-runtime-resolve.XXXXXX")" || { [ -f "$CLI" ] && return 0; return 1; }
+  # --background-if-cold: a missing dist is a ~10s compile and worth waiting for; a missing
+  # dependency tree is a multi-minute native build that must never stall a human at a prompt.
+  if dist="$("$BOOTSTRAP" --background-if-cold 2>"$err")" && [ -n "$dist" ]; then
+    rm -f "$err"
+    CLI="$dist/cli/session.js"
+    # Publish the resolution into the worktree as a symlink. It is ignored by .gitignore, it
+    # keeps every later hook on the zero-cost path, and it makes provenance readable: the
+    # target path names the source fingerprint the runtime was compiled from. Never clobber a
+    # real in-tree build — a developer running `npm run build` still wins in their own lane.
+    if [ ! -e "$ROOT/ops/mcp/dist" ] || [ -L "$ROOT/ops/mcp/dist" ]; then
+      ln -sfn "$dist" "$ROOT/ops/mcp/dist" 2>/dev/null || true
+    fi
+    return 0
+  fi
+  # Hand the bootstrap's own specific reason through; it already explains what failed.
+  reason="$(tr '\n' ' ' <"$err" | sed -e 's/icn-runtime-build: //g' -e 's/  */ /g' -e 's/ *$//')"
+  rm -f "$err"
+  if [ -f "$CLI" ]; then
+    # Not degraded: this session has a working runtime. Say what could not be re-checked so a
+    # stale in-tree build is not mistaken for a verified one.
+    printf 'agent-runtime: using the in-tree build; could not re-resolve — %s\n' \
+      "${reason:-runtime bootstrap failed}" >&2
+    return 0
+  fi
+  degrade "${reason:-runtime bootstrap failed}"
+}
+
+if [ "$cmd" = "register" ] || [ ! -f "$CLI" ]; then
+  resolve_cli
+fi
+[ -f "$CLI" ] || degrade "session CLI still unavailable at $CLI after bootstrap"
 
 exec node "$CLI" "$@"

--- a/ops/scripts/icn-agent-session
+++ b/ops/scripts/icn-agent-session
@@ -138,4 +138,29 @@ if [ "$cmd" = "register" ] || [ ! -f "$CLI" ]; then
 fi
 [ -f "$CLI" ] || degrade "session CLI still unavailable at $CLI after bootstrap"
 
+# PIN THE REGISTRY TO THIS REPOSITORY, EXPLICITLY.
+#
+# resolveDefaultDbPath() in ops/mcp/src/state/db.ts derives the shared registry by asking Git
+# for --git-common-dir relative to the CLI's own __dirname. That worked while the CLI could
+# only ever live at <worktree>/ops/mcp/dist/state/. A cached runtime lives OUTSIDE every
+# checkout, so the derivation found no repository and fell back to a per-installation database
+# — every bootstrapped lane would have registered into a registry that the MCP server and every
+# other worktree could not see, which is precisely the one-registry-per-repository invariant
+# that module exists to hold. Caught by dogfooding a genuinely fresh lane; fixtures could not
+# see it, because they never ran a cached runtime against a real repository.
+#
+# The wrapper is the right seam for this: it is the component that knows which checkout it is
+# serving, for the same reason it resolves ROOT from its own location. The value matches what
+# the TypeScript computes in-tree (git-common-dir, resolved, plus icn-ops.db), so in-tree and
+# cached runtimes address one identical file.
+if [ -z "${ICN_OPS_DB:-}" ]; then
+  COMMON="$(git -C "$ROOT" rev-parse --git-common-dir 2>/dev/null)"
+  if [ -n "$COMMON" ]; then
+    case "$COMMON" in /*) ;; *) COMMON="$ROOT/$COMMON" ;; esac
+    if COMMON="$(cd "$COMMON" 2>/dev/null && pwd -P)"; then
+      export ICN_OPS_DB="$COMMON/icn-ops.db"
+    fi
+  fi
+fi
+
 exec node "$CLI" "$@"

--- a/ops/scripts/icn-runtime-build
+++ b/ops/scripts/icn-runtime-build
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+#: capability: agent-runtime-bootstrap
+#: summary: Resolve a runtime build for THIS checkout's ops/mcp sources, building it once into a shared content-addressed cache.
+#: safety: modifies_local
+#
+# icn-runtime-build — make a fresh worktree a working agent lane with no human preparation.
+#
+# THE DEFECT THIS CLOSES
+#   ops/scripts/icn-agent-session needs ops/mcp/dist/cli/session.js. `dist/` is gitignored, so a
+#   newly created worktree never has it, and neither `wt-new` nor Claude Code's nested-worktree
+#   creation builds it. Measured on the dev VM at the time of the fix: 44 of 50 worktrees could
+#   not register, the registry reported zero sessions while four Claude activations were live,
+#   and the previous readiness-audit lane was itself unregistered. `mcp-host` worked only because
+#   its build happened to exist.
+#
+# WHY A SHARED CACHE AND NOT A PER-WORKTREE BUILD
+#   node_modules for ops/mcp is ~157M and contains better-sqlite3, a NATIVE module with an
+#   `npm rebuild` postinstall. Installing that per worktree is unaffordable in both time and
+#   disk. The registry itself is already ONE database per repository (ops/mcp/src/state/db.ts),
+#   and the MCP server is already launched from a single absolute path outside every task
+#   worktree, so a shared runtime is the shape this system already had everywhere except here.
+#
+# THE ANTI-STALE GUARANTEE — PRESERVED, THEN STRENGTHENED
+#   The old rule was "THIS SCRIPT'S OWN LOCATION WINS": never exec a sibling checkout's build,
+#   because a stale sibling could classify with old logic. That rule is kept verbatim for an
+#   in-tree dist (icn-agent-session still prefers ops/mcp/dist when it exists).
+#
+#   What this script adds is strictly stronger than a location rule. A cache entry is keyed by a
+#   SHA-256 over the exact bytes of this checkout's runtime sources — every file under
+#   ops/mcp/src plus package.json, package-lock.json and tsconfig.json, hashed with
+#   repo-relative paths so the key is identical across worktrees and independent of where the
+#   worktree lives. Executing <cache>/build/<fingerprint>/dist therefore proves the running
+#   bytes were compiled from THESE sources. A location rule only proves the build sat next to
+#   them; it never noticed an in-tree dist that had gone stale against its own src.
+#
+#   Consequence, stated plainly: editing ops/mcp/src changes the fingerprint, so the next
+#   session rebuilds rather than silently reusing the previous runtime. That is the point.
+#
+# CONCURRENCY
+#   Many agents can start at once. Each cache entry is built into a private temp directory and
+#   moved into place with rename(2), which is atomic on one filesystem, so a partially built
+#   tree is never observable under its final name. A completion marker is written INSIDE the
+#   temp directory before the rename, so "directory exists" and "build finished" cannot come
+#   apart. flock keeps concurrent starters from duplicating the work; it is an optimisation,
+#   not the correctness argument — two racing builds of the same fingerprint produce the same
+#   bytes, and the loser simply discards its copy.
+#
+# FAILURE SEMANTICS
+#   Every failure prints a specific reason to stderr and exits non-zero. This script NEVER
+#   prints a dist path it has not verified, so a caller cannot mistake a failed bootstrap for a
+#   working runtime. icn-agent-session turns that into its existing visible DEGRADED banner and
+#   never fabricates registration.
+#
+# Usage:
+#   icn-runtime-build              # print the absolute path of a usable dist directory
+#   icn-runtime-build --fingerprint  # print the runtime fingerprint only; build nothing
+#   icn-runtime-build --verbose    # narrate what is happening on stderr
+#
+# Environment:
+#   ICN_RUNTIME_CACHE          cache root (default ${XDG_CACHE_HOME:-$HOME/.cache}/icn/agent-runtime)
+#   ICN_RUNTIME_BUILD_TIMEOUT  seconds for the whole bootstrap (default 300)
+#   ICN_RUNTIME_NO_BUILD=1     resolve a cached build, never build one (used by tests)
+
+set -uo pipefail
+
+VERBOSE=0
+FINGERPRINT_ONLY=0
+BACKGROUND_IF_COLD=0
+for arg in "$@"; do
+  case "$arg" in
+    --verbose) VERBOSE=1 ;;
+    --fingerprint) FINGERPRINT_ONLY=1 ;;
+    --background-if-cold) BACKGROUND_IF_COLD=1 ;;
+    --help|-h)
+      printf '%s\n' \
+        'usage: icn-runtime-build [--fingerprint] [--background-if-cold] [--verbose]' \
+        '  (no args)             print the path of a usable dist directory, building if needed' \
+        '  --fingerprint         print the runtime fingerprint only; build nothing' \
+        '  --background-if-cold  build dist inline, but hand a cold dependency install to a' \
+        '                        detached background bootstrap instead of blocking the caller' \
+        '  --verbose             narrate progress on stderr'
+      exit 0 ;;
+    *) printf 'icn-runtime-build: unknown option: %s\n' "$arg" >&2; exit 2 ;;
+  esac
+done
+
+note() { [ "$VERBOSE" = 1 ] && printf 'icn-runtime-build: %s\n' "$1" >&2; return 0; }
+fail() { printf 'icn-runtime-build: %s\n' "$1" >&2; exit 1; }
+
+# Resolve the repo from THIS script's own location, following symlinks, exactly as
+# icn-agent-session does. A wrapper and the sources it fingerprints must be one checkout.
+self="${BASH_SOURCE[0]}"
+while [ -L "$self" ]; do
+  link="$(readlink "$self")"
+  case "$link" in /*) self="$link" ;; *) self="$(dirname "$self")/$link" ;; esac
+done
+ROOT="$(cd "$(dirname "$self")/../.." 2>/dev/null && pwd || true)"
+[ -n "$ROOT" ] && [ -d "$ROOT/ops/mcp" ] || fail "could not resolve an ICN repo root from $self"
+
+MCP="$ROOT/ops/mcp"
+[ -f "$MCP/package.json" ] || fail "$MCP/package.json is missing; this is not an ops/mcp checkout"
+
+CACHE="${ICN_RUNTIME_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/icn/agent-runtime}"
+# Two budgets, because the two halves cost wildly different amounts and only one of them is on
+# the session-start critical path. Measured on the dev VM (Node 22, 8 vCPU):
+#   dist  (tsc over 52 files, warm deps) ...... ~10s
+#   deps  (npm ci; better-sqlite3 compiles from source — no Node 22 prebuild) ... ~3m30s
+# A session may wait for the first. It must never wait for the second.
+BUDGET="${ICN_RUNTIME_BUILD_TIMEOUT:-300}"
+DEPS_BUDGET="${ICN_RUNTIME_DEPS_TIMEOUT:-1800}"
+
+# --- fingerprints -------------------------------------------------------------------------
+# Hashed with repo-relative paths so two worktrees holding identical sources agree on the key.
+# Absolute paths here would defeat the entire cache and reintroduce the per-worktree build.
+fingerprint() {
+  python3 - "$MCP" "$1" <<'PY'
+import hashlib, os, sys
+root, mode = sys.argv[1], sys.argv[2]
+manifest = ["package.json", "package-lock.json", "tsconfig.json"]
+rels = []
+if mode == "src":
+    src = os.path.join(root, "src")
+    for dirpath, dirnames, filenames in os.walk(src):
+        dirnames.sort()
+        for f in sorted(filenames):
+            rels.append(os.path.relpath(os.path.join(dirpath, f), root))
+    rels.extend(m for m in manifest if os.path.exists(os.path.join(root, m)))
+else:
+    # Dependency identity is the manifest pair alone: src churn must not force a reinstall of
+    # a 157M native-module tree that did not change.
+    rels = [m for m in ("package.json", "package-lock.json") if os.path.exists(os.path.join(root, m))]
+h = hashlib.sha256()
+for rel in sorted(rels):
+    h.update(rel.encode("utf-8") + b"\0")
+    with open(os.path.join(root, rel), "rb") as fh:
+        h.update(hashlib.sha256(fh.read()).digest())
+print(h.hexdigest()[:32])
+PY
+}
+
+SRC_FP="$(fingerprint src)" || fail "could not fingerprint ops/mcp sources"
+[ -n "$SRC_FP" ] || fail "empty source fingerprint"
+
+if [ "$FINGERPRINT_ONLY" = 1 ]; then printf '%s\n' "$SRC_FP"; exit 0; fi
+
+BUILD_DIR="$CACHE/build/$SRC_FP"
+BUILD_OK="$BUILD_DIR/.icn-runtime-ok"
+ENTRY="$BUILD_DIR/dist/cli/session.js"
+
+# Fast path. This is the overwhelmingly common case: a worktree branched from main has not
+# touched ops/mcp, so its fingerprint already names a finished build and nothing is compiled.
+if [ -f "$BUILD_OK" ] && [ -f "$ENTRY" ]; then
+  note "cache hit $SRC_FP"
+  printf '%s\n' "$BUILD_DIR/dist"
+  exit 0
+fi
+
+if [ "${ICN_RUNTIME_NO_BUILD:-0}" = 1 ]; then
+  fail "no cached runtime for fingerprint $SRC_FP and ICN_RUNTIME_NO_BUILD is set"
+fi
+
+command -v node >/dev/null 2>&1 || fail "node not found on PATH"
+command -v npm  >/dev/null 2>&1 || fail "npm not found on PATH"
+
+DEPS_FP="$(fingerprint deps)" || fail "could not fingerprint ops/mcp dependencies"
+DEPS_DIR="$CACHE/deps/$DEPS_FP"
+DEPS_OK="$DEPS_DIR/.icn-deps-ok"
+
+mkdir -p "$CACHE/build" "$CACHE/deps" "$CACHE/locks" "$CACHE/tmp" \
+  || fail "could not create the runtime cache under $CACHE"
+
+# Sweep staging directories abandoned by a SIGKILLed build. They are never load-bearing — a
+# finished entry only ever appears via rename(2) — but a hook killed at its timeout cannot run
+# its own cleanup, so without this the cache grows a new orphan on every such kill. Only
+# genuinely old ones go, so a concurrent build in progress is never touched.
+find "$CACHE/tmp" -mindepth 1 -maxdepth 1 -type d -mmin +120 -exec rm -rf {} + 2>/dev/null || true
+
+# Build inside the cache, never inside the worktree: a bootstrap that writes into the checkout
+# would dirty every lane it touched and show up in `git status` mid-review.
+stage() {
+  local kind="$1" fp="$2" target="$3" marker="$4"
+  local lock="$CACHE/locks/$kind-$fp.lock"
+  local tmp rc=0
+  tmp="$(mktemp -d "$CACHE/tmp/$kind-$fp.XXXXXX")" || fail "could not create a staging directory"
+
+  exec 9>"$lock" || { rm -rf "$tmp"; fail "could not open the $kind lock at $lock"; }
+  if ! flock -w "$BUDGET" 9; then
+    rm -rf "$tmp"
+    fail "timed out after ${BUDGET}s waiting for another agent's $kind build ($fp)"
+  fi
+
+  # Re-check under the lock: the process we queued behind has very likely just finished the
+  # exact build we were about to start.
+  if [ -f "$marker" ]; then
+    note "$kind $fp completed by a concurrent starter"
+    rm -rf "$tmp"
+    return 0
+  fi
+
+  if "build_$kind" "$tmp"; then
+    : > "$tmp/${marker##*/}"
+    # rename(2): the finished tree appears under its final name in one step, already marked
+    # complete, so no reader can observe a half-built cache entry.
+    if mv -T "$tmp" "$target" 2>/dev/null; then
+      note "$kind $fp built"
+    elif [ -f "$marker" ]; then
+      note "$kind $fp was completed concurrently; discarding this copy"
+    else
+      rc=1
+    fi
+  else
+    rc=1
+  fi
+
+  rm -rf "$tmp"
+  return "$rc"
+}
+
+deps_native_ok() { ( cd "$1" && node -e 'new (require("better-sqlite3"))(":memory:").close()' ) >/dev/null 2>&1; }
+
+build_deps() {
+  local tmp="$1"
+  # The staged package.json drops ops/mcp's own `postinstall: npm rebuild better-sqlite3`.
+  # MEASURED, not assumed: `npm ci` already builds better-sqlite3 from source (no Node 22
+  # prebuild exists for v9), so the postinstall compiles the identical binding a SECOND time —
+  # about 3m30s each on the dev VM. The lockfile is copied untouched, so dependency resolution
+  # is byte-identical; only the repo's own lifecycle script is deferred.
+  #
+  # Deferred, not dropped. The rebuild exists to repair a binding that does not match the
+  # running Node ABI, so it is run below as a REPAIR when the module actually fails to load.
+  # That ordering is strictly stricter than the original: always-rebuild never checked the
+  # result, and would happily cache a tree that still did not load.
+  python3 - "$MCP/package.json" "$tmp/package.json" <<'PY' || return 1
+import json, sys
+with open(sys.argv[1]) as fh:
+    pkg = json.load(fh)
+pkg.get("scripts", {}).pop("postinstall", None)
+with open(sys.argv[2], "w") as fh:
+    json.dump(pkg, fh, indent=2)
+PY
+  [ -f "$MCP/package-lock.json" ] && { cp "$MCP/package-lock.json" "$tmp/" || return 1; }
+  note "installing ops/mcp dependencies (better-sqlite3 compiles from source); once per lockfile"
+  # `npm ci` needs the lockfile; fall back to `npm install` only when the checkout has none.
+  local cmd=(npm ci --no-audit --no-fund --loglevel=error)
+  [ -f "$tmp/package-lock.json" ] || cmd=(npm install --no-audit --no-fund --loglevel=error)
+  ( cd "$tmp" && timeout "$DEPS_BUDGET" "${cmd[@]}" ) >&2 || return 1
+  [ -d "$tmp/node_modules" ] || return 1
+
+  # Prove the native module loads before this tree is marked usable. npm exits 0 having
+  # produced a binding that does not match the running Node ABI, and a cache entry that fails
+  # at every future session start is worse than no cache entry at all.
+  if ! deps_native_ok "$tmp"; then
+    note "better-sqlite3 did not load; running the rebuild repair"
+    ( cd "$tmp" && timeout "$DEPS_BUDGET" npm rebuild better-sqlite3 ) >&2 || return 1
+    deps_native_ok "$tmp" || {
+      printf 'icn-runtime-build: better-sqlite3 does not load under %s even after rebuild\n' \
+        "$(node -v)" >&2
+      return 1
+    }
+  fi
+  # Restore the checkout's real manifest so the cached tree records what the repository
+  # declares, not the trimmed copy the install was driven from.
+  cp "$MCP/package.json" "$tmp/package.json" || return 1
+  return 0
+}
+
+build_dist() {
+  local tmp="$1"
+  cp -a "$MCP/src" "$tmp/src" || return 1
+  cp "$MCP/package.json" "$tmp/" || return 1
+  cp "$MCP/tsconfig.json" "$tmp/" || return 1
+  # The symlink is part of the FINISHED entry, not just the compile: at run time Node resolves
+  # better-sqlite3 by walking up from dist/cli/, and this is what it finds.
+  ln -s "$DEPS_DIR/node_modules" "$tmp/node_modules" || return 1
+  note "compiling the session runtime for fingerprint $SRC_FP"
+  ( cd "$tmp" && timeout "$BUDGET" ./node_modules/.bin/tsc ) >&2 || return 1
+  [ -f "$tmp/dist/cli/session.js" ] || return 1
+  return 0
+}
+
+if [ ! -f "$DEPS_OK" ]; then
+  # The session-start caller takes this branch rather than stalling a human for minutes. The
+  # detached child runs the very same program with no flag, so there is one install path, and
+  # flock makes a second starter join the first rather than racing it.
+  if [ "$BACKGROUND_IF_COLD" = 1 ]; then
+    log="$CACHE/bootstrap.log"
+    if flock -n "$CACHE/locks/deps-$DEPS_FP.lock" true 2>/dev/null; then
+      ( setsid nohup "$self" --verbose >>"$log" 2>&1 & ) >/dev/null 2>&1
+      fail "dependency cache is cold; a background bootstrap was started (log: $log). This session is unregistered; the next one will not be."
+    fi
+    fail "dependency cache is cold and a background bootstrap is already running (log: $log). This session is unregistered; the next one will not be."
+  fi
+  stage deps "$DEPS_FP" "$DEPS_DIR" "$DEPS_OK" \
+    || fail "dependency install failed for $DEPS_FP (see the npm output above)"
+fi
+[ -f "$DEPS_OK" ] || fail "dependency cache $DEPS_DIR is still incomplete after installing"
+
+stage dist "$SRC_FP" "$BUILD_DIR" "$BUILD_OK" \
+  || fail "runtime build failed for $SRC_FP (see the tsc output above)"
+
+# Verify what we are about to hand out rather than trusting that the build said it worked.
+[ -f "$ENTRY" ] || fail "build completed but $ENTRY is missing"
+printf '%s\n' "$BUILD_DIR/dist"

--- a/ops/scripts/icn-runtime-build
+++ b/ops/scripts/icn-runtime-build
@@ -313,6 +313,23 @@ PY
   # Restore the checkout's real manifest so the cached tree records what the repository
   # declares, not the trimmed copy the install was driven from.
   cp "$MCP/package.json" "$tmp/package.json" || return 1
+
+  # PUBLISH ONLY WHAT WAS HASHED — the dependency-side counterpart of the same rule in
+  # build_dist. DEPS_FP is taken when the process starts, and this install can spend minutes
+  # queued behind another one. A manifest edit landing in that window would be installed and
+  # then marked complete under the OLD dependency fingerprint, so every lane still holding the
+  # old manifests would reuse a tree resolved from different inputs. The dist-side check does
+  # not cover this: it rejects the dist build while leaving the mis-keyed dependency entry and
+  # its .icn-deps-ok marker in place.
+  local staged_deps
+  staged_deps="$(fingerprint deps "$tmp")" || return 1
+  if [ "$staged_deps" != "$DEPS_FP" ]; then
+    printf 'icn-runtime-build: ops/mcp manifests changed while installing (%s -> %s); not publishing under a key that does not describe them\n' \
+      "$DEPS_FP" "$staged_deps" >&2
+    return 1
+  fi
+  printf '%s\n' "$DEPS_FP"  >"$tmp/.icn-deps-fp"
+  printf '%s\n' "$NODE_ABI" >"$tmp/.icn-runtime-abi"
   return 0
 }
 

--- a/ops/scripts/icn-runtime-build
+++ b/ops/scripts/icn-runtime-build
@@ -202,6 +202,18 @@ stage() {
     # rename(2): the finished tree appears under its final name in one step, already marked
     # complete, so no reader can observe a half-built cache entry.
     if mv -T "$tmp" "$target" 2>/dev/null; then
+      if [ "$kind" = dist ]; then
+        # CACHE-POISONING GUARD. A bootstrapped lane's ops/mcp/dist is a SYMLINK into this
+        # directory, so `npm --prefix ops/mcp run build` there would compile that lane's sources
+        # straight into a shared cache entry. When the lane's sources have changed its
+        # fingerprint has changed too, so the write lands in the entry for the OLD fingerprint —
+        # silently handing every other lane at that fingerprint a build made from different
+        # sources, which is precisely the anti-stale property this cache exists to provide.
+        # Read-only turns that into a loud EACCES. A legitimate rebuild belongs in a new
+        # fingerprint's entry, which is where the bootstrap already puts it.
+        # To clear the cache by hand: chmod -R u+w on the entry first.
+        chmod -R a-w "$target" 2>/dev/null || true
+      fi
       note "$kind $fp built"
     elif [ -f "$marker" ]; then
       note "$kind $fp was completed concurrently; discarding this copy"

--- a/ops/scripts/icn-runtime-build
+++ b/ops/scripts/icn-runtime-build
@@ -60,22 +60,26 @@
 #   ICN_RUNTIME_CACHE          cache root (default ${XDG_CACHE_HOME:-$HOME/.cache}/icn/agent-runtime)
 #   ICN_RUNTIME_BUILD_TIMEOUT  seconds for the whole bootstrap (default 300)
 #   ICN_RUNTIME_NO_BUILD=1     resolve a cached build, never build one (used by tests)
+#   ICN_RUNTIME_ABI            override the detected Node ABI/platform/arch (used by tests)
 
 set -uo pipefail
 
 VERBOSE=0
 FINGERPRINT_ONLY=0
+FINGERPRINT_SRC_ONLY=0
 BACKGROUND_IF_COLD=0
 for arg in "$@"; do
   case "$arg" in
     --verbose) VERBOSE=1 ;;
     --fingerprint) FINGERPRINT_ONLY=1 ;;
+    --fingerprint-src) FINGERPRINT_SRC_ONLY=1 ;;
     --background-if-cold) BACKGROUND_IF_COLD=1 ;;
     --help|-h)
       printf '%s\n' \
         'usage: icn-runtime-build [--fingerprint] [--background-if-cold] [--verbose]' \
         '  (no args)             print the path of a usable dist directory, building if needed' \
         '  --fingerprint         print the runtime fingerprint only; build nothing' \
+        '  --fingerprint-src     print the SOURCE fingerprint only; build nothing' \
         '  --background-if-cold  build dist inline, but hand a cold dependency install to a' \
         '                        detached background bootstrap instead of blocking the caller' \
         '  --verbose             narrate progress on stderr'
@@ -113,9 +117,9 @@ DEPS_BUDGET="${ICN_RUNTIME_DEPS_TIMEOUT:-1800}"
 # Hashed with repo-relative paths so two worktrees holding identical sources agree on the key.
 # Absolute paths here would defeat the entire cache and reintroduce the per-worktree build.
 fingerprint() {
-  python3 - "$MCP" "$1" <<'PY'
+  python3 - "${2:-$MCP}" "$1" "$NODE_ABI" <<'PY'
 import hashlib, os, sys
-root, mode = sys.argv[1], sys.argv[2]
+root, mode, abi = sys.argv[1], sys.argv[2], sys.argv[3]
 manifest = ["package.json", "package-lock.json", "tsconfig.json"]
 rels = []
 if mode == "src":
@@ -130,6 +134,12 @@ else:
     # a 157M native-module tree that did not change.
     rels = [m for m in ("package.json", "package-lock.json") if os.path.exists(os.path.join(root, m))]
 h = hashlib.sha256()
+if mode != "src":
+    # The installed tree contains a NATIVE better-sqlite3 binding, so its identity is the
+    # lockfile AND the ABI it was compiled against. Without this, upgrading Node kept the old
+    # entry valid by name: the cache hit returned before deps_native_ok() could notice the
+    # binding no longer loads, so every lane failed at CLI load with no path to repair itself.
+    h.update(b"abi\0" + abi.encode("utf-8") + b"\0")
 for rel in sorted(rels):
     h.update(rel.encode("utf-8") + b"\0")
     with open(os.path.join(root, rel), "rb") as fh:
@@ -138,31 +148,43 @@ print(h.hexdigest()[:32])
 PY
 }
 
+# The ABI the native module must match. Node is a hard requirement of every useful path here,
+# so it is resolved before any fingerprint rather than after the fast path.
+command -v node >/dev/null 2>&1 || fail "node not found on PATH"
+NODE_ABI="${ICN_RUNTIME_ABI:-$(node -p 'process.versions.modules + "-" + process.platform + "-" + process.arch' 2>/dev/null)}"
+[ -n "$NODE_ABI" ] || fail "could not read the Node ABI from $(command -v node)"
+
 SRC_FP="$(fingerprint src)" || fail "could not fingerprint ops/mcp sources"
 [ -n "$SRC_FP" ] || fail "empty source fingerprint"
+DEPS_FP="$(fingerprint deps)" || fail "could not fingerprint ops/mcp dependencies"
+[ -n "$DEPS_FP" ] || fail "empty dependency fingerprint"
 
-if [ "$FINGERPRINT_ONLY" = 1 ]; then printf '%s\n' "$SRC_FP"; exit 0; fi
+# The build key covers BOTH halves. A finished build holds a node_modules symlink into a
+# dependency entry, so a build identified by sources alone would keep pointing at the old
+# dependency tree after the ABI changed — valid by name, unloadable in fact.
+BUILD_FP="$(printf '%s:%s' "$SRC_FP" "$DEPS_FP" | sha256sum | cut -c1-32)"
 
-BUILD_DIR="$CACHE/build/$SRC_FP"
+if [ "$FINGERPRINT_SRC_ONLY" = 1 ]; then printf '%s\n' "$SRC_FP"; exit 0; fi
+if [ "$FINGERPRINT_ONLY" = 1 ]; then printf '%s\n' "$BUILD_FP"; exit 0; fi
+
+BUILD_DIR="$CACHE/build/$BUILD_FP"
 BUILD_OK="$BUILD_DIR/.icn-runtime-ok"
 ENTRY="$BUILD_DIR/dist/cli/session.js"
 
 # Fast path. This is the overwhelmingly common case: a worktree branched from main has not
 # touched ops/mcp, so its fingerprint already names a finished build and nothing is compiled.
 if [ -f "$BUILD_OK" ] && [ -f "$ENTRY" ]; then
-  note "cache hit $SRC_FP"
+  note "cache hit $BUILD_FP"
   printf '%s\n' "$BUILD_DIR/dist"
   exit 0
 fi
 
 if [ "${ICN_RUNTIME_NO_BUILD:-0}" = 1 ]; then
-  fail "no cached runtime for fingerprint $SRC_FP and ICN_RUNTIME_NO_BUILD is set"
+  fail "no cached runtime for fingerprint $BUILD_FP and ICN_RUNTIME_NO_BUILD is set"
 fi
 
-command -v node >/dev/null 2>&1 || fail "node not found on PATH"
 command -v npm  >/dev/null 2>&1 || fail "npm not found on PATH"
 
-DEPS_FP="$(fingerprint deps)" || fail "could not fingerprint ops/mcp dependencies"
 DEPS_DIR="$CACHE/deps/$DEPS_FP"
 DEPS_OK="$DEPS_DIR/.icn-deps-ok"
 
@@ -277,14 +299,33 @@ PY
 }
 
 build_dist() {
-  local tmp="$1"
+  local tmp="$1" staged_fp
   cp -a "$MCP/src" "$tmp/src" || return 1
   cp "$MCP/package.json" "$tmp/" || return 1
   cp "$MCP/tsconfig.json" "$tmp/" || return 1
+  # Copied so the staged tree is a faithful snapshot of everything the fingerprint covers.
+  [ -f "$MCP/package-lock.json" ] && { cp "$MCP/package-lock.json" "$tmp/" || return 1; }
+
+  # PUBLISH ONLY WHAT WAS HASHED. SRC_FP was taken when this process started; on the cold path
+  # that can be minutes earlier, because a dependency install runs first. An edit landing in
+  # that window would be compiled and then published under the OLD key, handing every lane at
+  # that key a runtime built from different sources — the exact anti-stale failure the
+  # content-addressed cache exists to prevent. Re-hash the snapshot actually staged and refuse
+  # rather than publish a mismatch; the next invocation simply builds the new fingerprint.
+  staged_fp="$(fingerprint src "$tmp")" || return 1
+  # Provenance, readable without re-deriving anything: which sources and which ABI this entry
+  # was compiled from. The build key is a hash of both, so it cannot be read back on its own.
+  printf '%s\n' "$SRC_FP"   >"$tmp/.icn-runtime-src"
+  printf '%s\n' "$NODE_ABI" >"$tmp/.icn-runtime-abi"
+  if [ "$staged_fp" != "$SRC_FP" ]; then
+    printf 'icn-runtime-build: ops/mcp sources changed while staging (%s -> %s); not publishing under a key that does not describe them\n' \
+      "$SRC_FP" "$staged_fp" >&2
+    return 1
+  fi
   # The symlink is part of the FINISHED entry, not just the compile: at run time Node resolves
   # better-sqlite3 by walking up from dist/cli/, and this is what it finds.
   ln -s "$DEPS_DIR/node_modules" "$tmp/node_modules" || return 1
-  note "compiling the session runtime for fingerprint $SRC_FP"
+  note "compiling the session runtime for fingerprint $BUILD_FP"
   ( cd "$tmp" && timeout "$BUDGET" ./node_modules/.bin/tsc ) >&2 || return 1
   [ -f "$tmp/dist/cli/session.js" ] || return 1
   return 0
@@ -296,19 +337,24 @@ if [ ! -f "$DEPS_OK" ]; then
   # flock makes a second starter join the first rather than racing it.
   if [ "$BACKGROUND_IF_COLD" = 1 ]; then
     log="$CACHE/bootstrap.log"
+    pidfile="$CACHE/bootstrap.pid"
     if flock -n "$CACHE/locks/deps-$DEPS_FP.lock" true 2>/dev/null; then
-      ( setsid nohup "$self" --verbose >>"$log" 2>&1 & ) >/dev/null 2>&1
-      fail "dependency cache is cold; a background bootstrap was started (log: $log). This session is unregistered; the next one will not be."
+      # The child's pid is RECORDED, not just spawned. A detached multi-minute native build
+      # that nothing can name is precisely the abandoned-process shape this repository keeps
+      # having to clean up by hand; a caller — a test tearing down, or a human wondering what
+      # is eating the CPU — must be able to find and wait on it.
+      ( setsid nohup "$self" --verbose >>"$log" 2>&1 & echo $! >"$pidfile" ) >/dev/null 2>&1
+      fail "dependency cache is cold; a background bootstrap was started (log: $log, pid: $(cat "$pidfile" 2>/dev/null)). This session is unregistered; the next one will not be."
     fi
-    fail "dependency cache is cold and a background bootstrap is already running (log: $log). This session is unregistered; the next one will not be."
+    fail "dependency cache is cold and a background bootstrap is already running (log: $log, pid: $(cat "$pidfile" 2>/dev/null)). This session is unregistered; the next one will not be."
   fi
   stage deps "$DEPS_FP" "$DEPS_DIR" "$DEPS_OK" \
     || fail "dependency install failed for $DEPS_FP (see the npm output above)"
 fi
 [ -f "$DEPS_OK" ] || fail "dependency cache $DEPS_DIR is still incomplete after installing"
 
-stage dist "$SRC_FP" "$BUILD_DIR" "$BUILD_OK" \
-  || fail "runtime build failed for $SRC_FP (see the tsc output above)"
+stage dist "$BUILD_FP" "$BUILD_DIR" "$BUILD_OK" \
+  || fail "runtime build failed for $BUILD_FP (see the tsc output above)"
 
 # Verify what we are about to hand out rather than trusting that the build said it worked.
 [ -f "$ENTRY" ] || fail "build completed but $ENTRY is missing"

--- a/ops/scripts/icn-runtime-build
+++ b/ops/scripts/icn-runtime-build
@@ -58,7 +58,8 @@
 #
 # Environment:
 #   ICN_RUNTIME_CACHE          cache root (default ${XDG_CACHE_HOME:-$HOME/.cache}/icn/agent-runtime)
-#   ICN_RUNTIME_BUILD_TIMEOUT  seconds for the whole bootstrap (default 300)
+#   ICN_RUNTIME_BUILD_TIMEOUT  seconds for the dist build and its lock wait (default 300)
+#   ICN_RUNTIME_DEPS_TIMEOUT   seconds for the dependency install and its lock wait (default 1800)
 #   ICN_RUNTIME_NO_BUILD=1     resolve a cached build, never build one (used by tests)
 #   ICN_RUNTIME_ABI            override the detected Node ABI/platform/arch (used by tests)
 
@@ -202,13 +203,18 @@ find "$CACHE/tmp" -mindepth 1 -maxdepth 1 -type d -mmin +120 -exec rm -rf {} + 2
 stage() {
   local kind="$1" fp="$2" target="$3" marker="$4"
   local lock="$CACHE/locks/$kind-$fp.lock"
-  local tmp rc=0
+  local tmp rc=0 wait_for
+  # Wait on the lock for as long as the HOLDER is allowed to take. Using the dist budget for
+  # both made a waiter give up after 300s while a concurrent dependency install was still
+  # legitimately running inside its 1800s budget — a spurious failure on the ordinary
+  # cold-start-together path.
+  case "$kind" in deps) wait_for="$DEPS_BUDGET" ;; *) wait_for="$BUDGET" ;; esac
   tmp="$(mktemp -d "$CACHE/tmp/$kind-$fp.XXXXXX")" || fail "could not create a staging directory"
 
   exec 9>"$lock" || { rm -rf "$tmp"; fail "could not open the $kind lock at $lock"; }
-  if ! flock -w "$BUDGET" 9; then
+  if ! flock -w "$wait_for" 9; then
     rm -rf "$tmp"
-    fail "timed out after ${BUDGET}s waiting for another agent's $kind build ($fp)"
+    fail "timed out after ${wait_for}s waiting for another agent's $kind build ($fp)"
   fi
 
   # Re-check under the lock: the process we queued behind has very likely just finished the
@@ -223,7 +229,10 @@ stage() {
     : > "$tmp/${marker##*/}"
     # rename(2): the finished tree appears under its final name in one step, already marked
     # complete, so no reader can observe a half-built cache entry.
-    if mv -T "$tmp" "$target" 2>/dev/null; then
+    # os.rename, not `mv -T`: -T is GNU-only, and plain `mv` moves INTO an existing directory
+    # rather than failing — the one behaviour that must not happen here. python3 is already a
+    # hard dependency of this script, and os.rename is the atomic primitive being relied on.
+    if python3 -c 'import os,sys; os.rename(sys.argv[1], sys.argv[2])' "$tmp" "$target" 2>/dev/null; then
       if [ "$kind" = dist ]; then
         # CACHE-POISONING GUARD. A bootstrapped lane's ops/mcp/dist is a SYMLINK into this
         # directory, so `npm --prefix ops/mcp run build` there would compile that lane's sources
@@ -235,6 +244,15 @@ stage() {
         # fingerprint's entry, which is where the bootstrap already puts it.
         # To clear the cache by hand: chmod -R u+w on the entry first.
         chmod -R a-w "$target" 2>/dev/null || true
+        # VERIFY the guard, do not assume it. On a filesystem that ignores or rejects the
+        # permission change, silently continuing would leave a writable shared entry that a
+        # lane's `npm run build` can overwrite — the exact poisoning this prevents, minus the
+        # protection. Say so; icn-agent-session then declines to publish the worktree symlink,
+        # which is the only path by which a lane can write here at all.
+        if [ -w "$target/dist" ]; then
+          printf 'icn-runtime-build: WARNING: %s could not be made read-only; the cache is unprotected against a lane rebuilding into it, so no ops/mcp/dist symlink will be published\n' \
+            "$target" >&2
+        fi
       fi
       note "$kind $fp built"
     elif [ -f "$marker" ]; then
@@ -338,7 +356,15 @@ if [ ! -f "$DEPS_OK" ]; then
   if [ "$BACKGROUND_IF_COLD" = 1 ]; then
     log="$CACHE/bootstrap.log"
     pidfile="$CACHE/bootstrap.pid"
-    if flock -n "$CACHE/locks/deps-$DEPS_FP.lock" true 2>/dev/null; then
+    # A LIVE bootstrap is detected by its recorded pid, and the spawn itself is serialised.
+    # `flock -n <file> true` held the lock only while `true` ran, so it was already released
+    # before the child could take it: every hook arriving together passed the probe and
+    # launched its own detached multi-minute install.
+    if [ -f "$pidfile" ] && kill -0 "$(cat "$pidfile" 2>/dev/null)" 2>/dev/null; then
+      fail "dependency cache is cold and a background bootstrap is already running (log: $log, pid: $(cat "$pidfile" 2>/dev/null)). This session is unregistered; the next one will not be."
+    fi
+    exec 8>"$CACHE/locks/spawn.lock" || fail "could not open the spawn lock"
+    if flock -n 8; then
       # The child's pid is RECORDED, not just spawned. A detached multi-minute native build
       # that nothing can name is precisely the abandoned-process shape this repository keeps
       # having to clean up by hand; a caller — a test tearing down, or a human wondering what

--- a/scripts/test-agent-runtime-bootstrap.sh
+++ b/scripts/test-agent-runtime-bootstrap.sh
@@ -27,7 +27,9 @@
 set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+# chmod first: published cache entries are deliberately read-only (the poisoning guard), and
+# plain `rm -rf` cannot remove them. Same escape hatch a human clearing the real cache needs.
+trap 'chmod -R u+w "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 PASS=0; FAIL=0
 ok()  { printf '  ok    %s\n' "$1"; PASS=$((PASS+1)); }
 bad() { printf '  FAIL  %s\n     %s\n' "$1" "${2:-}"; FAIL=$((FAIL+1)); }
@@ -191,6 +193,21 @@ if [ "$DEPS_AVAILABLE" = 1 ]; then
     ok "two lanes with identical sources share one fingerprint"
   else
     bad "identical sources produced different fingerprints" "$fp1 vs $fp2"
+  fi
+fi
+
+# --- case 4b: a published cache entry cannot be written into ---------------------------------
+# A bootstrapped lane's ops/mcp/dist is a symlink into the shared cache, so `npm run build` in
+# that lane would compile its sources into a cache entry other lanes are using. If the lane's
+# sources changed, the fingerprint changed too, and the write lands in the OLD fingerprint's
+# entry — handing every lane at that fingerprint a build made from different sources.
+if [ "$DEPS_AVAILABLE" = 1 ]; then
+  entry="$("$LANE1/ops/scripts/icn-runtime-build")"
+  if touch "$entry/poison.js" 2>/dev/null; then
+    bad "a published cache entry is writable — npm run build in a lane could poison it" "$entry"
+    rm -f "$entry/poison.js"
+  else
+    ok "a published cache entry rejects writes instead of being poisoned"
   fi
 fi
 

--- a/scripts/test-agent-runtime-bootstrap.sh
+++ b/scripts/test-agent-runtime-bootstrap.sh
@@ -143,20 +143,20 @@ if [ "$DEPS_AVAILABLE" = 1 ]; then
   wait
   paths="$(cat "$TMP"/conc.1 "$TMP"/conc.2 "$TMP"/conc.3 "$TMP"/conc.4 2>/dev/null | sort -u)"
   count="$(printf '%s\n' "$paths" | grep -c . )"
-  if [ "$count" = 1 ] && [ -f "$(printf '%s' "$paths")/cli/session.js" ]; then
+  if [ "$count" -eq 1 ] && [ -f "$(printf '%s' "$paths")/cli/session.js" ]; then
     ok "four concurrent cold starts agree on one usable build"
   else
     bad "concurrent starts disagreed or failed" "$(printf '%s' "$paths" | head -4)"
   fi
   entries="$(ls -1 "$CONC/build" 2>/dev/null | wc -l)"
-  if [ "$entries" = 1 ]; then
+  if [ "$entries" -eq 1 ]; then
     ok "concurrent starts leave exactly one cache entry"
   else
     bad "expected one build cache entry, found $entries" "$(ls -1 "$CONC/build" 2>/dev/null)"
   fi
   # A staging directory left behind would mean a partially built tree could be observed.
   leftovers="$(ls -1 "$CONC/tmp" 2>/dev/null | wc -l)"
-  if [ "$leftovers" = 0 ]; then
+  if [ "$leftovers" -eq 0 ]; then
     ok "no staging directories survive a concurrent build"
   else
     bad "staging directories leaked" "$(ls -1 "$CONC/tmp")"
@@ -281,13 +281,28 @@ fi
 
 # cold deps: asserted, not waited on. A cold dependency tree must hand off to a detached
 # bootstrap rather than stalling a human at a prompt for minutes.
+# Four at once, because that is how SessionStart hooks actually arrive on a cold machine. Each
+# must defer, and between them they must start EXACTLY ONE installer: `flock -n <file> true`
+# released the lock before the child could take it, so every arrival passed the probe and
+# launched its own detached multi-minute native build.
 NODEPS="$TMP/cache-nodeps"
-err="$(ICN_RUNTIME_CACHE="$NODEPS" \
-       "$LANE1/ops/scripts/icn-runtime-build" --background-if-cold 2>&1 >/dev/null)"
-if printf '%s' "$err" | grep -q 'background bootstrap'; then
-  ok "a cold dependency cache hands off to a background bootstrap instead of blocking"
+for i in 1 2 3 4; do
+  ( ICN_RUNTIME_CACHE="$NODEPS" "$LANE1/ops/scripts/icn-runtime-build" \
+      --background-if-cold >/dev/null 2>"$TMP/cold.$i.err" ) &
+done
+wait
+err="$(cat "$TMP"/cold.*.err 2>/dev/null)"
+deferred="$(grep -lc 'background bootstrap' "$TMP"/cold.*.err 2>/dev/null | wc -l)"
+if [ "$deferred" -eq 4 ]; then
+  ok "every concurrent cold start defers instead of blocking"
 else
-  bad "cold dependency cache did not defer to a background bootstrap" "$err"
+  bad "not all cold starts deferred ($deferred/4)" "$(printf '%s' "$err" | head -2)"
+fi
+started="$(grep -h 'background bootstrap was started' "$TMP"/cold.*.err 2>/dev/null | wc -l)"
+if [ "$started" -eq 1 ]; then
+  ok "a burst of concurrent cold starts launches exactly one installer"
+else
+  bad "expected exactly one launched installer, got $started" "$(printf '%s' "$err" | head -3)"
 fi
 # REAP IT. This case starts a REAL detached bootstrap, which would otherwise keep running npm ci
 # and a native compile for minutes after the suite exits — racing the teardown that deletes the

--- a/scripts/test-agent-runtime-bootstrap.sh
+++ b/scripts/test-agent-runtime-bootstrap.sh
@@ -196,6 +196,43 @@ if [ "$DEPS_AVAILABLE" = 1 ]; then
   fi
 fi
 
+# --- case 4a: the native ABI is part of the cache identity -----------------------------------
+# The installed tree holds a NATIVE better-sqlite3 binding. Keyed on the lockfile alone, an
+# entry stayed valid by name across a Node upgrade: the fast path returned the hit before
+# deps_native_ok() could notice the binding no longer loads, so every lane failed at CLI load
+# with no path to repair itself.
+if [ "$DEPS_AVAILABLE" = 1 ]; then
+  a="$(ICN_RUNTIME_ABI=abi-aaa "$LANE1/ops/scripts/icn-runtime-build" --fingerprint)"
+  b="$(ICN_RUNTIME_ABI=abi-bbb "$LANE1/ops/scripts/icn-runtime-build" --fingerprint)"
+  src_a="$(ICN_RUNTIME_ABI=abi-aaa "$LANE1/ops/scripts/icn-runtime-build" --fingerprint-src)"
+  src_b="$(ICN_RUNTIME_ABI=abi-bbb "$LANE1/ops/scripts/icn-runtime-build" --fingerprint-src)"
+  if [ "$a" != "$b" ]; then
+    ok "a different native ABI yields a different build identity"
+  else
+    bad "build identity ignored the ABI" "$a"
+  fi
+  if [ "$src_a" = "$src_b" ]; then
+    ok "the ABI does not disturb the SOURCE fingerprint"
+  else
+    bad "ABI leaked into the source fingerprint" "$src_a vs $src_b"
+  fi
+fi
+
+# --- case 4c: an entry records the sources it was compiled from ------------------------------
+# The build key is a hash of sources AND ABI, so it cannot be read back. Recording the source
+# fingerprint makes an entry self-describing, and lets this assert the property the staging
+# re-hash protects: what was published matches what was hashed.
+if [ "$DEPS_AVAILABLE" = 1 ]; then
+  entry="$("$LANE1/ops/scripts/icn-runtime-build")"
+  recorded="$(cat "$(dirname "$entry")/.icn-runtime-src" 2>/dev/null)"
+  current="$("$LANE1/ops/scripts/icn-runtime-build" --fingerprint-src)"
+  if [ -n "$recorded" ] && [ "$recorded" = "$current" ]; then
+    ok "a published entry records the source fingerprint it was compiled from"
+  else
+    bad "entry provenance missing or does not match its sources" "recorded=$recorded current=$current"
+  fi
+fi
+
 # --- case 4b: a published cache entry cannot be written into ---------------------------------
 # A bootstrapped lane's ops/mcp/dist is a symlink into the shared cache, so `npm run build` in
 # that lane would compile its sources into a cache entry other lanes are using. If the lane's
@@ -244,12 +281,26 @@ fi
 
 # cold deps: asserted, not waited on. A cold dependency tree must hand off to a detached
 # bootstrap rather than stalling a human at a prompt for minutes.
-err="$(ICN_RUNTIME_CACHE="$TMP/cache-nodeps" \
+NODEPS="$TMP/cache-nodeps"
+err="$(ICN_RUNTIME_CACHE="$NODEPS" \
        "$LANE1/ops/scripts/icn-runtime-build" --background-if-cold 2>&1 >/dev/null)"
 if printf '%s' "$err" | grep -q 'background bootstrap'; then
   ok "a cold dependency cache hands off to a background bootstrap instead of blocking"
 else
   bad "cold dependency cache did not defer to a background bootstrap" "$err"
+fi
+# REAP IT. This case starts a REAL detached bootstrap, which would otherwise keep running npm ci
+# and a native compile for minutes after the suite exits — racing the teardown that deletes the
+# directory it is installing into, and leaving exactly the kind of abandoned build this
+# repository keeps having to clean up by hand.
+BOOT_PID="$(cat "$NODEPS/bootstrap.pid" 2>/dev/null)"
+if [ -n "$BOOT_PID" ]; then
+  ok "the background bootstrap records its pid so it can be found and reaped"
+  kill -TERM -- "-$BOOT_PID" 2>/dev/null || kill -TERM "$BOOT_PID" 2>/dev/null
+  sleep 1
+  kill -KILL -- "-$BOOT_PID" 2>/dev/null || kill -KILL "$BOOT_PID" 2>/dev/null
+else
+  bad "the background bootstrap left no pid file; it cannot be reaped" "$NODEPS/bootstrap.pid"
 fi
 
 # --- case 6: a failed re-resolution must not take away a working runtime ---------------------

--- a/scripts/test-agent-runtime-bootstrap.sh
+++ b/scripts/test-agent-runtime-bootstrap.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# Acceptance suite for the fresh-worktree runtime bootstrap.
+#
+# WHY THIS EXISTS
+#   A worktree created by `wt-new`, by Claude Code's nested-worktree mechanism, or by hand has
+#   no ops/mcp/dist — `dist/` is gitignored and no creation path builds it. Because
+#   icn-agent-session required an in-tree build, every such lane was PERMANENTLY unregistered.
+#   Measured on the dev VM when this was found: 44 of 50 worktrees could not register, the
+#   registry reported zero sessions while four Claude activations were live, and the readiness
+#   audit that found it was itself running in an unregistered lane.
+#
+#   The defect was invisible to every existing test because they all ran somewhere that
+#   happened to have a build. The rule here is therefore: NEVER let a case start from a
+#   worktree that already has dist. Each case below creates a lane with no dist and asserts
+#   that the lane becomes a working, registered agent lane on its own.
+#
+# WHAT IS AND IS NOT SHARED WITH THE REAL MACHINE
+#   The dependency tree (~157M, better-sqlite3 compiled from source, ~3m30s) is machine-level
+#   state keyed by lockfile, exactly like having node installed at all. Cases that only need a
+#   working runtime borrow it through ICN_RUNTIME_CACHE/deps rather than recompiling it per
+#   run. What is never borrowed is the compiled ICN runtime itself: every case builds dist from
+#   the fixture's own sources, because that is the thing under test. The cold-dependency path
+#   is covered separately, and by assertion rather than by waiting (see "cold deps").
+#
+# Usage: scripts/test-agent-runtime-bootstrap.sh
+
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+PASS=0; FAIL=0
+ok()  { printf '  ok    %s\n' "$1"; PASS=$((PASS+1)); }
+bad() { printf '  FAIL  %s\n     %s\n' "$1" "${2:-}"; FAIL=$((FAIL+1)); }
+
+REAL_CACHE="${ICN_RUNTIME_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/icn/agent-runtime}"
+CACHE="$TMP/cache"
+mkdir -p "$CACHE"
+
+# Borrow only the dependency tree (see header). If the machine has never bootstrapped, the
+# build cases cannot run and say so rather than silently reporting green.
+DEPS_AVAILABLE=0
+if [ -d "$REAL_CACHE/deps" ] && [ -n "$(ls -A "$REAL_CACHE/deps" 2>/dev/null)" ]; then
+  ln -s "$REAL_CACHE/deps" "$CACHE/deps"
+  DEPS_AVAILABLE=1
+fi
+
+export ICN_RUNTIME_CACHE="$CACHE"
+
+# A fixture is a real Git repository holding only what the bootstrap and the CLI read. It is a
+# real repo because lane identity is Git-derived and a non-repo cwd is correctly refused.
+ORIGIN="$TMP/origin"
+mkdir -p "$ORIGIN"
+# .gitignore is part of the fixture, not incidental: the bootstrap publishes its resolution as
+# a symlink at ops/mcp/dist, and the "stays clean" case is only meaningful if the fixture
+# carries the same ignore rules the real repository does.
+for p in .gitignore ops/scripts ops/mcp/src ops/mcp/package.json ops/mcp/package-lock.json ops/mcp/tsconfig.json; do
+  [ -e "$REPO_ROOT/$p" ] || continue
+  mkdir -p "$ORIGIN/$(dirname "$p")"
+  cp -a "$REPO_ROOT/$p" "$ORIGIN/$(dirname "$p")/"
+done
+git -C "$ORIGIN" init -q -b main .
+git -C "$ORIGIN" add -A >/dev/null 2>&1
+git -C "$ORIGIN" -c user.email=fixture@local -c user.name=fixture commit -q -m "runtime bootstrap fixture"
+
+# Every lane gets its own registry file so cases cannot see each other's rows, and so a test
+# run can never write into the live ICN registry.
+session() { ICN_OPS_DB="$TMP/registry-$1.db" "$2/ops/scripts/icn-agent-session" "${@:3}"; }
+
+echo "fresh-worktree runtime bootstrap"
+
+# --- case 1: canonical fresh worktree (the wt-new shape) ------------------------------------
+LANE1="$TMP/lanes/task-fresh"
+mkdir -p "$TMP/lanes"
+git -C "$ORIGIN" worktree add -q -b task/fresh "$LANE1" main 2>/dev/null
+
+if [ -e "$LANE1/ops/mcp/dist" ]; then
+  bad "canonical lane fixture already has a dist — the case would prove nothing" "$LANE1"
+elif [ "$DEPS_AVAILABLE" = 0 ]; then
+  bad "no dependency cache at $REAL_CACHE/deps; run ops/scripts/icn-runtime-build first" \
+      "cannot prove fresh-worktree registration without it"
+else
+  out="$(session c1 "$LANE1" register --harness-key fresh-canonical-1 --cwd "$LANE1" \
+         --provider test 2>"$TMP/c1.err")"
+  if printf '%s' "$out" | grep -q '"session_id"'; then
+    ok "a canonical fresh worktree with no dist registers automatically"
+  else
+    bad "canonical fresh worktree did not register" "$(tail -3 "$TMP/c1.err")"
+  fi
+
+  # Identity must be the LANE, not the origin the worktree was cut from. A bootstrap that
+  # resolved the wrong repo or worktree would still print a session_id.
+  st="$(session c1 "$LANE1" status --harness-key fresh-canonical-1 2>/dev/null)"
+  if printf '%s' "$st" | grep -q '"registered":true'; then
+    ok "the registered session is readable back as registered"
+  else
+    bad "registered session did not read back" "$st"
+  fi
+  if printf '%s' "$st" | grep -q 'task-fresh'; then
+    ok "lane identity records the worktree, not the origin checkout"
+  else
+    bad "lane identity does not name the worktree" "$st"
+  fi
+fi
+
+# --- case 2: Claude-style nested worktree ---------------------------------------------------
+# Claude Code creates its per-session lane UNDER the selected project, at
+# <project>/.claude/worktrees/<name>. That path is a real Git worktree of the same store, but
+# it is nested inside another worktree — the shape the canonical tooling never produces.
+LANE2="$ORIGIN/.claude/worktrees/nested-lane"
+mkdir -p "$ORIGIN/.claude/worktrees"
+git -C "$ORIGIN" worktree add -q -b claude/nested "$LANE2" main 2>/dev/null
+
+if [ "$DEPS_AVAILABLE" = 1 ]; then
+  if [ -e "$LANE2/ops/mcp/dist" ]; then
+    bad "nested lane fixture already has a dist" "$LANE2"
+  else
+    out="$(session c2 "$LANE2" register --harness-key fresh-nested-1 --cwd "$LANE2" \
+           --provider test 2>"$TMP/c2.err")"
+    if printf '%s' "$out" | grep -q '"session_id"'; then
+      ok "a Claude-style nested worktree registers automatically"
+    else
+      bad "nested worktree did not register" "$(tail -3 "$TMP/c2.err")"
+    fi
+    st="$(session c2 "$LANE2" status --harness-key fresh-nested-1 2>/dev/null)"
+    if printf '%s' "$st" | grep -q 'nested-lane'; then
+      ok "nested lane identity is the nested worktree, not its parent"
+    else
+      bad "nested lane resolved to the wrong worktree" "$st"
+    fi
+  fi
+fi
+
+# --- case 3: concurrent cold starts ---------------------------------------------------------
+# Several agents may start at once against an empty build cache. They must all succeed, agree
+# on one answer, and leave exactly one cache entry — not a half-written tree.
+if [ "$DEPS_AVAILABLE" = 1 ]; then
+  CONC="$TMP/cache-conc"; mkdir -p "$CONC"; ln -s "$REAL_CACHE/deps" "$CONC/deps"
+  for i in 1 2 3 4; do
+    ( ICN_RUNTIME_CACHE="$CONC" "$LANE1/ops/scripts/icn-runtime-build" >"$TMP/conc.$i" 2>"$TMP/conc.$i.err" ) &
+  done
+  wait
+  paths="$(cat "$TMP"/conc.1 "$TMP"/conc.2 "$TMP"/conc.3 "$TMP"/conc.4 2>/dev/null | sort -u)"
+  count="$(printf '%s\n' "$paths" | grep -c . )"
+  if [ "$count" = 1 ] && [ -f "$(printf '%s' "$paths")/cli/session.js" ]; then
+    ok "four concurrent cold starts agree on one usable build"
+  else
+    bad "concurrent starts disagreed or failed" "$(printf '%s' "$paths" | head -4)"
+  fi
+  entries="$(ls -1 "$CONC/build" 2>/dev/null | wc -l)"
+  if [ "$entries" = 1 ]; then
+    ok "concurrent starts leave exactly one cache entry"
+  else
+    bad "expected one build cache entry, found $entries" "$(ls -1 "$CONC/build" 2>/dev/null)"
+  fi
+  # A staging directory left behind would mean a partially built tree could be observed.
+  leftovers="$(ls -1 "$CONC/tmp" 2>/dev/null | wc -l)"
+  if [ "$leftovers" = 0 ]; then
+    ok "no staging directories survive a concurrent build"
+  else
+    bad "staging directories leaked" "$(ls -1 "$CONC/tmp")"
+  fi
+fi
+
+# --- case 4: anti-stale ---------------------------------------------------------------------
+# The old rule was "this checkout's location wins". The replacement must be at least as strong:
+# a change to the runtime sources must NOT resolve to the build made from the old ones.
+if [ "$DEPS_AVAILABLE" = 1 ]; then
+  before_fp="$("$LANE1/ops/scripts/icn-runtime-build" --fingerprint)"
+  before_path="$("$LANE1/ops/scripts/icn-runtime-build")"
+  printf '\n// bootstrap acceptance: source change must change the fingerprint\n' \
+    >> "$LANE1/ops/mcp/src/state/db.ts"
+  after_fp="$("$LANE1/ops/scripts/icn-runtime-build" --fingerprint)"
+  if [ "$before_fp" != "$after_fp" ]; then
+    ok "editing a runtime source changes the fingerprint"
+  else
+    bad "fingerprint did not change after a source edit" "$before_fp"
+  fi
+  after_path="$(ICN_RUNTIME_NO_BUILD=1 "$LANE1/ops/scripts/icn-runtime-build" 2>/dev/null)"
+  if [ -z "$after_path" ]; then
+    ok "changed sources do not resolve to the build made from the old ones"
+  else
+    bad "stale build was handed out for changed sources" "$before_path -> $after_path"
+  fi
+  git -C "$LANE1" checkout -- ops/mcp/src/state/db.ts 2>/dev/null
+
+  # Path-independence: two lanes holding identical sources must agree, or the cache degenerates
+  # into a per-worktree build and the whole fix is undone.
+  fp1="$("$LANE1/ops/scripts/icn-runtime-build" --fingerprint)"
+  fp2="$("$LANE2/ops/scripts/icn-runtime-build" --fingerprint)"
+  if [ "$fp1" = "$fp2" ]; then
+    ok "two lanes with identical sources share one fingerprint"
+  else
+    bad "identical sources produced different fingerprints" "$fp1 vs $fp2"
+  fi
+fi
+
+# --- case 5: a broken bootstrap fails LOUDLY and registers nothing ---------------------------
+# The failure that started all of this was silent-by-accident. A bootstrap that cannot succeed
+# must say so and must never leave the caller believing lifecycle tracking is active.
+COLD="$TMP/cache-cold"; mkdir -p "$COLD"
+err="$(ICN_RUNTIME_CACHE="$COLD" ICN_RUNTIME_NO_BUILD=1 \
+       "$LANE1/ops/scripts/icn-runtime-build" 2>&1 >/dev/null)"
+rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$err" | grep -q 'no cached runtime'; then
+  ok "an unresolvable runtime exits non-zero with a specific reason"
+else
+  bad "unresolvable runtime did not fail loudly (rc=$rc)" "$err"
+fi
+
+# A lane of its own, and a fresh one: by now LANE1 has been bootstrapped and carries a working
+# dist symlink, which the in-tree fallback would (correctly) rescue. "Fails loudly" is only
+# meaningful where there is genuinely no runtime to fall back to.
+LANE3="$TMP/lanes/task-noruntime"
+git -C "$ORIGIN" worktree add -q -b task/noruntime "$LANE3" main 2>/dev/null
+out="$(ICN_RUNTIME_CACHE="$COLD" ICN_RUNTIME_NO_BUILD=1 \
+       session c5 "$LANE3" register --harness-key broken-1 --cwd "$LANE3" --provider test 2>"$TMP/c5.err")"
+if printf '%s' "$out" | grep -q '"session_id"'; then
+  bad "a broken bootstrap still reported a registration" "$out"
+else
+  ok "a broken bootstrap registers nothing"
+fi
+if grep -q 'DEGRADED (unregistered)' "$TMP/c5.err"; then
+  ok "a broken bootstrap prints the DEGRADED banner on stderr"
+else
+  bad "broken bootstrap failed silently" "$(cat "$TMP/c5.err")"
+fi
+
+# cold deps: asserted, not waited on. A cold dependency tree must hand off to a detached
+# bootstrap rather than stalling a human at a prompt for minutes.
+err="$(ICN_RUNTIME_CACHE="$TMP/cache-nodeps" \
+       "$LANE1/ops/scripts/icn-runtime-build" --background-if-cold 2>&1 >/dev/null)"
+if printf '%s' "$err" | grep -q 'background bootstrap'; then
+  ok "a cold dependency cache hands off to a background bootstrap instead of blocking"
+else
+  bad "cold dependency cache did not defer to a background bootstrap" "$err"
+fi
+
+# --- case 6: a failed re-resolution must not take away a working runtime ---------------------
+# Regression. The first version of this fix re-resolved unconditionally on `register` and
+# degraded when the bootstrap could not run — turning environments that HAD a working in-tree
+# dist (no npm, a partial checkout, a read-only cache) from working into unregistered. The
+# adoption gate caught it: its fixture carries a dist but no ops/mcp/package.json.
+if [ "$DEPS_AVAILABLE" = 1 ]; then
+  PARTIAL="$TMP/partial"
+  mkdir -p "$PARTIAL/ops/mcp"
+  cp -a "$REPO_ROOT/.gitignore" "$PARTIAL/" 2>/dev/null
+  cp -a "$REPO_ROOT/ops/scripts" "$PARTIAL/ops/"
+  # A working runtime, and deliberately no ops/mcp/package.json for the bootstrap to read.
+  ln -s "$("$LANE1/ops/scripts/icn-runtime-build")" "$PARTIAL/ops/mcp/dist"
+  git -C "$PARTIAL" init -q -b main .
+  git -C "$PARTIAL" -c user.email=f@l -c user.name=f commit -q --allow-empty -m partial
+
+  out="$(session c6 "$PARTIAL" register --harness-key partial-1 --cwd "$PARTIAL" \
+         --provider test 2>"$TMP/c6.err")"
+  if printf '%s' "$out" | grep -q '"session_id"'; then
+    ok "an unrunnable bootstrap falls back to the in-tree build instead of degrading"
+  else
+    bad "fallback to the in-tree build did not happen" "$(tail -3 "$TMP/c6.err")"
+  fi
+  if grep -q 'could not re-resolve' "$TMP/c6.err"; then
+    ok "the fallback says what it could not re-check rather than claiming a verified build"
+  else
+    bad "fallback was silent about the failed re-resolution" "$(cat "$TMP/c6.err")"
+  fi
+fi
+
+# --- case 7: the bootstrap never dirties the worktree ----------------------------------------
+# A bootstrap that showed up in `git status` would put build output into every review.
+if [ "$DEPS_AVAILABLE" = 1 ]; then
+  dirty="$(git -C "$LANE1" status --porcelain 2>/dev/null)"
+  if [ -z "$dirty" ]; then
+    ok "a bootstrapped lane stays clean in git status"
+  else
+    bad "bootstrap dirtied the worktree" "$dirty"
+  fi
+fi
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test-agent-runtime-bootstrap.sh
+++ b/scripts/test-agent-runtime-bootstrap.sh
@@ -264,7 +264,31 @@ if [ "$DEPS_AVAILABLE" = 1 ]; then
   fi
 fi
 
-# --- case 7: the bootstrap never dirties the worktree ----------------------------------------
+# --- case 7: a cached runtime still registers into the REPOSITORY's registry -----------------
+# Regression, and the reason every other case here pins ICN_OPS_DB is also the reason this one
+# must not. db.ts derives the shared registry from the CLI's own __dirname; a cached runtime
+# lives outside every checkout, so the derivation found no repository and silently fell back to
+# a per-installation database. Every bootstrapped lane would have registered somewhere the MCP
+# server and every other worktree could not see — the one-registry-per-repository invariant,
+# broken by the fix meant to make registration work at all.
+if [ "$DEPS_AVAILABLE" = 1 ]; then
+  COMMON="$(cd "$(git -C "$LANE1" rev-parse --git-common-dir)" && pwd -P)"
+  ( cd "$LANE1" && env -u ICN_OPS_DB "$LANE1/ops/scripts/icn-agent-session" register \
+      --harness-key registry-derivation-1 --cwd "$LANE1" --provider test ) \
+      >"$TMP/c7.out" 2>"$TMP/c7.err"
+  if grep -q 'could not derive the shared registry' "$TMP/c7.err"; then
+    bad "a cached runtime fell back to a per-installation registry" "$(head -2 "$TMP/c7.err")"
+  else
+    ok "a cached runtime does not fall back to a per-installation registry"
+  fi
+  if [ -f "$COMMON/icn-ops.db" ] && grep -q '"session_id"' "$TMP/c7.out"; then
+    ok "the session lands in the repository's shared registry ($COMMON/icn-ops.db)"
+  else
+    bad "session did not land in the repository registry" "expected $COMMON/icn-ops.db"
+  fi
+fi
+
+# --- case 8: the bootstrap never dirties the worktree ----------------------------------------
 # A bootstrap that showed up in `git status` would put build output into every review.
 if [ "$DEPS_AVAILABLE" = 1 ]; then
   dirty="$(git -C "$LANE1" status --porcelain 2>/dev/null)"


### PR DESCRIPTION
# Pull Request

## Delivery

- **Delivery lane**: STANDARD
- **Acceptance contract**: a brand-new ICN worktree with no prebuilt `ops/mcp/dist` — including a Claude-created nested `.claude/worktrees/<name>` lane — enters the supported agent lifecycle automatically, registering into the repository's shared registry, while preserving anti-stale and fail-safe semantics.
- **Explicit non-goals**: no change to lifecycle semantics, classification, release guarantees, merge policy, or any product/protocol behaviour; no dependency upgrades; no MCP-server launch rework.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN
Lane:                 STANDARD
Acceptance contract:  see the Delivery section above
Review generation:    CLOSED — FULL, automated reviewers; 11 threads, all classified BLOCKER
                      under blocker_predicate and fixed in three batches; 0 unresolved
Freeze head:          77020197ae09e4aaf6dade7fa4965ad9df2ca6d9
Known blockers:       0
Follow-up ledger:     none — every finding was a blocker and was fixed here
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## Summary

`ops/scripts/icn-agent-session` needs `ops/mcp/dist/cli/session.js`. `dist/` is gitignored, and
nothing on any worktree-creation path builds it — not `wt-new`, not Claude Code's nested
`.claude/worktrees/<name>` lane, not `git worktree add` by hand. A new lane was therefore not
briefly degraded but **permanently unregistered**.

Measured on the dev VM: **44 of 50 worktrees could not register**, the registry reported zero
sessions while four Claude activations were live, and the readiness audit that found this was
itself running unregistered. `mcp-host` worked only because its build happened to exist.

`ops/scripts/icn-runtime-build` resolves the session CLI from a shared cache keyed by a SHA-256
over the checkout's runtime sources (`ops/mcp/src/**` plus `package.json`, `package-lock.json`,
`tsconfig.json`), hashed with repo-relative paths so lanes holding identical sources share one
entry.

**The anti-stale rule is strengthened, not traded away.** "This checkout's location wins" only
proved a build sat *next to* the sources; it never noticed an in-tree `dist` gone stale against
its own `src`. A content-addressed key proves the running bytes were compiled from *these*
sources. An in-tree build still wins when present, so `npm run build` is unaffected.

**Costs, measured rather than assumed.** A cache hit is free (~100ms, and it is the normal case:
a lane branched from `main` has not touched `ops/mcp`). A first-of-its-kind source state costs one
`tsc` (~10s), built inline. The dependency tree (~157M; `better-sqlite3` compiles from source, no
Node 22 prebuild) is machine-level state keyed by the lockfile: a cold one is handed to a detached
background bootstrap rather than stalling a human, and the session says plainly that *it* is
unregistered and the next one will not be. `register` re-resolves once per session; the
per-tool-call events take the resolved path as-is rather than paying ~116ms each to re-answer a
question they do not ask.

Two defects found while building this, both now covered by cases:

1. **A failed re-resolution used to discard a working in-tree build**, regressing environments
   that had one (no npm, a partial checkout) from working to unregistered. Caught by the adoption
   gate, whose fixture carries a `dist` but no `ops/mcp/package.json`.
2. **A cached runtime registered into a per-installation database.** `resolveDefaultDbPath()`
   derives the registry from the CLI's own `__dirname`; a cached runtime lives outside every
   checkout, so the derivation found no repository and fell back — breaking the
   one-registry-per-repository invariant `ops/mcp/src/state/db.ts` exists to hold, inside the very
   change meant to make registration work. The wrapper now pins `ICN_OPS_DB` from
   `git-common-dir`. Found by dogfooding a real fresh lane; no fixture could have caught it,
   because fixtures pin `ICN_OPS_DB` for isolation — exactly the variable whose absence was broken.

## Layer classification
- [x] ops/coordination (process, refinery, hygiene)

## Boundary check
No institution-specific meaning, no private operational data, no public-website claim, no new ICN
primitives. This is host/agent-runtime plumbing only.

## What changed
- `ops/scripts/icn-runtime-build` (new) — content-addressed runtime bootstrap: fingerprint, shared
  cache, `flock` + `rename(2)` publication, background hand-off for a cold dependency tree,
  verify-then-repair for the native module, staging sweep.
- `ops/scripts/icn-agent-session` — resolve the CLI through the bootstrap when there is no in-tree
  build; re-resolve on `register` only; fall back to an in-tree build if the bootstrap cannot run;
  pin `ICN_OPS_DB` to the repository being served.
- `scripts/test-agent-runtime-bootstrap.sh` (new) — the acceptance suite, under a standing rule
  that no case may start from a worktree that already has a `dist`.
- `.gitignore` — ignore the `ops/mcp/dist` symlink the bootstrap publishes (`dist/` matches
  directories only).
- `.claude/settings.json` — SessionStart lifecycle hook timeout 10s → 60s, so a first-of-its-kind
  `tsc` fits inside the hook budget.
- `docs/architecture/AGENT_RUNTIME.md` — new §3.1 recording the seam, the cost model, and the
  strengthened anti-stale rule.
- `docs/reference/project-index/generated/agent-capabilities.json` — regenerated for the new helper.

## What did not change
Lifecycle semantics, heartbeat/progress distinctions, classification, release guarantees, merge
policy, `.mcp.json`, the plugin MCP launcher, and every product/protocol surface.

## Related
- Refs #2653 — the residual lifecycle-debt observation this does *not* subsume (orphaned processes
  that never registered remain invisible to the registry).

## Cross-repo dependency status
- Upstream PR(s): none
- Downstream PR(s): none
- This PR depends on upstream merging first: no

## Review-thread status
- [x] Prior review threads resolved or marked outdated, with reason. (none — new PR)
- [x] PR body matches the current diff.

## Work mode
- [x] Delivery tranche

## Risk

The bootstrap runs on the SessionStart path, so a defect here degrades session registration. The
failure mode is bounded by construction: every failure path prints a specific reason and exits
non-zero, `icn-agent-session` turns that into its existing visible DEGRADED banner, and no path
fabricates a registration. A cold dependency tree is explicitly *not* waited on.

Known limitations, deliberately left:
- `.mcp.json`'s `npm --prefix ./ops/mcp run start:stdio` and the plugin's `bin/icn-ops-mcp` still
  require an in-tree `node_modules`, so launching the MCP *server* from a fresh lane remains
  unfixed. Out of this PR's contract; the bootstrap's `dist` symlink does make
  `ops/mcp/dist/index.js` resolve, which is what the diagnostics check.
- The dependency cache is machine-level state. A cold machine's first session is unregistered by
  design, and says so.

## Type of change
- [x] Bug fix
- [x] Tests

## Verification

Run in a lane with **no** in-tree `ops/mcp` build — the shape the fix exists for:

- `scripts/test-agent-runtime-bootstrap.sh` → **26 passed, 0 failed**
- `scripts/test-agent-runtime-adoption-gate.sh` → **18 passed, 0 failed** (matches the clean-`main`
  baseline; was 14/4 before the in-tree-fallback fix)
- `python3 scripts/check-agent-runtime-adoption.py` → 25 checks passed, 0 failures
- `python3 scripts/check-agent-capabilities.py` → manifest true (43 MCP tools verified live)
- `python3 docs/scripts/doc_control_check.py` → OK (970 docs; pre-existing warnings only)

Dogfood against genuinely fresh worktrees created with no `dist` and no `node_modules`, driving the
real `.claude/hooks/session-lifecycle.sh` entrypoint with a `SessionStart` payload:

| lane | shape | result |
|---|---|---|
| `task-runtime-dogfood` | canonical (`wt-new` shape) | registered in **1.09s** |
| `…/.claude/worktrees/nested-probe` | Claude-created nested | registered in **1.04s** |

Both appear in `icn_ops_agent_runtime` / `list_sessions` through the MCP server running
out-of-tree from `mcp-host`, with correct `repo_id`, `worktree_id`, `worktree_path` and
`head_at_registration` — the end-to-end property that was broken.

`python3 scripts/generate-agent-context-spine.py --check` reports STALE. That is **pre-existing on
clean `main`** (verified independently at `8e41458e`) and is the subject of #2669, which regenerates
after this lands.

## Non-goals
Rework of the MCP server launch path, dependency upgrades, worktree-inventory cleanup, and any
change to lifecycle or merge semantics.

## Remaining unknowns
Whether the dependency cache should be provisioned ahead of time on a new machine (today the first
session warms it in the background and says so), and whether `.mcp.json` should route through the
same bootstrap — both deliberately out of scope here.

