### PR TITLE
fix(deps): take the h2 0.4.16 patch for RUSTSEC-2026-0258

### DIFF
--- a/icn/Cargo.lock
+++ b/icn/Cargo.lock
@@ -2484,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2697,7 +2697,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body",
  "httparse",
@@ -2758,7 +2758,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5822,7 +5822,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5862,7 +5862,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6261,7 +6261,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body",
  "http-body-util",


### PR DESCRIPTION
# Pull Request

## Delivery

- **Delivery lane**: FAST
- **Acceptance contract**: close the instance of RUSTSEC-2026-0258 that a lockfile change can close — `h2` 0.4.12 → 0.4.16 — without moving any dependency the resolver would not have moved anyway.
- **Explicit non-goals**: does **not** make `cargo audit` pass, does not touch the `h2` 0.3 path behind `actix-http`, does not add an advisory ignore, does not change any Cargo.toml.

<!-- ICN-DELIVERY-LIFECYCLE:BEGIN -->
```
ICN DELIVERY LIFECYCLE
State:                FROZEN
Lane:                 FAST
Acceptance contract:  see the Delivery section above
Review generation:    FULL, closed (copilot: no findings; codex: 1 finding, NOT_A_FINDING)
Freeze head:          417d160c6d61bc65fe2842c6fa9c615a9a654949
Known blockers:       none
Follow-up ledger:     none (h2 0.3 path is an explicit non-goal, stated above)
```
<!-- ICN-DELIVERY-LIFECYCLE:END -->

## Summary

`cargo audit` reports **two** vulnerabilities on `main`, both RUSTSEC-2026-0258 (*h2 unbounded
empty DATA frames*). This closes the one that can be closed without upstream movement.

Lockfile only: **`h2` 0.4.12 → 0.4.16**, a patch bump inside the 0.4 line that no `Cargo.toml`
constrains. It covers the `h2` that actually carries traffic — `hyper` 1.8.1, and through it
`axum` and `icn-rpc`.

## The three `socket2` lines, and why they are here

The diff is 14 lines: **4 for the advisory**, and **3 edges** (`hyper-util`, `quinn`, `quinn-udp`)
that move `socket2` 0.6.1 → 0.5.10. Those three are **not** caused by the `h2` bump. They are
pre-existing drift between the committed lockfile and what the pinned toolchain (`1.95.0`)
resolves, and they appear on *any* rewrite of the lockfile.

Reproduced on pristine `main` with a **no-op** re-pin of `h2` to the version it already has:

```
$ cargo update -p h2@0.4.12 --precise 0.4.12
 icn/Cargo.lock | 6 +++---     # the 3 socket2 edges, zero h2 lines
```

`hyper-util` 0.1.19 declares `socket2 = ">=0.5.9, <0.7"`. That range spans two semver-compatible
groups; `socket2` 0.5.10 is already selected in the graph, so the resolver reuses it instead of
adding a second copy. `main`'s 0.6.1 edges are a *valid* resolution — `cargo metadata --locked`
passes on `main` — but not one the resolver reproduces.

They are left as cargo produced them rather than hand-restored, because hand-editing `Cargo.lock`
into a state the pinned toolchain does not reproduce is worse than the churn: the same three lines
return on the next lockfile touch by anyone. **No package is added or removed** — both `socket2`
0.5.10 and 0.6.1 are in the build graph before and after; only three edges move between two
versions that were already being compiled.

## What this does not fix, and why

The second instance is **`h2` 0.3.27**, reached only through `actix-http` → `actix-files` →
`icn-gateway`. `actix-http` is already at its latest published version (**3.13.3**) and still
depends on `h2` 0.3, so no lockfile change resolves it.

Updating `actix-http` was tried and rejected: it moves `sha1` to 0.11 and pulls in `chacha20` and
`rand` 0.10 **without touching the `h2` 0.3 dependency at all** — broad dependency surgery, and
crypto-adjacent surgery at that, for zero security benefit.

So `cargo audit` still exits non-zero after this, and the Weekly Security Audit stays red.

## Next action for the remaining instance

A maintainer decision, deliberately not taken here:

1. **Wait for upstream** — actix-http moving to `h2` 0.4 resolves it with another lockfile bump.
2. **Time-box a documented ignore** in the audit config, so the remaining advisory is an explicit,
   dated risk acceptance and the audit signal becomes meaningful again for everything else.
3. **Drop the actix dependency** in `icn-gateway` — a real project, not a dependency bump.

Option 2 is the only one that restores a green signal soon, and it is a risk-acceptance call, not
an engineering one.

## Layer classification
- [x] ops/coordination (process, refinery, hygiene)

## What changed
- `icn/Cargo.lock`, and nothing else (7 insertions, 7 deletions):
  - `h2` 0.4.12 → 0.4.16 — version, checksum, and 2 consumer edges (`hyper`, `reqwest`).
  - 3 `socket2` consumer edges normalized by the resolver, as explained above.

## What did not change
Every `Cargo.toml`, the `h2` 0.3 path, the audit configuration, and all product code.
No package enters or leaves the dependency graph.

## Related
- RUSTSEC-2026-0258 — https://rustsec.org/advisories/RUSTSEC-2026-0258

## Type of change
- [x] Bug fix (security)

## Verification
- `cargo update -p h2@0.4.12 --precise 0.4.16` — resolves cleanly; the only movement beyond `h2`
  is the pre-existing `socket2` normalization, isolated above by a no-op re-pin.
- `cargo audit` before: **2 vulnerabilities**; after: **1** (the `h2` 0.3.27 path only). The
  remaining entries are unmaintained-crate warnings, which are already allowed.
- `cargo tree --invert --package h2@0.4.16` — consumers are `hyper` → `axum` / `hyper-rustls` /
  `hyper-timeout` / `hyper-util` / `icn-rpc` / `metrics-exporter-prometheus`
- Full build and test verification is CI's: a semver-compatible patch bump inside `0.4.x` needs
  the whole workspace compiled to mean anything, and CI does exactly that. `Build Release` and
  `Clippy` green on this head also prove the `socket2` resolution compiles.

## Risk
Minimal and bounded: a patch release within one minor line, no API surface change, and no package
added or removed. If `h2` 0.4.16 regressed anything, `Build Release` and `Test` catch it before
merge.

## Remaining unknowns
Whether the maintainer wants option 2 above (a dated, documented ignore) to restore a usable audit
signal while the `h2` 0.3 path waits on actix.

